### PR TITLE
Enrich the targets for common tests and proper checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ eunit: $(REBAR)
 
 .PHONY: proper
 proper: $(REBAR)
-	@ENABLE_COVER_COMPILE=1 $(REBAR) as test proper -d test/props -c
+	@ENABLE_COVER_COMPILE=1 $(REBAR) proper -d test/props -c
 
 .PHONY: ct
 ct: $(REBAR)
@@ -55,6 +55,14 @@ $1-ct:
 	$(REBAR) ct --name 'test@127.0.0.1' -v --suite $(shell $(CURDIR)/scripts/find-suites.sh $1)
 endef
 $(foreach app,$(APPS),$(eval $(call gen-app-ct-target,$(app))))
+
+## apps/name-prop targets
+.PHONY: $(APPS:%=%-prop)
+define gen-app-prop-target
+$1-prop:
+	$(REBAR) proper -d test/props -v -m $(shell $(CURDIR)/scripts/find-props.sh $1)
+endef
+$(foreach app,$(APPS),$(eval $(call gen-app-prop-target,$(app))))
 
 .PHONY: cover
 cover: $(REBAR)

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -10,6 +10,9 @@ find_app() {
     find "${appdir}" -mindepth 1 -maxdepth 1 -type d
 }
 
+# append emqx application first
+echo 'emqx'
+
 find_app 'apps'
 if [ -f 'EMQX_ENTERPRISE' ]; then
     find_app 'lib-ee'

--- a/scripts/find-props.sh
+++ b/scripts/find-props.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+## this script prints out all test/props/prop_*.erl files of a given app,
+## file names are separated by comma for proper's `-m` option
+
+set -euo pipefail
+
+# ensure dir
+cd -P -- "$(dirname -- "$0")/.."
+
+BASEDIR="."
+if [ "$1" != "emqx" ]; then
+    BASEDIR="$1"
+fi
+
+find "${BASEDIR}/test/props" -name "prop_*.erl" 2>/dev/null | xargs -I{} basename {} .erl | xargs | tr ' ' ','

--- a/scripts/find-suites.sh
+++ b/scripts/find-suites.sh
@@ -12,4 +12,4 @@ TESTDIR="test"
 if [ "$1" != "emqx" ]; then
     TESTDIR="$1/test"
 fi
-find "${TESTDIR}" -name "*_SUITE.erl" | tr -d '\r' | tr '\n' ','
+find "${TESTDIR}" -name "*_SUITE.erl" 2>/dev/null | xargs | tr ' ' ','

--- a/scripts/find-suites.sh
+++ b/scripts/find-suites.sh
@@ -8,6 +8,8 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "$0")/.."
 
-APPDIR="$1"
-
-find "${APPDIR}/test" -name "*_SUITE.erl" | tr -d '\r' | tr '\n' ','
+TESTDIR="test"
+if [ "$1" != "emqx" ]; then
+    TESTDIR="$1/test"
+fi
+find "${TESTDIR}" -name "*_SUITE.erl" | tr -d '\r' | tr '\n' ','


### PR DESCRIPTION
1. Support `make emqx-ct`
2. Support proper checking targets for each application. E.g: `make apps/emqx_web_hook-prop` or `make emqx-prop`

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information