### PR TITLE
chore(CI): use ghcr

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -12,12 +12,12 @@ jobs:
   prepare:
     strategy:
       matrix:
-        container:
-          - "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
-          - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
+        otp:
+          - "23.2.7.2-emqx-2"
+          - "24.0.5-emqx-1"
 
     runs-on: ubuntu-20.04
-    container: ${{ matrix.container }}
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-ubuntu20.04"
 
     outputs:
       profiles: ${{ steps.set_profile.outputs.profiles }}
@@ -306,7 +306,7 @@ jobs:
         done
     - name: build emqx packages
       env:
-        ERL_OTP: erl${{ matrix.otp }}
+        OTP: ${{ matrix.otp }}
         PROFILE: ${{ matrix.profile }}
         ARCH: ${{ matrix.arch }}
         SYSTEM: ${{ matrix.os }}
@@ -316,7 +316,7 @@ jobs:
         -v $(pwd):/emqx \
         --workdir /emqx \
         --platform linux/$ARCH \
-        emqx/build-env:$ERL_OTP-$SYSTEM \
+        ghcr.io/emqx/emqx-builder-helper/5.0:$OTP-$SYSTEM \
         bash -euc "make $PROFILE-zip || cat rebar3.crashdump; \
                    make $PROFILE-pkg || cat rebar3.crashdump; \
                    EMQX_NAME=$PROFILE && .ci/build_packages/tests.sh"
@@ -375,7 +375,7 @@ jobs:
         tags: emqx/${{ matrix.profile }}:${{ steps.version.outputs.version }}
         build-args: |
           PKG_VSN=${{ steps.version.outputs.version }}
-          BUILD_FROM=emqx/build-env:erl${{ matrix.otp }}-alpine
+          BUILD_FROM=ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-alpine3.14
           RUN_FROM=alpine:3.14
           EMQX_NAME=${{ matrix.profile }}
         file: source/deploy/docker/Dockerfile
@@ -395,7 +395,7 @@ jobs:
         tags: emqx/${{ matrix.profile }}:${{ steps.version.outputs.version }}
         build-args: |
           PKG_VSN=${{ steps.version.outputs.version }}
-          BUILD_FROM=emqx/build-env:erl${{ matrix.otp }}-alpine
+          BUILD_FROM=ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-alpine3.14
           RUN_FROM=alpine:3.14
           EMQX_NAME=${{ matrix.profile }}
         file: source/deploy/docker/Dockerfile

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -14,14 +14,13 @@ jobs:
 
     strategy:
       matrix:
-        erl_otp:
-        - erl24.0.5-emqx-1
-
+        otp:
+        - 24.0.5-emqx-1
         os:
         - ubuntu20.04
         - centos7
 
-    container: emqx/build-env:${{ matrix.erl_otp }}-${{ matrix.os }}
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-${{ matrix.os }}"
 
     steps:
     - uses: actions/checkout@v1
@@ -58,7 +57,7 @@ jobs:
 
     strategy:
       matrix:
-        erl_otp:
+        otp:
         - 24.0.5-emqx-1
 
     steps:
@@ -83,7 +82,7 @@ jobs:
       id: cache
       with:
         path: ~/.kerl
-        key: erl${{ matrix.erl_otp }}-macos10.15
+        key: erl${{ matrix.otp }}-macos10.15
     - name: build erlang
       if: steps.cache.outputs.cache-hit != 'true'
       timeout-minutes: 60
@@ -92,11 +91,11 @@ jobs:
         OTP_GITHUB_URL: https://github.com/emqx/otp
       run: |
         kerl update releases
-        kerl build ${{ matrix.erl_otp }}
-        kerl install ${{ matrix.erl_otp }} $HOME/.kerl/${{ matrix.erl_otp }}
+        kerl build ${{ matrix.otp }}
+        kerl install ${{ matrix.otp }} $HOME/.kerl/${{ matrix.otp }}
     - name: build
       run: |
-        . $HOME/.kerl/${{ matrix.erl_otp }}/activate
+        . $HOME/.kerl/${{ matrix.otp }}/activate
         make ensure-rebar3
         sudo cp rebar3 /usr/local/bin/rebar3
         make ${EMQX_NAME}-zip

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -4,13 +4,8 @@ on: [pull_request]
 
 jobs:
   check_deps_integrity:
-    strategy:
-      matrix:
-        container:
-          - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
-
     runs-on: ubuntu-20.04
-    container: ${{ matrix.container }}
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:24.0.5-emqx-1-ubuntu20.04"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_api_tests.yaml
+++ b/.github/workflows/run_api_tests.yaml
@@ -10,7 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:23.2.7.2-emqx-2-ubuntu20.04"
+
     steps:
     - uses: actions/checkout@v2
     - name: zip emqx-broker
@@ -27,6 +28,7 @@ jobs:
       with:
         name: emqx-broker
         path: _packages/**/*.zip
+
   api-test:
     needs: build
     runs-on: ubuntu-latest
@@ -94,6 +96,7 @@ jobs:
       with:
         name: jmeter_logs
         path: ./jmeter_logs
+
   delete-package:
     runs-on: ubuntu-20.04
     needs: api-test

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -8,31 +8,30 @@ on:
   pull_request:
 
 jobs:
-    check_all:
-        strategy:
-          matrix:
-            container:
-              - "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
-              - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
+  check_all:
+    strategy:
+      matrix:
+        otp:
+          - "23.2.7.2-emqx-2"
+          - "24.0.5-emqx-1"
 
-        runs-on: ubuntu-20.04
-        container: ${{ matrix.container }}
+    runs-on: ubuntu-20.04
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-ubuntu20.04"
 
-        steps:
-        - uses: actions/checkout@v2
-        - name: run
-          run: |
-            make ensure-rebar3
-            cp rebar3 apps/emqx/
-            cd apps/emqx
-            ./rebar3 xref
-            ./rebar3 dialyzer
-            ./rebar3 eunit -v
-            ./rebar3 ct -v
-            ./rebar3 proper -d test/props
-        - uses: actions/upload-artifact@v1
-          if: failure()
-          with:
-            name: logs
-            path: apps/emqx/_build/test/logs
-
+    steps:
+    - uses: actions/checkout@v2
+    - name: run
+      run: |
+        make ensure-rebar3
+        cp rebar3 apps/emqx/
+        cd apps/emqx
+        ./rebar3 xref
+        ./rebar3 dialyzer
+        ./rebar3 eunit -v
+        ./rebar3 ct -v
+        ./rebar3 proper -d test/props
+    - uses: actions/upload-artifact@v1
+      if: failure()
+      with:
+        name: logs
+        path: apps/emqx/_build/test/logs

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -11,12 +11,12 @@ jobs:
   prepare:
     strategy:
       matrix:
-        container:
-          - "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
-          - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
+        otp:
+          - "23.2.7.2-emqx-2"
+          - "24.0.5-emqx-1"
 
     runs-on: ubuntu-20.04
-    container: ${{ matrix.container }}
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-ubuntu20.04"
 
     outputs:
       profile: ${{ steps.profile.outputs.profile }}

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -11,12 +11,12 @@ jobs:
   relup_test:
     strategy:
       matrix:
-        container:
-          - "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
-          - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
+        otp:
+          - "23.2.7.2-emqx-2"
+          - "24.0.5-emqx-1"
 
     runs-on: ubuntu-20.04
-    container: ${{ matrix.container }}
+    container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-ubuntu20.04"
 
     defaults:
       run:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -11,12 +11,12 @@ jobs:
     run_static_analysis:
         strategy:
           matrix:
-            container:
-              - "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
-              - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
+            otp:
+              - "23.2.7.2-emqx-2"
+              - "24.0.5-emqx-1"
 
         runs-on: ubuntu-20.04
-        container: ${{ matrix.container }}
+        container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-ubuntu20.04"
 
         steps:
         - uses: actions/checkout@v2
@@ -34,12 +34,12 @@ jobs:
     run_proper_test:
         strategy:
           matrix:
-            container:
-              - "emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04"
-              - "emqx/build-env:erl24.0.5-emqx-1-ubuntu20.04"
+            otp:
+              - "23.2.7.2-emqx-2"
+              - "24.0.5-emqx-1"
 
         runs-on: ubuntu-20.04
-        container: ${{ matrix.container }}
+        container: "ghcr.io/emqx/emqx-builder-helper/5.0:${{ matrix.otp }}-ubuntu20.04"
 
         steps:
         - uses: actions/checkout@v2

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-2-alpine
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder-helper/5.0:24.0.5-emqx-1-alpine3.14
 ARG RUN_FROM=alpine:3.14
 FROM ${BUILD_FROM} AS builder
 


### PR DESCRIPTION
+ Now we use [this repository](https://github.com/emqx/emqx-builder-helper) to build the image and push it to [ghcr](https://github.com/emqx/emqx-builder-helper/pkgs/container/emqx-builder-helper), the `emqx/build-env` image will not be updated afterwards

+ `emqx-builder-helper` distinguish between compiling different `emqx` versions [using release](https://github.com/emqx/emqx-builder-helper/releases/tag/5.0).