### PR TITLE
Change global_gc to major mode

### DIFF
--- a/src/emqx_global_gc.erl
+++ b/src/emqx_global_gc.erl
@@ -94,7 +94,7 @@ ensure_timer(State) ->
 run_gc() -> lists:foreach(fun do_gc/1, processes()).
 
 do_gc(Pid) ->
-    is_waiting(Pid) andalso garbage_collect(Pid, [{type, 'minor'}]).
+    is_waiting(Pid) andalso garbage_collect(Pid).
 
 -compile({inline, [is_waiting/1]}).
 is_waiting(Pid) ->

--- a/test/mqtt_protocol_v5_SUITE.erl
+++ b/test/mqtt_protocol_v5_SUITE.erl
@@ -365,6 +365,7 @@ t_connect_will_delay_interval(_) ->
 
 %% [MQTT-3.1.4-3]
 t_connect_duplicate_clientid(_) ->
+    process_flag(trap_exit, true),
     {ok, Client1} = emqtt:start_link([
                                         {clientid, <<"t_connect_duplicate_clientid">>},
                                         {proto_ver, v5}
@@ -375,7 +376,12 @@ t_connect_duplicate_clientid(_) ->
                                         {proto_ver, v5}
                                         ]),
     {ok, _} = emqtt:connect(Client2),
-    ?assertEqual(142, receive_disconnect_reasoncode()).
+    ?assertEqual(142, receive_disconnect_reasoncode()),
+    waiting_client_process_exit(Client1),
+
+    ok = emqtt:disconnect(Client2),
+    waiting_client_process_exit(Client2),
+    process_flag(trap_exit, false).
 
 %%--------------------------------------------------------------------
 %% Connack


### PR DESCRIPTION
According to erlang docs:
```
{type, 'major' | 'minor'}
    Triggers garbage collection of requested type. Default value is 'major', 
    which would trigger a fullsweep GC. The option 'minor' is considered
    a hint and may lead to either minor or major GC run.
```

The `major` mode is better than `minor` for a lots of `SSL Connection`

