### PR TITLE
Fix allow_anonymous behavoir error

### DIFF
--- a/src/emqx_access_control.erl
+++ b/src/emqx_access_control.erl
@@ -29,12 +29,14 @@
 -spec(authenticate(emqx_types:credentials())
       -> {ok, emqx_types:credentials()} | {error, term()}).
 authenticate(Credentials) ->
-    case emqx_hooks:run_fold('client.authenticate', [], Credentials#{auth_result => init_auth_result(Credentials)}) of
-        #{auth_result := success} = NewCredentials ->
-            {ok, NewCredentials};
-        NewCredentials ->
-            {error, maps:get(auth_result, NewCredentials, unknown_error)}
-    end.
+    detect_anonymous_permission(Credentials, fun() ->
+        case emqx_hooks:run_fold('client.authenticate', [], Credentials#{auth_result => not_authorized}) of
+            #{auth_result := success} = NewCredentials ->
+                {ok, NewCredentials};
+            NewCredentials ->
+                {error, maps:get(auth_result, NewCredentials, unknown_error)}
+        end
+    end).
 
 %% @doc Check ACL
 -spec(check_acl(emqx_types:credentials(), emqx_types:pubsub(), emqx_types:topic()) -> allow | deny).
@@ -66,8 +68,17 @@ reload_acl() ->
         emqx_acl_cache:empty_acl_cache(),
     emqx_mod_acl_internal:reload_acl().
 
-init_auth_result(Credentials) ->
-    case emqx_zone:get_env(maps:get(zone, Credentials, undefined), allow_anonymous, false) of
-        true -> success;
-        false -> not_authorized
-    end.
+detect_anonymous_permission(#{username := undefined,
+                              password := undefined} = Credentials, Fun) ->
+    case anonymous_permission(Credentials) of
+        true -> {ok, Credentials};
+        false -> Fun()
+    end;
+
+detect_anonymous_permission(_Credentials, Fun) ->
+    Fun().
+
+anonymous_permission(Credentials) ->
+    emqx_zone:get_env(maps:get(zone, Credentials, undefined),
+                      allow_anonymous, false).
+


### PR DESCRIPTION
EMQ should allow the anonymous connection if the allow_anonymous option is true, although it has one or more auth plugins started.