### PR TITLE
Fix followed packet parse failure

### DIFF
--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -205,7 +205,6 @@ idle(EventType, Content, State) ->
 
 connected(enter, _, _State) ->
     %% What to do?
-    put(cnt, 0),
     keep_state_and_data;
 
 %% Handle Input

--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -192,10 +192,10 @@ idle(enter, _, State) ->
 idle(timeout, _Timeout, State) ->
     {stop, idle_timeout, State};
 
-idle(cast, {incoming, Packet, PState}, _State) ->
+idle(cast, {incoming, Packet}, State) ->
     handle_packet(Packet, fun(NState) ->
                               {next_state, connected, reset_parser(NState)}
-                          end, PState);
+                          end, State);
 
 idle(EventType, Content, State) ->
     ?HANDLE(EventType, Content, State).
@@ -205,15 +205,16 @@ idle(EventType, Content, State) ->
 
 connected(enter, _, _State) ->
     %% What to do?
+    put(cnt, 0),
     keep_state_and_data;
 
 %% Handle Input
-connected(cast, {incoming, Packet = ?PACKET(Type), PState}, _State) ->
+connected(cast, {incoming, Packet = ?PACKET(Type)}, State) ->
     _ = emqx_metrics:received(Packet),
     (Type == ?PUBLISH) andalso emqx_pd:update_counter(incoming_pubs, 1),
     handle_packet(Packet, fun(NState) ->
-                              {keep_state, reset_parser(NState)}
-                          end, PState);
+                              {keep_state, NState}
+                          end, State);
 
 %% Handle Output
 connected(info, {deliver, PubOrAck}, State = #state{proto_state = ProtoState}) ->
@@ -373,14 +374,14 @@ terminate(Reason, _StateName, #state{transport = Transport,
 %% Process incoming data
 
 process_incoming(<<>>, Packets, State) ->
-    {keep_state, State, next_events({Packets, State})};
+    {keep_state, State, next_events(Packets)};
 
 process_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
     try emqx_frame:parse(Data, ParseState) of
         {ok, Packet, Rest} ->
             process_incoming(Rest, [Packet|Packets], reset_parser(State));
         {more, NewParseState} ->
-            {keep_state, State#state{parse_state = NewParseState}, next_events({Packets, State})};
+            {keep_state, State#state{parse_state = NewParseState}, next_events(Packets)};
         {error, Reason} ->
             shutdown(Reason, State)
     catch
@@ -392,12 +393,10 @@ process_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
 reset_parser(State = #state{proto_state = ProtoState}) ->
     State#state{parse_state = emqx_protocol:parser(ProtoState)}.
 
-next_events([]) ->
-    [];
-next_events([{Packet, State}]) ->
-    {next_event, cast, {incoming, Packet, State}};
-next_events({Packets, State}) ->
-    [next_events([{Packet, State}]) || Packet <- lists:reverse(Packets)].
+next_events(Packets) when is_list(Packets) ->
+    [next_events(Packet) || Packet <- lists:reverse(Packets)];
+next_events(Packet) ->
+    {next_event, cast, {incoming, Packet}}.
 
 %%------------------------------------------------------------------------------
 %% Handle incoming packet


### PR DESCRIPTION
To fix #2303 
It will report the following error, when a connection sends a TCP frame contained many of MQTT packet and followed a split MQTT packet.
```
(emqx@127.0.0.1)1> 2019-03-19 15:04:07.929 [error] someclientid@127.0.0.1:54311 Parse failed for function_clause
Stacktrace:[{emqx_frame,parse_utf8_string,
                        [<<48,48,48,48,95,49,52,48,111,0,9,107,97,108,97,47,
                           107,97,108,97,48,48,48,48,48,48,48,48,48,48,48,48,
                           48,48,48,48,48,48,48,48,48,48,48,48,48,48,48,48>>],
                        [{file,"src/emqx_frame.erl"},{line,354}]},
            {emqx_frame,parse_packet,3,
                        [{file,"src/emqx_frame.erl"},{line,163}]},
            {emqx_frame,parse_frame,4,
                        [{file,"src/emqx_frame.erl"},{line,104}]},
            {emqx_connection,process_incoming,3,
                             [{file,"src/emqx_connection.erl"},{line,371}]},
            {gen_statem,call_state_function,5,
                        [{file,"gen_statem.erl"},{line,1660}]},
            {gen_statem,loop_event_state_function,6,
                        [{file,"gen_statem.erl"},{line,1023}]},
            {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,249}]}]
```