### PR TITLE
build: upgrade to otp sed 23.2.7.2-emqx-3

### DIFF
--- a/.ci/build_packages/Dockerfile
+++ b/.ci/build_packages/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
 FROM ${BUILD_FROM}
 
 ARG EMQX_NAME=emqx

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   erlang:
     container_name: erlang
-    image: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+    image: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
     env_file:
       - conf.env
     environment:

--- a/.ci/fvt_tests/local_relup_test_run.sh
+++ b/.ci/fvt_tests/local_relup_test_run.sh
@@ -28,7 +28,7 @@ exec docker run \
     -v "$TEMPDIR:/relup_test" \
     -w "/relup_test" \
     -e REBAR_COLOR=none \
-    -it emqx/relup-test-env:erl23.2.7.2-emqx-2-ubuntu20.04 \
+    -it emqx/relup-test-env:erl23.2.7.2-emqx-3-ubuntu20.04 \
         lux \
         --progress verbose \
         --case_timeout infinity \

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+    container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
 
     outputs:
       profiles: ${{ steps.set_profile.outputs.profiles}}
@@ -134,7 +134,7 @@ jobs:
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         erl_otp:
-          - 23.2.7.2-emqx-2
+          - 23.2.7.2-emqx-3
         exclude:
           - profile: emqx-edge
 
@@ -291,7 +291,7 @@ jobs:
         done
     - name: build emqx packages
       env:
-        ERL_OTP: erl23.2.7.2-emqx-2
+        ERL_OTP: erl23.2.7.2-emqx-3
         PROFILE: ${{ matrix.profile }}
         ARCH: ${{ matrix.arch }}
         SYSTEM: ${{ matrix.os }}

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         erl_otp:
-        - erl23.2.7.2-emqx-2
+        - erl23.2.7.2-emqx-3
         os:
         - ubuntu20.04
         - centos7
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         erl_otp:
-        - 23.2.7.2-emqx-2
+        - 23.2.7.2-emqx-3
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   check_deps_integrity:
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+    container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/run_acl_migration_tests.yaml
+++ b/.github/workflows/run_acl_migration_tests.yaml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
     test:
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+        container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
         strategy:
             fail-fast: true
         env:

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -180,7 +180,7 @@ jobs:
 
     relup_test_plan:
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+        container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
         outputs:
           profile: ${{ steps.profile-and-versions.outputs.profile }}
           vsn: ${{ steps.profile-and-versions.outputs.vsn }}
@@ -229,7 +229,7 @@ jobs:
     relup_test_build:
         needs: relup_test_plan
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+        container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
         defaults:
           run:
             shell: bash
@@ -273,7 +273,7 @@ jobs:
           - relup_test_plan
           - relup_test_build
         runs-on: ubuntu-20.04
-        container: emqx/relup-test-env:erl23.2.7.2-emqx-2-ubuntu20.04
+        container: emqx/relup-test-env:erl23.2.7.2-emqx-3-ubuntu20.04
         strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
     run_static_analysis:
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+        container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
 
         steps:
         - uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
 
     run_proper_test:
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.2.7.2-emqx-2-ubuntu20.04
+        container: emqx/build-env:erl23.2.7.2-emqx-3-ubuntu20.04
 
         steps:
         - uses: actions/checkout@v2

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-alpine-amd64
+ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-alpine
 ARG RUN_FROM=alpine:3.12
 FROM ${BUILD_FROM} AS builder
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-2-alpine-amd64
+ARG BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-alpine-amd64
 ARG RUN_FROM=alpine:3.12
 FROM ${BUILD_FROM} AS builder
 

--- a/docker.mk
+++ b/docker.mk
@@ -64,7 +64,7 @@ docker-build:
 
 	@docker build --no-cache \
 		--build-arg PKG_VSN=$(PKG_VSN)  \
-		--build-arg BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-alpine-$(ARCH)  \
+		--build-arg BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-alpine  \
 		--build-arg RUN_FROM=$(ARCH)/alpine:3.12 \
 		--build-arg EMQX_NAME=$(EMQX_NAME) \
 		--build-arg QEMU_ARCH=$(QEMU_ARCH) \

--- a/docker.mk
+++ b/docker.mk
@@ -64,7 +64,7 @@ docker-build:
 
 	@docker build --no-cache \
 		--build-arg PKG_VSN=$(PKG_VSN)  \
-		--build-arg BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-2-alpine-$(ARCH)  \
+		--build-arg BUILD_FROM=emqx/build-env:erl23.2.7.2-emqx-3-alpine-$(ARCH)  \
 		--build-arg RUN_FROM=$(ARCH)/alpine:3.12 \
 		--build-arg EMQX_NAME=$(EMQX_NAME) \
 		--build-arg QEMU_ARCH=$(QEMU_ARCH) \


### PR DESCRIPTION
There was a typo fix in ssl app for ecdsa_secp512r1_sha512
to ecdsa_secp521r1_sha512.

Hot-beam upgrade is supported when upgrading from OTP 23.2.7.2-emqx-2
just a 'ssl_cipher' module reload.

