### PR TITLE
ci: skip dialyzer race_condition checks

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -17,7 +17,7 @@
               deprecated_function_calls,warnings_as_errors,deprecated_functions]}.
 
 {dialyzer, [
-    {warnings, [unmatched_returns, error_handling, race_conditions]},
+    {warnings, [unmatched_returns, error_handling]},
     {plt_location, "."},
     {plt_prefix, "emqx_dialyzer"},
     {plt_apps, all_apps},


### PR DESCRIPTION
backported from 5.0
race_condition check is very RAM demanding

