### PR TITLE
fix(ws): take ws_cookie to clientinfo

### DIFF
--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -5,8 +5,11 @@
         4 -> % arch_32
             {1000, cuttlefish_bytesize:parse("32MB")}
     end,
-{"4.2.1",
+{"4.2.2",
   [
+    {"4.2.1", [
+      {load_module, emqx_channel, brutal_purge, soft_purge, []}
+    ]},
     {"4.2.0", [
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
       {apply, {application, set_env,
@@ -16,6 +19,9 @@
     ]}
   ],
   [
+    {"4.2.1", [
+      {load_module, emqx_channel, brutal_purge, soft_purge, []}
+    ]},
     {"4.2.0", [
       {load_module, emqx_channel, brutal_purge, soft_purge, []}
     ]}

--- a/src/emqx_channel.erl
+++ b/src/emqx_channel.erl
@@ -183,8 +183,9 @@ init(ConnInfo = #{peername := {PeerHost, _Port},
                      is_bridge    => false,
                      is_superuser => false
                     }, Options),
-    #channel{conninfo   = ConnInfo,
-             clientinfo = ClientInfo,
+    {NClientInfo, NConnInfo} = take_ws_cookie(ClientInfo, ConnInfo),
+    #channel{conninfo   = NConnInfo,
+             clientinfo = NClientInfo,
              topic_aliases = #{inbound => #{},
                                outbound => #{}
                               },
@@ -212,6 +213,14 @@ setting_peercert_infos(Peercert, ClientInfo, Options) ->
                    _   -> undefined
                end,
     ClientInfo#{username => Username, dn => DN, cn => CN}.
+
+take_ws_cookie(ClientInfo, ConnInfo) ->
+    case maps:take(ws_cookie, ConnInfo) of
+        {WsCookie, NConnInfo} ->
+            {ClientInfo#{ws_cookie => WsCookie}, NConnInfo};
+        _ ->
+            {ClientInfo, ConnInfo}
+    end.
 
 %%--------------------------------------------------------------------
 %% Handle incoming packet

--- a/test/emqx_channel_SUITE.erl
+++ b/test/emqx_channel_SUITE.erl
@@ -687,6 +687,18 @@ t_terminate(_) ->
     ok = emqx_channel:terminate(sock_error, channel(#{conn_state => connected})),
     ok = emqx_channel:terminate({shutdown, kicked}, channel(#{conn_state => connected})).
 
+t_ws_cookie_init(_) ->
+    WsCookie = [{<<"session_id">>, <<"xyz">>}],
+    ConnInfo = #{socktype => ws,
+                 peername => {{127,0,0,1}, 3456},
+                 sockname => {{127,0,0,1}, 1883},
+                 peercert => nossl,
+                 conn_mod => emqx_ws_connection,
+                 ws_cookie => WsCookie
+                },
+    Channel = emqx_channel:init(ConnInfo, [{zone, zone}]),
+    ?assertMatch(#{ws_cookie := WsCookie}, emqx_channel:info(clientinfo, Channel)).
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------


### PR DESCRIPTION
In the emqx_types.erl, we defined the ws_cookie attribute for the ws client, but didn't set it:

https://github.com/emqx/emqx/blob/fa31062a5ed673ddbd0ffcdd4b829c3dba2a911d/src/emqx_types.erl#L138



see: https://github.com/emqx/emqx/issues/3747#issuecomment-702268570