### PR TITLE
refactor: remove unused/old functions

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_ldap.erl
+++ b/apps/emqx_connector/src/emqx_connector_ldap.erl
@@ -28,7 +28,6 @@
         , on_stop/2
         , on_query/4
         , on_health_check/2
-        , on_jsonify/1
         ]).
 
 -export([do_health_check/1]).
@@ -42,9 +41,6 @@ roots() ->
 
 %% this schema has no sub-structs
 fields(_) -> [].
-
-on_jsonify(Config) ->
-    Config.
 
 %% ===================================================================
 on_start(InstId, #{servers := Servers0,

--- a/apps/emqx_connector/src/emqx_connector_mongo.erl
+++ b/apps/emqx_connector/src/emqx_connector_mongo.erl
@@ -31,7 +31,6 @@
         , on_stop/2
         , on_query/4
         , on_health_check/2
-        , on_jsonify/1
         ]).
 
 %% ecpool callback
@@ -96,9 +95,6 @@ mongo_fields() ->
                    nullable => true}}
     ] ++
     emqx_connector_schema_lib:ssl_fields().
-
-on_jsonify(Config) ->
-    Config.
 
 %% ===================================================================
 

--- a/apps/emqx_connector/src/emqx_connector_mysql.erl
+++ b/apps/emqx_connector/src/emqx_connector_mysql.erl
@@ -25,7 +25,6 @@
         , on_stop/2
         , on_query/4
         , on_health_check/2
-        , on_jsonify/1
         ]).
 
 -export([connect/1]).
@@ -42,11 +41,6 @@ roots() ->
 fields(config) ->
     emqx_connector_schema_lib:relational_db_fields() ++
     emqx_connector_schema_lib:ssl_fields().
-
-%%=====================================================================
-
-on_jsonify(#{server := Server}= Config) ->
-    Config#{server => emqx_connector_schema_lib:ip_port_to_string(Server)}.
 
 %% ===================================================================
 on_start(InstId, #{server := {Host, Port},

--- a/apps/emqx_connector/src/emqx_connector_pgsql.erl
+++ b/apps/emqx_connector/src/emqx_connector_pgsql.erl
@@ -28,7 +28,6 @@
         , on_stop/2
         , on_query/4
         , on_health_check/2
-        , on_jsonify/1
         ]).
 
 -export([connect/1]).
@@ -48,9 +47,6 @@ fields(config) ->
     [{named_queries, fun named_queries/1}] ++
     emqx_connector_schema_lib:relational_db_fields() ++
     emqx_connector_schema_lib:ssl_fields().
-
-on_jsonify(#{server := Server}= Config) ->
-    Config#{server => emqx_connector_schema_lib:ip_port_to_string(Server)}.
 
 named_queries(type) -> map();
 named_queries(nullable) -> true;

--- a/apps/emqx_connector/src/emqx_connector_redis.erl
+++ b/apps/emqx_connector/src/emqx_connector_redis.erl
@@ -43,7 +43,6 @@
         , on_stop/2
         , on_query/4
         , on_health_check/2
-        , on_jsonify/1
         ]).
 
 -export([do_health_check/1]).
@@ -84,9 +83,6 @@ fields(sentinel) ->
     ] ++
     redis_fields() ++
     emqx_connector_schema_lib:ssl_fields().
-
-on_jsonify(Config) ->
-    Config.
 
 %% ===================================================================
 on_start(InstId, #{redis_type := Type,

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -70,7 +70,6 @@
 -export([ call_start/3  %% start the instance
         , call_health_check/3 %% verify if the resource is working normally
         , call_stop/3   %% stop the instance
-        , call_jsonify/2
         ]).
 
 -export([ list_instances/0 %% list all the instances, id only.
@@ -86,10 +85,7 @@
 
 -optional_callbacks([ on_query/4
                     , on_health_check/2
-                    , on_jsonify/1
                     ]).
-
--callback on_jsonify(resource_config()) -> jsx:json_term().
 
 %% when calling emqx_resource:start/1
 -callback on_start(instance_id(), resource_config()) ->
@@ -283,13 +279,6 @@ call_health_check(InstId, Mod, ResourceState) ->
 -spec call_stop(instance_id(), module(), resource_state()) -> term().
 call_stop(InstId, Mod, ResourceState) ->
     ?SAFE_CALL(Mod:on_stop(InstId, ResourceState)).
-
--spec call_jsonify(module(), resource_config()) -> jsx:json_term().
-call_jsonify(Mod, Config) ->
-    case erlang:function_exported(Mod, on_jsonify, 1) of
-        false -> Config;
-        true -> ?SAFE_CALL(Mod:on_jsonify(Config))
-    end.
 
 -spec check_config(resource_type(), raw_resource_config()) ->
     {ok, resource_config()} | {error, term()}.


### PR DESCRIPTION
These functions are no longer called anywhere. They are old code which is no longer used. Cleaning up will help with code coverage as well as  keeping the interface cleaner for testing and other purposes.