### PR TITLE
updated the location of built emqx

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ git clone https://github.com/emqx/emqx-rel.git
 
 cd emqx-rel && make
 
-cd _rel/emqx && ./bin/emqx console
+cd _build/emqx/rel/emqx && ./bin/emqx console
 
 ```
 


### PR DESCRIPTION
The location of built folder of emqx is `_build/emqx/rel/emqx` in the current version, updated the **readme** to reflect the same.