### PR TITLE
[4.3] Upgrade to ekka 0.8.1.8

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -17,6 +17,10 @@ File format:
 * Fix updating `emqx_auth_mnesia.conf` password and restarting the new password does not take effect [#6717]
 * Fix import data crash when emqx_auth_mnesia's record is not empty [#6717]
 * Fix `os_mon.sysmem_high_watermark` may not alert after reboot.
+* Enhancement: Log client status before killing it for holding the lock for too long.
+  [emqx-6959](https://github.com/emqx/emqx/pull/6959)
+  [ekka-144](https://github.com/emqx/ekka/pull/144)
+  [ekka-146](https://github.com/emqx/ekka/pull/146)
 
 ## v4.3.11
 

--- a/rebar.config
+++ b/rebar.config
@@ -43,7 +43,7 @@
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.8.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.4"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.7"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.8"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.3.6"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "0.3.7"}}}


### PR DESCRIPTION
print client status before killing due to holding lock for too long

