### PR TITLE
Delete APPLICATION macro from erl-opts in rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -14,8 +14,7 @@
             warn_shadow_vars,
             warn_unused_import,
             warn_obsolete_guard,
-            debug_info,
-            {d, 'APPLICATION', emqx}]}.
+            debug_info]}.
 {xref_checks, [undefined_function_calls, undefined_functions,
                locals_not_used, deprecated_function_calls,
                warnings_as_errors, deprecated_functions]}.

--- a/test/emqx_shared_sub_SUITE.erl
+++ b/test/emqx_shared_sub_SUITE.erl
@@ -251,8 +251,8 @@ ensure_config(Strategy) ->
     ensure_config(Strategy, _AckEnabled = true).
 
 ensure_config(Strategy, AckEnabled) ->
-    application:set_env(?APPLICATION, shared_subscription_strategy, Strategy),
-    application:set_env(?APPLICATION, shared_dispatch_ack_enabled, AckEnabled),
+    application:set_env(emqx, shared_subscription_strategy, Strategy),
+    application:set_env(emqx, shared_dispatch_ack_enabled, AckEnabled),
     ok.
 
 subscribed(Group, Topic, Pid) ->


### PR DESCRIPTION
in case compiled in emqx-rel test profile, erl_opts is not respected