### PR TITLE
fix(2985): fix issue #2985 part 1

### DIFF
--- a/src/emqx_broker.erl
+++ b/src/emqx_broker.erl
@@ -437,12 +437,12 @@ init([Pool, Id]) ->
     {ok, #{pool => Pool, id => Id}}.
 
 handle_call({subscribe, Topic}, {FromPid, _Tag}, State) ->
-    case is_process_alive(FromPid) of
+    case sub_pre_check(FromPid) of
         true ->
             Res = emqx_router:do_add_route(Topic),
             {reply, Res, State};
         false ->
-            {noreply, State}
+            {reply, {error, req_dropped} ,State}
     end;
 
 handle_call({subscribe, Topic, I}, _From, State) ->
@@ -503,4 +503,21 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+sub_pre_check(Pid) ->
+    is_pid_links_port(Pid).
 
+-spec is_pid_links_port(pid()) -> boolean().
+is_pid_links_port(Pid) ->
+    case process_info(Pid, links) of
+        {links, Links} ->
+            has_port(Links);
+        undefined ->
+            false
+    end.
+
+has_port([])->
+    false;
+has_port([X | _]) when is_port(X) ->
+    true;
+has_port([X | T]) when is_pid(X) ->
+    has_port(T).


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes #2985, part 1.


 fix(emqx_broker): robustness improvments
    
    - emqx broker call should not timeout before client timeout.
    
    - Skip handling of subscribe call from a dead caller.

commit b59369fc7a138b154da4237eccc3ef41b4c5af18
Author: William Yang <mscame@gmail.com>
Date:   Thu Apr 8 15:04:02 2021 +0200

    perf(emqx_trie): reduce remote lock overheads in the cluster
    
    The network roundtrip time of taking multiple various locks in emqx_trie
    transaction kills the performance of handling a subscribe message.
    
    Take emqx_trie whole table locks to reduce the remote lock overheads in a
    cluster setup when there are more than 4 paths in a route.
    
    note 1,
    
    measured on a two-nodes cluster on the same host:
    
    without patch: 90 out of 10k clients are able to connect and subscribe,
                   others are all timeout.
                   (message rate: 100/s, sub timeout: 30s)
    
    with patch:    All 10k clients are able to connect and subscribe.
                   (message rate: 100/s, sub timeout: 30s)
    
    note 2, number 4 in this case is an arbitrary number.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, the reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information