### PR TITLE
Fix dialyzer error on the enterprise version

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -505,7 +505,8 @@ do_import_acl_mnesia(Acls) ->
 -ifdef(EMQX_ENTERPRISE).
 import_modules(Modules) ->
     case ets:info(emqx_modules) of
-        undefined -> [];
+        undefined ->
+            ok;
         _ ->
            lists:foreach(fun(#{<<"id">> := Id,
                                <<"type">> := Type,
@@ -649,9 +650,9 @@ do_import_data(Data, Version) ->
 
 -ifdef(EMQX_ENTERPRISE).
 do_import_extra_data(Data, _Version) ->
-    import_confs(maps:get(<<"configs">>, Data, []), maps:get(<<"listeners_state">>, Data, [])),
-    import_modules(maps:get(<<"modules">>, Data, [])),
-    import_schemas(maps:get(<<"schemas">>, Data, [])),
+    _ = import_confs(maps:get(<<"configs">>, Data, []), maps:get(<<"listeners_state">>, Data, [])),
+    _ = import_modules(maps:get(<<"modules">>, Data, [])),
+    _ = import_schemas(maps:get(<<"schemas">>, Data, [])),
     ok.
 -else.
 do_import_extra_data(_Data, _Version) -> ok.


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes 
```
apps/emqx_management/src/emqx_mgmt_data_backup.erl
 653: Expression produces a value of type 'ok' | [], but this value is unmatched
 654: Expression produces a value of type 'ok' | [{'ok',{_,_,_,_,_,_,_}}], but this value is unmatched
```

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information