### PR TITLE
Fix the bad link to ACL doc

### DIFF
--- a/etc/acl.conf
+++ b/etc/acl.conf
@@ -1,6 +1,6 @@
 %%--------------------------------------------------------------------
 %%
-%% [ACL](https://github.com/emqtt/emqttd/wiki/ACL)
+%% [ACL](http://emqtt.io/docs/v2/config.html#allow-anonymous-and-acl-file)
 %%
 %% -type who() :: all | binary() |
 %%                {ipaddr, esockd_access:cidr()} |


### PR DESCRIPTION
Prior to this change, the refered wiki link in acl.conf has been
deprecated.

Replace the deprecated link with the doc link in the official site.