### PR TITLE
refactor(emqx_coap): rename ps to pubsub

### DIFF
--- a/apps/emqx_coap/TODO
+++ b/apps/emqx_coap/TODO
@@ -2,7 +2,7 @@
     - Enhance all test case
 
 2. Remove the mqtt adaptor
-3. Remove the emqx_coap_ps_topics.erl
+3. Remove the emqx_coap_pubsub_topics.erl
 
 
 ### Problems

--- a/apps/emqx_coap/src/emqx_coap_app.erl
+++ b/apps/emqx_coap/src/emqx_coap_app.erl
@@ -29,12 +29,12 @@
 start(_Type, _Args) ->
     {ok, Sup} = emqx_coap_sup:start_link(),
     coap_server_registry:add_handler([<<"mqtt">>], emqx_coap_resource, undefined),
-    coap_server_registry:add_handler([<<"ps">>], emqx_coap_ps_resource, undefined),
-    _ = emqx_coap_ps_topics:start_link(),
+    coap_server_registry:add_handler([<<"ps">>], emqx_coap_pubsub_resource, undefined),
+    _ = emqx_coap_pubsub_topics:start_link(),
     emqx_coap_server:start(application:get_all_env(?APP)),
     {ok,Sup}.
 
 stop(_State) ->
     coap_server_registry:remove_handler([<<"mqtt">>], emqx_coap_resource, undefined),
-    coap_server_registry:remove_handler([<<"ps">>], emqx_coap_ps_resource, undefined),
+    coap_server_registry:remove_handler([<<"ps">>], emqx_coap_pubsub_resource, undefined),
     emqx_coap_server:stop(application:get_all_env(?APP)).

--- a/apps/emqx_coap/src/emqx_coap_pubsub_topics.erl
+++ b/apps/emqx_coap/src/emqx_coap_pubsub_topics.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_coap_ps_topics).
+-module(emqx_coap_pubsub_topics).
 
 -behaviour(gen_server).
 

--- a/apps/emqx_coap/src/emqx_coap_sup.erl
+++ b/apps/emqx_coap/src/emqx_coap_sup.erl
@@ -32,11 +32,11 @@ init(_Args) ->
                  shutdown => 5000,
                  type     => worker,
                  modules  => [emqx_coap_registry]},
-    PsTopics = #{id       => emqx_coap_ps_topics,
-                 start    => {emqx_coap_ps_topics, start_link, []},
+    PsTopics = #{id       => emqx_coap_pubsub_topics,
+                 start    => {emqx_coap_pubsub_topics, start_link, []},
                  restart  => permanent,
                  shutdown => 5000,
                  type     => worker,
-                 modules  => [emqx_coap_ps_topics]},
+                 modules  => [emqx_coap_pubsub_topics]},
     {ok, {{one_for_all, 10, 3600}, [Registry, PsTopics]}}.
 

--- a/apps/emqx_coap/test/emqx_coap_pubsub_SUITE.erl
+++ b/apps/emqx_coap/test/emqx_coap_pubsub_SUITE.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_coap_ps_SUITE).
+-module(emqx_coap_pubsub_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -54,7 +54,7 @@ t_update_max_age(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(TopicInPayload),
+    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(TopicInPayload),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
@@ -65,7 +65,7 @@ t_update_max_age(_Config) ->
     Reply1 = er_coap_client:request(post, URI, #coap_content{max_age = 70, format = <<"application/link-format">>, payload = Payload1}),
     {ok,created, #coap_content{location_path = LocPath}} = Reply1,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{TopicInPayload, MaxAge2, CT2, _ResPayload, _TimeStamp1}] = emqx_coap_ps_topics:lookup_topic_info(TopicInPayload),
+    [{TopicInPayload, MaxAge2, CT2, _ResPayload, _TimeStamp1}] = emqx_coap_pubsub_topics:lookup_topic_info(TopicInPayload),
     ?assertEqual(70, MaxAge2),
     ?assertEqual(<<"50">>, CT2),
 
@@ -82,7 +82,7 @@ t_create_subtopic(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(TopicInPayload),
+    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(TopicInPayload),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
@@ -99,7 +99,7 @@ t_create_subtopic(_Config) ->
     ?LOGT("Reply =~p", [Reply1]),
     {ok,created, #coap_content{location_path = LocPath1}} = Reply1,
     ?assertEqual([<<"/ps/topic1/subtopic">>] ,LocPath1),
-    [{FullTopic, MaxAge2, CT2, _ResPayload, _}] = emqx_coap_ps_topics:lookup_topic_info(FullTopic),
+    [{FullTopic, MaxAge2, CT2, _ResPayload, _}] = emqx_coap_pubsub_topics:lookup_topic_info(FullTopic),
     ?assertEqual(60, MaxAge2),
     ?assertEqual(<<"42">>, CT2),
 
@@ -114,13 +114,13 @@ t_over_max_age(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(TopicInPayload),
+    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(TopicInPayload),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(2, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
 
     timer:sleep(3000),
-    ?assertEqual(true, emqx_coap_ps_topics:is_topic_timeout(TopicInPayload)).
+    ?assertEqual(true, emqx_coap_pubsub_topics:is_topic_timeout(TopicInPayload)).
 
 t_refreash_max_age(_Config) ->
     TopicInPayload = <<"topic1">>,
@@ -132,7 +132,7 @@ t_refreash_max_age(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(TopicInPayload),
+    TopicInfo = [{TopicInPayload, MaxAge1, CT1, _ResPayload, TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(TopicInPayload),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?LOGT("TimeStamp=~p", [TimeStamp]),
     ?assertEqual(5, MaxAge1),
@@ -144,13 +144,13 @@ t_refreash_max_age(_Config) ->
     Reply1 = er_coap_client:request(post, URI, #coap_content{max_age = 5, format = <<"application/link-format">>, payload = Payload1}),
     {ok,created, #coap_content{location_path = LocPath}} = Reply1,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{TopicInPayload, MaxAge2, CT2, _ResPayload, TimeStamp1}] = emqx_coap_ps_topics:lookup_topic_info(TopicInPayload),
+    [{TopicInPayload, MaxAge2, CT2, _ResPayload, TimeStamp1}] = emqx_coap_pubsub_topics:lookup_topic_info(TopicInPayload),
     ?LOGT("TimeStamp1=~p", [TimeStamp1]),
     ?assertEqual(5, MaxAge2),
     ?assertEqual(<<"50">>, CT2),
 
     timer:sleep(3000),
-    ?assertEqual(false, emqx_coap_ps_topics:is_topic_timeout(TopicInPayload)),
+    ?assertEqual(false, emqx_coap_pubsub_topics:is_topic_timeout(TopicInPayload)),
 
     {ok, deleted, #coap_content{}} = er_coap_client:request(delete, RealURI).
 
@@ -168,7 +168,7 @@ t_case01_publish_post(_Config) ->
     ?LOGT("Reply =~p", [Reply1]),
     {ok,created, #coap_content{location_path = LocPath1}} = Reply1,
     ?assertEqual([<<"/ps/maintopic/topic1">>] ,LocPath1),
-    [{FullTopic, MaxAge, CT2, <<>>, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(FullTopic),
+    [{FullTopic, MaxAge, CT2, <<>>, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(FullTopic),
     ?assertEqual(60, MaxAge),
     ?assertEqual(<<"42">>, CT2),
 
@@ -183,7 +183,7 @@ t_case01_publish_post(_Config) ->
     Reply2 = er_coap_client:request(post, URI2, #coap_content{format = <<"application/octet-stream">>, payload = PubPayload}),
     ?LOGT("Reply =~p", [Reply2]),
     {ok,changed, _} = Reply2,
-    TopicInfo = [{FullTopic, MaxAge, CT2, PubPayload, _TimeStamp1}] = emqx_coap_ps_topics:lookup_topic_info(FullTopic),
+    TopicInfo = [{FullTopic, MaxAge, CT2, PubPayload, _TimeStamp1}] = emqx_coap_pubsub_topics:lookup_topic_info(FullTopic),
     ?LOGT("the topic info =~p", [TopicInfo]),
 
     assert_recv(FullTopic, PubPayload),
@@ -203,7 +203,7 @@ t_case02_publish_post(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(60, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
@@ -214,7 +214,7 @@ t_case02_publish_post(_Config) ->
     Reply1 = er_coap_client:request(post, URI, #coap_content{format = <<"application/octet-stream">>, payload = NewPayload}),
     ?LOGT("Reply =~p", [Reply1]),
     {ok,changed, _} = Reply1,
-    [{Topic, MaxAge, CT, NewPayload, _TimeStamp1}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, NewPayload, _TimeStamp1}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
 
     assert_recv(Topic, NewPayload),
     {ok, deleted, #coap_content{}} = er_coap_client:request(delete, URI).
@@ -233,7 +233,7 @@ t_case03_publish_post(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(60, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
@@ -258,13 +258,13 @@ t_case04_publish_post(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(5, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
     %% after max age timeout, the topic still exists but the status is timeout
     timer:sleep(6000),
-    ?assertEqual(true, emqx_coap_ps_topics:is_topic_timeout(Topic)),
+    ?assertEqual(true, emqx_coap_pubsub_topics:is_topic_timeout(Topic)),
 
     {ok, deleted, #coap_content{}} = er_coap_client:request(delete, URI).
 
@@ -281,7 +281,7 @@ t_case01_publish_put(_Config) ->
     ?LOGT("Reply =~p", [Reply1]),
     {ok,created, #coap_content{location_path = LocPath1}} = Reply1,
     ?assertEqual([<<"/ps/maintopic/topic1">>] ,LocPath1),
-    [{FullTopic, MaxAge, CT2, <<>>, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(FullTopic),
+    [{FullTopic, MaxAge, CT2, <<>>, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(FullTopic),
     ?assertEqual(60, MaxAge),
     ?assertEqual(<<"42">>, CT2),
 
@@ -296,7 +296,7 @@ t_case01_publish_put(_Config) ->
     Reply2 = er_coap_client:request(put, URI2, #coap_content{format = <<"application/octet-stream">>, payload = PubPayload}),
     ?LOGT("Reply =~p", [Reply2]),
     {ok,changed, _} = Reply2,
-    [{FullTopic, MaxAge, CT2, PubPayload, _TimeStamp1}] = emqx_coap_ps_topics:lookup_topic_info(FullTopic),
+    [{FullTopic, MaxAge, CT2, PubPayload, _TimeStamp1}] = emqx_coap_pubsub_topics:lookup_topic_info(FullTopic),
 
     assert_recv(FullTopic, PubPayload),
 
@@ -316,7 +316,7 @@ t_case02_publish_put(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(60, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
@@ -327,7 +327,7 @@ t_case02_publish_put(_Config) ->
     Reply1 = er_coap_client:request(put, URI, #coap_content{format = <<"application/octet-stream">>, payload = NewPayload}),
     ?LOGT("Reply =~p", [Reply1]),
     {ok,changed, _} = Reply1,
-    [{Topic, MaxAge, CT, NewPayload, _TimeStamp1}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, NewPayload, _TimeStamp1}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
 
     assert_recv(Topic, NewPayload),
 
@@ -347,7 +347,7 @@ t_case03_publish_put(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(60, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
@@ -372,7 +372,7 @@ t_case04_publish_put(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/topic1">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(5, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
@@ -381,7 +381,7 @@ t_case04_publish_put(_Config) ->
     % but there is one thing to do is we don't count in the publish message received from emqx(from other node).TBD!!!!!!!!!!!!!
     %%%%%%%%%%%%%%%%%%%%%%%%%%
     timer:sleep(6000),
-    ?assertEqual(true, emqx_coap_ps_topics:is_topic_timeout(Topic)),
+    ?assertEqual(true, emqx_coap_pubsub_topics:is_topic_timeout(Topic)),
 
     {ok, deleted, #coap_content{}} = er_coap_client:request(delete, URI).
 
@@ -396,7 +396,7 @@ t_case01_subscribe(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = [LocPath]}} = Reply,
     ?assertEqual(<<"/ps/topic1">> ,LocPath),
-    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
@@ -439,13 +439,13 @@ t_case02_subscribe(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/a/b">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(5, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
     %% Wait for the max age of the timer expires
     timer:sleep(6000),
-    ?assertEqual(true, emqx_coap_ps_topics:is_topic_timeout(Topic)),
+    ?assertEqual(true, emqx_coap_pubsub_topics:is_topic_timeout(Topic)),
 
     %% Subscribe to the timeout topic "a/b", still successfully，got {ok, nocontent} Method
     Uri = "coap://127.0.0.1/ps/"++PercentEncodedTopic++"?c=client1&u=tom&p=secret",
@@ -458,7 +458,7 @@ t_case02_subscribe(_Config) ->
     %% put to publish to topic "a/b"
     Reply2 = er_coap_client:request(put, URI, #coap_content{format = <<"application/octet-stream">>, payload = Payload}),
     {ok,changed, #coap_content{}} = Reply2,
-    [{Topic, MaxAge1, CT, Payload, TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge1, CT, Payload, TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT),
     ?assertEqual(false, TimeStamp =:= timeout),
@@ -505,7 +505,7 @@ t_case01_read(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = [LocPath]}} = Reply,
     ?assertEqual(<<"/ps/topic1">> ,LocPath),
-    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
@@ -530,7 +530,7 @@ t_case02_read(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = [LocPath]}} = Reply,
     ?assertEqual(<<"/ps/topic1">> ,LocPath),
-    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
@@ -565,7 +565,7 @@ t_case04_read(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = [LocPath]}} = Reply,
     ?assertEqual(<<"/ps/topic1">> ,LocPath),
-    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    TopicInfo = [{Topic, MaxAge1, CT1, _ResPayload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?LOGT("lookup topic info=~p", [TopicInfo]),
     ?assertEqual(60, MaxAge1),
     ?assertEqual(<<"42">>, CT1),
@@ -591,13 +591,13 @@ t_case05_read(_Config) ->
     ?LOGT("Reply =~p", [Reply]),
     {ok,created, #coap_content{location_path = LocPath}} = Reply,
     ?assertEqual([<<"/ps/a/b">>] ,LocPath),
-    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_ps_topics:lookup_topic_info(Topic),
+    [{Topic, MaxAge, CT, Payload, _TimeStamp}] = emqx_coap_pubsub_topics:lookup_topic_info(Topic),
     ?assertEqual(5, MaxAge),
     ?assertEqual(<<"42">>, CT),
 
     %% Wait for the max age of the timer expires
     timer:sleep(6000),
-    ?assertEqual(true, emqx_coap_ps_topics:is_topic_timeout(Topic)),
+    ?assertEqual(true, emqx_coap_pubsub_topics:is_topic_timeout(Topic)),
 
     %% GET to read the expired publish message, supposed to get {ok, nocontent}, but now got {ok, content}
     Reply1 = er_coap_client:request(get, URI),
@@ -636,8 +636,8 @@ t_case01_delete(_Config) ->
     ?LOGT("Reply=~p", [Reply1]),
     {ok, deleted, #coap_content{}}= ReplyD,
 
-    ?assertEqual(false, emqx_coap_ps_topics:is_topic_existed(TopicInPayload)),
-    ?assertEqual(false, emqx_coap_ps_topics:is_topic_existed(TopicInPayload1)).
+    ?assertEqual(false, emqx_coap_pubsub_topics:is_topic_existed(TopicInPayload)),
+    ?assertEqual(false, emqx_coap_pubsub_topics:is_topic_existed(TopicInPayload1)).
 
 t_case02_delete(_Config) ->
     TopicInPayload = <<"a/b">>,


### PR DESCRIPTION
Just rename modules `emqx_coap_ps_*` -> `emqx_coap_pubsub_*`.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information