### PR TITLE
Refine request & response topic prefix handeling

### DIFF
--- a/test/emqx_client_SUITE.erl
+++ b/test/emqx_client_SUITE.erl
@@ -62,17 +62,18 @@ request_response_exception(QoS) ->
     {ok, Client, _} = emqx_client:start_link([{proto_ver, v5},
                                                  {properties, #{ 'Request-Response-Information' => 0 }}]),
     ?assertError(no_response_information,
-                emqx_client:sub_request_topic(Client, QoS, <<"request_topic">>)),
+                 emqx_client:sub_request_topic(Client, QoS, <<"request_topic">>)),
     ok = emqx_client:disconnect(Client).
 
 request_response(QoS) ->
     {ok, Requester, _} = emqx_client:start_link([{proto_ver, v5},
+                                                 {client_id, <<"requester">>},
                                                  {properties, #{ 'Request-Response-Information' => 1}}]),
     {ok, Responser, _} = emqx_client:start_link([{proto_ver, v5},
+                                                 {client_id, <<"responser">>},
                                                  {properties, #{ 'Request-Response-Information' => 1}},
-                                                 {request_handler, fun(_) -> <<"ResponseTest">> end}]),
-    {ok, RequestTopic} = emqx_client:sub_request_topic(Responser, QoS, <<"request_topic">>),
-    ct:log("RequestTopic: ~p",[RequestTopic]),
+                                                 {request_handler, fun(Req) -> <<"ResponseTest">> end}]),
+    ok = emqx_client:sub_request_topic(Responser, QoS, <<"request_topic">>),
     {ok, <<"ResponseTest">>} = emqx_client:request(Requester, <<"response_topic">>, <<"request_topic">>, <<"request_payload">>, QoS),
     ok = emqx_client:set_request_handler(Responser, fun(<<"request_payload">>) ->
                                                             <<"ResponseFunctionTest">>;


### PR DESCRIPTION
Prior to this change emqx_client:request APIs need
to make several gen_statem calls in order to get the request/response
topic prefix stored in client state data.

This commit tries to:
1. make less gen_statem call to get topic prefix
2. move the gen_statem call to a separate call
   so make the topic construction functions side-effect free