### PR TITLE
fix(build): relup for otp24 failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 $(shell $(CURDIR)/scripts/git-hooks-init.sh)
-REBAR_VERSION = 3.14.3-emqx-8
+REBAR_VERSION = 3.18.0-emqx-1
 REBAR = $(CURDIR)/rebar3
 BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 $(shell $(CURDIR)/scripts/git-hooks-init.sh)
-REBAR_VERSION = 3.18.0-emqx-1
 REBAR = $(CURDIR)/rebar3
 BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts
@@ -31,7 +30,7 @@ all: $(REBAR) $(PROFILES)
 .PHONY: ensure-rebar3
 ensure-rebar3:
 	@$(SCRIPTS)/fail-on-old-otp-version.escript
-	@$(SCRIPTS)/ensure-rebar3.sh $(REBAR_VERSION)
+	@$(SCRIPTS)/ensure-rebar3.sh
 
 $(REBAR): ensure-rebar3
 

--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -2,8 +2,7 @@
 
 set -euo pipefail
 
-VERSION="$1"
-REBAR3_FILENAME="${REBAR3_FILENAME:-rebar3}"
+VERSION="3.14.3-emqx-8"
 
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
@@ -11,11 +10,12 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 DOWNLOAD_URL='https://github.com/emqx/rebar3/releases/download'
 
 download() {
-    curl -f -L "${DOWNLOAD_URL}/${VERSION}/${REBAR3_FILENAME}" -o ./rebar3
+    echo "downloading rebar3 ${VERSION}"
+    curl -f -L "${DOWNLOAD_URL}/${VERSION}/rebar3" -o ./rebar3
 }
 
-version_gt() {
-    test "$(echo "$@" | tr " " "n" | sort -V | head -n 1)" != "$1";
+version_gte() {
+    test "$(printf '%s\n' "$1" "$2" | sort -V | head -n 1)" = "$2"
 }
 
 # get the version number from the second line of the escript
@@ -25,13 +25,15 @@ version() {
     head -n 2 ./rebar3 | tail -n 1 | tr ' ' '\n' | grep -E '^.+-emqx-.+'
 }
 
-if [ -f 'rebar3' ] && [ "$(version)" = "$VERSION" ]; then
-    exit 0
+if version_gte "${OTP_VSN}" "24.0"; then
+    ## rebar3 tag 3.18.0-emqx-1 is compiled using otp24.1.5.
+    ## we have to use an otp24-compiled rebar3 because the defination of record #application{}
+    ## in systools.hrl is changed in otp24.
+    VERSION="3.18.0-emqx-1"
 fi
 
-if version_gt "${OTP_VSN}" "24.0.0"; then
-   echo "$OTP_VSN is greater than 24.0.0"
-   REBAR3_FILENAME="rebar3_otp24.1.5"
+if [ -f 'rebar3' ] && [ "$(version)" = "$VERSION" ]; then
+    exit 0
 fi
 
 download

--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -3,6 +3,7 @@
 set -euo pipefail
 
 VERSION="$1"
+REBAR3_FILENAME="${REBAR3_FILENAME:-rebar3}"
 
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
@@ -10,7 +11,11 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 DOWNLOAD_URL='https://github.com/emqx/rebar3/releases/download'
 
 download() {
-    curl -f -L "${DOWNLOAD_URL}/${VERSION}/rebar3" -o ./rebar3
+    curl -f -L "${DOWNLOAD_URL}/${VERSION}/${REBAR3_FILENAME}" -o ./rebar3
+}
+
+version_gt() {
+    test "$(echo "$@" | tr " " "n" | sort -V | head -n 1)" != "$1";
 }
 
 # get the version number from the second line of the escript
@@ -22,6 +27,11 @@ version() {
 
 if [ -f 'rebar3' ] && [ "$(version)" = "$VERSION" ]; then
     exit 0
+fi
+
+if version_gt "${OTP_VSN}" "24.0.0"; then
+   echo "$OTP_VSN is greater than 24.0.0"
+   REBAR3_FILENAME="rebar3_otp24.1.5"
 fi
 
 download


### PR DESCRIPTION
The defination of `#application{}` record in systools.hrl is changed in OTP 24.
So we need a rebar3 binary compiled with OTP 24.

