### PR TITLE
chore: Remove emqx_ct_helpers as dependency

### DIFF
--- a/apps/emqx/test/emqx_SUITE.erl
+++ b/apps/emqx/test/emqx_SUITE.erl
@@ -23,14 +23,14 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_emqx_pubsub_api(_) ->
     true = emqx:is_running(node()),

--- a/apps/emqx/test/emqx_access_control_SUITE.erl
+++ b/apps/emqx/test/emqx_access_control_SUITE.erl
@@ -22,15 +22,15 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules([router, broker]),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules([router, broker]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_authenticate(_) ->
     ?assertMatch({ok, _}, emqx_access_control:authenticate(clientinfo())).

--- a/apps/emqx/test/emqx_alarm_SUITE.erl
+++ b/apps/emqx/test/emqx_alarm_SUITE.erl
@@ -23,29 +23,29 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(t_size_limit, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     {ok, _} = emqx:update_config([alarm], #{
             <<"size_limit">> => 2
         }),
     Config;
 init_per_testcase(t_validity_period, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     {ok, _} = emqx:update_config([alarm], #{
             <<"validity_period">> => <<"1s">>
         }),
     Config;
 init_per_testcase(_, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_testcase(_, _Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_alarm(_) ->
     ok = emqx_alarm:activate(unknown_alarm),

--- a/apps/emqx/test/emqx_authentication_SUITE.erl
+++ b/apps/emqx/test/emqx_authentication_SUITE.erl
@@ -82,15 +82,15 @@ destroy(_State) ->
     ok.
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     application:set_env(ekka, strict_mode, true),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_) ->
-    emqx_ct_helpers:stop_apps([]),
+    emqx_common_test_helpers:stop_apps([]),
     ok.
 
 init_per_testcase(Case, Config) ->
@@ -297,7 +297,7 @@ update_config(Path, ConfigRequest) ->
     emqx:update_config(Path, ConfigRequest, #{rawconf_with_defaults => true}).
 
 certs(Certs) ->
-    CertsPath = emqx_ct_helpers:deps_path(emqx, "etc/certs"),
+    CertsPath = emqx_common_test_helpers:deps_path(emqx, "etc/certs"),
     lists:foldl(fun({Key, Filename}, Acc) ->
                     {ok, Bin} = file:read_file(filename:join([CertsPath, Filename])),
                     Acc#{Key => Bin}

--- a/apps/emqx/test/emqx_authz_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_authz_cache_SUITE.erl
@@ -21,15 +21,15 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 %%--------------------------------------------------------------------
 %% Test cases

--- a/apps/emqx/test/emqx_banned_SUITE.erl
+++ b/apps/emqx/test/emqx_banned_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     application:load(emqx),

--- a/apps/emqx/test/emqx_batch_SUITE.erl
+++ b/apps/emqx/test/emqx_batch_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_batch_full_commit(_) ->
     B0 = emqx_batch:init(#{batch_size => 3,

--- a/apps/emqx/test/emqx_boot_SUITE.erl
+++ b/apps/emqx/test/emqx_boot_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_is_enabled(_) ->
     ok = application:set_env(emqx, boot_modules, all),

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -27,15 +27,15 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(Case, Config) ->
     ?MODULE:Case({init, Config}).

--- a/apps/emqx/test/emqx_broker_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_helper_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(_TestCase, Config) ->
     emqx_broker_helper:start_link(),

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -25,7 +25,7 @@
 
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 force_gc_conf() ->
     #{bytes => 16777216,count => 16000,enable => true}.

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -77,14 +77,14 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     emqx_config:put_listener_conf(ssl, default, [ssl, verify], verify_peer),
     emqx_listeners:restart_listener('ssl:default'),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 %%--------------------------------------------------------------------
 %% Test cases for MQTT v3
@@ -324,7 +324,7 @@ tls_certcn_as_clientid(TLSVsn) ->
 tls_certcn_as_clientid(TLSVsn, RequiredTLSVsn) ->
     CN = <<"Client">>,
     emqx_config:put_zone_conf(default, [mqtt, peer_cert_as_clientid], cn),
-    SslConf = emqx_ct_helpers:client_ssl_twoway(TLSVsn),
+    SslConf = emqx_common_test_helpers:client_ssl_twoway(TLSVsn),
     {ok, Client} = emqtt:start_link([{port, 8883}, {ssl, true}, {ssl_opts, SslConf}]),
     {ok, _} = emqtt:connect(Client),
     #{clientinfo := #{clientid := CN}} = emqx_cm:get_chan_info(CN),

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -37,15 +37,15 @@
 %%--------------------------------------------------------------------
 suite() -> [{timetrap, {minutes, 2}}].
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 %%--------------------------------------------------------------------
 %% TODO: Add more test cases

--- a/apps/emqx/test/emqx_cm_locker_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_locker_SUITE.erl
@@ -21,15 +21,15 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_start_link(_) ->
     emqx_cm_locker:start_link().

--- a/apps/emqx/test/emqx_cm_registry_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_registry_SUITE.erl
@@ -25,15 +25,15 @@
 %% CT callbacks
 %%--------------------------------------------------------------------
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(_TestCase, Config) ->
     Config.

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1,0 +1,435 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_common_test_helpers).
+
+-define(THIS_APP, ?MODULE).
+-include_lib("common_test/include/ct.hrl").
+
+-type(special_config_handler() :: fun()).
+
+-type(apps() :: list(atom())).
+
+-export([ all/1
+        , boot_modules/1
+        , start_apps/1
+        , start_apps/2
+        , start_app/4
+        , stop_apps/1
+        , reload/2
+        , app_path/2
+        , deps_path/2
+        , flush/0
+        , flush/1
+        ]).
+
+-export([ ensure_mnesia_stopped/0
+        , wait_for/4
+        , change_emqx_opts/1
+        , change_emqx_opts/2
+        , client_ssl_twoway/0
+        , client_ssl_twoway/1
+        , client_ssl/0
+        , client_ssl/1
+        , wait_mqtt_payload/1
+        , not_wait_mqtt_payload/1
+        , render_config_file/2
+        , read_schema_configs/2
+        ]).
+
+-define( CERTS_PATH(CertName), filename:join( [ "etc", "certs", CertName ]) ).
+
+-define( MQTT_SSL_TWOWAY, [ { cacertfile, ?CERTS_PATH( "cacert.pem" ) },
+                            { verify, verify_peer },
+                            { fail_if_no_peer_cert, true } ] ).
+
+-define( MQTT_SSL_CLIENT_CERTS, [ { keyfile,    ?CERTS_PATH( "client-key.pem" ) },
+                                  { cacertfile, ?CERTS_PATH( "cacert.pem" ) },
+                                  { certfile,   ?CERTS_PATH( "client-cert.pem" ) } ] ).
+
+-define( TLS_1_3_CIPHERS, [ { versions, [ 'tlsv1.3' ] },
+                            { ciphers,  [ "TLS_AES_256_GCM_SHA384",
+                                          "TLS_AES_128_GCM_SHA256",
+                                          "TLS_CHACHA20_POLY1305_SHA256",
+                                          "TLS_AES_128_CCM_SHA256",
+                                          "TLS_AES_128_CCM_8_SHA256"
+                                        ] }
+                          ]).
+
+-define( TLS_OLD_CIPHERS,  [ { versions, [ 'tlsv1.1', 'tlsv1.2' ] },
+                             { ciphers,  [ "ECDHE-ECDSA-AES256-GCM-SHA384",
+                                           "ECDHE-RSA-AES256-GCM-SHA384",
+                                           "ECDHE-ECDSA-AES256-SHA384",
+                                           "ECDHE-RSA-AES256-SHA384",
+                                           "ECDHE-ECDSA-DES-CBC3-SHA",
+                                           "ECDH-ECDSA-AES256-GCM-SHA384",
+                                           "ECDH-RSA-AES256-GCM-SHA384",
+                                           "ECDH-ECDSA-AES256-SHA384",
+                                           "ECDH-RSA-AES256-SHA384",
+                                           "DHE-DSS-AES256-GCM-SHA384",
+                                           "DHE-DSS-AES256-SHA256",
+                                           "AES256-GCM-SHA384",
+                                           "AES256-SHA256",
+                                           "ECDHE-ECDSA-AES128-GCM-SHA256",
+                                           "ECDHE-RSA-AES128-GCM-SHA256",
+                                           "ECDHE-ECDSA-AES128-SHA256",
+                                           "ECDHE-RSA-AES128-SHA256",
+                                           "ECDH-ECDSA-AES128-GCM-SHA256",
+                                           "ECDH-RSA-AES128-GCM-SHA256",
+                                           "ECDH-ECDSA-AES128-SHA256",
+                                           "ECDH-RSA-AES128-SHA256",
+                                           "DHE-DSS-AES128-GCM-SHA256",
+                                           "DHE-DSS-AES128-SHA256",
+                                           "AES128-GCM-SHA256",
+                                           "AES128-SHA256",
+                                           "ECDHE-ECDSA-AES256-SHA",
+                                           "ECDHE-RSA-AES256-SHA",
+                                           "DHE-DSS-AES256-SHA",
+                                           "ECDH-ECDSA-AES256-SHA",
+                                           "ECDH-RSA-AES256-SHA",
+                                           "AES256-SHA",
+                                           "ECDHE-ECDSA-AES128-SHA",
+                                           "ECDHE-RSA-AES128-SHA",
+                                           "DHE-DSS-AES128-SHA",
+                                           "ECDH-ECDSA-AES128-SHA",
+                                           "ECDH-RSA-AES128-SHA",
+                                           "AES128-SHA"
+                                         ] }
+                            ]).
+
+
+%%------------------------------------------------------------------------------
+%% APIs
+%%------------------------------------------------------------------------------
+
+all(Suite) ->
+    lists:usort([F || {F, 1} <- Suite:module_info(exports),
+                      string:substr(atom_to_list(F), 1, 2) == "t_"
+                ]).
+
+-spec(boot_modules(all|list(atom())) -> ok).
+boot_modules(Mods) ->
+    application:set_env(emqx, boot_modules, Mods).
+
+-spec(start_apps(Apps :: apps()) -> ok).
+start_apps(Apps) ->
+    start_apps(Apps, fun(_) -> ok end).
+
+-spec(start_apps(Apps :: apps(), Handler :: special_config_handler()) -> ok).
+start_apps(Apps, Handler) when is_function(Handler) ->
+    %% Load all application code to beam vm first
+    %% Because, minirest, ekka etc.. application will scan these modules
+    lists:foreach(fun load/1, [emqx | Apps]),
+    lists:foreach(fun(App) -> start_app(App, Handler) end, [emqx | Apps]).
+
+load(App) ->
+    case application:load(App) of
+        ok -> ok;
+        {error, {already_loaded, _}} -> ok;
+        {error, Reason} -> error({failed_to_load_app, App, Reason})
+    end.
+
+start_app(App, Handler) ->
+    start_app(App,
+              app_schema(App),
+              app_path(App, filename:join(["etc", atom_to_list(App) ++ ".conf"])),
+              Handler).
+
+%% TODO: get rid of cuttlefish
+app_schema(App) ->
+    CuttlefishSchema = app_path(App, filename:join(["priv", atom_to_list(App) ++ ".schema"])),
+    case filelib:is_regular(CuttlefishSchema) of
+        true ->
+            CuttlefishSchema;
+        false ->
+            Mod = list_to_atom(atom_to_list(App) ++ "_schema"),
+            try
+                true = is_list(Mod:roots()),
+                Mod
+            catch
+                C : E ->
+                    error(#{app => App,
+                            file => CuttlefishSchema,
+                            module => Mod,
+                            exeption => C,
+                            reason => E
+                           })
+            end
+    end.
+
+mustache_vars(App) ->
+    [{platform_data_dir, app_path(App, "data")},
+     {platform_etc_dir,  app_path(App, "etc")},
+     {platform_log_dir,  app_path(App, "log")},
+     {platform_plugins_dir,  app_path(App, "plugins")}
+    ].
+
+start_app(App, Schema, ConfigFile, SpecAppConfig) ->
+    Vars = mustache_vars(App),
+    RenderedConfigFile = render_config_file(ConfigFile, Vars),
+    read_schema_configs(Schema, RenderedConfigFile),
+    force_set_config_file_paths(App, [RenderedConfigFile]),
+    SpecAppConfig(App),
+    case application:ensure_all_started(App) of
+        {ok, _} -> ok;
+        {error, Reason} -> error({failed_to_start_app, App, Reason})
+    end.
+
+render_config_file(ConfigFile, Vars0) ->
+    Temp = case file:read_file(ConfigFile) of
+               {ok, T} -> T;
+               {error, Reason} -> error({failed_to_read_config_template, ConfigFile, Reason})
+           end,
+    Vars = [{atom_to_list(N), iolist_to_binary(V)} || {N, V} <- Vars0],
+    Targ = bbmustache:render(Temp, Vars),
+    NewName = ConfigFile ++ ".rendered",
+    ok = file:write_file(NewName, Targ),
+    NewName.
+
+read_schema_configs(Schema, ConfigFile) ->
+    NewConfig = generate_config(Schema, ConfigFile),
+    lists:foreach(
+        fun({App, Configs}) ->
+            [application:set_env(App, Par, Value) || {Par, Value} <- Configs]
+        end, NewConfig).
+
+generate_config(SchemaModule, ConfigFile) when is_atom(SchemaModule) ->
+    {ok, Conf0} = hocon:load(ConfigFile, #{format => richmap}),
+    hocon_schema:generate(SchemaModule, Conf0);
+generate_config(SchemaFile, ConfigFile) ->
+    {ok, Conf1} = hocon:load(ConfigFile, #{format => proplists}),
+    Schema = cuttlefish_schema:files([SchemaFile]),
+    cuttlefish_generator:map(Schema, Conf1).
+
+-spec(stop_apps(list()) -> ok).
+stop_apps(Apps) ->
+    [application:stop(App) || App <- Apps ++ [emqx, mnesia]].
+
+%% backward compatible
+deps_path(App, RelativePath) -> app_path(App, RelativePath).
+
+app_path(App, RelativePath) ->
+    ok = ensure_app_loaded(App),
+    Lib = code:lib_dir(App),
+    safe_relative_path(filename:join([Lib, RelativePath])).
+
+assert_app_loaded(App) ->
+    case code:lib_dir(App) of
+        {error, bad_name} -> error({not_loaded, ?THIS_APP});
+        _ -> ok
+    end.
+
+ensure_app_loaded(?THIS_APP) ->
+    ok = assert_app_loaded(?THIS_APP);
+ensure_app_loaded(App) ->
+    case code:lib_dir(App) of
+        {error, bad_name} ->
+            ok = assert_app_loaded(?THIS_APP),
+            Dir0 = code:lib_dir(?THIS_APP),
+            LibRoot = upper_level(Dir0),
+            Dir = filename:join([LibRoot, atom_to_list(App), "ebin"]),
+            case code:add_pathz(Dir) of
+                true -> ok;
+                {error, bad_directory} -> error({bad_directory, Dir})
+            end,
+            case application:load(App) of
+                ok -> ok;
+                {error, Reason} -> error({failed_to_load, App, Reason})
+            end,
+            ok = assert_app_loaded(App);
+        _ ->
+            ok
+    end.
+
+upper_level(Dir) ->
+    Split = filename:split(Dir),
+    UpperReverse = tl(lists:reverse(Split)),
+    filename:join(lists:reverse(UpperReverse)).
+
+safe_relative_path(Path) ->
+    case filename:split(Path) of
+        ["/" | T] ->
+            T1 = do_safe_relative_path(filename:join(T)),
+            filename:join(["/", T1]);
+        _ ->
+            do_safe_relative_path(Path)
+    end.
+
+do_safe_relative_path(Path) ->
+    case safe_relative_path_2(Path) of
+        unsafe -> Path;
+        OK -> OK
+    end.
+
+-if(?OTP_RELEASE < 23).
+safe_relative_path_2(Path) ->
+    filename:safe_relative_path(Path).
+-else.
+safe_relative_path_2(Path) ->
+    {ok, Cwd} = file:get_cwd(),
+    filelib:safe_relative_path(Path, Cwd).
+-endif.
+
+-spec(reload(App :: atom(), SpecAppConfig :: special_config_handler()) -> ok).
+reload(App, SpecAppConfigHandler) ->
+    application:stop(App),
+    start_app(App, SpecAppConfigHandler),
+    application:start(App).
+
+ensure_mnesia_stopped() ->
+    ekka_mnesia:ensure_stopped(),
+    ekka_mnesia:delete_schema().
+
+%% Help function to wait for Fun to yield 'true'.
+wait_for(Fn, Ln, F, Timeout) ->
+    {Pid, Mref} = erlang:spawn_monitor(fun() -> wait_loop(F, catch_call(F)) end),
+    wait_for_down(Fn, Ln, Timeout, Pid, Mref, false).
+
+change_emqx_opts(SslType) ->
+    change_emqx_opts(SslType, []).
+
+change_emqx_opts(SslType, MoreOpts) ->
+    {ok, Listeners} = application:get_env(emqx, listeners),
+    NewListeners =
+        lists:map(fun(Listener) ->
+                          maybe_inject_listener_ssl_options(SslType, MoreOpts, Listener)
+                  end, Listeners),
+    application:set_env(emqx, listeners, NewListeners).
+
+maybe_inject_listener_ssl_options(SslType, MoreOpts, {sll, Port, Opts}) ->
+    %% this clause is kept to be backward compatible
+    %% new config for listener is a map, old is a three-element tuple
+    {ssl, Port, inject_listener_ssl_options(SslType, Opts, MoreOpts)};
+maybe_inject_listener_ssl_options(SslType, MoreOpts, #{proto := ssl, opts := Opts} = Listener) ->
+    Listener#{opts := inject_listener_ssl_options(SslType, Opts, MoreOpts)};
+maybe_inject_listener_ssl_options(_SslType, _MoreOpts, Listener) ->
+    Listener.
+
+inject_listener_ssl_options(SslType, Opts, MoreOpts) ->
+    SslOpts = proplists:get_value(ssl_options, Opts),
+    Keyfile = app_path(emqx, filename:join(["etc", "certs", "key.pem"])),
+    Certfile = app_path(emqx, filename:join(["etc", "certs", "cert.pem"])),
+    TupleList1 = lists:keyreplace(keyfile, 1, SslOpts, {keyfile, Keyfile}),
+    TupleList2 = lists:keyreplace(certfile, 1, TupleList1, {certfile, Certfile}),
+    TupleList3 =
+        case SslType of
+            ssl_twoway ->
+                CAfile = app_path(emqx, proplists:get_value(cacertfile, ?MQTT_SSL_TWOWAY)),
+                MutSslList = lists:keyreplace(cacertfile, 1, ?MQTT_SSL_TWOWAY, {cacertfile, CAfile}),
+                lists:merge(TupleList2, MutSslList);
+            _ ->
+                lists:filter(fun ({cacertfile, _}) -> false;
+                                 ({verify, _}) -> false;
+                                 ({fail_if_no_peer_cert, _}) -> false;
+                                 (_) -> true
+                             end, TupleList2)
+        end,
+    TupleList4 = emqx_misc:merge_opts(TupleList3, proplists:get_value(ssl_options, MoreOpts, [])),
+    NMoreOpts = emqx_misc:merge_opts(MoreOpts, [{ssl_options, TupleList4}]),
+    emqx_misc:merge_opts(Opts, NMoreOpts).
+
+flush() ->
+    flush([]).
+
+flush(Msgs) ->
+    receive
+        M -> flush([M|Msgs])
+    after
+        0 -> lists:reverse(Msgs)
+    end.
+
+client_ssl_twoway() ->
+    client_ssl_twoway(default).
+
+client_ssl_twoway(TLSVsn) ->
+    client_certs() ++ ciphers(TLSVsn).
+
+%% Paths prepended to cert filenames
+client_certs() ->
+    [ { Key, app_path(emqx, FilePath) } || { Key, FilePath } <- ?MQTT_SSL_CLIENT_CERTS ].
+
+client_ssl() ->
+    client_ssl(default).
+
+client_ssl(TLSVsn) ->
+    ciphers(TLSVsn) ++ [{reuse_sessions, true}].
+
+ciphers(default) -> []; %% determined via config file defaults
+ciphers('tlsv1.3') -> ?TLS_1_3_CIPHERS;
+ciphers(_OlderTLSVsn) -> ?TLS_OLD_CIPHERS.
+
+wait_mqtt_payload(Payload) ->
+    receive
+        {publish, #{payload := Payload}} ->
+            ct:pal("OK - received msg: ~p~n", [Payload])
+    after 1000 ->
+        ct:fail({timeout, Payload, {msg_box, flush()}})
+    end.
+
+not_wait_mqtt_payload(Payload) ->
+    receive
+        {publish, #{payload := Payload}} ->
+            ct:fail({received, Payload})
+    after 1000 ->
+        ct:pal("OK - msg ~p is not received", [Payload])
+    end.
+
+wait_for_down(Fn, Ln, Timeout, Pid, Mref, Kill) ->
+    receive
+        {'DOWN', Mref, process, Pid, normal} ->
+            ok;
+        {'DOWN', Mref, process, Pid, {unexpected, Result}} ->
+            erlang:error({unexpected, Fn, Ln, Result});
+        {'DOWN', Mref, process, Pid, {crashed, {C, E, S}}} ->
+            erlang:raise(C, {Fn, Ln, E}, S)
+    after
+        Timeout ->
+            case Kill of
+                true ->
+                    erlang:demonitor(Mref, [flush]),
+                    erlang:exit(Pid, kill),
+                    erlang:error({Fn, Ln, timeout});
+                false ->
+                    Pid ! stop,
+                    wait_for_down(Fn, Ln, Timeout, Pid, Mref, true)
+            end
+    end.
+
+wait_loop(_F, ok) -> exit(normal);
+wait_loop(F, LastRes) ->
+    receive
+        stop -> erlang:exit(LastRes)
+    after
+        100 ->
+            Res = catch_call(F),
+            wait_loop(F, Res)
+    end.
+
+catch_call(F) ->
+    try
+        case F() of
+            true -> ok;
+            Other -> {unexpected, Other}
+        end
+    catch
+        C : E : S ->
+            {crashed, {C, E, S}}
+    end.
+
+force_set_config_file_paths(emqx, Paths) ->
+    application:set_env(emqx, config_files, Paths);
+force_set_config_file_paths(_, _) ->
+    ok.

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -20,15 +20,15 @@
 -compile(nowarn_export_all).
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_fill_default_values(_) ->
     Conf = #{

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -23,7 +23,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
 %% CT callbacks

--- a/apps/emqx/test/emqx_ctl_SUITE.erl
+++ b/apps/emqx/test/emqx_ctl_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_logger:set_log_level(emergency),

--- a/apps/emqx/test/emqx_flapping_SUITE.erl
+++ b/apps/emqx/test/emqx_flapping_SUITE.erl
@@ -21,11 +21,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     emqx_config:put_zone_conf(default, [flapping_detect],
         #{max_count => 3,
           window_time => 100, % 0.1s
@@ -34,7 +34,7 @@ init_per_suite(Config) ->
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]),
+    emqx_common_test_helpers:stop_apps([]),
     ekka_mnesia:delete_schema(),    %% Clean emqx_banned table
     ok.
 

--- a/apps/emqx/test/emqx_gc_SUITE.erl
+++ b/apps/emqx/test/emqx_gc_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_init(_) ->
     GC1 = emqx_gc:init(#{count => 10, bytes => 0}),

--- a/apps/emqx/test/emqx_guid_SUITE.erl
+++ b/apps/emqx/test/emqx_guid_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_guid_gen(_) ->
     Guid1 = emqx_guid:gen(),

--- a/apps/emqx/test/emqx_hooks_SUITE.erl
+++ b/apps/emqx/test/emqx_hooks_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 % t_lookup(_) ->
 %     error('TODO').

--- a/apps/emqx/test/emqx_inflight_SUITE.erl
+++ b/apps/emqx/test/emqx_inflight_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_contain(_) ->
     Inflight = emqx_inflight:insert(k, v, emqx_inflight:new()),

--- a/apps/emqx/test/emqx_json_SUITE.erl
+++ b/apps/emqx/test/emqx_json_SUITE.erl
@@ -69,7 +69,7 @@
 %m #{<<"foo">> => [{}]}       NOT SUPPORT
 %%--------------------------------------------------------------------
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_decode_encode(_) ->
     null = decode(encode(null)),

--- a/apps/emqx/test/emqx_keepalive_SUITE.erl
+++ b/apps/emqx/test/emqx_keepalive_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_check(_) ->
     Keepalive = emqx_keepalive:init(60),

--- a/apps/emqx/test/emqx_limiter_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_SUITE.erl
@@ -25,7 +25,7 @@
 %% Setups
 %%--------------------------------------------------------------------
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(_, Cfg) ->
     _ = esockd_limiter:start_link(),

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -23,7 +23,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     NewConfig = generate_config(),

--- a/apps/emqx/test/emqx_logger_SUITE.erl
+++ b/apps/emqx/test/emqx_logger_SUITE.erl
@@ -25,7 +25,7 @@
 -define(a, "a").
 -define(SUPPORTED_LEVELS, [emergency, alert, critical, error, warning, notice, info, debug]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(_TestCase, Config) ->
     Config.

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -23,7 +23,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 suite() ->
     [{ct_hooks, [cth_surefire]}, {timetrap, {seconds, 30}}].

--- a/apps/emqx/test/emqx_metrics_SUITE.erl
+++ b/apps/emqx/test/emqx_metrics_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_new(_) ->
     with_metrics_server(

--- a/apps/emqx/test/emqx_misc_SUITE.erl
+++ b/apps/emqx/test/emqx_misc_SUITE.erl
@@ -28,7 +28,7 @@
                    {nodelay, true}
                   ]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_merge_opts(_) ->
     Opts = emqx_misc:merge_opts(?SOCKOPTS, [raw,

--- a/apps/emqx/test/emqx_mountpoint_SUITE.erl
+++ b/apps/emqx/test/emqx_mountpoint_SUITE.erl
@@ -28,7 +28,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_mount(_) ->
     Msg = emqx_message:make(<<"clientid">>, <<"topic">>, <<"payload">>),

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -29,15 +29,15 @@
                      send_pend
                     ]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(TestCase, Config) ->
     case erlang:function_exported(?MODULE, TestCase, 2) of

--- a/apps/emqx/test/emqx_mqtt_caps_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_caps_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_check_pub(_) ->
     OldConf = emqx:get_config([zones]),

--- a/apps/emqx/test/emqx_mqtt_props_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_props_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_id(_) ->
     foreach_prop(

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -39,19 +39,19 @@ all() ->
     ].
 
 groups() ->
-    TCs = emqx_ct:all(?MODULE),
+    TCs = emqx_common_test_helpers:all(?MODULE),
     [ {tcp,  [], TCs}
     , {quic, [], TCs}
     ].
 
 init_per_group(tcp, Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     [ {port, 1883}, {conn_fun, connect} | Config];
 init_per_group(quic, Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     [ {port, 14567}, {conn_fun, quic_connect} | Config];
 init_per_group(_, Config) ->
-    emqx_ct_helpers:stop_apps([]),
+    emqx_common_test_helpers:stop_apps([]),
     Config.
 
 end_per_group(_Group, _Config) ->
@@ -59,12 +59,12 @@ end_per_group(_Group, _Config) ->
 
 init_per_suite(Config) ->
     %% Start Apps
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(TestCase, Config) ->
     case erlang:function_exported(?MODULE, TestCase, 2) of

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -27,7 +27,7 @@
 
 -define(Q, emqx_mqueue).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_info(_) ->
     Q = ?Q:init(#{max_len => 5, store_qos0 => true}),

--- a/apps/emqx/test/emqx_olp_SUITE.erl
+++ b/apps/emqx/test/emqx_olp_SUITE.erl
@@ -24,14 +24,14 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("lc/include/lc.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(_, Config) ->
     emqx_olp:enable(),

--- a/apps/emqx/test/emqx_os_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_os_mon_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_config:put([sysmon, os], #{

--- a/apps/emqx/test/emqx_packet_SUITE.erl
+++ b/apps/emqx/test/emqx_packet_SUITE.erl
@@ -40,7 +40,7 @@
          {?AUTH, 'AUTH', ?AUTH_PACKET()}
         ]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_type(_) ->
     lists:foreach(fun({Type, _Name, Packet}) ->

--- a/apps/emqx/test/emqx_pd_SUITE.erl
+++ b/apps/emqx/test/emqx_pd_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_update_counter(_) ->
     ?assertEqual(undefined, emqx_pd:inc_counter(bytes, 1)),

--- a/apps/emqx/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx/test/emqx_plugins_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
 
@@ -40,14 +40,14 @@ init_per_suite(Config) ->
     ct:pal("Executing ~ts~n", [CmdPath]),
     ct:pal("~n ~ts~n", [os:cmd(CmdPath)]),
 
-    emqx_ct_helpers:boot_modules([]),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules([]),
+    emqx_common_test_helpers:start_apps([]),
     emqx_config:put([plugins, expand_plugins_dir], DataPath),
     ?assertEqual(ok, emqx_plugins:load()),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_load(_) ->
     ?assertEqual(ok, emqx_plugins:load()),

--- a/apps/emqx/test/emqx_pmon_SUITE.erl
+++ b/apps/emqx/test/emqx_pmon_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 % t_new(_) ->
 %     error('TODO').

--- a/apps/emqx/test/emqx_pqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_pqueue_SUITE.erl
@@ -24,7 +24,7 @@
 -define(PQ, emqx_pqueue).
 -define(SUITE, ?MODULE).
 
-all() -> emqx_ct:all(?SUITE).
+all() -> emqx_common_test_helpers:all(?SUITE).
 
 t_is_queue(_) ->
     Q = ?PQ:new(),

--- a/apps/emqx/test/emqx_reason_codes_SUITE.erl
+++ b/apps/emqx/test/emqx_reason_codes_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_frame_error(_) ->
     ?assertEqual(?RC_PACKET_TOO_LARGE, emqx_reason_codes:frame_error(frame_too_large)),

--- a/apps/emqx/test/emqx_request_responser_SUITE.erl
+++ b/apps/emqx/test/emqx_request_responser_SUITE.erl
@@ -22,12 +22,12 @@
 -include_lib("common_test/include/ct.hrl").
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 all() ->
     [request_response].

--- a/apps/emqx/test/emqx_router_SUITE.erl
+++ b/apps/emqx/test/emqx_router_SUITE.erl
@@ -24,15 +24,15 @@
 
 -define(R, emqx_router).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules([router]),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules([router]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 init_per_testcase(_TestCase, Config) ->
     clear_tables(),

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -23,14 +23,14 @@
 
 -define(ROUTER_HELPER, emqx_router_helper).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_monitor(_) ->
     ok = emqx_router_helper:monitor({undefined, node()}),

--- a/apps/emqx/test/emqx_sequence_SUITE.erl
+++ b/apps/emqx/test/emqx_sequence_SUITE.erl
@@ -27,7 +27,7 @@
         , reclaim/2
         ]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 % t_currval(_) ->
 %     error('TODO').

--- a/apps/emqx/test/emqx_session_SUITE.erl
+++ b/apps/emqx/test/emqx_session_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
 %% CT callbacks

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -26,21 +26,21 @@
 -define(SUITE, ?MODULE).
 
 -define(wait(For, Timeout),
-        emqx_ct_helpers:wait_for(
+        emqx_common_test_helpers:wait_for(
           ?FUNCTION_NAME, ?LINE, fun() -> For end, Timeout)).
 
 -define(ack, shared_sub_ack).
 -define(no_ack, no_ack).
 
-all() -> emqx_ct:all(?SUITE).
+all() -> emqx_common_test_helpers:all(?SUITE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_is_ack_required(_) ->
     ?assertEqual(false, emqx_shared_sub:is_ack_required(#message{headers = #{}})).

--- a/apps/emqx/test/emqx_stats_SUITE.erl
+++ b/apps/emqx/test/emqx_stats_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_cast_useless_msg(_)->
     emqx_stats:setstat('notExis', 1),

--- a/apps/emqx/test/emqx_sup_SUITE.erl
+++ b/apps/emqx/test/emqx_sup_SUITE.erl
@@ -21,15 +21,15 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_child(_) ->
     ?assertMatch({error, _}, emqx_sup:start_child(undef, worker)),

--- a/apps/emqx/test/emqx_sys_SUITE.erl
+++ b/apps/emqx/test/emqx_sys_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     application:load(emqx),

--- a/apps/emqx/test/emqx_sys_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_sys_mon_SUITE.erl
@@ -42,11 +42,11 @@
                      fmt("long_schedule warning: port = ~p", [?FAKE_PORT]), ?FAKE_INFO}
                     ]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(t_sys_mon, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([],
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([],
         fun(emqx) ->
             application:set_env(emqx, sysmon, [{busy_dist_port,true},
                                                 {busy_port,false},
@@ -58,8 +58,8 @@ init_per_testcase(t_sys_mon, Config) ->
         end),
     Config;
 init_per_testcase(t_sys_mon2, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([],
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([],
         fun(emqx) ->
             application:set_env(emqx, sysmon, [{busy_dist_port,false},
                                                 {busy_port,true},
@@ -72,12 +72,12 @@ init_per_testcase(t_sys_mon2, Config) ->
         end),
     Config;
 init_per_testcase(_, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_testcase(_, _Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_procinfo(_) ->
     ok = meck:new(emqx_vm, [passthrough, no_history]),

--- a/apps/emqx/test/emqx_tables_SUITE.erl
+++ b/apps/emqx/test/emqx_tables_SUITE.erl
@@ -23,7 +23,7 @@
 
 -define(TAB, ?MODULE).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_new(_) ->
     ok = emqx_tables:new(?TAB),

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -29,14 +29,14 @@
 %%--------------------------------------------------------------------
 %% Inital funcs
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]),
+    emqx_common_test_helpers:stop_apps([]),
     ok.
 %%--------------------------------------------------------------------
 %% Testcases

--- a/apps/emqx/test/emqx_topic_SUITE.erl
+++ b/apps/emqx/test/emqx_topic_SUITE.erl
@@ -36,7 +36,7 @@
 
 -define(N, 100000).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_wildcard(_) ->
     true  = wildcard(<<"a/b/#">>),

--- a/apps/emqx/test/emqx_tracer_SUITE.erl
+++ b/apps/emqx/test/emqx_tracer_SUITE.erl
@@ -26,12 +26,12 @@
 all() -> [t_trace_clientid, t_trace_topic].
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_trace_clientid(_Config) ->
     {ok, T} = emqtt:start_link([{host, "localhost"},

--- a/apps/emqx/test/emqx_trie_SUITE.erl
+++ b/apps/emqx/test/emqx_trie_SUITE.erl
@@ -30,7 +30,7 @@ all() ->
     ].
 
 groups() ->
-    Cases = emqx_ct:all(?MODULE),
+    Cases = emqx_common_test_helpers:all(?MODULE),
     [{compact, Cases}, {not_compact, Cases}].
 
 init_per_group(compact, Config) ->

--- a/apps/emqx/test/emqx_vm_SUITE.erl
+++ b/apps/emqx/test/emqx_vm_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_load(_Config) ->
     ?assertMatch([{load1, _}, {load5, _}, {load15, _}], emqx_vm:loads()).

--- a/apps/emqx/test/emqx_vm_mon_SUITE.erl
+++ b/apps/emqx/test/emqx_vm_mon_SUITE.erl
@@ -21,11 +21,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(t_alarms, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     emqx_config:put([sysmon, vm], #{
             process_high_watermark => 0,
             process_low_watermark => 0,
@@ -35,12 +35,12 @@ init_per_testcase(t_alarms, Config) ->
     {ok, _} = supervisor:restart_child(emqx_sys_sup, emqx_vm_mon),
     Config;
 init_per_testcase(_, Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_testcase(_, _Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_alarms(_) ->
     timer:sleep(500),

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -35,7 +35,7 @@
 
 -define(ws_conn, emqx_ws_connection).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
 %% CT callbacks
@@ -79,7 +79,7 @@ init_per_testcase(TestCase, Config) when
     Config;
 
 init_per_testcase(_, Config) ->
-    ok = emqx_ct_helpers:start_apps([]),
+    ok = emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_testcase(TestCase, _Config) when
@@ -98,7 +98,7 @@ end_per_testcase(TestCase, _Config) when
                   ]);
 
 end_per_testcase(_, Config) ->
-    emqx_ct_helpers:stop_apps([]),
+    emqx_common_test_helpers:stop_apps([]),
     Config.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_authn/test/emqx_authn_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_SUITE.erl
@@ -19,4 +19,4 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).

--- a/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
@@ -27,14 +27,14 @@
 % -define(AUTH, emqx_authn).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 % init_per_suite(Config) ->
-%     emqx_ct_helpers:start_apps([emqx_authn]),
+%     emqx_common_test_helpers:start_apps([emqx_authn]),
 %     Config.
 
 % end_per_suite(_) ->
-%     emqx_ct_helpers:stop_apps([emqx_authn]),
+%     emqx_common_test_helpers:stop_apps([emqx_authn]),
 %     ok.
 
 % t_jwt_authenticator(_) ->

--- a/apps/emqx_authn/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_mnesia_SUITE.erl
@@ -27,14 +27,14 @@
 % -define(AUTH, emqx_authn).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 % init_per_suite(Config) ->
-%     emqx_ct_helpers:start_apps([emqx_authn]),
+%     emqx_common_test_helpers:start_apps([emqx_authn]),
 %     Config.
 
 % end_per_suite(_) ->
-%     emqx_ct_helpers:stop_apps([emqx_authn]),
+%     emqx_common_test_helpers:stop_apps([emqx_authn]),
 %     ok.
 
 % t_mnesia_authenticator(_) ->

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -25,7 +25,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -44,14 +44,14 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
     Config.
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(?CMD_REPLCAE, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.
@@ -111,7 +111,7 @@ init_per_testcase(_, Config) ->
                   }).
 -define(SOURCE6, #{<<"type">> => <<"file">>,
                    <<"enable">> => true,
-                   <<"path">> => emqx_ct_helpers:deps_path(emqx_authz, "etc/acl.conf")
+                   <<"path">> => emqx_common_test_helpers:deps_path(emqx_authz, "etc/acl.conf")
                   }).
 
 

--- a/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
@@ -84,7 +84,7 @@
 
 all() ->
     []. %% Todo: Waiting for @terry-xiaoyu to fix the config_not_found error
-    % emqx_ct:all(?MODULE).
+    % emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -99,7 +99,7 @@ init_per_suite(Config) ->
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
 
-    ok = emqx_ct_helpers:start_apps([emqx_authz, emqx_dashboard], fun set_special_configs/1),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz, emqx_dashboard], fun set_special_configs/1),
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
 
@@ -107,7 +107,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_dashboard]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_dashboard]),
     meck:unload(emqx_schema),
     ok.
 

--- a/apps/emqx_authz/test/emqx_authz_api_settings_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_settings_SUITE.erl
@@ -38,20 +38,20 @@
 -define(BASE_PATH, "api").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
 
 init_per_suite(Config) ->
-    ok = emqx_ct_helpers:start_apps([emqx_authz, emqx_dashboard], fun set_special_configs/1),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz, emqx_dashboard], fun set_special_configs/1),
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
 
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_resource, emqx_authz, emqx_dashboard]),
+    emqx_common_test_helpers:stop_apps([emqx_resource, emqx_authz, emqx_dashboard]),
     ok.
 
 set_special_configs(emqx_dashboard) ->

--- a/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
@@ -97,7 +97,7 @@
 
 all() ->
     []. %% Todo: Waiting for @terry-xiaoyu to fix the config_not_found error
-    % emqx_ct:all(?MODULE).
+    % emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -118,7 +118,7 @@ init_per_suite(Config) ->
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
 
-    ok = emqx_ct_helpers:start_apps([emqx_authz, emqx_dashboard], fun set_special_configs/1),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz, emqx_dashboard], fun set_special_configs/1),
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
 
@@ -126,7 +126,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_resource, emqx_authz, emqx_dashboard]),
+    emqx_common_test_helpers:stop_apps([emqx_resource, emqx_authz, emqx_dashboard]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.
@@ -154,7 +154,7 @@ init_per_testcase(t_api, Config) ->
 
     meck:new(emqx, [non_strict, passthrough, no_history, no_link]),
     meck:expect(emqx, get_config, fun([node, data_dir]) ->
-                                          % emqx_ct_helpers:deps_path(emqx_authz, "test");
+                                          % emqx_common_test_helpers:deps_path(emqx_authz, "test");
                                           {data_dir, Data} = lists:keyfind(data_dir, 1, Config),
                                           Data;
                                      (C) -> meck:passthrough([C])

--- a/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
@@ -24,7 +24,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -42,7 +42,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
 
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
@@ -58,7 +58,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_mnesia_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mnesia_SUITE.erl
@@ -25,7 +25,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -39,7 +39,7 @@ init_per_suite(Config) ->
                                      end),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
 
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
@@ -49,7 +49,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz]),
+    emqx_common_test_helpers:stop_apps([emqx_authz]),
     meck:unload(emqx_schema),
     ok.
 

--- a/apps/emqx_authz/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mongodb_SUITE.erl
@@ -25,7 +25,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -43,7 +43,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
     Rules = [#{<<"type">> => <<"mongodb">>,
@@ -60,7 +60,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
@@ -25,7 +25,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -43,7 +43,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
 
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
@@ -62,7 +62,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_postgresql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_postgresql_SUITE.erl
@@ -25,7 +25,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -43,7 +43,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
 
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
@@ -62,7 +62,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
@@ -24,7 +24,7 @@
 -define(CONF_DEFAULT, <<"authorization: {sources: []}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
@@ -42,7 +42,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, remove, fun(_) -> ok end ),
 
     ok = emqx_config:init_load(emqx_authz_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
 
     {ok, _} = emqx:update_config([authorization, cache, enable], false),
     {ok, _} = emqx:update_config([authorization, no_match], deny),
@@ -60,7 +60,7 @@ init_per_suite(Config) ->
 
 end_per_suite(_Config) ->
     {ok, _} = emqx_authz:update(replace, []),
-    emqx_ct_helpers:stop_apps([emqx_authz, emqx_resource]),
+    emqx_common_test_helpers:stop_apps([emqx_authz, emqx_resource]),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
     ok.

--- a/apps/emqx_authz/test/emqx_authz_rule_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_rule_SUITE.erl
@@ -29,14 +29,14 @@
 -define(SOURCE5, {allow, {'or',  [{username, {re, "^test"}},  {clientid, {re, "test?"}}]},  publish, ["%u", "%c"]}).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_ct_helpers:start_apps([emqx_authz]),
+    ok = emqx_common_test_helpers:start_apps([emqx_authz]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_authz]),
+    emqx_common_test_helpers:stop_apps([emqx_authz]),
     ok.
 
 t_compile(_) ->

--- a/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
+++ b/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
@@ -86,8 +86,8 @@ init_per_suite(Config) ->
                 }
             ]
         }">>),
-    emqx_ct_helpers:start_apps([emqx_dashboard], fun set_special_configs/1),
-    emqx_ct_helpers:start_apps([?APP]),
+    emqx_common_test_helpers:start_apps([emqx_dashboard], fun set_special_configs/1),
+    emqx_common_test_helpers:start_apps([?APP]),
     Config.
 
 set_special_configs(emqx_dashboard) ->
@@ -118,7 +118,7 @@ end_per_suite(_) ->
     application:unload(?APP),
     meck:unload(emqx_resource),
     meck:unload(emqx_schema),
-    emqx_ct_helpers:stop_apps([emqx_dashboard, ?APP]).
+    emqx_common_test_helpers:stop_apps([emqx_dashboard, ?APP]).
 
 t_auto_subscribe(_) ->
     {ok, Client} = emqtt:start_link(#{username => ?CLIENT_USERNAME, clientid => ?CLIENT_ID}),

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -41,15 +41,15 @@
 
 all() ->
 %%    TODO: V5 API
-%%    emqx_ct:all(?MODULE).
+%%    emqx_common_test_helpers:all(?MODULE).
     [].
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([emqx_management, emqx_dashboard],fun set_special_configs/1),
+    emqx_common_test_helpers:start_apps([emqx_management, emqx_dashboard],fun set_special_configs/1),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_dashboard, emqx_management]),
+    emqx_common_test_helpers:stop_apps([emqx_dashboard, emqx_management]),
     ekka_mnesia:ensure_stopped().
 
 set_special_configs(emqx_management) ->

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -36,16 +36,16 @@ exhook: {
 %% Setups
 %%--------------------------------------------------------------------
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Cfg) ->
     _ = emqx_exhook_demo_svr:start(),
     ok = emqx_config:init_load(emqx_exhook_schema, ?CONF_DEFAULT),
-    emqx_ct_helpers:start_apps([emqx_exhook]),
+    emqx_common_test_helpers:start_apps([emqx_exhook]),
     Cfg.
 
 end_per_suite(_Cfg) ->
-    emqx_ct_helpers:stop_apps([emqx_exhook]),
+    emqx_common_test_helpers:stop_apps([emqx_exhook]),
     emqx_exhook_demo_svr:stop().
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_exhook/test/props/prop_exhook_hooks.erl
+++ b/apps/emqx_exhook/test/props/prop_exhook_hooks.erl
@@ -472,13 +472,13 @@ do_setup() ->
     logger:set_primary_config(#{level => warning}),
     _ = emqx_exhook_demo_svr:start(),
     ok = emqx_config:init_load(emqx_exhook_schema, ?CONF_DEFAULT),
-    emqx_ct_helpers:start_apps([emqx_exhook]),
+    emqx_common_test_helpers:start_apps([emqx_exhook]),
     %% waiting first loaded event
     {'on_provider_loaded', _} = emqx_exhook_demo_svr:take(),
     ok.
 
 do_teardown(_) ->
-    emqx_ct_helpers:stop_apps([emqx_exhook]),
+    emqx_common_test_helpers:stop_apps([emqx_exhook]),
     %% waiting last unloaded event
     {'on_provider_unloaded', _} = emqx_exhook_demo_svr:take(),
     _ = emqx_exhook_demo_svr:stop(),

--- a/apps/emqx_gateway/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_coap_SUITE.erl
@@ -45,10 +45,10 @@ gateway.coap
 -define(MQTT_PREFIX, "coap://127.0.0.1/mqtt").
 
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([emqx_gateway], fun set_special_cfg/1),
+    emqx_common_test_helpers:start_apps([emqx_gateway], fun set_special_cfg/1),
     Config.
 
 set_special_cfg(emqx_gateway) ->
@@ -58,7 +58,7 @@ set_special_cfg(_) ->
     ok.
 
 end_per_suite(Config) ->
-    emqx_ct_helpers:stop_apps([emqx_gateway]),
+    emqx_common_test_helpers:stop_apps([emqx_gateway]),
     Config.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
@@ -49,7 +49,7 @@ gateway.coap {
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),

--- a/apps/emqx_gateway/test/emqx_exproto_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_exproto_SUITE.erl
@@ -45,7 +45,7 @@ all() ->
     [{group, Name} || Name  <- metrics()].
 
 groups() ->
-    Cases = emqx_ct:all(?MODULE),
+    Cases = emqx_common_test_helpers:all(?MODULE),
     [{Name, Cases} || Name <- metrics()].
 
 %% @private
@@ -55,12 +55,12 @@ metrics() ->
 init_per_group(GrpName, Cfg) ->
     put(grpname, GrpName),
     Svrs = emqx_exproto_echo_svr:start(),
-    emqx_ct_helpers:start_apps([emqx_gateway], fun set_special_cfg/1),
+    emqx_common_test_helpers:start_apps([emqx_gateway], fun set_special_cfg/1),
     emqx_logger:set_log_level(debug),
     [{servers, Svrs}, {listener_type, GrpName} | Cfg].
 
 end_per_group(_, Cfg) ->
-    emqx_ct_helpers:stop_apps([emqx_gateway]),
+    emqx_common_test_helpers:stop_apps([emqx_gateway]),
     emqx_exproto_echo_svr:stop(proplists:get_value(servers, Cfg)).
 
 set_special_cfg(emqx_gateway) ->
@@ -448,7 +448,7 @@ client_ssl_opts() ->
     certs("client-key.pem", "client-cert.pem", "cacert.pem").
 
 certs(Key, Cert, CACert) ->
-    CertsPath = emqx_ct_helpers:deps_path(emqx, "etc/certs"),
+    CertsPath = emqx_common_test_helpers:deps_path(emqx, "etc/certs"),
     #{keyfile    => filename:join([ CertsPath, Key   ]),
       certfile   => filename:join([ CertsPath, Cert  ]),
       cacertfile => filename:join([ CertsPath, CACert])}.

--- a/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
@@ -26,16 +26,16 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     %% FIXME: Magic line. for saving gateway schema name for emqx_config
     emqx_config:init_load(emqx_gateway_schema, <<"gateway {}">>),
-    emqx_ct_helpers:start_apps([emqx_gateway]),
+    emqx_common_test_helpers:start_apps([emqx_gateway]),
     Conf.
 
 end_per_suite(_Conf) ->
-    emqx_ct_helpers:stop_apps([emqx_gateway]).
+    emqx_common_test_helpers:stop_apps([emqx_gateway]).
 
 init_per_testcase(_CaseName, Conf) ->
     _ = emqx_gateway_conf:unload_gateway(stomp),

--- a/apps/emqx_gateway/test/emqx_gateway_registry_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_registry_SUITE.erl
@@ -27,7 +27,7 @@ gateway: {
 }
 """>>).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
 %% Setups
@@ -35,11 +35,11 @@ all() -> emqx_ct:all(?MODULE).
 
 init_per_suite(Cfg) ->
     ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
-    emqx_ct_helpers:start_apps([emqx_gateway]),
+    emqx_common_test_helpers:start_apps([emqx_gateway]),
     Cfg.
 
 end_per_suite(_Cfg) ->
-    emqx_ct_helpers:stop_apps([emqx_gateway]),
+    emqx_common_test_helpers:stop_apps([emqx_gateway]),
     ok.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_gateway/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_SUITE.erl
@@ -150,12 +150,12 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(Config) ->
     timer:sleep(300),
-    emqx_ct_helpers:stop_apps([]),
+    emqx_common_test_helpers:stop_apps([]),
     Config.
 
 init_per_testcase(_AllTestCase, Config) ->

--- a/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
@@ -66,7 +66,7 @@ gateway.lwm2m {
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),

--- a/apps/emqx_gateway/test/emqx_sn_frame_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_sn_frame_SUITE.erl
@@ -27,7 +27,7 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 parse(D) ->
     {ok, P, _Rest, _State} = emqx_sn_frame:parse(D, #{}),

--- a/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
@@ -79,15 +79,15 @@ gateway.mqttsn {
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
-    emqx_ct_helpers:start_apps([emqx_gateway]),
+    emqx_common_test_helpers:start_apps([emqx_gateway]),
     Config.
 
 end_per_suite(_) ->
-    emqx_ct_helpers:stop_apps([emqx_gateway]).
+    emqx_common_test_helpers:stop_apps([emqx_gateway]).
 
 %%--------------------------------------------------------------------
 %% Test cases

--- a/apps/emqx_gateway/test/emqx_sn_registry_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_sn_registry_SUITE.erl
@@ -31,7 +31,7 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     application:ensure_all_started(ekka),

--- a/apps/emqx_gateway/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_stomp_SUITE.erl
@@ -35,7 +35,7 @@ gateway.stomp {
 }
 ">>).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
 %% Setups
@@ -43,11 +43,11 @@ all() -> emqx_ct:all(?MODULE).
 
 init_per_suite(Cfg) ->
     ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
-    emqx_ct_helpers:start_apps([emqx_gateway]),
+    emqx_common_test_helpers:start_apps([emqx_gateway]),
     Cfg.
 
 end_per_suite(_Cfg) ->
-    emqx_ct_helpers:stop_apps([emqx_gateway]),
+    emqx_common_test_helpers:stop_apps([emqx_gateway]),
     ok.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_gateway/test/emqx_stomp_heartbeat_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_stomp_heartbeat_SUITE.erl
@@ -19,7 +19,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 %%--------------------------------------------------------------------
 %% Test Cases

--- a/apps/emqx_limiter/test/emqx_limiter_SUITE.erl
+++ b/apps/emqx_limiter/test/emqx_limiter_SUITE.erl
@@ -79,15 +79,15 @@ emqx_limiter {
 %%--------------------------------------------------------------------
 %% Setups
 %%--------------------------------------------------------------------
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_limiter_schema, ?BASE_CONF),
-    emqx_ct_helpers:start_apps([?APP]),
+    emqx_common_test_helpers:start_apps([?APP]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([?APP]).
+    emqx_common_test_helpers:stop_apps([?APP]).
 
 init_per_testcase(_TestCase, Config) ->
     Config.

--- a/apps/emqx_machine/test/emqx_global_gc_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_global_gc_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_run_gc(_) ->
     ok = emqx_config:put([node, global_gc_interval], 1000),

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -23,14 +23,14 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([]),
+    emqx_common_test_helpers:start_apps([]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([]).
 
 t_shutdown_reboot(_Config) ->
     emqx_machine_boot:stop_apps(normal),

--- a/apps/emqx_management/test/emqx_mgmt_alarms_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_alarms_api_SUITE.erl
@@ -25,7 +25,7 @@
 -define(DE_ACT_ALARM, test_de_act_alarm).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -26,7 +26,7 @@ init_suite() ->
 init_suite(Apps) ->
     ekka_mnesia:start(),
     application:load(emqx_management),
-    emqx_ct_helpers:start_apps(Apps ++ [emqx_dashboard], fun set_special_configs/1).
+    emqx_common_test_helpers:start_apps(Apps ++ [emqx_dashboard], fun set_special_configs/1).
 
 
 end_suite() ->
@@ -34,7 +34,7 @@ end_suite() ->
 
 end_suite(Apps) ->
     application:unload(emqx_management),
-    emqx_ct_helpers:stop_apps(Apps ++ [emqx_dashboard]).
+    emqx_common_test_helpers:stop_apps(Apps ++ [emqx_dashboard]).
 
 set_special_configs(emqx_dashboard) ->
     Config = #{

--- a/apps/emqx_management/test/emqx_mgmt_clients_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_clients_api_SUITE.erl
@@ -20,7 +20,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_listeners_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_listeners_api_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_metrics_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_metrics_api_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_nodes_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_nodes_api_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_publish_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_publish_api_SUITE.erl
@@ -27,7 +27,7 @@
 -define(TOPIC2, <<"api_topic2">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_routes_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_routes_api_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_stats_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_stats_api_SUITE.erl
@@ -21,7 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_management/test/emqx_mgmt_subscription_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_subscription_api_SUITE.erl
@@ -30,7 +30,7 @@
 -define(TOPIC_SORT, #{?TOPIC1 => 1, ?TOPIC2 => 2}).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_modules/test/emqx_delayed_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_SUITE.erl
@@ -32,16 +32,16 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ekka_mnesia:start(),
     ok = emqx_delayed:mnesia(boot),
-    emqx_ct_helpers:start_apps([emqx_modules]),
+    emqx_common_test_helpers:start_apps([emqx_modules]),
     Config.
 
 end_per_suite(_) ->
-    emqx_ct_helpers:stop_apps([emqx_modules]).
+    emqx_common_test_helpers:stop_apps([emqx_modules]).
 
 %%--------------------------------------------------------------------
 %% Test cases

--- a/apps/emqx_modules/test/emqx_event_message_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_event_message_SUITE.erl
@@ -33,16 +33,16 @@ event_message: {
     \"$event/message_dropped\": true
   }""">>).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([emqx_modules]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([emqx_modules]),
     ok = emqx_config:init_load(emqx_modules_schema, ?EVENT_MESSAGE),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_modules]).
+    emqx_common_test_helpers:stop_apps([emqx_modules]).
 
 t_event_topic(_) ->
     ok = emqx_event_message:enable(),

--- a/apps/emqx_modules/test/emqx_rewrite_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_rewrite_SUITE.erl
@@ -38,15 +38,15 @@ rewrite: [
     }
 ]""">>).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([emqx_modules]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([emqx_modules]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_modules]).
+    emqx_common_test_helpers:stop_apps([emqx_modules]).
 
 %% Test case for emqx_mod_write
 t_mod_rewrite(_Config) ->

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -25,16 +25,16 @@
 
 -import(proplists, [get_value/2]).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = ekka_mnesia:start(),
     ok = emqx_telemetry:mnesia(boot),
-    emqx_ct_helpers:start_apps([emqx_modules]),
+    emqx_common_test_helpers:start_apps([emqx_modules]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_modules]).
+    emqx_common_test_helpers:stop_apps([emqx_modules]).
 
 t_uuid(_) ->
     UUID = emqx_telemetry:generate_uuid(),

--- a/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl
@@ -25,16 +25,16 @@ topic_metrics: []""">>).
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:boot_modules(all),
-    emqx_ct_helpers:start_apps([emqx_modules]),
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([emqx_modules]),
     ok = emqx_config:init_load(emqx_modules_schema, ?TOPIC),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_modules]).
+    emqx_common_test_helpers:stop_apps([emqx_modules]).
 
 t_nonexistent_topic_metrics(_) ->
     emqx_topic_metrics:enable(),

--- a/apps/emqx_plugin_libs/test/emqx_plugin_libs_rule_SUITE.erl
+++ b/apps/emqx_plugin_libs/test/emqx_plugin_libs_rule_SUITE.erl
@@ -23,7 +23,7 @@
 
 -define(PORT, 9876).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_http_connectivity(_) ->
     {ok, Socket} = gen_tcp:listen(?PORT, []),

--- a/apps/emqx_psk/test/emqx_psk_SUITE.erl
+++ b/apps/emqx_psk/test/emqx_psk_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("eunit/include/eunit.hrl").
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     meck:new(emqx_config, [non_strict, passthrough, no_history, no_link]),
@@ -35,12 +35,12 @@ init_per_suite(Config) ->
                                      ([psk, separator], _) -> <<":">>;
                                      (KeyPath, Default) -> meck:passthrough([KeyPath, Default])
                                   end),
-    emqx_ct_helpers:start_apps([emqx_psk]),
+    emqx_common_test_helpers:start_apps([emqx_psk]),
     Config.
 
 end_per_suite(_) ->
     meck:unload(emqx_config),
-    emqx_ct_helpers:stop_apps([emqx_psk]),
+    emqx_common_test_helpers:stop_apps([emqx_psk]),
     ok.
 
 t_psk_lookup(_) ->

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -24,7 +24,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 -define(BASE_CONF, <<"""
 emqx_retainer {
@@ -50,11 +50,11 @@ emqx_retainer {
 
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_retainer_schema, ?BASE_CONF),
-    emqx_ct_helpers:start_apps([emqx_retainer]),
+    emqx_common_test_helpers:start_apps([emqx_retainer]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_retainer]).
+    emqx_common_test_helpers:stop_apps([emqx_retainer]).
 %%--------------------------------------------------------------------
 %% Test Cases
 %%--------------------------------------------------------------------

--- a/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
@@ -37,7 +37,7 @@
 
 all() ->
     %%    TODO: V5 API
-    %%    emqx_ct:all(?MODULE).
+    %%    emqx_common_test_helpers:all(?MODULE).
     [].
 
 groups() ->
@@ -45,13 +45,13 @@ groups() ->
 
 init_per_suite(Config) ->
     application:stop(emqx_retainer),
-    emqx_ct_helpers:start_apps([emqx_retainer, emqx_management], fun set_special_configs/1),
+    emqx_common_test_helpers:start_apps([emqx_retainer, emqx_management], fun set_special_configs/1),
     create_default_app(),
     Config.
 
 end_per_suite(_Config) ->
     delete_default_app(),
-    emqx_ct_helpers:stop_apps([emqx_management, emqx_retainer]).
+    emqx_common_test_helpers:stop_apps([emqx_management, emqx_retainer]).
 
 init_per_testcase(_, Config) ->
     Config.

--- a/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
@@ -21,7 +21,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_testcase(_TestCase, Config) ->
     Config.

--- a/apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl
@@ -39,19 +39,19 @@ emqx_retainer {
         }
   }""">>).
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_config:init_load(emqx_retainer_schema, ?BASE_CONF),
     %% Meck emqtt
     ok = meck:new(emqtt, [non_strict, passthrough, no_history, no_link]),
     %% Start Apps
-    emqx_ct_helpers:start_apps([emqx_retainer]),
+    emqx_common_test_helpers:start_apps([emqx_retainer]),
     Config.
 
 end_per_suite(_Config) ->
     ok = meck:unload(emqtt),
-    emqx_ct_helpers:stop_apps([emqx_retainer]).
+    emqx_common_test_helpers:stop_apps([emqx_retainer]).
 
 client_info(Key, Client) ->
     maps:get(Key, maps:from_list(emqtt:info(Client)), undefined).

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -104,11 +104,11 @@ groups() ->
 
 init_per_suite(Config) ->
     application:load(emqx_machine),
-    ok = emqx_ct_helpers:start_apps([emqx_rule_engine]),
+    ok = emqx_common_test_helpers:start_apps([emqx_rule_engine]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_rule_engine]),
+    emqx_common_test_helpers:stop_apps([emqx_rule_engine]),
     ok.
 
 on_resource_create(_id, _) -> #{}.

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
@@ -9,16 +9,16 @@
 -define(CONF_DEFAULT, <<"rule_engine {rules {}}">>).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     application:load(emqx_machine),
     ok = emqx_config:init_load(emqx_rule_engine_schema, ?CONF_DEFAULT),
-    ok = emqx_ct_helpers:start_apps([emqx_rule_engine]),
+    ok = emqx_common_test_helpers:start_apps([emqx_rule_engine]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_rule_engine]),
+    emqx_common_test_helpers:stop_apps([emqx_rule_engine]),
     ok.
 
 init_per_testcase(_, Config) ->

--- a/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
@@ -5,7 +5,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-all() -> emqx_ct:all(?MODULE).
+all() -> emqx_common_test_helpers:all(?MODULE).
 
 t_mod_hook_fun(_) ->
     Funcs = emqx_rule_events:module_info(exports),

--- a/apps/emqx_rule_engine/test/emqx_rule_metrics_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_metrics_SUITE.erl
@@ -40,13 +40,13 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([emqx]),
+    emqx_common_test_helpers:start_apps([emqx]),
     {ok, _} = emqx_rule_metrics:start_link(),
     Config.
 
 end_per_suite(_Config) ->
     catch emqx_rule_metrics:stop(),
-    emqx_ct_helpers:stop_apps([emqx]),
+    emqx_common_test_helpers:stop_apps([emqx]),
     ok.
 
 init_per_testcase(_, Config) ->

--- a/apps/emqx_statsd/test/emqx_statsd_SUITE.erl
+++ b/apps/emqx_statsd/test/emqx_statsd_SUITE.erl
@@ -7,14 +7,14 @@
 -include_lib("eunit/include/eunit.hrl").
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([emqx_statsd]),
+    emqx_common_test_helpers:start_apps([emqx_statsd]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_statsd]).
+    emqx_common_test_helpers:stop_apps([emqx_statsd]).
 
 all() ->
-    emqx_ct:all(?MODULE).
+    emqx_common_test_helpers:all(?MODULE).
 
 t_statsd(_) ->
     {ok, Socket} = gen_udp:open(8125),

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -127,8 +127,8 @@ test_plugins() ->
 
 test_deps() ->
     [ {bbmustache, "1.10.0"}
-    , {emqx_ct_helpers, {git, "https://github.com/emqx/emqx-ct-helpers", {tag, "2.1.0"}}}
     , meck
+    , proper
     ].
 
 common_compile_opts() ->


### PR DESCRIPTION
Renamed `emqx_ct_helpers` -> `emqx_common_test_helpers` to avoid module name confusion if another dependency reintroduces the dependency on the `emqx_ct_helpers` app.

https://emqx.atlassian.net/browse/EMQX-1492