### PR TITLE
chore(presence): more fields for disconnected event

### DIFF
--- a/lib-ce/emqx_modules/src/emqx_modules.app.src
+++ b/lib-ce/emqx_modules/src/emqx_modules.app.src
@@ -1,6 +1,6 @@
 {application, emqx_modules,
  [{description, "EMQ X Module Management"},
-  {vsn, "4.3.2"},
+  {vsn, "4.3.3"},
   {modules, []},
   {applications, [kernel,stdlib]},
   {mod, {emqx_modules_app, []}},

--- a/lib-ce/emqx_modules/src/emqx_modules.appup.src
+++ b/lib-ce/emqx_modules/src/emqx_modules.appup.src
@@ -1,21 +1,31 @@
 %% -*-: erlang -*-
 {VSN,
   [
+    {"4.3.2", [
+      {load_module, emqx_mod_presence, brutal_purge, soft_purge, []}
+    ]},
     {"4.3.1", [
+      {load_module, emqx_mod_presence, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_api_topic_metrics, brutal_purge, soft_purge, []}
     ]},
     {"4.3.0", [
       {update, emqx_mod_delayed, {advanced, []}},
+      {load_module, emqx_mod_presence, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_api_topic_metrics, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, []}
   ],
   [
+    {"4.3.2", [
+      {load_module, emqx_mod_presence, brutal_purge, soft_purge, []}
+    ]},
     {"4.3.1", [
+      {load_module, emqx_mod_presence, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_api_topic_metrics, brutal_purge, soft_purge, []}
     ]},
     {"4.3.0", [
       {update, emqx_mod_delayed, {advanced, []}},
+      {load_module, emqx_mod_presence, brutal_purge, soft_purge, []},
       {load_module, emqx_mod_api_topic_metrics, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, []}


### PR DESCRIPTION
In the previous version,  the `disconnected` events miss some important fields to show a connection infos. i.e: `proto_name`, `proto_ver`


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility
N/A

## More information
Docs PR: https://github.com/emqx/emqx-docs/pull/812