### PR TITLE
Pin emqx-ct-helpers v1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ rebar.lock
 xrefr
 erlang.mk
 *.coverdata
+etc/emqx.conf.rendered

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ eunit:
 .PHONY: ct-setup
 ct-setup:
 	@mkdir -p data
-	@[ ! -f data/loaded_plugins ] && touch data/loaded_plugins
+	@if [ ! -f data/loaded_plugins ]; then touch data/loaded_plugins; fi
 	@ln -s -f '../../../../etc' _build/test/lib/emqx/
 	@ln -s -f '../../../../data' _build/test/lib/emqx/
 

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
         [{deps,
             [ {meck, "0.8.13"} % hex
             , {bbmustache, "1.7.0"} % hex
-            , {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "v1.0"}}}
+            , {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "v1.1.1"}}}
             ]}
         ]}
     ]}.

--- a/test/emqx_listeners_SUITE.erl
+++ b/test/emqx_listeners_SUITE.erl
@@ -49,9 +49,27 @@ restart_listeners(_) ->
     ok = emqx_listeners:restart(),
     ok = emqx_listeners:stop().
 
+render_config_file() ->
+    Path = local_path(["etc", "emqx.conf"]),
+    {ok, Temp} = file:read_file(Path),
+    Vars0 = mustache_vars(),
+    Vars = [{atom_to_list(N), iolist_to_binary(V)} || {N, V} <- Vars0],
+    Targ = bbmustache:render(Temp, Vars),
+    NewName = Path ++ ".rendered",
+    ok = file:write_file(NewName, Targ),
+    NewName.
+
+mustache_vars() ->
+    [{platform_data_dir, local_path(["data"])},
+     {platform_etc_dir,  local_path(["etc"])},
+     {platform_log_dir,  local_path(["log"])},
+     {platform_plugins_dir,  local_path(["plugins"])}
+    ].
+
 generate_config() ->
     Schema = cuttlefish_schema:files([local_path(["priv", "emqx.schema"])]),
-    Conf = conf_parse:file([local_path(["etc", "gen.emqx.conf"])]),
+    ConfFile = render_config_file(),
+    Conf = conf_parse:file(ConfFile),
     cuttlefish_generator:map(Schema, Conf).
 
 set_app_env({App, Lists}) ->

--- a/vars
+++ b/vars
@@ -1,9 +1,0 @@
-%% vars here are for test only, not intended for release
-
-{platform_bin_dir,  "bin"}.
-{platform_data_dir, "data"}.
-{platform_etc_dir,  "etc"}.
-{platform_lib_dir,  "lib"}.
-{platform_log_dir,  "log"}.
-{platform_plugins_dir,  "plugins"}.
-


### PR DESCRIPTION
Starting from ct-helpers v1.1, config file template is rendered in init suite steps.
So now we can stop rendering template before `make ct`