### PR TITLE
ci: exclude edge + rlog test

### DIFF
--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -44,7 +44,9 @@ jobs:
         cluster_db_backend:
           - mnesia
           - rlog
-
+        exclude:
+          - profile: emqx-edge
+            cluster_db_backend: rlog
     steps:
     - uses: actions/download-artifact@v2
       with:


### PR DESCRIPTION
Edge edition is running as single node.
