### PR TITLE
Add acking mechamism for shared dispatch

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1904,6 +1904,15 @@ broker.session_locking_strategy = quorum
 ## - hash
 broker.shared_subscription_strategy = random
 
+## Enable/disable shared dispatch acknowledgement for QoS1 and QoS2 messages
+## This should allow messages to be dispatched to a different subscriber in
+## the group in case the picked (based on shared_subscription_strategy) one # is offline
+##
+## Value: Enum
+## - true
+## - false
+broker.shared_dispatch_ack_enabled = false
+
 ## Enable batch clean for deleted routes.
 ##
 ## Value: Flag

--- a/include/emqx.hrl
+++ b/include/emqx.hrl
@@ -68,7 +68,9 @@
           %% Message Payload
           payload :: binary(),
           %% Timestamp
-          timestamp :: erlang:timestamp()
+          timestamp :: erlang:timestamp(),
+          %% shared dispatch ack fun
+          shared_dispatch_ack = no_ack :: no_ack | {pid(), reference()}
         }).
 
 -record(delivery, {

--- a/include/emqx.hrl
+++ b/include/emqx.hrl
@@ -68,9 +68,7 @@
           %% Message Payload
           payload :: binary(),
           %% Timestamp
-          timestamp :: erlang:timestamp(),
-          %% shared dispatch ack fun
-          shared_dispatch_ack = no_ack :: no_ack | {pid(), reference()}
+          timestamp :: erlang:timestamp()
         }).
 
 -record(delivery, {

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1719,6 +1719,12 @@ end}.
     ]}}
 ]}.
 
+%% @doc Enable or disable shared dispatch acknowledgement for QoS1 and QoS2 messages
+{mapping, "broker.shared_dispatch_ack_enabled", "emqx.shared_dispatch_ack_enabled",
+ [ {default, false},
+   {datatype, {enum, [true, false]}}
+ ]}.
+
 {mapping, "broker.route_batch_clean", "emqx.route_batch_clean", [
   {default, on},
   {datatype, flag}

--- a/src/emqx_packet.erl
+++ b/src/emqx_packet.erl
@@ -127,15 +127,13 @@ from_message(PacketId, #message{qos = QoS, flags = Flags, headers = Headers,
                  variable = Publish, payload = Payload}.
 
 publish_props(Headers) ->
-    maps:filter(fun('Payload-Format-Indicator', _) -> true;
-                   ('Response-Topic',           _) -> true;
-                   ('Correlation-Data',         _) -> true;
-                   ('User-Property',            _) -> true;
-                   ('Subscription-Identifier',  _) -> true;
-                   ('Content-Type',             _) -> true;
-                   ('Message-Expiry-Interval',  _) -> true;
-                   (_Key, _Val) -> false
-                end , Headers).
+    maps:with(['Payload-Format-Indicator',
+               'Response-Topic',
+               'Correlation-Data',
+               'User-Property',
+               'Subscription-Identifier',
+               'Content-Type',
+               'Message-Expiry-Interval'], Headers).
 
 %% @doc Message from Packet
 -spec(to_message(emqx_types:credentials(), emqx_mqtt_types:packet())

--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -257,6 +257,7 @@ subscribe(SPid, PacketId, Properties, TopicFilters) ->
     SubReq = {PacketId, Properties, TopicFilters},
     gen_server:cast(SPid, {subscribe, self(), SubReq}).
 
+%% @doc Called by connection processes when publishing messages
 -spec(publish(spid(), emqx_mqtt_types:packet_id(), emqx_types:message())
       -> {ok, emqx_types:deliver_results()}).
 publish(_SPid, _PacketId, Msg = #message{qos = ?QOS_0}) ->

--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -802,7 +802,7 @@ run_dispatch_steps([{nl, _}|Steps], Msg, State) ->
     run_dispatch_steps(Steps, Msg, State);
 run_dispatch_steps([{qos, SubQoS}|Steps], Msg0 = #message{qos = PubQoS}, State = #state{upgrade_qos = false}) ->
     %% Ack immediately if a shared dispatch QoS is downgraded to 0
-    Msg = case SubQoS =:= ?QOS0 of
+    Msg = case SubQoS =:= ?QOS_0 of
               true -> emqx_shared_sub:maybe_ack(Msg0);
               false -> Msg0
           end,

--- a/src/emqx_sm.erl
+++ b/src/emqx_sm.erl
@@ -59,8 +59,8 @@ open_session(SessAttrs = #{clean_start := true, client_id := ClientId, conn_pid 
                  end,
     emqx_sm_locker:trans(ClientId, CleanStart);
 
-open_session(SessAttrs = #{clean_start          := false,
-                           client_id            := ClientId}) ->
+open_session(SessAttrs = #{clean_start := false,
+                           client_id   := ClientId}) ->
     ResumeStart = fun(_) ->
                       case resume_session(ClientId, SessAttrs) of
                           {ok, SPid} ->

--- a/test/emqx_broker_SUITE.erl
+++ b/test/emqx_broker_SUITE.erl
@@ -164,7 +164,7 @@ start_session(_) ->
     emqx_session:publish(SessPid, 3, Message2),
     emqx_session:unsubscribe(SessPid, [{<<"topic/session">>, []}]),
     %% emqx_mock_client:stop(ClientPid).
-    emqx_mock_client:close_session(ClientPid, SessPid).
+    emqx_mock_client:close_session(ClientPid).
 
 %%--------------------------------------------------------------------
 %% Broker Group

--- a/test/emqx_mock_client.erl
+++ b/test/emqx_mock_client.erl
@@ -16,55 +16,54 @@
 
 -behaviour(gen_server).
 
--export([start_link/1, open_session/3, close_session/2, stop/1, get_last_message/1]).
+-export([start_link/1, open_session/3, open_session/4,
+         close_session/1, stop/1, get_last_message/1]).
 
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
 
--record(state, {clean_start, client_id, client_pid, last_msg}).
+-record(state, {clean_start, client_id, client_pid, last_msg, session_pid}).
 
 start_link(ClientId) ->
     gen_server:start_link(?MODULE, [ClientId], []).
 
 open_session(ClientPid, ClientId, Zone) ->
-    gen_server:call(ClientPid, {start_session, ClientPid, ClientId, Zone}).
+    open_session(ClientPid, ClientId, Zone, _Attrs = #{}).
 
-close_session(ClientPid, SessPid) ->
-    gen_server:call(ClientPid, {stop_session, SessPid}).
+open_session(ClientPid, ClientId, Zone, Attrs0) ->
+    Attrs1 = default_session_attributes(Zone, ClientId, ClientPid),
+    Attrs = maps:merge(Attrs1, Attrs0),
+    gen_server:call(ClientPid, {start_session, ClientPid, ClientId, Attrs}).
+
+%% close session and terminate the client itself
+close_session(ClientPid) ->
+    gen_server:call(ClientPid, stop_session, infinity).
 
 stop(CPid) ->
-    gen_server:call(CPid, stop).
+    gen_server:call(CPid, stop, infinity).
 
 get_last_message(Pid) ->
-    gen_server:call(Pid, get_last_message).
+    gen_server:call(Pid, get_last_message, infinity).
 
 init([ClientId]) ->
+    erlang:process_flag(trap_exit, true),
     {ok, #state{clean_start = true,
                 client_id = ClientId,
                 last_msg = undefined
                }
     }.
 
-handle_call({start_session, ClientPid, ClientId, Zone}, _From, State) ->
-    Attrs = #{ zone                 => Zone,
-               client_id            => ClientId,
-               conn_pid             => ClientPid,
-               clean_start          => true,
-               username             => undefined,
-               expiry_interval      => 0,
-               max_inflight         => 0,
-               topic_alias_maximum  => 0,
-               will_msg             => undefined
-             },
+handle_call({start_session, ClientPid, ClientId, Attrs}, _From, State) ->
     {ok, SessPid} = emqx_sm:open_session(Attrs),
     {reply, {ok, SessPid},
      State#state{clean_start = true,
                  client_id = ClientId,
-                 client_pid = ClientPid
+                 client_pid = ClientPid,
+                 session_pid = SessPid
                 }};
-handle_call({stop_session, SessPid}, _From, State) ->
-    emqx_sm:close_session(SessPid),
-    {stop, normal, ok, State};
+handle_call(stop_session, _From, #state{session_pid = Pid} = State) ->
+    is_pid(Pid) andalso is_process_alive(Pid) andalso emqx_sm:close_session(Pid),
+    {stop, normal, ok, State#state{session_pid = undefined}};
 handle_call(get_last_message, _From, #state{last_msg = Msg} = State) ->
     {reply, Msg, State};
 handle_call(stop, _From, State) ->
@@ -85,4 +84,16 @@ terminate(_Reason, _State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
+
+default_session_attributes(Zone, ClientId, ClientPid) ->
+    #{zone                => Zone,
+      client_id           => ClientId,
+      conn_pid            => ClientPid,
+      clean_start         => true,
+      username            => undefined,
+      expiry_interval     => 0,
+      max_inflight        => 0,
+      topic_alias_maximum => 0,
+      will_msg            => undefined
+     }.
 

--- a/test/emqx_session_SUITE.erl
+++ b/test/emqx_session_SUITE.erl
@@ -76,4 +76,4 @@ t_session_all(_) ->
     emqx_session:unsubscribe(SPid, [<<"topic">>]),
     timer:sleep(200),
     [] = emqx:subscriptions({SPid, <<"clientId">>}),
-    emqx_mock_client:close_session(ConnPid, SPid).
+    emqx_mock_client:close_session(ConnPid).


### PR DESCRIPTION
For QoS0 messages, no acking
For QoS1/2 messages, 'ACK' if any:

 - ACK when QoS is downgraded to 0
 - Message is sent to connection process

'NACK' if any:

 - There is no alive connection process for the receiving session
 - Message queue is full and the receiving session starts to drop old messages
 - The receiving session crash

Upon 'NACK', messages are dispatched to the 'next' subscriber in the group,
depending on the shared subscription dispatch strategy.