### PR TITLE
Dev/william/fix issue 2671 c1

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2259,9 +2259,11 @@ end}.
 %% key:   mnesia translational updates with per-key locks. recommended for single node setup.
 %% tab:   mnesia translational updates with table lock. recommended for multi-nodes setup.
 %% global: global lock protected updates. recommended for larger cluster.
+%% spawn: same as `key', but transaction is done in another proc, ideal for handling bursty traffic.
+%%
 {mapping, "broker.perf.route_lock_type", "emqx.route_lock_type", [
   {default, key},
-  {datatype, {enum, [key, tab, global]}}
+  {datatype, {enum, [key, tab, global, spawn]}}
 ]}.
 
 %% @doc Enable trie path compaction.


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes #2671 

intro. new lock type: 'spawn' of broker.perf.route_lock_type

mnesia get lock calls are not optimized for selective receive.

hence taking locks would be very expensive while there are tones of
messages in the brokers message queue.

This optimization run the transaction in a separate process to utilize
the selective receive optimization of the compiler.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information