### PR TITLE
fix(emqx_rpc): removed unnecessary call wrapper

### DIFF
--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -4,19 +4,22 @@ Instructions =
   [
    %% app 4.3.9 was released in e4.3.4(enterprise) but not v4.3.9(opensource)
    {"4.3.9", [
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.8", [
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.7", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
      {load_module,emqx_misc,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.6", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -24,7 +27,8 @@ Instructions =
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.5", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -34,7 +38,8 @@ Instructions =
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.4", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -45,7 +50,8 @@ Instructions =
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.3", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -58,7 +64,8 @@ Instructions =
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.2", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -74,7 +81,8 @@ Instructions =
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.1", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -94,7 +102,8 @@ Instructions =
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
+     {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
    ]},
    {"4.3.0", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -116,28 +125,33 @@ Instructions =
      {apply,{emqx_metrics,upgrade_retained_delayed_counter_type,[]}},
      {load_module,emqx_http_lib,brutal_purge,soft_purge,[]},
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
-     {load_module,emqx_ctl,brutal_purge,soft_purge,[]}
+     {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
    ]},
    {<<".*">>,[]}],
   [
    {"4.3.9", [
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.8", [
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
      {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.7", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
      {load_module,emqx_misc,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.6", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
      {load_module,emqx_misc,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.5", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -145,7 +159,8 @@ Instructions =
      {load_module,emqx_cm,brutal_purge,soft_purge,[]},
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.4", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -154,7 +169,8 @@ Instructions =
      {load_module,emqx_shared_sub,brutal_purge,soft_purge,[]},
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.3", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -165,7 +181,8 @@ Instructions =
      {load_module,emqx_cm,brutal_purge,soft_purge,[]},
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.2", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -179,7 +196,8 @@ Instructions =
      {load_module,emqx_cm,brutal_purge,soft_purge,[]},
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
-     {load_module,emqx_frame,brutal_purge,soft_purge,[]}
+     {load_module,emqx_frame,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
     ]},
    {"4.3.1", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -197,7 +215,8 @@ Instructions =
      {load_module,emqx_logger_textfmt,brutal_purge,soft_purge,[]},
      {load_module,emqx_http_lib,brutal_purge,soft_purge,[]},
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
-     {load_module,emqx_ctl,brutal_purge,soft_purge,[]}
+     {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
    ]},
    {"4.3.0", [
      {load_module,emqx_alarm_handler,brutal_purge,soft_purge,[]},
@@ -220,7 +239,8 @@ Instructions =
      {load_module,emqx_access_rule,brutal_purge,soft_purge,[]},
      {load_module,emqx_ctl,brutal_purge,soft_purge,[]},
      {load_module,emqx_pqueue,brutal_purge,soft_purge,[]},
-     {load_module,emqx_mqueue,brutal_purge,soft_purge,[]}
+     {load_module,emqx_mqueue,brutal_purge,soft_purge,[]},
+     {load_module,emqx_rpc,brutal_purge,soft_purge,[]}
    ]},
    {<<".*">>,[]}]},
 

--- a/src/emqx_rpc.erl
+++ b/src/emqx_rpc.erl
@@ -41,10 +41,10 @@ call(Key, Node, Mod, Fun, Args) ->
     filter_result(?RPC:call(rpc_node({Key, Node}), Mod, Fun, Args)).
 
 multicall(Nodes, Mod, Fun, Args) ->
-    filter_result(?RPC:multicall(rpc_nodes(Nodes), Mod, Fun, Args)).
+    ?RPC:multicall(rpc_nodes(Nodes), Mod, Fun, Args).
 
 multicall(Key, Nodes, Mod, Fun, Args) ->
-    filter_result(?RPC:multicall(rpc_nodes([{Key, Node} || Node <- Nodes]), Mod, Fun, Args)).
+    ?RPC:multicall(rpc_nodes([{Key, Node} || Node <- Nodes]), Mod, Fun, Args).
 
 cast(Node, Mod, Fun, Args) ->
     filter_result(?RPC:cast(rpc_node(Node), Mod, Fun, Args)).


### PR DESCRIPTION
Result of `?RPC:multicall(...)` is never a `{badtcp, ...}` tuple, it is always `{[...], [...]}`.