### PR TITLE
ci: fix base version match pattern

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -28,13 +28,13 @@ jobs:
         run: |
           cd source
           vsn="$(./pkg-vsn.sh)"
-          pre_vsn="$(echo $vsn | grep -oE '^[0-9]+.[0-9]')"
+          base_vsn_prefix="$(echo $vsn | grep -oE '^[0-9]+\.[0-9]+')"
           if make emqx-ee --dry-run > /dev/null 2>&1; then
-            old_vsns="$(git tag -l "e$pre_vsn.[0-9]" | xargs echo -n | sed "s/e$vsn//")"
+            old_vsns="$(git tag -l | grep -E "^e${base_vsn_prefix}\.[0-9]+$" | grep -v "e${vsn}" | xargs)"
             echo "::set-output name=old_vsns::$old_vsns"
             echo "::set-output name=profiles::[\"emqx-ee\"]"
           else
-            old_vsns="$(git tag -l "v$pre_vsn.[0-9]" | xargs echo -n | sed "s/v$vsn//")"
+            old_vsns="$(git tag -l | grep -E "^v${base_vsn_prefix}\.[0-9]+$" | grep -v "v${vsn}" | xargs)"
             echo "::set-output name=old_vsns::$old_vsns"
             echo "::set-output name=profiles::[\"emqx\", \"emqx-edge\"]"
           fi


### PR DESCRIPTION
`git tag -l "v$pre_vsn.[0-9]"` only matches 1 digit 

the new build has:
`OLD_VSNS: v4.3.0 v4.3.1 v4.3.10 v4.3.11 v4.3.2 v4.3.3 v4.3.4 v4.3.5 v4.3.6 v4.3.7 v4.3.8 v4.3.9`