### PR TITLE
feat(config): read schemas for apps from file at build time

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -516,6 +516,8 @@ fields(FieldName) ->
     extra_schema_fields(FieldName).
 
 -ifndef(EMQX_EXT_SCHEMAS).
+%% Function extra_schema_fields/1 only terminates with explicit exception
+-dialyzer([{nowarn_function, [extra_schema_fields/1]}]).
 extra_schema_fields(FieldName) -> error({unknown_field, FieldName}).
 -else.
 extra_schema_fields(FieldName) ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -79,22 +79,11 @@ structs() -> ["cluster", "node", "rpc", "log", "lager",
               "plugins", "sysmon", "alarm"]
              ++ ?MODULE:includes().
 
--ifdef(TEST).
-includes() ->[].
+-ifndef(EMQX_EXT_SCHEMAS).
+includes() -> [].
 -else.
 includes() ->
-    [ "emqx_data_bridge"
-    , "emqx_retainer"
-    , "emqx_statsd"
-    , "emqx_authn"
-    , "emqx_authz"
-    , "emqx_bridge_mqtt"
-    , "emqx_modules"
-    , "emqx_management"
-    , "emqx_dashboard"
-    , "emqx_gateway"
-    , "emqx_prometheus"
-    ].
+    [FieldName || {FieldName, _SchemaMod} <- ?EMQX_EXT_SCHEMAS].
 -endif.
 
 fields("cluster") ->
@@ -523,9 +512,16 @@ fields("alarm") ->
     , {"validity_period", t(duration(), undefined, "24h")}
     ];
 
-fields(ExtraField) ->
-    Mod = to_atom(ExtraField++"_schema"),
-    Mod:fields(ExtraField).
+fields(FieldName) ->
+    extra_schema_fields(FieldName).
+
+-ifndef(EMQX_EXT_SCHEMAS).
+extra_schema_fields(FieldName) -> error({unknown_field, FieldName}).
+-else.
+extra_schema_fields(FieldName) ->
+    {_, Mod} = lists:keyfind(FieldName, 1, ?EMQX_EXT_SCHEMAS),
+    Mod:fields(FieldName).
+-endif.
 
 mqtt_listener() ->
     base_listener() ++

--- a/extension_schemas.config
+++ b/extension_schemas.config
@@ -1,0 +1,17 @@
+%% -*-: erlang -*-
+%% This file lists all the hocon schemas other than the `emqx_schema`.
+%% Each element is a two-element tuple where the first element is the field name,
+%% and the second element is the schema module name.
+%%
+[ {"emqx_data_bridge", emqx_data_bridge_schema}
+, {"emqx_retainer", emqx_retainer_schema}
+, {"emqx_statsd", emqx_statsd_schema}
+, {"emqx_authn", emqx_authn_schema}
+, {"emqx_authz", emqx_authz_schema}
+, {"emqx_bridge_mqtt", emqx_bridge_mqtt_schema}
+, {"emqx_modules", emqx_modules_schema}
+, {"emqx_management", emqx_management_schema}
+, {"emqx_dashboard", emqx_dashboard_schema}
+, {"emqx_gateway", emqx_gateway_schema}
+, {"emqx_prometheus", emqx_prometheus_schema}
+].

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -79,6 +79,10 @@ is_cover_enabled() ->
 is_enterprise() ->
     filelib:is_regular("EMQX_ENTERPRISE").
 
+emqx_ext_schemas() ->
+    {ok, Schemas} = file:script("extension_schemas.config"),
+    Schemas.
+
 is_quicer_supported() ->
     not (false =/= os:getenv("BUILD_WITHOUT_QUIC") orelse
          is_win32() orelse is_centos_6()
@@ -134,6 +138,7 @@ common_compile_opts() ->
     , {d, snk_kind, msg}
     ] ++
     [{d, 'EMQX_ENTERPRISE'} || is_enterprise()] ++
+    [{d, 'EMQX_EXT_SCHEMAS', emqx_ext_schemas()}] ++
     [{d, 'EMQX_BENCHMARK'} || os:getenv("EMQX_BENCHMARK") =:= "1" ].
 
 prod_compile_opts() ->


### PR DESCRIPTION
We read the root field names and schema modules from extension_schemas.config, and assign it to the macro `EMQX_EXT_SCHEMAS`.