### PR TITLE
refactor: treat throw exception as `{error, Reason}` return

### DIFF
--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -90,6 +90,7 @@ get_raw_cluster_override_conf() ->
 
 -spec init(term()) -> {ok, state()}.
 init(_) ->
+    process_flag(trap_exit, true),
     {ok, #{handlers => #{?MOD => ?MODULE}}}.
 
 handle_call({add_handler, ConfKeyPath, HandlerName}, _From, State = #{handlers := Handlers}) ->
@@ -150,12 +151,8 @@ deep_put_handler2(Key, KeyPath, Handlers, Mod) ->
     end.
 
 handle_update_request(SchemaModule, ConfKeyPath, Handlers, UpdateArgs) ->
-    try process_update_request(ConfKeyPath, Handlers, UpdateArgs) of
-        {ok, NewRawConf, OverrideConf, Opts} ->
-            check_and_save_configs(SchemaModule, ConfKeyPath, Handlers, NewRawConf,
-                                   OverrideConf, UpdateArgs, Opts);
-        {error, Result} ->
-            {error, Result}
+    try
+        do_handle_update_request(SchemaModule, ConfKeyPath, Handlers, UpdateArgs)
     catch
         throw : Reason ->
             {error, Reason};
@@ -166,6 +163,15 @@ handle_update_request(SchemaModule, ConfKeyPath, Handlers, UpdateArgs) ->
                            stacktrace => ST
                           }),
             {error, config_update_crashed}
+    end.
+
+do_handle_update_request(SchemaModule, ConfKeyPath, Handlers, UpdateArgs) ->
+    case process_update_request(ConfKeyPath, Handlers, UpdateArgs) of
+        {ok, NewRawConf, OverrideConf, Opts} ->
+            check_and_save_configs(SchemaModule, ConfKeyPath, Handlers, NewRawConf,
+                                   OverrideConf, UpdateArgs, Opts);
+        {error, Result} ->
+            {error, Result}
     end.
 
 process_update_request(ConfKeyPath, _Handlers, {remove, Opts}) ->

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -102,24 +102,8 @@ handle_call({add_handler, ConfKeyPath, HandlerName}, _From, State = #{handlers :
 
 handle_call({change_config, SchemaModule, ConfKeyPath, UpdateArgs}, _From,
             #{handlers := Handlers} = State) ->
-    Reply = try
-        case process_update_request(ConfKeyPath, Handlers, UpdateArgs) of
-            {ok, NewRawConf, OverrideConf, Opts} ->
-                check_and_save_configs(SchemaModule, ConfKeyPath, Handlers, NewRawConf,
-                    OverrideConf, UpdateArgs, Opts);
-            {error, Result} ->
-                {error, Result}
-        end
-    catch Error:Reason:ST ->
-        ?SLOG(error, #{
-            msg => "change_config_failed",
-            exception => Error,
-            reason => Reason,
-            stacktrace => ST
-        }),
-        {error, Reason}
-    end,
-    {reply, Reply, State};
+    Result = handle_update_request(SchemaModule, ConfKeyPath, Handlers, UpdateArgs),
+    {reply, Result, State};
 handle_call(get_raw_cluster_override_conf, _From, State) ->
     Reply = emqx_config:read_override_conf(#{override_to => cluster}),
     {reply, Reply, State};
@@ -163,6 +147,25 @@ deep_put_handler2(Key, KeyPath, Handlers, Mod) ->
             {ok, Handlers#{Key => SubHandlers1}};
         Error ->
             Error
+    end.
+
+handle_update_request(SchemaModule, ConfKeyPath, Handlers, UpdateArgs) ->
+    try process_update_request(ConfKeyPath, Handlers, UpdateArgs) of
+        {ok, NewRawConf, OverrideConf, Opts} ->
+            check_and_save_configs(SchemaModule, ConfKeyPath, Handlers, NewRawConf,
+                                   OverrideConf, UpdateArgs, Opts);
+        {error, Result} ->
+            {error, Result}
+    catch
+        throw : Reason ->
+            {error, Reason};
+        Error : Reason : ST ->
+            ?SLOG(error, #{msg => "change_config_failed",
+                           exception => Error,
+                           reason => Reason,
+                           stacktrace => ST
+                          }),
+            {error, config_update_crashed}
     end.
 
 process_update_request(ConfKeyPath, _Handlers, {remove, Opts}) ->

--- a/apps/emqx/src/emqx_misc.erl
+++ b/apps/emqx/src/emqx_misc.erl
@@ -48,6 +48,7 @@
         , ipv6_probe/1
         , gen_id/0
         , gen_id/1
+        , explain_posix/1
         ]).
 
 -export([ bin2hexstr_A_F/1
@@ -313,6 +314,41 @@ clamp(Val, Min, Max) ->
        Val > Max -> Max;
        true -> Val
     end.
+
+%% @doc https://www.erlang.org/doc/man/file.html#posix-error-codes
+explain_posix(eacces) -> "Permission denied";
+explain_posix(eagain) -> "Resource temporarily unavailable";
+explain_posix(ebadf) -> "Bad file number";
+explain_posix(ebusy) -> "File busy";
+explain_posix(edquot) -> "Disk quota exceeded";
+explain_posix(eexist) -> "File already exists";
+explain_posix(efault) -> "Bad address in system call argument";
+explain_posix(efbig) -> "File too large";
+explain_posix(eintr) -> "Interrupted system call";
+explain_posix(einval) -> "Invalid argument argument file/socket";
+explain_posix(eio) -> "I/O error";
+explain_posix(eisdir) -> "Illegal operation on a directory";
+explain_posix(eloop) -> "Too many levels of symbolic links";
+explain_posix(emfile) -> "Too many open files";
+explain_posix(emlink) -> "Too many links";
+explain_posix(enametoolong) -> "Filename too long";
+explain_posix(enfile) -> "File table overflow";
+explain_posix(enodev) -> "No such device";
+explain_posix(enoent) -> "No such file or directory";
+explain_posix(enomem) -> "Not enough memory";
+explain_posix(enospc) -> "No space left on device";
+explain_posix(enotblk) -> "Block device required";
+explain_posix(enotdir) -> "Not a directory";
+explain_posix(enotsup) -> "Operation not supported";
+explain_posix(enxio) -> "No such device or address";
+explain_posix(eperm) -> "Not owner";
+explain_posix(epipe) -> "Broken pipe";
+explain_posix(erofs) -> "Read-only file system";
+explain_posix(espipe) -> "Invalid seek";
+explain_posix(esrch) -> "No such process";
+explain_posix(estale) -> "Stale remote file handle";
+explain_posix(exdev) -> "Cross-domain link";
+explain_posix(NotPosix) -> NotPosix.
 
 %%------------------------------------------------------------------------------
 %% Internal Functions

--- a/apps/emqx_authz/test/emqx_authz_file_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_file_SUITE.erl
@@ -75,12 +75,12 @@ t_invalid_file(_Config) ->
     ok = file:write_file(<<"acl.conf">>, <<"{{invalid term">>),
 
     ?assertMatch(
-       {error, {1, erl_parse, _}},
+       {error, bad_acl_file_content},
        emqx_authz:update(?CMD_REPLACE, [raw_file_authz_config()])).
 
 t_nonexistent_file(_Config) ->
     ?assertEqual(
-       {error, enoent},
+       {error, failed_to_read_acl_file},
        emqx_authz:update(?CMD_REPLACE,
                          [maps:merge(raw_file_authz_config(),
                                      #{<<"path">> => <<"nonexistent.conf">>})

--- a/apps/emqx_conf/include/emqx_conf.hrl
+++ b/apps/emqx_conf/include/emqx_conf.hrl
@@ -9,7 +9,7 @@
 
 -record(cluster_rpc_mfa, {
     tnx_id :: pos_integer(),
-    mfa :: mfa(),
+    mfa :: {module(), atom(), [any()]},
     created_at :: calendar:datetime(),
     initiator :: node()
 }).

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -73,7 +73,7 @@ admins(_) ->
           {"cluster_call status", "status"},
           {"cluster_call skip [node]", "increase one commit on specific node"},
           {"cluster_call tnxid <TnxId>", "get detailed about TnxId"},
-          {"cluster_call  fast_forward [node] [tnx_id]", "fast forwards to tnx_id" }
+          {"cluster_call fast_forward [node] [tnx_id]", "fast forwards to tnx_id" }
       ]).
 
 status() ->

--- a/lib-ee/emqx_license/src/emqx_license.erl
+++ b/lib-ee/emqx_license/src/emqx_license.erl
@@ -118,10 +118,10 @@ do_update({file, Filename}, _Conf) ->
                 {ok, _License} ->
                     #{<<"file">> => Filename};
                 {error, Reason} ->
-                    error(Reason)
+                    erlang:throw(Reason)
             end;
         {error, Reason} ->
-            error({invalid_license_file, Reason})
+            erlang:throw({invalid_license_file, Reason})
     end;
 
 do_update({key, Content}, _Conf) when is_binary(Content); is_list(Content) ->
@@ -129,8 +129,7 @@ do_update({key, Content}, _Conf) when is_binary(Content); is_list(Content) ->
         {ok, _License} ->
             #{<<"key">> => Content};
         {error, Reason} ->
-            ?SLOG(error, #{msg => "failed_to_parse_license", reason => Reason}),
-            error(Reason)
+            erlang:throw(Reason)
     end.
 
 check_max_clients_exceeded(MaxClients) ->

--- a/lib-ee/emqx_license/src/emqx_license.erl
+++ b/lib-ee/emqx_license/src/emqx_license.erl
@@ -129,6 +129,7 @@ do_update({key, Content}, _Conf) when is_binary(Content); is_list(Content) ->
         {ok, _License} ->
             #{<<"key">> => Content};
         {error, Reason} ->
+            ?SLOG(error, #{msg => "failed_to_parse_license", reason => Reason}),
             error(Reason)
     end.
 

--- a/lib-ee/emqx_license/src/emqx_license_parser.erl
+++ b/lib-ee/emqx_license/src/emqx_license_parser.erl
@@ -98,7 +98,7 @@ max_connections(#{module := Module, data := LicenseData}) ->
 %%--------------------------------------------------------------------
 
 do_parse(_Content, _Key, [], Errors) ->
-    {error, {unknown_format, lists:reverse(Errors)}};
+    {error, lists:reverse(Errors)};
 
 do_parse(Content, Key, [Module | Modules], Errors) ->
     try Module:parse(Content, Key) of
@@ -107,7 +107,7 @@ do_parse(Content, Key, [Module | Modules], Errors) ->
         {error, Error} ->
             do_parse(Content, Key, Modules, [{Module, Error} | Errors])
     catch
-        _Class:Error:_Stk ->
+        _Class : Error ->
             do_parse(Content, Key, Modules, [{Module, Error} | Errors])
     end.
 

--- a/lib-ee/emqx_license/test/emqx_license_SUITE.erl
+++ b/lib-ee/emqx_license/test/emqx_license_SUITE.erl
@@ -68,7 +68,7 @@ t_update_file(_Config) ->
 
     ok = file:write_file("license_with_invalid_content.lic", <<"bad license">>),
     ?assertMatch(
-       {error, {unknown_format, _}},
+       {error, [_ | _]},
        emqx_license:update_file("license_with_invalid_content.lic")),
 
     ?assertMatch(
@@ -77,7 +77,7 @@ t_update_file(_Config) ->
 
 t_update_value(_Config) ->
     ?assertMatch(
-       {error, {unknown_format, _}},
+       {error, [_ | _]},
        emqx_license:update_key("invalid.license")),
 
     {ok, LicenseValue} = file:read_file(emqx_license_test_lib:default_license()),

--- a/lib-ee/emqx_license/test/emqx_license_parser_SUITE.erl
+++ b/lib-ee/emqx_license/test/emqx_license_parser_SUITE.erl
@@ -45,8 +45,7 @@ t_parse(_Config) ->
     %% invalid version
     ?assertMatch(
        {error,
-        {unknown_format,
-         [{emqx_license_parser_v20220101,invalid_version}]}},
+        [{emqx_license_parser_v20220101,invalid_version}]},
        emqx_license_parser:parse(
          emqx_license_test_lib:make_license(
            ["220101",
@@ -63,8 +62,7 @@ t_parse(_Config) ->
     %% invalid field number
     ?assertMatch(
        {error,
-        {unknown_format,
-         [{emqx_license_parser_v20220101,invalid_field_number}]}},
+        [{emqx_license_parser_v20220101,invalid_field_number}]},
        emqx_license_parser:parse(
          emqx_license_test_lib:make_license(
            ["220111",
@@ -80,12 +78,11 @@ t_parse(_Config) ->
 
     ?assertMatch(
        {error,
-        {unknown_format,
          [{emqx_license_parser_v20220101,
            [{type,invalid_license_type},
             {customer_type,invalid_customer_type},
             {date_start,invalid_date},
-            {days,invalid_int_value}]}]}},
+            {days,invalid_int_value}]}]},
        emqx_license_parser:parse(
          emqx_license_test_lib:make_license(
            ["220111",
@@ -125,21 +122,20 @@ t_parse(_Config) ->
 
     ?assertMatch(
        {error,
-        {unknown_format,
-         [{emqx_license_parser_v20220101,invalid_signature}]}},
+         [{emqx_license_parser_v20220101,invalid_signature}]},
        emqx_license_parser:parse(
          iolist_to_binary([LicensePart, <<".">>, SignaturePart]),
          public_key_encoded())),
 
     %% totally invalid strings as license
     ?assertMatch(
-       {error, {unknown_format, _}},
+       {error, [_ | _]},
        emqx_license_parser:parse(
          <<"badlicense">>,
          public_key_encoded())),
 
     ?assertMatch(
-       {error, {unknown_format, _}},
+       {error, [_ | _]},
        emqx_license_parser:parse(
          <<"bad.license">>,
          public_key_encoded())).

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -11,7 +11,6 @@
 ## ./scripts/buildx.sh --profile emqx --pkgtype tgz --arch arm64 --builder ghcr.io/emqx/emqx-builder/4.4-4:24.1.5-3-debian10
 
 set -euo pipefail
-set -x
 
 help() {
     echo
@@ -90,6 +89,8 @@ if [ -z "${PROFILE:-}" ]    ||
     help
     exit 1
 fi
+
+set -x
 
 if [ -z "${WITH_ELIXIR:-}" ]; then
   WITH_ELIXIR=no


### PR DESCRIPTION
* Simplified emqx_license parser error list return value
* Catch badmatch exception and turn it into an error return so the license key is not logged
* Treat config change `throw`s as `{error, Reason}` returns, no need to log stacktrace
* `cluster_rpc` should not log arguments as it might contain senstive information
* Deleted `cluster_rpc` alarm description because it's duplicated information as in metadata

license update error log example:
```
2022-02-08T19:31:35.673205+01:00 [error] entrypoint: <<"emqx:update_config/3">>, line: 384, mfa: emqx_cluster_rpc:log_and_alarm/3, msg: cluster_rpc_apply_failed, result: {error,[{emqx_license_parser_v20220101,bad_license_format}]}, tnx_id: 7
2022-02-08T19:31:35.673959+01:00 [warning] line: 338, message: <<"cluster_rpc_apply_failed=7">>, mfa: emqx_alarm:do_actions/3, msg: alarm_is_activated, name: cluster_rpc_apply_failed
```
and then
```
2022-02-08T19:31:40.729476+01:00 [warning] line: 344, mfa: emqx_alarm:do_actions/3, msg: alarm_is_deactivated, name: cluster_rpc_apply_failed
``