### PR TITLE
feat(exproto): use client streaming APIs for handler

### DIFF
--- a/apps/emqx_exhook/rebar.config
+++ b/apps/emqx_exhook/rebar.config
@@ -1,11 +1,11 @@
 %%-*- mode: erlang -*-
 {plugins,
  [rebar3_proper,
-  {grpc_plugin, {git, "https://github.com/HJianBo/grpcbox_plugin", {tag, "v0.9.1"}}}
+  {grpc_plugin, {git, "https://github.com/HJianBo/grpcbox_plugin", {tag, "v0.10.0"}}}
 ]}.
 
 {deps,
- [{grpc, {git, "https://github.com/emqx/grpc", {tag, "0.5.0"}}}
+ [{grpc, {git, "https://github.com/emqx/grpc", {tag, "0.6.0"}}}
 ]}.
 
 {grpc,

--- a/apps/emqx_exproto/README.md
+++ b/apps/emqx_exproto/README.md
@@ -22,7 +22,3 @@ See: `priv/protos/exproto.proto`
 ## Recommended gRPC Framework
 
 See: https://github.com/grpc-ecosystem/awesome-grpc
-
-## Thanks
-
-- [grpcbox](https://github.com/tsloughter/grpcbox)

--- a/apps/emqx_exproto/priv/protos/exproto.proto
+++ b/apps/emqx_exproto/priv/protos/exproto.proto
@@ -47,17 +47,17 @@ service ConnectionHandler {
 
   // -- socket layer
 
-  rpc OnSocketCreated(SocketCreatedRequest) returns (EmptySuccess) {};
+  rpc OnSocketCreated(stream SocketCreatedRequest) returns (EmptySuccess) {};
 
-  rpc OnSocketClosed(SocketClosedRequest) returns (EmptySuccess) {};
+  rpc OnSocketClosed(stream SocketClosedRequest) returns (EmptySuccess) {};
 
-  rpc OnReceivedBytes(ReceivedBytesRequest) returns (EmptySuccess) {};
+  rpc OnReceivedBytes(stream ReceivedBytesRequest) returns (EmptySuccess) {};
 
   // -- pub/sub layer
 
-  rpc OnTimerTimeout(TimerTimeoutRequest) returns (EmptySuccess) {};
+  rpc OnTimerTimeout(stream TimerTimeoutRequest) returns (EmptySuccess) {};
 
-  rpc OnReceivedMessages(ReceivedMessagesRequest) returns (EmptySuccess) {};
+  rpc OnReceivedMessages(stream ReceivedMessagesRequest) returns (EmptySuccess) {};
 }
 
 message EmptySuccess { }

--- a/apps/emqx_exproto/rebar.config
+++ b/apps/emqx_exproto/rebar.config
@@ -9,11 +9,11 @@
             {parse_transform}]}.
 {plugins,
  [rebar3_proper,
-  {grpc_plugin, {git, "https://github.com/HJianBo/grpcbox_plugin", {tag, "v0.9.1"}}}
+  {grpc_plugin, {git, "https://github.com/HJianBo/grpcbox_plugin", {tag, "v0.10.0"}}}
 ]}.
 
 {deps,
- [{grpc, {git, "https://github.com/emqx/grpc", {tag, "0.5.0"}}}
+ [{grpc, {git, "https://github.com/emqx/grpc", {tag, "0.6.0"}}}
  ]}.
 
 {grpc,

--- a/apps/emqx_exproto/src/emqx_exproto_gsvr.erl
+++ b/apps/emqx_exproto/src/emqx_exproto_gsvr.erl
@@ -115,10 +115,10 @@ unsubscribe(Req = #{conn := Conn, topic := Topic}, Md) ->
 %%--------------------------------------------------------------------
 
 to_pid(ConnStr) ->
-    list_to_pid(binary_to_list(ConnStr)).
+    binary_to_term(base64:decode(ConnStr)).
 
 call(ConnStr, Req) ->
-    case catch  to_pid(ConnStr) of
+    case catch to_pid(ConnStr) of
         {'EXIT', {badarg, _}} ->
             {error, ?RESP_PARAMS_TYPE_ERROR,
                     <<"The conn type error">>};

--- a/apps/emqx_exproto/test/emqx_exproto_SUITE.erl
+++ b/apps/emqx_exproto/test/emqx_exproto_SUITE.erl
@@ -239,7 +239,6 @@ t_hook_connected_disconnected(Cfg) ->
     emqx:hook('client.connected', HookFun1),
     emqx:hook('client.disconnected', HookFun2),
 
-
     send(Sock, ConnBin),
     {ok, ConnAckBin} = recv(Sock, 5000),
 

--- a/apps/emqx_exproto/test/emqx_exproto_SUITE.erl
+++ b/apps/emqx_exproto/test/emqx_exproto_SUITE.erl
@@ -106,7 +106,7 @@ t_mountpoint_echo(Cfg) ->
     send(Sock, ConnBin),
     {ok, ConnAckBin} = recv(Sock, 5000),
 
-    SubBin = frame_subscribe(<<"t/#">>, 1),
+    SubBin = frame_subscribe(<<"t/dn">>, 1),
     SubAckBin = frame_suback(0),
 
     send(Sock, SubBin),


### PR DESCRIPTION
- Use the gRPC client streaming APIs to improve the
  ConnectionHandler server performance.
- Change the 'conn' field type to term binary