### PR TITLE
feat: make EMQX_DEPS_APPS static

### DIFF
--- a/apps/emqx_machine/src/emqx_machine.erl
+++ b/apps/emqx_machine/src/emqx_machine.erl
@@ -138,7 +138,32 @@ start_one_app(App) ->
 %% 1. due to static static config change
 %% 2. after join a cluster
 reboot_apps() ->
-    [gproc, esockd, ranch, cowboy, ekka, emqx | ?EMQX_DEP_APPS].
+    [ gproc
+    , esockd
+    , ranch
+    , cowboy
+    , ekka
+    , emqx
+    , emqx_prometheus
+    , emqx_modules
+    , emqx_dashboard
+    , emqx_connector
+    , emqx_gateway
+    , emqx_statsd
+    , emqx_resource
+    , emqx_rule_engine
+    , emqx_data_bridge
+    , emqx_bridge_mqtt
+    , emqx_plugin_libs
+    , emqx_config_helper
+    , emqx_management
+    , emqx_release_helper
+    , emqx_retainer
+    , emqx_exhook
+    , emqx_rule_actions
+    , emqx_authn
+    , emqx_authz
+    ].
 
 sorted_reboot_apps() ->
     Apps = [{App, app_deps(App)} || App <- reboot_apps()],

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -129,12 +129,10 @@ test_deps() ->
     ].
 
 common_compile_opts() ->
-    AppNames = app_names(),
     [ debug_info % alwyas include debug_info
     , {compile_info, [{emqx_vsn, get_vsn()}]}
     , {d, snk_kind, msg}
     ] ++
-    [{d, 'EMQX_DEP_APPS', AppNames -- [emqx, emqx_machine]}] ++
     [{d, 'EMQX_ENTERPRISE'} || is_enterprise()] ++
     [{d, 'EMQX_BENCHMARK'} || os:getenv("EMQX_BENCHMARK") =:= "1" ].
 


### PR DESCRIPTION
the `erlc_options` option for mix project doesn't works with `d` good, make it static to unblock the mix