### PR TITLE
feat(auth_http): support for getting websocket cookies

### DIFF
--- a/apps/emqx_auth_http/etc/emqx_auth_http.conf
+++ b/apps/emqx_auth_http/etc/emqx_auth_http.conf
@@ -28,6 +28,7 @@ auth.http.auth_req.content_type = x-www-form-urlencoded
 ##  - %p: sockport of server accepted
 ##  - %C: common name of client TLS cert
 ##  - %d: subject of client TLS cert
+##  - %k: websocket cookie
 ##
 ## Value: Params
 auth.http.auth_req.params = clientid=%c,username=%u,password=%P
@@ -58,6 +59,7 @@ auth.http.auth_req.params = clientid=%c,username=%u,password=%P
 ##  - %p: sockport of server accepted
 ##  - %C: common name of client TLS cert
 ##  - %d: subject of client TLS cert
+##  - %k: websocket cookie
 ##
 ## Value: Params
 #auth.http.super_req.params = clientid=%c,username=%u
@@ -87,6 +89,7 @@ auth.http.acl_req.content_type = x-www-form-urlencoded
 ##  - %r: protocol
 ##  - %m: mountpoint
 ##  - %t: topic
+##  - %k: websocket cookie
 ##
 ## Value: Params
 auth.http.acl_req.params = access=%A,username=%u,clientid=%c,ipaddr=%a,topic=%t,mountpoint=%m

--- a/apps/emqx_auth_http/src/emqx_auth_http_cli.erl
+++ b/apps/emqx_auth_http/src/emqx_auth_http_cli.erl
@@ -80,6 +80,7 @@ feedvar(Params, ClientInfo = #{clientid := ClientId,
                  ({Param, "%A"}) -> {Param, maps:get(access, ClientInfo, null)};
                  ({Param, "%t"}) -> {Param, maps:get(topic, ClientInfo, null)};
                  ({Param, "%m"}) -> {Param, maps:get(mountpoint, ClientInfo, null)};
+                 ({Param, "%k"}) -> {Param, emqx_json:encode(maps:get(ws_cookie, ClientInfo, null))};
                  ({Param, Var})  -> {Param, Var}
               end, Params).
 

--- a/apps/emqx_auth_http/test/emqx_auth_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_auth_http_SUITE.erl
@@ -171,3 +171,10 @@ t_comment_config(_) ->
     ?assertEqual(AuthCount - 1, length(emqx_hooks:lookup('client.authenticate'))),
     ?assertEqual(AclCount - 1, length(emqx_hooks:lookup('client.check_acl'))).
 
+t_feedvar(_) ->
+    Params = [{"cookie", "%k"}],
+    User0 = ?USER(<<"client1">>, <<"testuser">>, mqtt, {127,0,0,1}, external),
+    ?assertEqual([{"cookie", <<"null">>}], emqx_auth_http_cli:feedvar(Params, User0)),
+
+    User1 = User0#{ws_cookie => [{<<"k">>, <<"v">>}]},
+    ?assertEqual([{"cookie", <<"{\"k\":\"v\"}">>}], emqx_auth_http_cli:feedvar(Params, User1)).

--- a/src/emqx_types.erl
+++ b/src/emqx_types.erl
@@ -136,7 +136,7 @@
                         is_bridge    := boolean(),
                         is_superuser := boolean(),
                         mountpoint   := maybe(binary()),
-                        ws_cookie    => maybe(list()),
+                        ws_cookie    => wscookie(),
                         password     => maybe(binary()),
                         auth_result  => auth_result(),
                         anonymous    => boolean(),
@@ -150,6 +150,7 @@
 -type(peerhost() :: inet:ip_address()).
 -type(peername() :: {inet:ip_address(), inet:port_number()}
                   | inet:returned_non_ip_address()).
+-type(wscookie() :: [{binary(), binary()}]).
 -type(protocol() :: mqtt | 'mqtt-sn' | coap | lwm2m | stomp | none | atom()).
 -type(auth_result() :: success
                      | client_identifier_not_valid


### PR DESCRIPTION
This PR is taken from https://github.com/emqx/emqx-auth-http/pull/225

Sorry, @gerad I can't leave your commits to this PR since we merged the code repositories together in v4.3.0, it's two code repositories.