### PR TITLE
Add default terminate function

### DIFF
--- a/src/emqx_ws_connection.erl
+++ b/src/emqx_ws_connection.erl
@@ -281,8 +281,10 @@ websocket_info(Info, State = #state{chan_state = ChanState}) ->
 terminate(SockError, _Req, #state{chan_state  = ChanState,
                                   stop_reason = Reason}) ->
     ?LOG(debug, "Terminated for ~p, sockerror: ~p", [Reason, SockError]),
-    emqx_channel:terminate(Reason, ChanState).
+    emqx_channel:terminate(Reason, ChanState);
 
+terminate(_Reason, _Req, _State) ->
+    ok.
 %%--------------------------------------------------------------------
 %% Connected callback
 


### PR DESCRIPTION
[error] Ranch listener 'mqtt:ws', connection process <0.1702.0>, stream 1 had its request process <0.1703.0> exit with reason function_clause 
this error occurred when websocket_init function never called
eg. in https://github.com/emqx/emqx/blob/master/src/emqx_ws_connection.erl#L143