### PR TITLE
build: ensure git tag matches release version

### DIFF
--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -15,9 +15,21 @@ fi
 ## emqx_release.hrl is the single source of truth for release version
 RELEASE="$(grep -E "define.+EMQX_RELEASE.+${EDITION}" include/emqx_release.hrl | cut -d '"' -f2)"
 
-## git commit hash is added as suffix in case the git tag and release version is not an exact match
-if [ -d .git ] && ! git describe --tags --match "[e|v]${RELEASE}" --exact >/dev/null 2>&1; then
+git_exact_vsn() {
+    local tag
+    tag="$(git describe --tags --match "[e|v]*" --exact 2>/dev/null)"
+    echo "$tag" | sed 's/^[v|e]//g'
+}
+
+GIT_EXACT_VSN="$(git_exact_vsn)"
+if [ "$GIT_EXACT_VSN" != '' ]; then
+    if [ "$GIT_EXACT_VSN" != "$RELEASE" ]; then
+        echo "ERROR: Tagged $GIT_EXACT_VSN, but $RELEASE in include/emqx_release.hrl" 1>&2
+        exit 1
+    fi
+    SUFFIX=''
+else
     SUFFIX="-$(git rev-parse HEAD | cut -b1-8)"
 fi
 
-echo "${RELEASE}${SUFFIX:-}"
+echo "${RELEASE}${SUFFIX}"


### PR DESCRIPTION
We sometime forget to bump RELEASE version before we tag a new release.
This change is to ensure that when tagging a new release, the RELEASE version has been updated.