### PR TITLE
perf(esockd): upgrade esockd to 5.8.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -44,7 +44,7 @@
     [ {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.7.1"}}}
-    , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.4"}}}
+    , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.0"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.7.5"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.0"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.0.0"}}}


### PR DESCRIPTION
To better support hot upgrades, in esockd 5.8.0 we
avoid saving anonymous functions in state.