### PR TITLE
handle server error from emq_http_auth plugin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = emqttd
 PROJECT_DESCRIPTION = Erlang MQTT Broker
-PROJECT_VERSION = 2.3.9
+PROJECT_VERSION = 2.3.9-authfix
 
 DEPS = goldrush gproc lager esockd ekka mochiweb pbkdf2 lager_syslog bcrypt clique jsx
 
@@ -54,4 +54,3 @@ app:: rebar.config
 
 app.config::
 	./deps/cuttlefish/cuttlefish -l info -e etc/ -c etc/emq.conf -i priv/emq.schema -d data/
-

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 PROJECT = emqttd
 PROJECT_DESCRIPTION = Erlang MQTT Broker
-PROJECT_VERSION = 2.3.9-authfix
+PROJECT_VERSION = 2.3.10-authfix2
 
 DEPS = goldrush gproc lager esockd ekka mochiweb pbkdf2 lager_syslog bcrypt clique jsx
 
@@ -8,7 +8,7 @@ dep_goldrush     = git https://github.com/basho/goldrush 0.1.9
 dep_gproc        = git https://github.com/uwiger/gproc
 dep_getopt       = git https://github.com/jcomellas/getopt v0.8.2
 dep_lager        = git https://github.com/basho/lager master
-dep_esockd       = git https://github.com/emqtt/esockd v5.2.1
+dep_esockd       = git https://github.com/emqtt/esockd v5.2.2
 dep_ekka         = git https://github.com/emqtt/ekka v0.2.3
 dep_mochiweb     = git https://github.com/emqtt/mochiweb v4.2.2
 dep_pbkdf2       = git https://github.com/emqtt/pbkdf2 2.0.1

--- a/src/emqttd.app.src
+++ b/src/emqttd.app.src
@@ -1,6 +1,6 @@
 {application,emqttd,
              [{description,"Erlang MQTT Broker"},
-              {vsn,"2.3.9"},
+              {vsn,"2.3.9-authfix"},
               {modules,[]},
               {registered,[emqttd_sup]},
               {applications,[kernel,stdlib,gproc,lager,esockd,mochiweb,

--- a/src/emqttd.app.src
+++ b/src/emqttd.app.src
@@ -1,6 +1,6 @@
 {application,emqttd,
              [{description,"Erlang MQTT Broker"},
-              {vsn,"2.3.9-authfix"},
+              {vsn,"2.3.10-authfix2"},
               {modules,[]},
               {registered,[emqttd_sup]},
               {applications,[kernel,stdlib,gproc,lager,esockd,mochiweb,


### PR DESCRIPTION
fix for #1037

please ignore version changes.
I know that this change is possibly not compatible with all auth plugins and the return code check should not be part of the core emq module. But this change helps us to improve handling of auth server outages