### PR TITLE
fix: issue 2985 attempt 3

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2256,6 +2256,16 @@ end}.
   {datatype, flag}
 ]}.
 
+%% @doc performance toggle for subscribe/unsubscribe wildcard topic
+%%      change this toggle only if you have many wildcard topics.
+%% key:   mnesia translational updates with per-key locks. recommended for single node setup.
+%% tab:   mnesia translational updates with table lock. recommended for multi-nodes setup.
+%% global: global lock protected updates. recommended for larger cluster.
+{mapping, "broker.perf.route_lock_type", "emqx.route_lock_type", [
+  {default, key},
+  {datatype, {enum, [key, tab, global]}}
+]}.
+
 %%--------------------------------------------------------------------
 %% System Monitor
 %%--------------------------------------------------------------------

--- a/src/emqx_broker.erl
+++ b/src/emqx_broker.erl
@@ -419,7 +419,7 @@ safe_update_stats(Tab, Stat, MaxStat) ->
 -compile({inline, [call/2, cast/2, pick/1]}).
 
 call(Broker, Req) ->
-    gen_server:call(Broker, Req).
+    gen_server:call(Broker, Req, infinity).
 
 cast(Broker, Msg) ->
     gen_server:cast(Broker, Msg).

--- a/src/emqx_router.erl
+++ b/src/emqx_router.erl
@@ -118,7 +118,12 @@ do_add_route(Topic, Dest) when is_binary(Topic) ->
         false ->
             ok = emqx_router_helper:monitor(Dest),
             case emqx_topic:wildcard(Topic) of
-                true  -> trans(fun insert_trie_route/1, [Route]);
+                true  ->
+                    lock_router(),
+                    try trans(fun insert_trie_route/1, [Route])
+                    after
+                        unlock_router()
+                    end;
                 false -> insert_direct_route(Route)
             end
     end.
@@ -164,7 +169,12 @@ do_delete_route(Topic) when is_binary(Topic) ->
 do_delete_route(Topic, Dest) ->
     Route = #route{topic = Topic, dest = Dest},
     case emqx_topic:wildcard(Topic) of
-        true  -> trans(fun delete_trie_route/1, [Route]);
+        true  ->
+            lock_router(),
+            try trans(fun delete_trie_route/1, [Route])
+            after
+                unlock_router()
+            end;
         false -> delete_direct_route(Route)
     end.
 
@@ -249,8 +259,19 @@ delete_trie_route(Route = #route{topic = Topic}) ->
 %% @private
 -spec(trans(function(), list(any())) -> ok | {error, term()}).
 trans(Fun, Args) ->
-    case mnesia:transaction(Fun, Args) of
-        {atomic, Ok} -> Ok;
-        {aborted, Reason} -> {error, Reason}
+    mnesia:sync_dirty(Fun, Args).
+
+lock_router() ->
+    %% if Retry is not 0, global:set_lock could sleep a random time up to 8s.
+    %% Considering we have a limited number of brokers, it is safe to use sleep 1 ms.
+    case global:set_lock({?MODULE, self()}, [node() | nodes()], 0) of
+        false ->
+            %% Force to sleep 1ms instead.
+            timer:sleep(1),
+            lock_router();
+        true ->
+            ok
     end.
 
+unlock_router() ->
+    global:del_lock({?MODULE, self()}).

--- a/src/emqx_router.erl
+++ b/src/emqx_router.erl
@@ -259,7 +259,7 @@ delete_trie_route(Route = #route{topic = Topic}) ->
 %% @private
 -spec(trans(function(), list(any())) -> ok | {error, term()}).
 trans(Fun, Args) ->
-    mnesia:sync_dirty(Fun, Args).
+    mnesia:async_dirty(Fun, Args).
 
 lock_router() ->
     %% if Retry is not 0, global:set_lock could sleep a random time up to 8s.

--- a/src/emqx_router_sup.erl
+++ b/src/emqx_router_sup.erl
@@ -34,6 +34,10 @@ init([]) ->
                type     => worker,
                modules  => [emqx_router_helper]},
 
+    ok = persistent_term:put(emqx_route_lock_type,
+                             application:get_env(emqx, route_lock_type, key)
+                            ),
+
     %% Router pool
     RouterPool = emqx_pool_sup:spec([router_pool, hash,
                                      {emqx_router, start_link, []}]),

--- a/src/emqx_trie.erl
+++ b/src/emqx_trie.erl
@@ -31,7 +31,9 @@
         , delete/1
         ]).
 
--export([empty/0]).
+-export([ empty/0
+        , lock_tables/0
+        ]).
 
 -ifdef(TEST).
 -compile(export_all).
@@ -121,6 +123,11 @@ delete(Topic) when is_binary(Topic) ->
 -spec(empty() -> boolean()).
 empty() ->
     ets:info(?TRIE_TAB, size) == 0.
+
+-spec lock_tables() -> ok.
+lock_tables() ->
+    mnesia:write_lock_table(?TRIE_TAB),
+    mnesia:write_lock_table(?TRIE_NODE_TAB).
 
 %%--------------------------------------------------------------------
 %% Internal functions


### PR DESCRIPTION
Fixes #2985 attempt 3

Use cluster global lock to reduce the mnesia remote lock overhead and lock conflicts in a emqx cluster.

Tested locally, get roughly 10X performance gain for deep level wildcard topics.

Also, get good feedback from the community: 
https://github.com/emqx/emqx/issues/2985#issuecomment-822391161


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information