### PR TITLE
Fix topic_name validation bug

### DIFF
--- a/src/emqx_packet.erl
+++ b/src/emqx_packet.erl
@@ -55,6 +55,8 @@ validate(?UNSUBSCRIBE_PACKET(PacketId, TopicFilters)) ->
     validate_packet_id(PacketId)
         andalso ok == lists:foreach(fun emqx_topic:validate/1, TopicFilters);
 
+validate(?PUBLISH_PACKET(_QoS, <<>>, _, #{'Topic-Alias' := _I}, _)) ->
+    ok;
 validate(?PUBLISH_PACKET(_QoS, <<>>, _, _, _)) ->
     error(topic_name_invalid);
 validate(?PUBLISH_PACKET(_QoS, Topic, _, Properties, _)) ->


### PR DESCRIPTION
Prior to this change, the validation for the mqtt5.0 publish packet
which both contains zero-length topic name and topic alias is wrong

This change fix this bug.