### PR TITLE
Fix handling for MQTT spec

### DIFF
--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -219,7 +219,7 @@ idle(timeout, _Timeout, State) ->
 
 idle(cast, {incoming, Packet = ?CONNECT_PACKET(ConnPkt)}, State) ->
     #mqtt_packet_connect{proto_ver = ProtoVer, properties = Properties} = ConnPkt,
-    MaxPacketSize = maps:get('Maximum-Packet-Size', Properties, undefined),
+    MaxPacketSize = emqx_mqtt_props:get_property('Maximum-Packet-Size', Properties, undefined),
     NState = State#connection{serialize = serialize_fun(ProtoVer, MaxPacketSize)},
     SuccFun = fun(NewSt) -> {next_state, connected, NewSt} end,
     handle_incoming(Packet, SuccFun, NState);

--- a/src/emqx_metrics.erl
+++ b/src/emqx_metrics.erl
@@ -280,7 +280,8 @@ do_inc_recv(?PUBLISH_PACKET(QoS, _PktId)) ->
     case QoS of
         ?QOS_0 -> inc('messages.qos0.received');
         ?QOS_1 -> inc('messages.qos1.received');
-        ?QOS_2 -> inc('messages.qos2.received')
+        ?QOS_2 -> inc('messages.qos2.received');
+        _ -> ignore
     end,
     inc('packets.publish.received');
 do_inc_recv(?PACKET(?PUBACK)) ->

--- a/src/emqx_mqtt_props.erl
+++ b/src/emqx_mqtt_props.erl
@@ -28,6 +28,10 @@
 %% For tests
 -export([all/0]).
 
+-export([ set_property/3
+        , get_property/3
+        ]).
+
 -type(prop_name() :: atom()).
 -type(prop_id() :: pos_integer()).
 
@@ -178,4 +182,14 @@ validate_value(_Type, _Val) -> false.
 
 -spec(all() -> map()).
 all() -> ?PROPS_TABLE.
+
+set_property(Name, Value, undefined) ->
+    #{Name => Value};
+set_property(Name, Value, Props) ->
+    Props#{Name => Value}.
+
+get_property(_Name, undefined, Default) ->
+    Default;
+get_property(Name, Props, Default) ->
+    maps:get(Name, Props, Default).
 

--- a/src/emqx_packet.erl
+++ b/src/emqx_packet.erl
@@ -75,10 +75,11 @@ validate(?UNSUBSCRIBE_PACKET(PacketId, TopicFilters)) ->
 validate(?PUBLISH_PACKET(_QoS, <<>>, _, #{'Topic-Alias':= _I}, _)) ->
     true;
 validate(?PUBLISH_PACKET(_QoS, <<>>, _, _, _)) ->
-    error(topic_name_invalid);
-validate(?PUBLISH_PACKET(_QoS, Topic, _, Properties, _)) ->
-    ((not emqx_topic:wildcard(Topic)) orelse error(topic_name_invalid))
-        andalso validate_properties(?PUBLISH, Properties);
+    error(protocol_error);
+validate(?PUBLISH_PACKET(QoS, Topic, _, Properties, _)) ->
+    ((not (QoS =:= 3)) orelse error(qos_invalid))
+        andalso ((not emqx_topic:wildcard(Topic)) orelse error(topic_name_invalid))
+            andalso validate_properties(?PUBLISH, Properties);
 
 validate(?CONNECT_PACKET(#mqtt_packet_connect{properties = Properties})) ->
     validate_properties(?CONNECT, Properties);

--- a/src/emqx_protocol.erl
+++ b/src/emqx_protocol.erl
@@ -76,7 +76,7 @@ init(#mqtt_packet_connect{proto_name  = ProtoName,
               client_id     = ClientId,
               username      = Username,
               will_msg      = WillMsg,
-              alias_maximum = #{outbound => get_property('Topic-Alias-Maximum', Properties, 0),
+              alias_maximum = #{outbound => emqx_mqtt_props:get_property('Topic-Alias-Maximum', Properties, 0),
                                 inbound => maps:get(max_topic_alias, emqx_mqtt_caps:get_caps(Zone), 0)}
              }.
 
@@ -131,7 +131,3 @@ save_alias(AliasId, Topic, Proto = #protocol{topic_aliases = Aliases}) ->
 clear_will_msg(Protocol) ->
     Protocol#protocol{will_msg = undefined}.
 
-get_property(_Name, undefined, Default) ->
-    Default;
-get_property(Name, Props, Default) ->
-    maps:get(Name, Props, Default).

--- a/src/emqx_ws_connection.erl
+++ b/src/emqx_ws_connection.erl
@@ -192,7 +192,8 @@ websocket_init([Req, Opts]) ->
                         fsm_state   = idle,
                         parse_state = ParseState,
                         chan_state  = ChanState,
-                        pendings    = []}}.
+                        pendings    = [],
+                        serialize   = serialize_fun(?MQTT_PROTO_V5, undefined)}}.
 
 websocket_handle({binary, Data}, State) when is_list(Data) ->
     websocket_handle({binary, iolist_to_binary(Data)}, State);
@@ -255,8 +256,9 @@ websocket_info({cast, Msg}, State = #ws_connection{chan_state = ChanState}) ->
 
 websocket_info({incoming, Packet = ?CONNECT_PACKET(ConnPkt)},
                 State = #ws_connection{fsm_state = idle}) ->
-    #mqtt_packet_connect{proto_ver = ProtoVer} = ConnPkt,
-    NState = State#ws_connection{serialize = serialize_fun(ProtoVer)},
+    #mqtt_packet_connect{proto_ver = ProtoVer, properties = Properties} = ConnPkt,
+    MaxPacketSize = maps:get('Maximum-Packet-Size', Properties, undefined),
+    NState = State#ws_connection{serialize = serialize_fun(ProtoVer, MaxPacketSize)},
     handle_incoming(Packet, fun connected/1, NState);
 
 websocket_info({incoming, Packet}, State = #ws_connection{fsm_state = idle}) ->
@@ -348,14 +350,24 @@ process_incoming(Data, State = #ws_connection{parse_state = ParseState, chan_sta
             stop(Reason, State)
     catch
         error:Reason:Stk ->
-            ?LOG(error, "Parse failed for ~p~n\
-                 Stacktrace:~p~nFrame data: ~p", [Reason, Stk, Data]),
-            case emqx_channel:handle_out({disconnect, emqx_reason_codes:mqtt_frame_error(Reason)}, ChanState) of
+            ?LOG(error, "Parse failed for ~p~nStacktrace:~p~nFrame data: ~p", [Reason, Stk, Data]),
+            Result = 
+                case emqx_channel:info(connected, ChanState) of
+                    undefined ->
+                        emqx_channel:handle_out({connack, emqx_reason_codes:mqtt_frame_error(Reason)}, ChanState);
+                    true ->
+                        emqx_channel:handle_out({disconnect, emqx_reason_codes:mqtt_frame_error(Reason)}, ChanState);
+                    _ ->
+                        ignore
+                end,
+            case Result of
                 {stop, Reason0, OutPackets, NChanState} ->
                     NState = State#ws_connection{chan_state = NChanState},
                     stop(Reason0, enqueue(OutPackets, NState));
                 {stop, Reason0, NChanState} ->
-                    stop(Reason0, State#ws_connection{chan_state = NChanState})
+                    stop(Reason0, State#ws_connection{chan_state = NChanState});
+                ignore ->
+                    {ok, State}
             end
     end.
 
@@ -394,12 +406,19 @@ handle_outgoing(Packets, State = #ws_connection{serialize  = Serialize,
 %%--------------------------------------------------------------------
 %% Serialize fun
 
-serialize_fun(ProtoVer) ->
+serialize_fun(ProtoVer, MaxPacketSize) ->
     fun(Packet = ?PACKET(Type)) ->
-        ?LOG(debug, "SEND ~s", [emqx_packet:format(Packet)]),
-        _ = inc_outgoing_stats(Type),
-        _ = emqx_metrics:inc_sent(Packet),
-        emqx_frame:serialize(Packet, ProtoVer)
+        IoData = emqx_frame:serialize(Packet, ProtoVer),
+        case Type =/= ?PUBLISH orelse MaxPacketSize =:= undefined orelse iolist_size(IoData) =< MaxPacketSize of
+            true ->
+                ?LOG(debug, "SEND ~s", [emqx_packet:format(Packet)]),
+                _ = inc_outgoing_stats(Type),
+                _ = emqx_metrics:inc_sent(Packet),
+                IoData;
+            false ->
+                ?LOG(warning, "DROP ~s due to oversize packet size", [emqx_packet:format(Packet)]),
+                <<"">>
+        end
     end.
 
 %%--------------------------------------------------------------------

--- a/src/emqx_ws_connection.erl
+++ b/src/emqx_ws_connection.erl
@@ -257,7 +257,7 @@ websocket_info({cast, Msg}, State = #ws_connection{chan_state = ChanState}) ->
 websocket_info({incoming, Packet = ?CONNECT_PACKET(ConnPkt)},
                 State = #ws_connection{fsm_state = idle}) ->
     #mqtt_packet_connect{proto_ver = ProtoVer, properties = Properties} = ConnPkt,
-    MaxPacketSize = maps:get('Maximum-Packet-Size', Properties, undefined),
+    MaxPacketSize = emqx_mqtt_props:get_property('Maximum-Packet-Size', Properties, undefined),
     NState = State#ws_connection{serialize = serialize_fun(ProtoVer, MaxPacketSize)},
     handle_incoming(Packet, fun connected/1, NState);
 

--- a/test/emqx_channel_SUITE.erl
+++ b/test/emqx_channel_SUITE.erl
@@ -289,7 +289,7 @@ with_channel(Fun) ->
                  username    = <<"username">>,
                  password    = <<"passwd">>
                 },
-    Protocol = emqx_protocol:init(ConnPkt),
+    Protocol = emqx_protocol:init(ConnPkt, testing),
     Session = emqx_session:init(#{zone => testing},
                                 #{max_inflight    => 100,
                                   expiry_interval => 0

--- a/test/emqx_packet_SUITE.erl
+++ b/test/emqx_packet_SUITE.erl
@@ -49,7 +49,7 @@ t_validate(_) ->
                                      [{<<"topic">>, #{qos => ?QOS_0}}]))),
     ?assertError(topic_filters_invalid,
                  emqx_packet:validate(?UNSUBSCRIBE_PACKET(1,[]))),
-    ?assertError(topic_name_invalid,
+    ?assertError(protocol_error,
                  emqx_packet:validate(?PUBLISH_PACKET(1,<<>>,1,#{},<<"payload">>))),
     ?assertError(topic_name_invalid,
                  emqx_packet:validate(?PUBLISH_PACKET

--- a/test/emqx_protocol_SUITE.erl
+++ b/test/emqx_protocol_SUITE.erl
@@ -38,7 +38,7 @@ init_protocol() ->
                           client_id   = <<"clientid">>,
                           username    = <<"username">>,
                           password    = <<"passwd">>
-                         }).
+                         }, testing).
 
 end_per_suite(_Config) -> ok.
 
@@ -48,11 +48,11 @@ t_init_info_1(Config) ->
                    proto_ver     => ?MQTT_PROTO_V5,
                    clean_start   => true,
                    keepalive     => 30,
-                   conn_props    => #{},
                    will_msg      => undefined,
                    client_id     => <<"clientid">>,
                    username      => <<"username">>,
-                   topic_aliases => undefined
+                   topic_aliases => undefined,
+                   alias_maximum => #{outbound => 0, inbound => 0}
                   }, emqx_protocol:info(Proto)).
 
 t_init_info_2(Config) ->
@@ -65,8 +65,8 @@ t_init_info_2(Config) ->
     ?assertEqual(<<"username">>, emqx_protocol:info(username, Proto)),
     ?assertEqual(undefined, emqx_protocol:info(will_msg, Proto)),
     ?assertEqual(0, emqx_protocol:info(will_delay_interval, Proto)),
-    ?assertEqual(#{}, emqx_protocol:info(conn_props, Proto)),
-    ?assertEqual(undefined, emqx_protocol:info(topic_aliases, Proto)).
+    ?assertEqual(undefined, emqx_protocol:info(topic_aliases, Proto)),
+    ?assertEqual(#{outbound => 0, inbound => 0}, emqx_protocol:info(alias_maximum, Proto)).
 
 t_find_save_alias(Config) ->
     Proto = proplists:get_value(proto, Config),


### PR DESCRIPTION
Fix invalid QoS and protocol name, fix handling for Topic-Alias-Maximum and Maximum-Packet-Size, and send DISCONNECT Packet to client when the session is taken over.