### PR TITLE
Disable Superuser Request by Defualt

### DIFF
--- a/apps/emqx_auth_http/etc/emqx_auth_http.conf
+++ b/apps/emqx_auth_http/etc/emqx_auth_http.conf
@@ -42,7 +42,7 @@ auth.http.auth_req.params = clientid=%c,username=%u,password=%P
 ## Value: URL
 ##
 ## Examples: http://127.0.0.1:80/mqtt/superuser, https://[::1]:80/mqtt/superuser
-auth.http.super_req.url = http://127.0.0.1:80/mqtt/superuser
+# auth.http.super_req.url = http://127.0.0.1:80/mqtt/superuser
 
 ## HTTP Request Method for SuperUser Request
 ##

--- a/apps/emqx_auth_http/etc/emqx_auth_http.conf
+++ b/apps/emqx_auth_http/etc/emqx_auth_http.conf
@@ -47,13 +47,13 @@ auth.http.auth_req.params = clientid=%c,username=%u,password=%P
 ## HTTP Request Method for SuperUser Request
 ##
 ## Value: post | get
-auth.http.super_req.method = post
+# auth.http.super_req.method = post
 
 ## HTTP Request Headers for SuperUser Request, Content-Type header is configured by default.
 ## The possible values of the Content-Type header: application/x-www-form-urlencoded, application/json
 ##
 ## Examples: auth.http.super_req.headers.accept = */*
-auth.http.super_req.headers.content-type = application/x-www-form-urlencoded
+# auth.http.super_req.headers.content-type = application/x-www-form-urlencoded
 
 ## Parameters used to construct the request body or query string parameters
 ## When the request method is GET, these parameters will be converted into query string parameters
@@ -70,7 +70,7 @@ auth.http.super_req.headers.content-type = application/x-www-form-urlencoded
 ##  - %d: subject of client TLS cert
 ##
 ## Value: <K1>=<V1>,<K2>=<V2>,...
-auth.http.super_req.params = clientid=%c,username=%u
+# auth.http.super_req.params = clientid=%c,username=%u
 
 ## HTTP URL API path for ACL Request
 ## Comment out this config to disable ACL checks


### PR DESCRIPTION
I think we don't need superuser to be enabled by default but these default configurations cause superuser request be enabled by default acorrding the following code:

```erl
case application:get_env(?APP, super_req) of
    undefined ->
        emqx_hooks:put('client.authenticate', {emqx_auth_http, check, [#{auth => maps:from_list(AuthReq),
                                                                         super => undefined}]});
    {ok, SuperReq} ->
        PoolOpts1 = proplists:get_value(pool_opts, SuperReq),
        PoolName1 = proplists:get_value(pool_name, SuperReq),
        {ok, _} = ehttpc_sup:start_pool(PoolName1, PoolOpts1),
        emqx_hooks:put('client.authenticate', {emqx_auth_http, check, [#{auth => maps:from_list(AuthReq),
                                                                         super => maps:from_list(SuperReq)}]})
end
```

also by using environment variables there is no way to disable them.