### PR TITLE
Fix wrong /etc/emqx paths

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -127,18 +127,18 @@ cluster.autoclean = 5m
 ## Path to a file containing the client's private PEM-encoded key.
 ##
 ## Value: File
-## cluster.etcd.ssl.keyfile = {{ platform_etc_dir }}/certs/client-key.pem
+## cluster.etcd.ssl.keyfile = /{{ platform_etc_dir }}/emqx/certs/client-key.pem
 
 ## The path to a file containing the client's certificate.
 ##
 ## Value: File
-## cluster.etcd.ssl.certfile = {{ platform_etc_dir }}/certs/client.pem
+## cluster.etcd.ssl.certfile = /{{ platform_etc_dir }}/emqx/certs/client.pem
 
 ## Path to the file containing PEM-encoded CA certificates. The CA certificates
 ## are used during server authentication and when building the client certificate chain.
 ##
 ## Value: File
-## cluster.etcd.ssl.cacertfile = {{ platform_etc_dir }}/certs/ca.pem
+## cluster.etcd.ssl.cacertfile = /{{ platform_etc_dir }}/emqx/certs/ca.pem
 
 ##--------------------------------------------------------------------
 ## Cluster using Kubernates
@@ -268,7 +268,7 @@ node.crash_dump = {{ platform_log_dir }}/crash.dump
 ## Value: File
 ##
 ## vm.args: -ssl_dist_optfile <File>
-## node.ssl_dist_optfile = {{ platform_etc_dir }}/ssl_dist.conf
+## node.ssl_dist_optfile = /{{ platform_etc_dir }}/emqx/ssl_dist.conf
 
 ## Sets the net_kernel tick time. TickTime is specified in seconds.
 ## Notice that all communicating nodes are to have the same TickTime
@@ -456,7 +456,7 @@ acl_nomatch = allow
 ## Default ACL File.
 ##
 ## Value: File Name
-acl_file = {{ platform_etc_dir }}/acl.conf
+acl_file = /{{ platform_etc_dir }}/emqx/acl.conf
 
 ## Whether to enable ACL cache.
 ##
@@ -1168,20 +1168,20 @@ listener.ssl.external.handshake_timeout = 15s
 ## See: http://erlang.org/doc/man/ssl.html
 ##
 ## Value: File
-listener.ssl.external.keyfile = {{ platform_etc_dir }}/certs/key.pem
+listener.ssl.external.keyfile = /{{ platform_etc_dir }}/emqx/certs/key.pem
 
 ## Path to a file containing the user certificate.
 ##
 ## See: http://erlang.org/doc/man/ssl.html
 ##
 ## Value: File
-listener.ssl.external.certfile = {{ platform_etc_dir }}/certs/cert.pem
+listener.ssl.external.certfile = /{{ platform_etc_dir }}/emqx/certs/cert.pem
 
 ## Path to the file containing PEM-encoded CA certificates. The CA certificates
 ## are used during server authentication and when building the client certificate chain.
 ##
 ## Value: File
-## listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
+## listener.ssl.external.cacertfile = /{{ platform_etc_dir }}/emqx/certs/cacert.pem
 
 ## The Ephemeral Diffie-Helman key exchange is a very effective way of
 ## ensuring Forward Secrecy by exchanging a set of keys that never hit
@@ -1198,7 +1198,7 @@ listener.ssl.external.certfile = {{ platform_etc_dir }}/certs/cert.pem
 ## openssl dhparam -out dh-params.pem 2048
 ##
 ## Value: File
-## listener.ssl.external.dhfile = {{ platform_etc_dir }}/certs/dh-params.pem
+## listener.ssl.external.dhfile = /{{ platform_etc_dir }}/emqx/certs/dh-params.pem
 
 ## A server only does x509-path validation in mode verify_peer,
 ## as it then sends a certificate request to the client (this
@@ -1641,26 +1641,26 @@ listener.wss.external.verify_protocol_header = on
 ## See: listener.ssl.$name.keyfile
 ##
 ## Value: File
-listener.wss.external.keyfile = {{ platform_etc_dir }}/certs/key.pem
+listener.wss.external.keyfile = /{{ platform_etc_dir }}/emqx/certs/key.pem
 
 ## Path to a file containing the user certificate.
 ##
 ## See: listener.ssl.$name.certfile
 ##
 ## Value: File
-listener.wss.external.certfile = {{ platform_etc_dir }}/certs/cert.pem
+listener.wss.external.certfile = /{{ platform_etc_dir }}/emqx/certs/cert.pem
 
 ## Path to the file containing PEM-encoded CA certificates.
 ##
 ## See: listener.ssl.$name.cacert
 ##
 ## Value: File
-## listener.wss.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
+## listener.wss.external.cacertfile = /{{ platform_etc_dir }}/emqx/certs/cacert.pem
 
 ## See: listener.ssl.$name.dhfile
 ##
 ## Value: File
-## listener.ssl.external.dhfile = {{ platform_etc_dir }}/certs/dh-params.pem
+## listener.ssl.external.dhfile = /{{ platform_etc_dir }}/emqx/certs/dh-params.pem
 
 ## See: listener.ssl.$name.vefify
 ##
@@ -1872,7 +1872,7 @@ module.rewrite = off
 ## The etc dir for plugins' config.
 ##
 ## Value: Folder
-plugins.etc_dir = {{ platform_etc_dir }}/plugins/
+plugins.etc_dir = /{{ platform_etc_dir }}/emqx/plugins/
 
 ## The file to store loaded plugin names.
 ##


### PR DESCRIPTION
Currently, `{{ platform_etc_dir }}/certs/key.pem` turns to `etc/certs/key.pem` which is a wrong path. Need either change the `platform_etc_dir` value to emxq folder path or fix path manually everywhere (not only in `emqx.conf` like in this PR).

Please, check and make decision.