### PR TITLE
APIs for config hot update

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -302,7 +302,7 @@ do_get(Type, KeyPath) ->
 do_get(Type, [], Default) ->
     AllConf = lists:foldl(fun
             ({?PERSIS_KEY(Type0, RootName), Conf}, AccIn) when Type0 == Type ->
-                AccIn#{RootName => Conf};
+                AccIn#{conf_key(Type0, RootName) => Conf};
             (_, AccIn) -> AccIn
         end, #{}, persistent_term:get()),
     case map_size(AllConf) == 0 of
@@ -343,3 +343,8 @@ atom(Atom) when is_atom(Atom) ->
 
 bin(Bin) when is_binary(Bin) -> Bin;
 bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
+
+conf_key(?CONF, RootName) ->
+    atom(RootName);
+conf_key(?RAW_CONF, RootName) ->
+    bin(RootName).

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -156,14 +156,14 @@ update(KeyPath, UpdateReq) ->
 -spec update(module(), emqx_map_lib:config_key_path(), update_request()) ->
     ok | {error, term()}.
 update(SchemaModule, KeyPath, UpdateReq) ->
-    emqx_config_handler:update_config(SchemaModule, KeyPath, UpdateReq).
+    emqx_config_handler:update_config(SchemaModule, KeyPath, {update, UpdateReq}).
 
 -spec remove(emqx_map_lib:config_key_path()) -> ok | {error, term()}.
 remove(KeyPath) ->
     remove(emqx_schema, KeyPath).
 
 remove(SchemaModule, KeyPath) ->
-    emqx_config_handler:remove_config(SchemaModule, KeyPath).
+    emqx_config_handler:update_config(SchemaModule, KeyPath, remove).
 
 -spec get_raw(emqx_map_lib:config_key_path()) -> term().
 get_raw(KeyPath) -> do_get(?RAW_CONF, KeyPath).

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -40,6 +40,8 @@
     }
 }).
 
+-define(ERR_MSG(MSG), io_lib:format("~p", [MSG])).
+
 api_spec() ->
     {config_apis(), []}.
 
@@ -92,8 +94,11 @@ config(get, Req) ->
 
 config(delete, Req) ->
     %% TODO: remove the config specified by the query string param 'conf_path'
-    emqx_config:remove(conf_path_from_querystr(Req)),
-    {200};
+    case emqx_config:remove(conf_path_from_querystr(Req)) of
+        ok -> {200};
+        {error, Reason} ->
+            {400, ?ERR_MSG(Reason)}
+    end;
 
 config(put, Req) ->
     Path = [binary_to_atom(Key, latin1) || Key <- conf_path_from_querystr(Req)],

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -98,7 +98,7 @@ config(delete, Req) ->
 config(put, Req) ->
     Path = [binary_to_atom(Key, latin1) || Key <- conf_path_from_querystr(Req)],
     ok = emqx_config:update(Path, http_body(Req)),
-    {201, emqx_config:get_raw(Path)}.
+    {200, emqx_config:get_raw(Path)}.
 
 conf_path_from_querystr(Req) ->
     case proplists:get_value(<<"conf_path">>, cowboy_req:parse_qs(Req)) of

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -23,8 +23,6 @@
 -export([ config/2
         ]).
 
--define(CONFIG_NAMES, [log, rpc, broker, zones, sysmon, alarm]).
-
 -define(PARAM_CONF_PATH, [#{
     name => conf_path,
     in => query,
@@ -33,30 +31,34 @@
     schema => #{type => string, default => <<".">>}
 }]).
 
-api_spec() ->
-    {config_apis(), config_schemas()}.
+-define(TEXT_BODY(DESCR), #{
+    description => list_to_binary(DESCR),
+    content => #{
+        <<"text/plain">> => #{
+            schema => #{}
+        }
+    }
+}).
 
-config_schemas() ->
-    [#{RootName => #{type => object}} %% TODO: generate this from hocon schema
-     || RootName <- ?CONFIG_NAMES].
+api_spec() ->
+    {config_apis(), []}.
 
 config_apis() ->
-    [config_api(RootName) || RootName <- ?CONFIG_NAMES].
+    [config_api()].
 
-config_api(RootName) when is_atom(RootName) ->
-    RootNameStr = atom_to_list(RootName),
-    Descr = fun(Prefix) -> list_to_binary(Prefix ++ " " ++ RootNameStr) end,
+config_api() ->
     Metadata = #{
         get => #{
-            description => Descr("Get configs for"),
+            description => <<"Get configs">>,
             parameters => ?PARAM_CONF_PATH,
             responses => #{
-                <<"200">> => emqx_mgmt_util:response_schema(<<"The config value for log">>,
-                    RootName)
+                <<"200">> => ?TEXT_BODY("Get configs successfully"),
+                <<"404">> => emqx_mgmt_util:response_error_schema(
+                    <<"Config not found">>, ['NOT_FOUND'])
             }
         },
         delete => #{
-            description => Descr("Remove configs for"),
+            description => <<"Remove configs for">>,
             parameters => ?PARAM_CONF_PATH,
             responses => #{
                 <<"200">> => emqx_mgmt_util:response_schema(<<"Remove configs successfully">>),
@@ -65,45 +67,47 @@ config_api(RootName) when is_atom(RootName) ->
             }
         },
         put => #{
-            description => Descr("Update configs for"),
-            'requestBody' => emqx_mgmt_util:request_body_schema(RootName),
+            description => <<"Update configs for">>,
+            parameters => ?PARAM_CONF_PATH,
+            'requestBody' => ?TEXT_BODY("The format of the request body is depend on the 'conf_path' parameter in the query string"),
             responses => #{
-                <<"200">> => emqx_mgmt_util:response_schema(<<"Update configs successfully">>,
-                    RootName),
+                <<"200">> => ?TEXT_BODY("Update configs successfully"),
                 <<"400">> => emqx_mgmt_util:response_error_schema(
                     <<"Update configs failed">>, ['UPDATE_FAILED'])
             }
         }
     },
-    {"/configs/" ++ RootNameStr, Metadata, config}.
+    {"/configs", Metadata, config}.
 
 %%%==============================================================================================
 %% parameters trans
 config(get, Req) ->
     %% TODO: query the config specified by the query string param 'conf_path'
-    Conf = emqx_config:get_raw([root_name_from_path(Req) | conf_path_from_querystr(Req)]),
-    {200, Conf};
+    case emqx_config:find_raw(conf_path_from_querystr(Req)) of
+        {ok, Conf} ->
+            {200, Conf};
+        {not_found, _, _} ->
+            {404, #{code => 'NOT_FOUND', message => <<"Config cannot found">>}}
+    end;
 
 config(delete, Req) ->
     %% TODO: remove the config specified by the query string param 'conf_path'
-    emqx_config:remove([root_name_from_path(Req) | conf_path_from_querystr(Req)]),
+    emqx_config:remove(conf_path_from_querystr(Req)),
     {200};
 
 config(put, Req) ->
-    RootName = root_name_from_path(Req),
-    ok = emqx_config:update([RootName], http_body(Req)),
-    {200, emqx_config:get_raw([RootName])}.
-
-root_name_from_path(Req) ->
-    <<"/api/v5/configs/", RootName/binary>> = cowboy_req:path(Req),
-    string:trim(RootName, trailing, "/").
+    Path = [binary_to_atom(Key, latin1) || Key <- conf_path_from_querystr(Req)],
+    ok = emqx_config:update(Path, http_body(Req)),
+    {201, emqx_config:get_raw(Path)}.
 
 conf_path_from_querystr(Req) ->
     case proplists:get_value(<<"conf_path">>, cowboy_req:parse_qs(Req)) of
         undefined -> [];
-        Path -> [string:lexemes(Path, ". ")]
+        Path -> string:lexemes(Path, ". ")
     end.
 
 http_body(Req) ->
     {ok, Body, _} = cowboy_req:read_body(Req),
-    Body.
+    try jsx:decode(Body, [{return_maps, true}])
+    catch error:badarg -> Body
+    end.

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -1,0 +1,112 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_mgmt_api_configs).
+
+-behaviour(minirest_api).
+
+-export([api_spec/0]).
+
+-export([brokers/2]).
+
+api_spec() ->
+    {[config_apis()], config_schemas()}.
+
+config_schema() -> [
+    #{
+        broker => #{
+            type => object,
+        }
+    }
+|| RootKey <- ].
+
+config_apis() ->
+    Metadata = #{
+        get => #{
+            description => <<"EMQ X configs">>,
+            parameters => [#{
+                name => activated,
+                in => query,
+                description => <<"All configs, if not specified">>,
+                required => false,
+                schema => #{type => boolean, default => true}
+            }],
+            responses => #{
+                <<"200">> =>
+                emqx_mgmt_util:response_array_schema(<<"List all configs">>, config)}},
+        delete => #{
+            description => <<"Remove all deactivated configs">>,
+            responses => #{
+                <<"200">> =>
+                emqx_mgmt_util:response_schema(<<"Remove all deactivated configs ok">>)}}},
+    {"/configs", Metadata, configs}.
+
+%%%==============================================================================================
+%% parameters trans
+configs(get, Request) ->
+    case proplists:get_value(<<"activated">>, cowboy_req:parse_qs(Request), undefined) of
+        undefined ->
+            list(#{activated => undefined});
+        <<"true">> ->
+            list(#{activated => true});
+        <<"false">> ->
+            list(#{activated => false})
+    end;
+
+configs(delete, _Request) ->
+    delete().
+
+%%%==============================================================================================
+%% api apply
+list(#{activated := true}) ->
+    do_list(activated);
+list(#{activated := false}) ->
+    do_list(deactivated);
+list(#{activated := undefined}) ->
+    do_list(activated).
+
+delete() ->
+    _ = emqx_mgmt:delete_all_deactivated_configs(),
+    {200}.
+
+%%%==============================================================================================
+%% internal
+do_list(Type) ->
+    {Table, Function} =
+        case Type of
+            activated ->
+                {?ACTIVATED_ALARM, query_activated};
+            deactivated ->
+                {?DEACTIVATED_ALARM, query_deactivated}
+        end,
+    Response = emqx_mgmt_api:cluster_query([], {Table, []}, {?MODULE, Function}),
+    {200, Response}.
+
+query_activated(_, Start, Limit) ->
+    query(?ACTIVATED_ALARM, Start, Limit).
+
+query_deactivated(_, Start, Limit) ->
+    query(?DEACTIVATED_ALARM, Start, Limit).
+
+query(Table, Start, Limit) ->
+    Ms = [{'$1',[],['$1']}],
+    emqx_mgmt_api:select_table(Table, Ms, Start, Limit, fun format_config/1).
+
+format_config(Alarms) when is_list(Alarms) ->
+    [emqx_config:format(Alarm) || Alarm <- Alarms];
+
+format_config(Alarm) ->
+    emqx_config:format(Alarm).

--- a/apps/emqx_management/src/emqx_mgmt_http.erl
+++ b/apps/emqx_management/src/emqx_mgmt_http.erl
@@ -47,6 +47,14 @@ start_listener({Proto, Port, Options}) ->
         openapi => "3.0.0",
         info => #{title => "EMQ X API", version => "5.0.0"},
         servers => [#{url => ?BASE_PATH}],
+        tags => [#{
+            name => configs,
+            description => <<"The query string parameter `conf_path` is of jq format.">>,
+            externalDocs => #{
+                description => "Find out more about the path syntax in jq",
+                url => "https://stedolan.github.io/jq/manual/"
+            }
+        }],
         components => #{
             schemas => #{},
             securitySchemes => #{


### PR DESCRIPTION
I'd like to add a general config updating API for all the config map:

**PATH:**  /api/v5/configs?conf_path=<config-paths>

Examples:

```
## We can get the entire config map using 'conf_path=.' 
HTTP GET /api/v5/configs?conf_path=.

## To get all configs for alarm:
HTTP GET /api/v5/configs?conf_path=.alarm

## To replace all configs for alarm:
HTTP PUT /api/v5/configs?conf_path=.alarm

{"actions": ["log", "publish"],
  "size_limit": 1000,
  "validity_period": "12h"
}

## We can also set value for a specific config entry
HTTP PUT /api/v5/configs?conf_path=.alarm. validity_period

12h

## DELETE is used for "remove" the config, after removing a config the default value is used.
HTTP DELETE /api/v5/configs/alarm?conf_path=size_limit

```

1. I'd prefer using query string parameter `conf_path` rather than put it into the request body, because some "RESTful" HTTP clients might not allow to have HTTP body for `DELETE` method.

2. The `conf_path` is the path to the config entry, and it's of [jq](https://stedolan.github.io/jq/manual/) syntax.

3. The `DELETE` API removes the config if possible. That is, if a config item is mandatory, then it cannot be deleted and the API returns 400; if the config item is optional and has default value, then the default value will be used; if the config entry is a element of array or a `wildcard name` like listener name, then the config entry will be removed.

Note that **I don't want to support patch update configs that has arrays in their config path**. Because that would be too complex in syntax and introduces some costs for user to study:

e.g. Following config path is too complex:

`HTTP PUT /api/v5/configs/authz/rules/[id == "someid"]/ipaddress`


