### PR TITLE
4.3 fix upgrade base package download

### DIFF
--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -18,7 +18,7 @@ RELEASE="$(grep -E "define.+EMQX_RELEASE.+${EDITION}" include/emqx_release.hrl |
 git_exact_vsn() {
     local tag
     tag="$(git describe --tags --match "[e|v]*" --exact 2>/dev/null)"
-    echo "$tag" | sed 's/^[v|e]//g'
+    echo "${tag#[e|v]}"
 }
 
 GIT_EXACT_VSN="$(git_exact_vsn)"

--- a/scripts/find-props.sh
+++ b/scripts/find-props.sh
@@ -13,4 +13,5 @@ if [ "$1" != "emqx" ]; then
     BASEDIR="$1"
 fi
 
+# shellcheck disable=SC2038
 find "${BASEDIR}/test/props" -name "prop_*.erl" 2>/dev/null | xargs -I{} basename {} .erl | xargs | tr ' ' ','

--- a/scripts/find-suites.sh
+++ b/scripts/find-suites.sh
@@ -12,4 +12,5 @@ TESTDIR="test"
 if [ "$1" != "emqx" ]; then
     TESTDIR="$1/test"
 fi
+# shellcheck disable=SC2038
 find "${TESTDIR}" -name "*_SUITE.erl" 2>/dev/null | xargs | tr ' ' ','

--- a/scripts/relup-base-vsns.sh
+++ b/scripts/relup-base-vsns.sh
@@ -20,8 +20,8 @@ parse_semver() {
     echo "$1" | tr '.|-' ' '
 }
 
-PROFILE="${1:-}"
-[ -z "${PROFILE}" ] && usage
+EDITION="${1:-}"
+[ -z "${EDITION}" ] && usage
 
 ## Get the current release version
 ## e.g.
@@ -49,7 +49,7 @@ else
     IS_RELEASE=false
 fi
 
-case "${PROFILE}" in
+case "${EDITION}" in
     *enterprise*)
         GIT_TAG_PREFIX="e"
         ;;

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -3,7 +3,11 @@
 set -euo pipefail
 
 target_files=()
-while IFS='' read -r line; do target_files+=("$line"); done < <(grep -r -l --exclude-dir=.git --exclude-dir=_build "#!/bin/" .)
+while IFS='' read -r line;
+do
+  target_files+=("$line");
+done < <(git grep -r -l '^#!/\(bin/\|usr/bin/env bash\)' .)
+
 return_code=0
 for i in "${target_files[@]}"; do
   echo checking "$i" ...


### PR DESCRIPTION
changed from
`../scripts/relup-base-vsns.sh community`
to
`../scripts/relup-base-vsns.sh $EDITION`

also some shellcheck fixes.