### PR TITLE
chore(CI): cancel build of 32-bit docker

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -342,13 +342,6 @@ jobs:
           - [amd64, x86_64]
           - [arm64v8, aarch64]
           - [arm32v7, arm]
-          - [i386, i386]
-          - [s390x, s390x]
-        exclude:
-          - profile: emqx-ee
-            arch: [i386, i386]
-          - profile: emqx-ee
-            arch: [s390x, s390x]
 
     steps:
     - uses: actions/download-artifact@v2


### PR DESCRIPTION
@turtleDeng @tigercl @zmstone @qzhuyan @wivwiv 

Quic does not support 32-bit builds, do we still need to continue to support 32-bit docker images ?
