### PR TITLE
fix(build): change header of shell script to "#!/usr/bin/env bash"

### DIFF
--- a/scripts/get-otp-vsn.sh
+++ b/scripts/get-otp-vsn.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
This script got `W` as the OTP_VSN, I suspect it is because the script is evaluated using a shell other than bash.

```
#!/usr/bin/env escript
%% Rebar3 3.18.0-emqx-1
/c/Program Files/erl-23.0/bin/rebar3
OTP_VSN: W
rebar3 3.18.0-emqx-1 already exists
escript: exception error: undefined function rebar3:main/1
  in function  escript:run/2 (escript.erl, line 758)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 (init.erl, line [112](https://github.com/emqx/emqx/runs/5226132461?check_suite_focus=true#step:6:112)3)
  in call from init:do_boot/3 (init.erl, line 831)
mingw32-make: *** [Makefile:81: emqx] Error 127
```