### PR TITLE
chore(nodetool) ensure correct lib dirs

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -174,9 +174,10 @@ relx_gen_id() {
 # Control a node
 relx_nodetool() {
     command="$1"; shift
+    export RUNNER_ROOT_DIR
+    export REL_VSN
 
     ERL_FLAGS="$ERL_FLAGS $EPMD_ARG" \
-    ERL_LIBS="${LIB_EKKA_DIR}:${ERL_LIBS:-}" \
     "$ERTS_DIR/bin/escript" "$ROOTDIR/bin/nodetool" "$NAME_TYPE" "$NAME" \
                                 -setcookie "$COOKIE" "$command" "$@"
 }

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -19,6 +19,7 @@ main(Args) ->
                     ok
             end
     end,
+    ok = add_libs_dir(),
     ok = do_with_halt(Args, "mnesia_dir", fun create_mnesia_dir/2),
     ok = do_with_halt(Args, "chkconfig", fun("-config", X) -> chkconfig(X) end),
     ok = do_with_halt(Args, "chkconfig", fun chkconfig/1),
@@ -288,3 +289,22 @@ join([], Sep) when is_list(Sep) ->
     [];
 join([H|T], Sep) ->
     H ++ lists:append([Sep ++ X || X <- T]).
+
+add_libs_dir() ->
+    [_ | _] = RootDir = os:getenv("RUNNER_ROOT_DIR"),
+    RelFile = filename:join([RootDir, "releases",
+                             os:getenv("REL_VSN"),
+                             "emqx.rel"
+                            ]),
+    {ok, [{release, {_, _RelVsn}, {erts, _ErtsVsn}, Libs}]} = file:consult(RelFile),
+    lists:foreach(
+      fun({Name, Vsn}) -> add_lib_dir(RootDir, Name, Vsn);
+         ({Name, Vsn, _}) -> add_lib_dir(RootDir, Name, Vsn)
+      end, Libs).
+
+add_lib_dir(RootDir, Name, Vsn) ->
+    LibDir = filename:join([RootDir, lib, atom_to_list(Name) ++ "-" ++ Vsn, ebin]),
+    case code:add_pathz(LibDir) of
+        true -> ok;
+        {error, _} -> error(LibDir)
+    end.

--- a/data/emqx_vars
+++ b/data/emqx_vars
@@ -13,7 +13,6 @@ RUNNER_LIB_DIR="{{ runner_lib_dir }}"
 RUNNER_ETC_DIR="{{ runner_etc_dir }}"
 RUNNER_DATA_DIR="{{ runner_data_dir }}"
 RUNNER_USER="{{ runner_user }}"
-LIB_EKKA_DIR="${RUNNER_LIB_DIR}/ekka-$(grep ekka "${RUNNER_ROOT_DIR}/releases/RELEASES" | awk -F '\"' '{print $2}')"
 
 EMQX_LICENSE_CONF=''
 export EMQX_DESCRIPTION='{{ emqx_description }}'


### PR DESCRIPTION
Prioro to this change, ekka lib dir was added by inspecting
the ekka lib version in persisted RELEASES file.
However, this file may not be the true version if a hot
upgrade failed in the middle.
In this fix, it reads the per-version emqx.rel file
content to load lib paths.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information