### PR TITLE
feature(mgmt) restart a listener

### DIFF
--- a/lib-opensource/emqx_management/src/emqx_mgmt.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt.erl
@@ -102,6 +102,7 @@
 %% Listeners
 -export([ list_listeners/0
         , list_listeners/1
+        , restart_listener/2
         ]).
 
 %% Alarms
@@ -560,6 +561,12 @@ list_listeners(Node) when Node =:= node() ->
 list_listeners(Node) ->
     rpc_call(Node, list_listeners, [Node]).
 
+restart_listener(Node, Identifier) when Node =:= node() ->
+    emqx_listeners:restart_listener(Identifier);
+
+restart_listener(Node, Identifier) ->
+    rpc_call(Node, restart_listener, [Node, Identifier]).
+
 %%--------------------------------------------------------------------
 %% Get Alarms
 %%--------------------------------------------------------------------
@@ -978,3 +985,4 @@ action_to_prop_list({action_instance, ActionInstId, Name, FallbackActions, Args}
      {name, Name},
      {fallbacks, actions_to_prop_list(FallbackActions)},
      {args, Args}].
+

--- a/lib-opensource/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -30,7 +30,19 @@
             func   => list,
             descr  => "A list of listeners on the node"}).
 
--export([list/2]).
+-rest_api(#{name   => restart_listener,
+            method => 'PUT',
+            path   => "/listeners/:bin:identifier/restart",
+            func   => restart,
+            descr  => "Restart a listener in the cluster"}).
+
+-rest_api(#{name   => restart_node_listener,
+            method => 'PUT',
+            path   => "/nodes/:atom:node/listeners/:bin:identifier/restart",
+            func   => restart,
+            descr  => "Restart a listener on a node"}).
+
+-export([list/2, restart/2]).
 
 %% List listeners on a node.
 list(#{node := Node}, _Params) ->
@@ -40,6 +52,21 @@ list(#{node := Node}, _Params) ->
 list(_Binding, _Params) ->
     return({ok, [#{node => Node, listeners => format(Listeners)}
                               || {Node, Listeners} <- emqx_mgmt:list_listeners()]}).
+
+%% Restart listeners on a node.
+restart(#{node := Node, identifier := Identifier}, _Params) ->
+    case emqx_mgmt:restart_listener(Node, Identifier) of
+        ok -> return({ok, "Listener restarted."});
+        {error, Error} -> return({error, Error})
+    end;
+
+%% Restart listeners in the cluster.
+restart(#{identifier := Identifier}, _Params) ->
+    Results = [{Node, emqx_mgmt:restart_listener(Node, Identifier)} || {Node, _Info} <- emqx_mgmt:list_nodes()],
+    case lists:filter(fun({_, Result}) -> Result =/= ok end, Results) of
+        [] -> return(ok);
+        Errors -> return({error, Errors})
+    end.
 
 format(Listeners) when is_list(Listeners) ->
     [ Info#{listen_on => list_to_binary(esockd:to_string(ListenOn))}

--- a/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
@@ -550,10 +550,19 @@ listeners(["stop", _Proto, ListenOn]) ->
     end,
     stop_listener(emqx_listeners:find_by_listen_on(ListenOn1), ListenOn1);
 
+listeners(["restart", Identifier]) ->
+    case emqx_listeners:restart_listener(Identifier) of
+        ok ->
+            emqx_ctl:print("Restarted ~s listener successfully.~n", [Identifier]);
+        {error, Error} ->
+            emqx_ctl:print("Failed to restart ~s listener: ~0p~n", [Identifier, Error])
+    end;
+
 listeners(_) ->
     emqx_ctl:usage([{"listeners",                        "List listeners"},
                     {"listeners stop    <Identifier>",   "Stop a listener"},
-                    {"listeners stop    <Proto> <Port>", "Stop a listener"}
+                    {"listeners stop    <Proto> <Port>", "Stop a listener"},
+                    {"listeners restart <Identifier>",   "Restart a listener"}
                    ]).
 
 stop_listener(false, Input) ->

--- a/lib-opensource/emqx_management/test/emqx_mgmt_SUITE.erl
+++ b/lib-opensource/emqx_management/test/emqx_mgmt_SUITE.erl
@@ -294,6 +294,18 @@ t_listeners_cmd_new(_) ->
        "Stop mqtt:wss:external listener on 0.0.0.0:8084 successfully.\n",
        emqx_mgmt_cli:listeners(["stop", "mqtt:wss:external"])
       ),
+    ?assertEqual(
+       emqx_mgmt_cli:listeners(["restart", "mqtt:tcp:external"]),
+       "Restarted mqtt:tcp:external listener successfully.\n"
+      ),
+    ?assertEqual(
+       emqx_mgmt_cli:listeners(["restart", "mqtt:ssl:external"]),
+       "Restarted mqtt:ssl:external listener successfully.\n"
+      ),
+    ?assertEqual(
+       emqx_mgmt_cli:listeners(["restart", "bad:listener:identifier"]),
+       "Failed to restart bad:listener:identifier listener: {no_such_listener,\"bad:listener:identifier\"}\n"
+      ),
     unmock_print().
 
 t_plugins_cmd(_) ->


### PR DESCRIPTION
example:

```
emqx_ctl listener restart mqtt:ssl:external
```

or

```
PUT /api/v4/listeners/mqtt:ssl:external/restart
```

thank you @zmstone for providing the listener-identifier apis :)

originally coming from here: https://github.com/emqx/emqx-management/pull/307

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes #4013 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked.:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

existing `emqx_ctl listeners ...` commands are unaffected, as is `/api/v4/listeners`.

## More information
When listener is restarted, `clientsca` and other cert files' caches are invalidated, allows for "loading" new certs. See #4013 