### PR TITLE
feat(listeners): Add identifier to listeners

### DIFF
--- a/apps/emqx_coap/src/emqx_coap_server.erl
+++ b/apps/emqx_coap/src/emqx_coap_server.erl
@@ -55,7 +55,7 @@ start_listener({Proto, ListenOn, Opts}) ->
             io:format("Start coap:~s listener on ~s successfully.~n",
                       [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start coap:~s listener on ~s - ~0p~n!",
+            io:format(standard_error, "Failed to start coap:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason]),
             error(Reason)
     end.
@@ -71,7 +71,7 @@ stop_listener({Proto, ListenOn, _Opts}) ->
         ok -> io:format("Stop coap:~s listener on ~s successfully.~n",
                         [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to stop coap:~s listener on ~s - ~p~n.",
+            io:format(standard_error, "Failed to stop coap:~s listener on ~s: ~0p~n.",
                       [Proto, format(ListenOn), Reason])
     end,
     Ret.

--- a/apps/emqx_exproto/src/emqx_exproto.erl
+++ b/apps/emqx_exproto/src/emqx_exproto.erl
@@ -69,7 +69,7 @@ start_connection_handler_instance({_Proto, _LisType, _ListenOn, Opts}) ->
         {ok, _ClientChannelPid} ->
             {_Proto, _LisType, _ListenOn, [{handler, Name} | LisOpts]};
         {error, Reason} ->
-            io:format(standard_error, "Failed to start ~s's connection handler - ~0p~n!",
+            io:format(standard_error, "Failed to start ~s's connection handler: ~0p~n",
                       [Name, Reason]),
             error(Reason)
     end.
@@ -85,7 +85,7 @@ start_server({Name, Port, SSLOptions}) ->
             io:format("Start ~s gRPC server on ~w successfully.~n",
                       [Name, Port]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start ~s gRPC server on ~w - ~0p~n!",
+            io:format(standard_error, "Failed to start ~s gRPC server on ~w: ~0p~n",
                       [Name, Port, Reason]),
             error({failed_start_server, Reason})
     end.
@@ -101,7 +101,7 @@ start_listener({Proto, LisType, ListenOn, Opts}) ->
             io:format("Start ~s listener on ~s successfully.~n",
                       [Name, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start ~s listener on ~s - ~0p~n!",
+            io:format(standard_error, "Failed to start ~s listener on ~s: ~0p~n",
                       [Name, format(ListenOn), Reason]),
             error(Reason)
     end.
@@ -132,7 +132,7 @@ stop_listener({Proto, LisType, ListenOn, Opts}) ->
             io:format("Stop ~s listener on ~s successfully.~n",
                       [Name, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to stop ~s listener on ~s - ~p~n.",
+            io:format(standard_error, "Failed to stop ~s listener on ~s: ~0p~n",
                       [Name, format(ListenOn), Reason])
     end,
     StopRet.

--- a/apps/emqx_lwm2m/src/emqx_lwm2m_coap_server.erl
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m_coap_server.erl
@@ -47,7 +47,7 @@ start_listener({Proto, ListenOn, Opts}) ->
             io:format("Start lwm2m:~s listener on ~s successfully.~n",
                       [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start lwm2m:~s listener on ~s - ~0p~n!",
+            io:format(standard_error, "Failed to start lwm2m:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason]),
             error(Reason)
     end.
@@ -63,7 +63,7 @@ stop_listener({Proto, ListenOn, _Opts}) ->
         ok -> io:format("Stop lwm2m:~s listener on ~s successfully.~n",
                         [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to stop lwm2m:~s listener on ~s - ~p~n.",
+            io:format(standard_error, "Failed to stop lwm2m:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason])
     end,
     Ret.

--- a/apps/emqx_sn/src/emqx_sn_app.erl
+++ b/apps/emqx_sn/src/emqx_sn_app.erl
@@ -71,7 +71,7 @@ start_listener({Proto, ListenOn, Options}) ->
         {ok, _} -> io:format("Start mqttsn:~s listener on ~s successfully.~n",
                              [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start mqttsn:~s listener on ~s - ~0p~n!",
+            io:format(standard_error, "Failed to start mqttsn:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason]),
             error(Reason)
     end.
@@ -101,7 +101,7 @@ stop_listener({Proto, ListenOn, Opts}) ->
         ok -> io:format("Stop mqttsn:~s listener on ~s successfully.~n",
                         [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to stop mqttsn:~s listener on ~s - ~p~n.",
+            io:format(standard_error, "Failed to stop mqttsn:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason])
     end,
     StopRet.

--- a/apps/emqx_stomp/src/emqx_stomp.erl
+++ b/apps/emqx_stomp/src/emqx_stomp.erl
@@ -73,7 +73,7 @@ start_listener({Proto, ListenOn, Options}) ->
         {ok, _} -> io:format("Start stomp:~s listener on ~s successfully.~n",
                              [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start stomp:~s listener on ~s - ~0p~n!",
+            io:format(standard_error, "Failed to start stomp:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason]),
             error(Reason)
     end.
@@ -102,7 +102,7 @@ stop_listener({Proto, ListenOn, Opts}) ->
         ok -> io:format("Stop stomp:~s listener on ~s successfully.~n",
                         [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to stop stomp:~s listener on ~s - ~p~n.",
+            io:format(standard_error, "Failed to stop stomp:~s listener on ~s: ~0p~n",
                       [Proto, format(ListenOn), Reason])
     end,
     StopRet.

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -47,7 +47,7 @@ main(Args) ->
         {true, pong} ->
             ok;
         {false, pong} ->
-            io:format(standard_error, "Failed to connect to node ~p .\n", [TargetNode]),
+            io:format(standard_error, "Failed to connect to node ~p\n", [TargetNode]),
             halt(1);
         {_, pang} ->
             io:format(standard_error, "Node ~p not responding to pings.\n", [TargetNode]),

--- a/lib-opensource/emqx_management/src/emqx_mgmt.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt.erl
@@ -535,6 +535,7 @@ list_listeners(Node) when Node =:= node() ->
     Tcp = lists:map(fun({{Protocol, ListenOn}, _Pid}) ->
         #{protocol        => Protocol,
           listen_on       => ListenOn,
+          identifier      => emqx_listeners:find_id_by_listen_on(ListenOn),
           acceptors       => esockd:get_acceptors({Protocol, ListenOn}),
           max_conns       => esockd:get_max_connections({Protocol, ListenOn}),
           current_conns   => esockd:get_current_connections({Protocol, ListenOn}),

--- a/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
@@ -157,7 +157,7 @@ cluster(["join", SNode]) ->
         ignore ->
             emqx_ctl:print("Ignore.~n");
         {error, Error} ->
-            emqx_ctl:print("Failed to join the cluster: ~p~n", [Error])
+            emqx_ctl:print("Failed to join the cluster: ~0p~n", [Error])
     end;
 
 cluster(["leave"]) ->
@@ -166,7 +166,7 @@ cluster(["leave"]) ->
             emqx_ctl:print("Leave the cluster successfully.~n"),
             cluster(["status"]);
         {error, Error} ->
-            emqx_ctl:print("Failed to leave the cluster: ~p~n", [Error])
+            emqx_ctl:print("Failed to leave the cluster: ~0p~n", [Error])
     end;
 
 cluster(["force-leave", SNode]) ->
@@ -177,7 +177,7 @@ cluster(["force-leave", SNode]) ->
         ignore ->
             emqx_ctl:print("Ignore.~n");
         {error, Error} ->
-            emqx_ctl:print("Failed to remove the node from cluster: ~p~n", [Error])
+            emqx_ctl:print("Failed to remove the node from cluster: ~0p~n", [Error])
     end;
 
 cluster(["status"]) ->
@@ -536,7 +536,7 @@ listeners(["stop",  Name = "http" ++ _N | _MaybePort]) ->
         ok ->
             emqx_ctl:print("Stop ~s listener successfully.~n", [Name]);
         {error, Error} ->
-            emqx_ctl:print("Failed to stop ~s listener, error:~p~n", [Name, Error])
+            emqx_ctl:print("Failed to stop ~s listener: ~0p~n", [Name, Error])
     end;
 
 listeners(["stop", "mqtt:" ++ _ = Identifier]) ->
@@ -565,7 +565,7 @@ stop_listener(#{listen_on := ListenOn} = Listener, _Input) ->
         ok ->
             emqx_ctl:print("Stop ~s listener on ~s successfully.~n", [ID, ListenOnStr]);
         {error, Reason} ->
-            emqx_ctl:print("Failed to stop ~s listener on ~s - ~p~n.",
+            emqx_ctl:print("Failed to stop ~s listener on ~s: ~0p~n",
                            [ID, ListenOnStr, Reason])
     end.
 

--- a/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
@@ -549,18 +549,17 @@ listeners(["stop", _Proto, ListenOn]) ->
 
 listeners(_) ->
     emqx_ctl:usage([{"listeners",                        "List listeners"},
-                    {"listeners stop    <Proto> <Port>", "Stop a listener"}]).
+                    {"listeners stop    <Identifier>",   "Stop a listener"},
+                    {"listeners stop    <Proto> <Port>", "Stop a listener"}
+                   ]).
 
 stop_listener(false, Input) ->
     emqx_ctl:print("No such listener ~p~n", [Input]);
-stop_listener(#{listen_on := ListenOn} = Listener, _Input) ->
-    ID = emqx_listeners:identifier(Listener),
-    case emqx_listeners:stop_listener(Listener) of
-        ok ->
-            emqx_ctl:print("Stop ~s listener on ~s successfully.~n", [ID, ListenOn]);
-        {error, Error} ->
-            emqx_ctl:print("Failed to stop ~s listener on ~s, error:~p~n", [ID, ListenOn, Error])
-    end.
+stop_listener(#{} = Listener, _Input) ->
+    %% Discard reason here, reasons are io:format logged to group leader
+    %% in case of emqx_ctl RPC call, it's logged to the remore node.
+    _ = emqx_listeners:stop_listener(Listener),
+    ok.
 
 %%--------------------------------------------------------------------
 %% @doc data Command

--- a/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
@@ -554,16 +554,16 @@ listeners(_) ->
                    ]).
 
 stop_listener(false, Input) ->
-    ok = emqx_ctl:print("No such listener ~p~n", [Input]);
+    emqx_ctl:print("No such listener ~p~n", [Input]);
 stop_listener(#{listen_on := ListenOn} = Listener, _Input) ->
     ID = emqx_listeners:identifier(Listener),
     ListenOnStr = emqx_listeners:format_listen_on(ListenOn),
     case emqx_listeners:stop_listener(Listener) of
         ok ->
-            ok = emqx_ctl:print("Stop ~s listener on ~s successfully.~n", [ID, ListenOnStr]);
+            emqx_ctl:print("Stop ~s listener on ~s successfully.~n", [ID, ListenOnStr]);
         {error, Reason} ->
-            ok = emqx_ctl:print("Failed to stop ~s listener on ~s - ~p~n.",
-                                [ID, ListenOnStr, Reason])
+            emqx_ctl:print("Failed to stop ~s listener on ~s - ~p~n.",
+                           [ID, ListenOnStr, Reason])
     end.
 
 %%--------------------------------------------------------------------

--- a/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
+++ b/lib-opensource/emqx_management/src/emqx_mgmt_cli.erl
@@ -530,12 +530,13 @@ listeners([]) ->
                 foreach(fun indent_print/1, Info)
             end, ranch:info());
 
-listeners(["stop",  Name = "http" ++ _N, ListenOn]) ->
+listeners(["stop",  Name = "http" ++ _N | _MaybePort]) ->
+    %% _MaybePort is to be backward compatible, to stop http listener, there is no need for the port number
     case minirest:stop_http(list_to_atom(Name)) of
         ok ->
-            emqx_ctl:print("Stop ~s listener on ~s successfully.~n", [Name, ListenOn]);
+            emqx_ctl:print("Stop ~s listener successfully.~n", [Name]);
         {error, Error} ->
-            emqx_ctl:print("Failed to stop ~s listener on ~s, error:~p~n", [Name, ListenOn, Error])
+            emqx_ctl:print("Failed to stop ~s listener, error:~p~n", [Name, Error])
     end;
 
 listeners(["stop", "mqtt:" ++ _ = Identifier]) ->

--- a/lib-opensource/emqx_management/test/emqx_mgmt_SUITE.erl
+++ b/lib-opensource/emqx_management/test/emqx_mgmt_SUITE.erl
@@ -49,7 +49,8 @@ groups() ->
         t_broker_cmd,
         t_router_cmd,
         t_subscriptions_cmd,
-        t_listeners_cmd
+        t_listeners_cmd_old,
+        t_listeners_cmd_new
        ]}].
 
 apps() ->
@@ -275,12 +276,23 @@ t_subscriptions_cmd(_) ->
     ?assertEqual(emqx_mgmt_cli:subscriptions(["del", "client", "b/b/c"]), "ok~n"),
     unmock_print().
 
-t_listeners_cmd(_) ->
+t_listeners_cmd_old(_) ->
+    ok = emqx_listeners:ensure_all_started(),
     mock_print(),
     ?assertEqual(emqx_mgmt_cli:listeners([]), ok),
     ?assertEqual(
-       emqx_mgmt_cli:listeners(["stop", "wss", "8084"]),
-       "Stop wss listener on 8084 successfully.\n"
+       "Stop mqtt:wss:external listener on 0.0.0.0:8084 successfully.\n",
+       emqx_mgmt_cli:listeners(["stop", "wss", "8084"])
+      ),
+    unmock_print().
+
+t_listeners_cmd_new(_) ->
+    ok = emqx_listeners:ensure_all_started(),
+    mock_print(),
+    ?assertEqual(emqx_mgmt_cli:listeners([]), ok),
+    ?assertEqual(
+       "Stop mqtt:wss:external listener on 0.0.0.0:8084 successfully.\n",
+       emqx_mgmt_cli:listeners(["stop", "mqtt:wss:external"])
       ),
     unmock_print().
 

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1996,8 +1996,15 @@ end}.
                                   Other -> Other
                               end
                       end,
-                      [{Atom(Type), ListenOnN, [{deflate_options, DeflateOpts(Prefix)},
-                                              {tcp_options, TcpOpts(Prefix)} | LisOpts(Prefix)]}]
+                      [#{ proto => Atom(Type)
+                        , name => Name
+                        , listen_on => ListenOnN
+                        , opts => [ {deflate_options, DeflateOpts(Prefix)}
+                                  , {tcp_options, TcpOpts(Prefix)}
+                                  | LisOpts(Prefix)
+                                  ]
+                        }
+                      ]
                    end,
     SslListeners = fun(Type, Name) ->
                        Prefix = string:join(["listener", Type, Name], "."),
@@ -2005,9 +2012,16 @@ end}.
                            undefined ->
                                [];
                            ListenOn ->
-                               [{Atom(Type), ListenOn, [{deflate_options, DeflateOpts(Prefix)},
-                                                        {tcp_options, TcpOpts(Prefix)},
-                                                        {ssl_options, SslOpts(Prefix)} | LisOpts(Prefix)]}]
+                               [#{ proto => Atom(Type)
+                                 , name => Name
+                                 , listen_on => ListenOn
+                                 , opts => [ {deflate_options, DeflateOpts(Prefix)}
+                                           , {tcp_options, TcpOpts(Prefix)}
+                                           , {ssl_options, SslOpts(Prefix)}
+                                           | LisOpts(Prefix)
+                                           ]
+                                 }
+                               ]
                        end
                    end,
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -47,8 +47,8 @@ test_plugins() ->
 
 test_deps() ->
     [ {bbmustache, "1.10.0"}
-     , {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "1.3.5"}}}
-     , meck
+    , {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "1.3.6"}}}
+    , meck
     ].
 
 default_compile_opts() ->

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -28,7 +28,6 @@
 -export([ start_listener/1
         , start_listener/3
         , stop_listener/1
-        , stop_listener/3
         , restart_listener/1
         , restart_listener/3
         ]).
@@ -37,6 +36,7 @@
         , find_by_listen_on/1
         , find_by_id/1
         , identifier/1
+        , format_listen_on/1
         ]).
 
 -type(listener() :: #{ name := binary()
@@ -75,6 +75,10 @@ identifier(#{proto := Proto, name := Name}) ->
 -spec(start() -> ok).
 start() ->
     lists:foreach(fun start_listener/1, emqx:get_env(listeners, [])).
+
+%% @doc Format address:port for logging.
+-spec(format_listen_on(esockd:listen_on()) -> binary()).
+format_listen_on(ListenOn) -> format(ListenOn).
 
 -spec(start_listener(listener()) -> ok).
 start_listener(#{proto := Proto, name := Name, listen_on := ListenOn, opts := Options}) ->
@@ -171,16 +175,8 @@ stop() ->
     lists:foreach(fun stop_listener/1, emqx:get_env(listeners, [])).
 
 -spec(stop_listener(listener()) -> ok | {error, term()}).
-stop_listener(#{proto := Proto, name := Name, listen_on := ListenOn, opts := Opts}) ->
-    ID = identifier(Proto, Name),
-    StopRet = stop_listener(Proto, ListenOn, Opts),
-    case StopRet of
-        ok -> io:format("Stop ~s listener on ~s successfully.~n", [ID, format(ListenOn)]);
-        {error, Reason} ->
-            io:format(standard_error, "Failed to stop mqtt:~s listener on ~s - ~p~n.",
-                      [ID, format(ListenOn), Reason])
-    end,
-    StopRet.
+stop_listener(#{proto := Proto, listen_on := ListenOn, opts := Opts}) ->
+    stop_listener(Proto, ListenOn, Opts).
 
 -spec(stop_listener(esockd:proto(), esockd:listen_on(), [esockd:option()])
       -> ok | {error, term()}).

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -109,7 +109,7 @@ start_listener(#{proto := Proto, name := Name, listen_on := ListenOn, opts := Op
         {ok, _} -> io:format("Start ~s listener on ~s successfully.~n",
                              [ID, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start mqtt listener ~s on ~s - ~0p~n!",
+            io:format(standard_error, "Failed to start mqtt listener ~s on ~s: ~0p~n",
                       [ID, format(ListenOn), Reason]),
             error(Reason)
     end.

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -48,10 +48,10 @@
 
 %% @doc Find listener identifier by listen-on.
 %% Return empty string (binary) if listener is not found in config.
--spec(find_id_by_listen_on(esockd:listen_on()) -> binary()).
+-spec(find_id_by_listen_on(esockd:listen_on()) -> binary() | false).
 find_id_by_listen_on(ListenOn) ->
     case find_by_listen_on(ListenOn) of
-        false -> <<>>;
+        false -> false;
         L -> identifier(L)
     end.
 
@@ -238,7 +238,7 @@ identifier(Proto, Name) when is_atom(Proto) ->
 identifier(Proto, Name) ->
     iolist_to_binary(["mqtt", ":", Proto, ":", Name]).
 
-find_by_listen_on(ListenOn, []) -> error({unknown_listener, ListenOn});
+find_by_listen_on(_ListenOn, []) -> false;
 find_by_listen_on(ListenOn, [#{listen_on := ListenOn} = L | _]) -> L;
 find_by_listen_on(ListenOn, [_ | Rest]) -> find_by_listen_on(ListenOn, Rest).
 


### PR DESCRIPTION
Listeners are internally identifiered by the listen-on tuple
which is not UI friendly when we have to find a listener by this
'signature'.

The listeners are actually named in configs, but the names are
discarded in the parsing functions.

In this PR, the configured names are kept and passed to emqx
internal for more user-friendly lookups.
The `emqx_ctl listeners` print out has been refactored to
display the identifier in format `<Protocol>[:<Transport>]:<Name>`.
e.g. `http:management` and `mqtt:tcp:internal`.
And the `emqx_ctl listeners stop` interface has been updated to
use the identifier as input.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked.:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

For users, this PR only changes mqtt listeners' print-out lines.
Although the old stop CLI input is still supported,
the document as been updated to drop it: https://github.com/emqx/emqx-docs/pull/641

## More information