### PR TITLE
fix(CI): build packages failed on release upgrade testing

### DIFF
--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -187,7 +187,7 @@ relup_test(){
                 fi
                 ./emqx/bin/emqx_ctl status
                 ./emqx/bin/emqx versions
-                cp "${PACKAGE_PATH}/${EMQX_NAME}"-*-"${TARGET_VERSION}-${ARCH}".zip ./emqx/releases
+                cp "${PACKAGE_PATH}/${EMQX_NAME}-${TARGET_VERSION}-*-${ARCH}".zip ./emqx/releases
                 ./emqx/bin/emqx install "${TARGET_VERSION}"
                 [ "$(./emqx/bin/emqx versions |grep permanent | awk '{print $2}')" = "${TARGET_VERSION}" ] || exit 1
                 ./emqx/bin/emqx_ctl status


### PR DESCRIPTION
build_packages.yaml

-name: build emqx packages

```
   creating: emqx/dynlibs/
3741
  inflating: emqx/dynlibs/libtinfo.so.6  
3742
  inflating: emqx/dynlibs/libcrypto.so.1.1  
3743
+ ./emqx/bin/emqx start
3744
+ ./emqx/bin/emqx_ctl status
3745
EMQ X Enterprise 4.4.0 is started successfully!
3746
Node 'emqx@127.0.0.1' 4.4.0 is started
3747
+ ./emqx/bin/emqx versions
3748
Installed versions:
3749
* 4.4.0	permanent
3750

3751
+ cp '/emqx/_packages/emqx-ee/emqx-ee-*-4.4.0-a6d2367f-amd64.zip' ./emqx/releases
3752
cp: cannot stat '/emqx/_packages/emqx-ee/emqx-ee-*-4.4.0-a6d2367f-amd64.zip': No such file or directory
3753
Error: Process completed with exit code 1.
```