### PR TITLE
refactor: no more EMQX_ENTERPRISE compile flag

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -14,9 +14,6 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--ifndef(EMQX_RELEASE_HRL).
--define(EMQX_RELEASE_HRL, true).
-
 %% NOTE: this is the release version which is not always the same
 %% as the emqx app version defined in emqx.app.src
 %% App (plugin) versions are bumped independently.
@@ -27,13 +24,4 @@
 
 %% NOTE: This version number should be manually bumped for each release
 
--ifndef(EMQX_ENTERPRISE).
-
--define(EMQX_RELEASE, {opensource, "5.0-beta.1"}).
-
--else.
-
-
--endif.
-
--endif.
+-define(EMQX_RELEASE, "5.0-beta.2").

--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -20,6 +20,7 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-elvis([{elvis_style, god_modules, disable}]).
 
 %% Start/Stop the application
 -export([ start/0

--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -51,10 +51,6 @@
         , run_fold_hook/3
         ]).
 
-%% Troubleshooting
--export([ set_debug_secret/1
-        ]).
-
 %% Configs APIs
 -export([ get_config/1
         , get_config/2
@@ -70,29 +66,6 @@
         ]).
 
 -define(APP, ?MODULE).
-
-%% @hidden Path to the file which has debug_info encryption secret in it.
-%% Evaluate this function if there is a need to access encrypted debug_info.
-%% NOTE: Do not change the API to accept the secret text because it may
-%% get logged everywhere.
-set_debug_secret(PathToSecretFile) ->
-    SecretText =
-        case file:read_file(PathToSecretFile) of
-            {ok, Secret} ->
-                try string:trim(binary_to_list(Secret))
-                catch _ : _ -> error({badfile, PathToSecretFile})
-                end;
-            {error, Reason} ->
-                ?ULOG("Failed to read debug_info encryption key file ~ts: ~p~n",
-                      [PathToSecretFile, Reason]),
-                error(Reason)
-        end,
-    F = fun(init) -> ok;
-           (clear) -> ok;
-           ({debug_info, _Mode, _Module, _Filename}) -> SecretText
-        end,
-    _ = beam_lib:clear_crypto_key_fun(),
-    ok = beam_lib:crypto_key_fun(F).
 
 %%--------------------------------------------------------------------
 %% Bootstrap, is_running...

--- a/apps/emqx/src/emqx_misc.erl
+++ b/apps/emqx/src/emqx_misc.erl
@@ -17,6 +17,7 @@
 -module(emqx_misc).
 
 -compile(inline).
+-elvis([{elvis_style, god_modules, disable}]).
 
 -include("types.hrl").
 -include("logger.hrl").
@@ -92,9 +93,9 @@ maybe_apply(Fun, Arg) when is_function(Fun) ->
 -spec(compose(list(F)) -> G
   when F :: fun((any()) -> any()),
        G :: fun((any()) -> any())).
-compose([F|More]) -> compose(F, More).
+compose([F | More]) -> compose(F, More).
 
--spec(compose(F, G|[Gs]) -> C
+-spec(compose(F, G | [Gs]) -> C
   when F :: fun((X1) -> X2),
        G :: fun((X2) -> X3),
        Gs :: [fun((Xn) -> Xn1)],
@@ -102,19 +103,19 @@ compose([F|More]) -> compose(F, More).
        X3 :: any(), Xn :: any(), Xn1 :: any(), Xm :: any()).
 compose(F, G) when is_function(G) -> fun(X) -> G(F(X)) end;
 compose(F, [G]) -> compose(F, G);
-compose(F, [G|More]) -> compose(compose(F, G), More).
+compose(F, [G | More]) -> compose(compose(F, G), More).
 
 %% @doc RunFold
 run_fold([], Acc, _State) ->
     Acc;
-run_fold([Fun|More], Acc, State) ->
+run_fold([Fun | More], Acc, State) ->
     run_fold(More, Fun(Acc, State), State).
 
 %% @doc Pipeline
 pipeline([], Input, State) ->
     {ok, Input, State};
 
-pipeline([Fun|More], Input, State) ->
+pipeline([Fun | More], Input, State) ->
     case apply_fun(Fun, Input, State) of
         ok -> pipeline(More, Input, State);
         {ok, NState} ->
@@ -163,7 +164,7 @@ drain_deliver(0, Acc) ->
 drain_deliver(N, Acc) ->
     receive
         Deliver = {deliver, _Topic, _Msg} ->
-            drain_deliver(N-1, [Deliver|Acc])
+            drain_deliver(N-1, [Deliver | Acc])
     after 0 ->
         lists:reverse(Acc)
     end.
@@ -178,7 +179,7 @@ drain_down(0, Acc) ->
 drain_down(Cnt, Acc) ->
     receive
         {'DOWN', _MRef, process, Pid, _Reason} ->
-            drain_down(Cnt-1, [Pid|Acc])
+            drain_down(Cnt-1, [Pid | Acc])
     after 0 ->
         lists:reverse(Acc)
     end.
@@ -205,7 +206,7 @@ check_oom(Pid, #{max_message_queue_len := MaxQLen,
     end.
 
 do_check_oom([]) -> ok;
-do_check_oom([{Val, Max, Reason}|Rest]) ->
+do_check_oom([{Val, Max, Reason} | Rest]) ->
     case is_integer(Max) andalso (0 < Max) andalso (Max < Val) of
         true  -> {shutdown, Reason};
         false -> do_check_oom(Rest)
@@ -248,8 +249,8 @@ proc_stats(Pid) ->
                             reductions,
                             memory]) of
         undefined -> [];
-        [{message_queue_len, Len}|ProcStats] ->
-            [{mailbox_len, Len}|ProcStats]
+        [{message_queue_len, Len} | ProcStats] ->
+            [{mailbox_len, Len} | ProcStats]
     end.
 
 rand_seed() ->
@@ -269,9 +270,9 @@ index_of(E, L) ->
 
 index_of(_E, _I, []) ->
     error(badarg);
-index_of(E, I, [E|_]) ->
+index_of(E, I, [E | _]) ->
     I;
-index_of(E, I, [_|L]) ->
+index_of(E, I, [_ | L]) ->
     index_of(E, I+1, L).
 
 -spec(bin2hexstr_A_F(binary()) -> binary()).

--- a/apps/emqx/src/emqx_misc.erl
+++ b/apps/emqx/src/emqx_misc.erl
@@ -65,20 +65,12 @@ maybe_parse_ip(Host) ->
     end.
 
 %% @doc Add `ipv6_probe' socket option if it's supported.
+%% gen_tcp:ipv6_probe() -> true. is added to EMQ's OTP forks
 ipv6_probe(Opts) ->
-    case persistent_term:get({?MODULE, ipv6_probe_supported}, unknown) of
-        unknown ->
-            %% e.g. 23.2.7.1-emqx-2-x86_64-unknown-linux-gnu-64
-            OtpVsn = emqx_vm:get_otp_version(),
-            Bool = (match =:= re:run(OtpVsn, "emqx", [{capture, none}])),
-            _ = persistent_term:put({?MODULE, ipv6_probe_supported}, Bool),
-            ipv6_probe(Bool, Opts);
-        Bool ->
-            ipv6_probe(Bool, Opts)
+    case erlang:function_exported(gen_tcp, ipv6_probe, 0) of
+        true -> [{ipv6_probe, true} | Opts];
+        false -> Opts
     end.
-
-ipv6_probe(false, Opts) -> Opts;
-ipv6_probe(true, Opts) -> [{ipv6_probe, true} | Opts].
 
 %% @doc Merge options
 -spec(merge_opts(Opts, Opts) -> Opts when Opts :: proplists:proplist()).

--- a/apps/emqx/src/emqx_release.erl
+++ b/apps/emqx/src/emqx_release.erl
@@ -1,0 +1,86 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_release).
+
+-export([ edition/0
+        , put_edition/0
+        , put_edition/1
+        , description/0
+        , version/0
+        ]).
+
+-include("emqx_release.hrl").
+
+%% @doc Return EMQ X description.
+description() ->
+    case os:getenv("EMQX_DESCRIPTION") of
+        false -> "EMQ X Community Edition";
+        "" -> "EMQ X Community Edition";
+        Str -> string:strip(Str, both, $\n)
+    end.
+
+%% @doc Return EMQ X edition info.
+%% Read info from persistent_term at runtime.
+%% Or meck this function to run tests for another eidtion.
+-spec edition() -> ce | ee | edge.
+edition() ->
+    try persistent_term:get(emqx_edition)
+    catch error : badarg -> get_edition() end.
+
+%% @private initiate EMQ X edition info in persistent_term.
+put_edition() ->
+    ok = put_edition(get_edition()).
+
+%% @hidden This function is mostly for testing.
+%% Switch to another eidtion at runtime to run edition-specific tests.
+-spec put_edition(ce | ee | edge) -> ok.
+put_edition(Which) ->
+    persistent_term:put(emqx_edition, Which),
+    ok.
+
+-spec get_edition() -> ce | ee | edge.
+get_edition() ->
+    edition(description()).
+
+edition(Desc) ->
+    case re:run(Desc, "enterprise", [caseless]) of
+        {match, _} ->
+            ee;
+        _ ->
+            case re:run(Desc, "edge", [caseless]) of
+                {match, _} -> edge;
+                _ -> ce
+            end
+    end.
+
+%% @doc Return the release version.
+version() ->
+    case lists:keyfind(emqx_vsn, 1, ?MODULE:module_info(compile)) of
+        false ->    %% For TEST build or depedency build.
+            ?EMQX_RELEASE;
+        {_, Vsn} -> %% For emqx release build
+            VsnStr = ?EMQX_RELEASE,
+            case string:str(Vsn, VsnStr) of
+                1 -> ok;
+                _ ->
+                    erlang:error(#{ reason => version_mismatch
+                                  , source => VsnStr
+                                  , built_for => Vsn
+                                  })
+            end,
+            Vsn
+    end.

--- a/apps/emqx/test/emqx_authentication_SUITE.erl
+++ b/apps/emqx/test/emqx_authentication_SUITE.erl
@@ -270,7 +270,7 @@ t_restart(Config) when is_list(Config) ->
 
     ?assertEqual({ok, [test_chain]}, ?AUTHN:list_chain_names());
 
-t_restart({'end', Config}) ->
+t_restart({'end', _Config}) ->
     ?AUTHN:delete_chain(test_chain),
     ok.
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -16,16 +16,6 @@
 
 -module(emqx_dashboard_api).
 
--ifndef(EMQX_ENTERPRISE).
-
--define(RELEASE, community).
-
--else.
-
--define(VERSION, enterprise).
-
--endif.
-
 -behaviour(minirest_api).
 
 -include("emqx_dashboard.hrl").
@@ -200,7 +190,10 @@ login(post, #{body := Params}) ->
     case emqx_dashboard_admin:sign_token(Username, Password) of
         {ok, Token} ->
             Version = iolist_to_binary(proplists:get_value(version, emqx_sys:info())),
-            {200, #{token => Token, version => Version, license => #{edition => ?RELEASE}}};
+            {200, #{token => Token,
+                    version => Version,
+                    license => #{edition => emqx_release:edition()}
+                   }};
         {error, _} ->
             {401, #{code => ?ERROR_USERNAME_OR_PWD, message => <<"Auth filed">>}}
     end.

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -884,29 +884,27 @@ time_unit(<<"nanosecond">>) -> nanosecond.
 %% Here the emqx_rule_funcs module acts as a proxy, forwarding
 %% the function handling to the worker module.
 %% @end
--ifdef(EMQX_ENTERPRISE).
-'$handle_undefined_function'(schema_decode, [SchemaId, Data|MoreArgs]) ->
-    emqx_schema_parser:decode(SchemaId, Data, MoreArgs);
-'$handle_undefined_function'(schema_decode, Args) ->
-    error({args_count_error, {schema_decode, Args}});
+% '$handle_undefined_function'(schema_decode, [SchemaId, Data|MoreArgs]) ->
+%     emqx_schema_parser:decode(SchemaId, Data, MoreArgs);
+% '$handle_undefined_function'(schema_decode, Args) ->
+%     error({args_count_error, {schema_decode, Args}});
 
-'$handle_undefined_function'(schema_encode, [SchemaId, Term|MoreArgs]) ->
-    emqx_schema_parser:encode(SchemaId, Term, MoreArgs);
-'$handle_undefined_function'(schema_encode, Args) ->
-    error({args_count_error, {schema_encode, Args}});
+% '$handle_undefined_function'(schema_encode, [SchemaId, Term|MoreArgs]) ->
+%     emqx_schema_parser:encode(SchemaId, Term, MoreArgs);
+% '$handle_undefined_function'(schema_encode, Args) ->
+%     error({args_count_error, {schema_encode, Args}});
+
+% '$handle_undefined_function'(sprintf, [Format|Args]) ->
+%     erlang:apply(fun sprintf_s/2, [Format, Args]);
+
+% '$handle_undefined_function'(Fun, Args) ->
+%     error({sql_function_not_supported, function_literal(Fun, Args)}).
 
 '$handle_undefined_function'(sprintf, [Format|Args]) ->
     erlang:apply(fun sprintf_s/2, [Format, Args]);
 
 '$handle_undefined_function'(Fun, Args) ->
     error({sql_function_not_supported, function_literal(Fun, Args)}).
--else.
-'$handle_undefined_function'(sprintf, [Format|Args]) ->
-    erlang:apply(fun sprintf_s/2, [Format, Args]);
-
-'$handle_undefined_function'(Fun, Args) ->
-    error({sql_function_not_supported, function_literal(Fun, Args)}).
--endif. % EMQX_ENTERPRISE
 
 map_path(Key) ->
     {path, [{key, P} || P <- string:split(Key, ".", all)]}.

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -6,14 +6,8 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "$0")"
 
-if [ -f EMQX_ENTERPRISE ]; then
-    EDITION='enterprise'
-else
-    EDITION='opensource'
-fi
-
 ## emqx_release.hrl is the single source of truth for release version
-RELEASE="$(grep -E "define.+EMQX_RELEASE.+${EDITION}" apps/emqx/include/emqx_release.hrl | cut -d '"' -f2)"
+RELEASE="$(grep -E "define.+EMQX_RELEASE" apps/emqx/include/emqx_release.hrl | cut -d '"' -f2)"
 
 git_exact_vsn() {
     local tag

--- a/scripts/check-deps-integrity.escript
+++ b/scripts/check-deps-integrity.escript
@@ -7,12 +7,7 @@
 main([]) ->
     Files = ["rebar.config"] ++
             apps_rebar_config("apps") ++
-            case filelib:is_file("EMQX_ENTERPRISE") of
-                  true ->
-                    true = filelib:is_dir("lib-ee"),
-                    apps_rebar_config("lib-ee");
-                  false -> []
-              end,
+            apps_rebar_config("lib-ee"),
     Deps = collect_deps(Files, #{}),
     case count_bad_deps(Deps) of
         0 ->

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -11,9 +11,7 @@ find_app() {
 }
 
 find_app 'apps'
-if [ -f 'EMQX_ENTERPRISE' ]; then
-    find_app 'lib-ee'
-fi
+find_app 'lib-ee'
 
 ## find directories in lib-extra
 find_app 'lib-extra'

--- a/scripts/git-hook-pre-push.sh
+++ b/scripts/git-hook-pre-push.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 
 url="$2"
 
+# we keep this to secure OLD private repo
+# even after we have disclosed new code under EMQ BSL 1.0
 if [ -f 'EMQX_ENTERPRISE' ]; then
     if [[ "$url" != *emqx-enterprise* ]]; then
         echo "$(tput setaf 1)error: enterprise_code_to_non_enterprise_repo"


### PR DESCRIPTION
The compile flag was introduced in EQM X 4.3 series
where CE and EE code was diverged large enough which made
non-practicle to determin edition at runtime.

such approach made testing quite challenging as we'll have to
build with different compile flags inorder to run per-edition
test cases

After this refactoring, we try to retrieve edition info from EMQX's
description text, (put to PT for fast access) at runtime
so we can test ALL editions from a super-set edition (EE).

