### PR TITLE
build: ci tests.sh test specific package

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -318,13 +318,11 @@ jobs:
         SYSTEM: ${{ matrix.os }}
       working-directory: source
       run: |
-        docker run -i --rm \
-        -v $(pwd):/emqx \
-        --workdir /emqx \
-        --platform linux/$ARCH \
-        ghcr.io/emqx/emqx-builder/4.4-4:$OTP-$SYSTEM \
-        bash -euc "make ${PROFILE}-${PACKAGE} || cat rebar3.crashdump; \
-                   EMQX_NAME=$PROFILE && .ci/build_packages/tests.sh"
+        ./scripts/buildx.sh \
+          --profile "${PROFILE}" \
+          --pkgtype "${PACKAGE}" \
+          --arch "${ARCH}" \
+          --builder "ghcr.io/emqx/emqx-builder/4.4-4:${OTP}-${SYSTEM}"
     - name: create sha256
       working-directory: source
       env:

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -52,8 +52,11 @@ jobs:
         path: ./rebar3.crashdump
     - name: packages test
       run: |
-        export CODE_PATH=$GITHUB_WORKSPACE
-        .ci/build_packages/tests.sh
+        PKG_VSN="$(./pkg-vsn.sh)"
+        PKG_NAME="${EMQX_NAME}-${PKG_VSN}-otp${{ matrix.erl_otp }}-${{ matrix.os  }}-amd64"
+        export CODE_PATH="$GITHUB_WORKSPACE"
+        .ci/build_packages/tests.sh "$PKG_NAME" zip
+        .ci/build_packages/tests.sh "$PKG_NAME" pkg
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.os }}


### PR DESCRIPTION
Two changes

1. The package test script tests.sh is refactored to accept arguments to know which exact package to test
  instead of finding ALL packages in `_packages/$EMQX_NAME` directory,
  because when testing locally, it's very much the case that the _packages directory is not clean
1. `scripts/buildx.sh` was added in previous PR in order to make it easier to test cross-platform builds elsewhere (not just in github CI). This PR is to make use of this script in CI too

