### PR TITLE
build: fix find command for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ export EMQX_CE_DASHBOARD_VERSION ?= v4.3.5
 export DOCKERFILE := deploy/docker/Dockerfile
 ifeq ($(OS),Windows_NT)
 	export REBAR_COLOR=none
+	FIND=/usr/bin/find
+else
+	FIND=find
 endif
 
 PROFILE ?= emqx
@@ -90,8 +93,8 @@ $(PROFILES:%=clean-%):
 	@if [ -d _build/$(@:clean-%=%) ]; then \
 		rm rebar.lock \
 		rm -rf _build/$(@:clean-%=%)/rel; \
-		find _build/$(@:clean-%=%) -name '*.beam' -o -name '*.so' -o -name '*.app' -o -name '*.appup' -o -name '*.o' -o -name '*.d' -type f | xargs rm -f; \
-		find _build/$(@:clean-%=%) -type l -delete; \
+		$(FIND) _build/$(@:clean-%=%) -name '*.beam' -o -name '*.so' -o -name '*.app' -o -name '*.appup' -o -name '*.o' -o -name '*.d' -type f | xargs rm -f; \
+		$(FIND) _build/$(@:clean-%=%) -type l -delete; \
 	fi
 
 .PHONY: clean-all

--- a/build
+++ b/build
@@ -45,6 +45,13 @@ if [ "$(uname -s)" = 'Linux' ]; then
     esac
 fi
 
+if [ "${SYSTEM}" = 'windows' ]; then
+    # windows does not like the find
+    FIND="/usr/bin/find"
+else
+    FIND='find'
+fi
+
 log() {
     local msg="$1"
     # rebar3 prints ===>, so we print ===<
@@ -76,7 +83,7 @@ make_relup() {
                 rm -rf "$tmp_dir"
             fi
             releases+=( "$base_vsn" )
-        done < <(find _upgrade_base -maxdepth 1 -name "*$PROFILE-$SYSTEM*-$ARCH.zip" -type f)
+        done < <("$FIND" _upgrade_base -maxdepth 1 -name "*$PROFILE-$SYSTEM*-$ARCH.zip" -type f)
     fi
     if [ ${#releases[@]} -eq 0 ]; then
         log "No upgrade base found, relup ignored"
@@ -96,7 +103,7 @@ cp_dyn_libs() {
     mkdir -p "$target_dir"
     while read -r so_file; do
         cp -L "$so_file" "$target_dir/"
-    done < <(find "$rel_dir" -type f \( -name "*.so*" -o -name "beam.smp" \) -print0 \
+    done < <("$FIND" "$rel_dir" -type f \( -name "*.so*" -o -name "beam.smp" \) -print0 \
         | xargs -0 ldd \
         | grep -E '(libcrypto)|(libtinfo)' \
         | awk '{print $3}' \

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -5,9 +5,16 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "$0")/.."
 
+if [ "$(./scripts/get-distro.sh)" = 'windows' ]; then
+    # Otherwise windows may resolve to find.exe
+    FIND="/usr/bin/find"
+else
+    FIND='find'
+fi
+
 find_app() {
     local appdir="$1"
-    find "${appdir}" -mindepth 1 -maxdepth 1 -type d
+    "$FIND" "${appdir}" -mindepth 1 -maxdepth 1 -type d
 }
 
 # append emqx application first
@@ -23,4 +30,4 @@ fi
 ## find directories in lib-extra
 find_app 'lib-extra'
 ## find symlinks in lib-extra
-find 'lib-extra' -mindepth 1 -maxdepth 1 -type l -exec test -e {} \; -print
+"$FIND" 'lib-extra' -mindepth 1 -maxdepth 1 -type l -exec test -e {} \; -print


### PR DESCRIPTION
windows has its own find command

This PR is based on tag `v4.3.12`, so it can be forward-merged to `v4.4.0` for fixing windows build