### PR TITLE
Change from customized total heap size check to set process flag

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -836,7 +836,6 @@ end}.
 %% connection/session process.
 %% Message queue here is the Erlang process mailbox, but not the number
 %% of queued MQTT messages of QoS 1 and 2.
-%% Total heap size is the in Erlang 'words' not in 'bytes'.
 %% Zero or negative is to disable.
 {mapping, "zone.$name.force_shutdown_policy", "emqx.zones", [
   {default, "0 | 0MB"},
@@ -856,18 +855,20 @@ end}.
                                    {error, Reason} ->
                                        error(Reason);
                                    Bytes1 ->
-                                       #{bytes => Bytes1, count => list_to_integer(Count)}
+                                       #{bytes => Bytes1,
+                                         count => list_to_integer(Count)}
                                end,
                     {force_gc_policy, GcPolicy};
                ("force_shutdown_policy", Val) ->
                     [Len, Siz] = string:tokens(Val, "| "),
-                    ShutdownPolicy = case cuttlefish_bytesize:parse(Siz) of
-                                   {error, Reason} ->
-                                       error(Reason);
-                                   Siz1 ->
-                                         #{message_queue_len => list_to_integer(Len),
-                                           total_heap_size   => Siz1}
-                               end,
+                    ShutdownPolicy =
+                        case cuttlefish_bytesize:parse(Siz) of
+                            {error, Reason} ->
+                                error(Reason);
+                            Siz1 ->
+                                #{message_queue_len => list_to_integer(Len),
+                                  max_heap_size => Siz1}
+                        end,
                     {force_shutdown_policy, ShutdownPolicy};
                (Opt, Val) ->
                     {list_to_atom(Opt), Val}

--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -152,7 +152,7 @@ init([Transport, RawSocket, Options]) ->
                                      }),
             GcPolicy = emqx_zone:get_env(Zone, force_gc_policy, false),
             ok = emqx_gc:init(GcPolicy),
-            erlang:put(force_shutdown_policy, emqx_zone:get_env(Zone, force_shutdown_policy)),
+            ok = emqx_misc:init_proc_mng_policy(Zone),
             gen_server:enter_loop(?MODULE, [{hibernate_after, IdleTimout}],
                                   State, self(), IdleTimout);
         {error, Reason} ->

--- a/src/emqx_misc.erl
+++ b/src/emqx_misc.erl
@@ -15,7 +15,9 @@
 -module(emqx_misc).
 
 -export([merge_opts/2, start_timer/2, start_timer/3, cancel_timer/1,
-         proc_name/2, proc_stats/0, proc_stats/1, conn_proc_mng_policy/1]).
+         proc_name/2, proc_stats/0, proc_stats/1]).
+
+-export([init_proc_mng_policy/1, conn_proc_mng_policy/1]).
 
 %% @doc Merge options
 -spec(merge_opts(list(), list()) -> list()).
@@ -60,32 +62,35 @@ proc_stats(Pid) ->
 
 -define(DISABLED, 0).
 
+init_proc_mng_policy(Zone) ->
+    #{max_heap_size := MaxHeapSizeInBytes} = ShutdownPolicy =
+        emqx_zone:get_env(Zone, force_shutdown_policy),
+    MaxHeapSize = MaxHeapSizeInBytes div erlang:system_info(wordsize),
+    _ = erlang:process_flag(max_heap_size, MaxHeapSize), % zero is discarded
+    erlang:put(force_shutdown_policy, ShutdownPolicy),
+    ok.
+
 %% @doc Check self() process status against connection/session process management policy,
 %% return `continue | hibernate | {shutdown, Reason}' accordingly.
 %% `continue': There is nothing out of the ordinary.
 %% `hibernate': Nothing to process in my mailbox, and since this check is triggered
 %%              by a timer, we assume it is a fat chance to continue idel, hence hibernate.
-%% `shutdown': Some numbers (message queue length or heap size have hit the limit),
+%% `shutdown': Some numbers (message queue length hit the limit),
 %%             hence shutdown for greater good (system stability).
--spec(conn_proc_mng_policy(#{message_queue_len := integer(),
-                             total_heap_size := integer()
-                            } | undefined) -> continue | hibernate | {shutdown, _}).
-conn_proc_mng_policy(#{message_queue_len := MaxMsgQueueLen,
-                       total_heap_size := MaxTotalHeapSize
-                      }) ->
+-spec(conn_proc_mng_policy(#{message_queue_len => integer()} | false) ->
+            continue | hibernate | {shutdown, _}).
+conn_proc_mng_policy(#{message_queue_len := MaxMsgQueueLen}) ->
     Qlength = proc_info(message_queue_len),
     Checks =
         [{fun() -> is_message_queue_too_long(Qlength, MaxMsgQueueLen) end,
           {shutdown, message_queue_too_long}},
-         {fun() -> is_heap_size_too_large(MaxTotalHeapSize) end,
-          {shutdown, total_heap_size_too_large}},
          {fun() -> Qlength > 0 end, continue},
          {fun() -> true end, hibernate}
         ],
     check(Checks);
 conn_proc_mng_policy(_) ->
     %% disable by default
-    conn_proc_mng_policy(#{message_queue_len => 0, total_heap_size => 0}).
+    conn_proc_mng_policy(#{message_queue_len => 0}).
 
 check([{Pred, Result} | Rest]) ->
     case Pred() of
@@ -95,9 +100,6 @@ check([{Pred, Result} | Rest]) ->
 
 is_message_queue_too_long(Qlength, Max) ->
     is_enabled(Max) andalso Qlength > Max.
-
-is_heap_size_too_large(Max) ->
-    is_enabled(Max) andalso proc_info(total_heap_size) > Max.
 
 is_enabled(Max) -> is_integer(Max) andalso Max > ?DISABLED.
 

--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -357,7 +357,7 @@ init([Parent, #{zone        := Zone,
     emqx_hooks:run('session.created', [#{client_id => ClientId}, info(State)]),
     GcPolicy = emqx_zone:get_env(Zone, force_gc_policy, false),
     ok = emqx_gc:init(GcPolicy),
-    erlang:put(force_shutdown_policy, emqx_zone:get_env(Zone, force_shutdown_policy)),
+    ok = emqx_misc:init_proc_mng_policy(Zone),
     ok = proc_lib:init_ack(Parent, {ok, self()}),
     gen_server:enter_loop(?MODULE, [{hibernate_after, IdleTimout}], State).
 


### PR DESCRIPTION
The `max_heap_size` process flag can be used to limit total
heap size of a process, and it gives much more detailed
crash log if the limit is hit.

example log:
```
11> erlang:process_flag(max_heap_size, 2000).
#{error_logger => true,kill => true,size => 0}
12>
12> lists:seq(1,10000).
** exception exit: killed
13> =ERROR REPORT==== 22-Sep-2018::08:48:12.703215 ===
     Process:          <0.89.0>
     Context:          maximum heap size reached
     Max Heap Size:    2000
     Total Heap Size:  3548
     Kill:             true
     Error Logger:     true
     GC Info:          [{old_heap_block_size,1598},
                        {heap_block_size,1974},
                        {mbuf_size,0},
                        {recent_size,675},
                        {stack_size,24},
                        {old_heap_size,0},
                        {heap_size,963},
                        {bin_vheap_size,4},
                        {bin_vheap_block_size,46422},
                        {bin_old_vheap_size,0},
                        {bin_old_vheap_block_size,46422}]
```