### PR TITLE
Fix websocket bug.

### DIFF
--- a/src/emqx_ws_connection.erl
+++ b/src/emqx_ws_connection.erl
@@ -301,7 +301,6 @@ websocket_info(Info, State) ->
 terminate(SockError, _Req, #state{keepalive   = Keepalive,
                                   proto_state = ProtoState,
                                   shutdown    = Shutdown}) ->
-
     ?LOG(debug, "[WS Connection] Terminated for ~p, sockerror: ~p", [Shutdown, SockError]),
     emqx_keepalive:cancel(Keepalive),
     case {ProtoState, Shutdown} of
@@ -327,7 +326,8 @@ ensure_stats_timer(State) ->
     State.
 
 shutdown(Reason, State) ->
-    {stop, State#state{shutdown = Reason}}.
+    self() ! {stop, State#state{shutdown = Reason}},
+    {ok, State}.
 
 wsock_stats() ->
     [{Key, emqx_pd:get_counter(Key)} || Key <- ?SOCK_STATS].


### PR DESCRIPTION
Prior to this change, websocket connection would be closed directly
without sending connack packet when acl check fails.

This change fix this bug.