### PR TITLE
Backport 4.3

### DIFF
--- a/include/emqx_mqtt.hrl
+++ b/include/emqx_mqtt.hrl
@@ -30,11 +30,13 @@
 %% MQTT Protocol Version and Names
 %%--------------------------------------------------------------------
 
+-define(MQTT_SN_PROTO_V1, 1).
 -define(MQTT_PROTO_V3, 3).
 -define(MQTT_PROTO_V4, 4).
 -define(MQTT_PROTO_V5, 5).
 
 -define(PROTOCOL_NAMES, [
+    {?MQTT_SN_PROTO_V1, <<"MQTT-SN">>}, %% XXX:Compatible with emqx-sn plug-in
     {?MQTT_PROTO_V3, <<"MQIsdp">>},
     {?MQTT_PROTO_V4, <<"MQTT">>},
     {?MQTT_PROTO_V5, <<"MQTT">>}]).

--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -20,6 +20,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, []},
      {load_module, emqx_router, soft_purge, soft_purge, [emqx_trie]},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -40,6 +42,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, []},
      {load_module, emqx_router, soft_purge, soft_purge, [emqx_trie]},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -57,6 +61,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, []},
      {load_module, emqx_router, soft_purge, soft_purge, [emqx_trie]},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -72,6 +78,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, []},
      {load_module, emqx_router, soft_purge, soft_purge, [emqx_trie]},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -86,10 +94,17 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, []},
      {load_module, emqx_router, soft_purge, soft_purge, [emqx_trie]},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
    {<<"4.2.[6-7]">>, [
+     {load_module, emqx_channel, brutal_purge, soft_purge, []},
+     {load_module, emqx_connection, brutal_purge, soft_purge, []},
+     {load_module, emqx_ws_connection, brutal_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -114,6 +129,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, [emqx_router]},
      {load_module, emqx_router, soft_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -134,6 +151,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, [emqx_router]},
      {load_module, emqx_router, soft_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -151,6 +170,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, [emqx_router]},
      {load_module, emqx_router, soft_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -166,6 +187,8 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, [emqx_router]},
      {load_module, emqx_router, soft_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
@@ -180,10 +203,17 @@
      {load_module, emqx_broker, soft_purge, soft_purge, []},
      {load_module, emqx_trie, soft_purge, soft_purge, [emqx_router]},
      {load_module, emqx_router, soft_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},
    {<<"4.2.[6-7]">>, [
+     {load_module, emqx_channel, brutal_purge, soft_purge, []},
+     {load_module, emqx_connection, brutal_purge, soft_purge, []},
+     {load_module, emqx_ws_connection, brutal_purge, soft_purge, []},
+     {load_module, emqx_cm, brutal_purge, soft_purge, []},
+     {load_module, emqx_access_rule, brutal_purge, soft_purge, []},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
    ]},

--- a/src/emqx_access_rule.erl
+++ b/src/emqx_access_rule.erl
@@ -28,7 +28,8 @@
 -type(who() :: all | binary() |
                {client, binary()} |
                {user, binary()} |
-               {ipaddr, esockd_cidr:cidr_string()}).
+               {ipaddr, esockd_cidr:cidr_string()} |
+               {ipaddrs, list(esockd_cidr:cidr_string())}).
 
 -type(access() :: subscribe | publish | pubsub).
 
@@ -52,6 +53,8 @@ compile(who, all) ->
     all;
 compile(who, {ipaddr, CIDR}) ->
     {ipaddr, esockd_cidr:parse(CIDR, true)};
+compile(who, {ipaddrs, CIDRs}) ->
+    {ipaddrs, lists:map(fun(CIDR) -> esockd_cidr:parse(CIDR, true) end, CIDRs)};
 compile(who, {client, all}) ->
     {client, all};
 compile(who, {client, ClientId}) ->
@@ -108,8 +111,14 @@ match_who(#{username := Username}, {user, Username}) ->
     true;
 match_who(#{peerhost := undefined}, {ipaddr, _Tup}) ->
     false;
+match_who(#{peerhost := undefined}, {ipaddrs, _}) ->
+    false;
 match_who(#{peerhost := IP}, {ipaddr, CIDR}) ->
     esockd_cidr:match(IP, CIDR);
+match_who(#{peerhost := IP}, {ipaddrs, CIDRs}) ->
+    lists:any(fun(CIDR) ->
+        esockd_cidr:match(IP, CIDR)
+    end, CIDRs);
 match_who(ClientInfo, {'and', Conds}) when is_list(Conds) ->
     lists:foldl(fun(Who, Allow) ->
                   match_who(ClientInfo, Who) andalso Allow

--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -38,7 +38,7 @@
         , stats/1
         ]).
 
--export([call/2]).
+-export([call/2, call/3]).
 
 %% Callback
 -export([init/4]).
@@ -168,7 +168,9 @@ stats(#state{transport = Transport,
     lists:append([SockStats, ConnStats, ChanStats, ProcStats]).
 
 call(Pid, Req) ->
-    gen_server:call(Pid, Req, infinity).
+    call(Pid, Req, infinity).
+call(Pid, Req, Timeout) ->
+    gen_server:call(Pid, Req, Timeout).
 
 stop(Pid) ->
     gen_server:stop(Pid).

--- a/src/emqx_ws_connection.erl
+++ b/src/emqx_ws_connection.erl
@@ -34,7 +34,7 @@
         , stats/1
         ]).
 
--export([call/2]).
+-export([call/2, call/3]).
 
 %% WebSocket callbacks
 -export([ init/2
@@ -151,7 +151,10 @@ stats(#state{channel = Channel}) ->
 
 %% kick|discard|takeover
 -spec(call(pid(), Req :: term()) -> Reply :: term()).
-call(WsPid, Req) when is_pid(WsPid) ->
+call(WsPid, Req) ->
+    call(WsPid, Req, 5000).
+
+call(WsPid, Req, Timeout) when is_pid(WsPid) ->
     Mref = erlang:monitor(process, WsPid),
     WsPid ! {call, {self(), Mref}, Req},
     receive
@@ -160,7 +163,7 @@ call(WsPid, Req) when is_pid(WsPid) ->
             Reply;
         {'DOWN', Mref, _, _, Reason} ->
             exit(Reason)
-    after 5000 ->
+    after Timeout ->
         erlang:demonitor(Mref, [flush]),
         exit(timeout)
     end.

--- a/test/emqx_cm_SUITE.erl
+++ b/test/emqx_cm_SUITE.erl
@@ -77,7 +77,7 @@ t_get_set_chan_stats(_) ->
 
 t_open_session(_) ->
     ok = meck:new(emqx_connection, [passthrough, no_history]),
-    ok = meck:expect(emqx_connection, call, fun(_, _) -> ok end),
+    ok = meck:expect(emqx_connection, call, fun(_, _, _) -> ok end),
 
     ClientInfo = #{zone => external,
                    clientid => <<"clientid">>,
@@ -153,14 +153,14 @@ t_open_session_race_condition(_) ->
 
 t_discard_session(_) ->
     ok = meck:new(emqx_connection, [passthrough, no_history]),
-    ok = meck:expect(emqx_connection, call, fun(_, _) -> ok end),
+    ok = meck:expect(emqx_connection, call, fun(_, _, _) -> ok end),
     ok = emqx_cm:discard_session(<<"clientid">>),
     ok = emqx_cm:register_channel(<<"clientid">>, ?ChanInfo, []),
     ok = emqx_cm:discard_session(<<"clientid">>),
     ok = emqx_cm:unregister_channel(<<"clientid">>),
     ok = emqx_cm:register_channel(<<"clientid">>, ?ChanInfo, []),
     ok = emqx_cm:discard_session(<<"clientid">>),
-    ok = meck:expect(emqx_connection, call, fun(_, _) -> error(testing) end),
+    ok = meck:expect(emqx_connection, call, fun(_, _, _) -> error(testing) end),
     ok = emqx_cm:discard_session(<<"clientid">>),
     ok = emqx_cm:unregister_channel(<<"clientid">>),
     ok = meck:unload(emqx_connection).
@@ -180,7 +180,7 @@ t_takeover_session(_) ->
 
 t_kick_session(_) ->
     ok = meck:new(emqx_connection, [passthrough, no_history]),
-    ok = meck:expect(emqx_connection, call, fun(_, _) -> test end),
+    ok = meck:expect(emqx_connection, call, fun(_, _, _) -> test end),
     {error, not_found} = emqx_cm:kick_session(<<"clientid">>),
     ok = emqx_cm:register_channel(<<"clientid">>, ?ChanInfo, []),
     test = emqx_cm:kick_session(<<"clientid">>),

--- a/test/mqtt_protocol_v5_SUITE.erl
+++ b/test/mqtt_protocol_v5_SUITE.erl
@@ -278,7 +278,7 @@ t_connect_emit_stats_timeout(_) ->
     [ClientPid] = emqx_cm:lookup_channels(client_info(clientid, Client)),
 
     ?assert(is_reference(emqx_connection:info(stats_timer, sys:get_state(ClientPid)))),
-    timer:sleep(IdleTimeout),
+    timer:sleep(IdleTimeout+500),
     ?assertEqual(undefined, emqx_connection:info(stats_timer, sys:get_state(ClientPid))),
     ok = emqtt:disconnect(Client).
 


### PR DESCRIPTION
1. Export `emqx_channel:ensure_keepalive/2`, `emqx_channel:clear_keepalive` for `emqx-sn` plugin
2. Safer `emqx_connection:call/3` for `emqx_cm` module
3. Support `ipaddrs` for acl.conf