### PR TITLE
Fix the rebar-xref error

### DIFF
--- a/src/emqx_plugins.erl
+++ b/src/emqx_plugins.erl
@@ -168,15 +168,6 @@ list() ->
                       end, Plugins)
     end.
 
-all_plugin_attrs(CfgFiles) ->
-    lists:foldl(
-      fun(CfgFile, Acc) ->
-          case plugin(CfgFile) of
-              not_found -> Acc;
-              Attr -> Acc ++ [Attr]
-          end
-      end, [], CfgFiles).
-
 plugin(CfgFile) ->
     AppName = app_name(CfgFile),
     {ok, Attrs} = application:get_all_key(AppName),
@@ -335,4 +326,3 @@ write_loaded(AppNames) ->
             emqx_logger:error("Open File ~p Error: ~p", [File, Error]),
             {error, Error}
     end.
-

--- a/src/emqx_vm.erl
+++ b/src/emqx_vm.erl
@@ -148,9 +148,9 @@ microsecs() ->
     (Mega * 1000000 + Sec) * 1000000 + Micro.
 
 loads() ->
-    [{load1,  ftos(avg1()/256)},
-     {load5,  ftos(avg5()/256)},
-     {load15, ftos(avg15()/256)}].
+    [{load1,  ftos(cpu_sup:avg1()/256)},
+     {load5,  ftos(cpu_sup:avg5()/256)},
+     {load15, ftos(cpu_sup:avg15()/256)}].
 
 get_system_info() ->
     [{Key, format_system_info(Key, get_system_info(Key))} || Key <- ?SYSTEM_INFO].
@@ -418,28 +418,3 @@ mapping([{owner, V}|Entries], Acc) when is_pid(V) ->
     mapping(Entries, [{owner, Owner}|Acc]);
 mapping([{Key, Value}|Entries], Acc) ->
     mapping(Entries, [{Key, Value}|Acc]).
-
-avg1() ->
-   case cpu_sup:avg1() of
-        SystemLoad when is_integer(SystemLoad) ->
-            SystemLoad;
-        {error, Reason} ->
-            lager:error("Get the average system load in the last minute fail for ~p~n", [Reason]),
-            0.00
-    end.
-avg5() ->
-    case cpu_sup:avg5() of
-        SystemLoad when is_integer(SystemLoad) ->
-            SystemLoad;
-        {error, Reason} ->
-            lager:error("Get the average system load in the last 5 minutes fail for ~p~n", [Reason]),
-            0.00
-    end.
-avg15() ->
-    case cpu_sup:avg15() of
-        SystemLoad when is_integer(SystemLoad) ->
-            SystemLoad;
-        {error, Reason} ->
-            lager:error("Get the average system load in the last 15 minutes fail for ~p~n", [Reason]),
-            0.00
-    end.


### PR DESCRIPTION
Prior to this change, @turtle merged emqx30 to master branch and it
cause some problems. For example, there are still some codes using
lager to print log and there is one local function which is not been
used by other function.

This change fix this issue.