### PR TITLE
fix(cluster-webui): export emqx_modules_api:list_modules/1

### DIFF
--- a/lib-ce/emqx_modules/src/emqx_modules_api.erl
+++ b/lib-ce/emqx_modules/src/emqx_modules_api.erl
@@ -67,6 +67,7 @@
             descr  => "Reload a module in the cluster"}).
 
 -export([ list/2
+        , list_modules/1
         , load/2
         , unload/2
         , reload/2


### PR DESCRIPTION
Fix http.500 error when loading page:http://127.0.0.1:18083/#/modules on
a emqx cluster.


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information