### PR TITLE
chore(build): mod_vsn parse_transform is not for default profile

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,7 @@
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,
             warn_obsolete_guard,compressed]}.
 
-{overrides,[{add,[{erl_opts,[compressed,deterministic,
-                             {parse_transform,mod_vsn}]}]}
+{overrides,[{add,[{erl_opts,[compressed,deterministic]}]}
            ,{add,[{extra_src_dirs, [{"etc", [{recursive,true}]}]}]}
            ]}.
 {extra_src_dirs, [{"etc", [{recursive,true}]}]}.

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -33,22 +33,22 @@ test_deps() ->
     ].
 
 profiles() ->
-    [ {'emqx',          [ {erl_opts, [no_debug_info]}
+    [ {'emqx',          [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx')}
                         ]}
-    , {'emqx-pkg',      [ {erl_opts, [no_debug_info]}
+    , {'emqx-pkg',      [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx-pkg')}
                         ]}
-    , {'emqx-edge',     [ {erl_opts, [no_debug_info]}
+    , {'emqx-edge',     [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx-edge')}
                         ]}
-    , {'emqx-edge-pkg', [ {erl_opts, [no_debug_info]}
+    , {'emqx-edge-pkg', [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx-edge-pkg')}
                         ]}
-    , {check,           [ {erl_opts, [debug_info]}
+    , {check,           [ {erl_opts, [debug_info, {parse_transform, mod_vsn}]}
                         ]}
     , {test,            [ {deps, test_deps()}
-                        , {erl_opts, [debug_info] ++ erl_opts_i()}
+                        , {erl_opts, [debug_info, {parse_transform, mod_vsn}] ++ erl_opts_i()}
                         ]}
     ].
 


### PR DESCRIPTION
Since plugins are compile as default profile, the parse_transform
provided by relup_helper may not present when compiling other plugins