### PR TITLE
fix(emqx_connection): do not log einval error

### DIFF
--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -2,6 +2,7 @@
 {VSN,
  [
    {"4.3.1", [
+     {load_module, emqx_connection, brutal_purge, soft_purge, []},
      {load_module, emqx_congestion, brutal_purge, soft_purge, []},
      {load_module, emqx_node_dump, brutal_purge, soft_purge, []}
    ]},
@@ -18,6 +19,7 @@
  ],
  [
    {"4.3.1", [
+     {load_module, emqx_connection, brutal_purge, soft_purge, []},
      {load_module, emqx_congestion, brutal_purge, soft_purge, []},
      {load_module, emqx_node_dump, brutal_purge, soft_purge, []}
    ]},

--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -683,7 +683,10 @@ handle_info(activate_socket, State = #state{sockstate = OldSst}) ->
     end;
 
 handle_info({sock_error, Reason}, State) ->
-    Reason =/= closed andalso ?LOG(error, "Socket error: ~p", [Reason]),
+    case Reason =/= closed andalso Reason =/= einval of
+        true -> ?LOG(warning, "socket_error: ~p", [Reason]);
+        false -> ok
+    end,
     handle_info({sock_closed, Reason}, close_socket(State));
 
 handle_info(Info, State) ->


### PR DESCRIPTION
`inet:setopt(Sock, [{active, N}])` returns `{error, einval}` if the socket is already closed.
this is a very common situation when the client closed socket while the connection process is still processing its events

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information