### PR TITLE
refactor: delete logger parse transform

### DIFF
--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -61,4 +61,8 @@
         logger:log(Level, Data, #{ mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}
                                  , line => ?LINE})).
 
+%% print to 'user' group leader
+-define(ULOG(Fmt, Args), io:format(user, Fmt, Args)).
+-define(ELOG(Fmt, Args), io:format(standard_error, Fmt, Args)).
+
 -endif.

--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -17,8 +17,6 @@
 -ifndef(EMQX_LOGGER_HRL).
 -define(EMQX_LOGGER_HRL, true).
 
--compile({parse_transform, emqx_logger}).
-
 %% debug | info | notice | warning | error | critical | alert | emergency
 -define(DEBUG(Format), ?LOG(debug, Format, [])).
 -define(DEBUG(Format, Args), ?LOG(debug, Format, Args)).

--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -47,9 +47,7 @@
         case logger:allow(Level, ?MODULE) of
             true ->
                 logger:log(Level, (Format), (Args),
-                           (Meta)#{ mfa => <<(atom_to_binary(?MODULE, utf8))/binary, $:,
-                                             (atom_to_binary(?FUNCTION_NAME, utf8))/binary, $/,
-                                             (integer_to_binary(?FUNCTION_ARITY))/binary>>
+                           (Meta)#{ mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}
                                   , line => ?LINE
                                   });
             false ->
@@ -57,5 +55,10 @@
         end).
 
 -define(LOG(Level, Format, Args), ?LOG(Level, Format, Args, #{})).
+
+%% structured logging
+-define(SLOG(Level, Data),
+        logger:log(Level, Data, #{ mfa => {?MODULE, ?FUNCTION_NAME, ?FUNCTION_ARITY}
+                                 , line => ?LINE})).
 
 -endif.

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -15,7 +15,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.2"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.10.4"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.10.5"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.11.0"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}

--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -76,8 +76,8 @@ set_debug_secret(PathToSecretFile) ->
                 catch _ : _ -> error({badfile, PathToSecretFile})
                 end;
             {error, Reason} ->
-                io:format("Failed to read debug_info encryption key file ~s: ~p~n",
-                          [PathToSecretFile, Reason]),
+                ?ULOG("Failed to read debug_info encryption key file ~s: ~p~n",
+                      [PathToSecretFile, Reason]),
                 error(Reason)
         end,
     F = fun(init) -> ok;

--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -20,7 +20,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[EMQ X]").
 
 %% Start/Stop the application
 -export([ start/0

--- a/apps/emqx/src/emqx_alarm.erl
+++ b/apps/emqx/src/emqx_alarm.erl
@@ -22,8 +22,6 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
--logger_header("[Alarm Handler]").
-
 %% Mnesia bootstrap
 -export([mnesia/1]).
 

--- a/apps/emqx/src/emqx_alarm_handler.erl
+++ b/apps/emqx/src/emqx_alarm_handler.erl
@@ -21,7 +21,6 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
--logger_header("[Alarm Handler]").
 
 %% gen_event callbacks
 -export([ init/1

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -27,6 +27,8 @@
         ]).
 
 -include("emqx.hrl").
+-include("emqx_release.hrl").
+-include("logger.hrl").
 
 -define(APP, emqx).
 
@@ -37,7 +39,6 @@
                      , ?MOD_DELAYED_SHARD
                      ]).
 
--include("emqx_release.hrl").
 
 %%--------------------------------------------------------------------
 %% Application callbacks
@@ -113,17 +114,17 @@ start_ce_modules() ->
 print_otp_version_warning() -> ok.
 -else.
 print_otp_version_warning() ->
-    io:format("WARNING: Running on Erlang/OTP version ~p. Recommended: 23~n",
-              [?OTP_RELEASE]).
+    ?ULOG("WARNING: Running on Erlang/OTP version ~p. Recommended: 23~n",
+          [?OTP_RELEASE]).
 -endif. % OTP_RELEASE
 
 -ifndef(TEST).
 
 print_banner() ->
-    io:format("Starting ~s on node ~s~n", [?APP, node()]).
+    ?ULOG("Starting ~s on node ~s~n", [?APP, node()]).
 
 print_vsn() ->
-    io:format("~s ~s is running now!~n", [get_description(), get_release()]).
+    ?ULOG("~s ~s is running now!~n", [get_description(), get_release()]).
 
 -else. % TEST
 

--- a/apps/emqx/src/emqx_banned.erl
+++ b/apps/emqx/src/emqx_banned.erl
@@ -22,7 +22,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Banned]").
 
 %% Mnesia bootstrap
 -export([mnesia/1]).

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -23,7 +23,6 @@
 -include("types.hrl").
 -include("emqx_mqtt.hrl").
 
--logger_header("[Broker]").
 
 -export([start_link/2]).
 

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -21,7 +21,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Broker Helper]").
 
 -export([start_link/0]).
 

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -22,7 +22,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Channel]").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -24,7 +24,6 @@
 -include("types.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--logger_header("[CM]").
 
 -export([start_link/0]).
 

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -23,7 +23,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Registry]").
 
 -export([start_link/0]).
 

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -209,7 +209,7 @@ init_load(SchemaModule, RawRichConf) when is_map(RawRichConf) ->
 check_config(SchemaModule, RawConf) ->
     Opts = #{return_plain => true,
              nullable => true,
-             is_richmap => false
+             format => map
             },
     {AppEnvs, CheckedConf} =
         hocon_schema:map_translate(SchemaModule, RawConf, Opts),

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -23,7 +23,6 @@
 -include("types.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--logger_header("[MQTT]").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_ctl.erl
+++ b/apps/emqx/src/emqx_ctl.erl
@@ -21,7 +21,6 @@
 -include("types.hrl").
 -include("logger.hrl").
 
--logger_header("[Ctl]").
 
 -export([start_link/0, stop/0]).
 

--- a/apps/emqx/src/emqx_flapping.erl
+++ b/apps/emqx/src/emqx_flapping.erl
@@ -22,8 +22,6 @@
 -include("types.hrl").
 -include("logger.hrl").
 
--logger_header("[Flapping]").
-
 -export([start_link/0, stop/0]).
 
 %% API

--- a/apps/emqx/src/emqx_hooks.erl
+++ b/apps/emqx/src/emqx_hooks.erl
@@ -22,7 +22,6 @@
 -include("types.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
--logger_header("[Hooks]").
 
 -export([ start_link/0
         , stop/0

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -18,6 +18,7 @@
 -module(emqx_listeners).
 
 -include("emqx_mqtt.hrl").
+-include("logger.hrl").
 
 %% APIs
 -export([ list/0
@@ -108,14 +109,13 @@ start_listener(ZoneName, ListenerName, #{type := Type, bind := Bind} = Conf) ->
         {error, {already_started, Pid}} ->
             {error, {already_started, Pid}};
         {error, Reason} ->
-            io:format(standard_error, "Failed to start ~s listener ~s on ~s: ~0p~n",
-                      [Type, listener_id(ZoneName, ListenerName), format(Bind), Reason]),
+            ?ELOG("Failed to start ~s listener ~s on ~s: ~0p~n",
+                  [Type, listener_id(ZoneName, ListenerName), format(Bind), Reason]),
             error(Reason)
     end.
 
 -ifndef(TEST).
-console_print(Fmt, Args) ->
-    io:format(Fmt, Args).
+console_print(Fmt, Args) -> ?ULOG(Fmt, Args).
 -else.
 console_print(_Fmt, _Args) -> ok.
 -endif.

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -219,7 +219,7 @@ json_obj(Data, Config) ->
                       json_kv(K, V, D, Config)
               end, maps:new(), Data).
 
-json_kv(mfa, {M, F, A}, Data, _Config) -> %% snabbkaffe
+json_kv(mfa, {M, F, A}, Data, _Config) ->
     maps:put(mfa, <<(atom_to_binary(M, utf8))/binary, $:,
                     (atom_to_binary(F, utf8))/binary, $/,
                     (integer_to_binary(A))/binary>>, Data);

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -42,6 +42,9 @@
 
 -elvis([{elvis_style, no_nested_try_catch, #{ ignore => [emqx_logger_jsonfmt]}}]).
 
+%% this is what used when calling logger:log(Level, Report, Meta).
+-define(DEFAULT_FORMATTER, fun logger:format_otp_report/1).
+
 -type config() :: #{depth       => pos_integer() | unlimited,
                     report_cb   => logger:report_cb(),
                     single_line => boolean()}.
@@ -55,7 +58,11 @@ format(#{level := Level, msg := Msg, meta := Meta}, Config0) when is_map(Config0
 
 format(Msg, Meta, Config) ->
     Data0 =
-        try Meta#{msg => format_msg(Msg, Meta, Config)}
+        try maybe_format_msg(Msg, Meta, Config) of
+            Map when is_map(Map) ->
+                maps:merge(Map, Meta);
+            Bin when is_binary(Bin) ->
+                Meta#{msg => Bin}
         catch
             C:R:S ->
                 Meta#{ msg => "emqx_logger_jsonfmt_format_error"
@@ -68,12 +75,26 @@ format(Msg, Meta, Config) ->
     Data = maps:without([report_cb], Data0),
     jiffy:encode(json_obj(Data, Config)).
 
+maybe_format_msg({report, Report} = Msg, #{report_cb := Cb} = Meta, Config) ->
+    case is_map(Report) andalso Cb =:= ?DEFAULT_FORMATTER of
+        true ->
+            %% reporting a map without a customised format function
+            Report;
+        false ->
+            format_msg(Msg, Meta, Config)
+    end;
+maybe_format_msg(Msg, Meta, Config) ->
+    format_msg(Msg, Meta, Config).
+
 format_msg({string, Chardata}, Meta, Config) ->
+    %% already formatted
     format_msg({"~ts", [Chardata]}, Meta, Config);
 format_msg({report, _} = Msg, Meta, #{report_cb := Fun} = Config)
   when is_function(Fun,1); is_function(Fun,2) ->
+    %% a format callback function in config, no idea when this happens, but leaving it
     format_msg(Msg, Meta#{report_cb => Fun}, maps:remove(report_cb, Config));
 format_msg({report, Report}, #{report_cb := Fun} = Meta, Config) when is_function(Fun, 1) ->
+    %% a format callback function of arity 1
     case Fun(Report) of
         {Format, Args} when is_list(Format), is_list(Args) ->
             format_msg({Format, Args}, maps:remove(report_cb, Meta), Config);
@@ -84,6 +105,7 @@ format_msg({report, Report}, #{report_cb := Fun} = Meta, Config) when is_functio
              }
     end;
 format_msg({report, Report}, #{report_cb := Fun}, Config) when is_function(Fun, 2) ->
+    %% a format callback function of arity 2
     case Fun(Report, maps:with([depth, single_line], Config)) of
         Chardata when ?IS_STRING(Chardata) ->
             try

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -197,12 +197,18 @@ json_obj(Data, Config) ->
                       json_kv(K, V, D, Config)
               end, maps:new(), Data).
 
-json_kv(mfa, {M, F, A}, Data, _Config) -> %% emqx/snabbkaffe
+json_kv(mfa, {M, F, A}, Data, _Config) -> %% snabbkaffe
     maps:put(mfa, <<(atom_to_binary(M, utf8))/binary, $:,
                     (atom_to_binary(F, utf8))/binary, $/,
                     (integer_to_binary(A))/binary>>, Data);
 json_kv('$kind', Kind, Data, Config) -> %% snabbkaffe
     maps:put(msg, json(Kind, Config), Data);
+json_kv(gl, _, Data, _Config) ->
+    %% drop gl because it's not interesting
+    Data;
+json_kv(file, _, Data, _Config) ->
+    %% drop 'file' because we have mfa
+    Data;
 json_kv(K0, V, Data, Config) ->
     K = json_key(K0),
     case is_map(V) of

--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -26,6 +26,7 @@
         , peername  % formatted as a part of templated message
         , clientid  % formatted as a part of templated message
         , gl        % not interesting
+        , file
         ]).
 
 check_config(X) -> logger_formatter:check_config(X).

--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -19,26 +19,24 @@
 -export([format/2]).
 -export([check_config/1]).
 
-%% metadata fields which we do not wish to merge into log data
--define(WITHOUT_MERGE,
-        [ report_cb % just a callback
-        , time      % formatted as a part of templated message
-        , peername  % formatted as a part of templated message
-        , clientid  % formatted as a part of templated message
-        , gl        % not interesting
-        , file
-        ]).
-
 check_config(X) -> logger_formatter:check_config(X).
 
-format(#{msg := Msg0, meta := Meta} = Event, Config) ->
-    Msg = maybe_merge(Msg0, Meta),
-    logger_formatter:format(Event#{msg := Msg}, Config).
+format(#{msg := {report, Report}, meta := Meta} = Event, Config) when is_map(Report) ->
+    logger_formatter:format(Event#{msg := {report, enrich(Report, Meta)}}, Config);
+format(#{msg := {Fmt, Args}, meta := Meta} = Event, Config) when is_list(Fmt) ->
+    {NewFmt, NewArgs} = enrich_fmt(Fmt, Args, Meta),
+    logger_formatter:format(Event#{msg := {NewFmt, NewArgs}}, Config).
 
-maybe_merge({report, Report}, Meta) when is_map(Report) ->
-    {report, maps:merge(Report, filter(Meta))};
-maybe_merge(Report, _Meta) ->
-    Report.
+enrich(Report, #{mfa := Mfa, line := Line}) ->
+    Report#{mfa => mfa(Mfa), line => Line};
+enrich(Report, _) -> Report.
 
-filter(Meta) ->
-    maps:without(?WITHOUT_MERGE, Meta).
+enrich_fmt(Fmt, Args, #{mfa := Mfa, line := Line}) ->
+    {Fmt ++ " mfa: ~s line: ~w", Args ++ [mfa(Mfa), Line]};
+enrich_fmt(Fmt, Args, _) ->
+    {Fmt, Args}.
+
+mfa({M, F, A}) ->
+    <<(atom_to_binary(M, utf8))/binary, $:,
+      (atom_to_binary(F, utf8))/binary, $/,
+      (integer_to_binary(A))/binary>>.

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -24,7 +24,6 @@
 -include("emqx_mqtt.hrl").
 -include("emqx.hrl").
 
--logger_header("[Metrics]").
 
 -export([ start_link/0
         , stop/0

--- a/apps/emqx/src/emqx_os_mon.erl
+++ b/apps/emqx/src/emqx_os_mon.erl
@@ -20,7 +20,6 @@
 
 -include("logger.hrl").
 
--logger_header("[OS_MON]").
 
 -export([start_link/0]).
 

--- a/apps/emqx/src/emqx_plugins.erl
+++ b/apps/emqx/src/emqx_plugins.erl
@@ -19,7 +19,6 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
--logger_header("[Plugins]").
 
 -export([ load/0
         , load/1

--- a/apps/emqx/src/emqx_pool.erl
+++ b/apps/emqx/src/emqx_pool.erl
@@ -21,7 +21,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Pool]").
 
 %% APIs
 -export([start_link/2]).

--- a/apps/emqx/src/emqx_psk.erl
+++ b/apps/emqx/src/emqx_psk.erl
@@ -18,7 +18,6 @@
 
 -include("logger.hrl").
 
--logger_header("[PSK]").
 
 %% SSL PSK Callbacks
 -export([lookup/3]).

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -23,7 +23,6 @@
 -include("types.hrl").
 -include_lib("ekka/include/ekka.hrl").
 
--logger_header("[Router]").
 
 %% Mnesia bootstrap
 -export([mnesia/1]).

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -22,7 +22,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Router Helper]").
 
 %% Mnesia bootstrap
 -export([mnesia/1]).

--- a/apps/emqx/src/emqx_rule_actions_trans.erl
+++ b/apps/emqx/src/emqx_rule_actions_trans.erl
@@ -18,18 +18,14 @@ trans([Form | AST], ResAST) ->
   trans(AST, [Form | ResAST]).
 
 trans_func_clauses("on_action_create_" ++ _ = _FuncName , Clauses) ->
-  %io:format("~n[[transing function: ~p]]~n", [_FuncName]),
-  %io:format("~n-----old clauses:~n", []), merl:print(Clauses),
   NewClauses = [
     begin
       Bindings = lists:flatten(get_vars(Args) ++ get_vars(Body, lefth)),
       Body2 = append_to_result(Bindings, Body),
       {clause, LineNo, Args, Guards, Body2}
     end || {clause, LineNo, Args, Guards, Body} <- Clauses],
-  %io:format("~n-----new clauses: ~n"), merl:print(NewClauses),
   NewClauses;
 trans_func_clauses(_FuncName, Clauses) ->
-  %io:format("~n[[discarding function: ~p]]~n", [_FuncName]),
   Clauses.
 
 get_vars(Exprs) ->

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -48,7 +48,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Session]").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -23,7 +23,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Shared Sub]").
 
 %% Mnesia bootstrap
 -export([mnesia/1]).

--- a/apps/emqx/src/emqx_stats.erl
+++ b/apps/emqx/src/emqx_stats.erl
@@ -22,7 +22,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[Stats]").
 
 %% APIs
 -export([ start_link/0

--- a/apps/emqx/src/emqx_sys.erl
+++ b/apps/emqx/src/emqx_sys.erl
@@ -22,7 +22,6 @@
 -include("types.hrl").
 -include("logger.hrl").
 
--logger_header("[SYS]").
 
 -export([ start_link/0
         , stop/0

--- a/apps/emqx/src/emqx_sys_mon.erl
+++ b/apps/emqx/src/emqx_sys_mon.erl
@@ -21,7 +21,6 @@
 -include("types.hrl").
 -include("logger.hrl").
 
--logger_header("[SYSMON]").
 
 -export([start_link/0]).
 

--- a/apps/emqx/src/emqx_tracer.erl
+++ b/apps/emqx/src/emqx_tracer.erl
@@ -19,7 +19,6 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 
--logger_header("[Tracer]").
 
 %% APIs
 -export([ trace/2

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -22,7 +22,6 @@
 -include("logger.hrl").
 -include("types.hrl").
 
--logger_header("[MQTT/WS]").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -20,7 +20,6 @@
 -include("emqx_authz.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[AuthZ]").
 
 -export([ register_metrics/0
         , init/0

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_sup.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_sup.erl
@@ -20,7 +20,6 @@
 -include("emqx_bridge_mqtt.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[Bridge]").
 
 %% APIs
 -export([ start_link/0

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_worker.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_worker.erl
@@ -116,7 +116,6 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
--logger_header("[Bridge]").
 
 %% same as default in-flight limit for emqtt
 -define(DEFAULT_BATCH_SIZE, 32).

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -27,6 +27,7 @@
 %% Authorization
 -export([authorize_appid/1]).
 
+-include_lib("emqx/include/logger.hrl").
 
 -define(BASE_PATH, "/api/v5").
 
@@ -67,7 +68,7 @@ start_listener({Proto, Port, Options}) ->
         dispatch => Dispatch},
     MinirestOptions = maps:merge(Minirest, RanchOptions),
     {ok, _} = minirest:start(listener_name(Proto), MinirestOptions),
-    io:format("Start ~p listener on ~p successfully.~n", [listener_name(Proto), Port]).
+    ?ULOG("Start ~p listener on ~p successfully.~n", [listener_name(Proto), Port]).
 
 apps() ->
     [App || {App, _, _} <- application:loaded_applications(),
@@ -90,7 +91,7 @@ ranch_opts(Port, Options0) ->
     maps:from_list([{port, Port} | Options]).
 
 stop_listener({Proto, Port, _}) ->
-    io:format("Stop dashboard listener on ~s successfully.~n",[format(Port)]),
+    ?ULOG("Stop dashboard listener on ~s successfully.~n", [format(Port)]),
     minirest:stop(listener_name(Proto)).
 
 listeners() ->

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -20,7 +20,6 @@
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[PGW-Conn]").
 
 %% API
 -export([ start_link/3

--- a/apps/emqx_gateway/src/coap/emqx_coap_impl.erl
+++ b/apps/emqx_gateway/src/coap/emqx_coap_impl.erl
@@ -31,6 +31,8 @@
         , on_insta_destroy/3
         ]).
 
+-include_lib("emqx/include/logger.hrl").
+
 -dialyzer({nowarn_function, [load/0]}).
 
 %%--------------------------------------------------------------------
@@ -103,13 +105,12 @@ start_listener(InstaId, Ctx, ResourceMod, {Type, ListenOn, SocketOpts, Cfg}) ->
     Cfg2 = Cfg#{resource => ResourceMod},
     case start_listener(InstaId, Ctx, Type, ListenOn, SocketOpts, Cfg2) of
         {ok, Pid} ->
-            io:format("Start coap ~s:~s listener on ~s successfully.~n",
-                      [InstaId, Type, ListenOnStr]),
+            ?ULOG("Start coap ~s:~s listener on ~s successfully.~n",
+                  [InstaId, Type, ListenOnStr]),
             Pid;
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to start coap ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]),
+            ?ELOG("Failed to start coap ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason]),
             throw({badconf, Reason})
     end.
 
@@ -136,13 +137,11 @@ stop_listener(InstaId, {Type, ListenOn, SocketOpts, Cfg}) ->
     StopRet = stop_listener(InstaId, Type, ListenOn, SocketOpts, Cfg),
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case StopRet of
-        ok -> io:format("Stop coap ~s:~s listener on ~s successfully.~n",
+        ok -> ?ULOG("Stop coap ~s:~s listener on ~s successfully.~n",
                         [InstaId, Type, ListenOnStr]);
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to stop coap ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]
-                     )
+            ?ELOG("Failed to stop coap ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason])
     end,
     StopRet.
 

--- a/apps/emqx_gateway/src/coap/resources/emqx_coap_mqtt_resource.erl
+++ b/apps/emqx_gateway/src/coap/resources/emqx_coap_mqtt_resource.erl
@@ -22,7 +22,6 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx_gateway/src/coap/include/emqx_coap.hrl").
 
--logger_header("[CoAP-RES]").
 
 -export([ init/1
         , stop/1

--- a/apps/emqx_gateway/src/coap/resources/emqx_coap_pubsub_resource.erl
+++ b/apps/emqx_gateway/src/coap/resources/emqx_coap_pubsub_resource.erl
@@ -22,7 +22,6 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_gateway/src/coap/include/emqx_coap.hrl").
 
--logger_header("[CoAP-PS-RES]").
 
 -export([ init/1
         , stop/1

--- a/apps/emqx_gateway/src/coap/resources/emqx_coap_pubsub_topics.erl
+++ b/apps/emqx_gateway/src/coap/resources/emqx_coap_pubsub_topics.erl
@@ -21,7 +21,6 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_gateway/src/coap/include/emqx_coap.hrl").
 
--logger_header("[CoAP-PS-TOPICS]").
 
 -export([ start_link/0
         , stop/1

--- a/apps/emqx_gateway/src/emqx_gateway_app.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_app.erl
@@ -20,7 +20,6 @@
 
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[Gateway]").
 
 -export([start/2, stop/1]).
 

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -26,7 +26,6 @@
 -include("include/emqx_gateway.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[PGW-CM]").
 
 %% APIs
 -export([start_link/1]).

--- a/apps/emqx_gateway/src/emqx_gateway_cm_registry.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm_registry.erl
@@ -19,7 +19,6 @@
 
 -behaviour(gen_server).
 
--logger_header("[PGW-CM-Registy]").
 
 -export([start_link/1]).
 

--- a/apps/emqx_gateway/src/emqx_gateway_ctx.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_ctx.erl
@@ -19,7 +19,6 @@
 
 -include("include/emqx_gateway.hrl").
 
--logger_header(["PGW-Ctx"]).
 
 %% @doc The running context for a Connection/Channel process.
 %%

--- a/apps/emqx_gateway/src/emqx_gateway_insta_sup.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_insta_sup.erl
@@ -21,7 +21,6 @@
 
 -include("include/emqx_gateway.hrl").
 
--logger_header("[PGW-Insta-Sup]").
 
 %% APIs
 -export([ start_link/3

--- a/apps/emqx_gateway/src/emqx_gateway_metrics.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_metrics.erl
@@ -20,7 +20,6 @@
 
 -include("include/emqx_gateway.hrl").
 
--logger_header("[PGW-Metrics]").
 
 %% APIs
 -export([start_link/1]).

--- a/apps/emqx_gateway/src/emqx_gateway_registry.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_registry.erl
@@ -19,7 +19,6 @@
 
 -include("include/emqx_gateway.hrl").
 
--logger_header("[PGW-Registry]").
 
 -behavior(gen_server).
 

--- a/apps/emqx_gateway/src/exhook/emqx_exhook.erl
+++ b/apps/emqx_gateway/src/exhook/emqx_exhook.erl
@@ -19,7 +19,6 @@
 -include("src/exhook/include/emqx_exhook.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[ExHook]").
 
 %% Mgmt APIs
 -export([ enable/2

--- a/apps/emqx_gateway/src/exhook/emqx_exhook_handler.erl
+++ b/apps/emqx_gateway/src/exhook/emqx_exhook_handler.erl
@@ -20,7 +20,6 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[ExHook]").
 
 -export([ on_client_connect/2
         , on_client_connack/3

--- a/apps/emqx_gateway/src/exhook/emqx_exhook_server.erl
+++ b/apps/emqx_gateway/src/exhook/emqx_exhook_server.erl
@@ -19,7 +19,6 @@
 -include("src/exhook/include/emqx_exhook.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[ExHook Svr]").
 
 -define(CNTER, emqx_exhook_counter).
 -define(PB_CLIENT_MOD, emqx_exhook_v_1_hook_provider_client).

--- a/apps/emqx_gateway/src/exproto/emqx_exproto_channel.erl
+++ b/apps/emqx_gateway/src/exproto/emqx_exproto_channel.erl
@@ -21,7 +21,6 @@
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[ExProto Channel]").
 
 -export([ info/1
         , info/2

--- a/apps/emqx_gateway/src/exproto/emqx_exproto_gcli.erl
+++ b/apps/emqx_gateway/src/exproto/emqx_exproto_gcli.erl
@@ -21,7 +21,6 @@
 
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[ExProto gClient]").
 
 %% APIs
 -export([async_call/3]).

--- a/apps/emqx_gateway/src/exproto/emqx_exproto_gsvr.erl
+++ b/apps/emqx_gateway/src/exproto/emqx_exproto_gsvr.erl
@@ -22,7 +22,6 @@
 -include("src/exproto/include/emqx_exproto.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[ExProto gServer]").
 
 -define(IS_QOS(X), (X =:= 0 orelse X =:= 1 orelse X =:= 2)).
 

--- a/apps/emqx_gateway/src/exproto/emqx_exproto_impl.erl
+++ b/apps/emqx_gateway/src/exproto/emqx_exproto_impl.erl
@@ -32,6 +32,8 @@
         , on_insta_destroy/3
         ]).
 
+-include_lib("emqx/include/logger.hrl").
+
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
@@ -64,8 +66,7 @@ start_grpc_server(InstaId, Options = #{bind := ListenOn}) ->
                       [{ssl_options, SslOpts}]
               end,
     _ = grpc:start_server(InstaId, ListenOn, Services, SvrOptions),
-    io:format("Start ~s gRPC server on ~p successfully.~n",
-               [InstaId, ListenOn]).
+    ?ULOG("Start ~s gRPC server on ~p successfully.~n", [InstaId, ListenOn]).
 
 start_grpc_client_channel(InstaId, Options = #{address := UriStr}) ->
     UriMap = uri_string:parse(UriStr),
@@ -146,13 +147,12 @@ start_listener(InstaId, Ctx, {Type, ListenOn, SocketOpts, Cfg}) ->
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case start_listener(InstaId, Ctx, Type, ListenOn, SocketOpts, Cfg) of
         {ok, Pid} ->
-            io:format("Start exproto ~s:~s listener on ~s successfully.~n",
+            ?ULOG("Start exproto ~s:~s listener on ~s successfully.~n",
                       [InstaId, Type, ListenOnStr]),
             Pid;
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to start exproto ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]),
+            ?ELOG("Failed to start exproto ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason]),
             throw({badconf, Reason})
     end.
 
@@ -204,13 +204,11 @@ stop_listener(InstaId, {Type, ListenOn, SocketOpts, Cfg}) ->
     StopRet = stop_listener(InstaId, Type, ListenOn, SocketOpts, Cfg),
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case StopRet of
-        ok -> io:format("Stop exproto ~s:~s listener on ~s successfully.~n",
-                        [InstaId, Type, ListenOnStr]);
+        ok -> ?ULOG("Stop exproto ~s:~s listener on ~s successfully.~n",
+                    [InstaId, Type, ListenOnStr]);
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to stop exproto ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]
-                     )
+            ?ELOG("Failed to stop exproto ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason])
     end,
     StopRet.
 

--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_coap_server.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_coap_server.erl
@@ -28,8 +28,7 @@
         , stop_listener/2
         ]).
 
--define(LOG(Level, Format, Args),
-    logger:Level("LwM2M: " ++ Format, Args)).
+-include_lib("emqx/include/logger.hrl").
 
 start(Envs) ->
     start_listeners(Envs).
@@ -50,11 +49,11 @@ stop_listeners(Envs) ->
 start_listener({Proto, ListenOn, Opts}) ->
     case start_listener(Proto, ListenOn, Opts) of
         {ok, _Pid} ->
-            io:format("Start lwm2m:~s listener on ~s successfully.~n",
-                      [Proto, format(ListenOn)]);
+            ?ULOG("Start lwm2m:~s listener on ~s successfully.~n",
+                  [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to start lwm2m:~s listener on ~s: ~0p~n",
-                      [Proto, format(ListenOn), Reason]),
+            ?ELOG("Failed to start lwm2m:~s listener on ~s: ~0p~n",
+                  [Proto, format(ListenOn), Reason]),
             error(Reason)
     end.
 
@@ -66,11 +65,11 @@ start_listener(dtls, ListenOn, Opts) ->
 stop_listener({Proto, ListenOn, _Opts}) ->
     Ret = stop_listener(Proto, ListenOn),
     case Ret of
-        ok -> io:format("Stop lwm2m:~s listener on ~s successfully.~n",
-                        [Proto, format(ListenOn)]);
+        ok -> ?ULOG("Stop lwm2m:~s listener on ~s successfully.~n",
+                    [Proto, format(ListenOn)]);
         {error, Reason} ->
-            io:format(standard_error, "Failed to stop lwm2m:~s listener on ~s: ~0p~n",
-                      [Proto, format(ListenOn), Reason])
+            ?ELOG("Failed to stop lwm2m:~s listener on ~s: ~0p~n",
+                  [Proto, format(ListenOn), Reason])
     end,
     Ret.
 

--- a/apps/emqx_gateway/src/mqttsn/emqx_sn_broadcast.erl
+++ b/apps/emqx_gateway/src/mqttsn/emqx_sn_broadcast.erl
@@ -19,6 +19,7 @@
 -behaviour(gen_server).
 
 -include("src/mqttsn/include/emqx_sn.hrl").
+-include_lib("emqx/include/logger.hrl").
 
 -export([ start_link/2
         , stop/0
@@ -31,8 +32,6 @@
 -record(state, {gwid, sock, port, addrs, duration, tref}).
 
 -define(DEFAULT_DURATION, 15*60*1000).
--define(LOG(Level, Format, Args),
-        emqx_logger:Level("MQTT-SN(broadcast): " ++ Format, Args)).
 
 %%--------------------------------------------------------------------
 %% API

--- a/apps/emqx_gateway/src/mqttsn/emqx_sn_channel.erl
+++ b/apps/emqx_gateway/src/mqttsn/emqx_sn_channel.erl
@@ -23,7 +23,6 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[SN-Proto]").
 
 %% API
 -export([ info/1

--- a/apps/emqx_gateway/src/mqttsn/emqx_sn_impl.erl
+++ b/apps/emqx_gateway/src/mqttsn/emqx_sn_impl.erl
@@ -32,6 +32,8 @@
         , on_insta_destroy/3
         ]).
 
+-include_lib("emqx/include/logger.hrl").
+
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
@@ -113,13 +115,12 @@ start_listener(InstaId, Ctx, {Type, ListenOn, SocketOpts, Cfg}) ->
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case start_listener(InstaId, Ctx, Type, ListenOn, SocketOpts, Cfg) of
         {ok, Pid} ->
-            io:format("Start mqttsn ~s:~s listener on ~s successfully.~n",
-                      [InstaId, Type, ListenOnStr]),
+            ?ULOG("Start mqttsn ~s:~s listener on ~s successfully.~n",
+                  [InstaId, Type, ListenOnStr]),
             Pid;
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to start mqttsn ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]),
+            ?ELOG("Failed to start mqttsn ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason]),
             throw({badconf, Reason})
     end.
 
@@ -150,13 +151,11 @@ stop_listener(InstaId, {Type, ListenOn, SocketOpts, Cfg}) ->
     StopRet = stop_listener(InstaId, Type, ListenOn, SocketOpts, Cfg),
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case StopRet of
-        ok -> io:format("Stop mqttsn ~s:~s listener on ~s successfully.~n",
-                        [InstaId, Type, ListenOnStr]);
+        ok -> ?ULOG("Stop mqttsn ~s:~s listener on ~s successfully.~n",
+                    [InstaId, Type, ListenOnStr]);
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to stop mqttsn ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]
-                     )
+            ?ELOG("Failed to stop mqttsn ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason])
     end,
     StopRet.
 

--- a/apps/emqx_gateway/src/stomp/emqx_stomp_channel.erl
+++ b/apps/emqx_gateway/src/stomp/emqx_stomp_channel.erl
@@ -22,7 +22,6 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[Stomp-Proto]").
 
 -import(proplists, [get_value/2, get_value/3]).
 

--- a/apps/emqx_gateway/src/stomp/emqx_stomp_impl.erl
+++ b/apps/emqx_gateway/src/stomp/emqx_stomp_impl.erl
@@ -16,8 +16,6 @@
 
 -module(emqx_stomp_impl).
 
--include_lib("emqx_gateway/include/emqx_gateway.hrl").
-
 -behavior(emqx_gateway_impl).
 
 %% APIs
@@ -30,6 +28,9 @@
         , on_insta_update/4
         , on_insta_destroy/3
         ]).
+
+-include_lib("emqx_gateway/include/emqx_gateway.hrl").
+-include_lib("emqx/include/logger.hrl").
 
 %%--------------------------------------------------------------------
 %% APIs
@@ -97,13 +98,12 @@ start_listener(InstaId, Ctx, {Type, ListenOn, SocketOpts, Cfg}) ->
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case start_listener(InstaId, Ctx, Type, ListenOn, SocketOpts, Cfg) of
         {ok, Pid} ->
-            io:format("Start stomp ~s:~s listener on ~s successfully.~n",
-                      [InstaId, Type, ListenOnStr]),
+            ?ULOG("Start stomp ~s:~s listener on ~s successfully.~n",
+                  [InstaId, Type, ListenOnStr]),
             Pid;
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to start stomp ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]),
+            ?ELOG("Failed to start stomp ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason]),
             throw({badconf, Reason})
     end.
 
@@ -134,13 +134,11 @@ stop_listener(InstaId, {Type, ListenOn, SocketOpts, Cfg}) ->
     StopRet = stop_listener(InstaId, Type, ListenOn, SocketOpts, Cfg),
     ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
     case StopRet of
-        ok -> io:format("Stop stomp ~s:~s listener on ~s successfully.~n",
-                        [InstaId, Type, ListenOnStr]);
+        ok -> ?ULOG("Stop stomp ~s:~s listener on ~s successfully.~n",
+                    [InstaId, Type, ListenOnStr]);
         {error, Reason} ->
-            io:format(standard_error,
-                      "Failed to stop stomp ~s:~s listener on ~s: ~0p~n",
-                      [InstaId, Type, ListenOnStr, Reason]
-                     )
+            ?ELOG("Failed to stop stomp ~s:~s listener on ~s: ~0p~n",
+                  [InstaId, Type, ListenOnStr, Reason])
     end,
     StopRet.
 

--- a/apps/emqx_management/src/emqx_mgmt_http.erl
+++ b/apps/emqx_management/src/emqx_mgmt_http.erl
@@ -24,6 +24,7 @@
 -export([authorize_appid/1]).
 
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/logger.hrl").
 
 -define(APP, emqx_management).
 
@@ -63,7 +64,7 @@ start_listener({Proto, Port, Options}) ->
         swagger_global_spec => GlobalSpec},
     MinirestOptions = maps:merge(Minirest, RanchOptions),
     {ok, _} = minirest:start(listener_name(Proto), MinirestOptions),
-    io:format("Start ~p listener on ~p successfully.~n", [listener_name(Proto), Port]).
+    ?ULOG("Start ~p listener on ~p successfully.~n", [listener_name(Proto), Port]).
 
 ranch_opts(Port, Options0) ->
     Options = lists:foldl(
@@ -79,7 +80,7 @@ ranch_opts(Port, Options0) ->
     maps:from_list([{port, Port} | Options]).
 
 stop_listener({Proto, Port, _}) ->
-    io:format("Stop http:management listener on ~s successfully.~n",[format(Port)]),
+    ?ULOG("Stop http:management listener on ~s successfully.~n",[format(Port)]),
     minirest:stop(listener_name(Proto)).
 
 listeners() ->

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -21,7 +21,6 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[Delayed]").
 
 %% Mnesia bootstrap
 -export([mnesia/1]).

--- a/apps/emqx_modules/src/emqx_topic_metrics.erl
+++ b/apps/emqx_modules/src/emqx_topic_metrics.erl
@@ -22,7 +22,6 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
--logger_header("[TOPIC_METRICS]").
 
 -export([ on_message_publish/1
         , on_message_delivered/2

--- a/apps/emqx_resource/src/emqx_resource_transform.erl
+++ b/apps/emqx_resource/src/emqx_resource_transform.erl
@@ -59,7 +59,6 @@ form(Mod, Form) ->
         ?Q("-module('@_').") ->
             {[Form], fix_spec_attrs(), fix_spec_funcs(Mod)};
         _ ->
-            %io:format("---other form: ~p~n", [Form]),
             {[Form], [], []}
     end.
 

--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -22,7 +22,6 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[Retainer]").
 
 -export([start_link/0]).
 

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -23,7 +23,6 @@
 -include_lib("stdlib/include/ms_transform.hrl").
 -include_lib("stdlib/include/qlc.hrl").
 
--logger_header("[Retainer]").
 
 -export([delete_message/2
         , store_retained/2

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -119,10 +119,10 @@ on_action_create_inspect(Id, Params) ->
 
 -spec on_action_inspect(selected_data(), env_vars()) -> any().
 on_action_inspect(Selected, Envs) ->
-    io:format("[inspect]~n"
-              "\tSelected Data: ~p~n"
-              "\tEnvs: ~p~n"
-              "\tAction Init Params: ~p~n", [Selected, Envs, ?bound_v('Params', Envs)]),
+    ?ULOG("[inspect]~n"
+          "\tSelected Data: ~p~n"
+          "\tEnvs: ~p~n"
+          "\tAction Init Params: ~p~n", [Selected, Envs, ?bound_v('Params', Envs)]),
     emqx_rule_metrics:inc_actions_success(?bound_v('Id', Envs)).
 
 

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -19,7 +19,6 @@
 -include("rule_engine.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[RuleEngineAPI]").
 
 -rest_api(#{name   => create_rule,
             method => 'POST',

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -20,7 +20,6 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--logger_header("[RuleEvents]").
 
 -export([ load/1
         , unload/0

--- a/apps/emqx_rule_engine/src/emqx_rule_monitor.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_monitor.erl
@@ -20,7 +20,6 @@
 
 -include("rule_engine.hrl").
 -include_lib("emqx/include/logger.hrl").
--logger_header("[Rule Monitor]").
 
 -export([init/1,
          handle_call/3,

--- a/apps/emqx_rule_engine/src/emqx_rule_registry.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_registry.erl
@@ -150,14 +150,14 @@ mnesia(copy) ->
     ok = ekka_mnesia:copy_table(?RES_TYPE_TAB, ram_copies).
 
 dump() ->
-    io:format("Rules: ~p~n"
-              "ActionInstParams: ~p~n"
-              "Resources: ~p~n"
-              "ResourceParams: ~p~n",
-            [ets:tab2list(?RULE_TAB),
-             ets:tab2list(?ACTION_INST_PARAMS_TAB),
-             ets:tab2list(?RES_TAB),
-             ets:tab2list(?RES_PARAMS_TAB)]).
+    ?ULOG("Rules: ~p~n"
+          "ActionInstParams: ~p~n"
+          "Resources: ~p~n"
+          "ResourceParams: ~p~n",
+          [ets:tab2list(?RULE_TAB),
+           ets:tab2list(?ACTION_INST_PARAMS_TAB),
+           ets:tab2list(?RES_TAB),
+           ets:tab2list(?RES_PARAMS_TAB)]).
 
 %%------------------------------------------------------------------------------
 %% Start the registry

--- a/rebar.config
+++ b/rebar.config
@@ -60,7 +60,7 @@
     , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.1
     , {getopt, "1.0.1"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.13.0"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.10.5"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.11.0"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.3.0"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.1.0"}}}
     ]}.


### PR DESCRIPTION
* Refactored json/text formatter to include MFA, and LINE info in log messages
* Deleted emqx_logger parse-transform
  parse-transform has been causing trouble for builds especially for external plugins, with MFA and LINE added, there should be no need for the log headers
* Unified io:format calls to use the came macros: `ULOG` for `stdout` and `ELOG` for `stderr`
* Stopped using logger formater callbacks, the anonymous function may cause `badfun` exception during upgrade.