### PR TITLE
revert: fix(config): delete needless config

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1087,16 +1087,16 @@ listener.tcp.external.access.1 = allow all
 
 ## Enable the option for X.509 certificate based authentication.
 ## EMQX will use the common name of certificate as MQTT username.
-## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
+## The proxy-protocol protocol can get the certificate CN through tcp
 ##
-## Value: cn | dn | crt | pem | md5
+## Value: cn
 ## listener.tcp.external.peer_cert_as_username = cn
 
 ## Enable the option for X.509 certificate based authentication.
 ## EMQX will use the common name of certificate as MQTT clientid.
-## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
+## The proxy-protocol protocol can get the certificate CN through tcp
 ##
-## Value: cn | dn | crt | pem | md5
+## Value: cn
 ## listener.tcp.external.peer_cert_as_clientid = cn
 
 ## The TCP backlog defines the maximum length that the queue of pending

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1085,6 +1085,20 @@ listener.tcp.external.access.1 = allow all
 ## Value: Duration
 ## listener.tcp.external.proxy_protocol_timeout = 3s
 
+## Enable the option for X.509 certificate based authentication.
+## EMQX will use the common name of certificate as MQTT username.
+## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
+##
+## Value: cn | dn | crt | pem | md5
+## listener.tcp.external.peer_cert_as_username = cn
+
+## Enable the option for X.509 certificate based authentication.
+## EMQX will use the common name of certificate as MQTT clientid.
+## 'pem' encodes CRT in base64, and md5 is the md5 hash of CRT.
+##
+## Value: cn | dn | crt | pem | md5
+## listener.tcp.external.peer_cert_as_clientid = cn
+
 ## The TCP backlog defines the maximum length that the queue of pending
 ## connections can grow to.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1211,12 +1211,14 @@ end}.
   {datatype, {duration, ms}}
 ]}.
 
+%% The proxy-protocol protocol can get the certificate CN through tcp
 {mapping, "listener.tcp.$name.peer_cert_as_username", "emqx.listeners", [
-  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+  {datatype, {enum, [cn]}}
 ]}.
 
+%% The proxy-protocol protocol can get the certificate CN through tcp
 {mapping, "listener.tcp.$name.peer_cert_as_clientid", "emqx.listeners", [
-  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+  {datatype, {enum, [cn]}}
 ]}.
 
 {mapping, "listener.tcp.$name.backlog", "emqx.listeners", [

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1211,6 +1211,14 @@ end}.
   {datatype, {duration, ms}}
 ]}.
 
+{mapping, "listener.tcp.$name.peer_cert_as_username", "emqx.listeners", [
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+]}.
+
+{mapping, "listener.tcp.$name.peer_cert_as_clientid", "emqx.listeners", [
+  {datatype, {enum, [cn, dn, crt, pem, md5]}}
+]}.
+
 {mapping, "listener.tcp.$name.backlog", "emqx.listeners", [
   {datatype, integer},
   {default, 1024}


### PR DESCRIPTION
revert: fix(config): delete peer_cert_as_username and peer_cert_as_clientid in tcp listener

This reverts commit: 4bf0ad1bafd573bbb4d7590b8ea34e053b3467b7