### PR TITLE
refactor(config): replace all ':' with '=' in the *.conf

### DIFF
--- a/apps/emqx/etc/emqx.conf
+++ b/apps/emqx/etc/emqx.conf
@@ -7,7 +7,7 @@ broker {
   ## @doc broker.sys_msg_interval
   ## ValueType: Duration | disabled
   ## Default: 1m
-  sys_msg_interval: 1m
+  sys_msg_interval = 1m
 
   ## System heartbeat interval of publishing following heart beat message:
   ##  - "$SYS/brokers/<node>/uptime"
@@ -16,7 +16,7 @@ broker {
   ## @doc broker.sys_heartbeat_interval
   ## ValueType: Duration
   ## Default: 30s | disabled
-  sys_heartbeat_interval: 30s
+  sys_heartbeat_interval = 30s
 
   ## Session locking strategy in a cluster.
   ##
@@ -27,7 +27,7 @@ broker {
   ##   - quorum: select some nodes to lock the session
   ##   - all: lock the session on all of the nodes in the cluster
   ## Default: quorum
-  session_locking_strategy: quorum
+  session_locking_strategy = quorum
 
   ## Dispatch strategy for shared subscription
   ##
@@ -39,7 +39,7 @@ broker {
   ##     until the susbcriber disconnected.
   ##   - hash: select the subscribers by the hash of clientIds
   ## Default: round_robin
-  shared_subscription_strategy: round_robin
+  shared_subscription_strategy = round_robin
 
   ## Enable/disable shared dispatch acknowledgement for QoS1 and QoS2 messages
   ## This should allow messages to be dispatched to a different subscriber in
@@ -48,14 +48,14 @@ broker {
   ## @doc broker.shared_dispatch_ack_enabled
   ## ValueType: Boolean
   ## Default: false
-  shared_dispatch_ack_enabled: false
+  shared_dispatch_ack_enabled = false
 
   ## Enable batch clean for deleted routes.
   ##
   ## @doc broker.route_batch_clean
   ## ValueType: Boolean
   ## Default: true
-  route_batch_clean: true
+  route_batch_clean = true
 
   ## Performance toggle for subscribe/unsubscribe wildcard topic.
   ## Change this toggle only when there are many wildcard topics.
@@ -69,7 +69,7 @@ broker {
   ##  - tab:   mnesia translational updates with table lock. recommended for multi-nodes setup.
   ##  - global: global lock protected updates. recommended for larger cluster.
   ## Default: key
-  perf.route_lock_type: key
+  perf.route_lock_type = key
 
   ## Enable trie path compaction.
   ## Enabling it significantly improves wildcard topic subscribe
@@ -85,7 +85,7 @@ broker {
   ## @doc broker.perf.trie_compaction
   ## ValueType: Boolean
   ## Default: true
-  perf.trie_compaction: true
+  perf.trie_compaction = true
 }
 
 ##==================================================================
@@ -126,14 +126,14 @@ zones.default {
   ## @doc zones.<name>.auth.enable
   ## ValueType: Boolean
   ## Default: false
-  auth.enable: false
+  auth.enable = false
 
   ## Enable per connection statistics.
   ##
   ## @doc zones.<name>.stats.enable
   ## ValueType: Boolean
   ## Default: true
-  stats.enable: true
+  stats.enable = true
 
   ## Maximum number of concurrent connections in this zone.
   ##
@@ -143,7 +143,7 @@ zones.default {
   ## @doc zones.<name>.overall_max_connections
   ## ValueType: Number | infinity
   ## Default: infinity
-  overall_max_connections: infinity
+  overall_max_connections = infinity
 
   mqtt {
     ## When publishing or subscribing, prefix all topics with a mountpoint string.
@@ -167,7 +167,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.mountpoint
     ## ValueType: String
     ## Default: ""
-    mountpoint: ""
+    mountpoint = ""
 
     ## How long time the MQTT connection will be disconnected if the
     ## TCP connection is established but MQTT CONNECT has not been
@@ -176,14 +176,14 @@ zones.default {
     ## @doc zones.<name>.mqtt.idle_timeout
     ## ValueType: Duration
     ## Default: 15s
-    idle_timeout: 15s
+    idle_timeout = 15s
 
     ## Maximum MQTT packet size allowed.
     ##
     ## @doc zones.<name>.mqtt.max_packet_size
     ## ValueType: Bytes
     ## Default: 1MB
-    max_packet_size: 1MB
+    max_packet_size = 1MB
 
     ## Maximum length of MQTT clientId allowed.
     ##
@@ -191,7 +191,7 @@ zones.default {
     ## ValueType: Integer
     ## Range: [23, 65535]
     ## Default: 65535
-    max_clientid_len: 65535
+    max_clientid_len = 65535
 
     ## Maximum topic levels allowed.
     ##
@@ -199,14 +199,14 @@ zones.default {
     ## ValueType: Integer
     ## Range: [1, 65535]
     ## Default: 65535
-    max_topic_levels: 65535
+    max_topic_levels = 65535
 
     ## Maximum QoS allowed.
     ##
     ## @doc zones.<name>.mqtt.max_qos_allowed
     ## ValueType: 0 | 1 | 2
     ## Default: 2
-    max_qos_allowed: 2
+    max_qos_allowed = 2
 
     ## Maximum Topic Alias, 0 means no topic alias supported.
     ##
@@ -214,42 +214,42 @@ zones.default {
     ## ValueType: Integer
     ## Range: [0, 65535]
     ## Default: 65535
-    max_topic_alias: 65535
+    max_topic_alias = 65535
 
     ## Whether the Server supports MQTT retained messages.
     ##
     ## @doc zones.<name>.mqtt.retain_available
     ## ValueType: Boolean
     ## Default: true
-    retain_available: true
+    retain_available = true
 
     ## Whether the Server supports MQTT Wildcard Subscriptions
     ##
     ## @doc zones.<name>.mqtt.wildcard_subscription
     ## ValueType: Boolean
     ## Default: true
-    wildcard_subscription: true
+    wildcard_subscription = true
 
     ## Whether the Server supports MQTT Shared Subscriptions.
     ##
     ## @doc zones.<name>.mqtt.shared_subscription
     ## ValueType: Boolean
     ## Default: true
-    shared_subscription: true
+    shared_subscription = true
 
     ## Whether to ignore loop delivery of messages.(for mqtt v3.1.1)
     ##
     ## @doc zones.<name>.mqtt.ignore_loop_deliver
     ## ValueType: Boolean
     ## Default: false
-    ignore_loop_deliver: false
+    ignore_loop_deliver = false
 
     ## Whether to parse the MQTT frame in strict mode
     ##
     ## @doc zones.<name>.mqtt.strict_mode
     ## ValueType: Boolean
     ## Default: false
-    strict_mode: false
+    strict_mode = false
 
     ## Specify the response information returned to the client
     ##
@@ -258,14 +258,14 @@ zones.default {
     ## @doc zones.<name>.mqtt.response_information
     ## ValueType: String
     ## Default: ""
-    response_information: ""
+    response_information = ""
 
     ## Server Keep Alive of MQTT 5.0
     ##
     ## @doc zones.<name>.mqtt.server_keepalive
     ## ValueType: Number | disabled
     ## Default: disabled
-    server_keepalive: disabled
+    server_keepalive = disabled
 
     ## The backoff for MQTT keepalive timeout. The broker will kick a connection out
     ## until 'Keepalive * backoff * 2' timeout.
@@ -274,7 +274,7 @@ zones.default {
     ## ValueType: Float
     ## Range: (0.5, 1]
     ## Default: 0.75
-    keepalive_backoff: 0.75
+    keepalive_backoff = 0.75
 
     ## Maximum number of subscriptions allowed.
     ##
@@ -282,14 +282,14 @@ zones.default {
     ## ValueType: Integer | infinity
     ## Range: [1, infinity)
     ## Default: infinity
-    max_subscriptions: infinity
+    max_subscriptions = infinity
 
     ## Force to upgrade QoS according to subscription.
     ##
     ## @doc zones.<name>.mqtt.upgrade_qos
     ## ValueType: Boolean
     ## Default: false
-    upgrade_qos: false
+    upgrade_qos = false
 
     ## Maximum size of the Inflight Window storing QoS1/2 messages delivered but unacked.
     ##
@@ -297,14 +297,14 @@ zones.default {
     ## ValueType: Integer
     ## Range: [1, 65535]
     ## Default: 32
-    max_inflight: 32
+    max_inflight = 32
 
     ## Retry interval for QoS1/2 message delivering.
     ##
     ## @doc zones.<name>.mqtt.retry_interval
     ## ValueType: Duration
     ## Default: 30s
-    retry_interval: 30s
+    retry_interval = 30s
 
     ## Maximum QoS2 packets (Client -> Broker) awaiting PUBREL.
     ##
@@ -312,21 +312,21 @@ zones.default {
     ## ValueType: Integer | infinity
     ## Range: [1, infinity)
     ## Default: 100
-    max_awaiting_rel: 100
+    max_awaiting_rel = 100
 
     ## The QoS2 messages (Client -> Broker) will be dropped if awaiting PUBREL timeout.
     ##
     ## @doc zones.<name>.mqtt.await_rel_timeout
     ## ValueType: Duration
     ## Default: 300s
-    await_rel_timeout: 300s
+    await_rel_timeout = 300s
 
     ## Default session expiry interval for MQTT V3.1.1 connections.
     ##
     ## @doc zones.<name>.mqtt.session_expiry_interval
     ## ValueType: Duration
     ## Default: 2h
-    session_expiry_interval: 2h
+    session_expiry_interval = 2h
 
     ## Maximum queue length. Enqueued messages when persistent client disconnected,
     ## or inflight window is full.
@@ -335,7 +335,7 @@ zones.default {
     ## ValueType: Integer | infinity
     ## Range: [0, infinity)
     ## Default: 1000
-    max_mqueue_len: 1000
+    max_mqueue_len = 1000
 
     ## Topic priorities.
     ##
@@ -355,28 +355,28 @@ zones.default {
     ##  To configure "topic/1" > "topic/2":
     ##    mqueue_priorities: {"topic/1": 10, "topic/2": 8}
     ## Default: disabled
-    mqueue_priorities: disabled
+    mqueue_priorities = disabled
 
     ## Default to highest priority for topics not matching priority table
     ##
     ## @doc zones.<name>.mqtt.mqueue_default_priority
     ## ValueType: highest | lowest
     ## Default: lowest
-    mqueue_default_priority: lowest
+    mqueue_default_priority = lowest
 
     ## Whether to enqueue QoS0 messages.
     ##
     ## @doc zones.<name>.mqtt.mqueue_store_qos0
     ## ValueType: Boolean
     ## Default: true
-    mqueue_store_qos0: true
+    mqueue_store_qos0 = true
 
     ## Whether use username replace client id
     ##
     ## @doc zones.<name>.mqtt.use_username_as_clientid
     ## ValueType: Boolean
     ## Default: false
-    use_username_as_clientid: false
+    use_username_as_clientid = false
 
     ## Use the CN, DN or CRT field from the client certificate as a username.
     ## Only works for SSL connection.
@@ -384,7 +384,7 @@ zones.default {
     ## @doc zones.<name>.mqtt.peer_cert_as_username
     ## ValueType: cn | dn | crt | disabled
     ## Default: disabled
-    peer_cert_as_username: disabled
+    peer_cert_as_username = disabled
 
     ## Use the CN, DN or CRT field from the client certificate as a clientid.
     ## Only works for SSL connection.
@@ -392,7 +392,7 @@ zones.default {
     ## @doc zones.<name>.mqtt.peer_cert_as_clientid
     ## ValueType: cn | dn | crt | disabled
     ## Default: disabled
-    peer_cert_as_clientid: disabled
+    peer_cert_as_clientid = disabled
 
   }
 
@@ -403,14 +403,14 @@ zones.default {
     ## @doc zones.<name>.authorization.enable
     ## ValueType: Boolean
     ## Default: true
-    enable: true
+    enable = true
 
     ## The action when authorization check reject current operation
     ##
     ## @doc zones.<name>.authorization.deny_action
     ## ValueType: ignore | disconnect
     ## Default: ignore
-    deny_action: ignore
+    deny_action = ignore
 
     ## Whether to enable Authorization cache.
     ##
@@ -419,7 +419,7 @@ zones.default {
     ## @doc zones.<name>.authorization.cache.enable
     ## ValueType: Boolean
     ## Default: true
-    cache.enable: true
+    cache.enable = true
 
     ## The maximum count of Authorization entries can be cached for a client.
     ##
@@ -427,14 +427,14 @@ zones.default {
     ## ValueType: Integer
     ## Range: [0, 1048576]
     ## Default: 32
-    cache.max_size: 32
+    cache.max_size = 32
 
     ## The time after which an Authorization cache entry will be deleted
     ##
     ## @doc zones.<name>.authorization.cache.ttl
     ## ValueType: Duration
     ## Default: 1m
-    cache.ttl: 1m
+    cache.ttl = 1m
   }
 
   flapping_detect {
@@ -448,79 +448,79 @@ zones.default {
     ## @doc zones.<name>.flapping_detect.enable
     ## ValueType: Boolean
     ## Default: true
-    enable: false
+    enable = false
 
     ## The max disconnect allowed of a MQTT Client in `window_time`
     ##
     ## @doc zones.<name>.flapping_detect.max_count
     ## ValueType: Integer
     ## Default: 15
-    max_count: 15
+    max_count = 15
 
     ## The time window for flapping detect
     ##
     ## @doc zones.<name>.flapping_detect.window_time
     ## ValueType: Duration
     ## Default: 1m
-    window_time: 1m
+    window_time = 1m
 
     ## How long the clientid will be banned
     ##
     ## @doc zones.<name>.flapping_detect.ban_time
     ## ValueType: Duration
     ## Default: 5m
-    ban_time: 5m
+    ban_time = 5m
 
   }
 
-  force_shutdown: {
+  force_shutdown {
     ## Enable force_shutdown
     ##
     ## @doc zones.<name>.force_shutdown.enable
     ## ValueType: Boolean
     ## Default: true
-    enable: true
+    enable = true
 
     ## Max message queue length
     ## @doc zones.<name>.force_shutdown.max_message_queue_len
     ## ValueType: Integer
     ## Range: (0, infinity)
     ## Default: 1000
-    max_message_queue_len: 1000
+    max_message_queue_len = 1000
 
     ## Total heap size
     ##
     ## @doc zones.<name>.force_shutdown.max_heap_size
     ## ValueType: Size
     ## Default: 32MB
-    max_heap_size: 32MB
+    max_heap_size = 32MB
   }
 
-  force_gc: {
+  force_gc {
     ## Force the MQTT connection process GC after this number of
     ## messages or bytes passed through.
     ##
     ## @doc zones.<name>.force_gc.enable
     ## ValueType: Boolean
     ## Default: true
-    enable: true
+    enable = true
 
     ## GC the process after how many messages received
     ## @doc zones.<name>.force_gc.max_message_queue_len
     ## ValueType: Integer
     ## Range: (0, infinity)
     ## Default: 16000
-    count: 16000
+    count = 16000
 
     ## GC the process after how much bytes passed through
     ##
     ## @doc zones.<name>.force_gc.bytes
     ## ValueType: Size
     ## Default: 16MB
-    bytes: 16MB
+    bytes = 16MB
   }
 
-  conn_congestion: {
+  conn_congestion {
     ## Whether to alarm the congested connections.
     ##
     ## Sometimes the mqtt connection (usually an MQTT subscriber) may
@@ -541,7 +541,7 @@ zones.default {
     ## @doc zones.<name>.conn_congestion.enable_alarm
     ## ValueType: Boolean
     ## Default: true
-    enable_alarm: true
+    enable_alarm = true
 
     ## Won't clear the congested alarm in how long time.
     ## The alarm is cleared only when there're no pending bytes in
@@ -553,10 +553,10 @@ zones.default {
     ## @doc zones.<name>.conn_congestion.min_alarm_sustain_duration
     ## ValueType: Duration
     ## Default: 1m
-    min_alarm_sustain_duration: 1m
+    min_alarm_sustain_duration = 1m
   }
 
-  listeners.mqtt_tcp:
+  listeners.mqtt_tcp
   #${example_common_tcp_options} # common options can be written in a separate config entry and reference it from here.
   {
 
@@ -568,7 +568,7 @@ zones.default {
     ##   - ws:   MQTT over Websocket
     ##   - quic: MQTT over QUIC
     ## Required: true
-    type: tcp
+    type = tcp
 
     ## The IP address and port that the listener will bind.
     ##
@@ -576,21 +576,21 @@ zones.default {
     ## ValueType: IPAddress | Port | IPAddrPort
     ## Required: true
     ## Examples: 1883, 127.0.0.1:1883, ::1:1883
-    bind: "0.0.0.0:1883"
+    bind = "0.0.0.0:1883"
 
     ## The size of the acceptor pool for this listener.
     ##
     ## @doc zones.<name>.listeners.<name>.acceptors
     ## ValueType: Number
     ## Default: 16
-    acceptors: 16
+    acceptors = 16
 
     ## Maximum number of concurrent connections.
     ##
     ## @doc zones.<name>.listeners.<name>.max_connections
     ## ValueType: Number | infinity
     ## Default: infinity
-    max_connections: 1024000
+    max_connections = 1024000
 
     ## The access control rules for this listener.
     ##
@@ -604,7 +604,7 @@ zones.default {
     ##     "deny 192.168.0.0/24",
     ##     "all all"
     ##   ]
-    access_rules: [
+    access_rules = [
       "allow all"
     ]
 
@@ -616,7 +616,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol
     ## ValueType: Boolean
     ## Default: false
-    proxy_protocol: false
+    proxy_protocol = false
 
     ## Sets the timeout for proxy protocol. EMQ X will close the TCP connection
     ## if no proxy protocol packet recevied within the timeout.
@@ -624,7 +624,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol_timeout
     ## ValueType: Duration
     ## Default: 3s
-    proxy_protocol_timeout: 3s
+    proxy_protocol_timeout = 3s
 
     rate_limit {
       ## Maximum connections per second.
@@ -634,7 +634,7 @@ zones.default {
       ## Default: 1000
       ## Examples:
       ##   max_conn_rate: 1000
-      max_conn_rate: 1000
+      max_conn_rate = 1000
 
       ## Message limit for the a external MQTT connection.
       ##
@@ -643,7 +643,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messages per 10 seconds.
       ##   conn_messages_in: "100,10s"
-      conn_messages_in: "100,10s"
+      conn_messages_in = "100,10s"
 
       ## Limit the rate of receiving packets for a MQTT connection.
       ## The rate is counted by bytes of packets per second.
@@ -657,7 +657,7 @@ zones.default {
       ## Examples: 100KB incoming per 10 seconds.
       ##   conn_bytes_in: "100KB,10s"
       ##
-      conn_bytes_in: "100KB,10s"
+      conn_bytes_in = "100KB,10s"
 
       ## Messages quota for the each of external MQTT connection.
       ## This value consumed by the number of recipient on a message.
@@ -667,7 +667,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messaegs per 1s:
       ##   quota.conn_messages_routing: "100,1s"
-      quota.conn_messages_routing: "100,1s"
+      quota.conn_messages_routing = "100,1s"
 
       ## Messages quota for the all of external MQTT connections.
       ## This value consumed by the number of recipient on a message.
@@ -678,17 +678,17 @@ zones.default {
       ## Examples: 200000 messages per 1s:
       ##    quota.overall_messages_routing: "200000,1s"
       ##
-      quota.overall_messages_routing: "200000,1s"
+      quota.overall_messages_routing = "200000,1s"
     }
 
     ## TCP options
     ## See ${example_common_tcp_options} for more information
-    tcp.backlog: 1024
-    tcp.buffer: 4KB
+    tcp.backlog = 1024
+    tcp.buffer = 4KB
   }
 
   ## MQTT/SSL - SSL Listener for MQTT Protocol
-  listeners.mqtt_ssl:
+  listeners.mqtt_ssl
   #${example_common_tcp_options} ${example_common_ssl_options} # common options can be written in a separate config entry and reference it from here.
   {
 
@@ -700,7 +700,7 @@ zones.default {
     ##   - ws:   MQTT over Websocket
     ##   - quic: MQTT over QUIC
     ## Required: true
-    type: tcp
+    type = tcp
 
     ## The IP address and port that the listener will bind.
     ##
@@ -708,21 +708,21 @@ zones.default {
     ## ValueType: IPAddress | Port | IPAddrPort
     ## Required: true
     ## Examples: 8883, 127.0.0.1:8883, ::1:8883
-    bind: "0.0.0.0:8883"
+    bind = "0.0.0.0:8883"
 
     ## The size of the acceptor pool for this listener.
     ##
     ## @doc zones.<name>.listeners.<name>.acceptors
     ## ValueType: Number
     ## Default: 16
-    acceptors: 16
+    acceptors = 16
 
     ## Maximum number of concurrent connections.
     ##
     ## @doc zones.<name>.listeners.<name>.max_connections
     ## ValueType: Number | infinity
     ## Default: infinity
-    max_connections: 512000
+    max_connections = 512000
 
     ## The access control rules for this listener.
     ##
@@ -736,7 +736,7 @@ zones.default {
     ##     "deny 192.168.0.0/24",
     ##     "all all"
     ##   ]
-    access_rules: [
+    access_rules = [
       "allow all"
     ]
 
@@ -748,7 +748,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol
     ## ValueType: Boolean
     ## Default: true
-    proxy_protocol: false
+    proxy_protocol = false
 
     ## Sets the timeout for proxy protocol. EMQ X will close the TCP connection
     ## if no proxy protocol packet recevied within the timeout.
@@ -756,7 +756,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol_timeout
     ## ValueType: Duration
     ## Default: 3s
-    proxy_protocol_timeout: 3s
+    proxy_protocol_timeout = 3s
 
     rate_limit {
       ## Maximum connections per second.
@@ -766,7 +766,7 @@ zones.default {
       ## Default: 1000
       ## Examples:
       ##   max_conn_rate: 1000
-      max_conn_rate: 1000
+      max_conn_rate = 1000
 
       ## Message limit for the a external MQTT connection.
       ##
@@ -775,7 +775,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messages per 10 seconds.
       ##   conn_messages_in: "100,10s"
-      conn_messages_in: "100,10s"
+      conn_messages_in = "100,10s"
 
       ## Limit the rate of receiving packets for a MQTT connection.
       ## The rate is counted by bytes of packets per second.
@@ -789,7 +789,7 @@ zones.default {
       ## Examples: 100KB incoming per 10 seconds.
       ##   conn_bytes_in: "100KB,10s"
       ##
-      conn_bytes_in: "100KB,10s"
+      conn_bytes_in = "100KB,10s"
 
       ## Messages quota for the each of external MQTT connection.
       ## This value consumed by the number of recipient on a message.
@@ -799,7 +799,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messaegs per 1s:
       ##   quota.conn_messages_routing: "100,1s"
-      quota.conn_messages_routing: "100,1s"
+      quota.conn_messages_routing = "100,1s"
 
       ## Messages quota for the all of external MQTT connections.
       ## This value consumed by the number of recipient on a message.
@@ -810,24 +810,24 @@ zones.default {
       ## Examples: 200000 messages per 1s:
       ##    quota.overall_messages_routing: "200000,1s"
       ##
-      quota.overall_messages_routing: "200000,1s"
+      quota.overall_messages_routing = "200000,1s"
     }
 
     ## SSL options
     ## See ${example_common_ssl_options} for more information
-    ssl.enable: true
-    ssl.versions: ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
-    ssl.keyfile: "{{ platform_etc_dir }}/certs/key.pem"
-    ssl.certfile: "{{ platform_etc_dir }}/certs/cert.pem"
-    ssl.cacertfile: "{{ platform_etc_dir }}/certs/cacert.pem"
+    ssl.enable = true
+    ssl.versions = ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
+    ssl.keyfile = "{{ platform_etc_dir }}/certs/key.pem"
+    ssl.certfile = "{{ platform_etc_dir }}/certs/cert.pem"
+    ssl.cacertfile = "{{ platform_etc_dir }}/certs/cacert.pem"
 
     ## TCP options
     ## See ${example_common_tcp_options} for more information
-    tcp.backlog: 1024
-    tcp.buffer: 4KB
+    tcp.backlog = 1024
+    tcp.buffer = 4KB
   }
 
-  listeners.mqtt_quic:
+  listeners.mqtt_quic
   {
     ## The type of the listener.
     ##
@@ -837,7 +837,7 @@ zones.default {
     ##   - ws:   MQTT over Websocket
     ##   - quic: MQTT over QUIC
     ## Required: true
-    type: quic
+    type = quic
 
     ## The IP address and port that the listener will bind.
     ##
@@ -845,38 +845,38 @@ zones.default {
     ## ValueType: IPAddress | Port | IPAddrPort
     ## Required: true
     ## Examples: 14567, 127.0.0.1:14567, ::1:14567
-    bind: "0.0.0.0:14567"
+    bind = "0.0.0.0:14567"
 
     ## The size of the acceptor pool for this listener.
     ##
     ## @doc zones.<name>.listeners.<name>.acceptors
     ## ValueType: Number
     ## Default: 16
-    acceptors: 16
+    acceptors = 16
 
     ## Maximum number of concurrent connections.
     ##
     ## @doc zones.<name>.listeners.<name>.max_connections
     ## ValueType: Number | infinity
     ## Default: infinity
-    max_connections: 1024000
+    max_connections = 1024000
 
     ## Path to the file containing the user's private PEM-encoded key.
     ##
     ## @doc zones.<name>.listeners.<name>.keyfile
     ## ValueType: String
     ## Default: "{{ platform_etc_dir }}/certs/key.pem"
-    keyfile: "{{ platform_etc_dir }}/certs/key.pem"
+    keyfile = "{{ platform_etc_dir }}/certs/key.pem"
 
     ## Path to a file containing the user certificate.
     ##
     ## @doc zones.<name>.listeners.<name>.certfile
     ## ValueType: String
     ## Default: "{{ platform_etc_dir }}/certs/cert.pem"
-    certfile: "{{ platform_etc_dir }}/certs/cert.pem"
+    certfile = "{{ platform_etc_dir }}/certs/cert.pem"
   }
 
-  listeners.mqtt_ws:
+  listeners.mqtt_ws
   #${example_common_tcp_options} ${example_common_websocket_options} # common options can be written in a separate config entry and reference it from here.
   {
 
@@ -888,7 +888,7 @@ zones.default {
     ##   - ws:   MQTT over Websocket
     ##   - quic: MQTT over QUIC
     ## Required: true
-    type: ws
+    type = ws
 
     ## The IP address and port that the listener will bind.
     ##
@@ -896,21 +896,21 @@ zones.default {
     ## ValueType: IPAddress | Port | IPAddrPort
     ## Required: true
     ## Examples: 8083, 127.0.0.1:8083, ::1:8083
-    bind: "0.0.0.0:8083"
+    bind = "0.0.0.0:8083"
 
     ## The size of the acceptor pool for this listener.
     ##
     ## @doc zones.<name>.listeners.<name>.acceptors
     ## ValueType: Number
     ## Default: 16
-    acceptors: 16
+    acceptors = 16
 
     ## Maximum number of concurrent connections.
     ##
     ## @doc zones.<name>.listeners.<name>.max_connections
     ## ValueType: Number | infinity
     ## Default: infinity
-    max_connections: 1024000
+    max_connections = 1024000
 
     ## The access control rules for this listener.
     ##
@@ -924,7 +924,7 @@ zones.default {
     ##     "deny 192.168.0.0/24",
     ##     "all all"
     ##   ]
-    access_rules: [
+    access_rules = [
       "allow all"
     ]
 
@@ -936,7 +936,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol
     ## ValueType: Boolean
     ## Default: true
-    proxy_protocol: false
+    proxy_protocol = false
 
     ## Sets the timeout for proxy protocol. EMQ X will close the TCP connection
     ## if no proxy protocol packet recevied within the timeout.
@@ -944,7 +944,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol_timeout
     ## ValueType: Duration
     ## Default: 3s
-    proxy_protocol_timeout: 3s
+    proxy_protocol_timeout = 3s
 
     rate_limit {
       ## Maximum connections per second.
@@ -954,7 +954,7 @@ zones.default {
       ## Default: 1000
       ## Examples:
       ##   max_conn_rate: 1000
-      max_conn_rate: 1000
+      max_conn_rate = 1000
 
       ## Message limit for the a external MQTT connection.
       ##
@@ -963,7 +963,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messages per 10 seconds.
       ##   conn_messages_in: "100,10s"
-      conn_messages_in: "100,10s"
+      conn_messages_in = "100,10s"
 
       ## Limit the rate of receiving packets for a MQTT connection.
       ## The rate is counted by bytes of packets per second.
@@ -977,7 +977,7 @@ zones.default {
       ## Examples: 100KB incoming per 10 seconds.
       ##   conn_bytes_in: "100KB,10s"
       ##
-      conn_bytes_in: "100KB,10s"
+      conn_bytes_in = "100KB,10s"
 
       ## Messages quota for the each of external MQTT connection.
       ## This value consumed by the number of recipient on a message.
@@ -987,7 +987,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messaegs per 1s:
       ##   quota.conn_messages_routing: "100,1s"
-      quota.conn_messages_routing: "100,1s"
+      quota.conn_messages_routing = "100,1s"
 
       ## Messages quota for the all of external MQTT connections.
       ## This value consumed by the number of recipient on a message.
@@ -998,20 +998,20 @@ zones.default {
       ## Examples: 200000 messages per 1s:
       ##    quota.overall_messages_routing: "200000,1s"
       ##
-      quota.overall_messages_routing: "200000,1s"
+      quota.overall_messages_routing = "200000,1s"
     }
 
     ## TCP options
     ## See ${example_common_tcp_options} for more information
-    tcp.backlog: 1024
-    tcp.buffer: 4KB
+    tcp.backlog = 1024
+    tcp.buffer = 4KB
 
     ## Websocket options
     ## See ${example_common_websocket_options} for more information
-    websocket.idle_timeout: 86400s
+    websocket.idle_timeout = 86400s
   }
 
-  listeners.mqtt_wss:
+  listeners.mqtt_wss
   #${example_common_tcp_options} ${example_common_ssl_options} ${example_common_websocket_options} # common options can be written in a separate config entry and reference it from here.
   {
 
@@ -1023,7 +1023,7 @@ zones.default {
     ##   - ws:   MQTT over Websocket
     ##   - quic: MQTT over QUIC
     ## Required: true
-    type: ws
+    type = ws
 
     ## The IP address and port that the listener will bind.
     ##
@@ -1031,21 +1031,21 @@ zones.default {
     ## ValueType: IPAddress | Port | IPAddrPort
     ## Required: true
     ## Examples: 8084, 127.0.0.1:8084, ::1:8084
-    bind: "0.0.0.0:8084"
+    bind = "0.0.0.0:8084"
 
     ## The size of the acceptor pool for this listener.
     ##
     ## @doc zones.<name>.listeners.<name>.acceptors
     ## ValueType: Number
     ## Default: 16
-    acceptors: 16
+    acceptors = 16
 
     ## Maximum number of concurrent connections.
     ##
     ## @doc zones.<name>.listeners.<name>.max_connections
     ## ValueType: Number | infinity
     ## Default: infinity
-    max_connections: 512000
+    max_connections = 512000
 
     ## The access control rules for this listener.
     ##
@@ -1059,7 +1059,7 @@ zones.default {
     ##     "deny 192.168.0.0/24",
     ##     "all all"
     ##   ]
-    access_rules: [
+    access_rules = [
       "allow all"
     ]
 
@@ -1071,7 +1071,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol
     ## ValueType: Boolean
     ## Default: true
-    proxy_protocol: false
+    proxy_protocol = false
 
     ## Sets the timeout for proxy protocol. EMQ X will close the TCP connection
     ## if no proxy protocol packet recevied within the timeout.
@@ -1079,7 +1079,7 @@ zones.default {
     ## @doc zones.<name>.listeners.<name>.proxy_protocol_timeout
     ## ValueType: Duration
     ## Default: 3s
-    proxy_protocol_timeout: 3s
+    proxy_protocol_timeout = 3s
 
     rate_limit {
       ## Maximum connections per second.
@@ -1089,7 +1089,7 @@ zones.default {
       ## Default: 1000
       ## Examples:
       ##   max_conn_rate: 1000
-      max_conn_rate: 1000
+      max_conn_rate = 1000
 
       ## Message limit for the a external MQTT connection.
       ##
@@ -1098,7 +1098,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messages per 10 seconds.
       ##   conn_messages_in: "100,10s"
-      conn_messages_in: "100,10s"
+      conn_messages_in = "100,10s"
 
       ## Limit the rate of receiving packets for a MQTT connection.
       ## The rate is counted by bytes of packets per second.
@@ -1112,7 +1112,7 @@ zones.default {
       ## Examples: 100KB incoming per 10 seconds.
       ##   conn_bytes_in: "100KB,10s"
       ##
-      conn_bytes_in: "100KB,10s"
+      conn_bytes_in = "100KB,10s"
 
       ## Messages quota for the each of external MQTT connection.
       ## This value consumed by the number of recipient on a message.
@@ -1122,7 +1122,7 @@ zones.default {
       ## Default: infinity
       ## Examples: 100 messaegs per 1s:
       ##   quota.conn_messages_routing: "100,1s"
-      quota.conn_messages_routing: "100,1s"
+      quota.conn_messages_routing = "100,1s"
 
       ## Messages quota for the all of external MQTT connections.
       ## This value consumed by the number of recipient on a message.
@@ -1133,24 +1133,24 @@ zones.default {
       ## Examples: 200000 messages per 1s:
       ##    quota.overall_messages_routing: "200000,1s"
       ##
-      quota.overall_messages_routing: "200000,1s"
+      quota.overall_messages_routing = "200000,1s"
     }
 
     ## SSL options
     ## See ${example_common_ssl_options} for more information
-    ssl.enable: true
-    ssl.keyfile: "{{ platform_etc_dir }}/certs/key.pem"
-    ssl.certfile: "{{ platform_etc_dir }}/certs/cert.pem"
-    ssl.cacertfile: "{{ platform_etc_dir }}/certs/cacert.pem"
+    ssl.enable = true
+    ssl.keyfile = "{{ platform_etc_dir }}/certs/key.pem"
+    ssl.certfile = "{{ platform_etc_dir }}/certs/cert.pem"
+    ssl.cacertfile = "{{ platform_etc_dir }}/certs/cacert.pem"
 
     ## TCP options
     ## See ${example_common_tcp_options} for more information
-    tcp.backlog: 1024
-    tcp.buffer: 4KB
+    tcp.backlog = 1024
+    tcp.buffer = 4KB
 
     ## Websocket options
     ## See ${example_common_websocket_options} for more information
-    websocket.idle_timeout: 86400s
+    websocket.idle_timeout = 86400s
   }
 
 }
@@ -1158,15 +1158,15 @@ zones.default {
 #This is an example zone which has less "strict" settings.
 #It's useful to clients connecting the broker from trusted networks.
 zones.internal {
-  authorization.enable: true
-  auth.enable: false
-  listeners.mqtt_internal: {
-    type: tcp
-    bind: "127.0.0.1:11883"
-    acceptors: 4
-    max_connections: 1024000
-    tcp.active_n: 1000
-    tcp.backlog: 512
+  authorization.enable = true
+  auth.enable = false
+  listeners.mqtt_internal {
+    type = tcp
+    bind = "127.0.0.1:11883"
+    acceptors = 4
+    max_connections = 1024000
+    tcp.active_n = 1000
+    tcp.backlog = 512
   }
 }
 
@@ -1179,21 +1179,21 @@ sysmon {
   ## @doc sysmon.vm.process_check_interval
   ## ValueType: Duration
   ## Default: 30s
-  vm.process_check_interval: 30s
+  vm.process_check_interval = 30s
 
   ## The threshold, as percentage of processes, for how many processes can simultaneously exist at the local node before the corresponding alarm is set.
   ##
   ## @doc sysmon.vm.process_high_watermark
   ## ValueType: Percentage
   ## Default: 80%
-  vm.process_high_watermark: 80%
+  vm.process_high_watermark = 80%
 
   ## The threshold, as percentage of processes, for how many processes can simultaneously exist at the local node before the corresponding alarm is clear.
   ##
   ## @doc sysmon.vm.process_low_watermark
   ## ValueType: Percentage
   ## Default: 60%
-  vm.process_low_watermark: 60%
+  vm.process_low_watermark = 60%
 
   ## Enable Long GC monitoring.
   ## Notice: don't enable the monitor in production for:
@@ -1202,7 +1202,7 @@ sysmon {
   ## @doc sysmon.vm.long_gc
   ## ValueType: Duration | disabled
   ## Default: disabled
-  vm.long_gc: disabled
+  vm.long_gc = disabled
 
   ## Enable Long Schedule(ms) monitoring.
   ##
@@ -1211,7 +1211,7 @@ sysmon {
   ## @doc sysmon.vm.long_schedule
   ## ValueType: Duration | disabled
   ## Default: disabled
-  vm.long_schedule: 240ms
+  vm.long_schedule = 240ms
 
   ## Enable Large Heap monitoring.
   ##
@@ -1220,7 +1220,7 @@ sysmon {
   ## @doc sysmon.vm.large_heap
   ## ValueType: Size | disabled
   ## Default: 32MB
-  vm.large_heap: 32MB
+  vm.large_heap = 32MB
 
   ## Enable Busy Port monitoring.
   ##
@@ -1229,7 +1229,7 @@ sysmon {
   ## @doc sysmon.vm.busy_port
   ## ValueType: Boolean
   ## Default: true
-  vm.busy_port: true
+  vm.busy_port = true
 
   ## Enable Busy Dist Port monitoring.
   ##
@@ -1238,49 +1238,49 @@ sysmon {
   ## @doc sysmon.vm.busy_dist_port
   ## ValueType: Boolean
   ## Default: true
-  vm.busy_dist_port: true
+  vm.busy_dist_port = true
 
   ## The time interval for the periodic cpu check
   ##
   ## @doc sysmon.os.cpu_check_interval
   ## ValueType: Duration
   ## Default: 60s
-  os.cpu_check_interval: 60s
+  os.cpu_check_interval = 60s
 
   ## The threshold, as percentage of system cpu, for how much system cpu can be used before the corresponding alarm is set.
   ##
   ## @doc sysmon.os.cpu_high_watermark
   ## ValueType: Percentage
   ## Default: 80%
-  os.cpu_high_watermark: 80%
+  os.cpu_high_watermark = 80%
 
   ## The threshold, as percentage of system cpu, for how much system cpu can be used before the corresponding alarm is clear.
   ##
   ## @doc sysmon.os.cpu_low_watermark
   ## ValueType: Percentage
   ## Default: 60%
-  os.cpu_low_watermark: 60%
+  os.cpu_low_watermark = 60%
 
   ## The time interval for the periodic memory check
   ##
   ## @doc sysmon.os.mem_check_interval
   ## ValueType: Duration | disabled
   ## Default: 60s
-  os.mem_check_interval: 60s
+  os.mem_check_interval = 60s
 
   ## The threshold, as percentage of system memory, for how much system memory can be allocated before the corresponding alarm is set.
   ##
   ## @doc sysmon.os.sysmem_high_watermark
   ## ValueType: Percentage
   ## Default: 70%
-  os.sysmem_high_watermark: 70%
+  os.sysmem_high_watermark = 70%
 
   ## The threshold, as percentage of system memory, for how much system memory can be allocated by one Erlang process before the corresponding alarm is set.
   ##
   ## @doc sysmon.os.procmem_high_watermark
   ## ValueType: Percentage
   ## Default: 5%
-  os.procmem_high_watermark: 5%
+  os.procmem_high_watermark = 5%
 }
 
 ##==================================================================
@@ -1292,21 +1292,21 @@ alarm {
   ## @doc alarm.actions
   ## ValueType: Array<AlarmAction>
   ## Default: [log, publish]
-  actions: [log, publish]
+  actions = [log, publish]
 
   ## The maximum number of deactivated alarms
   ##
   ## @doc alarm.size_limit
   ## ValueType: Integer
   ## Default: 1000
-  size_limit: 1000
+  size_limit = 1000
 
   ## Validity Period of deactivated alarms
   ##
   ## @doc alarm.validity_period
   ## ValueType: Duration
   ## Default: 24h
-  validity_period: 24h
+  validity_period = 24h
 }
 
 ## Config references for listeners
@@ -1321,7 +1321,7 @@ example_common_tcp_options {
   ## @doc listeners.<name>.tcp.active_n
   ## ValueType: Number
   ## Default: 100
-  tcp.active_n: 100
+  tcp.active_n = 100
 
   ## TCP backlog defines the maximum length that the queue of
   ## pending connections can grow to.
@@ -1330,21 +1330,21 @@ example_common_tcp_options {
   ## ValueType: Number
   ## Range: [0, 1048576]
   ## Default: 1024
-  tcp.backlog: 1024
+  tcp.backlog = 1024
 
   ## The TCP send timeout for the connections.
   ##
   ## @doc listeners.<name>.tcp.send_timeout
   ## ValueType: Duration
   ## Default: 15s
-  tcp.send_timeout: 15s
+  tcp.send_timeout = 15s
 
   ## Close the connection if send timeout.
   ##
   ## @doc listeners.<name>.tcp.send_timeout_close
   ## ValueType: Boolean
   ## Default: true
-  tcp.send_timeout_close: true
+  tcp.send_timeout_close = true
 
   ## The TCP receive buffer(os kernel) for the connections.
   ##
@@ -1373,21 +1373,21 @@ example_common_tcp_options {
   ## @doc listeners.<name>.tcp.high_watermark
   ## ValueType: Size
   ## Default: 1MB
-  tcp.high_watermark: 1MB
+  tcp.high_watermark = 1MB
 
   ## The TCP_NODELAY flag for the connections.
   ##
   ## @doc listeners.<name>.tcp.nodelay
   ## ValueType: Boolean
   ## Default: false
-  tcp.nodelay: false
+  tcp.nodelay = false
 
   ## The SO_REUSEADDR flag for the connections.
   ##
   ## @doc listeners.<name>.tcp.reuseaddr
   ## ValueType: Boolean
   ## Default: true
-  tcp.reuseaddr: true
+  tcp.reuseaddr = true
 }
 
 ## Socket options for SSL connections
@@ -1401,7 +1401,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.reuse_sessions
   ## ValueType: Boolean
   ## Default: true
-  ssl.reuse_sessions: true
+  ssl.reuse_sessions = true
 
   ## SSL parameter renegotiation is a feature that allows a client and a server
   ## to renegotiate the parameters of the SSL connection on the fly.
@@ -1411,7 +1411,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.secure_renegotiate
   ## ValueType: Boolean
   ## Default: true
-  ssl.secure_renegotiate: true
+  ssl.secure_renegotiate = true
 
   ## An important security setting, it forces the cipher to be set based
   ## on the server-specified order instead of the client-specified order,
@@ -1421,21 +1421,21 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.honor_cipher_order
   ## ValueType: Boolean
   ## Default: true
-  ssl.honor_cipher_order: true
+  ssl.honor_cipher_order = true
 
   ## TLS versions only to protect from POODLE attack.
   ##
   ## @doc listeners.<name>.ssl.versions
   ## ValueType: Array<TLSVersion>
   ## Default: ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
-  ssl.versions: ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
+  ssl.versions = ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
 
   ## TLS Handshake timeout.
   ##
   ## @doc listeners.<name>.ssl.handshake_timeout
   ## ValueType: Duration
   ## Default: 15s
-  ssl.handshake_timeout: 15s
+  ssl.handshake_timeout = 15s
 
   ## Maximum number of non-self-issued intermediate certificates that
   ## can follow the peer certificate in a valid certification path.
@@ -1443,21 +1443,21 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.depth
   ## ValueType: Integer
   ## Default: 10
-  ssl.depth: 10
+  ssl.depth = 10
 
   ## Path to the file containing the user's private PEM-encoded key.
   ##
   ## @doc listeners.<name>.ssl.keyfile
   ## ValueType: File
   ## Default: "{{ platform_etc_dir }}/certs/key.pem"
-  ssl.keyfile: "{{ platform_etc_dir }}/certs/key.pem"
+  ssl.keyfile = "{{ platform_etc_dir }}/certs/key.pem"
 
   ## Path to a file containing the user certificate.
   ##
   ## @doc listeners.<name>.ssl.certfile
   ## ValueType: File
   ## Default: "{{ platform_etc_dir }}/certs/cert.pem"
-  ssl.certfile: "{{ platform_etc_dir }}/certs/cert.pem"
+  ssl.certfile = "{{ platform_etc_dir }}/certs/cert.pem"
 
   ## Path to the file containing PEM-encoded CA certificates. The CA certificates
   ## are used during server authentication and when building the client certificate chain.
@@ -1465,7 +1465,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.cacertfile
   ## ValueType: File
   ## Default: "{{ platform_etc_dir }}/certs/cacert.pem"
-  ssl.cacertfile: "{{ platform_etc_dir }}/certs/cacert.pem"
+  ssl.cacertfile = "{{ platform_etc_dir }}/certs/cacert.pem"
 
   ## Maximum number of non-self-issued intermediate certificates that
   ## can follow the peer certificate in a valid certification path.
@@ -1473,7 +1473,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.depth
   ## ValueType: Number
   ## Default: 10
-  ssl.depth: 10
+  ssl.depth = 10
 
   ## String containing the user's password. Only used if the private keyfile
   ## is password-protected.
@@ -1513,7 +1513,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.verify
   ## ValueType: verify_peer | verify_none
   ## Default: verify_none
-  ssl.verify: verify_none
+  ssl.verify = verify_none
 
   ## Used together with {verify, verify_peer} by an SSL server. If set to true,
   ## the server fails if the client does not have a certificate to send, that is,
@@ -1522,7 +1522,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.fail_if_no_peer_cert
   ## ValueType: Boolean
   ## Default: true
-  ssl.fail_if_no_peer_cert: false
+  ssl.fail_if_no_peer_cert = false
 
   ## This is the single most important configuration option of an Erlang SSL
   ## application. Ciphers (and their ordering) define the way the client and
@@ -1543,7 +1543,7 @@ example_common_ssl_options {
   ## @doc listeners.<name>.ssl.ciphers
   ## ValueType: Array<Cipher>
   ## Default: [ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES256-SHA384,ECDHE-RSA-AES256-SHA384,ECDHE-ECDSA-DES-CBC3-SHA,ECDH-ECDSA-AES256-GCM-SHA384,ECDH-RSA-AES256-GCM-SHA384,ECDH-ECDSA-AES256-SHA384,ECDH-RSA-AES256-SHA384,DHE-DSS-AES256-GCM-SHA384,DHE-DSS-AES256-SHA256,AES256-GCM-SHA384,AES256-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES128-SHA256,ECDHE-RSA-AES128-SHA256,ECDH-ECDSA-AES128-GCM-SHA256,ECDH-RSA-AES128-GCM-SHA256,ECDH-ECDSA-AES128-SHA256,ECDH-RSA-AES128-SHA256,DHE-DSS-AES128-GCM-SHA256,DHE-DSS-AES128-SHA256,AES128-GCM-SHA256,AES128-SHA256,ECDHE-ECDSA-AES256-SHA,ECDHE-RSA-AES256-SHA,DHE-DSS-AES256-SHA,ECDH-ECDSA-AES256-SHA,ECDH-RSA-AES256-SHA,AES256-SHA,ECDHE-ECDSA-AES128-SHA,ECDHE-RSA-AES128-SHA,DHE-DSS-AES128-SHA,ECDH-ECDSA-AES128-SHA,ECDH-RSA-AES128-SHA,AES128-SHA,PSK-AES128-CBC-SHA,PSK-AES256-CBC-SHA,PSK-3DES-EDE-CBC-SHA,PSK-RC4-SHA]
-  ssl.ciphers: [ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES256-SHA384,ECDHE-RSA-AES256-SHA384,ECDHE-ECDSA-DES-CBC3-SHA,ECDH-ECDSA-AES256-GCM-SHA384,ECDH-RSA-AES256-GCM-SHA384,ECDH-ECDSA-AES256-SHA384,ECDH-RSA-AES256-SHA384,DHE-DSS-AES256-GCM-SHA384,DHE-DSS-AES256-SHA256,AES256-GCM-SHA384,AES256-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES128-SHA256,ECDHE-RSA-AES128-SHA256,ECDH-ECDSA-AES128-GCM-SHA256,ECDH-RSA-AES128-GCM-SHA256,ECDH-ECDSA-AES128-SHA256,ECDH-RSA-AES128-SHA256,DHE-DSS-AES128-GCM-SHA256,DHE-DSS-AES128-SHA256,AES128-GCM-SHA256,AES128-SHA256,ECDHE-ECDSA-AES256-SHA,ECDHE-RSA-AES256-SHA,DHE-DSS-AES256-SHA,ECDH-ECDSA-AES256-SHA,ECDH-RSA-AES256-SHA,AES256-SHA,ECDHE-ECDSA-AES128-SHA,ECDHE-RSA-AES128-SHA,DHE-DSS-AES128-SHA,ECDH-ECDSA-AES128-SHA,ECDH-RSA-AES128-SHA,AES128-SHA,PSK-AES128-CBC-SHA,PSK-AES256-CBC-SHA,PSK-3DES-EDE-CBC-SHA,PSK-RC4-SHA]
+  ssl.ciphers = [ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES256-SHA384,ECDHE-RSA-AES256-SHA384,ECDHE-ECDSA-DES-CBC3-SHA,ECDH-ECDSA-AES256-GCM-SHA384,ECDH-RSA-AES256-GCM-SHA384,ECDH-ECDSA-AES256-SHA384,ECDH-RSA-AES256-SHA384,DHE-DSS-AES256-GCM-SHA384,DHE-DSS-AES256-SHA256,AES256-GCM-SHA384,AES256-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES128-SHA256,ECDHE-RSA-AES128-SHA256,ECDH-ECDSA-AES128-GCM-SHA256,ECDH-RSA-AES128-GCM-SHA256,ECDH-ECDSA-AES128-SHA256,ECDH-RSA-AES128-SHA256,DHE-DSS-AES128-GCM-SHA256,DHE-DSS-AES128-SHA256,AES128-GCM-SHA256,AES128-SHA256,ECDHE-ECDSA-AES256-SHA,ECDHE-RSA-AES256-SHA,DHE-DSS-AES256-SHA,ECDH-ECDSA-AES256-SHA,ECDH-RSA-AES256-SHA,AES256-SHA,ECDHE-ECDSA-AES128-SHA,ECDHE-RSA-AES128-SHA,DHE-DSS-AES128-SHA,ECDH-ECDSA-AES128-SHA,ECDH-RSA-AES128-SHA,AES128-SHA,PSK-AES128-CBC-SHA,PSK-AES256-CBC-SHA,PSK-3DES-EDE-CBC-SHA,PSK-RC4-SHA]
 
 }
 
@@ -1554,14 +1554,14 @@ example_common_websocket_options {
   ## @doc listeners.<name>.websocket.mqtt_path
   ## ValueType: Path
   ## Default: "/mqtt"
-  websocket.mqtt_path: "/mqtt"
+  websocket.mqtt_path = "/mqtt"
 
   ## Whether a WebSocket message is allowed to contain multiple MQTT packets
   ##
   ## @doc listeners.<name>.websocket.mqtt_piggyback
   ## ValueType: single | multiple
   ## Default: multiple
-  websocket.mqtt_piggyback: multiple
+  websocket.mqtt_piggyback = multiple
 
   ## The compress flag for external WebSocket connections.
   ##
@@ -1570,21 +1570,21 @@ example_common_websocket_options {
   ## @doc listeners.<name>.websocket.compress
   ## ValueType: Boolean
   ## Default: false
-  websocket.compress: false
+  websocket.compress = false
 
   ## The idle timeout for external WebSocket connections.
   ##
   ## @doc listeners.<name>.websocket.idle_timeout
   ## ValueType: Duration | infinity
   ## Default: infinity
-  websocket.idle_timeout: infinity
+  websocket.idle_timeout = infinity
 
   ## The max frame size for external WebSocket connections.
   ##
   ## @doc listeners.<name>.websocket.max_frame_size
   ## ValueType: Size
   ## Default: infinity
-  websocket.max_frame_size: infinity
+  websocket.max_frame_size = infinity
 
   ## If set to true, the server fails if the client does not
   ## have a Sec-WebSocket-Protocol to send.
@@ -1593,21 +1593,21 @@ example_common_websocket_options {
   ## @doc listeners.<name>.websocket.fail_if_no_subprotocol
   ## ValueType: Boolean
   ## Default: true
-  websocket.fail_if_no_subprotocol: true
+  websocket.fail_if_no_subprotocol = true
 
   ## Supported subprotocols
   ##
   ## @doc listeners.<name>.websocket.supported_subprotocols
   ## ValueType: String
   ## Default: mqtt, mqtt-v3, mqtt-v3.1.1, mqtt-v5
-  websocket.supported_subprotocols: "mqtt, mqtt-v3, mqtt-v3.1.1, mqtt-v5"
+  websocket.supported_subprotocols = "mqtt, mqtt-v3, mqtt-v3.1.1, mqtt-v5"
 
   ## Enable origin check in header for websocket connection
   ##
   ## @doc listeners.<name>.websocket.check_origin_enable
   ## ValueType: Boolean
   ## Default: false
-  websocket.check_origin_enable: false
+  websocket.check_origin_enable = false
 
   ## Allow origin to be absent in header in websocket connection
   ## when check_origin_enable is true
@@ -1615,7 +1615,7 @@ example_common_websocket_options {
   ## @doc listeners.<name>.websocket.allow_origin_absence
   ## ValueType: Boolean
   ## Default: true
-  websocket.allow_origin_absence: true
+  websocket.allow_origin_absence = true
 
   ## Comma separated list of allowed origin in header for websocket connection
   ##
@@ -1625,7 +1625,7 @@ example_common_websocket_options {
   ##  local http dashboard url
   ## check_origins: "http://localhost:18083, http://127.0.0.1:18083"
   ## Default: ""
-  websocket.check_origins: "http://localhost:18083, http://127.0.0.1:18083"
+  websocket.check_origins = "http://localhost:18083, http://127.0.0.1:18083"
 
   ## Specify which HTTP header for real source IP if the EMQ X cluster is
   ## deployed behind NGINX or HAProxy.
@@ -1633,7 +1633,7 @@ example_common_websocket_options {
   ## @doc listeners.<name>.websocket.proxy_address_header
   ## ValueType: String
   ## Default: X-Forwarded-For
-  websocket.proxy_address_header: X-Forwarded-For
+  websocket.proxy_address_header = X-Forwarded-For
 
   ## Specify which HTTP header for real source port if the EMQ X cluster is
   ## deployed behind NGINX or HAProxy.
@@ -1641,7 +1641,7 @@ example_common_websocket_options {
   ## @doc listeners.<name>.websocket.proxy_port_header
   ## ValueType: String
   ## Default: X-Forwarded-Port
-  websocket.proxy_port_header: X-Forwarded-Port
+  websocket.proxy_port_header = X-Forwarded-Port
 
   websocket.deflate_opts {
     ## The level of deflate options for external WebSocket connections.
@@ -1649,7 +1649,7 @@ example_common_websocket_options {
     ## @doc listeners.<name>.websocket.deflate_opts.level
     ## ValueType: none | default | best_compression | best_speed
     ## Default: default
-    level: default
+    level = default
 
     ## The mem_level of deflate options for external WebSocket connections.
     ##
@@ -1657,28 +1657,28 @@ example_common_websocket_options {
     ## ValueType: Integer
     ## Range: [1,9]
     ## Default: 8
-    mem_level: 8
+    mem_level = 8
 
     ## The strategy of deflate options for external WebSocket connections.
     ##
     ## @doc listeners.<name>.websocket.deflate_opts.strategy
     ## ValueType: default | filtered | huffman_only | rle
     ## Default: default
-    strategy: default
+    strategy = default
 
     ## The deflate option for external WebSocket connections.
     ##
     ## @doc listeners.<name>.websocket.deflate_opts.server_context_takeover
     ## ValueType: takeover | no_takeover
     ## Default: takeover
-    server_context_takeover: takeover
+    server_context_takeover = takeover
 
     ## The deflate option for external WebSocket connections.
     ##
     ## @doc listeners.<name>.websocket.deflate_opts.client_context_takeover
     ## ValueType: takeover | no_takeover
     ## Default: takeover
-    client_context_takeover: takeover
+    client_context_takeover = takeover
 
     ## The deflate options for external WebSocket connections.
     ##
@@ -1687,7 +1687,7 @@ example_common_websocket_options {
     ## ValueType: Integer
     ## Range: [8,15]
     ## Default: 15
-    server_max_window_bits: 15
+    server_max_window_bits = 15
 
     ## The deflate options for external WebSocket connections.
     ##
@@ -1695,6 +1695,6 @@ example_common_websocket_options {
     ## ValueType: Integer
     ## Range: [8,15]
     ## Default: 15
-    client_max_window_bits: 15
+    client_max_window_bits = 15
   }
 }

--- a/apps/emqx/test/emqx_plugins_SUITE_data/emqx_hocon_plugin/etc/emqx_hocon_plugin.conf
+++ b/apps/emqx/test/emqx_plugins_SUITE_data/emqx_hocon_plugin/etc/emqx_hocon_plugin.conf
@@ -1,3 +1,3 @@
-emqx_hocon_plugin: {
-    name: test
+emqx_hocon_plugin {
+    name = test
 }

--- a/apps/emqx_authn/etc/emqx_authn.conf
+++ b/apps/emqx_authn/etc/emqx_authn.conf
@@ -1,6 +1,6 @@
-authentication: {
-    enable: false
-    authenticators: [
+authentication {
+    enable = false
+    authenticators = [
         # {
         #     name: "authenticator1"
         #     mechanism: password-based

--- a/apps/emqx_authz/etc/emqx_authz.conf
+++ b/apps/emqx_authz/etc/emqx_authz.conf
@@ -1,5 +1,5 @@
-authorization:{
-    rules: [
+authorization {
+    rules = [
        # {
        #      type: http
        #      config: {
@@ -66,9 +66,9 @@ authorization:{
        #     find: { "$or": [ { "username": "%u" }, { "clientid": "%c" } ] }
        # },
        {
-           permission: allow
-           action: all
-           topics: ["#"]
+           permission = allow
+           action = all
+           topics = ["#"]
        }
     ]
 }

--- a/apps/emqx_bridge_mqtt/etc/emqx_bridge_mqtt.conf
+++ b/apps/emqx_bridge_mqtt/etc/emqx_bridge_mqtt.conf
@@ -2,7 +2,7 @@
 ## Configuration for EMQ X MQTT Broker Bridge
 ##====================================================================
 
-emqx_bridge_mqtt:{
+emqx_bridge_mqtt {
     bridges:[
         # {
         #     name: "mqtt1"
@@ -11,13 +11,13 @@ emqx_bridge_mqtt:{
         #     forward_mountpoint: ""
         #     reconnect_interval: "30s"
         #     batch_size: 100
-        #     queue:{
+        #     queue {
         #         replayq_dir: "{{ platform_data_dir }}/replayq/bridge_mqtt/"
         #         replayq_seg_bytes: "100MB"
         #         replayq_offload_mode: false
         #         replayq_max_total_bytes: "1GB"
         #     },
-        #     config:{
+        #     config {
         #         conn_type: mqtt
         #         address: "127.0.0.1:1883"
         #         proto_ver: v4
@@ -43,13 +43,13 @@ emqx_bridge_mqtt:{
         #     forward_mountpoint: ""
         #     reconnect_interval: "30s"
         #     batch_size: 100
-        #     queue:{
+        #     queue {
         #         replayq_dir: "{{ platform_data_dir }}/replayq/bridge_mqtt/"
         #         replayq_seg_bytes: "100MB"
         #         replayq_offload_mode: false
         #         replayq_max_total_bytes: "1GB"
         #     },
-        #     config:{
+        #     config {
         #         conn_type: rpc
         #         node: "emqx@127.0.0.1"
         #     }

--- a/apps/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/apps/emqx_dashboard/etc/emqx_dashboard.conf
@@ -2,24 +2,24 @@
 ## EMQ X Dashboard
 ##--------------------------------------------------------------------
 
-emqx_dashboard:{
-    default_username: "admin"
-    default_password: "public"
+emqx_dashboard {
+    default_username = "admin"
+    default_password = "public"
     ## notice: sample_interval should be divisible by 60.
-    sample_interval: 10s
+    sample_interval = 10s
     ## api jwt timeout. default is 30 minute
-    token_expired_time: 60m
-    listeners: [
+    token_expired_time = 60m
+    listeners = [
         {
-            num_acceptors: 4
-            max_connections: 512
-            protocol: http
-            port: 18083
-            backlog: 512
-            send_timeout: 15s
-            send_timeout_close: true
-            inet6: false
-            ipv6_v6only: false
+            num_acceptors = 4
+            max_connections = 512
+            protocol = http
+            port = 18083
+            backlog = 512
+            send_timeout = 15s
+            send_timeout_close = true
+            inet6 = false
+            ipv6_v6only = false
         }
 ##        ,
 ##        {

--- a/apps/emqx_data_bridge/etc/emqx_data_bridge.conf
+++ b/apps/emqx_data_bridge/etc/emqx_data_bridge.conf
@@ -2,7 +2,7 @@
 ## EMQ X Bridge Plugin
 ##--------------------------------------------------------------------
 
-emqx_data_bridge:{
+emqx_data_bridge {
     bridges:[
         #    {name: "mysql_bridge_1"
         #     type: mysql

--- a/apps/emqx_exhook/etc/emqx_exhook.conf
+++ b/apps/emqx_exhook/etc/emqx_exhook.conf
@@ -2,19 +2,19 @@
 ## EMQ X Hooks
 ##====================================================================
 
-exhook: {
+exhook {
     ## The default value or action will be returned, while the request to
     ## the gRPC server failed or no available grpc server running.
     ##
     ## Default: deny
     ## Value: ignore | deny
-    request_failed_action: deny
+    request_failed_action = deny
 
     ## The timeout to request grpc server
     ##
     ## Default: 5s
     ## Value: Duration
-    request_timeout: 5s
+    request_timeout = 5s
 
     ## Whether to automatically reconnect (initialize) the gRPC server
     ##
@@ -23,9 +23,9 @@ exhook: {
     ##
     ## Default: false
     ## Value: false | Duration
-    auto_reconnect: 60s
+    auto_reconnect = 60s
 
-    servers: [
+    servers = [
     #    { name: "default"
     #      url: "http://127.0.0.1:9000"
     #      #ssl: {

--- a/apps/emqx_gateway/etc/emqx_gateway.conf
+++ b/apps/emqx_gateway/etc/emqx_gateway.conf
@@ -6,130 +6,130 @@
 ## In the final version, it will be commented out.
 
 gateway.stomp {
-  frame: {
-    max_headers: 10
-    max_headers_length: 1024
-    max_body_length: 8192
+  frame {
+    max_headers = 10
+    max_headers_length = 1024
+    max_body_length = 8192
   }
 
-  clientinfo_override: {
-    username: "${Packet.headers.login}"
-    password: "${Packet.headers.passcode}"
+  clientinfo_override {
+    username = "${Packet.headers.login}"
+    password = "${Packet.headers.passcode}"
   }
 
-  authentication: {
-    enable: true
-    authenticators: [
+  authentication {
+    enable = true
+    authenticators = [
       {
-        name: "authenticator1"
-        mechanism: password-based
-        server_type: built-in-database
-        user_id_type: clientid
+        name = "authenticator1"
+        mechanism = password-based
+        server_type = built-in-database
+        user_id_type = clientid
        }
     ]
   }
 
-  listener.tcp.1: {
-    bind: 61613
-    acceptors: 16
-    max_connections: 1024000
-    max_conn_rate: 1000
-    active_n: 100
+  listener.tcp.1 {
+    bind = 61613
+    acceptors = 16
+    max_connections = 1024000
+    max_conn_rate = 1000
+    active_n = 100
   }
 }
 
-gateway.coap: {
+gateway.coap {
 
-  enable_stats: false
+  enable_stats = false
 
   #authentication.enable: false
-  authentication: {
-    enable: true
-    authenticators: [
+  authentication {
+    enable = true
+    authenticators = [
       {
-        name: "authenticator1"
-        mechanism: password-based
-        server_type: built-in-database
-        user_id_type: clientid
+        name = "authenticator1"
+        mechanism = password-based
+        server_type = built-in-database
+        user_id_type = clientid
       }
     ]
   }
 
-  heartbeat: 30s
-  notify_type: qos
-  subscribe_qos: qos0
-  publish_qos: qos1
-  listener.udp.1: {
-    bind: 5683
+  heartbeat = 30s
+  notify_type = qos
+  subscribe_qos = qos0
+  publish_qos = qos1
+  listener.udp.1 {
+    bind = 5683
   }
 }
 
-gateway.mqttsn: {
+gateway.mqttsn {
   ## The MQTT-SN Gateway ID in ADVERTISE message.
-  gateway_id: 1
+  gateway_id = 1
 
   ## Enable broadcast this gateway to WLAN
-  broadcast: true
+  broadcast = true
 
   ## To control whether write statistics data into ETS table
   ## for dashbord to read.
-  enable_stats: true
+  enable_stats = true
 
   ## To control whether accept and process the received
   ## publish message with qos=-1.
-  enable_qos3: true
+  enable_qos3 = true
 
   ## Idle timeout for a MQTT-SN channel
-  idle_timeout: 30s
+  idle_timeout = 30s
 
   ## The pre-defined topic name corresponding to the pre-defined topic
   ## id of N.
   ## Note that the pre-defined topic id of 0 is reserved.
-  predefined: [
-    { id: 1
-      topic: "/predefined/topic/name/hello"
+  predefined = [
+    { id = 1
+      topic = "/predefined/topic/name/hello"
     },
-    { id: 2
-      topic: "/predefined/topic/name/nice"
+    { id = 2
+      topic = "/predefined/topic/name/nice"
     }
   ]
 
   ### ClientInfo override
-  clientinfo_override: {
-    username: "mqtt_sn_user"
-    password: "abc"
+  clientinfo_override {
+    username = "mqtt_sn_user"
+    password = "abc"
   }
 
-  listener.udp.1: {
-    bind: 1884
-    max_connections: 10240000
-    max_conn_rate: 1000
+  listener.udp.1 {
+    bind = 1884
+    max_connections = 10240000
+    max_conn_rate = 1000
   }
 }
 
-gateway.exproto: {
+gateway.exproto {
   ## The gRPC server to accept requests
-  server: {
-    bind: 9100
+  server {
+    bind = 9100
     #ssl.keyfile:
     #ssl.certfile:
     #ssl.cacertfile:
   }
 
-  handler: {
-    address: "http://127.0.0.1:9001"
+  handler {
+    address = "http://127.0.0.1:9001"
     #ssl.keyfile:
     #ssl.certfile:
     #ssl.cacertfile:
   }
 
-  authentication.enable: false
+  authentication.enable = false
 
-  listener.tcp.1: {
-    bind: 7993
-    acceptors: 8
-    max_connections: 10240
-    max_conn_rate: 1000
+  listener.tcp.1 {
+    bind = 7993
+    acceptors = 8
+    max_connections = 10240
+    max_conn_rate = 1000
   }
 
   #listener.ssl.1: {}
@@ -137,29 +137,29 @@ gateway.exproto: {
   #listener.dtls.1: {}
 }
 
-gateway.lwm2m: {
+gateway.lwm2m {
 
-  xml_dir: "{{ platform_etc_dir }}/lwm2m_xml"
+  xml_dir = "{{ platform_etc_dir }}/lwm2m_xml"
 
-  lifetime_min: 1s
-  lifetime_max: 86400s
-  qmode_time_windonw: 22
-  auto_observe: false
+  lifetime_min = 1s
+  lifetime_max = 86400s
+  qmode_time_windonw = 22
+  auto_observe = false
 
-  mountpoint: "lwm2m/%e/"
+  mountpoint = "lwm2m/%e/"
 
   ## always | contains_object_list
-  update_msg_publish_condition: contains_object_list
+  update_msg_publish_condition = contains_object_list
 
-  translators: {
-    command: "dn/#"
-    response: "up/resp"
-    notify: "up/notify"
-    register: "up/resp"
-    update: "up/resp"
+  translators {
+    command = "dn/#"
+    response = "up/resp"
+    notify = "up/notify"
+    register = "up/resp"
+    update = "up/resp"
   }
 
   listener.udp.1 {
-      bind: 5783
+      bind = 5783
   }
 }

--- a/apps/emqx_machine/etc/emqx_machine.conf
+++ b/apps/emqx_machine/etc/emqx_machine.conf
@@ -11,35 +11,35 @@ node {
   ## @doc node.name
   ## ValueType: NodeName
   ## Default: emqx@127.0.0.1
-  name: "emqx@127.0.0.1"
+  name = "emqx@127.0.0.1"
 
   ## Cookie for distributed node communication.
   ##
   ## @doc node.cookie
   ## ValueType: String
   ## Default: emqxsecretcookie
-  cookie: emqxsecretcookie
+  cookie = emqxsecretcookie
 
   ## Data dir for the node
   ##
   ## @doc node.data_dir
   ## ValueType: Folder
   ## Default: "{{ platform_data_dir }}/"
-  data_dir: "{{ platform_data_dir }}/"
+  data_dir = "{{ platform_data_dir }}/"
 
   ## Dir of crash dump file.
   ##
   ## @doc node.crash_dump_dir
   ## ValueType: Folder
   ## Default: "{{ platform_log_dir }}/"
-  crash_dump_dir: "{{ platform_log_dir }}/"
+  crash_dump_dir = "{{ platform_log_dir }}/"
 
   ## Global GC Interval.
   ##
   ## @doc node.global_gc_interval
   ## ValueType: Duration
   ## Default: 15m
-  global_gc_interval: 15m
+  global_gc_interval = 15m
 
   ## Sets the net_kernel tick time in seconds.
   ## Notice that all communicating nodes are to have the same
@@ -50,7 +50,7 @@ node {
   ## @doc node.dist_net_ticktime
   ## ValueType: Number
   ## Default: 2m
-  dist_net_ticktime: 2m
+  dist_net_ticktime = 2m
 
   ## Sets the port range for the listener socket of a distributed
   ## Erlang node.
@@ -63,7 +63,7 @@ node {
   ## ValueType: Integer
   ## Range: [1024,65535]
   ## Default: 6369
-  dist_listen_min: 6369
+  dist_listen_min = 6369
 
   ## Sets the port range for the listener socket of a distributed
   ## Erlang node.
@@ -76,7 +76,7 @@ node {
   ## ValueType: Integer
   ## Range: [1024,65535]
   ## Default: 6369
-  dist_listen_max: 6369
+  dist_listen_max = 6369
 
   ## Sets the maximum depth of call stack back-traces in the exit
   ## reason element of 'EXIT' tuples.
@@ -87,7 +87,7 @@ node {
   ## ValueType: Integer
   ## Range: [0,1024]
   ## Default: 23
-  backtrace_depth: 23
+  backtrace_depth = 23
 
 }
 
@@ -100,14 +100,14 @@ cluster {
   ## @doc cluster.name
   ## ValueType: String
   ## Default: emqxcl
-  name: emqxcl
+  name = emqxcl
 
   ## Enable cluster autoheal from network partition.
   ##
   ## @doc cluster.autoheal
   ## ValueType: Boolean
   ## Default: true
-  autoheal: true
+  autoheal = true
 
   ## Autoclean down node. A down node will be removed from the cluster
   ## if this value > 0.
@@ -115,7 +115,7 @@ cluster {
   ## @doc cluster.autoclean
   ## ValueType: Duration
   ## Default: 5m
-  autoclean: 5m
+  autoclean = 5m
 
   ## Node discovery strategy to join the cluster.
   ##
@@ -129,7 +129,7 @@ cluster {
   ##   - k8s:    Kubernetes
   ##
   ## Default: manual
-  discovery_strategy: manual
+  discovery_strategy = manual
 
   ##----------------------------------------------------------------
   ## Cluster using static node list
@@ -140,7 +140,7 @@ cluster {
     ## @doc cluster.static.seeds
     ## ValueType: Array<NodeName>
     ## Default: []
-    seeds: ["emqx1@127.0.0.1", "emqx2@127.0.0.1"]
+    seeds = ["emqx1@127.0.0.1", "emqx2@127.0.0.1"]
   }
 
   ##----------------------------------------------------------------
@@ -152,21 +152,21 @@ cluster {
     ## @doc cluster.mcast.addr
     ## ValueType: IPAddress
     ## Default: "239.192.0.1"
-    addr: "239.192.0.1"
+    addr = "239.192.0.1"
 
     ## Multicast Ports.
     ##
     ## @doc cluster.mcast.ports
     ## ValueType: Array<Port>
     ## Default: [4369, 4370]
-    ports: [4369, 4370]
+    ports = [4369, 4370]
 
     ## Multicast Iface.
     ##
     ## @doc cluster.mcast.iface
     ## ValueType: IPAddress
     ## Default: "0.0.0.0"
-    iface: "0.0.0.0"
+    iface = "0.0.0.0"
 
     ## Multicast Ttl.
     ##
@@ -174,14 +174,14 @@ cluster {
     ## ValueType: Integer
     ## Range: [0,255]
     ## Default: 255
-    ttl: 255
+    ttl = 255
 
     ## Multicast loop.
     ##
     ## @doc cluster.mcast.loop
     ## ValueType: Boolean
     ## Default: true
-    loop: true
+    loop = true
   }
 
   ##----------------------------------------------------------------
@@ -193,14 +193,14 @@ cluster {
     ## @doc cluster.dns.name
     ## ValueType: String
     ## Default: localhost
-    name: localhost
+    name = localhost
 
     ## The App name is used to build 'node.name' with IP address.
     ##
     ## @doc cluster.dns.app
     ## ValueType: String
     ## Default: emqx
-    app: emqx
+    app = emqx
   }
 
   ##----------------------------------------------------------------
@@ -212,7 +212,7 @@ cluster {
     ## @doc cluster.etcd.server
     ## ValueType: URL
     ## Required: true
-    server: "http://127.0.0.1:2379"
+    server = "http://127.0.0.1:2379"
 
     ## The prefix helps build nodes path in etcd. Each node in the cluster
     ## will create a path in etcd: v2/keys/<prefix>/<name>/<node.name>
@@ -220,28 +220,28 @@ cluster {
     ## @doc cluster.etcd.prefix
     ## ValueType: String
     ## Default: emqxcl
-    prefix: emqxcl
+    prefix = emqxcl
 
     ## The TTL for node's path in etcd.
     ##
     ## @doc cluster.etcd.node_ttl
     ## ValueType: Duration
     ## Default: 1m
-    node_ttl: 1m
+    node_ttl = 1m
 
     ## Path to the file containing the user's private PEM-encoded key.
     ##
     ## @doc cluster.etcd.ssl.keyfile
     ## ValueType: File
     ## Default: "{{ platform_etc_dir }}/certs/key.pem"
-    ssl.keyfile: "{{ platform_etc_dir }}/certs/key.pem"
+    ssl.keyfile = "{{ platform_etc_dir }}/certs/key.pem"
 
     ## Path to a file containing the user certificate.
     ##
     ## @doc cluster.etcd.ssl.certfile
     ## ValueType: File
     ## Default: "{{ platform_etc_dir }}/certs/cert.pem"
-    ssl.certfile: "{{ platform_etc_dir }}/certs/cert.pem"
+    ssl.certfile = "{{ platform_etc_dir }}/certs/cert.pem"
 
     ## Path to the file containing PEM-encoded CA certificates. The CA certificates
     ## are used during server authentication and when building the client certificate chain.
@@ -249,7 +249,7 @@ cluster {
     ## @doc cluster.etcd.ssl.cacertfile
     ## ValueType: File
     ## Default: "{{ platform_etc_dir }}/certs/cacert.pem"
-    ssl.cacertfile: "{{ platform_etc_dir }}/certs/cacert.pem"
+    ssl.cacertfile = "{{ platform_etc_dir }}/certs/cacert.pem"
   }
 
   ##----------------------------------------------------------------
@@ -261,47 +261,47 @@ cluster {
     ## @doc cluster.k8s.apiserver
     ## ValueType: URL
     ## Required: true
-    apiserver: "http://10.110.111.204:8080"
+    apiserver = "http://10.110.111.204:8080"
 
     ## The service name helps lookup EMQ nodes in the cluster.
     ##
     ## @doc cluster.k8s.service_name
     ## ValueType: String
     ## Default: emqx
-    service_name: emqx
+    service_name = emqx
 
     ## The address type is used to extract host from k8s service.
     ##
     ## @doc cluster.k8s.address_type
     ## ValueType: ip | dns | hostname
     ## Default: ip
-    address_type: ip
+    address_type = ip
 
     ## The app name helps build 'node.name'.
     ##
     ## @doc cluster.k8s.app_name
     ## ValueType: String
     ## Default: emqx
-    app_name: emqx
+    app_name = emqx
 
     ## The suffix added to dns and hostname get from k8s service
     ##
     ## @doc cluster.k8s.suffix
     ## ValueType: String
     ## Default: "pod.local"
-    suffix: "pod.local"
+    suffix = "pod.local"
 
     ## Kubernetes Namespace
     ##
     ## @doc cluster.k8s.namespace
     ## ValueType: String
     ## Default: default
-    namespace: default
+    namespace = default
   }
 
-  db_backend: mnesia
+  db_backend = mnesia
 
-  rlog: {
+  rlog {
       # role: core
       # core_nodes: []
   }
@@ -326,7 +326,7 @@ log {
   ## @doc log.primary_level
   ## ValueType: debug | info | notice | warning | error | critical | alert | emergency
   ## Default: warning
-  primary_level: warning
+  primary_level = warning
 
   ##----------------------------------------------------------------
   ## The console log handler send log messages to emqx console
@@ -335,7 +335,7 @@ log {
   ## @doc log.console_handler.enable
   ## ValueType: Boolean
   ## Default: false
-  console_handler.enable: false
+  console_handler.enable = false
 
   ## The log level of this handler
   ## All the log messages with levels lower than this level will
@@ -344,13 +344,13 @@ log {
   ## @doc log.console_handler.level
   ## ValueType: debug | info | notice | warning | error | critical | alert | emergency
   ## Default: warning
-  console_handler.level: warning
+  console_handler.level = warning
 
   ##----------------------------------------------------------------
   ## The file log handlers send log messages to files
   ##----------------------------------------------------------------
   ## file_handlers.<name>
-  file_handlers.emqx_log: {
+  file_handlers.emqx_log {
     ## The log level filter of this handler
     ## All the log messages with levels lower than this level will
     ## be dropped.
@@ -358,7 +358,7 @@ log {
     ## @doc log.file_handlers.<name>.level
     ## ValueType: debug | info | notice | warning | error | critical | alert | emergency
     ## Default: warning
-    level: warning
+    level = warning
 
     ## The log file for specified level.
     ##
@@ -373,7 +373,7 @@ log {
     ## @doc log.file_handlers.<name>.file
     ## ValueType: File
     ## Required: true
-    file: "{{ platform_log_dir }}/emqx.log"
+    file = "{{ platform_log_dir }}/emqx.log"
 
     ## Enables the log rotation.
     ## With this enabled, new log files will be created when the current
@@ -382,7 +382,7 @@ log {
     ## @doc log.file_handlers.<name>.rotation.enable
     ## ValueType: Boolean
     ## Default: true
-    rotation.enable: true
+    rotation.enable = true
 
     ## Maximum rotation count of log files.
     ##
@@ -390,7 +390,7 @@ log {
     ## ValueType: Integer
     ## Range: [1, 2048]
     ## Default: 10
-    rotation.count: 10
+    rotation.count = 10
 
     ## Maximum size of each log file.
     ##
@@ -401,16 +401,16 @@ log {
     ## @doc log.file_handlers.<name>.max_size
     ## ValueType: Size | infinity
     ## Default: 10MB
-    max_size: 10MB
+    max_size = 10MB
   }
 
   ## file_handlers.<name>
   ##
   ## You could also create multiple file handlers for different
   ## log level for example:
-  file_handlers.emqx_error_log: {
-    level: error
-    file: "{{ platform_log_dir }}/error.log"
+  file_handlers.emqx_error_log {
+    level = error
+    file = "{{ platform_log_dir }}/error.log"
   }
 
   ## Timezone offset to display in logs
@@ -421,7 +421,7 @@ log {
   ##  - "utc" for Universal Coordinated Time (UTC)
   ##  - "+hh:mm" or "-hh:mm" for a specified offset
   ## Default: system
-  time_offset: system
+  time_offset = system
 
   ## Limits the total number of characters printed for each log event.
   ##
@@ -429,7 +429,7 @@ log {
   ## ValueType: unlimited | Integer
   ## Range: [0, +Inf)
   ## Default: unlimited
-  chars_limit: unlimited
+  chars_limit = unlimited
 
   ## Maximum depth for Erlang term log formatting
   ## and Erlang process message queue inspection.
@@ -437,19 +437,19 @@ log {
   ## @doc log.max_depth
   ## ValueType: unlimited | Integer
   ## Default: 80
-  max_depth: 80
+  max_depth = 80
 
   ## Log formatter
   ## @doc log.formatter
   ## ValueType: text | json
   ## Default: text
-  formatter: text
+  formatter = text
 
   ## Log to single line
   ## @doc log.single_line
   ## ValueType: Boolean
   ## Default: true
-  single_line: true
+  single_line = true
 
   ## The max allowed queue length before switching to sync mode.
   ##
@@ -460,7 +460,7 @@ log {
   ## ValueType: Integer
   ## Range: [0, ${log.drop_mode_qlen}]
   ## Default: 100
-  sync_mode_qlen: 100
+  sync_mode_qlen = 100
 
   ## The max allowed queue length before switching to drop mode.
   ##
@@ -472,7 +472,7 @@ log {
   ## ValueType: Integer
   ## Range: [${log.sync_mode_qlen}, ${log.flush_qlen}]
   ## Default: 3000
-  drop_mode_qlen: 3000
+  drop_mode_qlen = 3000
 
   ## The max allowed queue length before switching to flush mode.
   ##
@@ -485,7 +485,7 @@ log {
   ## ValueType: Integer
   ## Range: [${log.drop_mode_qlen}, infinity)
   ## Default: 8000
-  flush_qlen: 8000
+  flush_qlen = 8000
 
   ## Kill the log handler when it gets overloaded.
   ##
@@ -498,7 +498,7 @@ log {
   ## @doc log.overload_kill.enable
   ## ValueType: Boolean
   ## Default: true
-  overload_kill.enable: true
+  overload_kill.enable = true
 
   ## The max allowed queue length before killing the log hanlder.
   ##
@@ -510,7 +510,7 @@ log {
   ## ValueType: Integer
   ## Range: [0, 1048576]
   ## Default: 20000
-  overload_kill.qlen: 20000
+  overload_kill.qlen = 20000
 
   ## The max allowed memory size before killing the log hanlder.
   ##
@@ -521,7 +521,7 @@ log {
   ## @doc log.overload_kill.mem_size
   ## ValueType: Size
   ## Default: 30MB
-  overload_kill.mem_size: 30MB
+  overload_kill.mem_size = 30MB
 
   ## Restart the log hanlder after some seconds.
   ##
@@ -531,7 +531,7 @@ log {
   ## @doc log.overload_kill.restart_after
   ## ValueType: Duration
   ## Default: 5s
-  overload_kill.restart_after: 5s
+  overload_kill.restart_after = 5s
 
   ## Controlling Bursts of Log Requests.
   ##
@@ -547,7 +547,7 @@ log {
   ## @doc log.burst_limit.enable
   ## ValueType: Boolean
   ## Default: false
-  burst_limit.enable: false
+  burst_limit.enable = false
 
   ## This config controls the maximum number of events to handle within
   ## a time frame. After the limit is reached, successive events are
@@ -556,14 +556,14 @@ log {
   ## @doc log.burst_limit.max_count
   ## ValueType: Integer
   ## Default: 10000
-  burst_limit.max_count: 10000
+  burst_limit.max_count = 10000
 
   ## See the previous description of burst_limit_max_count.
   ##
   ## @doc log.burst_limit.window_time
   ## ValueType: duration
   ## Default: 1s
-  burst_limit.window_time: 1s
+  burst_limit.window_time = 1s
 }
 
 ##==================================================================
@@ -575,7 +575,7 @@ rpc {
   ## @doc rpc.mode
   ## ValueType: sync | async
   ## Default: async
-  mode: async
+  mode = async
 
   ## Max batch size of async RPC requests.
   ##
@@ -586,7 +586,7 @@ rpc {
   ## ValueType: Integer
   ## Range: [0, 1048576]
   ## Default: 0
-  async_batch_size: 256
+  async_batch_size = 256
 
   ## RPC port discovery
   ##
@@ -601,7 +601,7 @@ rpc {
   ##     an integer, then the listening port will be `5370 + <N>`
   ##
   ## Default: `stateless`.
-  port_discovery: stateless
+  port_discovery = stateless
 
   ## TCP server port for RPC.
   ##
@@ -611,7 +611,7 @@ rpc {
   ## ValueType: Integer
   ## Range: [1024-65535]
   ## Defaults: 5369
-  tcp_server_port: 5369
+  tcp_server_port = 5369
 
   ## Number of outgoing RPC connections.
   ##
@@ -622,75 +622,75 @@ rpc {
   ## ValueType: Integer
   ## Range: [1, 256]
   ## Defaults: 1
-  tcp_client_num: 1
+  tcp_client_num = 1
 
   ## RCP Client connect timeout.
   ##
   ## @doc rpc.connect_timeout
   ## ValueType: Duration
   ## Default: 5s
-  connect_timeout: 5s
+  connect_timeout = 5s
 
   ## TCP send timeout of RPC client and server.
   ##
   ## @doc rpc.send_timeout
   ## ValueType: Duration
   ## Default: 5s
-  send_timeout: 5s
+  send_timeout = 5s
 
   ## Authentication timeout
   ##
   ## @doc rpc.authentication_timeout
   ## ValueType: Duration
   ## Default: 5s
-  authentication_timeout: 5s
+  authentication_timeout = 5s
 
   ## Default receive timeout for call() functions
   ##
   ## @doc rpc.call_receive_timeout
   ## ValueType: Duration
   ## Default: 15s
-  call_receive_timeout: 15s
+  call_receive_timeout = 15s
 
   ## Socket idle keepalive.
   ##
   ## @doc rpc.socket_keepalive_idle
   ## ValueType: Duration
   ## Default: 900s
-  socket_keepalive_idle: 900s
+  socket_keepalive_idle = 900s
 
   ## TCP Keepalive probes interval.
   ##
   ## @doc rpc.socket_keepalive_interval
   ## ValueType: Duration
   ## Default: 75s
-  socket_keepalive_interval: 75s
+  socket_keepalive_interval = 75s
 
   ## Probes lost to close the connection
   ##
   ## @doc rpc.socket_keepalive_count
   ## ValueType: Integer
   ## Default: 9
-  socket_keepalive_count: 9
+  socket_keepalive_count = 9
 
   ## Size of TCP send buffer.
   ##
   ## @doc rpc.socket_sndbuf
   ## ValueType: Size
   ## Default: 1MB
-  socket_sndbuf: 1MB
+  socket_sndbuf = 1MB
 
   ## Size of TCP receive buffer.
   ##
   ## @doc rpc.socket_recbuf
   ## ValueType: Size
   ## Default: 1MB
-  socket_recbuf: 1MB
+  socket_recbuf = 1MB
 
   ## Size of user-level software socket buffer.
   ##
   ## @doc rpc.socket_buffer
   ## ValueType: Size
   ## Default: 1MB
-  socket_buffer: 1MB
+  socket_buffer = 1MB
 }

--- a/apps/emqx_management/etc/emqx_management.conf
+++ b/apps/emqx_management/etc/emqx_management.conf
@@ -1,22 +1,22 @@
-emqx_management:{
-    applications: [
+emqx_management {
+    applications = [
         {
-            id: "admin",
-            secret: "public"
+            id = "admin",
+            secret = "public"
         }
     ]
-    max_row_limit: 10000
-    listeners: [
+    max_row_limit = 10000
+    listeners = [
         {
-            num_acceptors: 4
-            max_connections: 512
-            protocol: http
-            port: 8081
-            backlog: 512
-            send_timeout: 15s
-            send_timeout_close: true
-            inet6: false
-            ipv6_v6only: false
+            num_acceptors = 4
+            max_connections = 512
+            protocol = http
+            port = 8081
+            backlog = 512
+            send_timeout = 15s
+            send_timeout_close = true
+            inet6 = false
+            ipv6_v6only = false
         }
 ##        ,
 ##        {

--- a/apps/emqx_modules/etc/emqx_modules.conf
+++ b/apps/emqx_modules/etc/emqx_modules.conf
@@ -1,19 +1,19 @@
-delayed: {
-    enable: true
-    max_delayed_messages: 0
+delayed {
+    enable = true
+    max_delayed_messages = 0
 }
 
-recon: {
-    enable: true
+recon {
+    enable = true
 }
 
-telemetry: {
-    enable: true
+telemetry {
+    enable = true
 }
 
 event_message {
-    "$event/client_connected": true
-    "$event/client_disconnected": true
+    "$event/client_connected" = true
+    "$event/client_disconnected" = true
     # "$event/client_subscribed": false
     # "$event/client_unsubscribed": false
     # "$event/message_delivered": false
@@ -21,17 +21,17 @@ event_message {
     # "$event/message_dropped": false
 }
 
-topic_metrics:{
-    topics: ["topic/#"]
+topic_metrics {
+    topics = ["topic/#"]
 }
 
-rewrite:{
-    rules: [
+rewrite {
+    rules = [
         {
-            action: publish
-            source_topic: "x/#"
-            re: "^x/y/(.+)$"
-            dest_topic: "z/y/$1"
+            action = publish
+            source_topic = "x/#"
+            re = "^x/y/(.+)$"
+            dest_topic = "z/y/$1"
         }
     ]
 }

--- a/apps/emqx_prometheus/etc/emqx_prometheus.conf
+++ b/apps/emqx_prometheus/etc/emqx_prometheus.conf
@@ -1,8 +1,8 @@
 ##--------------------------------------------------------------------
 ## emqx_prometheus for EMQ X
 ##--------------------------------------------------------------------
-prometheus: {
-    push_gateway_server: "http://127.0.0.1:9091"
-    interval: "15s"
-    enable: true
+prometheus {
+    push_gateway_server = "http://127.0.0.1:9091"
+    interval = "15s"
+    enable = true
 }

--- a/apps/emqx_retainer/etc/emqx_retainer.conf
+++ b/apps/emqx_retainer/etc/emqx_retainer.conf
@@ -5,9 +5,9 @@
 ## Where to store the retained messages.
 ##
 ## Notice that all nodes in the same cluster have to be configured to
-emqx_retainer: {
+emqx_retainer {
   ## enable/disable emqx_retainer
-  enable: true
+  enable = true
 
   ## Periodic interval for cleaning up expired messages. Never clear if the value is 0.
   ##
@@ -22,12 +22,12 @@ emqx_retainer: {
   ##  - 20s: 20 seconds
   ##
   ## Default: 0s
-  msg_clear_interval: 0s
+  msg_clear_interval = 0s
 
   ## Message retention time. 0 means message will never be expired.
   ##
   ## Default: 0s
-  msg_expiry_interval: 0s
+  msg_expiry_interval = 0s
 
   ## The message read and deliver flow rate control
   ## When a client subscribe to a wildcard topic, may many retained messages will be loaded.
@@ -37,42 +37,42 @@ emqx_retainer: {
   ##    deliver ->
   ##    repeat this, until all retianed messages are delivered
   ##
-  flow_control: {
+  flow_control {
     ## The max messages number per read from storage. 0 means no limit
     ##
     ## Default: 0
-    max_read_number: 0
+    max_read_number = 0
 
     ## The max number of retained message can be delivered in emqx per quota_release_interval.0 means no limit
     ##
     ## Default: 0
-    msg_deliver_quota: 0
+    msg_deliver_quota = 0
 
     ## deliver quota reset interval
     ##
     ## Default: 0s
-    quota_release_interval: 0s
+    quota_release_interval = 0s
   }
 
   ## Maximum retained message size.
   ##
   ## Value: Bytes
-  max_payload_size: 1MB
+  max_payload_size = 1MB
 
   ## Storage connect parameters
   ##
   ## Value: built_in_database
   ##
-  config: {
+  config {
 
-    type: built_in_database
+    type = built_in_database
 
     ## storage_type: ram | disc | disc_only
-    storage_type: ram
+    storage_type = ram
 
     ## Maximum number of retained messages. 0 means no limit.
     ##
     ## Value: Number >= 0
-    max_retained_messages: 0
+    max_retained_messages = 0
     }
 }

--- a/apps/emqx_rule_engine/etc/emqx_rule_engine.conf
+++ b/apps/emqx_rule_engine/etc/emqx_rule_engine.conf
@@ -1,6 +1,6 @@
 ##====================================================================
 ## Rule Engine for EMQ X R5.0
 ##====================================================================
-emqx_rule_engine:{
-    ignore_sys_message: true
+emqx_rule_engine {
+    ignore_sys_message = true
 }

--- a/apps/emqx_statsd/etc/emqx_statsd.conf
+++ b/apps/emqx_statsd/etc/emqx_statsd.conf
@@ -2,9 +2,9 @@
 ## Statsd for EMQ X
 ##--------------------------------------------------------------------
 
-statsd:{
-    enable: true
-    server: "127.0.0.1:8125"
-    sample_time_interval: "10s"
-    flush_time_interval: "10s"
+statsd {
+    enable = true
+    server = "127.0.0.1:8125"
+    sample_time_interval = "10s"
+    flush_time_interval = "10s"
 }


### PR DESCRIPTION
This is the first step to configuration structure change: using '=' instead of ':' in the *.conf files.