### PR TITLE
build: do not allow user override PKG_VSN

### DIFF
--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -122,7 +122,14 @@ get_release() ->
             release_in_macro();
         {_, Vsn} -> %% For emqx release build
             VsnStr = release_in_macro(),
-            1 = string:str(Vsn, VsnStr), %% assert
+            case string:str(Vsn, VsnStr) of
+                1 -> ok;
+                _ ->
+                    erlang:error(#{ reason => version_mismatch
+                                  , source => VsnStr
+                                  , built_for => Vsn
+                                  })
+            end,
             Vsn
     end.
 

--- a/build
+++ b/build
@@ -12,7 +12,7 @@ ARTIFACT="$2"
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
-PKG_VSN="${PKG_VSN:-$(./pkg-vsn.sh)}"
+PKG_VSN="$(./pkg-vsn.sh)"
 export PKG_VSN
 
 if [ "$(uname -s)" = 'Darwin' ]; then

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -406,18 +406,8 @@ find_conf_files(App) ->
         false -> []
     end.
 
-env(Name, Default) ->
-    case os:getenv(Name) of
-        "" -> Default;
-        false -> Default;
-        Value -> Value
-    end.
-
 get_vsn() ->
-    PkgVsn = case env("PKG_VSN", false) of
-                 false -> os:cmd("./pkg-vsn.sh");
-                 Vsn -> Vsn
-             end,
+    PkgVsn = os:cmd("./pkg-vsn.sh"),
     re:replace(PkgVsn, "\n", "", [{return ,list}]).
 
 maybe_dump(Config) ->


### PR DESCRIPTION
We have an assertion in code, allowing user to override
will compile but not run.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information