### PR TITLE
Standardize the test case sm and cm

### DIFF
--- a/test/emqx_client_SUITE.erl
+++ b/test/emqx_client_SUITE.erl
@@ -32,9 +32,8 @@
                       <<"+/+">>, <<"TopicA/#">>]).
 
 all() ->
-    [ {group, mqttv4},
-      {group, mqttv5}
-    ].
+    [{group, mqttv4},
+     {group, mqttv5}].
 
 groups() ->
     [{mqttv4, [non_parallel_tests],
@@ -48,8 +47,7 @@ groups() ->
        dollar_topics_test]},
      {mqttv5, [non_parallel_tests],
       [request_response,
-       share_sub_request_topic]}
-].
+       share_sub_request_topic]}].
 
 init_per_suite(Config) ->
     emqx_ct_broker_helpers:run_setup_steps(),

--- a/test/emqx_sm_SUITE.erl
+++ b/test/emqx_sm_SUITE.erl
@@ -31,15 +31,26 @@
                  topic_alias_maximum => 0,
                  will_msg            => undefined}).
 
-all() -> [t_open_session, t_close_session, t_resume_session, t_discard_session, t_register_session,
-          t_unregister_session, t_set_session_attrs, t_get_session_attrs, t_get_session_stats, t_set_session_stats, t_lookup_session_pids].
+all() -> [{group, sm}].
 
-t_open_session(_) ->
+groups() ->
+    [{sm, [non_parallel_tests],
+      [t_open_close_session,
+       t_resume_session,
+       t_discard_session,
+       t_register_unregister_session,
+       t_get_set_session_attrs,
+       t_get_set_session_stats,
+       t_lookup_session_pids]}].
+
+init_per_suite(Config) ->
     emqx_ct_broker_helpers:run_setup_steps(),
-    {ok, ClientPid} = emqx_mock_client:start_link(<<"client">>),
-    ?assertMatch({ok, _}, emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid})).
+    Config.
 
-t_close_session(_) ->
+end_per_suite(_Config) ->
+    emqx_ct_broker_helpers:run_teardown_steps().
+
+t_open_close_session(_) ->
     {ok, ClientPid} = emqx_mock_client:start_link(<<"client">>),
     {ok, SPid} = emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid}),
     ?assertEqual(ok, emqx_sm:close_session(SPid)).
@@ -54,41 +65,27 @@ t_discard_session(_) ->
     {ok, _SPid} = emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid}),
     ?assertEqual(ok, emqx_sm:discard_session(<<"client1">>)).
 
-t_register_session(_) ->
+t_register_unregister_session(_) ->
     Pid = self(),
     {ok, _ClientPid} = emqx_mock_client:start_link(<<"client">>),
     ?assertEqual(ok, emqx_sm:register_session(<<"client">>)),
-    ?assertEqual(ok, emqx_sm:register_session(<<"client">>), Pid).
-
-t_unregister_session(_) ->
-    {ok, _ClientPid} = emqx_mock_client:start_link(<<"client">>),
-    Pid = self(),
-    emqx_sm:register_session(<<"client">>),
+    ?assertEqual(ok, emqx_sm:register_session(<<"client">>, Pid)),
     ?assertEqual(ok, emqx_sm:unregister_session(<<"client">>)),
     ?assertEqual(ok, emqx_sm:unregister_session(<<"client">>), Pid).
 
-t_set_session_attrs(_) ->
+t_get_set_session_attrs(_) ->
     {ok, ClientPid} = emqx_mock_client:start_link(<<"client">>),
     {ok, SPid} = emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid}),
     ?assertEqual(true, emqx_sm:set_session_attrs(<<"client">>, [?ATTRS#{conn_pid => ClientPid}])),
-    ?assertEqual(true, emqx_sm:set_session_attrs(<<"client">>, SPid, [?ATTRS#{conn_pid => ClientPid}])).
+    ?assertEqual(true, emqx_sm:set_session_attrs(<<"client">>, SPid, [?ATTRS#{conn_pid => ClientPid}])),
+    [SAttr] = emqx_sm:get_session_attrs(<<"client">>, SPid),
+    ?assertEqual(<<"client">>, maps:get(client_id, SAttr)).
 
-t_get_session_attrs(_) ->
-    {ok, ClientPid} = emqx_mock_client:start_link(<<"client">>),
-    {ok, SPid} = emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid}),
-    SAttrs = emqx_sm:get_session_attrs(<<"client">>, SPid),
-    ?assertEqual(<<"client">>, proplists:get_value(client_id, SAttrs)).
-
-t_set_session_stats(_) ->
+t_get_set_session_stats(_) ->
     {ok, ClientPid} = emqx_mock_client:start_link(<<"client">>),
     {ok, SPid} = emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid}),
     ?assertEqual(true, emqx_sm:set_session_stats(<<"client">>, [{inflight, 10}])),
-    ?assertEqual(true, emqx_sm:set_session_stats(<<"client">>, SPid, [{inflight, 10}])).
-
-t_get_session_stats(_) ->
-    {ok, ClientPid} = emqx_mock_client:start_link(<<"client">>),
-    {ok, SPid} = emqx_sm:open_session(?ATTRS#{conn_pid => ClientPid}),
-    emqx_sm:set_session_stats(<<"client">>, SPid, [{inflight, 10}]),
+    ?assertEqual(true, emqx_sm:set_session_stats(<<"client">>, SPid, [{inflight, 10}])),
     ?assertEqual([{inflight, 10}], emqx_sm:get_session_stats(<<"client">>, SPid)).
 
 t_lookup_session_pids(_) ->


### PR DESCRIPTION
Prior to this change, the test case in sm and cm is messed and difficult to maintain.

This change fix this problem.