### PR TITLE
Generate a config file for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ rebar3.crashdump
 .DS_Store
 rebar.config
 emqx.iml
+bbmustache/
+etc/gen.emqx.conf

--- a/test/emqx_ct_broker_helpers.erl
+++ b/test/emqx_ct_broker_helpers.erl
@@ -63,7 +63,7 @@ run_teardown_steps() ->
 
 generate_config() ->
     Schema = cuttlefish_schema:files([local_path(["priv", "emqx.schema"])]),
-    Conf = conf_parse:file([local_path(["etc", "emqx.conf"])]),
+    Conf = conf_parse:file([local_path(["etc", "gen.emqx.conf"])]),
     cuttlefish_generator:map(Schema, Conf).
 
 get_base_dir(Module) ->

--- a/test/emqx_listeners_SUITE.erl
+++ b/test/emqx_listeners_SUITE.erl
@@ -49,7 +49,7 @@ restart_listeners(_) ->
     
 generate_config() ->
     Schema = cuttlefish_schema:files([local_path(["priv", "emqx.schema"])]),
-    Conf = conf_parse:file([local_path(["etc", "emqx.conf"])]),
+    Conf = conf_parse:file([local_path(["etc", "gen.emqx.conf"])]),
     cuttlefish_generator:map(Schema, Conf).
 
 set_app_env({App, Lists}) ->

--- a/vars
+++ b/vars
@@ -1,0 +1,9 @@
+%% vars here are for test only, not intended for release
+
+{platform_bin_dir,  "bin"}.
+{platform_data_dir, "data"}.
+{platform_etc_dir,  "etc"}.
+{platform_lib_dir,  "lib"}.
+{platform_log_dir,  "log"}.
+{platform_plugins_dir,  "plugins"}.
+


### PR DESCRIPTION
Prior to this change, the template file etc/emqx.conf is used
directly in testing, as a result, mustache dir:s are created

In this change, Makefile steps are added to download bbmustach
and load the template input then replace with variableds defined
in 'vars' file, saved to etc/gen.emqx.conf for testing