### PR TITLE
refactor(authn api): use config schemas for request validations

### DIFF
--- a/apps/emqx/src/emqx_authentication_config.erl
+++ b/apps/emqx/src/emqx_authentication_config.erl
@@ -268,4 +268,3 @@ dir(ChainName, ID) when is_binary(ID) ->
     binary:replace(iolist_to_binary([to_bin(ChainName), "-", ID]), <<":">>, <<"-">>);
 dir(ChainName, Config) when is_map(Config) ->
     dir(ChainName, authenticator_id(Config)).
-

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -352,10 +352,13 @@ listener_id(Type, ListenerName) ->
     list_to_atom(lists:append([str(Type), ":", str(ListenerName)])).
 
 parse_listener_id(Id) ->
-    [Type, Name] = string:split(str(Id), ":", leading),
-    case lists:member(Type, ?TYPES_STRING) of
-        true -> {list_to_existing_atom(Type), list_to_atom(Name)};
-        false -> {error, {invalid_listener_id, Id}}
+    case string:split(str(Id), ":", leading) of
+        [Type, Name] ->
+            case lists:member(Type, ?TYPES_STRING) of
+                true -> {list_to_existing_atom(Type), list_to_atom(Name)};
+                false -> {error, {invalid_listener_id, Id}}
+            end;
+        _ -> {error, {invalid_listener_id, Id}}
     end.
 
 zone(Opts) ->

--- a/apps/emqx_authn/src/emqx_authn_schema.erl
+++ b/apps/emqx_authn/src/emqx_authn_schema.erl
@@ -21,12 +21,11 @@
 -export([ common_fields/0
         , roots/0
         , fields/1
+        , authenticator_type/0
         ]).
 
 %% only for doc generation
-roots() -> [{authenticator_config,
-             #{type => hoconsc:union(config_refs([Module || {_AuthnType, Module} <- emqx_authn:providers()]))
-               }}].
+roots() -> [{authenticator_config, hoconsc:mk(authenticator_type())}].
 
 fields(_) -> [].
 
@@ -37,6 +36,9 @@ common_fields() ->
 enable(type) -> boolean();
 enable(default) -> true;
 enable(_) -> undefined.
+
+authenticator_type() ->
+    hoconsc:union(config_refs([Module || {_AuthnType, Module} <- emqx_authn:providers()])).
 
 config_refs(Modules) ->
     lists:append([Module:refs() || Module <- Modules]).

--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -18,7 +18,7 @@
 -compile(nowarn_export_all).
 -compile(export_all).
 
--include("emqx_authz.hrl").
+-include("emqx_authn.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
@@ -27,11 +27,26 @@
 -define(API_VERSION, "v5").
 -define(BASE_PATH, "api").
 
+-define(TCP_DEFAULT, 'tcp:default').
+
+-define(
+    assertAuthenticatorsMatch(Guard, Path),
+    (fun() ->
+        {ok, 200, Response} = request(get, uri(Path)),
+        ?assertMatch(Guard, jiffy:decode(Response, [return_maps]))
+     end)()).
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 groups() ->
     [].
+
+init_per_testcase(_, Config) ->
+    delete_authenticators([authentication], ?GLOBAL),
+    delete_authenticators([listeners, tcp, default, authentication], ?TCP_DEFAULT),
+    {atomic, ok} = mria:clear_table(emqx_authn_mnesia),
+    Config.
 
 init_per_suite(Config) ->
     ok = emqx_common_test_helpers:start_apps([emqx_authn, emqx_dashboard], fun set_special_configs/1),
@@ -55,10 +70,379 @@ set_special_configs(emqx_dashboard) ->
 set_special_configs(_App) ->
     ok.
 
-t_create_http_authn(_) ->
-    {ok, 200, _} = request(post, uri(["authentication"]),
-                           emqx_authn_test_lib:http_example()),
-    {ok, 200, _} = request(get, uri(["authentication"])).
+%%------------------------------------------------------------------------------
+%% Tests
+%%------------------------------------------------------------------------------
+
+t_invalid_listener(_) ->
+    {ok, 404, _} = request(get, uri(["listeners", "invalid", "authentication"])),
+    {ok, 404, _} = request(get, uri(["listeners", "in:valid", "authentication"])).
+
+t_authenticators(_) ->
+    test_authenticators([]).
+
+t_authenticator(_) ->
+    test_authenticator([]).
+
+t_authenticator_users(_) ->
+    test_authenticator_users([]).
+
+t_authenticator_user(_) ->
+    test_authenticator_user([]).
+
+t_authenticator_move(_) ->
+    test_authenticator_move([]).
+
+t_authenticator_import_users(_) ->
+    test_authenticator_import_users([]).
+
+t_listener_authenticators(_) ->
+    test_authenticators(["listeners", ?TCP_DEFAULT]).
+
+t_listener_authenticator(_) ->
+    test_authenticator(["listeners", ?TCP_DEFAULT]).
+
+t_listener_authenticator_users(_) ->
+    test_authenticator_users(["listeners", ?TCP_DEFAULT]).
+
+t_listener_authenticator_user(_) ->
+    test_authenticator_user(["listeners", ?TCP_DEFAULT]).
+
+t_listener_authenticator_move(_) ->
+    test_authenticator_move(["listeners", ?TCP_DEFAULT]).
+
+t_listener_authenticator_import_users(_) ->
+    test_authenticator_import_users(["listeners", ?TCP_DEFAULT]).
+
+test_authenticators(PathPrefix) ->
+
+    ValidConfig = emqx_authn_test_lib:http_example(),
+    {ok, 200, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication"]),
+                    ValidConfig),
+
+    InvalidConfig = ValidConfig#{method => <<"delete">>},
+    {ok, 400, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication"]),
+                    InvalidConfig),
+
+    ?assertAuthenticatorsMatch(
+        [#{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"http">>}],
+        PathPrefix ++ ["authentication"]).
+
+test_authenticator(PathPrefix) ->
+    ValidConfig0 = emqx_authn_test_lib:http_example(),
+
+    {ok, 200, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication"]),
+                    ValidConfig0),
+
+    {ok, 200, _} = request(
+                    get,
+                    uri(PathPrefix ++ ["authentication", "password-based:http"])),
+
+    {ok, 404, _} = request(
+                    get,
+                    uri(PathPrefix ++ ["authentication", "password-based:redis"])),
+
+
+    {ok, 404, _} = request(
+                    put,
+                    uri(PathPrefix ++ ["authentication", "password-based:built-in-database"]),
+                    emqx_authn_test_lib:built_in_database_example()),
+
+    InvalidConfig0 = ValidConfig0#{method => <<"delete">>},
+    {ok, 400, _} = request(
+                    put,
+                    uri(PathPrefix ++ ["authentication", "password-based:http"]),
+                    InvalidConfig0),
+
+    ValidConfig1 = ValidConfig0#{pool_size => 9},
+    {ok, 200, _} = request(
+                    put,
+                    uri(PathPrefix ++ ["authentication", "password-based:http"]),
+                    ValidConfig1),
+
+    {ok, 404, _} = request(
+                    delete,
+                    uri(PathPrefix ++ ["authentication", "password-based:redis"])),
+
+    {ok, 204, _} = request(
+                    delete,
+                    uri(PathPrefix ++ ["authentication", "password-based:http"])),
+
+    ?assertAuthenticatorsMatch([], PathPrefix ++ ["authentication"]).
+
+test_authenticator_users(PathPrefix) ->
+    {ok, 200, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication"]),
+                    emqx_authn_test_lib:built_in_database_example()),
+
+    InvalidUsers = [
+        #{clientid => <<"u1">>, password => <<"p1">>},
+        #{user_id => <<"u2">>},
+        #{user_id => <<"u3">>, password => <<"p3">>, foobar => <<"foobar">>}],
+
+    lists:foreach(
+        fun(User) ->
+            {ok, 400, _} = request(
+                            post,
+                            uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users"]),
+                            User)
+        end,
+        InvalidUsers),
+
+
+    ValidUsers = [
+        #{user_id => <<"u1">>, password => <<"p1">>},
+        #{user_id => <<"u2">>, password => <<"p2">>, is_superuser => true},
+        #{user_id => <<"u3">>, password => <<"p3">>}],
+
+    lists:foreach(
+        fun(User) ->
+            {ok, 201, _} = request(
+                                post,
+                                uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users"]),
+                                User)
+        end,
+        ValidUsers),
+
+    {ok, 200, Page1Data} =
+        request(
+            get,
+            uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users"]) ++ "?page=1&limit=2"),
+
+    Page1Users = response_data(Page1Data),
+
+    {ok, 200, Page2Data} =
+        request(
+            get,
+            uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users"]) ++ "?page=2&limit=2"),
+
+    Page2Users = response_data(Page2Data),
+
+    ?assertEqual(2, length(Page1Users)),
+    ?assertEqual(1, length(Page2Users)),
+
+    ?assertEqual(
+        [<<"u1">>, <<"u2">>, <<"u3">>],
+        lists:usort([ UserId || #{<<"user_id">> := UserId} <- Page1Users ++ Page2Users])).
+
+test_authenticator_user(PathPrefix) ->
+    {ok, 200, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication"]),
+                        emqx_authn_test_lib:built_in_database_example()),
+
+    User = #{user_id => <<"u1">>, password => <<"p1">>},
+    {ok, 201, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users"]),
+                        User),
+
+    {ok, 404, _} = request(
+                        get,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users", "u123"])),
+
+    {ok, 409, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users"]),
+                        User),
+
+    {ok, 200, UserData} = request(
+                            get,
+                            uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users", "u1"])),
+
+    FetchedUser = jiffy:decode(UserData, [return_maps]),
+    ?assertMatch(#{<<"user_id">> := <<"u1">>}, FetchedUser),
+    ?assertNotMatch(#{<<"password">> := _}, FetchedUser),
+
+    ValidUserUpdates = [
+        #{password => <<"p1">>},
+        #{password => <<"p1">>, is_superuser => true}],
+
+    lists:foreach(
+        fun(UserUpdate) ->
+            {ok, 200, _} = request(
+                            put,
+                            uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users", "u1"]),
+                            UserUpdate)
+        end,
+        ValidUserUpdates),
+
+    InvalidUserUpdates = [
+        #{user_id => <<"u1">>, password => <<"p1">>},
+        #{is_superuser => true}],
+
+    lists:foreach(
+        fun(UserUpdate) ->
+            {ok, 400, _} = request(
+                            put,
+                            uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users", "u1"]),
+                            UserUpdate)
+        end,
+        InvalidUserUpdates),
+
+    {ok, 404, _} = request(
+                    delete,
+                    uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users", "u123"])),
+
+    {ok, 204, _} = request(
+                    delete,
+                    uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "users", "u1"])).
+
+test_authenticator_move(PathPrefix) ->
+    AuthenticatorConfs = [
+        emqx_authn_test_lib:http_example(),
+        emqx_authn_test_lib:jwt_example(),
+        emqx_authn_test_lib:built_in_database_example()
+    ],
+
+    lists:foreach(
+        fun(Conf) ->
+            {ok, 200, _} = request(
+                            post,
+                            uri(PathPrefix ++ ["authentication"]),
+                            Conf)
+        end,
+        AuthenticatorConfs),
+
+    ?assertAuthenticatorsMatch(
+        [
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"http">>},
+            #{<<"mechanism">> := <<"jwt">>},
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"built-in-database">>}
+        ],
+        PathPrefix ++ ["authentication"]),
+
+    % Invalid moves
+
+    {ok, 400, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"up">>}),
+
+    {ok, 400, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{}),
+
+    {ok, 404, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"before:invalid">>}),
+
+    {ok, 404, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"before:password-based:redis">>}),
+
+    {ok, 404, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"before:password-based:redis">>}),
+
+    % Valid moves
+
+    {ok, 204, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"top">>}),
+
+    ?assertAuthenticatorsMatch(
+        [
+            #{<<"mechanism">> := <<"jwt">>},
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"http">>},
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"built-in-database">>}
+        ],
+        PathPrefix ++ ["authentication"]),
+
+    {ok, 204, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"bottom">>}),
+
+    ?assertAuthenticatorsMatch(
+        [
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"http">>},
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"built-in-database">>},
+            #{<<"mechanism">> := <<"jwt">>}
+        ],
+        PathPrefix ++ ["authentication"]),
+
+    {ok, 204, _} = request(
+                    post,
+                    uri(PathPrefix ++ ["authentication", "jwt", "move"]),
+                    #{position => <<"before:password-based:built-in-database">>}),
+
+    ?assertAuthenticatorsMatch(
+        [
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"http">>},
+            #{<<"mechanism">> := <<"jwt">>},
+            #{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"built-in-database">>}
+        ],
+        PathPrefix ++ ["authentication"]).
+
+test_authenticator_import_users(PathPrefix) ->
+    {ok, 200, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication"]),
+                        emqx_authn_test_lib:built_in_database_example()),
+
+    {ok, 400, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "import_users"]),
+                        #{}),
+
+    {ok, 400, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "import_users"]),
+                        #{filename => <<"/etc/passwd">>}),
+
+    {ok, 400, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "import_users"]),
+                        #{filename => <<"/not_exists.csv">>}),
+
+    Dir = code:lib_dir(emqx_authn, test),
+    JSONFileName = filename:join([Dir, <<"data/user-credentials.json">>]),
+    CSVFileName = filename:join([Dir, <<"data/user-credentials.csv">>]),
+
+    {ok, 204, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "import_users"]),
+                        #{filename => JSONFileName}),
+
+    {ok, 204, _} = request(
+                        post,
+                        uri(PathPrefix ++ ["authentication", "password-based:built-in-database", "import_users"]),
+                        #{filename => CSVFileName}).
+
+%%------------------------------------------------------------------------------
+%% Helpers
+%%------------------------------------------------------------------------------
+
+delete_authenticators(Path, Chain) ->
+    case emqx_authentication:list_authenticators(Chain) of
+        {error, _} -> ok;
+        {ok, Authenticators} ->
+            lists:foreach(
+                fun(#{id := ID}) ->
+                    emqx:update_config(
+                        Path,
+                        {delete_authenticator, Chain, ID},
+                        #{rawconf_with_defaults => true})
+                end,
+                Authenticators)
+    end.
+
+response_data(Response) ->
+    #{<<"data">> := Data} = jiffy:decode(Response, [return_maps]),
+    Data.
 
 request(Method, Url) ->
     request(Method, Url, []).
@@ -83,10 +467,7 @@ request(Method, Url, Body) ->
 
 uri() -> uri([]).
 uri(Parts) when is_list(Parts) ->
-    NParts = [E || E <- Parts],
-    ?HOST ++ filename:join([?BASE_PATH, ?API_VERSION | NParts]).
-
-get_sources(Result) -> jsx:decode(Result).
+    ?HOST ++ filename:join([?BASE_PATH, ?API_VERSION | Parts]).
 
 auth_header() ->
     Username = <<"admin">>,
@@ -94,6 +475,5 @@ auth_header() ->
     {ok, Token} = emqx_dashboard_admin:sign_token(Username, Password),
     {"Authorization", "Bearer " ++ binary_to_list(Token)}.
 
-to_json(Hocon) ->
-    {ok, Map} =hocon:binary(Hocon),
+to_json(Map) ->
     jiffy:encode(Map).

--- a/apps/emqx_authn/test/emqx_authn_test_lib.erl
+++ b/apps/emqx_authn/test/emqx_authn_test_lib.erl
@@ -19,20 +19,15 @@
 -compile(nowarn_export_all).
 -compile(export_all).
 
+authenticator_example(Id) ->
+    #{Id := #{value := Example}} = emqx_authn_api:authenticator_examples(),
+    Example.
+
 http_example() ->
-"""
-{
-  mechanism = \"password-based\"
-  backend = http
-  method = post
-  url = \"http://127.0.0.2:8080\"
-  headers = {\"content-type\" = \"application/json\"}
-  body = {username = \"${username}\",
-          password = \"${password}\"}
-  pool_size = 8
-  connect_timeout = 5000
-  request_timeout = 5000
-  enable_pipelining = true
-  ssl = {enable = false}
-}
-""".
+    authenticator_example('password-based:http').
+
+built_in_database_example() ->
+    authenticator_example('password-based:built-in-database').
+
+jwt_example() ->
+    authenticator_example(jwt).

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -41,7 +41,7 @@
 namespace() -> "dashboard".
 
 api_spec() ->
-    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
 
 paths() -> ["/login", "/logout", "/users",
     "/users/:username", "/users/:username/change_pwd"].

--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -10,7 +10,7 @@
     t_ref_array_with_key/1, t_ref_array_without_key/1
 ]).
 -export([
-    t_object_trans/1, t_nest_object_trans/1, t_local_ref_trans/1,
+    t_object_trans/1, t_object_notrans/1, t_nest_object_trans/1, t_local_ref_trans/1,
     t_remote_ref_trans/1, t_nest_ref_trans/1,
     t_ref_array_with_key_trans/1, t_ref_array_without_key_trans/1,
     t_ref_trans_error/1, t_object_trans_error/1
@@ -32,7 +32,7 @@ groups() -> [
         t_ref_array_with_key, t_ref_array_without_key, t_nest_ref]},
     {validation, [parallel],
         [
-            t_object_trans, t_local_ref_trans, t_remote_ref_trans,
+            t_object_trans, t_object_notrans, t_local_ref_trans, t_remote_ref_trans,
             t_ref_array_with_key_trans, t_ref_array_without_key_trans, t_nest_ref_trans,
             t_ref_trans_error, t_object_trans_error
             %% t_nest_object_trans,
@@ -173,8 +173,29 @@ t_ref_array_without_key(_Config) ->
     ok.
 
 t_api_spec(_Config) ->
-    emqx_dashboard_swagger:spec(?MODULE),
-    ok.
+    {Spec0, _} = emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}),
+    Path = "/object",
+    Body = #{
+        <<"per_page">> => 1,
+        <<"timeout">> => <<"infinity">>,
+        <<"inner_ref">> => #{
+            <<"webhook-host">> => <<"127.0.0.1:80">>,
+            <<"log_dir">> => <<"var/log/test">>,
+            <<"tag">> => <<"god_tag">>
+        }
+    },
+
+    Filter0 = filter(Spec0, Path),
+    ?assertMatch(
+        {ok, #{body := ActualBody}},
+        trans_requestBody(Path, Body, Filter0)),
+
+    {Spec1, _} = emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}),
+    Filter1 = filter(Spec1, Path),
+    ?assertMatch(
+        {ok, #{body := #{<<"timeout">> := infinity}}},
+        trans_requestBody(Path, Body, Filter1)).
+
 
 t_object_trans(_Config) ->
     Path = "/object",
@@ -203,6 +224,21 @@ t_object_trans(_Config) ->
         },
     {ok, ActualBody} = trans_requestBody(Path, Body),
     ?assertEqual(Expect, ActualBody),
+    ok.
+
+t_object_notrans(_Config) ->
+    Path = "/object",
+    Body = #{
+        <<"per_page">> => 1,
+        <<"timeout">> => <<"infinity">>,
+        <<"inner_ref">> => #{
+            <<"webhook-host">> => <<"127.0.0.1:80">>,
+            <<"log_dir">> => <<"var/log/test">>,
+            <<"tag">> => <<"god_tag">>
+        }
+    },
+    {ok, #{body := ActualBody}} = trans_requestBody(Path, Body, fun emqx_dashboard_swagger:filter_check_request/2),
+    ?assertEqual(Body, ActualBody),
     ok.
 
 t_nest_object_trans(_Config) ->
@@ -337,6 +373,7 @@ t_ref_array_with_key_trans(_Config) ->
     {ok, NewRequest} = trans_requestBody(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
+
 t_ref_array_without_key_trans(_Config) ->
     Path = "/ref/array/without/key",
     Body = [#{
@@ -401,10 +438,18 @@ validate(Path, ExpectSpec, ExpectRefs) ->
     ?assertEqual(ExpectRefs, Refs),
     {Spec, emqx_dashboard_swagger:components(Refs)}.
 
+
+filter(ApiSpec, Path) ->
+    [Filter] = [F || {P, _, _, #{filter := F}} <- ApiSpec, P =:= Path],
+    Filter.
+
 trans_requestBody(Path, Body) ->
+    trans_requestBody(Path, Body, fun emqx_dashboard_swagger:filter_check_request_and_translate_body/2).
+
+trans_requestBody(Path, Body, Filter) ->
     Meta = #{module => ?MODULE, method => post, path => Path},
     Request = #{bindings => #{}, query_string => #{}, body => Body},
-    emqx_dashboard_swagger:translate_req(Request, Meta).
+    Filter(Request, Meta).
 
 api_spec() -> emqx_dashboard_swagger:spec(?MODULE).
 paths() ->

--- a/apps/emqx_modules/src/emqx_rewrite_api.erl
+++ b/apps/emqx_modules/src/emqx_rewrite_api.erl
@@ -33,7 +33,7 @@
                         ]).
 
 api_spec() ->
-    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
 
 paths() ->
     ["/mqtt/topic_rewrite"].


### PR DESCRIPTION
Here we reuse config schemas for validations and preserve existing examples.

**Important** Although this PR specifies existing config schemas for responses too, this does not break functionality of returning ids added to authenticator configs in responses. This is because currently response schemas are used for documentation, but not for validation. 

<img width="748" alt="CleanShot 2021-10-25 at 23 10 13@2x" src="https://user-images.githubusercontent.com/4236/138763655-d50b1a5c-cb97-4e76-8b5b-7cdabd7d5125.png">

We probably should
* Add more examples, for actions and parameters not represented in configs;
* Test all methods at least on builtin database.