### PR TITLE
ci(quic): conditionally quicer build

### DIFF
--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -12,13 +12,16 @@ case "$(uname -m)" in
         ARCH='amd64'
         ;;
     aarch64)
+        EMQX_NO_QUIC=0
         ARCH='arm64'
         ;;
     arm*)
+        EMQX_NO_QUIC=0
         ARCH=arm
         ;;
 esac
 export ARCH
+export EMQX_NO_QUIC
 
 emqx_prepare(){
     mkdir -p "${PACKAGE_PATH}"

--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -115,10 +115,10 @@ emqx_test(){
 
 running_test(){
     # sed -i '/emqx_telemetry/d' /var/lib/emqx/loaded_plugins
-    start_cmd="export EMQX_ZONE__EXTERNAL__SERVER_KEEPALIVE=60 EMQX_MQTT__MAX_TOPIC_ALIAS=10; \
-        [[ $(arch) == *arm* || $(arch) == aarch64 ]] && export EMQX_LISTENER__QUIC__EXTERNAL__ENDPOINT=''; emqx start"
+    start_env="export EMQX_ZONE__EXTERNAL__SERVER_KEEPALIVE=60 EMQX_MQTT__MAX_TOPIC_ALIAS=10; \
+        [[ $(arch) == *arm* || $(arch) == aarch64 ]] && export EMQX_LISTENER__QUIC__EXTERNAL__ENDPOINT=''"
 
-    if ! su - emqx -c "$start_cmd"; then
+    if ! su - emqx -c "$start_env ; emqx start"; then
         cat /var/log/emqx/erlang.log.1 || true
         cat /var/log/emqx/emqx.log.1 || true
         exit 1
@@ -140,6 +140,7 @@ running_test(){
     if [ "$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')" = ubuntu ] \
     || [ "$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')" = debian ] ;then
 
+        echo "$start_env" >> /etc/default/emqx
         if ! service emqx start; then
             cat /var/log/emqx/erlang.log.1 || true
             cat /var/log/emqx/emqx.log.1 || true

--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -12,16 +12,13 @@ case "$(uname -m)" in
         ARCH='amd64'
         ;;
     aarch64)
-        EMQX_NO_QUIC=0
         ARCH='arm64'
         ;;
     arm*)
-        EMQX_NO_QUIC=0
         ARCH=arm
         ;;
 esac
 export ARCH
-export EMQX_NO_QUIC
 
 emqx_prepare(){
     mkdir -p "${PACKAGE_PATH}"
@@ -120,6 +117,7 @@ running_test(){
            EMQX_MQTT__MAX_TOPIC_ALIAS=10
     # sed -i '/emqx_telemetry/d' /var/lib/emqx/loaded_plugins
 
+    [[ "$ARCH" == arm* ]] && export EMQX_LISTENER__QUIC__EXTERNAL__ENDPOINT=""
     if ! emqx start; then
         cat /var/log/emqx/erlang.log.1 || true
         cat /var/log/emqx/emqx.log.1 || true

--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -113,12 +113,11 @@ emqx_test(){
 }
 
 running_test(){
-    export EMQX_ZONE__EXTERNAL__SERVER_KEEPALIVE=60 \
-           EMQX_MQTT__MAX_TOPIC_ALIAS=10
     # sed -i '/emqx_telemetry/d' /var/lib/emqx/loaded_plugins
+    start_cmd="export EMQX_ZONE__EXTERNAL__SERVER_KEEPALIVE=60 EMQX_MQTT__MAX_TOPIC_ALIAS=10; \
+        [[ $(arch) == *arm* || $(arch) == aarch64 ]] && export EMQX_LISTENER__QUIC__EXTERNAL__ENDPOINT=''; emqx start"
 
-    [[ "$ARCH" == arm* ]] && export EMQX_LISTENER__QUIC__EXTERNAL__ENDPOINT=""
-    if ! emqx start; then
+    if ! su - emqx -c "$start_cmd"; then
         cat /var/log/emqx/erlang.log.1 || true
         cat /var/log/emqx/emqx.log.1 || true
         exit 1

--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -38,7 +38,8 @@ emqx_test(){
                 packagename=$(basename "${PACKAGE_PATH}/${EMQX_NAME}"-*.zip)
                 unzip -q "${PACKAGE_PATH}/${packagename}"
                 export EMQX_ZONE__EXTERNAL__SERVER_KEEPALIVE=60 \
-                       EMQX_MQTT__MAX_TOPIC_ALIAS=10
+                    EMQX_MQTT__MAX_TOPIC_ALIAS=10
+                [[ $(arch) == *arm* || $(arch) == aarch64 ]] && export EMQX_LISTENER__QUIC__EXTERNAL__ENDPOINT=''
                 # sed -i '/emqx_telemetry/d' "${PACKAGE_PATH}"/emqx/data/loaded_plugins
 
                 echo "running ${packagename} start"

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -63,6 +63,7 @@ jobs:
     if: endsWith(github.repository, 'emqx')
 
     strategy:
+      fail-fast: false
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         exclude:
@@ -131,6 +132,7 @@ jobs:
     needs: prepare
 
     strategy:
+      fail-fast: false
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         erl_otp:
@@ -210,6 +212,7 @@ jobs:
     needs: prepare
 
     strategy:
+      fail-fast: false
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         arch:

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -42,6 +42,7 @@ jobs:
         if: endsWith(github.repository, 'emqx')
         run: |
           make -C source deps-all
+          rm source/rebar.lock
           zip -ryq source.zip source/* source/.[^.]*
       - name: get_all_deps
         if: endsWith(github.repository, 'enterprise')

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -340,6 +340,7 @@ jobs:
     needs: prepare
 
     strategy:
+      fail-fast: false
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         arch:

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -20,7 +20,6 @@
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {branch, "2.0.4"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
-    , {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.5"}}}
     ]}.
 
 {plugins, [rebar3_proper]}.

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -31,7 +31,8 @@
            [ meck
            , {bbmustache,"1.10.0"}
            , {emqx_ct_helpers, {git,"https://github.com/emqx/emqx-ct-helpers", {branch,"hocon"}}}
-           , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.1"}}}
+           %, {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.1"}}}
+           , {emqtt, {git, "https://github.com/emqx/emqtt", {branch, "main"}}}
            ]},
          {extra_src_dirs, [{"test",[recursive]}]}
        ]}

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -30,8 +30,7 @@
            [ meck
            , {bbmustache,"1.10.0"}
            , {emqx_ct_helpers, {git,"https://github.com/emqx/emqx-ct-helpers", {branch,"hocon"}}}
-           %, {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.1"}}}
-           , {emqtt, {git, "https://github.com/emqx/emqtt", {branch, "main"}}}
+           , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.2"}}}
            ]},
          {extra_src_dirs, [{"test",[recursive]}]}
        ]}

--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -1,11 +1,30 @@
-Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {branch, "0.6.0"}}},
-AddBcrypt = fun(C) ->
-    {deps, Deps0} = lists:keyfind(deps, 1, C),
-    Deps = [Bcrypt | Deps0],
-    lists:keystore(deps, 1, C, {deps, Deps})
-end,
+IsCentos6 = fun() ->
+                case file:read_file("/etc/centos-release") of
+                    {ok, <<"CentOS release 6", _/binary >>} ->
+                        true;
+                    _ ->
+                        false
+                end
+            end,
 
-case os:type() of
-    {win32, _} -> CONFIG;
-    _ -> AddBcrypt(CONFIG)
-end.
+IsWin32 = fun() ->
+                win32 =:= element(1, os:type())
+          end,
+
+IsQuicSupp = fun() ->
+                not (IsCentos6() orelse IsWin32() orelse
+                     false =/= os:getenv("EMQX_BUILD_WITHOUT_QUIC")
+                    )
+             end,
+
+Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {branch, "0.6.0"}}},
+Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {branch, "main"}}},
+
+ExtraDeps = fun(C) ->
+                {deps, Deps0} = lists:keyfind(deps, 1, C),
+                Deps = Deps0 ++ [Bcrypt || not IsWin32()] ++
+                [ Quicer || IsQuicSupp()],
+                lists:keystore(deps, 1, C, {deps, Deps})
+            end,
+
+ExtraDeps(CONFIG).

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -4,7 +4,7 @@
   {vsn, "5.0.0"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
-  {applications, [kernel,stdlib,gproc,gen_rpc,esockd,cowboy,sasl,os_mon,quicer,jiffy]},
+  {applications, [kernel,stdlib,gproc,gen_rpc,esockd,cowboy,sasl,os_mon,jiffy]},
   {mod, {emqx_app,[]}},
   {env, []},
   {licenses, ["Apache-2.0"]},

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -49,6 +49,8 @@ start(_Type, _Args) ->
     _ = load_ce_modules(),
     ekka:start(),
     ok = ekka_rlog:wait_for_shards(?EMQX_SHARDS, infinity),
+    false == os:getenv("EMQX_NO_QUIC")
+        andalso application:ensure_all_started(quicer),
     {ok, Sup} = emqx_sup:start_link(),
     ok = start_autocluster(),
     % ok = emqx_plugins:init(),

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -145,9 +145,8 @@ start_listener(Proto, ListenOn, Options) when Proto == https; Proto == wss ->
 
 %% Start MQTT/QUIC listener
 start_listener(quic, ListenOn, Options) ->
-    IsQuicEnabled = false == os:getenv("EMQX_NO_QUIC"),
     case [ A || {quicer, _, _} = A<-application:which_applications() ] of
-        [_] when IsQuicEnabled ->
+        [_] ->
             %% @fixme unsure why we need reopen lib and reopen config.
             quicer_nif:open_lib(),
             quicer_nif:reg_open(),

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -106,6 +106,8 @@ format_listen_on(ListenOn) -> format(ListenOn).
 start_listener(#{proto := Proto, name := Name, listen_on := ListenOn, opts := Options}) ->
     ID = identifier(Proto, Name),
     case start_listener(Proto, ListenOn, Options) of
+        {ok, skipped} ->
+            console_print("Start ~s listener on ~s skpped.~n", [ID, format(ListenOn)]);
         {ok, _} ->
             console_print("Start ~s listener on ~s successfully.~n", [ID, format(ListenOn)]);
         {error, Reason} ->
@@ -123,7 +125,7 @@ console_print(_Fmt, _Args) -> ok.
 
 %% Start MQTT/TCP listener
 -spec(start_listener(esockd:proto(), esockd:listen_on(), [esockd:option()])
-      -> {ok, pid()} | {error, term()}).
+      -> {ok, pid() | skipped} | {error, term()}).
 start_listener(tcp, ListenOn, Options) ->
     start_mqtt_listener('mqtt:tcp', ListenOn, Options);
 
@@ -143,24 +145,32 @@ start_listener(Proto, ListenOn, Options) when Proto == https; Proto == wss ->
 
 %% Start MQTT/QUIC listener
 start_listener(quic, ListenOn, Options) ->
-    %% @fixme unsure why we need reopen lib and reopen config.
-    quicer_nif:open_lib(),
-    quicer_nif:reg_open(),
-    SSLOpts = proplists:get_value(ssl_options, Options),
-    DefAcceptors = erlang:system_info(schedulers_online) * 8,
-    ListenOpts = [ {cert, proplists:get_value(certfile, SSLOpts)}
-                 , {key, proplists:get_value(keyfile, SSLOpts)}
-                 , {alpn, ["mqtt"]}
-                 , {conn_acceptors, proplists:get_value(acceptors, Options, DefAcceptors)}
-                 , {idle_timeout_ms, proplists:get_value(idle_timeout, Options, 60000)}
-                 ],
-    ConnectionOpts = [ {conn_callback, emqx_quic_connection}
-                     , {peer_unidi_stream_count, 1}
-                     , {peer_bidi_stream_count, 10}
-                       | Options
-                     ],
-    StreamOpts = [],
-    quicer:start_listener('mqtt:quic', ListenOn, {ListenOpts, ConnectionOpts, StreamOpts}).
+    IsQuicEnabled = false == os:getenv("EMQX_NO_QUIC"),
+    case [ A || {quicer, _, _} = A<-application:which_applications() ] of
+        [_] when IsQuicEnabled ->
+            %% @fixme unsure why we need reopen lib and reopen config.
+            quicer_nif:open_lib(),
+            quicer_nif:reg_open(),
+            SSLOpts = proplists:get_value(ssl_options, Options),
+            DefAcceptors = erlang:system_info(schedulers_online) * 8,
+            ListenOpts = [ {cert, proplists:get_value(certfile, SSLOpts)}
+                         , {key, proplists:get_value(keyfile, SSLOpts)}
+                         , {alpn, ["mqtt"]}
+                         , {conn_acceptors, proplists:get_value(acceptors, Options, DefAcceptors)}
+                         , {idle_timeout_ms, proplists:get_value(idle_timeout, Options, 60000)}
+                         ],
+            ConnectionOpts = [ {conn_callback, emqx_quic_connection}
+                             , {peer_unidi_stream_count, 1}
+                             , {peer_bidi_stream_count, 10}
+                             | Options
+                             ],
+            StreamOpts = [],
+            quicer:start_listener('mqtt:quic', ListenOn, {ListenOpts, ConnectionOpts, StreamOpts});
+        [] ->
+            io:format(standard_error, "INFO: quicer application is unavailable/disabled~n",
+                      []),
+            {ok, skipped}
+    end.
 
 replace(Opts, Key, Value) -> [{Key, Value} | proplists:delete(Key, Opts)].
 

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -333,7 +333,7 @@ fields("quic_listener") ->
     [ {"$name", ref("quic_listener_settings")}];
 
 fields("listener_settings") ->
-    [ {"endpoint", t(union(ip_port(), integer()))}
+    [ {"endpoint", t(union([ip_port(), integer(), ""]))}
     , {"acceptors", t(integer(), undefined, 8)}
     , {"max_connections", t(integer(), undefined, 1024)}
     , {"max_conn_rate", t(integer())}
@@ -785,6 +785,7 @@ tr_listeners(Conf) ->
     TcpListeners = fun(Type, Name) ->
         Prefix = string:join(["listener", Type, Name], "."),
         ListenOnN = case conf_get(Prefix ++ ".endpoint", Conf) of
+                        "" -> [];
                         undefined -> [];
                         ListenOn  -> ListenOn
                     end,
@@ -801,6 +802,8 @@ tr_listeners(Conf) ->
     SslListeners = fun(Type, Name) ->
         Prefix = string:join(["listener", Type, Name], "."),
         case conf_get(Prefix ++ ".endpoint", Conf) of
+            "" ->
+                [];
             undefined ->
                 [];
             ListenOn ->

--- a/rebar.config
+++ b/rebar.config
@@ -63,8 +63,6 @@
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.9.0"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.2.1"}}}
-    %, {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.5"}}}
-    , {quicer, {git, "https://github.com/emqx/quic.git", {branch, "main"}}}
     ]}.
 
 {xref_ignores,

--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,8 @@
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.9.0"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.2.1"}}}
-    , {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.5"}}}
+    %, {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.5"}}}
+    , {quicer, {git, "https://github.com/emqx/quic.git", {branch, "main"}}}
     ]}.
 
 {xref_ignores,

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.1"}}}
     , {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.2"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {branch, "2.0.4"}}}
-    , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.1"}}}
+    , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.2"}}}
     , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.2"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
     , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.1


### PR DESCRIPTION
This PR address the build issue in ci: build-package.

- conditionally quicer build
- Skip quic listener in test of arm platform
- skip quicer build on cento6 due to too old header files.
- env vars to control Quicer build
   1. set `EMQX_NO_QUIC` to disable the start of quic listener

Left TODOs:
Disable NIF compiling in quicker project instead.
Investigate why open quic port failed with qemu emulator.


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information