### PR TITLE
refactor: improve the speed of hexstr and binary conversions

### DIFF
--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -273,7 +273,7 @@ clientinfo(ClientInfo =
 
 message(#message{id = Id, qos = Qos, from = From, topic = Topic, payload = Payload, timestamp = Ts}) ->
     #{node => stringfy(node()),
-      id => hexstr(Id),
+      id => emqx_guid:to_hexstr(Id),
       qos => Qos,
       from => stringfy(From),
       topic => Topic,
@@ -303,12 +303,6 @@ stringfy(Term) when is_atom(Term) ->
     atom_to_binary(Term, utf8);
 stringfy(Term) ->
     unicode:characters_to_binary((io_lib:format("~0p", [Term]))).
-
-hexstr(B) ->
-    << <<(hexchar(H)), (hexchar(L))>> || <<H:4, L:4>> <= B>>.
-
-hexchar(I) when I >= 0 andalso I < 10 -> I + $0;
-hexchar(I) -> I - 10 + $A.
 
 %%--------------------------------------------------------------------
 %% Acc funcs

--- a/apps/emqx_exproto/src/emqx_exproto_channel.erl
+++ b/apps/emqx_exproto/src/emqx_exproto_channel.erl
@@ -205,7 +205,7 @@ handle_deliver(Delivers, Channel = #channel{clientinfo = ClientInfo}) ->
                                           [ClientInfo], Msg),
                NMsg = emqx_mountpoint:unmount(Mountpoint, Msg1),
                #{node => NodeStr,
-                 id => hexstr(emqx_message:id(NMsg)),
+                 id => emqx_guid:to_hexstr(emqx_message:id(NMsg)),
                  qos => emqx_message:qos(NMsg),
                  from => fmt_from(emqx_message:from(NMsg)),
                  topic => emqx_message:topic(NMsg),
@@ -590,9 +590,6 @@ default_clientinfo(#{peername := {PeerHost, _},
 
 stringfy(Reason) ->
     unicode:characters_to_binary((io_lib:format("~0p", [Reason]))).
-
-hexstr(Bin) ->
-    [io_lib:format("~2.16.0B",[X]) || <<X:8>> <= Bin].
 
 fmt_from(undefined) -> <<>>;
 fmt_from(Bin) when is_binary(Bin) -> Bin;

--- a/apps/emqx_lwm2m/src/emqx_lwm2m_cmd_handler.erl
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m_cmd_handler.erl
@@ -303,18 +303,7 @@ bin(Float) when is_float(Float) -> float_to_binary(Float).
 
 decoding(Datas, <<"hex">>) ->
     lists:map(fun(Data = #{<<"value">> := Value}) ->
-        Data#{<<"value">> => hexstr_to_bin(binary_to_list(Value))}
+        Data#{<<"value">> => emqx_misc:hexstr2bin(Value)}
     end, Datas);
 decoding(Datas, _) ->
     Datas.
-
-hexstr_to_bin(S) ->
-  hexstr_to_bin(S, []).
-hexstr_to_bin([], Acc) ->
-  list_to_binary(lists:reverse(Acc));
-hexstr_to_bin([X,Y|T], Acc) ->
-  {ok, [V], []} = io_lib:fread("~16u", [X,Y]),
-  hexstr_to_bin(T, [V | Acc]);
-hexstr_to_bin([X|T], Acc) ->
-  {ok, [V], []} = io_lib:fread("~16u", lists:flatten([X,"0"])),
-  hexstr_to_bin(T, [V | Acc]).

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -512,12 +512,10 @@ map(Data) ->
     emqx_rule_utils:map(Data).
 
 bin2hexstr(Bin) when is_binary(Bin) ->
-    IntL = binary_to_list(Bin),
-    list_to_binary([io_lib:format("~2.16.0B", [Int]) || Int <- IntL]).
+    emqx_misc:bin2hexstr(Bin).
 
 hexstr2bin(Str) when is_binary(Str) ->
-    list_to_binary([binary_to_integer(W, 16) || <<W:2/binary>> <= Str]).
-
+    emqx_misc:hexstr2bin(Str).
 
 %%------------------------------------------------------------------------------
 %% NULL Funcs
@@ -776,14 +774,7 @@ sha256(S) when is_binary(S) ->
     hash(sha256, S).
 
 hash(Type, Data) ->
-    hexstring(crypto:hash(Type, Data)).
-
-hexstring(<<X:128/big-unsigned-integer>>) ->
-    iolist_to_binary(io_lib:format("~32.16.0b", [X]));
-hexstring(<<X:160/big-unsigned-integer>>) ->
-    iolist_to_binary(io_lib:format("~40.16.0b", [X]));
-hexstring(<<X:256/big-unsigned-integer>>) ->
-    iolist_to_binary(io_lib:format("~64.16.0b", [X])).
+    emqx_misc:bin2hexstr(crypto:hash(Type, Data)).
 
 %%------------------------------------------------------------------------------
 %% Data encode and decode Funcs

--- a/src/emqx_guid.erl
+++ b/src/emqx_guid.erl
@@ -136,11 +136,11 @@ npid() ->
                     PidByte3:8, PidByte4:8>>,
     NPid.
 
-to_hexstr(<<I:128>>) ->
-    list_to_binary(integer_to_list(I, 16)).
+to_hexstr(I) when byte_size(I) =:= 16 ->
+    emqx_misc:bin2hexstr(I).
 
-from_hexstr(S) ->
-    I = list_to_integer(binary_to_list(S), 16), <<I:128>>.
+from_hexstr(S) when byte_size(S) =:= 32 ->
+    emqx_misc:hexstr2bin(S).
 
 to_base62(<<I:128>>) ->
     emqx_base62:encode(I).

--- a/src/emqx_misc.erl
+++ b/src/emqx_misc.erl
@@ -45,6 +45,10 @@
         , index_of/2
         ]).
 
+-export([ bin2hexstr/1
+        , hexstr2bin/1
+        ]).
+
 %% @doc Merge options
 -spec(merge_opts(Opts, Opts) -> Opts when Opts :: proplists:proplist()).
 merge_opts(Defaults, Options) ->
@@ -232,4 +236,19 @@ index_of(E, I, [E|_]) ->
     I;
 index_of(E, I, [_|L]) ->
     index_of(E, I+1, L).
+
+-spec(bin2hexstr(binary()) -> binary()).
+bin2hexstr(B) when is_binary(B) ->
+    << <<(int2hexchar(H)), (int2hexchar(L))>> || <<H:4, L:4>> <= B>>.
+
+int2hexchar(I) when I >= 0 andalso I < 10 -> I + $0;
+int2hexchar(I) -> I - 10 + $A.
+
+-spec(hexstr2bin(binary()) -> binary()).
+hexstr2bin(B) when is_binary(B) ->
+    << <<(hexchar2int(H)*16 + hexchar2int(L))>> || <<H:8, L:8>> <= B>>.
+
+hexchar2int(I) when I >= $0 andalso I =< $9 -> I - $0;
+hexchar2int(I) when I >= $A andalso I =< $F -> I - $A + 10;
+hexchar2int(I) when I >= $a andalso I =< $f -> I - $a + 10.
 

--- a/src/emqx_tracer.erl
+++ b/src/emqx_tracer.erl
@@ -161,9 +161,4 @@ handler_name(Bin) ->
     end.
 
 hashstr(Bin) ->
-    hexstr(crypto:hash(sha, Bin)).
-
-hexstr(Bin) ->
-    lists:flatten(
-        [io_lib:format("~2.16.0B", [Int])
-         || Int <- binary_to_list(Bin)]).
+    binary_to_list(emqx_misc:bin2hexstr(Bin)).


### PR DESCRIPTION
Binary to hexstr:

| -     | Times per second |
| ----- | ---------------- |
| Older | 14 k/s           |
| Now   | 256 k/s          |

Hexstr to binary:

| -     | Times per second |
| ----- | ---------------- |
| Older | 15.77 k/s        |
| Now   | 243.90 k/s       |

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information