### PR TITLE
Fix config max inflight overflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,4 +131,11 @@ $1: $(subst -pkg,,$1)-zip $1-tar
 endef
 $(foreach pt,$(PKG_PROFILES),$(eval $(call gen-pkg-target,$(pt))))
 
+.PHONY: run
+run: $(PROFILE) quickrun
+
+.PHONY: quickrun
+quickrun:
+	./_build/$(PROFILE)/rel/emqx/bin/emqx console
+
 include docker.mk

--- a/include/emqx_mqtt.hrl
+++ b/include/emqx_mqtt.hrl
@@ -181,8 +181,7 @@
 -define(MAX_PACKET_ID, 16#FFFF).
 -define(MAX_PACKET_SIZE, 16#FFFFFFF).
 -define(MAX_TOPIC_AlIAS, 16#FFFF).
-
--define(MAX_INFLIGHT_HARD_LIMIT, 32767).
+-define(RECEIVE_MAXIMUM_LIMIT, ?MAX_PACKET_ID).
 
 %%--------------------------------------------------------------------
 %% MQTT Frame Mask

--- a/include/emqx_mqtt.hrl
+++ b/include/emqx_mqtt.hrl
@@ -182,6 +182,8 @@
 -define(MAX_PACKET_SIZE, 16#FFFFFFF).
 -define(MAX_TOPIC_AlIAS, 16#FFFF).
 
+-define(MAX_INFLIGHT_HARD_LIMIT, 32767).
+
 %%--------------------------------------------------------------------
 %% MQTT Frame Mask
 %%--------------------------------------------------------------------

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -936,8 +936,8 @@ end}.
 %% 0 is equivalent to maximum allowed
 {mapping, "zone.$name.max_inflight", "emqx.zones", [
   {default, 0},
-  {datatype, integer}
-  {validators, ["range:1-32767"]},
+  {datatype, integer},
+  {validators, ["range:1-32767"]}
 ]}.
 
 %% @doc Retry interval for redelivering QoS1/2 messages.

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -933,10 +933,11 @@ end}.
 ]}.
 
 %% @doc Max number of QoS 1 and 2 messages that can be “inflight” at one time.
-%% 0 means no limit
+%% 0 is equivalent to maximum allowed
 {mapping, "zone.$name.max_inflight", "emqx.zones", [
   {default, 0},
   {datatype, integer}
+  {validators, ["range:1-32767"]},
 ]}.
 
 %% @doc Retry interval for redelivering QoS1/2 messages.

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -937,7 +937,7 @@ end}.
 {mapping, "zone.$name.max_inflight", "emqx.zones", [
   {default, 0},
   {datatype, integer},
-  {validators, ["range:1-32767"]}
+  {validators, ["range:1-65535"]}
 ]}.
 
 %% @doc Retry interval for redelivering QoS1/2 messages.

--- a/src/emqx_session.erl
+++ b/src/emqx_session.erl
@@ -662,7 +662,7 @@ inc_expired_cnt(message, N) ->
 
 -compile({inline, [next_pkt_id/1]}).
 
-next_pkt_id(Session = #session{next_pkt_id = 16#FFFF}) ->
+next_pkt_id(Session = #session{next_pkt_id = ?MAX_PACKET_ID}) ->
     Session#session{next_pkt_id = 1};
 
 next_pkt_id(Session = #session{next_pkt_id = Id}) ->


### PR DESCRIPTION
Packet IDs are wrapped around to 1 after 65535.
Allowing a larger inflight limit will only increase the chance of inflight packet ID clash.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information