### PR TITLE
fix(alarm): watermark replace >= =< with > <

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.erl
@@ -42,11 +42,11 @@ init(#{clientid_list := ClientidList, username_list := UsernameList}) ->
             {attributes, record_info(fields, emqx_user)},
             {storage_properties, [{ets, [{read_concurrency, true}]}]}]),
     lists:foreach(fun({Clientid, Password}) ->
-    emqx_auth_mnesia_cli:add_default_user(clientid, iolist_to_binary(Clientid), iolist_to_binary(Password))
+        emqx_auth_mnesia_cli:add_default_user(clientid, iolist_to_binary(Clientid), iolist_to_binary(Password))
     end, ClientidList),
 
     lists:foreach(fun({Username, Password}) ->
-    emqx_auth_mnesia_cli:add_default_user(username, iolist_to_binary(Username), iolist_to_binary(Password))
+        emqx_auth_mnesia_cli:add_default_user(username, iolist_to_binary(Username), iolist_to_binary(Password))
     end, UsernameList),
 
     ok = ekka_mnesia:copy_table(?TABLE, disc_copies).

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_cli.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_cli.erl
@@ -78,14 +78,14 @@ add_default_user(Type, Key, Password) ->
                             username -> user
                         end,
                     ?LOG(warning,
-                        "[Auth Mnesia] auth.client.x.~p=~s's password in the emqx_auth_mnesia.conf\n"
+                        "[Auth Mnesia] auth.client.x.~p=~s password in the emqx_auth_mnesia.conf\n"
                         "does not match the password in the database(mnesia).\n"
                         "1. If you have already changed the password via the HTTP API, this warning has no effect.\n"
-                        "You can remove the warning from emqx_auth_mnesia.conf to resolve the warning.\n"
+                        "You can remove the `auth.client.x.~p=~s` from emqx_auth_mnesia.conf to resolve this warning.\n"
                         "2. If you just want to update the password by manually changing the configuration file,\n"
                         "you need to delete the old user and password using `emqx_ctl ~p delete ~s` first\n"
                         "the new password in emqx_auth_mnesia.conf can take effect after reboot.",
-                        [Type, Key, TypeCtl, Key]),
+                        [Type, Key, Type, Key, TypeCtl, Key]),
                     ok
             end;
         Error -> Error

--- a/src/emqx_os_mon.erl
+++ b/src/emqx_os_mon.erl
@@ -147,12 +147,12 @@ handle_info({timeout, Timer, check}, State = #{timer := Timer,
     case emqx_vm:cpu_util() of %% TODO: should be improved?
         0 ->
             State#{timer := undefined};
-        Busy when Busy >= CPUHighWatermark ->
+        Busy when Busy > CPUHighWatermark ->
             emqx_alarm:activate(high_cpu_usage, #{usage => Busy,
                                                   high_watermark => CPUHighWatermark,
                                                   low_watermark => CPULowWatermark}),
             ensure_check_timer(State);
-        Busy when Busy =< CPULowWatermark ->
+        Busy when Busy < CPULowWatermark ->
             emqx_alarm:deactivate(high_cpu_usage),
             ensure_check_timer(State);
         _Busy ->
@@ -191,7 +191,7 @@ ensure_system_memory_alarm(HW) ->
         undefined -> ok;
         _Pid ->
             {Allocated, Total, _Worst} = memsup:get_memory_data(),
-            case Total =/= 0 andalso Allocated/Total * 100 >= HW of
+            case Total =/= 0 andalso Allocated/Total * 100 > HW of
                 true -> emqx_alarm:activate(high_system_memory_usage, #{high_watermark => HW});
                 false -> ok
             end

--- a/src/emqx_vm_mon.erl
+++ b/src/emqx_vm_mon.erl
@@ -112,7 +112,7 @@ handle_info({timeout, Timer, check},
                       process_low_watermark := ProcLowWatermark}) ->
     ProcessCount = erlang:system_info(process_count),
     case ProcessCount / erlang:system_info(process_limit) * 100 of
-        Percent when Percent >= ProcHighWatermark ->
+        Percent when Percent > ProcHighWatermark ->
             emqx_alarm:activate(too_many_processes, #{usage => Percent,
                                                       high_watermark => ProcHighWatermark,
                                                       low_watermark => ProcLowWatermark});


### PR DESCRIPTION
Watermark use `>` `<` to check condition.

the `sysmem_high_watermark` is checked with `>` `<` https://github.com/erlang/otp/blob/master/lib/os_mon/src/memsup.erl#L392-L396

Need to unify the watermark check standard, PS: the dashboard UI also use > <

```bash
os_mon.cpu_high_watermark = 80%
os_mon.cpu_low_watermark = 60%
os_mon.sysmem_high_watermark = 70%
os_mon.procmem_high_watermark = 5%
vm_mon.process_high_watermark = 80%
vm_mon.process_low_watermark = 60%
```