### PR TITLE
Move extra vm args to file vm.args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ NO_AUTOPATCH = cuttlefish
 ERLC_OPTS += +debug_info -DAPPLICATION=emqx
 
 BUILD_DEPS = cuttlefish
-dep_cuttlefish = git-emqx https://github.com/emqx/cuttlefish v2.1.1
+dep_cuttlefish = git-emqx https://github.com/emqx/cuttlefish v2.2.0
 
 #TEST_DEPS = emqx_ct_helplers
 #dep_emqx_ct_helplers = git git@github.com:emqx/emqx-ct-helpers

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -160,47 +160,6 @@ node.name = emqx@127.0.0.1
 ## Value: String
 node.cookie = emqxsecretcookie
 
-## Sets the maximum number of simultaneously existing processes for this
-## system if a Number is passed as value.
-##
-## See: http://erlang.org/doc/man/erl.html
-##
-## Value: Number [1024-134217727]
-##
-## vm.args: +P Number
-node.process_limit = 256000
-
-## Sets the maximum number of simultaneously existing ports for this system.
-##
-## See: http://erlang.org/doc/man/erl.html
-##
-## Value: Number [1024-134217727]
-##
-## vm.args: +Q Number
-node.max_ports = 256000
-
-## Crash dump log file.
-##
-## Value: Log file
-node.crash_dump = {{ platform_log_dir }}/crash.dump
-
-## Specify the erlang distributed protocol.
-##
-## Value: Enum
-##  - inet_tcp: the default; handles TCP streams with IPv4 addressing.
-##  - inet6_tcp: handles TCP with IPv6 addressing.
-##  - inet_tls: using TLS for Erlang Distribution.
-##
-## vm.args: -proto_dist inet_tcp
-node.proto_dist = inet_tcp
-
-## Specify SSL Options in the file if using SSL for Erlang Distribution.
-##
-## Value: File
-##
-## vm.args: -ssl_dist_optfile <File>
-## node.ssl_dist_optfile = {{ platform_etc_dir }}/ssl_dist.conf
-
 ## Sets the port range for the listener socket of a distributed Erlang node.
 ## Note that if there are firewalls between clustered nodes, this port segment
 ## for nodes’ communication should be allowed.

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -160,35 +160,6 @@ node.name = emqx@127.0.0.1
 ## Value: String
 node.cookie = emqxsecretcookie
 
-## Enable SMP support of Erlang VM.
-##
-## Value: enable | auto | disable
-node.smp = auto
-
-## Heartbeat monitoring of an Erlang runtime system. Comment the line to disable
-## heartbeat, or set the value as 'on'
-##
-## Value: on
-##
-## vm.args: -heart
-## node.heartbeat = on
-
-## Enable kernel poll.
-##
-## Value: on | off
-##
-## Default: on
-node.kernel_poll = on
-
-## Sets the number of threads in async thread pool. Valid range is 0-1024.
-##
-## See: http://erlang.org/doc/man/erl.html
-##
-## Value: 0-1024
-##
-## vm.args: +A Number
-node.async_threads = 32
-
 ## Sets the maximum number of simultaneously existing processes for this
 ## system if a Number is passed as value.
 ##
@@ -207,30 +178,6 @@ node.process_limit = 256000
 ##
 ## vm.args: +Q Number
 node.max_ports = 256000
-
-## Set the distribution buffer busy limit (dist_buf_busy_limit).
-##
-## See: http://erlang.org/doc/man/erl.html
-##
-## Value: Number [1KB-2GB]
-##
-## vm.args: +zdbbl size
-node.dist_buffer_size = 8MB
-
-## Sets the maximum number of ETS tables. Note that mnesia and SSL will
-## create temporary ETS tables.
-##
-## Value: Number
-##
-## vm.args: +e Number
-node.max_ets_tables = 256000
-
-## Tweak GC to run more often.
-##
-## Value: Number [0-65535]
-##
-## vm.args: -env ERL_FULLSWEEP_AFTER Number
-node.fullsweep_after = 1000
 
 ## Crash dump log file.
 ##
@@ -253,17 +200,6 @@ node.proto_dist = inet_tcp
 ##
 ## vm.args: -ssl_dist_optfile <File>
 ## node.ssl_dist_optfile = {{ platform_etc_dir }}/ssl_dist.conf
-
-## Sets the net_kernel tick time. TickTime is specified in seconds.
-## Notice that all communicating nodes are to have the same TickTime
-## value specified.
-##
-## See: http://www.erlang.org/doc/man/kernel_app.html#net_ticktime
-##
-## Value: Number
-##
-## vm.args: -kernel net_ticktime Number
-node.dist_net_ticktime = 60
 
 ## Sets the port range for the listener socket of a distributed Erlang node.
 ## Note that if there are firewalls between clustered nodes, this port segment

--- a/etc/vm.args.cloud
+++ b/etc/vm.args.cloud
@@ -1,0 +1,93 @@
+##############################
+# Erlang VM Args
+##############################
+
+## NOTE:
+## Basic args like '-name' and '-setcookie' should be configured in emqx.conf
+## If they are configured in both file, the args configured in emqx.conf will
+## be used.
+
+## Sets the maximum number of simultaneously existing processes for this system.
++P 256000
+
+## Sets the maximum number of simultaneously existing ports for this system.
++Q 262144
+
+## Sets the maximum number of ETS tables
++e 256000
+
+## Sets the maximum number of atoms the virtual machine can handle.
+#+t 1048576
+
+## Set the location of crash dumps
+-env ERL_CRASH_DUMP {{ platform_log_dir }}/crash.dump
+
+## Set how many times generational garbages collections can be done without
+## forcing a fullsweep collection.
+#-env ERL_FULLSWEEP_AFTER 1000
+
+## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
+## (Disabled by default..use with caution!)
+#-heart
+
+## Specify the erlang distributed protocol.
+## Can be one of: inet_tcp, inet6_tcp, inet_tls
+#-proto_dist inet_tcp
+
+## Specify SSL Options in the file if using SSL for Erlang Distribution.
+## Used only when -proto_dist set to inet_tls
+#-ssl_dist_optfile {{ platform_etc_dir }}/ssl_dist.conf
+
+## Specifies the net_kernel tick time in seconds.
+## This is the approximate time a connected node may be unresponsive until
+## it is considered down and thereby disconnected.
+#-kernel net_ticktime 60
+
+## Sets the distribution buffer busy limit (dist_buf_busy_limit).
++zdbbl 8192
+
+## Sets default scheduler hint for port parallelism.
++spp true
+
+## Sets the number of threads in async thread pool. Valid range is 0-1024.
++A 8
+
+## Sets the default heap size of processes to the size Size.
+#+hms 233
+
+## Sets the default binary virtual heap size of processes to the size Size.
+#+hmbs 46422
+
+## Sets the number of IO pollsets to use when polling for I/O.
+#+IOp 1
+
+## Sets the number of IO poll threads to use when polling for I/O.
+#+IOt 1
+
+## Sets the number of scheduler threads to create and scheduler threads to set online.
+#+S 8:8
+
+## Sets the number of dirty CPU scheduler threads to create and dirty CPU scheduler threads to set online.
+#+SDcpu 8:8
+
+## Sets the number of dirty I/O scheduler threads to create.
+#+SDio 10
+
+## Suggested stack size, in kilowords, for scheduler threads.
+#+sss 32
+
+## Suggested stack size, in kilowords, for dirty CPU scheduler threads.
+#+sssdcpu 40
+
+## Suggested stack size, in kilowords, for dirty IO scheduler threads.
+#+sssdio 40
+
+## Sets scheduler bind type.
+## Can be one of: u, ns, ts, ps, s, nnts, nnps, tnnps, db
+#+sbt db
+
+## Sets a user-defined CPU topology.
+#+sct L0-3c0-3p0N0:L4-7c0-3p1N1
+
+## Sets the mapping of warning messages for error_logger
+#+W w

--- a/etc/vm.args.cloud
+++ b/etc/vm.args.cloud
@@ -3,9 +3,11 @@
 ##############################
 
 ## NOTE:
-## Basic args like '-name' and '-setcookie' should be configured in emqx.conf
-## If they are configured in both file, the args configured in emqx.conf will
-## be used.
+##
+## Arguments configured in this file might be overridden by configs from `emqx.conf`.
+##
+## Some basic VM arguments are to be configured in `emqx.conf`,
+## such as `node.name` for `-name` and `node.cooke` for `-setcookie`.
 
 ## Sets the maximum number of simultaneously existing processes for this system.
 +P 256000

--- a/etc/vm.args.edge
+++ b/etc/vm.args.edge
@@ -3,9 +3,11 @@
 ##############################
 
 ## NOTE:
-## Basic args like '-name' and '-setcookie' should be configured in emqx.conf
-## If they are configured in both file, the args configured in emqx.conf will
-## be used.
+##
+## Arguments configured in this file might be overridden by configs from `emqx.conf`.
+##
+## Some basic VM arguments are to be configured in `emqx.conf`,
+## such as `node.name` for `-name` and `node.cooke` for `-setcookie`.
 
 ## Sets the maximum number of simultaneously existing processes for this system.
 +P 20480

--- a/etc/vm.args.edge
+++ b/etc/vm.args.edge
@@ -1,0 +1,93 @@
+##############################
+# Erlang VM Args
+##############################
+
+## NOTE:
+## Basic args like '-name' and '-setcookie' should be configured in emqx.conf
+## If they are configured in both file, the args configured in emqx.conf will
+## be used.
+
+## Sets the maximum number of simultaneously existing processes for this system.
++P 20480
+
+## Sets the maximum number of simultaneously existing ports for this system.
++Q 4096
+
+## Sets the maximum number of ETS tables
++e 512
+
+## Sets the maximum number of atoms the virtual machine can handle.
++t 65536
+
+## Set the location of crash dumps
+-env ERL_CRASH_DUMP {{ platform_log_dir }}/crash.dump
+
+## Set how many times generational garbages collections can be done without
+## forcing a fullsweep collection.
+-env ERL_FULLSWEEP_AFTER 0
+
+## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
+## (Disabled by default..use with caution!)
+#-heart
+
+## Specify the erlang distributed protocol.
+## Can be one of: inet_tcp, inet6_tcp, inet_tls
+#-proto_dist inet_tcp
+
+## Specify SSL Options in the file if using SSL for Erlang Distribution.
+## Used only when -proto_dist set to inet_tls
+#-ssl_dist_optfile {{ platform_etc_dir }}/ssl_dist.conf
+
+## Specifies the net_kernel tick time in seconds.
+## This is the approximate time a connected node may be unresponsive until
+## it is considered down and thereby disconnected.
+#-kernel net_ticktime 60
+
+## Sets the distribution buffer busy limit (dist_buf_busy_limit).
++zdbbl 1024
+
+## Sets default scheduler hint for port parallelism.
++spp false
+
+## Sets the number of threads in async thread pool. Valid range is 0-1024.
++A 1
+
+## Sets the default heap size of processes to the size Size.
+#+hms 233
+
+## Sets the default binary virtual heap size of processes to the size Size.
+#+hmbs 46422
+
+## Sets the number of IO pollsets to use when polling for I/O.
++IOp 1
+
+## Sets the number of IO poll threads to use when polling for I/O.
++IOt 1
+
+## Sets the number of scheduler threads to create and scheduler threads to set online.
++S 1:1
+
+## Sets the number of dirty CPU scheduler threads to create and dirty CPU scheduler threads to set online.
++SDcpu 1:1
+
+## Sets the number of dirty I/O scheduler threads to create.
++SDio 1
+
+## Suggested stack size, in kilowords, for scheduler threads.
+#+sss 32
+
+## Suggested stack size, in kilowords, for dirty CPU scheduler threads.
+#+sssdcpu 40
+
+## Suggested stack size, in kilowords, for dirty IO scheduler threads.
+#+sssdio 40
+
+## Sets scheduler bind type.
+## Can be one of: u, ns, ts, ps, s, nnts, nnps, tnnps, db
+#+sbt db
+
+## Sets a user-defined CPU topology.
+#+sct L0-3c0-3p0N0:L4-7c0-3p1N1
+
+## Sets the mapping of warning messages for error_logger
+#+W w

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -191,40 +191,6 @@ end}.
   {default, "emqxsecretcookie"}
 ]}.
 
-%% @doc SMP Support
-{mapping, "node.smp", "vm_args.-smp", [
-  {default, auto},
-  {datatype, {enum, [enable, auto, disable]}},
-  hidden
-]}.
-
-%% @doc http://erlang.org/doc/man/heart.html
-{mapping, "node.heartbeat", "vm_args.-heart", [
-  {datatype, flag},
-  hidden
-]}.
-
-{translation, "vm_args.-heart", fun(Conf) ->
-    case cuttlefish:conf_get("node.heartbeat", Conf) of
-        true  -> "";
-        false -> cuttlefish:invalid("should be 'on' or comment the line!")
-    end
-end}.
-
-%% @doc Enable Kernel Poll
-{mapping, "node.kernel_poll", "vm_args.+K", [
-  {default, on},
-  {datatype, flag},
-  hidden
-]}.
-
-%% @doc More information at: http://erlang.org/doc/man/erl.html
-{mapping, "node.async_threads", "vm_args.+A", [
-  {default, 64},
-  {datatype, integer},
-  {validators, ["range:0-1024"]}
-]}.
-
 %% @doc Erlang Process Limit
 {mapping, "node.process_limit", "vm_args.+P", [
   {datatype, integer},
@@ -245,64 +211,10 @@ end}.
 {validator, "range4ports", "must be 1024 to 134217727",
  fun(X) -> X >= 1024 andalso X =< 134217727 end}.
 
-%% @doc http://www.erlang.org/doc/man/erl.html#%2bzdbbl
-{mapping, "node.dist_buffer_size", "vm_args.+zdbbl", [
-  {datatype, bytesize},
-  {commented, "32MB"},
-  hidden,
-  {validators, ["zdbbl_range"]}
-]}.
-
-{translation, "vm_args.+zdbbl",
- fun(Conf) ->
-  ZDBBL = cuttlefish:conf_get("node.dist_buffer_size", Conf, undefined),
-  case ZDBBL of
-    undefined -> undefined;
-    X when is_integer(X) -> cuttlefish_util:ceiling(X / 1024); %% Bytes to Kilobytes;
-    _ -> undefined
-  end
- end
-}.
-
-{validator, "zdbbl_range", "must be between 1KB and 2097151KB",
- fun(ZDBBL) ->
-  %% 2097151KB = 2147482624
-  ZDBBL >= 1024 andalso ZDBBL =< 2147482624
- end
-}.
-
-%% @doc http://www.erlang.org/doc/man/erlang.html#system_flag-2
-{mapping, "node.fullsweep_after", "vm_args.-env ERL_FULLSWEEP_AFTER", [
-  {default, 1000},
-  {datatype, integer},
-  hidden,
-  {validators, ["positive_integer"]}
-]}.
-
-{validator, "positive_integer", "must be a positive integer",
-  fun(X) -> X >= 0 end}.
-
-%% Note: OTP R15 and earlier uses -env ERL_MAX_ETS_TABLES,
-%% R16+ uses +e
-%% @doc The ETS table limit
-{mapping, "node.max_ets_tables",
-  cuttlefish:otp("R16", "vm_args.+e", "vm_args.-env ERL_MAX_ETS_TABLES"), [
-  {default, 256000},
-  {datatype, integer},
-  hidden
-]}.
-
 %% @doc Set the location of crash dumps
 {mapping, "node.crash_dump", "vm_args.-env ERL_CRASH_DUMP", [
   {default, "{{crash_dump}}"},
   {datatype, file},
-  hidden
-]}.
-
-%% @doc http://www.erlang.org/doc/man/kernel_app.html#net_ticktime
-{mapping, "node.dist_net_ticktime", "vm_args.-kernel net_ticktime", [
-  {commented, 60},
-  {datatype, integer},
   hidden
 ]}.
 

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -173,49 +173,9 @@ end}.
   {default, "emqx@127.0.0.1"}
 ]}.
 
-%% @doc The erlang distributed protocol
-{mapping, "node.proto_dist", "vm_args.-proto_dist", [
-  %{default, "inet_tcp"},
-  {datatype, {enum, [inet_tcp, inet6_tcp, inet_tls]}},
-  hidden
-]}.
-
-%% @doc Specify SSL Options in the file if using SSL for erlang distribution
-{mapping, "node.ssl_dist_optfile", "vm_args.-ssl_dist_optfile", [
-  {datatype, string},
-  hidden
-]}.
-
 %% @doc Secret cookie for distributed erlang node
 {mapping, "node.cookie", "vm_args.-setcookie", [
   {default, "emqxsecretcookie"}
-]}.
-
-%% @doc Erlang Process Limit
-{mapping, "node.process_limit", "vm_args.+P", [
-  {datatype, integer},
-  {default, 256000},
-  hidden
-]}.
-
-%% Note: OTP R15 and earlier uses -env ERL_MAX_PORTS, R16+ uses +Q
-%% @doc The number of concurrent ports/sockets
-%% Valid range is 1024-134217727
-{mapping, "node.max_ports",
-  cuttlefish:otp("R16", "vm_args.+Q", "vm_args.-env ERL_MAX_PORTS"), [
-  {default, 262144},
-  {datatype, integer},
-  {validators, ["range4ports"]}
-]}.
-
-{validator, "range4ports", "must be 1024 to 134217727",
- fun(X) -> X >= 1024 andalso X =< 134217727 end}.
-
-%% @doc Set the location of crash dumps
-{mapping, "node.crash_dump", "vm_args.-env ERL_CRASH_DUMP", [
-  {default, "{{crash_dump}}"},
-  {datatype, file},
-  hidden
 ]}.
 
 %% @doc http://www.erlang.org/doc/man/kernel_app.html

--- a/rebar.config
+++ b/rebar.config
@@ -9,7 +9,7 @@
      {ekka, "v0.5.1"},
      {clique, "develop"},
      {esockd, "v5.4.2"},
-     {cuttlefish, "v2.1.1"}
+     {cuttlefish, "v2.2.0"}
     ]}.
 
 {edoc_opts, [{preprocess, true}]}.


### PR DESCRIPTION
I added a new vm.args file in PR https://github.com/emqx/emqx-rel/pull/280.
The vm configs in emqx.conf will be merged into that vm.args at emqx startup.