### PR TITLE
Improve will message

### DIFF
--- a/src/emqx_packet.erl
+++ b/src/emqx_packet.erl
@@ -55,6 +55,8 @@ validate(?UNSUBSCRIBE_PACKET(PacketId, TopicFilters)) ->
     validate_packet_id(PacketId)
         andalso ok == lists:foreach(fun emqx_topic:validate/1, TopicFilters);
 
+validate(?PUBLISH_PACKET(_QoS, <<>>, #{'Topic-Alias':= _I}, _)) ->
+    true;
 validate(?PUBLISH_PACKET(_QoS, <<>>, _, _, _)) ->
     error(topic_name_invalid);
 validate(?PUBLISH_PACKET(_QoS, Topic, _, Properties, _)) ->

--- a/src/emqx_protocol.erl
+++ b/src/emqx_protocol.erl
@@ -610,14 +610,14 @@ try_open_session(PState = #pstate{zone        = Zone,
 set_session_attrs({max_inflight, #pstate{zone = Zone, proto_ver = ProtoVer, conn_props = ConnProps}}, SessAttrs) ->
     maps:put(max_inflight, if
                                ProtoVer =:= ?MQTT_PROTO_V5 ->
-                                   maps:get('Receive-Maximum', ConnProps, 65535);
+                                   get_property('Receive-Maximum', ConnProps, 65535);
                                true -> 
                                    emqx_zone:get_env(Zone, max_inflight, 65535)
                            end, SessAttrs);
 set_session_attrs({expiry_interval, #pstate{zone = Zone, proto_ver = ProtoVer, conn_props = ConnProps, clean_start = CleanStart}}, SessAttrs) ->
     maps:put(expiry_interval, if
                                ProtoVer =:= ?MQTT_PROTO_V5 ->
-                                   maps:get('Session-Expiry-Interval', ConnProps, 0);
+                                   get_property('Session-Expiry-Interval', ConnProps, 0);
                                true -> 
                                    case CleanStart of
                                        true -> 0;
@@ -628,7 +628,7 @@ set_session_attrs({expiry_interval, #pstate{zone = Zone, proto_ver = ProtoVer, c
 set_session_attrs({topic_alias_maximum, #pstate{zone = Zone, proto_ver = ProtoVer, conn_props = ConnProps}}, SessAttrs) ->
     maps:put(topic_alias_maximum, if
                                     ProtoVer =:= ?MQTT_PROTO_V5 ->
-                                        maps:get('Topic-Alias-Maximum', ConnProps, 0);
+                                        get_property('Topic-Alias-Maximum', ConnProps, 0);
                                     true -> 
                                         emqx_zone:get_env(Zone, max_topic_alias, 0)
                                   end, SessAttrs);

--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -542,7 +542,7 @@ handle_cast({resume, ConnPid}, State = #state{client_id       = ClientId,
     %% Clean Session: true -> false???
     CleanStart andalso emqx_sm:set_session_attrs(ClientId, attrs(State1)),
 
-    emqx_hooks:run('session.resumed', [#{client_id => ClientId}, attrs(State)]),
+    emqx_hooks:run('session.resumed', [#{client_id => ClientId, session => self()}, attrs(State)]),
 
     %% Replay delivery and Dequeue pending messages
     noreply(dequeue(retry_delivery(true, State1)));


### PR DESCRIPTION
The Server delays publishing the Client’s Will Message until the Will Delay Interval has passed or the Session ends, whichever happens first. If a new Network Connection to this Session is made before the Will Delay Interval has passed, the Server MUST NOT send the Will Message.