### PR TITLE
Ipv6 probe runtime detection

### DIFF
--- a/apps/emqx_auth_http/src/emqx_auth_http_app.erl
+++ b/apps/emqx_auth_http/src/emqx_auth_http_app.erl
@@ -60,7 +60,7 @@ translate_env(EnvName) ->
             Path = path(Path0),
             MoreOpts = case Scheme of
                         http ->
-                            [{transport_opts, [ipv6_probe]}];
+                            [{transport_opts, emqx_misc:ipv6_probe([])}];
                         https ->
                             CACertFile = application:get_env(?APP, cacertfile, undefined),
                             CertFile = application:get_env(?APP, certfile, undefined),
@@ -85,7 +85,7 @@ translate_env(EnvName) ->
                                        , {ciphers, emqx_tls_lib:default_ciphers()}
                                        | TLSOpts
                                        ],
-                            [{transport, ssl}, {transport_opts, [ipv6_probe | NTLSOpts]}]
+                            [{transport, ssl}, {transport_opts, emqx_misc:ipv6_probe(NTLSOpts)}]
                         end,
             PoolOpts = [{host, Host},
                         {port, Port},

--- a/apps/emqx_auth_http/test/emqx_auth_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_auth_http_SUITE.erl
@@ -138,10 +138,10 @@ set_https_client_opts() ->
     application:set_env(emqx_auth_http, server_name_indication, "disable").
 
 %% @private
-http_server(http, inet) -> "http://127.0.0.1:8991";
-http_server(http, inet6) -> "http://[::1]:8991";
-http_server(https, inet) -> "https://127.0.0.1:8991";
-http_server(https, inet6) -> "https://[::1]:8991".
+http_server(http, inet) -> "http://127.0.0.1:8991"; % ipv4
+http_server(http, inet6) -> "http://localhost:8991"; % test hostname resolution
+http_server(https, inet) -> "https://localhost:8991"; % test hostname resolution
+http_server(https, inet6) -> "https://[::1]:8991". % ipv6
 
 %%------------------------------------------------------------------------------
 %% Testcases

--- a/apps/emqx_rule_engine/src/emqx_rule_utils.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_utils.erl
@@ -204,7 +204,7 @@ http_connectivity(Url) ->
 http_connectivity(Url, Timeout) ->
     case emqx_http_lib:uri_parse(Url) of
         {ok, #{host := Host, port := Port}} ->
-            tcp_connectivity(str(Host), Port, Timeout);
+            tcp_connectivity(Host, Port, Timeout);
         {error, Reason} ->
             {error, Reason}
     end.
@@ -220,7 +220,7 @@ tcp_connectivity(Host, Port) ->
                        Timeout :: integer())
         -> ok | {error, Reason :: term()}).
 tcp_connectivity(Host, Port, Timeout) ->
-    case gen_tcp:connect(Host, Port, [], Timeout) of
+    case gen_tcp:connect(Host, Port, emqx_misc:ipv6_probe([]), Timeout) of
         {ok, Sock} -> gen_tcp:close(Sock), ok;
         {error, Reason} -> {error, Reason}
     end.

--- a/apps/emqx_web_hook/src/emqx_web_hook_actions.erl
+++ b/apps/emqx_web_hook/src/emqx_web_hook_actions.erl
@@ -331,10 +331,12 @@ pool_opts(Params = #{<<"url">> := URL}, ResId) ->
     PoolSize = maps:get(<<"pool_size">>, Params, 32),
     ConnectTimeout =
         cuttlefish_duration:parse(str(maps:get(<<"connect_timeout">>, Params, <<"5s">>))),
-    TransportOpts = case Scheme =:= https of
-                        true  -> [ipv6_probe | get_ssl_opts(Params, ResId)];
-                        false -> [ipv6_probe]
-                    end,
+    TransportOpts0 =
+        case Scheme =:= https of
+            true  -> [get_ssl_opts(Params, ResId)];
+            false -> []
+        end,
+    TransportOpts = emqx_misc:ipv6_probe(TransportOpts0),
     Opts = case Scheme =:= https  of
                true  -> [{transport_opts, TransportOpts}, {transport, ssl}];
                false -> [{transport_opts, TransportOpts}]

--- a/apps/emqx_web_hook/src/emqx_web_hook_app.erl
+++ b/apps/emqx_web_hook/src/emqx_web_hook_app.erl
@@ -41,16 +41,15 @@ stop(_State) ->
 
 translate_env() ->
     {ok, URL} = application:get_env(?APP, url),
-    {ok, #{host := Host0,
+    {ok, #{host := Host,
            path := Path0,
            port := Port,
            scheme := Scheme}} = emqx_http_lib:uri_parse(URL),
     Path = path(Path0),
-    {Inet, Host} = parse_host(Host0),
     PoolSize = application:get_env(?APP, pool_size, 32),
     MoreOpts = case Scheme of
                    http ->
-                       [{transport_opts, [Inet]}];
+                       [{transport_opts, [ipv6_probe]}];
                    https ->
                        CACertFile = application:get_env(?APP, cacertfile, undefined),
                        CertFile = application:get_env(?APP, certfile, undefined),
@@ -75,7 +74,7 @@ translate_env() ->
                                   , {ciphers, emqx_tls_lib:default_ciphers()}
                                   | TLSOpts
                                   ],
-                       [{transport, ssl}, {transport_opts, [Inet | NTLSOpts]}]
+                       [{transport, ssl}, {transport_opts, [ipv6_probe | NTLSOpts]}]
                 end,
     PoolOpts = [{host, Host},
                 {port, Port},
@@ -98,14 +97,3 @@ path(Path) ->
 set_content_type(Headers) ->
     NHeaders = proplists:delete(<<"Content-Type">>, proplists:delete(<<"content-type">>, Headers)),
     [{<<"content-type">>, <<"application/json">>} | NHeaders].
-
-parse_host(Host) ->
-    case inet:parse_address(Host) of
-        {ok, Addr} when size(Addr) =:= 4 -> {inet, Addr};
-        {ok, Addr} when size(Addr) =:= 8 -> {inet6, Addr};
-        {error, einval} ->
-            case inet:getaddr(Host, inet6) of
-                {ok, _} -> {inet6, Host};
-                {error, _} -> {inet, Host}
-            end
-    end.

--- a/apps/emqx_web_hook/src/emqx_web_hook_app.erl
+++ b/apps/emqx_web_hook/src/emqx_web_hook_app.erl
@@ -49,7 +49,7 @@ translate_env() ->
     PoolSize = application:get_env(?APP, pool_size, 32),
     MoreOpts = case Scheme of
                    http ->
-                       [{transport_opts, [ipv6_probe]}];
+                       [{transport_opts, emqx_misc:ipv6_probe([])}];
                    https ->
                        CACertFile = application:get_env(?APP, cacertfile, undefined),
                        CertFile = application:get_env(?APP, certfile, undefined),
@@ -74,7 +74,7 @@ translate_env() ->
                                   , {ciphers, emqx_tls_lib:default_ciphers()}
                                   | TLSOpts
                                   ],
-                       [{transport, ssl}, {transport_opts, [ipv6_probe | NTLSOpts]}]
+                       [{transport, ssl}, {transport_opts, emqx_misc:ipv6_probe(NTLSOpts)}]
                 end,
     PoolOpts = [{host, Host},
                 {port, Port},

--- a/src/emqx_http_lib.erl
+++ b/src/emqx_http_lib.erl
@@ -91,7 +91,7 @@ do_parse(URI) ->
             normalise_parse_result(Map2)
     end.
 
-normalise_parse_result(#{host := _, scheme := Scheme0} = Map) ->
+normalise_parse_result(#{host := Host, scheme := Scheme0} = Map) ->
     Scheme = atom_scheme(Scheme0),
     DefaultPort = case https =:= Scheme of
                       true  -> 443;
@@ -101,7 +101,8 @@ normalise_parse_result(#{host := _, scheme := Scheme0} = Map) ->
                N when is_number(N) -> N;
                _ -> DefaultPort
            end,
-    Map#{ scheme => Scheme
+    Map#{ scheme := Scheme
+        , host := emqx_misc:maybe_parse_ip(Host)
         , port => Port
         }.
 

--- a/src/emqx_misc.erl
+++ b/src/emqx_misc.erl
@@ -43,12 +43,29 @@
         , now_to_secs/1
         , now_to_ms/1
         , index_of/2
+        , ipv6_probe/1
         ]).
 
 -export([ bin2hexstr_A_F/1
         , bin2hexstr_a_f/1
         , hexstr2bin/1
         ]).
+
+%% @doc Add `ipv6_probe' socket option if it's supported.
+ipv6_probe(Opts) ->
+    case persistent_term:get({?MODULE, ipv6_probe_supported}, unknown) of
+        unknown ->
+            %% e.g. 23.2.7.1-emqx-2-x86_64-unknown-linux-gnu-64
+            OtpVsn = emqx_vm:get_otp_version(),
+            Bool = (match =:= re:run(OtpVsn, "emqx", [{capture, none}])),
+            _ = persistent_term:put({?MODULE, ipv6_probe_supported}, Bool),
+            ipv6_probe(Bool, Opts);
+        Bool ->
+            ipv6_probe(Bool, Opts)
+    end.
+
+ipv6_probe(false, Opts) -> Opts;
+ipv6_probe(true, Opts) -> [ipv6_probe | Opts].
 
 %% @doc Merge options
 -spec(merge_opts(Opts, Opts) -> Opts when Opts :: proplists:proplist()).
@@ -258,3 +275,10 @@ hexchar2int(I) when I >= $0 andalso I =< $9 -> I - $0;
 hexchar2int(I) when I >= $A andalso I =< $F -> I - $A + 10;
 hexchar2int(I) when I >= $a andalso I =< $f -> I - $a + 10.
 
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+ipv6_probe_test() ->
+    ?assertEqual([ipv6_probe], ipv6_probe([])).
+
+-endif.

--- a/src/emqx_misc.erl
+++ b/src/emqx_misc.erl
@@ -43,6 +43,7 @@
         , now_to_secs/1
         , now_to_ms/1
         , index_of/2
+        , maybe_parse_ip/1
         , ipv6_probe/1
         ]).
 
@@ -50,6 +51,14 @@
         , bin2hexstr_a_f/1
         , hexstr2bin/1
         ]).
+
+%% @doc Parse v4 or v6 string format address to tuple.
+%% `Host' itself is returned if it's not an ip string.
+maybe_parse_ip(Host) ->
+    case inet:parse_address(Host) of
+        {ok, Addr} when is_tuple(Addr) -> Addr;
+        {error, einval} -> Host
+    end.
 
 %% @doc Add `ipv6_probe' socket option if it's supported.
 ipv6_probe(Opts) ->
@@ -65,7 +74,7 @@ ipv6_probe(Opts) ->
     end.
 
 ipv6_probe(false, Opts) -> Opts;
-ipv6_probe(true, Opts) -> [ipv6_probe | Opts].
+ipv6_probe(true, Opts) -> [{ipv6_probe, true} | Opts].
 
 %% @doc Merge options
 -spec(merge_opts(Opts, Opts) -> Opts when Opts :: proplists:proplist()).
@@ -279,6 +288,6 @@ hexchar2int(I) when I >= $a andalso I =< $f -> I - $a + 10.
 -include_lib("eunit/include/eunit.hrl").
 
 ipv6_probe_test() ->
-    ?assertEqual([ipv6_probe], ipv6_probe([])).
+    ?assertEqual([{ipv6_probe, true}], ipv6_probe([])).
 
 -endif.

--- a/src/emqx_vm.erl
+++ b/src/emqx_vm.erl
@@ -40,6 +40,7 @@
 -export([ get_ets_list/0
         , get_ets_info/0
         , get_ets_info/1
+        , get_otp_version/0
         ]).
 
 -export([cpu_util/0]).
@@ -367,3 +368,21 @@ compat_windows(Fun) ->
             end
     end.
 
+%% @doc Return on which Eralng/OTP the current vm is running.
+get_otp_version() ->
+    string:trim(binary_to_list(read_otp_version())).
+
+read_otp_version() ->
+    ReleasesDir = filename:join([code:root_dir(), "releases"]),
+    Filename = filename:join([ReleasesDir, emqx_app:get_release(), "BUILT_ON"]),
+    case file:read_file(Filename) of
+        {ok, Vsn} ->
+            %% running on EQM X release
+            Vsn;
+        {error, enoent} ->
+            %% running tests etc.
+            OtpMajor = erlang:system_info(otp_release),
+            OtpVsnFile = file:read_file(filename:join([ReleasesDir, OtpMajor, "OTP_VERSION"])),
+            {ok, Vsn} = file:read_file(OtpVsnFile),
+            Vsn
+    end.

--- a/src/emqx_vm.erl
+++ b/src/emqx_vm.erl
@@ -382,7 +382,7 @@ read_otp_version() ->
         {error, enoent} ->
             %% running tests etc.
             OtpMajor = erlang:system_info(otp_release),
-            OtpVsnFile = file:read_file(filename:join([ReleasesDir, OtpMajor, "OTP_VERSION"])),
+            OtpVsnFile = filename:join([ReleasesDir, OtpMajor, "OTP_VERSION"]),
             {ok, Vsn} = file:read_file(OtpVsnFile),
             Vsn
     end.

--- a/test/emqx_http_lib_tests.erl
+++ b/test/emqx_http_lib_tests.erl
@@ -62,13 +62,18 @@ uri_parse_test_() ->
        end
       }
     , {"normalise",
-       fun() -> ?assertMatch({ok, #{scheme := https}},
+       fun() -> ?assertMatch({ok, #{scheme := https, host := {127, 0, 0, 1}}},
                              emqx_http_lib:uri_parse("HTTPS://127.0.0.1"))
        end
       }
     , {"unsupported_scheme",
        fun() -> ?assertEqual({error, {unsupported_scheme, <<"wss">>}},
                              emqx_http_lib:uri_parse("wss://127.0.0.1"))
+       end
+      }
+    , {"ipv6 host",
+       fun() -> ?assertMatch({ok, #{scheme := http, host := T}} when size(T) =:= 8,
+                             emqx_http_lib:uri_parse("http://[::1]:80"))
        end
       }
     ].


### PR DESCRIPTION
prior to this PR:
Ipv6 support in `emqx_auth_http` uses `emqx_web_hook` a static ipv6 resolution during start/restart.
which is: if the target hostname has a ipv6 DNS resolution, then the apps will try to use ipv6 for the rest of its lifecycle.
this could be problematic if a host supports dual-stack but the services is only listening on an ipv4 interface.

after this PR:
`ipv6_probe` option is added to `gen_tcp:connect` option, 
so it tries to reach the service on ipv6 (if it has a ipv6 from DNS resolution)
if it succeeds, everyone is happy, otherwise fallback to the default `gen_tcp:connect` behaviour.

NOTE: `ipv6_probe` is only available in EMQ's otp.git fork.
see: https://github.com/emqx/otp/commit/18c07d55ab1615a59b5dd2f081c98e6fc330d30f