### PR TITLE
fix(emqx_broker): Preserve message order across the cluster

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -344,7 +344,7 @@ rpc.port_discovery = stateless
 ##
 ## Value: Interger [0-256]
 ## Default = 1
-#rpc.tcp_client_num = 1
+#rpc.tcp_client_num = 0
 
 ## RCP Client connect timeout.
 ##

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -376,7 +376,7 @@ end}.
 
 {translation, "gen_rpc.tcp_client_num", fun(Conf) ->
   case cuttlefish:conf_get("rpc.tcp_client_num", Conf) of
-    0 -> 1; %% keep allowing 0 for backward compatibility
+    0 -> max(1, erlang:system_info(schedulers) div 2);
     V -> V
   end
 end}.

--- a/rebar.config
+++ b/rebar.config
@@ -44,7 +44,7 @@
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.8.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.0"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.3"}}}
-    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
+    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.6.0"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.3.6"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "0.3.7"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.1"}}}


### PR DESCRIPTION
Fixes: #4658

