### PR TITLE
fix(emqx_frame): poor large frame concatenation performance

### DIFF
--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -475,7 +475,7 @@ terminate(Reason, State = #state{channel = Channel, transport = Transport,
         E : C : S ->
             ?tp(warning, unclean_terminate, #{exception => E, context => C, stacktrace => S})
     end,
-    ?tp(debug, terminate, #{}),
+    ?tp(info, terminate, #{reason => Reason}),
     maybe_raise_excption(Reason).
 
 %% close socket, discard new state, always return ok.


### PR DESCRIPTION
piror to this change, binary concatenation eats most of the CPU

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes  #4787

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information