### PR TITLE
refactor(bin/emqx): invoke hocon_cli from nodetool

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -27,6 +27,15 @@ mkdir -p "$CONFIGS_DIR"
 # hocon try to read environment variables starting with "EMQX_"
 export HOCON_ENV_OVERRIDE_PREFIX='EMQX_'
 
+export ROOTDIR="$RUNNER_ROOT_DIR"
+export ERTS_DIR="$ROOTDIR/erts-$ERTS_VSN"
+export BINDIR="$ERTS_DIR/bin"
+export EMU="beam"
+export PROGNAME="erl"
+export LD_LIBRARY_PATH="$ERTS_DIR/lib:$LD_LIBRARY_PATH"
+export ERTS_LIB_DIR="$ERTS_DIR/../lib"
+MNESIA_DATA_DIR="$RUNNER_DATA_DIR/mnesia/$NAME"
+
 relx_usage() {
     command="$1"
 
@@ -183,6 +192,12 @@ relx_nodetool() {
                                 -setcookie "$COOKIE" "$command" "$@"
 }
 
+call_hocon() {
+    export RUNNER_ROOT_DIR
+    export REL_VSN
+    "$ERTS_DIR/bin/escript" "$ROOTDIR/bin/nodetool" hocon "$@"
+}
+
 # Run an escript in the node's environment
 relx_escript() {
     shift; scriptpath="$1"; shift
@@ -210,12 +225,12 @@ generate_config() {
 
     ## timestamp for each generation
     local NOW_TIME
-    NOW_TIME="$("$ERTS_PATH"/escript "$RUNNER_ROOT_DIR"/bin/hocon now_time)"
+    NOW_TIME="$(call_hocon now_time)"
 
     ## ths command populates two files: app.<time>.config and vm.<time>.args
     ## disable SC2086 to allow EMQX_LICENSE_CONF_OPTION to split
     # shellcheck disable=SC2086
-    "$ERTS_PATH"/escript "$RUNNER_ROOT_DIR"/bin/hocon -t "$NOW_TIME" -s emqx_schema -c "$RUNNER_ETC_DIR"/emqx.conf $EMQX_LICENSE_CONF_OPTION -d "$RUNNER_DATA_DIR"/configs generate
+    call_hocon -t "$NOW_TIME" -s emqx_schema -c "$RUNNER_ETC_DIR"/emqx.conf $EMQX_LICENSE_CONF_OPTION -d "$RUNNER_DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     local CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"
@@ -306,7 +321,7 @@ if [ -z "$NAME_ARG" ]; then
         else
             # for boot commands, inspect emqx.conf for node name
             # todo: use get command from hocon escript
-            NODENAME="$("$ERTS_PATH"/escript "$RUNNER_ROOT_DIR"/bin/hocon -s emqx_schema -c "$RUNNER_ETC_DIR"/emqx.conf get node.name | tr -d \")"
+            NODENAME="$(call_hocon -s emqx_schema -c "$RUNNER_ETC_DIR"/emqx.conf get node.name | tr -d \")"
         fi
     fi
     if [ -z "$NODENAME" ]; then
@@ -332,7 +347,7 @@ PIPE_DIR="${PIPE_DIR:-/$RUNNER_DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 COOKIE="${EMQX_NODE_COOKIE:-}"
 if [ -z "$COOKIE" ]; then
     if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
-        COOKIE="$("$ERTS_PATH"/escript "$RUNNER_ROOT_DIR"/bin/hocon -s emqx_schema -c "$RUNNER_ETC_DIR"/emqx.conf get node.cookie | tr -d \")"
+        COOKIE="$(call_hocon -s emqx_schema -c "$RUNNER_ETC_DIR"/emqx.conf get node.cookie | tr -d \")"
     else
         # shellcheck disable=SC2012,SC2086
         LATEST_VM_ARGS="$(ls -t $CONFIGS_DIR/vm.*.args | head -1)"
@@ -356,15 +371,6 @@ if [ -z "$PROTO_DIST" ]; then
 else
     PROTO_DIST_ARG="-proto_dist $PROTO_DIST"
 fi
-
-export ROOTDIR="$RUNNER_ROOT_DIR"
-export ERTS_DIR="$ROOTDIR/erts-$ERTS_VSN"
-export BINDIR="$ERTS_DIR/bin"
-export EMU="beam"
-export PROGNAME="erl"
-export LD_LIBRARY_PATH="$ERTS_DIR/lib:$LD_LIBRARY_PATH"
-export ERTS_LIB_DIR="$ERTS_DIR/../lib"
-MNESIA_DATA_DIR="$RUNNER_DATA_DIR/mnesia/$NAME"
 
 cd "$ROOTDIR"
 

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -20,6 +20,15 @@ main(Args) ->
             end
     end,
     ok = add_libs_dir(),
+    case Args of
+        ["hocon" | Rest] ->
+            %% forward the call to hocon_cli
+            hocon_cli:main(Rest);
+        _ ->
+            do(Args)
+    end.
+
+do(Args) ->
     ok = do_with_halt(Args, "mnesia_dir", fun create_mnesia_dir/2),
     ok = do_with_halt(Args, "chkconfig", fun("-config", X) -> chkconfig(X) end),
     ok = do_with_halt(Args, "chkconfig", fun chkconfig/1),

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -341,8 +341,6 @@ relx_overlay(ReleaseType) ->
     , {template, "bin/emqx_ctl.cmd", "bin/emqx_ctl.cmd"}
     , {copy, "bin/nodetool", "bin/nodetool"}
     , {copy, "bin/nodetool", "bin/nodetool-{{release_version}}"}
-    , {copy, "_build/default/lib/hocon/hocon", "bin/hocon"}
-    , {copy, "_build/default/lib/hocon/hocon", "bin/hocon-{{release_version}}"}
     ] ++ case is_enterprise() of
              true -> ee_etc_overlay(ReleaseType);
              false -> etc_overlay(ReleaseType)


### PR DESCRIPTION
nodetool has all lib paths set up correctly by reading the
persisted RELEASES file

calling hocon escript directly has two problems:
1. it may not be able to find the beams compiled
2. if we use ERL_LIBS, it may find the version after hot beam upgrade

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information