### PR TITLE
refactor: delete ssl key password config

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1012,15 +1012,6 @@ the file if it is to be added.
           #{default => Df("depth", 10)
            })
       }
-    , {"password",
-       sc(string(),
-          #{ sensitive => true
-           , nullable => true
-           , desc =>
-"""String containing the user's password. Only used if the private
-keyfile is password-protected."""
-           })
-      }
     , {"versions",
        sc(hoconsc:array(typerefl:atom()),
           #{ default => default_tls_vsns(maps:get(versions, Defaults, tls_all_available))


### PR DESCRIPTION
meaning we will not support encrypted private keys for SSL keyfile
reason: we store PEM file on disk, and we store passowrd in config
file which is also on disk, adding an encryption for PEM will not
add security, rather only makes configuration convoluted

