### PR TITLE
ci: use exclude instead of include for build matrix

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -346,8 +346,12 @@ jobs:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         registry:
           - 'docker.io'
-        include:
-          - profile: emqx
+          - 'public.ecr.aws'
+        exclude:
+          # we don't have an aws ecr repo for enterprise and edge yet
+          - profile: emqx-edge
+            registry: 'public.ecr.aws'
+          - profile: emqx-ee
             registry: 'public.ecr.aws'
 
     steps:


### PR DESCRIPTION
include is unconditional, as a result, it brins in emqx profile
to enterprise repo

