### PR TITLE
fix(log): format the message id to hexstring before printing

### DIFF
--- a/src/emqx_message.erl
+++ b/src/emqx_message.erl
@@ -342,7 +342,8 @@ format(#message{id = Id,
                 flags = Flags,
                 headers = Headers}) ->
     io_lib:format("Message(Id=~s, QoS=~w, Topic=~s, From=~p, Flags=~s, Headers=~s)",
-                  [Id, QoS, Topic, From, format(flags, Flags), format(headers, Headers)]).
+                  [emqx_guid:to_hexstr(Id), QoS, Topic, From, format(flags, Flags),
+                   format(headers, Headers)]).
 
 format(flags, Flags) ->
     io_lib:format("~p", [[Flag || {Flag, true} <- maps:to_list(Flags)]]);


### PR DESCRIPTION
The log message after this change:

```
2022-02-10T10:14:53.325313+08:00 [warning] abc@127.0.0.1:57923 [Session] Dropped msg due to mqueue is full: Message(Id=0005D7A083FD3D11F443000007C10001, QoS=0, Topic=t/1, From=<<"123">>, Flags=[nl], Headers=#{peerhost => {127,0,0,1}, properties => #{},proto_ver => 4,protocol => mqtt,username => <<"123">>})
```