### PR TITLE
refactor(emqx): the congestion alarm

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -894,11 +894,11 @@ zone.external.enable_flapping_detect = off
 
 ## Won't clear the congested alarm in how long time.
 ## The alarm is cleared only when there're no pending bytes in the queue, and also it has been
-## `wont_clear_alarm_in` time since the last time we considered the connection is "congested".
+## `min_alarm_sustain_duration` time since the last time we considered the connection is "congested".
 ##
 ## This is to avoid clearing and sending the alarm again too often.
 ## Default: 1m
-#zone.external.conn_congestion.wont_clear_alarm_in = 1m
+#zone.external.conn_congestion.min_alarm_sustain_duration = 1m
 
 ## Messages quota for the each of external MQTT connection.
 ## This value consumed by the number of recipient on a message.

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -876,6 +876,30 @@ zone.external.enable_flapping_detect = off
 ## Example: 100KB incoming per 10 seconds.
 #zone.external.rate_limit.conn_bytes_in = 100KB,10s
 
+## Whether to alarm the congested connections.
+##
+## Sometimes the mqtt connection (usually an MQTT subscriber) may get "congested" because
+## there're too many packets to sent. The socket trys to buffer the packets until the buffer is
+## full. If more packets comes after that, the packets will be "pending" in a queue
+## and we consider the connection is "congested".
+##
+## Enable this to send an alarm when there's any bytes pending in the queue. You could set
+## the `listener.tcp.<ZoneName>.sndbuf` to a larger value if the alarm is triggered too often.
+##
+## The name of the alarm is of format "conn_congestion/<ClientID>/<Username>".
+## Where the <ClientID> is the client-id of the congested MQTT connection.
+## And the <Username> is the username or "unknown_user" of not provided by the client.
+## Default: off
+#zone.external.conn_congestion.alarm = off
+
+## Won't clear the congested alarm in how long time.
+## The alarm is cleared only when there're no pending bytes in the queue, and also it has been
+## `wont_clear_alarm_in` time since the last time we considered the connection is "congested".
+##
+## This is to avoid clearing and sending the alarm again too often.
+## Default: 1m
+#zone.external.conn_congestion.wont_clear_alarm_in = 1m
+
 ## Messages quota for the each of external MQTT connection.
 ## This value consumed by the number of recipient on a message.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1017,7 +1017,7 @@ end}.
   {default, off}
 ]}.
 
-{mapping, "zone.$name.conn_congestion.wont_clear_alarm_in", "emqx.zones", [
+{mapping, "zone.$name.conn_congestion.min_alarm_sustain_duration", "emqx.zones", [
   {default, "1m"},
   {datatype, {duration, ms}}
 ]}.
@@ -1153,8 +1153,8 @@ end}.
                    {ratelimit, {conn_bytes_in, Ratelimit(Val)}};
                (["conn_congestion", "alarm"], Val) ->
                    {conn_congestion_alarm_enabled, Val};
-               (["conn_congestion", "wont_clear_alarm_in"], Val) ->
-                   {conn_congestion_wont_clear_alarm_in, Val};
+               (["conn_congestion", "min_alarm_sustain_duration"], Val) ->
+                   {conn_congestion_min_alarm_sustain_duration, Val};
                (["quota", "conn_messages_routing"], Val) ->
                    {quota, {conn_messages_routing, Ratelimit(Val)}};
                (["quota", "overall_messages_routing"], Val) ->

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1012,6 +1012,16 @@ end}.
   {datatype, string}
 ]}.
 
+{mapping, "zone.$name.conn_congestion.alarm", "emqx.zones", [
+  {datatype, flag},
+  {default, off}
+]}.
+
+{mapping, "zone.$name.conn_congestion.wont_clear_alarm_in", "emqx.zones", [
+  {default, "1m"},
+  {datatype, {duration, ms}}
+]}.
+
 {mapping, "zone.$name.quota.conn_messages_routing", "emqx.zones", [
   {datatype, string}
 ]}.
@@ -1141,6 +1151,10 @@ end}.
                    {ratelimit, {conn_messages_in, Ratelimit(Val)}};
                (["rate_limit", "conn_bytes_in"], Val) ->
                    {ratelimit, {conn_bytes_in, Ratelimit(Val)}};
+               (["conn_congestion", "alarm"], Val) ->
+                   {conn_congestion_alarm_enabled, Val};
+               (["conn_congestion", "wont_clear_alarm_in"], Val) ->
+                   {conn_congestion_wont_clear_alarm_in, Val};
                (["quota", "conn_messages_routing"], Val) ->
                    {quota, {conn_messages_routing, Ratelimit(Val)}};
                (["quota", "overall_messages_routing"], Val) ->

--- a/src/emqx_alarm.erl
+++ b/src/emqx_alarm.erl
@@ -379,7 +379,7 @@ normalize_message(partition, #{occurred := Node}) ->
     list_to_binary(io_lib:format("Partition occurs at node ~s", [Node]));
 normalize_message(<<"resource", _/binary>>, #{type := Type, id := ID}) ->
     list_to_binary(io_lib:format("Resource ~s(~s) is down", [Type, ID]));
-normalize_message(<<"mqtt_conn/congested/", Info/binary>>, _) ->
-    list_to_binary(io_lib:format("MQTT connection congested: ~s", [Info]));
+normalize_message(<<"conn_congestion/", Info/binary>>, _) ->
+    list_to_binary(io_lib:format("connection congested: ~s", [Info]));
 normalize_message(_Name, _UnknownDetails) ->
     <<"Unknown alarm">>.

--- a/src/emqx_congestion.erl
+++ b/src/emqx_congestion.erl
@@ -65,7 +65,8 @@ alarm_congestion(Socket, Transport, Channel, Reason) ->
 
 cancel_alarm_congestion(Socket, Transport, Channel, Reason) ->
     Zone = emqx_channel:info(zone, Channel),
-    WontClearIn = emqx_zone:get_env(Zone, conn_congestion_wont_clear_alarm_in, ?WONT_CLEAR_IN),
+    WontClearIn = emqx_zone:get_env(Zone, conn_congestion_min_alarm_sustain_duration,
+                    ?WONT_CLEAR_IN),
     case has_alarm_sent(Reason) andalso long_time_since_last_alarm(Reason, WontClearIn) of
         true -> do_cancel_alarm_congestion(Socket, Transport, Channel, Reason);
         false -> ok


### PR DESCRIPTION
I'd like to remove the "too_many_publish" alarm as it seems unnecessary, and it is almost always triggered together with the "congestion" alarm in the production.

The only user for this alarm now is SANY and we could change the rule SQL for them if they upgrades to 4.3.0 later. 

Fixes https://github.com/emqx/emqx/issues/4398

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information