### PR TITLE
Update message expiry interval

### DIFF
--- a/src/emqx_message.erl
+++ b/src/emqx_message.erl
@@ -22,7 +22,7 @@
 -export([get_flag/2, get_flag/3, set_flag/2, set_flag/3, unset_flag/2]).
 -export([set_headers/2]).
 -export([get_header/2, get_header/3, set_header/3]).
--export([is_expired/1, check_expiry/1, check_expiry/2, update_expiry/1]).
+-export([is_expired/1, update_expiry/1]).
 -export([format/1]).
 
 -type(flag() :: atom()).
@@ -100,21 +100,6 @@ is_expired(#message{headers = #{'Message-Expiry-Interval' := Interval}, timestam
 is_expired(_Msg) ->
     false.
 
--spec(check_expiry(emqx_types:message()) -> {ok, pos_integer()} | expired | false).
-check_expiry(Msg = #message{timestamp = CreatedAt}) ->
-    check_expiry(Msg, CreatedAt);
-check_expiry(_Msg) ->
-    false.
-
--spec(check_expiry(emqx_types:message(), erlang:timestamp()) -> {ok, pos_integer()} | expired | false).
-check_expiry(#message{headers = #{'Message-Expiry-Interval' := Interval}}, Since) ->
-    case Interval - (elapsed(Since) div 1000) of
-        Timeout when Timeout > 0 -> {ok, Timeout};
-        _ -> expired
-    end;
-check_expiry(_Msg, _Since) ->
-    false.
-
 update_expiry(Msg = #message{headers = #{'Message-Expiry-Interval' := Interval}, timestamp = CreatedAt}) ->
     case elapsed(CreatedAt) of
         Elapsed when Elapsed > 0 ->
@@ -138,4 +123,3 @@ format(flags, Flags) ->
     io_lib:format("~p", [[Flag || {Flag, true} <- maps:to_list(Flags)]]);
 format(headers, Headers) ->
     io_lib:format("~p", [Headers]).
-

--- a/test/emqx_message_SUITE.erl
+++ b/test/emqx_message_SUITE.erl
@@ -29,7 +29,7 @@ all() ->
         message_flag,
         message_header,
         message_format,
-        message_expired 
+        message_expired
     ].
 
 message_make(_) ->
@@ -53,7 +53,7 @@ message_flag(_) ->
     ?assert(emqx_message:get_flag(dup, Msg6)),
     ?assert(emqx_message:get_flag(retain, Msg6)).
 
-message_header(_) -> 
+message_header(_) ->
     Msg = emqx_message:make(<<"clientid">>, <<"topic">>, <<"payload">>),
     Msg1 = emqx_message:set_headers(#{a => 1, b => 2}, Msg),
     Msg2 = emqx_message:set_header(c, 3, Msg1),
@@ -68,11 +68,8 @@ message_expired(_) ->
     Msg1 = emqx_message:set_headers(#{'Message-Expiry-Interval' => 1}, Msg),
     timer:sleep(500),
     ?assertNot(emqx_message:is_expired(Msg1)),
-    {ok, 1} = emqx_message:check_expiry(Msg1),
     timer:sleep(600),
     ?assert(emqx_message:is_expired(Msg1)),
-    expired = emqx_message:check_expiry(Msg1),
     timer:sleep(1000),
     Msg2 = emqx_message:update_expiry(Msg1),
     ?assertEqual(1, emqx_message:get_header('Message-Expiry-Interval', Msg2)).
-


### PR DESCRIPTION
Prior to this change, emqx did not update message expiry interval and
there are duplicated functions to verify whether the message is expired.

This change delete the duplicated functions and add update action for
unexpired message.