### PR TITLE
fix: typo takeovered -> takenover

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -994,7 +994,7 @@ handle_call({takeover, 'end'}, Channel = #channel{session  = Session,
     %% TODO: Should not drain deliver here (side effect)
     Delivers = emqx_misc:drain_deliver(),
     AllPendings = lists:append(Delivers, Pendings),
-    disconnect_and_shutdown(takeovered, AllPendings, Channel);
+    disconnect_and_shutdown(takenover, AllPendings, Channel);
 
 handle_call(list_authz_cache, Channel) ->
     {reply, emqx_authz_cache:list_authz_cache(), Channel};
@@ -1201,7 +1201,7 @@ terminate(normal, Channel) ->
 terminate({shutdown, kicked}, Channel) ->
     run_terminate_hook(kicked, Channel);
 terminate({shutdown, Reason}, Channel) when Reason =:= discarded;
-                                            Reason =:= takeovered ->
+                                            Reason =:= takenover ->
     run_terminate_hook(Reason, Channel);
 terminate(Reason, Channel = #channel{will_msg = WillMsg}) ->
     (WillMsg =/= undefined) andalso publish_will_msg(WillMsg),
@@ -1754,7 +1754,7 @@ publish_will_msg(Msg) ->
 disconnect_reason(?RC_SUCCESS) -> normal;
 disconnect_reason(ReasonCode)  -> emqx_reason_codes:name(ReasonCode).
 
-reason_code(takeovered) -> ?RC_SESSION_TAKEN_OVER;
+reason_code(takenover) -> ?RC_SESSION_TAKEN_OVER;
 reason_code(discarded) -> ?RC_SESSION_TAKEN_OVER;
 reason_code(_) -> ?RC_NORMAL_DISCONNECTION.
 

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -179,7 +179,7 @@
 -define(SESSION_METRICS,
         [{counter, 'session.created'},
          {counter, 'session.resumed'},
-         {counter, 'session.takeovered'},
+         {counter, 'session.takenover'},
          {counter, 'session.discarded'},
          {counter, 'session.terminated'}
         ]).
@@ -581,7 +581,7 @@ reserved_idx('client.disconnected')          -> 209;
 
 reserved_idx('session.created')              -> 220;
 reserved_idx('session.resumed')              -> 221;
-reserved_idx('session.takeovered')           -> 222;
+reserved_idx('session.takenover')            -> 222;
 reserved_idx('session.discarded')            -> 223;
 reserved_idx('session.terminated')           -> 224;
 

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -678,8 +678,8 @@ replay(Session = #session{inflight = Inflight}) ->
 -spec(terminate(emqx_types:clientinfo(), Reason :: term(), session()) -> ok).
 terminate(ClientInfo, discarded, Session) ->
     run_hook('session.discarded', [ClientInfo, info(Session)]);
-terminate(ClientInfo, takeovered, Session) ->
-    run_hook('session.takeovered', [ClientInfo, info(Session)]);
+terminate(ClientInfo, takenover, Session) ->
+    run_hook('session.takenover', [ClientInfo, info(Session)]);
 terminate(ClientInfo, Reason, Session) ->
     run_hook('session.terminated', [ClientInfo, Reason, info(Session)]).
 

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -713,7 +713,7 @@ t_handle_call_takeover_begin(_) ->
 
 t_handle_call_takeover_end(_) ->
     ok = meck:expect(emqx_session, takeover, fun(_) -> ok end),
-    {shutdown, takeovered, [], _, _Chan} =
+    {shutdown, takenover, [], _, _Chan} =
         emqx_channel:handle_call({takeover, 'end'}, channel()).
 
 t_handle_call_quota(_) ->

--- a/apps/emqx_exhook/docs/design-cn.md
+++ b/apps/emqx_exhook/docs/design-cn.md
@@ -26,7 +26,7 @@
 架构如下：
 
 ```
-  EMQ X                                    
+  EMQ X
 +========================+                 +========+==========+
 |    ExHook              |                 |        |          |
 |   +----------------+   |      gRPC       | gRPC   |  User's  |
@@ -84,7 +84,7 @@ service HookProvider {
 
   rpc OnSessionDiscarded(SessionDiscardedRequest) returns (EmptySuccess) {};
 
-  rpc OnSessionTakeovered(SessionTakeoveredRequest) returns (EmptySuccess) {};
+  rpc OnSessionTakenover(SessionTakenoverRequest) returns (EmptySuccess) {};
 
   rpc OnSessionTerminated(SessionTerminatedRequest) returns (EmptySuccess) {};
 

--- a/apps/emqx_exhook/include/emqx_exhook.hrl
+++ b/apps/emqx_exhook/include/emqx_exhook.hrl
@@ -33,7 +33,7 @@
       , {'session.unsubscribed',{emqx_exhook_handler, on_session_unsubscribed, []}}
       , {'session.resumed',     {emqx_exhook_handler, on_session_resumed,      []}}
       , {'session.discarded',   {emqx_exhook_handler, on_session_discarded,    []}}
-      , {'session.takeovered',  {emqx_exhook_handler, on_session_takeovered,   []}}
+      , {'session.takenover',   {emqx_exhook_handler, on_session_takenover,    []}}
       , {'session.terminated',  {emqx_exhook_handler, on_session_terminated,   []}}
       , {'message.publish',     {emqx_exhook_handler, on_message_publish,      []}}
       , {'message.delivered',   {emqx_exhook_handler, on_message_delivered,    []}}

--- a/apps/emqx_exhook/priv/protos/exhook.proto
+++ b/apps/emqx_exhook/priv/protos/exhook.proto
@@ -56,7 +56,7 @@ service HookProvider {
 
   rpc OnSessionDiscarded(SessionDiscardedRequest) returns (EmptySuccess) {};
 
-  rpc OnSessionTakeovered(SessionTakeoveredRequest) returns (EmptySuccess) {};
+  rpc OnSessionTakenover(SessionTakenoverRequest) returns (EmptySuccess) {};
 
   rpc OnSessionTerminated(SessionTerminatedRequest) returns (EmptySuccess) {};
 
@@ -190,7 +190,7 @@ message SessionDiscardedRequest {
   ClientInfo clientinfo = 1;
 }
 
-message SessionTakeoveredRequest {
+message SessionTakenoverRequest {
 
   ClientInfo clientinfo = 1;
 }
@@ -284,7 +284,7 @@ message HookSpec {
   //
   //   "session.created",      "session.subscribed"
   //   "session.unsubscribed", "session.resumed"
-  //   "session.discarded",    "session.takeovered"
+  //   "session.discarded",    "session.takenover"
   //   "session.terminated"
   //
   //   "message.publish", "message.delivered"

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -37,7 +37,7 @@
         , on_session_unsubscribed/3
         , on_session_resumed/2
         , on_session_discarded/2
-        , on_session_takeovered/2
+        , on_session_takenover/2
         , on_session_terminated/3
         ]).
 
@@ -170,9 +170,9 @@ on_session_discarded(ClientInfo, _SessInfo) ->
     Req = #{clientinfo => clientinfo(ClientInfo)},
     cast('session.discarded', Req).
 
-on_session_takeovered(ClientInfo, _SessInfo) ->
+on_session_takenover(ClientInfo, _SessInfo) ->
     Req = #{clientinfo => clientinfo(ClientInfo)},
-    cast('session.takeovered', Req).
+    cast('session.takenover', Req).
 
 on_session_terminated(ClientInfo, Reason, _SessInfo) ->
     Req = #{clientinfo => clientinfo(ClientInfo),

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -64,7 +64,7 @@
                    | 'session.unsubscribed'
                    | 'session.resumed'
                    | 'session.discarded'
-                   | 'session.takeovered'
+                   | 'session.takenover'
                    | 'session.terminated'
                    | 'message.publish'
                    | 'message.delivered'
@@ -307,7 +307,7 @@ hk2func('session.subscribed') -> 'on_session_subscribed';
 hk2func('session.unsubscribed') -> 'on_session_unsubscribed';
 hk2func('session.resumed') -> 'on_session_resumed';
 hk2func('session.discarded') -> 'on_session_discarded';
-hk2func('session.takeovered') -> 'on_session_takeovered';
+hk2func('session.takenover') -> 'on_session_takenover';
 hk2func('session.terminated') -> 'on_session_terminated';
 hk2func('message.publish') -> 'on_message_publish';
 hk2func('message.delivered') ->'on_message_delivered';
@@ -325,5 +325,5 @@ available_hooks() ->
      'client.disconnected', 'client.authenticate', 'client.authorize',
      'client.subscribe', 'client.unsubscribe',
      'session.created', 'session.subscribed', 'session.unsubscribed',
-     'session.resumed', 'session.discarded', 'session.takeovered',
+     'session.resumed', 'session.discarded', 'session.takenover',
      'session.terminated' | message_hooks()].

--- a/apps/emqx_exhook/test/emqx_exhook_demo_svr.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_demo_svr.erl
@@ -41,7 +41,7 @@
         , on_session_unsubscribed/2
         , on_session_resumed/2
         , on_session_discarded/2
-        , on_session_takeovered/2
+        , on_session_takenover/2
         , on_session_terminated/2
         , on_message_publish/2
         , on_message_delivered/2
@@ -130,7 +130,7 @@ on_provider_loaded(Req, Md) ->
                      #{name => <<"session.unsubscribed">>},
                      #{name => <<"session.resumed">>},
                      #{name => <<"session.discarded">>},
-                     #{name => <<"session.takeovered">>},
+                     #{name => <<"session.takenover">>},
                      #{name => <<"session.terminated">>},
                      #{name => <<"message.publish">>},
                      #{name => <<"message.delivered">>},
@@ -274,10 +274,10 @@ on_session_discarded(Req, Md) ->
     %io:format("fun: ~p, req: ~0p~n", [?FUNCTION_NAME, Req]),
     {ok, #{}, Md}.
 
--spec on_session_takeovered(emqx_exhook_pb:session_takeovered_request(), grpc:metadata())
+-spec on_session_takenover(emqx_exhook_pb:session_takenover_request(), grpc:metadata())
     -> {ok, emqx_exhook_pb:empty_success(), grpc:metadata()}
      | {error, grpc_cowboy_h:error_response()}.
-on_session_takeovered(Req, Md) ->
+on_session_takenover(Req, Md) ->
     ?MODULE:in({?FUNCTION_NAME, Req}),
     %io:format("fun: ~p, req: ~0p~n", [?FUNCTION_NAME, Req]),
     {ok, #{}, Md}.

--- a/apps/emqx_exhook/test/props/prop_exhook_hooks.erl
+++ b/apps/emqx_exhook/test/props/prop_exhook_hooks.erl
@@ -257,11 +257,11 @@ prop_session_discared() ->
             true
         end).
 
-prop_session_takeovered() ->
+prop_session_takenover() ->
     ?ALL({ClientInfo, SessInfo}, {clientinfo(), sessioninfo()},
         begin
-            ok = emqx_hooks:run('session.takeovered', [ClientInfo, SessInfo]),
-            {'on_session_takeovered', Resp} = emqx_exhook_demo_svr:take(),
+            ok = emqx_hooks:run('session.takenover', [ClientInfo, SessInfo]),
+            {'on_session_takenover', Resp} = emqx_exhook_demo_svr:take(),
             Expected =
                 #{clientinfo => from_clientinfo(ClientInfo)
                  },

--- a/apps/emqx_gateway/src/mqttsn/emqx_sn_channel.erl
+++ b/apps/emqx_gateway/src/mqttsn/emqx_sn_channel.erl
@@ -1233,7 +1233,7 @@ handle_call(discard, _From, Channel) ->
 %    %% TODO: Should not drain deliver here (side effect)
 %    Delivers = emqx_misc:drain_deliver(),
 %    AllPendings = lists:append(Delivers, Pendings),
-%    shutdown_and_reply(takeovered, AllPendings, Channel);
+%    shutdown_and_reply(takenover, AllPendings, Channel);
 
 %handle_call(list_authz_cache, _From, Channel) ->
 %    {reply, emqx_authz_cache:list_authz_cache(), Channel};

--- a/apps/emqx_gateway/src/stomp/emqx_stomp_channel.erl
+++ b/apps/emqx_gateway/src/stomp/emqx_stomp_channel.erl
@@ -713,7 +713,7 @@ handle_call(discard, _From, Channel) ->
 %    %% TODO: Should not drain deliver here (side effect)
 %    Delivers = emqx_misc:drain_deliver(),
 %    AllPendings = lists:append(Delivers, Pendings),
-%    shutdown_and_reply(takeovered, AllPendings, Channel);
+%    shutdown_and_reply(takenover, AllPendings, Channel);
 
 handle_call(list_authz_cache, _From, Channel) ->
     %% This won't work

--- a/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
@@ -126,7 +126,7 @@ properties() ->
         {'session.created',                 integer, <<"Number of sessions created">>},
         {'session.discarded',               integer, <<"Number of sessions dropped because Clean Session or Clean Start is true">>},
         {'session.resumed',                 integer, <<"Number of sessions resumed because Clean Session or Clean Start is false">>},
-        {'session.takeovered',              integer, <<"Number of sessions takeovered because Clean Session or Clean Start is false">>},
+        {'session.takenover',               integer, <<"Number of sessions takenover because Clean Session or Clean Start is false">>},
         {'session.terminated',              integer, <<"Number of terminated sessions">>}
     ].
 

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -413,8 +413,8 @@ emqx_collect(emqx_session_created, Stats) ->
     counter_metric(?C('session.created', Stats));
 emqx_collect(emqx_session_resumed, Stats) ->
     counter_metric(?C('session.resumed', Stats));
-emqx_collect(emqx_session_takeovered, Stats) ->
-    counter_metric(?C('session.takeovered', Stats));
+emqx_collect(emqx_session_takenover, Stats) ->
+    counter_metric(?C('session.takenover', Stats));
 emqx_collect(emqx_session_discarded, Stats) ->
     counter_metric(?C('session.discarded', Stats));
 emqx_collect(emqx_session_terminated, Stats) ->
@@ -559,7 +559,7 @@ emqx_metrics_client() ->
 emqx_metrics_session() ->
     [ emqx_session_created
     , emqx_session_resumed
-    , emqx_session_takeovered
+    , emqx_session_takenover
     , emqx_session_discarded
     , emqx_session_terminated
     ].


### PR DESCRIPTION
This breaks compatibility for the plugins which hooks to the old name `session.takeovered`