### PR TITLE
fix(scripts): Finds node name and cookie from vm.args

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -280,12 +280,13 @@ if [ -z "$NAME_ARG" ]; then
     [ -z "$NODENAME" ] && [ -n "$EMQX_NAME" ] && [ -n "$EMQX_HOST" ] && NODENAME="${EMQX_NAME}@${EMQX_HOST}"
     if [ -z "$NODENAME" ] && [ "$IS_BOOT_COMMAND" = 'no' ]; then
         # for non-boot commands, inspect vm.<time>.args for node name
+        # shellcheck disable=SC2012,SC2086
         LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
         if [ -z "$LATEST_VM_ARGS" ]; then
             echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
             exit 1
         fi
-        NODENAME="$(grep -E '^-name' $LATEST_VM_ARGS | awk '{print $2}')"
+        NODENAME="$(grep -E '^-name' "$LATEST_VM_ARGS" | awk '{print $2}')"
     else
         # for boot commands, inspect emqx.conf for node name
         NODENAME=$(grep -E '^[ \t]*node.name[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
@@ -316,12 +317,13 @@ PIPE_DIR="${PIPE_DIR:-/$RUNNER_DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 # or inspect vm.<time>.args
 COOKIE="${EMQX_NODE_COOKIE:-}"
 if [ -z "$COOKIE" ] && [ "$IS_BOOT_COMMAND" = 'no' ]; then
+    # shellcheck disable=SC2012,SC2086
     LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
     if [ -z "$LATEST_VM_ARGS" ]; then
         echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
         exit 1
     fi
-    COOKIE="$(grep -E '^-setcookie' $LATEST_VM_ARGS | awk '{print $2}')"
+    COOKIE="$(grep -E '^-setcookie' "$LATEST_VM_ARGS" | awk '{print $2}')"
     if [ -z "$COOKIE" ]; then
         echoerr "Please set node.cookie in $RUNNER_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE_COOKIE"
         exit 1

--- a/bin/emqx
+++ b/bin/emqx
@@ -278,18 +278,20 @@ if [ -z "$NAME_ARG" ]; then
     NODENAME="${EMQX_NODE_NAME:-}"
     # compatible with docker entrypoint
     [ -z "$NODENAME" ] && [ -n "$EMQX_NAME" ] && [ -n "$EMQX_HOST" ] && NODENAME="${EMQX_NAME}@${EMQX_HOST}"
-    if [ -z "$NODENAME" ] && [ "$IS_BOOT_COMMAND" = 'no' ]; then
-        # for non-boot commands, inspect vm.<time>.args for node name
-        # shellcheck disable=SC2012,SC2086
-        LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
-        if [ -z "$LATEST_VM_ARGS" ]; then
-            echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
-            exit 1
+    if [ -z "$NODENAME" ]; then
+        if [ "$IS_BOOT_COMMAND" = 'no' ]; then
+            # for non-boot commands, inspect vm.<time>.args for node name
+            # shellcheck disable=SC2012,SC2086
+            LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
+            if [ -z "$LATEST_VM_ARGS" ]; then
+                echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
+                exit 1
+            fi
+            NODENAME="$(grep -E '^-name' "$LATEST_VM_ARGS" | awk '{print $2}')"
+        else
+            # for boot commands, inspect emqx.conf for node name
+            NODENAME=$(grep -E '^[ \t]*node.name[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
         fi
-        NODENAME="$(grep -E '^-name' "$LATEST_VM_ARGS" | awk '{print $2}')"
-    else
-        # for boot commands, inspect emqx.conf for node name
-        NODENAME=$(grep -E '^[ \t]*node.name[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
     fi
     if [ -z "$NODENAME" ]; then
         echoerr "Failed to resolve emqx node name"
@@ -299,9 +301,8 @@ if [ -z "$NAME_ARG" ]; then
         echoerr "Maybe set environment variable ENQX_NODE_NAME='name@host.name'"
         echoerr "or set EMQX_NAME='name' EMQX_HOST='host.name'"
         exit 1
-    else
-        NAME_ARG="-name ${NODENAME# *}"
     fi
+    NAME_ARG="-name ${NODENAME# *}"
 fi
 
 # Extract the name type and name from the NAME_ARG for REMSH
@@ -312,22 +313,24 @@ export ESCRIPT_NAME="$NODENAME"
 
 PIPE_DIR="${PIPE_DIR:-/$RUNNER_DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 
-# COOKIE is only needed for non-boot commands
-# so, either read environment variable override
-# or inspect vm.<time>.args
 COOKIE="${EMQX_NODE_COOKIE:-}"
-if [ -z "$COOKIE" ] && [ "$IS_BOOT_COMMAND" = 'no' ]; then
-    # shellcheck disable=SC2012,SC2086
-    LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
-    if [ -z "$LATEST_VM_ARGS" ]; then
-        echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
-        exit 1
+if [ -z "$COOKIE" ]; then
+    if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
+        COOKIE=$(grep -E '^[ \t]*node.cookie[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
+    else
+        # shellcheck disable=SC2012,SC2086
+        LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
+        if [ -z "$LATEST_VM_ARGS" ]; then
+            echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
+            exit 1
+        fi
+        COOKIE="$(grep -E '^-setcookie' "$LATEST_VM_ARGS" | awk '{print $2}')"
     fi
-    COOKIE="$(grep -E '^-setcookie' "$LATEST_VM_ARGS" | awk '{print $2}')"
-    if [ -z "$COOKIE" ]; then
-        echoerr "Please set node.cookie in $RUNNER_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE_COOKIE"
-        exit 1
-    fi
+fi
+
+if [ -z "$COOKIE" ]; then
+    echoerr "Please set node.cookie in $RUNNER_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE_COOKIE"
+    exit 1
 fi
 
 # Support for IPv6 Dist. See: https://github.com/emqtt/emqttd/issues/1460

--- a/bin/emqx
+++ b/bin/emqx
@@ -260,15 +260,43 @@ if [ -z "$RELX_CONFIG_PATH" ]; then
     fi
 fi
 
+IS_BOOT_COMMAND='no'
+case "$1" in
+    start|start_boot)
+        IS_BOOT_COMMAND='yes'
+        ;;
+    console|console_clean|console_boot)
+        IS_BOOT_COMMAND='yes'
+        ;;
+    foreground)
+        IS_BOOT_COMMAND='yes'
+        ;;
+esac
+
+
 if [ -z "$NAME_ARG" ]; then
     NODENAME="${EMQX_NODE_NAME:-}"
     # compatible with docker entrypoint
     [ -z "$NODENAME" ] && [ -n "$EMQX_NAME" ] && [ -n "$EMQX_HOST" ] && NODENAME="${EMQX_NAME}@${EMQX_HOST}"
-    [ -z "$NODENAME" ] && NODENAME=$(grep -E '^[ \t]*node.name[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
+    if [ -z "$NODENAME" ] && [ "$IS_BOOT_COMMAND" = 'no' ]; then
+        # for non-boot commands, inspect vm.<time>.args for node name
+        LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
+        if [ -z "$LATEST_VM_ARGS" ]; then
+            echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
+            exit 1
+        fi
+        NODENAME="$(grep -E '^-name' $LATEST_VM_ARGS | awk '{print $2}')"
+    else
+        # for boot commands, inspect emqx.conf for node name
+        NODENAME=$(grep -E '^[ \t]*node.name[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
+    fi
     if [ -z "$NODENAME" ]; then
-        echoerr "vm.args needs to have a -name parameter."
-        echoerr "  -sname is not supported."
-        echoerr "perhaps you do not have read permissions on $RUNNER_ETC_DIR/emqx.conf"
+        echoerr "Failed to resolve emqx node name"
+        if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
+            echoerr "Make user emqx has read permissions on $RUNNER_ETC_DIR/emqx.conf"
+        fi
+        echoerr "Maybe set environment variable ENQX_NODE_NAME='name@host.name'"
+        echoerr "or set EMQX_NAME='name' EMQX_HOST='host.name'"
         exit 1
     else
         NAME_ARG="-name ${NODENAME# *}"
@@ -283,21 +311,22 @@ export ESCRIPT_NAME="$NODENAME"
 
 PIPE_DIR="${PIPE_DIR:-/$RUNNER_DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 
-# Extract the target cookie
-if [ -z "$COOKIE_ARG" ]; then
-    COOKIE="${EMQX_NODE_COOKIE:-}"
-    [ -z "$COOKIE" ] && COOKIE=$(grep -E '^[ \t]*node.cookie[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
-    if [ -z "$COOKIE" ]; then
-        echoerr "vm.args needs to have a -setcookie parameter."
-        echoerr "please check $RUNNER_ETC_DIR/emqx.conf"
+# COOKIE is only needed for non-boot commands
+# so, either read environment variable override
+# or inspect vm.<time>.args
+COOKIE="${EMQX_NODE_COOKIE:-}"
+if [ -z "$COOKIE" ] && [ "$IS_BOOT_COMMAND" = 'no' ]; then
+    LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
+    if [ -z "$LATEST_VM_ARGS" ]; then
+        echo "For command $1, there is no vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
         exit 1
-    else
-        COOKIE_ARG="-setcookie $COOKIE"
+    fi
+    COOKIE="$(grep -E '^-setcookie' $LATEST_VM_ARGS | awk '{print $2}')"
+    if [ -z "$COOKIE" ]; then
+        echoerr "Please set node.cookie in $RUNNER_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE_COOKIE"
+        exit 1
     fi
 fi
-
-# Extract cookie name from COOKIE_ARG
-COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
 
 # Support for IPv6 Dist. See: https://github.com/emqtt/emqttd/issues/1460
 PROTO_DIST=$(grep -E '^[ \t]*cluster.proto_dist[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)

--- a/bin/emqx_ctl
+++ b/bin/emqx_ctl
@@ -8,6 +8,7 @@ ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
 # shellcheck disable=SC1090
 . "$ROOT_DIR"/releases/emqx_vars
 
+# shellcheck disable=SC2012,SC2086
 LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
 if [ -z "$LATEST_VM_ARGS" ]; then
     echo "No vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
@@ -41,7 +42,7 @@ relx_nodetool() {
 if [ -z "$NAME_ARG" ]; then
     NODENAME="${EMQX_NODE_NAME:-}"
     [ -z "$NODENAME" ] && [ -n "$EMQX_NAME" ] && [ -n "$EMQX_HOST" ] && NODENAME="${EMQX_NAME}@${EMQX_HOST}"
-    [ -z "$NODENAME" ] && NODENAME="$(grep -E '^-name' $LATEST_VM_ARGS | awk '{print $2}')"
+    [ -z "$NODENAME" ] && NODENAME="$(grep -E '^-name' "$LATEST_VM_ARGS" | awk '{print $2}')"
     if [ -z "$NODENAME" ]; then
         echoerr "vm.args needs to have a -name parameter."
         echoerr "  -sname is not supported."
@@ -57,7 +58,7 @@ NAME_TYPE="$(echo "$NAME_ARG" | awk '{print $1}')"
 NAME="$(echo "$NAME_ARG" | awk '{print $2}')"
 
 COOKIE="${EMQX_NODE_COOKIE:-}"
-[ -z "$COOKIE" ] && COOKIE="$(grep -E '^-setcookie' $LATEST_VM_ARGS | awk '{print $2}')"
+[ -z "$COOKIE" ] && COOKIE="$(grep -E '^-setcookie' "$LATEST_VM_ARGS" | awk '{print $2}')"
 if [ -z "$COOKIE" ]; then
     echoerr "Please set node.cookie in $RUNNER_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE_COOKIE"
     exit 1

--- a/bin/emqx_ctl
+++ b/bin/emqx_ctl
@@ -8,6 +8,12 @@ ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
 # shellcheck disable=SC1090
 . "$ROOT_DIR"/releases/emqx_vars
 
+LATEST_VM_ARGS="$(ls -t $RUNNER_DATA_DIR/configs/vm.*.args | head -1)"
+if [ -z "$LATEST_VM_ARGS" ]; then
+    echo "No vm.*.args config file found in $RUNNER_DATA_DIR/configs/"
+    exit 1
+fi
+
 # Echo to stderr on errors
 echoerr() { echo "$@" 1>&2; }
 
@@ -34,9 +40,8 @@ relx_nodetool() {
 
 if [ -z "$NAME_ARG" ]; then
     NODENAME="${EMQX_NODE_NAME:-}"
-    # compatible with docker entrypoint
     [ -z "$NODENAME" ] && [ -n "$EMQX_NAME" ] && [ -n "$EMQX_HOST" ] && NODENAME="${EMQX_NAME}@${EMQX_HOST}"
-    [ -z "$NODENAME" ] && NODENAME=$(grep -E '^[ \t]*node.name[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
+    [ -z "$NODENAME" ] && NODENAME="$(grep -E '^-name' $LATEST_VM_ARGS | awk '{print $2}')"
     if [ -z "$NODENAME" ]; then
         echoerr "vm.args needs to have a -name parameter."
         echoerr "  -sname is not supported."
@@ -51,21 +56,12 @@ fi
 NAME_TYPE="$(echo "$NAME_ARG" | awk '{print $1}')"
 NAME="$(echo "$NAME_ARG" | awk '{print $2}')"
 
-# Extract the target cookie
-if [ -z "$COOKIE_ARG" ]; then
-    COOKIE="${EMQX_NODE_COOKIE:-}"
-    [ -z "$COOKIE" ] && COOKIE=$(grep -E '^[ \t]*node.cookie[ \t]*=[ \t]*' "$RUNNER_ETC_DIR/emqx.conf" 2> /dev/null | tail -1 | cut -d = -f 2-)
-    if [ -z "$COOKIE" ]; then
-        echoerr "vm.args needs to have a -setcookie parameter."
-        echoerr "please check $RUNNER_ETC_DIR/emqx.conf"
-        exit 1
-    else
-        COOKIE_ARG="-setcookie $COOKIE"
-    fi
+COOKIE="${EMQX_NODE_COOKIE:-}"
+[ -z "$COOKIE" ] && COOKIE="$(grep -E '^-setcookie' $LATEST_VM_ARGS | awk '{print $2}')"
+if [ -z "$COOKIE" ]; then
+    echoerr "Please set node.cookie in $RUNNER_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE_COOKIE"
+    exit 1
 fi
-
-# Extract cookie name from COOKIE_ARG
-COOKIE="$(echo "$COOKIE_ARG" | awk '{print $2}')"
 
 # Support for IPv6 Dist. See: https://github.com/emqtt/emqttd/issues/1460
 PROTO_DIST=$(grep -E '^[ \t]*cluster.proto_dist[ \t]*=[ \t]*' "$RUNNER_ETC_DIR"/emqx.conf 2> /dev/null | tail -1 | cut -d = -f 2-)

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -24,13 +24,13 @@ main(Args) ->
     ok = do_with_halt(Args, "chkconfig", fun chkconfig/1),
     Args1 = do_with_ret(Args, "-name",
                         fun(TargetName) ->
-                                ThisNode = append_node_suffix(TargetName, "_maint_"),
+                                ThisNode = this_node_name(TargetName),
                                 {ok, _} = net_kernel:start([ThisNode, longnames]),
                                 put(target_node, nodename(TargetName))
                         end),
     Args2 = do_with_ret(Args1, "-sname",
                         fun(TargetName) ->
-                                ThisNode = append_node_suffix(TargetName, "_maint_"),
+                                ThisNode = this_node_name(TargetName),
                                 {ok, _} = net_kernel:start([ThisNode, shortnames]),
                                 put(target_node, nodename(TargetName))
                         end),
@@ -200,13 +200,9 @@ nodename(Name) ->
             list_to_atom(lists:concat([Node, "@", Host]))
     end.
 
-append_node_suffix(Name, Suffix) ->
-    case re:split(Name, "@", [{return, list}, unicode]) of
-        [Node, Host] ->
-            list_to_atom(lists:concat([Node, Suffix, os:getpid(), "@", Host]));
-        [Node] ->
-            list_to_atom(lists:concat([Node, Suffix, os:getpid()]))
-    end.
+this_node_name(Name) ->
+    [Node, Host] = re:split(Name, "@", [{return, list}, unicode]),
+    list_to_atom(lists:concat(["remsh_maint_", Node, os:getpid(), "@", Host])).
 
 %% For windows???
 create_mnesia_dir(DataDir, NodeName) ->


### PR DESCRIPTION
For node name and cookie overriden from environment variable
the only way to find it from another shell is to inspect
the vm.args file.

For node boot commands, the vm.args file may not have been created
yet, so we need to inspect node name in emqx.conf

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information