### PR TITLE
build: define default builder docker image tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,8 @@ REBAR_VERSION = 3.14.3-emqx-8
 REBAR = $(CURDIR)/rebar3
 BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts
+export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/4.4-2:23.3.4.9-3-alpine3.14
+export EMQX_DEFAULT_RUNNER = alpine:3.14
 export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export PKG_VSN ?= $(shell $(CURDIR)/pkg-vsn.sh)
 export EMQX_DESC ?= EMQ X
@@ -96,6 +98,7 @@ $(PROFILES:%=clean-%):
 
 .PHONY: clean-all
 clean-all:
+	@rm -f rebar.lock
 	@rm -rf _build
 
 .PHONY: deps-all

--- a/build
+++ b/build
@@ -126,13 +126,12 @@ make_zip() {
 
 ## This function builds the default docker image based on alpine:3.14 (by default)
 make_docker() {
-    EMQX_RUNNER_IMAGE="${EMQX_RUNNER_IMAGE:-alpine:3.14}"
-    EMQX_RUNNER_IMAGE_COMPACT="$(echo "$EMQX_RUNNER_IMAGE" | tr -d ':')"
-    EMQX_BUILDER="${EMQX_BUILDER:-ghcr.io/emqx/emqx-builder/4.4-2:${OTP_VSN}-${EMQX_RUNNER_IMAGE_COMPACT}}"
+    EMQX_BUILDER="${EMQX_BUILDER:-${EMQX_DEFAULT_BUILDER}}"
+    EMQX_RUNNER="${EMQX_RUNNER:-${EMQX_DEFAULT_RUNNER}}"
     set -x
     docker build --no-cache --pull \
        --build-arg BUILD_FROM="${EMQX_BUILDER}" \
-       --build-arg RUN_FROM="${EMQX_RUNNER_IMAGE}" \
+       --build-arg RUN_FROM="${EMQX_RUNNER}" \
        --build-arg EMQX_NAME="$PROFILE" \
        --tag "emqx/$PROFILE:${PKG_VSN}" \
        -f "${DOCKERFILE}" .


### PR DESCRIPTION
prior to this change, the OTP_VSN varaible was taken from
the docker host's OTP version which may differ from the
desired OTP version for the docker builder image.

