### PR TITLE
Backport: fix(helm-chart): force headless svc ready while pod is not ready

### DIFF
--- a/deploy/charts/emqx/templates/service.yaml
+++ b/deploy/charts/emqx/templates/service.yaml
@@ -121,6 +121,7 @@ spec:
   type: ClusterIP
   sessionAffinity: None
   clusterIP: None
+  publishNotReadyAddresses: true
   ports:
   - name: mqtt
     port: {{ .Values.service.mqtt | default 1883 }}


### PR DESCRIPTION
fixs: #5254

The dist port behind headless svc should to be accessible during emqx
cluster boot.

Endpoints of headless SVC is not in 'ready' state that prevents nodes to talk to
each other, this issue only happens when K8s host node is restarted and
all emqx nodes are deployed on the same host.

