### PR TITLE
fix(eqmx_st_statistics): add ignore_before_create in config

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -2219,6 +2219,11 @@ module.presence.qos = 1
 ## Default: 10 seconds
 #module.st_statistics.threshold_time = 10S
 
+## ignore the messages that before than session created
+##
+## Default: true
+#module.st_statistics.ignore_before_create = true
+
 ## Time window of slow topics statistics
 ##
 ## Value: 5 minutes

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2193,6 +2193,11 @@ end}.
   {datatype, {duration, ms}}
 ]}.
 
+{mapping, "module.st_statistics.ignore_before_create", "emqx.modules", [
+  {default, true},
+  {datatype, {enum, [true, false]}}
+]}.
+
 {mapping, "module.st_statistics.time_window", "emqx.modules", [
   {default, "5M"},
   {datatype, {duration, ms}}


### PR DESCRIPTION
allows not to process the message before the session is created
to solve the problem caused by clean session = false

