### PR TITLE
MQTT bridge via TLS

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1614,7 +1614,11 @@ bridge.aws.client_id = bridge_aws
 ## The Clean start flag of a remote bridge.
 ##
 ## Value: boolean
-bridge.aws.clean_start = false
+## Default: true
+##
+## NOTE: Some IoT platforms require clean_start
+##       must be set to 'true'
+## bridge.aws.clean_start = true
 
 ## The username for a remote bridge.
 ##
@@ -1684,12 +1688,12 @@ bridge.aws.ssl = off
 ## Value: File
 ## bridge.aws.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 
-## SSL Certfile of the bridge.
+## Client SSL Certfile of the bridge.
 ##
 ## Value: File
 ## bridge.aws.certfile = {{ platform_etc_dir }}/certs/client-cert.pem
 
-## SSL Keyfile of the bridge.
+## Client SSL Keyfile of the bridge.
 ##
 ## Value: File
 ## bridge.aws.keyfile = {{ platform_etc_dir }}/certs/client-key.pem
@@ -1747,7 +1751,11 @@ bridge.aws.ssl = off
 ## The Clean start flag of a remote bridge.
 ##
 ## Value: boolean
-## bridge.azure.clean_start = false
+## Default: true
+##
+## NOTE: Some IoT platforms require clean_start
+##       must be set to 'true'
+## bridge.azure.clean_start = true
 
 ## The username for a remote bridge.
 ##
@@ -1813,12 +1821,12 @@ bridge.aws.ssl = off
 ## Value: File
 ## bridge.azure.cacertfile = cacert.pem
 
-## SSL Certfile of the bridge.
+## Client SSL Certfile of the bridge.
 ##
 ## Value: File
 ## bridge.azure.certfile = cert.pem
 
-## SSL Keyfile of the bridge.
+## Client SSL Keyfile of the bridge.
 ##
 ## Value: File
 ## bridge.azure.keyfile = key.pem

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1674,21 +1674,25 @@ bridge.aws.mqueue_type = memory
 ## Value: Number
 bridge.aws.max_pending_messages = 10000
 
+## Bribge to remote server via SSL.
+##
+## Value: on | off
+bridge.aws.ssl = off
 
 ## PEM-encoded CA certificates of the bridge.
 ##
 ## Value: File
-## bridge.aws.cacertfile = cacert.pem
+## bridge.aws.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 
 ## SSL Certfile of the bridge.
 ##
 ## Value: File
-## bridge.aws.certfile = cert.pem
+## bridge.aws.certfile = {{ platform_etc_dir }}/certs/client-cert.pem
 
 ## SSL Keyfile of the bridge.
 ##
 ## Value: File
-## bridge.aws.keyfile = key.pem
+## bridge.aws.keyfile = {{ platform_etc_dir }}/certs/client-key.pem
 
 ## SSL Ciphers used by the bridge.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1552,6 +1552,11 @@ end}.
   {datatype, string}
 ]}.
 
+{mapping, "bridge.$name.ssl", "emqx.bridges", [
+  {datatype, flag},
+  {default, off}
+]}.
+
 {mapping, "bridge.$name.cacertfile", "emqx.bridges", [
   {datatype, string}
 ]}.
@@ -1575,11 +1580,12 @@ end}.
 
 {mapping, "bridge.$name.keepalive", "emqx.bridges", [
   {default, "10s"},
-  {datatype, {duration, s}}
+  {datatype, {duration, ms}}
 ]}.
 
 {mapping, "bridge.$name.tls_versions", "emqx.bridges", [
-  {datatype, string}
+  {datatype, string},
+  {default, "tlsv1,tlsv1.1,tlsv1.2"}
 ]}.
 
 {mapping, "bridge.$name.subscription.$id.topic", "emqx.bridges", [
@@ -1597,12 +1603,11 @@ end}.
 
 {mapping, "bridge.$name.reconnect_interval", "emqx.bridges", [
   {default, "30s"},
-  {datatype, {duration, s}}
+  {datatype, {duration, ms}}
 ]}.
 
 
 {translation, "emqx.bridges", fun(Conf) ->
-
     Split = fun(undefined) -> undefined; (S) -> string:tokens(S, ",") end,
 
     IsSsl = fun(cacertfile)   -> true;
@@ -1625,11 +1630,12 @@ end}.
                 case IsSsl(Opt) of
                     true ->
                         SslOpts = [Parse(Opt, Val)|proplists:get_value(ssl_opts, Opts, [])],
-                        lists:ukeymerge(1, [{ssl_opts, SslOpts}], Opts);
+                        lists:ukeymerge(1, [{ssl_opts, SslOpts}], lists:usort(Opts));
                     false ->
                         [{Opt, Val}|Opts]
                 end
             end,
+
     Subscriptions = fun(Name) ->
                             Configs = cuttlefish_variable:filter_by_prefix("bridge." ++ Name ++ ".subscription", Conf),
                             lists:zip([Topic || {_, Topic} <- lists:sort([{I, Topic} || {[_, _, "subscription", I, "topic"], Topic} <- Configs])],
@@ -1639,11 +1645,10 @@ end}.
     maps:to_list(
       lists:foldl(
         fun({["bridge", Name, Opt], Val}, Acc) ->
+                %% e.g #{aws => [{OptKey, OptVal}]}
+                Init = [{list_to_atom(Opt), Val},{subscriptions, Subscriptions(Name)}],
                 maps:update_with(list_to_atom(Name),
-                                 fun(Opts) ->
-                                         Merge(list_to_atom(Opt), Val, Opts)
-                                 end, [{list_to_atom(Opt), Val},
-                                       {subscriptions, Subscriptions(Name)}], Acc);
+                                 fun(Opts) -> Merge(list_to_atom(Opt), Val, Opts) end, Init, Acc);
            (_, Acc) -> Acc
         end, #{}, lists:usort(cuttlefish_variable:filter_by_prefix("bridge.", Conf))))
 

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1549,7 +1549,8 @@ end}.
 ]}.
 
 {mapping, "bridge.$name.forwards", "emqx.bridges", [
-  {datatype, string}
+  {datatype, string},
+  {default, ""}
 ]}.
 
 {mapping, "bridge.$name.ssl", "emqx.bridges", [
@@ -1624,22 +1625,24 @@ end}.
                     {ciphers, Split(Ciphers)};
                (Opt, Val) ->
                     {Opt, Val}
-               end,
+            end,
 
-    Merge = fun(Opt, Val, Opts) ->
-                case IsSsl(Opt) of
-                    true ->
-                        SslOpts = [Parse(Opt, Val)|proplists:get_value(ssl_opts, Opts, [])],
-                        lists:ukeymerge(1, [{ssl_opts, SslOpts}], lists:usort(Opts));
-                    false ->
-                        [{Opt, Val}|Opts]
-                end
+    Merge = fun(forwards, Val, Opts) ->
+                  [{forwards, string:tokens(Val, ",")}|Opts];
+               (Opt, Val, Opts) ->
+                  case IsSsl(Opt) of
+                      true ->
+                          SslOpts = [Parse(Opt, Val)|proplists:get_value(ssl_opts, Opts, [])],
+                          lists:ukeymerge(1, [{ssl_opts, SslOpts}], lists:usort(Opts));
+                      false ->
+                          [{Opt, Val}|Opts]
+                  end
             end,
 
     Subscriptions = fun(Name) ->
-                            Configs = cuttlefish_variable:filter_by_prefix("bridge." ++ Name ++ ".subscription", Conf),
-                            lists:zip([Topic || {_, Topic} <- lists:sort([{I, Topic} || {[_, _, "subscription", I, "topic"], Topic} <- Configs])],
-                                      [QoS || {_, QoS} <- lists:sort([{I, QoS} || {[_, _, "subscription", I, "qos"], QoS} <- Configs])])
+                        Configs = cuttlefish_variable:filter_by_prefix("bridge." ++ Name ++ ".subscription", Conf),
+                        lists:zip([Topic || {_, Topic} <- lists:sort([{I, Topic} || {[_, _, "subscription", I, "topic"], Topic} <- Configs])],
+                                  [QoS || {_, QoS} <- lists:sort([{I, QoS} || {[_, _, "subscription", I, "qos"], QoS} <- Configs])])
                     end,
 
     maps:to_list(


### PR DESCRIPTION
### Bug fixes
- Convert the retry-interval to milliseconds in schema.
- Sort the config options before pass them to `lists:ukeymerge/3`.

### Enhancements:
- Add an extra option to control if ssl is enabled.
- Before connecting to remote broker, using `ssl:cipher_suites(all, TlsVerion)` to fetch all the supported ciphers to include RSA key exchange ciphers. This is important if we're using the default RSA key in `etc/certs/`.

### Change the API of `emqx_client:start_link`
Prior to this change, emqx_client:start_link does 2 works in one call:
- init an erlang process for emqx_client
- send MQTT CONNECT to remote broker

But this solution have some drawbacks:

- the return value of `start_link` compiles the return values of the 2
 works: {ok, Pid, MqttResult}. It is inconsistent with the return value
 of `gen_statem:start_link`, may causes confusions.

- the return mode of the 2 works are different:
  `start_link` should always return {ok, Pid} or {error, Reason}, but
 connecting to mqtt may throw out exceptions as it handles the
 socket. But the caller couldn't have thought of the exception, he would
 pattern match on the result of `emqx_client:start_link`, but it crashed!

- If the init work succeed but the connection failed, the caller couldn't
get a Pid from the return value, but indeed it was created inside the
emqx_client. This hides the fact that the Pid was created, and when the
Pid dies, the caller would receive an message from a Pid it doesn' know about.

This change divided these 2 work into 2 separate APIs:

- `start_link/1` is to build and verify the options, and returns {ok,Pid}
 (on success) or {error, Reason} (on failure).
- `connect/1` is to send MQTT CONNECT, and returns {ok, MQTTResult::properties()} or
 {error, MQTTReason}. MQTT reason codes will contains in the `MQTTReason`.