### PR TITLE
fix(lwm2m): check integer range for better singed-unsigned int decode

### DIFF
--- a/apps/emqx_lwm2m/src/emqx_lwm2m.app.src
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m.app.src
@@ -1,6 +1,6 @@
 {application,emqx_lwm2m,
              [{description,"EMQ X LwM2M Gateway"},
-              {vsn, "4.3.2"}, % strict semver, bump manually!
+              {vsn, "4.3.3"}, % strict semver, bump manually!
               {modules,[]},
               {registered,[emqx_lwm2m_sup]},
               {applications,[kernel,stdlib,lwm2m_coap]},

--- a/apps/emqx_lwm2m/src/emqx_lwm2m.appup.src
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m.appup.src
@@ -1,12 +1,12 @@
 %% -*-: erlang -*-
 {VSN,
   [
-    {<<"4.3.[0-1]">>, [
+    {<<"4\.3\.[0-2]">>, [
       {restart_application, emqx_lwm2m}
     ]}
   ],
   [
-    {<<"4.3.[0-1]">>, [
+    {<<"4\.3\.[0-2]">>, [
       {restart_application, emqx_lwm2m}
     ]}
   ]

--- a/apps/emqx_lwm2m/src/emqx_lwm2m_xml_object.erl
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m_xml_object.erl
@@ -24,6 +24,7 @@
         , get_object_name/1
         , get_object_and_resource_id/2
         , get_resource_type/2
+        , get_resource_range/2
         , get_resource_name/2
         , get_resource_operations/2
         ]).
@@ -61,6 +62,13 @@ get_resource_type(ResourceIdInt, ObjDefinition) ->
     ResourceIdString = integer_to_list(ResourceIdInt),
     [#xmlText{value=DataType}] = xmerl_xpath:string("Resources/Item[@ID=\""++ResourceIdString++"\"]/Type/text()", ObjDefinition),
     DataType.
+
+get_resource_range(ResourceIdInt, ObjDefinition) ->
+    ResourceIdString = integer_to_list(ResourceIdInt),
+    case xmerl_xpath:string("Resources/Item[@ID=\""++ResourceIdString++"\"]/RangeEnumeration/text()", ObjDefinition) of
+        [#xmlText{value=Range}] -> Range;
+        _ -> ""
+    end.
 
 get_resource_name(ResourceIdInt, ObjDefinition) ->
     ResourceIdString = integer_to_list(ResourceIdInt),


### PR DESCRIPTION
Prior to this change, there was statistically 50% percent chance to get a Integer value decoded < 0.
Changed to:
1. get Integer range,
2. decode to unsigned, if the value fits in integer range, return unsigned
3. return signed