### PR TITLE
feat(swagger): define mgmt config_api by hocon schema

### DIFF
--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
@@ -34,10 +34,10 @@ fields("auto_subscribe") ->
 
 fields("topic") ->
     [ {topic, sc(binary(), #{})}
-    , {qos, sc(typerefl:union([0, 1, 2]), #{default => 0})}
-    , {rh,  sc(typerefl:union([0, 1, 2]), #{default => 0})}
-    , {rap, sc(typerefl:union([0, 1]), #{default => 0})}
-    , {nl,  sc(typerefl:union([0, 1]), #{default => 0})}
+    , {qos, sc(hoconsc:enum([0, 1, 2]), #{default => 0})}
+    , {rh,  sc(hoconsc:enum([0, 1, 2]), #{default => 0})}
+    , {rap, sc(hoconsc:enum([0, 1]), #{default => 0})}
+    , {nl,  sc(hoconsc:enum([0, 1]), #{default => 0})}
     ].
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -103,7 +103,7 @@ error_codes(Codes = [_ | _], MsgExample) ->
     ].
 
 support_check_schema(#{check_schema := true}) -> ?DEFAULT_FILTER;
-support_check_schema(#{check_schema := Func})when is_function(Func, 2) -> #{filter => Func};
+support_check_schema(#{check_schema := Func}) when is_function(Func, 2) -> #{filter => Func};
 support_check_schema(_) -> #{filter => undefined}.
 
 parse_spec_ref(Module, Path) ->
@@ -191,11 +191,11 @@ parameters(Params, Module) ->
         lists:foldl(fun(Param, {Acc, RefsAcc}) ->
             case Param of
                 ?REF(StructName) ->
-                    {[#{<<"$ref">> => ?TO_COMPONENTS_PARAM(Module, StructName)} |Acc],
-                        [{Module, StructName, parameter}|RefsAcc]};
+                    {[#{<<"$ref">> => ?TO_COMPONENTS_PARAM(Module, StructName)} | Acc],
+                        [{Module, StructName, parameter} | RefsAcc]};
                 ?R_REF(RModule, StructName) ->
-                    {[#{<<"$ref">> => ?TO_COMPONENTS_PARAM(RModule, StructName)} |Acc],
-                        [{RModule, StructName, parameter}|RefsAcc]};
+                    {[#{<<"$ref">> => ?TO_COMPONENTS_PARAM(RModule, StructName)} | Acc],
+                        [{RModule, StructName, parameter} | RefsAcc]};
                 {Name, Type} ->
                     In = hocon_schema:field_schema(Type, in),
                     In =:= undefined andalso throw({error, <<"missing in:path/query field in parameters">>}),
@@ -300,10 +300,13 @@ components([{Module, Field, parameter} | Refs], SpecAcc, SubRefsAcc) ->
     NewSpecAcc = SpecAcc#{?TO_REF(Namespace, Field) => Param},
     components(Refs, NewSpecAcc, SubRefs ++ SubRefsAcc).
 
+%% Semantic error at components.schemas.xxx:xx:xx
+%% Component names can only contain the characters A-Z a-z 0-9 - . _
+%% So replace ':' by '-'.
 namespace(Module) ->
     case hocon_schema:namespace(Module) of
         undefined -> Module;
-        NameSpace -> NameSpace
+        NameSpace -> re:replace(to_bin(NameSpace), ":","-",[global])
     end.
 
 hocon_schema_to_spec(?R_REF(Module, StructName), _LocalModule) ->
@@ -312,13 +315,20 @@ hocon_schema_to_spec(?R_REF(Module, StructName), _LocalModule) ->
 hocon_schema_to_spec(?REF(StructName), LocalModule) ->
     {#{<<"$ref">> => ?TO_COMPONENTS_SCHEMA(LocalModule, StructName)},
         [{LocalModule, StructName}]};
-hocon_schema_to_spec(Type, _LocalModule) when ?IS_TYPEREFL(Type) ->
-    {typename_to_spec(typerefl:name(Type)), []};
+hocon_schema_to_spec(Type, LocalModule) when ?IS_TYPEREFL(Type) ->
+    {typename_to_spec(typerefl:name(Type), LocalModule), []};
 hocon_schema_to_spec(?ARRAY(Item), LocalModule) ->
     {Schema, Refs} = hocon_schema_to_spec(Item, LocalModule),
     {#{type => array, items => Schema}, Refs};
+hocon_schema_to_spec(?LAZY(Item), LocalModule) ->
+    hocon_schema_to_spec(Item, LocalModule);
 hocon_schema_to_spec(?ENUM(Items), _LocalModule) ->
     {#{type => string, enum => Items}, []};
+hocon_schema_to_spec(?MAP(Name, Type), LocalModule) ->
+    {Schema, SubRefs} = hocon_schema_to_spec(Type, LocalModule),
+    {#{<<"type">> => object,
+        <<"properties">> => #{<<"$", (to_bin(Name))/binary>> => Schema}},
+        SubRefs};
 hocon_schema_to_spec(?UNION(Types), LocalModule) ->
     {OneOf, Refs} = lists:foldl(fun(Type, {Acc, RefsAcc}) ->
         {Schema, SubRefs} = hocon_schema_to_spec(Type, LocalModule),
@@ -328,38 +338,98 @@ hocon_schema_to_spec(?UNION(Types), LocalModule) ->
 hocon_schema_to_spec(Atom, _LocalModule) when is_atom(Atom) ->
     {#{type => string, enum => [Atom]}, []}.
 
-typename_to_spec("boolean()") -> #{type => boolean, example => true};
-typename_to_spec("binary()") -> #{type => string, example =><<"binary example">>};
-typename_to_spec("float()") -> #{type =>number, example =>3.14159};
-typename_to_spec("integer()") -> #{type =>integer, example =>100};
-typename_to_spec("number()") -> #{type =>number, example =>42};
-typename_to_spec("string()") -> #{type =>string, example =><<"string example">>};
-typename_to_spec("atom()") -> #{type =>string, example =>atom};
-typename_to_spec("duration()") -> #{type =>string, example =><<"12m">>};
-typename_to_spec("duration_s()") -> #{type =>string, example =><<"1h">>};
-typename_to_spec("duration_ms()") -> #{type =>string, example =><<"32s">>};
-typename_to_spec("percent()") -> #{type =>number, example =><<"12%">>};
-typename_to_spec("file()") -> #{type =>string, example =><<"/path/to/file">>};
-typename_to_spec("ip_port()") -> #{type => string, example =><<"127.0.0.1:80">>};
-typename_to_spec(Name) ->
+%% todo: Find a way to fetch enum value from user_id_type().
+typename_to_spec("user_id_type()", _Mod) -> #{type => string, enum => [clientid, username]};
+typename_to_spec("term()", _Mod) -> #{type => string, example => "term"};
+typename_to_spec("boolean()", _Mod) -> #{type => boolean, example => true};
+typename_to_spec("binary()", _Mod) -> #{type => string, example => <<"binary-example">>};
+typename_to_spec("float()", _Mod) -> #{type => number, example => 3.14159};
+typename_to_spec("integer()", _Mod) -> #{type => integer, example => 100};
+typename_to_spec("non_neg_integer()", _Mod) -> #{type => integer, minimum => 1, example => 100};
+typename_to_spec("number()", _Mod) -> #{type => number, example => 42};
+typename_to_spec("string()", _Mod) -> #{type => string, example => <<"string-example">>};
+typename_to_spec("atom()", _Mod) -> #{type => string, example => atom};
+typename_to_spec("duration()", _Mod) -> #{type => string, example => <<"12m">>};
+typename_to_spec("duration_s()", _Mod) -> #{type => string, example => <<"1h">>};
+typename_to_spec("duration_ms()", _Mod) -> #{type => string, example => <<"32s">>};
+typename_to_spec("percent()", _Mod) -> #{type => number, example => <<"12%">>};
+typename_to_spec("file()", _Mod) -> #{type => string, example => <<"/path/to/file">>};
+typename_to_spec("ip_port()", _Mod) -> #{type => string, example => <<"127.0.0.1:80">>};
+typename_to_spec("url()", _Mod) -> #{type => string, example => <<"http://127.0.0.1">>};
+typename_to_spec("server()", Mod) -> typename_to_spec("ip_port()", Mod);
+typename_to_spec("connect_timeout()", Mod) -> typename_to_spec("timeout()", Mod);
+typename_to_spec("timeout()", _Mod) -> #{<<"oneOf">> => [#{type => string, example => infinity},
+    #{type => integer, example => 100}], example => infinity};
+typename_to_spec("bytesize()", _Mod) -> #{type => string, example => <<"32MB">>};
+typename_to_spec("wordsize()", _Mod) -> #{type => string, example => <<"1024KB">>};
+typename_to_spec("map()", _Mod) -> #{type => string, example => <<>>};
+typename_to_spec("comma_separated_list()", _Mod) -> #{type => string, example => <<"item1,item2">>};
+typename_to_spec("comma_separated_atoms()", _Mod) -> #{type => string, example => <<"item1,item2">>};
+typename_to_spec("pool_type()", _Mod) -> #{type => string, enum => [random, hash], example => hash};
+typename_to_spec("log_level()", _Mod) ->
+    #{type => string, enum => [debug, info, notice, warning, error, critical, alert, emergency, all]};
+typename_to_spec(Name, Mod) ->
+    Spec = range(Name),
+    Spec1 = remote_module_type(Spec, Name, Mod),
+    Spec2 = typerefl_array(Spec1, Name, Mod),
+    Spec3 = integer(Spec2, Name),
+    Spec3 =:= nomatch andalso
+        throw({error, #{msg => <<"Unsupport Type">>, type => Name, module => Mod}}),
+    Spec3.
+
+range(Name) ->
     case string:split(Name, "..") of
-        [MinStr, MaxStr] -> %% 1..10
-            {Min, []} = string:to_integer(MinStr),
-            {Max, []} = string:to_integer(MaxStr),
-            #{type => integer, example => Min, minimum => Min, maximum => Max};
-        _ -> %% Module:Type().
-            case string:split(Name, ":") of
-                [_Module, Type] -> typename_to_spec(Type);
-                _ -> throw({error, #{msg => <<"Unsupport Type">>, type => Name}})
-            end
+        [MinStr, MaxStr] -> %% 1..10 1..inf -inf..10
+            Schema = #{type => integer},
+            Schema1 = add_integer_prop(Schema, minimum, MinStr),
+            add_integer_prop(Schema1, maximum, MaxStr);
+        _ -> nomatch
     end.
 
-to_bin(List) when is_list(List) -> list_to_binary(List);
+%% Module:Type
+remote_module_type(nomatch, Name, Mod) ->
+    case string:split(Name, ":") of
+        [_Module, Type] -> typename_to_spec(Type, Mod);
+        _ -> nomatch
+    end;
+remote_module_type(Spec, _Name, _Mod) -> Spec.
+
+%% [string()] or [integer()] or [xxx].
+typerefl_array(nomatch, Name, Mod) ->
+    case string:trim(Name, leading, "[") of
+        Name -> nomatch;
+        Name1 ->
+            case string:trim(Name1, trailing, "]") of
+                Name1 -> notmatch;
+                Name2 ->
+                    Schema = typename_to_spec(Name2, Mod),
+                    #{type => array, items => Schema}
+            end
+    end;
+typerefl_array(Spec, _Name, _Mod) -> Spec.
+
+%% integer(1)
+integer(nomatch, Name) ->
+    case string:to_integer(Name) of
+        {Int, []} -> #{type => integer, enum => [Int], example => Int, default => Int};
+        _ -> nomatch
+    end;
+integer(Spec, _Name) -> Spec.
+
+add_integer_prop(Schema, Key, Value) ->
+    case string:to_integer(Value) of
+        {error, no_integer} -> Schema;
+        {Int, []}when Key =:= minimum -> Schema#{Key => Int, example => Int};
+        {Int, []} -> Schema#{Key => Int}
+    end.
+
+to_bin([Atom | _] = List) when is_atom(Atom) -> iolist_to_binary(io_lib:format("~p", [List]));
+to_bin(List) when is_list(List) -> unicode:characters_to_binary(List);
 to_bin(B) when is_boolean(B) -> B;
 to_bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
 to_bin(X) -> X.
 
-parse_object(PropList = [_|_], Module) when is_list(PropList) ->
+parse_object(PropList = [_ | _], Module) when is_list(PropList) ->
     {Props, Required, Refs} =
         lists:foldl(fun({Name, Hocon}, {Acc, RequiredAcc, RefsAcc}) ->
             NameBin = to_bin(Name),

--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -121,7 +121,7 @@ t_nest_ref(_Config) ->
         #{<<"emqx_swagger_requestBody_SUITE.good_ref">> => #{<<"properties">> => [
             {<<"webhook-host">>, #{default => <<"127.0.0.1:80">>, example => <<"127.0.0.1:80">>,type => string}},
             {<<"log_dir">>, #{example => <<"var/log/emqx">>,type => string}},
-            {<<"tag">>, #{description => <<"tag">>, example => <<"binary example">>,type => string}}],
+            {<<"tag">>, #{description => <<"tag">>, example => <<"binary-example">>,type => string}}],
             <<"type">> => object}}]),
     {_, Components} = validate("/ref/nest/ref", Spec, Refs),
     ?assertEqual(ExpectComponents, Components),

--- a/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
@@ -13,7 +13,7 @@
 -export([all/0, suite/0, groups/0]).
 -export([paths/0, api_spec/0, schema/1, fields/1]).
 -export([t_simple_binary/1, t_object/1, t_nest_object/1, t_empty/1, t_error/1,
-    t_raw_local_ref/1, t_raw_remote_ref/1, t_hocon_schema_function/1,
+    t_raw_local_ref/1, t_raw_remote_ref/1, t_hocon_schema_function/1, t_complicated_type/1,
     t_local_ref/1, t_remote_ref/1, t_bad_ref/1, t_none_ref/1, t_nest_ref/1,
     t_ref_array_with_key/1, t_ref_array_without_key/1, t_api_spec/1]).
 
@@ -21,7 +21,7 @@ all() -> [{group, spec}].
 suite() -> [{timetrap, {minutes, 1}}].
 groups() -> [
     {spec, [parallel], [
-        t_api_spec, t_simple_binary, t_object, t_nest_object, t_error,
+        t_api_spec, t_simple_binary, t_object, t_nest_object, t_error, t_complicated_type,
         t_raw_local_ref, t_raw_remote_ref, t_empty, t_hocon_schema_function,
         t_local_ref, t_remote_ref, t_bad_ref, t_none_ref,
         t_ref_array_with_key, t_ref_array_without_key, t_nest_ref]}
@@ -54,7 +54,7 @@ t_error(_Config) ->
     #{<<"application/json">> => #{<<"schema">> => #{<<"type">> => object,
         <<"properties">> =>
         [
-            {<<"code">>, #{enum => ['Bad1','Bad2'], type => string}},
+            {<<"code">>, #{enum => ['Bad1', 'Bad2'], type => string}},
             {<<"message">>, #{description => <<"Details description of the error.">>,
                 example => <<"Bad request desc">>, type => string}}]
     }}}},
@@ -156,6 +156,38 @@ t_nest_ref(_Config) ->
     validate(Path, Object, ExpectRefs),
     ok.
 
+t_complicated_type(_Config) ->
+    Path = "/ref/complicated_type",
+    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{<<"properties">> =>
+    [
+        {<<"no_neg_integer">>, #{example => 100, minimum => 1, type => integer}},
+        {<<"url">>, #{example => <<"http://127.0.0.1">>, type => string}},
+        {<<"server">>, #{example => <<"127.0.0.1:80">>, type => string}},
+        {<<"connect_timeout">>, #{example => infinity, <<"oneOf">> => [
+            #{example => infinity, type => string},
+            #{example => 100, type => integer}]}},
+        {<<"pool_type">>, #{enum => [random, hash], example => hash, type => string}},
+        {<<"timeout">>, #{example => infinity,
+            <<"oneOf">> =>
+            [#{example => infinity, type => string}, #{example => 100, type => integer}]}},
+        {<<"bytesize">>, #{example => <<"32MB">>, type => string}},
+        {<<"wordsize">>, #{example => <<"1024KB">>, type => string}},
+        {<<"maps">>, #{example => <<>>, type => string}},
+        {<<"comma_separated_list">>, #{example => <<"item1,item2">>, type => string}},
+        {<<"comma_separated_atoms">>, #{example => <<"item1,item2">>, type => string}},
+        {<<"log_level">>,
+            #{enum => [debug, info, notice, warning, error, critical, alert, emergency, all], type => string}},
+        {<<"fix_integer">>, #{default => 100, enum => [100], example => 100,type => integer}}
+    ],
+        <<"type">> => object}}}},
+    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path),
+    ?assertEqual(test, OperationId),
+    Response = maps:get(responses, maps:get(post, Spec)),
+    ?assertEqual(Object, maps:get(<<"200">>, Response)),
+    ?assertEqual([], Refs),
+    ok.
+
+
 t_ref_array_with_key(_Config) ->
     Path = "/ref/array/with/key",
     Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
@@ -163,10 +195,10 @@ t_ref_array_with_key(_Config) ->
             {<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
             {<<"timeout">>, #{default => 5, <<"oneOf">> =>
             [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-            {<<"assert">>, #{description => <<"money">>, example => 3.14159,type => number}},
-            {<<"number_ex">>, #{description => <<"number example">>, example => 42,type => number}},
-            {<<"percent_ex">>, #{description => <<"percent example">>, example => <<"12%">>,type => number}},
-            {<<"duration_ms_ex">>, #{description => <<"duration ms example">>, example => <<"32s">>,type => string}},
+            {<<"assert">>, #{description => <<"money">>, example => 3.14159, type => number}},
+            {<<"number_ex">>, #{description => <<"number example">>, example => 42, type => number}},
+            {<<"percent_ex">>, #{description => <<"percent example">>, example => <<"12%">>, type => number}},
+            {<<"duration_ms_ex">>, #{description => <<"duration ms example">>, example => <<"32s">>, type => string}},
             {<<"atom_ex">>, #{description => <<"atom ex">>, example => atom, type => string}},
             {<<"array_refs">>, #{items => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}, type => array}}
         ]}
@@ -201,7 +233,7 @@ t_hocon_schema_function(_Config) ->
         }},
         #{<<"emqx_swagger_remote_schema.ref3">> => #{<<"type">> => object,
             <<"properties">> => [
-                {<<"ip">>, #{description => <<"IP:Port">>, example => <<"127.0.0.1:80">>,type => string}},
+                {<<"ip">>, #{description => <<"IP:Port">>, example => <<"127.0.0.1:80">>, type => string}},
                 {<<"version">>, #{description => <<"a good version">>, example => <<"1.0.0">>, type => string}}]
         }},
         #{<<"emqx_swagger_remote_schema.root">> => #{required => [<<"default_password">>, <<"default_username">>],
@@ -289,6 +321,27 @@ schema("/error") ->
         get => #{responses => #{
             400 => emqx_dashboard_swagger:error_codes(['Bad1', 'Bad2'], <<"Bad request desc">>),
             404 => emqx_dashboard_swagger:error_codes(['Not-Found'])
+        }}
+    };
+schema("/ref/complicated_type") ->
+    #{
+        operationId => test,
+        post => #{responses => #{
+            200 => [
+                {no_neg_integer, hoconsc:mk(non_neg_integer(), #{})},
+                {url, hoconsc:mk(emqx_connector_http:url(), #{})},
+                {server, hoconsc:mk(emqx_connector_redis:server(), #{})},
+                {connect_timeout, hoconsc:mk(emqx_connector_http:connect_timeout(), #{})},
+                {pool_type, hoconsc:mk(emqx_connector_http:pool_type(), #{})},
+                {timeout, hoconsc:mk(timeout(), #{})},
+                {bytesize, hoconsc:mk(emqx_schema:bytesize(), #{})},
+                {wordsize, hoconsc:mk(emqx_schema:wordsize(), #{})},
+                {maps, hoconsc:mk(map(), #{})},
+                {comma_separated_list, hoconsc:mk(emqx_schema:comma_separated_list(), #{})},
+                {comma_separated_atoms, hoconsc:mk(emqx_schema:comma_separated_atoms(), #{})},
+                {log_level, hoconsc:mk(emqx_machine_schema:log_level(), #{})},
+                {fix_integer, hoconsc:mk(typerefl:integer(100), #{})}
+            ]
         }}
     }.
 

--- a/apps/emqx_exhook/src/emqx_exhook_schema.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_schema.erl
@@ -40,13 +40,13 @@ roots() -> [exhook].
 
 fields(exhook) ->
     [ {request_failed_action,
-       sc(union([deny, ignore]),
+       sc(hoconsc:enum([deny, ignore]),
           #{default => deny})}
     , {request_timeout,
        sc(duration(),
           #{default => "5s"})}
     , {auto_reconnect,
-       sc(union([false, duration()]),
+       sc(hoconsc:union([false, duration()]),
           #{ default => "60s"
            })}
     , {servers,

--- a/apps/emqx_gateway/src/coap/emqx_coap_api.erl
+++ b/apps/emqx_gateway/src/coap/emqx_coap_api.erl
@@ -83,7 +83,7 @@ request_parameters() ->
 request_properties() ->
     properties([ {token, string, "message token, can be empty"}
                , {method, string, "request method type", ["get", "put", "post", "delete"]}
-               , {timeout, string, "timespan for response", "10s"}
+               , {timeout, string, "timespan for response"}
                , {content_type, string, "payload type",
                   [<<"text/plain">>, <<"application/json">>, <<"application/octet-stream">>]}
                , {payload, string, "payload"}]).

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -232,7 +232,7 @@ gateway_common_options() ->
 
 common_listener_opts() ->
     [ {enable, sc(boolean(), true)}
-    , {bind, sc(union(ip_port(), integer()))}
+    , {bind, sc(hoconsc:union([ip_port(), integer()]))}
     , {max_connections, sc(integer(), 1024)}
     , {max_conn_rate, sc(integer())}
     , {authentication,  authentication()}

--- a/apps/emqx_modules/src/emqx_modules_schema.erl
+++ b/apps/emqx_modules/src/emqx_modules_schema.erl
@@ -28,14 +28,12 @@ namespace() -> modules.
 
 roots() ->
     ["delayed",
-     "recon",
      "telemetry",
      "event_message",
      array("rewrite"),
      array("topic_metrics")].
 
-fields(Name) when Name =:= "recon";
-                  Name =:= "telemetry" ->
+fields("telemetry") ->
     [ {enable, hoconsc:mk(boolean(), #{default => false})}
     ];
 


### PR DESCRIPTION
1. replace typrefl:union/1  by hoconsc:enum/1 or hoconsc:union/1.
2. swagger's component's name: replace namespace's `:` by `-`.
3. swagger support more complicate type, such as `url()`.
4. remove unused recon from emqx_module_schema.
5. refactor config api.

- add `/configs` to return all configs.
- repalce `/configs_reset/xx_path_xx` by `/configs_reset/:root_name`
- generate API from emqx_machine_schema:roots().
- 