### PR TITLE
feature(emqx_bridge_mqtt): ${node} in topic config

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mqtt,
  [{description, "EMQ X Bridge to MQTT Broker"},
-  {vsn, "4.3.3"}, % strict semver, bump manually!
+  {vsn, "4.3.12"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [kernel,stdlib,replayq,emqtt]},

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mqtt,
  [{description, "EMQ X Bridge to MQTT Broker"},
-  {vsn, "4.3.12"}, % strict semver, bump manually!
+  {vsn, "4.3.4"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [kernel,stdlib,replayq,emqtt]},

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.appup.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.appup.src
@@ -10,7 +10,7 @@
      {load_module,emqx_bridge_mqtt_actions,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
   [{"4.3.3",[{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]}]},
-   {<<"4.3.[1-2]">>,
+   {<<"4\\.3\\.[1-2]">>,
     [{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]},
      {load_module,emqx_bridge_mqtt_actions,brutal_purge,soft_purge,[]}]},
    {"4.3.0",

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.appup.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.appup.src
@@ -1,24 +1,20 @@
-%% -*-: erlang -*-
-
-{"4.3.3",
-  [
-    {<<"4.3.[1-2]">>, [
-      {load_module, emqx_bridge_mqtt_actions, brutal_purge, soft_purge, []}
-    ]},
-    {"4.3.0", [
-      {load_module, emqx_bridge_worker, brutal_purge, soft_purge, []},
-      {load_module, emqx_bridge_mqtt_actions, brutal_purge, soft_purge, []}
-    ]},
-    {<<".*">>, []}
-  ],
-  [
-    {<<"4.3.[1-2]">>, [
-      {load_module, emqx_bridge_mqtt_actions, brutal_purge, soft_purge, []}
-    ]},
-    {"4.3.0", [
-      {load_module, emqx_bridge_worker, brutal_purge, soft_purge, []},
-      {load_module, emqx_bridge_mqtt_actions, brutal_purge, soft_purge, []}
-    ]},
-    {<<".*">>, []}
-  ]
-}.
+%% -*- mode: erlang -*-
+{VSN,
+  [{"4.3.3",[{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]}]},
+   {<<"4.3.[1-2]">>,
+    [{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]},
+     {load_module,emqx_bridge_mqtt_actions,brutal_purge,soft_purge,[]}]},
+   {"4.3.0",
+    [{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]},
+     {load_module,emqx_bridge_worker,brutal_purge,soft_purge,[]},
+     {load_module,emqx_bridge_mqtt_actions,brutal_purge,soft_purge,[]}]},
+   {<<".*">>,[]}],
+  [{"4.3.3",[{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]}]},
+   {<<"4.3.[1-2]">>,
+    [{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]},
+     {load_module,emqx_bridge_mqtt_actions,brutal_purge,soft_purge,[]}]},
+   {"4.3.0",
+    [{load_module,emqx_bridge_mqtt,brutal_purge,soft_purge,[]},
+     {load_module,emqx_bridge_worker,brutal_purge,soft_purge,[]},
+     {load_module,emqx_bridge_mqtt_actions,brutal_purge,soft_purge,[]}]},
+   {<<".*">>,[]}]}.

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.erl
@@ -37,6 +37,9 @@
         , handle_disconnected/2
         ]).
 
+%% for testing
+-export([ replvar/1 ]).
+
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
@@ -176,12 +179,12 @@ subscribe_remote_topics(ClientPid, Subscriptions) ->
                           end
                   end, Subscriptions).
 
+replvar(Options) ->
+    replvar([topic, clientid, max_inflight], Options).
+
 %%--------------------------------------------------------------------
 %% Internal funcs
 %%--------------------------------------------------------------------
-
-replvar(Options) ->
-    replvar([topic, clientid, max_inflight], Options).
 
 replvar([], Options) ->
     Options;

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.erl
@@ -181,7 +181,7 @@ subscribe_remote_topics(ClientPid, Subscriptions) ->
 %%--------------------------------------------------------------------
 
 replvar(Options) ->
-    replvar([clientid, max_inflight], Options).
+    replvar([topic, clientid, max_inflight], Options).
 
 replvar([], Options) ->
     Options;
@@ -194,8 +194,8 @@ replvar([Key|More], Options) ->
     end.
 
 %% ${node} => node()
-feedvar(clientid, ClientId, _) ->
-    iolist_to_binary(re:replace(ClientId, "\\${node}", atom_to_list(node())));
+feedvar(Key, Value, _) when Key =:= topic; Key =:= clientid ->
+    iolist_to_binary(re:replace(Value, "\\${node}", atom_to_list(node())));
 
 feedvar(max_inflight, 0, _) ->
     infinity;

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_tests.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_tests.erl
@@ -45,3 +45,14 @@ send_and_ack_test() ->
     after
         meck:unload(emqtt)
     end.
+
+replvar_test() ->
+    Node = atom_to_list(node()),
+    Config = #{clientid => <<"Hey ${node}">>, topic => <<"topic ${node}">>, other => <<"other">>},
+
+    ReplacedConfig = emqx_bridge_mqtt:replvar(Config),
+
+    ExpectedConfig = #{clientid => iolist_to_binary("Hey " ++ Node),
+                       topic    => iolist_to_binary("topic " ++ Node),
+                       other    => <<"other">>},
+    ?assertEqual(ExpectedConfig, ReplacedConfig).

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard,
  [{description, "EMQ X Web Dashboard"},
-  {vsn, "4.3.12"}, % strict semver, bump manually!
+  {vsn, "4.3.9"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_dashboard_sup]},
   {applications, [kernel,stdlib,mnesia,minirest]},

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard,
  [{description, "EMQ X Web Dashboard"},
-  {vsn, "4.3.8"}, % strict semver, bump manually!
+  {vsn, "4.3.12"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_dashboard_sup]},
   {applications, [kernel,stdlib,mnesia,minirest]},


### PR DESCRIPTION
Adds ${node} interpolation in topic option of configuration
Just like the clientid already works

Closes: #6431