### PR TITLE
feat(logging): make supervisor progress configurable

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -485,6 +485,12 @@ end}.
   {datatype, integer}
 ]}.
 
+{mapping, "log.supervisor_reports", "kernel.logger", [
+  {default, error},
+  {datatype, {enum, [error, progress]}},
+  hidden
+]}.
+
 %% @doc format logs in a single line.
 {mapping, "log.single_line", "kernel.logger", [
   {default, false},
@@ -635,13 +641,21 @@ end}.
                   BasicConf#{max_no_bytes => MaxNoBytes}
                 end,
 
+    Filters = case cuttlefish:conf_get("log.supervisor_reports", Conf) of
+                  error -> [{drop_progress_reports, {fun logger_filters:progress/2, stop}}];
+                  progress -> []
+              end,
+
     %% For the default logger that outputs to console
     DefaultHandler =
         if LogTo =:= console orelse LogTo =:= both ->
                 [{handler, console, logger_std_h,
                     #{level => LogLevel,
                       config => #{type => standard_io},
-                      formatter => Formatter}}];
+                      formatter => Formatter,
+                      filters => Filters
+                     }
+                 }];
            true ->
                 [{handler, default, undefined}]
         end,
@@ -653,7 +667,9 @@ end}.
                     #{level => LogLevel,
                       config => FileConf(cuttlefish:conf_get("log.file", Conf)),
                       formatter => Formatter,
-                      filesync_repeat_interval => no_repeat}}];
+                      filesync_repeat_interval => no_repeat,
+                      filters => Filters
+                     }}];
            true -> []
         end,
 


### PR DESCRIPTION
by default, when primary log level is set to debug or info
application controller prints supervisor progress info.

this new config make use of logger's built-in filters
for progress report

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information