### PR TITLE
Force shutdown

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -550,6 +550,14 @@ zone.external.acl_deny_action = ignore
 ## Numbers delimited by `|'. Zero or negative is to disable.
 zone.external.force_gc_policy = 1000|1MB
 
+## Max message queue length and total heap size to force shutdown
+## connection/session process.
+## Message queue here is the Erlang process mailbox, but not the number
+## of queued MQTT messages of QoS 1 and 2.
+##
+## Numbers delimited by `|'. Zero or negative is to disable.
+zone.external.force_shutdown_policy = 10000|1024MB
+
 ## Maximum MQTT packet size allowed.
 ##
 ## Value: Bytes

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -556,7 +556,11 @@ zone.external.force_gc_policy = 1000|1MB
 ## of queued MQTT messages of QoS 1 and 2.
 ##
 ## Numbers delimited by `|'. Zero or negative is to disable.
-zone.external.force_shutdown_policy = 10000|1024MB
+##
+## Default:
+##   - 8000|800MB on ARCH_64 system
+##   - 1000|100MB on ARCH_32 sytem
+## zone.external.force_shutdown_policy = 8000|800MB
 
 ## Maximum MQTT packet size allowed.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -900,22 +900,22 @@ end}.
                                end,
                     {force_gc_policy, GcPolicy};
                ("force_shutdown_policy", "default") ->
-                    {DefaultLen, DefaultSiz} =
+                    {DefaultLen, DefaultSize} =
                         case erlang:system_info(wordsize) of
-                          8 -> % arch_64
-                            {8000, cuttlefish_bytesize:parse("800MB")};
-                          4 -> % arch_32
-                            {1000, cuttlefish_bytesize:parse("100MB")}
+                            8 -> % arch_64
+                              {8000, cuttlefish_bytesize:parse("800MB")};
+                            4 -> % arch_32
+                              {1000, cuttlefish_bytesize:parse("100MB")}
                         end,
                     {force_shutdown_policy, #{message_queue_len => DefaultLen,
-                                              max_heap_size => DefaultSiz}};
+                                              max_heap_size => DefaultSize}};
                ("force_shutdown_policy", Val) ->
                     [Len, Siz] = string:tokens(Val, "| "),
                     MaxSiz = case erlang:system_info(wordsize) of
-                              8 -> % arch_64
-                                (1 bsl 59) - 1;
-                              4 -> % arch_32
-                                (1 bsl 27) - 1
+                                8 -> % arch_64
+                                  (1 bsl 59) - 1;
+                                4 -> % arch_32
+                                  (1 bsl 27) - 1
                              end,
                     ShutdownPolicy =
                       case cuttlefish_bytesize:parse(Siz) of

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -854,7 +854,7 @@ end}.
 %% of queued MQTT messages of QoS 1 and 2.
 %% Zero or negative is to disable.
 {mapping, "zone.$name.force_shutdown_policy", "emqx.zones", [
-  {default, "0 | 0MB"},
+  {default, "default"},
   {datatype, string}
 ]}.
 
@@ -903,15 +903,34 @@ end}.
                                          count => list_to_integer(Count)}
                                end,
                     {force_gc_policy, GcPolicy};
+               ("force_shutdown_policy", "default") ->
+                    {DefaultLen, DefaultSiz} =
+                        case erlang:system_info(wordsize) of
+                          8 -> % arch_64
+                            {8000, cuttlefish_bytesize:parse("800MB")};
+                          4 -> % arch_32
+                            {1000, cuttlefish_bytesize:parse("100MB")}
+                        end,
+                    {force_shutdown_policy, #{message_queue_len => DefaultLen,
+                                              max_heap_size => DefaultSiz}};
                ("force_shutdown_policy", Val) ->
                     [Len, Siz] = string:tokens(Val, "| "),
-                    ShutdownPolicy = case cuttlefish_bytesize:parse(Siz) of
-                                         {error, Reason} ->
-                                             error(Reason);
-                                         Siz1 ->
-                                             #{message_queue_len => list_to_integer(Len),
-                                               max_heap_size => Siz1}
-                                     end,
+                    MaxSiz = case erlang:system_info(wordsize) of
+                              8 -> % arch_64
+                                (1 bsl 59) - 1;
+                              4 -> % arch_32
+                                (1 bsl 27) - 1
+                             end,
+                    ShutdownPolicy =
+                      case cuttlefish_bytesize:parse(Siz) of
+                          {error, Reason} ->
+                              error(Reason);
+                          Siz1 when Siz1 > MaxSiz ->
+                              cuttlefish:invalid(io_lib:format("force_shutdown_policy: heap-size ~s is too large", [Siz]));
+                          Siz1 ->
+                              #{message_queue_len => list_to_integer(Len),
+                                max_heap_size => Siz1}
+                      end,
                     {force_shutdown_policy, ShutdownPolicy};
                ("mqueue_priorities", Val) ->
                     case Val of

--- a/src/emqx_ws_connection.erl
+++ b/src/emqx_ws_connection.erl
@@ -160,6 +160,7 @@ websocket_init(#state{request = Req, options = Options}) ->
     EnableStats = emqx_zone:get_env(Zone, enable_stats, true),
     IdleTimout = emqx_zone:get_env(Zone, idle_timeout, 30000),
     emqx_logger:set_metadata_peername(esockd_net:format(Peername)),
+    ok = emqx_misc:init_proc_mng_policy(Zone),
     {ok, #state{peername     = Peername,
                 sockname     = Sockname,
                 parse_state  = ParserState,


### PR DESCRIPTION
The erlang:process_flag(max_heap_size, MaxHeapSize) can only set a MaxHeapSize of `small integer`, which is smaller than 2^59 on 64-bit systems, and 2^27 on 32-bit systems.