### PR TITLE
chore(build): upgrade rebar3 to fix ct

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,12 @@ examples
 
 ```bash
 ./rebar3 ct --dir test,apps/emqx_sn,apps/emqx_coap
-./rebar3 ct --suite test/emqx_SUITE.erl,apps/emqx_auth_http/test/emqx_auth_http_SUITE.erl
-./rebar3 ct --suite test/emqx_SUITE.erl --testcase t_restart
+./rebar3 ct --dir apps/emqx_auth_mnesi --suite emqx_acl_mnesia_SUITE
+./rebar3 ct --dir apps/emqx_auth_mnesi --suite emqx_acl_mnesia_SUITE --case t_rest_api
 ```
+
+NOTE: Do *NOT* use full (relative) path to SUITE files like this `--suite apps/emqx_auth_mnesia/test/emqx_acl_mnesia_SUITE.erl`,
+because it will lead to a full copy of `apps` dir into `_buid/test/lib/emqx`.
 
 ## FAQ
 


### PR DESCRIPTION
Rebar3 version 3.14.3-emqx-4 fixed an issue where apps dir
is full-copy to _buid/test/lib/emqx/apps when running
ct with --dir apps/xxx or --suite apps/xxx/test/yyy_SUITE

This behaviour is confusing because there could be multpile
beam files for the same module in the same profile.
e.g.
_build/test/lib/xxx/test/yyy_SUITE
_build/test/lib/emqx/apps/xxx/test/yyy_SUITE