### PR TITLE
chore(bin/emqx): print pid info if failed to stop

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -308,6 +308,8 @@ is_down() {
             ps -p "$parent"
             return 0
         fi
+        echo "ERROR: $PID is still around"
+        ps -p "$PID"
         return 1
     fi
     # it's gone


### PR DESCRIPTION
this is to add some debug info output when fail to stop.

in bin/emqx:
`ps -p $PID` indicated the pid is still around.

but in ci script:
`ps -ef | grep ...` can not find it any more.