### PR TITLE
Reinitialize authentication after crashes

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -714,6 +714,8 @@ create_authenticator(ConfKeyPath, ChainName, Config) ->
             {ok, AuthenticatorConfig} = find_config(ID, AuthenticatorsConfig),
             {200, maps:put(id, ID, convert_certs(fill_defaults(AuthenticatorConfig)))};
         {error, {_, _, Reason}} ->
+            serialize_error(Reason);
+        {error, Reason} ->
             serialize_error(Reason)
     end.
 
@@ -896,13 +898,13 @@ serialize_error({bad_ssl_config, Details}) ->
             message => binfmt("bad_ssl_config ~p", [Details])}};
 serialize_error({missing_parameter, Detail}) ->
     {400, #{code => <<"MISSING_PARAMETER">>,
-            message => binfmt("Missing required parameter", [Detail])}};
+            message => binfmt("Missing required parameter ~p", [Detail])}};
 serialize_error({invalid_parameter, Name}) ->
     {400, #{code => <<"INVALID_PARAMETER">>,
             message => binfmt("Invalid value for '~p'", [Name])}};
 serialize_error({unknown_authn_type, Type}) ->
     {400, #{code => <<"BAD_REQUEST">>,
-            message => binfmt("Unknown type '~ts'", [Type])}};
+            message => binfmt("Unknown authentication provider ~p", [Type])}};
 serialize_error({bad_authenticator_config, Reason}) ->
     {400, #{code => <<"BAD_REQUEST">>,
             message => binfmt("Bad authenticator config ~p", [Reason])}};

--- a/apps/emqx_authn/src/emqx_authn_initializer.erl
+++ b/apps/emqx_authn/src/emqx_authn_initializer.erl
@@ -1,0 +1,161 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_authn_initializer).
+
+-behaviour(gen_statem).
+
+-define(DEFAULT_INTERVAL, 5).
+
+-include("emqx_authn.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
+%% APIs
+-export([start_link/0,
+         start_link/1,
+         initialize/0,
+         deinitialize/0
+        ]).
+
+%% gen_statem callbacks
+-export([init/1,
+         callback_mode/0,
+         handle_event/4,
+         code_change/4
+        ]).
+
+-type(opts() :: #{name := atom(),
+                  interval := non_neg_integer(),
+                  init_fun := fun((pid()) -> any())}).
+
+%%--------------------------------------------------------------------
+%% External interface
+%%--------------------------------------------------------------------
+
+-spec(start_link() -> gen_statem:start_ret()).
+start_link() ->
+        start_link(
+          #{name => ?AUTHN,
+            interval => ?DEFAULT_INTERVAL,
+            init_fun => fun(_) -> initialize() end}).
+
+-spec(start_link(opts()) -> gen_statem:start_ret()).
+start_link(#{} = Opts) ->
+        gen_statem:start_link(?MODULE, Opts, []).
+
+-spec(initialize() -> ok).
+initialize() ->
+    _ = ?AUTHN:register_providers(emqx_authn:providers()),
+
+    lists:foreach(
+      fun({ChainName, RawAuthConfigs}) ->
+              AuthConfig = emqx_authn:check_configs(RawAuthConfigs),
+              ?AUTHN:initialize_authentication(
+                 ChainName,
+                 AuthConfig)
+      end,
+      chain_configs()).
+
+-spec(deinitialize() -> ok).
+deinitialize() ->
+    ok = ?AUTHN:deregister_providers(provider_types()).
+
+%%--------------------------------------------------------------------
+%% gen_statem callbacks
+%%--------------------------------------------------------------------
+
+callback_mode() -> handle_event_function.
+
+init(#{init_fun := Fun,
+       name := Name,
+       interval := Interval} = Data)
+  when
+      is_function(Fun, 1)
+      and is_atom(Name)
+      and is_integer(Interval) ->
+    {ok, waiting_for_process, Data, [{state_timeout, 0, check_process}]}.
+
+handle_event(state_timeout, check_process, waiting_for_process, Data) ->
+    handle_check_process(Data);
+
+handle_event(internal, {initialize, Pid}, initializing, Data) ->
+    handle_initialize(Pid, Data);
+
+handle_event(info, Msg, idle, Data) ->
+    handle_info(Msg, Data);
+
+handle_event(EventType, Event, State, Data) ->
+    handle_unknown(EventType, Event, State, Data).
+
+code_change(_OldVsn, State, Data, _Extra) ->
+    {ok, State, Data}.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+handle_check_process(#{name := Name, interval := Interval} = Data) ->
+    case whereis(Name) of
+        undefined ->
+            ?tp(debug, emqx_authn_initializer_no_process, #{name => Name}),
+            {keep_state_and_data, [{state_timeout, Interval, check_process}]};
+        Pid ->
+            ?tp(info, emqx_authn_initializer_process_registered, #{name => Name}),
+            {next_state, initializing, Data, [{next_event, internal, {initialize, Pid}}]}
+    end.
+
+handle_initialize(Pid, #{init_fun := InitFun, name := Name} = Data) ->
+    _ = InitFun(Pid),
+    Ref = monitor(process, Pid),
+    ?tp(info, emqx_authn_initializer_process_initialized, #{name => Name}),
+    {next_state, idle, Data#{ref => Ref}, [{hibernate, true}]}.
+
+handle_info({'DOWN', Ref, process, _Pid, _Info} = Msg, #{ref := Ref, name:= Name} = Data) ->
+    NewData = maps:without([ref], Data),
+    ?tp(warning, emqx_authn_initializer_process_died, #{name => Name, message => Msg}),
+    {next_state, waiting_for_process, NewData, [{state_timeout, 0, check_process}]}.
+
+handle_unknown(EventType, Event, State, Data) ->
+    ?SLOG(warning,
+          #{msg => "emqx_authn_initializer received unknown event",
+            event_type => EventType,
+            event => Event,
+            state => State,
+            data => Data
+           }),
+    keep_state_and_data.
+
+chain_configs() ->
+    [global_chain_config() | listener_chain_configs()].
+
+global_chain_config() ->
+    {?GLOBAL, emqx:get_raw_config([<<"authentication">>], [])}.
+
+listener_chain_configs() ->
+    lists:map(
+     fun({ListenerID, _}) ->
+        {ListenerID, emqx:get_raw_config(auth_config_path(ListenerID), [])}
+     end,
+     emqx_listeners:list()).
+
+auth_config_path(ListenerID) ->
+    [<<"listeners">>]
+    ++ binary:split(atom_to_binary(ListenerID), <<":">>)
+    ++ [<<"authentication">>].
+
+provider_types() ->
+    lists:map(fun({Type, _Module}) -> Type end, emqx_authn:providers()).

--- a/apps/emqx_authn/src/emqx_authn_sup.erl
+++ b/apps/emqx_authn/src/emqx_authn_sup.erl
@@ -26,5 +26,14 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    ChildSpecs = [],
-    {ok, {{one_for_one, 10, 10}, ChildSpecs}}.
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 10,
+                 period => 10},
+    ChildSpecs = [
+        #{id => emqx_authn_initializer,
+          start => {emqx_authn_initializer, start_link, []},
+          restart => permanent,
+          type => worker,
+          modules => [emqx_authn_initializer]}
+    ],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -124,11 +124,17 @@ test_authenticators(PathPrefix) ->
                      uri(PathPrefix ++ ["authentication"]),
                      ValidConfig),
 
-    InvalidConfig = ValidConfig#{method => <<"delete">>},
+    InvalidConfig0 = ValidConfig#{method => <<"delete">>},
     {ok, 400, _} = request(
                      post,
                      uri(PathPrefix ++ ["authentication"]),
-                     InvalidConfig),
+                     InvalidConfig0),
+
+    InvalidConfig1 = ValidConfig#{backend => <<"ftp">>},
+    {ok, 400, _} = request(
+                     post,
+                     uri(PathPrefix ++ ["authentication"]),
+                     InvalidConfig1),
 
     ?assertAuthenticatorsMatch(
        [#{<<"mechanism">> := <<"password-based">>, <<"backend">> := <<"http">>}],

--- a/apps/emqx_authn/test/emqx_authn_initializer_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_initializer_SUITE.erl
@@ -1,0 +1,114 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_authn_initializer_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+-include("emqx_authn.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+groups() ->
+    [].
+
+init_per_suite(Config) ->
+    ok = emqx_common_test_helpers:start_apps([emqx_authn], fun set_special_configs/1),
+    Config.
+
+set_special_configs(emqx_authn) ->
+    Config = #{
+               <<"mechanism">> => <<"password-based">>,
+               <<"backend">> => <<"built-in-database">>,
+               <<"user_id_type">> => <<"username">>,
+               <<"password_hash_algorithm">> => #{
+                                                  <<"name">> => <<"sha256">>
+                                                 },
+               <<"enable">> => <<"true">>},
+    emqx_config:put_raw([<<"authentication">>], Config),
+    emqx_config:put_raw([<<"listeners">>, <<"ssl">>, <<"default">>, <<"authentication">>], Config),
+    ok;
+
+set_special_configs(_App) ->
+    ok.
+
+end_per_suite(_Config) ->
+    emqx_common_test_helpers:stop_apps([emqx_authn]),
+    ok.
+
+t_config_reinitialization(_Config) ->
+    {ok, Chains0} = ?AUTHN:list_chain_names(),
+    ?assertEqual([?GLOBAL, 'ssl:default'], lists:sort(Chains0)),
+
+    erlang:exit(whereis(?AUTHN), kill),
+
+    timer:sleep(10),
+    {ok, Chains1} = ?AUTHN:list_chain_names(),
+    ?assertEqual([?GLOBAL, 'ssl:default'], lists:sort(Chains1)).
+
+t_idempotency(_Config) ->
+    ok = emqx_authn_initializer:initialize(),
+
+    [Pid0] = [P || {emqx_authn_initializer, P, _, _} <- supervisor:which_children(emqx_authn_sup)],
+    exit(Pid0, kill),
+    timer:sleep(20),
+
+    [Pid1] = [P || {emqx_authn_initializer, P, _, _} <- supervisor:which_children(emqx_authn_sup)],
+    {current_function,{erlang, hibernate, 3}} = erlang:process_info(Pid1, current_function).
+
+t_register_and_die(_Config) ->
+    InitFun = fun(_Pid) ->
+                      timer:sleep(10)
+              end,
+
+    {ok, _} = emqx_authn_initializer:start_link(
+                #{
+                  interval => 5,
+                  init_fun => InitFun,
+                  name => test_process
+                 }),
+
+    ?check_trace(
+       begin
+           ?wait_async_action(
+              spawn(fun() ->
+                            register(test_process, self()),
+                            timer:sleep(20)
+                    end),
+              #{?snk_kind := emqx_authn_initializer_process_died, name := test_process},
+              1000)
+       end,
+       fun(_, Trace) ->
+               ?assert(
+                  ?strict_causality(
+                     #{?snk_kind := emqx_authn_initializer_process_registered,
+                       name := test_process},
+                     #{?snk_kind := emqx_authn_initializer_process_initialized,
+                       name := test_process},
+                     Trace)),
+
+               ?assert(
+                  ?strict_causality(
+                     #{?snk_kind := emqx_authn_initializer_process_initialized,
+                       name := test_process},
+                     #{?snk_kind := emqx_authn_initializer_process_died,
+                       name := test_process},
+                     Trace))
+       end).


### PR DESCRIPTION
Currently, `emqx_authentication` is configured externally by `emqx_authn` application when it starts. So if `emqx_authentication` crashes it is never configured again.

Here we try to handle this.