### PR TITLE
build: rename distro from 'rhel' to 'el'

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -294,9 +294,9 @@ jobs:
             export ARCH="arm"
         fi
         if [ "$SYSTEM" = 'centos7' ]; then
-          DISTRO='rhel7'
+          DISTRO='el7'
         elif [ "$SYSTEM" = 'rockylinux8' ]; then
-          DISTRO='rhel8'
+          DISTRO='el8'
         else
           DISTRO=${SYSTEM}
         fi

--- a/build
+++ b/build
@@ -150,7 +150,7 @@ make_docker() {
 ## Name               Default                         Example
 ## ---------------------------------------------------------------------
 ## EMQX_BASE_IMAGE    current os                      centos:7
-## EMQX_ZIP_PACKAGE   _packages/<current-zip-target>  /tmp/emqx-4.4.0-otp24.1.5-3-rhel7-amd64.zip
+## EMQX_ZIP_PACKAGE   _packages/<current-zip-target>  /tmp/emqx-4.4.0-otp24.1.5-3-el7-amd64.zip
 ## EMQX_IMAGE_TAG     emqx/emqx:<current-vns-rel>     emqx/emqx:testing-tag
 ##
 make_docker_testing() {
@@ -159,7 +159,7 @@ make_docker_testing() {
             ubuntu20*)
                 EMQX_BASE_IMAGE="ubuntu:20.04"
                 ;;
-            rhel8)
+            el8)
                 EMQX_BASE_IMAGE="rockylinux:8"
                 ;;
             *)

--- a/scripts/get-distro.sh
+++ b/scripts/get-distro.sh
@@ -11,7 +11,7 @@ if [ "$(uname -s)" = 'Darwin' ]; then
     SYSTEM="$(echo "${DIST}${VERSION_ID}" | gsed -r 's/([a-zA-Z]*)-.*/\1/g')"
 elif [ "$(uname -s)" = 'Linux' ]; then
     if grep -q -i 'rhel' /etc/*-release; then
-        DIST='rhel'
+        DIST='el'
         VERSION_ID="$(rpm --eval '%{rhel}')"
     else
         DIST="$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')"


### PR DESCRIPTION
e.g. `emqx-4.4.0-otp24.1.5-3-el7-amd64.zip`

background: we have previously renamed `centos` to `rhel` when we replaced the centos8 build with rockylinux8.

reason for this change: rh is short for 'redhat', although it's rhel used internally in the etc/*-release files, it seems more common to name packages with `el7` and `el8`.