### PR TITLE
fix(boot_script): LD_LIBRARY_PATH: unbound variable

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -204,7 +204,10 @@ fi
 if ! check_erlang_start >/dev/null 2>&1; then
     BUILT_ON="$(head -1 "${REL_DIR}/BUILT_ON")"
     ## failed to start, might be due to missing libs, try to be portable
-    export LD_LIBRARY_PATH="$DYNLIBS_DIR:$LD_LIBRARY_PATH"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-$DYNLIBS_DIR}"
+    if [ "$LD_LIBRARY_PATH" != "$DYNLIBS_DIR" ]; then
+        export LD_LIBRARY_PATH="$DYNLIBS_DIR:$LD_LIBRARY_PATH"
+    fi
     if ! check_erlang_start; then
         ## it's hopeless
         echoerr "FATAL: Unable to start Erlang."

--- a/bin/emqx
+++ b/bin/emqx
@@ -431,6 +431,26 @@ wait_for() {
     done
 }
 
+wait_until_return_val() {
+    local RESULT
+    local WAIT_TIME
+    local CMD
+    RESULT="$1"
+    WAIT_TIME="$2"
+    shift 2
+    CMD="$*"
+    while true; do
+        if [ "$($CMD 2>/dev/null)" = "$RESULT" ]; then
+            return 0
+        fi
+        if [ "$WAIT_TIME" -le 0 ]; then
+            return 1
+        fi
+        WAIT_TIME=$((WAIT_TIME - 1))
+        sleep 1
+    done
+}
+
 latest_vm_args() {
     local hint_var_name="$1"
     local vm_args_file
@@ -556,7 +576,8 @@ case "${COMMAND}" in
                           "$(relx_start_command)"
 
         WAIT_TIME=${WAIT_FOR_ERLANG:-15}
-        if wait_for "$WAIT_TIME" 'relx_nodetool' 'ping'; then
+        if wait_until_return_val "true" "$WAIT_TIME" 'relx_nodetool' \
+                'eval' 'emqx:is_running()'; then
             echo "$EMQX_DESCRIPTION $REL_VSN is started successfully!"
             exit 0
         else


### PR DESCRIPTION
This PR include fixes for following 2 issues:

**1. Starting emqx fails with `unbound variable` error:**
```
[root@xmeter-controler emqx]# ./bin/emqx start
./bin/emqx: line 207: LD_LIBRARY_PATH: unbound variable
```
The emqx is installed from a zip ball, and openssl-1.1.1 is not installed on the node.

Only emqx-5.0 has this issue, because we set the `-u` option (treat unset variables as errors) at the beginning of the boot script `./bin/emqx`. But in previous versions, `-u` is not set.

**2. Starting emqx fails but it shows `EMQ X Community Edition 5.0-beta.2-7faf2512 is started successfully!` (After I fixed the above problem)**
```
[root@xmeter-controler emqx]# ./bin/emqx start
EMQ X Community Edition 5.0-beta.2-7faf2512 is started successfully!

[root@xmeter-controler emqx]# ./bin/emqx attach
WARNING: There seem to be missing dynamic libs from the OS. Using libs from /root/emqx/emqx/emqx/dynlibs
Node 'emqx@127.0.0.1' not responding to pings.
ERROR: node_is_not_running!

[root@xmeter-controler emqx]# ./bin/emqx console
WARNING: There seem to be missing dynamic libs from the OS. Using libs from /root/emqx/emqx/emqx/dynlibs
log.console_handler.enable = EMQX_LOG__CONSOLE_HANDLER__ENABLE = true
Erlang/OTP 24 [erts-12.1.5] [emqx] [64-bit] [smp:8:8] [ds:8:8:8] [async-threads:4]

{"Kernel pid terminated",application_controller,"{application_start_failure,kernel,{{shutdown,{failed_to_start_child,kernel_safe_sup,{on_load_function_failed,quicer_nif}}},{kernel,start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,kernel,{{shutdown,{failed_to_start_child,kernel_safe_sup,{on_load_function_failed,quicer_nif}}},{kernel,start,[normal,[]]}}})

Crash dump is being written to: log/erl_crash.dump...done
```