### PR TITLE
chore(recon): add observer_cli to emqx_ctl

### DIFF
--- a/apps/emqx_modules/src/emqx_recon.erl
+++ b/apps/emqx_modules/src/emqx_recon.erl
@@ -32,6 +32,8 @@ enable() ->
 disable() ->
     emqx_ctl:unregister_command(recon).
 
+cmd(["observer_cli"]) ->
+    observer_cli:start();
 cmd(["memory"]) ->
     Print = fun(Key, Keyword) ->
               emqx_ctl:print("~-20s: ~w~n", [concat(Key, Keyword), recon_alloc:memory(Key, Keyword)])
@@ -56,7 +58,8 @@ cmd(["proc_count", Attr, N]) ->
     emqx_ctl:print("~p~n", [recon:proc_count(list_to_atom(Attr), list_to_integer(N))]);
 
 cmd(_) ->
-    emqx_ctl:usage([{"recon memory",           "recon_alloc:memory/2"},
+    emqx_ctl:usage([{"observer_cli",           "observer_cli:start()"},
+                    {"recon memory",           "recon_alloc:memory/2"},
                     {"recon allocated",        "recon_alloc:memory(allocated_types, current|max)"},
                     {"recon bin_leak",         "recon:bin_leak(100)"},
                     {"recon node_stats",       "recon:node_stats(10, 1000)"},

--- a/rebar.config
+++ b/rebar.config
@@ -57,8 +57,7 @@
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.2"}}}
     , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.2"}}}
-    , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
-    , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.1
+    , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.x
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.14.1"}}}
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.11.1"}}}


### PR DESCRIPTION
Add a new command, Keep all previous functions by recon.
```erlang
emqx_ctl observer_cli
```