### PR TITLE
feat(emqx_metrics): add new functions to count message received

### DIFF
--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -6,14 +6,19 @@
         4 -> % arch_32
             {1000, cuttlefish_bytesize:parse("32MB")}
     end,
-{"4.2.2",
+{"4.2.3",
   [
+    {"4.2.2", [
+      {load_module, emqx_metrics, brutal_purge, soft_purge, []}
+    ]},
     {"4.2.1", [
+      {load_module, emqx_metrics, brutal_purge, soft_purge, []},
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
       {load_module, emqx_json, brutal_purge, soft_purge, []}
     ]},
     {"4.2.0", [
+      {load_module, emqx_metrics, brutal_purge, soft_purge, []},
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
       {load_module, emqx_json, brutal_purge, soft_purge, []},
@@ -24,12 +29,17 @@
     ]}
   ],
   [
+    {"4.2.2", [
+      {load_module, emqx_metrics, brutal_purge, soft_purge, []}
+    ]},
     {"4.2.1", [
+      {load_module, emqx_metrics, brutal_purge, soft_purge, []}
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
       {load_module, emqx_json, brutal_purge, soft_purge, []}
     ]},
     {"4.2.0", [
+      {load_module, emqx_metrics, brutal_purge, soft_purge, []}
       {load_module, emqx_channel, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_topic_metrics, brutal_purge, soft_purge, []},
       {load_module, emqx_json, brutal_purge, soft_purge, []}

--- a/src/emqx_metrics.erl
+++ b/src/emqx_metrics.erl
@@ -21,6 +21,7 @@
 -include("logger.hrl").
 -include("types.hrl").
 -include("emqx_mqtt.hrl").
+-include("emqx.hrl").
 
 -logger_header("[Metrics]").
 
@@ -49,7 +50,8 @@
         ]).
 
 %% Inc received/sent metrics
--export([ inc_recv/1
+-export([ inc_msg/1
+        , inc_recv/1
         , inc_sent/1
         ]).
 
@@ -312,6 +314,15 @@ update_counter(Name, Value) ->
 %%--------------------------------------------------------------------
 %% Inc received/sent metrics
 %%--------------------------------------------------------------------
+
+-spec(inc_msg(emqx_types:massage()) -> ok).
+inc_msg(Msg) ->
+    case Msg#message.qos of
+        0 -> inc('messages.qos0.received');
+        1 -> inc('messages.qos1.received');
+        2 -> inc('messages.qos2.received')
+    end,
+    inc('messages.received').
 
 %% @doc Inc packets received.
 -spec(inc_recv(emqx_types:packet()) -> ok).


### PR DESCRIPTION
**Motivation:**

In some scenarios, we find that the metrics `messages.dropped` is much larger than `messages.received`.

Therefore, we should count messages received at other locations as well.

**Related PR:** 
https://github.com/emqx/emqx-rule-engine/pull/193
https://github.com/emqx/emqx-management/pull/284