### PR TITLE
chore(update_appup): Improve `update_appup.escript`

### DIFF
--- a/scripts/update_appup.escript
+++ b/scripts/update_appup.escript
@@ -587,10 +587,5 @@ log(Msg) ->
 log(Msg, Args) ->
     io:format(standard_error, Msg, Args).
 
-ensure_string(Str) when is_binary(Str) ->
-    binary_to_list(Str);
-ensure_string(Str) when is_list(Str) ->
-    Str.
-
 otp_standard_apps() ->
     [ssl, mnesia, kernel, asn1, stdlib].

--- a/scripts/update_appup.escript
+++ b/scripts/update_appup.escript
@@ -316,7 +316,7 @@ contains_restart_application(Application, Actions) ->
 find_application_stop_instruction(Application, Actions) ->
     {Before, After0} =
         lists:splitwith(
-          fun({apply, {application, stop, [Application]}}) ->
+          fun({apply, {application, stop, [App]}}) when App =:= Application ->
                   false;
              (_) ->
                   true
@@ -345,7 +345,7 @@ ensure_version(Version, OldInstructions) ->
     case contains_version(Version, OldVersions) of
         false ->
             [{Version, []} | OldInstructions];
-        _ ->
+        true ->
             OldInstructions
     end.
 
@@ -358,10 +358,8 @@ contains_version(Needle, Haystack) when is_list(Needle) ->
                   nomatch ->
                       false
               end;
-         (Needle) ->
-              true;
-         (_) ->
-              false
+         (Vsn) ->
+              Vsn =:= Needle
       end,
       Haystack).
 

--- a/scripts/update_appup.escript
+++ b/scripts/update_appup.escript
@@ -315,11 +315,11 @@ merge_update_actions(App, Changes, Vsns) ->
     lists:map(fun(Ret = {<<".*">>, _}) ->
                       Ret;
                  ({Vsn, Actions}) ->
-                      {Vsn, do_merge_update_actions(App, Vsn, Changes, Actions)}
+                      {Vsn, do_merge_update_actions(App, Changes, Actions)}
               end,
               Vsns).
 
-do_merge_update_actions(App, Vsn, {New0, Changed0, Deleted0}, OldActions) ->
+do_merge_update_actions(App, {New0, Changed0, Deleted0}, OldActions) ->
     AppSpecific = app_specific_actions(App) -- OldActions,
     AlreadyHandled = lists:flatten(lists:map(fun process_old_action/1, OldActions)),
     New = New0 -- AlreadyHandled,


### PR DESCRIPTION
It is suggested to the review to read this PR by commit.

#### Make the script regex-aware

This change makes the `update_appup.escript` check whether the new
version of an application (the _current_ one) is already contained in
entries in the _new_ .appup file for that application if such .appup
file contains regexes.

NOTE: this does not cover the case in which we calculate the
difference between _old_ and _new_ appup entries, and those consist of
regexes.  In such case, we would need to check if one regex is
"contained" in the other, which is not currently supported by this
patch.

#### Do not use `load_module` instructions if `restart_application` is present

Since the appup instruction `restart_application` already loads all
modules of a given application, there is no need to introduce those
instructions if a restart is already present.

#### Do not force `.appup.src` render if contents are the same

To avoid losing comments and/or manual indentation in appup files that
are already up to date, we now check whether the contents have the
exact same terms as those we are about to write to an existint .appup
file.

#### Insert `load_module`s after `application:stop`, if present

If there is already any `application:stop(Application)` call in the
appup instructions, we prefer to add `load_module` instructions after
it, so we can be sure that the load is replaced safely.

#### Add expected versions check

For apps inside emqx umbrella, we try to bump only the patch part of
their version numbers, and use only 3-part version
numbers (`Major.Minor.Patch`).  With those assumptions, we may infer
all versions that need to be covered in a given upgrade, and check if
those are covered in regexes.