### PR TITLE
chore: delete EMQX_NAME and EMQX_HOST env variables

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -316,12 +316,9 @@ esac
 ## Possible ways to configure emqx node name:
 ## 1. configure node.name in emqx.conf
 ## 2. override with environment variable EMQX_NODE_NAME
-## 3. override with environment variable EMQX_NAME and EMQX_HOST (deprecated)
 ## Node name is either short-name (without '@'), e.g. 'emqx'
 ## or long name (with '@') e.g. 'emqx@example.net' or 'emqx@127.0.0.1'
 NAME="${EMQX_NODE_NAME:-}"
-# to be backward compatible
-[ -n "$EMQX_NAME" ] && [ -n "$EMQX_HOST" ] && NAME="${EMQX_NAME}@${EMQX_HOST}"
 if [ -z "$NAME" ]; then
     if [ "$IS_BOOT_COMMAND" = 'no' ]; then
         # for non-boot commands, inspect vm.<time>.args for node name

--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -16,30 +16,26 @@ shopt -s nullglob
 
 LOCAL_IP=$(hostname -i | grep -oE '((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])' | head -n 1)
 
-## EMQ Base settings and plugins setting
-# Base settings in /opt/emqx/etc/emqx.conf
-# Plugin settings in /opt/emqx/etc/plugins
-
-if [[ -z "$EMQX_NAME" ]]; then
-    EMQX_NAME="$(hostname)"
-    export EMQX_NAME
-fi
-
-if [[ -z "$EMQX_HOST" ]]; then
-    if [[ "$EMQX_CLUSTER__K8S__ADDRESS_TYPE" == "dns" ]] && [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
-        EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-"pod.cluster.local"}
-        EMQX_HOST="${LOCAL_IP//./-}.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX"
-    elif [[ "$EMQX_CLUSTER__K8S__ADDRESS_TYPE" == 'hostname' ]] && [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
-        EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-'svc.cluster.local'}
-        EMQX_HOST=$(grep -h "^$LOCAL_IP" /etc/hosts | grep -o "$(hostname).*.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX")
-    else
-        EMQX_HOST="$LOCAL_IP"
-    fi
-    export EMQX_HOST
-fi
-
 if [[ -z "$EMQX_NODE_NAME" ]]; then
+
+    if [[ -z "$EMQX_NAME" ]]; then
+        EMQX_NAME="$(hostname)"
+    fi
+
+    if [[ -z "$EMQX_HOST" ]]; then
+        if [[ "$EMQX_CLUSTER__K8S__ADDRESS_TYPE" == "dns" ]] && [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
+            EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-"pod.cluster.local"}
+            EMQX_HOST="${LOCAL_IP//./-}.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX"
+        elif [[ "$EMQX_CLUSTER__K8S__ADDRESS_TYPE" == 'hostname' ]] && [[ -n "$EMQX_CLUSTER__K8S__NAMESPACE" ]]; then
+            EMQX_CLUSTER__K8S__SUFFIX=${EMQX_CLUSTER__K8S__SUFFIX:-'svc.cluster.local'}
+            EMQX_HOST=$(grep -h "^$LOCAL_IP" /etc/hosts | grep -o "$(hostname).*.$EMQX_CLUSTER__K8S__NAMESPACE.$EMQX_CLUSTER__K8S__SUFFIX")
+        else
+            EMQX_HOST="$LOCAL_IP"
+        fi
+    fi
     export EMQX_NODE_NAME="$EMQX_NAME@$EMQX_HOST"
+    unset EMQX_NAME
+    unset EMQX_HOST
 fi
 
 # fill tuples on specific file


### PR DESCRIPTION
Starting from v5, we are going to support only EMQX_NODE_NAME