### PR TITLE
feat: show config doc in dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/4.4-2:23.3.4.9-3-alpine3
 export EMQX_DEFAULT_RUNNER = alpine:3.14
 export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export PKG_VSN ?= $(shell $(CURDIR)/pkg-vsn.sh)
-export EMQX_DASHBOARD_VERSION ?= v0.17.0
+export EMQX_DASHBOARD_VERSION ?= v0.18.0
 export DOCKERFILE := deploy/docker/Dockerfile
 export DOCKERFILE_TESTING := deploy/docker/Dockerfile.testing
 ifeq ($(OS),Windows_NT)

--- a/build
+++ b/build
@@ -64,7 +64,7 @@ make_doc() {
     libs_dir2="$("$FIND" "_build/$PROFILE/lib/" -maxdepth 2 -name ebin -type d)"
     # shellcheck disable=SC2086
     erl -noshell -pa $libs_dir1 $libs_dir2 -eval \
-        "F = filename:join(['_build', '${PROFILE}', lib, emqx_dashboard, priv, 'config.md']), \
+        "F = filename:join(['_build', '${PROFILE}', lib, emqx_dashboard, priv, www, static, 'config.md']), \
          io:format(\"===< Generating: ~s~n\", [F]),
          ok = emqx_conf:gen_doc(F), \
          halt(0)."


### PR DESCRIPTION
With dashboard version 0.18.0, the config doc markdown file can be rendered in the dashboard page
The rendering is still very primitive for now.
More CSS will be added by @ysfscream in future iterations of the dashboard
In-page references are not working for now. will be fixed.
preview:
![image](https://user-images.githubusercontent.com/164324/149504699-8d276b1a-2359-4e4f-b5d1-e6cede7e75ce.png)


