### PR TITLE
refactor(swagger): new code style of swagger API callbacks

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -76,12 +76,15 @@ stop_listeners() ->
 %%--------------------------------------------------------------------
 %% internal
 
+%% confine apps to emqx_dashboard only for demo
 apps() ->
-    [App || {App, _, _} <- application:loaded_applications(),
-        case re:run(atom_to_list(App), "^emqx") of
-            {match,[{0,4}]} -> true;
-            _ -> false
-        end].
+    [emqx_dashboard].
+% apps() ->
+%     [App || {App, _, _} <- application:loaded_applications(),
+%         case re:run(atom_to_list(App), "^emqx") of
+%             {match,[{0,4}]} -> true;
+%             _ -> false
+%         end].
 
 listeners() ->
     [begin


### PR DESCRIPTION
After this change, a callback module for `-behaviour(minirest_api)` looks like below:

```
api_spec() ->
    emqx_dashboard_swagger:spec(?MODULE, [{"/exhooks", [get, post]}]).

paths("/exhooks", get) ->
    #{tags => ?TAGS,
       description => <<"List all servers">>,
       responses => #{200 => mk(array(ref(detail_server_info)), #{})}
      };
paths("/exhooks", post) ->
    #{tags => ?TAGS,
       description => <<"Add a servers">>,
       'requestBody' => server_conf_schema(),
       responses =>
              #{201 => mk(ref(detail_server_info), #{}),
                 500 => error_codes([?BAD_RPC], <<"Bad RPC">>)}
      }.

handle_paths("/exhooks", get, #{}) ->
    200;
handle_paths("/exhooks", post, #{}) ->
    200.
```

Below is the callbacks before the change:

```
api_spec() ->
    emqx_dashboard_swagger:spec(?MODULE).

paths() -> ["/exhooks"].

schema(("/exhooks")) ->
    #{
      'operationId' => exhooks,
      get => #{tags => ?TAGS,
               description => <<"List all servers">>,
               responses => #{200 => mk(array(ref(detail_server_info)), #{})}
              },
      post => #{tags => ?TAGS,
                description => <<"Add a servers">>,
                'requestBody' => server_conf_schema(),
                responses => #{201 => mk(ref(detail_server_info), #{}),
                               500 => error_codes([?BAD_RPC], <<"Bad RPC">>)
                              }
               }
    };

exhooks(get, _) ->
    200;
exhooks(post, #{body := Body}) ->
    200.
```