### PR TITLE
fix: 4.4.0 failed to join 4.3.0 cluster

### DIFF
--- a/apps/emqx_sn/test/emqx_sn_registry_SUITE.erl
+++ b/apps/emqx_sn/test/emqx_sn_registry_SUITE.erl
@@ -42,7 +42,7 @@ end_per_suite(_Config) ->
 
 init_per_testcase(_TestCase, Config) ->
     ekka_mnesia:start(),
-    emqx_sn_registry:mnesia(boot),
+    emqx_sn_registry:create_table(),
     mnesia:clear_table(emqx_sn_registry),
     PredefTopics = application:get_env(emqx_sn, predefined, []),
     {ok, _Pid} = ?REGISTRY:start_link(PredefTopics),
@@ -118,4 +118,3 @@ register_a_lot(N, Max) when N < Max ->
     Topic = iolist_to_binary(["Topic", integer_to_list(N)]),
     ?assertEqual(N, ?REGISTRY:register_topic(<<"ClientId">>, Topic)),
     register_a_lot(N+1, Max).
-


### PR DESCRIPTION
`emqx_sn_registry` table is not available on 4.3.0, we should create it at runtime.
```erlang
{'EXIT',{{badmatch,{no_exists,{emqx_sn_registry,cstruct}}},[{emqx_sn_registry,mnesia,1,[{file,"emqx_sn_registry.erl"},
{line,71}]},{ekka_boot,'-apply_module_attributes/1-lc$^1/1-1-',2,[{file,"ekka_boot.erl"},{line,23}]},{ekka_boot,'-
apply_module_attributes/1-lc$^0/1-0-',1,[{file,"ekka_boot.erl"},{line,23}]},{ekka_mnesia,join_cluster,1,
[{file,"ekka_mnesia.erl"},{line,163}]},{ekka_cluster,join,1,[{file,"ekka_cluster.erl"},{line,59}]},{ekka,join,1,[]}]}}

```