### PR TITLE
fix: rm unknown call (`ct:pal`)

### DIFF
--- a/apps/emqx_exhook/src/emqx_exhook_mgr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mgr.erl
@@ -162,9 +162,7 @@ pre_config_update(_, {enable, Name, Enable}, OldConf) ->
     case replace_conf(Name,
                       fun(Conf) -> Conf#{<<"enable">> => Enable} end, OldConf) of
         not_found -> {error, not_found};
-        NewConf ->
-            ct:pal(">>>> enable Name:~p Enable:~p, New:~p~n", [Name, Enable, NewConf]),
-            {ok, NewConf}
+        NewConf -> {ok, NewConf}
     end.
 
 post_config_update(_KeyPath, UpdateReq, NewConf, _OldConf, _AppEnvs) ->


### PR DESCRIPTION
Warning during release build:

```
===> Assembling release emqx-5.0.0-beta.2-f68d574a...
===> There are missing function calls in the release.
===> Make sure all applications needed at runtime are included in the release.
===> emqx_exhook_mgr:pre_config_update/3 calls undefined function ct:pal/2
```