### PR TITLE
Fix issue#2619

### DIFF
--- a/src/emqx_ws_channel.erl
+++ b/src/emqx_ws_channel.erl
@@ -206,7 +206,7 @@ websocket_handle({binary, Data}, State = #state{parse_state = ParseState}) ->
                                     end,
                             State#state{parse_state = NParseState});
         {error, Reason} ->
-             ?LOG(error, "Frame error: ~p", [Reason]),
+            ?LOG(error, "Frame error: ~p", [Reason]),
             shutdown(Reason, State)
     catch
         error:Reason:Stk ->

--- a/src/emqx_ws_channel.erl
+++ b/src/emqx_ws_channel.erl
@@ -206,7 +206,7 @@ websocket_handle({binary, Data}, State = #state{parse_state = ParseState}) ->
                                     end,
                             State#state{parse_state = NParseState});
         {error, Reason} ->
-            ?LOG(error, "Frame error: ~p", [Reason]),
+             ?LOG(error, "Frame error: ~p", [Reason]),
             shutdown(Reason, State)
     catch
         error:Reason:Stk ->
@@ -221,7 +221,11 @@ websocket_handle(Frame, State)
     {ok, ensure_stats_timer(State)};
 websocket_handle({FrameType, _}, State)
   when FrameType =:= ping; FrameType =:= pong ->
-    {ok, ensure_stats_timer(State)}.
+    {ok, ensure_stats_timer(State)};
+%% According to mqtt spec[https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901285]
+websocket_handle({_OtherFrameType, _}, State) ->
+    ?LOG(error, "Frame error: Other type of data frame"),
+    shutdown(other_frame_type, State).
 
 websocket_info({call, From, info}, State) ->
     gen_server:reply(From, info(State)),


### PR DESCRIPTION
Prior to this change, the websocket connection would not be disconnected
when the dataframe type is the other frame type. However, in the mqtt spec, it
should be disconnected.

Here is the [mqtt 5.0 spec](https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901285)

This change fixes this inconsistent behavior with the mqtt 5.0 spec 