### PR TITLE
feat(emqx_message): add from_map

### DIFF
--- a/src/emqx_message.erl
+++ b/src/emqx_message.erl
@@ -67,7 +67,20 @@
 -export([ to_packet/2
         , to_map/1
         , to_list/1
+        , from_map/1
         ]).
+
+-export_type([message_map/0]).
+
+-type(message_map() :: #{id := binary(),
+                        qos := 0 | 1 | 2,
+                        from := atom() | binary(),
+                        flags := emqx_types:flags(),
+                        headers := emqx_types:headers(),
+                        topic := emqx_types:topic(),
+                        payload := emqx_types:payload(),
+                        timestamp := integer()}
+     ).
 
 -export([format/1]).
 
@@ -266,7 +279,7 @@ filter_pub_props(Props) ->
               ], Props).
 
 %% @doc Message to map
--spec(to_map(emqx_types:message()) -> map()).
+-spec(to_map(emqx_types:message()) -> message_map()).
 to_map(#message{
           id = Id,
           qos = QoS,
@@ -291,6 +304,28 @@ to_map(#message{
 -spec(to_list(emqx_types:message()) -> list()).
 to_list(Msg) ->
     lists:zip(record_info(fields, message), tl(tuple_to_list(Msg))).
+
+%% @doc Map to message
+-spec(from_map(message_map()) -> emqx_types:message()).
+from_map(#{id := Id,
+           qos := QoS,
+           from := From,
+           flags := Flags,
+           headers := Headers,
+           topic := Topic,
+           payload := Payload,
+           timestamp := Timestamp
+          }) ->
+    #message{
+        id = Id,
+        qos = QoS,
+        from = From,
+        flags = Flags,
+        headers = Headers,
+        topic = Topic,
+        payload = Payload,
+        timestamp = Timestamp
+    }.
 
 %% MilliSeconds
 elapsed(Since) ->

--- a/test/emqx_message_SUITE.erl
+++ b/test/emqx_message_SUITE.erl
@@ -210,3 +210,15 @@ t_to_map(_) ->
     ?assertEqual(List, emqx_message:to_list(Msg)),
     ?assertEqual(maps:from_list(List), emqx_message:to_map(Msg)).
 
+t_from_map(_) ->
+    Msg = emqx_message:make(<<"clientid">>, ?QOS_1, <<"topic">>, <<"payload">>),
+    Map = #{id => emqx_message:id(Msg),
+            qos => ?QOS_1,
+            from => <<"clientid">>,
+            flags => #{},
+            headers => #{},
+            topic => <<"topic">>,
+            payload => <<"payload">>,
+            timestamp => emqx_message:timestamp(Msg)},
+    ?assertEqual(Map, emqx_message:to_map(Msg)),
+    ?assertEqual(Msg, emqx_message:from_map(emqx_message:to_map(Msg))).


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Allow extra plugins to play with message without importing `emqx.hrl`.

Example:
```
on_message_publish(Message, _Env) ->
    MMessage = emqx_message:to_map(Message),
    case maps:get(topic, MMessage) of
        <<"$SYS/", _/binary>> ->
            {ok, Message};
        _ ->
            NewMessage = emqx_message:to_message(MMessage#{from => <<"overwritten">>}),
            io:format("Publish ~s~n", [emqx_message:format(NewMessage)]),
            {ok, NewMessage}
    end.
```

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information