### PR TITLE
Breaking Change: Add new hooks for client and session lifecircle

### DIFF
--- a/src/emqx_access_control.erl
+++ b/src/emqx_access_control.erl
@@ -24,6 +24,8 @@
         , reload_acl/0
         ]).
 
+-import(emqx_hooks, [run_fold/3]).
+
 -type(result() :: #{auth_result := emqx_types:auth_result(),
                     anonymous := boolean()
                    }).
@@ -34,9 +36,9 @@
 
 -spec(authenticate(emqx_types:clientinfo()) -> {ok, result()} | {error, term()}).
 authenticate(ClientInfo = #{zone := Zone}) ->
-    case emqx_hooks:run_fold('client.authenticate', [ClientInfo], default_auth_result(Zone)) of
+    case run_fold('client.authenticate', [ClientInfo], default_auth_result(Zone)) of
         Result = #{auth_result := success} ->
-	        {ok, Result};
+            {ok, Result};
 	    Result ->
             {error, maps:get(auth_result, Result, unknown_error)}
     end.
@@ -61,7 +63,7 @@ check_acl_cache(ClientInfo, PubSub, Topic) ->
 
 do_check_acl(ClientInfo = #{zone := Zone}, PubSub, Topic) ->
     Default = emqx_zone:get_env(Zone, acl_nomatch, deny),
-    case emqx_hooks:run_fold('client.check_acl', [ClientInfo, PubSub, Topic], Default) of
+    case run_fold('client.check_acl', [ClientInfo, PubSub, Topic], Default) of
         allow  -> allow;
         _Other -> deny
     end.

--- a/src/emqx_broker.erl
+++ b/src/emqx_broker.erl
@@ -230,7 +230,7 @@ delivery(Msg) -> #delivery{sender = self(), message = Msg}.
 -spec(route([emqx_types:route_entry()], emqx_types:delivery())
       -> emqx_types:publish_result()).
 route([], #delivery{message = Msg}) ->
-    emqx_hooks:run('message.dropped', [#{node => node()}, Msg]),
+    ok = emqx_hooks:run('message.dropped', [Msg, #{node => node()}, no_subscribers]),
     ok = inc_dropped_cnt(Msg),
     [];
 
@@ -282,8 +282,8 @@ forward(Node, To, Delivery, sync) ->
 -spec(dispatch(emqx_topic:topic(), emqx_types:delivery()) -> emqx_types:deliver_result()).
 dispatch(Topic, #delivery{message = Msg}) ->
     case subscribers(Topic) of
-        [] -> emqx_hooks:run('message.dropped', [#{node => node()}, Msg]),
-              _ = inc_dropped_cnt(Topic),
+        [] -> ok = emqx_hooks:run('message.dropped', [Msg, #{node => node()}, no_subscribers]),
+              ok = inc_dropped_cnt(Topic),
               {error, no_subscribers};
         [Sub] -> %% optimize?
             dispatch(Sub, Topic, Msg);

--- a/src/emqx_mod_presence.erl
+++ b/src/emqx_mod_presence.erl
@@ -28,12 +28,12 @@
         , unload/1
         ]).
 
--export([ on_client_connected/4
+-export([ on_client_connected/3
         , on_client_disconnected/4
         ]).
 
 -ifdef(TEST).
--export([ reason/1 ]).
+-export([reason/1]).
 -endif.
 
 load(Env) ->
@@ -44,26 +44,12 @@ unload(_Env) ->
     emqx_hooks:del('client.connected',    {?MODULE, on_client_connected}),
     emqx_hooks:del('client.disconnected', {?MODULE, on_client_disconnected}).
 
-on_client_connected(ClientInfo, ConnAck, ConnInfo, Env) ->
-    #{peerhost := PeerHost} = ClientInfo,
-    #{clean_start := CleanStart,
-      proto_name := ProtoName,
-      proto_ver := ProtoVer,
-      keepalive := Keepalive,
-      expiry_interval := ExpiryInterval} = ConnInfo,
-    ClientId = clientid(ClientInfo, ConnInfo),
-    Username = username(ClientInfo, ConnInfo),
-    Presence = #{clientid => ClientId,
-                 username => Username,
-                 ipaddress => ntoa(PeerHost),
-                 proto_name => ProtoName,
-                 proto_ver => ProtoVer,
-                 keepalive => Keepalive,
-                 connack => ConnAck,
-                 clean_start => CleanStart,
-                 expiry_interval => ExpiryInterval,
-                 ts => erlang:system_time(millisecond)
-                },
+%%--------------------------------------------------------------------
+%% Callbacks
+%%--------------------------------------------------------------------
+
+on_client_connected(ClientInfo = #{clientid := ClientId}, ConnInfo, Env) ->
+    Presence = connected_presence(ClientInfo, ConnInfo),
     case emqx_json:safe_encode(Presence) of
         {ok, Payload} ->
             emqx_broker:safe_publish(
@@ -72,12 +58,12 @@ on_client_connected(ClientInfo, ConnAck, ConnInfo, Env) ->
             ?LOG(error, "Failed to encode 'connected' presence: ~p", [Presence])
     end.
 
-on_client_disconnected(ClientInfo, Reason, ConnInfo, Env) ->
-    ClientId = clientid(ClientInfo, ConnInfo),
-    Username = username(ClientInfo, ConnInfo),
+on_client_disconnected(_ClientInfo = #{clientid := ClientId, username := Username},
+                       Reason, _ConnInfo = #{disconnected_at := DisconnectedAt}, Env) ->
     Presence = #{clientid => ClientId,
                  username => Username,
                  reason => reason(Reason),
+                 disconnected_at => DisconnectedAt,
                  ts => erlang:system_time(millisecond)
                 },
     case emqx_json:safe_encode(Presence) of
@@ -88,11 +74,35 @@ on_client_disconnected(ClientInfo, Reason, ConnInfo, Env) ->
             ?LOG(error, "Failed to encode 'disconnected' presence: ~p", [Presence])
     end.
 
-clientid(#{clientid := undefined}, #{clientid := ClientId}) -> ClientId;
-clientid(#{clientid := ClientId}, _ConnInfo) -> ClientId.
+%%--------------------------------------------------------------------
+%% Helper functions
+%%--------------------------------------------------------------------
 
-username(#{username := undefined}, #{username := Username}) -> Username;
-username(#{username := Username}, _ConnInfo) -> Username.
+connected_presence(#{peerhost := PeerHost,
+                     sockport := SockPort,
+                     clientid := ClientId,
+                     username := Username
+                    },
+                   #{clean_start := CleanStart,
+                     proto_name := ProtoName,
+                     proto_ver := ProtoVer,
+                     keepalive := Keepalive,
+                     connected_at := ConnectedAt,
+                     expiry_interval := ExpiryInterval
+                    }) ->
+    #{clientid => ClientId,
+      username => Username,
+      ipaddress => ntoa(PeerHost),
+      sockport => SockPort,
+      proto_name => ProtoName,
+      proto_ver => ProtoVer,
+      keepalive => Keepalive,
+      connack => 0, %% Deprecated?
+      clean_start => CleanStart,
+      expiry_interval => ExpiryInterval,
+      connected_at => ConnectedAt,
+      ts => erlang:system_time(millisecond)
+     }.
 
 make_msg(QoS, Topic, Payload) ->
     emqx_message:set_flag(
@@ -106,6 +116,7 @@ topic(disconnected, ClientId) ->
 
 qos(Env) -> proplists:get_value(qos, Env, 0).
 
+-compile({inline, [reason/1]}).
 reason(Reason) when is_atom(Reason) -> Reason;
 reason({shutdown, Reason}) when is_atom(Reason) -> Reason;
 reason({Error, _}) when is_atom(Error) -> Error;

--- a/src/emqx_mod_subscription.erl
+++ b/src/emqx_mod_subscription.erl
@@ -27,7 +27,7 @@
         ]).
 
 %% APIs
--export([on_client_connected/4]).
+-export([on_client_connected/3]).
 
 %%--------------------------------------------------------------------
 %% Load/Unload Hook
@@ -36,8 +36,7 @@
 load(Topics) ->
     emqx_hooks:add('client.connected', {?MODULE, on_client_connected, [Topics]}).
 
-on_client_connected(#{clientid := ClientId,
-                      username := Username}, ?RC_SUCCESS, _ConnInfo, Topics) ->
+on_client_connected(#{clientid := ClientId, username := Username}, _ConnInfo, Topics) ->
     Replace = fun(Topic) ->
                       rep(<<"%u">>, Username, rep(<<"%c">>, ClientId, Topic))
               end,
@@ -47,9 +46,9 @@ on_client_connected(#{clientid := ClientId,
 unload(_) ->
     emqx_hooks:del('client.connected', {?MODULE, on_client_connected}).
 
-%%------------------------------------------------------------------------------
+%%--------------------------------------------------------------------
 %% Internal functions
-%%------------------------------------------------------------------------------
+%%--------------------------------------------------------------------
 
 rep(<<"%c">>, ClientId, Topic) ->
     emqx_topic:feed_var(<<"%c">>, ClientId, Topic);

--- a/test/emqx_connection_SUITE.erl
+++ b/test/emqx_connection_SUITE.erl
@@ -44,6 +44,10 @@ init_per_suite(Config) ->
     ok = meck:expect(emqx_metrics, inc, fun(_, _) -> ok end),
     ok = meck:expect(emqx_metrics, inc_recv, fun(_) -> ok end),
     ok = meck:expect(emqx_metrics, inc_sent, fun(_) -> ok end),
+    %% Meck Hooks
+    ok = meck:new(emqx_hooks, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_hooks, run, fun(_Hook, _Args) -> ok end),
+    ok = meck:expect(emqx_hooks, run_fold, fun(_Hook, _Args, Acc) -> {ok, Acc} end),
     Config.
 
 end_per_suite(_Config) ->

--- a/test/emqx_session_SUITE.erl
+++ b/test/emqx_session_SUITE.erl
@@ -30,7 +30,6 @@ all() -> emqx_ct:all(?MODULE).
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    %% Broker
     ok = meck:new([emqx_hooks, emqx_metrics, emqx_broker],
                   [passthrough, no_history, no_link]),
     ok = meck:expect(emqx_metrics, inc, fun(_) -> ok end),
@@ -329,7 +328,7 @@ t_takeover(_) ->
 t_resume(_) ->
     ok = meck:expect(emqx_broker, subscribe, fun(_, _, _) -> ok end),
     Session = session(#{subscriptions => #{<<"t">> => ?DEFAULT_SUBOPTS}}),
-    ok = emqx_session:resume(<<"clientid">>, Session).
+    ok = emqx_session:resume(#{clientid => <<"clientid">>}, Session).
 
 t_replay(_) ->
     Delivers = [delivery(?QOS_1, <<"t1">>), delivery(?QOS_2, <<"t2">>)],


### PR DESCRIPTION
## Hooks for Client

- client.connect: MQTT CONNECT Packet Received
- client.connack: MQTT CONNACK Packet Sent
- client.connected: The MQTT Client is connected
- client.disconnected: The MQTT Client is disconnected
- client.authenticate: Authenticate the MQTT Client
- client.check_acl: Check Pub/Sub ACL
- client.subscribe: MQTT SUBSCRIBE Packet Received
- client.unsubscribe: MQTT UNSUBSCRIBE Packet Received

## Hooks for Session

session.created: A new session is created
session.subscribed: After session subscribed a topic
session.unsubscribed: After session unsubscribed a topic
session.resumed: A session is resumed
session.takeovered: A session is takeovered
session.discarded: A session is discarded
session.terminated:  A session is terminated

## Hooks for Message

message.publish:  A message is published
message.delivered: A message is delivered
message.acked: A messaeg is acked
message.dropped: A message is dropped due to no subscribers