### PR TITLE
Improve bridge and connector APIs

### DIFF
--- a/apps/emqx_bridge/etc/emqx_bridge.conf
+++ b/apps/emqx_bridge/etc/emqx_bridge.conf
@@ -4,6 +4,7 @@
 
 ## MQTT bridges to/from another MQTT broker
 #bridges.mqtt.my_ingress_mqtt_bridge {
+#    enable = true
 #    connector = "mqtt:my_mqtt_connector"
 #    direction = ingress
 #    ## topic mappings for this bridge
@@ -16,6 +17,7 @@
 #}
 #
 #bridges.mqtt.my_egress_mqtt_bridge {
+#    enable = true
 #    connector = "mqtt:my_mqtt_connector"
 #    direction = egress
 #    ## topic mappings for this bridge
@@ -28,6 +30,7 @@
 #
 ## HTTP bridges to an HTTP server
 #bridges.http.my_http_bridge {
+#    enable = true
 #    ## NOTE: we cannot use placehodler variables in the `scheme://host:port` part of the url
 #    url = "http://localhost:9901/messages/${topic}"
 #    request_timeout = "30s"

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -18,7 +18,8 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--export([post_config_update/5]).
+-export([ post_config_update/5
+        ]).
 
 -export([ load_hook/0
         , unload_hook/0
@@ -103,14 +104,13 @@ bridge_type(emqx_connector_http) -> http.
 post_config_update(_, _Req, NewConf, OldConf, _AppEnv) ->
     #{added := Added, removed := Removed, changed := Updated}
         = diff_confs(NewConf, OldConf),
-    Result = perform_bridge_changes([
+    _ = perform_bridge_changes([
         {fun remove/3, Removed},
         {fun create/3, Added},
         {fun update/3, Updated}
     ]),
     ok = unload_hook(),
-    ok = load_hook(NewConf),
-    Result.
+    ok = load_hook(NewConf).
 
 perform_bridge_changes(Tasks) ->
     perform_bridge_changes(Tasks, ok).
@@ -187,15 +187,11 @@ restart(Type, Name) ->
 create(Type, Name, Conf) ->
     ?SLOG(info, #{msg => "create bridge", type => Type, name => Name,
         config => Conf}),
-    ResId = resource_id(Type, Name),
-    case emqx_resource:create_local(ResId,
-            emqx_bridge:resource_type(Type), parse_confs(Type, Name, Conf)) of
-        {ok, already_created} ->
-            emqx_resource:get_instance(ResId);
-        {ok, Data} ->
-            {ok, Data};
-        {error, Reason} ->
-            {error, Reason}
+    case emqx_resource:create_local(resource_id(Type, Name), emqx_bridge:resource_type(Type),
+            parse_confs(Type, Name, Conf)) of
+        {ok, already_created} -> maybe_disable_bridge(Type, Name, Conf);
+        {ok, _} -> maybe_disable_bridge(Type, Name, Conf);
+        {error, Reason} -> {error, Reason}
     end.
 
 update(Type, Name, {_OldConf, Conf}) ->
@@ -209,7 +205,10 @@ update(Type, Name, {_OldConf, Conf}) ->
     %%
     ?SLOG(info, #{msg => "update bridge", type => Type, name => Name,
         config => Conf}),
-    recreate(Type, Name, Conf).
+    case recreate(Type, Name, Conf) of
+        {ok, _} -> maybe_disable_bridge(Type, Name, Conf);
+        {error, _} = Err -> Err
+    end.
 
 recreate(Type, Name) ->
     recreate(Type, Name, emqx:get_raw_config([bridges, Type, Name])).
@@ -326,6 +325,11 @@ parse_url(Url) ->
             error({invalid_url, Url})
     end.
 
+maybe_disable_bridge(Type, Name, Conf) ->
+    case maps:get(enable, Conf, true) of
+        false -> stop(Type, Name);
+        true -> ok
+    end.
 
 bin(Bin) when is_binary(Bin) -> Bin;
 bin(Str) when is_list(Str) -> list_to_binary(Str);

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -37,6 +37,7 @@
         , lookup/2
         , lookup/3
         , list/0
+        , list_bridges_by_connector/1
         , create/3
         , recreate/2
         , recreate/3
@@ -159,6 +160,10 @@ list() ->
                     end
                 end, Bridges, maps:to_list(NameAndConf))
         end, [], maps:to_list(emqx:get_raw_config([bridges], #{}))).
+
+list_bridges_by_connector(ConnectorId) ->
+    [B || B = #{raw_config := #{<<"connector">> := Id}} <- list(),
+         ConnectorId =:= Id].
 
 lookup(Type, Name) ->
     RawConf = emqx:get_raw_config([bridges, Type, Name], #{}),

--- a/apps/emqx_bridge/src/emqx_bridge_app.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_app.erl
@@ -19,16 +19,35 @@
 
 -export([start/2, stop/1]).
 
+-export([ pre_config_update/3
+        ]).
+
+-define(TOP_LELVE_HDLR_PATH, (emqx_bridge:config_key_path())).
+-define(LEAF_NODE_HDLR_PATH, (emqx_bridge:config_key_path() ++ ['?', '?'])).
+
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_bridge_sup:start_link(),
     ok = emqx_bridge:load(),
     ok = emqx_bridge:load_hook(),
-    emqx_config_handler:add_handler(emqx_bridge:config_key_path(), emqx_bridge),
+    emqx_config_handler:add_handler(?LEAF_NODE_HDLR_PATH, ?MODULE),
+    emqx_config_handler:add_handler(?TOP_LELVE_HDLR_PATH, emqx_bridge),
     {ok, Sup}.
 
 stop(_State) ->
-    emqx_conf:remove_handler(emqx_bridge:config_key_path()),
+    emqx_conf:remove_handler(?LEAF_NODE_HDLR_PATH),
+    emqx_conf:remove_handler(?TOP_LELVE_HDLR_PATH),
     ok = emqx_bridge:unload_hook(),
     ok.
 
+-define(IS_OPER(O), when Oper == start; Oper == stop; Oper == restart).
+pre_config_update(_, Oper, undefined) ?IS_OPER(Oper) ->
+    {error, bridge_not_found};
+pre_config_update(_, Oper, OldConfig) ?IS_OPER(Oper) ->
+    {ok, OldConfig#{<<"enable">> => operation_to_enable(Oper)}};
+pre_config_update(_, Conf, _OldConfig) ->
+    {ok, Conf}.
+
 %% internal functions
+operation_to_enable(start) -> true;
+operation_to_enable(stop) -> false;
+operation_to_enable(restart) -> true.

--- a/apps/emqx_bridge/src/emqx_bridge_http_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_http_schema.erl
@@ -79,7 +79,13 @@ fields("get") ->
     ] ++ fields("post").
 
 basic_config() ->
-    proplists:delete(base_url, emqx_connector_http:fields(config)).
+    [ {enable,
+        mk(boolean(),
+           #{ desc =>"Enable or disable this bridge"
+            , default => true
+            })}
+    ]
+    ++ proplists:delete(base_url, emqx_connector_http:fields(config)).
 
 %%======================================================================================
 id_field() ->

--- a/apps/emqx_bridge/src/emqx_bridge_mqtt_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_mqtt_schema.erl
@@ -11,28 +11,30 @@
 roots() -> [].
 
 fields("ingress") ->
-    [ direction(ingress, emqx_connector_mqtt_schema:ingress_desc())
-    , emqx_bridge_schema:connector_name()
-    ] ++ proplists:delete(hookpoint, emqx_connector_mqtt_schema:fields("ingress"));
+    [ emqx_bridge_schema:direction_field(ingress, emqx_connector_mqtt_schema:ingress_desc())
+    ]
+    ++ emqx_bridge_schema:common_bridge_fields()
+    ++ proplists:delete(hookpoint, emqx_connector_mqtt_schema:fields("ingress"));
 
 fields("egress") ->
-    [ direction(egress, emqx_connector_mqtt_schema:egress_desc())
-    , emqx_bridge_schema:connector_name()
-    ] ++ emqx_connector_mqtt_schema:fields("egress");
+    [ emqx_bridge_schema:direction_field(egress, emqx_connector_mqtt_schema:egress_desc())
+    ]
+    ++ emqx_bridge_schema:common_bridge_fields()
+    ++ emqx_connector_mqtt_schema:fields("egress");
 
 fields("post_ingress") ->
     [ type_field()
     , name_field()
-    ] ++ fields("ingress");
+    ] ++ proplists:delete(enable, fields("ingress"));
 fields("post_egress") ->
     [ type_field()
     , name_field()
-    ] ++ fields("egress");
+    ] ++ proplists:delete(enable, fields("egress"));
 
 fields("put_ingress") ->
-    fields("ingress");
+    proplists:delete(enable, fields("ingress"));
 fields("put_egress") ->
-    fields("egress");
+    proplists:delete(enable, fields("egress"));
 
 fields("get_ingress") ->
     [ id_field()
@@ -42,13 +44,6 @@ fields("get_egress") ->
     ] ++ fields("post_egress").
 
 %%======================================================================================
-direction(Dir, Desc) ->
-    {direction, mk(Dir,
-        #{ nullable => false
-         , desc => "The direction of the bridge. Can be one of 'ingress' or 'egress'.<br>"
-            ++ Desc
-         })}.
-
 id_field() ->
     {id, mk(binary(), #{desc => "The Bridge Id", example => "mqtt:my_mqtt_bridge"})}.
 

--- a/apps/emqx_bridge/src/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_schema.erl
@@ -11,7 +11,8 @@
         , post_request/0
         ]).
 
--export([ connector_name/0
+-export([ common_bridge_fields/0
+        , direction_field/2
         ]).
 
 %%======================================================================================
@@ -23,17 +24,6 @@
 %% For HTTP APIs
 get_response() ->
     http_schema("get").
-
-connector_name() ->
-    {connector,
-        mk(binary(),
-           #{ nullable => false
-            , desc =>"""
-The connector name to be used for this bridge.
-Connectors are configured as 'connectors.{type}.{name}',
-for example 'connectors.http.mybridge'.
-"""
-            })}.
 
 put_request() ->
     http_schema("put").
@@ -48,6 +38,30 @@ http_schema(Method) ->
         end, ?CONN_TYPES),
     hoconsc:union([ref(emqx_bridge_http_schema, Method)
                    | Schemas]).
+
+common_bridge_fields() ->
+    [ {enable,
+        mk(boolean(),
+           #{ desc =>"Enable or disable this bridge"
+            , default => true
+            })}
+    , {connector,
+        mk(binary(),
+           #{ nullable => false
+            , desc =>"""
+The connector name to be used for this bridge.
+Connectors are configured as 'connectors.{type}.{name}',
+for example 'connectors.http.mybridge'.
+"""
+            })}
+    ].
+
+direction_field(Dir, Desc) ->
+    {direction, mk(Dir,
+        #{ nullable => false
+         , desc => "The direction of the bridge. Can be one of 'ingress' or 'egress'.<br>"
+            ++ Desc
+         })}.
 
 %%======================================================================================
 %% For config files

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -234,37 +234,27 @@ t_start_stop_bridges(_) ->
          , <<"url">> := URL1
          }, jsx:decode(Bridge)),
     %% stop it
-    {ok, 200, <<>>} = request(post,
-        uri(["nodes", node(), "bridges", ?BRIDGE_ID, "operation", "stop"]),
-        <<"">>),
+    {ok, 200, <<>>} = request(post, operation_path(stop), <<"">>),
     {ok, 200, Bridge2} = request(get, uri(["bridges", ?BRIDGE_ID]), []),
     ?assertMatch(#{ <<"id">> := ?BRIDGE_ID
                   , <<"status">> := <<"disconnected">>
                   }, jsx:decode(Bridge2)),
     %% start again
-    {ok, 200, <<>>} = request(post,
-        uri(["nodes", node(), "bridges", ?BRIDGE_ID, "operation", "start"]),
-        <<"">>),
+    {ok, 200, <<>>} = request(post, operation_path(start), <<"">>),
     {ok, 200, Bridge3} = request(get, uri(["bridges", ?BRIDGE_ID]), []),
     ?assertMatch(#{ <<"id">> := ?BRIDGE_ID
                   , <<"status">> := <<"connected">>
                   }, jsx:decode(Bridge3)),
     %% restart an already started bridge
-    {ok, 200, <<>>} = request(post,
-        uri(["nodes", node(), "bridges", ?BRIDGE_ID, "operation", "restart"]),
-        <<"">>),
+    {ok, 200, <<>>} = request(post, operation_path(restart), <<"">>),
     {ok, 200, Bridge3} = request(get, uri(["bridges", ?BRIDGE_ID]), []),
     ?assertMatch(#{ <<"id">> := ?BRIDGE_ID
                   , <<"status">> := <<"connected">>
                   }, jsx:decode(Bridge3)),
     %% stop it again
-    {ok, 200, <<>>} = request(post,
-        uri(["nodes", node(), "bridges", ?BRIDGE_ID, "operation", "stop"]),
-        <<"">>),
+    {ok, 200, <<>>} = request(post, operation_path(stop), <<"">>),
     %% restart a stopped bridge
-    {ok, 200, <<>>} = request(post,
-        uri(["nodes", node(), "bridges", ?BRIDGE_ID, "operation", "restart"]),
-        <<"">>),
+    {ok, 200, <<>>} = request(post, operation_path(restart), <<"">>),
     {ok, 200, Bridge4} = request(get, uri(["bridges", ?BRIDGE_ID]), []),
     ?assertMatch(#{ <<"id">> := ?BRIDGE_ID
                   , <<"status">> := <<"connected">>
@@ -306,3 +296,5 @@ auth_header_() ->
     {ok, Token} = emqx_dashboard_admin:sign_token(Username, Password),
     {"Authorization", "Bearer " ++ binary_to_list(Token)}.
 
+operation_path(Oper) ->
+    uri(["bridges", ?BRIDGE_ID, "operation", Oper]).

--- a/apps/emqx_connector/src/emqx_connector_mqtt.erl
+++ b/apps/emqx_connector/src/emqx_connector_mqtt.erl
@@ -54,11 +54,14 @@ fields("config") ->
     emqx_connector_mqtt_schema:fields("config");
 
 fields("get") ->
-    [{id, mk(binary(),
+    [ {id, mk(binary(),
         #{ desc => "The connector Id"
          , example => <<"mqtt:my_mqtt_connector">>
-         })}]
-    ++ fields("post");
+         })}
+    , {num_of_bridges, mk(integer(),
+        #{ desc => "The current number of bridges that are using this connector"
+         })}
+    ] ++ fields("post");
 
 fields("put") ->
     emqx_connector_mqtt_schema:fields("connector");

--- a/apps/emqx_connector/src/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/emqx_connector_schema.erl
@@ -13,6 +13,7 @@
         , post_request/0
         ]).
 
+%% the config for http bridges do not need connectors
 -define(CONN_TYPES, [mqtt]).
 
 %%======================================================================================

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -199,9 +199,9 @@ t_mqtt_conn_bridge_ingress(_) ->
                                , <<"name">> => ?CONNECTR_NAME
                                }),
 
-    %ct:pal("---connector: ~p", [Connector]),
     ?assertMatch(#{ <<"id">> := ?CONNECTR_ID
                   , <<"server">> := <<"127.0.0.1:1883">>
+                  , <<"num_of_bridges">> := 0
                   , <<"username">> := User1
                   , <<"password">> := <<"">>
                   , <<"proto_ver">> := <<"v4">>
@@ -216,7 +216,6 @@ t_mqtt_conn_bridge_ingress(_) ->
             <<"name">> => ?BRIDGE_NAME_INGRESS
         }),
 
-    %ct:pal("---bridge: ~p", [Bridge]),
     ?assertMatch(#{ <<"id">> := ?BRIDGE_ID_INGRESS
                   , <<"type">> := <<"mqtt">>
                   , <<"status">> := <<"connected">>
@@ -245,6 +244,12 @@ t_mqtt_conn_bridge_ingress(_) ->
         after 100 ->
             false
         end),
+
+    %% get the connector by id, verify the num_of_bridges now is 1
+    {ok, 200, Connector1Str} = request(get, uri(["connectors", ?CONNECTR_ID]), []),
+    ?assertMatch(#{ <<"id">> := ?CONNECTR_ID
+                  , <<"num_of_bridges">> := 1
+                  }, jsx:decode(Connector1Str)),
 
     %% delete the bridge
     {ok, 204, <<>>} = request(delete, uri(["bridges", ?BRIDGE_ID_INGRESS]), []),


### PR DESCRIPTION
- [x] The GET /connector/:id should return the current number of bridges, using `num_of_bridges` field.
- [x] After a bridge is disable/enabled, we should make the change permanent, so we have to add a config `enable` for each bridge: `bridges.mqtt.a.enable`
