### PR TITLE
chore(doc): replace : by _ in namespace

### DIFF
--- a/apps/emqx_authn/src/enhanced_authn/emqx_enhanced_authn_scram_mnesia.erl
+++ b/apps/emqx_authn/src/enhanced_authn/emqx_enhanced_authn_scram_mnesia.erl
@@ -77,7 +77,7 @@ mnesia(copy) ->
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:scram:builtin-db".
+namespace() -> "authn-scram-builtin_db".
 
 roots() -> [config].
 

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -40,7 +40,7 @@
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:password-based:http-server".
+namespace() -> "authn-password_based-http_server".
 
 roots() ->
     [ {config, {union, [ hoconsc:ref(?MODULE, get)

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -37,7 +37,7 @@
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:jwt".
+namespace() -> "authn-jwt".
 
 roots() ->
     [ {config, {union, [ hoconsc:mk('hmac-based')

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mnesia.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mnesia.erl
@@ -84,7 +84,7 @@ mnesia(copy) ->
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:password-based:builtin-db".
+namespace() -> "authn-password_based-builtin_db".
 
 roots() -> [config].
 

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
@@ -39,7 +39,7 @@
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:password-based:mongodb".
+namespace() -> "authn-password_based-mongodb".
 
 roots() ->
     [ {config, {union, [ hoconsc:mk(standalone)

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mysql.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mysql.erl
@@ -39,7 +39,7 @@
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:password-based:mysql".
+namespace() -> "authn-password_based-mysql".
 
 roots() -> [config].
 

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_pgsql.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_pgsql.erl
@@ -40,7 +40,7 @@
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:password-based:postgresql".
+namespace() -> "authn-password_based-postgresql".
 
 roots() -> [config].
 

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
@@ -39,7 +39,7 @@
 %% Hocon Schema
 %%------------------------------------------------------------------------------
 
-namespace() -> "authn:password-based:redis".
+namespace() -> "authn-password_based-redis".
 
 roots() ->
     [ {config, {union, [ hoconsc:mk(standalone)


### PR DESCRIPTION
swagger: Component names can only contain the characters A-Z a-z 0-9 - . _
we already use:
```
namespace.ref
build-in

```
Keep the documentation and swagger output in the same namespace, so replace `:` with `_`.