### PR TITLE
Fix badmatch bug for reload_acl

### DIFF
--- a/src/emqx_mod_acl_internal.erl
+++ b/src/emqx_mod_acl_internal.erl
@@ -104,7 +104,7 @@ match(Credentials, Topic, [Rule|Rules]) ->
 -spec(reload_acl() -> ok | {error, term()}).
 reload_acl() ->
     try load_rules_from_file(acl_file()) of
-        ok ->
+        _ ->
             emqx_logger:info("Reload acl_file ~s successfully", [acl_file()]),
             ok;
         {error, Error} ->


### PR DESCRIPTION
### Description
Fix badmatch for `reload_acl()`, The return value of `load_rules_form_file` is maps not `ok`

``` erlang
 _ ->
         emqx_logger:info("Reload acl_file ~s successfully", [acl_file()]),
         ok;
```