### PR TITLE
fix(bin_emqx): remove `vm_args` backup in `install`

### DIFF
--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -304,7 +304,7 @@ permafy(TargetNode, RelName, Vsn) ->
                   make_permanent, [Vsn], ?TIMEOUT),
     ?INFO("Made release permanent: ~p", [Vsn]),
     %% upgrade/downgrade the scripts by replacing them
-    Scripts = [RelNameStr, RelNameStr++"_ctl", "cuttlefish", "nodetool",
+    Scripts = [RelNameStr, RelNameStr ++ "_ctl", "nodetool",
                "install_upgrade.escript"],
     [{ok, _} = file:copy(filename:join(["bin", File++"-"++Vsn]),
                          filename:join(["bin", File]))

--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -248,10 +248,6 @@ parse_version(V) when is_list(V) ->
     hd(string:tokens(V,"/")).
 
 check_and_install(TargetNode, Vsn) ->
-    %% Backup the vm.args. VM args should be unchanged during hot upgrade
-    %% but we still backup it here
-    {ok, [[CurrVmArgs]]} = rpc:call(TargetNode, init, get_argument, [vm_args], ?TIMEOUT),
-    {ok, _} = file:copy(CurrVmArgs, filename:join(["releases", Vsn, "vm.args"])),
     %% Backup the sys.config, this will be used when we check and install release
     %% NOTE: We cannot backup the old sys.config directly, because the
     %% configs for plugins are only in app-envs, not in the old sys.config


### PR DESCRIPTION
The `install_upgrade.escript` depended on being able to retrieve the
`vm_args` argument from `init`, but that options has been removed
recently.  Since this backup was unused, we also remove it here.

Also, the `cuttlefish` script reference is removed, since it is no longer 
present in the release.

