### PR TITLE
chore(extra-plugin): statement plugin tag

### DIFF
--- a/lib-extra/README.md
+++ b/lib-extra/README.md
@@ -19,6 +19,15 @@ e.g. For an Erlang plugin named `plugin_foo`:
 }.
 ```
 
+Note: The `-emqx_plugin(?MODULE)` attribute should be added to
+`<plugin-name>_app.erl` file to indicate that this is an EMQ X Broker plugin.
+
+For example:
+```erlang
+%% plugin_foo_app.erl
+-emqx_plugin(?MODULE)
+```
+
 ## Build a release
 
 ```


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->

Clarify that the user's plugins must include the attribute `-emqx_plugin(xxx)`, otherwise, the `emqx_ctl plugins` command will not find the changed plugins.

see:


https://github.com/emqx/emqx/blob/61c677423e57378618d9e14112d38f6282e23354/src/emqx_plugins.erl#L125-L133

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information