### PR TITLE
[Gateway] Standardize HTTP-APIs return value and Status/Error Code

### DIFF
--- a/apps/emqx_gateway/etc/emqx_gateway.conf.example
+++ b/apps/emqx_gateway/etc/emqx_gateway.conf.example
@@ -70,9 +70,9 @@ gateway.stomp {
     ## SSL options
     ## See ${example_common_ssl_options} for more information
     ssl.versions = ["tlsv1.3", "tlsv1.2", "tlsv1.1", "tlsv1"]
-    ssl.keyfile = "{{ platform_etc_dir }}/certs/key.pem"
-    ssl.certfile = "{{ platform_etc_dir }}/certs/cert.pem"
     ssl.cacertfile = "{{ platform_etc_dir }}/certs/cacert.pem"
+    ssl.certfile = "{{ platform_etc_dir }}/certs/cert.pem"
+    ssl.keyfile = "{{ platform_etc_dir }}/certs/key.pem"
     #ssl.verify = verify_none
     #ssl.fail_if_no_peer_cert = false
     #ssl.server_name_indication = disable

--- a/apps/emqx_gateway/include/emqx_gateway_http.hrl
+++ b/apps/emqx_gateway/include/emqx_gateway_http.hrl
@@ -23,6 +23,4 @@
                      [?BAD_REQUEST], <<"Bad request">>)
           , 404 => emqx_dashboard_swagger:error_codes(
                      [?NOT_FOUND], <<"Not Found">>)
-          , 500 => emqx_dashboard_swagger:error_codes(
-                     [?INTERNAL_ERROR], <<"Internal Server Error">>)
          }).

--- a/apps/emqx_gateway/include/emqx_gateway_http.hrl
+++ b/apps/emqx_gateway/include/emqx_gateway_http.hrl
@@ -1,0 +1,28 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-define(BAD_REQUEST, 'BAD_REQUEST').
+-define(NOT_FOUND, 'NOT_FOUND').
+-define(INTERNAL_ERROR, 'INTERNAL_SERVER_ERROR').
+
+-define(STANDARD_RESP(R),
+        R#{ 400 => emqx_dashboard_swagger:error_codes(
+                     [?BAD_REQUEST], <<"Bad request">>)
+          , 404 => emqx_dashboard_swagger:error_codes(
+                     [?NOT_FOUND], <<"Not Found">>)
+          , 500 => emqx_dashboard_swagger:error_codes(
+                     [?INTERNAL_ERROR], <<"Internal Server Error">>)
+         }).

--- a/apps/emqx_gateway/src/coap/emqx_coap_api.erl
+++ b/apps/emqx_gateway/src/coap/emqx_coap_api.erl
@@ -25,7 +25,7 @@
 
 -export([request/2]).
 
--define(PREFIX, "/gateway/coap/:clientid").
+-define(PREFIX, "/gateway/coap/clients/:clientid").
 -define(DEF_WAIT_TIME, 10).
 
 -import(emqx_mgmt_util, [ schema/1

--- a/apps/emqx_gateway/src/emqx_gateway_api.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api.erl
@@ -318,20 +318,26 @@ listeners_schema(?R_REF(_Mod, udp_tcp_listeners)) ->
 %% examples
 
 examples_gateway_confs() ->
-    #{ a_stomp_gateway =>
-        #{ enable => true
-         , enable_stats => true
-         , idle_timeout => <<"30s">>
-         , mountpoint => <<"stomp/">>
-         , frame =>
-            #{ max_header => 10
-             , make_header_length => 1024
-             , max_body_length => 65535
+    #{ stomp_gateway =>
+        #{ summary => <<"A simple STOMP gateway configs">>
+         , value =>
+            #{ enable => true
+             , enable_stats => true
+             , idle_timeout => <<"30s">>
+             , mountpoint => <<"stomp/">>
+             , frame =>
+                #{ max_header => 10
+                 , make_header_length => 1024
+                 , max_body_length => 65535
+                 }
              }
          }
-     , a_mqttsn_gateway =>
-        #{ enable => true
-         , enable_stats => true
+     , mqttsn_gateway =>
+        #{ summary => <<"A simple MQTT-SN gateway configs">>
+         , value =>
+            #{ enable => true
+             , enable_stats => true
+             }
          }
      }.
 

--- a/apps/emqx_gateway/src/emqx_gateway_api.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api.erl
@@ -16,22 +16,30 @@
 %%
 -module(emqx_gateway_api).
 
+-include("emqx_gateway_http.hrl").
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/emqx_placeholder.hrl").
 -include_lib("emqx/include/emqx_authentication.hrl").
 
 -behaviour(minirest_api).
 
+-import(hoconsc, [mk/2, ref/1, ref/2]).
+
 -import(emqx_gateway_http,
         [ return_http_error/2
         , with_gateway/2
-        , schema_bad_request/0
-        , schema_not_found/0
-        , schema_internal_error/0
-        , schema_no_content/0
         ]).
 
-%% minirest behaviour callbacks
--export([api_spec/0]).
+%% minirest/dashbaord_swagger behaviour callbacks
+-export([ api_spec/0
+        , paths/0
+        , schema/1
+        ]).
+
+-export([ roots/0
+        , fields/1
+        ]).
 
 %% http handlers
 -export([ gateway/2
@@ -44,12 +52,12 @@
 %%--------------------------------------------------------------------
 
 api_spec() ->
-    {metadata(apis()), []}.
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
-apis() ->
-    [ {"/gateway", gateway}
-    , {"/gateway/:name", gateway_insta}
-    , {"/gateway/:name/stats", gateway_insta_stats}
+paths() ->
+    [ "/gateway"
+    , "/gateway/:name"
+    , "/gateway/:name/stats"
     ].
 
 %%--------------------------------------------------------------------
@@ -137,270 +145,195 @@ gateway_insta_stats(get, _Req) ->
 %% Swagger defines
 %%--------------------------------------------------------------------
 
-metadata(APIs) ->
-    metadata(APIs, []).
-metadata([], APIAcc) ->
-    lists:reverse(APIAcc);
-metadata([{Path, Fun}|More], APIAcc) ->
-    Methods = [get, post, put, delete, patch],
-    Mds = lists:foldl(fun(M, Acc) ->
-              try
-                  Acc#{M => swagger(Path, M)}
-              catch
-                  error : function_clause ->
-                      Acc
-              end
-          end, #{}, Methods),
-    metadata(More, [{Path, Mds, Fun} | APIAcc]).
-
-swagger("/gateway", get) ->
-    #{ description => <<"Get gateway list">>
-     , parameters => params_gateway_status_in_qs()
-     , responses =>
-        #{ <<"200">> => schema_gateway_overview_list() }
+schema("/gateway") ->
+    #{ 'operationId' => gateway,
+       get =>
+         #{ description => <<"Get gateway list">>
+          , parameters => params_gateway_status_in_qs()
+          , responses =>
+              ?STANDARD_RESP(#{200 => ref(gateway_overview)})
+          },
+       post =>
+         #{ description => <<"Load a gateway">>
+          , 'requestBody' => schema_gateways_conf()
+          , responses =>
+              ?STANDARD_RESP(#{201 => schema_gateways_conf()})
+          }
      };
-swagger("/gateway", post) ->
-    #{ description => <<"Load a gateway">>
-     , requestBody => schema_gateway_conf()
-     , responses =>
-        #{ <<"400">> => schema_bad_request()
-         , <<"404">> => schema_not_found()
-         , <<"500">> => schema_internal_error()
-         , <<"204">> => schema_no_content()
-         }
+schema("/gateway/:name") ->
+    #{ 'operationId' => gateway_insta,
+       get =>
+         #{ description => <<"Get the gateway configurations">>
+          , parameters => params_gateway_name_in_path()
+          , responses =>
+              ?STANDARD_RESP(#{200 => schema_gateways_conf()})
+          },
+       delete =>
+         #{ description => <<"Delete/Unload the gateway">>
+          , parameters => params_gateway_name_in_path()
+          , responses =>
+              ?STANDARD_RESP(#{204 => <<"Deleted">>})
+          },
+       put =>
+         #{ description => <<"Update the gateway configurations/status">>
+          , parameters => params_gateway_name_in_path()
+          , 'requestBody' => schema_gateways_conf()
+          , responses =>
+              ?STANDARD_RESP(#{200 => schema_gateways_conf()})
+          }
      };
-swagger("/gateway/:name", get) ->
-    #{ description => <<"Get the gateway configurations">>
-     , parameters => params_gateway_name_in_path()
-     , responses =>
-        #{ <<"400">> => schema_bad_request()
-         , <<"404">> => schema_not_found()
-         , <<"500">> => schema_internal_error()
-         , <<"200">> => schema_gateway_conf()
-         }
-      };
-swagger("/gateway/:name", delete) ->
-    #{ description => <<"Delete/Unload the gateway">>
-     , parameters => params_gateway_name_in_path()
-     , responses =>
-        #{ <<"400">> => schema_bad_request()
-         , <<"404">> => schema_not_found()
-         , <<"500">> => schema_internal_error()
-         , <<"204">> => schema_no_content()
-         }
-      };
-swagger("/gateway/:name", put) ->
-    #{ description => <<"Update the gateway configurations/status">>
-     , parameters => params_gateway_name_in_path()
-     , requestBody => schema_gateway_conf()
-     , responses =>
-        #{ <<"400">> => schema_bad_request()
-         , <<"404">> => schema_not_found()
-         , <<"500">> => schema_internal_error()
-         , <<"200">> => schema_no_content()
-         }
-     };
-swagger("/gateway/:name/stats", get) ->
-    #{ description => <<"Get gateway Statistic">>
-     , parameters => params_gateway_name_in_path()
-     , responses =>
-        #{ <<"400">> => schema_bad_request()
-         , <<"404">> => schema_not_found()
-         , <<"500">> => schema_internal_error()
-         , <<"200">> => schema_gateway_stats()
-         }
+schema("/gateway/:name/stats") ->
+    #{ 'operationId' => gateway_insta_stats,
+       get =>
+         #{ description => <<"Get gateway Statistic">>
+          , parameters => params_gateway_name_in_path()
+          , responses =>
+              ?STANDARD_RESP(
+                 #{200 => emqx_dashboard_swagger:schema_with_examples(
+                           ref(gateway_stats),
+                           examples_gateway_stats())
+                  })
+          }
      }.
 
 %%--------------------------------------------------------------------
 %% params defines
 
 params_gateway_name_in_path() ->
-    [#{ name => name
-      , in => path
-      , schema => #{type => string}
-      , required => true
-      }].
+    [{name,
+      mk(binary(),
+         #{ in => path
+          , desc => <<"Gateway Name">>
+          })}
+    ].
 
 params_gateway_status_in_qs() ->
-    [#{ name => status
-      , in => query
-      , schema => #{type => string}
-      , required => false
-      }].
+    [{status,
+      mk(binary(),
+         #{ in => query
+          , nullable => true
+          , desc => <<"Gateway Status">>
+          })}
+    ].
 
 %%--------------------------------------------------------------------
 %% schemas
 
-schema_gateway_overview_list() ->
-    emqx_mgmt_util:array_schema(
-      #{ type => object
-       , properties => properties_gateway_overview()
-       },
-      <<"Gateway list">>
+roots() ->
+    [ gateway_overview
+    , gateway_stats
+    ].
+
+fields(gateway_overview) ->
+    [ {name,
+       mk(string(),
+          #{ desc => <<"Gateway Name">>})}
+    , {status,
+       mk(hoconsc:enum([running, stopped, unloaded]),
+          #{ desc => <<"The Gateway status">>})}
+    , {created_at,
+       mk(string(),
+          #{desc => <<"The Gateway created datetime">>})}
+    , {started_at,
+       mk(string(),
+          #{ nullable => true
+           , desc => <<"The Gateway started datetime">>})}
+    , {stopped_at,
+       mk(string(),
+          #{ nullable => true
+           , desc => <<"The Gateway stopped datetime">>})}
+    , {max_connections,
+       mk(integer(),
+          #{ desc => <<"The Gateway allowed maximum connections/clients">>})}
+    , {current_connections,
+       mk(integer(),
+          #{ desc => <<"The Gateway current connected connections/clients">>
+           })}
+    , {listeners,
+       mk(hoconsc:array(ref(gateway_listener_overview)),
+         #{ nullable => {true, recursively}
+          , desc => <<"The Gateway listeners overview">>})}
+    ];
+fields(gateway_listener_overview) ->
+    [ {id,
+       mk(string(),
+          #{ desc => <<"Listener ID">>})}
+    , {running,
+       mk(boolean(),
+          #{ desc => <<"Listener Running status">>})}
+    , {type,
+       mk(hoconsc:enum([tcp, ssl, udp, dtls]),
+          #{ desc => <<"Listener Type">>})}
+    ];
+
+fields(Gw) when Gw == stomp; Gw == mqttsn;
+                Gw == coap;  Gw == lwm2m;
+                Gw == exproto ->
+    convert_listener_struct(emqx_gateway_schema:fields(Gw));
+fields(Listener) when Listener == tcp_listener;
+                      Listener == ssl_listener;
+                      Listener == udp_listener;
+                      Listener == dtls_listener ->
+    [ {type,
+       mk(hoconsc:union([tcp, ssl, udp, dtls]),
+          #{ desc => <<"Listener type">>})}
+    , {name,
+       mk(string(),
+          #{ desc => <<"Listener Name">>})}
+    , {running,
+       mk(boolean(),
+          #{ desc => <<"Listener running status">>})}
+    ] ++ emqx_gateway_schema:fields(Listener);
+
+fields(gateway_stats) ->
+    [{key, mk(string(), #{})}].
+
+schema_gateways_conf() ->
+    %% XXX: We need convert the emqx_gateway_schema's listener map
+    %% structure to array
+    emqx_dashboard_swagger:schema_with_examples(
+      hoconsc:union([ref(stomp), ref(mqttsn),
+                     ref(coap), ref(lwm2m), ref(exproto)]),
+      examples_gateway_confs()
      ).
 
-%% XXX: This is whole confs for all type gateways. It is used to fill the
-%% default configurations and generate the swagger-schema
-%%
-%% NOTE: It is a temporary measure to generate swagger-schema
--define(COAP_GATEWAY_CONFS,
-#{?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY =>
-      #{<<"mechanism">> => <<"password-based">>,
-        <<"name">> => <<"authenticator1">>,
-        <<"server_type">> => <<"built-in-database">>,
-        <<"user_id_type">> => <<"clientid">>},
-  <<"name">> => <<"coap">>,
-  <<"enable">> => true,
-  <<"enable_stats">> => true,<<"heartbeat">> => <<"30s">>,
-  <<"idle_timeout">> => <<"30s">>,
-  <<"listeners">> => [
-      #{<<"id">> => <<"coap:udp:default">>,
-        <<"type">> => <<"udp">>,
-        <<"running">> => true,
-        <<"acceptors">> => 8,<<"bind">> => 5683,
-        <<"max_conn_rate">> => 1000,
-        <<"max_connections">> => 10240}],
-  <<"mountpoint">> => <<>>,<<"notify_type">> => <<"qos">>,
-  <<"publish_qos">> => <<"qos1">>,
-  <<"subscribe_qos">> => <<"qos0">>}
-).
+convert_listener_struct(Schema) ->
+    {value, {listeners,
+             #{type := Type}}, Schema1} = lists:keytake(listeners, 1, Schema),
+    ListenerSchema = hoconsc:mk(listeners_schema(Type),
+                                #{ nullable => {true, recursively}
+                                 , desc => <<"The gateway listeners">>
+                                 }),
+    lists:keystore(listeners, 1, Schema1, {listeners, ListenerSchema}).
 
--define(EXPROTO_GATEWAY_CONFS,
-#{<<"enable">> => true,
-  <<"name">> => <<"exproto">>,
-  <<"enable_stats">> => true,
-  <<"handler">> =>
-      #{<<"address">> => <<"http://127.0.0.1:9001">>},
-  <<"idle_timeout">> => <<"30s">>,
-  <<"listeners">> => [
-      #{<<"id">> => <<"exproto:tcp:default">>,
-        <<"type">> => <<"tcp">>,
-        <<"running">> => true,
-        <<"acceptors">> => 8,<<"bind">> => 7993,
-        <<"max_conn_rate">> => 1000,
-        <<"max_connections">> => 10240}],
-  <<"mountpoint">> => <<>>,
-  <<"server">> => #{<<"bind">> => 9100}}
-).
-
--define(LWM2M_GATEWAY_CONFS,
-#{<<"auto_observe">> => false,
-  <<"name">> => <<"lwm2m">>,
-  <<"enable">> => true,
-  <<"enable_stats">> => true,
-  <<"idle_timeout">> => <<"30s">>,
-  <<"lifetime_max">> => <<"86400s">>,
-  <<"lifetime_min">> => <<"1s">>,
-  <<"listeners">> => [
-      #{<<"id">> => <<"lwm2m:udp:default">>,
-        <<"type">> => <<"udp">>,
-        <<"running">> => true,
-        <<"bind">> => 5783}],
-  <<"mountpoint">> => <<"lwm2m/", ?PH_S_ENDPOINT_NAME, "/">>,
-  <<"qmode_time_windonw">> => 22,
-  <<"translators">> =>
-      #{<<"command">> => <<"dn/#">>,<<"notify">> => <<"up/notify">>,
-        <<"register">> => <<"up/resp">>,
-        <<"response">> => <<"up/resp">>,
-        <<"update">> => <<"up/resp">>},
-  <<"update_msg_publish_condition">> =>
-      <<"contains_object_list">>,
-  <<"xml_dir">> => <<"etc/lwm2m_xml">>}
-).
-
--define(MQTTSN_GATEWAY_CONFS,
-#{<<"broadcast">> => true,
-  <<"clientinfo_override">> =>
-      #{<<"password">> => <<"abc">>,
-        <<"username">> => <<"mqtt_sn_user">>},
-  <<"enable">> => true,
-  <<"name">> => <<"mqtt-sn">>,
-  <<"enable_qos3">> => true,<<"enable_stats">> => true,
-  <<"gateway_id">> => 1,<<"idle_timeout">> => <<"30s">>,
-  <<"listeners">> => [
-      #{<<"id">> => <<"mqttsn:udp:default">>,
-        <<"type">> => <<"udp">>,
-        <<"running">> => true,
-        <<"bind">> => 1884,<<"max_conn_rate">> => 1000,
-                    <<"max_connections">> => 10240000}],
-  <<"mountpoint">> => <<>>,
-  <<"predefined">> =>
-      [#{<<"id">> => 1,
-         <<"topic">> => <<"/predefined/topic/name/hello">>},
-       #{<<"id">> => 2,
-         <<"topic">> => <<"/predefined/topic/name/nice">>}]}
-).
-
--define(STOMP_GATEWAY_CONFS,
-#{?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY =>
-      #{<<"mechanism">> => <<"password-based">>,
-        <<"name">> => <<"authenticator1">>,
-        <<"server_type">> => <<"built-in-database">>,
-        <<"user_id_type">> => <<"clientid">>},
-  <<"clientinfo_override">> =>
-      #{<<"password">> => <<"${Packet.headers.passcode}">>,
-        <<"username">> => <<"${Packet.headers.login}">>},
-  <<"enable">> => true,
-  <<"name">> => <<"stomp">>,
-  <<"enable_stats">> => true,
-  <<"frame">> =>
-      #{<<"max_body_length">> => 8192,<<"max_headers">> => 10,
-        <<"max_headers_length">> => 1024},
-  <<"idle_timeout">> => <<"30s">>,
-  <<"listeners">> => [
-      #{<<"id">> => <<"stomp:tcp:default">>,
-        <<"type">> => <<"tcp">>,
-        <<"running">> => true,
-        <<"acceptors">> => 16,<<"active_n">> => 100,
-        <<"bind">> => 61613,<<"max_conn_rate">> => 1000,
-        <<"max_connections">> => 1024000}],
-  <<"mountpoint">> => <<>>}
-).
-
-%% --- END
-
-schema_gateway_conf() ->
-    emqx_mgmt_util:schema(
-      #{oneOf =>
-        [ emqx_mgmt_api_configs:gen_schema(?STOMP_GATEWAY_CONFS)
-        , emqx_mgmt_api_configs:gen_schema(?MQTTSN_GATEWAY_CONFS)
-        , emqx_mgmt_api_configs:gen_schema(?COAP_GATEWAY_CONFS)
-        , emqx_mgmt_api_configs:gen_schema(?LWM2M_GATEWAY_CONFS)
-        , emqx_mgmt_api_configs:gen_schema(?EXPROTO_GATEWAY_CONFS)
-        ]}).
-
-schema_gateway_stats() ->
-    emqx_mgmt_util:schema(
-      #{ type => object
-       , properties =>
-        #{ a_key => #{type => string}
-       }}).
+listeners_schema(?R_REF(_Mod, tcp_listeners)) ->
+    hoconsc:array(hoconsc:union([ref(tcp_listener), ref(ssl_listener)]));
+listeners_schema(?R_REF(_Mod, udp_listeners)) ->
+    hoconsc:array(hoconsc:union([ref(udp_listener), ref(dtls_listener)]));
+listeners_schema(?R_REF(_Mod, udp_tcp_listeners)) ->
+    hoconsc:array(hoconsc:union([ref(tcp_listener), ref(ssl_listener),
+                                 ref(udp_listener), ref(dtls_listener)])).
 
 %%--------------------------------------------------------------------
-%% properties
+%% examples
 
-properties_gateway_overview() ->
-    ListenerProps =
-        [ {id, string,
-           <<"Listener ID">>}
-        , {running, boolean,
-           <<"Listener Running status">>}
-        , {type, string,
-           <<"Listener Type">>, [<<"tcp">>, <<"ssl">>, <<"udp">>, <<"dtls">>]}
-        ],
-    emqx_mgmt_util:properties(
-      [ {name, string,
-         <<"Gateway Name">>}
-      , {status, string,
-         <<"Gateway Status">>,
-         [<<"running">>, <<"stopped">>, <<"unloaded">>]}
-      , {created_at, string,
-         <<>>}
-      , {started_at, string,
-         <<>>}
-      , {stopped_at, string,
-         <<>>}
-      , {max_connections, integer, <<>>}
-      , {current_connections, integer, <<>>}
-      , {listeners, {array, object}, ListenerProps}
-      ]).
+examples_gateway_confs() ->
+    #{ a_stomp_gateway =>
+        #{ enable => true
+         , enable_stats => true
+         , idle_timeout => <<"30s">>
+         , mountpoint => <<"stomp/">>
+         , frame =>
+            #{ max_header => 10
+             , make_header_length => 1024
+             , max_body_length => 65535
+             }
+         }
+     , a_mqttsn_gateway =>
+        #{ enable => true
+         , enable_stats => true
+         }
+     }.
+
+examples_gateway_stats() ->
+    #{}.

--- a/apps/emqx_gateway/src/emqx_gateway_api.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api.erl
@@ -269,12 +269,18 @@ fields(gateway_listener_overview) ->
 fields(Gw) when Gw == stomp; Gw == mqttsn;
                 Gw == coap;  Gw == lwm2m;
                 Gw == exproto ->
-    convert_listener_struct(emqx_gateway_schema:fields(Gw));
+    [{name,
+      mk(string(), #{ desc => <<"Gateway Name">>})}
+    ] ++ convert_listener_struct(emqx_gateway_schema:fields(Gw));
 fields(Listener) when Listener == tcp_listener;
                       Listener == ssl_listener;
                       Listener == udp_listener;
                       Listener == dtls_listener ->
-    [ {type,
+    [ {id,
+       mk(string(),
+          #{ nullable => true
+           , desc => <<"Listener ID">>})}
+    , {type,
        mk(hoconsc:union([tcp, ssl, udp, dtls]),
           #{ desc => <<"Listener type">>})}
     , {name,
@@ -282,7 +288,8 @@ fields(Listener) when Listener == tcp_listener;
           #{ desc => <<"Listener Name">>})}
     , {running,
        mk(boolean(),
-          #{ desc => <<"Listener running status">>})}
+          #{ nullable => true
+           , desc => <<"Listener running status">>})}
     ] ++ emqx_gateway_schema:fields(Listener);
 
 fields(gateway_stats) ->
@@ -292,8 +299,9 @@ schema_gateways_conf() ->
     %% XXX: We need convert the emqx_gateway_schema's listener map
     %% structure to array
     emqx_dashboard_swagger:schema_with_examples(
-      hoconsc:union([ref(stomp), ref(mqttsn),
-                     ref(coap), ref(lwm2m), ref(exproto)]),
+      hoconsc:union([ref(?MODULE, stomp), ref(?MODULE, mqttsn),
+                     ref(?MODULE, coap), ref(?MODULE, lwm2m),
+                     ref(?MODULE, exproto)]),
       examples_gateway_confs()
      ).
 

--- a/apps/emqx_gateway/src/emqx_gateway_api_authn.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_authn.erl
@@ -13,16 +13,13 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
-%%
+
 -module(emqx_gateway_api_authn).
 
 -behaviour(minirest_api).
 
+-include("emqx_gateway_http.hrl").
 -include_lib("typerefl/include/types.hrl").
-
--define(BAD_REQUEST, 'BAD_REQUEST').
--define(NOT_FOUND, 'NOT_FOUND').
--define(INTERNAL_ERROR, 'INTERNAL_SERVER_ERROR').
 
 -import(hoconsc, [mk/2, ref/2]).
 -import(emqx_dashboard_swagger, [error_codes/2]).
@@ -162,48 +159,30 @@ schema("/gateway/:name/authentication") ->
          #{ description => <<"Get the gateway authentication">>
           , parameters => params_gateway_name_in_path()
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                    <<"Ineternal Server Error">>)
-               , 200 => schema_authn()
-               , 204 => <<"Authentication does not initiated">>
-               }
+              ?STANDARD_RESP(
+                 #{ 200 => schema_authn()
+                  , 204 => <<"Authentication does not initiated">>
+                  })
           },
        put =>
          #{ description => <<"Update authentication for the gateway">>
           , parameters => params_gateway_name_in_path()
           , 'requestBody' => schema_authn()
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 200 => schema_authn()
-               }
+              ?STANDARD_RESP(#{200 => schema_authn()})
           },
        post =>
          #{ description => <<"Add authentication for the gateway">>
           , parameters => params_gateway_name_in_path()
           , 'requestBody' => schema_authn()
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 201 => schema_authn()
-               }
+              ?STANDARD_RESP(#{201 => schema_authn()})
           },
        delete =>
          #{ description => <<"Remove the gateway authentication">>
           , parameters => params_gateway_name_in_path()
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 204 => <<"Deleted">>
-              }
+              ?STANDARD_RESP(#{204 => <<"Deleted">>})
           }
      };
 schema("/gateway/:name/authentication/users") ->
@@ -213,14 +192,11 @@ schema("/gateway/:name/authentication/users") ->
           , parameters => params_gateway_name_in_path() ++
                           params_paging_in_qs()
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 200 => emqx_dashboard_swagger:schema_with_example(
-                          ref(emqx_authn_api, response_user),
-                          emqx_authn_api:response_user_examples())
-              }
+              ?STANDARD_RESP(
+                 #{ 200 => emqx_dashboard_swagger:schema_with_example(
+                             ref(emqx_authn_api, response_user),
+                             emqx_authn_api:response_user_examples())
+                  })
           },
        post =>
          #{ description => <<"Add user for the authentication">>
@@ -229,14 +205,11 @@ schema("/gateway/:name/authentication/users") ->
                                ref(emqx_authn_api, request_user_create),
                                emqx_authn_api:request_user_create_examples())
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 201 => emqx_dashboard_swagger:schema_with_example(
-                          ref(emqx_authn_api, response_user),
-                          emqx_authn_api:response_user_examples())
-              }
+              ?STANDARD_RESP(
+                 #{ 201 => emqx_dashboard_swagger:schema_with_example(
+                             ref(emqx_authn_api, response_user),
+                             emqx_authn_api:response_user_examples())
+                  })
           }
      };
 schema("/gateway/:name/authentication/users/:uid") ->
@@ -247,14 +220,11 @@ schema("/gateway/:name/authentication/users/:uid") ->
            , parameters => params_gateway_name_in_path() ++
                            params_userid_in_path()
            , responses =>
-               #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-                , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-                , 200 => emqx_dashboard_swagger:schema_with_example(
-                           ref(emqx_authn_api, response_user),
-                           emqx_authn_api:response_user_examples())
-                }
+               ?STANDARD_RESP(
+                  #{ 200 => emqx_dashboard_swagger:schema_with_example(
+                              ref(emqx_authn_api, response_user),
+                              emqx_authn_api:response_user_examples())
+                   })
            },
         put =>
           #{ description => <<"Update the user info for the gateway "
@@ -265,14 +235,11 @@ schema("/gateway/:name/authentication/users/:uid") ->
                                 ref(emqx_authn_api, request_user_update),
                                 emqx_authn_api:request_user_update_examples())
            , responses =>
-               #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-                , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-                , 200 => emqx_dashboard_swagger:schema_with_example(
-                           ref(emqx_authn_api, response_user),
-                           emqx_authn_api:response_user_examples())
-                }
+               ?STANDARD_RESP(
+                  #{ 200 => emqx_dashboard_swagger:schema_with_example(
+                              ref(emqx_authn_api, response_user),
+                              emqx_authn_api:response_user_examples())
+                   })
            },
         delete =>
           #{ description => <<"Delete the user for the gateway "
@@ -280,12 +247,7 @@ schema("/gateway/:name/authentication/users/:uid") ->
            , parameters => params_gateway_name_in_path() ++
                            params_userid_in_path()
            , responses =>
-               #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-                , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-                , 204 => <<"User Deleted">>
-                }
+               ?STANDARD_RESP(#{204 => <<"User Deleted">>})
            }
      };
 schema("/gateway/:name/authentication/import_users") ->
@@ -298,13 +260,7 @@ schema("/gateway/:name/authentication/import_users") ->
                              emqx_authn_api:request_import_users_examples()
                             )
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-               %% XXX: Put a hint message into 204 return ?
-               , 204 => <<"Imported">>
-              }
+              ?STANDARD_RESP(#{204 => <<"Imported">>})
           }
      }.
 

--- a/apps/emqx_gateway/src/emqx_gateway_api_authn.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_authn.erl
@@ -82,17 +82,15 @@ authn(get, #{bindings := #{name := Name0}}) ->
 authn(put, #{bindings := #{name := Name0},
              body := Body}) ->
     with_gateway(Name0, fun(GwName, _) ->
-        %% TODO: return the authn instances?
-        ok = emqx_gateway_http:update_authn(GwName, Body),
-        {204}
+        {ok, Authn} = emqx_gateway_http:update_authn(GwName, Body),
+        {200, Authn}
     end);
 
 authn(post, #{bindings := #{name := Name0},
               body := Body}) ->
     with_gateway(Name0, fun(GwName, _) ->
-        %% TODO: return the authn instances?
-        ok = emqx_gateway_http:add_authn(GwName, Body),
-        {204}
+        {ok, Authn} = emqx_gateway_http:add_authn(GwName, Body),
+        {201, Authn}
     end);
 
 authn(delete, #{bindings := #{name := Name0}}) ->
@@ -181,7 +179,7 @@ schema("/gateway/:name/authentication") ->
                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
                , 500 => error_codes([?INTERNAL_ERROR],
                                    <<"Ineternal Server Error">>)
-               , 204 => <<"Updated">> %% XXX: ??? return the updated object
+               , 200 => schema_authn()
                }
           },
        post =>
@@ -193,7 +191,7 @@ schema("/gateway/:name/authentication") ->
                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
                , 500 => error_codes([?INTERNAL_ERROR],
                                    <<"Ineternal Server Error">>)
-               , 204 => <<"Added">>
+               , 201 => schema_authn()
                }
           },
        delete =>

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -225,7 +225,7 @@ schema("/gateway/:name/listeners") ->
           , parameters => params_gateway_name_in_path()
           , responses =>
               ?STANDARD_RESP(
-                 #{ 200 => emqx_dashboard_swagger:schema_with_examples(
+                 #{ 200 => emqx_dashboard_swagger:schema_with_example(
                              hoconsc:array(ref(listener)),
                              examples_listener_list())
                   })
@@ -240,7 +240,7 @@ schema("/gateway/:name/listeners") ->
               ?STANDARD_RESP(
                  #{ 201 => emqx_dashboard_swagger:schema_with_examples(
                              ref(listener),
-                             examples_listener_list())
+                             examples_listener())
                   })
           }
      };
@@ -580,7 +580,96 @@ common_listener_opts() ->
 %% examples
 
 examples_listener_list() ->
-    #{stomp_listeners => [examples_listener()]}.
+    [Config || #{value := Config} <- maps:values(examples_listener())].
 
 examples_listener() ->
-    #{}.
+    #{ tcp_listener=>
+        #{ summary => <<"A simple tcp listener example">>
+         , value =>
+            #{ bind => <<"61613">>
+             , acceptors => 16
+             , max_connections => 1024000
+             , max_conn_rate => 1000
+             , tcp =>
+                #{ active_n => 100
+                 , backlog => 1024
+                 , send_timeout => <<"15s">>
+                 , send_timeout_close => true
+                 , recbuf => <<"10KB">>
+                 , sndbuf => <<"10KB">>
+                 , buffer => <<"10KB">>
+                 , high_watermark => <<"1MB">>
+                 , nodelay => false
+                 , reuseaddr => true
+                 }
+             }
+         }
+     , ssl_listener =>
+        #{ summary => <<"A simple ssl listener example">>
+         , value =>
+            #{ bind => <<"61614">>
+             , acceptors => 16
+             , max_connections => 1024000
+             , max_conn_rate => 1000
+             , access_rules => [<<"allow all">>]
+             , ssl =>
+                #{ versions => [<<"tlsv1.3">>, <<"tlsv1.2">>,
+                                <<"tlsv1.1">>, <<"tlsv1">>]
+                 , cacertfile => <<"etc/certs/cacert.pem">>
+                 , certfile => <<"etc/certs/cert.pem">>
+                 , keyfile => <<"etc/certs/key.pem">>
+                 , verify => <<"verify_none">>
+                 , fail_if_no_peer_cert => false
+                 , server_name_indication => disable
+                 }
+             , tcp =>
+                #{ active_n => 100
+                 , backlog => 1024
+                 }
+             }
+         }
+     , udp_listener =>
+        #{ summary => <<"A simple udp listener example">>
+         , value =>
+            #{ bind => <<"0.0.0.0:1884">>
+             , udp =>
+                #{ active_n => 100
+                 , recbuf => <<"10KB">>
+                 , sndbuf => <<"10KB">>
+                 , buffer => <<"10KB">>
+                 , reuseaddr => true
+                 }
+             }
+         }
+     , dtls_listener =>
+        #{ summary => <<"A simple dtls listener example">>
+         , value =>
+            #{ bind => <<"5684">>
+             , acceptors => 16
+             , max_connections => 1024000
+             , max_conn_rate => 1000
+             , access_rules => [<<"allow all">>]
+             , ssl =>
+                #{ versions => [<<"dtlsv1.2">>, <<"dtlsv1">>]
+                 , cacertfile => <<"etc/certs/cacert.pem">>
+                 , certfile => <<"etc/certs/cert.pem">>
+                 , keyfile => <<"etc/certs/key.pem">>
+                 , verify => <<"verify_none">>
+                 , fail_if_no_peer_cert => false
+                 , server_name_indication => disable
+                 }
+             , tcp =>
+                #{ active_n => 100
+                 , backlog => 1024
+                 }
+             }
+         }
+     , dtls_listener_with_psk_ciphers =>
+        #{ summary => <<"todo">>
+         , value =>
+            #{}
+         }
+     , lisetner_with_authn =>
+        #{ summary => <<"todo">>
+         , value => #{}}
+     }.

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -18,14 +18,10 @@
 
 -behaviour(minirest_api).
 
+-include("emqx_gateway_http.hrl").
 -include_lib("typerefl/include/types.hrl").
 
--define(BAD_REQUEST, 'BAD_REQUEST').
--define(NOT_FOUND, 'NOT_FOUND').
--define(INTERNAL_ERROR, 'INTERNAL_SERVER_ERROR').
-
 -import(hoconsc, [mk/2, ref/1, ref/2]).
--import(emqx_dashboard_swagger, [error_codes/2]).
 
 -import(emqx_gateway_http,
         [ return_http_error/2
@@ -228,14 +224,11 @@ schema("/gateway/:name/listeners") ->
          #{ description => <<"Get the gateway listeners">>
           , parameters => params_gateway_name_in_path()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 200 => emqx_dashboard_swagger:schema_with_examples(
-                         hoconsc:array(ref(listener)),
-                         examples_listener_list())
-              }
+              ?STANDARD_RESP(
+                 #{ 200 => emqx_dashboard_swagger:schema_with_examples(
+                             hoconsc:array(ref(listener)),
+                             examples_listener_list())
+                  })
           },
        post =>
          #{ description => <<"Create the gateway listener">>
@@ -244,14 +237,11 @@ schema("/gateway/:name/listeners") ->
                              ref(listener),
                              examples_listener())
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 201 => emqx_dashboard_swagger:schema_with_examples(
-                         ref(listener),
-                         examples_listener_list())
-              }
+              ?STANDARD_RESP(
+                 #{ 201 => emqx_dashboard_swagger:schema_with_examples(
+                             ref(listener),
+                             examples_listener_list())
+                  })
           }
      };
 schema("/gateway/:name/listeners/:id") ->
@@ -261,26 +251,18 @@ schema("/gateway/:name/listeners/:id") ->
           , parameters => params_gateway_name_in_path()
                           ++ params_listener_id_in_path()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 200 => emqx_dashboard_swagger:schema_with_examples(
-                         ref(listener),
-                         examples_listener())
-              }
+              ?STANDARD_RESP(
+                 #{ 200 => emqx_dashboard_swagger:schema_with_examples(
+                             ref(listener),
+                             examples_listener())
+                  })
            },
        delete =>
          #{ description => <<"Delete the gateway listener">>
           , parameters => params_gateway_name_in_path()
                           ++ params_listener_id_in_path()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 204 => <<"Deleted">>
-              }
+              ?STANDARD_RESP(#{204 => <<"Deleted">>})
            },
        put =>
          #{ description => <<"Update the gateway listener">>
@@ -290,14 +272,11 @@ schema("/gateway/:name/listeners/:id") ->
                              ref(listener),
                              examples_listener())
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 200 => emqx_dashboard_swagger:schema_with_examples(
-                         ref(listener),
-                         examples_listener())
-              }
+              ?STANDARD_RESP(
+                 #{ 200 => emqx_dashboard_swagger:schema_with_examples(
+                             ref(listener),
+                             examples_listener())
+                  })
           }
      };
 schema("/gateway/:name/listeners/:id/authentication") ->
@@ -307,13 +286,10 @@ schema("/gateway/:name/listeners/:id/authentication") ->
           , parameters => params_gateway_name_in_path()
                           ++ params_listener_id_in_path()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 200 => schema_authn()
-              , 204 => <<"Authentication does not initiated">>
-              }
+              ?STANDARD_RESP(
+                 #{ 200 => schema_authn()
+                  , 204 => <<"Authentication does not initiated">>
+                  })
           },
        post =>
          #{ description => <<"Add authentication for the listener">>
@@ -321,12 +297,7 @@ schema("/gateway/:name/listeners/:id/authentication") ->
                           ++ params_listener_id_in_path()
           , 'requestBody' => schema_authn()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 201 => schema_authn()
-              }
+               ?STANDARD_RESP(#{201 => schema_authn()})
           },
        put =>
          #{ description => <<"Update authentication for the listener">>
@@ -334,24 +305,14 @@ schema("/gateway/:name/listeners/:id/authentication") ->
                           ++ params_listener_id_in_path()
           , 'requestBody' => schema_authn()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 200 => schema_authn()
-              }
+              ?STANDARD_RESP(#{200 => schema_authn()})
           },
        delete =>
          #{ description => <<"Remove authentication for the listener">>
           , parameters => params_gateway_name_in_path()
                           ++ params_listener_id_in_path()
           , responses =>
-             #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-              , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-              , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-              , 200 => <<"Deleted">>
-              }
+              ?STANDARD_RESP(#{200 => <<"Deleted">>})
           }
      };
 schema("/gateway/:name/listeners/:id/authentication/users") ->
@@ -362,14 +323,11 @@ schema("/gateway/:name/listeners/:id/authentication/users") ->
                           params_listener_id_in_path() ++
                           params_paging_in_qs()
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 200 => emqx_dashboard_swagger:schema_with_example(
-                          ref(emqx_authn_api, response_user),
-                          emqx_authn_api:response_user_examples())
-              }
+              ?STANDARD_RESP(
+                 #{ 200 => emqx_dashboard_swagger:schema_with_example(
+                             ref(emqx_authn_api, response_user),
+                             emqx_authn_api:response_user_examples())
+                  })
           },
        post =>
          #{ description => <<"Add user for the authentication">>
@@ -379,14 +337,11 @@ schema("/gateway/:name/listeners/:id/authentication/users") ->
                                ref(emqx_authn_api, request_user_create),
                                emqx_authn_api:request_user_create_examples())
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                   <<"Ineternal Server Error">>)
-               , 201 => emqx_dashboard_swagger:schema_with_example(
-                          ref(emqx_authn_api, response_user),
-                          emqx_authn_api:response_user_examples())
-              }
+              ?STANDARD_RESP(
+                 #{ 201 => emqx_dashboard_swagger:schema_with_example(
+                             ref(emqx_authn_api, response_user),
+                             emqx_authn_api:response_user_examples())
+                  })
           }
      };
 schema("/gateway/:name/listeners/:id/authentication/users/:uid") ->
@@ -398,14 +353,11 @@ schema("/gateway/:name/listeners/:id/authentication/users/:uid") ->
                            params_listener_id_in_path() ++
                            params_userid_in_path()
            , responses =>
-               #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-                , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-                , 200 => emqx_dashboard_swagger:schema_with_example(
-                           ref(emqx_authn_api, response_user),
-                           emqx_authn_api:response_user_examples())
-                }
+               ?STANDARD_RESP(
+                  #{ 200 => emqx_dashboard_swagger:schema_with_example(
+                              ref(emqx_authn_api, response_user),
+                              emqx_authn_api:response_user_examples())
+                   })
            },
         put =>
           #{ description => <<"Update the user info for the gateway "
@@ -417,14 +369,11 @@ schema("/gateway/:name/listeners/:id/authentication/users/:uid") ->
                                ref(emqx_authn_api, request_user_update),
                                emqx_authn_api:request_user_update_examples())
            , responses =>
-               #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-                , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-                , 200 => emqx_dashboard_swagger:schema_with_example(
-                           ref(emqx_authn_api, response_user),
-                           emqx_authn_api:response_user_examples())
-                }
+               ?STANDARD_RESP(
+                  #{ 200 => emqx_dashboard_swagger:schema_with_example(
+                              ref(emqx_authn_api, response_user),
+                              emqx_authn_api:response_user_examples())
+                   })
            },
         delete =>
           #{ description => <<"Delete the user for the gateway "
@@ -433,12 +382,7 @@ schema("/gateway/:name/listeners/:id/authentication/users/:uid") ->
                            params_listener_id_in_path() ++
                            params_userid_in_path()
            , responses =>
-               #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-                , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-                , 500 => error_codes([?INTERNAL_ERROR],
-                                     <<"Ineternal Server Error">>)
-                , 204 =>  <<"Deleted">>
-                }
+               ?STANDARD_RESP(#{204 =>  <<"Deleted">>})
            }
      };
 schema("/gateway/:name/listeners/:id/authentication/import_users") ->
@@ -452,12 +396,7 @@ schema("/gateway/:name/listeners/:id/authentication/import_users") ->
                              emqx_authn_api:request_import_users_examples()
                             )
           , responses =>
-              #{ 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>)
-               , 404 => error_codes([?NOT_FOUND], <<"Not Found">>)
-               , 500 => error_codes([?INTERNAL_ERROR],
-                                    <<"Ineternal Server Error">>)
-               , 204 => <<"Imported">>
-              }
+              ?STANDARD_RESP(#{204 => <<"Imported">>})
           }
      }.
 

--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -248,7 +248,7 @@ update(Req) ->
     res(emqx_conf:update([gateway], Req, #{override_to => cluster})).
 
 res({ok, Result}) -> {ok, Result};
-res({error, {error, {pre_config_update,emqx_gateway_conf,Reason}}}) -> {error, Reason};
+res({error, {pre_config_update,emqx_gateway_conf,Reason}}) -> {error, Reason};
 res({error, Reason}) -> {error, Reason}.
 
 bin({LType, LName}) ->

--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -60,7 +60,7 @@
 
 -type atom_or_bin() :: atom() | binary().
 -type ok_or_err() :: ok | {error, term()}.
--type map_or_err() :: map() | {error, term()}.
+-type map_or_err() :: {ok, map()} | {error, term()}.
 -type listener_ref() :: {ListenerType :: atom_or_bin(),
                          ListenerName :: atom_or_bin()}.
 

--- a/apps/emqx_gateway/src/emqx_gateway_http.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_http.erl
@@ -146,14 +146,14 @@ get_listeners_status(GwName, Config) ->
 %% Mgmt APIs - listeners
 %%--------------------------------------------------------------------
 
--spec add_listener(atom() | binary(), map()) -> ok.
+-spec add_listener(atom() | binary(), map()) -> {ok, map()}.
 add_listener(ListenerId, NewConf0) ->
     {GwName, Type, Name} = emqx_gateway_utils:parse_listener_id(ListenerId),
     NewConf = maps:without([<<"id">>, <<"name">>,
                             <<"type">>, <<"running">>], NewConf0),
     confexp(emqx_gateway_conf:add_listener(GwName, {Type, Name}, NewConf)).
 
--spec update_listener(atom() | binary(), map()) -> ok.
+-spec update_listener(atom() | binary(), map()) -> {ok, map()}.
 update_listener(ListenerId, NewConf0) ->
     {GwName, Type, Name} = emqx_gateway_utils:parse_listener_id(ListenerId),
 
@@ -194,23 +194,23 @@ wrap_chain_name(ChainName, Conf) ->
             Conf
     end.
 
--spec add_authn(gateway_name(), map()) -> ok.
+-spec add_authn(gateway_name(), map()) -> {ok, map()}.
 add_authn(GwName, AuthConf) ->
     confexp(emqx_gateway_conf:add_authn(GwName, AuthConf)).
 
--spec add_authn(gateway_name(), binary(), map()) -> ok.
+-spec add_authn(gateway_name(), binary(), map()) -> {ok, map()}.
 add_authn(GwName, ListenerId, AuthConf) ->
-    {_, Type, Name} = emqx_gateway_utils:parse_listener_id(ListenerId),
-    confexp(emqx_gateway_conf:add_authn(GwName, {Type, Name}, AuthConf)).
+    {_, LType, LName} = emqx_gateway_utils:parse_listener_id(ListenerId),
+    confexp(emqx_gateway_conf:add_authn(GwName, {LType, LName}, AuthConf)).
 
--spec update_authn(gateway_name(), map()) -> ok.
+-spec update_authn(gateway_name(), map()) -> {ok, map()}.
 update_authn(GwName, AuthConf) ->
     confexp(emqx_gateway_conf:update_authn(GwName, AuthConf)).
 
--spec update_authn(gateway_name(), binary(), map()) -> ok.
+-spec update_authn(gateway_name(), binary(), map()) -> {ok, map()}.
 update_authn(GwName, ListenerId, AuthConf) ->
-    {_, Type, Name} = emqx_gateway_utils:parse_listener_id(ListenerId),
-    confexp(emqx_gateway_conf:update_authn(GwName, {Type, Name}, AuthConf)).
+    {_, LType, LName} = emqx_gateway_utils:parse_listener_id(ListenerId),
+    confexp(emqx_gateway_conf:update_authn(GwName, {LType, LName}, AuthConf)).
 
 -spec remove_authn(gateway_name()) -> ok.
 remove_authn(GwName) ->
@@ -218,10 +218,11 @@ remove_authn(GwName) ->
 
 -spec remove_authn(gateway_name(), binary()) -> ok.
 remove_authn(GwName, ListenerId) ->
-    {_, Type, Name} = emqx_gateway_utils:parse_listener_id(ListenerId),
-    confexp(emqx_gateway_conf:remove_authn(GwName, {Type, Name})).
+    {_, LType, LName} = emqx_gateway_utils:parse_listener_id(ListenerId),
+    confexp(emqx_gateway_conf:remove_authn(GwName, {LType, LName})).
 
 confexp(ok) -> ok;
+confexp({ok, Res}) -> {ok, Res};
 confexp({error, not_found}) ->
     error({update_conf_error, not_found});
 confexp({error, already_exist}) ->

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -143,9 +143,9 @@ The client just sends its PUBLISH messages to a GW"
        sc(hoconsc:array(ref(mqttsn_predefined)),
           #{ default => []
            , desc =>
-"The Pre-defined topic ids and topic names.<br>
+<<"The Pre-defined topic ids and topic names.<br>
 A 'pre-defined' topic id is a topic id whose mapping to a topic name
-is known in advance by both the client's application and the gateway"
+is known in advance by both the client’s application and the gateway">>
            })}
     , {listeners, sc(ref(udp_listeners))}
     ] ++ gateway_common_options();

--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_api.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_api.erl
@@ -23,7 +23,7 @@
 
 -export([lookup_cmd/2, observe/2, read/2, write/2]).
 
--define(PATH(Suffix), "/gateway/lwm2m/:clientid"Suffix).
+-define(PATH(Suffix), "/gateway/lwm2m/clients/:clientid"Suffix).
 -define(DATA_TYPE, ['Integer', 'Float', 'Time', 'String', 'Boolean', 'Opaque', 'Objlnk']).
 
 -import(hoconsc, [mk/2, ref/1, ref/2]).

--- a/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
@@ -67,7 +67,7 @@ end_per_suite(Config) ->
 t_send_request_api(_) ->
     ClientId = start_client(),
     timer:sleep(200),
-    Path = emqx_mgmt_api_test_util:api_path(["gateway/coap/client1/request"]),
+    Path = emqx_mgmt_api_test_util:api_path(["gateway/coap/clients/client1/request"]),
     Token = <<"atoken">>,
     Payload = <<"simple echo this">>,
     Req = #{token => Token,

--- a/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
@@ -40,7 +40,9 @@ gateway.coap {
 
 -define(HOST, "127.0.0.1").
 -define(PORT, 5683).
--define(CONN_URI, "coap://127.0.0.1/mqtt/connection?clientid=client1&username=admin&password=public").
+-define(CONN_URI,
+          "coap://127.0.0.1/mqtt/connection?clientid=client1&"
+          "username=admin&password=public").
 
 -define(LOGT(Format, Args), ct:pal("TEST_SUITE: " ++ Format, Args)).
 
@@ -117,26 +119,40 @@ test_send_coap_request(UdpSock, Method, Content, Options, MsgId) ->
             Request = Request0#coap_message{id = MsgId},
             ?LOGT("send_coap_request Request=~p", [Request]),
             RequestBinary = emqx_coap_frame:serialize_pkt(Request, undefined),
-            ?LOGT("test udp socket send to ~p:~p, data=~p", [IpAddr, Port, RequestBinary]),
+            ?LOGT("test udp socket send to ~p:~p, data=~p",
+                  [IpAddr, Port, RequestBinary]),
             ok = gen_udp:send(UdpSock, IpAddr, Port, RequestBinary);
         {SchemeDiff, ChIdDiff, _, _} ->
-            error(lists:flatten(io_lib:format("scheme ~ts or ChId ~ts does not match with socket", [SchemeDiff, ChIdDiff])))
+            error(
+              lists:flatten(
+                io_lib:format(
+                    "scheme ~ts or ChId ~ts does not match with socket",
+                    [SchemeDiff, ChIdDiff])
+               ))
     end.
 
 test_recv_coap_response(UdpSock) ->
     {ok, {Address, Port, Packet}} = gen_udp:recv(UdpSock, 0, 2000),
     {ok, Response, _, _} = emqx_coap_frame:parse(Packet, undefined),
-    ?LOGT("test udp receive from ~p:~p, data1=~p, Response=~p", [Address, Port, Packet, Response]),
-    #coap_message{type = ack, method = Method, id=Id, token = Token, options = Options, payload = Payload} = Response,
-    ?LOGT("receive coap response Method=~p, Id=~p, Token=~p, Options=~p, Payload=~p", [Method, Id, Token, Options, Payload]),
+    ?LOGT("test udp receive from ~p:~p, data1=~p, Response=~p",
+          [Address, Port, Packet, Response]),
+    #coap_message{
+       type = ack, method = Method, id = Id,
+       token = Token, options = Options, payload = Payload} = Response,
+    ?LOGT("receive coap response Method=~p, Id=~p, Token=~p, "
+          "Options=~p, Payload=~p", [Method, Id, Token, Options, Payload]),
     Response.
 
 test_recv_coap_request(UdpSock) ->
     case gen_udp:recv(UdpSock, 0) of
         {ok, {_Address, _Port, Packet}} ->
             {ok, Request, _, _} = emqx_coap_frame:parse(Packet, undefined),
-            #coap_message{type = con, method = Method, id=Id, token = Token, payload = Payload, options = Options} = Request,
-            ?LOGT("receive coap request Method=~p, Id=~p, Token=~p, Options=~p, Payload=~p", [Method, Id, Token, Options, Payload]),
+            #coap_message{
+               type = con, method = Method, id = Id,
+               token = Token, payload = Payload, options = Options} = Request,
+            ?LOGT("receive coap request Method=~p, Id=~p, "
+                  "Token=~p, Options=~p, Payload=~p",
+                  [Method, Id, Token, Options, Payload]),
             Request;
         {error, Reason} ->
             ?LOGT("test_recv_coap_request failed, Reason=~p", [Reason]),

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -196,12 +196,12 @@ t_authn(_) ->
                  backend => <<"built-in-database">>,
                  user_id_type => <<"clientid">>
                 },
-    {204, _} = request(post, "/gateway/stomp/authentication", AuthConf),
+    {201, _} = request(post, "/gateway/stomp/authentication", AuthConf),
     {200, ConfResp} = request(get, "/gateway/stomp/authentication"),
     assert_confs(AuthConf, ConfResp),
 
     AuthConf2 = maps:merge(AuthConf, #{user_id_type => <<"username">>}),
-    {204, _} = request(put, "/gateway/stomp/authentication", AuthConf2),
+    {200, _} = request(put, "/gateway/stomp/authentication", AuthConf2),
 
     {200, ConfResp2} = request(get, "/gateway/stomp/authentication"),
     assert_confs(AuthConf2, ConfResp2),
@@ -219,7 +219,7 @@ t_authn_data_mgmt(_) ->
                  backend => <<"built-in-database">>,
                  user_id_type => <<"clientid">>
                 },
-    {204, _} = request(post, "/gateway/stomp/authentication", AuthConf),
+    {201, _} = request(post, "/gateway/stomp/authentication", AuthConf),
     {200, ConfResp} = request(get, "/gateway/stomp/authentication"),
     assert_confs(AuthConf, ConfResp),
 
@@ -262,14 +262,14 @@ t_listeners(_) ->
                 type => <<"tcp">>,
                 bind => <<"61613">>
                },
-    {204, _} = request(post, "/gateway/stomp/listeners", LisConf),
+    {201, _} = request(post, "/gateway/stomp/listeners", LisConf),
     {200, ConfResp} = request(get, "/gateway/stomp/listeners"),
     assert_confs([LisConf], ConfResp),
     {200, ConfResp1} = request(get, "/gateway/stomp/listeners/stomp:tcp:def"),
     assert_confs(LisConf, ConfResp1),
 
     LisConf2 = maps:merge(LisConf, #{bind => <<"61614">>}),
-    {204, _} = request(
+    {200, _} = request(
                  put,
                  "/gateway/stomp/listeners/stomp:tcp:def",
                  LisConf2
@@ -298,12 +298,12 @@ t_listeners_authn(_) ->
                  user_id_type => <<"clientid">>
                 },
     Path = "/gateway/stomp/listeners/stomp:tcp:def/authentication",
-    {204, _} = request(post, Path, AuthConf),
+    {201, _} = request(post, Path, AuthConf),
     {200, ConfResp2} = request(get, Path),
     assert_confs(AuthConf, ConfResp2),
 
     AuthConf2 = maps:merge(AuthConf, #{user_id_type => <<"username">>}),
-    {204, _} = request(put, Path, AuthConf2),
+    {200, _} = request(put, Path, AuthConf2),
 
     {200, ConfResp3} = request(get, Path),
     assert_confs(AuthConf2, ConfResp3),
@@ -325,7 +325,7 @@ t_listeners_authn_data_mgmt(_) ->
                  user_id_type => <<"clientid">>
                 },
     Path = "/gateway/stomp/listeners/stomp:tcp:def/authentication",
-    {204, _} = request(post, Path, AuthConf),
+    {201, _} = request(post, Path, AuthConf),
     {200, ConfResp2} = request(get, Path),
     assert_confs(AuthConf, ConfResp2),
 

--- a/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
@@ -268,12 +268,12 @@ t_load_remove_authn(_) ->
     ok = emqx_gateway_conf:load_gateway(<<"stomp">>, StompConf),
     assert_confs(StompConf, emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:add_authn(<<"stomp">>, ?CONF_STOMP_AUTHN_1),
+    {ok, _} = emqx_gateway_conf:add_authn(<<"stomp">>, ?CONF_STOMP_AUTHN_1),
     assert_confs(
       maps:put(<<"authentication">>, ?CONF_STOMP_AUTHN_1, StompConf),
       emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:update_authn(<<"stomp">>, ?CONF_STOMP_AUTHN_2),
+    {ok, _} = emqx_gateway_conf:update_authn(<<"stomp">>, ?CONF_STOMP_AUTHN_2),
     assert_confs(
       maps:put(<<"authentication">>, ?CONF_STOMP_AUTHN_2, StompConf),
       emqx:get_raw_config([gateway, stomp])),
@@ -295,14 +295,16 @@ t_load_remove_listeners(_) ->
     ok = emqx_gateway_conf:load_gateway(<<"stomp">>, StompConf),
     assert_confs(StompConf, emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:add_listener(
-           <<"stomp">>, {<<"tcp">>, <<"default">>}, ?CONF_STOMP_LISTENER_1),
+    {ok, _} = emqx_gateway_conf:add_listener(
+                <<"stomp">>, {<<"tcp">>, <<"default">>},
+                ?CONF_STOMP_LISTENER_1),
     assert_confs(
       maps:merge(StompConf, listener(?CONF_STOMP_LISTENER_1)),
       emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:update_listener(
-           <<"stomp">>, {<<"tcp">>, <<"default">>}, ?CONF_STOMP_LISTENER_2),
+    {ok, _} = emqx_gateway_conf:update_listener(
+                <<"stomp">>, {<<"tcp">>, <<"default">>},
+                ?CONF_STOMP_LISTENER_2),
     assert_confs(
       maps:merge(StompConf, listener(?CONF_STOMP_LISTENER_2)),
       emqx:get_raw_config([gateway, stomp])),
@@ -339,12 +341,12 @@ t_load_remove_listener_authn(_) ->
     ok = emqx_gateway_conf:load_gateway(<<"stomp">>, StompConf),
     assert_confs(StompConf, emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:add_authn(
-           <<"stomp">>, {<<"tcp">>, <<"default">>}, ?CONF_STOMP_AUTHN_1),
+    {ok, _} = emqx_gateway_conf:add_authn(
+                <<"stomp">>, {<<"tcp">>, <<"default">>}, ?CONF_STOMP_AUTHN_1),
     assert_confs(StompConf1, emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:update_authn(
-           <<"stomp">>, {<<"tcp">>, <<"default">>}, ?CONF_STOMP_AUTHN_2),
+    {ok, _} = emqx_gateway_conf:update_authn(
+                <<"stomp">>, {<<"tcp">>, <<"default">>}, ?CONF_STOMP_AUTHN_2),
     assert_confs(StompConf2, emqx:get_raw_config([gateway, stomp])),
 
     ok = emqx_gateway_conf:remove_authn(
@@ -403,14 +405,16 @@ t_add_listener_with_certs_content(_) ->
     ok = emqx_gateway_conf:load_gateway(<<"stomp">>, StompConf),
     assert_confs(StompConf, emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:add_listener(
-           <<"stomp">>, {<<"ssl">>, <<"default">>}, ?CONF_STOMP_LISTENER_SSL),
+    {ok, _} = emqx_gateway_conf:add_listener(
+                <<"stomp">>, {<<"ssl">>, <<"default">>},
+                ?CONF_STOMP_LISTENER_SSL),
     assert_confs(
       maps:merge(StompConf, ssl_listener(?CONF_STOMP_LISTENER_SSL)),
       emqx:get_raw_config([gateway, stomp])),
 
-    ok = emqx_gateway_conf:update_listener(
-           <<"stomp">>, {<<"ssl">>, <<"default">>}, ?CONF_STOMP_LISTENER_SSL_2),
+    {ok, _} = emqx_gateway_conf:update_listener(
+                <<"stomp">>, {<<"ssl">>, <<"default">>},
+                ?CONF_STOMP_LISTENER_SSL_2),
     assert_confs(
       maps:merge(StompConf, ssl_listener(?CONF_STOMP_LISTENER_SSL_2)),
       emqx:get_raw_config([gateway, stomp])),

--- a/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
@@ -301,7 +301,7 @@ t_observe(Config) ->
 %%% Internal Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 call_lookup_api(ClientId, Path, Action) ->
-    ApiPath = emqx_mgmt_api_test_util:api_path(["gateway/lwm2m", ClientId, "lookup_cmd"]),
+    ApiPath = emqx_mgmt_api_test_util:api_path(["gateway/lwm2m/clients", ClientId, "lookup_cmd"]),
     Auth = emqx_mgmt_api_test_util:auth_header_(),
     Query = io_lib:format("path=~ts&action=~ts", [Path, Action]),
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, ApiPath, Query, Auth),
@@ -309,7 +309,7 @@ call_lookup_api(ClientId, Path, Action) ->
     Response.
 
 call_send_api(ClientId, Cmd, Query) ->
-    ApiPath = emqx_mgmt_api_test_util:api_path(["gateway/lwm2m", ClientId, Cmd]),
+    ApiPath = emqx_mgmt_api_test_util:api_path(["gateway/lwm2m/clients", ClientId, Cmd]),
     Auth = emqx_mgmt_api_test_util:auth_header_(),
     {ok, Response} = emqx_mgmt_api_test_util:request_api(post, ApiPath, Query, Auth),
     ?LOGT("rest api response:~ts~n", [Response]),


### PR DESCRIPTION
Refactored the implementation of Gateway HTTP APIs:
1. Modify the coap/lwm2m API path from `/gateway/lwm2m/{clientid}` to `/gateway/lwm2m/clients/{clientid}`
2. Return the resource created/updated result
3. Rewrites the implementation of the swagger api using emqx_dasbhoard_swagger