### PR TITLE
fix(json): fix decoding/encoding empty object error

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
  [{gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}},
   {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
   {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.7.1"}}},
-  {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.3"}}},
+  {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}},
   {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.7.4"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.0"}}},
   {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.0.0"}}}

--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -1,3 +1,4 @@
+%% -*-: erlang -*-
 {DefaultLen, DefaultSize} =
     case WordSize = erlang:system_info(wordsize) of
         8 -> % arch_64
@@ -9,10 +10,13 @@
   [
     {"4.2.1", [
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
-      {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []}
+      {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
+      {load_module, emqx_json, brutal_purge, soft_purge, []}
     ]},
     {"4.2.0", [
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
+      {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
+      {load_module, emqx_json, brutal_purge, soft_purge, []},
       {apply, {application, set_env,
                 [emqx, force_shutdown_policy,
                  #{message_queue_len => DefaultLen,
@@ -22,10 +26,13 @@
   [
     {"4.2.1", [
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
-      {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []}
+      {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
+      {load_module, emqx_json, brutal_purge, soft_purge, []}
     ]},
     {"4.2.0", [
-      {load_module, emqx_channel, brutal_purge, soft_purge, []}
+      {load_module, emqx_channel, brutal_purge, soft_purge, []},
+      {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
+      {load_module, emqx_json, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/src/emqx_json.erl
+++ b/src/emqx_json.erl
@@ -103,6 +103,8 @@ safe_decode(Json, Opts) ->
           , from_ejson/1
           ]}).
 
+to_ejson([{}]) ->
+    {[]};
 to_ejson([{_, _}|_] = L) ->
     {[{K, to_ejson(V)} || {K, V} <- L ]};
 to_ejson(L) when is_list(L) ->
@@ -111,6 +113,8 @@ to_ejson(T) -> T.
 
 from_ejson(L) when is_list(L) ->
     [from_ejson(E) || E <- L];
+from_ejson({[]}) ->
+    [{}];
 from_ejson({L}) ->
     [{Name, from_ejson(Value)} || {Name, Value} <- L];
 from_ejson(T) -> T.
@@ -118,4 +122,3 @@ from_ejson(T) -> T.
 to_binary(B) when is_binary(B) -> B;
 to_binary(L) when is_list(L) ->
     iolist_to_binary(L).
-


### PR DESCRIPTION
In the previous version (v4.0 - v4.2.1), there is an ambiguity here, and it is not possible to distinguish between empty objects and arrays:

``` erlang
1> emqx_json:decode("{\"k\": {}}").
[{<<"k">>,[]}]

2> emqx_json:decode("{\"k\": []}").
[{<<"k">>,[]}]
```

After this fix:

``` erlang
1> emqx_json:decode("{\"k\": {}}").
[{<<"k">>,[{}]}]
```