### PR TITLE
chore(deps): deps in rebar must not be use branch

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -17,7 +17,7 @@
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v4.0.1"}}} %% todo delete when plugins use hocon
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.9.6"}}}
-    , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {branch, "2.0.4"}}}
+    , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
     ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -54,7 +54,7 @@
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.1.1"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.1"}}}
     , {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.2"}}}
-    , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {branch, "2.0.4"}}}
+    , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.2"}}}
     , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.2"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}

--- a/scripts/check-deps-integrity.escript
+++ b/scripts/check-deps-integrity.escript
@@ -48,7 +48,7 @@ do_collect_deps([{Name, Ref} | Deps], File, Acc) ->
 count_bad_deps([]) -> 0;
 count_bad_deps([{Name, Refs0} | Rest]) ->
     Refs = lists:keysort(1, Refs0),
-    case is_unique_ref(Refs) of
+    case is_unique_ref(Refs) andalso not_branch_ref(Refs) of
         true ->
             count_bad_deps(Rest);
         false ->
@@ -61,3 +61,7 @@ is_unique_ref([{Ref, _File1}, {Ref, File2} | Rest]) ->
     is_unique_ref([{Ref, File2} | Rest]);
 is_unique_ref(_) ->
     false.
+
+not_branch_ref([]) -> true;
+not_branch_ref([{{git, _Repo, {branch, _Branch}}, _File} | _Rest]) -> false;
+not_branch_ref([_Ref | Rest]) -> not_branch_ref(Rest).


### PR DESCRIPTION
Hi, All
I don't think we should introduce branch dependencies in master, which can make the project unstable, and we can use tags or commit ids to indicate dependencies
