### PR TITLE
Add a retry mechanism for exhook

### DIFF
--- a/apps/emqx_exhook/etc/emqx_exhook.conf
+++ b/apps/emqx_exhook/etc/emqx_exhook.conf
@@ -2,8 +2,31 @@
 ## EMQ X Hooks
 ##====================================================================
 
+## The default value or action will be returned, while the request to
+## the gRPC server failed or no available grpc server running.
+##
+## Default: ignore
+## Value: ignore | deny
+#exhook.request_failed_action = ignore
+
+## The timeout to request grpc server
+##
+## Default: 5s
+## Value: Duration
+#exhook.request_timeout = 5s
+
+## Whether to automatically reconnect (initialize) the gRPC server
+##
+## When gRPC is not available, exhook tries to request the gRPC service at
+## that interval and reinitialize the list of mounted hooks.
+##
+## Default: false
+## Value: false | Duration
+#exhook.auto_reconnect = 60s
+
+
 ##--------------------------------------------------------------------
-## Server Address
+## The Hook callback servers
 
 ## The gRPC server url
 ##

--- a/apps/emqx_exhook/etc/emqx_exhook.conf
+++ b/apps/emqx_exhook/etc/emqx_exhook.conf
@@ -5,9 +5,9 @@
 ## The default value or action will be returned, while the request to
 ## the gRPC server failed or no available grpc server running.
 ##
-## Default: ignore
+## Default: deny
 ## Value: ignore | deny
-#exhook.request_failed_action = ignore
+#exhook.request_failed_action = deny
 
 ## The timeout to request grpc server
 ##

--- a/apps/emqx_exhook/priv/emqx_exhook.schema
+++ b/apps/emqx_exhook/priv/emqx_exhook.schema
@@ -1,7 +1,7 @@
 %%-*- mode: erlang -*-
 
 {mapping, "exhook.request_failed_action", "emqx_exhook.request_failed_action", [
-  {default, "ignore"},
+  {default, "deny"},
   {datatype, {enum, [ignore, deny]}}
 ]}.
 

--- a/apps/emqx_exhook/priv/emqx_exhook.schema
+++ b/apps/emqx_exhook/priv/emqx_exhook.schema
@@ -1,5 +1,31 @@
 %%-*- mode: erlang -*-
 
+{mapping, "exhook.request_failed_action", "emqx_exhook.request_failed_action", [
+  {default, "ignore"},
+  {datatype, {enum, [ignore, deny]}}
+]}.
+
+{mapping, "exhook.request_timeout", "emqx_exhook.request_timeout", [
+  {default, "5s"},
+  {datatype, {duration, ms}}
+]}.
+
+{mapping, "exhook.auto_reconnect", "emqx_exhook.auto_reconnect", [
+  {default, "60s"},
+  {datatype, string}
+]}.
+
+{translation, "emqx_exhook.auto_reconnect", fun(Conf) ->
+  case cuttlefish:conf_get("exhook.auto_reconnect", Conf) of
+      "false" -> false;
+      Dur ->
+          case cuttlefish_duration:parse(Dur, ms) of
+              Ms when is_integer(Ms) -> Ms;
+              {error, Reason} -> error(Reason)
+          end
+  end
+end}.
+
 {mapping, "exhook.server.$name.url", "emqx_exhook.servers", [
   {datatype, string}
 ]}.

--- a/apps/emqx_exhook/src/emqx_exhook.app.src
+++ b/apps/emqx_exhook/src/emqx_exhook.app.src
@@ -1,6 +1,6 @@
 {application, emqx_exhook,
  [{description, "EMQ X Extension for Hook"},
-  {vsn, "4.3.3"},
+  {vsn, "4.3.4"},
   {modules, []},
   {registered, []},
   {mod, {emqx_exhook_app, []}},

--- a/apps/emqx_exhook/src/emqx_exhook.appup.src
+++ b/apps/emqx_exhook/src/emqx_exhook.appup.src
@@ -1,32 +1,14 @@
 %% -*-: erlang -*-
 {VSN,
  [
-    {"4.3.2", [
-      {load_module, emqx_exhook_app, brutal_purge, soft_purge, []}
-    ]},
-    {"4.3.1", [
-      {load_module, emqx_exhook_app, brutal_purge, soft_purge, []},
-      {load_module, emqx_exhook_server, brutal_purge, soft_purge, []}
-    ]},
-    {"4.3.0", [
-      {load_module, emqx_exhook_app, brutal_purge, soft_purge, []},
-      {load_module, emqx_exhook_pb, brutal_purge, soft_purge, []},
-      {load_module, emqx_exhook_server, brutal_purge, soft_purge, []}
+    {<<"4.3.[0-3]">>, [
+        {restart_application, emqx_exhook}
     ]},
     {<<".*">>, []}
  ],
  [
-    {"4.3.2", [
-      {load_module, emqx_exhook_app, brutal_purge, soft_purge, []}
-    ]},
-    {"4.3.1", [
-      {load_module, emqx_exhook_app, brutal_purge, soft_purge, []},
-      {load_module, emqx_exhook_server, brutal_purge, soft_purge, []}
-    ]},
-    {"4.3.0", [
-      {load_module, emqx_exhook_app, brutal_purge, soft_purge, []},
-      {load_module, emqx_exhook_pb, brutal_purge, soft_purge, []},
-      {load_module, emqx_exhook_server, brutal_purge, soft_purge, []}
+    {<<"4.3.[0-3]">>, [
+         {restart_application, emqx_exhook}
     ]},
     {<<".*">>, []}
  ]

--- a/apps/emqx_exhook/src/emqx_exhook.erl
+++ b/apps/emqx_exhook/src/emqx_exhook.erl
@@ -21,10 +21,8 @@
 
 -logger_header("[ExHook]").
 
-%% Mgmt APIs
--export([ enable/2
+-export([ enable/1
         , disable/1
-        , disable_all/0
         , list/0
         ]).
 
@@ -36,64 +34,54 @@
 %% Mgmt APIs
 %%--------------------------------------------------------------------
 
-%% XXX: Only return the running servers
--spec list() -> [emqx_exhook_server:server()].
-list() ->
-    [server(Name) || Name <- running()].
-
--spec enable(atom()|string(), list()) -> ok | {error, term()}.
-enable(Name, Opts) ->
-    case lists:member(Name, running()) of
-        true ->
-            {error, already_started};
-        _ ->
-            case emqx_exhook_server:load(Name, Opts) of
-                {ok, ServiceState} ->
-                    save(Name, ServiceState);
-                {error, Reason} ->
-                    ?LOG(error, "Load server ~p failed: ~p", [Name, Reason]),
-                    {error, Reason}
-            end
-    end.
+-spec enable(atom()|string()) -> ok | {error, term()}.
+enable(Name) ->
+    with_mngr(fun(Pid) -> emqx_exhook_mngr:enable(Pid, Name) end).
 
 -spec disable(atom()|string()) -> ok | {error, term()}.
 disable(Name) ->
-    case server(Name) of
-        undefined -> {error, not_running};
-        Service ->
-            ok = emqx_exhook_server:unload(Service),
-            unsave(Name)
+    with_mngr(fun(Pid) -> emqx_exhook_mngr:disable(Pid, Name) end).
+
+-spec list() -> [atom() | string()].
+list() ->
+    with_mngr(fun(Pid) -> emqx_exhook_mngr:list(Pid) end).
+
+with_mngr(Fun) ->
+    case lists:keyfind(emqx_exhook_mngr, 1,
+                       supervisor:which_children(emqx_exhook_sup)) of
+        {_, Pid, _, _} ->
+            Fun(Pid);
+        _ ->
+            {error, no_manager_svr}
     end.
 
--spec disable_all() -> ok.
-disable_all() ->
-    lists:foreach(fun disable/1, running()).
-
-%%----------------------------------------------------------
+%%--------------------------------------------------------------------
 %% Dispatch APIs
-%%----------------------------------------------------------
+%%--------------------------------------------------------------------
 
 -spec cast(atom(), map()) -> ok.
 cast(Hookpoint, Req) ->
-    cast(Hookpoint, Req, running()).
+    cast(Hookpoint, Req, emqx_exhook_mngr:running()).
 
 cast(_, _, []) ->
     ok;
 cast(Hookpoint, Req, [ServiceName|More]) ->
     %% XXX: Need a real asynchronous running
-    _ = emqx_exhook_server:call(Hookpoint, Req, server(ServiceName)),
+    _ = emqx_exhook_server:call(Hookpoint, Req,
+                                emqx_exhook_mngr:server(ServiceName)),
     cast(Hookpoint, Req, More).
 
 -spec call_fold(atom(), term(), function())
   -> {ok, term()}
    | {stop, term()}.
 call_fold(Hookpoint, Req, AccFun) ->
-    call_fold(Hookpoint, Req, AccFun, running()).
+    call_fold(Hookpoint, Req, AccFun, emqx_exhook_mngr:running()).
 
 call_fold(_, Req, _, []) ->
     {ok, Req};
 call_fold(Hookpoint, Req, AccFun, [ServiceName|More]) ->
-    case emqx_exhook_server:call(Hookpoint, Req, server(ServiceName)) of
+    case emqx_exhook_server:call(Hookpoint, Req,
+                                 emqx_exhook_mngr:server(ServiceName)) of
         {ok, Resp} ->
             case AccFun(Req, Resp) of
                 {stop, NReq} -> {stop, NReq};
@@ -102,35 +90,4 @@ call_fold(Hookpoint, Req, AccFun, [ServiceName|More]) ->
             end;
         _ ->
             call_fold(Hookpoint, Req, AccFun, More)
-    end.
-
-%%----------------------------------------------------------
-%% Storage
-
--compile({inline, [save/2]}).
-save(Name, ServiceState) ->
-    Saved = persistent_term:get(?APP, []),
-    persistent_term:put(?APP, lists:reverse([Name | Saved])),
-    persistent_term:put({?APP, Name}, ServiceState).
-
--compile({inline, [unsave/1]}).
-unsave(Name) ->
-    case persistent_term:get(?APP, []) of
-        [] ->
-            persistent_term:erase(?APP);
-        Saved ->
-            persistent_term:put(?APP, lists:delete(Name, Saved))
-    end,
-    persistent_term:erase({?APP, Name}),
-    ok.
-
--compile({inline, [running/0]}).
-running() ->
-    persistent_term:get(?APP, []).
-
--compile({inline, [server/1]}).
-server(Name) ->
-    case catch persistent_term:get({?APP, Name}) of
-        {'EXIT', {badarg,_}} -> undefined;
-        Service -> Service
     end.

--- a/apps/emqx_exhook/src/emqx_exhook_app.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_app.erl
@@ -22,18 +22,9 @@
 
 -emqx_plugin(extension).
 
--define(CNTER, emqx_exhook_counter).
-
 -export([ start/2
         , stop/1
         , prep_stop/1
-        ]).
-
-%% Internal export
--export([ load_server/2
-        , unload_server/1
-        , unload_exhooks/0
-        , init_hooks_cnter/0
         ]).
 
 %%--------------------------------------------------------------------
@@ -42,53 +33,12 @@
 
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_exhook_sup:start_link(),
-
-    %% Init counter
-    init_hooks_cnter(),
-
-    %% Load all dirvers
-    load_all_servers(),
-
-    %% Register CLI
     emqx_ctl:register_command(exhook, {emqx_exhook_cli, cli}, []),
     {ok, Sup}.
 
 prep_stop(State) ->
     emqx_ctl:unregister_command(exhook),
-    _ = unload_exhooks(),
-    ok = unload_all_servers(),
     State.
 
 stop(_State) ->
     ok.
-
-%%--------------------------------------------------------------------
-%% Internal funcs
-%%--------------------------------------------------------------------
-
-load_all_servers() ->
-    lists:foreach(fun({Name, Options}) ->
-        load_server(Name, Options)
-    end, application:get_env(?APP, servers, [])).
-
-unload_all_servers() ->
-    emqx_exhook:disable_all().
-
-load_server(Name, Options) ->
-    emqx_exhook:enable(Name, Options).
-
-unload_server(Name) ->
-    emqx_exhook:disable(Name).
-
-unload_exhooks() ->
-    [emqx:unhook(Name, {M, F}) ||
-     {Name, {M, F, _A}} <- ?ENABLED_HOOKS].
-
-init_hooks_cnter() ->
-    try
-        _ = ets:new(?CNTER, [named_table, public]), ok
-    catch
-        error:badarg:_ ->
-            ok
-    end.
-

--- a/apps/emqx_exhook/src/emqx_exhook_cli.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_cli.erl
@@ -22,25 +22,18 @@
 
 cli(["server", "list"]) ->
     if_enabled(fun() ->
-        Services = emqx_exhook:list(),
-        [emqx_ctl:print("HookServer(~s)~n",
-                        [emqx_exhook_server:format(Service)]) || Service <- Services]
+        ServerNames = emqx_exhook:list(),
+        [emqx_ctl:print("Server(~s)~n", [format(Name)]) || Name <- ServerNames]
     end);
 
-cli(["server", "enable", Name0]) ->
+cli(["server", "enable", Name]) ->
     if_enabled(fun() ->
-        Name = list_to_atom(Name0),
-        case proplists:get_value(Name, application:get_env(?APP, servers, [])) of
-            undefined ->
-                emqx_ctl:print("not_found~n");
-            Opts ->
-                print(emqx_exhook:enable(Name, Opts))
-        end
+        print(emqx_exhook:enable(list_to_existing_atom(Name)))
     end);
 
 cli(["server", "disable", Name]) ->
     if_enabled(fun() ->
-        print(emqx_exhook:disable(list_to_atom(Name)))
+        print(emqx_exhook:disable(list_to_existing_atom(Name)))
     end);
 
 cli(["server", "stats"]) ->
@@ -65,7 +58,8 @@ print({error, Reason}) ->
 
 if_enabled(Fun) ->
     case lists:keymember(?APP, 1, application:which_applications()) of
-        true -> Fun();
+        true ->
+            Fun();
         _ -> hint()
     end.
 
@@ -79,3 +73,11 @@ stats() ->
             _ -> Acc
         end
     end, [], emqx_metrics:all())).
+
+format(Name) ->
+    case emqx_exhook_mngr:server(Name) of
+        undefined ->
+            io_lib:format("name=~s, hooks=#{}, active=false", [Name]);
+        Server ->
+            emqx_exhook_server:format(Server)
+    end.

--- a/apps/emqx_exhook/src/emqx_exhook_mngr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mngr.erl
@@ -1,0 +1,171 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% @doc Manage the server status and reload strategy
+-module(emqx_exhook_mngr).
+
+-behaviour(gen_server).
+
+-include("emqx_exhook.hrl").
+-include_lib("emqx/include/logger.hrl").
+
+%% APIs
+-export([start_link/2]).
+
+%% gen_server callbacks
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
+
+-record(state, {
+          %% Running servers
+          running :: map(),
+          %% Wait to reload servers
+          waiting :: map(),
+          %% Marked stopped servers
+          stopped :: map(),
+          %% Auto reconnect timer interval
+          auto_reconnect :: false | non_neg_integer(),
+          %% Timer references
+          trefs :: map()
+         }).
+
+-type servers() :: [{Name :: atom(), server_options()}].
+
+-type server_options() :: [ {scheme, http | https}
+                          | {host, string()}
+                          | {port, inet:port_number()}
+                          ].
+
+-define(CNTER, emqx_exhook_counter).
+
+%%--------------------------------------------------------------------
+%% APIs
+%%--------------------------------------------------------------------
+
+-spec start_link(servers(), false | non_neg_integer())
+    ->ignore
+     | {ok, pid()}
+     | {error, any()}.
+start_link(Servers, AutoReconnect) ->
+    gen_server:start_link(?MODULE, [Servers, AutoReconnect], []).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init([Servers, AutoReconnect]) ->
+    %% XXX: Due to the ExHook Module in the enterprise,
+    %% this process may start multiple times and they will share this table
+    try
+        _ = ets:new(?CNTER, [named_table, public]), ok
+    catch
+        error:badarg:_ ->
+            ok
+    end,
+
+    %% Load the hook servers
+    {Waiting, Running} = load_all_servers(Servers),
+    {ok, ensure_reload_timer(
+           #state{waiting = Waiting,
+                  running = Running,
+                  stopped = #{},
+                  auto_reconnect = AutoReconnect,
+                  trefs = #{}
+                 }
+          )}.
+
+%% @private
+load_all_servers(Servers) ->
+    load_all_servers(Servers, #{}, #{}).
+load_all_servers([], Waiting, Running) ->
+    {Waiting, Running};
+load_all_servers([{Name, Options}|More], Waiting, Running) ->
+    {NWaiting, NRunning} = case emqx_exhook:enable(Name, Options) of
+        ok ->
+            {Waiting, Running#{Name => Options}};
+        {error, _} ->
+            {Waiting#{Name => Options}, Running}
+    end,
+    load_all_servers(More, NWaiting, NRunning).
+
+handle_call(_Request, _From, State) ->
+    Reply = ok,
+    {reply, Reply, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({timeout, _Ref, {reload, Name}},
+            State0 = #state{waiting = Waiting,
+                            running = Running,
+                            trefs = TRefs}) ->
+    State = State0#state{trefs = maps:remove(Name, TRefs)},
+    case maps:get(Name, Waiting, undefined) of
+        undefined ->
+            {noreply, State};
+        Options ->
+            case emqx_exhook:enable(Name, Options) of
+                ok ->
+                    ?LOG(warning, "Reconnect to exhook callback server "
+                                  "\"~s\" successfully!", [Name]),
+                    {noreply, State#state{
+                                running = maps:put(Name, Options, Running),
+                                waiting = maps:remove(Name, Waiting)}
+                    };
+                {error, _} ->
+                    {noreply, ensure_reload_timer(State)}
+            end
+    end;
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    _ = emqx_exhook:disable_all(),
+    _ = unload_exhooks(),
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%%--------------------------------------------------------------------
+%% Internal funcs
+%%--------------------------------------------------------------------
+
+unload_exhooks() ->
+    [emqx:unhook(Name, {M, F}) ||
+     {Name, {M, F, _A}} <- ?ENABLED_HOOKS].
+
+ensure_reload_timer(State = #state{auto_reconnect = false}) ->
+    State;
+ensure_reload_timer(State = #state{waiting = Waiting,
+                                   trefs = TRefs,
+                                   auto_reconnect = Intv}) ->
+    NRefs = maps:fold(fun(Name, _, AccIn) ->
+        case maps:get(Name, AccIn, undefined) of
+            undefined ->
+                Ref = erlang:start_timer(Intv, self(), {reload, Name}),
+                AccIn#{Name => Ref};
+            _HasRef ->
+                AccIn
+        end
+    end, TRefs, Waiting),
+    State#state{trefs = NRefs}.

--- a/apps/emqx_exhook/src/emqx_exhook_mngr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mngr.erl
@@ -101,6 +101,7 @@ call(Pid, Req) ->
 %%--------------------------------------------------------------------
 
 init([Servers, AutoReconnect, ReqOpts]) ->
+    process_flag(trap_exit, true),
     %% XXX: Due to the ExHook Module in the enterprise,
     %% this process may start multiple times and they will share this table
     try
@@ -182,11 +183,11 @@ handle_info({timeout, _Ref, {reload, Name}}, State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
-terminate(_Reason, State = #state{stopped = Stopped}) ->
+terminate(_Reason, State = #state{running = Running}) ->
     _ = maps:fold(fun(Name, _, AccIn) ->
             {ok, NAccIn} = do_unload_server(Name, AccIn),
             NAccIn
-        end, State, Stopped),
+        end, State, Running),
     _ = unload_exhooks(),
     ok.
 

--- a/apps/emqx_exhook/src/emqx_exhook_sup.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_sup.erl
@@ -30,6 +30,7 @@
             #{ id => Mod
              , start => {Mod, start_link, Args}
              , type => Type
+             , shutdown => 15000
              }
        ).
 

--- a/apps/emqx_exhook/src/emqx_exhook_sup.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_sup.erl
@@ -41,7 +41,8 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    Mngr = ?CHILD(emqx_exhook_mngr, worker, [servers(), auto_reconnect()]),
+    Mngr = ?CHILD(emqx_exhook_mngr, worker,
+                  [servers(), auto_reconnect(), request_options()]),
     {ok, {{one_for_one, 10, 100}, [Mngr]}}.
 
 servers() ->
@@ -49,6 +50,9 @@ servers() ->
 
 auto_reconnect() ->
     application:get_env(emqx_exhook, auto_reconnect, 60000).
+
+request_options() ->
+    #{timeout => application:get_env(emqx_exhook, request_timeout, 5000)}.
 
 %%--------------------------------------------------------------------
 %% APIs

--- a/apps/emqx_exhook/src/emqx_exhook_sup.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_sup.erl
@@ -47,13 +47,18 @@ init([]) ->
     {ok, {{one_for_one, 10, 100}, [Mngr]}}.
 
 servers() ->
-    application:get_env(emqx_exhook, servers, []).
+    env(servers, []).
 
 auto_reconnect() ->
-    application:get_env(emqx_exhook, auto_reconnect, 60000).
+    env(auto_reconnect, 60000).
 
 request_options() ->
-    #{timeout => application:get_env(emqx_exhook, request_timeout, 5000)}.
+    #{timeout => env(request_timeout, 5000),
+      request_failed_action => env(request_failed_action, deny)
+     }.
+
+env(Key, Def) ->
+    application:get_env(emqx_exhook, Key, Def).
 
 %%--------------------------------------------------------------------
 %% APIs

--- a/apps/emqx_exhook/src/emqx_exhook_sup.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_sup.erl
@@ -26,6 +26,13 @@
         , stop_grpc_client_channel/1
         ]).
 
+-define(CHILD(Mod, Type, Args),
+            #{ id => Mod
+             , start => {Mod, start_link, Args}
+             , type => Type
+             }
+       ).
+
 %%--------------------------------------------------------------------
 %%  Supervisor APIs & Callbacks
 %%--------------------------------------------------------------------
@@ -34,7 +41,14 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    {ok, {{one_for_one, 10, 100}, []}}.
+    Mngr = ?CHILD(emqx_exhook_mngr, worker, [servers(), auto_reconnect()]),
+    {ok, {{one_for_one, 10, 100}, [Mngr]}}.
+
+servers() ->
+    application:get_env(emqx_exhook, servers, []).
+
+auto_reconnect() ->
+    application:get_env(emqx_exhook, auto_reconnect, 60000).
 
 %%--------------------------------------------------------------------
 %% APIs

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -52,17 +52,12 @@ set_special_cfgs(emqx_exhook) ->
 t_noserver_nohook(_) ->
     emqx_exhook:disable(default),
     ?assertEqual([], ets:tab2list(emqx_hooks)),
-
-    Opts = proplists:get_value(
-             default,
-             application:get_env(emqx_exhook, servers, [])
-            ),
-    ok = emqx_exhook:enable(default, Opts),
+    ok = emqx_exhook:enable(default),
     ?assertNotEqual([], ets:tab2list(emqx_hooks)).
 
 t_cli_list(_) ->
     meck_print(),
-    ?assertEqual( [[emqx_exhook_server:format(Svr) || Svr <- emqx_exhook:list()]]
+    ?assertEqual( [[emqx_exhook_server:format(emqx_exhook_mngr:server(Name)) || Name  <- emqx_exhook:list()]]
                 , emqx_exhook_cli:cli(["server", "list"])
                 ),
     unmeck_print().
@@ -71,7 +66,7 @@ t_cli_enable_disable(_) ->
     meck_print(),
     ?assertEqual([already_started], emqx_exhook_cli:cli(["server", "enable", "default"])),
     ?assertEqual(ok, emqx_exhook_cli:cli(["server", "disable", "default"])),
-    ?assertEqual([], emqx_exhook_cli:cli(["server", "list"])),
+    ?assertEqual([["name=default, hooks=#{}, active=false"]], emqx_exhook_cli:cli(["server", "list"])),
 
     ?assertEqual([not_running], emqx_exhook_cli:cli(["server", "disable", "default"])),
     ?assertEqual(ok, emqx_exhook_cli:cli(["server", "enable", "default"])),


### PR DESCRIPTION
In this PR, we have enhanced the exhook experience:

1. we have added a retry mechanism to allow grpc-server to be started and stopped at any time.

2. A new `request_failed_action` option has been added. It allows customizing the result of a failed request to the grpc-server. For example, return authentication failure, or ignore the request.