### PR TITLE
Add space before plugins.etc_dir in emqx.conf

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1839,7 +1839,7 @@ module.rewrite = off
 ## The etc dir for plugins' config.
 ##
 ## Value: Folder
-plugins.etc_dir ={{ platform_etc_dir }}/plugins/
+plugins.etc_dir = {{ platform_etc_dir }}/plugins/
 
 ## The file to store loaded plugin names.
 ##


### PR DESCRIPTION
Hi

I experienced a problem when I was trying to load plugins via `emqx_ctl`. 
It clearly doesn't see my `etc/plugins/emqx_auth_pgsql.conf` file because in error logs I see default values not mine.

Adding space before `plugins.etc_dir` in emqx.conf helped immediately.

I have almost zero knowledge about erlang and cuttlefish library but it seems like this space is required. Feel free to reject if I am wrong