### PR TITLE
ci: enable ci tests on pushes.

### DIFF
--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   push:
+    branch:
+      - master
     tags:
       - v*
       - e*

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -1,6 +1,6 @@
 name: Check Rebar Dependencies
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   check_deps_integrity:

--- a/.github/workflows/elixir_apps_check.yaml
+++ b/.github/workflows/elixir_apps_check.yaml
@@ -2,7 +2,7 @@
 
 name: Check Elixir Release Applications
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   elixir_apps_check:

--- a/.github/workflows/elixir_deps_check.yaml
+++ b/.github/workflows/elixir_deps_check.yaml
@@ -2,7 +2,7 @@
 
 name: Elixir Dependency Version Check
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   elixir_deps_check:

--- a/.github/workflows/run_api_tests.yaml
+++ b/.github/workflows/run_api_tests.yaml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   push:
+    branch:
+      - *
     tags:
       - e*
       - v*

--- a/.github/workflows/run_broker_tests.yaml
+++ b/.github/workflows/run_broker_tests.yaml
@@ -2,6 +2,8 @@ name: Broker tests
 
 on:
   push:
+    branch:
+      - *
     tags:
       - v*
   pull_request:

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -2,6 +2,8 @@ name: Check emqx app standalone
 
 on:
   push:
+    branch:
+      - *
     tags:
       - v*
       - e*

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   push:
+    branch:
+      - *
     tags:
       - v*
   pull_request:

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   push:
+    branch:
+      - *
     tags:
       - v*
       - e*

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -6,6 +6,8 @@ concurrency:
 
 on:
   push:
+    branch:
+      - *
     tags:
       - v*
       - e*

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,6 +1,6 @@
 name: Shellcheck
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
   shellcheck:


### PR DESCRIPTION
- Secure tests on master branch after merge.

- Improve build cache hit rates
  Due to security reason, github only allow reuse cache from
  - same branch
  - base branch
  - default branch

  Branch Feature-A could not reuse the cache from Feature-B

- Developers could run the workflow in their own forked repo before make the PR, this could relieve the runners on upstream repo

