### PR TITLE
Retry the closed stream

### DIFF
--- a/apps/emqx_exhook/rebar.config
+++ b/apps/emqx_exhook/rebar.config
@@ -5,7 +5,7 @@
 ]}.
 
 {deps,
- [{grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.2"}}}
+ [{grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.3"}}}
 ]}.
 
 {grpc,

--- a/apps/emqx_exproto/rebar.config
+++ b/apps/emqx_exproto/rebar.config
@@ -13,7 +13,7 @@
 ]}.
 
 {deps,
- [{grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.2"}}}
+ [{grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.3"}}}
  ]}.
 
 {grpc,

--- a/apps/emqx_exproto/src/emqx_exproto.app.src
+++ b/apps/emqx_exproto/src/emqx_exproto.app.src
@@ -1,6 +1,6 @@
 {application, emqx_exproto,
  [{description, "EMQ X Extension for Protocol"},
-  {vsn, "4.3.1"}, %% strict semver
+  {vsn, "4.3.2"}, %% strict semver
   {modules, []},
   {registered, []},
   {mod, {emqx_exproto_app, []}},

--- a/apps/emqx_exproto/src/emqx_exproto.appup.src
+++ b/apps/emqx_exproto/src/emqx_exproto.appup.src
@@ -1,14 +1,24 @@
 %% -*-: erlang -*-
 {VSN,
  [
+    {"4.3.1", [
+      {load_module, emqx_exproto_gcli, brutal_purge, soft_purge, []},
+      {load_module, emqx_exproto_channel, brutal_purge, soft_purge, []}
+    ]},
     {"4.3.0", [
+      {load_module, emqx_exproto_gcli, brutal_purge, soft_purge, []},
       {load_module, emqx_exproto_conn, brutal_purge, soft_purge, []},
       {load_module, emqx_exproto_channel, brutal_purge, soft_purge, []}
     ]},
     {<<".*">>, []}
  ],
  [
+    {"4.3.1", [
+      {load_module, emqx_exproto_gcli, brutal_purge, soft_purge, []},
+      {load_module, emqx_exproto_channel, brutal_purge, soft_purge, []}
+    ]},
     {"4.3.0", [
+      {load_module, emqx_exproto_gcli, brutal_purge, soft_purge, []},
       {load_module, emqx_exproto_conn, brutal_purge, soft_purge, []},
       {load_module, emqx_exproto_channel, brutal_purge, soft_purge, []}
     ]},

--- a/apps/emqx_exproto/src/emqx_exproto_channel.erl
+++ b/apps/emqx_exproto/src/emqx_exproto_channel.erl
@@ -243,7 +243,7 @@ handle_timeout(_TRef, {keepalive, StatVal},
     end;
 
 handle_timeout(_TRef, force_close, Channel = #channel{closed_reason = Reason}) ->
-    {shutdown, {error, {force_close, Reason}}, Channel};
+    {shutdown, Reason, Channel};
 
 handle_timeout(_TRef, Msg, Channel) ->
     ?WARN("Unexpected timeout: ~p", [Msg]),
@@ -269,7 +269,7 @@ handle_call({auth, ClientInfo0, Password},
             Channel = #channel{conninfo = ConnInfo,
                                clientinfo = ClientInfo}) ->
     ClientInfo1 = enrich_clientinfo(ClientInfo0, ClientInfo),
-    NConnInfo = enrich_conninfo(ClientInfo1, ConnInfo),
+    NConnInfo = enrich_conninfo(ClientInfo0, ConnInfo),
 
     Channel1 = Channel#channel{conninfo = NConnInfo,
                                clientinfo = ClientInfo1},
@@ -373,13 +373,13 @@ handle_info({sock_closed, Reason},
     case queue:len(Queue) =:= 0
          andalso Inflight =:= undefined of
         true ->
-            Channel1 = ensure_disconnected({sock_closed, Reason}, Channel),
-            {shutdown, {sock_closed, Reason}, Channel1};
+            Channel1 = ensure_disconnected(Reason, Channel),
+            {shutdown, Reason, Channel1};
         _ ->
             %% delayed close process for flushing all callback funcs to gRPC server
-            Channel1 = Channel#channel{closed_reason = {sock_closed, Reason}},
+            Channel1 = Channel#channel{closed_reason = Reason},
             Channel2 = ensure_timer(force_timer, Channel1),
-            {ok, ensure_disconnected({sock_closed, Reason}, Channel2)}
+            {ok, ensure_disconnected(Reason, Channel2)}
     end;
 
 handle_info({hreply, on_socket_created, ok}, Channel) ->


### PR DESCRIPTION
After the stream held by emqx_exproto_gcli is closed, it is not working to initiate grpc requests to the backend service. 

This would cause all client processing fail.