### PR TITLE
chore: upgrade lwm2m_coap to 1.1.4

### DIFF
--- a/apps/emqx_lwm2m/rebar.config
+++ b/apps/emqx_lwm2m/rebar.config
@@ -1,5 +1,5 @@
 {deps,
- [{lwm2m_coap, {git, "https://github.com/emqx/lwm2m-coap", {tag, "v1.1.2"}}}
+ [{lwm2m_coap, {git, "https://github.com/emqx/lwm2m-coap", {tag, "v1.1.4"}}}
  ]}.
 
 {profiles,


### PR DESCRIPTION
Wait for the predecessor PR merge to complete https://github.com/emqx/lwm2m-coap/pull/16

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information