### PR TITLE
refactor: build tar gz instead of zip

### DIFF
--- a/.ci/fvt_tests/relup.lux
+++ b/.ci/fvt_tests/relup.lux
@@ -22,7 +22,7 @@
 
 [shell emqx]
     !cd $PACKAGE_PATH
-    !unzip -q -o $PROFILE-ubuntu20.04-$(echo $old_vsn | sed  -r 's/[v|e]//g')-amd64.zip
+    !tar -zxf ${PROFILE}-$(echo $old_vsn | sed  -r 's/[v|e]//g')-*-ubuntu20.04-amd64.tar.gz
     ?SH-PROMPT
 
     !cd emqx
@@ -82,7 +82,7 @@
     !echo "" > log/emqx.log.1
     ?SH-PROMPT
 
-    !cp -f ../$PROFILE-ubuntu20.04-$VSN-amd64.zip releases/
+    !cp -f ../$PROFILE-$VSN-*-ubuntu20.04-amd64.tar.gz releases/
 
     !./bin/emqx install $VSN
     ?Made release permanent: "$VSN"
@@ -107,7 +107,7 @@
     !echo "" > log/emqx.log.1
     ?SH-PROMPT
 
-    !cp -f ../$PROFILE-ubuntu20.04-$VSN-amd64.zip releases/
+    !cp -f ../$PROFILE-$VSN-*-ubuntu20.04-amd64.tar.gz releases/
 
     !./bin/emqx install $VSN
     ?Made release permanent: "$VSN"

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -85,11 +85,11 @@ jobs:
         $version = $( "${{ github.ref }}" -replace "^(.*)/(.*)/" )
         if ($version -match "^v[0-9]+\.[0-9]+(\.[0-9]+)?") {
           $regex = "[0-9]+\.[0-9]+(-alpha|-beta|-rc)?\.[0-9]+"
-          $pkg_name = "${{ matrix.profile }}-$([regex]::matches($version, $regex).value)-otp${{ matrix.otp }}-windows-amd64.zip"
-          }
+          $pkg_name = "${{ matrix.profile }}-$([regex]::matches($version, $regex).value)-otp${{ matrix.otp }}-windows-amd64.tar.gz"
+        }
         else {
-          $pkg_name = "${{ matrix.profile }}-$($version -replace '/')-otp${{ matrix.otp }}-windows-amd64.zip"
-          }
+          $pkg_name = "${{ matrix.profile }}-$($version -replace '/')-otp${{ matrix.otp }}-windows-amd64.tar.gz"
+        }
         ## We do not build/release bcrypt and quic for windows package
         Remove-Item -Recurse -Force -Path _build/default/lib/bcrypt/
         Remove-Item -Recurse -Force -Path _build/default/lib/quicer/
@@ -192,12 +192,12 @@ jobs:
         make ensure-rebar3
         sudo cp rebar3 /usr/local/bin/rebar3
         rm -rf _build/${{ matrix.profile }}/lib
-        make ${{ matrix.profile }}-zip
+        make ${{ matrix.profile }}-tgz
     - name: test
       working-directory: source
       run: |
-        pkg_name=$(find _packages/${{ matrix.profile }} -mindepth 1 -maxdepth 1 -iname \*.zip)
-        unzip -q $pkg_name
+        pkg_name=$(find _packages/${{ matrix.profile }} -mindepth 1 -maxdepth 1 -iname \*.tar.gz)
+        tar -zxf $pkg_name
         # gsed -i '/emqx_telemetry/d' ./emqx/data/loaded_plugins
         ./emqx/bin/emqx start || cat emqx/log/erlang.log.1
         ready='no'
@@ -297,7 +297,7 @@ jobs:
       with:
         path: source/_build/default/lib/quicer/
         key: ${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
-    - name: downloads old emqx zip packages
+    - name: download old emqx tgz packages
       env:
         OTP_VSN: ${{ matrix.otp }}
         PROFILE: ${{ matrix.profile }}
@@ -320,10 +320,10 @@ jobs:
         old_vsns=($(echo $OLD_VSNS | tr ' ' ' '))
         for tag in ${old_vsns[@]}; do
           package_name="${PROFILE}-${tag#[e|v]}-otp${OTP_VSN}-${SYSTEM}-${ARCH}"
-          if [ ! -z "$(echo $(curl -I -m 10 -o /dev/null -s -w %{http_code} https://s3-us-west-2.amazonaws.com/packages.emqx/$broker/$tag/$package_name.zip) | grep -oE "^[23]+")" ]; then
-            wget --no-verbose https://s3-us-west-2.amazonaws.com/packages.emqx/$broker/$tag/$package_name.zip
-            wget --no-verbose https://s3-us-west-2.amazonaws.com/packages.emqx/$broker/$tag/$package_name.zip.sha256
-            echo "$(cat $package_name.zip.sha256) $package_name.zip" | sha256sum -c || exit 1
+          if [ ! -z "$(echo $(curl -I -m 10 -o /dev/null -s -w %{http_code} https://s3-us-west-2.amazonaws.com/packages.emqx/$broker/$tag/$package_name.tar.gz) | grep -oE "^[23]+")" ]; then
+            wget --no-verbose https://s3-us-west-2.amazonaws.com/packages.emqx/$broker/$tag/$package_name.tar.gz
+            wget --no-verbose https://s3-us-west-2.amazonaws.com/packages.emqx/$broker/$tag/$package_name.tar.gz.sha256
+            echo "$(cat $package_name.tar.gz.sha256) $package_name.tar.gz" | sha256sum -c || exit 1
           fi
         done
     - name: build emqx packages
@@ -336,10 +336,10 @@ jobs:
       run: |
         ./scripts/buildx.sh \
           --profile "${PROFILE}" \
-          --pkgtype "zip" \
+          --pkgtype "tgz" \
           --arch "${ARCH}" \
           --builder "ghcr.io/emqx/emqx-builder/5.0-3:${OTP}-${SYSTEM}"
-        ## the pkg build is incremental on the zip build
+        ## the pkg build is incremental on the tgz build
         ./scripts/buildx.sh \
           --profile "${PROFILE}" \
           --pkgtype "pkg" \

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -63,10 +63,10 @@ jobs:
       with:
         path: _build/default/lib/quicer/
         key: ${{ matrix.os }}-${{ matrix.otp }}-amd64-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
-    - name: build and test zip package
+    - name: build and test tgz package
       run: |
-        make ${EMQX_NAME}-zip
-        .ci/build_packages/tests.sh "$EMQX_PKG_NAME" zip
+        make ${EMQX_NAME}-tgz
+        .ci/build_packages/tests.sh "$EMQX_PKG_NAME" tgz
     - name: run static checks
       if: contains(matrix.os, 'ubuntu')
       run: |
@@ -78,7 +78,7 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: ${{ matrix.profile}}-${{ matrix.otp }}-${{ matrix.os }}
-        path: _packages/**/*.zip
+        path: _packages/${{ matrix.profile}}/*.tar.gz
   mac:
     strategy:
       fail-fast: false
@@ -140,11 +140,11 @@ jobs:
         . $HOME/.kerl/${{ matrix.otp }}/activate
         make ensure-rebar3
         sudo cp rebar3 /usr/local/bin/rebar3
-        make ${{ matrix.profile }}-zip
+        make ${{ matrix.profile }}-tgz
     - name: test
       run: |
-        pkg_name=$(find _packages/${{ matrix.profile }} -mindepth 1 -maxdepth 1 -iname \*.zip)
-        unzip -q $pkg_name
+        pkg_name=$(find _packages/${{ matrix.profile }} -mindepth 1 -maxdepth 1 -iname \*.tar.gz)
+        tar -zxf $pkg_name
         # gsed -i '/emqx_telemetry/d' ./emqx/data/loaded_plugins
         ./emqx/bin/emqx start || cat emqx/log/erlang.log.1
         ready='no'
@@ -166,4 +166,4 @@ jobs:
     - uses: actions/upload-artifact@v2
       with:
         name: macos
-        path: _packages/**/*.zip
+        path: _packages/**/*.tar.gz

--- a/.github/workflows/run_api_tests.yaml
+++ b/.github/workflows/run_api_tests.yaml
@@ -18,21 +18,18 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: zip emqx-broker
-      if: endsWith(github.repository, 'emqx')
+    - name: build EMQ X CE and EE tgz package
       run: |
-        make emqx-zip
-    - name: zip emqx-broker
-      if: endsWith(github.repository, 'enterprise')
-      run: |
-        echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
-        git config --global credential.helper store
-        make emqx-enterprise-zip
+        make emqx-tgz
+        make emqx-enterprise-tgz
     - uses: actions/upload-artifact@v2
       with:
-        name: emqx-broker
-        path: _packages/**/*.zip
-
+        name: emqx-ce
+        path: _packages/emqx/*.tar.gz
+    - uses: actions/upload-artifact@v2
+      with:
+        name: emqx-ee
+        path: _packages/emqx-enterprise/*.tar.gz
   api-test:
     needs: build
     runs-on: ubuntu-latest
@@ -57,6 +54,9 @@ jobs:
           - api_topic_rewrite
           - api_event_message
           - api_stats
+        edition:
+          - emqx-ce
+            #TODO: add emqx-ee
     steps:
     - uses: actions/checkout@v2
       with:
@@ -70,13 +70,13 @@ jobs:
         architecture: x64 # (x64 or x86) - defaults to x64
     - uses: actions/download-artifact@v2
       with:
-        name: emqx-broker
+        name: ${{ matrix.edition }}
         path: .
-    - name: start emqx-broker
+    - name: start EMQ X service
       env:
         EMQX_LISTENERS__WSS__DEFAULT__BIND: "0.0.0.0:8085"
       run: |
-        unzip ./emqx/*.zip
+        tar -zxf ./*.tar.gz
         ./emqx/bin/emqx start
     - name: install jmeter
       timeout-minutes: 10
@@ -117,4 +117,7 @@ jobs:
     steps:
     - uses: geekyeggo/delete-artifact@v1
       with:
-        name: emqx-broker
+        name: emqx-ce
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: emqx-ee

--- a/.github/workflows/run_api_tests.yaml
+++ b/.github/workflows/run_api_tests.yaml
@@ -24,11 +24,11 @@ jobs:
         make emqx-enterprise-tgz
     - uses: actions/upload-artifact@v2
       with:
-        name: emqx-ce
+        name: emqx-community
         path: _packages/emqx/*.tar.gz
     - uses: actions/upload-artifact@v2
       with:
-        name: emqx-ee
+        name: emqx-enterprise
         path: _packages/emqx-enterprise/*.tar.gz
   api-test:
     needs: build
@@ -55,8 +55,8 @@ jobs:
           - api_event_message
           - api_stats
         edition:
-          - emqx-ce
-            #TODO: add emqx-ee
+          - emqx-community
+            #TODO: add emqx-enterprise
     steps:
     - uses: actions/checkout@v2
       with:
@@ -117,7 +117,7 @@ jobs:
     steps:
     - uses: geekyeggo/delete-artifact@v1
       with:
-        name: emqx-ce
+        name: emqx-community
     - uses: geekyeggo/delete-artifact@v1
       with:
-        name: emqx-ee
+        name: emqx-enterprise

--- a/.github/workflows/run_api_tests.yaml
+++ b/.github/workflows/run_api_tests.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: "ghcr.io/emqx/emqx-builder/5.0:23.2.7.2-emqx-2-ubuntu20.04"
+    container: "ghcr.io/emqx/emqx-builder/5.0-3:24.1.5-3-ubuntu20.04"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -85,10 +85,10 @@ jobs:
         cd emqx/_upgrade_base
         old_vsns=($(echo $OLD_VSNS | tr ' ' ' '))
         for old_vsn in ${old_vsns[@]}; do
-          wget --no-verbose https://s3-us-west-2.amazonaws.com/packages.emqx/$BROKER/$old_vsn/$PROFILE-${old_vsn#[e|v]}-otp${OTP_VSN}-ubuntu20.04-amd64.zip
+          wget --no-verbose https://s3-us-west-2.amazonaws.com/packages.emqx/$BROKER/$old_vsn/$PROFILE-${old_vsn#[e|v]}-otp${OTP_VSN}-ubuntu20.04-amd64.tar.gz
         done
     - name: build emqx
-      run: make -C emqx ${PROFILE}-zip
+      run: make -C emqx ${PROFILE}-tgz
     - name: build emqtt-bench
       run: make -C emqtt-bench
     - name: build lux
@@ -105,8 +105,8 @@ jobs:
         set -e -x -u
         if [ -n "$OLD_VSNS" ]; then
             mkdir -p packages
-            cp emqx/_packages/${PROFILE}/*.zip packages
-            cp emqx/_upgrade_base/*.zip packages
+            cp emqx/_packages/${PROFILE}/*.tar.gz packages
+            cp emqx/_upgrade_base/*.tar.gz packages
             lux \
             --case_timeout infinity \
             --var PROFILE=$PROFILE \

--- a/Makefile
+++ b/Makefile
@@ -152,17 +152,17 @@ define gen-relup-target
 $1-relup: $(COMMON_DEPS)
 	@$(BUILD) $1 relup
 endef
-ALL_ZIPS = $(REL_PROFILES)
-$(foreach zt,$(ALL_ZIPS),$(eval $(call gen-relup-target,$(zt))))
+ALL_TGZS = $(REL_PROFILES)
+$(foreach zt,$(ALL_TGZS),$(eval $(call gen-relup-target,$(zt))))
 
-## zip target is to create a release package .zip with relup
-.PHONY: $(REL_PROFILES:%=%-zip)
-define gen-zip-target
-$1-zip: $1-relup
-	@$(BUILD) $1 zip
+## tgz target is to create a release package .tar.gz with relup
+.PHONY: $(REL_PROFILES:%=%-tgz)
+define gen-tgz-target
+$1-tgz: $1-relup
+	@$(BUILD) $1 tgz
 endef
-ALL_ZIPS = $(REL_PROFILES)
-$(foreach zt,$(ALL_ZIPS),$(eval $(call gen-zip-target,$(zt))))
+ALL_TGZS = $(REL_PROFILES)
+$(foreach zt,$(ALL_TGZS),$(eval $(call gen-tgz-target,$(zt))))
 
 ## A pkg target depend on a regular release
 .PHONY: $(PKG_PROFILES)
@@ -185,20 +185,20 @@ define gen-docker-target
 $1-docker: $(COMMON_DEPS)
 	@$(BUILD) $1 docker
 endef
-ALL_ZIPS = $(REL_PROFILES)
-$(foreach zt,$(ALL_ZIPS),$(eval $(call gen-docker-target,$(zt))))
+ALL_TGZS = $(REL_PROFILES)
+$(foreach zt,$(ALL_TGZS),$(eval $(call gen-docker-target,$(zt))))
 
 ## emqx-docker-testing
 ## emqx-enterprise-docker-testing
-## is to directly copy a unzipped zip-package to a
+## is to directly copy a extracted tgz-package to a
 ## base image such as ubuntu20.04. Mostly for testing
 .PHONY: $(REL_PROFILES:%=%-docker-testing)
 define gen-docker-target-testing
 $1-docker-testing: $(COMMON_DEPS)
 	@$(BUILD) $1 docker-testing
 endef
-ALL_ZIPS = $(REL_PROFILES)
-$(foreach zt,$(ALL_ZIPS),$(eval $(call gen-docker-target-testing,$(zt))))
+ALL_TGZS = $(REL_PROFILES)
+$(foreach zt,$(ALL_TGZS),$(eval $(call gen-docker-target-testing,$(zt))))
 
 conf-segs:
 	@scripts/merge-config.escript

--- a/bin/emqx
+++ b/bin/emqx
@@ -149,7 +149,6 @@ usage() {
         echo "release package tarball has already been deployed at one"
         echo "of the following locations:"
         echo "      releases/<relname>-<version>.tar.gz"
-        echo "      releases/<relname>-<version>.zip"
         ;;
     install)
         echo "Usage: $REL_NAME install [VERSION]"
@@ -157,7 +156,6 @@ usage() {
         echo "release package tarball has already been deployed at one"
         echo "of the following locations:"
         echo "      releases/<relname>-<version>.tar.gz"
-        echo "      releases/<relname>-<version>.zip"
         echo ""
         echo "     --no-permanent   Install release package VERSION but"
         echo "                      don't make it permanent"
@@ -173,7 +171,6 @@ usage() {
         echo "that a release package tarball has already been deployed at one"
         echo "of the following locations:"
         echo "      releases/<relname>-<version>.tar.gz"
-        echo "      releases/<relname>-<version>.zip"
         echo ""
         echo "     --no-permanent   Install release package VERSION but"
         echo "                      don't make it permanent"
@@ -184,7 +181,6 @@ usage() {
         echo "that a release package tarball has already been deployed at one"
         echo "of the following locations:"
         echo "      releases/<relname>-<version>.tar.gz"
-        echo "      releases/<relname>-<version>.zip"
         echo ""
         echo "     --no-permanent   Install release package VERSION but"
         echo "                      don't make it permanent"

--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -184,7 +184,6 @@ find_and_link_release_package(Version, RelName) ->
     %% we've found where the actual release package is located
     ReleaseLink = filename:join(["releases", Version,
                                  RelNameStr ++ ".tar.gz"]),
-    ok = unpack_zipballs(RelNameStr, Version),
     TarBalls = [
         filename:join(["releases",
                         RelNameStr ++ "-" ++ Version ++ ".tar.gz"]),
@@ -218,22 +217,6 @@ find_and_link_release_package(Version, RelName) ->
             end,
             {Filename, ReleaseHandlerPackageLink}
     end.
-
-unpack_zipballs(RelNameStr, Version) ->
-    {ok, Cwd} = file:get_cwd(),
-    GzFile = filename:absname(filename:join(["releases", RelNameStr ++ "-" ++ Version ++ ".tar.gz"])),
-    ZipFiles = filelib:wildcard(filename:join(["releases", RelNameStr ++ "-*" ++ Version ++ "*.zip"])),
-    ?INFO("unzip ~p", [ZipFiles]),
-    [begin
-        TmdTarD="/tmp/emqx_untar_" ++ integer_to_list(erlang:system_time()),
-        ok = filelib:ensure_dir(filename:join([TmdTarD, "dummy"])),
-        {ok, _} = file:copy(Zip, filename:join([TmdTarD, "emqx.zip"])),
-        ok = file:set_cwd(filename:join([TmdTarD])),
-        {ok, _FileList} = zip:unzip("emqx.zip"),
-        ok = file:set_cwd(filename:join([TmdTarD, "emqx"])),
-        ok = erl_tar:create(GzFile, filelib:wildcard("*"), [compressed])
-     end || Zip <- ZipFiles],
-    file:set_cwd(Cwd).
 
 first_value(_Fun, []) -> no_value;
 first_value(Fun, [Value | Rest]) ->

--- a/build
+++ b/build
@@ -2,7 +2,7 @@
 
 # This script helps to build release artifacts.
 # arg1: profile, e.g. emqx | emqx-edge | emqx-pkg | emqx-edge-pkg
-# arg2: artifact, e.g. rel | relup | zip | pkg
+# arg2: artifact, e.g. rel | relup | tgz | pkg
 
 set -euo pipefail
 
@@ -79,28 +79,18 @@ make_rel() {
     fi
 }
 
-## unzip previous version .zip files to _build/$PROFILE/rel/emqx/releases before making relup
+## extract previous version .tar.gz files to _build/$PROFILE/rel/emqx before making relup
 make_relup() {
-    local lib_dir="_build/$PROFILE/rel/emqx/lib"
-    local releases_dir="_build/$PROFILE/rel/emqx/releases"
-    mkdir -p "$lib_dir" "$releases_dir"
+    local rel_dir="_build/$PROFILE/rel/emqx"
+    mkdir -p "${rel_dir}/lib"
+    mkdir -p "${rel_dir}/releases"
     local releases=()
-    if [ -d "$releases_dir" ]; then
-        while read -r zip; do
-            local base_vsn
-            base_vsn="$(echo "$zip" | grep -oE "[0-9]+\.[0-9]+(\.[0-9]+|(-(alpha|beta)\.[0-9]))(-[0-9a-e]{8})?")"
-            if [ ! -d "$releases_dir/$base_vsn" ]; then
-                local tmp_dir
-                tmp_dir="$(mktemp -d -t emqx.XXXXXXX)"
-                unzip -q "$zip" "emqx/releases/*" -d "$tmp_dir"
-                unzip -q "$zip" "emqx/lib/*" -d "$tmp_dir"
-                cp -r -n "$tmp_dir/emqx/releases"/* "$releases_dir"
-                cp -r -n "$tmp_dir/emqx/lib"/* "$lib_dir"
-                rm -rf "$tmp_dir"
-            fi
-            releases+=( "$base_vsn" )
-        done < <("$FIND" _upgrade_base -maxdepth 1 -name "*$PROFILE-otp${OTP_VSN}-$SYSTEM*-$ARCH.zip" -type f)
-    fi
+    while read -r tgzfile ; do
+        local base_vsn
+        base_vsn="$(echo "$tgzfile" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)\.[0-9])?(-[0-9a-f]{8})?" | head -1)"
+        tar -C "$rel_dir" -zxf ---keep-old-files "$tgzfile" emqx/releases emqx/lib
+        releases+=( "$base_vsn" )
+    done < <("$FIND" _upgrade_base -maxdepth 1 -name "$PROFILE*${SYSTEM}-${ARCH}.tar.gz" -type f)
     if [ ${#releases[@]} -eq 0 ]; then
         log "No upgrade base found, relup ignored"
         return 0
@@ -126,9 +116,9 @@ cp_dyn_libs() {
         | sort -u)
 }
 
-## make_zip turns .tar.gz into a .zip with a slightly different name.
+## Re-pack the relx assembled .tar.gz to EMQ X's package naming scheme
 ## It assumes the .tar.gz has been built -- relies on Makefile dependency
-make_zip() {
+make_tgz() {
     # build the tarball again to ensure relup is included
     make_rel
 
@@ -142,14 +132,14 @@ make_zip() {
     if [ ! -f "$tarball" ]; then
         log "ERROR: $tarball is not found"
     fi
-    local zipball
-    zipball="${pkgpath}/${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.zip"
+    local target
+    target="${pkgpath}/${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.tar.gz"
     tar zxf "${tarball}" -C "${tard}/emqx"
-    ## try to be portable for zip packages.
+    ## try to be portable for tar.gz packages.
     ## for DEB and RPM packages the dependencies are resoved by yum and apt
     cp_dyn_libs "${tard}/emqx"
-    (cd "${tard}" && zip -qr - emqx) > "${zipball}"
-    log "Zip package successfully created: ${zipball}"
+    (cd "${tard}" && tar -cz emqx) > "${target}"
+    log "Tarball successfully repacked: ${target}"
 }
 
 ## This function builds the default docker image based on alpine:3.14 (by default)
@@ -166,7 +156,7 @@ make_docker() {
 }
 
 ## This function accepts any base docker image,
-## a emqx zip-image, and a image tag (for the image to be built),
+## a emqx tgz-image, and a image tag (for the image to be built),
 ## to build a docker image which runs EMQ X
 ##
 ## Export below variables to quickly build an image
@@ -174,7 +164,7 @@ make_docker() {
 ## Name               Default                         Example
 ## ---------------------------------------------------------------------
 ## EMQX_BASE_IMAGE    current os                      centos:7
-## EMQX_ZIP_PACKAGE   _packages/<current-zip-target>  /tmp/emqx-4.4.0-otp23.3.4.9-3-centos7-amd64.zip
+## EMQX_TGZ_packages/<current-tgz-target>  /tmp/emqx-4.4.0-otp23.3.4.9-3-centos7-amd64.tar.gz
 ## EMQX_IMAGE_TAG     emqx/emqx:<current-vns-rel>     emqx/emqx:testing-tag
 ##
 make_docker_testing() {
@@ -193,17 +183,17 @@ make_docker_testing() {
         esac
     fi
     EMQX_IMAGE_TAG="${EMQX_IMAGE_TAG:-emqx/$PROFILE:${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}}"
-    local defaultzip
-    defaultzip="_packages/${PROFILE}/${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.zip"
-    local zip="${EMQX_ZIP_PACKAGE:-$defaultzip}"
-    if [ ! -f "$zip" ]; then
-        log "ERROR: $zip not built?"
+    local default_tgz
+    default_tgz="_packages/${PROFILE}/${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.tar.gz"
+    local tgz="${EMQX_TGZ_PACKAGE:-$default_tgz}"
+    if [ ! -f "$tgz" ]; then
+        log "ERROR: $tgz not built?"
         exit 1
     fi
     set -x
     docker build \
        --build-arg BUILD_FROM="${EMQX_BASE_IMAGE}" \
-       --build-arg EMQX_ZIP_PACKAGE="${zip}" \
+       --build-arg EMQX_TGZ_PACKAGE="${tgz}" \
        --tag "$EMQX_IMAGE_TAG" \
        -f "${DOCKERFILE_TESTING}" .
 }
@@ -220,8 +210,8 @@ case "$ARTIFACT" in
     relup)
         make_relup
         ;;
-    zip)
-        make_zip
+    tgz)
+        make_tgz
         ;;
     pkg)
         if [ -z "${PKGERDIR:-}" ]; then

--- a/deploy/packages/deb/debian/control
+++ b/deploy/packages/deb/debian/control
@@ -9,4 +9,4 @@ Homepage: https://www.emqx.com
 Package: emqx
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
-Description: EMQX, a distributed, massively scalable, highly extensible MQTT message broker written in Erlang/OTP
+Description: EMQ X, a distributed, massively scalable, highly extensible MQTT message broker.

--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -14,7 +14,7 @@ Release: %{_release}%{?dist}
 Summary: emqx
 Group: System Environment/Daemons
 License: Apache License Version 2.0
-URL: https://www.emqx.io
+URL: https://www.emqx.com
 BuildRoot: %{_tmppath}/%{_name}-%{_version}-root
 Provides: %{_name}
 AutoReq: 0
@@ -26,7 +26,7 @@ Requires: libatomic
 %endif
 
 %description
-EMQX, a distributed, massively scalable, highly extensible MQTT message broker written in Erlang/OTP.
+EMQ X, a distributed, massively scalable, highly extensible MQTT message broker.
 
 %prep
 

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -8,7 +8,7 @@
 ## i.e. will not work if docker command has to be executed with sudo
 
 ## example:
-## ./scripts/buildx.sh --profile emqx --pkgtype zip --arch arm64 --builder ghcr.io/emqx/emqx-builder/4.4-4:24.1.5-3-debian10
+## ./scripts/buildx.sh --profile emqx --pkgtype tgz --arch arm64 --builder ghcr.io/emqx/emqx-builder/4.4-4:24.1.5-3-debian10
 
 set -euo pipefail
 
@@ -16,7 +16,8 @@ help() {
     echo
     echo "-h|--help:           To display this usage information"
     echo "--profile <PROFILE>: EMQ X profile to build, e.g. emqx, emqx-edge"
-    echo "--pkgtype zip|pkg:   Specify which package to build, zip for .zip and pkg for .rpm or .deb"
+    echo "--pkgtype tgz|pkg:   Specify which package to build, tgz for .tar.gz"
+    echo "                     and pkg for .rpm or .deb"
     echo "--arch amd64|arm64:  Target arch to build the EMQ X package for"
     echo "--src_dir <SRC_DIR>: EMQ X source ode in this dir, default to PWD"
     echo "--builder <BUILDER>: Builder image to pull"
@@ -62,8 +63,8 @@ if [ -z "${PROFILE:-}" ] || [ -z "${PKGTYPE:-}" ] || [ -z "${BUILDER:-}" ] || [ 
     exit 1
 fi
 
-if [ "$PKGTYPE" != 'zip' ] && [ "$PKGTYPE" != 'pkg' ]; then
-    echo "Bad --pkgtype option, should be zip or pkg"
+if [ "$PKGTYPE" != 'tgz' ] && [ "$PKGTYPE" != 'pkg' ]; then
+    echo "Bad --pkgtype option, should be tgz or pkg"
     exit 1
 fi
 

--- a/scripts/update_appup.escript
+++ b/scripts/update_appup.escript
@@ -32,8 +32,8 @@ Options:
   --make-command    A command used to assemble the release
   --release-dir     Release directory
   --src-dirs        Directories where source code is found. Defaults to '{src,apps,lib-*}/**/'
-  --binary-rel-url  Binary release URL pattern. %TAG% variable is substituted with the release tag.
-                    E.g. \"https://github.com/emqx/emqx/releases/download/v%TAG%/emqx-centos7-%TAG%-amd64.zip\"
+  --binary-rel-url  Binary release URL pattern. %VSN% variable is substituted with the version in release tag.
+                    E.g. \"https://github.com/emqx/emqx/releases/download/v%VSN%/emqx-%VSN%-otp-24.1.5-3-centos7-amd64.tar.gz\"
 ".
 
 -record(app,
@@ -172,8 +172,8 @@ download_prev_release(Tag, #{binary_rel_url := {ok, URL0}, clone_url := Repo}) -
     Dir = filename:basename(Repo, ".git") ++ [$-|Tag],
     Filename = filename:join(BaseDir, Dir),
     Script = "mkdir -p ${OUTFILE} &&
-              wget -c -O ${OUTFILE}.zip ${URL} &&
-              unzip -n -d ${OUTFILE} ${OUTFILE}.zip",
+              wget -c -O ${OUTFILE}.tar.gz ${URL} &&
+              tar -zxf ${OUTFILE} ${OUTFILE}.tar.gz",
     Env = [{"TAG", Tag}, {"OUTFILE", Filename}, {"URL", URL}],
     bash(Script, Env),
     {ok, Filename}.


### PR DESCRIPTION
the reason why EMQ X packages were released in .zip but not .tar.gz is lost.
maybe it was Windows, now that `tar` command comes natively in Windows, it's no longer a strong argument.

due to the .zip legacy, we had to re-pack the .tar.gz package generated by rebar release to .zip when releasing
and when upgrading, we had to re-pack .zip to .tar.gz because OTP release handler does not work with .zip

starting from 5.0, we'll aim to release .tar.gz packages instead.