### PR TITLE
ci(cross-build-package): revert build cache for docker img

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -378,9 +378,6 @@ jobs:
         # NOTE: for docker, only support latest otp version, not a matrix
         otp:
           - 24.1.5-3 # update to latest
-        arch:
-          - amd64
-          - arm64
 
     steps:
     - uses: actions/download-artifact@v2
@@ -412,33 +409,12 @@ jobs:
       with:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
-
-    - name: Get deps git refs for cache
-      id: deps-refs
-      run: |
-        cd source
-        make ensure-rebar3
-        sudo cp rebar3 /usr/local/bin/rebar3
-        scripts/get-dep-refs.sh
-        make clean-all
-
-    - name: load rocksdb cache
-      uses: actions/cache@v2
-      with:
-        path: source/_build/default/lib/rocksdb/
-        key: alpine3.14-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_ROCKSDB_REF }}
-    - name: load quicer cache
-      uses: actions/cache@v2
-      with:
-        path: source/_build/default/lib/quicer/
-        key: alpine3.14-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
-
     - uses: docker/build-push-action@v2
       with:
         push: ${{ github.event_name == 'release' && !github.event.release.prerelease }}
         pull: true
         no-cache: true
-        platforms: linux/${{ matrix.arch }}
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |


### PR DESCRIPTION
- The docker img use os: alpine, it is unliked to hit a cache.
- The build cache method casue the tag get overwritten among multi
arch builds

