### PR TITLE
fix(bridge_mqtt): fix inflight reference booking

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_stub_conn.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_stub_conn.erl
@@ -1,0 +1,40 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_stub_conn).
+
+-behaviour(emqx_bridge_connect).
+
+%% behaviour callbacks
+-export([ start/1
+        , send/2
+        , stop/1
+        ]).
+
+-type ack_ref() :: emqx_bridge_worker:ack_ref().
+-type batch() :: emqx_bridge_worker:batch().
+
+start(Cfg) ->
+    {ok, Cfg}.
+
+stop(_) -> ok.
+
+%% @doc Callback for `emqx_bridge_connect' behaviour
+-spec send(_, batch()) -> {ok, ack_ref()} | {error, any()}.
+send(#{stub_pid := Pid}, Batch) ->
+    Ref = make_ref(),
+    Pid ! {stub_message, self(), Ref, Batch},
+    {ok, Ref}.

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_worker_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_worker_SUITE.erl
@@ -67,6 +67,13 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     emqx_ct_helpers:stop_apps([emqx_bridge_mqtt]).
 
+init_per_testcase(_TestCase, Config) ->
+    ok = snabbkaffe:start_trace(),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok = snabbkaffe:stop().
+
 t_mngr(Config) when is_list(Config) ->
     Subs = [{<<"a">>, 1}, {<<"b">>, 2}],
     Cfg = #{address => node(),
@@ -188,7 +195,6 @@ t_stub_normal(Config) when is_list(Config) ->
            },
     {ok, Pid} = emqx_bridge_worker:start_link(?FUNCTION_NAME, Cfg),
     ClientId = <<"ClientId">>,
-    snabbkaffe:start_trace(),
     try
         {ok, ConnPid} = emqtt:start_link([{clientid, ClientId}]),
         {ok, _} = emqtt:connect(ConnPid),
@@ -202,7 +208,6 @@ t_stub_normal(Config) when is_list(Config) ->
         ?SNK_WAIT(replayq_drained),
         emqtt:disconnect(ConnPid)
     after
-        snabbkaffe:stop(),
         ok = emqx_bridge_worker:stop(Pid)
     end.
 
@@ -218,7 +223,6 @@ t_stub_overflow(Config) when is_list(Config) ->
            },
     {ok, Worker} = emqx_bridge_worker:start_link(?FUNCTION_NAME, Cfg),
     ClientId = <<"ClientId">>,
-    snabbkaffe:start_trace(),
     try
         {ok, ConnPid} = emqtt:start_link([{clientid, ClientId}]),
         {ok, _} = emqtt:connect(ConnPid),
@@ -236,7 +240,6 @@ t_stub_overflow(Config) when is_list(Config) ->
         ?SNK_WAIT(replayq_drained),
         emqtt:disconnect(ConnPid)
     after
-        snabbkaffe:stop(),
         ok = emqx_bridge_worker:stop(Worker)
     end.
 
@@ -252,7 +255,6 @@ t_stub_random_order(Config) when is_list(Config) ->
            },
     {ok, Worker} = emqx_bridge_worker:start_link(?FUNCTION_NAME, Cfg),
     ClientId = <<"ClientId">>,
-    snabbkaffe:start_trace(),
     try
         {ok, ConnPid} = emqtt:start_link([{clientid, ClientId}]),
         {ok, _} = emqtt:connect(ConnPid),
@@ -268,7 +270,6 @@ t_stub_random_order(Config) when is_list(Config) ->
         ?SNK_WAIT(replayq_drained),
         emqtt:disconnect(ConnPid)
     after
-        snabbkaffe:stop(),
         ok = emqx_bridge_worker:stop(Worker)
     end.
 

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_worker_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_worker_SUITE.erl
@@ -16,19 +16,18 @@
 
 -module(emqx_bridge_worker_SUITE).
 
--export([ all/0
-        , init_per_suite/1
-        , end_per_suite/1]).
--export([ t_rpc/1
-        , t_mqtt/1
-        , t_mngr/1]).
+-compile(export_all).
+-compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(wait(For, Timeout), emqx_ct_helpers:wait_for(?FUNCTION_NAME, ?LINE, fun() -> For end, Timeout)).
+
+-define(SNK_WAIT(WHAT), ?assertMatch({ok, _}, ?block_until(#{?snk_kind := WHAT}, 2000, 1000))).
 
 receive_messages(Count) ->
     receive_messages(Count, []).
@@ -45,10 +44,15 @@ receive_messages(Count, Msgs) ->
         Msgs
     end.
 
-all() -> [ t_rpc
-         , t_mqtt
-         , t_mngr
-         ].
+all() ->
+    lists:filtermap(
+      fun({FunName, _Arity}) ->
+              case atom_to_list(FunName) of
+                  "t_" ++ _ -> {true, FunName};
+                  _ -> false
+              end
+      end,
+      ?MODULE:module_info(exports)).
 
 init_per_suite(Config) ->
     case node() of
@@ -173,4 +177,110 @@ t_mqtt(Config) when is_list(Config) ->
         emqtt:disconnect(ConnPid)
     after
         ok = emqx_bridge_worker:stop(Pid)
+    end.
+
+t_stub_normal(Config) when is_list(Config) ->
+    Cfg = #{forwards => [<<"t_stub_normal/#">>],
+            connect_module => emqx_bridge_stub_conn,
+            forward_mountpoint => <<"forwarded">>,
+            start_type => auto,
+            stub_pid => self()
+           },
+    {ok, Pid} = emqx_bridge_worker:start_link(?FUNCTION_NAME, Cfg),
+    ClientId = <<"ClientId">>,
+    snabbkaffe:start_trace(),
+    try
+        {ok, ConnPid} = emqtt:start_link([{clientid, ClientId}]),
+        {ok, _} = emqtt:connect(ConnPid),
+        {ok, _PacketId} = emqtt:publish(ConnPid, <<"t_stub_normal/one">>, <<"hello">>, ?QOS_1),
+        receive
+            {stub_message, WorkerPid, BatchRef, _Batch} ->
+                WorkerPid ! {batch_ack, BatchRef},
+                ok
+        end,
+        ?SNK_WAIT(inflight_drained),
+        ?SNK_WAIT(replayq_drained),
+        emqtt:disconnect(ConnPid)
+    after
+        snabbkaffe:stop(),
+        ok = emqx_bridge_worker:stop(Pid)
+    end.
+
+t_stub_overflow(Config) when is_list(Config) ->
+    Topic = <<"t_stub_overflow/one">>,
+    MaxInflight = 20,
+    Cfg = #{forwards => [Topic],
+            connect_module => emqx_bridge_stub_conn,
+            forward_mountpoint => <<"forwarded">>,
+            start_type => auto,
+            stub_pid => self(),
+            max_inflight => MaxInflight
+           },
+    {ok, Worker} = emqx_bridge_worker:start_link(?FUNCTION_NAME, Cfg),
+    ClientId = <<"ClientId">>,
+    snabbkaffe:start_trace(),
+    try
+        {ok, ConnPid} = emqtt:start_link([{clientid, ClientId}]),
+        {ok, _} = emqtt:connect(ConnPid),
+        lists:foreach(
+          fun(I) ->
+                  Data = integer_to_binary(I),
+                  _ = emqtt:publish(ConnPid, Topic, Data, ?QOS_1)
+          end, lists:seq(1, MaxInflight * 2)),
+        ?SNK_WAIT(inflight_full),
+        Acks = stub_receive(MaxInflight),
+        lists:foreach(fun({Pid, Ref}) -> Pid ! {batch_ack, Ref} end, Acks),
+        Acks2 = stub_receive(MaxInflight),
+        lists:foreach(fun({Pid, Ref}) -> Pid ! {batch_ack, Ref} end, Acks2),
+        ?SNK_WAIT(inflight_drained),
+        ?SNK_WAIT(replayq_drained),
+        emqtt:disconnect(ConnPid)
+    after
+        snabbkaffe:stop(),
+        ok = emqx_bridge_worker:stop(Worker)
+    end.
+
+t_stub_random_order(Config) when is_list(Config) ->
+    Topic = <<"t_stub_random_order/a">>,
+    MaxInflight = 10,
+    Cfg = #{forwards => [Topic],
+            connect_module => emqx_bridge_stub_conn,
+            forward_mountpoint => <<"forwarded">>,
+            start_type => auto,
+            stub_pid => self(),
+            max_inflight => MaxInflight
+           },
+    {ok, Worker} = emqx_bridge_worker:start_link(?FUNCTION_NAME, Cfg),
+    ClientId = <<"ClientId">>,
+    snabbkaffe:start_trace(),
+    try
+        {ok, ConnPid} = emqtt:start_link([{clientid, ClientId}]),
+        {ok, _} = emqtt:connect(ConnPid),
+        lists:foreach(
+          fun(I) ->
+                  Data = integer_to_binary(I),
+                  _ = emqtt:publish(ConnPid, Topic, Data, ?QOS_1)
+          end, lists:seq(1, MaxInflight)),
+        Acks = stub_receive(MaxInflight),
+        lists:foreach(fun({Pid, Ref}) -> Pid ! {batch_ack, Ref} end,
+                      lists:reverse(Acks)),
+        ?SNK_WAIT(inflight_drained),
+        ?SNK_WAIT(replayq_drained),
+        emqtt:disconnect(ConnPid)
+    after
+        snabbkaffe:stop(),
+        ok = emqx_bridge_worker:stop(Worker)
+    end.
+
+stub_receive(N) ->
+    stub_receive(N, []).
+
+stub_receive(0, Acc) -> lists:reverse(Acc);
+stub_receive(N, Acc) ->
+    receive
+        {stub_message, WorkerPid, BatchRef, _Batch} ->
+            stub_receive(N - 1, [{WorkerPid, BatchRef} | Acc])
+    after
+        5000 ->
+            lists:reverse(Acc)
     end.

--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -74,8 +74,13 @@ print_otp_version_warning() ->
 print_banner() ->
     io:format("Starting ~s on node ~s~n", [?APP, node()]).
 
+-ifndef(TEST).
 print_vsn() ->
     io:format("~s ~s is running now!~n", [get_description(), get_release()]).
+-else.
+print_vsn() ->
+    ok.
+-endif.
 
 get_description() ->
     {ok, Descr0} = application:get_key(?APP, description),

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -106,13 +106,20 @@ format_listen_on(ListenOn) -> format(ListenOn).
 start_listener(#{proto := Proto, name := Name, listen_on := ListenOn, opts := Options}) ->
     ID = identifier(Proto, Name),
     case start_listener(Proto, ListenOn, Options) of
-        {ok, _} -> io:format("Start ~s listener on ~s successfully.~n",
-                             [ID, format(ListenOn)]);
+        {ok, _} ->
+            console_print("Start ~s listener on ~s successfully.~n", [ID, format(ListenOn)]);
         {error, Reason} ->
             io:format(standard_error, "Failed to start mqtt listener ~s on ~s: ~0p~n",
                       [ID, format(ListenOn), Reason]),
             error(Reason)
     end.
+
+-ifndef(TEST).
+console_print(Fmt, Args) ->
+    io:format(Fmt, Args).
+-else.
+console_print(_Fmt, _Args) -> ok.
+-endif.
 
 %% Start MQTT/TCP listener
 -spec(start_listener(esockd:proto(), esockd:listen_on(), [esockd:option()])

--- a/test/emqx_connection_SUITE.erl
+++ b/test/emqx_connection_SUITE.erl
@@ -414,8 +414,8 @@ t_oom_shutdown(_) ->
     with_conn(
       fun(Pid) ->
               Pid ! {tcp_passive, foo},
-              ?block_until(#{?snk_kind := check_oom}, 100),
-              ?block_until(#{?snk_kind := terminate}, 10),
+              {ok, _} = ?block_until(#{?snk_kind := check_oom}, 1000),
+              {ok, _} = ?block_until(#{?snk_kind := terminate}, 100),
               Trace = snabbkaffe:collect_trace(),
               ?assertEqual(1, length(?of_kind(terminate, Trace))),
               receive


### PR DESCRIPTION
Fixes #3629 

Prior to this change, the inflight batches are referenced
by the last packet ID for non-QoS-0 messages, other packet
IDs sent back from downstream causes an error log:
"Can't be found from the inflight"

Even worse, the batch is appended back to the queue for retry.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information