### PR TITLE
fix(emqx.conf): default wss max_connection from 16 to 102400

### DIFF
--- a/apps/emqx/etc/emqx.conf
+++ b/apps/emqx/etc/emqx.conf
@@ -1878,7 +1878,7 @@ listener.wss.external {
   ## Maximum number of concurrent MQTT/Webwocket/SSL connections.
   ##
   ## Value: Number
-  max_connections: 16
+  max_connections: 102400
 
   ## Maximum MQTT/WebSocket/SSL connections per second.
   ##


### PR DESCRIPTION

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information