### PR TITLE
fix(nodetool): add_pathz -> add_patha

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -317,7 +317,7 @@ add_libs_dir() ->
 
 add_lib_dir(RootDir, Name, Vsn) ->
     LibDir = filename:join([RootDir, lib, atom_to_list(Name) ++ "-" ++ Vsn, ebin]),
-    case code:add_pathz(LibDir) of
+    case code:add_patha(LibDir) of
         true -> ok;
         {error, _} -> error(LibDir)
     end.


### PR DESCRIPTION
Just learned that some of the erts distributions implicitly add paths, some don't.
call code:add_patha to ensure overrides whatever implicitly added paths.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information