### PR TITLE
fix(elixir): put Patch in version and add missing deps

### DIFF
--- a/.github/workflows/elixir_release.yml
+++ b/.github/workflows/elixir_release.yml
@@ -7,6 +7,7 @@ concurrency:
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -24,4 +24,8 @@
 
 %% NOTE: This version number should be manually bumped for each release
 
--define(EMQX_RELEASE, "5.0-beta.3").
+%% NOTE: This version number should have 3 numeric parts
+%% (Major.Minor.Patch), and extra info can be added after a final
+%% hyphen.
+
+-define(EMQX_RELEASE, "5.0.0-beta.3").

--- a/apps/emqx_authn/rebar.config
+++ b/apps/emqx_authn/rebar.config
@@ -1,4 +1,5 @@
 {deps, [ {emqx, {path, "../emqx"}}
+       , {emqx_connector, {path, "../emqx_connector"}}
        ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/apps/emqx_authz/rebar.config
+++ b/apps/emqx_authz/rebar.config
@@ -1,5 +1,7 @@
 {erl_opts, [debug_info, nowarn_unused_import]}.
-{deps, [{emqx, {path, "../emqx"}}]}.
+{deps, [ {emqx, {path, "../emqx"}}
+       , {emqx_connector, {path, "../emqx_connector"}}
+       ]}.
 
 {shell, [
   % {config, "config/sys.config"},

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -1,5 +1,6 @@
 {deps,
- [ %% FIXME: tag this as v3.1.3
+ [ {emqx, {path, "../emqx"}},
+   %% FIXME: tag this as v3.1.3
    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {ref, "9994c76adca40d91a2545102230ccce2423fd8a7"}}},
    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.22.2"}}},
    {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.9"}}}

--- a/apps/emqx_statsd/rebar.config
+++ b/apps/emqx_statsd/rebar.config
@@ -1,5 +1,7 @@
 {erl_opts, [debug_info]}.
-{deps, [{estatsd, {git, "https://github.com/emqx/estatsd", {tag, "0.1.0"}}}]}.
+{deps, [ {emqx, {path, "../emqx"}}
+       , {estatsd, {git, "https://github.com/emqx/estatsd", {tag, "0.1.0"}}}
+       ]}.
 
 {shell, [
   % {config, "config/sys.config"},


### PR DESCRIPTION
Elixir requires that we use version of the form `Major.Minor.Patch`.
Also, Mix requires dependecies to be declared in `rebar.config` so it
can include the header files correctly.
