### PR TITLE
Refactor return values of config update

### DIFF
--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -193,30 +193,30 @@ run_fold_hook(HookPoint, Args, Acc) ->
     emqx_hooks:run_fold(HookPoint, Args, Acc).
 
 -spec update_config(emqx_map_lib:config_key_path(), emqx_config:update_request()) ->
-    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+    {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 update_config(KeyPath, UpdateReq) ->
     update_config(KeyPath, UpdateReq, #{}).
 
 -spec update_config(emqx_map_lib:config_key_path(), emqx_config:update_request(),
              emqx_config:update_opts()) ->
-    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+    {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 update_config([RootName | _] = KeyPath, UpdateReq, Opts) ->
     emqx_config_handler:update_config(emqx_config:get_schema_mod(RootName), KeyPath,
         {{update, UpdateReq}, Opts}).
 
 -spec remove_config(emqx_map_lib:config_key_path()) ->
-    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+    {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 remove_config(KeyPath) ->
     remove_config(KeyPath, #{}).
 
 -spec remove_config(emqx_map_lib:config_key_path(), emqx_config:update_opts()) ->
-    ok | {error, term()}.
+    {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 remove_config([RootName | _] = KeyPath, Opts) ->
     emqx_config_handler:update_config(emqx_config:get_schema_mod(RootName),
         KeyPath, {remove, Opts}).
 
 -spec reset_config(emqx_map_lib:config_key_path(), emqx_config:update_opts()) ->
-    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+    {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 reset_config([RootName | _] = KeyPath, Opts) ->
     case emqx_config:get_default_value(KeyPath) of
         {ok, Default} ->

--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -55,6 +55,13 @@
 -export([ set_debug_secret/1
         ]).
 
+-export([ update_config/2
+        , update_config/3
+        , remove_config/1
+        , remove_config/2
+        , reset_config/2
+        ]).
+
 -define(APP, ?MODULE).
 
 %% @hidden Path to the file which has debug_info encryption secret in it.
@@ -184,3 +191,37 @@ run_hook(HookPoint, Args) ->
 -spec(run_fold_hook(emqx_hooks:hookpoint(), list(any()), any()) -> any()).
 run_fold_hook(HookPoint, Args, Acc) ->
     emqx_hooks:run_fold(HookPoint, Args, Acc).
+
+-spec update_config(emqx_map_lib:config_key_path(), emqx_config:update_request()) ->
+    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+update_config(KeyPath, UpdateReq) ->
+    update_config(KeyPath, UpdateReq, #{}).
+
+-spec update_config(emqx_map_lib:config_key_path(), emqx_config:update_request(),
+             emqx_config:update_opts()) ->
+    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+update_config([RootName | _] = KeyPath, UpdateReq, Opts) ->
+    emqx_config_handler:update_config(emqx_config:get_schema_mod(RootName), KeyPath,
+        {{update, UpdateReq}, Opts}).
+
+-spec remove_config(emqx_map_lib:config_key_path()) ->
+    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+remove_config(KeyPath) ->
+    remove_config(KeyPath, #{}).
+
+-spec remove_config(emqx_map_lib:config_key_path(), emqx_config:update_opts()) ->
+    ok | {error, term()}.
+remove_config([RootName | _] = KeyPath, Opts) ->
+    emqx_config_handler:update_config(emqx_config:get_schema_mod(RootName),
+        KeyPath, {remove, Opts}).
+
+-spec reset_config(emqx_map_lib:config_key_path(), emqx_config:update_opts()) ->
+    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+reset_config([RootName | _] = KeyPath, Opts) ->
+    case emqx_config:get_default_value(KeyPath) of
+        {ok, Default} ->
+            emqx_config_handler:update_config(emqx_config:get_schema_mod(RootName), KeyPath,
+                {{update, Default}, Opts});
+        {error, _} = Error ->
+            Error
+    end.

--- a/apps/emqx/src/emqx_alarm.erl
+++ b/apps/emqx/src/emqx_alarm.erl
@@ -28,7 +28,7 @@
 -boot_mnesia({mnesia, [boot]}).
 -copy_mnesia({mnesia, [copy]}).
 
--export([pre_config_update/2]).
+-export([post_config_update/3]).
 
 -export([ start_link/0
         , stop/0
@@ -151,14 +151,9 @@ get_alarms(activated) ->
 get_alarms(deactivated) ->
     gen_server:call(?MODULE, {get_alarms, deactivated}).
 
-pre_config_update(#{<<"validity_period">> := Period0} = NewConf, OldConf) ->
-    ?MODULE ! {update_timer, hocon_postprocess:duration(Period0)},
-    merge(OldConf, NewConf);
-pre_config_update(NewConf, OldConf) ->
-    merge(OldConf, NewConf).
-
-merge(undefined, New) -> New;
-merge(Old, New) -> maps:merge(Old, New).
+post_config_update(_, #{validity_period := Period0}, _OldConf) ->
+    ?MODULE ! {update_timer, Period0},
+    ok.
 
 format(#activated_alarm{name = Name, message = Message, activate_at = At, details = Details}) ->
     Now = erlang:system_time(microsecond),

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -88,8 +88,17 @@
         error:badarg -> EXP_ON_FAIL
     end).
 
--export_type([update_request/0, raw_config/0, config/0]).
+-export_type([update_request/0, raw_config/0, config/0,
+              update_opts/0, update_cmd/0, update_args/0]).
+
 -type update_request() :: term().
+-type update_cmd() :: {update, update_request()} | remove.
+-type update_opts() :: #{
+        %% fill the default values into the rawconf map
+        rawconf_with_defaults => boolean()
+    }.
+-type update_args() :: {update_cmd(), Opts :: update_opts()}.
+
 %% raw_config() is the config that is NOT parsed and tranlated by hocon schema
 -type raw_config() :: #{binary() => term()} | undefined.
 %% config() is the config that is parsed and tranlated by hocon schema
@@ -188,7 +197,7 @@ update(KeyPath, UpdateReq) ->
     update(KeyPath, UpdateReq, #{}).
 
 -spec update(emqx_map_lib:config_key_path(), update_request(),
-             emqx_config_handler:update_opts()) ->
+             update_opts()) ->
     {ok, config(), raw_config()} | {error, term()}.
 update([RootName | _] = KeyPath, UpdateReq, Opts) ->
     emqx_config_handler:update_config(get_schema_mod(RootName), KeyPath,
@@ -198,12 +207,12 @@ update([RootName | _] = KeyPath, UpdateReq, Opts) ->
 remove(KeyPath) ->
     remove(KeyPath, #{}).
 
--spec remove(emqx_map_lib:config_key_path(), emqx_config_handler:update_opts()) ->
+-spec remove(emqx_map_lib:config_key_path(), update_opts()) ->
     ok | {error, term()}.
 remove([RootName | _] = KeyPath, Opts) ->
     emqx_config_handler:update_config(get_schema_mod(RootName), KeyPath, {remove, Opts}).
 
--spec reset(emqx_map_lib:config_key_path(), emqx_config_handler:update_opts()) ->
+-spec reset(emqx_map_lib:config_key_path(), update_opts()) ->
     {ok, config(), raw_config()} | {error, term()}.
 reset([RootName | _] = KeyPath, Opts) ->
     case get_default_value(KeyPath) of

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -82,7 +82,8 @@
     end).
 
 -export_type([update_request/0, raw_config/0, config/0,
-              update_opts/0, update_cmd/0, update_args/0]).
+              update_opts/0, update_cmd/0, update_args/0,
+              update_error/0, update_result/0]).
 
 -type update_request() :: term().
 -type update_cmd() :: {update, update_request()} | remove.
@@ -91,6 +92,13 @@
         rawconf_with_defaults => boolean()
     }.
 -type update_args() :: {update_cmd(), Opts :: update_opts()}.
+-type update_stage() :: pre_config_update | post_config_update.
+-type update_error() :: {update_stage(), module(), term()} | {save_configs, term()} | term().
+-type update_result() :: #{
+    config := emqx_config:config(),
+    raw_config := emqx_config:raw_config(),
+    post_config_update => #{module() => any()}
+}.
 
 %% raw_config() is the config that is NOT parsed and tranlated by hocon schema
 -type raw_config() :: #{binary() => term()} | undefined.

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -61,13 +61,6 @@
         , find_listener_conf/3
         ]).
 
--export([ update/2
-        , update/3
-        , remove/1
-        , remove/2
-        , reset/2
-        ]).
-
 -export([ get_raw/1
         , get_raw/2
         , put_raw/1
@@ -190,38 +183,6 @@ put(Config) ->
 
 -spec put(emqx_map_lib:config_key_path(), term()) -> ok.
 put(KeyPath, Config) -> do_put(?CONF, KeyPath, Config).
-
--spec update(emqx_map_lib:config_key_path(), update_request()) ->
-    {ok, config(), raw_config()} | {error, term()}.
-update(KeyPath, UpdateReq) ->
-    update(KeyPath, UpdateReq, #{}).
-
--spec update(emqx_map_lib:config_key_path(), update_request(),
-             update_opts()) ->
-    {ok, config(), raw_config()} | {error, term()}.
-update([RootName | _] = KeyPath, UpdateReq, Opts) ->
-    emqx_config_handler:update_config(get_schema_mod(RootName), KeyPath,
-        {{update, UpdateReq}, Opts}).
-
--spec remove(emqx_map_lib:config_key_path()) -> {ok, config(), raw_config()} | {error, term()}.
-remove(KeyPath) ->
-    remove(KeyPath, #{}).
-
--spec remove(emqx_map_lib:config_key_path(), update_opts()) ->
-    ok | {error, term()}.
-remove([RootName | _] = KeyPath, Opts) ->
-    emqx_config_handler:update_config(get_schema_mod(RootName), KeyPath, {remove, Opts}).
-
--spec reset(emqx_map_lib:config_key_path(), update_opts()) ->
-    {ok, config(), raw_config()} | {error, term()}.
-reset([RootName | _] = KeyPath, Opts) ->
-    case get_default_value(KeyPath) of
-        {ok, Default} ->
-            emqx_config_handler:update_config(get_schema_mod(RootName), KeyPath,
-                {{update, Default}, Opts});
-        {error, _} = Error ->
-            Error
-    end.
 
 -spec get_default_value(emqx_map_lib:config_key_path()) -> {ok, term()} | {error, term()}.
 get_default_value([RootName | _] = KeyPath) ->

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -38,6 +38,13 @@
 
 -define(MOD, {mod}).
 
+-define(ATOM_CONF_PATH(PATH, EXP, EXP_ON_FAIL),
+    try [safe_atom(Key) || Key <- PATH] of
+        AtomKeyPath -> EXP
+    catch
+        error:badarg -> EXP_ON_FAIL
+    end).
+
 -type handler_name() :: module().
 -type handlers() :: #{emqx_config:config_key() => handlers(), ?MOD => handler_name()}.
 
@@ -62,7 +69,8 @@ start_link() ->
 -spec update_config(module(), emqx_config:config_key_path(), emqx_config:update_args()) ->
     {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 update_config(SchemaModule, ConfKeyPath, UpdateArgs) ->
-    gen_server:call(?MODULE, {change_config, SchemaModule, ConfKeyPath, UpdateArgs}).
+    ?ATOM_CONF_PATH(ConfKeyPath, gen_server:call(?MODULE, {change_config, SchemaModule,
+        AtomKeyPath, UpdateArgs}), {error, ConfKeyPath}).
 
 -spec add_handler(emqx_config:config_key_path(), handler_name()) -> ok.
 add_handler(ConfKeyPath, HandlerName) ->
@@ -224,3 +232,10 @@ bin_path(ConfKeyPath) -> [bin(Key) || Key <- ConfKeyPath].
 
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
 bin(B) when is_binary(B) -> B.
+
+safe_atom(Bin) when is_binary(Bin) ->
+    binary_to_existing_atom(Bin, latin1);
+safe_atom(Str) when is_list(Str) ->
+    list_to_existing_atom(Str);
+safe_atom(Atom) when is_atom(Atom) ->
+    Atom.

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -46,10 +46,10 @@
                     ]).
 
 -callback pre_config_update(emqx_config:update_request(), emqx_config:raw_config()) ->
-    emqx_config:update_request().
+    {ok, emqx_config:update_request()} | {error, term()}.
 
 -callback post_config_update(emqx_config:update_request(), emqx_config:config(),
-    emqx_config:config()) -> any().
+    emqx_config:config()) -> ok | {ok, Result::any()} | {error, Reason::term()}.
 
 -type state() :: #{
     handlers := handlers(),
@@ -60,7 +60,7 @@ start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, {}, []).
 
 -spec update_config(module(), emqx_config:config_key_path(), emqx_config:update_args()) ->
-    {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
+    {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
 update_config(SchemaModule, ConfKeyPath, UpdateArgs) ->
     gen_server:call(?MODULE, {change_config, SchemaModule, ConfKeyPath, UpdateArgs}).
 
@@ -79,24 +79,23 @@ handle_call({add_child, ConfKeyPath, HandlerName}, _From,
     {reply, ok, State#{handlers =>
         emqx_map_lib:deep_put(ConfKeyPath, Handlers, #{?MOD => HandlerName})}};
 
-handle_call({change_config, SchemaModule, ConfKeyPath, {_Cmd, Opts} = UpdateArgs}, _From,
+handle_call({change_config, SchemaModule, ConfKeyPath, UpdateArgs}, _From,
             #{handlers := Handlers} = State) ->
     OldConf = emqx_config:get([]),
     OldRawConf = emqx_config:get_raw([]),
-    Result = try
-        {NewRawConf, OverrideConf} = process_upadate_request(ConfKeyPath, OldRawConf,
-            Handlers, UpdateArgs),
-        {AppEnvs, CheckedConf} = emqx_config:check_config(SchemaModule, NewRawConf),
-        _ = do_post_config_update(ConfKeyPath, Handlers, OldConf, CheckedConf, UpdateArgs),
-        case emqx_config:save_configs(AppEnvs, CheckedConf, NewRawConf, OverrideConf) of
-            ok -> {ok, emqx_config:get([]), return_rawconf(Opts)};
-            Err -> Err
+    Reply = try
+        case process_update_request(ConfKeyPath, OldRawConf, Handlers, UpdateArgs) of
+            {ok, NewRawConf, OverrideConf} ->
+                check_and_save_configs(SchemaModule, ConfKeyPath, Handlers, NewRawConf, OldConf,
+                    OverrideConf, UpdateArgs);
+            {error, Result} ->
+                {error, Result}
         end
     catch Error:Reason:ST ->
         ?LOG(error, "change_config failed: ~p", [{Error, Reason, ST}]),
         {error, Reason}
     end,
-    {reply, Result, State};
+    {reply, Reply, State};
 
 handle_call(_Request, _From, State) ->
     Reply = ok,
@@ -114,32 +113,56 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-process_upadate_request(ConfKeyPath, OldRawConf, _Handlers, {remove, _Opts}) ->
+process_update_request(ConfKeyPath, OldRawConf, _Handlers, {remove, _Opts}) ->
     BinKeyPath = bin_path(ConfKeyPath),
     NewRawConf = emqx_map_lib:deep_remove(BinKeyPath, OldRawConf),
     OverrideConf = emqx_map_lib:deep_remove(BinKeyPath, emqx_config:read_override_conf()),
-    {NewRawConf, OverrideConf};
-process_upadate_request(ConfKeyPath, OldRawConf, Handlers, {{update, UpdateReq}, _Opts}) ->
-    NewRawConf = do_update_config(ConfKeyPath, Handlers, OldRawConf, UpdateReq),
-    OverrideConf = update_override_config(NewRawConf),
-    {NewRawConf, OverrideConf}.
+    {ok, NewRawConf, OverrideConf};
+process_update_request(ConfKeyPath, OldRawConf, Handlers, {{update, UpdateReq}, _Opts}) ->
+    case do_update_config(ConfKeyPath, Handlers, OldRawConf, UpdateReq) of
+        {ok, NewRawConf} ->
+            OverrideConf = update_override_config(NewRawConf),
+            {ok, NewRawConf, OverrideConf};
+        Error -> Error
+    end.
 
 do_update_config([], Handlers, OldRawConf, UpdateReq) ->
     call_pre_config_update(Handlers, OldRawConf, UpdateReq);
 do_update_config([ConfKey | ConfKeyPath], Handlers, OldRawConf, UpdateReq) ->
     SubOldRawConf = get_sub_config(bin(ConfKey), OldRawConf),
     SubHandlers = maps:get(ConfKey, Handlers, #{}),
-    NewUpdateReq = do_update_config(ConfKeyPath, SubHandlers, SubOldRawConf, UpdateReq),
-    call_pre_config_update(Handlers, OldRawConf, #{bin(ConfKey) => NewUpdateReq}).
+    case do_update_config(ConfKeyPath, SubHandlers, SubOldRawConf, UpdateReq) of
+        {ok, NewUpdateReq} ->
+            call_pre_config_update(Handlers, OldRawConf, #{bin(ConfKey) => NewUpdateReq});
+        Error ->
+            Error
+    end.
 
-do_post_config_update([], Handlers, OldConf, NewConf, UpdateArgs) ->
-    call_post_config_update(Handlers, OldConf, NewConf, up_req(UpdateArgs));
-do_post_config_update([ConfKey | ConfKeyPath], Handlers, OldConf, NewConf, UpdateArgs) ->
+check_and_save_configs(SchemaModule, ConfKeyPath, Handlers, NewRawConf, OldConf, OverrideConf,
+        UpdateArgs) ->
+    {AppEnvs, CheckedConf} = emqx_config:check_config(SchemaModule, NewRawConf),
+    case do_post_config_update(ConfKeyPath, Handlers, OldConf, CheckedConf, UpdateArgs, #{}) of
+        {ok, Result0} ->
+            case save_configs(AppEnvs, CheckedConf, NewRawConf, OverrideConf, UpdateArgs) of
+                {ok, Result1} ->
+                    {ok, Result1#{post_config_update => Result0}};
+                Error -> Error
+            end;
+        Error -> Error
+    end.
+
+do_post_config_update([], Handlers, OldConf, NewConf, UpdateArgs, Result) ->
+    call_post_config_update(Handlers, OldConf, NewConf, up_req(UpdateArgs), Result);
+do_post_config_update([ConfKey | ConfKeyPath], Handlers, OldConf, NewConf, UpdateArgs, Result) ->
     SubOldConf = get_sub_config(ConfKey, OldConf),
     SubNewConf = get_sub_config(ConfKey, NewConf),
     SubHandlers = maps:get(ConfKey, Handlers, #{}),
-    _ = do_post_config_update(ConfKeyPath, SubHandlers, SubOldConf, SubNewConf, UpdateArgs),
-    call_post_config_update(Handlers, OldConf, NewConf, up_req(UpdateArgs)).
+    case do_post_config_update(ConfKeyPath, SubHandlers, SubOldConf, SubNewConf, UpdateArgs,
+            Result) of
+        {ok, Result1} ->
+            call_post_config_update(Handlers, OldConf, NewConf, up_req(UpdateArgs), Result1);
+        Error -> Error
+    end.
 
 get_sub_config(ConfKey, Conf) when is_map(Conf) ->
     maps:get(ConfKey, Conf, undefined);
@@ -149,15 +172,30 @@ get_sub_config(_, _Conf) -> %% the Conf is a primitive
 call_pre_config_update(Handlers, OldRawConf, UpdateReq) ->
     HandlerName = maps:get(?MOD, Handlers, undefined),
     case erlang:function_exported(HandlerName, pre_config_update, 2) of
-        true -> HandlerName:pre_config_update(UpdateReq, OldRawConf);
+        true ->
+            case HandlerName:pre_config_update(UpdateReq, OldRawConf) of
+                {ok, NewUpdateReq} -> {ok, NewUpdateReq};
+                {error, Reason} -> {error, {pre_config_update, HandlerName, Reason}}
+            end;
         false -> merge_to_old_config(UpdateReq, OldRawConf)
     end.
 
-call_post_config_update(Handlers, OldConf, NewConf, UpdateReq) ->
+call_post_config_update(Handlers, OldConf, NewConf, UpdateReq, Result) ->
     HandlerName = maps:get(?MOD, Handlers, undefined),
     case erlang:function_exported(HandlerName, post_config_update, 3) of
-        true -> HandlerName:post_config_update(UpdateReq, NewConf, OldConf);
-        false -> ok
+        true ->
+            case HandlerName:post_config_update(UpdateReq, NewConf, OldConf) of
+                ok -> {ok, Result};
+                {ok, Result1} -> {ok, Result#{HandlerName => Result1}};
+                {error, Reason} -> {error, {post_config_update, HandlerName, Reason}}
+            end;
+        false -> {ok, Result}
+    end.
+
+save_configs(AppEnvs, CheckedConf, NewRawConf, OverrideConf, {_Cmd, Opts}) ->
+    case emqx_config:save_configs(AppEnvs, CheckedConf, NewRawConf, OverrideConf) of
+        ok -> {ok, #{config => emqx_config:get([]), raw_config => return_rawconf(Opts)}};
+        {error, Reason} -> {error, {save_configs, Reason}}
     end.
 
 %% The default callback of config handlers
@@ -166,9 +204,9 @@ call_post_config_update(Handlers, OldConf, NewConf, UpdateReq) ->
 %%   2. either the old or the new config is not of map type
 %% the behaviour is merging the new the config to the old config if they are maps.
 merge_to_old_config(UpdateReq, RawConf) when is_map(UpdateReq), is_map(RawConf) ->
-    maps:merge(RawConf, UpdateReq);
+    {ok, maps:merge(RawConf, UpdateReq)};
 merge_to_old_config(UpdateReq, _RawConf) ->
-    UpdateReq.
+    {ok, UpdateReq}.
 
 update_override_config(RawConf) ->
     OldConf = emqx_config:read_override_conf(),

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -38,15 +38,8 @@
 
 -define(MOD, {mod}).
 
--export_type([update_opts/0, update_cmd/0, update_args/0]).
 -type handler_name() :: module().
 -type handlers() :: #{emqx_config:config_key() => handlers(), ?MOD => handler_name()}.
--type update_cmd() :: {update, emqx_config:update_request()} | remove.
--type update_opts() :: #{
-        %% fill the default values into the rawconf map
-        rawconf_with_defaults => boolean()
-    }.
--type update_args() :: {update_cmd(), Opts :: update_opts()}.
 
 -optional_callbacks([ pre_config_update/2
                     , post_config_update/3
@@ -66,7 +59,7 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, {}, []).
 
--spec update_config(module(), emqx_config:config_key_path(), update_args()) ->
+-spec update_config(module(), emqx_config:config_key_path(), emqx_config:update_args()) ->
     {ok, emqx_config:config(), emqx_config:raw_config()} | {error, term()}.
 update_config(SchemaModule, ConfKeyPath, UpdateArgs) ->
     gen_server:call(?MODULE, {change_config, SchemaModule, ConfKeyPath, UpdateArgs}).

--- a/apps/emqx/test/emqx_alarm_SUITE.erl
+++ b/apps/emqx/test/emqx_alarm_SUITE.erl
@@ -28,14 +28,14 @@ all() -> emqx_ct:all(?MODULE).
 init_per_testcase(t_size_limit, Config) ->
     emqx_ct_helpers:boot_modules(all),
     emqx_ct_helpers:start_apps([]),
-    {ok, _, _} = emqx:update_config([alarm], #{
+    {ok, _} = emqx:update_config([alarm], #{
             <<"size_limit">> => 2
         }),
     Config;
 init_per_testcase(t_validity_period, Config) ->
     emqx_ct_helpers:boot_modules(all),
     emqx_ct_helpers:start_apps([]),
-    {ok, _, _} = emqx:update_config([alarm], #{
+    {ok, _} = emqx:update_config([alarm], #{
             <<"validity_period">> => <<"1s">>
         }),
     Config;

--- a/apps/emqx/test/emqx_alarm_SUITE.erl
+++ b/apps/emqx/test/emqx_alarm_SUITE.erl
@@ -28,14 +28,14 @@ all() -> emqx_ct:all(?MODULE).
 init_per_testcase(t_size_limit, Config) ->
     emqx_ct_helpers:boot_modules(all),
     emqx_ct_helpers:start_apps([]),
-    {ok, _, _} = emqx_config:update([alarm], #{
+    {ok, _, _} = emqx:update_config([alarm], #{
             <<"size_limit">> => 2
         }),
     Config;
 init_per_testcase(t_validity_period, Config) ->
     emqx_ct_helpers:boot_modules(all),
     emqx_ct_helpers:start_apps([]),
-    {ok, _, _} = emqx_config:update([alarm], #{
+    {ok, _, _} = emqx:update_config([alarm], #{
             <<"validity_period">> => <<"1s">>
         }),
     Config;

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -61,10 +61,10 @@ lookup(Id) ->
     end.
 
 move(Id, Position) ->
-    emqx_config:update(?CONF_KEY_PATH, {move, Id, Position}).
+    emqx:update_config(?CONF_KEY_PATH, {move, Id, Position}).
 
 update(Cmd, Rules) ->
-    emqx_config:update(?CONF_KEY_PATH, {Cmd, Rules}).
+    emqx:update_config(?CONF_KEY_PATH, {Cmd, Rules}).
 
 pre_config_update({move, Id, <<"top">>}, Conf) when is_list(Conf) ->
     {Index, _} = find_rule_by_id(Id),

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -69,12 +69,12 @@ update(Cmd, Rules) ->
 pre_config_update({move, Id, <<"top">>}, Conf) when is_list(Conf) ->
     {Index, _} = find_rule_by_id(Id),
     {List1, List2} = lists:split(Index, Conf),
-    [lists:nth(Index, Conf)] ++ lists:droplast(List1) ++ List2;
+    {ok, [lists:nth(Index, Conf)] ++ lists:droplast(List1) ++ List2};
 
 pre_config_update({move, Id, <<"bottom">>}, Conf) when is_list(Conf) ->
     {Index, _} = find_rule_by_id(Id),
     {List1, List2} = lists:split(Index, Conf),
-    lists:droplast(List1) ++ List2 ++ [lists:nth(Index, Conf)];
+    {ok, lists:droplast(List1) ++ List2 ++ [lists:nth(Index, Conf)]};
 
 pre_config_update({move, Id, #{<<"before">> := BeforeId}}, Conf) when is_list(Conf) ->
     {Index1, _} = find_rule_by_id(Id),
@@ -83,9 +83,9 @@ pre_config_update({move, Id, #{<<"before">> := BeforeId}}, Conf) when is_list(Co
     Conf2 = lists:nth(Index2, Conf),
 
     {List1, List2} = lists:split(Index2, Conf),
-    lists:delete(Conf1, lists:droplast(List1))
-    ++ [Conf1] ++ [Conf2]
-    ++ lists:delete(Conf1, List2);
+    {ok, lists:delete(Conf1, lists:droplast(List1))
+        ++ [Conf1] ++ [Conf2]
+        ++ lists:delete(Conf1, List2)};
 
 pre_config_update({move, Id, #{<<"after">> := AfterId}}, Conf) when is_list(Conf) ->
     {Index1, _} = find_rule_by_id(Id),
@@ -93,21 +93,21 @@ pre_config_update({move, Id, #{<<"after">> := AfterId}}, Conf) when is_list(Conf
     {Index2, _} = find_rule_by_id(AfterId),
 
     {List1, List2} = lists:split(Index2, Conf),
-    lists:delete(Conf1, List1)
-    ++ [Conf1]
-    ++ lists:delete(Conf1, List2);
+    {ok, lists:delete(Conf1, List1)
+        ++ [Conf1]
+        ++ lists:delete(Conf1, List2)};
 
 pre_config_update({head, Rules}, Conf) when is_list(Rules), is_list(Conf) ->
-    Rules ++ Conf;
+    {ok, Rules ++ Conf};
 pre_config_update({tail, Rules}, Conf) when is_list(Rules), is_list(Conf) ->
-    Conf ++ Rules;
+    {ok, Conf ++ Rules};
 pre_config_update({{replace_once, Id}, Rule}, Conf) when is_map(Rule), is_list(Conf) ->
     {Index, _} = find_rule_by_id(Id),
     {List1, List2} = lists:split(Index, Conf),
-    lists:droplast(List1) ++ [Rule] ++ List2;
+    {ok, lists:droplast(List1) ++ [Rule] ++ List2};
 pre_config_update({_, Rules}, _Conf) when is_list(Rules)->
     %% overwrite the entire config!
-    Rules.
+    {ok, Rules}.
 
 post_config_update(_, undefined, _Conf) ->
     ok;

--- a/apps/emqx_authz/src/emqx_authz_api.erl
+++ b/apps/emqx_authz/src/emqx_authz_api.erl
@@ -449,7 +449,7 @@ rules(post, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     RawConfig = jsx:decode(Body, [return_maps]),
     case emqx_authz:update(head, [RawConfig]) of
-        {ok, _, _} -> {204};
+        {ok, _} -> {204};
         {error, Reason} ->
             {400, #{code => <<"BAD_REQUEST">>,
                     messgae => atom_to_binary(Reason)}}
@@ -458,7 +458,7 @@ rules(put, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     RawConfig = jsx:decode(Body, [return_maps]),
     case emqx_authz:update(replace, RawConfig) of
-        {ok, _, _} -> {204};
+        {ok, _} -> {204};
         {error, Reason} ->
             {400, #{code => <<"BAD_REQUEST">>,
                     messgae => atom_to_binary(Reason)}}
@@ -486,7 +486,7 @@ rule(put, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     RawConfig = jsx:decode(Body, [return_maps]),
     case emqx_authz:update({replace_once, RuleId}, RawConfig) of
-        {ok, _, _} -> {204};
+        {ok, _} -> {204};
         {error, not_found_rule} ->
             {404, #{code => <<"NOT_FOUND">>,
                     messgae => <<"rule ", RuleId/binary, " not found">>}};
@@ -497,7 +497,7 @@ rule(put, Request) ->
 rule(delete, Request) ->
     RuleId = cowboy_req:binding(id, Request),
     case emqx_authz:update({replace_once, RuleId}, #{}) of
-        {ok, _, _} -> {204};
+        {ok, _} -> {204};
         {error, Reason} ->
             {400, #{code => <<"BAD_REQUEST">>,
                     messgae => atom_to_binary(Reason)}}
@@ -507,7 +507,7 @@ move_rule(post, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     #{<<"position">> := Position} = jsx:decode(Body, [return_maps]),
     case emqx_authz:move(RuleId, Position) of
-        {ok, _, _} -> {204};
+        {ok, _} -> {204};
         {error, not_found_rule} ->
             {404, #{code => <<"NOT_FOUND">>,
                     messgae => <<"rule ", RuleId/binary, " not found">>}};

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -33,8 +33,8 @@ groups() ->
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -33,17 +33,17 @@ groups() ->
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz]),
     ok.
 
 init_per_testcase(_, Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     Config.
 
 -define(RULE1, #{<<"principal">> => <<"all">>,
@@ -82,9 +82,9 @@ init_per_testcase(_, Config) ->
 %%------------------------------------------------------------------------------
 
 t_update_rule(_) ->
-    {ok, _, _} = emqx_authz:update(replace, [?RULE2]),
-    {ok, _, _} = emqx_authz:update(head, [?RULE1]),
-    {ok, _, _} = emqx_authz:update(tail, [?RULE3]),
+    {ok, _} = emqx_authz:update(replace, [?RULE2]),
+    {ok, _} = emqx_authz:update(head, [?RULE1]),
+    {ok, _} = emqx_authz:update(tail, [?RULE3]),
 
     Lists1 = emqx_authz:check_rules([?RULE1, ?RULE2, ?RULE3]),
     ?assertMatch(Lists1, emqx_config:get([authorization, rules], [])),
@@ -107,7 +107,7 @@ t_update_rule(_) ->
       }
     ] = emqx_authz:lookup(),
 
-    {ok, _, _} = emqx_authz:update({replace_once, Id3}, ?RULE4),
+    {ok, _} = emqx_authz:update({replace_once, Id3}, ?RULE4),
     Lists2 = emqx_authz:check_rules([?RULE1, ?RULE2, ?RULE4]),
     ?assertMatch(Lists2, emqx_config:get([authorization, rules], [])),
 
@@ -132,38 +132,38 @@ t_update_rule(_) ->
       }
     ] = emqx_authz:lookup(),
 
-    {ok, _, _} = emqx_authz:update(replace, []).
+    {ok, _} = emqx_authz:update(replace, []).
 
 t_move_rule(_) ->
-    {ok, _, _} = emqx_authz:update(replace, [?RULE1, ?RULE2, ?RULE3, ?RULE4]),
+    {ok, _} = emqx_authz:update(replace, [?RULE1, ?RULE2, ?RULE3, ?RULE4]),
     [#{annotations := #{id := Id1}},
      #{annotations := #{id := Id2}},
      #{annotations := #{id := Id3}},
      #{annotations := #{id := Id4}}
     ] = emqx_authz:lookup(),
 
-    {ok, _, _} = emqx_authz:move(Id4, <<"top">>),
+    {ok, _} = emqx_authz:move(Id4, <<"top">>),
     ?assertMatch([#{annotations := #{id := Id4}},
                   #{annotations := #{id := Id1}},
                   #{annotations := #{id := Id2}},
                   #{annotations := #{id := Id3}}
                  ], emqx_authz:lookup()),
 
-    {ok, _, _} = emqx_authz:move(Id1, <<"bottom">>),
+    {ok, _} = emqx_authz:move(Id1, <<"bottom">>),
     ?assertMatch([#{annotations := #{id := Id4}},
                   #{annotations := #{id := Id2}},
                   #{annotations := #{id := Id3}},
                   #{annotations := #{id := Id1}}
                  ], emqx_authz:lookup()),
 
-    {ok, _, _} = emqx_authz:move(Id3, #{<<"before">> => Id4}),
+    {ok, _} = emqx_authz:move(Id3, #{<<"before">> => Id4}),
     ?assertMatch([#{annotations := #{id := Id3}},
                   #{annotations := #{id := Id4}},
                   #{annotations := #{id := Id2}},
                   #{annotations := #{id := Id1}}
                  ], emqx_authz:lookup()),
 
-    {ok, _, _} = emqx_authz:move(Id2, #{<<"after">> => Id1}),
+    {ok, _} = emqx_authz:move(Id2, #{<<"after">> => Id1}),
     ?assertMatch([#{annotations := #{id := Id3}},
                   #{annotations := #{id := Id4}},
                   #{annotations := #{id := Id1}},

--- a/apps/emqx_authz/test/emqx_authz_api_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_SUITE.erl
@@ -76,8 +76,8 @@ init_per_suite(Config) ->
     ekka_mnesia:start(),
     emqx_mgmt_auth:mnesia(boot),
     ok = emqx_ct_helpers:start_apps([emqx_management, emqx_authz], fun set_special_configs/1),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
 
     Config.
 

--- a/apps/emqx_authz/test/emqx_authz_api_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_SUITE.erl
@@ -76,13 +76,13 @@ init_per_suite(Config) ->
     ekka_mnesia:start(),
     emqx_mgmt_auth:mnesia(boot),
     ok = emqx_ct_helpers:start_apps([emqx_management, emqx_authz], fun set_special_configs/1),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
 
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz, emqx_management]),
     ok.
 
@@ -155,7 +155,7 @@ t_api(_) ->
     ok.
 
 t_move_rule(_) ->
-    {ok, _, _} = emqx_authz:update(replace, [?RULE1, ?RULE2, ?RULE3, ?RULE4]),
+    {ok, _} = emqx_authz:update(replace, [?RULE1, ?RULE2, ?RULE3, ?RULE4]),
     [#{annotations := #{id := Id1}},
      #{annotations := #{id := Id2}},
      #{annotations := #{id := Id3}},

--- a/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"url">> => <<"https://fake.com:443/">>,
                     <<"headers">> => #{},

--- a/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"url">> => <<"https://fake.com:443/">>,
                     <<"headers">> => #{},
@@ -46,11 +46,11 @@ init_per_suite(Config) ->
                 <<"principal">> => <<"all">>,
                 <<"type">> => <<"http">>}
             ],
-    {ok, _, _} = emqx_authz:update(replace, Rules),
+    {ok, _} = emqx_authz:update(replace, Rules),
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_mongo_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mongo_SUITE.erl
@@ -34,8 +34,8 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                         <<"mongo_type">> => <<"single">>,
                         <<"server">> => <<"127.0.0.1:27017">>,

--- a/apps/emqx_authz/test/emqx_authz_mongo_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mongo_SUITE.erl
@@ -34,8 +34,8 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                         <<"mongo_type">> => <<"single">>,
                         <<"server">> => <<"127.0.0.1:27017">>,
@@ -47,11 +47,11 @@ init_per_suite(Config) ->
                 <<"find">> => #{<<"a">> => <<"b">>},
                 <<"type">> => <<"mongo">>}
             ],
-    {ok, _, _} = emqx_authz:update(replace, Rules),
+    {ok, _} = emqx_authz:update(replace, Rules),
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"server">> => <<"127.0.0.1:27017">>,
                     <<"pool_size">> => 1,

--- a/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"server">> => <<"127.0.0.1:27017">>,
                     <<"pool_size">> => 1,
@@ -49,11 +49,11 @@ init_per_suite(Config) ->
                 <<"principal">> => <<"all">>,
                 <<"sql">> => <<"abcb">>,
                 <<"type">> => <<"mysql">> }],
-    {ok, _, _} = emqx_authz:update(replace, Rules),
+    {ok, _} = emqx_authz:update(replace, Rules),
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource).
 

--- a/apps/emqx_authz/test/emqx_authz_pgsql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_pgsql_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"server">> => <<"127.0.0.1:27017">>,
                     <<"pool_size">> => 1,

--- a/apps/emqx_authz/test/emqx_authz_pgsql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_pgsql_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"server">> => <<"127.0.0.1:27017">>,
                     <<"pool_size">> => 1,
@@ -48,11 +48,11 @@ init_per_suite(Config) ->
                 },
                 <<"sql">> => <<"abcb">>,
                 <<"type">> => <<"pgsql">> }],
-    {ok, _, _} = emqx_authz:update(replace, Rules),
+    {ok, _} = emqx_authz:update(replace, Rules),
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource).
 

--- a/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
+    {ok, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"server">> => <<"127.0.0.1:27017">>,
                     <<"pool_size">> => 1,
@@ -47,11 +47,11 @@ init_per_suite(Config) ->
                 },
                 <<"cmd">> => <<"HGETALL mqtt_authz:%u">>,
                 <<"type">> => <<"redis">> }],
-    {ok, _, _} = emqx_authz:update(replace, Rules),
+    {ok, _} = emqx_authz:update(replace, Rules),
     Config.
 
 end_per_suite(_Config) ->
-    {ok, _, _} = emqx_authz:update(replace, []),
+    {ok, _} = emqx_authz:update(replace, []),
     emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource).
 

--- a/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
@@ -35,8 +35,8 @@ init_per_suite(Config) ->
 
     ok = emqx_ct_helpers:start_apps([emqx_authz]),
 
-    {ok, _, _} = emqx_config:update([zones, default, authorization, cache, enable], false),
-    {ok, _, _} = emqx_config:update([zones, default, authorization, enable], true),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, cache, enable], false),
+    {ok, _, _} = emqx:update_config([zones, default, authorization, enable], true),
     Rules = [#{ <<"config">> => #{
                     <<"server">> => <<"127.0.0.1:27017">>,
                     <<"pool_size">> => 1,

--- a/apps/emqx_data_bridge/src/emqx_data_bridge.erl
+++ b/apps/emqx_data_bridge/src/emqx_data_bridge.erl
@@ -60,4 +60,4 @@ config_key_path() ->
     [emqx_data_bridge, bridges].
 
 update_config(ConfigReq) ->
-    emqx_config:update(config_key_path(), ConfigReq).
+    emqx:update_config(config_key_path(), ConfigReq).

--- a/apps/emqx_data_bridge/src/emqx_data_bridge_api.erl
+++ b/apps/emqx_data_bridge/src/emqx_data_bridge_api.erl
@@ -124,7 +124,7 @@ format_api_reply(#{resource_type := Type, id := Id, config := Conf, status := St
 
 update_config_and_reply(Name, BridgeType, Config, Data) ->
     case emqx_data_bridge:update_config({update, ?BRIDGE(Name, BridgeType, Config)}) of
-        {ok, _, _} ->
+        {ok, _} ->
             {200, #{code => 0, data => format_api_reply(
                         emqx_resource_api:format_data(Data))}};
         {error, Reason} ->
@@ -133,7 +133,7 @@ update_config_and_reply(Name, BridgeType, Config, Data) ->
 
 delete_config_and_reply(Name) ->
     case emqx_data_bridge:update_config({delete, Name}) of
-        {ok, _, _} -> {200, #{code => 0, data => #{}}};
+        {ok, _} -> {200, #{code => 0, data => #{}}};
         {error, Reason} ->
             {500, #{code => 102, message => emqx_resource_api:stringnify(Reason)}}
     end.

--- a/apps/emqx_data_bridge/src/emqx_data_bridge_app.erl
+++ b/apps/emqx_data_bridge/src/emqx_data_bridge_app.erl
@@ -32,12 +32,12 @@ stop(_State) ->
 
 %% internal functions
 pre_config_update({update, Bridge = #{<<"name">> := Name}}, OldConf) ->
-    [Bridge | remove_bridge(Name, OldConf)];
+    {ok, [Bridge | remove_bridge(Name, OldConf)]};
 pre_config_update({delete, Name}, OldConf) ->
-    remove_bridge(Name, OldConf);
+    {ok, remove_bridge(Name, OldConf)};
 pre_config_update(NewConf, _OldConf) when is_list(NewConf) ->
     %% overwrite the entire config!
-    NewConf.
+    {ok, NewConf}.
 
 remove_bridge(_Name, undefined) ->
     [];

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -113,7 +113,7 @@ config(get, Req) ->
 
 config(put, Req) ->
     Path = conf_path(Req),
-    {ok, _, RawConf} = emqx:update_config(Path, http_body(Req),
+    {ok, #{raw_config := RawConf}} = emqx:update_config(Path, http_body(Req),
         #{rawconf_with_defaults => true}),
     {200, emqx_map_lib:deep_get(Path, emqx_map_lib:jsonable_map(RawConf))}.
 
@@ -121,7 +121,7 @@ config_reset(post, Req) ->
     %% reset the config specified by the query string param 'conf_path'
     Path = conf_path_reset(Req) ++ conf_path_from_querystr(Req),
     case emqx:reset_config(Path, #{}) of
-        {ok, _, _} -> {200};
+        {ok, _} -> {200};
         {error, Reason} ->
             {400, ?ERR_MSG(Reason)}
     end.

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -113,14 +113,14 @@ config(get, Req) ->
 
 config(put, Req) ->
     Path = conf_path(Req),
-    {ok, _, RawConf} = emqx_config:update(Path, http_body(Req),
+    {ok, _, RawConf} = emqx:update_config(Path, http_body(Req),
         #{rawconf_with_defaults => true}),
     {200, emqx_map_lib:deep_get(Path, emqx_map_lib:jsonable_map(RawConf))}.
 
 config_reset(post, Req) ->
     %% reset the config specified by the query string param 'conf_path'
     Path = conf_path_reset(Req) ++ conf_path_from_querystr(Req),
-    case emqx_config:reset(Path, #{}) of
+    case emqx:reset_config(Path, #{}) of
         {ok, _, _} -> {200};
         {error, Reason} ->
             {400, ?ERR_MSG(Reason)}

--- a/apps/emqx_modules/src/emqx_rewrite.erl
+++ b/apps/emqx_modules/src/emqx_rewrite.erl
@@ -56,7 +56,8 @@ list() ->
 
 update(Rules0) ->
     Rewrite = emqx_config:get_raw([<<"rewrite">>], #{}),
-    {ok, Config, _} = emqx_config:update([rewrite], maps:put(<<"rules">>, Rules0, Rewrite)),
+    {ok, #{config := Config}} = emqx:update_config([rewrite], maps:put(<<"rules">>,
+        Rules0, Rewrite)),
     Rules = maps:get(rules, maps:get(rewrite, Config, #{}), []),
     case Rules of
         [] ->

--- a/apps/emqx_modules/src/emqx_rewrite_api.erl
+++ b/apps/emqx_modules/src/emqx_rewrite_api.erl
@@ -1,0 +1,66 @@
+-module(emqx_rewrite_api).
+
+-behaviour(minirest_api).
+
+-export([api_spec/0]).
+
+-export([topic_rewrite/2]).
+
+-define(MAX_RULES_LIMIT, 20).
+
+-define(EXCEED_LIMIT, 'EXCEED_LIMIT').
+
+api_spec() ->
+    {[rewrite_api()], []}.
+
+topic_rewrite_schema() ->
+    #{
+        type => object,
+        properties => #{
+            action => #{
+                type => string,
+                description => <<"Node">>,
+                enum => [subscribe, publish]},
+            source_topic => #{
+                type => string,
+                description => <<"Topic">>},
+            re => #{
+                type => string,
+                description => <<"Regular expressions">>},
+            dest_topic => #{
+                type => string,
+                description => <<"Destination topic">>}
+        }
+    }.
+
+rewrite_api() ->
+    Path = "/mqtt/topic_rewrite",
+    Metadata = #{
+        get => #{
+            description => <<"List topic rewrite">>,
+            responses => #{
+                <<"200">> =>
+                    emqx_mgmt_util:response_array_schema(<<"List all rewrite rules">>, topic_rewrite_schema())}},
+        post => #{
+            description => <<"Update topic rewrite">>,
+            'requestBody' => emqx_mgmt_util:request_body_array_schema(topic_rewrite_schema()),
+            response => #{
+                <<"200">> =>
+                    emqx_mgmt_util:response_schema(<<"Update topic rewrite success">>, topic_rewrite_schema()),
+                <<"413">> => emqx_mgmt_util:response_error_schema(<<"Rules count exceed max limit">>, [?EXCEED_LIMIT])}}},
+    {Path, Metadata, topic_rewrite}.
+
+topic_rewrite(get, _Request) ->
+    {200, emqx_rewrite:list()};
+
+topic_rewrite(post, Request) ->
+    {ok, Body, _} = cowboy_req:read_body(Request),
+    Params = emqx_json:decode(Body, [return_maps]),
+    case length(Params) < ?MAX_RULES_LIMIT of
+        true ->
+            ok = emqx_rewrite:update(Params),
+            {200, emqx_rewrite:list()};
+        _ ->
+            Message = list_to_binary(io_lib:format("Max rewrite rules count is ~p", [?MAX_RULES_LIMIT])),
+            {413, #{code => ?EXCEED_LIMIT, message => Message}}
+    end.

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -113,7 +113,7 @@ prometheus(put, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     Params = emqx_json:decode(Body, [return_maps]),
     Enable = maps:get(<<"enable">>, Params),
-    {ok, _, _} = emqx:update_config([prometheus], Params),
+    {ok, _} = emqx:update_config([prometheus], Params),
     enable_prometheus(Enable).
 
 % stats(_Bindings, Params) ->

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -113,7 +113,7 @@ prometheus(put, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     Params = emqx_json:decode(Body, [return_maps]),
     Enable = maps:get(<<"enable">>, Params),
-    {ok, _, _} = emqx_config:update([prometheus], Params),
+    {ok, _, _} = emqx:update_config([prometheus], Params),
     enable_prometheus(Enable).
 
 % stats(_Bindings, Params) ->

--- a/apps/emqx_statsd/src/emqx_statsd_api.erl
+++ b/apps/emqx_statsd/src/emqx_statsd_api.erl
@@ -91,7 +91,7 @@ statsd(put, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     Params = emqx_json:decode(Body, [return_maps]),
     Enable = maps:get(<<"enable">>, Params),
-    {ok, _, _} = emqx:update_config([statsd], Params),
+    {ok, _} = emqx:update_config([statsd], Params),
     enable_statsd(Enable).
 
 enable_statsd(true) ->

--- a/apps/emqx_statsd/src/emqx_statsd_api.erl
+++ b/apps/emqx_statsd/src/emqx_statsd_api.erl
@@ -91,7 +91,7 @@ statsd(put, Request) ->
     {ok, Body, _} = cowboy_req:read_body(Request),
     Params = emqx_json:decode(Body, [return_maps]),
     Enable = maps:get(<<"enable">>, Params),
-    {ok, _, _} = emqx_config:update([statsd], Params),
+    {ok, _, _} = emqx:update_config([statsd], Params),
     enable_statsd(Enable).
 
 enable_statsd(true) ->


### PR DESCRIPTION
- remove the circular dependency between emqx_config and emqx_config_handler
- refactor the return values of emqx:update_config/2,3, to make sure the return value contains sufficient information about:
  1. if success, the return values of `Handler:post_config_update/3` all the config handlers
  2. if failed, either the reason of the failure, such as written to disk failed or the hocon_schema validation failed; or the error returned by the `Handler:pre_config_update/3` and `Handler:post_config_update/3` all the config handlers
- add one more callback function `Handler:config_update_failed/3` to give each handler a chance to do some clean works.
