### PR TITLE
Use `emqx_stats` to record the size of the retained/delayed tables instead of `emqx_metrics`

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -1,6 +1,6 @@
 {application, emqx_retainer,
  [{description, "EMQ X Retainer"},
-  {vsn, "4.3.0"}, % strict semver, bump manually!
+  {vsn, "4.3.1"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_retainer_sup]},
   {applications, [kernel,stdlib]},

--- a/apps/emqx_retainer/src/emqx_retainer.appup.src
+++ b/apps/emqx_retainer/src/emqx_retainer.appup.src
@@ -1,0 +1,15 @@
+%% -*-: erlang -*-
+{VSN,
+  [
+    {"4.3.0", [
+      {load_module, emqx_retainer, brutal_purge, soft_purge, []}
+    ]},
+    {<<".*">>, []}
+  ],
+  [
+    {"4.3.0", [
+      {load_module, emqx_retainer, brutal_purge, soft_purge, []}
+    ]},
+    {<<".*">>, []}
+  ]
+}.

--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -200,7 +200,7 @@ sort_retained(Msgs)  ->
 store_retained(Msg = #message{topic = Topic, payload = Payload}, Env) ->
     case {is_table_full(Env), is_too_big(size(Payload), Env)} of
         {false, false} ->
-            ok = emqx_metrics:set('messages.retained', retained_count()),
+            ok = emqx_metrics:inc('messages.retained'),
             mnesia:dirty_write(?TAB, #retained{topic = topic2tokens(Topic),
                                                msg = Msg,
                                                expiry_time = get_expiry_time(Msg, Env)});

--- a/lib-ce/emqx_modules/src/emqx_modules.app.src
+++ b/lib-ce/emqx_modules/src/emqx_modules.app.src
@@ -1,6 +1,6 @@
 {application, emqx_modules,
  [{description, "EMQ X Module Management"},
-  {vsn, "4.3.0"},
+  {vsn, "4.3.1"},
   {modules, []},
   {applications, [kernel,stdlib]},
   {mod, {emqx_modules_app, []}},

--- a/lib-ce/emqx_modules/src/emqx_modules.appup.src
+++ b/lib-ce/emqx_modules/src/emqx_modules.appup.src
@@ -1,0 +1,15 @@
+%% -*-: erlang -*-
+{VSN,
+  [
+    {"4.3.0", [
+      {update, emqx_mod_delayed, {advanced, []}}
+    ]},
+    {<<".*">>, []}
+  ],
+  [
+    {"4.3.0", [
+      {update, emqx_mod_delayed, {advanced, []}}
+    ]},
+    {<<".*">>, []}
+  ]
+}.

--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -1,14 +1,20 @@
 %% -*-: erlang -*-
 {VSN,
- [ {"4.3.0",
-    [ {load_module, emqx_logger_jsonfmt, brutal_purge, soft_purge, []}
-    ]},
+ [
+   {"4.3.0", [
+     {load_module, emqx_logger_jsonfmt, brutal_purge, soft_purge, []},
+     {load_module, emqx_metrics, brutal_purge, soft_purge, []},
+     {apply, {emqx_metrics, upgrade_retained_delayed_counter_type, []}}
+   ]},
    {<<".*">>, []}
  ],
  [
-   {"4.3.0",
-    [ {load_module, emqx_logger_jsonfmt, brutal_purge, soft_purge, []}
-    ]},
+   {"4.3.0", [
+     {load_module, emqx_logger_jsonfmt, brutal_purge, soft_purge, []},
+     %% Just load the module. We don't need to change the 'messages.retained'
+     %% and 'messages.retained' counter type.
+     {load_module, emqx_metrics, brutal_purge, soft_purge, []}
+   ]},
    {<<".*">>, []}
  ]
 }.

--- a/src/emqx_metrics.erl
+++ b/src/emqx_metrics.erl
@@ -65,6 +65,10 @@
         , code_change/3
         ]).
 
+%% BACKW: v4.3.0
+-export([ upgrade_retained_delayed_counter_type/0
+        ]).
+
 -export_type([metric_idx/0]).
 
 -compile({inline, [inc/1, inc/2, dec/1, dec/2]}).
@@ -145,8 +149,8 @@
          {counter, 'messages.dropped.expired'},  % QoS2 Messages expired
          {counter, 'messages.dropped.no_subscribers'},  % Messages dropped
          {counter, 'messages.forward'},       % Messages forward
-         {gauge,   'messages.retained'},      % Messages retained
-         {gauge,   'messages.delayed'},       % Messages delayed
+         {counter, 'messages.retained'},      % Messages retained
+         {counter, 'messages.delayed'},       % Messages delayed
          {counter, 'messages.delivered'},     % Messages delivered
          {counter, 'messages.acked'}          % Messages acked
         ]).
@@ -194,6 +198,19 @@ start_link() ->
 
 -spec(stop() -> ok).
 stop() -> gen_server:stop(?SERVER).
+
+%% BACKW: v4.3.0
+upgrade_retained_delayed_counter_type() ->
+    case ets:info(?TAB, name) of
+        ?TAB ->
+            [M1] = ets:lookup(?TAB, 'messages.retained'),
+            [M2] = ets:lookup(?TAB, 'messages.delayed'),
+            true = ets:insert(?TAB, M1#metric{type = counter}),
+            true = ets:insert(?TAB, M2#metric{type = counter}),
+            ok;
+        _ ->
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Metrics API


### PR DESCRIPTION
The metrics for messages.* should show the number of times such kinds of messages are received. It should be a `counter` type rather than a `gauge`

Finally, these metrics and statistics are used by emqx_prometheus. We fix these indicator types to be more conducive to using them in Prometheus.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information