### PR TITLE
chore(authn mnesia): reimplement emqx_authn_mnesia provider tests

### DIFF
--- a/apps/emqx_authn/test/data/user-credentials-malformed-0.json
+++ b/apps/emqx_authn/test/data/user-credentials-malformed-0.json
@@ -1,0 +1,14 @@
+[
+    {
+        "userid":"myuser1",
+        "password_hash":"c5e46903df45e5dc096dc74657610dbee8deaacae656df88a1788f1847390242",
+        "salt": "e378187547bf2d6f0545a3f441aa4d8a",
+        "is_superuser": true
+    },
+    {
+        "user_id":"myuser2",
+        "password_hash":"f4d17f300b11e522fd33f497c11b126ef1ea5149c74d2220f9a16dc876d4567b",
+        "salt": "6d3f9bd5b54d94b98adbcfe10b6d181f",
+        "is_superuser": false
+    }
+]

--- a/apps/emqx_authn/test/data/user-credentials-malformed-1.json
+++ b/apps/emqx_authn/test/data/user-credentials-malformed-1.json
@@ -1,0 +1,14 @@
+[
+    {
+        "user_id":"myuser1",
+        "password_hash":"c5e46903df45e5dc096dc74657610dbee8deaacae656df88a1788f1847390242",
+        "salt": "e378187547bf2d6f0545a3f441aa4d8a",
+        "is_superuser": true
+    ,
+    {
+        "user_id":"myuser2",
+        "password_hash":"f4d17f300b11e522fd33f497c11b126ef1ea5149c74d2220f9a16dc876d4567b",
+        "salt": "6d3f9bd5b54d94b98adbcfe10b6d181f",
+        "is_superuser": false
+    }
+]

--- a/apps/emqx_authn/test/data/user-credentials-malformed.csv
+++ b/apps/emqx_authn/test/data/user-credentials-malformed.csv
@@ -1,0 +1,3 @@
+user_id,password_hash,salt,is_superuser
+myuser3,b6c743545a7817ae8c8f624371d5f5f0373234bb0ff36b8ffbf19bce0e06ab75,de1024f462fb83910fd13151bd4bd235,true
+myuser4,ee68c985a69208b6eda8c6c9b4c7c2d2b15ee2352cdd64a903171710a9


### PR DESCRIPTION
The tests that had been commented out and were using `emqx_authentication` module now belong to its own tests.