### PR TITLE
Refactor config 3 layers

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -21,6 +21,7 @@
 -export([ init_load/1
         , init_load/2
         , read_override_conf/1
+        , delete_override_conf_files/0
         , check_config/2
         , fill_defaults/1
         , fill_defaults/2
@@ -252,23 +253,7 @@ init_load(SchemaMod) ->
 %% in the rear of the list overrides prior values.
 -spec init_load(module(), [string()] | binary() | hocon:config()) -> ok.
 init_load(SchemaMod, Conf) when is_list(Conf) orelse is_binary(Conf) ->
-    IncDir = include_dirs(),
-    ParseOptions = #{format => map, include_dirs => IncDir},
-    Parser = case is_binary(Conf) of
-              true -> fun hocon:binary/2;
-              false -> fun hocon:files/2
-             end,
-    case Parser(Conf, ParseOptions) of
-        {ok, RawRichConf} ->
-            init_load(SchemaMod, RawRichConf);
-        {error, Reason} ->
-            ?SLOG(error, #{msg => "failed_to_load_hocon_conf",
-                           reason => Reason,
-                           pwd => file:get_cwd(),
-                           include_dirs => IncDir
-                          }),
-            error(failed_to_load_hocon_conf)
-    end;
+    init_load(SchemaMod, parse_hocon(Conf));
 init_load(SchemaMod, RawConf) when is_map(RawConf) ->
     ok = save_schema_mod_and_names(SchemaMod),
     %% Merge environment varialbe overrides on top
@@ -276,7 +261,6 @@ init_load(SchemaMod, RawConf) when is_map(RawConf) ->
     ClusterOverrides = read_override_conf(#{override_to => cluster}),
     LocalOverrides = read_override_conf(#{override_to => local}),
     Overrides = hocon:deep_merge(ClusterOverrides, LocalOverrides),
-    %% TODO: log overrides
     RawConfWithOverrides = hocon:deep_merge(RawConfWithEnvs, Overrides),
     %% check configs against the schema
     {_AppEnvs, CheckedConf} =
@@ -284,6 +268,28 @@ init_load(SchemaMod, RawConf) when is_map(RawConf) ->
     RootNames = get_root_names(),
     ok = save_to_config_map(maps:with(get_atom_root_names(), CheckedConf),
                             maps:with(RootNames, RawConfWithEnvs)).
+
+parse_hocon(Conf) ->
+    IncDirs = include_dirs(),
+    case do_parse_hocon(Conf, IncDirs) of
+        {ok, HoconMap} ->
+            HoconMap;
+        {error, Reason} ->
+            ?SLOG(error, #{msg => "failed_to_load_hocon_conf",
+                           reason => Reason,
+                           pwd => file:get_cwd(),
+                           include_dirs => IncDirs,
+                           config_file => Conf
+                          }),
+            error(failed_to_load_hocon_conf)
+    end.
+
+do_parse_hocon(Conf, IncDirs) ->
+    Opts = #{format => map, include_dirs => IncDirs},
+    case is_binary(Conf) of
+        true -> hocon:binary(Conf, Opts);
+        false -> hocon:files(Conf, Opts)
+    end.
 
 include_dirs() ->
     [filename:join(emqx:data_dir(), "configs")].
@@ -327,6 +333,23 @@ fill_defaults(SchemaMod, RawConf) ->
     hocon_schema:check_plain(SchemaMod, RawConf,
         #{nullable => true, only_fill_defaults => true},
         root_names_from_conf(RawConf)).
+
+
+%% @doc Only for test cleanups.
+%% Delete override config files.
+-spec delete_override_conf_files() -> ok.
+delete_override_conf_files() ->
+    F1 = override_conf_file(#{override_to => local}),
+    F2 = override_conf_file(#{override_to => cluster}),
+    ok = ensure_file_deleted(F1),
+    ok = ensure_file_deleted(F2).
+
+ensure_file_deleted(F) ->
+    case file:delete(F) of
+        ok -> ok;
+        {error, enoent} -> ok;
+        {error, Reason} -> error({F, Reason})
+    end.
 
 -spec read_override_conf(map()) -> raw_config().
 read_override_conf(#{} = Opts) ->

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -48,6 +48,7 @@
         , not_wait_mqtt_payload/1
         , render_config_file/2
         , read_schema_configs/2
+        , load_config/2
         ]).
 
 -define( CERTS_PATH(CertName), filename:join( [ "etc", "certs", CertName ]) ).
@@ -428,3 +429,7 @@ copy_certs(emqx_conf, Dest0) ->
     os:cmd( ["cp -rf ", From, "/certs ", Dest, "/"]),
     ok;
 copy_certs(_, _) -> ok.
+
+load_config(SchemaModule, Config) ->
+    ok = emqx_config:delete_override_conf_files(),
+    ok = emqx_config:init_load(SchemaModule, Config).

--- a/apps/emqx/test/emqx_ratelimiter_SUITE.erl
+++ b/apps/emqx/test/emqx_ratelimiter_SUITE.erl
@@ -96,7 +96,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_limiter_schema, ?BASE_CONF),
+    ok = emqx_common_test_helpers:load_config(emqx_limiter_schema, ?BASE_CONF),
     emqx_common_test_helpers:start_apps([?APP]),
     Config.
 
@@ -107,7 +107,7 @@ init_per_testcase(_TestCase, Config) ->
     Config.
 
 base_conf() ->
-    emqx_config:init_load(emqx_limiter_schema, ?BASE_CONF).
+    emqx_common_test_helpers:load_config(emqx_limiter_schema, ?BASE_CONF).
 
 %%--------------------------------------------------------------------
 %% Test Cases Bucket Level

--- a/apps/emqx_authz/src/emqx_authz_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_schema.erl
@@ -96,10 +96,11 @@ fields(file) ->
     , {path, #{type => string(),
                desc => """
 Path to the file which contains the ACL rules.<br>
-If the file provisioned before starting EMQ X node, it can be placed anywhere
-as long as EMQ X has read access to it.
-In case rule set is created from EMQ X dashboard or management HTTP API,
-the file will be placed in `certs/authz` sub directory inside EMQ X's `data_dir`,
+If the file provisioned before starting EMQ X node,
+it can be placed anywhere as long as EMQ X has read access to it.
+
+In case the rule-set is created from EMQ X dashboard or management API,
+the file will be placed in `authz` sub directory inside EMQ X's `data_dir`,
 and the new rules will override all rules from the old config file.
 """
               }}

--- a/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
+++ b/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
@@ -58,7 +58,7 @@ init_per_suite(Config) ->
 
     application:load(emqx_dashboard),
     application:load(?APP),
-    ok = emqx_config:init_load(emqx_auto_subscribe_schema,
+    ok = emqx_common_test_helpers:load_config(emqx_auto_subscribe_schema,
         <<"auto_subscribe {
             topics = [
                 {

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -64,7 +64,7 @@ init_per_suite(Config) ->
     _ = application:stop(emqx_resource),
     _ = application:stop(emqx_connector),
     ok = emqx_common_test_helpers:start_apps([emqx_bridge, emqx_dashboard]),
-    ok = emqx_config:init_load(emqx_bridge_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_bridge_schema, ?CONF_DEFAULT),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -97,9 +97,9 @@ init_per_suite(Config) ->
     _ = application:stop(emqx_connector),
     ok = emqx_common_test_helpers:start_apps([emqx_rule_engine, emqx_connector,
         emqx_bridge, emqx_dashboard]),
-    ok = emqx_config:init_load(emqx_connector_schema, <<"connectors: {}">>),
-    ok = emqx_config:init_load(emqx_rule_engine_schema, <<"rule_engine {rules {}}">>),
-    ok = emqx_config:init_load(emqx_bridge_schema, ?BRIDGE_CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_connector_schema, <<"connectors: {}">>),
+    ok = emqx_common_test_helpers:load_config(emqx_rule_engine_schema, <<"rule_engine {rules {}}">>),
+    ok = emqx_common_test_helpers:load_config(emqx_bridge_schema, ?BRIDGE_CONF_DEFAULT),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -59,7 +59,7 @@ init_per_suite(Cfg) ->
     meck:expect(emqx_alarm, deactivate, 3, ok),
 
     _ = emqx_exhook_demo_svr:start(),
-    ok = emqx_config:init_load(emqx_exhook_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_exhook_schema, ?CONF_DEFAULT),
     emqx_common_test_helpers:start_apps([emqx_exhook]),
     Cfg.
 

--- a/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
@@ -50,7 +50,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_alarm, deactivate, 3, ok),
 
     _ = emqx_exhook_demo_svr:start(),
-    ok = emqx_config:init_load(emqx_exhook_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_exhook_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_exhook]),
     [Conf] = emqx:get_config([exhook, servers]),
     [{template, Conf} | Config].

--- a/apps/emqx_gateway/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_coap_SUITE.erl
@@ -53,7 +53,7 @@ gateway.coap
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_gateway]),
     Config.
 

--- a/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_coap_api_SUITE.erl
@@ -54,7 +54,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_gateway]),
     Config.
 

--- a/apps/emqx_gateway/test/emqx_gateway_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_SUITE.erl
@@ -32,7 +32,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
-    emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_common_test_helpers:start_apps([emqx_gateway]),
     Conf.
 

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -40,7 +40,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
-    emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_conf, emqx_authn, emqx_gateway]),
     Conf.
 

--- a/apps/emqx_gateway/test/emqx_gateway_cli_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cli_SUITE.erl
@@ -54,7 +54,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
-    emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_conf, emqx_authn, emqx_gateway]),
     Conf.
 

--- a/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cm_SUITE.erl
@@ -34,7 +34,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
-    emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_common_test_helpers:start_apps([]),
 
     ok = meck:new(emqx_gateway_metrics, [passthrough, no_history, no_link]),

--- a/apps/emqx_gateway/test/emqx_gateway_cm_registry_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cm_registry_SUITE.erl
@@ -34,7 +34,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
-    emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_common_test_helpers:start_apps([]),
     Conf.
 

--- a/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
@@ -34,7 +34,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
-    emqx_config:init_load(emqx_gateway_schema, <<"gateway {}">>),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, <<"gateway {}">>),
     emqx_common_test_helpers:start_apps([emqx_conf, emqx_authn, emqx_gateway]),
     Conf.
 

--- a/apps/emqx_gateway/test/emqx_gateway_metrics_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_metrics_SUITE.erl
@@ -33,7 +33,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
-    emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_common_test_helpers:start_apps([]),
     Conf.
 

--- a/apps/emqx_gateway/test/emqx_gateway_registry_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_registry_SUITE.erl
@@ -34,7 +34,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 %%--------------------------------------------------------------------
 
 init_per_suite(Cfg) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_common_test_helpers:start_apps([emqx_gateway]),
     Cfg.
 

--- a/apps/emqx_gateway/test/emqx_lwm2m_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_SUITE.erl
@@ -173,7 +173,7 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_AllTestCase, Config) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
 
     {ok, _} = application:ensure_all_started(emqx_gateway),
     {ok, ClientUdpSock} = gen_udp:open(0, [binary, {active, false}]),

--- a/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
@@ -69,7 +69,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     application:load(emqx_gateway),
     emqx_mgmt_api_test_util:init_suite([emqx_conf]),
     Config.
@@ -81,7 +81,7 @@ end_per_suite(Config) ->
     Config.
 
 init_per_testcase(_AllTestCase, Config) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     {ok, _} = application:ensure_all_started(emqx_gateway),
     {ok, ClientUdpSock} = gen_udp:open(0, [binary, {active, false}]),
 

--- a/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
@@ -88,7 +88,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_gateway]),
     Config.
 

--- a/apps/emqx_gateway/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_stomp_SUITE.erl
@@ -49,7 +49,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 %%--------------------------------------------------------------------
 
 init_per_suite(Cfg) ->
-    ok = emqx_config:init_load(emqx_gateway_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_gateway]),
     Cfg.
 

--- a/apps/emqx_modules/test/emqx_event_message_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_event_message_SUITE.erl
@@ -38,7 +38,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 init_per_suite(Config) ->
     emqx_common_test_helpers:boot_modules(all),
     emqx_common_test_helpers:start_apps([emqx_modules]),
-    ok = emqx_config:init_load(emqx_modules_schema, ?EVENT_MESSAGE),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?EVENT_MESSAGE),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_modules/test/emqx_modules_conf_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_modules_conf_SUITE.erl
@@ -29,7 +29,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
-    emqx_config:init_load(emqx_modules_schema, <<"gateway {}">>),
+    emqx_common_test_helpers:load_config(emqx_modules_schema, <<"gateway {}">>),
     emqx_common_test_helpers:start_apps([emqx_conf, emqx_modules]),
     Conf.
 

--- a/apps/emqx_modules/test/emqx_rewrite_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_rewrite_SUITE.erl
@@ -112,7 +112,7 @@ t_rewrite_re_error(_Config) ->
     ok.
 
 t_list(_Config) ->
-    ok = emqx_config:init_load(emqx_modules_schema, ?REWRITE),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?REWRITE),
     Expect = [
         #{<<"action">> => <<"publish">>,
             <<"dest_topic">> => <<"z/y/$1">>,
@@ -130,7 +130,7 @@ t_list(_Config) ->
     ok.
 
 t_update(_Config) ->
-    ok = emqx_config:init_load(emqx_modules_schema, ?REWRITE),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?REWRITE),
     Init = emqx_rewrite:list(),
     Rules = [#{
         <<"source_topic">> => <<"test/#">>,
@@ -144,7 +144,7 @@ t_update(_Config) ->
     ok.
 
 t_update_disable(_Config) ->
-    ok = emqx_config:init_load(emqx_modules_schema, ?REWRITE),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?REWRITE),
     ?assertEqual(ok, emqx_rewrite:update([])),
     timer:sleep(150),
 
@@ -159,7 +159,7 @@ t_update_disable(_Config) ->
     ok.
 
 t_update_re_failed(_Config) ->
-    ok = emqx_config:init_load(emqx_modules_schema, ?REWRITE),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?REWRITE),
     Rules = [#{
         <<"source_topic">> => <<"test/#">>,
         <<"re">> => <<"*^test/*">>,
@@ -188,7 +188,7 @@ receive_publish(Timeout) ->
     end.
 
 init() ->
-    ok = emqx_config:init_load(emqx_modules_schema, ?REWRITE),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?REWRITE),
     ok = emqx_rewrite:enable(),
     {ok, C} = emqtt:start_link([{clientid, <<"rewrite_client">>}]),
     {ok, _} = emqtt:connect(C),

--- a/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl
@@ -30,7 +30,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 init_per_suite(Config) ->
     emqx_common_test_helpers:boot_modules(all),
     emqx_common_test_helpers:start_apps([emqx_modules]),
-    ok = emqx_config:init_load(emqx_modules_schema, ?TOPIC),
+    ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?TOPIC),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -57,7 +57,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_alarm, activate, 3, ok),
     meck:expect(emqx_alarm, deactivate, 3, ok),
 
-    ok = emqx_config:init_load(emqx_retainer_schema, ?BASE_CONF),
+    ok = emqx_common_test_helpers:load_config(emqx_retainer_schema, ?BASE_CONF),
     emqx_common_test_helpers:start_apps([emqx_retainer]),
     Config.
 

--- a/apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_mqtt_v5_SUITE.erl
@@ -42,7 +42,7 @@ retainer {
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_retainer_schema, ?BASE_CONF),
+    ok = emqx_common_test_helpers:load_config(emqx_retainer_schema, ?BASE_CONF),
     %% Meck emqtt
     ok = meck:new(emqtt, [non_strict, passthrough, no_history, no_link]),
     %% Start Apps

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
@@ -13,7 +13,7 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(emqx_conf),
-    ok = emqx_config:init_load(emqx_rule_engine_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_rule_engine_schema, ?CONF_DEFAULT),
     ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx_rule_engine]),
     Config.
 

--- a/apps/emqx_slow_subs/test/emqx_slow_subs_SUITE.erl
+++ b/apps/emqx_slow_subs/test/emqx_slow_subs_SUITE.erl
@@ -40,7 +40,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_config:init_load(emqx_slow_subs_schema, ?BASE_CONF),
+    ok = emqx_common_test_helpers:load_config(emqx_slow_subs_schema, ?BASE_CONF),
     emqx_common_test_helpers:start_apps([emqx_slow_subs]),
     Config.
 

--- a/apps/emqx_slow_subs/test/emqx_slow_subs_api_SUITE.erl
+++ b/apps/emqx_slow_subs/test/emqx_slow_subs_api_SUITE.erl
@@ -57,7 +57,7 @@ init_per_suite(Config) ->
     meck:expect(emqx_alarm, activate, 3, ok),
     meck:expect(emqx_alarm, deactivate, 3, ok),
 
-    ok = emqx_config:init_load(emqx_slow_subs_schema, ?CONF_DEFAULT),
+    ok = emqx_common_test_helpers:load_config(emqx_slow_subs_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_slow_subs]),
     {ok, _} = application:ensure_all_started(emqx_authn),
     Config.

--- a/scripts/merge-config.escript
+++ b/scripts/merge-config.escript
@@ -21,9 +21,7 @@ main(_) ->
                                    false -> Acc
                                end
                        end, BaseConf, Cfgs),
-    ClusterInc = "include \"cluster-override.conf\"\n",
-    LocalInc = "include \"local-override.conf\"\n",
-    ok = file:write_file("apps/emqx_conf/etc/emqx.conf.all", [Conf, ClusterInc, LocalInc]).
+    ok = file:write_file("apps/emqx_conf/etc/emqx.conf.all", Conf).
 
 get_all_cfgs(Root) ->
     Apps = filelib:wildcard("*", Root) -- ["emqx_machine", "emqx_conf"],


### PR DESCRIPTION
Prior to this change, configs had 4 layers:
1. base (emqx.conf)
2. cluster override
3. local override
4. environment variables

environment variables at the top layer causes inconsistent behaviour
when override at runtime, environment vars are overridden by cluster/local overrides
when restarted later, environment vars are applied on top of cluster/local overrides

After this change
base + environment vars are merged to the base layer.
overrides are always on top