### PR TITLE
Unload emqx_alarm_handler before unloading plugins when shuting down

### DIFF
--- a/src/emqx.erl
+++ b/src/emqx.erl
@@ -159,6 +159,7 @@ shutdown() ->
 
 shutdown(Reason) ->
     emqx_logger:error("emqx shutdown for ~s", [Reason]),
+    emqx_alarm_handler:unload(),
     emqx_plugins:unload(),
     lists:foreach(fun application:stop/1, [emqx, ekka, cowboy, ranch, esockd, gproc]).
 

--- a/src/emqx_alarm_handler.erl
+++ b/src/emqx_alarm_handler.erl
@@ -32,6 +32,7 @@
          terminate/2]).
 
 -export([load/0,
+         unload/0,
          get_alarms/0]).
 
 -record(common_alarm, {id, desc}).
@@ -67,6 +68,10 @@ mnesia(copy) ->
 
 load() ->
     gen_event:swap_handler(alarm_handler, {alarm_handler, swap}, {?MODULE, []}).
+
+%% on the way shutting down, give it back to OTP
+unload() ->
+    gen_event:swap_handler(alarm_handler, {?MODULE, swap}, {alarm_handler, []}).
 
 get_alarms() ->
     gen_event:call(alarm_handler, ?MODULE, get_alarms).

--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -43,7 +43,7 @@ start(_Type, _Args) ->
 
     emqx_alarm_handler:load(),
     emqx_logger_handler:init(),
-    
+
     print_vsn(),
     {ok, Sup}.
 


### PR DESCRIPTION
emqx_alarm_handler publishes mqtt messages,
having it running while plugins are shutdown triggered some
annoying crashes