### PR TITLE
chore(test): rename mgmt_xxx_api_SUITE to mgmt_api_xxx_SUITE

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_alarms_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_alarms_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_alarms_api_SUITE).
+-module(emqx_mgmt_api_alarms_SUITE).
 
 
 -compile(export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_app_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_app_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_auth_api_SUITE).
+-module(emqx_mgmt_api_app_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_banned_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_banned_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_banned_api_SUITE).
+-module(emqx_mgmt_api_banned_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_clients_api_SUITE).
+-module(emqx_mgmt_api_clients_SUITE).
 -compile(export_all).
 -compile(nowarn_export_all).
 

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_listeners_api_SUITE).
+-module(emqx_mgmt_api_listeners_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_metrics_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_metrics_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_metrics_api_SUITE).
+-module(emqx_mgmt_api_metrics_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_stats_api_SUITE).
+-module(emqx_mgmt_api_nodes_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -30,14 +30,39 @@ init_per_suite(Config) ->
 end_per_suite(_) ->
     emqx_mgmt_api_test_util:end_suite().
 
-t_stats_api(_) ->
-    StatsPath = emqx_mgmt_api_test_util:api_path(["stats?aggregate=true"]),
-    SystemStats = emqx_mgmt:get_stats(),
+t_nodes_api(_) ->
+    NodesPath = emqx_mgmt_api_test_util:api_path(["nodes"]),
+    {ok, Nodes} = emqx_mgmt_api_test_util:request_api(get, NodesPath),
+    NodesResponse = emqx_json:decode(Nodes, [return_maps]),
+    LocalNodeInfo = hd(NodesResponse),
+    Node = binary_to_atom(maps:get(<<"node">>, LocalNodeInfo), utf8),
+    ?assertEqual(Node, node()),
+
+    NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
+    {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
+    NodeNameResponse =
+        binary_to_atom(maps:get(<<"node">>, emqx_json:decode(NodeInfo, [return_maps])), utf8),
+    ?assertEqual(node(), NodeNameResponse).
+
+t_node_stats_api() ->
+    StatsPath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_binary(node(), utf8), "stats"]),
+    SystemStats= emqx_mgmt:get_stats(),
     {ok, StatsResponse} = emqx_mgmt_api_test_util:request_api(get, StatsPath),
     Stats = emqx_json:decode(StatsResponse, [return_maps]),
-    ?assertEqual(erlang:length(maps:keys(SystemStats)), erlang:length(maps:keys(Stats))),
     Fun =
         fun(Key) ->
             ?assertEqual(maps:get(Key, SystemStats), maps:get(atom_to_binary(Key, utf8), Stats))
         end,
     lists:foreach(Fun, maps:keys(SystemStats)).
+
+t_node_metrics_api() ->
+    MetricsPath =
+        emqx_mgmt_api_test_util:api_path(["nodes", atom_to_binary(node(), utf8), "metrics"]),
+    SystemMetrics= emqx_mgmt:get_metrics(),
+    {ok, MetricsResponse} = emqx_mgmt_api_test_util:request_api(get, MetricsPath),
+    Metrics = emqx_json:decode(MetricsResponse, [return_maps]),
+    Fun =
+        fun(Key) ->
+            ?assertEqual(maps:get(Key, SystemMetrics), maps:get(atom_to_binary(Key, utf8), Metrics))
+        end,
+    lists:foreach(Fun, maps:keys(SystemMetrics)).

--- a/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_publish_api_SUITE).
+-module(emqx_mgmt_api_publish_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -78,4 +78,3 @@ receive_assert(Topic, Qos, Payload) ->
     after 5000 ->
         timeout
     end.
-

--- a/apps/emqx_management/test/emqx_mgmt_api_routes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_routes_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_routes_api_SUITE).
+-module(emqx_mgmt_api_routes_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_stats_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_stats_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_nodes_api_SUITE).
+-module(emqx_mgmt_api_stats_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -30,39 +30,14 @@ init_per_suite(Config) ->
 end_per_suite(_) ->
     emqx_mgmt_api_test_util:end_suite().
 
-t_nodes_api(_) ->
-    NodesPath = emqx_mgmt_api_test_util:api_path(["nodes"]),
-    {ok, Nodes} = emqx_mgmt_api_test_util:request_api(get, NodesPath),
-    NodesResponse = emqx_json:decode(Nodes, [return_maps]),
-    LocalNodeInfo = hd(NodesResponse),
-    Node = binary_to_atom(maps:get(<<"node">>, LocalNodeInfo), utf8),
-    ?assertEqual(Node, node()),
-
-    NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
-    {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
-    NodeNameResponse =
-        binary_to_atom(maps:get(<<"node">>, emqx_json:decode(NodeInfo, [return_maps])), utf8),
-    ?assertEqual(node(), NodeNameResponse).
-
-t_node_stats_api() ->
-    StatsPath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_binary(node(), utf8), "stats"]),
-    SystemStats= emqx_mgmt:get_stats(),
+t_stats_api(_) ->
+    StatsPath = emqx_mgmt_api_test_util:api_path(["stats?aggregate=true"]),
+    SystemStats = emqx_mgmt:get_stats(),
     {ok, StatsResponse} = emqx_mgmt_api_test_util:request_api(get, StatsPath),
     Stats = emqx_json:decode(StatsResponse, [return_maps]),
+    ?assertEqual(erlang:length(maps:keys(SystemStats)), erlang:length(maps:keys(Stats))),
     Fun =
         fun(Key) ->
             ?assertEqual(maps:get(Key, SystemStats), maps:get(atom_to_binary(Key, utf8), Stats))
         end,
     lists:foreach(Fun, maps:keys(SystemStats)).
-
-t_node_metrics_api() ->
-    MetricsPath =
-        emqx_mgmt_api_test_util:api_path(["nodes", atom_to_binary(node(), utf8), "metrics"]),
-    SystemMetrics= emqx_mgmt:get_metrics(),
-    {ok, MetricsResponse} = emqx_mgmt_api_test_util:request_api(get, MetricsPath),
-    Metrics = emqx_json:decode(MetricsResponse, [return_maps]),
-    Fun =
-        fun(Key) ->
-            ?assertEqual(maps:get(Key, SystemMetrics), maps:get(atom_to_binary(Key, utf8), Metrics))
-        end,
-    lists:foreach(Fun, maps:keys(SystemMetrics)).

--- a/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_subscription_api_SUITE).
+-module(emqx_mgmt_api_subscription_SUITE).
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_mgmt_trace_api_SUITE).
+-module(emqx_mgmt_api_trace_SUITE).
 
 %% API
 -compile(export_all).


### PR DESCRIPTION
In order to match the source file and SUITE file:
such as 
`emqx_mgmt_api_banned.erl`'s SUITE should be `emqx_mgmt_api_banned_SUITE.erl` instead of `emqx_mgmt_banned_api_SUITE.erl`