### PR TITLE
Enlarge chars_limit to 8192

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -371,8 +371,8 @@ log.file = emqx.log
 ## Limits the total number of characters printed for each log event.
 ##
 ## Value: Integer
-## Default: 1024
-log.chars_limit = 1024
+## Default: 8192
+log.chars_limit = 8192
 
 ## Maximum size of each log file.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -421,7 +421,7 @@ end}.
 ]}.
 
 {mapping, "log.chars_limit", "kernel.logger", [
-  {default, 1024},
+  {default, 8192},
   {datatype, integer}
 ]}.
 


### PR DESCRIPTION
The default chars_limit 1024 is not large enough for crash logs. Change it to 8192.

@johnfwhitmore