### PR TITLE
Enable force_shutdown_policy by default #2494

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -550,6 +550,14 @@ zone.external.acl_deny_action = ignore
 ## Numbers delimited by `|'. Zero or negative is to disable.
 zone.external.force_gc_policy = 1000|1MB
 
+## Max message queue length and total heap size to force shutdown
+## connection/session process.
+## Message queue here is the Erlang process mailbox, but not the number
+## of queued MQTT messages of QoS 1 and 2.
+##
+## Numbers delimited by `|'. Zero or negative is to disable.
+zone.external.force_shutdown_policy = 10000|1024MB
+
 ## Maximum MQTT packet size allowed.
 ##
 ## Value: Bytes


### PR DESCRIPTION
Set default max-queue-len to 10000, and default max-heap-size to 1024MB.