### PR TITLE
perf(broker): use long living trans worker.

### DIFF
--- a/src/emqx_router.erl
+++ b/src/emqx_router.erl
@@ -308,17 +308,8 @@ trans(Worker, Fun, Args) when is_pid(Worker) ->
     Worker ! {work, MonRef, Fun, Args},
     receive
         {MonRef, TransRes} ->
-            case erlang:demonitor(MonRef, [info]) of
-                true -> %% likely, no flush
-                    ok;
-                false -> %% unlikely to happen
-                    receive
-                        {_, MonRef, _, _, _} ->
-                            ok
-                    after 0 ->
-                            ok
-                    end
-               end,
+            %% note! Caller should remember to flush 'DownMsg'
+            true = erlang:demonitor(MonRef),
             TransRes;
         {'DOWN', MonRef, process, Worker, Info} ->
             {error, {trans_worker_crash, Info}}

--- a/src/emqx_router.erl
+++ b/src/emqx_router.erl
@@ -308,8 +308,9 @@ trans(Worker, Fun, Args) when is_pid(Worker) ->
     Worker ! {work, MonRef, Fun, Args},
     receive
         {MonRef, TransRes} ->
-            %% note! Caller should remember to flush 'DownMsg'
-            true = erlang:demonitor(MonRef),
+            %% most likely flush won't happen.
+            %% flush will only happen when demonitor failed (Worker is already dead)
+            erlang:demonitor(MonRef, [flush]),
             TransRes;
         {'DOWN', MonRef, process, Worker, Info} ->
             {error, {trans_worker_crash, Info}}

--- a/test/emqx_router_SUITE.erl
+++ b/test/emqx_router_SUITE.erl
@@ -72,16 +72,6 @@ t_add_delete(_) ->
     ?R:delete_route(<<"a/+/b">>, node()),
     ?assertEqual([], ?R:topics()).
 
-t_do_add_delete(_) ->
-    ?R:do_add_route(<<"a/b/c">>),
-    ?R:do_add_route(<<"a/b/c">>, node()),
-    ?R:do_add_route(<<"a/+/b">>, node()),
-    ?assertEqual([<<"a/+/b">>, <<"a/b/c">>], lists:sort(?R:topics())),
-
-    ?R:do_delete_route(<<"a/b/c">>, node()),
-    ?R:do_delete_route(<<"a/+/b">>),
-    ?assertEqual([], ?R:topics()).
-
 t_match_routes(_) ->
     ?R:add_route(<<"a/b/c">>),
     ?R:add_route(<<"a/+/c">>, node()),

--- a/test/emqx_shared_sub_SUITE.erl
+++ b/test/emqx_shared_sub_SUITE.erl
@@ -296,7 +296,7 @@ last_message(ExpectedPayload, Pids) ->
 
 t_dispatch(_) ->
     ok = ensure_config(random),
-    Topic = <<"foo">>,
+    Topic = <<"foo/#">>,
     ?assertEqual({error, no_subscribers},
                  emqx_shared_sub:dispatch(<<"group1">>, Topic, #delivery{message = #message{}})),
     emqx:subscribe(Topic, #{qos => 2, share => <<"group1">>}),


### PR DESCRIPTION
This is a supplement patch for https://github.com/emqx/emqx/pull/4711

Use long-living trans worker instead, to reduce process spawn overhead and ensure the selective recv optimization at the broker process side.

the benchmark shows the performance gain is around 2x when there are 8k messages in msgq.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information