### PR TITLE
refactor(listener): GET /listeners API returns full config of listeners

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -94,8 +94,8 @@
 -type update_stage() :: pre_config_update | post_config_update.
 -type update_error() :: {update_stage(), module(), term()} | {save_configs, term()} | term().
 -type update_result() :: #{
-    config := emqx_config:config(),
-    raw_config := emqx_config:raw_config(),
+    config => emqx_config:config(),
+    raw_config => emqx_config:raw_config(),
     post_config_update => #{module() => any()}
 }.
 

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -23,6 +23,7 @@
 
 %% API functions
 -export([ start_link/0
+        , stop/0
         , add_handler/2
         , remove_handler/1
         , update_config/3
@@ -67,6 +68,9 @@
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, {}, []).
+
+stop() ->
+    gen_server:stop(?MODULE).
 
 -spec update_config(module(), emqx_config:config_key_path(), emqx_config:update_args()) ->
     {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -265,12 +265,12 @@ format_addr({Addr, Port}) when is_tuple(Addr) ->
     io_lib:format("~s:~w", [inet:ntoa(Addr), Port]).
 
 listener_id(Type, ListenerName) ->
-    list_to_atom(lists:append([atom_to_list(Type), ":", atom_to_list(ListenerName)])).
+    list_to_atom(lists:append([str(Type), ":", str(ListenerName)])).
 
 parse_listener_id(Id) ->
     try
-        [Zone, Listen] = string:split(atom_to_list(Id), ":", leading),
-        {list_to_existing_atom(Zone), list_to_existing_atom(Listen)}
+        [Type, Name] = string:split(str(Id), ":", leading),
+        {list_to_existing_atom(Type), list_to_atom(Name)}
     catch
         _ : _ -> error({invalid_listener_id, Id})
     end.
@@ -291,8 +291,8 @@ tcp_opts(Opts) ->
 
 foreach_listeners(Do) ->
     lists:foreach(
-        fun({ZoneName, LName, LConf}) ->
-                Do(ZoneName, LName, LConf)
+        fun({Type, LName, LConf}) ->
+                Do(Type, LName, LConf)
         end, do_list()).
 
 has_enabled_listener_conf_by_type(Type) ->
@@ -307,3 +307,10 @@ apply_on_listener(ListenerId, Do) ->
         {not_found, _, _} -> error({listener_config_not_found, Type, ListenerName});
         {ok, Conf} -> Do(Type, ListenerName, Conf)
     end.
+
+str(A) when is_atom(A) ->
+    atom_to_list(A);
+str(B) when is_binary(B) ->
+    binary_to_list(B);
+str(S) when is_list(S) ->
+    S.

--- a/apps/emqx/src/emqx_map_lib.erl
+++ b/apps/emqx/src/emqx_map_lib.erl
@@ -32,8 +32,7 @@
 -export_type([config_key/0, config_key_path/0]).
 -type config_key() :: atom() | binary().
 -type config_key_path() :: [config_key()].
--type convert_fun() :: fun((K::any(), V::any(), Args::list()) ->
-    {K1::any(), V1::any()} | drop).
+-type convert_fun() :: fun((...) -> {K1::any(), V1::any()} | drop).
 
 %%-----------------------------------------------------------------
 -spec deep_get(config_key_path(), map()) -> term().

--- a/apps/emqx/src/emqx_map_lib.erl
+++ b/apps/emqx/src/emqx_map_lib.erl
@@ -131,20 +131,20 @@ jsonable_map(Map, JsonableFun) ->
     deep_convert(Map, fun binary_string_kv/3, [JsonableFun]).
 
 -spec diff_maps(map(), map()) ->
-    #{added := [map()], identical := [map()], removed := [map()],
-      changed := [#{any() => {OldValue::any(), NewValue::any()}}]}.
+    #{added := map(), identical := map(), removed := map(),
+      changed := #{any() => {OldValue::any(), NewValue::any()}}}.
 diff_maps(NewMap, OldMap) ->
-    InitR = #{identical => [], changed => [], removed => []},
+    InitR = #{identical => #{}, changed => #{}, removed => #{}},
     {Result, RemInNew} =
         lists:foldl(fun({OldK, OldV}, {Result0 = #{identical := I, changed := U, removed := D},
                         RemNewMap}) ->
             Result1 = case maps:find(OldK, NewMap) of
                 error ->
-                    Result0#{removed => [#{OldK => OldV} | D]};
+                    Result0#{removed => D#{OldK => OldV}};
                 {ok, NewV} when NewV == OldV ->
-                    Result0#{identical => [#{OldK => OldV} | I]};
+                    Result0#{identical => I#{OldK => OldV}};
                 {ok, NewV} ->
-                    Result0#{changed => [#{OldK => {OldV, NewV}} | U]}
+                    Result0#{changed => U#{OldK => {OldV, NewV}}}
             end,
             {Result1, maps:remove(OldK, RemNewMap)}
         end, {InitR, NewMap}, maps:to_list(OldMap)),

--- a/apps/emqx/src/emqx_map_lib.erl
+++ b/apps/emqx/src/emqx_map_lib.erl
@@ -27,6 +27,7 @@
         , jsonable_map/2
         , binary_string/1
         , deep_convert/3
+        , diff_maps/2
         ]).
 
 -export_type([config_key/0, config_key_path/0]).
@@ -128,6 +129,27 @@ jsonable_map(Map) ->
 
 jsonable_map(Map, JsonableFun) ->
     deep_convert(Map, fun binary_string_kv/3, [JsonableFun]).
+
+-spec diff_maps(map(), map()) ->
+    #{added := [map()], identical := [map()], removed := [map()],
+      changed := [#{any() => {OldValue::any(), NewValue::any()}}]}.
+diff_maps(NewMap, OldMap) ->
+    InitR = #{identical => [], changed => [], removed => []},
+    {Result, RemInNew} =
+        lists:foldl(fun({OldK, OldV}, {Result0 = #{identical := I, changed := U, removed := D},
+                        RemNewMap}) ->
+            Result1 = case maps:find(OldK, NewMap) of
+                error ->
+                    Result0#{removed => [#{OldK => OldV} | D]};
+                {ok, NewV} when NewV == OldV ->
+                    Result0#{identical => [#{OldK => OldV} | I]};
+                {ok, NewV} ->
+                    Result0#{changed => [#{OldK => {OldV, NewV}} | U]}
+            end,
+            {Result1, maps:remove(OldK, RemNewMap)}
+        end, {InitR, NewMap}, maps:to_list(OldMap)),
+    Result#{added => RemInNew}.
+
 
 binary_string_kv(K, V, JsonableFun) ->
     case JsonableFun(K, V) of

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -341,7 +341,7 @@ mqtt_listener() ->
     ].
 
 base_listener() ->
-    [ {"bind", t(union(ip_port(), integer()))}
+    [ {"bind", hoconsc:t(union(ip_port(), integer()), #{nullable => false})}
     , {"acceptors", t(integer(), undefined, 16)}
     , {"max_connections", maybe_infinity(integer(), infinity)}
     , {"mountpoint", t(binary(), undefined, <<>>)}

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -37,6 +37,14 @@ end_per_suite(_Config) ->
     application:stop(esockd),
     application:stop(cowboy).
 
+init_per_testcase(_, Config) ->
+    {ok, _} = emqx_config_handler:start_link(),
+    Config.
+
+end_per_testcase(_, _Config) ->
+    _ = emqx_config_handler:stop(),
+    ok.
+
 t_start_stop_listeners(_) ->
     ok = emqx_listeners:start(),
     ?assertException(error, _, emqx_listeners:start_listener({ws,{"127.0.0.1", 8083}, []})),

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -507,8 +507,12 @@ update_listener(Id, Config) ->
 
 update_listener(Node, Id, Config) when Node =:= node() ->
     {Type, Name} = emqx_listeners:parse_listener_id(Id),
-    {ok, #{raw_config := RawConf}} = emqx:update_config([listeners, Type, Name], Config, #{}),
-    RawConf#{node => Node, id => Id, running => true};
+    case emqx:update_config([listeners, Type, Name], Config, #{}) of
+        {ok, #{raw_config := RawConf}} ->
+            RawConf#{node => Node, id => Id, running => true};
+        {error, Reason} ->
+            error(Reason)
+    end;
 update_listener(Node, Id, Config) ->
     rpc_call(Node, update_listener, [Node, Id, Config]).
 

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -90,6 +90,8 @@
         , list_listeners_by_id/1
         , get_listener/2
         , manage_listener/2
+        , update_listener/2
+        , update_listener/3
         ]).
 
 %% Alarms
@@ -473,7 +475,7 @@ list_listeners() ->
     lists:append([list_listeners(Node) || Node <- ekka_mnesia:running_nodes()]).
 
 list_listeners(Node) when Node =:= node() ->
-    [{Id, maps:put(node, Node, Conf)} || {Id, Conf} <- emqx_listeners:list()];
+    [Conf#{node => Node, id => Id} || {Id, Conf} <- emqx_listeners:list()];
 
 list_listeners(Node) ->
     rpc_call(Node, list_listeners, [Node]).
@@ -500,6 +502,16 @@ manage_listener(Operation, #{id := ID, node := Node}) when Node =:= node()->
     erlang:apply(emqx_listeners, Operation, [ID]);
 manage_listener(Operation, Param = #{node := Node}) ->
     rpc_call(Node, manage_listener, [Operation, Param]).
+
+update_listener(Id, Config) ->
+    [update_listener(Node, Id, Config) || Node <- ekka_mnesia:running_nodes()].
+
+update_listener(Node, Id, Config) when Node =:= node() ->
+    {Type, Name} = emqx_listeners:parse_listener_id(Id),
+    {ok, #{raw_config := RawConf}} = emqx:update_config([listeners, Type, Name], Config, #{}),
+    RawConf#{node => Node, id => Id, running => true};
+update_listener(Node, Id, Config) ->
+    rpc_call(Node, update_listener, [Node, Id, Config]).
 
 %%--------------------------------------------------------------------
 %% Get Alarms

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -92,6 +92,8 @@
         , manage_listener/2
         , update_listener/2
         , update_listener/3
+        , remove_listener/1
+        , remove_listener/2
         ]).
 
 %% Alarms
@@ -515,6 +517,19 @@ update_listener(Node, Id, Config) when Node =:= node() ->
     end;
 update_listener(Node, Id, Config) ->
     rpc_call(Node, update_listener, [Node, Id, Config]).
+
+remove_listener(Id) ->
+    [remove_listener(Node, Id) || Node <- ekka_mnesia:running_nodes()].
+
+remove_listener(Node, Id) when Node =:= node() ->
+    {Type, Name} = emqx_listeners:parse_listener_id(Id),
+    case emqx:remove_config([listeners, Type, Name], #{}) of
+        {ok, _} -> ok;
+        {error, Reason} ->
+            error(Reason)
+    end;
+remove_listener(Node, Id) ->
+    rpc_call(Node, remove_listener, [Node, Id]).
 
 %%--------------------------------------------------------------------
 %% Get Alarms

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -480,20 +480,19 @@ list_listeners(Node) when Node =:= node() ->
 list_listeners(Node) ->
     rpc_call(Node, list_listeners, [Node]).
 
-list_listeners_by_id(Identifier) ->
-    listener_id_filter(Identifier, list_listeners()).
+list_listeners_by_id(Id) ->
+    listener_id_filter(Id, list_listeners()).
 
-get_listener(Node, Identifier) ->
-    case listener_id_filter(Identifier, list_listeners(Node)) of
+get_listener(Node, Id) ->
+    case listener_id_filter(Id, list_listeners(Node)) of
         [] ->
             {error, not_found};
         [Listener] ->
             Listener
     end.
 
-listener_id_filter(Identifier, Listeners) ->
-    Filter =
-        fun({Id, _}) -> Id =:= Identifier end,
+listener_id_filter(Id, Listeners) ->
+    Filter = fun(#{id := Id0}) -> Id0 =:= Id end,
     lists:filter(Filter, Listeners).
 
 -spec manage_listener(Operation :: start_listener|stop_listener|restart_listener, Param :: map()) ->

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -188,7 +188,7 @@ gen_schema(_Conf) ->
     #{type => string}.
 
 with_default_value(Type, Value) ->
-    Type#{example => emqx_map_lib:jsonable_value(Value)}.
+    Type#{example => emqx_map_lib:binary_string(Value)}.
 
 path_join(Path) ->
     path_join(Path, "/").

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -132,7 +132,7 @@ api_get_update_listener_by_id_on_node() ->
 
 api_manage_listeners() ->
     Metadata = #{
-        get => #{
+        post => #{
             description => <<"Restart listeners on all nodes in the cluster">>,
             parameters => [
                 param_path_id(),

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -52,13 +52,23 @@ request_api(Method, Url, Auth) ->
 request_api(Method, Url, QueryParams, Auth) ->
     request_api(Method, Url, QueryParams, Auth, []).
 
-request_api(Method, Url, QueryParams, Auth, []) ->
+request_api(Method, Url, QueryParams, Auth, [])
+    when (Method =:= options) orelse
+         (Method =:= get) orelse
+         (Method =:= put) orelse
+         (Method =:= head) orelse
+         (Method =:= delete) orelse
+         (Method =:= trace) ->
     NewUrl = case QueryParams of
                  "" -> Url;
                  _ -> Url ++ "?" ++ QueryParams
              end,
     do_request_api(Method, {NewUrl, [Auth]});
-request_api(Method, Url, QueryParams, Auth, Body) ->
+request_api(Method, Url, QueryParams, Auth, Body)
+    when (Method =:= post) orelse
+         (Method =:= patch) orelse
+         (Method =:= put) orelse
+         (Method =:= delete) ->
     NewUrl = case QueryParams of
                  "" -> Url;
                  _ -> Url ++ "?" ++ QueryParams

--- a/apps/emqx_management/test/emqx_mgmt_listeners_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_listeners_api_SUITE.erl
@@ -58,8 +58,8 @@ t_manage_listener(_) ->
     manage_listener(ID, "restart", true).
 
 manage_listener(ID, Operation, Running) ->
-    Path = emqx_mgmt_api_test_util:api_path(["listeners", ID, Operation]),
-    {ok, _} = emqx_mgmt_api_test_util:request_api(get, Path),
+    Path = emqx_mgmt_api_test_util:api_path(["listeners", ID, "operation", Operation]),
+    {ok, _} = emqx_mgmt_api_test_util:request_api(post, Path),
     timer:sleep(500),
     GetPath = emqx_mgmt_api_test_util:api_path(["listeners", ID]),
     {ok, ListenersResponse} = emqx_mgmt_api_test_util:request_api(get, GetPath),
@@ -106,10 +106,8 @@ comparison_listener(Local, Response) ->
     ?assertEqual(maps:get(id, Local), binary_to_atom(maps:get(<<"id">>, Response))),
     ?assertEqual(maps:get(node, Local), binary_to_atom(maps:get(<<"node">>, Response))),
     ?assertEqual(maps:get(acceptors, Local), maps:get(<<"acceptors">>, Response)),
-    ?assertEqual(maps:get(max_conn, Local), maps:get(<<"max_conn">>, Response)),
-    ?assertEqual(maps:get(listen_on, Local), maps:get(<<"listen_on">>, Response)),
     ?assertEqual(maps:get(running, Local), maps:get(<<"running">>, Response)).
 
 
-listener_stats(Listener, Stats) ->
-    ?assertEqual(maps:get(<<"running">>, Listener), Stats).
+listener_stats(Listener, ExpectedStats) ->
+    ?assertEqual(ExpectedStats, maps:get(<<"running">>, Listener)).


### PR DESCRIPTION
- refactor the code of HTTP APIs for starting/stoping listeners.
- add the APIs for updating/creating/deleting configs of listeners.