### PR TITLE
fix(bin/emqx): fix boot log

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -598,13 +598,8 @@ case "$1" in
             -mnesia dir "\"${MNESIA_DATA_DIR}\"" \
             $RELX_CONFIG_PATH $CONFIG_ARGS $EPMD_ARG
 
-        # Dump environment info for logging purposes
-        echo "Exec: $*" -- ${1+$ARGS}
-        echo "Root: $ROOTDIR"
-
         # Log the startup
-        echo "$RUNNER_ROOT_DIR"
-        logger -t "${REL_NAME[$$]}" "Starting up"
+        logger -t "${REL_NAME}[$$]" "$* -- ${1+$ARGS}"
 
         # Start the VM
         exec "$@" -- ${1+$ARGS}
@@ -644,9 +639,8 @@ case "$1" in
             -mnesia dir "\"${MNESIA_DATA_DIR}\"" \
             $RELX_CONFIG_PATH $CONFIG_ARGS $EPMD_ARG
 
-        # Dump environment info for logging purposes
-        echo "Exec: $*" -- ${1+$ARGS}
-        echo "Root: $ROOTDIR"
+        # Log the startup
+        logger -t "${REL_NAME}[$$]" "$* -- ${1+$ARGS}"
 
         # Start the VM
         exec "$@" -- ${1+$ARGS}


### PR DESCRIPTION
prior to this fix the logger message (syslog) has the name and pid
missing.
with this change, the programe name, and its boot command is logged
to syslog, so the console boot is cleaner

