### PR TITLE
4.2 beta.2 dummy topics

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -685,6 +685,19 @@ zone.external.idle_timeout = 15s
 ## Value: Flag
 zone.external.enable_acl = on
 
+## Enable Dummy-Topics.
+##
+## Dummy topics are topics that will not be delivered to subscribers,
+## but messages on such topics can still be handled by the emqx plugins.
+##
+## It is useful when we want to handle the messages on some specific
+## topics (e.g. using rule engine) but don't want them being delivered
+## to the subscribers. As a use case, dummy topics can be used as
+## message endpoints only for collecting data to databases.
+##
+## Value: Flag
+zone.external.enable_dummy_topics = off
+
 ## Enable ban check.
 ##
 ## Value: Flag

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -828,6 +828,12 @@ end}.
   {datatype, {enum, [allow, deny]}}
 ]}.
 
+%%
+{mapping, "zone.$name.enable_dummy_topics", "emqx.zones", [
+  {default, off},
+  {datatype, flag}
+]}.
+
 %% @doc Enable ACL check.
 {mapping, "zone.$name.enable_acl", "emqx.zones", [
   {default, off},

--- a/src/emqx.erl
+++ b/src/emqx.erl
@@ -79,6 +79,7 @@ start() ->
     %% Check OS
     %% Check VM
     %% Check Mnesia
+    io:format("emqx starting..."),
     application:ensure_all_started(?APP).
 
 -spec(restart(string()) -> ok).

--- a/src/emqx_channel.erl
+++ b/src/emqx_channel.erl
@@ -504,8 +504,9 @@ packet_to_message(Packet, #channel{
               username => Username,
               peerhost => PeerHost})).
 
-do_publish(_PacketId, Msg = #message{qos = ?QOS_0}, Channel) ->
-    Result = emqx_broker:publish(Msg),
+do_publish(_PacketId, Msg = #message{qos = ?QOS_0}, Channel = #channel{
+                     clientinfo = #{zone := Zone}}) ->
+    Result = emqx_broker:publish(emqx_message:set_header(zone, Zone, Msg)),
     NChannel = ensure_quota(Result, Channel),
     {ok, NChannel};
 

--- a/src/emqx_cm_sup.erl
+++ b/src/emqx_cm_sup.erl
@@ -32,6 +32,12 @@ init([]) ->
                shutdown => 1000,
                type => worker,
                modules => [emqx_banned]},
+    DummyTopics = #{id => dummy_topics,
+                    start => {emqx_dummy_topics, start_link, []},
+                    restart => permanent,
+                    shutdown => 1000,
+                    type => worker,
+                    modules => [emqx_dummy_topics]},
     Flapping = #{id => flapping,
                  start => {emqx_flapping, start_link, []},
                  restart => permanent,
@@ -66,5 +72,5 @@ init([]) ->
                  intensity => 100,
                  period => 10
                 },
-    {ok, {SupFlags, [Banned, Flapping, Locker, Registry, Manager]}}.
+    {ok, {SupFlags, [Banned, DummyTopics, Flapping, Locker, Registry, Manager]}}.
 

--- a/src/emqx_dummy_topics.erl
+++ b/src/emqx_dummy_topics.erl
@@ -1,0 +1,212 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_dummy_topics).
+
+-behaviour(gen_server).
+
+%% Mnesia bootstrap
+-export([mnesia/1]).
+
+-boot_mnesia({mnesia, [boot]}).
+-copy_mnesia({mnesia, [copy]}).
+
+%% APIs
+-export([ match/1
+        , add/1
+        , del/1
+        , list/0
+        , has/1
+        ]).
+
+%% API functions
+-export([start_link/0]).
+
+%% gen_server callbacks
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-record(state, {}).
+
+-record(dummy_topics, {
+    topic :: emqx_types:topic(),
+    created_at :: integer()
+}).
+
+-define(TIRE, {?MODULE, trie}).
+-define(TOPICS, ?MODULE).
+
+%%--------------------------------------------------------------------
+%% Mnesia bootstrap
+%%--------------------------------------------------------------------
+
+mnesia(boot) ->
+    ok = ekka_mnesia:create_table(?TOPICS, [
+                {type, set},
+                {disc_copies, [node()]},
+                {local_content, true},
+                {record_name, dummy_topics},
+                {attributes, record_info(fields, dummy_topics)},
+                {storage_properties, [{ets, [{read_concurrency, true}]}]}
+            ]);
+
+mnesia(copy) ->
+    ok = ekka_mnesia:copy_table(?TOPICS).
+
+%%%===================================================================
+%%% API functions
+%%%===================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec match(emqx_types:topic()) -> boolean().
+match(Topic) ->
+    trie_match(Topic, get_trie()).
+
+-spec add(emqx_types:topic()) -> ok.
+add(Topic) ->
+    gen_server:cast(?MODULE, {add_topic, Topic}).
+
+-spec del(emqx_types:topic()) -> ok.
+del(Topic) ->
+    gen_server:cast(?MODULE, {del_topic, Topic}).
+
+-spec list() -> [emqx_types:topic()].
+list() ->
+    [#{topic => Topic, created_at => Timestamp}
+     || #dummy_topics{topic = Topic, created_at = Timestamp}
+        <- ets:tab2list(?TOPICS)].
+
+-spec has(emqx_types:topic()) -> boolean().
+has(Topic) ->
+    ets:member(?TOPICS, Topic).
+
+%%%===================================================================
+%%% gen_server callbacks
+%%%===================================================================
+
+init([]) ->
+    ok = init_trie(),
+    {ok, #state{}}.
+
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({add_topic, Topic}, State) ->
+    ok = mnesia:dirty_write(?TOPICS,
+            #dummy_topics{
+                topic = Topic,
+                created_at = erlang:system_time(millisecond)
+            }),
+    ok = set_trie(trie_add(Topic, get_trie())),
+    {noreply, State};
+
+handle_cast({del_topic, Topic}, State) ->
+    true = mnesia:dirty_delete(?TOPICS, Topic),
+    ok = set_trie(trie_del(Topic, get_trie())),
+    {noreply, State};
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%%===================================================================
+%%% Trie
+%%%===================================================================
+
+init_trie() ->
+    set_trie(
+        lists:foldl(fun(#dummy_topics{topic = Topic}, Trie) ->
+                trie_add(Topic, Trie)
+            end, new_trie(), ets:tab2list(?TOPICS))).
+
+new_trie() ->
+    #{counters => nil}.
+
+get_trie() ->
+    persistent_term:get(?TIRE).
+
+set_trie(Trie) ->
+    persistent_term:put(?TIRE, Trie).
+
+trie_add(Topic, Trie) ->
+    do_trie_add(emqx_topic:words(Topic), Trie).
+
+do_trie_add([W | Words], Trie = #{counters := Cnt}) ->
+    SubTrie = maps:get(W, Trie, new_trie()),
+    Trie#{W => do_trie_add(Words, SubTrie),
+          counters => incr(W, Cnt)};
+do_trie_add([], Trie) ->
+    Trie.
+
+trie_del(Topic, Trie) ->
+    do_trie_del(emqx_topic:words(Topic), Trie).
+
+do_trie_del(_Words, Trie = #{counters := nil}) ->
+    Trie;
+do_trie_del([W | Words], Trie = #{counters := Cnt}) when is_map(Cnt) ->
+    SubTrie = maps:get(W, Trie, new_trie()),
+    case maps:get(W, Cnt, 1) of
+        1 ->
+            Trie2 = maps:remove(W, Trie),
+            Trie2#{counters => maps:remove(W, Cnt)};
+        N ->
+            Trie#{W => do_trie_del(Words, SubTrie),
+                  counters => N - 1}
+    end;
+do_trie_del([], Trie) ->
+    Trie.
+
+trie_match(_Topic, #{counters := nil}) ->
+    false;
+trie_match(Topic, Trie) ->
+    do_trie_match(emqx_topic:words(Topic), Trie).
+
+do_trie_match([], #{counters := nil}) ->
+    true;
+do_trie_match([], #{'#' := _}) ->
+    true;
+do_trie_match([], _Trie) ->
+    false;
+do_trie_match(_Words, #{counters := nil}) ->
+    false;
+do_trie_match([W | Words], Trie = #{counters := Cnt}) when is_map(Cnt) ->
+    case maps:find(W, Trie) of
+        error -> false;
+        {ok, SubTrie} ->
+            do_trie_match(Words, SubTrie)
+    end.
+
+%%%===================================================================
+%%% Helper Functions
+%%%===================================================================
+
+incr(Word, nil) -> #{Word => 1};
+incr(Word, Counters) when is_map(Counters) ->
+    Counters#{Word => maps:get(Word, Counters, 0) + 1}.

--- a/src/emqx_zone.erl
+++ b/src/emqx_zone.erl
@@ -37,6 +37,7 @@
           , stats_timer/1
           , enable_stats/1
           , enable_acl/1
+          , enable_dummy_topics/1
           , enable_ban/1
           , enable_flapping_detect/1
           , ignore_loop_deliver/1
@@ -68,6 +69,7 @@
         , stats_timer/1
         , enable_stats/1
         , enable_acl/1
+        , enable_dummy_topics/1
         , enable_ban/1
         , enable_flapping_detect/1
         , ignore_loop_deliver/1
@@ -178,6 +180,10 @@ enable_stats(Zone) ->
 -spec(enable_acl(zone()) -> boolean()).
 enable_acl(Zone) ->
     get_env(Zone, enable_acl, true).
+
+-spec(enable_dummy_topics(zone()) -> boolean()).
+enable_dummy_topics(Zone) ->
+    get_env(Zone, enable_dummy_topics, false).
 
 -spec(enable_ban(zone()) -> boolean()).
 enable_ban(Zone) ->

--- a/test/emqx_dummy_topics_SUITE.erl
+++ b/test/emqx_dummy_topics_SUITE.erl
@@ -1,0 +1,119 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_dummy_topics_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("emqx.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+all() -> emqx_ct:all(?MODULE).
+
+init_per_suite(Config) ->
+    ok = application:load(emqx),
+    ok = ekka:start(),
+    %% for coverage
+    ok = emqx_dummy_topics:mnesia(boot),
+    ok = emqx_dummy_topics:mnesia(copy),
+    Config.
+
+end_per_suite(_Config) ->
+    ekka:stop(),
+    ekka_mnesia:ensure_stopped(),
+    ekka_mnesia:delete_schema().
+
+init_per_testcase(_, Config) ->
+    {ok, _} = emqx_dummy_topics:start_link(),
+    Config.
+
+end_per_testcase(_, Config) ->
+    ok = emqx_dummy_topics:stop(),
+    Config.
+
+t_topic_add_has_del_list(_) ->
+    ?assertEqual([], emqx_dummy_topics:list()),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"t/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"t/2">>)),
+    ct:sleep(100),
+    ?assert(emqx_dummy_topics:has(<<"t/1">>)),
+    ?assert(emqx_dummy_topics:has(<<"t/2">>)),
+    ?assertEqual(2,
+        length([Elm || Elm = #{topic := Topic, created_at := CreatedAt}
+                <- emqx_dummy_topics:list(),
+                 is_binary(Topic), is_integer(CreatedAt)])),
+    ?assertEqual(ok, emqx_dummy_topics:del(<<"t/1">>)),
+    ct:sleep(100),
+    ?assertNot(emqx_dummy_topics:has(<<"t/1">>)),
+    ?assert(emqx_dummy_topics:has(<<"t/2">>)),
+    ?assertEqual(1,
+        length([Elm || Elm = #{topic := Topic, created_at := CreatedAt}
+                <- emqx_dummy_topics:list(),
+                 is_binary(Topic), is_integer(CreatedAt)])).
+
+t_topic_match_1(_) ->
+    ?assertEqual([], emqx_dummy_topics:list()),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"a/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"a/1/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"a/1/1/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"a/2">>)),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"b/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:add(<<"a/1">>)), %% duplicated
+    ?assertEqual(5, length(emqx_dummy_topics:list())),
+    ?assert(emqx_dummy_topics:match(<<"a/1">>)),
+    ?assert(emqx_dummy_topics:match(<<"a/1/1">>)),
+    ?assert(emqx_dummy_topics:match(<<"a/1/1/1">>)),
+    ?assert(emqx_dummy_topics:match(<<"a/2">>)),
+    ?assert(emqx_dummy_topics:match(<<"b/1">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"a/3">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"b/2">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"t">>)),
+    ?assertEqual(ok, emqx_dummy_topics:del(<<"a/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:del(<<"a/1/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:del(<<"a/1/1/1">>)),
+    ?assertEqual(ok, emqx_dummy_topics:del(<<"a/2">>)),
+    ?assertEqual(ok, emqx_dummy_topics:del(<<"b/1">>)),
+    ?assertEqual(0, length(emqx_dummy_topics:list())),
+    ?assertNot(emqx_dummy_topics:match(<<"a/1">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"a/1/1">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"a/1/1/1">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"a/2">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"b/1">>)).
+
+t_topic_match_2(_) ->
+    ?assertEqual([], emqx_dummy_topics:list()),
+    ok = emqx_dummy_topics:add(<<"#">>),
+    ct:pal("------- ~p~n", [emqx_dummy_topics:get_trie()]),
+    ?assertEqual(1, length(emqx_dummy_topics:list())),
+    ?assert(emqx_dummy_topics:match(<<>>)),
+    ok = emqx_dummy_topics:del(<<"#">>),
+    ?assertEqual(0, length(emqx_dummy_topics:list())).
+
+t_topic_match_3(_) ->
+    ?assertEqual([], emqx_dummy_topics:list()),
+    ok = emqx_dummy_topics:add(<<"#">>),
+    ok = emqx_dummy_topics:add(<<"+">>),
+    ct:pal("------- ~p~n", [emqx_dummy_topics:get_trie()]),
+    ?assertEqual(2, length(emqx_dummy_topics:list())),
+    ?assertNot(emqx_dummy_topics:match(<<"$">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"$ab">>)),
+    ?assertNot(emqx_dummy_topics:match(<<"$a/b">>)),
+    ?assert(emqx_dummy_topics:match(<<"/">>)),
+    ?assert(emqx_dummy_topics:match(<<"a/b">>)),
+    ok = emqx_dummy_topics:del(<<"#">>),
+    ok = emqx_dummy_topics:del(<<"+">>),
+    ?assertEqual(0, length(emqx_dummy_topics:list())).

--- a/test/props/prop_emqx_dummy_topics.erl
+++ b/test/props/prop_emqx_dummy_topics.erl
@@ -1,0 +1,94 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+
+-module(prop_emqx_dummy_topics).
+
+-include_lib("proper/include/proper.hrl").
+
+-export([prop_dummy_topic_match/0]).
+
+
+-define(ALL(Vars, Types, Exprs),
+        ?SETUP(fun() ->
+            State = do_setup(),
+            fun() -> do_teardown(State) end
+         end, ?FORALL(Vars, Types, Exprs))).
+
+%%--------------------------------------------------------------------
+%% Properties
+%%--------------------------------------------------------------------
+
+prop_dummy_topic_match() ->
+    ?ALL({Topic, Filter},
+         {topic(), topic_filter()},
+         %% '#' should always be the last level
+         %% but I don't want to comply with that
+         case re:run(Filter, "#/.*") of
+            nomatch ->
+                ok = emqx_dummy_topics:add(Filter),
+                Expected = emqx_topic:match(Topic, Filter),
+                Got = emqx_dummy_topics:match(Topic),
+                %io:format("topic: ~p, fileter: ~p~nres: ~p, ~p~n",
+                %    [Topic, Filter, Expected, Got]),
+                ok = emqx_dummy_topics:del(Filter),
+                Expected =:= Got;
+            {match, _} ->
+                true
+         end).
+
+%%--------------------------------------------------------------------
+%% Helper
+%%--------------------------------------------------------------------
+
+do_setup() ->
+    ok = ekka:start(),
+    %% for coverage
+    ok = emqx_dummy_topics:mnesia(boot),
+    ok = emqx_dummy_topics:mnesia(copy),
+    ok = emqx_logger:set_log_level(emergency),
+    {ok, _} = emqx_dummy_topics:start_link().
+
+do_teardown(_) ->
+    ok = emqx_dummy_topics:stop(),
+    ekka:stop(),
+    ekka_mnesia:ensure_stopped(),
+    ok = emqx_logger:set_log_level(error).
+
+%%--------------------------------------------------------------------
+%% Generator
+%%--------------------------------------------------------------------
+topic_filter() ->
+    CharSet = list(oneof([
+            range(48, 57), %% [0-9]
+            range(65, 90), %% [A-Z]
+            range(97, 122), %% [a-z]
+            $/,
+            $$,
+            $#,
+            $+
+          ])),
+    ?LET(Chars, CharSet, iolist_to_binary(Chars)).
+
+topic() ->
+    CharSet = list(oneof([
+            range(48, 57), %% [0-9]
+            range(65, 90), %% [A-Z]
+            range(97, 122), %% [a-z]
+            $/,
+            $$
+          ])),
+    ?LET(Chars, CharSet, iolist_to_binary(Chars)).


### PR DESCRIPTION
Dummy topics are topics that will not be delivered to subscribers, but messages on such topics can still be handled by the emqx plugins.

It is useful when we want to handle the messages on some specific topics (e.g. using rule engine) but don't want them being delivered to the subscribers. As a use case, dummy topics can be used as message endpoints only for collecting data to databases.
