### PR TITLE
fix(listeners): fix typo in listener type

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -111,7 +111,7 @@ current_conns(ID, ListenOn) ->
     {Type, Name} = parse_listener_id(ID),
     current_conns(Type, Name, ListenOn).
 
-current_conns(Type, Name, ListenOn) when Type == tcl; Type == ssl ->
+current_conns(Type, Name, ListenOn) when Type == tcp; Type == ssl ->
     esockd:get_current_connections({listener_id(Type, Name), ListenOn});
 current_conns(Type, Name, _ListenOn) when Type =:= ws; Type =:= wss ->
     proplists:get_value(all_connections, ranch:info(listener_id(Type, Name)));
@@ -122,7 +122,7 @@ max_conns(ID, ListenOn) ->
     {Type, Name} = parse_listener_id(ID),
     max_conns(Type, Name, ListenOn).
 
-max_conns(Type, Name, ListenOn) when Type == tcl; Type == ssl ->
+max_conns(Type, Name, ListenOn) when Type == tcp; Type == ssl ->
     esockd:get_max_connections({listener_id(Type, Name), ListenOn});
 max_conns(Type, Name, _ListenOn) when Type =:= ws; Type =:= wss ->
     proplists:get_value(max_connections, ranch:info(listener_id(Type, Name)));

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -132,7 +132,7 @@ basic_conf() ->
       zones => zone_conf()
     }.
 
-set_test_listenser_confs() ->
+set_test_listener_confs() ->
     Conf = emqx_config:get([]),
     emqx_config:put(basic_conf()),
     Conf.
@@ -179,7 +179,7 @@ end_per_suite(_Config) ->
                 ]).
 
 init_per_testcase(_TestCase, Config) ->
-    NewConf = set_test_listenser_confs(),
+    NewConf = set_test_listener_confs(),
     [{config, NewConf}|Config].
 
 end_per_testcase(_TestCase, Config) ->

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -59,7 +59,7 @@ init_per_suite(Config) ->
     ok = meck:expect(emqx_alarm, deactivate, fun(_) -> ok end),
     ok = meck:expect(emqx_alarm, deactivate, fun(_, _) -> ok end),
 
-    emqx_channel_SUITE:set_test_listenser_confs(),
+    emqx_channel_SUITE:set_test_listener_confs(),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -42,6 +42,7 @@ init_per_testcase(Case, Config)
   when Case =:= t_max_conns_tcp; Case =:= t_current_conns_tcp ->
     {ok, _} = emqx_config_handler:start_link(),
     PrevListeners = emqx_config:get([listeners, tcp], #{}),
+    PrevRateLimit = emqx_config:get([rate_limit], #{}),
     emqx_config:put([listeners, tcp], #{ listener_test =>
                                              #{ bind => {"127.0.0.1", 9999}
                                               , max_connections => 4321
@@ -53,6 +54,7 @@ init_per_testcase(Case, Config)
     ok = emqx_listeners:start(),
     [ {listener_conf, ListenerConf}
     , {prev_listener_conf, PrevListeners}
+    , {prev_rate_limit_conf, PrevRateLimit}
     | Config];
 init_per_testcase(_, Config) ->
     {ok, _} = emqx_config_handler:start_link(),
@@ -61,7 +63,9 @@ init_per_testcase(_, Config) ->
 end_per_testcase(Case, Config)
   when Case =:= t_max_conns_tcp; Case =:= t_current_conns_tcp ->
     PrevListener = ?config(prev_listener_conf, Config),
+    PrevRateLimit = ?config(prev_rate_limit_conf, Config),
     emqx_config:put([listeners, tcp], PrevListener),
+    emqx_config:put([rate_limit], PrevRateLimit),
     emqx_listeners:stop(),
     _ = emqx_config_handler:stop(),
     ok;

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -22,6 +22,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -37,10 +38,33 @@ end_per_suite(_Config) ->
     application:stop(esockd),
     application:stop(cowboy).
 
+init_per_testcase(Case, Config)
+  when Case =:= t_max_conns_tcp; Case =:= t_current_conns_tcp ->
+    {ok, _} = emqx_config_handler:start_link(),
+    PrevListeners = emqx_config:get([listeners, tcp], #{}),
+    emqx_config:put([listeners, tcp], #{ listener_test =>
+                                             #{ bind => {"127.0.0.1", 9999}
+                                              , max_connections => 4321
+                                              }
+                                  }),
+    emqx_config:put([rate_limit], #{max_conn_rate => 1000}),
+    ListenerConf = #{ bind => {"127.0.0.1", 9999}
+                    },
+    ok = emqx_listeners:start(),
+    [ {listener_conf, ListenerConf}
+    , {prev_listener_conf, PrevListeners}
+    | Config];
 init_per_testcase(_, Config) ->
     {ok, _} = emqx_config_handler:start_link(),
     Config.
 
+end_per_testcase(Case, Config)
+  when Case =:= t_max_conns_tcp; Case =:= t_current_conns_tcp ->
+    PrevListener = ?config(prev_listener_conf, Config),
+    emqx_config:put([listeners, tcp], PrevListener),
+    emqx_listeners:stop(),
+    _ = emqx_config_handler:stop(),
+    ok;
 end_per_testcase(_, _Config) ->
     _ = emqx_config_handler:stop(),
     ok.
@@ -55,6 +79,14 @@ t_restart_listeners(_) ->
     ok = emqx_listeners:stop(),
     ok = emqx_listeners:restart(),
     ok = emqx_listeners:stop().
+
+t_max_conns_tcp(_) ->
+    %% Note: Using a string representation for the bind address like
+    %% "127.0.0.1" does not work
+    ?assertEqual(4321, emqx_listeners:max_conns('tcp:listener_test', {{127,0,0,1}, 9999})).
+
+t_current_conns_tcp(_) ->
+    ?assertEqual(0, emqx_listeners:current_conns('tcp:listener_test', {{127,0,0,1}, 9999})).
 
 render_config_file() ->
     Path = local_path(["etc", "emqx.conf"]),
@@ -101,4 +133,3 @@ get_base_dir(Module) ->
 
 get_base_dir() ->
     get_base_dir(?MODULE).
-

--- a/apps/emqx/test/emqx_session_SUITE.erl
+++ b/apps/emqx/test/emqx_session_SUITE.erl
@@ -29,7 +29,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    emqx_channel_SUITE:set_test_listenser_confs(),
+    emqx_channel_SUITE:set_test_listener_confs(),
     ok = meck:new([emqx_hooks, emqx_metrics, emqx_broker],
                   [passthrough, no_history, no_link]),
     ok = meck:expect(emqx_metrics, inc, fun(_) -> ok end),


### PR DESCRIPTION
`emqx_listeners:{current,max}_conns` were matching on type `tcl`.
However, this type doesn't exist (it's not defined in
`?TYPES_STRING`). Therefore, this clause would never match.  It seems
that the intention was that it shouldbe `tcp`.

