### PR TITLE
refactor(authz): hide mnesia authz implementation details

### DIFF
--- a/apps/emqx_authz/include/emqx_authz.hrl
+++ b/apps/emqx_authz/include/emqx_authz.hrl
@@ -8,29 +8,6 @@
                     (A =:= all)       orelse (A =:= <<"all">>)
                    )).
 
--define(ACL_SHARDED, emqx_acl_sharded).
-
--define(ACL_TABLE, emqx_acl).
-
-%% To save some space, use an integer for label, 0 for 'all', {1, Username} and {2, ClientId}.
--define(ACL_TABLE_ALL, 0).
--define(ACL_TABLE_USERNAME, 1).
--define(ACL_TABLE_CLIENTID, 2).
-
--type(action() :: subscribe | publish | all).
--type(permission() :: allow | deny).
-
--record(emqx_acl, {
-          who :: ?ACL_TABLE_ALL| {?ACL_TABLE_USERNAME, binary()} | {?ACL_TABLE_CLIENTID, binary()},
-          rules :: [ {permission(), action(), emqx_topic:topic()} ]
-         }).
-
--record(authz_metrics, {
-        allow = 'client.authorize.allow',
-        deny = 'client.authorize.deny',
-        ignore = 'client.authorize.ignore'
-    }).
-
 -define(CMD_REPLACE, replace).
 -define(CMD_DELETE, delete).
 -define(CMD_PREPEND, prepend).
@@ -41,12 +18,6 @@
 -define(CMD_MOVE_BOTTOM, <<"bottom">>).
 -define(CMD_MOVE_BEFORE(Before), {<<"before">>, Before}).
 -define(CMD_MOVE_AFTER(After), {<<"after">>, After}).
-
--define(METRICS(Type), tl(tuple_to_list(#Type{}))).
--define(METRICS(Type, K), #Type{}#Type.K).
-
--define(AUTHZ_METRICS, ?METRICS(authz_metrics)).
--define(AUTHZ_METRICS(K), ?METRICS(authz_metrics, K)).
 
 -define(CONF_KEY_PATH, [authorization, sources]).
 

--- a/apps/emqx_authz/src/emqx_authz_app.erl
+++ b/apps/emqx_authz/src/emqx_authz_app.erl
@@ -23,12 +23,10 @@
 
 -behaviour(application).
 
--include("emqx_authz.hrl").
-
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-    ok = mria_rlog:wait_for_shards([?ACL_SHARDED], infinity),
+    ok = emqx_authz_mnesia:init_tables(),
     {ok, Sup} = emqx_authz_sup:start_link(),
     ok = emqx_authz:init(),
     {ok, Sup}.
@@ -36,5 +34,3 @@ start(_StartType, _StartArgs) ->
 stop(_State) ->
     ok = emqx_authz:deinit(),
     ok.
-
-%% internal functions

--- a/apps/emqx_authz/src/emqx_authz_http.erl
+++ b/apps/emqx_authz/src/emqx_authz_http.erl
@@ -41,7 +41,7 @@ description() ->
     "AuthZ with http".
 
 init(#{url := Url} = Source) ->
-    NSource= maps:put(base_url, maps:remove(query, Url), Source),
+    NSource = maps:put(base_url, maps:remove(query, Url), Source),
     case emqx_authz_utils:create_resource(emqx_connector_http, NSource) of
         {error, Reason} -> error({load_config_error, Reason});
         {ok, Id} -> Source#{annotations => #{id => Id}}

--- a/apps/emqx_authz/src/emqx_authz_mnesia.erl
+++ b/apps/emqx_authz/src/emqx_authz_mnesia.erl
@@ -16,19 +16,51 @@
 
 -module(emqx_authz_mnesia).
 
--include("emqx_authz.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
 -include_lib("emqx/include/logger.hrl").
+
+-define(ACL_SHARDED, emqx_acl_sharded).
+
+-define(ACL_TABLE, emqx_acl).
+
+%% To save some space, use an integer for label, 0 for 'all', {1, Username} and {2, ClientId}.
+-define(ACL_TABLE_ALL, 0).
+-define(ACL_TABLE_USERNAME, 1).
+-define(ACL_TABLE_CLIENTID, 2).
+
+-type(username() :: {username, binary()}).
+-type(clientid() :: {clientid, binary()}).
+-type(who() :: username() | clientid() | all).
+
+-type(rule() :: {emqx_authz_rule:permission(), emqx_authz_rule:action(), emqx_topic:topic()}).
+-type(rules() :: [rule()]).
+
+-record(emqx_acl, {
+          who :: ?ACL_TABLE_ALL | {?ACL_TABLE_USERNAME, binary()} | {?ACL_TABLE_CLIENTID, binary()},
+          rules :: rules()
+         }).
 
 -behaviour(emqx_authz).
 
 %% AuthZ Callbacks
--export([ mnesia/1
-        , description/0
+-export([ description/0
         , init/1
         , destroy/1
         , dry_run/1
         , authorize/4
+        ]).
+
+%% Management API
+-export([ mnesia/1
+        , init_tables/0
+        , store_rules/2
+        , purge_rules/0
+        , get_rules/1
+        , delete_rules/1
+        , list_clientid_rules/0
+        , list_username_rules/0
+        , record_count/0
         ]).
 
 -ifdef(TEST).
@@ -46,6 +78,10 @@ mnesia(boot) ->
             {storage, disc_copies},
             {attributes, record_info(fields, ?ACL_TABLE)},
             {storage_properties, [{ets, [{read_concurrency, true}]}]}]).
+
+%%--------------------------------------------------------------------
+%% emqx_authz callbacks
+%%--------------------------------------------------------------------
 
 description() ->
     "AuthZ with Mnesia".
@@ -73,6 +109,78 @@ authorize(#{username := Username,
                 [#emqx_acl{rules = Rules2}] when is_list(Rules2) -> Rules2
             end,
     do_authorize(Client, PubSub, Topic, Rules).
+
+%%--------------------------------------------------------------------
+%% Management API
+%%--------------------------------------------------------------------
+
+init_tables() ->
+    ok = mria_rlog:wait_for_shards([?ACL_SHARDED], infinity).
+
+-spec(store_rules(who(), rules()) -> ok).
+store_rules({username, Username}, Rules) ->
+    Record = #emqx_acl{who = {?ACL_TABLE_USERNAME, Username}, rules = Rules},
+    mria:dirty_write(Record);
+store_rules({clientid, Clientid}, Rules) ->
+    Record = #emqx_acl{who = {?ACL_TABLE_CLIENTID, Clientid}, rules = Rules},
+    mria:dirty_write(Record);
+store_rules(all, Rules) ->
+    Record = #emqx_acl{who = ?ACL_TABLE_ALL, rules = Rules},
+    mria:dirty_write(Record).
+
+-spec(purge_rules() -> ok).
+purge_rules() ->
+    ok = lists:foreach(
+           fun(Key) ->
+                   ok = mria:dirty_delete(?ACL_TABLE, Key)
+           end,
+           mnesia:dirty_all_keys(?ACL_TABLE)).
+
+-spec(get_rules(who()) -> {ok, rules()} | not_found).
+get_rules({username, Username}) ->
+    do_get_rules({?ACL_TABLE_USERNAME, Username});
+get_rules({clientid, Clientid}) ->
+    do_get_rules({?ACL_TABLE_CLIENTID, Clientid});
+get_rules(all) ->
+    do_get_rules(?ACL_TABLE_ALL).
+
+-spec(delete_rules(who()) -> ok).
+delete_rules({username, Username}) ->
+    mria:dirty_delete(?ACL_TABLE, {?ACL_TABLE_USERNAME, Username});
+delete_rules({clientid, Clientid}) ->
+    mria:dirty_delete(?ACL_TABLE, {?ACL_TABLE_CLIENTID, Clientid});
+delete_rules(all) ->
+    mria:dirty_delete(?ACL_TABLE, ?ACL_TABLE_ALL).
+
+-spec(list_username_rules() -> {mria:table(), ets:match_spec()}).
+list_username_rules() ->
+    MatchSpec = ets:fun2ms(
+                  fun(#emqx_acl{who = {?ACL_TABLE_USERNAME, Username}, rules = Rules}) ->
+                          [{username, Username}, {rules, Rules}]
+                  end),
+    {?ACL_TABLE, MatchSpec}.
+
+-spec(list_clientid_rules() -> {mria:table(), ets:match_spec()}).
+list_clientid_rules() ->
+    MatchSpec = ets:fun2ms(
+                  fun(#emqx_acl{who = {?ACL_TABLE_CLIENTID, Clientid}, rules = Rules}) ->
+                          [{clientid, Clientid}, {rules, Rules}]
+                  end),
+    {?ACL_TABLE, MatchSpec}.
+
+-spec(record_count() -> non_neg_integer()).
+record_count() ->
+    mnesia:table_info(?ACL_TABLE, size).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+do_get_rules(Key) ->
+    case mnesia:dirty_read(?ACL_TABLE, Key) of
+        [#emqx_acl{rules = Rules}] -> {ok, Rules};
+        [] -> not_found
+    end.
 
 do_authorize(_Client, _PubSub, _Topic, []) -> nomatch;
 do_authorize(Client, PubSub, Topic, [ {Permission, Action, TopicFilter} | Tail]) ->

--- a/apps/emqx_authz/src/emqx_authz_rule.erl
+++ b/apps/emqx_authz/src/emqx_authz_rule.erl
@@ -43,9 +43,14 @@
                {'or',  [ipaddress() | username() | clientid()]} |
                all).
 
+-type(action() :: subscribe | publish | all).
+-type(permission() :: allow | deny).
+
 -type(rule() :: {permission(), who(), action(), list(emqx_types:topic())}).
 
--export_type([rule/0]).
+-export_type([ action/0
+             , permission/0
+             ]).
 
 compile({Permission, all})
   when ?ALLOW_DENY(Permission) -> {Permission, all, all, [compile_topic(<<"#">>)]};

--- a/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
@@ -217,7 +217,7 @@ t_api(_) ->
         request( delete
                , uri(["authorization", "sources", "built-in-database", "purge-all"])
                , []),
-    ?assertEqual([], mnesia:dirty_all_keys(?ACL_TABLE)),
+    ?assertEqual(0, emqx_authz_mnesia:record_count()),
     ok.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_authz/test/emqx_authz_mnesia_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mnesia_SUITE.erl
@@ -55,24 +55,25 @@ set_special_configs(_App) ->
     ok.
 
 init_per_testcase(t_authz, Config) ->
-    mria:dirty_write(#emqx_acl{who = {?ACL_TABLE_USERNAME, <<"test_username">>},
-                               rules = [{allow, publish, <<"test/", ?PH_S_USERNAME>>},
-                                        {allow, subscribe, <<"eq #">>}
-                                       ]
-                              }),
-    mria:dirty_write(#emqx_acl{who = {?ACL_TABLE_CLIENTID, <<"test_clientid">>},
-                               rules = [{allow, publish, <<"test/", ?PH_S_CLIENTID>>},
-                                        {deny, subscribe, <<"eq #">>}
-                                       ]
-                              }),
-    mria:dirty_write(#emqx_acl{who = ?ACL_TABLE_ALL,
-                               rules = [{deny, all, <<"#">>}]
-                              }),
+     emqx_authz_mnesia:store_rules(
+       {username, <<"test_username">>},
+       [{allow, publish, <<"test/", ?PH_S_USERNAME>>},
+        {allow, subscribe, <<"eq #">>}]),
+
+     emqx_authz_mnesia:store_rules(
+       {clientid, <<"test_clientid">>},
+       [{allow, publish, <<"test/", ?PH_S_CLIENTID>>},
+        {deny, subscribe, <<"eq #">>}]),
+
+     emqx_authz_mnesia:store_rules(
+       all,
+       [{deny, all, <<"#">>}]),
+
     Config;
 init_per_testcase(_, Config) -> Config.
 
 end_per_testcase(t_authz, Config) ->
-    [ mria:dirty_delete(?ACL_TABLE, K) || K <- mnesia:dirty_all_keys(?ACL_TABLE)],
+    ok = emqx_authz_mnesia:purge_rules(),
     Config;
 end_per_testcase(_, Config) -> Config.
 


### PR DESCRIPTION
* Eliminate type and record sharing through `emqx_authz.hrl`.
* Hide all mria/mnesia interactions inside mnesia authz backend.

