### PR TITLE
ci(stale): avoid spending operations on pull requests

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -27,5 +27,7 @@ jobs:
             This issue has been automatically marked as stale because it has not had
             recent activity. It will be closed if no further activity occurs. Thank you
             for your contributions.
+          # we don't want stalebot to analyze pull requests
+          only-pr-labels: "ZZZDisabledZZZ"
 
 ...

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -29,5 +29,6 @@ jobs:
             for your contributions.
           # we don't want stalebot to analyze pull requests
           only-pr-labels: "ZZZDisabledZZZ"
+          operations-per-run: 80
 
 ...


### PR DESCRIPTION
We are interested in using stale actions only for issues, and
currently there's no clear/clean way of making it not enumerate pull
requests.  As a workaround, we attempt to minimize the number of
operations spent on pull requests by making it run only on pull
requests which have an inexistent tag, thus skipping all PRs.

