### PR TITLE
Sasl log to console

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-erlang 23.2.2
+erlang 23.2.7.1-emqx-1

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -408,8 +408,7 @@ rpc.socket_buffer = 1MB
 ## Where to emit the logs.
 ## Enable the console (standard output) logs.
 ##
-## Value: off | file | console | both
-## - off: disable logs entirely
+## Value: file | console | both
 ## - file: write logs only to file
 ## - console: write logs only to standard I/O
 ## - both: write logs both to file and standard I/O

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -457,7 +457,7 @@ end}.
 
 {mapping, "log.to", "kernel.logger", [
   {default, file},
-  {datatype, {enum, [off, file, console, both]}}
+  {datatype, {enum, [file, console, both]}}
 ]}.
 
 {mapping, "log.level", "kernel.logger", [
@@ -468,11 +468,6 @@ end}.
 {mapping, "log.primary_log_level", "kernel.logger_level", [
    {default, warning},
    {datatype, {enum, [debug, info, notice, warning, error, critical, alert, emergency, all]}}
-]}.
-
-{mapping, "log.logger_sasl_compatible", "kernel.logger_sasl_compatible", [
-  {default, true},
-  {datatype, {enum, [true, false]}}
 ]}.
 
 {mapping, "log.dir", "kernel.logger", [
@@ -560,12 +555,6 @@ end}.
   {datatype, string}
 ]}.
 
-{mapping, "log.sasl", "sasl.sasl_error_logger", [
-  {default, off},
-  {datatype, flag},
-  hidden
-]}.
-
 {mapping, "log.error_logger", "kernel.error_logger", [
   {default, silent},
   {datatype, {enum, [silent]}},
@@ -649,7 +638,7 @@ end}.
     %% For the default logger that outputs to console
     DefaultHandler =
         if LogTo =:= console orelse LogTo =:= both ->
-                [{handler, default, logger_std_h,
+                [{handler, console, logger_std_h,
                     #{level => LogLevel,
                       config => #{type => standard_io},
                       formatter => Formatter}}];


### PR DESCRIPTION
we have been using `logger_sasl_compatible` in the wrong way.
luckily it only affect the default handler.
so this is only an issue for 4.3 (in which we started using `foreground` mode for docker)

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information