### PR TITLE
feat(helm): add externalIPs to chart

### DIFF
--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.4.0
+version: 4.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.3.1
+version: 4.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.3.0
+version: 4.3.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -63,6 +63,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `service.nodePorts.dashboard`  | Kubernetes node port for dashboard. |nil|
 | `service.loadBalancerIP`  | loadBalancerIP for Service |	nil |
 | `service.loadBalancerSourceRanges` |	Address(es) that are allowed when service is LoadBalancer |	[] |
+| `service.externalIPs` |	ExternalIPs for the service |	[] |
 | `service.annotations` |	Service annotations |	{}(evaluated as a template)|
 | `ingress.dashboard.enabled` |	Enable ingress for EMQX Dashboard |	false |
 | `ingress.dashboard.path` | Ingress path for EMQX Dashboard |	/ |

--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.service.loadBalancerSourceRanges }}
   loadBalancerSourceRanges: {{- toYaml .Values.service.loadBalancerSourceRanges | nindent 4 }}
   {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs: {{- toYaml .Values.service.externalIPs | nindent 4 }}
+  {{- end }}
   {{- end }}
   ports:
   - name: mqtt

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -145,6 +145,9 @@ service:
   ## - 10.10.10.0/24
   ##
   loadBalancerSourceRanges: []
+  ## Set the ExternalIPs
+  ##
+  externalIPs: []
   ## Provide any additional annotations which may be required. Evaluated as a template
   ##
   annotations: {}


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

Let `externalIPs` be configurable in the Helm chart

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information