### PR TITLE
Stop alarm before emqx stops

### DIFF
--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -51,6 +51,7 @@ start(_Type, _Args) ->
 
 -spec(stop(State :: term()) -> term()).
 stop(_State) ->
+    emqx_alarm_handler:unload(),
     emqx_listeners:stop(),
     emqx_modules:unload().
 


### PR DESCRIPTION
Fix the following issue when stopping the erlang vm.

```
2019-05-28 16:51:09.687 [error] [Broker] Publish error: badarg
{message,<<0,5,137,238,196,39,86,239,244,67,0,0,5,182,0,0>>,
         0,emqx_alarm_handler,
         #{dup => false,sys => true},
         #{'Content-Type' => <<"application/json">>},
         <<"$SYS/brokers/emqx@127.0.0.1/alarms/system_memory_high_watermark/clear">>,
         <<>>,
         {1559,33469,687553}}
[{ets,lookup,[emqx_hooks,'message.publish'],[]},
 {emqx_hooks,lookup,1,
             [{file,"/Users/emqer/code/emqx-enterprise-rel/_build/emqx/lib/emqx_backend_mongo/_build/default/lib/emqx/src/emqx_hooks.erl"}
```