### PR TITLE
fix(user_property): use list of json-encodable maps for User-Property

### DIFF
--- a/src/emqx_frame.erl
+++ b/src/emqx_frame.erl
@@ -411,7 +411,7 @@ parse_reason_codes(Bin) ->
 
 parse_utf8_pair(<<Len1:16/big, Key:Len1/binary,
                   Len2:16/big, Val:Len2/binary, Rest/binary>>) ->
-    {{Key, Val}, Rest}.
+    {#{key => Key, value => Val}, Rest}.
 
 parse_utf8_string(Bin, false) ->
     {undefined, Bin};
@@ -637,11 +637,11 @@ serialize_property('Maximum-QoS', Val) ->
     <<16#24, Val>>;
 serialize_property('Retain-Available', Val) ->
     <<16#25, Val>>;
-serialize_property('User-Property', {Key, Val}) ->
+serialize_property('User-Property', #{key := Key, value := Val}) ->
     <<16#26, (serialize_utf8_pair({Key, Val}))/binary>>;
 serialize_property('User-Property', Props) when is_list(Props) ->
-    << <<(serialize_property('User-Property', {Key, Val}))/binary>>
-       || {Key, Val} <- Props >>;
+    << <<(serialize_property('User-Property', #{key => Key, value => Val}))/binary>>
+       || #{key := Key, value := Val} <- Props >>;
 serialize_property('Maximum-Packet-Size', Val) ->
     <<16#27, Val:32/big>>;
 serialize_property('Wildcard-Subscription-Available', Val) ->

--- a/src/emqx_mqtt_props.erl
+++ b/src/emqx_mqtt_props.erl
@@ -165,7 +165,7 @@ validate_value('Four-Byte-Integer', Val) ->
     is_integer(Val) andalso 0 =< Val andalso Val =< 16#FFFFFFFF;
 validate_value('Variable-Byte-Integer', Val) ->
     is_integer(Val) andalso 0 =< Val andalso Val =< 16#7FFFFFFF;
-validate_value('UTF8-String-Pair', {Name, Val}) ->
+validate_value('UTF8-String-Pair', #{key := Name, value := Val}) ->
     validate_value('UTF8-Encoded-String', Name)
         andalso validate_value('UTF8-Encoded-String', Val);
 validate_value('UTF8-String-Pair', Pairs) when is_list(Pairs) ->

--- a/test/emqx_channel_SUITE.erl
+++ b/test/emqx_channel_SUITE.erl
@@ -611,8 +611,12 @@ t_process_alias(_) ->
 t_packing_alias(_) ->
     Packet1 = #mqtt_packet{variable = #mqtt_packet_publish{
                                          topic_name = <<"x">>,
-                                         properties = #{'User-Property' => [{<<"k">>, <<"v">>}]}
-                                        }},
+                                         properties = #{
+                                            'User-Property' => [#{
+                                                key => <<"k">>,
+                                                value => <<"v">>
+                                            }]
+                                        }}},
     Packet2 = #mqtt_packet{variable = #mqtt_packet_publish{topic_name = <<"y">>}},
     Channel = emqx_channel:set_field(alias_maximum, #{outbound => 1}, channel()),
 
@@ -621,7 +625,10 @@ t_packing_alias(_) ->
                                             topic_name = <<"x">>,
                                             properties = #{
                                                 'Topic-Alias' => 1,
-                                                'User-Property' => [{<<"k">>, <<"v">>}]
+                                                'User-Property' => [#{
+                                                    key => <<"k">>,
+                                                    value => <<"v">>
+                                                }]
                                              }
                                            }}, RePacket1),
 
@@ -630,7 +637,10 @@ t_packing_alias(_) ->
                                             topic_name = <<>>,
                                             properties = #{
                                                 'Topic-Alias' => 1,
-                                                'User-Property' => [{<<"k">>, <<"v">>}]
+                                                'User-Property' => [#{
+                                                    key => <<"k">>,
+                                                    value => <<"v">>
+                                                }]
                                              }}}, RePacket2),
 
     {RePacket3, _} = emqx_channel:packing_alias(Packet2, NChannel2),

--- a/test/emqx_frame_SUITE.erl
+++ b/test/emqx_frame_SUITE.erl
@@ -175,7 +175,7 @@ t_serialize_parse_v5_connect(_) ->
                   'Content-Type'             => <<"text/json">>,
                   'Response-Topic'           => <<"topic">>,
                   'Correlation-Data'         => <<"correlateid">>,
-                  'User-Property'            => [{<<"k">>, <<"v">>}]
+                  'User-Property'            => [#{key => <<"k">>, value => <<"v">>}]
                  },
     Packet = ?CONNECT_PACKET(
                 #mqtt_packet_connect{proto_name   = <<"MQTT">>,
@@ -431,7 +431,7 @@ t_serialize_parse_suback(_) ->
 
 t_serialize_parse_suback_v5(_) ->
     Packet = ?SUBACK_PACKET(1, #{'Reason-String' => <<"success">>,
-                                 'User-Property' => [{<<"key">>, <<"value">>}]},
+                                 'User-Property' => [#{key => <<"key">>, value => <<"value">>}]},
                             [?QOS_0, ?QOS_1, 128]),
     ?assertEqual(Packet, parse_serialize(Packet, #{version => ?MQTT_PROTO_V5})).
 
@@ -452,7 +452,7 @@ t_serialize_parse_unsubscribe(_) ->
     ?catch_error(bad_packet_id, parse_serialize(?UNSUBSCRIBE_PACKET(0, [<<"TopicA">>]))).
 
 t_serialize_parse_unsubscribe_v5(_) ->
-    Props = #{'User-Property' => [{<<"key">>, <<"val">>}]},
+    Props = #{'User-Property' => [#{key => <<"key">>, value => <<"val">>}]},
     Packet = ?UNSUBSCRIBE_PACKET(10, Props, [<<"Topic1">>, <<"Topic2">>]),
     ?assertEqual(Packet, parse_serialize(Packet, #{version => ?MQTT_PROTO_V5})).
 
@@ -462,7 +462,7 @@ t_serialize_parse_unsuback(_) ->
 
 t_serialize_parse_unsuback_v5(_) ->
     Packet = ?UNSUBACK_PACKET(10, #{'Reason-String' => <<"Not authorized">>,
-                                    'User-Property' => [{<<"key">>, <<"val">>}]},
+                                    'User-Property' => [#{key => <<"key">>, value => <<"val">>}]},
                               [16#87, 16#87, 16#87]),
     ?assertEqual(Packet, parse_serialize(Packet, #{version => ?MQTT_PROTO_V5})).
 
@@ -495,8 +495,8 @@ t_serialize_parse_auth_v5(_) ->
                           #{'Authentication-Method' => <<"oauth2">>,
                             'Authentication-Data' => <<"3zekkd">>,
                             'Reason-String' => <<"success">>,
-                            'User-Property' => [{<<"key1">>, <<"val1">>},
-                                                {<<"key2">>, <<"val2">>}]
+                            'User-Property' => [#{key => <<"key1">>, value => <<"val1">>},
+                                                #{key => <<"key2">>, value => <<"val2">>}]
                            }),
     ?assertEqual(Packet, parse_serialize(Packet, #{version => ?MQTT_PROTO_V5})),
     ?assertEqual(Packet, parse_serialize(Packet, #{version => ?MQTT_PROTO_V5,

--- a/test/emqx_mqtt_props_SUITE.erl
+++ b/test/emqx_mqtt_props_SUITE.erl
@@ -66,8 +66,8 @@ t_validate(_) ->
 t_validate_value(_) ->
     ok = emqx_mqtt_props:validate(#{'Correlation-Data' => <<"correlation-id">>}),
     ok = emqx_mqtt_props:validate(#{'Reason-String' => <<"Unknown Reason">>}),
-    ok = emqx_mqtt_props:validate(#{'User-Property' => {<<"Prop">>, <<"Val">>}}),
-    ok = emqx_mqtt_props:validate(#{'User-Property' => [{<<"Prop">>, <<"Val">>}]}),
+    ok = emqx_mqtt_props:validate(#{'User-Property' => #{key => <<"Prop">>, value => <<"Val">>}}),
+    ok = emqx_mqtt_props:validate(#{'User-Property' => [#{key => <<"Prop">>, value => <<"Val">>}]}),
     ?catch_error({bad_property_value, {'Payload-Format-Indicator', 16#FFFF}},
                  emqx_mqtt_props:validate(#{'Payload-Format-Indicator' => 16#FFFF})),
     ?catch_error({bad_property_value, {'Server-Keep-Alive', 16#FFFFFF}},


### PR DESCRIPTION
Hello! Please, consider my small solution for one problem in web-hook...

**Motivation**
We use web-hooks, and in web-hooks we want to retrieve all User-Property pairs of PUBLISH message. But when message with User-Property is published and passed through rule-engine to web-hook, web-hook fails due to exception `bad_ejson`, raised by `emqx_json:encode/1`, beacuse in published message 'User-Property' is represented just by list of tuple, which cannot be encoded to json.

I thought about a different ways, how to fix this problem. One way was about extending definition of `emqx_json:encode/1`, but it requires recursive traversal through all nodes of message (or selected message) structure and it can affect performance (and I think, significantly). Other way just add simple SQL function to emqx-rule-engine, like `user_property_pairs`, returning structure, which can be encoded to json (and it is very simple approach!), but to my mind, this problem encourages to more global solution. Also I noted, that in some places there is a code, folding all User-Property pairs into map (by `maps:from_list/1`) and it's not correct solution, because according standard MQTTv5, User-Property may contain pairs with duplicated keys.

So, finally I decided ti implement this solution with changing datastrusture of User-Property from pairs list to maps. Please, look at this PR and explain, is this slution correct, or no...and how problem described above can be fixed correctly.

Thank you!
Looking forward for you comments!