### PR TITLE
chore(mix): use MIX_ENV to define build profile and edition

### DIFF
--- a/.github/workflows/elixir_release.yml
+++ b/.github/workflows/elixir_release.yml
@@ -23,12 +23,12 @@ jobs:
         run: make emqx-elixir
       - name: start release
         run: |
-          cd _build/prod/rel/emqx
+          cd _build/emqx/rel/emqx
           bin/emqx start
       - name: check if started
         run: |
           sleep 10
           nc -zv localhost 1883
-          cd _build/prod/rel/emqx
+          cd _build/emqx/rel/emqx
           bin/emqx ping
           bin/emqx ctl status

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -97,10 +97,13 @@ jobs:
       working-directory: source
       run: |
         set -x
-        IMAGE=emqx/${{ matrix.profile }}:$(./pkg-vsn.sh ${{ matrix.profile }})
         if [[ "${{ matrix.profile }}" = *-elixir ]]
         then
           export IS_ELIXIR=yes
+          PROFILE=$(echo ${{ matrix.profile }} | sed -e "s/-elixir//g")
+          IMAGE=emqx/$PROFILE:$(./pkg-vsn.sh ${{ matrix.profile }})-elixir
+        else
+          IMAGE=emqx/${{ matrix.profile }}:$(./pkg-vsn.sh ${{ matrix.profile }})
         fi
         ./.ci/docker-compose-file/scripts/run-emqx.sh $IMAGE ${{ matrix.cluster_db_backend }}
     - name: make paho tests

--- a/Makefile
+++ b/Makefile
@@ -229,9 +229,9 @@ $(REL_PROFILES:%=%-elixir) $(PKG_PROFILES:%=%-elixir): $(COMMON_DEPS) $(ELIXIR_C
 define gen-elixirpkg-target
 # the Elixir places the tar in a different path than Rebar3
 $1-elixirpkg: $1-pkg-elixir
-	@env TAR_PKG_DIR=_build/prod \
+	@env TAR_PKG_DIR=_build/$1-pkg \
 	     IS_ELIXIR=yes \
-	     $(BUILD) $1 pkg
+	     $(BUILD) $1-pkg pkg
 endef
 $(foreach pt,$(REL_PROFILES),$(eval $(call gen-elixirpkg-target,$(pt))))
 

--- a/build
+++ b/build
@@ -86,7 +86,7 @@ make_rel() {
 
 make_elixir_rel() {
   export_release_vars "$PROFILE"
-  env MIX_ENV=prod mix release --overwrite
+  mix release --overwrite
 }
 
 ## extract previous version .tar.gz files to _build/$PROFILE/rel/emqx before making relup
@@ -138,7 +138,7 @@ make_tgz() {
       # ensure tarball exists
       ELIXIR_MAKE_TAR=yes make_elixir_rel
 
-      local relpath="_build/prod"
+      local relpath="_build/${PROFILE}"
       target="${pkgpath}/${PROFILE}-${PKG_VSN}-elixir${ELIXIR_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.tar.gz"
     else
       # build the tarball again to ensure relup is included
@@ -170,12 +170,18 @@ make_tgz() {
 make_docker() {
     EMQX_BUILDER="${EMQX_BUILDER:-${EMQX_DEFAULT_BUILDER}}"
     EMQX_RUNNER="${EMQX_RUNNER:-${EMQX_DEFAULT_RUNNER}}"
+
+    if [[ "$PROFILE" = *-elixir ]]
+    then
+      PKG_VSN="$PKG_VSN-elixir"
+    fi
+
     set -x
     docker build --no-cache --pull \
        --build-arg BUILD_FROM="${EMQX_BUILDER}" \
        --build-arg RUN_FROM="${EMQX_RUNNER}" \
        --build-arg EMQX_NAME="$PROFILE" \
-       --tag "emqx/$PROFILE:${PKG_VSN}" \
+       --tag "emqx/${PROFILE%%-elixir}:${PKG_VSN}" \
        -f "${DOCKERFILE}" .
 }
 
@@ -227,46 +233,17 @@ make_docker_testing() {
 export_release_vars() {
   local profile="$1"
   case "$profile" in
-    emqx)
-      export EMQX_RLEASE_TYPE=cloud \
-             EMQX_PACKAGE_TYPE=bin \
-             EMQX_EDITION_TYPE=community \
-             ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-no}
+    emqx|emqx-edge|emqx-enterprise)
+      export ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-no}
       ;;
-    emqx-edge)
-      export EMQX_RLEASE_TYPE=edge \
-             EMQX_PACKAGE_TYPE=bin \
-             EMQX_EDITION_TYPE=community \
-             ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-no}
-      ;;
-    emqx-enterprise)
-      export EMQX_RLEASE_TYPE=cloud \
-             EMQX_PACKAGE_TYPE=bin \
-             EMQX_EDITION_TYPE=enterprise \
-             ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-no}
-      ;;
-    emqx-pkg)
-      export EMQX_RLEASE_TYPE=cloud \
-             EMQX_PACKAGE_TYPE=pkg \
-             EMQX_EDITION_TYPE=community \
-             ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-yes}
-      ;;
-    emqx-edge-pkg)
-      export EMQX_RLEASE_TYPE=edge \
-             EMQX_PACKAGE_TYPE=pkg \
-             EMQX_EDITION_TYPE=community \
-             ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-yes}
-      ;;
-    emqx-enterprise-pkg)
-      export EMQX_RLEASE_TYPE=cloud \
-             EMQX_PACKAGE_TYPE=pkg \
-             EMQX_EDITION_TYPE=enterprise \
-             ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-yes}
+    emqx-pkg|emqx-edge-pkg|emqx-enterprise-pkg)
+      export ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-yes}
       ;;
     *)
       echo Invalid profile "$profile"
       exit 1
   esac
+  export MIX_ENV="$profile"
 }
 
 log "building artifact=$ARTIFACT for profile=$PROFILE"

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -22,16 +22,13 @@ COPY . /emqx
 
 ARG EMQX_NAME=emqx
 
-RUN if [[ "$EMQX_NAME" = *-elixir ]]; then \
-      export EMQX_LIB_PATH="_build/prod/lib"; \
-      export EMQX_REL_PATH="/emqx/_build/prod/rel/emqx"; \
-    else \
-      export EMQX_LIB_PATH="_build/$EMQX_NAME/lib"; \
-      export EMQX_REL_PATH="/emqx/_build/$EMQX_NAME/rel/emqx"; \
-    fi \
+RUN export PROFILE="$EMQX_NAME" \
+    && export EMQX_NAME=${EMQX_NAME%%-elixir} \
+    && export EMQX_LIB_PATH="_build/$EMQX_NAME/lib" \
+    && export EMQX_REL_PATH="/emqx/_build/$EMQX_NAME/rel/emqx" \
     && cd /emqx \
     && rm -rf $EMQX_LIB_PATH \
-    && make $EMQX_NAME \
+    && make $PROFILE \
     && mkdir -p /emqx-rel \
     && mv $EMQX_REL_PATH /emqx-rel
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -186,6 +186,7 @@ profiles_dev() ->
 
 %% RelType: cloud (full size) | edge (slim size)
 %% PkgType: bin | pkg
+%% Edition: ce (community) | ee (enterprise)
 relx(Vsn, RelType, PkgType, Edition) ->
     [ {include_src,false}
     , {include_erts, true}


### PR DESCRIPTION
Instead of reading some enviroment variables to define the build profile for the Elixir build, we use the MIX_ENV value to emulate Rebar3's profiles.  Also, that makes the build output directory more similar to EMQ X's current scheme.