### PR TITLE
[5.0] refactor(retainer): use ordered_set Mnesia table type

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -48,12 +48,16 @@ create_resource(#{storage_type := StorageType}) ->
                  disc      -> disc_copies;
                  disc_only -> disc_only_copies
              end,
+    TableType = case StorageType of
+                    disc_only -> set;
+                    _ -> ordered_set
+                end,
     StoreProps = [{ets, [compressed,
                          {read_concurrency, true},
                          {write_concurrency, true}]},
                   {dets, [{auto_save, 1000}]}],
     ok = mria:create_table(?TAB, [
-                {type, set},
+                {type, TableType},
                 {rlog_shard, ?RETAINER_SHARD},
                 {storage, Copies},
                 {record_name, retained},


### PR DESCRIPTION
ordered_set is compatible to set in all the existing APIs
and in addition, it provides a more deterministic traversing
cursor in case we want to change the current dirty_select
based "select ALL" implementation

