### PR TITLE
Remove bin_key_map/1

### DIFF
--- a/src/emqx_message.erl
+++ b/src/emqx_message.erl
@@ -44,8 +44,6 @@
 
 -export([ to_map/1
         , to_list/1
-        , to_bin_key_map/1
-        , to_bin_key_list/1
         ]).
 
 -export([format/1]).
@@ -159,23 +157,10 @@ update_expiry(Msg) -> Msg.
 to_map(Msg) ->
     maps:from_list(to_list(Msg)).
 
-%% @doc Message to map
--spec(to_bin_key_map(emqx_types:message()) -> #{binary() => any()}).
-to_bin_key_map(Msg) ->
-    maps:from_list(to_bin_key_list(Msg)).
-
 %% @doc Message to tuple list
 -spec(to_list(emqx_types:message()) -> map()).
 to_list(Msg) ->
     lists:zip(record_info(fields, message), tl(tuple_to_list(Msg))).
-
-%% @doc Message to tuple list
--spec(to_bin_key_list(emqx_types:message()) -> map()).
-to_bin_key_list(Msg) ->
-    lists:zipwith(
-        fun(Key, Val) ->
-            {bin(Key), bin_key_map(Val)}
-        end, record_info(fields, message), tl(tuple_to_list(Msg))).
 
 %% MilliSeconds
 elapsed(Since) ->
@@ -191,14 +176,3 @@ format(flags, Flags) ->
     io_lib:format("~p", [[Flag || {Flag, true} <- maps:to_list(Flags)]]);
 format(headers, Headers) ->
     io_lib:format("~p", [Headers]).
-
-bin_key_map(Map) when is_map(Map) ->
-    maps:fold(fun(Key, Val, Acc) ->
-                      Acc#{bin(Key) => bin_key_map(Val)}
-              end, #{}, Map);
-bin_key_map(Data) ->
-    Data.
-
-bin(Bin) when is_binary(Bin) -> Bin;
-bin(Atom) when is_atom(Atom) -> list_to_binary(atom_to_list(Atom));
-bin(Str) when is_list(Str) -> list_to_binary(Str).

--- a/test/emqx_bridge_SUITE.erl
+++ b/test/emqx_bridge_SUITE.erl
@@ -87,6 +87,7 @@ t_rpc(Config) when is_list(Config) ->
         %% message from a different client, to avoid getting terminated by no-local
         Msg1 = emqx_message:make(<<"ClientId-2">>, ?QOS_2, <<"t_rpc/one">>, <<"hello">>),
         ok = emqx_session:subscribe(SPid, [{<<"forwarded/t_rpc/one">>, #{qos => ?QOS_1}}]),
+        ct:sleep(100),
         PacketId = 1,
         emqx_session:publish(SPid, PacketId, Msg1),
         ?wait(case emqx_mock_client:get_last_message(ConnPid) of


### PR DESCRIPTION
`bin_key_map/1` is not necessary and has to be removed from this module.