### PR TITLE
chore(ct): remove verbose output during tests

### DIFF
--- a/apps/emqx_gateway/test/emqx_exproto_echo_svr.erl
+++ b/apps/emqx_gateway/test/emqx_exproto_echo_svr.erl
@@ -40,7 +40,7 @@
         , on_received_messages/2
         ]).
 
--define(LOG(Fmt, Args), io:format(standard_error, Fmt, Args)).
+-define(LOG(Fmt, Args), ct:pal(Fmt, Args)).
 
 -define(HTTP, #{grpc_opts => #{service_protos => [emqx_exproto_pb],
                                services => #{'emqx.exproto.v1.ConnectionHandler' => ?MODULE}},

--- a/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
@@ -36,7 +36,7 @@
 -define(FLAG_RETAIN(X),X).
 -define(FLAG_SESSION(X),X).
 
--define(LOG(Format, Args), ct:print("TEST: " ++ Format, Args)).
+-define(LOG(Format, Args), ct:pal("TEST: " ++ Format, Args)).
 
 -define(MAX_PRED_TOPIC_ID, 2).
 -define(PREDEF_TOPIC_ID1, 1).

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -148,7 +148,6 @@ init_per_testcase(t_events, Config) ->
         #{id => <<"rule:t_events">>,
             sql => SQL,
             outputs => [
-                #{function => console},
                 #{function => <<"emqx_rule_engine_SUITE:output_record_triggered_events">>,
                   args => #{}}
             ],


### PR DESCRIPTION
Currently, when tests fail, it's a bit tedious to scroll and find actual errors.