### PR TITLE
fix: trace_name format [A-Za-z0-9-_];retry if trace_file not find

### DIFF
--- a/apps/emqx_plugin_libs/test/emqx_trace_SUITE.erl
+++ b/apps/emqx_plugin_libs/test/emqx_trace_SUITE.erl
@@ -130,7 +130,7 @@ t_create_failed(_Config) ->
     InvalidPackets4 = [{<<"name">>, <<"/test">>}, {<<"clientid">>, <<"t">>},
         {<<"type">>, <<"clientid">>}],
     {error, Reason9} = emqx_trace:create(InvalidPackets4),
-    ?assertEqual(<<"name cannot contain /">>, iolist_to_binary(Reason9)),
+    ?assertEqual(<<"Name should be ^[A-Za-z]+[A-Za-z0-9-_]*$">>, iolist_to_binary(Reason9)),
 
     ?assertEqual({error, "type=[topic,clientid,ip_address] required"},
         emqx_trace:create([{<<"name">>, <<"test-name">>}, {<<"clientid">>, <<"good">>}])),

--- a/test/emqx_trace_handler_SUITE.erl
+++ b/test/emqx_trace_handler_SUITE.erl
@@ -200,6 +200,7 @@ t_trace_ip_address(_Config) ->
 
 
 filesync(Name, Type) ->
+    ct:sleep(50),
     filesync(Name, Type, 3).
 
 %% sometime the handler process is not started yet.


### PR DESCRIPTION
1. ensure trace name be `[A-Za-z0-9-_]`,
2. if the start time is set earlier than the current time, it will cause the handler to not be created when the user views the trace file, so keep waiting until it is created successfully for one second.
3. find trace_file name not by string:prefix/2, to fix name crash


```erlang
021-12-06T14:39:44.703624+08:00 [error] GET /api/v4/trace/cluster_client_id/log error: 
{case_clause,{badrpc,{'EXIT',{{case_clause,["trace_cluster_client_id_2021-12-06.log",
"trace_cluster_client_id_122_2021-12-06.log"]},
[{emqx_trace_api,read_trace_file,3,[{file,"emqx_trace_api.erl"},{line,172}]}]}}}}, stacktrace:, 
```