### PR TITLE
chore(cover): add coverall back

### DIFF
--- a/.ci/apps_tests/docker-compose.yaml
+++ b/.ci/apps_tests/docker-compose.yaml
@@ -12,6 +12,14 @@ services:
       - ldap_server
     networks:
       - emqx_bridge
+    environment:
+      GITHUB_ACTIONS: ${GITHUB_ACTIONS}
+      GITHUB_TOKEN: ${GITHUB_TOKEN}
+      GITHUB_RUN_ID: ${GITHUB_RUN_ID}
+      GITHUB_SHA: ${GITHUB_SHA}
+      GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}
+      GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}
+      GITHUB_REF: ${GITHUB_REF}
     volumes:
       - ../../.:/emqx
     working_dir: /emqx

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -25,6 +25,7 @@ jobs:
             MONGO_TAG: 4
             PGSQL_TAG: 13
             LDAP_TAG: 2.4.50
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           run: |
             docker-compose -f .ci/apps_tests/docker-compose.yaml build --no-cache
             docker-compose -f .ci/apps_tests/docker-compose.yaml up -d
@@ -48,6 +49,7 @@ jobs:
             docker exec -i erlang bash -c "make xref"
             docker exec -i erlang bash -c "make ct"
             docker exec -i erlang bash -c "make cover"
+            docker exec -i erlang bash -c "make coveralls"
         - uses: actions/upload-artifact@v1
           if: failure()
           with:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,10 @@ get-dashboard:
 eunit: $(REBAR)
 	$(REBAR) eunit
 
+.PHONY: proper
+proper: $(REBAR)
+	$(REBAR) as test proper -d test/props -c
+
 .PHONY: ct
 ct: $(REBAR)
 	$(REBAR) ct --name 'test@127.0.0.1' -c -v
@@ -40,7 +44,7 @@ cover: $(REBAR)
 	$(REBAR) cover
 
 .PHONY: coveralls
-cover: $(REBAR)
+coveralls: $(REBAR)
 	$(REBAR) as test coveralls send
 
 .PHONY: $(REL_PROFILES)

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,10 @@ ct: $(REBAR)
 cover: $(REBAR)
 	$(REBAR) cover
 
+.PHONY: coveralls
+cover: $(REBAR)
+	$(REBAR) as test coveralls send
+
 .PHONY: $(REL_PROFILES)
 $(REL_PROFILES:%=%): $(REBAR) get-dashboard
 ifneq ($(shell echo $(@) |grep edge),)

--- a/rebar.config
+++ b/rebar.config
@@ -11,8 +11,7 @@
 {erl_opts, [warn_unused_vars,warn_shadow_vars,warn_unused_import,
             warn_obsolete_guard,compressed]}.
 
-{overrides,[{add,[{erl_opts,[compressed,deterministic]}]}
-           ,{add,[{extra_src_dirs, [{"etc", [{recursive,true}]}]}]}
+{overrides,[{add,[{extra_src_dirs, [{"etc", [{recursive,true}]}]}]}
            ]}.
 {extra_src_dirs, [{"etc", [{recursive,true}]}]}.
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -28,7 +28,8 @@ plugins() ->
     ].
 
 test_plugins() ->
-    [ {coveralls, {git, "https://github.com/emqx/coveralls-erl", {branch, "github"}}}
+    [ rebar3_proper,
+      {coveralls, {git, "https://github.com/emqx/coveralls-erl", {branch, "github"}}}
     ].
 
 test_deps() ->

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -4,7 +4,7 @@
 
 do(Dir, CONFIG) ->
     ok = compile_and_load_pase_transforms(Dir),
-    dump(deps(CONFIG) ++ dialyzer(CONFIG) ++ config()).
+    dump(deps(CONFIG) ++ dialyzer(CONFIG) ++ coveralls() ++ config()).
 
 bcrypt() ->
     {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {branch, "0.6.0"}}}.
@@ -27,28 +27,36 @@ plugins() ->
       {er_coap_client, {git, "https://github.com/emqx/er_coap_client", {tag, "v1.0"}}}
     ].
 
+test_plugins() ->
+    [ {coveralls, {git, "https://github.com/emqx/coveralls-erl", {branch, "github"}}}
+    ].
+
 test_deps() ->
     [ {bbmustache, "1.10.0"}
     , {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "1.3.4"}}}
     , meck
     ].
 
+default_compile_opts() ->
+    [compressed, deterministic, no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}].
+
 profiles() ->
-    [ {'emqx',          [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
+    [ {'emqx',          [ {erl_opts, default_compile_opts()}
                         , {relx, relx('emqx')}
                         ]}
-    , {'emqx-pkg',      [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
+    , {'emqx-pkg',      [ {erl_opts, default_compile_opts()}
                         , {relx, relx('emqx-pkg')}
                         ]}
-    , {'emqx-edge',     [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
+    , {'emqx-edge',     [ {erl_opts, default_compile_opts()}
                         , {relx, relx('emqx-edge')}
                         ]}
-    , {'emqx-edge-pkg', [ {erl_opts, [no_debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
+    , {'emqx-edge-pkg', [ {erl_opts, default_compile_opts()}
                         , {relx, relx('emqx-edge-pkg')}
                         ]}
     , {check,           [ {erl_opts, [debug_info, warnings_as_errors, {parse_transform, mod_vsn}]}
                         ]}
     , {test,            [ {deps, test_deps()}
+                        , {plugins, test_plugins()}
                         , {erl_opts, [debug_info, {parse_transform, mod_vsn}] ++ erl_opts_i()}
                         ]}
     ].
@@ -293,6 +301,26 @@ dialyzer(Config) ->
             lists:keystore(dialyzer, 1, Config, {dialyzer, OldDialyzerConfig ++ [{exclude_apps, AppsToExclude}]});
         false ->
             Config
+    end.
+
+coveralls() ->
+    case {os:getenv("GITHUB_ACTIONS"), os:getenv("GITHUB_TOKEN")} of
+      {"true", Token} when is_list(Token) ->
+        Cfgs = [{coveralls_repo_token, Token},
+                {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
+                {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
+                {coveralls_service_number, os:getenv("GITHUB_RUN_NUMBER")},
+                {coveralls_coverdata, "_build/test/cover/*.coverdata"},
+                {coveralls_service_name, "github"}],
+        case os:getenv("GITHUB_EVENT_NAME") =:= "pull_request"
+            andalso string:tokens(os:getenv("GITHUB_REF"), "/") of
+            [_, "pull", PRNO, _] ->
+                [{coveralls_service_pull_request, PRNO} | Cfgs];
+            _ ->
+                Cfgs
+        end;
+      _ ->
+        []
     end.
 
 list_dir(Dir) ->


### PR DESCRIPTION
1. Use `emqx/coveralls-erl ` to send coverage information to coveralls.io. and use `rebar.config.erl:coveralls/0` to add its necessary configuration to it.
2. In order to get the necessary compilation information, we cannot set deterministic to all applications under `apps/*`

3. In Addition, this PR also adds proptest to the makefile so that subsequent versions can add it to the CI.