### PR TITLE
Don't call the authentication chain, if enable the anonymous option

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -403,7 +403,9 @@ log.rotation.count = 5
 ## Authentication/Access Control
 ##--------------------------------------------------------------------
 
-## Allow anonymous authentication by default if no auth plugins loaded.
+## Allow anonymous client to access system. If this option is turned
+## on, the authentication chain will no longer be executed
+##
 ## Notice: Disable the option in production deployment!
 ##
 ## Value: true | false


### PR DESCRIPTION
```properties
## Allow anonymous client to access system. If this option is turned
## on, the authentication chain will no longer be executed
##
## Notice: Disable the option in production deployment!
##
## Value: true | false
allow_anonymous = true
```