### PR TITLE
feat(peer_cert_as_clientid): peer_cert_as_clientid = cn | dn | crt | pem | md5

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1088,9 +1088,17 @@ listener.tcp.external.access.1 = allow all
 
 ## Enable the option for X.509 certificate based authentication.
 ## EMQX will use the common name of certificate as MQTT username.
+## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
 ##
-## Value: cn | dn | crt
+## Value: cn | dn | crt | pem | md5
 ## listener.tcp.external.peer_cert_as_username = cn
+
+## Enable the option for X.509 certificate based authentication.
+## EMQX will use the common name of certificate as MQTT clientid.
+## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
+##
+## Value: cn | dn | crt | pem | md5
+## listener.tcp.external.peer_cert_as_clientid = cn
 
 ## The TCP backlog defines the maximum length that the queue of pending
 ## connections can grow to.
@@ -1443,9 +1451,17 @@ listener.ssl.external.ciphers = TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TL
 
 ## Use the CN, DN or CRT field from the client certificate as a username.
 ## Notice that 'verify' should be set as 'verify_peer'.
+## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
 ##
-## Value: cn | dn | crt
+## Value: cn | dn | crt | pem | md5
 ## listener.ssl.external.peer_cert_as_username = cn
+
+## Use the CN, DN or CRT field from the client certificate as a username.
+## Notice that 'verify' should be set as 'verify_peer'.
+## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
+##
+## Value: cn | dn | crt | pem | md5
+## listener.ssl.external.peer_cert_as_clientid = cn
 
 ## TCP backlog for the SSL connection.
 ##
@@ -1890,8 +1906,13 @@ listener.wss.external.ciphers = TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TL
 
 ## See: listener.ssl.$name.peer_cert_as_username
 ##
-## Value: cn | dn | crt
+## Value: cn | dn | crt | pem | md5
 ## listener.wss.external.peer_cert_as_username = cn
+
+## See: listener.ssl.$name.peer_cert_as_clientid
+##
+## Value: cn | dn | crt | pem | md5
+## listener.wss.external.peer_cert_as_clientid = cn
 
 ## TCP backlog for the WebSocket/SSL connection.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1211,7 +1211,11 @@ end}.
 ]}.
 
 {mapping, "listener.tcp.$name.peer_cert_as_username", "emqx.listeners", [
-  {datatype, {enum, [cn, dn, crt]}}
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+]}.
+
+{mapping, "listener.tcp.$name.peer_cert_as_clientid", "emqx.listeners", [
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
 ]}.
 
 {mapping, "listener.tcp.$name.backlog", "emqx.listeners", [
@@ -1425,7 +1429,11 @@ end}.
 ]}.
 
 {mapping, "listener.ssl.$name.peer_cert_as_username", "emqx.listeners", [
-  {datatype, {enum, [cn, dn, crt]}}
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+]}.
+
+{mapping, "listener.ssl.$name.peer_cert_as_clientid", "emqx.listeners", [
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
 ]}.
 
 %%--------------------------------------------------------------------
@@ -1765,7 +1773,11 @@ end}.
 ]}.
 
 {mapping, "listener.wss.$name.peer_cert_as_username", "emqx.listeners", [
-  {datatype, {enum, [cn, dn, crt]}}
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+]}.
+
+{mapping, "listener.wss.$name.peer_cert_as_clientid", "emqx.listeners", [
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
 ]}.
 
 {mapping, "listener.wss.$name.compress", "emqx.listeners", [
@@ -1905,6 +1917,7 @@ end}.
                           {fail_if_no_subprotocol, cuttlefish:conf_get(Prefix ++ ".fail_if_no_subprotocol", Conf, undefined)},
                           {supported_subprotocols, string:tokens(cuttlefish:conf_get(Prefix ++ ".supported_subprotocols", Conf, ""), ", ")},
                           {peer_cert_as_username, cuttlefish:conf_get(Prefix ++ ".peer_cert_as_username", Conf, undefined)},
+                          {peer_cert_as_clientid, cuttlefish:conf_get(Prefix ++ ".peer_cert_as_clientid", Conf, undefined)},
                           {compress, cuttlefish:conf_get(Prefix ++ ".compress", Conf, undefined)},
                           {idle_timeout, cuttlefish:conf_get(Prefix ++ ".idle_timeout", Conf, undefined)},
                           {max_frame_size, cuttlefish:conf_get(Prefix ++ ".max_frame_size", Conf, undefined)},


### PR DESCRIPTION
pem is base64 encoded instead of binary crt
md5 is md5 hash of crt
peer_cert_as_clientid is like peer_cert_as_username

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked.:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility
existing `peer_cert_as_username` options are unaffected

## More information
peer_cert_as_username=crt breaks exhook proto utf8 parsing of username

crt cannot be used in a topic name due to being invalid utf8
pem cannot be used in a topic name due to having slashes

peer_cert_as_clientid = md5 allows to e.g. subscribe to "t/%c" with ACL

My actual use case involves both `peer_cert_as_username = pem` and `peer_cert_as_clientid = md5`. I need to retrieve the original cert in some case, and identify the client_id by their cert with the `md5` hash.
Previously I had accomplished this with a combination of rule-engine rule and exhook, but since exhook changed to gRPC, `peer_cert_as_username = crt` does not work at all due to the gRPC lib failing when trying to convert the binary to utf8 string.