### PR TITLE
feat(shell): add restricted shell and user_default

### DIFF
--- a/apps/emqx/etc/emqx_cloud/vm.args
+++ b/apps/emqx/etc/emqx_cloud/vm.args
@@ -36,6 +36,11 @@
 ## Can be one of: inet_tcp, inet6_tcp, inet_tls
 #-proto_dist inet_tcp
 
+## The shell is started in a restricted mode.
+## In this mode, the shell evaluates a function call only if allowed.
+## Prevent user from accidentally calling a function from the prompt that could harm a running system.
+-stdlib restricted_shell emqx_restricted_shell
+
 ## Specify SSL Options in the file if using SSL for Erlang Distribution.
 ## Used only when -proto_dist set to inet_tls
 #-ssl_dist_optfile {{ platform_etc_dir }}/ssl_dist.conf

--- a/apps/emqx/etc/emqx_edge/vm.args
+++ b/apps/emqx/etc/emqx_edge/vm.args
@@ -35,6 +35,11 @@
 ## Can be one of: inet_tcp, inet6_tcp, inet_tls
 #-proto_dist inet_tcp
 
+## The shell is started in a restricted mode.
+## In this mode, the shell evaluates a function call only if allowed.
+## Prevent user from accidentally calling a function from the prompt that could harm a running system.
+-stdlib restricted_shell emqx_restricted_shell
+
 ## Specify SSL Options in the file if using SSL for Erlang Distribution.
 ## Used only when -proto_dist set to inet_tls
 #-ssl_dist_optfile {{ platform_etc_dir }}/ssl_dist.conf

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -366,6 +366,11 @@ merge_default(Options) ->
 
 format_addr(Port) when is_integer(Port) ->
     io_lib:format(":~w", [Port]);
+%% Print only the port number when bound on all interfaces
+format_addr({{0, 0, 0, 0}, Port}) ->
+    format_addr(Port);
+format_addr({{0, 0, 0, 0, 0, 0, 0, 0}, Port}) ->
+    format_addr(Port);
 format_addr({Addr, Port}) when is_list(Addr) ->
     io_lib:format("~ts:~w", [Addr, Port]);
 format_addr({Addr, Port}) when is_tuple(Addr) ->

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -365,7 +365,7 @@ merge_default(Options) ->
     end.
 
 format_addr(Port) when is_integer(Port) ->
-    io_lib:format("0.0.0.0:~w", [Port]);
+    io_lib:format(":~w", [Port]);
 format_addr({Addr, Port}) when is_list(Addr) ->
     io_lib:format("~ts:~w", [Addr, Port]);
 format_addr({Addr, Port}) when is_tuple(Addr) ->

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -48,6 +48,8 @@
 
 -export([post_config_update/5]).
 
+-export([format_addr/1]).
+
 -define(CONF_KEY_PATH, [listeners]).
 -define(TYPES_STRING, ["tcp","ssl","ws","wss","quic"]).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -66,7 +66,7 @@ start_listeners() ->
             Minirest = BaseMinirest#{protocol => Protocol},
             case minirest:start(Name, RanchOptions, Minirest) of
                 {ok, _} ->
-                    ?ULOG("Start listener ~ts on ~p successfully.~n", [Name, emqx_listeners:format_addr(Bind)]),
+                    ?ULOG("Start listener ~ts on ~ts successfully.~n", [Name, emqx_listeners:format_addr(Bind)]),
                     Acc;
                 {error, _Reason} ->
                     %% Don't record the reason because minirest already does(too much logs noise).
@@ -82,7 +82,7 @@ stop_listeners() ->
     [begin
         case minirest:stop(Name) of
             ok ->
-                ?ULOG("Stop listener ~ts on ~p successfully.~n", [Name, emqx_listeners:format_addr(Port)]);
+                ?ULOG("Stop listener ~ts on ~ts successfully.~n", [Name, emqx_listeners:format_addr(Port)]);
             {error, not_found} ->
                 ?SLOG(warning, #{msg => "stop_listener_failed", name => Name, port => Port})
         end

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -66,7 +66,7 @@ start_listeners() ->
             Minirest = BaseMinirest#{protocol => Protocol},
             case minirest:start(Name, RanchOptions, Minirest) of
                 {ok, _} ->
-                    ?ULOG("Listener ~ts on ~ts started.~n", [Name, emqx_listeners:format_addr(Bind)]),
+                    ?ULOG("Start listener ~ts on ~p successfully.~n", [Name, emqx_listeners:format_addr(Bind)]),
                     Acc;
                 {error, _Reason} ->
                     %% Don't record the reason because minirest already does(too much logs noise).
@@ -82,7 +82,7 @@ stop_listeners() ->
     [begin
         case minirest:stop(Name) of
             ok ->
-                ?ULOG("Listener ~ts on ~ts stopped.~n", [Name, emqx_listeners:format_addr(Port)]);
+                ?ULOG("Stop listener ~ts on ~p successfully.~n", [Name, emqx_listeners:format_addr(Port)]);
             {error, not_found} ->
                 ?SLOG(warning, #{msg => "stop_listener_failed", name => Name, port => Port})
         end

--- a/apps/emqx_machine/src/emqx_machine_app.erl
+++ b/apps/emqx_machine/src/emqx_machine_app.erl
@@ -24,7 +24,7 @@
 
 start(_Type, _Args) ->
     ok = emqx_machine:start(),
-    emqx_restricted_shell:set_prompt_func(),
+    _ = emqx_restricted_shell:set_prompt_func(),
     emqx_machine_sup:start_link().
 
 stop(_State) ->

--- a/apps/emqx_machine/src/emqx_machine_app.erl
+++ b/apps/emqx_machine/src/emqx_machine_app.erl
@@ -24,6 +24,7 @@
 
 start(_Type, _Args) ->
     ok = emqx_machine:start(),
+    emqx_restricted_shell:set_prompt_func(),
     emqx_machine_sup:start_link().
 
 stop(_State) ->

--- a/apps/emqx_machine/src/emqx_restricted_shell.erl
+++ b/apps/emqx_machine/src/emqx_restricted_shell.erl
@@ -17,6 +17,7 @@
 -module(emqx_restricted_shell).
 
 -export([local_allowed/3, non_local_allowed/3]).
+-export([set_prompt_func/0, prompt_func/1]).
 -export([lock/0, unlock/0, is_locked/0]).
 
 -include_lib("emqx/include/logger.hrl").
@@ -37,6 +38,17 @@ is_locked() ->
 
 lock() -> application:set_env(?APP, ?IS_LOCKED, true).
 unlock() -> application:set_env(?APP, ?IS_LOCKED, false).
+
+set_prompt_func() ->
+    shell:prompt_func({?MODULE, prompt_func}).
+
+prompt_func(PropList) ->
+    Line = proplists:get_value(history, PropList, 1),
+    Version = emqx_release:version(),
+    case is_alive() of
+        true  -> io_lib:format(<<"~ts(~s)~w> ">>, [Version, node(), Line]);
+        false -> io_lib:format(<<"~ts ~w> ">>, [Version, Line])
+    end.
 
 local_allowed(MF, Args, State) ->
     IsAllowed = is_allowed(MF, ?LOCAL_NOT_ALLOWED),

--- a/apps/emqx_machine/src/emqx_restricted_shell.erl
+++ b/apps/emqx_machine/src/emqx_restricted_shell.erl
@@ -1,0 +1,93 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_restricted_shell).
+
+-export([local_allowed/3, non_local_allowed/3]).
+-export([lock/0, unlock/0, is_locked/0]).
+
+-include_lib("emqx/include/logger.hrl").
+
+-define(APP, 'emqx_machine').
+-define(IS_LOCKED, 'restricted.is_locked').
+-define(MAX_HEAP_SIZE, 1024 * 1024 * 1).
+-define(MAX_ARGS_SIZE, 1024 * 10).
+
+-define(RED_BG, "\e[48;2;184;0;0m").
+-define(RESET, "\e[0m").
+
+-define(LOCAL_NOT_ALLOWED, [halt, q]).
+-define(NON_LOCAL_NOT_ALLOWED, [{erlang, halt}, {c, q}, {init, stop}, {init, restart}, {init, reboot}]).
+
+is_locked() ->
+    {ok, false} =/= application:get_env(?APP, ?IS_LOCKED).
+
+lock() -> application:set_env(?APP, ?IS_LOCKED, true).
+unlock() -> application:set_env(?APP, ?IS_LOCKED, false).
+
+local_allowed(MF, Args, State) ->
+    IsAllowed = is_allowed(MF, ?LOCAL_NOT_ALLOWED),
+    log(IsAllowed, MF, Args),
+    {IsAllowed, State}.
+
+non_local_allowed(MF, Args, State) ->
+    IsAllowed = is_allowed(MF, ?NON_LOCAL_NOT_ALLOWED),
+    log(IsAllowed, MF, Args),
+    {IsAllowed, State}.
+
+is_allowed(MF, NotAllowed) ->
+    case lists:member(MF, NotAllowed) of
+        true -> not is_locked();
+        false -> true
+    end.
+
+limit_warning(MF, Args) ->
+    max_heap_size_warning(MF, Args),
+    max_args_warning(MF, Args).
+
+max_args_warning(MF, Args) ->
+    ArgsSize = erts_debug:flat_size(Args),
+    case ArgsSize < ?MAX_ARGS_SIZE of
+        true -> ok;
+        false ->
+            warning("[WARNING] current_args_size:~w, max_args_size:~w", [ArgsSize, ?MAX_ARGS_SIZE]),
+            ?SLOG(warning, #{msg => "execute_function_in_shell_max_args_size",
+                function => MF,
+                args => Args,
+                args_size => ArgsSize,
+                max_heap_size => ?MAX_ARGS_SIZE})
+    end.
+
+max_heap_size_warning(MF, Args) ->
+    {heap_size, HeapSize} = erlang:process_info(self(), heap_size),
+    case HeapSize < ?MAX_HEAP_SIZE of
+        true -> ok;
+        false ->
+            warning("[WARNING] current_heap_size:~w, max_heap_size_warning:~w", [HeapSize, ?MAX_HEAP_SIZE]),
+            ?SLOG(warning, #{msg => "shell_process_exceed_max_heap_size",
+                current_heap_size => HeapSize,
+                function => MF,
+                args => Args,
+                max_heap_size => ?MAX_HEAP_SIZE})
+    end.
+
+log(true, MF, Args) -> limit_warning(MF, Args);
+log(false, MF, Args) ->
+    warning("DANGEROUS FUNCTION: DO NOT ALLOWED IN SHELL!!!!!", []),
+    ?SLOG(error, #{msg => "execute_function_in_shell_not_allowed", function => MF, args => Args}).
+
+warning(Format, Args) ->
+    io:format(?RED_BG ++ Format ++ ?RESET ++ "~n", Args).

--- a/apps/emqx_machine/src/user_default.erl
+++ b/apps/emqx_machine/src/user_default.erl
@@ -20,7 +20,6 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx_conf/include/emqx_conf.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
--include_lib("emqx_slow_subs/include/emqx_slow_subs.hrl").
 
 %% API
 -export([lock/0, unlock/0]).

--- a/apps/emqx_machine/src/user_default.erl
+++ b/apps/emqx_machine/src/user_default.erl
@@ -15,11 +15,14 @@
 %%--------------------------------------------------------------------
 -module(user_default).
 
+%% INCLUDE BEGIN
+%% Import all the record definitions from the header file into the erlang shell.
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx_conf/include/emqx_conf.hrl").
 -include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
+%% INCLUDE END
 
 %% API
 -export([lock/0, unlock/0]).

--- a/apps/emqx_machine/src/user_default.erl
+++ b/apps/emqx_machine/src/user_default.erl
@@ -1,0 +1,29 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(user_default).
+
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx_conf/include/emqx_conf.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
+-include_lib("emqx_slow_subs/include/emqx_slow_subs.hrl").
+
+%% API
+-export([lock/0, unlock/0]).
+
+lock() -> emqx_restricted_shell:lock().
+unlock() -> emqx_restricted_shell:unlock().

--- a/apps/emqx_machine/test/emqx_restricted_shell_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_restricted_shell_SUITE.erl
@@ -1,0 +1,72 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_restricted_shell_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    emqx_common_test_helpers:start_apps([]),
+    Config.
+
+end_per_suite(_Config) ->
+    emqx_common_test_helpers:stop_apps([]).
+
+t_local_allowed(_Config) ->
+    LocalProhibited = [halt, q],
+    State = undefined,
+    lists:foreach(fun(LocalFunc) ->
+        ?assertEqual({false, State}, emqx_restricted_shell:local_allowed(LocalFunc, [], State))
+                  end, LocalProhibited),
+    LocalAllowed = [ls, pwd],
+    lists:foreach(fun(LocalFunc) ->
+        ?assertEqual({true, State},emqx_restricted_shell:local_allowed(LocalFunc, [], State))
+                  end, LocalAllowed),
+    ok.
+
+t_non_local_allowed(_Config) ->
+    RemoteProhibited = [{erlang, halt}, {c, q}, {init, stop}, {init, restart}, {init, reboot}],
+    State = undefined,
+    lists:foreach(fun(RemoteFunc) ->
+        ?assertEqual({false, State}, emqx_restricted_shell:non_local_allowed(RemoteFunc, [], State))
+                  end, RemoteProhibited),
+    RemoteAllowed = [{erlang, date}, {erlang, system_time}],
+    lists:foreach(fun(RemoteFunc) ->
+        ?assertEqual({true, State}, emqx_restricted_shell:local_allowed(RemoteFunc, [], State))
+                  end, RemoteAllowed),
+    ok.
+
+t_lock(_Config) ->
+    State = undefined,
+    emqx_restricted_shell:lock(),
+    ?assertEqual({false, State}, emqx_restricted_shell:local_allowed(q, [], State)),
+    ?assertEqual({true, State}, emqx_restricted_shell:local_allowed(ls, [], State)),
+    ?assertEqual({false, State}, emqx_restricted_shell:non_local_allowed({init, stop}, [], State)),
+    ?assertEqual({true, State}, emqx_restricted_shell:non_local_allowed({inet, getifaddrs}, [], State)),
+    emqx_restricted_shell:unlock(),
+    ?assertEqual({true, State}, emqx_restricted_shell:local_allowed(q, [], State)),
+    ?assertEqual({true, State}, emqx_restricted_shell:local_allowed(ls, [], State)),
+    ?assertEqual({true, State}, emqx_restricted_shell:non_local_allowed({init, stop}, [], State)),
+    ?assertEqual({true, State}, emqx_restricted_shell:non_local_allowed({inet, getifaddrs}, [], State)),
+    emqx_restricted_shell:lock(),
+    ok.


### PR DESCRIPTION
1. Add `user_default.erl` to import record defined from `*hrl`.
2. Don't allow danger function execute in shell, such as `init:stop,q, halt`
3. Add log when shell process's heap_size/args_size is too huge.
4. update dashboard listener prompt.
```shell
Listener quic:default on :14567 started.
Listener ssl:default on :8883 started.
Listener tcp:default on :1883 started.
Listener ws:default on :8083 started.
Listener wss:default on :8084 started.
Start listener dashboard:http:18083 on :18083 successfully.
```

```erlang
log.console_handler.enable = EMQX_LOG__CONSOLE_HANDLER__ENABLE = true
Erlang/OTP 24 [erts-12.0.2] [source] [64-bit] [smp:8:8] [ds:8:8:8] [async-threads:4] [jit]

Listener quic:default on 0.0.0.0:14567 started.
Listener ssl:default on 0.0.0.0:8883 started.
Listener tcp:default on 0.0.0.0:1883 started.
Listener ws:default on 0.0.0.0:8083 started.
Listener wss:default on 0.0.0.0:8084 started.
Listener dashboard:http:18083 on 0.0.0.0:18083 started.
EMQ X Community Edition 5.0.0-beta.3-f24c05b1 is running now!
Restricted Eshell V12.0.2  (abort with ^G)
5.0.0-beta.3-f24c05b1(emqx@127.0.0.1)1> q().
DANGEROUS FUNCTION: FORBIDDEN IN SHELL!!!!!
2022-02-07T15:35:26.400687+08:00 [error] args: [], function: q, line: 105, mfa: emqx_restricted_shell:log/3, msg: execute_function_in_shell_prohibited
** exception exit: restricted shell does not allow q()
5.0.0-beta.3-f24c05b1(emqx@127.0.0.1)2> erlang:halt().
DANGEROUS FUNCTION: FORBIDDEN IN SHELL!!!!!
2022-02-07T15:35:32.595407+08:00 [error] args: [], function: {erlang,halt}, line: 105, mfa: emqx_restricted_shell:log/3, msg: execute_function_in_shell_prohibited
** exception exit: restricted shell does not allow halt()
5.0.0-beta.3-f24c05b1(emqx@127.0.0.1)3> halt().
DANGEROUS FUNCTION: FORBIDDEN IN SHELL!!!!!
2022-02-07T15:35:34.695281+08:00 [error] args: [], function: {erlang,halt}, line: 105, mfa: emqx_restricted_shell:log/3, msg: execute_function_in_shell_prohibited
** exception exit: restricted shell does not allow halt()
5.0.0-beta.3-f24c05b1(emqx@127.0.0.1)4> unlock().
ok
5.0.0-beta.3-f24c05b1(emqx@127.0.0.1)5> halt().
[os_mon] memory supervisor port (memsup): Erlang has closed
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed

```