### PR TITLE
fix(emqx_telemetry): add default value to get_value

### DIFF
--- a/apps/emqx_modules/src/emqx_telemetry.erl
+++ b/apps/emqx_modules/src/emqx_telemetry.erl
@@ -237,8 +237,9 @@ os_info() ->
                                                               end,
                                                      [{Var, NValue} | Acc]
                                                  end, [], string:tokens(os:cmd("cat /etc/os-release"), "\n")),
-                            [{os_name, get_value("NAME", OSInfo)},
-                             {os_version, get_value("VERSION", OSInfo, get_value("VERSION_ID", OSInfo))}];
+                            [{os_name, get_value("NAME", OSInfo, "Unknown")},
+                             {os_version, get_value("VERSION", OSInfo,
+                                                    get_value("VERSION_ID", OSInfo, "Unknown"))}];
                         _ ->
                             [{os_name, "Unknown"},
                              {os_version, "Unknown"}]


### PR DESCRIPTION

>>> os info in emqx_telemetry [{"BUG_REPORT_URL","https://bugs.debian.org/"},
                               {"SUPPORT_URL",
                                "https://www.debian.org/support"},
                               {"HOME_URL","https://www.debian.org/"},
                               {"ID","debian"},
                               {"NAME","Debian GNU/Linux"},
                               {"PRETTY_NAME",
                                "Debian GNU/Linux bookworm/sid"}]
