### PR TITLE
No chars limit by default

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -371,8 +371,8 @@ log.file = emqx.log
 ## Limits the total number of characters printed for each log event.
 ##
 ## Value: Integer
-## Default: 8192
-log.chars_limit = 8192
+## Default: No Limit
+#log.chars_limit = 8192
 
 ## Maximum size of each log file.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -421,7 +421,7 @@ end}.
 ]}.
 
 {mapping, "log.chars_limit", "kernel.logger", [
-  {default, 8192},
+  {default, -1},
   {datatype, integer}
 ]}.
 


### PR DESCRIPTION
Some times the crash logs is too long to print it out, if the chars_limit defaults to 8192:

```
** Reason for termination == 
** ...
```