### PR TITLE
build: remove 'compile' step before 'release'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ coveralls: $(REBAR)
 
 .PHONY: $(REL_PROFILES)
 $(REL_PROFILES:%=%): $(REBAR) get-dashboard conf-segs
-	@$(REBAR) as $(@) do compile,release
+	@$(REBAR) as $(@) do release
 
 ## Not calling rebar3 clean because
 ## 1. rebar3 clean relies on rebar3, meaning it reads config, fetches dependencies etc.


### PR DESCRIPTION
'compile' is implict dependent step for 'release'

