### PR TITLE
fix: Running on Openshift clusters with restricted writable filesystem containers

### DIFF
--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -63,8 +63,6 @@ spec:
           claimName: {{ tpl . $ }}
         {{- end }}
       {{- end }}
-      - name: emqx-config
-        emptyDir: {}
       {{- if .Values.emqxLicneseSecretName  }}
       - name: emqx-license
         secret:
@@ -132,15 +130,13 @@ spec:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:
           - name: emqx-data
-            mountPath: "/opt/emqx/data/mnesia"
+            mountPath: "/opt/emqx/data"
           {{ if .Values.emqxLicneseSecretName  }}
           - name: emqx-license
             mountPath: "/opt/emqx/etc/emqx.lic"
             subPath: "emqx.lic"
             readOnly: true
           {{ end }}
-          - name: emqx-config
-            mountPath: /opt/emqx/data/configs/
           readinessProbe:
             httpGet:
               path: /api/v5/status

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -63,6 +63,8 @@ spec:
           claimName: {{ tpl . $ }}
         {{- end }}
       {{- end }}
+      - name: emqx-config
+        emptyDir: {}
       {{- if .Values.emqxLicneseSecretName  }}
       - name: emqx-license
         secret:
@@ -137,6 +139,8 @@ spec:
             subPath: "emqx.lic"
             readOnly: true
           {{ end }}
+          - name: emqx-config
+            mountPath: /opt/emqx/data/configs/
           readinessProbe:
             httpGet:
               path: /api/v5/status


### PR DESCRIPTION
emqx pods try to write a config file in the `/opt/emqx/data/configs/` path during the startup, which fails on Openshift clusters, since users are restricted to run containers with writable filesystems (which indeed is a good security practice).

So the pod goes into CrashLoopBackOff state with the following errors in logs:

```
2021-08-12T11:26:56.505718+00:00 [error] Error writing /opt/emqx/data/configs/app.2021.08.12.11.26.38.config: permission denied
2021-08-12T11:26:56.505907+00:00 [error] Error writing /opt/emqx/data/configs/vm.2021.08.12.11.26.38.args: permission denied
```


This PR mounts an emptyDir volume in `/opt/emqx/data/configs/` path which mitigates this issue.

Tested on Openshift 4.7