### PR TITLE
chore(deps): upgrade esockd to 5.6.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -4,7 +4,7 @@
  [{gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}},
   {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.4"}}},
   {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.7.1"}}},
-  {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.6.1"}}},
+  {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.6.2"}}},
   {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.7.3"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.4.1"}}},
   {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.0.0"}}}


### PR DESCRIPTION
esockd: avoid the `ssl_close_timeout` send to channel