### PR TITLE
fix(mgmt): remove the useless match

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -303,8 +303,8 @@ list_subscriptions_via_topic(Node, Topic, {M,F}) when Node =:= node() ->
     MatchSpec = [{{{'_', '$1'}, '_'}, [{'=:=','$1', Topic}], ['$_']}],
     M:F(ets:select(emqx_suboption, MatchSpec));
 
-list_subscriptions_via_topic(Node, {topic, Topic}, FormatFun) ->
-    rpc_call(Node, list_subscriptions_via_topic, [Node, {topic, Topic}, FormatFun]).
+list_subscriptions_via_topic(Node, Topic, FormatFun) ->
+    rpc_call(Node, list_subscriptions_via_topic, [Node, Topic, FormatFun]).
 
 lookup_subscriptions(ClientId) ->
     lists:append([lookup_subscriptions(Node, ClientId) || Node <- ekka_mnesia:running_nodes()]).


### PR DESCRIPTION
Currently, the `{topic, Topic}` pattern is not used for management.
Moreover it will casue a `function_caluse` while the previous caluse not
matched


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information