### PR TITLE
chore(style): set warnings_as_errors compile option

### DIFF
--- a/apps/emqx_coap/src/emqx_coap_mqtt_adapter.erl
+++ b/apps/emqx_coap/src/emqx_coap_mqtt_adapter.erl
@@ -50,8 +50,6 @@
 
 -record(state, {peername, clientid, username, password, sub_topics = [], connected_at}).
 
--type(state() :: #state{}).
-
 -define(ALIVE_INTERVAL, 20000).
 
 -define(CONN_STATS, [recv_pkt, recv_msg, send_pkt, send_msg]).

--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
 {extra_src_dirs, [{"etc", [{recursive,true}]}]}.
 
 {xref_checks,[undefined_function_calls,undefined_functions,locals_not_used,
-              deprecated_function_calls,warnings_as_errors, deprecated_functions]}.
+              deprecated_function_calls,warnings_as_errors,deprecated_functions]}.
 
 {dialyzer, [
     {warnings, [unmatched_returns, error_handling, race_conditions]},

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -34,19 +34,19 @@ test_deps() ->
     ].
 
 profiles() ->
-    [ {'emqx',          [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
+    [ {'emqx',          [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx')}
                         ]}
-    , {'emqx-pkg',      [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
+    , {'emqx-pkg',      [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx-pkg')}
                         ]}
-    , {'emqx-edge',     [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
+    , {'emqx-edge',     [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx-edge')}
                         ]}
-    , {'emqx-edge-pkg', [ {erl_opts, [no_debug_info, {parse_transform, mod_vsn}]}
+    , {'emqx-edge-pkg', [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
                         , {relx, relx('emqx-edge-pkg')}
                         ]}
-    , {check,           [ {erl_opts, [debug_info, {parse_transform, mod_vsn}]}
+    , {check,           [ {erl_opts, [debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
                         ]}
     , {test,            [ {deps, test_deps()}
                         , {erl_opts, [debug_info, {parse_transform, mod_vsn}] ++ erl_opts_i()}

--- a/src/emqx_alarm.erl
+++ b/src/emqx_alarm.erl
@@ -83,7 +83,6 @@
           timer = undefined :: undefined | reference()
         }).
 
--type state() :: #state{}.
 -type action() :: log | publish | event.
 
 -define(ACTIVATED_ALARM, emqx_activated_alarm).


### PR DESCRIPTION
Usually, we can't detect some unused variables, functions, and type declarations in time for review, so we should set the `wanrings_as_errors` compiler option to help us.

This is also a way to improve the quality of our code