### PR TITLE
fix(emqx_schema): call new hocon_schema API to get field value

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -15,7 +15,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.2"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.10.4"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.10.3"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.10.4"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -638,7 +638,7 @@ formatter(text, CharsLimit, SingleLine) ->
 %% utils
 -spec(conf_get(string() | [string()], hocon:config()) -> term()).
 conf_get(Key, Conf) ->
-    V = hocon_schema:deep_get(Key, Conf, value),
+    V = hocon_schema:get_value(Key, Conf),
     case is_binary(V) of
         true ->
             binary_to_list(V);
@@ -647,7 +647,7 @@ conf_get(Key, Conf) ->
     end.
 
 conf_get(Key, Conf, Default) ->
-    V = hocon_schema:deep_get(Key, Conf, value, Default),
+    V = hocon_schema:get_value(Key, Conf, Default),
     case is_binary(V) of
         true ->
             binary_to_list(V);
@@ -863,11 +863,9 @@ options(k8s, Conf) ->
 options(manual, _Conf) ->
     [].
 
-to_atom(#{value := Val}= _RichMap) ->
-    to_atom(Val);
 to_atom(Atom) when is_atom(Atom) ->
     Atom;
 to_atom(Str) when is_list(Str) ->
     list_to_atom(Str);
 to_atom(Bin) when is_binary(Bin) ->
-    list_to_atom(binary_to_list(Bin)).
+    binary_to_atom(Bin, utf8).

--- a/rebar.config
+++ b/rebar.config
@@ -60,7 +60,7 @@
     , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.1
     , {getopt, "1.0.1"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.10.3"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.10.4"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.3.0"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.1.0"}}}
     ]}.


### PR DESCRIPTION
Pin `hocon` version `0.10.4` which has the `atom_key` option fixed:
After this change `atom_key` only affects struct fields,
but not fields inside a non-type-safe `map()`.

Also, `hocon` version `0.10.4` uses `$hc` prefixed atoms for
`richmap`'s meta-fields names, this makes possible for us to use
`value`, `metadata` and `type` in both rich-map and plain-map
without clashing with `hocon`.