### PR TITLE
Improve authn/authz error log when query failed.

### DIFF
--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -77,15 +77,15 @@
 
 %% Only evaluate when necessary
 %% Always debug the trace events.
--define(TRACE(Event, Msg, Meta),
+-define(TRACE(Tag, Msg, Meta),
     begin
     case persistent_term:get(?TRACE_FILTER, undefined) of
         undefined -> ok;
         [] -> ok;
         List ->
-           emqx_trace:log(List, Event, Msg, Meta)
+           emqx_trace:log(List, Msg, Meta#{trace_tag => Tag})
     end,
-    ?SLOG(debug, (emqx_trace_formatter:format_meta(Meta))#{msg => Msg, trace_event => Event},
+    ?SLOG(debug, (emqx_trace_formatter:format_meta(Meta))#{msg => Msg, trace_tag => Tag},
         #{trace_filter => ignore})
     end).
 

--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -82,11 +82,10 @@
     case persistent_term:get(?TRACE_FILTER, undefined) of
         undefined -> ok;
         [] -> ok;
-        List ->
-           emqx_trace:log(List, Msg, Meta#{trace_tag => Tag})
+        List -> emqx_trace:log(List, Msg, Meta#{trace_tag => Tag})
     end,
-    ?SLOG(debug, (emqx_trace_formatter:format_meta(Meta))#{msg => Msg, trace_tag => Tag},
-        #{trace_filter => ignore})
+    ?SLOG(debug, (emqx_trace_formatter:format_meta(Meta))#{msg => Msg, tag => Tag},
+        #{is_trace => false})
     end).
 
 %% print to 'user' group leader

--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -83,7 +83,8 @@
         [] -> ok;
         List ->
            emqx_trace:log(List, Event, Msg, Meta)
-    end
+    end,
+    ?SLOG(debug, Meta#{msg => Msg})
     end).
 
 %% print to 'user' group leader

--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -76,6 +76,7 @@
 -define(TRACE_FILTER, emqx_trace_filter).
 
 %% Only evaluate when necessary
+%% Always debug the trace events.
 -define(TRACE(Event, Msg, Meta),
     begin
     case persistent_term:get(?TRACE_FILTER, undefined) of
@@ -84,7 +85,8 @@
         List ->
            emqx_trace:log(List, Event, Msg, Meta)
     end,
-    ?SLOG(debug, Meta#{msg => Msg})
+    ?SLOG(debug, (emqx_trace_formatter:format_meta(Meta))#{msg => Msg, trace_event => Event},
+        #{trace_filter => ignore})
     end).
 
 %% print to 'user' group leader

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -27,7 +27,7 @@
 -export([ publish/1
         , subscribe/3
         , unsubscribe/2
-        , log/4
+        , log/3
         ]).
 
 -export([ start_link/0
@@ -94,13 +94,13 @@ unsubscribe(<<"$SYS/", _/binary>>, _SubOpts) -> ignore;
 unsubscribe(Topic, SubOpts) ->
     ?TRACE("UNSUBSCRIBE", "unsubscribe", #{topic => Topic, sub_opts => SubOpts}).
 
-log(List, Event, Msg, Meta0) ->
+log(List, Msg, Meta0) ->
     Meta =
         case logger:get_process_metadata() of
             undefined -> Meta0;
             ProcMeta -> maps:merge(ProcMeta, Meta0)
         end,
-    Log = #{level => debug, trace_event => Event, meta => Meta, msg => Msg},
+    Log = #{level => debug, meta => Meta, msg => Msg},
     log_filter(List, Log).
 
 log_filter([], _Log) -> ok;

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -100,7 +100,7 @@ log(List, Event, Msg, Meta0) ->
             undefined -> Meta0;
             ProcMeta -> maps:merge(ProcMeta, Meta0)
         end,
-    Log = #{level => trace, event => Event, meta => Meta, msg => Msg},
+    Log = #{level => debug, trace_event => Event, meta => Meta, msg => Msg},
     log_filter(List, Log).
 
 log_filter([], _Log) -> ok;

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -120,10 +120,12 @@ running() ->
     lists:foldl(fun filter_traces/2, [], emqx_logger:get_log_handlers(started)).
 
 -spec filter_clientid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
+filter_clientid(#{level := debug, meta := #{trace_filter := _}}, _) -> stop;
 filter_clientid(#{meta := #{clientid := ClientId}} = Log, {ClientId, _Name}) -> Log;
 filter_clientid(_Log, _ExpectId) -> stop.
 
 -spec filter_topic(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
+filter_topic(#{level := debug, meta := #{trace_filter := _}}, _) -> stop;
 filter_topic(#{meta := #{topic := Topic}} = Log, {TopicFilter, _Name}) ->
     case emqx_topic:match(Topic, TopicFilter) of
         true -> Log;
@@ -132,6 +134,7 @@ filter_topic(#{meta := #{topic := Topic}} = Log, {TopicFilter, _Name}) ->
 filter_topic(_Log, _ExpectId) -> stop.
 
 -spec filter_ip_address(logger:log_event(), {string(), atom()}) -> logger:log_event() | stop.
+filter_ip_address(#{level := debug, meta := #{trace_filter := _}}, _) -> stop;
 filter_ip_address(#{meta := #{peername := Peername}} = Log, {IP, _Name}) ->
     case lists:prefix(IP, Peername) of
         true -> Log;

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -120,27 +120,27 @@ running() ->
     lists:foldl(fun filter_traces/2, [], emqx_logger:get_log_handlers(started)).
 
 -spec filter_clientid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
-filter_clientid(#{level := debug, meta := #{trace_filter := _}}, _) -> stop;
-filter_clientid(#{meta := #{clientid := ClientId}} = Log, {ClientId, _Name}) -> Log;
+filter_clientid(#{meta := Meta = #{clientid := ClientId}} = Log, {MatchId, _Name}) ->
+    filter_ret(ClientId =:= MatchId andalso is_trace(Meta), Log);
 filter_clientid(_Log, _ExpectId) -> stop.
 
 -spec filter_topic(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
-filter_topic(#{level := debug, meta := #{trace_filter := _}}, _) -> stop;
-filter_topic(#{meta := #{topic := Topic}} = Log, {TopicFilter, _Name}) ->
-    case emqx_topic:match(Topic, TopicFilter) of
-        true -> Log;
-        false -> stop
-    end;
+filter_topic(#{meta := Meta = #{topic := Topic}} = Log, {TopicFilter, _Name}) ->
+    filter_ret(is_trace(Meta) andalso emqx_topic:match(Topic, TopicFilter), Log);
 filter_topic(_Log, _ExpectId) -> stop.
 
 -spec filter_ip_address(logger:log_event(), {string(), atom()}) -> logger:log_event() | stop.
-filter_ip_address(#{level := debug, meta := #{trace_filter := _}}, _) -> stop;
-filter_ip_address(#{meta := #{peername := Peername}} = Log, {IP, _Name}) ->
-    case lists:prefix(IP, Peername) of
-        true -> Log;
-        false -> stop
-    end;
+filter_ip_address(#{meta := Meta = #{peername := Peername}} = Log, {IP, _Name}) ->
+    filter_ret(is_trace(Meta) andalso lists:prefix(IP, Peername), Log);
 filter_ip_address(_Log, _ExpectId) -> stop.
+
+-compile({inline, [is_trace/1, filter_ret/2]}).
+%% TRUE when is_trace is missing.
+is_trace(#{is_trace := false}) -> false;
+is_trace(_) -> true.
+
+filter_ret(true, Log) -> Log;
+filter_ret(false, _Log) -> stop.
 
 filters(#{type := clientid, filter := Filter, name := Name}) ->
     [{clientid, {fun ?MODULE:filter_clientid/2, {Filter, Name}}}];

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwks_connector.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwks_connector.erl
@@ -101,7 +101,7 @@ handle_info({http, {RequestID, Result}},
                                         endpoint => Endpoint,
                                         reason => Reason}),
                        State1;
-                   {_StatusLine, _Headers, Body} ->
+                   {StatusLine, Headers, Body} ->
                        try
                            JWKS = jose_jwk:from(emqx_json:decode(Body, [return_maps])),
                            {_, JWKs} = JWKS#jose_jwk.keys,
@@ -109,6 +109,8 @@ handle_info({http, {RequestID, Result}},
                        catch _:_ ->
                                  ?SLOG(warning, #{msg => "invalid_jwks_returned",
                                                   endpoint => Endpoint,
+                                                  status => StatusLine,
+                                                  headers => Headers,
                                                   body => Body}),
                                  State1
                        end

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -18,6 +18,7 @@
 
 -include("emqx_authn.hrl").
 -include_lib("typerefl/include/types.hrl").
+-include_lib("emqx/include/logger.hrl").
 
 -behaviour(hocon_schema).
 -behaviour(emqx_authentication).
@@ -272,7 +273,7 @@ verify(JWS, [JWK | More], VerifyClaims) ->
             verify(JWS, More, VerifyClaims)
     catch
         _:_Reason:_Stacktrace ->
-            %% TODO: Add log
+            ?TRACE("JWT", "authn_jwt_invalid_signature", #{jwk => JWK, jws => JWS}),
             {error, invalid_signature}
     end.
 

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -272,7 +272,7 @@ verify(JWS, [JWK | More], VerifyClaims) ->
         {false, _, _} ->
             verify(JWS, More, VerifyClaims)
     catch
-        _:_Reason:_Stacktrace ->
+        _:_Reason ->
             ?TRACE("JWT", "authn_jwt_invalid_signature", #{jwk => JWK, jws => JWS}),
             {error, invalid_signature}
     end.

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
@@ -143,6 +143,8 @@ authenticate(#{password := Password} = Credential,
         {error, Reason} ->
             ?SLOG(error, #{msg => "mongodb_query_failed",
                            resource => ResourceId,
+                           collection => Collection,
+                           selector => Selector2,
                            reason => Reason}),
             ignore;
         Doc ->
@@ -152,6 +154,8 @@ authenticate(#{password := Password} = Credential,
                 {error, {cannot_find_password_hash_field, PasswordHashField}} ->
                     ?SLOG(error, #{msg => "cannot_find_password_hash_field",
                                    resource => ResourceId,
+                                   collection => Collection,
+                                   selector => Selector2,
                                    password_hash_field => PasswordHashField}),
                     ignore;
                 {error, Reason} ->

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mysql.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mysql.erl
@@ -123,6 +123,9 @@ authenticate(#{password := Password} = Credential,
         {error, Reason} ->
             ?SLOG(error, #{msg => "mysql_query_failed",
                            resource => ResourceId,
+                           query => Query,
+                           params => Params,
+                           timeout => Timeout,
                            reason => Reason}),
             ignore
     end.

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_pgsql.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_pgsql.erl
@@ -119,6 +119,8 @@ authenticate(#{password := Password} = Credential,
         {error, Reason} ->
             ?SLOG(error, #{msg => "postgresql_query_failed",
                            resource => ResourceId,
+                           query => Query,
+                           params => Params,
                            reason => Reason}),
             ignore
     end.

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_pgsql.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_pgsql.erl
@@ -119,7 +119,6 @@ authenticate(#{password := Password} = Credential,
         {error, Reason} ->
             ?SLOG(error, #{msg => "postgresql_query_failed",
                            resource => ResourceId,
-                           query => Query,
                            params => Params,
                            reason => Reason}),
             ignore

--- a/apps/emqx_authz/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_authz/src/emqx_authz_mongodb.erl
@@ -67,6 +67,8 @@ authorize(Client, PubSub, Topic,
         {error, Reason} ->
             ?SLOG(error, #{msg => "query_mongo_error",
                            reason => Reason,
+                           collection => Collection,
+                           selector => RenderedSelector,
                            resource_id => ResourceID}),
             nomatch;
         [] -> nomatch;

--- a/apps/emqx_authz/src/emqx_authz_mysql.erl
+++ b/apps/emqx_authz/src/emqx_authz_mysql.erl
@@ -58,13 +58,16 @@ authorize(Client, PubSub, Topic,
                                query := {Query, Params}
                               }
              }) ->
-    case emqx_resource:query(ResourceID, {sql, Query, replvar(Params, Client)}) of
+    RenderParams = replvar(Params, Client),
+    case emqx_resource:query(ResourceID, {sql, Query, RenderParams}) of
         {ok, _Columns, []} -> nomatch;
         {ok, Columns, Rows} ->
             do_authorize(Client, PubSub, Topic, Columns, Rows);
         {error, Reason} ->
             ?SLOG(error, #{ msg => "query_mysql_error"
                           , reason => Reason
+                          , query => Query
+                          , params => RenderParams
                           , resource_id => ResourceID}),
             nomatch
     end.

--- a/apps/emqx_authz/src/emqx_authz_redis.erl
+++ b/apps/emqx_authz/src/emqx_authz_redis.erl
@@ -63,6 +63,7 @@ authorize(Client, PubSub, Topic,
         {error, Reason} ->
             ?SLOG(error, #{ msg => "query_redis_error"
                           , reason => Reason
+                          , cmd => NCMD
                           , resource_id => ResourceID}),
             nomatch
     end.


### PR DESCRIPTION
1. Add more detail log when authn/authz query error(locate the problem faster).
2. Don't log error when authn_redis query result is empty.
3. Always debug when tracing.