### PR TITLE
Logger header

### DIFF
--- a/include/logger.hrl
+++ b/include/logger.hrl
@@ -14,6 +14,8 @@
 
 %% debug | info | notice | warning | error | critical | alert | emergency
 
+-compile({parse_transform, emqx_logger}).
+
 -define(DEBUG(Format), ?LOG(debug, Format, [])).
 -define(DEBUG(Format, Args), ?LOG(debug, Format, Args)).
 
@@ -39,5 +41,5 @@
 
 -define(LOG(Level, Format, Args),
         begin
-          (logger:log(Level,#{},#{report_cb => fun(_) -> {(Format), (Args)} end}))
+          (logger:log(Level,#{},#{report_cb => fun(_) -> {'$logger_header'()++(Format), (Args)} end}))
         end).

--- a/rebar.config
+++ b/rebar.config
@@ -24,6 +24,8 @@
 
 {plugins, [coveralls]}.
 
+{erl_first_files, ["src/emqx_logger.erl"]}.
+
 {profiles,
     [{test,
         [{deps,

--- a/src/emqx.erl
+++ b/src/emqx.erl
@@ -18,6 +18,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[EMQ X]").
+
 %% Start/Stop the application
 -export([ start/0
         , restart/1
@@ -183,7 +185,7 @@ shutdown() ->
     shutdown(normal).
 
 shutdown(Reason) ->
-    ?LOG(critical, "[EMQ X] emqx shutdown for ~s", [Reason]),
+    ?LOG(critical, "emqx shutdown for ~s", [Reason]),
     emqx_alarm_handler:unload(),
     emqx_plugins:unload(),
     lists:foreach(fun application:stop/1, [emqx, ekka, cowboy, ranch, esockd, gproc]).

--- a/src/emqx_alarm_handler.erl
+++ b/src/emqx_alarm_handler.erl
@@ -19,6 +19,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[Alarm Handler]").
+
 %% Mnesia bootstrap
 -export([mnesia/1]).
 
@@ -93,17 +95,17 @@ init(_) ->
 handle_event({set_alarm, {AlarmId, AlarmDesc = #alarm{timestamp = undefined}}}, State) ->
     handle_event({set_alarm, {AlarmId, AlarmDesc#alarm{timestamp = os:timestamp()}}}, State);
 handle_event({set_alarm, Alarm = {AlarmId, AlarmDesc}}, State) ->
-    ?LOG(warning, "[Alarm Handler] ~p set", [Alarm]),
+    ?LOG(warning, "~p set", [Alarm]),
     case encode_alarm(Alarm) of
         {ok, Json} ->
             emqx_broker:safe_publish(alarm_msg(topic(alert, maybe_to_binary(AlarmId)), Json));
         {error, Reason} ->
-            ?LOG(error, "[Alarm Handler] Failed to encode alarm: ~p", [Reason])
+            ?LOG(error, "Failed to encode alarm: ~p", [Reason])
     end,
     set_alarm_(AlarmId, AlarmDesc),
     {ok, State};
 handle_event({clear_alarm, AlarmId}, State) ->
-    ?LOG(notice, "[Alarm Handler] ~p clear", [AlarmId]),
+    ?LOG(notice, "~p clear", [AlarmId]),
     emqx_broker:safe_publish(alarm_msg(topic(clear, maybe_to_binary(AlarmId)), <<"">>)),
     clear_alarm_(AlarmId),
     {ok, State};

--- a/src/emqx_banned.erl
+++ b/src/emqx_banned.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Banned]").
+
 %% Mnesia bootstrap
 -export([mnesia/1]).
 
@@ -88,11 +90,11 @@ init([]) ->
     {ok, ensure_expiry_timer(#{expiry_timer => undefined})}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Banned] unexpected call: ~p", [Req]),
+    ?LOG(error, "unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Banned] unexpected msg: ~p", [Msg]),
+    ?LOG(error, "unexpected msg: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({timeout, TRef, expire}, State = #{expiry_timer := TRef}) ->
@@ -100,7 +102,7 @@ handle_info({timeout, TRef, expire}, State = #{expiry_timer := TRef}) ->
     {noreply, ensure_expiry_timer(State), hibernate};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Banned] unexpected info: ~p", [Info]),
+    ?LOG(error, "unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, #{expiry_timer := TRef}) ->

--- a/src/emqx_bridge_connect.erl
+++ b/src/emqx_bridge_connect.erl
@@ -31,6 +31,8 @@
 
 -include("logger.hrl").
 
+-logger_header("[Bridge Connect]").
+
 %% establish the connection to remote node/cluster
 %% protal worker (the caller process) should be expecting
 %% a message {disconnected, conn_ref()} when disconnected.
@@ -54,7 +56,7 @@ start(Module, Config) ->
             {ok, Ref, Conn};
         {error, Reason} ->
             Config1 = obfuscate(Config),
-            ?LOG(error, "[Bridge connect] Failed to connect with module=~p\n"
+            ?LOG(error, "Failed to connect with module=~p\n"
                  "config=~p\nreason:~p", [Module, Config1, Reason]),
             {error, Reason}
     end.

--- a/src/emqx_bridge_sup.erl
+++ b/src/emqx_bridge_sup.erl
@@ -17,6 +17,8 @@
 
 -include("logger.hrl").
 
+-logger_header("[Bridge]").
+
 %% APIs
 -export([ start_link/0
         , start_link/1
@@ -74,6 +76,6 @@ drop_bridge(Id) ->
         ok ->
             supervisor:delete_child(?SUP, Id);
         Error ->
-            ?LOG(error, "[Bridge] Delete bridge failed, error : ~p", [Error]),
+            ?LOG(error, "Delete bridge failed, error : ~p", [Error]),
             Error
     end.

--- a/src/emqx_broker_helper.erl
+++ b/src/emqx_broker_helper.erl
@@ -19,6 +19,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Broker Helper]").
+
 -export([start_link/0]).
 
 %% APIs
@@ -110,7 +112,7 @@ init([]) ->
     {ok, #{pmon => emqx_pmon:new()}}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Broker Helper] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({register_sub, SubPid, SubId}, State = #{pmon := PMon}) ->
@@ -119,7 +121,7 @@ handle_cast({register_sub, SubPid, SubId}, State = #{pmon := PMon}) ->
     {noreply, State#{pmon := emqx_pmon:monitor(SubPid, PMon)}};
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Broker Helper] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({'DOWN', _MRef, process, SubPid, _Reason}, State = #{pmon := PMon}) ->
@@ -130,7 +132,7 @@ handle_info({'DOWN', _MRef, process, SubPid, _Reason}, State = #{pmon := PMon}) 
     {noreply, State#{pmon := PMon1}};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Broker Helper] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_cm.erl
+++ b/src/emqx_cm.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[CM]").
+
 -export([start_link/0]).
 
 -export([ register_connection/1
@@ -159,7 +161,7 @@ init([]) ->
     {ok, #{conn_pmon => emqx_pmon:new()}}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[CM] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({notify, {registered, ClientId, ConnPid}}, State = #{conn_pmon := PMon}) ->
@@ -169,7 +171,7 @@ handle_cast({notify, {unregistered, ConnPid}}, State = #{conn_pmon := PMon}) ->
     {noreply, State#{conn_pmon := emqx_pmon:demonitor(ConnPid, PMon)}};
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[CM] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({'DOWN', _MRef, process, Pid, _Reason}, State = #{conn_pmon := PMon}) ->
@@ -180,7 +182,7 @@ handle_info({'DOWN', _MRef, process, Pid, _Reason}, State = #{conn_pmon := PMon}
     {noreply, State#{conn_pmon := PMon1}};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[CM] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_ctl.erl
+++ b/src/emqx_ctl.erl
@@ -18,6 +18,8 @@
 
 -include("logger.hrl").
 
+-logger_header("[Ctl]").
+
 -export([start_link/0]).
 
 -export([ register_command/2
@@ -79,7 +81,7 @@ run_command(Cmd, Args) when is_atom(Cmd) ->
                 _ -> ok
             catch
                 _:Reason:Stacktrace ->
-                    ?ERROR("[Ctl] CMD Error:~p, Stacktrace:~p", [Reason, Stacktrace]),
+                    ?ERROR("CMD Error:~p, Stacktrace:~p", [Reason, Stacktrace]),
                     {error, Reason}
             end;
         [] ->
@@ -107,14 +109,14 @@ init([]) ->
     {ok, #state{seq = 0}}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Ctl] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({register_command, Cmd, MF, Opts}, State = #state{seq = Seq}) ->
     case ets:match(?TAB, {{'$1', Cmd}, '_', '_'}) of
         [] -> ets:insert(?TAB, {{Seq, Cmd}, MF, Opts});
         [[OriginSeq] | _] ->
-            ?LOG(warning, "[Ctl] CMD ~s is overidden by ~p", [Cmd, MF]),
+            ?LOG(warning, "CMD ~s is overidden by ~p", [Cmd, MF]),
             ets:insert(?TAB, {{OriginSeq, Cmd}, MF, Opts})
     end,
     noreply(next_seq(State));
@@ -124,11 +126,11 @@ handle_cast({unregister_command, Cmd}, State) ->
     noreply(State);
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Ctl] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     noreply(State).
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Ctl] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     noreply(State).
 
 terminate(_Reason, _State) ->

--- a/src/emqx_hooks.erl
+++ b/src/emqx_hooks.erl
@@ -19,6 +19,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Hooks]").
+
 -export([start_link/0, stop/0]).
 
 %% Hooks API
@@ -181,7 +183,7 @@ handle_call({add, HookPoint, Callback = #callback{action = Action}}, _From, Stat
     {reply, Reply, State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Hooks] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({del, HookPoint, Action}, State) ->
@@ -194,11 +196,11 @@ handle_cast({del, HookPoint, Action}, State) ->
     {noreply, State};
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Hooks] Unexpected msg: ~p", [Msg]),
+    ?LOG(error, "Unexpected msg: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Hooks] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_logger.erl
+++ b/src/emqx_logger.erl
@@ -173,6 +173,7 @@ trans([{eof, L} | AST], LogHeader, ResAST) ->
 trans([{attribute, _, module, _Mod} = M | AST], Header, ResAST) ->
     trans(AST, Header, [export_header_fun(), M | ResAST]);
 trans([{attribute, _, logger_header, Header} | AST], _, ResAST) ->
+    io_lib:printable_list(Header) orelse error({invalid_string, Header}),
     trans(AST, Header, ResAST);
 trans([F | AST], LogHeader, ResAST) ->
     trans(AST, LogHeader, [F | ResAST]).

--- a/src/emqx_logger.erl
+++ b/src/emqx_logger.erl
@@ -48,6 +48,8 @@
         , get_log_handler/1
         ]).
 
+-export([parse_transform/2]).
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -120,6 +122,9 @@ set_log_level(Level) ->
         {error, Error} -> {error, {primary_logger_level, Error}}
     end.
 
+parse_transform(AST, _Opts) ->
+    trans(AST, "", []).
+
 %%------------------------------------------------------------------------------
 %% Internal Functions
 %%------------------------------------------------------------------------------
@@ -160,3 +165,26 @@ rollback([{ID, Level} | List]) ->
     rollback(List);
 rollback([]) -> ok.
 
+%% Generate a function '$logger_header'/0 into the source code
+trans([], LogHeader, ResAST) ->
+    lists:reverse([header_fun(LogHeader) | ResAST]);
+trans([{eof, L} | AST], LogHeader, ResAST) ->
+    lists:reverse([{eof, L}, header_fun(LogHeader) | ResAST]) ++ AST;
+trans([{attribute, _, module, _Mod} = M | AST], Header, ResAST) ->
+    trans(AST, Header, [export_header_fun(), M | ResAST]);
+trans([{attribute, _, logger_header, Header} | AST], _, ResAST) ->
+    trans(AST, Header, ResAST);
+trans([F | AST], LogHeader, ResAST) ->
+    trans(AST, LogHeader, [F | ResAST]).
+
+export_header_fun() ->
+    {attribute,erl_anno:new(0),export,[{'$logger_header',0}]}.
+
+header_fun(LogHeader) ->
+    L = erl_anno:new(0),
+    {function,L,'$logger_header',0,
+         [{clause,L,
+             [], [], [{string,L,pad(LogHeader)}]}]}.
+
+pad("") -> "";
+pad(Str) -> Str ++ " ".

--- a/src/emqx_metrics.erl
+++ b/src/emqx_metrics.erl
@@ -20,6 +20,8 @@
 -include("types.hrl").
 -include("emqx_mqtt.hrl").
 
+-logger_header("[Metrics]").
+
 -export([ start_link/0
         , stop/0
         ]).
@@ -357,13 +359,13 @@ init([]) ->
     {ok, #state{next_idx = ?RESERVED_IDX + 1}, hibernate}.
 
 handle_call({create, Type, Name}, _From, State = #state{next_idx = ?MAX_SIZE}) ->
-    ?LOG(error, "[Metrics] Failed to create ~s:~s for index exceeded.", [Type, Name]),
+    ?LOG(error, "Failed to create ~s:~s for index exceeded.", [Type, Name]),
     {reply, {error, metric_index_exceeded}, State};
 
 handle_call({create, Type, Name}, _From, State = #state{next_idx = NextIdx}) ->
     case ets:lookup(?TAB, Name) of
         [#metric{idx = Idx}] ->
-            ?LOG(warning, "[Metrics] ~s already exists.", [Name]),
+            ?LOG(warning, "~s already exists.", [Name]),
             {reply, {ok, Idx}, State};
         [] ->
             Metric = #metric{name = Name, type = Type, idx = NextIdx},
@@ -372,15 +374,15 @@ handle_call({create, Type, Name}, _From, State = #state{next_idx = NextIdx}) ->
     end;
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Metrics] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Metrics] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Metrics] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_mod_acl_internal.erl
+++ b/src/emqx_mod_acl_internal.erl
@@ -19,6 +19,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[ACL_INTERNAL]").
+
 %% APIs
 -export([ all_rules/0
         , check_acl/5
@@ -99,7 +101,7 @@ rules_from_file(AclFile) ->
             #{publish   => [Rule || Rule <- Rules, filter(publish, Rule)],
               subscribe => [Rule || Rule <- Rules, filter(subscribe, Rule)]};
         {error, Reason} ->
-            ?LOG(alert, "[ACL_INTERNAL] Failed to read ~s: ~p", [AclFile, Reason]),
+            ?LOG(alert, "Failed to read ~s: ~p", [AclFile, Reason]),
             #{}
     end.
 

--- a/src/emqx_mod_presence.erl
+++ b/src/emqx_mod_presence.erl
@@ -19,6 +19,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[Presence]").
+
 %% APIs
 -export([ on_client_connected/4
         , on_client_disconnected/3
@@ -54,7 +56,7 @@ on_client_connected(#{client_id := ClientId,
         {ok, Payload} ->
             emqx:publish(message(qos(Env), topic(connected, ClientId), Payload));
         {error, Reason} ->
-            ?LOG(error, "[Presence] Encoding connected event error: ~p", [Reason])
+            ?LOG(error, "Encoding connected event error: ~p", [Reason])
     end.
 
 on_client_disconnected(#{client_id := ClientId, username := Username}, Reason, Env) ->
@@ -65,7 +67,7 @@ on_client_disconnected(#{client_id := ClientId, username := Username}, Reason, E
         {ok, Payload} ->
             emqx_broker:publish(message(qos(Env), topic(disconnected, ClientId), Payload));
         {error, Reason} ->
-            ?LOG(error, "[Presence] Encoding disconnected event error: ~p", [Reason])
+            ?LOG(error, "Encoding disconnected event error: ~p", [Reason])
     end.
 
 unload(_Env) ->

--- a/src/emqx_modules.erl
+++ b/src/emqx_modules.erl
@@ -16,6 +16,8 @@
 
 -include("logger.hrl").
 
+-logger_header("[Modules]").
+
 -export([ load/0
         , unload/0
         ]).
@@ -26,7 +28,7 @@ load() ->
     lists:foreach(
       fun({Mod, Env}) ->
         ok = Mod:load(Env),
-        ?LOG(info, "[Modules] Load ~s module successfully.", [Mod])
+        ?LOG(info, "Load ~s module successfully.", [Mod])
       end, emqx_config:get_env(modules, [])).
 
 -spec(unload() -> ok).

--- a/src/emqx_mountpoint.erl
+++ b/src/emqx_mountpoint.erl
@@ -17,6 +17,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[Mountpoint]").
+
 -export([ mount/2
         , unmount/2
         ]).
@@ -46,7 +48,7 @@ unmount(MountPoint, Msg = #message{topic = Topic}) ->
         {MountPoint, Topic1} -> Msg#message{topic = Topic1}
     catch
         _Error:Reason ->
-            ?LOG(error, "[Mountpoint] Unmount error : ~p", [Reason]),
+            ?LOG(error, "Unmount error : ~p", [Reason]),
             Msg
     end.
 

--- a/src/emqx_os_mon.erl
+++ b/src/emqx_os_mon.erl
@@ -18,6 +18,8 @@
 
 -include("logger.hrl").
 
+-logger_header("[OS Monitor]").
+
 -export([start_link/1]).
 
 %% gen_server callbacks
@@ -132,7 +134,7 @@ handle_info({timeout, Timer, check}, State = #{timer := Timer,
         0 ->
             {noreply, State#{timer := undefined}};
         {error, Reason} ->
-            ?LOG(error, "[OS Monitor] Failed to get cpu utilization: ~p", [Reason]),
+            ?LOG(error, "Failed to get cpu utilization: ~p", [Reason]),
             {noreply, ensure_check_timer(State)};
         Busy when Busy / 100 >= CPUHighWatermark ->
             alarm_handler:set_alarm({cpu_high_watermark, Busy}),

--- a/src/emqx_plugins.erl
+++ b/src/emqx_plugins.erl
@@ -17,6 +17,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[Plugins]").
+
 -export([init/0]).
 
 -export([ load/0
@@ -86,7 +88,7 @@ load_expand_plugin(PluginDir) ->
     end, Modules),
     case filelib:wildcard(Ebin ++ "/*.app") of
         [App|_] -> application:load(list_to_atom(filename:basename(App, ".app")));
-        _ -> ?LOG(alert, "[Plugins] Plugin not found."),
+        _ -> ?LOG(alert, "Plugin not found."),
              {error, load_app_fail}
     end.
 
@@ -112,7 +114,7 @@ with_loaded_file(File, SuccFun) ->
             Names = filter_plugins(Names0),
             SuccFun(Names);
         {error, Error} ->
-            ?LOG(alert, "[Plugins] Failed to read: ~p, error: ~p", [File, Error]),
+            ?LOG(alert, "Failed to read: ~p, error: ~p", [File, Error]),
             {error, Error}
     end.
 
@@ -126,7 +128,7 @@ load_plugins(Names, Persistent) ->
     Plugins = list(), NotFound = Names -- names(Plugins),
     case NotFound of
         []       -> ok;
-        NotFound -> ?LOG(alert, "[Plugins] Cannot find plugins: ~p", [NotFound])
+        NotFound -> ?LOG(alert, "Cannot find plugins: ~p", [NotFound])
     end,
     NeedToLoad = Names -- NotFound -- names(started_app),
     [load_plugin(find_plugin(Name, Plugins), Persistent) || Name <- NeedToLoad].
@@ -171,12 +173,12 @@ plugin(AppName) ->
 load(PluginName) when is_atom(PluginName) ->
     case lists:member(PluginName, names(started_app)) of
         true ->
-            ?LOG(notice, "[Plugins] Plugin ~s is already started", [PluginName]),
+            ?LOG(notice, "Plugin ~s is already started", [PluginName]),
             {error, already_started};
         false ->
             case find_plugin(PluginName) of
                 false ->
-                    ?LOG(alert, "[Plugins] Plugin ~s not found", [PluginName]),
+                    ?LOG(alert, "Plugin ~s not found", [PluginName]),
                     {error, not_found};
                 Plugin ->
                     load_plugin(Plugin, true)
@@ -204,12 +206,12 @@ load_app(App) ->
 start_app(App, SuccFun) ->
     case application:ensure_all_started(App) of
         {ok, Started} ->
-            ?LOG(info, "[Plugins] Started plugins: ~p", [Started]),
-            ?LOG(info, "[Plugins] Load plugin ~s successfully", [App]),
+            ?LOG(info, "Started plugins: ~p", [Started]),
+            ?LOG(info, "Load plugin ~s successfully", [App]),
             SuccFun(App),
             {ok, Started};
         {error, {ErrApp, Reason}} ->
-            ?LOG(error, "[Plugins] Load plugin ~s failed, cannot start plugin ~s for ~p", [App, ErrApp, Reason]),
+            ?LOG(error, "Load plugin ~s failed, cannot start plugin ~s for ~p", [App, ErrApp, Reason]),
             {error, {ErrApp, Reason}}
     end.
 
@@ -226,10 +228,10 @@ unload(PluginName) when is_atom(PluginName) ->
         {true, true} ->
             unload_plugin(PluginName, true);
         {false, _} ->
-            ?LOG(error, "[Plugins] Plugin ~s is not started", [PluginName]),
+            ?LOG(error, "Plugin ~s is not started", [PluginName]),
             {error, not_started};
         {true, false} ->
-            ?LOG(error, "[Plugins] ~s is not a plugin, cannot unload it", [PluginName]),
+            ?LOG(error, "~s is not a plugin, cannot unload it", [PluginName]),
             {error, not_found}
     end.
 
@@ -244,11 +246,11 @@ unload_plugin(App, Persistent) ->
 stop_app(App) ->
     case application:stop(App) of
         ok ->
-            ?LOG(info, "[Plugins] Stop plugin ~s successfully", [App]), ok;
+            ?LOG(info, "Stop plugin ~s successfully", [App]), ok;
         {error, {not_started, App}} ->
-            ?LOG(error, "[Plugins] Plugin ~s is not started", [App]), ok;
+            ?LOG(error, "Plugin ~s is not started", [App]), ok;
         {error, Reason} ->
-            ?LOG(error, "[Plugins] Stop plugin ~s error: ~p", [App]), {error, Reason}
+            ?LOG(error, "Stop plugin ~s error: ~p", [App]), {error, Reason}
     end.
 
 %%--------------------------------------------------------------------
@@ -276,7 +278,7 @@ plugin_loaded(Name, true) ->
                     ignore
             end;
         {error, Error} ->
-            ?LOG(error, "[Plugins] Cannot read loaded plugins: ~p", [Error])
+            ?LOG(error, "Cannot read loaded plugins: ~p", [Error])
     end.
 
 plugin_unloaded(_Name, false) ->
@@ -289,10 +291,10 @@ plugin_unloaded(Name, true) ->
                 true ->
                     write_loaded(lists:delete(Name, Names));
                 false ->
-                    ?LOG(error, "[Plugins] Cannot find ~s in loaded_file", [Name])
+                    ?LOG(error, "Cannot find ~s in loaded_file", [Name])
             end;
         {error, Error} ->
-            ?LOG(error, "[Plugins] Cannot read loaded_plugins: ~p", [Error])
+            ?LOG(error, "Cannot read loaded_plugins: ~p", [Error])
     end.
 
 read_loaded() ->
@@ -311,6 +313,6 @@ write_loaded(AppNames) ->
                 file:write(Fd, iolist_to_binary(io_lib:format("~p.~n", [Name])))
             end, AppNames);
         {error, Error} ->
-            ?LOG(error, "[Plugins] Open File ~p Error: ~p", [File, Error]),
+            ?LOG(error, "Open File ~p Error: ~p", [File, Error]),
             {error, Error}
     end.

--- a/src/emqx_pool.erl
+++ b/src/emqx_pool.erl
@@ -19,6 +19,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Pool]").
+
 %% APIs
 -export([start_link/2]).
 
@@ -97,22 +99,22 @@ handle_call({submit, Task}, _From, State) ->
     {reply, catch run(Task), State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Pool] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({async_submit, Task}, State) ->
     try run(Task)
     catch _:Error:Stacktrace ->
-        ?LOG(error, "[Pool] Error: ~p, ~p", [Error, Stacktrace])
+        ?LOG(error, "Error: ~p, ~p", [Error, Stacktrace])
     end,
     {noreply, State};
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Pool] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Pool] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, #{pool := Pool, id := Id}) ->

--- a/src/emqx_protocol.erl
+++ b/src/emqx_protocol.erl
@@ -20,6 +20,8 @@
 -include("emqx_mqtt.hrl").
 -include("logger.hrl").
 
+-logger_header("[Protocol]").
+
 -export([ info/1
         , attrs/1
         , attr/2
@@ -413,11 +415,11 @@ process(?CONNECT_PACKET(
                               %% Success
                               {?RC_SUCCESS, SP, PState4};
                           {error, Error} ->
-                              ?LOG(error, "[Protocol] Failed to open session: ~p", [Error]),
+                              ?LOG(error, "Failed to open session: ~p", [Error]),
                               {?RC_UNSPECIFIED_ERROR, PState1#pstate{credentials = Credentials0}}
                       end;
                   {error, Reason} ->
-                      ?LOG(warning, "[Protocol] Client ~s (Username: '~s') login failed for ~p", [NewClientId, Username, Reason]),
+                      ?LOG(warning, "Client ~s (Username: '~s') login failed for ~p", [NewClientId, Username, Reason]),
                       {emqx_reason_codes:connack_error(Reason), PState1#pstate{credentials = Credentials}}
               end;
           {error, ReasonCode} ->
@@ -429,7 +431,7 @@ process(Packet = ?PUBLISH_PACKET(?QOS_0, Topic, _PacketId, _Payload), PState = #
         ok ->
             do_publish(Packet, PState);
         {error, ReasonCode} ->
-            ?LOG(warning, "[Protocol] Cannot publish qos0 message to ~s for ~s",
+            ?LOG(warning, "Cannot publish qos0 message to ~s for ~s",
                  [Topic, emqx_reason_codes:text(ReasonCode)]),
             AclDenyAction = emqx_zone:get_env(Zone, acl_deny_action, ignore),
             do_acl_deny_action(AclDenyAction, Packet, ReasonCode, PState)
@@ -440,7 +442,7 @@ process(Packet = ?PUBLISH_PACKET(?QOS_1, Topic, PacketId, _Payload), PState = #p
         ok ->
             do_publish(Packet, PState);
         {error, ReasonCode} ->
-            ?LOG(warning, "[Protocol] Cannot publish qos1 message to ~s for ~s", [Topic, emqx_reason_codes:text(ReasonCode)]),
+            ?LOG(warning, "Cannot publish qos1 message to ~s for ~s", [Topic, emqx_reason_codes:text(ReasonCode)]),
             case deliver({puback, PacketId, ReasonCode}, PState) of
                 {ok, PState1} ->
                     AclDenyAction = emqx_zone:get_env(Zone, acl_deny_action, ignore),
@@ -454,7 +456,7 @@ process(Packet = ?PUBLISH_PACKET(?QOS_2, Topic, PacketId, _Payload), PState = #p
         ok ->
             do_publish(Packet, PState);
         {error, ReasonCode} ->
-            ?LOG(warning, "[Protocol] Cannot publish qos2 message to ~s for ~s",
+            ?LOG(warning, "Cannot publish qos2 message to ~s for ~s",
                  [Topic, emqx_reason_codes:text(ReasonCode)]),
             case deliver({pubrec, PacketId, ReasonCode}, PState) of
                 {ok, PState1} ->
@@ -501,7 +503,7 @@ process(Packet = ?SUBSCRIBE_PACKET(PacketId, Properties, RawTopicFilters),
                                 ({Topic, #{rc := Code}}, {Topics, Codes}) ->
                                     {[Topic|Topics], [Code|Codes]}
                             end, {[], []}, TopicFilters),
-            ?LOG(warning, "[Protocol] Cannot subscribe ~p for ~p",
+            ?LOG(warning, "Cannot subscribe ~p for ~p",
                  [SubTopics, [emqx_reason_codes:text(R) || R <- ReasonCodes]]),
             case deliver({suback, PacketId, ReasonCodes}, PState) of
                 {ok, PState1} ->
@@ -844,7 +846,7 @@ check_will_acl(#mqtt_packet_connect{will_topic = WillTopic},
     case do_acl_check(EnableAcl, publish, Credentials, WillTopic) of
         ok -> ok;
         Other ->
-            ?LOG(warning, "[Protocol] Cannot publish will message to ~p for acl denied", [WillTopic]),
+            ?LOG(warning, "Cannot publish will message to ~p for acl denied", [WillTopic]),
             Other
     end.
 
@@ -898,9 +900,9 @@ check_sub_acl(TopicFilters, #pstate{zone = Zone, credentials = Credentials}) ->
       end, {ok, []}, TopicFilters).
 
 trace(recv, Packet) ->
-    ?LOG(debug, "[Protocol] RECV ~s", [emqx_packet:format(Packet)]);
+    ?LOG(debug, "RECV ~s", [emqx_packet:format(Packet)]);
 trace(send, Packet) ->
-    ?LOG(debug, "[Protocol] SEND ~s", [emqx_packet:format(Packet)]).
+    ?LOG(debug, "SEND ~s", [emqx_packet:format(Packet)]).
 
 inc_stats(recv, Type, PState = #pstate{recv_stats = Stats}) ->
     PState#pstate{recv_stats = inc_stats(Type, Stats)};
@@ -926,7 +928,7 @@ terminate(Reason, PState) when Reason =:= conflict;
 
 terminate(Reason, PState = #pstate{credentials = Credentials}) ->
     do_flapping_detect(disconnect, PState),
-    ?LOG(info, "[Protocol] Shutdown for ~p", [Reason]),
+    ?LOG(info, "Shutdown for ~p", [Reason]),
     ok = emqx_hooks:run('client.disconnected', [Credentials, Reason]).
 
 start_keepalive(0, _PState) ->

--- a/src/emqx_psk.erl
+++ b/src/emqx_psk.erl
@@ -16,6 +16,8 @@
 
 -include("logger.hrl").
 
+-logger_header("[PSK]").
+
 %% SSL PSK Callbacks
 -export([lookup/3]).
 
@@ -27,10 +29,10 @@ lookup(psk, ClientPSKID, _UserState) ->
     try emqx_hooks:run_fold('tls_handshake.psk_lookup', [ClientPSKID], not_found) of
         SharedSecret when is_binary(SharedSecret) -> {ok, SharedSecret};
         Error ->
-            ?LOG(error, "[PSK] Look PSK for PSKID ~p error: ~p", [ClientPSKID, Error]),
+            ?LOG(error, "Look PSK for PSKID ~p error: ~p", [ClientPSKID, Error]),
             error
     catch
         Except:Error:Stacktrace ->
-          ?LOG(error, "[PSK] Lookup PSK failed, ~p: ~p", [{Except,Error}, Stacktrace]),
+          ?LOG(error, "Lookup PSK failed, ~p: ~p", [{Except,Error}, Stacktrace]),
           error
     end.

--- a/src/emqx_router.erl
+++ b/src/emqx_router.erl
@@ -21,6 +21,8 @@
 -include("types.hrl").
 -include_lib("ekka/include/ekka.hrl").
 
+-logger_header("[Router]").
+
 %% Mnesia bootstrap
 -export([mnesia/1]).
 
@@ -198,15 +200,15 @@ handle_call({delete_route, Topic, Dest}, _From, State) ->
     {reply, Ok, State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Router] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Router] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Router] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, #{pool := Pool, id := Id}) ->

--- a/src/emqx_router_helper.erl
+++ b/src/emqx_router_helper.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Router Helper]").
+
 %% Mnesia bootstrap
 -export([mnesia/1]).
 
@@ -103,11 +105,11 @@ init([]) ->
     {ok, #{nodes => Nodes}, hibernate}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Router Helper] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Router Helper] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({mnesia_table_event, {write, {?ROUTING_NODE, Node, _}, _}}, State = #{nodes := Nodes}) ->
@@ -123,7 +125,7 @@ handle_info({mnesia_table_event, {delete, {?ROUTING_NODE, _Node}, _}}, State) ->
     {noreply, State};
 
 handle_info({mnesia_table_event, Event}, State) ->
-    ?LOG(error, "[Router Helper] Unexpected mnesia_table_event: ~p", [Event]),
+    ?LOG(error, "Unexpected mnesia_table_event: ~p", [Event]),
     {noreply, State};
 
 handle_info({nodedown, Node}, State = #{nodes := Nodes}) ->
@@ -141,7 +143,7 @@ handle_info({membership, _Event}, State) ->
     {noreply, State};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Route Helper] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_session_sup.erl
+++ b/src/emqx_session_sup.erl
@@ -19,6 +19,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Session Supervisor]").
+
 -export([start_link/1]).
 
 -export([ start_session/1
@@ -92,7 +94,7 @@ handle_call({start_session, SessAttrs = #{client_id := ClientId}}, _From,
             reply({error, Reason}, State)
     catch
         _:Error:Stk ->
-            ?LOG(error, "[Session Supervisor] Failed to start session ~p: ~p, stacktrace:~n~p",
+            ?LOG(error, "Failed to start session ~p: ~p, stacktrace:~n~p",
                    [ClientId, Error, Stk]),
             reply({error, Error}, State)
     end;
@@ -101,11 +103,11 @@ handle_call(count_sessions, _From, State = #state{sessions = SessMap}) ->
     {reply, maps:size(SessMap), State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Session Supervisor] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Session Supervisor] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({'EXIT', Pid, _Reason}, State = #state{sessions = SessMap, clean_down = CleanDown}) ->
@@ -117,7 +119,7 @@ handle_info({'EXIT', Pid, _Reason}, State = #state{sessions = SessMap, clean_dow
     {noreply, State#state{sessions = SessMap1}};
 
 handle_info(Info, State) ->
-    ?LOG(notice, "[Session Supervisor] Unexpected info: ~p", [Info]),
+    ?LOG(notice, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, State) ->

--- a/src/emqx_shared_sub.erl
+++ b/src/emqx_shared_sub.erl
@@ -21,6 +21,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Shared Sub]").
+
 %% Mnesia bootstrap
 -export([mnesia/1]).
 
@@ -310,11 +312,11 @@ handle_call({unsubscribe, Group, Topic, SubPid}, _From, State) ->
     {reply, ok, State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Shared Sub] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Shared Sub] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({mnesia_table_event, {write, NewRecord, _}}, State = #state{pmon = PMon}) ->
@@ -329,12 +331,12 @@ handle_info({mnesia_table_event, _Event}, State) ->
     {noreply, State};
 
 handle_info({'DOWN', _MRef, process, SubPid, _Reason}, State = #state{pmon = PMon}) ->
-    ?LOG(info, "[Shared Sub] Shared subscriber down: ~p", [SubPid]),
+    ?LOG(info, "Shared subscriber down: ~p", [SubPid]),
     cleanup_down(SubPid),
     {noreply, update_stats(State#state{pmon = emqx_pmon:erase(SubPid, PMon)})};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Shared Sub] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_sm.erl
+++ b/src/emqx_sm.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[SM]").
+
 %% APIs
 -export([start_link/0]).
 
@@ -114,7 +116,7 @@ discard_session(ClientId, ConnPid) when is_binary(ClientId) ->
           try emqx_session:discard(SessPid, ConnPid)
           catch
               _:Error:_Stk ->
-                  ?LOG(warning, "[SM] Failed to discard ~p: ~p", [SessPid, Error])
+                  ?LOG(warning, "Failed to discard ~p: ~p", [SessPid, Error])
           end
       end, lookup_session_pids(ClientId)).
 
@@ -128,7 +130,7 @@ resume_session(ClientId, SessAttrs = #{conn_pid := ConnPid}) ->
             {ok, SessPid};
         SessPids ->
             [SessPid|StalePids] = lists:reverse(SessPids),
-            ?LOG(error, "[SM] More than one session found: ~p", [SessPids]),
+            ?LOG(error, "More than one session found: ~p", [SessPids]),
             lists:foreach(fun(StalePid) ->
                               catch emqx_session:discard(StalePid, ConnPid)
                           end, StalePids),
@@ -254,15 +256,15 @@ init([]) ->
     {ok, #{}}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[SM] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[SM] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[SM] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_sm_registry.erl
+++ b/src/emqx_sm_registry.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Registry]").
+
 -export([start_link/0]).
 
 -export([ is_enabled/0
@@ -96,11 +98,11 @@ init([]) ->
     {ok, #{}}.
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Registry] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Registry] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({membership, {mnesia, down, Node}}, State) ->
@@ -114,7 +116,7 @@ handle_info({membership, _Event}, State) ->
     {noreply, State};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Registry] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_stats.erl
+++ b/src/emqx_stats.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Stats]").
+
 %% APIs
 -export([ start_link/0
         , start_link/1
@@ -184,7 +186,7 @@ handle_call(stop, _From, State) ->
     {stop, normal, ok, State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Stats] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({setstat, Stat, MaxStat, Val}, State) ->
@@ -202,7 +204,7 @@ handle_cast({setstat, Stat, MaxStat, Val}, State) ->
 handle_cast({update_interval, Update = #update{name = Name}}, State = #state{updates = Updates}) ->
     case lists:keyfind(Name, #update.name, Updates) of
         #update{} ->
-            ?LOG(warning, "[Stats] Duplicated update: ~s", [Name]),
+            ?LOG(warning, "Duplicated update: ~s", [Name]),
             {noreply, State};
         false ->
             {noreply, State#state{updates = [Update | Updates]}}
@@ -212,7 +214,7 @@ handle_cast({cancel_update, Name}, State = #state{updates = Updates}) ->
     {noreply, State#state{updates = lists:keydelete(Name, #update.name, Updates)}};
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Stats] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({timeout, TRef, tick}, State = #state{timer = TRef, updates = Updates}) ->
@@ -222,7 +224,7 @@ handle_info({timeout, TRef, tick}, State = #state{timer = TRef, updates = Update
                          try UpFun()
                          catch
                              _:Error ->
-                                 ?LOG(error, "[Stats] update ~s failed: ~p", [Name, Error])
+                                 ?LOG(error, "update ~s failed: ~p", [Name, Error])
                          end,
                          [Update#update{countdown = I} | Acc];
                     (Update = #update{countdown = C}, Acc) ->
@@ -231,7 +233,7 @@ handle_info({timeout, TRef, tick}, State = #state{timer = TRef, updates = Update
     {noreply, start_timer(State#state{updates = Updates1}), hibernate};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Stats] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, #state{timer = TRef}) ->
@@ -252,5 +254,5 @@ safe_update_element(Key, Val) ->
             true
     catch
         error:badarg ->
-            ?LOG(warning, "[Stats] Update ~p to ~p failed", [Key, Val])
+            ?LOG(warning, "Update ~p to ~p failed", [Key, Val])
     end.

--- a/src/emqx_sys.erl
+++ b/src/emqx_sys.erl
@@ -19,6 +19,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[SYS]").
+
 -export([start_link/0]).
 
 -export([ version/0
@@ -117,11 +119,11 @@ handle_call(uptime, _From, State) ->
     {reply, uptime(State), State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[SYS] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[SYS] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({timeout, TRef, heartbeat}, State = #state{heartbeat = TRef}) ->
@@ -138,7 +140,7 @@ handle_info({timeout, TRef, tick}, State = #state{ticker = TRef, version = Versi
     {noreply, tick(State), hibernate};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[SYS] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, #state{heartbeat = TRef1, ticker = TRef2}) ->

--- a/src/emqx_sys_mon.erl
+++ b/src/emqx_sys_mon.erl
@@ -19,6 +19,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[SYSMON]").
+
 -export([start_link/1]).
 
 %% compress unused warning
@@ -88,18 +90,18 @@ parse_opt([_Opt|Opts], Acc) ->
     parse_opt(Opts, Acc).
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[SYSMON] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[SYSMON] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info({monitor, Pid, long_gc, Info}, State) ->
     suppress({long_gc, Pid},
              fun() ->
                  WarnMsg = io_lib:format("long_gc warning: pid = ~p, info: ~p", [Pid, Info]),
-                 ?LOG(warning, "[SYSMON] ~s~n~p", [WarnMsg, procinfo(Pid)]),
+                 ?LOG(warning, "~s~n~p", [WarnMsg, procinfo(Pid)]),
                  safe_publish(long_gc, WarnMsg)
              end, State);
 
@@ -107,7 +109,7 @@ handle_info({monitor, Pid, long_schedule, Info}, State) when is_pid(Pid) ->
     suppress({long_schedule, Pid},
              fun() ->
                  WarnMsg = io_lib:format("long_schedule warning: pid = ~p, info: ~p", [Pid, Info]),
-                 ?LOG(warning, "[SYSMON] ~s~n~p", [WarnMsg, procinfo(Pid)]),
+                 ?LOG(warning, "~s~n~p", [WarnMsg, procinfo(Pid)]),
                  safe_publish(long_schedule, WarnMsg)
              end, State);
 
@@ -115,7 +117,7 @@ handle_info({monitor, Port, long_schedule, Info}, State) when is_port(Port) ->
     suppress({long_schedule, Port},
              fun() ->
                  WarnMsg = io_lib:format("long_schedule warning: port = ~p, info: ~p", [Port, Info]),
-                 ?LOG(warning, "[SYSMON] ~s~n~p", [WarnMsg, erlang:port_info(Port)]),
+                 ?LOG(warning, "~s~n~p", [WarnMsg, erlang:port_info(Port)]),
                  safe_publish(long_schedule, WarnMsg)
              end, State);
 
@@ -123,7 +125,7 @@ handle_info({monitor, Pid, large_heap, Info}, State) ->
     suppress({large_heap, Pid},
              fun() ->
                  WarnMsg = io_lib:format("large_heap warning: pid = ~p, info: ~p", [Pid, Info]),
-                 ?LOG(warning, "[SYSMON] ~s~n~p", [WarnMsg, procinfo(Pid)]),
+                 ?LOG(warning, "~s~n~p", [WarnMsg, procinfo(Pid)]),
                  safe_publish(large_heap, WarnMsg)
              end, State);
 
@@ -131,7 +133,7 @@ handle_info({monitor, SusPid, busy_port, Port}, State) ->
     suppress({busy_port, Port},
              fun() ->
                  WarnMsg = io_lib:format("busy_port warning: suspid = ~p, port = ~p", [SusPid, Port]),
-                 ?LOG(warning, "[SYSMON] ~s~n~p~n~p", [WarnMsg, procinfo(SusPid), erlang:port_info(Port)]),
+                 ?LOG(warning, "~s~n~p~n~p", [WarnMsg, procinfo(SusPid), erlang:port_info(Port)]),
                  safe_publish(busy_port, WarnMsg)
              end, State);
 
@@ -139,7 +141,7 @@ handle_info({monitor, SusPid, busy_dist_port, Port}, State) ->
     suppress({busy_dist_port, Port},
              fun() ->
                  WarnMsg = io_lib:format("busy_dist_port warning: suspid = ~p, port = ~p", [SusPid, Port]),
-                 ?LOG(warning, "[SYSMON] ~s~n~p~n~p", [WarnMsg, procinfo(SusPid), erlang:port_info(Port)]),
+                 ?LOG(warning, "~s~n~p~n~p", [WarnMsg, procinfo(SusPid), erlang:port_info(Port)]),
                  safe_publish(busy_dist_port, WarnMsg)
              end, State);
 
@@ -147,7 +149,7 @@ handle_info({timeout, _Ref, reset}, State) ->
     {noreply, State#{events := []}, hibernate};
 
 handle_info(Info, State) ->
-    ?LOG(error, "[SYSMON] Unexpected Info: ~p", [Info]),
+    ?LOG(error, "Unexpected Info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, #{timer := TRef}) ->

--- a/src/emqx_tracer.erl
+++ b/src/emqx_tracer.erl
@@ -19,6 +19,8 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
+-logger_header("[Tracer]").
+
 %% APIs
 -export([start_link/0]).
 
@@ -121,10 +123,10 @@ handle_call({start_trace, Who, Level, LogFile}, _From, State = #state{traces = T
                                   filters => [{meta_key_filter,
                                               {fun filter_by_meta_key/2, Who} }]}) of
         ok ->
-            ?LOG(info, "[Tracer] Start trace for ~p", [Who]),
+            ?LOG(info, "Start trace for ~p", [Who]),
             {reply, ok, State#state{traces = maps:put(Who, {Level, LogFile}, Traces)}};
         {error, Reason} ->
-            ?LOG(error, "[Tracer] Start trace for ~p failed, error: ~p", [Who, Reason]),
+            ?LOG(error, "Start trace for ~p failed, error: ~p", [Who, Reason]),
             {reply, {error, Reason}, State}
     end;
 
@@ -133,9 +135,9 @@ handle_call({stop_trace, Who}, _From, State = #state{traces = Traces}) ->
         {ok, _LogFile} ->
             case logger:remove_handler(handler_id(Who)) of
                 ok ->
-                    ?LOG(info, "[Tracer] Stop trace for ~p", [Who]);
+                    ?LOG(info, "Stop trace for ~p", [Who]);
                 {error, Reason} ->
-                    ?LOG(error, "[Tracer] Stop trace for ~p failed, error: ~p", [Who, Reason])
+                    ?LOG(error, "Stop trace for ~p failed, error: ~p", [Who, Reason])
             end,
             {reply, ok, State#state{traces = maps:remove(Who, Traces)}};
         error ->
@@ -146,15 +148,15 @@ handle_call(lookup_traces, _From, State = #state{traces = Traces}) ->
     {reply, [{Who, LogFile} || {Who, LogFile} <- maps:to_list(Traces)], State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Tracer] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Tracer] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Tracer] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/src/emqx_ws_channel.erl
+++ b/src/emqx_ws_channel.erl
@@ -20,6 +20,8 @@
 -include("emqx_mqtt.hrl").
 -include("logger.hrl").
 
+-logger_header("[WS Channel]").
+
 -export([ info/1
         , attrs/1
         , stats/1
@@ -143,11 +145,11 @@ websocket_init(#state{request = Req, options = Options}) ->
     WsCookie = try cowboy_req:parse_cookies(Req)
                catch
                    error:badarg ->
-                       ?LOG(error, "[WS Channel] Illegal cookie"),
+                       ?LOG(error, "Illegal cookie"),
                        undefined;
                    Error:Reason ->
                        ?LOG(error,
-                            "[WS Channel] Cookie is parsed failed, Error: ~p, Reason ~p",
+                            "Cookie is parsed failed, Error: ~p, Reason ~p",
                             [Error, Reason]),
                        undefined
                end,
@@ -189,7 +191,7 @@ websocket_handle({binary, <<>>}, State) ->
 websocket_handle({binary, [<<>>]}, State) ->
     {ok, ensure_stats_timer(State)};
 websocket_handle({binary, Data}, State = #state{parse_state = ParseState}) ->
-    ?LOG(debug, "[WS Channel] RECV ~p", [Data]),
+    ?LOG(debug, "RECV ~p", [Data]),
     BinSize = iolist_size(Data),
     emqx_pd:update_counter(recv_oct, BinSize),
     ok = emqx_metrics:inc('bytes.received', BinSize),
@@ -204,11 +206,11 @@ websocket_handle({binary, Data}, State = #state{parse_state = ParseState}) ->
                                     end,
                             State#state{parse_state = NParseState});
         {error, Reason} ->
-            ?LOG(error, "[WS Channel] Frame error: ~p", [Reason]),
+            ?LOG(error, "Frame error: ~p", [Reason]),
             shutdown(Reason, State)
     catch
         error:Reason:Stk ->
-            ?LOG(error, "[WS Channel] Parse failed for ~p~n\
+            ?LOG(error, "Parse failed for ~p~n\
                  Stacktrace:~p~nFrame data: ~p", [Reason, Stk, Data]),
             shutdown(parse_error, State)
     end;
@@ -255,12 +257,12 @@ websocket_info({timeout, Timer, emit_stats},
     {ok, State#state{stats_timer = undefined}, hibernate};
 
 websocket_info({keepalive, start, Interval}, State) ->
-    ?LOG(debug, "[WS Channel] Keepalive at the interval of ~p", [Interval]),
+    ?LOG(debug, "Keepalive at the interval of ~p", [Interval]),
     case emqx_keepalive:start(stat_fun(), Interval, {keepalive, check}) of
         {ok, KeepAlive} ->
             {ok, State#state{keepalive = KeepAlive}};
         {error, Error} ->
-            ?LOG(warning, "[WS Channel] Keepalive error: ~p", [Error]),
+            ?LOG(warning, "Keepalive error: ~p", [Error]),
             shutdown(Error, State)
     end;
 
@@ -269,19 +271,19 @@ websocket_info({keepalive, check}, State = #state{keepalive = KeepAlive}) ->
         {ok, KeepAlive1} ->
             {ok, State#state{keepalive = KeepAlive1}};
         {error, timeout} ->
-            ?LOG(debug, "[WS Channel] Keepalive Timeout!"),
+            ?LOG(debug, "Keepalive Timeout!"),
             shutdown(keepalive_timeout, State);
         {error, Error} ->
-            ?LOG(error, "[WS Channel] Keepalive error: ~p", [Error]),
+            ?LOG(error, "Keepalive error: ~p", [Error]),
             shutdown(keepalive_error, State)
     end;
 
 websocket_info({shutdown, discard, {ClientId, ByPid}}, State) ->
-    ?LOG(warning, "[WS Channel] Discarded by ~s:~p", [ClientId, ByPid]),
+    ?LOG(warning, "Discarded by ~s:~p", [ClientId, ByPid]),
     shutdown(discard, State);
 
 websocket_info({shutdown, conflict, {ClientId, NewPid}}, State) ->
-    ?LOG(warning, "[WS Channel] Clientid '~s' conflict with ~p", [ClientId, NewPid]),
+    ?LOG(warning, "Clientid '~s' conflict with ~p", [ClientId, NewPid]),
     shutdown(conflict, State);
 
 websocket_info({binary, Data}, State) ->
@@ -294,13 +296,13 @@ websocket_info({stop, Reason}, State) ->
     {stop, State#state{shutdown = Reason}};
 
 websocket_info(Info, State) ->
-    ?LOG(error, "[WS Channel] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {ok, State}.
 
 terminate(SockError, _Req, #state{keepalive   = Keepalive,
                                   proto_state = ProtoState,
                                   shutdown    = Shutdown}) ->
-    ?LOG(debug, "[WS Channel] Terminated for ~p, sockerror: ~p",
+    ?LOG(debug, "Terminated for ~p, sockerror: ~p",
          [Shutdown, SockError]),
     emqx_keepalive:cancel(Keepalive),
     case {ProtoState, Shutdown} of
@@ -320,7 +322,7 @@ handle_incoming(Packet, SuccFun, State = #state{proto_state = ProtoState}) ->
         {ok, NProtoState} ->
             SuccFun(State#state{proto_state = NProtoState});
         {error, Reason} ->
-            ?LOG(error, "[WS Channel] Protocol error: ~p", [Reason]),
+            ?LOG(error, "Protocol error: ~p", [Reason]),
             shutdown(Reason, State);
         {error, Reason, NProtoState} ->
             shutdown(Reason, State#state{proto_state = NProtoState});

--- a/src/emqx_zone.erl
+++ b/src/emqx_zone.erl
@@ -20,6 +20,8 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-logger_header("[Zone]").
+
 %% APIs
 -export([start_link/0]).
 
@@ -96,7 +98,7 @@ handle_call(force_reload, _From, State) ->
     {reply, ok, State};
 
 handle_call(Req, _From, State) ->
-    ?LOG(error, "[Zone] Unexpected call: ~p", [Req]),
+    ?LOG(error, "Unexpected call: ~p", [Req]),
     {reply, ignored, State}.
 
 handle_cast({set_env, Zone, Key, Val}, State) ->
@@ -104,11 +106,11 @@ handle_cast({set_env, Zone, Key, Val}, State) ->
     {noreply, State};
 
 handle_cast(Msg, State) ->
-    ?LOG(error, "[Zone] Unexpected cast: ~p", [Msg]),
+    ?LOG(error, "Unexpected cast: ~p", [Msg]),
     {noreply, State}.
 
 handle_info(Info, State) ->
-    ?LOG(error, "[Zone] Unexpected info: ~p", [Info]),
+    ?LOG(error, "Unexpected info: ~p", [Info]),
     {noreply, State}.
 
 terminate(_Reason, _State) ->


### PR DESCRIPTION
Improve the `?LOG` macro by supporting a module level log message header.

The logger header is provided by the module attribute `logger_header`, and its value must be a string (list).

If no logger header provided, no extra info will be prefixed to the log message.

e.g. 
```
-include("logger.hrl").
-logger_header("[EMQ]").

?LOG(info, "Hi there!").
```

will give the following outputs:

```
[EMQ] Hi there!
```
