### PR TITLE
chore: ensure remsh prefix for remote nodes

### DIFF
--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -344,7 +344,7 @@ start_distribution(TargetNode, NameTypeArg, Cookie) ->
 
 make_script_node(Node) ->
     [Name, Host] = string:tokens(atom_to_list(Node), "@"),
-    list_to_atom(lists:concat([Name, "_upgrader_", os:getpid(), "@", Host])).
+    list_to_atom(lists:concat(["remsh_" ++ Name, "_upgrader_", os:getpid(), "@", Host])).
 
 %% get name type from arg
 get_name_type(NameTypeArg) ->


### PR DESCRIPTION
for remsh prefixed nodes, ekka pick a random port to listen on
instead of following the conventional port mapping rule:
ekka listens on 4370 for emqx or emqx0 and 4371 for emqx1 and so on

