### PR TITLE
Enlarger burst value of rate_limit

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -860,7 +860,7 @@ listener.tcp.external.zone = external
 ##
 ## Value: rate,burst
 ## Unit: Bps
-## listener.tcp.external.rate_limit = 1024,4096
+## listener.tcp.external.rate_limit = 1024,52428800
 
 ## The access control rules for the MQTT/TCP listener.
 ##
@@ -991,7 +991,7 @@ listener.tcp.internal.zone = internal
 ##
 ## Value: rate,burst
 ## Unit: Bps
-## listener.tcp.internal.rate_limit = 1000000,2000000
+## listener.tcp.internal.rate_limit = 1000000,52428800
 
 ## The TCP backlog of internal MQTT/TCP Listener.
 ##
@@ -1101,7 +1101,7 @@ listener.ssl.external.access.1 = allow all
 ##
 ## Value: rate,burst
 ## Unit: Bps
-## listener.ssl.external.rate_limit = 1024,4096
+## listener.ssl.external.rate_limit = 1024,52428800
 
 ## Enable the Proxy Protocol V1/2 if the EMQ cluster is deployed behind
 ## HAProxy or Nginx.
@@ -1335,7 +1335,7 @@ listener.ws.external.max_conn_rate = 1000
 ##
 ## Value: rate,burst
 ## Unit: Bps
-## listener.ws.external.rate_limit = 1024,4096
+## listener.ws.external.rate_limit = 1024,52428800
 
 ## Zone of the external MQTT/WebSocket listener belonged to.
 ##
@@ -1543,7 +1543,7 @@ listener.wss.external.max_conn_rate = 1000
 ##
 ## Value: rate,burst
 ## Unit: Bps
-## listener.wss.external.rate_limit = 1024,4096
+## listener.wss.external.rate_limit = 1024,52428800
 
 ## Zone of the external MQTT/WebSocket/SSL listener belonged to.
 ##

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -859,6 +859,9 @@ listener.tcp.external.zone = external
 ## Rate limit for the external MQTT/TCP connections. Format is 'rate,burst'.
 ##
 ## Value: rate,burst
+##   - rate: The average limit value for per second
+##   - burst: The maximum allowed for each check, To avoid frequent restriction
+##            this value is recommended to be set to `(max_packet_size * active_n)/2`
 ## Unit: Bps
 ## listener.tcp.external.rate_limit = 1024,52428800
 
@@ -990,8 +993,11 @@ listener.tcp.internal.zone = internal
 ## See: listener.tcp.$name.rate_limit
 ##
 ## Value: rate,burst
+##   - rate: The average limit value for per second
+##   - burst: The maximum allowed for each check, To avoid frequent restriction
+##            this value is recommended to be set to `(max_packet_size * active_n)/2`
 ## Unit: Bps
-## listener.tcp.internal.rate_limit = 1000000,52428800
+## listener.tcp.internal.rate_limit = 1000000,524288000
 
 ## The TCP backlog of internal MQTT/TCP Listener.
 ##
@@ -1100,6 +1106,9 @@ listener.ssl.external.access.1 = allow all
 ## Rate limit for the external MQTT/SSL connections.
 ##
 ## Value: rate,burst
+##   - rate: The average limit value for per second
+##   - burst: The maximum allowed for each check, To avoid frequent restriction
+##            this value is recommended to be set to `(max_packet_size * active_n)/2`
 ## Unit: Bps
 ## listener.ssl.external.rate_limit = 1024,52428800
 
@@ -1334,8 +1343,11 @@ listener.ws.external.max_conn_rate = 1000
 ## Rate limit for the MQTT/WebSocket connections.
 ##
 ## Value: rate,burst
+##   - rate: The average limit value for per second
+##   - burst: The maximum allowed for each check, To avoid frequent restriction
+##            this value is recommended to be set to `(max_packet_size * 1)/2`
 ## Unit: Bps
-## listener.ws.external.rate_limit = 1024,52428800
+## listener.ws.external.rate_limit = 1024,524288
 
 ## Zone of the external MQTT/WebSocket listener belonged to.
 ##
@@ -1542,8 +1554,11 @@ listener.wss.external.max_conn_rate = 1000
 ## Rate limit for the MQTT/WebSocket/SSL connections.
 ##
 ## Value: rate,burst
+##   - rate: The average limit value for per second
+##   - burst: The maximum allowed for each check, To avoid frequent restriction
+##            this value is recommended to be set to `(max_packet_size * 1)/2`
 ## Unit: Bps
-## listener.wss.external.rate_limit = 1024,52428800
+## listener.wss.external.rate_limit = 1024,524288
 
 ## Zone of the external MQTT/WebSocket/SSL listener belonged to.
 ##


### PR DESCRIPTION
According to the [Token Bucket](https://en.wikipedia.org/wiki/Token_bucket) algorithm, the process will be paused if the requested Tokens large than the burst or remaining tokens.

if we set the burst value to 4096 by default, this process will always be blocked.

So, the reasonable default value should be `(max_packet_size * active_n) / 2`


Unfortunately, the `ws/wss` don't implement the `rate_limit` mechanism. so the `listener.ws.external.rate_limit` is not work now.