### PR TITLE
Fix alarm report bug

### DIFF
--- a/src/emqx_os_mon.erl
+++ b/src/emqx_os_mon.erl
@@ -139,7 +139,7 @@ handle_info({timeout, Timer, check}, State = #{timer := Timer,
                 true -> alarm_handler:clear_alarm(cpu_high_watermark);
                 false -> ok
             end,
-            {noreply, ensure_check_timer(State)}
+            {noreply, ensure_check_timer(State#{cpu_alarm := false})}
     end.
 
 terminate(_Reason, #{timer := Timer}) ->

--- a/src/emqx_os_mon.erl
+++ b/src/emqx_os_mon.erl
@@ -97,7 +97,8 @@ init([Opts]) ->
     {ok, ensure_check_timer(#{cpu_high_watermark => proplists:get_value(cpu_high_watermark, Opts, 0.80),
                               cpu_low_watermark => proplists:get_value(cpu_low_watermark, Opts, 0.60),
                               cpu_check_interval => proplists:get_value(cpu_check_interval, Opts, 60),
-                              timer => undefined})}.
+                              timer => undefined,
+                              cpu_alarm => false})}.
 
 handle_call(get_cpu_check_interval, _From, State) ->
     {reply, maps:get(cpu_check_interval, State, undefined), State};
@@ -122,7 +123,8 @@ handle_cast(_Request, State) ->
 
 handle_info({timeout, Timer, check}, State = #{timer := Timer, 
                                                cpu_high_watermark := CPUHighWatermark,
-                                               cpu_low_watermark := CPULowWatermark}) ->
+                                               cpu_low_watermark := CPULowWatermark,
+                                               cpu_alarm := CPUAlarm}) ->
     case cpu_sup:util() of
         0 ->
             {noreply, State#{timer := undefined}};
@@ -131,9 +133,12 @@ handle_info({timeout, Timer, check}, State = #{timer := Timer,
             {noreply, ensure_check_timer(State)};
         Busy when Busy / 100 >= CPUHighWatermark ->
             alarm_handler:set_alarm({cpu_high_watermark, Busy}),
-            {noreply, ensure_check_timer(State)};
+            {noreply, ensure_check_timer(State#{cpu_alarm := true})};
         Busy when Busy / 100 < CPULowWatermark ->
-            alarm_handler:clear_alarm(cpu_high_watermark),
+            case CPUAlarm of
+                true -> alarm_handler:clear_alarm(cpu_high_watermark);
+                false -> ok
+            end,
             {noreply, ensure_check_timer(State)}
     end.
 

--- a/src/emqx_vm_mon.erl
+++ b/src/emqx_vm_mon.erl
@@ -68,7 +68,7 @@ init([Opts]) ->
                               process_high_watermark => proplists:get_value(process_high_watermark, Opts, 0.70),
                               process_low_watermark => proplists:get_value(process_low_watermark, Opts, 0.50),
                               timer => undefined,
-                              process_alarm => false})}.
+                              is_process_alarm_set => false})}.
 
 handle_call(get_check_interval, _From, State) ->
     {reply, maps:get(check_interval, State, undefined), State};
@@ -94,18 +94,18 @@ handle_cast(_Request, State) ->
 handle_info({timeout, Timer, check}, State = #{timer := Timer,
                                                process_high_watermark := ProcHighWatermark,
                                                process_low_watermark := ProcLowWatermark,
-                                               process_alarm := ProcessAlarm}) ->
+                                               is_process_alarm_set := IsProcessAlarmSet}) ->
     ProcessCount = erlang:system_info(process_count),
     case ProcessCount / erlang:system_info(process_limit) of
         Percent when Percent >= ProcHighWatermark ->
             alarm_handler:set_alarm({too_many_processes, ProcessCount}),
-            {noreply, ensure_check_timer(State#{process_alarm := true})};
+            {noreply, ensure_check_timer(State#{is_process_alarm_set := true})};
         Percent when Percent < ProcLowWatermark ->
-            case ProcessAlarm of
+            case IsProcessAlarmSet of
                 true -> alarm_handler:clear_alarm(too_many_processes);
                 false -> ok
             end,
-            {noreply, ensure_check_timer(State#{process_alarm := false})}
+            {noreply, ensure_check_timer(State#{is_process_alarm_set := false})}
     end.
 
 terminate(_Reason, #{timer := Timer}) ->


### PR DESCRIPTION
Broker can set cpu and process alarm repeatedly, but only clear the alarm if it has already been set.