### PR TITLE
Disable lager

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -424,6 +424,17 @@ end}.
   hidden
 ]}.
 
+%% disable lager
+{mapping, "lager.handlers", "lager.handlers", [
+  {default, []},
+  hidden
+]}.
+{mapping, "lager.crash_log", "lager.crash_log", [
+  {default, off},
+  {datatype, flag},
+  hidden
+]}.
+
 {translation, "emqx.primary_log_level", fun(Conf) ->
     cuttlefish:conf_get("log.level", Conf)
 end}.


### PR DESCRIPTION
This PR removes lager handlers and the `crash.log`, in case of some dependencies or plugins of emqx use lager.