### PR TITLE
Extend persistent sessions

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -178,7 +178,11 @@ set_conn_state(ConnState, Channel) ->
 get_session(#channel{session = Session}) ->
     Session.
 
-set_session(Session, Channel) ->
+set_session(Session, Channel = #channel{clientinfo = ClientInfo, conninfo = ConnInfo}) ->
+    %% Assume that this is also an updated session. Allow side effect.
+    ClientID = maps:get(clientid, ClientInfo, undefined),
+    ExpiryInterval = maps:get(expiry_interval, ConnInfo, 0),
+    emqx_session:db_put(ClientID, ExpiryInterval, Session),
     Channel#channel{session = Session}.
 
 %% TODO: Add more stats.
@@ -345,10 +349,10 @@ handle_in(?PUBACK_PACKET(PacketId, _ReasonCode, Properties), Channel
     case emqx_session:puback(PacketId, Session) of
         {ok, Msg, NSession} ->
             ok = after_message_acked(ClientInfo, Msg, Properties),
-            {ok, Channel#channel{session = NSession}};
+            {ok, set_session(NSession, Channel)};
         {ok, Msg, Publishes, NSession} ->
             ok = after_message_acked(ClientInfo, Msg, Properties),
-            handle_out(publish, Publishes, Channel#channel{session = NSession});
+            handle_out(publish, Publishes, set_session(NSession, Channel));
         {error, ?RC_PACKET_IDENTIFIER_IN_USE} ->
             ?LOG(warning, "The PUBACK PacketId ~w is inuse.", [PacketId]),
             ok = emqx_metrics:inc('packets.puback.inuse'),
@@ -364,7 +368,7 @@ handle_in(?PUBREC_PACKET(PacketId, _ReasonCode, Properties), Channel
     case emqx_session:pubrec(PacketId, Session) of
         {ok, Msg, NSession} ->
             ok = after_message_acked(ClientInfo, Msg, Properties),
-            NChannel = Channel#channel{session = NSession},
+            NChannel = set_session(NSession, Channel),
             handle_out(pubrel, {PacketId, ?RC_SUCCESS}, NChannel);
         {error, RC = ?RC_PACKET_IDENTIFIER_IN_USE} ->
             ?LOG(warning, "The PUBREC PacketId ~w is inuse.", [PacketId]),
@@ -379,7 +383,7 @@ handle_in(?PUBREC_PACKET(PacketId, _ReasonCode, Properties), Channel
 handle_in(?PUBREL_PACKET(PacketId, _ReasonCode), Channel = #channel{session = Session}) ->
     case emqx_session:pubrel(PacketId, Session) of
         {ok, NSession} ->
-            NChannel = Channel#channel{session = NSession},
+            NChannel = set_session(NSession, Channel),
             handle_out(pubcomp, {PacketId, ?RC_SUCCESS}, NChannel);
         {error, RC = ?RC_PACKET_IDENTIFIER_NOT_FOUND} ->
             ?LOG(warning, "The PUBREL PacketId ~w is not found.", [PacketId]),
@@ -390,9 +394,9 @@ handle_in(?PUBREL_PACKET(PacketId, _ReasonCode), Channel = #channel{session = Se
 handle_in(?PUBCOMP_PACKET(PacketId, _ReasonCode), Channel = #channel{session = Session}) ->
     case emqx_session:pubcomp(PacketId, Session) of
         {ok, NSession} ->
-            {ok, Channel#channel{session = NSession}};
+            {ok, set_session(NSession, Channel)};
         {ok, Publishes, NSession} ->
-            handle_out(publish, Publishes, Channel#channel{session = NSession});
+            handle_out(publish, Publishes, set_session(NSession, Channel));
         {error, ?RC_PACKET_IDENTIFIER_IN_USE} ->
             ok = emqx_metrics:inc('packets.pubcomp.inuse'),
             {ok, Channel};
@@ -589,7 +593,8 @@ do_publish(PacketId, Msg = #message{qos = ?QOS_2},
     case emqx_session:publish(PacketId, Msg, Session) of
         {ok, PubRes, NSession} ->
             RC = puback_reason_code(PubRes),
-            NChannel1 = ensure_timer(await_timer, Channel#channel{session = NSession}),
+            NChannel0 = set_session(NSession, Channel),
+            NChannel1 = ensure_timer(await_timer, NChannel0),
             NChannel2 = ensure_quota(PubRes, NChannel1),
             handle_out(pubrec, {PacketId, RC}, NChannel2);
         {error, RC = ?RC_PACKET_IDENTIFIER_IN_USE} ->
@@ -658,7 +663,7 @@ do_subscribe(TopicFilter, SubOpts = #{qos := QoS}, Channel =
     NSubOpts = enrich_subopts(maps:merge(?DEFAULT_SUBOPTS, SubOpts), Channel),
     case emqx_session:subscribe(ClientInfo, NTopicFilter, NSubOpts, Session) of
         {ok, NSession} ->
-            {QoS, Channel#channel{session = NSession}};
+            {QoS, set_session(NSession, Channel)};
         {error, RC} ->
             ?LOG(warning, "Cannot subscribe ~s due to ~s.",
                  [TopicFilter, emqx_reason_codes:text(RC)]),
@@ -686,7 +691,7 @@ do_unsubscribe(TopicFilter, SubOpts, Channel =
     TopicFilter1 = emqx_mountpoint:mount(MountPoint, TopicFilter),
     case emqx_session:unsubscribe(ClientInfo, TopicFilter1, SubOpts, Session) of
         {ok, NSession} ->
-            {?RC_SUCCESS, Channel#channel{session = NSession}};
+            {?RC_SUCCESS, set_session(NSession, Channel)};
         {error, RC} -> {RC, Channel}
     end.
 %%--------------------------------------------------------------------
@@ -711,7 +716,9 @@ process_disconnect(ReasonCode, Properties, Channel) ->
 
 maybe_update_expiry_interval(#{'Session-Expiry-Interval' := Interval},
                              Channel = #channel{conninfo = ConnInfo}) ->
-    Channel#channel{conninfo = ConnInfo#{expiry_interval => Interval}};
+    NChannel = Channel#channel{conninfo = ConnInfo#{expiry_interval => Interval}},
+    %% We need to update the expiry interval on the session as well
+    set_session(NChannel#channel.session, NChannel);
 maybe_update_expiry_interval(_Properties, Channel) -> Channel.
 
 %%--------------------------------------------------------------------
@@ -724,7 +731,7 @@ handle_deliver(Delivers, Channel = #channel{conn_state = disconnected,
                                             session    = Session,
                                             clientinfo = #{clientid := ClientId}}) ->
     NSession = emqx_session:enqueue(ignore_local(maybe_nack(Delivers), ClientId, Session), Session),
-    {ok, Channel#channel{session = NSession}};
+    {ok, set_session(NSession, Channel)};
 
 handle_deliver(Delivers, Channel = #channel{takeover = true,
                                             pendings = Pendings,
@@ -737,10 +744,10 @@ handle_deliver(Delivers, Channel = #channel{session = Session,
                                             clientinfo = #{clientid := ClientId}}) ->
     case emqx_session:deliver(ignore_local(Delivers, ClientId, Session), Session) of
         {ok, Publishes, NSession} ->
-            NChannel = Channel#channel{session = NSession},
+            NChannel = set_session(NSession, Channel),
             handle_out(publish, Publishes, ensure_timer(retry_timer, NChannel));
         {ok, NSession} ->
-            {ok, Channel#channel{session = NSession}}
+            {ok, set_session(NSession, Channel)}
     end.
 
 ignore_local(Delivers, Subscriber, Session) ->
@@ -856,13 +863,13 @@ return_connack(AckPacket, Channel) ->
     case maybe_resume_session(Channel) of
         ignore -> {ok, Replies, Channel};
         {ok, Publishes, NSession} ->
-            NChannel = Channel#channel{session  = NSession,
-                                       resuming = false,
+            NChannel0 = Channel#channel{resuming = false,
                                        pendings = []
                                       },
-            {Packets, NChannel1} = do_deliver(Publishes, NChannel),
+            NChannel1 = set_session(NSession, NChannel0),
+            {Packets, NChannel2} = do_deliver(Publishes, NChannel1),
             Outgoing = [{outgoing, Packets} || length(Packets) > 0],
-            {ok, Replies ++ Outgoing, NChannel1}
+            {ok, Replies ++ Outgoing, NChannel2}
     end.
 
 %%--------------------------------------------------------------------
@@ -1020,9 +1027,9 @@ handle_timeout(_TRef, retry_delivery,
                Channel = #channel{session = Session}) ->
     case emqx_session:retry(Session) of
         {ok, NSession} ->
-            {ok, clean_timer(retry_timer, Channel#channel{session = NSession})};
+            {ok, clean_timer(retry_timer, set_session(NSession, Channel))};
         {ok, Publishes, Timeout, NSession} ->
-            NChannel = Channel#channel{session = NSession},
+            NChannel = set_session(NSession, Channel),
             handle_out(publish, Publishes, reset_timer(retry_timer, Timeout, NChannel))
     end;
 
@@ -1033,9 +1040,9 @@ handle_timeout(_TRef, expire_awaiting_rel,
                Channel = #channel{session = Session}) ->
     case emqx_session:expire(awaiting_rel, Session) of
         {ok, NSession} ->
-            {ok, clean_timer(await_timer, Channel#channel{session = NSession})};
+            {ok, clean_timer(await_timer, set_session(NSession, Channel))};
         {ok, Timeout, NSession} ->
-            {ok, reset_timer(await_timer, Timeout, Channel#channel{session = NSession})}
+            {ok, reset_timer(await_timer, Timeout, set_session(NSession, Channel))}
     end;
 
 handle_timeout(_TRef, expire_session, Channel) ->

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -55,6 +55,15 @@
 -compile(nowarn_export_all).
 -endif.
 
+%% DB API
+-export([ mnesia/1
+        , db_get/1
+        , db_put/3
+        ]).
+
+-boot_mnesia({mnesia, [boot]}).
+-copy_mnesia({mnesia, [copy]}).
+
 -export([init/2]).
 
 -export([ info/1
@@ -155,6 +164,27 @@
 
 
 %%--------------------------------------------------------------------
+%% Mnesia bootstrap
+%%--------------------------------------------------------------------
+
+-define(SESSION_STORE, emqx_session_store).
+-record(session_store, { id               :: binary()
+                       , expiry_interval  :: non_neg_integer()
+                       , ts               :: non_neg_integer()
+                       , session          :: #session{}}).
+
+mnesia(boot) ->
+    ok = ekka_mnesia:create_table(?SESSION_STORE, [
+                {type, set},
+                {ram_copies, [node()]},
+                {record_name, session_store},
+                {attributes, record_info(fields, session_store)},
+                {storage_properties, [{ets, [{read_concurrency, true}]}]}]);
+
+mnesia(copy) ->
+    ok = ekka_mnesia:copy_table(?SESSION_STORE, ram_copies).
+
+%%--------------------------------------------------------------------
 %% Init a Session
 %%--------------------------------------------------------------------
 
@@ -180,6 +210,41 @@ init_mqueue(Zone) ->
                        priorities => get_env(Zone, mqueue_priorities, none),
                        default_priority => get_env(Zone, mqueue_default_priority, lowest)
                       }).
+
+%%--------------------------------------------------------------------
+%% DB API
+%%--------------------------------------------------------------------
+
+db_put(undefined,_ExpiryInterval, #session{}) ->
+    ok;
+db_put(SessionID, ExpiryInterval, #session{} = Session) when is_binary(SessionID),
+                                                             is_integer(ExpiryInterval) ->
+    SS = #session_store{ id              = SessionID
+                       , expiry_interval = ExpiryInterval
+                       , ts              = erlang:system_time(millisecond)
+                       , session         = Session},
+    case use_db_session(SS) of
+        false -> mnesia:dirty_delete(?SESSION_STORE, SessionID);
+        true  -> mnesia:dirty_write(?SESSION_STORE, SS)
+    end.
+
+db_get(SessionID) when is_binary(SessionID) ->
+    case mnesia:dirty_read(?SESSION_STORE, SessionID) of
+        [] -> [];
+        [#session_store{session = S} = SS] ->
+            case use_db_session(SS) of
+                true  -> [S];
+                false -> []
+            end
+    end.
+
+%% @private [MQTT-3.1.2-23]
+use_db_session(#session_store{expiry_interval = 0}) ->
+    false;
+use_db_session(#session_store{expiry_interval = 16#FFFFFFFF}) ->
+    true;
+use_db_session(#session_store{expiry_interval = E, ts = TS}) ->
+    E*1000 + TS > erlang:system_time(millisecond).
 
 %%--------------------------------------------------------------------
 %% Info, Stats

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -46,6 +46,7 @@ init_per_suite(Config) ->
     ok = meck:expect(emqx_hooks, run_fold, fun(_Hook, _Args, Acc) -> Acc end),
     %% Session Meck
     ok = meck:new(emqx_session, [passthrough, no_history, no_link]),
+    meck:expect(emqx_session, db_put, fun(_, _, _) -> ok end),
     %% Metrics
     ok = meck:new(emqx_metrics, [passthrough, no_history, no_link]),
     ok = meck:expect(emqx_metrics, inc, fun(_) -> ok end),


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Makes persistent sessions (i.e., Session-Expiry-Interval > 0) more robust by adding a database table for storing the sessions.
The database table is spread over nodes, giving another node a chance of resuming a session if the node hosting the session goes down.


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information