### PR TITLE
Change primary logger level to all

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -387,8 +387,13 @@ end}.
   {datatype, {enum, [off, file, console, both]}}
 ]}.
 
-{mapping, "log.level", "kernel.logger_level", [
+{mapping, "log.level", "kernel.logger", [
   {default, error},
+  {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, all]}}
+]}.
+
+{mapping, "log.primary_level", "emqx.primary_log_level", [
+  {default, all},
   {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, all]}}
 ]}.
 
@@ -429,7 +434,7 @@ end}.
 
 {translation, "kernel.logger", fun(Conf) ->
     LogTo = cuttlefish:conf_get("log.to", Conf),
-    TopLogLevel = cuttlefish:conf_get("log.level", Conf),
+    LogLevel = cuttlefish:conf_get("log.level", Conf),
     Formatter = {emqx_logger_formatter,
                   #{template =>
                       [time," [",level,"] ",
@@ -450,7 +455,7 @@ end}.
     DefaultHandler =
         if LogTo =:= console orelse LogTo =:= both ->
                 [{handler, default, logger_std_h,
-                    #{level => TopLogLevel,
+                    #{level => LogLevel,
                       config => #{type => standard_io},
                       formatter => Formatter}}];
            true ->
@@ -461,7 +466,7 @@ end}.
     FileHandler =
         if LogTo =:= file orelse LogTo =:= both ->
               [{handler, file, logger_disk_log_h,
-                    #{level => TopLogLevel,
+                    #{level => LogLevel,
                       config => FileConf(cuttlefish:conf_get("log.file", Conf)),
                       formatter => Formatter,
                       filesync_repeat_interval => no_repeat}}];

--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -25,6 +25,12 @@
 %%--------------------------------------------------------------------
 
 start(_Type, _Args) ->
+    %% We configure the primary logger level to `all` here, rather than set the
+    %%   kernel config `logger_level = all` before starting the erlang vm.
+    %% This is because the latter approach an annoying debug msg will be printed out:
+    %%   "[debug] got_unexpected_message {'EXIT',<0.1198.0>,normal}"
+    logger:set_primary_config(level, application:get_env(emqx, primary_log_level, all)),
+
     print_banner(),
     ekka:start(),
     {ok, Sup} = emqx_sup:start_link(),

--- a/src/emqx_tracer.erl
+++ b/src/emqx_tracer.erl
@@ -25,7 +25,7 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3]).
 
--record(state, {level, org_top_level, traces}).
+-record(state, {level, traces}).
 
 -type(trace_who() :: {client_id | topic, binary()}).
 
@@ -82,20 +82,18 @@ lookup_traces() ->
 
 init([]) ->
     {ok, #state{level = emqx_config:get_env(trace_level, debug),
-                org_top_level = get_top_level(),
                 traces = #{}}}.
 
 handle_call({start_trace, Who, LogFile}, _From, State = #state{level = Level, traces = Traces}) ->
     case logger:add_handler(handler_id(Who), logger_disk_log_h,
                                 #{level => Level,
                                   formatter => ?FORMAT,
-                                  filesync_repeat_interval => 1000,
+                                  filesync_repeat_interval => no_repeat,
                                   config => #{type => halt, file => LogFile},
                                   filter_default => stop,
                                   filters => [{meta_key_filter,
                                                {fun filter_by_meta_key/2, Who} }]}) of
         ok ->
-            set_top_level(all), % open the top logger level to 'all'
             emqx_logger:info("[Tracer] start trace for ~p", [Who]),
             {reply, ok, State#state{traces = maps:put(Who, LogFile, Traces)}};
         {error, Reason} ->
@@ -103,7 +101,7 @@ handle_call({start_trace, Who, LogFile}, _From, State = #state{level = Level, tr
             {reply, {error, Reason}, State}
     end;
 
-handle_call({stop_trace, Who}, _From, State = #state{org_top_level = OrgTopLevel, traces = Traces}) ->
+handle_call({stop_trace, Who}, _From, State = #state{traces = Traces}) ->
     case maps:find(Who, Traces) of
         {ok, _LogFile} ->
             case logger:remove_handler(handler_id(Who)) of
@@ -112,7 +110,6 @@ handle_call({stop_trace, Who}, _From, State = #state{org_top_level = OrgTopLevel
                 {error, Reason} ->
                     emqx_logger:error("[Tracer] stop trace for ~p failed, error: ~p", [Who, Reason])
             end,
-            set_top_level(OrgTopLevel), % reset the top logger level to original value
             {reply, ok, State#state{traces = maps:remove(Who, Traces)}};
         error ->
             {reply, {error, not_found}, State}
@@ -143,13 +140,6 @@ handler_id({topic, Topic}) ->
     list_to_atom("topic_" ++ binary_to_list(Topic));
 handler_id({client_id, ClientId}) ->
     list_to_atom("clientid_" ++ binary_to_list(ClientId)).
-
-get_top_level() ->
-    #{level := OrgTopLevel} = logger:get_primary_config(),
-    OrgTopLevel.
-
-set_top_level(Level) ->
-    logger:set_primary_config(level, Level).
 
 filter_by_meta_key(#{meta:=Meta}=LogEvent, {MetaKey, MetaValue}) ->
     case maps:find(MetaKey, Meta) of


### PR DESCRIPTION
- keep the kernel config `logger_level` untouched (defaults to notice), as an annoying debug msg will be printed out at erlang VM startup: "[debug] got_unexpected_message {'EXIT',<0.1198.0>,normal}" 

- set the primary logger level to `all` at emq startup. The level can be configured by `emqx.primary_log_level`. But it is not exposed to the user in emqx.conf, as I think it might confuse the user if there were 2 configs: `emqx.primary_log_level` and `log.level`.

- The tracer module traces all the logs related to current client (by clientid) or topic, at debug level. This log level can be configured by `emqx.trace_level`, but this is not a good idea. I think we should change the trace CLI from `trace client <ClientId> <LogFile>` to `trace client <ClientId> <Log-Level> <LogFile>`