### PR TITLE
fix(exhook): allow certificate options absent

### DIFF
--- a/apps/emqx_exhook/priv/emqx_exhook.schema
+++ b/apps/emqx_exhook/priv/emqx_exhook.schema
@@ -26,9 +26,9 @@
                               [{scheme, https}, {host, Host}, {port, Port},
                                {ssl_options,
                                  Filter([{ssl, true},
-                                         {certfile, cuttlefish:conf_get(Prefix ++ ".ssl.certfile", Conf)},
-                                         {keyfile, cuttlefish:conf_get(Prefix ++ ".ssl.keyfile", Conf)},
-                                         {cacertfile, cuttlefish:conf_get(Prefix ++ ".ssl.cacertfile", Conf)}
+                                         {certfile, cuttlefish:conf_get(Prefix ++ ".ssl.certfile", Conf, undefined)},
+                                         {keyfile, cuttlefish:conf_get(Prefix ++ ".ssl.keyfile", Conf, undefined)},
+                                         {cacertfile, cuttlefish:conf_get(Prefix ++ ".ssl.cacertfile", Conf, undefined)}
                                         ])}];
                           _ -> error(invalid_server_options)
                       end


### PR DESCRIPTION
Under HTTPS, the plugin will not start correctly if the certificate is absent


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information