### PR TITLE
Using the entire certificate as username

### DIFF
--- a/etc/emq.conf
+++ b/etc/emq.conf
@@ -991,10 +991,10 @@ listener.ssl.external.certfile = {{ platform_etc_dir }}/certs/cert.pem
 ## Value: on | off
 ## listener.ssl.external.honor_cipher_order = on
 
-## Use the CN or DN value from the client certificate as a username.
+## Use the CN, DN or CRT value from the client certificate as a username.
 ## Notice that 'verify' should be set as 'verify_peer'.
 ##
-## Value: cn | dn
+## Value: cn | dn | crt
 ## listener.ssl.external.peer_cert_as_username = cn
 
 ## TCP backlog for the SSL connection.
@@ -1322,7 +1322,7 @@ listener.wss.external.certfile = {{ platform_etc_dir }}/certs/cert.pem
 
 ## See: listener.ssl.<name>.peer_cert_as_username
 ##
-## Value: cn | dn
+## Value: cn | dn | crt
 ## listener.wss.external.peer_cert_as_username = cn
 
 ## TCP backlog for the WebSocket/SSL connection.

--- a/priv/emq.schema
+++ b/priv/emq.schema
@@ -820,7 +820,7 @@ end}.
 ]}.
 
 {mapping, "listener.tcp.$name.peer_cert_as_username", "emqttd.listeners", [
-  {datatype, {enum, [cn, dn]}}
+  {datatype, {enum, [cn, dn, crt]}}
 ]}.
 
 {mapping, "listener.tcp.$name.backlog", "emqttd.listeners", [
@@ -1006,7 +1006,7 @@ end}.
 ]}.
 
 {mapping, "listener.ssl.$name.peer_cert_as_username", "emqttd.listeners", [
-  {datatype, {enum, [cn, dn]}}
+  {datatype, {enum, [cn, dn, crt]}}
 ]}.
 
 %%--------------------------------------------------------------------
@@ -1248,7 +1248,7 @@ end}.
 ]}.
 
 {mapping, "listener.wss.$name.peer_cert_as_username", "emqttd.listeners", [
-  {datatype, {enum, [cn, dn]}}
+  {datatype, {enum, [cn, dn, crt]}}
 ]}.
 
 {translation, "emqttd.listeners", fun(Conf) ->

--- a/src/emqttd_protocol.erl
+++ b/src/emqttd_protocol.erl
@@ -89,7 +89,10 @@ enrich_opt([_ | ConnOpts], Conn, State) ->
 peercert_username(cn, Conn) ->
     Conn:peer_cert_common_name();
 peercert_username(dn, Conn) ->
-    Conn:peer_cert_subject().
+    Conn:peer_cert_subject();
+peercert_username(crt, Conn) ->
+    {ok, Cert} = Conn:peercert(),
+    binary_to_list(Cert).
 
 repl_username_with_peercert(State = #proto_state{peercert_username = undefined}) ->
     State;


### PR DESCRIPTION
In some occasions having only the DN/CN at the authentication step is not enough to ensure the connection identity. In my specific case, I need to send the entire certificate to a specific service (using an authentication plugin).

It seems to me the better approach is to allow the user to get the entire certificate (the binary in this case) and do whatever is necessary on the authentication step.

Please let me know if this makes sense project-wise and if any change is demanded.

Thanks.