### PR TITLE
feat(dashboard): support bind specific ip(port or ip:port).

### DIFF
--- a/apps/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/apps/emqx_dashboard/etc/emqx_dashboard.conf
@@ -14,7 +14,7 @@ dashboard {
             protocol = http
             num_acceptors = 4
             max_connections = 512
-            port = 18083
+            bind = 18083
             backlog = 512
             send_timeout = 5s
             inet6 = false
@@ -23,7 +23,7 @@ dashboard {
     #    ,
     #     {
     #         protocol = https
-    #         port = 18084
+    #         bind = "127.0.0.1:18084"
     #         num_acceptors = 2
     #         backlog = 512
     #         send_timeout = 5s

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -80,9 +80,13 @@ start_listeners() ->
 
 stop_listeners() ->
     [begin
-        _ = minirest:stop(Name),
-        ?ULOG("Stop listener ~ts on ~p successfully.~n", [Name, Port])
-    end || {Name, _, Port, _} <- listeners()].
+        case minirest:stop(Name) of
+            ok ->
+                ?ULOG("Stop listener ~ts on ~p successfully.~n", [Name, Port]);
+            {error, not_found} ->
+                ?SLOG(warning, #{msg => "stop_listener_failed", name => Name, port => Port})
+        end
+     end || {Name, _, Port, _} <- listeners()].
 
 %%--------------------------------------------------------------------
 %% internal

--- a/apps/emqx_dashboard/src/emqx_dashboard_app.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_app.erl
@@ -27,10 +27,13 @@
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_dashboard_sup:start_link(),
     ok = mria_rlog:wait_for_shards([?DASHBOARD_SHARD], infinity),
-    _ = emqx_dashboard:start_listeners(),
-    emqx_dashboard_cli:load(),
-    {ok, _Result} = emqx_dashboard_admin:add_default_user(),
-    {ok, Sup}.
+    case emqx_dashboard:start_listeners() of
+        ok ->
+            emqx_dashboard_cli:load(),
+            {ok, _Result} = emqx_dashboard_admin:add_default_user(),
+            {ok, Sup};
+        {error, Reason} -> {error, Reason}
+    end.
 
 stop(_State) ->
     emqx_dashboard_cli:unload(),

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -29,8 +29,8 @@ fields("dashboard") ->
         sc(hoconsc:array(hoconsc:union([hoconsc:ref(?MODULE, "http"),
             hoconsc:ref(?MODULE, "https")])),
             #{ desc =>
-"""HTTP(s) listeners identified by their protocol type,
-is used to serve dashboard UI and restful HTTP API.<br>
+"""HTTP(s) listeners are identified by their protocol type and are
+used to serve dashboard UI and restful HTTP API.<br>
 Listeners must have a unique combination of port number and IP address.<br>
 For example, an HTTP listener can listen on all configured IP addresses
 on a given port for a machine by specifying the IP address 0.0.0.0.<br>

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -5,7 +5,7 @@
    %% FIXME: tag this as v3.1.3
    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {ref, "9994c76adca40d91a2545102230ccce2423fd8a7"}}},
    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.23.0"}}},
-   {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.10"}}}
+   {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.11"}}}
  ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule EMQXUmbrella.MixProject do
       {:mria, github: "emqx/mria", tag: "0.1.5", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.11.3", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.0", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.2.10", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.2.11", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.3", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.1.5"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.11.3"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.0"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.10"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.11"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.3"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}


### PR DESCRIPTION
Fix the: https://github.com/emqx/emqx/pull/5198

Allow to configure listening address in dashboard.
