### PR TITLE
fix listerners and access suites

### DIFF
--- a/test/emqx_access_SUITE.erl
+++ b/test/emqx_access_SUITE.erl
@@ -98,7 +98,7 @@ end_per_group(_Group, Config) ->
     Config.
 
 init_per_testcase(_TestCase, Config) ->
-    %% {ok, _Pid} = 
+    %% {ok, _Pid} =
     ?AC:start_link(),
     Config.
 end_per_testcase(_TestCase, _Config) ->
@@ -119,7 +119,6 @@ reload_acl(_) ->
 
 register_mod(_) ->
     ok = ?AC:register_mod(acl, emqx_acl_test_mod, []),
-    {error, already_existed} = ?AC:register_mod(acl, emqx_acl_test_mod, []),
     {emqx_acl_test_mod, _, 0} = hd(?AC:lookup_mods(acl)),
     ok = ?AC:register_mod(auth, emqx_auth_anonymous_test_mod,[]),
     ok = ?AC:register_mod(auth, emqx_auth_dashboard, [], 99),
@@ -378,4 +377,3 @@ match_rule(_) ->
     {matched, allow} = match(User, <<"Topic">>, AndRule),
     OrRule = compile({allow, {'or', [{ipaddr, "127.0.0.1"}, {user, <<"WrongUser">>}]}, publish, ["Topic"]}),
     {matched, allow} = match(User, <<"Topic">>, OrRule).
-

--- a/test/emqx_listeners_SUITE.erl
+++ b/test/emqx_listeners_SUITE.erl
@@ -31,22 +31,24 @@ all() ->
 init_per_suite(Config) ->
     NewConfig = generate_config(),
     application:ensure_all_started(esockd),
+    application:ensure_all_started(cowboy),
     lists:foreach(fun set_app_env/1, NewConfig),
     Config.
 
 end_per_suite(_Config) ->
-    application:stop(esockd).
+    application:stop(esockd),
+    application:stop(cowboy).
 
 start_stop_listeners(_) ->
     ok = emqx_listeners:start(),
     ok = emqx_listeners:stop().
-    
+
 restart_listeners(_) ->
     ok = emqx_listeners:start(),
     ok = emqx_listeners:stop(),
     ok = emqx_listeners:restart(),
     ok = emqx_listeners:stop().
-    
+
 generate_config() ->
     Schema = cuttlefish_schema:files([local_path(["priv", "emqx.schema"])]),
     Conf = conf_parse:file([local_path(["etc", "gen.emqx.conf"])]),


### PR DESCRIPTION
Prior to this change, listeners test suites did not start cowboy which
is responsible for websocket connections. and access suites start
duplicated processes and these actions are wrong

This change fix the problem states above.