### PR TITLE
chore: fix copyright update script to include more files

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 EMQ X, highly scalable, highly available distributed MQTT messaging platform for IoT.
-Copyright (c) 2017-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+Copyright (c) 2017-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 
 This product contains code developed at EMQ Technologies Co., Ltd.
 Visit https://www.emqx.come to learn more.

--- a/apps/emqx/NOTICE
+++ b/apps/emqx/NOTICE
@@ -1,5 +1,5 @@
 EMQ X, highly scalable, highly available distributed MQTT messaging platform for IoT.
-Copyright (c) 2017-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+Copyright (c) 2017-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 
 This product contains code developed at EMQ Technologies Co., Ltd.
 Visit https://www.emqx.come to learn more.

--- a/apps/emqx_exhook/priv/protos/exhook.proto
+++ b/apps/emqx_exhook/priv/protos/exhook.proto
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright (c) 2020-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+// Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/emqx_gateway/src/exproto/protos/exproto.proto
+++ b/apps/emqx_gateway/src/exproto/protos/exproto.proto
@@ -1,5 +1,5 @@
 //------------------------------------------------------------------------------
-// Copyright (c) 2020-2021 EMQ Technologies Co., Ltd. All Rights Reserved.
+// Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/apps/emqx_rule_engine/README.md
+++ b/apps/emqx_rule_engine/README.md
@@ -36,15 +36,3 @@ iot rule "Rule Name"
 ```
 select id, time, temperature as t from "topic/a" where t > 50;
 ```
-
-## License
-
-Copyright (c) 2019-2021 [EMQ Technologies Co., Ltd](https://emqx.io). All Rights Reserved.
-
-Licensed under the Apache License, Version 2.0 (the "License");you may not use this file except in compliance with the License.You may obtain a copy of the License at
-
-[http://www.apache.org/licenses/LICENSE-2.0](http://www.apache.org/licenses/LICENSE-2.0)
-
-Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and limitations under the License.
-

--- a/scripts/update-copyright-years.sh
+++ b/scripts/update-copyright-years.sh
@@ -8,29 +8,32 @@ THIS_YEAR="$(date +'%Y')"
 
 fix_copyright_year() {
     local file="$1"
-    if [[ $file != *.erl ]] && \
-       [[ $file != *.ex ]] && \
-       [[ $file != *.hrl ]] && \
-       [[ $file != *.proto ]]; then
-        ## Ignore other file
-        return 0
-    fi
     local copyright_line
     copyright_line="$(head -2 "$file" | grep -E "Copyright\s\(c\)\s.+\sEMQ" || true)"
-    local begin_year
-    begin_year="$(echo "$copyright_line" | sed -E 's#%% Copyright \(c\) (20..).*#\1#g')"
-    if [ "$begin_year" = "$THIS_YEAR" ]; then
-        ## new file added this year
-        return 0
-    fi
     if [ -z "$copyright_line" ]; then
         ## No Copyright info, it is not intended to add one from this script
         echo "Ignored $file"
         return 0
     fi
-    sed -E "s#(%% Copyright \(c\) 20..)(-20.. | )(.*)#\1-$THIS_YEAR \3#g" -i "$file"
+    local begin_year
+    begin_year="$(echo "$copyright_line" | sed -E 's#(.*Copyright \(c\)) (20..).*#\2#g')"
+    if [ "$begin_year" = "$THIS_YEAR" ]; then
+        ## new file added this year
+        return 0
+    fi
+    sed -E "s#(.*Copyright \(c\) 20..)(-20.. | )(.*)#\1-$THIS_YEAR \3#g" -i "$file"
 }
 
 while read -r file; do
+    if [[ $file != *.erl ]] && \
+       [[ $file != *.ex ]] && \
+       [[ $file != *.hrl ]] && \
+       [[ $file != *.proto ]]; then
+        ## Ignore other file
+        continue
+    fi
     fix_copyright_year "$file"
 done < <(git ls-files)
+
+fix_copyright_year apps/emqx/NOTICE
+fix_copyright_year NOTICE


### PR DESCRIPTION
* Fixed the match pattern from `"%% Copyright.."` to `".*Copyright..."` to include proto files and NOTICE
* Refactored the fix function to accept any file as input so we can fix NOTICE 
