### PR TITLE
chore: emqx stop prints ok after stop

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -632,6 +632,7 @@ case "${COMMAND}" in
             ps -p "$PID"
             exit 1
         fi
+        echo "ok"
         logger -t "${REL_NAME}[${PID}]" "STOP: OK"
         ;;
 


### PR DESCRIPTION
This is to make it behave the same as older versions

