### PR TITLE
Fix type validation for User-Property

### DIFF
--- a/src/emqx_mqtt_props.erl
+++ b/src/emqx_mqtt_props.erl
@@ -143,6 +143,6 @@ validate_value('UTF8-Encoded-String', Val)  ->
     is_binary(Val);
 validate_value('Binary-Data', Val) ->
     is_binary(Val);
-validate_value('User-Property', Val) ->
+validate_value('UTF8-String-Pair', Val) ->
     is_tuple(Val) orelse is_list(Val).
 


### PR DESCRIPTION
There is no User-Property type but UTF8-String-Pair. At the moment it is impossible to publish message that includes User-Property for that reason.