### PR TITLE
chore(docker): manual port setting for gen_rpc when start in docker

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -78,4 +78,10 @@ EXPOSE 1883 8081 8083 8084 8883 11883 18083 4369 4370 5369 6369 6370
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 
+# The default rpc port discovery 'stateless' is mostly for clusters
+# having static node names. So it's troulbe-free for multiple emqx nodes
+# running on the same host.
+# When start emqx in docker, it's mostly one emqx node in one container
+ENV EMQX_RPC__PORT_DISCOVERY=manual
+
 CMD ["/opt/emqx/bin/emqx", "foreground"]


### PR DESCRIPTION

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information