### PR TITLE
Add support for logger per module filtering

### DIFF
--- a/include/logger.hrl
+++ b/include/logger.hrl
@@ -41,5 +41,5 @@
 
 -define(LOG(Level, Format, Args),
         begin
-          (logger:log(Level,#{},#{report_cb => fun(_) -> {'$logger_header'()++(Format), (Args)} end}))
+          (logger:log(Level,#{},#{report_cb => fun(_) -> {'$logger_header'()++(Format), (Args)} end, mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}}))
         end).

--- a/src/emqx_tracer.erl
+++ b/src/emqx_tracer.erl
@@ -69,7 +69,7 @@ trace(publish, #message{topic = <<"$SYS/", _/binary>>}) ->
     ignore;
 trace(publish, #message{from = From, topic = Topic, payload = Payload})
         when is_binary(From); is_atom(From) ->
-    emqx_logger:info(#{topic => Topic}, "PUBLISH to ~s: ~p", [Topic, Payload]).
+    emqx_logger:info(#{topic => Topic, mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY} }, "PUBLISH to ~s: ~p", [Topic, Payload]).
 
 %%------------------------------------------------------------------------------
 %% Start/Stop trace


### PR DESCRIPTION
Add mfa to the meta data to support the Erlang Logger's per module / per app filtering

For more details, see the note here:
http://erlang.org/doc/man/logger.html#set_module_level-2