### PR TITLE
fix(emqx_app): stop listeners in application prep_stop callback

### DIFF
--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -19,6 +19,7 @@
 -behaviour(application).
 
 -export([ start/2
+        , prep_stop/1
         , stop/1
         , get_description/0
         , get_release/0
@@ -63,11 +64,12 @@ start(_Type, _Args) ->
     print_vsn(),
     {ok, Sup}.
 
--spec(stop(State :: term()) -> term()).
-stop(_State) ->
+prep_stop(_State) ->
     ok = emqx_alarm_handler:unload(),
     emqx_boot:is_enabled(listeners)
       andalso emqx_listeners:stop().
+
+stop(_State) -> ok.
 
 set_backtrace_depth() ->
     Depth = emqx_config:get([node, backtrace_depth]),


### PR DESCRIPTION
Application:stop is call after the root supervisor is stopped,
in our case, prior to this fix, emqx_sup is stopped before
the listeners (hence the emqx_connection processes).

This causes shutdown to emit a lot of error logs
e.g. emqx_broker pool is down, but emqx_connection process is still
trying to call the pool

full investigation here: https://zmstone.notion.site/Erlang-application-stop-order-091b1bdb9c184c68bab8c8928574c903

ported back to 4.3:

https://github.com/emqx/emqx/pull/5332