### PR TITLE
fix(test): testcase t_validity_period failed occasionally

### DIFF
--- a/apps/emqx/test/emqx_alarm_SUITE.erl
+++ b/apps/emqx/test/emqx_alarm_SUITE.erl
@@ -90,7 +90,7 @@ t_validity_period(_) ->
     ok = emqx_alarm:activate(a),
     ok = emqx_alarm:deactivate(a),
     ?assertNotEqual({error, not_found}, get_alarm(a, emqx_alarm:get_alarms(deactivated))),
-    ct:sleep(2000),
+    ct:sleep(3000),
     ?assertEqual({error, not_found}, get_alarm(a, emqx_alarm:get_alarms(deactivated))).
 
 get_alarm(Name, [Alarm = #{name := Name} | _More]) ->


### PR DESCRIPTION
```
2021-09-29T12:39:34.3544383Z %%% emqx_alarm_SUITE ==> t_validity_period: FAILED
32021-09-29T12:39:34.3545400Z %%% emqx_alarm_SUITE ==> 
42021-09-29T12:39:34.3546200Z Failure/Error: ?assertEqual({error,not_found}, get_alarm ( a , emqx_alarm : get_alarms ( deactivated ) ))
52021-09-29T12:39:34.3551519Z   expected: {error,not_found}
62021-09-29T12:39:34.3552251Z        got: #{activate_at => 1632919172320229,activated => false,
72021-09-29T12:39:34.3552885Z               deactivate_at => 1632919172320506,details => #{},
82021-09-29T12:39:34.3553476Z               message => <<"Unknown alarm">>,name => a}
92021-09-29T12:39:34.3553971Z       line: 94
102021-09-29T12:39:34.3573666Z 
112021-09-29T12:39:36.5399798Z %%% emqx_authentication_SUITE: .....
```

I don’t know why this happened, I tried this test 100 times on my MacBook but failed to reproduce it.
I think there’s a small chance the test case is too slow so that the timer is not triggered, I’ll change the sleep time to 3s if this is the case.
