### PR TITLE
Add badtcp clause to handle gen_rpc

### DIFF
--- a/src/emqx_broker.erl
+++ b/src/emqx_broker.erl
@@ -229,11 +229,8 @@ aggre(Routes) ->
 forward(Node, To, Delivery) ->
     %% rpc:call to ensure the delivery, but the latency:(
     case emqx_rpc:call(Node, ?BROKER, dispatch, [To, Delivery]) of
-        {badrpc, Reason} ->
-            ?ERROR("[Broker] Failed to forward msg to ~s: ~p", [Node, Reason]),
-            Delivery;
-        {badtcp, Reason} ->
-            ?ERROR("[Broker] Failed to forward msg to ~s: ~p", [Node, Reason]),
+        {Error, Reason} ->
+            ?ERROR("[Broker] Failed to forward msg to ~s: ~p ~p", [Node, Error, Reason]),
             Delivery;
         Delivery1 -> Delivery1
     end.

--- a/src/emqx_broker.erl
+++ b/src/emqx_broker.erl
@@ -229,8 +229,8 @@ aggre(Routes) ->
 forward(Node, To, Delivery) ->
     %% rpc:call to ensure the delivery, but the latency:(
     case emqx_rpc:call(Node, ?BROKER, dispatch, [To, Delivery]) of
-        {Error, Reason} ->
-            ?ERROR("[Broker] Failed to forward msg to ~s: ~p ~p", [Node, Error, Reason]),
+        {badrpc, Reason} ->
+            ?ERROR("[Broker] Failed to forward msg to ~s: ~p", [Node, Reason]),
             Delivery;
         Delivery1 -> Delivery1
     end.

--- a/src/emqx_broker.erl
+++ b/src/emqx_broker.erl
@@ -232,6 +232,9 @@ forward(Node, To, Delivery) ->
         {badrpc, Reason} ->
             ?ERROR("[Broker] Failed to forward msg to ~s: ~p", [Node, Reason]),
             Delivery;
+        {badtcp, Reason} ->
+            ?ERROR("[Broker] Failed to forward msg to ~s: ~p", [Node, Reason]),
+            Delivery;
         Delivery1 -> Delivery1
     end.
 

--- a/src/emqx_rpc.erl
+++ b/src/emqx_rpc.erl
@@ -45,6 +45,6 @@ filter_results([Delivery | WaitDelivery], Acc) ->
     case Delivery of 
         {badrpc, Reason} -> [{badrpc, Reason} | Acc], filter_results(WaitDelivery, Acc);
         {badtcp, Reason} -> [{badrpc, Reason} | Acc], filter_results(WaitDelivery, Acc);
-        Delivery1        -> Delivery1
+        Delivery1        -> [Delivery1 | Acc], filter_results(WaitDelivery, Acc)
     end.
 

--- a/src/emqx_rpc.erl
+++ b/src/emqx_rpc.erl
@@ -37,7 +37,7 @@ filter_result(Delivery) ->
     end.
 
 filter_results(Deliverys) ->
-    filter_results(Delivery, []).
+    filter_results(Deliverys, []).
 
 filter_results([], Acc) ->
     Acc;

--- a/src/emqx_rpc.erl
+++ b/src/emqx_rpc.erl
@@ -21,10 +21,17 @@
 -define(RPC, gen_rpc).
 
 call(Node, Mod, Fun, Args) ->
-    ?RPC:call(Node, Mod, Fun, Args).
+    filter_result(?RPC:call(Node, Mod, Fun, Args)).
 
 multicall(Nodes, Mod, Fun, Args) ->
-    ?RPC:multicall(Nodes, Mod, Fun, Args).
+    filter_result(?RPC:multicall(Nodes, Mod, Fun, Args)).
 
 cast(Node, Mod, Fun, Args) ->
-    ?RPC:cast(Node, Mod, Fun, Args).
+    filter_result(?RPC:cast(Node, Mod, Fun, Args)).
+
+filter_result(Delivery) ->
+    case Delivery of 
+        {badrpc, Reason} -> {badrpc, Reason};
+        {badtcp, Reason} -> {badrpc, Reason};
+        Delivery1        -> Delivery1
+    end.

--- a/src/emqx_rpc.erl
+++ b/src/emqx_rpc.erl
@@ -24,7 +24,7 @@ call(Node, Mod, Fun, Args) ->
     filter_result(?RPC:call(Node, Mod, Fun, Args)).
 
 multicall(Nodes, Mod, Fun, Args) ->
-    filter_result(?RPC:multicall(Nodes, Mod, Fun, Args)).
+    filter_results(?RPC:multicall(Nodes, Mod, Fun, Args)).
 
 cast(Node, Mod, Fun, Args) ->
     filter_result(?RPC:cast(Node, Mod, Fun, Args)).
@@ -35,3 +35,16 @@ filter_result(Delivery) ->
         {badtcp, Reason} -> {badrpc, Reason};
         Delivery1        -> Delivery1
     end.
+
+filter_results(Deliverys) ->
+    filter_results(Delivery, []).
+
+filter_results([], Acc) ->
+    Acc;
+filter_results([Delivery | WaitDelivery], Acc) ->
+    case Delivery of 
+        {badrpc, Reason} -> [{badrpc, Reason} | Acc], filter_results(WaitDelivery, Acc);
+        {badtcp, Reason} -> [{badrpc, Reason} | Acc], filter_results(WaitDelivery, Acc);
+        Delivery1        -> Delivery1
+    end.
+


### PR DESCRIPTION
### Description:
https://github.com/emqx/emqx/issues/2290
  There are two reasons for `gen_rpc:call() `'s failure, One is `bad_rpc`,and  `bad_tcp`, So add `bad_tcp` clause to handle `gen_rpc:call()`
#### Add code:
```erlang
filter_result(Delivery) ->
    case Delivery of 
        {badrpc, Reason} -> {badrpc, Reason};
        {badtcp, Reason} -> {badrpc, Reason};
        Delivery1        -> Delivery1
    end.
```