### PR TITLE
chore(build): upgrade to rebar3 3.14.3-emqx-6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 $(shell $(CURDIR)/scripts/git-hooks-init.sh)
-REBAR_VERSION = 3.14.3-emqx-5
+REBAR_VERSION = 3.14.3-emqx-6
 REBAR = $(CURDIR)/rebar3
 BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts


### PR DESCRIPTION
This rebar3 version has two fixes comparing to 3.14.3-emqx-5
1. For elixir plugin build, ensure vsn in app info
2. Error details in rebar3 exception if .app is not found
   when generating release

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information