### PR TITLE
refactor(authn,authz): unify variable interpolation

### DIFF
--- a/apps/emqx_authn/test/emqx_authn_pgsql_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_pgsql_SUITE.erl
@@ -31,7 +31,7 @@
 -define(PATH, [authentication]).
 
 all() ->
-    [{group, require_seeds}, t_create_invalid, t_parse_query].
+    [{group, require_seeds}, t_create_invalid].
 
 groups() ->
     [{require_seeds, [], [t_create, t_authenticate, t_update, t_destroy, t_is_superuser]}].
@@ -251,18 +251,6 @@ test_is_superuser({Field, Value, ExpectedValue}) ->
     ?assertEqual(
        {ok, #{is_superuser => ExpectedValue}},
        emqx_access_control:authenticate(Credentials)).
-
-
-t_parse_query(_) ->
-    Query1 = ?PH_USERNAME,
-    ?assertEqual({<<"$1">>, [?PH_USERNAME]}, emqx_authn_pgsql:parse_query(Query1)),
-
-    Query2 = <<?PH_USERNAME/binary, ", ", ?PH_CLIENTID/binary>>,
-    ?assertEqual({<<"$1, $2">>, [?PH_USERNAME, ?PH_CLIENTID]},
-        emqx_authn_pgsql:parse_query(Query2)),
-
-    Query3 = <<"nomatch">>,
-    ?assertEqual({<<"nomatch">>, []}, emqx_authn_pgsql:parse_query(Query3)).
 
 %%------------------------------------------------------------------------------
 %% Helpers

--- a/apps/emqx_authz/src/emqx_authz_api_sources.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_sources.erl
@@ -42,6 +42,8 @@
                      ]
         }).
 
+-define(IS_TRUE(Val), ((Val =:= true) or (Val =:= <<"true">>))).
+
 -export([ get_raw_sources/0
         , get_raw_source/1
         ]).
@@ -462,8 +464,7 @@ read_certs(#{<<"ssl">> := SSL} = Source) ->
     end;
 read_certs(Source) -> Source.
 
-maybe_write_certs(#{<<"ssl">> := #{<<"enable">> := True} = SSL} = Source)
-  when (True =:= true) or (True =:= <<"true">>) ->
+maybe_write_certs(#{<<"ssl">> := #{<<"enable">> := True} = SSL} = Source) when ?IS_TRUE(True) ->
     Type = maps:get(<<"type">>, Source),
     {ok, Return} = emqx_tls_lib:ensure_ssl_files(filename:join(["authz", Type]), SSL),
     maps:put(<<"ssl">>, Return, Source);

--- a/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
@@ -159,7 +159,7 @@ t_query_params(_Config) ->
            #{<<"url">> => <<"http://127.0.0.1:33333/authz/users/?"
                             "username=${username}&"
                             "clientid=${clientid}&"
-                            "peerhost=${host}&"
+                            "peerhost=${peerhost}&"
                             "proto_name=${proto_name}&"
                             "mountpoint=${mountpoint}&"
                             "topic=${topic}&"
@@ -204,7 +204,7 @@ t_json_body(_Config) ->
            #{<<"method">> => <<"post">>,
              <<"body">> => #{<<"username">> => <<"${username}">>,
                              <<"CLIENT">> => <<"${clientid}">>,
-                             <<"peerhost">> => <<"${host}">>,
+                             <<"peerhost">> => <<"${peerhost}">>,
                              <<"proto_name">> => <<"${proto_name}">>,
                              <<"mountpoint">> => <<"${mountpoint}">>,
                              <<"topic">> => <<"${topic}">>,
@@ -250,7 +250,7 @@ t_form_body(_Config) ->
            #{<<"method">> => <<"post">>,
              <<"body">> => #{<<"username">> => <<"${username}">>,
                              <<"clientid">> => <<"${clientid}">>,
-                             <<"peerhost">> => <<"${host}">>,
+                             <<"peerhost">> => <<"${peerhost}">>,
                              <<"proto_name">> => <<"${proto_name}">>,
                              <<"mountpoint">> => <<"${mountpoint}">>,
                              <<"topic">> => <<"${topic}">>,

--- a/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
@@ -86,7 +86,7 @@ t_topic_rules(_Config) ->
 
 
 t_lookups(_Config) ->
-    ClientInfo = #{clientid => <<"clientid">>,
+    ClientInfo = #{clientid => <<"client id">>,
                    cn => <<"cn">>,
                    dn => <<"dn">>,
                    username => <<"username">>,
@@ -95,7 +95,7 @@ t_lookups(_Config) ->
                    listener => {tcp, default}
                   },
 
-    ByClientid = #{<<"mqtt_user:clientid">> =>
+    ByClientid = #{<<"mqtt_user:client id">> =>
                    #{<<"a">> => <<"all">>}},
 
     ok = setup_sample(ByClientid),

--- a/apps/emqx_plugin_libs/src/emqx_placeholder.erl
+++ b/apps/emqx_plugin_libs/src/emqx_placeholder.erl
@@ -18,6 +18,7 @@
 
 %% preprocess and process template string with place holders
 -export([ preproc_tmpl/1
+        , preproc_tmpl/2
         , proc_tmpl/2
         , proc_tmpl/3
         , preproc_cmd/1
@@ -28,43 +29,66 @@
         , proc_sql/2
         , proc_sql_param_str/2
         , proc_cql_param_str/2
-        ]).
+        , preproc_tmpl_deep/1
+        , preproc_tmpl_deep/2
+        , proc_tmpl_deep/2
+        , proc_tmpl_deep/3
 
--import(emqx_plugin_libs_rule, [bin/1]).
+        , bin/1
+        , sql_data/1
+        ]).
 
 -define(EX_PLACE_HOLDER, "(\\$\\{[a-zA-Z0-9\\._]+\\})").
 -define(EX_WITHE_CHARS, "\\s"). %% Space and CRLF
 
--type(tmpl_token() :: list({var, binary()} | {str, binary()})).
+-type tmpl_token() :: list({var, binary()} | {str, binary()}).
 
--type(tmpl_cmd() :: list(tmpl_token())).
+-type tmpl_cmd() :: list(tmpl_token()).
 
--type(prepare_statement_key() :: binary()).
+-type prepare_statement_key() :: binary().
 
-%% preprocess template string with place holders
--spec(preproc_tmpl(binary()) -> tmpl_token()).
+-type var_trans() ::
+            fun((FoundValue :: term()) -> binary()) |
+            fun((Placeholder :: term(), FoundValue :: term()) -> binary()).
+
+-type preproc_tmpl_opts() :: #{placeholders => list(binary())}.
+
+-type preproc_sql_opts() :: #{placeholders => list(binary()),
+                              replace_with => '?' | '$n'}.
+
+-type preproc_deep_opts() :: #{placeholders => list(binary()),
+                               process_keys => boolean()}.
+
+-type proc_tmpl_opts() :: #{return => rawlist | full_binary,
+                            var_trans => var_trans()}.
+
+-type deep_template() ::
+        #{deep_template() => deep_template()} |
+        {tuple, [deep_template()]} |
+        [deep_template()] |
+        {tmpl, tmpl_token()} |
+        {value, term()}.
+
+%%------------------------------------------------------------------------------
+%% APIs
+%%------------------------------------------------------------------------------
+
+-spec preproc_tmpl(binary()) -> tmpl_token().
 preproc_tmpl(Str) ->
-    Tokens = re:split(Str, ?EX_PLACE_HOLDER, [{return,binary},group,trim]),
-    preproc_tmpl(Tokens, []).
+    preproc_tmpl(Str, #{}).
 
-preproc_tmpl([], Acc) ->
-    lists:reverse(Acc);
-preproc_tmpl([[Str, Phld] | Tokens], Acc) ->
-    preproc_tmpl(Tokens,
-        put_head(var, parse_nested(unwrap(Phld)),
-            put_head(str, Str, Acc)));
-preproc_tmpl([[Str] | Tokens], Acc) ->
-    preproc_tmpl(Tokens, put_head(str, Str, Acc)).
+-spec preproc_tmpl(binary(), preproc_tmpl_opts()) -> tmpl_token().
+preproc_tmpl(Str, Opts) ->
+    RE = preproc_var_re(Opts),
+    Tokens = re:split(Str, RE, [{return, binary}, group, trim]),
+    do_preproc_tmpl(Tokens, []).
 
-put_head(_Type, <<>>, List) -> List;
-put_head(Type, Term, List) ->
-    [{Type, Term} | List].
 
--spec(proc_tmpl(tmpl_token(), map()) -> binary()).
+-spec proc_tmpl(tmpl_token(), map()) -> binary().
 proc_tmpl(Tokens, Data) ->
     proc_tmpl(Tokens, Data, #{return => full_binary}).
 
--spec(proc_tmpl(tmpl_token(), map(), map()) -> binary() | list()).
+-spec proc_tmpl(tmpl_token(), map(), proc_tmpl_opts()) -> binary() | list().
 proc_tmpl(Tokens, Data, Opts = #{return := full_binary}) ->
     Trans = maps:get(var_trans, Opts, fun emqx_plugin_libs_rule:bin/1),
     list_to_binary(
@@ -74,53 +98,133 @@ proc_tmpl(Tokens, Data, Opts = #{return := rawlist}) ->
     Trans = maps:get(var_trans, Opts, undefined),
     lists:map(
         fun ({str, Str}) -> Str;
-            ({var, Phld}) when is_function(Trans) ->
+            ({var, Phld}) when is_function(Trans, 1) ->
                 Trans(get_phld_var(Phld, Data));
+            ({var, Phld}) when is_function(Trans, 2) ->
+                Trans(Phld, get_phld_var(Phld, Data));
             ({var, Phld}) ->
                 get_phld_var(Phld, Data)
         end, Tokens).
 
 
--spec(preproc_cmd(binary()) -> tmpl_cmd()).
+-spec preproc_cmd(binary()) -> tmpl_cmd().
 preproc_cmd(Str) ->
     SubStrList = re:split(Str, ?EX_WITHE_CHARS, [{return,binary},trim]),
     [preproc_tmpl(SubStr) || SubStr <- SubStrList].
 
--spec(proc_cmd([tmpl_token()], map()) -> binary() | list()).
+-spec proc_cmd([tmpl_token()], map()) -> binary() | list().
 proc_cmd(Tokens, Data) ->
     proc_cmd(Tokens, Data, #{return => full_binary}).
--spec(proc_cmd([tmpl_token()], map(), map()) -> list()).
+-spec proc_cmd([tmpl_token()], map(), map()) -> list().
 proc_cmd(Tokens, Data, Opts) ->
     [proc_tmpl(Tks, Data, Opts) || Tks <- Tokens].
 
+
 %% preprocess SQL with place holders
--spec(preproc_sql(Sql::binary()) -> {prepare_statement_key(), tmpl_token()}).
+-spec preproc_sql(Sql::binary()) -> {prepare_statement_key(), tmpl_token()}.
 preproc_sql(Sql) ->
     preproc_sql(Sql, '?').
 
--spec(preproc_sql(Sql::binary(), ReplaceWith :: '?' | '$n')
-        -> {prepare_statement_key(), tmpl_token()}).
+-spec preproc_sql(binary(), '?' | '$n' | preproc_sql_opts()) ->
+        {prepare_statement_key(), tmpl_token()}.
+preproc_sql(Sql, ReplaceWith) when is_atom(ReplaceWith) ->
+    preproc_sql(Sql, #{replace_with => ReplaceWith});
 
-preproc_sql(Sql, ReplaceWith) ->
-    case re:run(Sql, ?EX_PLACE_HOLDER, [{capture, all_but_first, binary}, global]) of
+preproc_sql(Sql, Opts) ->
+    RE = preproc_var_re(Opts),
+    ReplaceWith = maps:get(replace_with, Opts, '?'),
+    case re:run(Sql, RE, [{capture, all_but_first, binary}, global]) of
         {match, PlaceHolders} ->
             PhKs = [parse_nested(unwrap(Phld)) || [Phld | _] <- PlaceHolders],
-            {replace_with(Sql, ReplaceWith), [{var, Phld} || Phld <- PhKs]};
+            {replace_with(Sql, RE, ReplaceWith), [{var, Phld} || Phld <- PhKs]};
         nomatch ->
             {Sql, []}
     end.
 
--spec(proc_sql(tmpl_token(), map()) -> list()).
+
+-spec proc_sql(tmpl_token(), map()) -> list().
 proc_sql(Tokens, Data) ->
     proc_tmpl(Tokens, Data, #{return => rawlist, var_trans => fun sql_data/1}).
 
--spec(proc_sql_param_str(tmpl_token(), map()) -> binary()).
+
+-spec proc_sql_param_str(tmpl_token(), map()) -> binary().
 proc_sql_param_str(Tokens, Data) ->
     proc_param_str(Tokens, Data, fun quote_sql/1).
 
--spec(proc_cql_param_str(tmpl_token(), map()) -> binary()).
+
+-spec proc_cql_param_str(tmpl_token(), map()) -> binary().
 proc_cql_param_str(Tokens, Data) ->
     proc_param_str(Tokens, Data, fun quote_cql/1).
+
+
+-spec preproc_tmpl_deep(term()) -> deep_template().
+preproc_tmpl_deep(Data) ->
+    preproc_tmpl_deep(Data, #{process_keys => true}).
+
+-spec preproc_tmpl_deep(term(), preproc_deep_opts()) -> deep_template().
+preproc_tmpl_deep(List, Opts) when is_list(List) ->
+    [preproc_tmpl_deep(El, Opts) || El <- List];
+
+preproc_tmpl_deep(Map, Opts) when is_map(Map) ->
+    maps:from_list(
+      lists:map(
+        fun({K, V}) ->
+                {preproc_tmpl_deep_map_key(K, Opts),
+                 preproc_tmpl_deep(V, Opts)}
+        end,
+        maps:to_list(Map)));
+
+preproc_tmpl_deep(Binary, Opts) when is_binary(Binary) ->
+    {tmpl, preproc_tmpl(Binary, Opts)};
+
+preproc_tmpl_deep(Tuple, Opts) when is_tuple(Tuple) ->
+    {tuple, preproc_tmpl_deep(tuple_to_list(Tuple), Opts)};
+
+preproc_tmpl_deep(Other, _Opts) ->
+    {value, Other}.
+
+
+-spec proc_tmpl_deep(deep_template(), map()) -> term().
+proc_tmpl_deep(DeepTmpl, Data) ->
+    proc_tmpl_deep(DeepTmpl, Data, #{return => full_binary}).
+
+-spec proc_tmpl_deep(deep_template(), map(), proc_tmpl_opts()) -> term().
+proc_tmpl_deep(List, Data, Opts) when is_list(List) ->
+    [proc_tmpl_deep(El, Data, Opts) || El <- List];
+
+proc_tmpl_deep(Map, Data, Opts) when is_map(Map) ->
+    maps:from_list(
+      lists:map(
+        fun({K, V}) ->
+                {proc_tmpl_deep(K, Data, Opts),
+                 proc_tmpl_deep(V, Data, Opts)}
+        end,
+        maps:to_list(Map)));
+
+proc_tmpl_deep({value, Value}, _Data, _Opts) -> Value;
+
+proc_tmpl_deep({tmpl, Tokens}, Data, Opts) -> proc_tmpl(Tokens, Data, Opts);
+
+proc_tmpl_deep({tuple, Elements}, Data, Opts) ->
+    list_to_tuple([proc_tmpl_deep(El, Data, Opts) || El <- Elements]).
+
+
+-spec sql_data(term()) -> term().
+sql_data(undefined) -> null;
+sql_data(List) when is_list(List) -> List;
+sql_data(Bin) when is_binary(Bin) -> Bin;
+sql_data(Num) when is_number(Num) -> Num;
+sql_data(Bool) when is_boolean(Bool) -> Bool;
+sql_data(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
+sql_data(Map) when is_map(Map) -> emqx_json:encode(Map).
+
+
+-spec bin(term()) -> binary().
+bin(Val) -> emqx_plugin_libs_rule:bin(Val).
+
+%%------------------------------------------------------------------------------
+%% Internal functions
+%%------------------------------------------------------------------------------
 
 proc_param_str(Tokens, Data, Quote) ->
     iolist_to_binary(
@@ -132,10 +236,42 @@ get_phld_var(Fun, Data) when is_function(Fun) ->
 get_phld_var(Phld, Data) ->
     emqx_rule_maps:nested_get(Phld, Data).
 
-replace_with(Tmpl, '?') ->
-    re:replace(Tmpl, ?EX_PLACE_HOLDER, "?", [{return, binary}, global]);
-replace_with(Tmpl, '$n') ->
-    Parts = re:split(Tmpl, ?EX_PLACE_HOLDER, [{return, binary}, trim, group]),
+preproc_var_re(#{placeholders := PHs}) ->
+    "(" ++ string:join([ph_to_re(PH) || PH <- PHs], "|") ++ ")";
+preproc_var_re(#{}) ->
+    ?EX_PLACE_HOLDER.
+
+ph_to_re(VarPH) ->
+    re:replace(VarPH, "[\\$\\{\\}]", "\\\\&", [global, {return, list}]).
+
+do_preproc_tmpl([], Acc) ->
+    lists:reverse(Acc);
+do_preproc_tmpl([[Str, Phld] | Tokens], Acc) ->
+    do_preproc_tmpl(
+      Tokens,
+      put_head(
+        var,
+        parse_nested(unwrap(Phld)),
+        put_head(str, Str, Acc)));
+do_preproc_tmpl([[Str] | Tokens], Acc) ->
+    do_preproc_tmpl(
+      Tokens,
+      put_head(str, Str, Acc)).
+
+put_head(_Type, <<>>, List) -> List;
+put_head(Type, Term, List) ->
+    [{Type, Term} | List].
+
+preproc_tmpl_deep_map_key(Key, #{process_keys := true} = Opts) ->
+    preproc_tmpl_deep(Key, Opts);
+
+preproc_tmpl_deep_map_key(Key, _) ->
+    {value, Key}.
+
+replace_with(Tmpl, RE, '?') ->
+    re:replace(Tmpl, RE, "?", [{return, binary}, global]);
+replace_with(Tmpl, RE, '$n') ->
+    Parts = re:split(Tmpl, RE, [{return, binary}, trim, group]),
     {Res, _} =
         lists:foldl(
             fun([Tkn, _Phld], {Acc, Seq}) ->
@@ -154,14 +290,6 @@ parse_nested(Attr) ->
 
 unwrap(<<"${", Val/binary>>) ->
     binary:part(Val, {0, byte_size(Val)-1}).
-
-sql_data(undefined) -> null;
-sql_data(List) when is_list(List) -> List;
-sql_data(Bin) when is_binary(Bin) -> Bin;
-sql_data(Num) when is_number(Num) -> Num;
-sql_data(Bool) when is_boolean(Bool) -> Bool;
-sql_data(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8);
-sql_data(Map) when is_map(Map) -> emqx_json:encode(Map).
 
 quote_sql(Str) ->
     quote(Str, <<"\\\\'">>).

--- a/apps/emqx_plugin_libs/test/emqx_placeholder_SUITE.erl
+++ b/apps/emqx_plugin_libs/test/emqx_placeholder_SUITE.erl
@@ -30,6 +30,18 @@ t_proc_tmpl(_) ->
     ?assertEqual(<<"a:1,b:1,c:1.0,d:{\"d1\":\"hi\"}">>,
                  emqx_placeholder:proc_tmpl(Tks, Selected)).
 
+t_proc_tmpl_path(_) ->
+    Selected = #{d => #{d1 => <<"hi">>}},
+    Tks = emqx_placeholder:preproc_tmpl(<<"d.d1:${d.d1}">>),
+    ?assertEqual(<<"d.d1:hi">>,
+                 emqx_placeholder:proc_tmpl(Tks, Selected)).
+
+t_proc_tmpl_custom_ph(_) ->
+    Selected = #{a => <<"a">>, b => <<"b">>},
+    Tks = emqx_placeholder:preproc_tmpl(<<"a:${a},b:${b}">>, #{placeholders => [<<"${a}">>]}),
+    ?assertEqual(<<"a:a,b:${b}">>,
+                 emqx_placeholder:proc_tmpl(Tks, Selected)).
+
 t_proc_tmpl1(_) ->
     Selected = #{a => <<"1">>, b => 1, c => 1.0, d => #{d1 => <<"hi">>}},
     Tks = emqx_placeholder:preproc_tmpl(<<"a:$a,b:b},c:{c},d:${d">>),
@@ -59,6 +71,7 @@ t_preproc_sql1(_) ->
     ?assertEqual(<<"a:$1,b:$2,c:$3,d:$4">>, PrepareStatement),
     ?assertEqual([<<"1">>,1,1.0,<<"{\"d1\":\"hi\"}">>],
                  emqx_placeholder:proc_sql(ParamsTokens, Selected)).
+
 t_preproc_sql2(_) ->
     Selected = #{a => <<"1">>, b => 1, c => 1.0, d => #{d1 => <<"hi">>}},
     {PrepareStatement, ParamsTokens} =
@@ -89,3 +102,29 @@ t_preproc_sql5(_) ->
     ParamsTokens = emqx_placeholder:preproc_tmpl(<<"a:${a},b:${b},c:${c},d:${d}">>),
     ?assertEqual(<<"a:'1''''2',b:1,c:1.0,d:'{\"d1\":\"someone''s phone\"}'">>,
                  emqx_placeholder:proc_cql_param_str(ParamsTokens, Selected)).
+
+t_preproc_sql6(_) ->
+    Selected = #{a => <<"a">>, b => <<"b">>},
+    {PrepareStatement, ParamsTokens} = emqx_placeholder:preproc_sql(
+                                         <<"a:${a},b:${b}">>,
+                                         #{replace_with => '$n',
+                                           placeholders => [<<"${a}">>]}),
+    ?assertEqual(<<"a:$1,b:${b}">>, PrepareStatement),
+    ?assertEqual([<<"a">>],
+                 emqx_placeholder:proc_sql(ParamsTokens, Selected)).
+
+t_preproc_tmpl_deep(_) ->
+    Selected = #{a => <<"1">>, b => 1, c => 1.0, d => #{d1 => <<"hi">>}},
+
+    Tmpl0 = emqx_placeholder:preproc_tmpl_deep(
+             #{<<"${a}">> => [<<"${b}">>, "c", 2, 3.0, '${d}', {[<<"${c}">>], 0}]}),
+    ?assertEqual(
+       #{<<"1">> => [<<"1">>, "c", 2, 3.0, '${d}', {[<<"1.0">>], 0}]},
+       emqx_placeholder:proc_tmpl_deep(Tmpl0, Selected)),
+
+    Tmpl1 = emqx_placeholder:preproc_tmpl_deep(
+             #{<<"${a}">> => [<<"${b}">>, "c", 2, 3.0, '${d}', {[<<"${c}">>], 0}]},
+             #{process_keys => false}),
+    ?assertEqual(
+       #{<<"${a}">> => [<<"1">>, "c", 2, 3.0, '${d}', {[<<"1.0">>], 0}]},
+       emqx_placeholder:proc_tmpl_deep(Tmpl1, Selected)).


### PR DESCRIPTION
Almost each authn/authz backend reimplements placeholder substitution. This eliminates code duplication.