### PR TITLE
fix(config): add missing enum constructors for `shared_subscription_strategy`

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -828,7 +828,7 @@ fields("broker") ->
            })
       }
     , {"shared_subscription_strategy",
-       sc(hoconsc:enum([random, round_robin]),
+       sc(hoconsc:enum([random, round_robin, sticky, hash_topic, hash_clientid]),
           #{ default => round_robin
            })
       }


### PR DESCRIPTION
Currently, there's [code](https://github.com/emqx/emqx/blob/048afa6d2d693f6c53e8103fa132362c5915e641/apps/emqx/src/emqx_shared_sub.erl#L270-L279) and tests that expect the possibility of
values `sticky`, `hash_topic` and `hash_clientid` in the
`node.shared_subscritpion_strategy` configuration, but the schema enum
does not contain those constructors.

There's also a `hash` constructor expected, but apparently it's just for backwards compatibility (same as `hash_clientid`), so maybe we can skip it in 5.0