### PR TITLE
test(rlog): reenable RLOG FVT tests

### DIFF
--- a/.ci/docker-compose-file/docker-compose-emqx-cluster-rlog.override.yaml
+++ b/.ci/docker-compose-file/docker-compose-emqx-cluster-rlog.override.yaml
@@ -12,6 +12,7 @@ services:
   emqx1:
     <<: *default-emqx
     container_name: node1.emqx.io
+    restart: on-failure
     environment:
       - "EMQX_HOST=node1.emqx.io"
       - "EMQX_CLUSTER__DB_BACKEND=rlog"
@@ -23,6 +24,9 @@ services:
   emqx2:
     <<: *default-emqx
     container_name: node2.emqx.io
+    depends_on:
+      - emqx1
+    restart: on-failure
     environment:
       - "EMQX_HOST=node2.emqx.io"
       - "EMQX_CLUSTER__DB_BACKEND=rlog"

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -73,8 +73,7 @@ jobs:
           - 24.1.1-emqx-1
         cluster_db_backend:
           - "mnesia"
-          # FIXME: temporarily disabled: too flaky at the moment
-          # - "rlog"
+          - "rlog"
 
     steps:
     - uses: actions/download-artifact@v2


### PR DESCRIPTION
The RLOG DB backend tests in FVT were temporarily disabled due to some
paho tests being specially flaky in CI.

In particular, those tests had the common pattern of subscribing to a
topic, immediately publishing to that topic and then waiting for the
response.  When in CI and using RLOG, there seems to be more delays in
replication of data, and often this pattern would fail in the
constraint testing enviroment.

