### PR TITLE
Load hooks from plugins explicitly

### DIFF
--- a/src/emqx_plugins.erl
+++ b/src/emqx_plugins.erl
@@ -179,7 +179,10 @@ load(PluginName) when is_atom(PluginName) ->
 load_plugin(#plugin{name = Name}, Persistent) ->
     case load_app(Name) of
         ok ->
-            start_app(Name, fun(App) -> plugin_loaded(App, Persistent) end);
+            start_app(Name, fun(App) ->
+                                App:load(),
+                                plugin_loaded(App, Persistent)
+                            end);
         {error, Error} ->
             {error, Error}
     end.


### PR DESCRIPTION
When load plugins using CLI or API, we used to start the plugin application, and let the plugin register the hooks themselves. 

But the plugins now have rule engine actions. Registering the hooks in the callback function `application:start/2` is not a good idea, as the rule engine actions may perform the same thing as the hooks.

e.g. The hook callback `emqx_webhook:on_message_publish/2` might do the same thing as the action `webhook:forward_action`.

The solution here is, start all the plugin's application at emqx startup, and callback the `APP:load/0 ` explicitly when load plugins using CLI or API.