### PR TITLE
refactor: remove dollar sign from config fields

### DIFF
--- a/.github/workflows/run_api_tests.yaml
+++ b/.github/workflows/run_api_tests.yaml
@@ -86,7 +86,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: emqx/emqx-fvt
-        ref: 1.0.4-dev1
+        ref: 1.0.4-dev2
         path: .
     - uses: actions/setup-java@v1
       with:

--- a/apps/emqx_modules/etc/emqx_modules.conf
+++ b/apps/emqx_modules/etc/emqx_modules.conf
@@ -14,13 +14,13 @@ telemetry {
 }
 
 event_message {
-    "$event/client_connected" = true
-    "$event/client_disconnected" = true
-    # "$event/client_subscribed": false
-    # "$event/client_unsubscribed": false
-    # "$event/message_delivered": false
-    # "$event/message_acked": false
-    # "$event/message_dropped": false
+    client_connected = true
+    client_disconnected = true
+    # client_subscribed = false
+    # client_unsubscribed = false
+    # message_delivered = false
+    # message_acked = false
+    # message_dropped = false
 }
 
 topic_metrics: [

--- a/apps/emqx_modules/src/emqx_event_message.erl
+++ b/apps/emqx_modules/src/emqx_event_message.erl
@@ -58,19 +58,19 @@ enable() ->
     lists:foreach(fun({_Topic, false}) -> ok;
                      ({Topic, true}) ->
         case Topic of
-            '$event/client_connected' ->
+            client_connected ->
                 emqx_hooks:put('client.connected', {?MODULE, on_client_connected, []});
-            '$event/client_disconnected' ->
+            client_disconnected ->
                 emqx_hooks:put('client.disconnected', {?MODULE, on_client_disconnected, []});
-            '$event/client_subscribed' ->
+            client_subscribed ->
                 emqx_hooks:put('session.subscribed', {?MODULE, on_client_subscribed, []});
-            '$event/client_unsubscribed' ->
+            client_unsubscribed ->
                 emqx_hooks:put('session.unsubscribed', {?MODULE, on_client_unsubscribed, []});
-            '$event/message_delivered' ->
+            message_delivered ->
                 emqx_hooks:put('message.delivered', {?MODULE, on_message_delivered, []});
-            '$event/message_acked' ->
+            message_acked ->
                 emqx_hooks:put('message.acked', {?MODULE, on_message_acked, []});
-            '$event/message_dropped' ->
+            message_dropped ->
                 emqx_hooks:put('message.dropped', {?MODULE, on_message_dropped, []});
             _ ->
                 ok
@@ -81,19 +81,19 @@ disable() ->
     lists:foreach(fun({_Topic, false}) -> ok;
                      ({Topic, true}) ->
         case Topic of
-            '$event/client_connected' ->
+            client_connected ->
                 emqx_hooks:del('client.connected', {?MODULE, on_client_connected});
-            '$event/client_disconnected' ->
+            client_disconnected ->
                 emqx_hooks:del('client.disconnected', {?MODULE, on_client_disconnected});
-            '$event/client_subscribed' ->
+            client_subscribed ->
                 emqx_hooks:del('session.subscribed', {?MODULE, on_client_subscribed});
-            '$event/client_unsubscribed' ->
+            client_unsubscribed ->
                 emqx_hooks:del('session.unsubscribed', {?MODULE, on_client_unsubscribed});
-            '$event/message_delivered' ->
+            message_delivered ->
                 emqx_hooks:del('message.delivered', {?MODULE, on_message_delivered});
-            '$event/message_acked' ->
+            message_acked ->
                 emqx_hooks:del('message.acked', {?MODULE, on_message_acked});
-            '$event/message_dropped' ->
+            message_dropped ->
                 emqx_hooks:del('message.dropped', {?MODULE, on_message_dropped});
             _ ->
                 ok

--- a/apps/emqx_modules/src/emqx_modules_schema.erl
+++ b/apps/emqx_modules/src/emqx_modules_schema.erl
@@ -57,28 +57,44 @@ fields("rewrite") ->
 
 
 fields("event_message") ->
-    [ { '$event/client_connected'
-      , sc( boolean()
-          , #{desc => <<"Client connected to EMQ X event">>, default => false})}
-    , { '$event/client_disconnected'
-      , sc(boolean()
-          , #{desc => <<"Client disconnected to EMQ X event">>, default => false})}
-    , { '$event/client_subscribed'
-      , sc( boolean()
-          , #{desc => <<"Client subscribe topic event">>, default => false})}
-    , { '$event/client_unsubscribed'
-      , sc( boolean()
-          , #{desc => <<"Client unsubscribe topic event">>, default => false})}
-    , { '$event/message_delivered'
-      , sc( boolean()
-          , #{desc => <<"Message delivered event">>, default => false})}
-    , { '$event/message_acked'
-      , sc( boolean()
-          , #{desc => <<"Message acked event">>, default => false})}
-    , { '$event/message_dropped'
-      , sc( boolean()
-          , #{desc => <<"Message dropped event">>, default => false})}
-    ];
+    Fields =
+        [ { client_connected
+        , sc( boolean()
+            , #{desc => <<"Enable/disable client_connected event messages">>,
+                default => false})}
+        , { client_disconnected
+        , sc(boolean()
+            , #{desc => <<"Enable/disable client_disconnected event messages">>,
+                default => false})}
+        , { client_subscribed
+        , sc( boolean()
+            , #{desc => <<"Enable/disable client_subscribed event messages">>,
+                default => false})}
+        , { client_unsubscribed
+        , sc( boolean()
+            , #{desc => <<"Enable/disable client_unsubscribed event messages">>,
+                default => false})}
+        , { message_delivered
+        , sc( boolean()
+            , #{desc => <<"Enable/disable message_delivered event messages">>,
+                default => false})}
+        , { message_acked
+        , sc( boolean()
+            , #{desc => <<"Enable/disable message_acked event messages">>,
+                default => false})}
+        , { message_dropped
+        , sc( boolean()
+            , #{desc => <<"Enable/disable message_dropped event messages">>,
+                default => false})}
+        ],
+    #{fields => Fields,
+      desc => """
+Enable/Disable system event messages.
+The messages are plublished to '$event' prefixed topics.
+For example, if `client_disconnected` is set to `true`,
+a message is published to `$event/client_connected` topic
+whenver a client is connected.
+"""};
 
 fields("topic_metrics") ->
     [{topic, sc(binary(), #{})}].

--- a/apps/emqx_modules/test/emqx_event_message_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_event_message_SUITE.erl
@@ -24,14 +24,14 @@
 
 -define(EVENT_MESSAGE, <<"""
 event_message: {
-    \"$event/client_connected\": true
-    \"$event/client_disconnected\": true
-    \"$event/client_subscribed\": true
-    \"$event/client_unsubscribed\": true
-    \"$event/message_delivered\": true
-    \"$event/message_acked\": true
-    \"$event/message_dropped\": true
-  }""">>).
+    client_connected: true
+    client_disconnected: true
+    client_subscribed: true
+    client_unsubscribed: true
+    message_delivered: true
+    message_acked: true
+    message_dropped: true
+}""">>).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 


### PR DESCRIPTION
Dollar sign is used for map types.
Doc will be confusing