### PR TITLE
Fix the massages order when batch dispatching

### DIFF
--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -798,7 +798,7 @@ handle_dispatch(Msgs, State = #state{inflight = Inflight,
                                      subscriptions = SubMap}) ->
     SessProps = #{client_id => ClientId, username => Username},
     %% Drain the mailbox and batch deliver
-    Msgs1 = drain_m(batch_n(Inflight), Msgs),
+    Msgs1 = Msgs ++ drain_m(batch_n(Inflight)),
     %% Ack the messages for shared subscription
     Msgs2 = maybe_ack_shared(Msgs1, State),
     %% Process suboptions
@@ -820,6 +820,9 @@ batch_n(Inflight) ->
         0 -> ?DEFAULT_BATCH_N;
         Sz -> Sz - emqx_inflight:size(Inflight)
     end.
+
+drain_m(Cnt) ->
+    drain_m(Cnt, []).
 
 drain_m(Cnt, Msgs) when Cnt =< 0 ->
     lists:reverse(Msgs);


### PR DESCRIPTION
```erlang
handle_dispatch(Msgs, State = #state{inflight = Inflight,            % [1, 2, 3]
                                     client_id = ClientId,
                                     username = Username,
                                     subscriptions = SubMap}) ->
    SessProps = #{client_id => ClientId, username => Username},
    %% Drain the mailbox and batch deliver
    Msgs1 = drain_m(batch_n(Inflight), Msgs),                        % [3, 2, 1, 4, 5, 6]
    %% Ack the messages for shared subscription
    Msgs2 = maybe_ack_shared(Msgs1, State),
    %% Process suboptions
    Msgs3 = lists:foldr(
              fun({Topic, Msg}, Acc) ->
                      SubOpts = find_subopts(Topic, SubMap),
                      case process_subopts(SubOpts, Msg, State) of
                          {ok, Msg1} -> [Msg1|Acc];
                          ignore ->
                              emqx_hooks:run('message.dropped', [SessProps, Msg]),
                              Acc
                      end
              end, [], Msgs2),
    NState = batch_process(Msgs3, State),
    noreply(ensure_stats_timer(NState)).

drain_m(Cnt, Msgs) when Cnt =< 0 ->
    lists:reverse(Msgs);
drain_m(Cnt, Msgs) ->
    receive
        {dispatch, Topic, Msg} when is_record(Msg, message)->
            drain_m(Cnt-1, [{Topic, Msg} | Msgs]);                   % [4, 1, 2, 3]
        {dispatch, Topic, InMsgs} when is_list(InMsgs) ->
            Msgs1 = lists:foldl(
                      fun(Msg, Acc) ->
                              [{Topic, Msg} | Acc]                   % [6, 5, 4, 1, 2, 3]
                      end, Msgs, InMsgs),
            drain_m(Cnt-length(InMsgs), Msgs1)
    after 0 ->
        lists:reverse(Msgs)
    end.
```

The `Msgs` has not been sorted in function `handle_dispatch`, so I think we assume that it has been sorted before passed in. But before returning from `drain_m`, the `Msgs` is reversed.

i.e.

```erlang
%% at first
Msgs = [1, 2, 3]

%% receive 1 message from mailbox ( receive {dispatch, Topic, Msg} )
[4 | [1, 2, 3]] -> [4, 1, 2, 3]

%% receive 2 messages at once ( receive {dispatch, Topic, InMsgs} -> foldl )
[6| [5| [4, 1, 2, 3]]] -> [6, 5, 4, 1, 2, 3]

%% then reverse
[3, 2, 1, 4, 5, 6]
                  
%% but it should be
[1, 2, 3, 4, 5, 6]
```

And we don't know the length of the passed in `Msgs`, it has already been a batch, what about draining the mailbox only when handling one message, not a message list? I notice that only `emqx_retainer` will dispatch a bunch of messages.