### PR TITLE
chore(cover): don't use deterministic in test or cover profiles

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -44,8 +44,7 @@ filter_extra_deps([{Plugin, _} = P | More], Filter, Acc) ->
 
 overrides() ->
     [ {add, [ {extra_src_dirs, [{"etc", [{recursive,true}]}]}
-            , {erl_opts, [ deterministic
-                         , {compile_info, [{emqx_vsn, get_vsn()}]}
+            , {erl_opts, [ {compile_info, [{emqx_vsn, get_vsn()}]}
                          ]}
             ]}
     ] ++ community_plugin_overrides().


### PR DESCRIPTION
The deterministic option will drop the directory information
of the source file, so that coverall cannot get the source directory
information and calculate the coverage rate.

<!-- Please describe the current behavior and link to a relevant issue. -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information