### PR TITLE
 Fix badmatch error in the batch_process of session

### DIFF
--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -390,7 +390,7 @@ deliver_fun(ConnPid) when node(ConnPid) == node() ->
 deliver_fun(ConnPid) ->
     Node = node(ConnPid),
     fun(Packet) ->
-            emqx_rpc:cast(Node, erlang, send, [ConnPid, {deliver, Packet}])
+        true = emqx_rpc:cast(Node, erlang, send, [ConnPid, {deliver, Packet}]), ok
     end.
 
 handle_call(info, _From, State) ->


### PR DESCRIPTION
To fix #2336, `badmatch` crashing error will take place at:
```erlang
%% emqx_session.erl#L895
batch_process(Msgs, State) ->
    {ok, Publishes, NState} = process_msgs(Msgs, [], State),
    %% true will be returned when gen_rpc:cast called
    ok = batch_deliver(Publishes, NState),          
    maybe_gc(msg_cnt(Msgs), NState).
``` 