### PR TITLE
fix(emqx_event_message): drop invalid data from  header in the event messages 

### DIFF
--- a/apps/emqx_modules/src/emqx_event_message.erl
+++ b/apps/emqx_modules/src/emqx_event_message.erl
@@ -172,7 +172,7 @@ on_message_acked(_ClientInfo = #{
     case ignore_sys_message(Message) of
         true -> ok;
         false ->
-            Message1 = remove_header(Message),
+            Message1 = remove_internal_headers(Message),
             Payload0 = base_message(Message1),
             Payload = Payload0#{
                 from_clientid => ClientId,
@@ -266,5 +266,5 @@ publish_event_msg(Topic, Payload) ->
     _ = emqx_broker:safe_publish(make_msg(Topic, emqx_json:encode(Payload))),
     ok.
 
-remove_header(Message) ->
+remove_internal_headers(Message) ->
     emqx_message:remove_header(shared_dispatch_ack, Message).

--- a/apps/emqx_modules/src/emqx_event_message.erl
+++ b/apps/emqx_modules/src/emqx_event_message.erl
@@ -172,7 +172,8 @@ on_message_acked(_ClientInfo = #{
     case ignore_sys_message(Message) of
         true -> ok;
         false ->
-            Payload0 = base_message(Message),
+            Message1 = remove_header(Message),
+            Payload0 = base_message(Message1),
             Payload = Payload0#{
                 from_clientid => ClientId,
                 from_username => emqx_message:get_header(username, Message, undefined),
@@ -264,3 +265,6 @@ ignore_sys_message(#message{flags = Flags}) ->
 publish_event_msg(Topic, Payload) ->
     _ = emqx_broker:safe_publish(make_msg(Topic, emqx_json:encode(Payload))),
     ok.
+
+remove_header(Message) ->
+    emqx_message:remove_header(shared_dispatch_ack, Message).


### PR DESCRIPTION
an error is as follows:

`Failed to execute {emqx_event_message,on_message_acked,[]}: {error,{invalid_ejson,{<0.2344.0>,#Ref<0.239986819.3418095617.239774>}},[{jiffy,encode,2,[{file,"jiffy.erl"},{line,99}]},{emqx_json,encode,1,[{file,"emqx_json.erl"},{line,58}]},{emqx_event_message,publish_event_msg,2,[{file,"emqx_event_message.erl"},{line,266}]},{emqx_event_message,on_message_acked,2,[{file,"emqx_event_message.erl"},{line,184}]},{emqx_hooks,safe_execute,2,[{file,"emqx_hooks.erl"},{line,205}]},{emqx_hooks,do_run,2,[{file,"emqx_hooks.erl"},{line,171}]},{emqx_channel,handle_in,2,[{file,"emqx_channel.erl"},{line,652}]},{emqx_connection,with_channel,3,[{file,"emqx_connection.erl"},{line,672}]},{emqx_connection,process_msg,2,[{file,"emqx_connection.erl"},{line,369}]},{emqx_connection,process_msg,2,[{file,"emqx_connection.erl"},{line,375}]},{emqx_connection,handle_recv,3,[{file,"emqx_connection.erl"},{line,333}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]} mfa: emqx_hooks:safe_execute/2 line: 209`