### PR TITLE
chore(ekka): bump ekka to 0.8.1.6

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,7 @@
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.8.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.0"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.5"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.6"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.3.6"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "0.3.7"}}}


### PR DESCRIPTION
We're doing this to remove some missing change warnings when updating
emqx v4.3.10.  Ekka's appup was updated in emqx/ekka#140 .

<details>
<summary> `update_appup.escript` output after update (running against 4.3.10) </summary>

```
Found the previous appup file: _build/emqx/rel/emqx/lib/ekka-0.8.1.6/ebin/ekka.appup
INFO: Application 'ekka' has been updated: "0.8.1.4" -> "0.8.1.6"
... elided ...
ERROR: Appup file for the external dependency 'ehttpc' is not complete.
       Missing changes: #{down =>
                              [{"0.1.10",
                                [{load_module,ehttpc_pool,brutal_purge,soft_purge,[]},
                                 {load_module,ehttpc,brutal_purge,soft_purge,[]}]},
                               {<<"0\\.1\\.0">>,
                                [{load_module,ehttpc_pool,brutal_purge,soft_purge,[]},
                                 {load_module,ehttpc,brutal_purge,soft_purge,[]}]},
                               {<<"0\\.1\\.[1-7]">>,
                                [{load_module,ehttpc_pool,brutal_purge,soft_purge,[]},
                                 {load_module,ehttpc,brutal_purge,soft_purge,[]}]}],
                          up =>
                              [{"0.1.10",
                                [{load_module,ehttpc_pool,brutal_purge,soft_purge,[]},
                                 {load_module,ehttpc,brutal_purge,soft_purge,[]}]},
                               {<<"0\\.1\\.[0-7]">>,
                                [{load_module,ehttpc_pool,brutal_purge,soft_purge,[]},
                                 {load_module,ehttpc,brutal_purge,soft_purge,[]}]}]}
NOTE: Some changes above might be already covered by regexes.

ERROR: Incomplete appups found. Please inspect the output for more details.
```

</details>
