### PR TITLE
Use MQTT Bridge as Data Source or Data Sink of Rules

### DIFF
--- a/apps/emqx_bridge/etc/emqx_bridge.conf
+++ b/apps/emqx_bridge/etc/emqx_bridge.conf
@@ -25,25 +25,23 @@
 #        certfile = "{{ platform_etc_dir }}/certs/client-cert.pem"
 #        cacertfile = "{{ platform_etc_dir }}/certs/cacert.pem"
 #    }
-#    ## we will create one MQTT connection for each element of the `ingress_channels`
-#    ingress_channels: [{
-#        ## the `id` will be used as part of the clientid
-#        id = "pull_msgs_from_aws"
+#    ## We will create one MQTT connection for each element of the `ingress_channels`
+#    ## Syntax: ingress_channels.<id>
+#    ingress_channels.pull_msgs_from_aws {
 #        subscribe_remote_topic = "aws/#"
 #        subscribe_qos = 1
 #        local_topic = "from_aws/${topic}"
 #        payload = "${payload}"
 #        qos = "${qos}"
 #        retain = "${retain}"
-#    }]
-#    ## we will create one MQTT connection for each element of the `egress_channels`
-#    egress_channels: [{
-#        ## the `id` will be used as part of the clientid
-#        id = "push_msgs_to_aws"
+#    }
+#    ## We will create one MQTT connection for each element of the `egress_channels`
+#    ## Syntax: egress_channels.<id>
+#    egress_channels.push_msgs_to_aws {
 #        subscribe_local_topic = "emqx/#"
 #        remote_topic = "from_emqx/${topic}"
 #        payload = "${payload}"
 #        qos = 1
 #        retain = false
-#    }]
+#    }
 #}

--- a/apps/emqx_bridge/src/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_schema.erl
@@ -5,9 +5,9 @@
 %%======================================================================================
 %% Hocon Schema Definitions
 
-roots() -> ["bridges"].
+roots() -> [bridges].
 
-fields("bridges") ->
+fields(bridges) ->
     [{mqtt, hoconsc:mk(hoconsc:map(name, hoconsc:ref(?MODULE, "mqtt_bridge")))}];
 
 fields("mqtt_bridge") ->

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
@@ -43,13 +43,15 @@ fields("config") ->
     ] ++ emqx_connector_schema_lib:ssl_fields();
 
 fields("ingress_channels") ->
-    [ {subscribe_remote_topic, #{type => binary(), nullable => false}}
-    , {local_topic, hoconsc:mk(binary(), #{default => <<"${topic}">>})}
+    %% the message maybe subscribed by rules, in this case 'local_topic' is not necessary
+    [ {subscribe_remote_topic, hoconsc:mk(binary(), #{nullable => false})}
+    , {local_topic, hoconsc:mk(binary())}
     , {subscribe_qos, hoconsc:mk(qos(), #{default => 1})}
     ] ++ common_inout_confs();
 
 fields("egress_channels") ->
-    [ {subscribe_local_topic, #{type => binary(), nullable => false}}
+    %% the message maybe sent from rules, in this case 'subscribe_local_topic' is not necessary
+    [ {subscribe_local_topic, hoconsc:mk(binary())}
     , {remote_topic, hoconsc:mk(binary(), #{default => <<"${topic}">>})}
     ] ++ common_inout_confs();
 

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
@@ -38,8 +38,8 @@ fields("config") ->
     , {retry_interval, hoconsc:mk(emqx_schema:duration_ms(), #{default => "30s"})}
     , {max_inflight, hoconsc:mk(integer(), #{default => 32})}
     , {replayq, hoconsc:mk(hoconsc:ref(?MODULE, "replayq"))}
-    , {ingress_channels, hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, "ingress_channels")), #{default => []})}
-    , {egress_channels, hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, "egress_channels")), #{default => []})}
+    , {ingress_channels, hoconsc:mk(hoconsc:map(id, hoconsc:ref(?MODULE, "ingress_channels")), #{default => []})}
+    , {egress_channels, hoconsc:mk(hoconsc:map(id, hoconsc:ref(?MODULE, "egress_channels")), #{default => []})}
     ] ++ emqx_connector_schema_lib:ssl_fields();
 
 fields("ingress_channels") ->
@@ -61,9 +61,6 @@ fields("replayq") ->
     ].
 
 common_inout_confs() ->
-    [{id, #{type => binary(), nullable => false}}] ++ publish_confs().
-
-publish_confs() ->
     [ {qos, hoconsc:mk(qos(), #{default => <<"${qos}">>})}
     , {retain, hoconsc:mk(hoconsc:union([boolean(), binary()]), #{default => <<"${retain}">>})}
     , {payload, hoconsc:mk(binary(), #{default => <<"${payload}">>})}

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
@@ -87,6 +87,7 @@
         , ensure_stopped/1
         , status/1
         , ping/1
+        , send_to_remote/2
         ]).
 
 -export([ get_forwards/1
@@ -171,6 +172,11 @@ ping(Pid) when is_pid(Pid) ->
 ping(Name) ->
     gen_statem:call(name(Name), ping).
 
+send_to_remote(Pid, Msg) when is_pid(Pid) ->
+    gen_statem:cast(Pid, {send_to_remote, Msg});
+send_to_remote(Name, Msg) ->
+    gen_statem:cast(name(Name), {send_to_remote, Msg}).
+
 %% @doc Return all forwards (local subscriptions).
 -spec get_forwards(id()) -> [topic()].
 get_forwards(Name) -> gen_statem:call(name(Name), get_forwards, timer:seconds(1000)).
@@ -194,7 +200,6 @@ init(#{name := Name} = ConnectOpts) ->
     }}.
 
 init_state(Opts) ->
-    IfRecordMetrics = maps:get(if_record_metrics, Opts, true),
     ReconnDelayMs = maps:get(reconnect_interval, Opts, ?DEFAULT_RECONNECT_DELAY_MS),
     StartType = maps:get(start_type, Opts, manual),
     Mountpoint = maps:get(forward_mountpoint, Opts, undefined),
@@ -208,7 +213,6 @@ init_state(Opts) ->
       inflight => [],
       max_inflight => MaxInflightSize,
       connection => undefined,
-      if_record_metrics => IfRecordMetrics,
       name => Name}.
 
 open_replayq(Name, QCfg) ->
@@ -321,17 +325,15 @@ common(_StateName, {call, From}, get_forwards, #{connect_opts := #{forwards := F
     {keep_state_and_data, [{reply, From, Forwards}]};
 common(_StateName, {call, From}, get_subscriptions, #{connection := Connection}) ->
     {keep_state_and_data, [{reply, From, maps:get(subscriptions, Connection, #{})}]};
-common(_StateName, info, {deliver, _, Msg},
-       State = #{replayq := Q, if_record_metrics := IfRecordMetric}) ->
+common(_StateName, info, {deliver, _, Msg}, State = #{replayq := Q}) ->
     Msgs = collect([Msg]),
-    bridges_metrics_inc(IfRecordMetric,
-                        'bridge.mqtt.message_received',
-                        length(Msgs)
-                       ),
     NewQ = replayq:append(Q, Msgs),
     {keep_state, State#{replayq => NewQ}, {next_event, internal, maybe_send}};
 common(_StateName, info, {'EXIT', _, _}, State) ->
     {keep_state, State};
+common(_StateName, cast, {send_to_remote, Msg}, #{replayq := Q} = State) ->
+    NewQ = replayq:append(Q, [Msg]),
+    {keep_state, State#{replayq => NewQ}, {next_event, internal, maybe_send}};
 common(StateName, Type, Content, #{name := Name} = State) ->
     ?LOG(notice, "Bridge ~p discarded ~p type event at state ~p:~p",
           [Name, Type, StateName, Content]),
@@ -401,11 +403,10 @@ do_send(#{connect_opts := #{forwards := undefined}}, _QAckRef, Batch) ->
 do_send(#{inflight := Inflight,
           connection := Connection,
           mountpoint := Mountpoint,
-          connect_opts := #{forwards := Forwards},
-          if_record_metrics := IfRecordMetrics} = State, QAckRef, [_ | _] = Batch) ->
+          connect_opts := #{forwards := Forwards}} = State, QAckRef, [_ | _] = Batch) ->
     Vars = emqx_connector_mqtt_msg:make_pub_vars(Mountpoint, Forwards),
     ExportMsg = fun(Message) ->
-                    bridges_metrics_inc(IfRecordMetrics, 'bridge.mqtt.message_sent'),
+                    emqx_metrics:inc('bridge.mqtt.message_sent_to_remote'),
                     emqx_connector_mqtt_msg:to_remote_msg(Message, Vars)
                 end,
     ?LOG(debug, "publish to remote broker, msg: ~p, vars: ~p", [Batch, Vars]),
@@ -464,6 +465,8 @@ drop_acked_batches(Q, [#{send_ack_ref := Refs,
             All
     end.
 
+subscribe_local_topic(undefined, _Name) ->
+    ok;
 subscribe_local_topic(Topic, Name) ->
     do_subscribe(Topic, Name).
 
@@ -487,7 +490,7 @@ disconnect(#{connection := Conn} = State) when Conn =/= undefined ->
     emqx_connector_mqtt_mod:stop(Conn),
     State#{connection => undefined};
 disconnect(State) ->
-        State.
+    State.
 
 %% Called only when replayq needs to dump it to disk.
 msg_marshaller(Bin) when is_binary(Bin) -> emqx_connector_mqtt_msg:from_binary(Bin);
@@ -502,19 +505,9 @@ name(Id) -> list_to_atom(str(Id)).
 
 register_metrics() ->
     lists:foreach(fun emqx_metrics:ensure/1,
-                  ['bridge.mqtt.message_sent',
-                   'bridge.mqtt.message_received'
+                  ['bridge.mqtt.message_sent_to_remote',
+                   'bridge.mqtt.message_received_from_remote'
                   ]).
-
-bridges_metrics_inc(true, Metric) ->
-    emqx_metrics:inc(Metric);
-bridges_metrics_inc(_IsRecordMetric, _Metric) ->
-    ok.
-
-bridges_metrics_inc(true, Metric, Value) ->
-    emqx_metrics:inc(Metric, Value);
-bridges_metrics_inc(_IsRecordMetric, _Metric, _Value) ->
-    ok.
 
 obfuscate(Map) ->
     maps:fold(fun(K, V, Acc) ->


### PR DESCRIPTION
- If the MQTT Bridge is started along (without using the rule engine), it can forward local message to the remote broker, and vice versa.
- And the MQTT Bridge may be configured not to subscribe local topics, or not to send messages (from remote broker) to local broker. In this case the bridge can be used as a data-source or data-sink of rules. 