### PR TITLE
Expose Internal MQTT Service

### DIFF
--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -121,11 +121,11 @@ spec:
           - name: dashboard
             containerPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
           {{- if not (empty .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL) }}
-          - name: dashboardtls
+          - name: internalmqtt
             containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL }}
           {{- end }}
           {{- if not (empty .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTPS) }}
-          - name: internalmqtt
+          - name: dashboardtls
             containerPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTPS }}
           {{- end }}
           - name: ekka

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -120,8 +120,12 @@ spec:
             containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__WSS__EXTERNAL | default 8084 }}
           - name: dashboard
             containerPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTP | default 18083 }}
-          {{- if not (empty .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTPS) }}
+          {{- if not (empty .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL) }}
           - name: dashboardtls
+            containerPort: {{ .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL }}
+          {{- end }}
+          {{- if not (empty .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTPS) }}
+          - name: internalmqtt
             containerPort: {{ .Values.emqxConfig.EMQX_DASHBOARD__LISTENER__HTTPS }}
           {{- end }}
           - name: ekka

--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -35,6 +35,17 @@ spec:
     {{- else if eq .Values.service.type "ClusterIP" }}
     nodePort: null
     {{- end }}
+    {{- if not (empty .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL) }}
+  - name: internalmqtt
+    port: {{ .Values.service.internalmqtt | default 11883 }}
+    protocol: TCP
+    targetPort: internalmqtt
+    {{- if and (or (eq .Values.service.type "NodePort") (eq .Values.service.type "LoadBalancer")) (not (empty .Values.service.nodePorts.internalmqtt)) }}
+    nodePort: {{ .Values.service.nodePorts.internalmqtt }}
+    {{- else if eq .Values.service.type "ClusterIP" }}
+    nodePort: null
+    {{- end }}
+    {{ end }}
   - name: mqttssl
     port: {{ .Values.service.mqttssl | default 8883 }}
     protocol: TCP
@@ -115,6 +126,12 @@ spec:
     port: {{ .Values.service.mqtt | default 1883 }}
     protocol: TCP
     targetPort: mqtt
+    {{- if not (empty .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL) }}
+  - name: mqtt
+    port: {{ .Values.service.internalmqtt | default 11883 }}
+    protocol: TCP
+    targetPort: internalmqtt
+    {{ end }}
   - name: mqttssl
     port: {{ .Values.service.mqttssl | default 8883 }}
     protocol: TCP

--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -127,7 +127,7 @@ spec:
     protocol: TCP
     targetPort: mqtt
     {{- if not (empty .Values.emqxConfig.EMQX_LISTENER__TCP__INTERNAL) }}
-  - name: mqtt
+  - name: internalmqtt
     port: {{ .Values.service.internalmqtt | default 11883 }}
     protocol: TCP
     targetPort: internalmqtt


### PR DESCRIPTION
Having an internal MQTT service on a pod doesn't have many use cases but by exposing it on a cluster we can connect our internal services to the MQTT without ACL or authentication. In this PR users can enable this service by setting the following variable:

```
EMQX_LISTENER__TCP__INTERNAL: 11883
```

just like the other environment variables.