### PR TITLE
Separate ets tables for shared subscription

### DIFF
--- a/src/emqx_broker_sup.erl
+++ b/src/emqx_broker_sup.erl
@@ -54,15 +54,15 @@ init([]) ->
 
 create_tab(suboption) ->
     %% Suboption: {Topic, Sub} -> [{qos, 1}]
-    emqx_tables:new(emqx_suboption, [set | ?TAB_OPTS]);
+    emqx_tables:new(emqx_suboption, [set | ?TAB_OPTS]),
+    emqx_tables:new(emqx_shared_suboption, [set | ?TAB_OPTS]);
 
 create_tab(subscriber) ->
     %% Subscriber: Topic -> Sub1, Sub2, Sub3, ..., SubN
-    %% duplicate_bag: o(1) insert
-    emqx_tables:new(emqx_subscriber, [duplicate_bag | ?TAB_OPTS]);
+    emqx_tables:new(emqx_subscriber, [bag | ?TAB_OPTS]);
 
 create_tab(subscription) ->
     %% Subscription: Sub -> Topic1, Topic2, Topic3, ..., TopicN
-    %% bag: o(n) insert
-    emqx_tables:new(emqx_subscription, [bag | ?TAB_OPTS]).
+    emqx_tables:new(emqx_subscription, [bag | ?TAB_OPTS]),
+    emqx_tables:new(emqx_shared_subscription, [bag | ?TAB_OPTS]).
 

--- a/src/emqx_types.erl
+++ b/src/emqx_types.erl
@@ -18,7 +18,7 @@
 
 -export_type([zone/0]).
 -export_type([startlink_ret/0, ok_or_error/1]).
--export_type([pubsub/0, topic/0, subid/0, subopts/0]).
+-export_type([pubsub/0, topic/0, subid/0, subopts/0, subgroup/0]).
 -export_type([client_id/0, username/0, password/0, peername/0, protocol/0]).
 -export_type([credentials/0, session/0]).
 -export_type([subscription/0, subscriber/0, topic_table/0]).
@@ -33,6 +33,7 @@
 -type(pubsub() :: publish | subscribe).
 -type(topic() :: binary()).
 -type(subid() :: binary() | atom()).
+-type(subgroup() :: binary()).
 -type(subopts() :: #{qos    := integer(),
                      share  => binary(),
                      atom() => term()

--- a/test/emqx_broker_SUITE.erl
+++ b/test/emqx_broker_SUITE.erl
@@ -162,7 +162,7 @@ start_session(_) ->
     emqx_session:subscribe(SessPid, [{<<"topic/session">>, #{qos => 2}}]),
     Message2 = emqx_message:make(<<"clientId">>, 1, <<"topic/session">>, <<"test">>),
     emqx_session:publish(SessPid, 3, Message2),
-    emqx_session:unsubscribe(SessPid, [{<<"topic/session">>, []}]),
+    emqx_session:unsubscribe(SessPid, [{<<"topic/session">>, #{}}]),
     %% emqx_mock_client:stop(ClientPid).
     emqx_mock_client:close_session(ClientPid).
 


### PR DESCRIPTION
- Add extra ETS tables for shared subscription:.
   emqx_shared_suboption.
   emqx_shared_subscription.

- Change the ETS table `emqx_subscriber` to type `bag`:
   emqx_tables:new(emqx_subscriber, [bag | ?TAB_OPTS]);

- Rename the Mnesia table of shared subscriber to `emqx_shared_subscriber`

- Remove submap and submon from broker, we don't need to handle `DOWN` msgs in broker process now.

- Fix some bugs related to normal topic and shared topic are both subscribed by a same client. 
   e.g. If a client has already subscribed to 2 topics: `t1` and `$share/g1/t1`, unsubscribing `t1` will also clean the subscription tables of `$share/g1/t1`.