### PR TITLE
fix(system_monitor): Fix warning spam

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -62,7 +62,7 @@
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.4.3"}}}
     , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.4"}}}
     , {observer_cli, "1.7.1"} % NOTE: depends on recon 2.5.x
-    , {system_monitor, {git, "https://github.com/klarna-incubator/system_monitor", {tag, "2.2.0"}}}
+    , {system_monitor, {git, "https://github.com/k32/system_monitor", {tag, "2.2.1"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.16.0"}}}
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.22.0"}}}


### PR DESCRIPTION
Diff: https://github.com/k32/system_monitor/commit/3b4b381bf9503695cd764ecf22067ac6542cee89
EMQX is expexted to have millions of processes, so this warning makes little sense. Also removed the other warning from the list, we can add it back if needed.