### PR TITLE
chore(emqx.app): bump emqx app to vsn 4.3.10

### DIFF
--- a/src/emqx.app.src
+++ b/src/emqx.app.src
@@ -1,7 +1,7 @@
 {application, emqx,
  [{id, "emqx"},
   {description, "EMQ X"},
-  {vsn, "4.3.9"}, % strict semver, bump manually!
+  {vsn, "4.3.10"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [kernel,stdlib,gproc,gen_rpc,esockd,cowboy,sasl,os_mon]},

--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -1,7 +1,11 @@
 %% -*- mode: erlang -*-
 Instructions =
-{"4.3.9",
+{"4.3.10",
   [
+   %% app 4.3.9 was released in e4.3.4(enterprise) but not v4.3.9(opensource)
+   {"4.3.9", [
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+    ]},
    {"4.3.8", [
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
@@ -116,6 +120,14 @@ Instructions =
    ]},
    {<<".*">>,[]}],
   [
+   {"4.3.9", [
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+    ]},
+   {"4.3.8", [
+     {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
+     {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+    ]},
    {"4.3.7", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
      {load_module,emqx_misc,brutal_purge,soft_purge,[]},


### PR DESCRIPTION
app 4.3.9 was release as a part of enterprise e4.3.4
but opensource v4.3.9 is not releasd yet, but we have
to bump app version to 4.3.10 to make appup work for the next
release (either opensource or enterprise).

