### PR TITLE
Add Chart Icon

### DIFF
--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -1,5 +1,6 @@
 apiVersion: v2
 name: emqx
+icon: https://github.com/emqx.png
 description: A Helm chart for EMQ X
 # A chart can be either an 'application' or a 'library' chart.
 #


### PR DESCRIPTION
This is a fancy feature recommends by `helm lint` and for example causes the EMQX logo to show on the Openshift panel as follows. I am using the Github logo so it uses the latest logo from EMQX's Github organization.

![image](https://user-images.githubusercontent.com/8181240/129366343-4398f030-9e1e-4f1d-9fb9-f1f816de6a28.png)
