### PR TITLE
Remove simple log handler at startup

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -426,9 +426,15 @@ end}.
   {datatype, file}
 ]}.
 
-{mapping, "sasl", "sasl.sasl_error_logger", [
+{mapping, "log.sasl", "sasl.sasl_error_logger", [
   {default, off},
   {datatype, flag},
+  hidden
+]}.
+
+{mapping, "log.error_logger", "kernel.error_logger", [
+  {default, silent},
+  {datatype, {enum, [silent]}},
   hidden
 ]}.
 


### PR DESCRIPTION
The simple logger handler is not removed if we set the `log.to=file` in
emqx.conf.

```
{18-11-28 20:18}EMQ:~/code/emqx30/_rel/emqx@emqx30✗✗✗✗✗✗ emqer%
➜  ./bin/emqx_ctl log handlers list
LogHandler(id=file, level=error, destination=log/emqx.log)
LogHandler(id=simple, level=all, destination=unknown)
```

This might be an issue of OTP logger:
https://bugs.erlang.org/browse/ERL-788

I set the error_logger to silent as a workaround.