### PR TITLE
fix(emqx_bridge_mqtt): fix retry_inflight

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_stub_conn.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_stub_conn.erl
@@ -34,7 +34,7 @@ stop(_) -> ok.
 
 %% @doc Callback for `emqx_bridge_connect' behaviour
 -spec send(_, batch()) -> {ok, ack_ref()} | {error, any()}.
-send(#{stub_pid := Pid}, Batch) ->
+send(#{client_pid := Pid}, Batch) ->
     Ref = make_ref(),
     Pid ! {stub_message, self(), Ref, Batch},
     {ok, Ref}.


### PR DESCRIPTION
This bug is likely the cause of packet ID mismatch reported in #3629

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information