### PR TITLE
chore: fix main-v4.3 support for networking.k8s.io/v1

### DIFF
--- a/deploy/charts/emqx/templates/ingress.yaml
+++ b/deploy/charts/emqx/templates/ingress.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.ingress.dashboard.enabled -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -17,15 +19,28 @@ metadata:
     {{- toYaml .Values.ingress.dashboard.annotations | nindent 4 }}
   {{- end }}
 spec:
+{{- if and .Values.ingress.dashboard.ingressClassName (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.dashboard.ingressClassName }}
+{{- end }}
   rules:
   {{- range $host := .Values.ingress.dashboard.hosts }}
   - host: {{ $host }}
     http:
       paths:
       - path: /
+        {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+        pathType: ImplementationSpecific
+        {{- end }}
         backend:
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ include "emqx.fullname" $ }}
+            port:
+              number: {{ $.Values.service.dashboard }}
+          {{- else }}
           serviceName: {{ include "emqx.fullname" $ }}
           servicePort: {{ $.Values.service.dashboard }}
+          {{- end }}
   {{- end -}}
   {{- if .Values.ingress.dashboard.tls }}
   tls:
@@ -34,7 +49,9 @@ spec:
 ---
 {{- end }}
 {{- if .Values.ingress.mgmt.enabled -}}
-{{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1beta1
 {{- else -}}
 apiVersion: extensions/v1beta1
@@ -52,15 +69,28 @@ metadata:
     {{- toYaml .Values.ingress.mgmt.annotations | nindent 4 }}
   {{- end }}
 spec:
+{{- if and .Values.ingress.mgmt.ingressClassName (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.mgmt.ingressClassName }}
+{{- end }}
   rules:
   {{- range $host := .Values.ingress.mgmt.hosts }}
   - host: {{ $host }}
     http:
       paths:
       - path: /
+        {{- if (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+        pathType: ImplementationSpecific
+        {{- end }}
         backend:
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: {{ include "emqx.fullname" $ }}
+            port:
+              number: {{ $.Values.service.mgmt }}
+          {{- else }}
           serviceName: {{ include "emqx.fullname" $ }}
           servicePort: {{ $.Values.service.mgmt }}
+          {{- end }}
   {{- end -}}
   {{- if .Values.ingress.mgmt.tls }}
   tls:


### PR DESCRIPTION
Hi, I think main-v4.3 has not adapted to different kubectl version, here is the changes.