### PR TITLE
fix(export): Mod:call/3 not exported

### DIFF
--- a/apps/emqx_coap/src/emqx_coap_mqtt_adapter.erl
+++ b/apps/emqx_coap/src/emqx_coap_mqtt_adapter.erl
@@ -37,7 +37,9 @@
         , stop/1
         ]).
 
--export([call/2]).
+-export([ call/2
+        , call/3
+        ]).
 
 %% gen_server.
 -export([ init/1
@@ -93,6 +95,9 @@ publish(Pid, Topic, Payload) ->
 
 %% For emqx_management plugin
 call(Pid, Msg) ->
+    call(Pid, Msg, infinity).
+
+call(Pid, Msg, _) ->
     Pid ! Msg, ok.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_exproto/src/emqx_exproto_conn.erl
+++ b/apps/emqx_exproto/src/emqx_exproto_conn.erl
@@ -32,6 +32,7 @@
         ]).
 
 -export([ call/2
+        , call/3
         , cast/2
         ]).
 
@@ -154,7 +155,10 @@ stats(#state{socket  = Socket,
     lists:append([SockStats, ConnStats, ChanStats, ProcStats]).
 
 call(Pid, Req) ->
-    gen_server:call(Pid, Req, infinity).
+    call(Pid, Req, infinity).
+
+call(Pid, Req, Timeout) ->
+    gen_server:call(Pid, Req, Timeout).
 
 cast(Pid, Req) ->
     gen_server:cast(Pid, Req).

--- a/apps/emqx_lwm2m/src/emqx_lwm2m_protocol.erl
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m_protocol.erl
@@ -36,7 +36,9 @@
         ]).
 
 %% For Mgmt
--export([call/2]).
+-export([ call/2
+        , call/3
+        ]).
 
 -record(lwm2m_state, { peername
                      , endpoint_name
@@ -63,7 +65,10 @@
 %%--------------------------------------------------------------------
 
 call(Pid, Msg) ->
-    case catch gen_server:call(Pid, Msg) of
+    call(Pid, Msg, 5000).
+
+call(Pid, Msg, Timeout) ->
+    case catch gen_server:call(Pid, Msg, Timeout) of
         ok -> ok;
         {'EXIT', {{shutdown, kick},_}} -> ok;
         Error -> {error, Error}

--- a/apps/emqx_sn/src/emqx_sn_gateway.erl
+++ b/apps/emqx_sn/src/emqx_sn_gateway.erl
@@ -32,7 +32,9 @@
         , stats/1
         ]).
 
--export([call/2]).
+-export([ call/2
+        , call/3
+        ]).
 
 %% SUB/UNSUB Asynchronously, called by plugins.
 -export([ subscribe/2
@@ -691,7 +693,10 @@ stats(#state{socket = Socket, channel = Channel}) ->
     lists:append([SockStats, ConnStats, ChanStats, ProcStats]).
 
 call(Pid, Req) ->
-    gen_server:call(Pid, Req, infinity).
+    call(Pid, Req, infinity).
+
+call(Pid, Req, Timeout) ->
+    gen_server:call(Pid, Req, Timeout).
 
 %%--------------------------------------------------------------------
 %% Internal Functions


### PR DESCRIPTION
Some of the connection module also need the call/3 function to be exported.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information