### PR TITLE
fix(config): use config value default log.to for daemon mode

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -20,8 +20,8 @@ mkdir -p "$RUNNER_LOG_DIR"
 # Make sure data directory exists
 mkdir -p "$RUNNER_DATA_DIR"
 
-# cuttlefish try to read environment variables starting with "EMQX_", if not specified
-export CUTTLEFISH_ENV_OVERRIDE_PREFIX="${CUTTLEFISH_ENV_OVERRIDE_PREFIX:-EMQX_}"
+# cuttlefish try to read environment variables starting with "EMQX_"
+export CUTTLEFISH_ENV_OVERRIDE_PREFIX='EMQX_'
 
 relx_usage() {
     command="$1"

--- a/bin/emqx
+++ b/bin/emqx
@@ -339,6 +339,10 @@ case "$1" in
         # Bootstrap daemon command (check perms & drop to $RUNNER_USER)
         bootstrapd
 
+        # this flag passes down to console mode
+        # so we know it's intended to be run in daemon mode
+        export _EMQX_START_MODE="$1"
+
         # Save this for later.
         CMD=$1
         case "$1" in
@@ -519,7 +523,9 @@ case "$1" in
         esac
 
         # set before generate_config
-        export EMQX_LOG__TO='console'
+        if [ "${_EMQX_START_MODE:-}" = '' ]; then
+            export EMQX_LOG__TO="${EMQX_LOG__TO:-console}"
+        fi
 
         #generate app.config and vm.args
         generate_config
@@ -562,7 +568,7 @@ case "$1" in
         # or other supervision services
 
         # set before generate_config
-        export EMQX_LOG__TO='console'
+        export EMQX_LOG__TO="${EMQX_LOG__TO:-console}"
 
         #generate app.config and vm.args
         generate_config


### PR DESCRIPTION
Fixes two issues
1. when start in daemon mode (`start` command), it recursively uses the `console` command, added a flag to by pass the overrride
2. Do not override user provided `MEQX_LOG__TO`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information