### PR TITLE
fix(ci): fix shellcheck file pattern

### DIFF
--- a/.ci/docker-compose-file/scripts/run-emqx.sh
+++ b/.ci/docker-compose-file/scripts/run-emqx.sh
@@ -39,6 +39,7 @@ is_cluster_up() {
     is_node_listening node2.emqx.io
 }
 
+# shellcheck disable=SC2086
 docker-compose \
   -f .ci/docker-compose-file/docker-compose-emqx-cluster.yaml \
   $CLUSTER_OVERRIDES \

--- a/bin/emqx
+++ b/bin/emqx
@@ -10,7 +10,7 @@ if [ "$DEBUG" -eq 1 ]; then
 fi
 
 ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
-# shellcheck disable=SC1090
+# shellcheck disable=SC1090,SC1091
 . "$ROOT_DIR"/releases/emqx_vars
 
 # defined in emqx_vars

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -12,7 +12,7 @@ RELEASE="$(grep -E "define.+EMQX_RELEASE" apps/emqx/include/emqx_release.hrl | c
 git_exact_vsn() {
     local tag
     tag="$(git describe --tags --match "[e|v]*" --exact 2>/dev/null)"
-    echo "$tag" | sed 's/^[v|e]//g'
+    echo "${tag//^[v|e]/}"
 }
 
 GIT_EXACT_VSN="$(git_exact_vsn)"

--- a/scripts/find-props.sh
+++ b/scripts/find-props.sh
@@ -13,4 +13,5 @@ if [ "$1" != "emqx" ]; then
     BASEDIR="$1"
 fi
 
-find "${BASEDIR}/test/props" -name "prop_*.erl" 2>/dev/null | xargs -I{} basename {} .erl | xargs | tr ' ' ','
+find "${BASEDIR}/test/props" -name "prop_*.erl" -print0 2>/dev/null | \
+  xargs -0 -I{} basename {} .erl | xargs | tr ' ' ','

--- a/scripts/find-suites.sh
+++ b/scripts/find-suites.sh
@@ -9,4 +9,4 @@ set -euo pipefail
 cd -P -- "$(dirname -- "$0")/.."
 
 TESTDIR="$1/test"
-find "${TESTDIR}" -name "*_SUITE.erl" 2>/dev/null | xargs | tr ' ' ','
+find "${TESTDIR}" -name "*_SUITE.erl" -print0 2>/dev/null | xargs -0 | tr ' ' ','

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -6,7 +6,7 @@ target_files=()
 while IFS='' read -r line;
 do
   target_files+=("$line");
-done < <(git grep -r -l "^#!/bin/" .)
+done < <(git grep -r -l '^#!/\(bin/\|usr/bin/env bash\)' .)
 return_code=0
 for i in "${target_files[@]}"; do
   echo checking "$i" ...


### PR DESCRIPTION
Since we started to use the portable shebang style for our scripts, we
need to update the pattern used to find scripts for Shellcheck to
check.

