### PR TITLE
fix(ekka): Upgrade to 0.8.0 to allow remsh

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,7 @@
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.7.1"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.7.5"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.0"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.0"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.0.0"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "0.3.3"}}}


### PR DESCRIPTION
Before ekka 0.8.0, when epmd is not used, ekka_dist would calculate
a port number from node name. This does not work for remote consoles
because a remsh node name is like remsh81random0-<target-node>
i.e. the calculated port number is always the same as the target node.

The fix in 0.8.0 allows remsh prefixed nodes to use a range of
ports to listen.