### PR TITLE
fix(ci): temporarily disable rlog FVT tests (flakiness)

### DIFF
--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -73,7 +73,8 @@ jobs:
           - 24.1.1-emqx-1
         cluster_db_backend:
           - "mnesia"
-          - "rlog"
+          # FIXME: temporarily disabled: too flaky at the moment
+          # - "rlog"
 
     steps:
     - uses: actions/download-artifact@v2


### PR DESCRIPTION
A few FVT tests are very flaky when run in rlog core+replicant cluster
configuration (for instance `V5/test_publish.py::test_topic`). We are
disabling this test configuration temporarily while we investigate
further and mitigate it.

