### PR TITLE
fix(cuttlefish-schema): parse IP addr for SSL listeners.

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2006,19 +2006,18 @@ end}.
                           {honor_cipher_order, cuttlefish:conf_get(Prefix ++ ".honor_cipher_order", Conf, undefined)}])
               end,
 
+    Listen_fix = fun({Ip, Port}) -> case inet:parse_address(Ip) of
+                                      {ok, R} -> {R, Port};
+                                            _ -> {Ip, Port}
+                                    end;
+                     (Other) -> Other
+                 end,
+
     TcpListeners = fun(Type, Name) ->
                       Prefix = string:join(["listener", Type, Name], "."),
                       ListenOnN = case cuttlefish:conf_get(Prefix, Conf, undefined) of
                           undefined -> [];
-                          ListenOn  ->
-                              case ListenOn of
-                                  {Ip, Port} ->
-                                          case inet:parse_address(Ip) of
-                                              {ok ,R} -> {R, Port};
-                                              _ -> {Ip, Port}
-                                          end;
-                                  Other -> Other
-                              end
+                          ListenOn  -> Listen_fix(ListenOn)
                       end,
                       [#{ proto => Atom(Type)
                         , name => Name
@@ -2038,7 +2037,7 @@ end}.
                            ListenOn ->
                                [#{ proto => Atom(Type)
                                  , name => Name
-                                 , listen_on => ListenOn
+                                 , listen_on => Listen_fix(ListenOn)
                                  , opts => [ {deflate_options, DeflateOpts(Prefix)}
                                            , {tcp_options, TcpOpts(Prefix)}
                                            , {ssl_options, SslOpts(Prefix)}


### PR DESCRIPTION
Convert IP addr str to tuple to please ranch.

Other types of listeners seem me to be happy with the tuple format as well.

Fixes: #4426


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information