### PR TITLE
fix(broker): Fix MQTT message ordering in the cluster

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -16,7 +16,7 @@
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.0"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.11.2"}}}
-    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
+    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.0"}}}
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.22.0"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}

--- a/apps/emqx/src/emqx_rpc.erl
+++ b/apps/emqx/src/emqx_rpc.erl
@@ -30,27 +30,27 @@
           , rpc_nodes/1
           ]}).
 
--define(RPC, gen_rpc).
-
 -define(DefaultClientNum, 1).
 
 call(Node, Mod, Fun, Args) ->
-    filter_result(?RPC:call(rpc_node(Node), Mod, Fun, Args)).
+    filter_result(gen_rpc:call(rpc_node(Node), Mod, Fun, Args)).
 
 call(Key, Node, Mod, Fun, Args) ->
-    filter_result(?RPC:call(rpc_node({Key, Node}), Mod, Fun, Args)).
+    filter_result(gen_rpc:call(rpc_node({Key, Node}), Mod, Fun, Args)).
 
 multicall(Nodes, Mod, Fun, Args) ->
-    filter_result(?RPC:multicall(rpc_nodes(Nodes), Mod, Fun, Args)).
+    filter_result(gen_rpc:multicall(rpc_nodes(Nodes), Mod, Fun, Args)).
 
 multicall(Key, Nodes, Mod, Fun, Args) ->
-    filter_result(?RPC:multicall(rpc_nodes([{Key, Node} || Node <- Nodes]), Mod, Fun, Args)).
+    filter_result(gen_rpc:multicall(rpc_nodes([{Key, Node} || Node <- Nodes]), Mod, Fun, Args)).
 
 cast(Node, Mod, Fun, Args) ->
-    filter_result(?RPC:cast(rpc_node(Node), Mod, Fun, Args)).
+    %% Note: using a non-ordered cast here, since the generated key is
+    %% random anyway:
+    filter_result(gen_rpc:cast(rpc_node(Node), Mod, Fun, Args)).
 
 cast(Key, Node, Mod, Fun, Args) ->
-    filter_result(?RPC:cast(rpc_node({Key, Node}), Mod, Fun, Args)).
+    filter_result(gen_rpc:ordered_cast(rpc_node({Key, Node}), Mod, Fun, Args)).
 
 rpc_node(Node) when is_atom(Node) ->
     {Node, rand:uniform(max_client_num())};

--- a/rebar.config
+++ b/rebar.config
@@ -54,7 +54,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.0"}}}
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.1.5"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.11.2"}}}
-    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
+    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.0"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.7"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.1"}}}
     , {replayq, "0.3.3"}


### PR DESCRIPTION
Fix message ordering in the clustered setup with `async' RPC mode.
It was broken due to expected behavior of `gen_rpc' library `cast',
that executed the function in a temporary worker process.

