### PR TITLE
chore(deps): upgrade cowboy to 2.8.2

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -42,7 +42,7 @@
 {deps,
     [ {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
-    , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.7.1"}}}
+    , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.8.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.0"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.0"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.0"}}}


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->

cowboy prints a large number of extraneous logs when load-balance continually invokes health checks to emqx.

Related PR: https://github.com/emqx/cowboy/pull/5



**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked.:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information