### PR TITLE
Get rel vsn fallback

### DIFF
--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -70,18 +70,15 @@ get_description() ->
         Str -> string:strip(Str, both, $\n)
     end.
 
--ifdef(TEST).
-%% When testing, the 'cover' compiler stripps aways compile info
-get_release() -> release_in_macro().
--else.
-%% Otherwise print the build number,
-%% which may have a git commit in its suffix.
 get_release() ->
-    {_, Vsn} = lists:keyfind(emqx_vsn, 1, ?MODULE:module_info(compile)),
-    VsnStr = release_in_macro(),
-    1 = string:str(Vsn, VsnStr), %% assert
-    Vsn.
--endif.
+    case lists:keyfind(emqx_vsn, 1, ?MODULE:module_info(compile)) of
+        false ->
+            release_in_macro();
+        {_, Vsn} ->
+            VsnStr = release_in_macro(),
+            1 = string:str(Vsn, VsnStr), %% assert
+            Vsn
+    end.
 
 release_in_macro() ->
     element(2, ?EMQX_RELEASE).

--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -72,9 +72,9 @@ get_description() ->
 
 get_release() ->
     case lists:keyfind(emqx_vsn, 1, ?MODULE:module_info(compile)) of
-        false ->
+        false ->    %% For TEST build or depedency build.
             release_in_macro();
-        {_, Vsn} ->
+        {_, Vsn} -> %% For emqx release build
             VsnStr = release_in_macro(),
             1 = string:str(Vsn, VsnStr), %% assert
             Vsn


### PR DESCRIPTION
This fixes a problem when emqx is built as a dependency of emqtt (CT build).

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information