### PR TITLE
fix(rlog): Ensure the correct order of table initalization

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_app.erl
+++ b/apps/emqx_authn/src/emqx_authn_app.erl
@@ -27,8 +27,8 @@
         ]).
 
 start(_StartType, _StartArgs) ->
-    {ok, Sup} = emqx_authn_sup:start_link(),
     ok = ekka_rlog:wait_for_shards([?AUTH_SHARD], infinity),
+    {ok, Sup} = emqx_authn_sup:start_link(),
     initialize(),
     {ok, Sup}.
 

--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -3,7 +3,7 @@
   {vsn, "0.1.0"},
   {registered, []},
   {mod, {emqx_gateway_app, []}},
-  {applications, [kernel, stdlib, grpc, lwm2m_coap, emqx]},
+  {applications, [kernel, stdlib, grpc, lwm2m_coap, emqx, emqx_authn]},
   {env, []},
   {modules, []},
   {licenses, ["Apache 2.0"]},


### PR DESCRIPTION
This PR makes sure that the shards are initialized before usage