### PR TITLE
fix(emqx_app): stop listeners in application prep_stop callback

### DIFF
--- a/src/emqx_app.erl
+++ b/src/emqx_app.erl
@@ -19,6 +19,7 @@
 -behaviour(application).
 
 -export([ start/2
+        , prep_stop/1
         , stop/1
         , get_description/0
         , get_release/0
@@ -50,11 +51,13 @@ start(_Type, _Args) ->
     print_vsn(),
     {ok, Sup}.
 
--spec(stop(State :: term()) -> term()).
-stop(_State) ->
+prep_stop(_State) ->
     ok = emqx_alarm_handler:unload(),
     emqx_boot:is_enabled(listeners)
       andalso emqx_listeners:stop().
+
+stop(_State) ->
+    ok.
 
 set_backtrace_depth() ->
     Depth = application:get_env(?APP, backtrace_depth, 16),


### PR DESCRIPTION
Application:stop is call after the root supervisor is stopped,
in our case, prior to this fix, emqx_sup is stopped before
the listeners (hence the emqx_connection processes).

This causes shutdown to emit a lot of error logs
e.g. emqx_broker pool is down, but emqx_connection process is still
trying to call the pool

