### PR TITLE
Do no execute rebar-clean before distclean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ endef
 
 include erlang.mk
 
-clean:: gen-clean rebar-clean
+clean:: gen-clean
 
 .PHONY: gen-clean
 gen-clean:
@@ -122,7 +122,7 @@ rebar-ct: app.config
 rebar-clean:
 	@rebar3 clean
 
-distclean:: rebar-clean
+distclean::
 	@rm -rf _build cover deps logs log data
 	@rm -f rebar.lock compile_commands.json cuttlefish
 


### PR DESCRIPTION
Prior to this change, this project support to be built with rebar3 and
erlang.mk meanwhile but when we want to make distclean, this project
would execute rebar-clean which would get dependencies via rebar3, it
slow down the procedure of distclean.