### PR TITLE
Delete dep-vsn-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,26 +113,3 @@ rebar-clean:
 distclean::
 	@rm -rf _build cover deps logs log data
 	@rm -f rebar.lock compile_commands.json cuttlefish
-
-## Below are for version consistency check during erlang.mk and rebar3 dual mode support
-none=
-space = $(none) $(none)
-comma = ,
-quote = \"
-curly_l = "{"
-curly_r = "}"
-dep-versions = [$(foreach dep,$(DEPS) $(BUILD_DEPS),$(curly_l)$(dep),$(quote)$(word $(words $(dep_$(dep))),$(dep_$(dep)))$(quote)$(curly_r)$(comma))[]]
-
-.PHONY: dep-vsn-check
-dep-vsn-check:
-	$(verbose) erl -noshell -eval \
-		"MkVsns = lists:sort(lists:flatten($(dep-versions))), \
-		{ok, Conf} = file:consult('rebar.config'), \
-		{_, Deps1} = lists:keyfind(deps, 1, Conf), \
-		{_, Deps2} = lists:keyfind(github_emqx_deps, 1, Conf), \
-		F = fun({N, V}) when is_list(V) -> {N, V}; ({N, {git, _, {branch, V}}}) -> {N, V} end, \
-		RebarVsns = lists:sort(lists:map(F, Deps1 ++ Deps2)), \
-		case {RebarVsns -- MkVsns, MkVsns -- RebarVsns} of \
-		  {[], []} -> halt(0); \
-		  {Rebar, Mk} -> erlang:error({deps_version_discrepancy, [{rebar, Rebar}, {mk, Mk}]}) \
-		end."

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,4 +1,3 @@
-
 CONFIG0 = case os:getenv("REBAR_GIT_CLONE_OPTIONS") of
               "--depth 1" ->
                   CONFIG;


### PR DESCRIPTION
Prior to this change, there are multiple lines and variable which is
used to check dependencies consistency between makefile and
rebar.config. However, these lines have been added into erlang.mk now.

This change delete duplicated rule `dep-vsn-check`