### PR TITLE
Fix config descriptions of ACL cache

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -434,22 +434,20 @@ acl_nomatch = allow
 ## Value: File Name
 acl_file = {{ platform_etc_dir }}/acl.conf
 
-## Whether to enable ACL cache for publish.
-## The ACL cache size
-## The maximum count of ACL entries allowed for a client.
+## Whether to enable ACL cache.
+##
+## If enabled, ACLs roles for each client will be cached in the memory
 ##
 ## Value: on | off
 enable_acl_cache = on
 
-## The ACL cache size
-## The maximum count of ACL entries allowed for a client.
+## The maximum count of ACL entries can be cached for a client.
 ##
 ## Value: Integer greater than 0
 ## Default: 32
 acl_cache_max_size = 32
 
-## The ACL cache time-to-live.
-## The time after which an ACL cache entry will be invalid
+## The time after which an ACL cache entry will be deleted
 ##
 ## Value: Duration
 ## Default: 1 minute


### PR DESCRIPTION
The descriptions of ACL cache in emqx.conf should be updated.