### PR TITLE
chore(emqx_lwm2m): pin lwm2m-coap v2.0.0

### DIFF
--- a/apps/emqx_lwm2m/rebar.config
+++ b/apps/emqx_lwm2m/rebar.config
@@ -1,5 +1,7 @@
 {deps,
- [{lwm2m_coap, {git, "https://github.com/emqx/lwm2m-coap", {tag, "v1.1.2"}}}
+  %% lwm2m-coap v.1.* is for emqx v4.3.*
+  %% lwm2m-coap v.2.* is for emqx v5.*
+ [{lwm2m_coap, {git, "https://github.com/emqx/lwm2m-coap", {tag, "v2.0.0"}}}
  ]}.
 
 {profiles,


### PR DESCRIPTION
v2.0.0 has emqx_http_lib added as a rebar dependency
v1.* is for emqx v4.3.*


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information