### PR TITLE
chore(coap): upgrade gen_coap to v0.3.2

### DIFF
--- a/apps/emqx_coap/rebar.config
+++ b/apps/emqx_coap/rebar.config
@@ -1,28 +1,4 @@
 {deps,
  [
-  {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.3.1"}}}
- ]}.
-
-{edoc_opts, [{preprocess, true}]}.
-{erl_opts, [warn_unused_vars,
-            warn_shadow_vars,
-            warn_unused_import,
-            warn_obsolete_guard,
-            debug_info,
-            {parse_transform}]}.
-
-{xref_checks, [undefined_function_calls, undefined_functions,
-               locals_not_used, deprecated_function_calls,
-               warnings_as_errors, deprecated_functions]}.
-{cover_enabled, true}.
-{cover_opts, [verbose]}.
-{cover_export_enabled, true}.
-
-{profiles,
- [{test,
-   [{deps,
-     [{er_coap_client, {git, "https://github.com/emqx/er_coap_client", {tag, "v1.0"}}},
-      {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "1.2.2"}}}
-     ]}
-   ]}
+  {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.3.2"}}}
  ]}.


### PR DESCRIPTION
The 0.3.2 fixes some redundant log printing in a DTLS
connection

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information