### PR TITLE
Refactor http lib add uri parse

### DIFF
--- a/src/emqx_http_lib.erl
+++ b/src/emqx_http_lib.erl
@@ -16,7 +16,20 @@
 
 -module(emqx_http_lib).
 
--export([uri_encode/1, uri_decode/1]).
+-export([ uri_encode/1
+        , uri_decode/1
+        , uri_parse/1
+        ]).
+
+-export_type([uri_map/0]).
+
+-type uri_map() :: #{scheme := http | https,
+                     host := unicode:chardata(),
+                     port := non_neg_integer(),
+                     path => unicode:chardata(),
+                     query => unicode:chardata(),
+                     fragment => unicode:chardata(),
+                     userinfo => unicode:chardata()}.
 
 %% @doc Decode percent-encoded URI.
 %% This is copied from http_uri.erl which has been deprecated since OTP-23
@@ -34,6 +47,51 @@ uri_decode(<<>>) ->
 -spec uri_encode(binary()) -> binary().
 uri_encode(URI) when is_binary(URI) ->
     << <<(uri_encode_binary(Char))/binary>> || <<Char>> <= URI >>.
+
+%% @doc Parse URI into a map as uri_string:uri_map(), but with two fields
+%% normalised: (1): port number is never 'undefined', default ports are used
+%% if missing. (2): scheme is always atom.
+-spec uri_parse(string() | binary()) -> {ok, uri_map()} | {error, any()}.
+uri_parse(URI) ->
+    try
+        {ok, do_parse(uri_string:normalize(URI))}
+    catch
+        throw : Reason ->
+            {error, Reason}
+    end.
+
+do_parse({error, Reason, Which}) -> throw({Reason, Which});
+do_parse(URI) ->
+    %% ensure we return string() instead of binary() in uri_map() values.
+    Map = uri_string:parse(unicode:characters_to_list(URI)),
+    case maps:is_key(scheme, Map) of
+        true ->
+            normalise_parse_result(Map);
+        false ->
+            %% missing scheme, add "http://" and try again
+            Map2 = uri_string:parse(unicode:characters_to_list(["http://", URI])),
+            normalise_parse_result(Map2)
+    end.
+
+normalise_parse_result(#{host := _, scheme := Scheme0} = Map) ->
+    Scheme = atom_scheme(Scheme0),
+    DefaultPort = case https =:= Scheme of
+                      true  -> 443;
+                      false -> 80
+                  end,
+    Port = case maps:get(port, Map, undefined) of
+               N when is_number(N) -> N;
+               _ -> DefaultPort
+           end,
+    Map#{ scheme => Scheme
+        , port => Port
+        }.
+
+%% NOTE: so far we only support http schemes.
+atom_scheme(Scheme) when is_list(Scheme) -> atom_scheme(list_to_binary(Scheme));
+atom_scheme(<<"https">>) -> https;
+atom_scheme(<<"http">>) -> http;
+atom_scheme(Other) -> throw({unsupported_scheme, Other}).
 
 uri_encode_binary(Char) ->
     case reserved(Char)  of

--- a/test/emqx_http_lib_tests.erl
+++ b/test/emqx_http_lib_tests.erl
@@ -44,3 +44,31 @@ test_prop_uri(URI) ->
     Decoded2 =  uri_string:percent_decode(Encoded),
     ?assertEqual(URI, Decoded2),
     true.
+
+uri_parse_test_() ->
+    [ {"default port http",
+       fun() -> ?assertMatch({ok, #{port := 80, scheme := http, host := "localhost"}},
+                             emqx_http_lib:uri_parse("localhost"))
+       end
+      }
+    , {"default port https",
+       fun() -> ?assertMatch({ok, #{port := 443, scheme := https}},
+                             emqx_http_lib:uri_parse("https://localhost"))
+       end
+      }
+    , {"bad url",
+       fun() -> ?assertMatch({error, {invalid_uri, _}},
+                             emqx_http_lib:uri_parse("https://localhost:notnumber"))
+       end
+      }
+    , {"normalise",
+       fun() -> ?assertMatch({ok, #{scheme := https}},
+                             emqx_http_lib:uri_parse("HTTPS://127.0.0.1"))
+       end
+      }
+    , {"unsupported_scheme",
+       fun() -> ?assertEqual({error, {unsupported_scheme, <<"wss">>}},
+                             emqx_http_lib:uri_parse("wss://127.0.0.1"))
+       end
+      }
+    ].


### PR DESCRIPTION
## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information

This abstraction is need for enterprise to compile because we still have code calling the deprecated (by OTP) http_url module there.

And there was a bug in the old code.
in `uri_string:uri_map()`, the port field might be missing, and it could be `undefined` too
we have code to handle the 'missing' but not `undefined`.