### PR TITLE
ci(pytest): pin pytest version at 6.2.5

### DIFF
--- a/.ci/docker-compose-file/python/pytest.sh
+++ b/.ci/docker-compose-file/python/pytest.sh
@@ -19,7 +19,7 @@ fi
 
 apk update && apk add git curl
 git clone -b develop-4.0 https://github.com/emqx/paho.mqtt.testing.git /paho.mqtt.testing
-pip install pytest
+pip install pytest==6.2.5
 
 pytest -v /paho.mqtt.testing/interoperability/test_client/V5/test_connect.py -k test_basic --host "$TARGET_HOST"
 RESULT=$?


### PR DESCRIPTION
After a major version release (7.0.0), our current FVT tests all
failed due to some change in the lib.  Our pytest version in CI was
not pinned, and picked this update up.

