### PR TITLE
chore(formatting): reformat api modules for elvis compliance

### DIFF
--- a/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
@@ -61,45 +61,99 @@ t_public_ref(_Config) ->
     Expect = [
         #{<<"$ref">> => <<"#/components/parameters/public.page">>},
         #{<<"$ref">> => <<"#/components/parameters/public.limit">>}
-        ],
+    ],
     {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path),
     ?assertEqual(test, OperationId),
     Params = maps:get(parameters, maps:get(post, Spec)),
     ?assertEqual(Expect, Params),
-    ?assertEqual([
-        {emqx_dashboard_swagger, limit, parameter},
-        {emqx_dashboard_swagger, page, parameter}
-    ], Refs),
-    ExpectRefs = [
-        #{<<"public.limit">> => #{description => <<"Results per page(max 100)">>, example => 50,in => query,name => limit,
-            schema => #{default => 100,example => 1,maximum => 100, minimum => 1,type => integer}}},
-        #{<<"public.page">> => #{description => <<"Page number of the results to fetch.">>,
-            example => 1,in => query,name => page,
-            schema => #{default => 1,example => 100,type => integer}}}],
+    ?assertEqual(
+        [
+            {emqx_dashboard_swagger, limit, parameter},
+            {emqx_dashboard_swagger, page, parameter}
+        ],
+        Refs
+    ),
+    ExpectRefs =
+        [
+            #{
+                <<"public.limit">> => #{
+                    description => <<"Results per page(max 100)">>,
+                    example => 50,
+                    in => query,
+                    name => limit,
+                    schema => #{
+                        default => 100,
+                        example => 1,
+                        maximum => 100,
+                        minimum => 1,
+                        type => integer
+                    }
+                }
+            },
+            #{
+                <<"public.page">> => #{
+                    description => <<"Page number of the results to fetch.">>,
+                    example => 1,
+                    in => query,
+                    name => page,
+                    schema => #{
+                        default => 1,
+                        example => 100,
+                        type => integer
+                    }
+                }
+            }
+        ],
     ?assertEqual(ExpectRefs, emqx_dashboard_swagger:components(Refs)),
     ok.
 
 t_in_mix(_Config) ->
     Expect =
-        [#{description => <<"Indicates which sorts of issues to return">>,
-            example => <<"all">>,in => query,name => filter,
-            schema => #{enum => [assigned,created,mentioned,all],type => string}},
-            #{description => <<"Indicates the state of the issues to return.">>,
-                example => <<"12m">>,in => path,name => state,required => true,
-                schema => #{example => <<"1h">>,type => string}},
-            #{example => 10,in => query,name => per_page, required => false,
-                schema => #{default => 5,example => 1,maximum => 50,minimum => 1, type => integer}},
-            #{in => query,name => is_admin, schema => #{example => true,type => boolean}},
-            #{in => query,name => timeout,
-                schema => #{<<"oneOf">> => [#{enum => [infinity],type => string},
-                    #{example => 30,maximum => 60,minimum => 30, type => integer}]}}],
+        [
+            #{
+                description => <<"Indicates which sorts of issues to return">>,
+                example => <<"all">>,
+                in => query,
+                name => filter,
+                schema => #{enum => [assigned, created, mentioned, all], type => string}
+            },
+            #{
+                description => <<"Indicates the state of the issues to return.">>,
+                example => <<"12m">>,
+                in => path,
+                name => state,
+                required => true,
+                schema => #{example => <<"1h">>, type => string}
+            },
+            #{
+                example => 10,
+                in => query,
+                name => per_page,
+                required => false,
+                schema => #{
+                    default => 5, example => 1, maximum => 50, minimum => 1, type => integer
+                }
+            },
+            #{in => query, name => is_admin, schema => #{example => true, type => boolean}},
+            #{
+                in => query,
+                name => timeout,
+                schema => #{
+                    <<"oneOf">> => [
+                        #{enum => [infinity], type => string},
+                        #{example => 30, maximum => 60, minimum => 30, type => integer}
+                    ]
+                }
+            }
+        ],
     ExpectMeta = #{
-            tags => [tags, good],
-            description => <<"good description">>,
-            summary => <<"good summary">>,
-            security => [],
-            deprecated => true,
-            responses => #{<<"200">> => #{description => <<"ok">>}}},
+        tags => [tags, good],
+        description => <<"good description">>,
+        summary => <<"good summary">>,
+        security => [],
+        deprecated => true,
+        responses => #{<<"200">> => #{description => <<"ok">>}}
+    },
     GotSpec = validate("/test/in/mix/:state", Expect),
     ?assertEqual(ExpectMeta, maps:without([parameters], maps:get(post, GotSpec))),
     ok.
@@ -173,10 +227,17 @@ t_in_mix_trans(_Config) ->
         <<"is_admin">> => true,
         <<"timeout">> => <<"34">>
     },
-    Expect = {ok,
-        #{body => #{},
+    Expect =
+        {ok, #{
+            body => #{},
             bindings => #{state => 720},
-            query_string => #{<<"filter">> => created,<<"is_admin">> => true, <<"per_page">> => 5,<<"timeout">> => 34}}},
+            query_string => #{
+                <<"filter">> => created,
+                <<"is_admin">> => true,
+                <<"per_page">> => 5,
+                <<"timeout">> => 34
+            }
+        }},
     ?assertEqual(Expect, trans_parameters(Path, Bindings, Query)),
     ok.
 
@@ -263,31 +324,35 @@ paths() -> ["/test/in/:filter", "/test/in/query", "/test/in/mix/:state", "/test/
 
 schema("/test/in/:filter") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => [
                 {filter,
-                    mk(hoconsc:enum([assigned, created, mentioned, all]),
-                        #{in => path, desc => <<"Indicates which sorts of issues to return">>, example => "all"})}
+                    mk(hoconsc:enum([assigned, created, mentioned, all]), #{
+                        in => path,
+                        desc => <<"Indicates which sorts of issues to return">>,
+                        example => "all"
+                    })}
             ],
             responses => #{200 => <<"ok">>}
         }
     };
 schema("/test/in/query") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => [
                 {per_page,
-                    mk(range(1, 100),
-                        #{in => query, desc => <<"results per page (max 100)">>, example => 1})}
+                    mk(range(1, 100), #{
+                        in => query, desc => <<"results per page (max 100)">>, example => 1
+                    })}
             ],
             responses => #{200 => <<"ok">>}
         }
     };
 schema("/test/in/ref/local") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => [hoconsc:ref(page)],
             responses => #{200 => <<"ok">>}
@@ -295,7 +360,7 @@ schema("/test/in/ref/local") ->
     };
 schema("/test/in/ref") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => [hoconsc:ref(?MODULE, page)],
             responses => #{200 => <<"ok">>}
@@ -303,7 +368,7 @@ schema("/test/in/ref") ->
     };
 schema("/test/in/ref/public") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => [
                 hoconsc:ref(emqx_dashboard_swagger, page),
@@ -314,7 +379,7 @@ schema("/test/in/ref/public") ->
     };
 schema("/test/in/mix/:state") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             tags => [tags, good],
             description => <<"good description">>,
@@ -322,12 +387,22 @@ schema("/test/in/mix/:state") ->
             security => [],
             deprecated => true,
             parameters => [
-                {filter, hoconsc:mk(hoconsc:enum([assigned, created, mentioned, all]),
-                    #{in => query, desc => <<"Indicates which sorts of issues to return">>, example => "all"})},
-                {state, mk(emqx_schema:duration_s(),
-                    #{in => path, required => true, example => "12m", desc => <<"Indicates the state of the issues to return.">>})},
-                {per_page, mk(range(1, 50),
-                    #{in => query, required => false, example => 10, default => 5})},
+                {filter,
+                    hoconsc:mk(hoconsc:enum([assigned, created, mentioned, all]), #{
+                        in => query,
+                        desc => <<"Indicates which sorts of issues to return">>,
+                        example => "all"
+                    })},
+                {state,
+                    mk(emqx_schema:duration_s(), #{
+                        in => path,
+                        required => true,
+                        example => "12m",
+                        desc => <<"Indicates the state of the issues to return.">>
+                    })},
+                {per_page,
+                    mk(range(1, 50),
+                       #{in => query, required => false, example => 10, default => 5})},
                 {is_admin, mk(boolean(), #{in => query})},
                 {timeout, mk(hoconsc:union([range(30, 60), infinity]), #{in => query})}
             ],
@@ -336,7 +411,7 @@ schema("/test/in/mix/:state") ->
     };
 schema("/test/without/in") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => [
                 {'x-request-id', mk(binary(), #{})}
@@ -352,20 +427,25 @@ schema("/nullable/true") ->
     to_schema([{'userid', mk(binary(), #{in => query, nullable => true})}]);
 schema("/method/ok") ->
     Response = #{responses => #{200 => <<"ok">>}},
-    lists:foldl(fun(Method, Acc) ->  Acc#{Method => Response} end,
-        #{operationId => test}, ?METHODS);
+    lists:foldl(
+      fun(Method, Acc) -> Acc#{Method => Response} end,
+      #{operation_id => test},
+      ?METHODS);
 schema("/method/error") ->
-    #{operationId => test, bar => #{200 => <<"ok">>}}.
+    #{operation_id => test, bar => #{200 => <<"ok">>}}.
 
 fields(page) ->
     [
         {per_page,
-            mk(range(1, 100),
-                #{in => query, desc => <<"results per page (max 100)">>, example => 1})}
+            mk(range(1, 100), #{
+                in => query,
+                desc => <<"results per page (max 100)">>,
+                example => 1
+            })}
     ].
 to_schema(Params) ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{
             parameters => Params,
             responses => #{200 => <<"ok">>}

--- a/apps/emqx_dashboard/test/emqx_swagger_request_body_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_request_body_SUITE.erl
@@ -1,4 +1,4 @@
--module(emqx_swagger_requestBody_SUITE).
+-module(emqx_swagger_request_body_SUITE).
 
 -behaviour(minirest_api).
 -behaviour(hocon_schema).
@@ -41,88 +41,222 @@ groups() -> [
 
 t_object(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> =>
-            #{<<"application/json">> =>
-            #{<<"schema">> =>
-            #{required => [<<"timeout">>, <<"per_page">>],
-                <<"properties">> =>[
-                    {<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-                    {<<"timeout">>, #{default => 5, <<"oneOf">> => [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-                    {<<"inner_ref">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}}],
-                <<"type">> => object}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> => #{
+                            required => [<<"timeout">>, <<"per_page">>],
+                            <<"properties">> => [
+                                {<<"per_page">>, #{
+                                    description => <<"good per page desc">>,
+                                    example => 1,
+                                    maximum => 100,
+                                    minimum => 1,
+                                    type => integer
+                                }},
+                                {<<"timeout">>, #{
+                                    default => 5,
+                                    <<"oneOf">> => [
+                                        #{example => <<"1h">>, type => string},
+                                        #{enum => [infinity], type => string}
+                                    ]
+                                }},
+                                {<<"inner_ref">>, #{
+                <<"$ref">> =>
+                    <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                                }}
+                            ],
+                            <<"type">> => object
+                        }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, good_ref}],
     validate("/object", Spec, Refs),
     ok.
 
 t_nest_object(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> =>
-            #{<<"schema">> =>
-            #{required => [<<"timeout">>],
-                <<"properties">> =>
-                [{<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-                    {<<"timeout">>, #{default => 5, <<"oneOf">> =>
-                    [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-                    {<<"nest_object">>,
-                        #{<<"properties">> =>
-                        [{<<"good_nest_1">>, #{example => 100, type => integer}},
-                            {<<"good_nest_2">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}}],<<"type">> => object}},
-                    {<<"inner_ref">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}}],
-                <<"type">> => object}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> => #{
+                            required => [<<"timeout">>],
+                            <<"properties">> => [
+                                {<<"per_page">>, #{
+                                    description => <<"good per page desc">>,
+                                    example => 1,
+                                    maximum => 100,
+                                    minimum => 1,
+                                    type => integer
+                                }},
+                                {<<"timeout">>, #{
+                                    default => 5,
+                                    <<"oneOf">> =>
+                                        [
+                                            #{example => <<"1h">>, type => string},
+                                            #{enum => [infinity], type => string}
+                                        ]
+                                }},
+                                {<<"nest_object">>, #{
+                                    <<"properties">> =>
+                                        [
+                                            {<<"good_nest_1">>, #{
+                                                example => 100, type => integer
+                                            }},
+                                            {<<"good_nest_2">>, #{
+                    <<"$ref">> =>
+                        <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                                            }}
+                                        ],
+                                    <<"type">> => object
+                                }},
+                                {<<"inner_ref">>, #{
+                    <<"$ref">> =>
+                        <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                                }}
+                            ],
+                            <<"type">> => object
+                        }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, good_ref}],
     validate("/nest/object", Spec, Refs),
     ok.
 
 t_local_ref(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> =>
-            #{<<"schema">> => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> => #{
+            <<"$ref">> =>
+                <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                        }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, good_ref}],
     validate("/ref/local", Spec, Refs),
     ok.
 
 t_remote_ref(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> =>
-            #{<<"schema">> => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref2">>}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> => #{
+                            <<"$ref">> =>
+                                <<"#/components/schemas/emqx_swagger_remote_schema.ref2">>
+                        }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{emqx_swagger_remote_schema, "ref2"}],
     {_, Components} = validate("/ref/remote", Spec, Refs),
     ExpectComponents = [
-        #{<<"emqx_swagger_remote_schema.ref2">> => #{<<"properties">> => [
-            {<<"page">>, #{description => <<"good page">>,example => 1, maximum => 100,minimum => 1,type => integer}},
-        {<<"another_ref">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref3">>}}], <<"type">> => object}},
-        #{<<"emqx_swagger_remote_schema.ref3">> => #{<<"properties">> => [
-            {<<"ip">>, #{description => <<"IP:Port">>, example => <<"127.0.0.1:80">>,type => string}},
-            {<<"version">>, #{description => <<"a good version">>, example => <<"1.0.0">>,type => string}}],
-            <<"type">> => object}}],
+        #{
+            <<"emqx_swagger_remote_schema.ref2">> => #{
+                <<"properties">> => [
+                    {<<"page">>, #{
+                        description => <<"good page">>,
+                        example => 1,
+                        maximum => 100,
+                        minimum => 1,
+                        type => integer
+                    }},
+                    {<<"another_ref">>, #{
+                        <<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref3">>
+                    }}
+                ],
+                <<"type">> => object
+            }
+        },
+        #{
+            <<"emqx_swagger_remote_schema.ref3">> => #{
+                <<"properties">> => [
+                    {<<"ip">>, #{
+                        description => <<"IP:Port">>, example => <<"127.0.0.1:80">>, type => string
+                    }},
+                    {<<"version">>, #{
+                        description => <<"a good version">>, example => <<"1.0.0">>, type => string
+                    }}
+                ],
+                <<"type">> => object
+            }
+        }
+    ],
     ?assertEqual(ExpectComponents, Components),
     ok.
 
 t_nest_ref(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> =>
-            #{<<"schema">> => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.nest_ref">>}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> => #{
+                            <<"$ref">> =>
+                                <<"#/components/schemas/emqx_swagger_request_body_SUITE.nest_ref">>
+                        }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, nest_ref}],
     ExpectComponents = lists:sort([
-        #{<<"emqx_swagger_requestBody_SUITE.nest_ref">> => #{<<"properties">> => [
-            {<<"env">>, #{enum => [test,dev,prod],type => string}},
-            {<<"another_ref">>, #{description => <<"nest ref">>, <<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}}],
-            <<"type">> => object}},
-        #{<<"emqx_swagger_requestBody_SUITE.good_ref">> => #{<<"properties">> => [
-            {<<"webhook-host">>, #{default => <<"127.0.0.1:80">>, example => <<"127.0.0.1:80">>,type => string}},
-            {<<"log_dir">>, #{example => <<"var/log/emqx">>,type => string}},
-            {<<"tag">>, #{description => <<"tag">>, example => <<"binary-example">>,type => string}}],
-            <<"type">> => object}}]),
+        #{
+            <<"emqx_swagger_request_body_SUITE.nest_ref">> => #{
+                <<"properties">> => [
+                    {<<"env">>, #{enum => [test, dev, prod], type => string}},
+                    {<<"another_ref">>, #{
+                        description => <<"nest ref">>,
+                        <<"$ref">> =>
+                            <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                    }}
+                ],
+                <<"type">> => object
+            }
+        },
+        #{
+            <<"emqx_swagger_request_body_SUITE.good_ref">> => #{
+                <<"properties">> => [
+                    {<<"webhook-host">>, #{
+                        default => <<"127.0.0.1:80">>, example => <<"127.0.0.1:80">>, type => string
+                    }},
+                    {<<"log_dir">>, #{example => <<"var/log/emqx">>, type => string}},
+                    {<<"tag">>, #{
+                        description => <<"tag">>, example => <<"binary-example">>, type => string
+                    }}
+                ],
+                <<"type">> => object
+            }
+        }
+    ]),
     {_, Components} = validate("/ref/nest/ref", Spec, Refs),
     ?assertEqual(ExpectComponents, Components),
     ok.
@@ -136,38 +270,97 @@ t_none_ref(_Config) ->
 t_bad_ref(_Config) ->
     Path = "/ref/bad",
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> => #{<<"schema">> =>
-            #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.bad_ref">>}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> =>
+                            #{
+            <<"$ref">> =>
+                <<"#/components/schemas/emqx_swagger_request_body_SUITE.bad_ref">>
+                            }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, bad_ref}],
     Fields = fields(bad_ref),
-    ?assertThrow({error, #{msg := <<"Object only supports not empty proplists">>, args := Fields}},
-        validate(Path, Spec, Refs)),
+    ?assertThrow(
+        {error, #{msg := <<"Object only supports not empty proplists">>, args := Fields}},
+        validate(Path, Spec, Refs)
+    ),
     ok.
 
 t_ref_array_with_key(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> =>
-            #{<<"schema">> => #{required => [<<"timeout">>],
-                <<"type">> => object, <<"properties">> =>
-                [
-                    {<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-                    {<<"timeout">>, #{default => 5, <<"oneOf">> => [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-                    {<<"array_refs">>, #{items => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}, type => array}}
-                ]}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> =>
+                        #{
+                            <<"schema">> => #{
+                                required => [<<"timeout">>],
+                                <<"type">> => object,
+                                <<"properties">> =>
+                                    [
+                                        {<<"per_page">>, #{
+                                            description => <<"good per page desc">>,
+                                            example => 1,
+                                            maximum => 100,
+                                            minimum => 1,
+                                            type => integer
+                                        }},
+                                        {<<"timeout">>, #{
+                                            default => 5,
+                                            <<"oneOf">> => [
+                                                #{example => <<"1h">>, type => string},
+                                                #{enum => [infinity], type => string}
+                                            ]
+                                        }},
+                                        {<<"array_refs">>, #{
+                                            items => #{
+                            <<"$ref">> =>
+                                <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                                            },
+                                            type => array
+                                        }}
+                                    ]
+                            }
+                        }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, good_ref}],
     validate("/ref/array/with/key", Spec, Refs),
     ok.
 
 t_ref_array_without_key(_Config) ->
     Spec = #{
-        post => #{parameters => [],
-            requestBody => #{<<"content">> => #{<<"application/json">> => #{<<"schema">> =>
-            #{items => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}, type => array}}}},
-            responses => #{<<"200">> => #{description => <<"ok">>}}}},
+        post => #{
+            parameters => [],
+            request_body => #{
+                <<"content">> => #{
+                    <<"application/json">> => #{
+                        <<"schema">> =>
+                            #{
+                                items => #{
+                <<"$ref">> =>
+                    <<"#/components/schemas/emqx_swagger_request_body_SUITE.good_ref">>
+                                },
+                                type => array
+                            }
+                    }
+                }
+            },
+            responses => #{<<"200">> => #{description => <<"ok">>}}
+        }
+    },
     Refs = [{?MODULE, good_ref}],
     validate("/ref/array/without/key", Spec, Refs),
     ok.
@@ -188,14 +381,17 @@ t_api_spec(_Config) ->
     Filter0 = filter(Spec0, Path),
     ?assertMatch(
         {ok, #{body := #{<<"timeout">> := <<"infinity">>}}},
-        trans_requestBody(Path, Body, Filter0)),
+        trans_request_body(Path, Body, Filter0)
+    ),
 
-    {Spec1, _} = emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}),
+    {Spec1, _} = emqx_dashboard_swagger:spec(?MODULE, #{
+        check_schema => true, translate_body => true
+    }),
     Filter1 = filter(Spec1, Path),
     ?assertMatch(
         {ok, #{body := #{<<"timeout">> := infinity}}},
-        trans_requestBody(Path, Body, Filter1)).
-
+        trans_request_body(Path, Body, Filter1)
+    ).
 
 t_object_trans(_Config) ->
     Path = "/object",
@@ -222,7 +418,7 @@ t_object_trans(_Config) ->
                     <<"webhook-host">> => {{127, 0, 0, 1}, 80}}
             }
         },
-    {ok, ActualBody} = trans_requestBody(Path, Body),
+    {ok, ActualBody} = trans_request_body(Path, Body),
     ?assertEqual(Expect, ActualBody),
     ok.
 
@@ -237,7 +433,8 @@ t_object_notrans(_Config) ->
             <<"tag">> => <<"god_tag">>
         }
     },
-    {ok, #{body := ActualBody}} = trans_requestBody(Path, Body, fun emqx_dashboard_swagger:filter_check_request/2),
+    {ok, #{body := ActualBody}} = trans_request_body(Path, Body,
+        fun emqx_dashboard_swagger:filter_check_request/2),
     ?assertEqual(Body, ActualBody),
     ok.
 
@@ -266,7 +463,7 @@ t_nest_object_trans(_Config) ->
         body => #{<<"per_page">> => 10,
             <<"timeout">> => 600}
     },
-    {ok, NewRequest} = trans_requestBody(Path, Body),
+    {ok, NewRequest} = trans_request_body(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
 
@@ -286,7 +483,7 @@ t_local_ref_trans(_Config) ->
             <<"webhook-host">> => {{127, 0, 0, 1}, 80}
         }
     },
-    {ok, NewRequest} = trans_requestBody(Path, Body),
+    {ok, NewRequest} = trans_request_body(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
 
@@ -308,7 +505,7 @@ t_remote_ref_trans(_Config) ->
                 <<"ip">> => {{198,12,2,1}, 89}}
         }
     },
-    {ok, NewRequest} = trans_requestBody(Path, Body),
+    {ok, NewRequest} = trans_request_body(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
 
@@ -329,7 +526,7 @@ t_nest_ref_trans(_Config) ->
                 <<"webhook-host">> => {{127, 0, 0, 1}, 80}},
             <<"env">> => prod}
     },
-    {ok, NewRequest} = trans_requestBody(Path, Body),
+    {ok, NewRequest} = trans_request_body(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
 
@@ -370,7 +567,7 @@ t_ref_array_with_key_trans(_Config) ->
             ]
         }
     },
-    {ok, NewRequest} = trans_requestBody(Path, Body),
+    {ok, NewRequest} = trans_request_body(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
 
@@ -401,7 +598,7 @@ t_ref_array_without_key_trans(_Config) ->
                 <<"webhook-host">> => {{127, 0, 0, 1}, 81}
             }]
     },
-    {ok, NewRequest} = trans_requestBody(Path, Body),
+    {ok, NewRequest} = trans_request_body(Path, Body),
     ?assertEqual(Expect, NewRequest),
     ok.
 
@@ -413,7 +610,7 @@ t_ref_trans_error(_Config) ->
             <<"tag">> => <<"A">>,
             <<"webhook-host">> => "127.0..0.1:80"
         }},
-    {400, 'BAD_REQUEST', _} = trans_requestBody(Path, Body),
+    {400, 'BAD_REQUEST', _} = trans_request_body(Path, Body),
     ok.
 
 t_object_trans_error(_Config) ->
@@ -427,7 +624,7 @@ t_object_trans_error(_Config) ->
             <<"tag">> => <<"god_tag">>
         }
     },
-    {400, 'BAD_REQUEST', Reason} = trans_requestBody(Path, Body),
+    {400, 'BAD_REQUEST', Reason} = trans_request_body(Path, Body),
     ?assertNotEqual(nomatch, binary:match(Reason, [<<"webhook-host">>])),
     ok.
 
@@ -443,17 +640,25 @@ filter(ApiSpec, Path) ->
     [Filter] = [F || {P, _, _, #{filter := F}} <- ApiSpec, P =:= Path],
     Filter.
 
-trans_requestBody(Path, Body) ->
-    trans_requestBody(Path, Body, fun emqx_dashboard_swagger:filter_check_request_and_translate_body/2).
+trans_request_body(Path, Body) ->
+    trans_request_body(Path, Body,
+        fun emqx_dashboard_swagger:filter_check_request_and_translate_body/2).
 
-trans_requestBody(Path, Body, Filter) ->
+trans_request_body(Path, Body, Filter) ->
     Meta = #{module => ?MODULE, method => post, path => Path},
     Request = #{bindings => #{}, query_string => #{}, body => Body},
     Filter(Request, Meta).
 
 api_spec() -> emqx_dashboard_swagger:spec(?MODULE).
 paths() ->
-    ["/object", "/nest/object", "/ref/local", "/ref/nest/ref", "/ref/array/with/key", "/ref/array/without/key"].
+    [
+        "/object",
+        "/nest/object",
+        "/ref/local",
+        "/ref/nest/ref",
+        "/ref/array/with/key",
+        "/ref/array/without/key"
+    ].
 
 schema("/object") ->
     to_schema([
@@ -493,8 +698,8 @@ schema("/ref/array/without/key") ->
 
 to_schema(Body) ->
     #{
-        operationId => test,
-        post => #{requestBody => Body, responses => #{200 => <<"ok">>}}
+        operation_id => test,
+        post => #{request_body => Body, responses => #{200 => <<"ok">>}}
     }.
 
 fields(good_ref) ->

--- a/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
@@ -37,35 +37,81 @@ t_simple_binary(_config) ->
 t_object(_config) ->
     Path = "/object",
     Object =
-        #{<<"content">> => #{<<"application/json">> =>
-        #{<<"schema">> => #{required => [<<"timeout">>, <<"per_page">>],
-            <<"properties">> => [
-                {<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-                {<<"timeout">>, #{default => 5, <<"oneOf">> => [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-                {<<"inner_ref">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}}],
-            <<"type">> => object}}}},
+        #{
+            <<"content">> => #{
+                <<"application/json">> =>
+                    #{
+                        <<"schema">> => #{
+                            required => [<<"timeout">>, <<"per_page">>],
+                            <<"properties">> => [
+                                {<<"per_page">>, #{
+                                    description => <<"good per page desc">>,
+                                    example => 1,
+                                    maximum => 100,
+                                    minimum => 1,
+                                    type => integer
+                                }},
+                                {<<"timeout">>, #{
+                                    default => 5,
+                                    <<"oneOf">> => [
+                                        #{example => <<"1h">>, type => string},
+                                        #{enum => [infinity], type => string}
+                                    ]
+                                }},
+                                {<<"inner_ref">>, #{
+                    <<"$ref">> =>
+                        <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                                }}
+                            ],
+                            <<"type">> => object
+                        }
+                    }
+            }
+        },
     ExpectRefs = [{?MODULE, good_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_error(_Config) ->
     Path = "/error",
-    Error400 = #{<<"content">> =>
-    #{<<"application/json">> => #{<<"schema">> => #{<<"type">> => object,
-        <<"properties">> =>
-        [
-            {<<"code">>, #{enum => ['Bad1', 'Bad2'], type => string}},
-            {<<"message">>, #{description => <<"Details description of the error.">>,
-                example => <<"Bad request desc">>, type => string}}]
-    }}}},
-    Error404 = #{<<"content">> =>
-    #{<<"application/json">> => #{<<"schema">> => #{<<"type">> => object,
-        <<"properties">> =>
-        [
-            {<<"code">>, #{enum => ['Not-Found'], type => string}},
-            {<<"message">>, #{description => <<"Details description of the error.">>,
-                example => <<"Error code to troubleshoot problems.">>, type => string}}]
-    }}}},
+    Error400 = #{
+        <<"content">> =>
+            #{
+                <<"application/json">> => #{
+                    <<"schema">> => #{
+                        <<"type">> => object,
+                        <<"properties">> =>
+                            [
+                                {<<"code">>, #{enum => ['Bad1', 'Bad2'], type => string}},
+                                {<<"message">>, #{
+                                    description => <<"Details description of the error.">>,
+                                    example => <<"Bad request desc">>,
+                                    type => string
+                                }}
+                            ]
+                    }
+                }
+            }
+    },
+    Error404 = #{
+        <<"content">> =>
+            #{
+                <<"application/json">> => #{
+                    <<"schema">> => #{
+                        <<"type">> => object,
+                        <<"properties">> =>
+                            [
+                                {<<"code">>, #{enum => ['Not-Found'], type => string}},
+                                {<<"message">>, #{
+                                    description => <<"Details description of the error.">>,
+                                    example => <<"Error code to troubleshoot problems.">>,
+                                    type => string
+                                }}
+                            ]
+                    }
+                }
+            }
+    },
     {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path),
     ?assertEqual(test, OperationId),
     Response = maps:get(responses, maps:get(get, Spec)),
@@ -78,108 +124,232 @@ t_error(_Config) ->
 t_nest_object(_Config) ->
     Path = "/nest/object",
     Object =
-        #{<<"content">> => #{<<"application/json">> => #{<<"schema">> =>
-        #{required => [<<"timeout">>], <<"type">> => object, <<"properties">> => [
-            {<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-            {<<"timeout">>, #{default => 5, <<"oneOf">> =>
-            [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-            {<<"nest_object">>, #{<<"type">> => object, <<"properties">> => [
-                {<<"good_nest_1">>, #{example => 100, type => integer}},
-                {<<"good_nest_2">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}
-                }]}},
-            {<<"inner_ref">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}}]
-        }}}},
+        #{
+            <<"content">> => #{
+                <<"application/json">> => #{
+                    <<"schema">> =>
+                        #{
+                            required => [<<"timeout">>],
+                            <<"type">> => object,
+                            <<"properties">> => [
+                                {<<"per_page">>, #{
+                                    description => <<"good per page desc">>,
+                                    example => 1,
+                                    maximum => 100,
+                                    minimum => 1,
+                                    type => integer
+                                }},
+                                {<<"timeout">>, #{
+                                    default => 5,
+                                    <<"oneOf">> =>
+                                        [
+                                            #{example => <<"1h">>, type => string},
+                                            #{enum => [infinity], type => string}
+                                        ]
+                                }},
+                                {<<"nest_object">>, #{
+                                    <<"type">> => object,
+                                    <<"properties">> => [
+                                        {<<"good_nest_1">>, #{example => 100, type => integer}},
+                                        {<<"good_nest_2">>, #{
+                        <<"$ref">> =>
+                            <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                                        }}
+                                    ]
+                                }},
+                                {<<"inner_ref">>, #{
+                            <<"$ref">> =>
+                                <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                                }}
+                            ]
+                        }
+                }
+            }
+        },
     ExpectRefs = [{?MODULE, good_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_empty(_Config) ->
-    ?assertThrow({error,
-        #{msg := <<"Object only supports not empty proplists">>,
-            args := [], module := ?MODULE}}, validate("/empty", error, [])),
+    ?assertThrow(
+        {error, #{
+            msg := <<"Object only supports not empty proplists">>,
+            args := [],
+            module := ?MODULE
+        }},
+        validate("/empty", error, [])
+    ),
     ok.
 
 t_raw_local_ref(_Config) ->
     Path = "/raw/ref/local",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
-        <<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> => #{
+                    <<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                }
+            }
+        }
+    },
     ExpectRefs = [{?MODULE, good_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_raw_remote_ref(_Config) ->
     Path = "/raw/ref/remote",
-    Object = #{<<"content">> =>
-    #{<<"application/json">> => #{<<"schema">> => #{
-        <<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>}}}},
+    Object = #{
+        <<"content">> =>
+            #{
+                <<"application/json">> => #{
+                    <<"schema">> => #{
+                        <<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>
+                    }
+                }
+            }
+    },
     ExpectRefs = [{emqx_swagger_remote_schema, "ref1"}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_local_ref(_Config) ->
     Path = "/ref/local",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
-        <<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> => #{
+                    <<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                }
+            }
+        }
+    },
     ExpectRefs = [{?MODULE, good_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_remote_ref(_Config) ->
     Path = "/ref/remote",
-    Object = #{<<"content">> =>
-    #{<<"application/json">> => #{<<"schema">> => #{
-        <<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>}}}},
+    Object = #{
+        <<"content">> =>
+            #{
+                <<"application/json">> => #{
+                    <<"schema">> => #{
+                        <<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>
+                    }
+                }
+            }
+    },
     ExpectRefs = [{emqx_swagger_remote_schema, "ref1"}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_bad_ref(_Config) ->
     Path = "/ref/bad",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> =>
-    #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.bad_ref">>}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> =>
+                    #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.bad_ref">>}
+            }
+        }
+    },
     ExpectRefs = [{?MODULE, bad_ref}],
-    ?assertThrow({error, #{module := ?MODULE, msg := <<"Object only supports not empty proplists">>}},
-        validate(Path, Object, ExpectRefs)),
+    ?assertThrow(
+        {error, #{module := ?MODULE, msg := <<"Object only supports not empty proplists">>}},
+        validate(Path, Object, ExpectRefs)
+    ),
     ok.
 
 t_none_ref(_Config) ->
     Path = "/ref/none",
-    ?assertThrow({error, #{mfa := {?MODULE, schema, ["/ref/none"]},
-        reason := function_clause}}, validate(Path, #{}, [])),
+    ?assertThrow(
+        {error, #{
+            mfa := {?MODULE, schema, ["/ref/none"]},
+            reason := function_clause
+        }},
+        validate(Path, #{}, [])
+    ),
     ok.
 
 t_nest_ref(_Config) ->
     Path = "/ref/nest/ref",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
-        <<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.nest_ref">>}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> => #{
+                    <<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.nest_ref">>
+                }
+            }
+        }
+    },
     ExpectRefs = [{?MODULE, nest_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
-
 t_complicated_type(_Config) ->
     Path = "/ref/complicated_type",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{<<"properties">> =>
-    [
-        {<<"no_neg_integer">>, #{example => 100, minimum => 1, type => integer}},
-        {<<"url">>, #{example => <<"http://127.0.0.1">>, type => string}},
-        {<<"server">>, #{example => <<"127.0.0.1:80">>, type => string}},
-        {<<"connect_timeout">>, #{example => infinity, <<"oneOf">> => [
-            #{example => infinity, type => string},
-            #{example => 100, type => integer}]}},
-        {<<"pool_type">>, #{enum => [random, hash], example => hash, type => string}},
-        {<<"timeout">>, #{example => infinity,
-            <<"oneOf">> =>
-            [#{example => infinity, type => string}, #{example => 100, type => integer}]}},
-        {<<"bytesize">>, #{example => <<"32MB">>, type => string}},
-        {<<"wordsize">>, #{example => <<"1024KB">>, type => string}},
-        {<<"maps">>, #{example => #{}, type => object}},
-        {<<"comma_separated_list">>, #{example => <<"item1,item2">>, type => string}},
-        {<<"comma_separated_atoms">>, #{example => <<"item1,item2">>, type => string}},
-        {<<"log_level">>,
-            #{enum => [debug, info, notice, warning, error, critical, alert, emergency, all], type => string}},
-        {<<"fix_integer">>, #{default => 100, enum => [100], example => 100,type => integer}}
-    ],
-        <<"type">> => object}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> => #{
+                    <<"properties">> =>
+                        [
+                            {<<"no_neg_integer">>, #{
+                                example => 100,
+                                minimum => 1,
+                                type => integer
+                            }},
+                            {<<"url">>, #{example => <<"http://127.0.0.1">>, type => string}},
+                            {<<"server">>, #{example => <<"127.0.0.1:80">>, type => string}},
+                            {<<"connect_timeout">>, #{
+                                example => infinity,
+                                <<"oneOf">> => [
+                                    #{example => infinity, type => string},
+                                    #{example => 100, type => integer}
+                                ]
+                            }},
+                            {<<"pool_type">>, #{
+                                enum => [random, hash], example => hash, type => string
+                            }},
+                            {<<"timeout">>, #{
+                                example => infinity,
+                                <<"oneOf">> =>
+                                    [
+                                        #{example => infinity, type => string},
+                                        #{example => 100, type => integer}
+                                    ]
+                            }},
+                            {<<"bytesize">>, #{example => <<"32MB">>, type => string}},
+                            {<<"wordsize">>, #{example => <<"1024KB">>, type => string}},
+                            {<<"maps">>, #{example => #{}, type => object}},
+                            {<<"comma_separated_list">>, #{
+                                example => <<"item1,item2">>, type => string
+                            }},
+                            {<<"comma_separated_atoms">>, #{
+                                example => <<"item1,item2">>, type => string
+                            }},
+                            {<<"log_level">>, #{
+                                enum => [
+                                    debug,
+                                    info,
+                                    notice,
+                                    warning,
+                                    error,
+                                    critical,
+                                    alert,
+                                    emergency,
+                                    all
+                                ],
+                                type => string
+                            }},
+                            {<<"fix_integer">>, #{
+                                default => 100, enum => [100], example => 100, type => integer
+                            }}
+                        ],
+                    <<"type">> => object
+                }
+            }
+        }
+    },
     {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path),
     ?assertEqual(test, OperationId),
     Response = maps:get(responses, maps:get(post, Spec)),
@@ -187,66 +357,171 @@ t_complicated_type(_Config) ->
     ?assertEqual([], Refs),
     ok.
 
-
 t_ref_array_with_key(_Config) ->
     Path = "/ref/array/with/key",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
-        required => [<<"timeout">>], <<"type">> => object, <<"properties">> => [
-            {<<"per_page">>, #{description => <<"good per page desc">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-            {<<"timeout">>, #{default => 5, <<"oneOf">> =>
-            [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-            {<<"assert">>, #{description => <<"money">>, example => 3.14159, type => number}},
-            {<<"number_ex">>, #{description => <<"number example">>, example => 42, type => number}},
-            {<<"percent_ex">>, #{description => <<"percent example">>, example => <<"12%">>, type => number}},
-            {<<"duration_ms_ex">>, #{description => <<"duration ms example">>, example => <<"32s">>, type => string}},
-            {<<"atom_ex">>, #{description => <<"atom ex">>, example => atom, type => string}},
-            {<<"array_refs">>, #{items => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}, type => array}}
-        ]}
-    }}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> => #{
+                    required => [<<"timeout">>],
+                    <<"type">> => object,
+                    <<"properties">> => [
+                        {<<"per_page">>, #{
+                            description => <<"good per page desc">>,
+                            example => 1,
+                            maximum => 100,
+                            minimum => 1,
+                            type => integer
+                        }},
+                        {<<"timeout">>, #{
+                            default => 5,
+                            <<"oneOf">> =>
+                                [
+                                    #{example => <<"1h">>, type => string},
+                                    #{enum => [infinity], type => string}
+                                ]
+                        }},
+                        {<<"assert">>, #{
+                            description => <<"money">>, example => 3.14159, type => number
+                        }},
+                        {<<"number_ex">>, #{
+                            description => <<"number example">>, example => 42, type => number
+                        }},
+                        {<<"percent_ex">>, #{
+                            description => <<"percent example">>,
+                            example => <<"12%">>,
+                            type => number
+                        }},
+                        {<<"duration_ms_ex">>, #{
+                            description => <<"duration ms example">>,
+                            example => <<"32s">>,
+                            type => string
+                        }},
+                        {<<"atom_ex">>, #{
+                            description => <<"atom ex">>, example => atom, type => string
+                        }},
+                        {<<"array_refs">>, #{
+                            items => #{
+                                <<"$ref">> =>
+                                    <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                            },
+                            type => array
+                        }}
+                    ]
+                }
+            }
+        }
+    },
     ExpectRefs = [{?MODULE, good_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
 
 t_ref_array_without_key(_Config) ->
     Path = "/ref/array/without/key",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
-        items => #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>},
-        type => array}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> => #{
+                    items => #{
+                        <<"$ref">> =>
+                            <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>
+                    },
+                    type => array
+                }
+            }
+        }
+    },
     ExpectRefs = [{?MODULE, good_ref}],
     validate(Path, Object, ExpectRefs),
     ok.
 t_hocon_schema_function(_Config) ->
     Path = "/ref/hocon/schema/function",
-    Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> =>
-    #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.root">>}}}},
+    Object = #{
+        <<"content">> => #{
+            <<"application/json">> => #{
+                <<"schema">> =>
+                    #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.root">>}
+            }
+        }
+    },
     ExpectComponents = [
-        #{<<"emqx_swagger_remote_schema.ref1">> => #{<<"type">> => object,
-            <<"properties">> => [
-                {<<"protocol">>, #{enum => [http, https], type => string}},
-                {<<"port">>, #{default => 18083, example => 100, type => integer}}]
-        }},
-        #{<<"emqx_swagger_remote_schema.ref2">> => #{<<"type">> => object,
-            <<"properties">> => [
-                {<<"page">>, #{description => <<"good page">>, example => 1, maximum => 100, minimum => 1, type => integer}},
-                {<<"another_ref">>, #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref3">>}}
-            ]
-        }},
-        #{<<"emqx_swagger_remote_schema.ref3">> => #{<<"type">> => object,
-            <<"properties">> => [
-                {<<"ip">>, #{description => <<"IP:Port">>, example => <<"127.0.0.1:80">>, type => string}},
-                {<<"version">>, #{description => <<"a good version">>, example => <<"1.0.0">>, type => string}}]
-        }},
-        #{<<"emqx_swagger_remote_schema.root">> => #{required => [<<"default_password">>, <<"default_username">>],
-            <<"properties">> => [{<<"listeners">>, #{items =>
-            #{<<"oneOf">> =>
-            [#{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref2">>},
-                #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>}]}, type => array}},
-                {<<"default_username">>,
-                    #{default => <<"admin">>, example => <<"string-example">>, type => string}},
-                {<<"default_password">>, #{default => <<"public">>, example => <<"string-example">>, type => string}},
-                {<<"sample_interval">>, #{default => <<"10s">>, example => <<"1h">>, type => string}},
-                {<<"token_expired_time">>, #{default => <<"30m">>, example => <<"12m">>, type => string}}],
-            <<"type">> => object}}],
+        #{
+            <<"emqx_swagger_remote_schema.ref1">> => #{
+                <<"type">> => object,
+                <<"properties">> => [
+                    {<<"protocol">>, #{enum => [http, https], type => string}},
+                    {<<"port">>, #{default => 18083, example => 100, type => integer}}
+                ]
+            }
+        },
+        #{
+            <<"emqx_swagger_remote_schema.ref2">> => #{
+                <<"type">> => object,
+                <<"properties">> => [
+                    {<<"page">>, #{
+                        description => <<"good page">>,
+                        example => 1,
+                        maximum => 100,
+                        minimum => 1,
+                        type => integer
+                    }},
+                    {<<"another_ref">>, #{
+                        <<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref3">>
+                    }}
+                ]
+            }
+        },
+        #{
+            <<"emqx_swagger_remote_schema.ref3">> => #{
+                <<"type">> => object,
+                <<"properties">> => [
+                    {<<"ip">>, #{
+                        description => <<"IP:Port">>, example => <<"127.0.0.1:80">>, type => string
+                    }},
+                    {<<"version">>, #{
+                        description => <<"a good version">>, example => <<"1.0.0">>, type => string
+                    }}
+                ]
+            }
+        },
+        #{
+            <<"emqx_swagger_remote_schema.root">> => #{
+                required => [<<"default_password">>, <<"default_username">>],
+                <<"properties">> => [
+                    {<<"listeners">>, #{
+                        items =>
+                            #{
+                                <<"oneOf">> =>
+                                    [
+                                        #{
+                        <<"$ref">> =>
+                            <<"#/components/schemas/emqx_swagger_remote_schema.ref2">>
+                                        },
+                                        #{
+                        <<"$ref">> =>
+                            <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>
+                                        }
+                                    ]
+                            },
+                        type => array
+                    }},
+                    {<<"default_username">>, #{
+                        default => <<"admin">>, example => <<"string-example">>, type => string
+                    }},
+                    {<<"default_password">>, #{
+                        default => <<"public">>, example => <<"string-example">>, type => string
+                    }},
+                    {<<"sample_interval">>, #{
+                        default => <<"10s">>, example => <<"1h">>, type => string
+                    }},
+                    {<<"token_expired_time">>, #{
+                        default => <<"30m">>, example => <<"12m">>, type => string
+                    }}
+                ],
+                <<"type">> => object
+            }
+        }
+    ],
     ExpectRefs = [{emqx_swagger_remote_schema, "root"}],
     {_, Components} = validate(Path, Object, ExpectRefs),
     ?assertEqual(ExpectComponents, Components),
@@ -259,10 +534,18 @@ t_api_spec(_Config) ->
 api_spec() -> emqx_dashboard_swagger:spec(?MODULE).
 
 paths() ->
-    ["/simple/bin", "/object", "/nest/object", "/ref/local",
-        "/ref/nest/ref", "/raw/ref/local", "/raw/ref/remote",
-        "/ref/array/with/key", "/ref/array/without/key",
-        "/ref/hocon/schema/function"].
+    [
+        "/simple/bin",
+        "/object",
+        "/nest/object",
+        "/ref/local",
+        "/ref/nest/ref",
+        "/raw/ref/local",
+        "/raw/ref/remote",
+        "/ref/array/with/key",
+        "/ref/array/without/key",
+        "/ref/hocon/schema/function"
+    ].
 
 schema("/simple/bin") ->
     to_schema(<<"binary ok">>);
@@ -317,7 +600,7 @@ schema("/ref/hocon/schema/function") ->
     to_schema(mk(hoconsc:ref(emqx_swagger_remote_schema, "root"), #{}));
 schema("/error") ->
     #{
-        operationId => test,
+        operation_id => test,
         get => #{responses => #{
             400 => emqx_dashboard_swagger:error_codes(['Bad1', 'Bad2'], <<"Bad request desc">>),
             404 => emqx_dashboard_swagger:error_codes(['Not-Found'])
@@ -325,7 +608,7 @@ schema("/error") ->
     };
 schema("/ref/complicated_type") ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{responses => #{
             200 => [
                 {no_neg_integer, hoconsc:mk(non_neg_integer(), #{})},
@@ -357,7 +640,7 @@ validate(Path, ExpectObject, ExpectRefs) ->
 
 to_schema(Object) ->
     #{
-        operationId => test,
+        operation_id => test,
         post => #{responses => #{200 => Object, 201 => Object}}
     }.
 


### PR DESCRIPTION
😅 
Now we have Elvis enabled, which complaints about `requestBody` and `operationId` params present in many files.

This PRs renames these parameters and keeps backward compatibility. Consequently it reformats the concerned files, so there are many changes.

Having this merged, we will be able simply change `requestBody =>` to `request_body =>` and `operationId` to `operation_id =>` to please Elvis when changing `_api` modules.

Of course, we may make not this changes and use `'requestBody'` and `'operationId'` wherever we need to pass `requestBody` and `operationId`. But why have Elvis and bypass its rules at the same time? 😄




  







