### PR TITLE
chore(build): pin port_compiler v1.11.1

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -77,7 +77,6 @@ jobs:
     - name: build
       env:
         PYTHON: python
-        DIAGNOSTIC: 1
       run: |
         $env:PATH = "${{ steps.install_erlang.outputs.erlpath }}\bin;$env:PATH"
 

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -77,7 +77,7 @@ jobs:
     - name: build
       env:
         PYTHON: python
-        DIAGNOSTIC: 1 
+        DIAGNOSTIC: 1
       run: |
         $env:PATH = "${{ steps.install_erlang.outputs.erlpath }}\bin;$env:PATH"
 
@@ -89,8 +89,10 @@ jobs:
         else {
           $pkg_name = "${{ matrix.profile }}-windows-$($version -replace '/').zip"
           }
-
         cd source
+        ## We do not build/release bcrypt for windows package
+        Remove-Item -Recurse -Force -Path _build/default/lib/bcrypt/
+        Remove-Item -Force -Path rebar.lock
         make ${{ matrix.profile }}
         mkdir -p _packages/${{ matrix.profile }}
         Compress-Archive -Path _build/${{ matrix.profile }}/rel/emqx -DestinationPath _build/${{ matrix.profile }}/rel/$pkg_name

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -85,6 +85,9 @@ project_app_dirs() ->
 plugins(HasElixir) ->
     [ {relup_helper,{git,"https://github.com/emqx/relup_helper", {tag, "2.0.0"}}}
     , {er_coap_client, {git, "https://github.com/emqx/er_coap_client", {tag, "v1.0"}}}
+      %% emqx main project does not require port-compiler
+      %% pin at root level for deterministic
+    , {pc, {git, "https://github.com/emqx/port_compiler.git", {tag, "v1.11.1"}}}
     | [ rebar_mix || HasElixir ]
     ]
     %% test plugins are concatenated to default profile plugins


### PR DESCRIPTION
Port compiler bug in v1.11.0:
In windows builds, cl.exe produces .obj files
link.exe looks for .o files to link.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information