### PR TITLE
docs: better config doc

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_schema.erl
+++ b/apps/emqx_authn/src/emqx_authn_schema.erl
@@ -50,8 +50,7 @@ config_refs(Modules) ->
 %% in emqx_schema, 'authentication' is a map() type which is to allow
 %% EMQ X more plugable.
 root_type() ->
-    T = authenticator_type(),
-    hoconsc:union([T, hoconsc:array(T)]).
+    hoconsc:array(authenticator_type()).
 
 mechanism(Name) ->
     hoconsc:mk(hoconsc:enum([Name]),

--- a/apps/emqx_connector/src/emqx_connector_http.erl
+++ b/apps/emqx_connector/src/emqx_connector_http.erl
@@ -36,7 +36,9 @@
 
 -export([ roots/0
         , fields/1
-        , validations/0]).
+        , validations/0
+        , namespace/0
+        ]).
 
 -export([ check_ssl_opts/2
         ]).
@@ -50,6 +52,9 @@
 
 %%=====================================================================
 %% Hocon schema
+
+namespace() -> "connector-http".
+
 roots() ->
     fields(config).
 


### PR DESCRIPTION
* simplify authn root type doc.
  The `authentication` root config is an array, when it's a single-element array, the wrapping `[]` can be omitted,
  so schema was `union([union([...]), array(union[...]))`, which makes the generated doc quite bloated with repeated information. This PR has the wrapping union removed, so it always appears to be an array in the config doc.
  The special rule for single-element array is explained in the description

* the `request` root key now has a namespace: `connector-http:request`, just for documentation purpose.