### PR TITLE
Dev/william/fix issue 2671 c2

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -2268,8 +2268,8 @@ broker.shared_dispatch_ack_enabled = false
 ## Value: Flag
 broker.route_batch_clean = off
 
-## Performance toggle for subscribe/unsubscribe wildcard topic
-## change this toggle only when there are many wildcard topics.
+## Performance toggle for subscribe/unsubscribe wildcard topic.
+## Change this toggle only when there are many wildcard topics.
 ## Value: Enum
 ##  - key:   mnesia translational updates with per-key locks. recommended for single node setup.
 ##  - tab:   mnesia translational updates with table lock. recommended for multi-nodes setup.

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2259,9 +2259,11 @@ end}.
 %% key:   mnesia translational updates with per-key locks. recommended for single node setup.
 %% tab:   mnesia translational updates with table lock. recommended for multi-nodes setup.
 %% global: global lock protected updates. recommended for larger cluster.
+%% spawn: same as `key', but transaction is done in another proc, ideal for handling bursty traffic.
+%%
 {mapping, "broker.perf.route_lock_type", "emqx.route_lock_type", [
   {default, key},
-  {datatype, {enum, [key, tab, global]}}
+  {datatype, {enum, [key, tab, global, spawn]}}
 ]}.
 
 %% @doc Enable trie path compaction.

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2254,16 +2254,16 @@ end}.
   {datatype, flag}
 ]}.
 
-%% @doc performance toggle for subscribe/unsubscribe wildcard topic
-%%      change this toggle only when there are many wildcard topics.
+%% @doc Performance toggle for subscribe/unsubscribe wildcard topic.
+%%      Change this toggle only when there are many wildcard topics.
 %% key:   mnesia translational updates with per-key locks. recommended for single node setup.
 %% tab:   mnesia translational updates with table lock. recommended for multi-nodes setup.
 %% global: global lock protected updates. recommended for larger cluster.
-%% spawn: same as `key', but transaction is done in another proc, ideal for handling bursty traffic.
+%% NOTE: when changing from/to 'global' lock, it requires all nodes in the cluster
 %%
 {mapping, "broker.perf.route_lock_type", "emqx.route_lock_type", [
   {default, key},
-  {datatype, {enum, [key, tab, global, spawn]}}
+  {datatype, {enum, [key, tab, global]}}
 ]}.
 
 %% @doc Enable trie path compaction.

--- a/src/emqx_router.erl
+++ b/src/emqx_router.erl
@@ -263,32 +263,31 @@ maybe_trans(Fun, Args) ->
             trans(fun() ->
                           emqx_trie:lock_tables(),
                           apply(Fun, Args)
-                  end, []);
-        spawn ->
-            %% trigger selective receive optimization of compiler,
-            %% ideal for handling busty traffic.
-            Ref = erlang:make_ref(),
-            Owner = self(),
-            {WPid, RefMon} = spawn_monitor(fun() ->
-                                                Res = trans(Fun, Args),
-                                                Owner ! {Ref, Res}
-                                        end),
-            receive
-                {Ref, TransRes} ->
-                    receive
-                        {'DOWN', RefMon, process, WPid, normal} -> ok
-                    end,
-                    TransRes;
-                {'DOWN', RefMon, process, WPid, _Info} ->
-                    {error, trans_crash}
-            end
+                  end, [])
     end.
 
 -spec(trans(function(), list(any())) -> ok | {error, term()}).
 trans(Fun, Args) ->
-    case mnesia:transaction(Fun, Args) of
-        {atomic, Ok} -> Ok;
-        {aborted, Reason} -> {error, Reason}
+    %% trigger selective receive optimization of compiler,
+    %% ideal for handling bursty traffic.
+    Ref = erlang:make_ref(),
+    Owner = self(),
+    {WPid, RefMon} = spawn_monitor(
+                       fun() ->
+                               Res = case mnesia:transaction(Fun, Args) of
+                                         {atomic, Ok} -> Ok;
+                                         {aborted, Reason} -> {error, Reason}
+                                     end,
+                               Owner ! {Ref, Res}
+                       end),
+    receive
+        {Ref, TransRes} ->
+            receive
+                {'DOWN', RefMon, process, WPid, normal} -> ok
+            end,
+            TransRes;
+        {'DOWN', RefMon, process, WPid, Info} ->
+            {error, {trans_crash, Info}}
     end.
 
 lock_router() ->


### PR DESCRIPTION
Same as in https://github.com/emqx/emqx/pull/4709 but make 'spawn transaction' as default trans behavior.

trigger selective receive optimization of compiler to speed up mnesia transaction when the calling process has lots of msgs in process mailbox.

This solves the performance issue of wildcard subscriptions becomes very slow when there is message congestion in the broker process, such as busrty traffic of subscriptions or clients going offline and triggers a huge amount of unsubscriptions in a short peroid.

The benchmark (OTP23) shows that with 10k msgs in the mailbox, this approach is 10x faster than the old one.

Probably fix #2671 

notes

1.  ideally the fix should be done in the OTP but this workaround is the cheapest solution for the moment that emqx could provide.
2. Another supplement solution would be to increase the number of workers in the brokers' worker pool. 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information