### PR TITLE
fix(lwm2m): write incorrect integer to device

### DIFF
--- a/apps/emqx_lwm2m/src/emqx_lwm2m.app.src
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m.app.src
@@ -1,6 +1,6 @@
 {application,emqx_lwm2m,
              [{description,"EMQ X LwM2M Gateway"},
-              {vsn, "4.3.2"}, % strict semver, bump manually!
+              {vsn, "4.3.3"}, % strict semver, bump manually!
               {modules,[]},
               {registered,[emqx_lwm2m_sup]},
               {applications,[kernel,stdlib,lwm2m_coap]},

--- a/apps/emqx_lwm2m/src/emqx_lwm2m.appup.src
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m.appup.src
@@ -1,13 +1,19 @@
 %% -*-: erlang -*-
-{VSN,
+{"4.3.3",
   [
     {<<"4.3.[0-1]">>, [
       {restart_application, emqx_lwm2m}
+    ]},
+    {"4.3.2", [
+      {load_module, emqx_lwm2m_message, brutal_purge, soft_purge, []}
     ]}
   ],
   [
     {<<"4.3.[0-1]">>, [
       {restart_application, emqx_lwm2m}
+    ]},
+    {"4.3.2", [
+      {load_module, emqx_lwm2m_message, brutal_purge, soft_purge, []}
     ]}
   ]
 }.

--- a/apps/emqx_lwm2m/src/emqx_lwm2m_message.erl
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m_message.erl
@@ -364,21 +364,21 @@ encode_number(Int) when is_integer(Int) ->
 encode_number(Float) when is_float(Float) ->
     <<Float:64/float>>.
 
-encode_int(Int) when Int >= 0 ->
-    binary:encode_unsigned(Int);
-encode_int(Int) when Int < 0 ->
-    Size = byte_size_of_signed(-Int) * 8,
+encode_int(Int) ->
+    Size = int_byte_size(Int) * 8,
     <<Int:Size/signed>>.
 
-byte_size_of_signed(UInt) ->
-    byte_size_of_signed(UInt, 0).
+int_byte_size(Int) when Int >= 0 ->
+    do_int_byte_size(Int, 0);
+int_byte_size(Int) when Int < 0 ->
+    do_int_byte_size(-Int, 0).
 
-byte_size_of_signed(UInt, N) ->
+do_int_byte_size(UInt, N) ->
     BitSize = (8*N - 1),
     Max = (1 bsl BitSize),
     if
-        UInt =< Max -> N;
-        UInt > Max -> byte_size_of_signed(UInt, N+1)
+        UInt < Max -> N;
+        UInt >= Max -> do_int_byte_size(UInt, N+1)
     end.
 
 binary_to_number(NumStr) ->

--- a/apps/emqx_lwm2m/src/emqx_lwm2m_message.erl
+++ b/apps/emqx_lwm2m/src/emqx_lwm2m_message.erl
@@ -22,6 +22,9 @@
         , opaque_to_json/2
         , translate_json/1
         ]).
+-ifdef(TEST).
+-export([ bits/1 ]).
+-endif.
 
 -include("emqx_lwm2m.hrl").
 
@@ -364,23 +367,6 @@ encode_number(Int) when is_integer(Int) ->
 encode_number(Float) when is_float(Float) ->
     <<Float:64/float>>.
 
-encode_int(Int) ->
-    Size = int_byte_size(Int) * 8,
-    <<Int:Size/signed>>.
-
-int_byte_size(Int) when Int >= 0 ->
-    do_int_byte_size(Int, 0);
-int_byte_size(Int) when Int < 0 ->
-    do_int_byte_size(-Int, 0).
-
-do_int_byte_size(UInt, N) ->
-    BitSize = (8*N - 1),
-    Max = (1 bsl BitSize),
-    if
-        UInt < Max -> N;
-        UInt >= Max -> do_int_byte_size(UInt, N+1)
-    end.
-
 binary_to_number(NumStr) ->
     try
         binary_to_integer(NumStr)
@@ -388,3 +374,26 @@ binary_to_number(NumStr) ->
         error:badarg ->
             binary_to_float(NumStr)
     end.
+
+encode_int(Int) ->
+    Bits = bits(Int),
+    <<Int:Bits/signed>>.
+
+bits(I) when I < 0 -> bits_neg(I);
+bits(I) -> bits_pos(I).
+
+%% Quote:
+%% Integer: An 8, 16, 32 or 64-bit signed integer.
+%% The valid range of the value for a Resource SHOULD be defined.
+%% This data type is also used for the purpose of enumeration.
+%%
+%% NOTE: Integer should not be encoded to 24-bits, 40-bits, etc.
+bits_pos(I) when I < (1 bsl 7)  -> 8;
+bits_pos(I) when I < (1 bsl 15) -> 16;
+bits_pos(I) when I < (1 bsl 31) -> 32;
+bits_pos(I) when I < (1 bsl 63) -> 64.
+
+bits_neg(I) when I >= -((1 bsl 7))  -> 8;
+bits_neg(I) when I >= -((1 bsl 15)) -> 16;
+bits_neg(I) when I >= -((1 bsl 31)) -> 32;
+bits_neg(I) when I >= -((1 bsl 63)) -> 64.

--- a/apps/emqx_lwm2m/test/emqx_lwm2m_message_tests.erl
+++ b/apps/emqx_lwm2m/test/emqx_lwm2m_message_tests.erl
@@ -1,0 +1,21 @@
+-module(emqx_lwm2m_message_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-import(emqx_lwm2m_message, [bits/1]).
+
+bits_pos_test() ->
+    ?assertEqual(8, bits(0)),
+    ?assertEqual(8, bits(1)),
+    ?assertEqual(8, bits(127)),
+    ?assertEqual(16, bits(128)),
+    ?assertEqual(16, bits(129)),
+    ok.
+
+bits_neg_test() ->
+    ?assertEqual(8, bits(-1)),
+    ?assertEqual(8, bits(-2)),
+    ?assertEqual(8, bits(-127)),
+    ?assertEqual(8, bits(-128)),
+    ?assertEqual(16, bits(-129)),
+    ok.


### PR DESCRIPTION
Fix https://github.com/emqx/emqx/issues/4989

We should always write a signed integer to the device, no matter it is a positive or negative integer.