### PR TITLE
chore(test): just for testing the CI

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -1,5 +1,7 @@
 -module('rebar.config').
 
+%% just test the CI
+%%
 -export([do/2]).
 
 do(Dir, CONFIG) ->


### PR DESCRIPTION
```
/home/runner/work/_actions/gleam-lang/setup-erlang/v1.1.2/main.sh 24.0.5
5
/tmp/tmp.mWGS50iZGu ~/work/emqx/emqx
6
Installing required packages
7
Reading package lists...
8
Building dependency tree...
9
Reading state information...
10
libsctp1 is already the newest version (1.0.18+dfsg-1).
11
libsctp1 set to manually installed.
12
libwxbase3.0-0v5 is already the newest version (3.0.4+dfsg-15build1).
13
libwxbase3.0-0v5 set to manually installed.
14
libwxgtk3.0-gtk3-0v5 is already the newest version (3.0.4+dfsg-15build1).
15
libwxgtk3.0-gtk3-0v5 set to manually installed.
16
0 upgraded, 0 newly installed, 0 to remove and 13 not upgraded.
17
Downloading Erlang/OTP 24.0.5 package
18
--2021-08-22 02:17:41--  https://packages.erlang-solutions.com/erlang/debian/pool/esl-erlang_24.0.5-1~ubuntu~focal_amd64.deb
19
Resolving packages.erlang-solutions.com (packages.erlang-solutions.com)... 13.32.182.122, 13.32.182.48, 13.32.182.42, ...
20
Connecting to packages.erlang-solutions.com (packages.erlang-solutions.com)|13.32.182.122|:443... connected.
21
ERROR: cannot verify packages.erlang-solutions.com's certificate, issued by ‘CN=Go Daddy Secure Certificate Authority - G2,OU=http://certs.godaddy.com/repository/,O=GoDaddy.com\\, Inc.,L=Scottsdale,ST=Arizona,C=US’:
22
  Issued certificate has expired.
23
To connect to packages.erlang-solutions.com insecurely, use `--no-check-certificate'.
24
Error: The process '/home/runner/work/_actions/gleam-lang/setup-erlang/v1.1.2/main.sh' failed with exit code 5
```