### PR TITLE
perf(trie): do not call ets:info/2 to check if table is empty

### DIFF
--- a/src/emqx_trie.erl
+++ b/src/emqx_trie.erl
@@ -122,7 +122,7 @@ match(Topic) when is_binary(Topic) ->
 
 %% @doc Is the trie empty?
 -spec(empty() -> boolean()).
-empty() -> ets:info(?TRIE, size) == 0.
+empty() -> ets:first(?TRIE) =:= '$end_of_table'.
 
 -spec lock_tables() -> ok.
 lock_tables() ->


### PR DESCRIPTION
emqx_trie table is a ordered_set, with write_concurrency set to
true, the counter is not centrialsed, the ets:info/2 call to
check size == 0 is very expensive

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information