### PR TITLE
build: fix windows build

### DIFF
--- a/.ci/build_packages/tests.sh
+++ b/.ci/build_packages/tests.sh
@@ -24,8 +24,6 @@ export RELUP_PACKAGE_PATH="${CODE_PATH}/_upgrade_base"
 # export EMQX_NODE_NAME="emqx-on-$(uname -m)@127.0.0.1"
 # export EMQX_NODE_COOKIE=$(date +%s%N)
 
-PKG_VSN="$($CODE_PATH/pkg-vsn.sh)"
-OTP_VSN="$($CODE_PATH/scripts/get-otp-vsn.sh)"
 SYSTEM="$($CODE_PATH/scripts/get-distro.sh)"
 
 if [ "$PACKAGE_TYPE" = 'zip' ]; then
@@ -41,21 +39,8 @@ else
     esac
 fi
 
-ARCH="$(uname -m)"
-case "$ARCH" in
-    x86_64)
-        ARCH='amd64'
-        ;;
-    aarch64)
-        ARCH='arm64'
-        ;;
-    arm*)
-        ARCH=arm
-        ;;
-esac
-export ARCH
-
-PACKAGE_NAME="${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}"
+PACKAGE_NAME="${PROFILE}-$($CODE_PATH/scripts/pkg-full-vsn.sh)"
+OLD_PACKAGE_PATTERN="${PROFILE}-$($CODE_PATH/scripts/pkg-full-vsn.sh 'vsn_matcher')"
 PACKAGE_FILE_NAME="${PACKAGE_NAME}.${PKG_SUFFIX}"
 
 PACKAGE_FILE="${PACKAGE_PATH}/${PACKAGE_FILE_NAME}"
@@ -79,7 +64,7 @@ emqx_test(){
         "zip")
             unzip -q "${PACKAGE_PATH}/${packagename}"
             export EMQX_ZONE__EXTERNAL__SERVER__KEEPALIVE=60 \
-                    EMQX_MQTT__MAX_TOPIC_ALIAS=10
+                   EMQX_MQTT__MAX_TOPIC_ALIAS=10
             sed -i '/emqx_telemetry/d' "${PACKAGE_PATH}"/emqx/data/loaded_plugins
 
             echo "running ${packagename} start"
@@ -178,34 +163,33 @@ running_test(){
 
 relup_test(){
     TARGET_VERSION="$("$CODE_PATH"/pkg-vsn.sh)"
-    if [ -d "${RELUP_PACKAGE_PATH}" ];then
-        cd "${RELUP_PACKAGE_PATH}"
-
-        find . -maxdepth 1 -name "${PROFILE}-*-${ARCH}.zip" |
-            while read -r pkg; do
-                packagename=$(basename "${pkg}")
-                unzip -q "$packagename"
-                if ! ./emqx/bin/emqx start; then
-                    cat emqx/log/erlang.log.1 || true
-                    cat emqx/log/emqx.log.1 || true
-                    exit 1
-                fi
-                ./emqx/bin/emqx_ctl status
-                ./emqx/bin/emqx versions
-                cp "${PACKAGE_PATH}/${PROFILE}-${TARGET_VERSION}"-*-"${ARCH}".zip ./emqx/releases
-                ./emqx/bin/emqx install "${TARGET_VERSION}"
-                [ "$(./emqx/bin/emqx versions |grep permanent | awk '{print $2}')" = "${TARGET_VERSION}" ] || exit 1
-                export EMQX_WAIT_FOR_STOP=300
-                ./emqx/bin/emqx_ctl status
-                if ! ./emqx/bin/emqx stop; then
-                    cat emqx/log/erlang.log.1 || true
-                    cat emqx/log/emqx.log.1 || true
-                    echo "failed to stop emqx"
-                    exit 1
-                fi
-                rm -rf emqx
-            done
-   fi
+    if [ ! -d "${RELUP_PACKAGE_PATH}" ];then
+        return 0
+    fi
+    cd "${RELUP_PACKAGE_PATH}"
+    while read -r pkg; do
+        packagename=$(basename "${pkg}")
+        unzip -q "$packagename"
+        if ! ./emqx/bin/emqx start; then
+            cat emqx/log/erlang.log.1 || true
+            cat emqx/log/emqx.log.1 || true
+            exit 1
+        fi
+        ./emqx/bin/emqx_ctl status
+        ./emqx/bin/emqx versions
+        cp "${PACKAGE_PATH}/${PROFILE}-${TARGET_VERSION}"-*.zip ./emqx/releases/
+        ./emqx/bin/emqx install "${TARGET_VERSION}"
+        [ "$(./emqx/bin/emqx versions |grep permanent | awk '{print $2}')" = "${TARGET_VERSION}" ] || exit 1
+        export EMQX_WAIT_FOR_STOP=300
+        ./emqx/bin/emqx_ctl status
+        if ! ./emqx/bin/emqx stop; then
+            cat emqx/log/erlang.log.1 || true
+            cat emqx/log/emqx.log.1 || true
+            echo "failed to stop emqx"
+            exit 1
+        fi
+        rm -rf emqx
+    done < <(find . -maxdepth 1 -name "${OLD_PACKAGE_PATTERN}.zip")
 }
 
 emqx_prepare

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+build text eol=lf
 * text=auto
 *.* text eol=lf
 *.jpg -text

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -91,19 +91,11 @@ jobs:
       env:
         PYTHON: python
         DIAGNOSTIC: 1
+        PROFILE: emqx
       working-directory: source
       run: |
         $env:PATH = "${{ steps.install_erlang.outputs.erlpath }}\bin;$env:PATH"
         erl -eval "erlang:display(crypto:info_lib())" -s init stop
-
-        $version = $( "${{ github.ref }}" -replace "^(.*)/(.*)/" )
-        if ($version -match "^v[0-9]+\.[0-9]+(\.[0-9]+)?") {
-          $regex = "[0-9]+\.[0-9]+(-alpha|-beta|-rc)?\.[0-9]+"
-          $pkg_name = "${{ matrix.profile }}-$([regex]::matches($version, $regex).value)-otp${{ matrix.otp }}-windows-amd64.zip"
-          }
-        else {
-          $pkg_name = "${{ matrix.profile }}-$($version -replace '/')-otp${{ matrix.otp }}-windows-amd64.zip"
-          }
         ## We do not build/release bcrypt for windows package
         Remove-Item -Recurse -Force -Path _build/default/lib/bcrypt/
         if (Test-Path rebar.lock) {
@@ -115,11 +107,7 @@ jobs:
         head -2 rebar3
         which rebar3
         rebar3 --help
-        make ${{ matrix.profile }}
-        mkdir -p _packages/${{ matrix.profile }}
-        Compress-Archive -Path _build/${{ matrix.profile }}/rel/emqx -DestinationPath _build/${{ matrix.profile }}/rel/$pkg_name
-        mv _build/${{ matrix.profile }}/rel/$pkg_name _packages/${{ matrix.profile }}
-        sha256sum "_packages/${{ matrix.profile }}/$pkg_name" | head -c 64 > "_packages/${{ matrix.profile }}/${pkg_name}.sha256"
+        make ${{ matrix.profile }}-zip
     - name: run emqx
       timeout-minutes: 1
       working-directory: source
@@ -132,7 +120,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
-        name: ${{ matrix.profile }}
+        name: ${{ matrix.profile }}-windows
         path: source/_packages/${{ matrix.profile }}/.
 
   mac:
@@ -214,8 +202,6 @@ jobs:
           exit 1
         fi
         rm -rf emqx
-        #sha256sum $pkg_name | head -c64  > $pkg_name.sha256
-        openssl dgst -sha256 $pkg_name | awk '{print $2}'  > $pkg_name.sha256
     - uses: actions/upload-artifact@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
@@ -368,7 +354,7 @@ jobs:
             registry: 'public.ecr.aws'
           - profile: emqx-ee
             registry: 'public.ecr.aws'
-        
+
     steps:
     - uses: actions/download-artifact@v2
       with:
@@ -459,6 +445,9 @@ jobs:
         otp:
           - 23.3.4.9-3
           - 24.1.5-3
+        include:
+          - profile: emqx
+            otp: windows # otp version on windows is rather fixed
 
     steps:
     - uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ export DOCKERFILE := deploy/docker/Dockerfile
 export DOCKERFILE_TESTING := deploy/docker/Dockerfile.testing
 ifeq ($(OS),Windows_NT)
 	export REBAR_COLOR=none
+	FIND=/usr/bin/find
+else
+	FIND=find
 endif
 
 PROFILE ?= emqx
@@ -91,8 +94,8 @@ $(PROFILES:%=clean-%):
 	@if [ -d _build/$(@:clean-%=%) ]; then \
 		rm rebar.lock \
 		rm -rf _build/$(@:clean-%=%)/rel; \
-		find _build/$(@:clean-%=%) -name '*.beam' -o -name '*.so' -o -name '*.app' -o -name '*.appup' -o -name '*.o' -o -name '*.d' -type f | xargs rm -f; \
-		find _build/$(@:clean-%=%) -type l -delete; \
+		$(FIND) _build/$(@:clean-%=%) -name '*.beam' -o -name '*.so' -o -name '*.app' -o -name '*.appup' -o -name '*.o' -o -name '*.d' -type f | xargs rm -f; \
+		$(FIND) _build/$(@:clean-%=%) -type l -delete; \
 	fi
 
 .PHONY: clean-all

--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -365,7 +365,7 @@ start_distribution(TargetNode, NameTypeArg, Cookie) ->
 
 make_script_node(Node) ->
     [Name, Host] = string:tokens(atom_to_list(Node), "@"),
-    list_to_atom(lists:concat([Name, "_upgrader_", os:getpid(), "@", Host])).
+    list_to_atom(lists:concat(["remsh_", Name, "_upgrader_", os:getpid(), "@", Host])).
 
 %% get name type from arg
 get_name_type(NameTypeArg) ->

--- a/build
+++ b/build
@@ -17,20 +17,6 @@ export PKG_VSN
 
 SYSTEM="$(./scripts/get-distro.sh)"
 
-ARCH="$(uname -m)"
-case "$ARCH" in
-    x86_64)
-        ARCH='amd64'
-        ;;
-    aarch64)
-        ARCH='arm64'
-        ;;
-    arm*)
-        ARCH=arm
-        ;;
-esac
-export ARCH
-
 ##
 ## Support RPM and Debian based linux systems
 ##
@@ -45,6 +31,28 @@ if [ "$(uname -s)" = 'Linux' ]; then
     esac
 fi
 
+if [ "${SYSTEM}" = 'windows' ]; then
+    # windows does not like the find
+    FIND="/usr/bin/find"
+else
+    FIND='find'
+fi
+
+UNAME="$(uname -m)"
+case "$UNAME" in
+    x86_64)
+        ARCH='amd64'
+        ;;
+    aarch64)
+        ARCH='arm64'
+        ;;
+    arm*)
+        ARCH=arm
+        ;;
+esac
+# used in -pkg Makefile:s
+export ARCH
+
 log() {
     local msg="$1"
     # rebar3 prints ===>, so we print ===<
@@ -52,15 +60,16 @@ log() {
 }
 
 make_rel() {
-    # shellcheck disable=SC1010
-    ./rebar3 as "$PROFILE" do release,tar
+    ./rebar3 as "$PROFILE" tar
 }
 
 ## unzip previous version .zip files to _build/$PROFILE/rel/emqx/releases before making relup
 make_relup() {
     local lib_dir="_build/$PROFILE/rel/emqx/lib"
     local releases_dir="_build/$PROFILE/rel/emqx/releases"
-    mkdir -p "$lib_dir" "$releases_dir"
+    local name_pattern
+    name_pattern="${PROFILE}-$(./scripts/pkg-full-vsn.sh 'vsn_matcher')"
+    mkdir -p "$lib_dir" "$releases_dir" '_upgrade_base'
     local releases=()
     if [ -d "$releases_dir" ]; then
         while read -r zip; do
@@ -76,7 +85,7 @@ make_relup() {
                 rm -rf "$tmp_dir"
             fi
             releases+=( "$base_vsn" )
-        done < <(find _upgrade_base -maxdepth 1 -name "${PROFILE}-*-otp${OTP_VSN}-${SYSTEM}-${ARCH}.zip" -type f)
+        done < <("$FIND" _upgrade_base -maxdepth 1 -name "${name_pattern}.zip" -type f)
     fi
     if [ ${#releases[@]} -eq 0 ]; then
         log "No upgrade base found, relup ignored"
@@ -87,6 +96,8 @@ make_relup() {
     ./rebar3 as "$PROFILE" relup --relname emqx --relvsn "${PKG_VSN}"
 }
 
+## try to be portable for zip packages.
+## for DEB and RPM packages the dependencies are resoved by yum and apt
 cp_dyn_libs() {
     local rel_dir="$1"
     local target_dir="${rel_dir}/dynlibs"
@@ -96,36 +107,55 @@ cp_dyn_libs() {
     mkdir -p "$target_dir"
     while read -r so_file; do
         cp -L "$so_file" "$target_dir/"
-    done < <(find "$rel_dir" -type f \( -name "*.so*" -o -name "beam.smp" \) -print0 \
+    done < <("$FIND" "$rel_dir" -type f \( -name "*.so*" -o -name "beam.smp" \) -print0 \
         | xargs -0 ldd \
         | grep -E '(libcrypto)|(libtinfo)' \
         | awk '{print $3}' \
         | sort -u)
 }
 
+
 ## make_zip turns .tar.gz into a .zip with a slightly different name.
 ## It assumes the .tar.gz has been built -- relies on Makefile dependency
 make_zip() {
     # build the tarball again to ensure relup is included
     make_rel
-
-    tard="/tmp/emqx_untar_${PKG_VSN}"
-    rm -rf "${tard}"
+    # use relative path because abs path is tricky in windows
+    tard="tmp/zip-wd-${PKG_VSN}"
+    rm -rf "${tard}/emqx"
     mkdir -p "${tard}/emqx"
     local relpath="_build/${PROFILE}/rel/emqx"
     local pkgpath="_packages/${PROFILE}"
+    local pkgname
+    pkgname="${PROFILE}-$(./scripts/pkg-full-vsn.sh).zip"
     mkdir -p "${pkgpath}"
-    local tarball="${relpath}/emqx-${PKG_VSN}.tar.gz"
-    if [ ! -f "$tarball" ]; then
-        log "ERROR: $tarball is not found"
-    fi
-    local zipball
-    zipball="${pkgpath}/${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.zip"
+    local tarname="emqx-${PKG_VSN}.tar.gz"
+    local tarball="${relpath}/${tarname}"
+    local target_zip="${pkgpath}/${pkgname}"
     tar zxf "${tarball}" -C "${tard}/emqx"
-    ## try to be portable for zip packages.
-    ## for DEB and RPM packages the dependencies are resoved by yum and apt
     cp_dyn_libs "${tard}/emqx"
-    (cd "${tard}" && zip -qr - emqx) > "${zipball}"
+    pushd "${tard}" >/dev/null
+    case "$SYSTEM" in
+        windows*)
+            7z a "${pkgname}" emqx
+            ;;
+        *)
+            zip -qr "${pkgname}" emqx
+            ;;
+    esac
+    popd >/dev/null
+    mv "${tard}/${pkgname}" "${target_zip}"
+    case "$SYSTEM" in
+        macos*)
+            # sha256sum may not be available on macos
+            openssl dgst -sha256 "${target_zip}" | cut -d ' ' -f 2  > "${target_zip}.sha256"
+            ;;
+        *)
+            sha256sum "${target_zip}" | head -c 64 > "${target_zip}.sha256"
+            ;;
+    esac
+    log "Zip package successfully created: ${target_zip}"
+    log "Zip package sha256sum: $(cat "${target_zip}.sha256")"
 }
 
 ## This function builds the default docker image based on alpine:3.14 (by default)
@@ -170,7 +200,7 @@ make_docker_testing() {
     fi
     EMQX_IMAGE_TAG="${EMQX_IMAGE_TAG:-emqx/$PROFILE:${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}}"
     local defaultzip
-    defaultzip="_packages/${PROFILE}/${PROFILE}-${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}.zip"
+    defaultzip="_packages/${PROFILE}/${PROFILE}-$(./scripts/pkg-full-vsn.sh).zip"
     local zip="${EMQX_ZIP_PACKAGE:-$defaultzip}"
     if [ ! -f "$zip" ]; then
         log "ERROR: $zip not built?"
@@ -201,7 +231,7 @@ case "$ARTIFACT" in
             log "Skipped making deb/rpm package for $SYSTEM"
             exit 0
         fi
-        make -C "deploy/packages/${PKGERDIR}" clean
+        EMQX_REL="$(pwd)" make -C "deploy/packages/${PKGERDIR}" clean
         EMQX_REL="$(pwd)" EMQX_BUILD="${PROFILE}" SYSTEM="${SYSTEM}" make -C "deploy/packages/${PKGERDIR}"
         ;;
     docker)

--- a/deploy/packages/deb/Makefile
+++ b/deploy/packages/deb/Makefile
@@ -1,4 +1,3 @@
-ARCH ?= amd64
 TOPDIR := /tmp/emqx
 # Keep this short to avoid bloating beam files with long file path info
 SRCDIR := $(TOPDIR)/$(PKG_VSN)
@@ -8,7 +7,7 @@ EMQX_NAME=$(subst -pkg,,$(EMQX_BUILD))
 
 TAR_PKG := $(EMQX_REL)/_build/$(EMQX_BUILD)/rel/emqx/emqx-$(PKG_VSN).tar.gz
 SOURCE_PKG := $(EMQX_NAME)_$(PKG_VSN)_$(shell dpkg --print-architecture)
-TARGET_PKG := $(EMQX_NAME)-$(PKG_VSN)-otp$(OTP_VSN)-$(SYSTEM)-$(ARCH)
+TARGET_PKG := $(EMQX_NAME)-$(shell $(EMQX_REL)/scripts/pkg-full-vsn.sh)
 
 .PHONY: all
 all: | $(BUILT)
@@ -22,6 +21,8 @@ all: | $(BUILT)
 	cd $(SRCDIR) && dpkg-buildpackage -us -uc
 	mkdir -p $(EMQX_REL)/_packages/$(EMQX_NAME)
 	cp $(SRCDIR)/../$(SOURCE_PKG).deb $(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).deb
+	sha256sum $(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).deb | head -c 64 > \
+		$(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).deb.sha256
 
 $(BUILT):
 	mkdir -p $(TOPDIR) $(SRCDIR)

--- a/deploy/packages/rpm/Makefile
+++ b/deploy/packages/rpm/Makefile
@@ -17,8 +17,8 @@ endif
 EMQX_NAME=$(subst -pkg,,$(EMQX_BUILD))
 
 TAR_PKG := $(EMQX_REL)/_build/$(EMQX_BUILD)/rel/emqx/emqx-$(PKG_VSN).tar.gz
-TARGET_PKG := $(EMQX_NAME)-$(PKG_VSN)-otp$(OTP_VSN)-$(SYSTEM)-$(ARCH)
 SOURCE_PKG := emqx-$(RPM_VSN)-$(RPM_REL).$(shell uname -m)
+TARGET_PKG := $(EMQX_NAME)-$(shell $(EMQX_REL)/scripts/pkg-full-vsn.sh)
 
 SYSTEMD := $(shell if command -v systemctl >/dev/null 2>&1; then echo yes; fi)
 # Not $(PWD) as it does not work for make -C
@@ -48,6 +48,8 @@ all: | $(BUILT)
 		emqx.spec
 	mkdir -p $(EMQX_REL)/_packages/$(EMQX_NAME)
 	cp $(TOPDIR)/RPMS/$(shell uname -m)/$(SOURCE_PKG).rpm $(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).rpm
+	sha256sum $(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).rpm | head -c 64 > \
+		$(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).rpm.sha256
 
 $(BUILT):
 	mkdir -p $(TOPDIR) $(SRCDIR) $(SRCDIR)/BUILT

--- a/include/emqx_release.hrl
+++ b/include/emqx_release.hrl
@@ -29,7 +29,7 @@
 
 -ifndef(EMQX_ENTERPRISE).
 
--define(EMQX_RELEASE, {opensource, "4.4.0"}).
+-define(EMQX_RELEASE, {opensource, "4.4.1-rc.1"}).
 
 -else.
 

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard,
  [{description, "EMQ X Web Dashboard"},
-  {vsn, "4.4.1"}, % strict semver, bump manually!
+  {vsn, "4.4.2"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_dashboard_sup]},
   {applications, [kernel,stdlib,mnesia,minirest]},

--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -2,7 +2,21 @@
 
 set -euo pipefail
 
-VERSION="3.14.3-emqx-8"
+## rebar3 tag 3.18.0-emqx-1 is compiled using otp24.1.5.
+## we have to use an otp24-compiled rebar3 because the defination of record #application{}
+## in systools.hrl is changed in otp24.
+case ${OTP_VSN} in
+    23*)
+        VERSION="3.14.3-emqx-8"
+        ;;
+    24*)
+        VERSION="3.18.0-emqx-1"
+        ;;
+    *)
+        echo "Unsupporetd Erlang/OTP version $OTP_VSN"
+        exit 1
+        ;;
+esac
 
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
@@ -14,10 +28,6 @@ download() {
     curl -f -L "${DOWNLOAD_URL}/${VERSION}/rebar3" -o ./rebar3
 }
 
-version_gte() {
-    test "$(printf '%s\n' "$1" "$2" | sort -V | head -n 1)" = "$2"
-}
-
 # get the version number from the second line of the escript
 # because command `rebar3 -v` tries to load rebar.config
 # which is slow and may print some logs
@@ -25,16 +35,7 @@ version() {
     head -n 2 ./rebar3 | tail -n 1 | tr ' ' '\n' | grep -E '^.+-emqx-.+'
 }
 
-echo "OTP_VSN: ${OTP_VSN}"
-if version_gte "${OTP_VSN}" "24.0"; then
-    ## rebar3 tag 3.18.0-emqx-1 is compiled using otp24.1.5.
-    ## we have to use an otp24-compiled rebar3 because the defination of record #application{}
-    ## in systools.hrl is changed in otp24.
-    VERSION="3.18.0-emqx-1"
-fi
-
 if [ -f 'rebar3' ] && [ "$(version)" = "$VERSION" ]; then
-    echo "rebar3 ${VERSION} already exists"
     exit 0
 fi
 

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -5,9 +5,16 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "$0")/.."
 
+if [ "$(./scripts/get-distro.sh)" = 'windows' ]; then
+    # Otherwise windows may resolve to find.exe
+    FIND="/usr/bin/find"
+else
+    FIND='find'
+fi
+
 find_app() {
     local appdir="$1"
-    find "${appdir}" -mindepth 1 -maxdepth 1 -type d
+    "$FIND" "${appdir}" -mindepth 1 -maxdepth 1 -type d
 }
 
 # append emqx application first
@@ -23,4 +30,4 @@ fi
 ## find directories in lib-extra
 find_app 'lib-extra'
 ## find symlinks in lib-extra
-find 'lib-extra' -mindepth 1 -maxdepth 1 -type l -exec test -e {} \; -print
+"$FIND" 'lib-extra' -mindepth 1 -maxdepth 1 -type l -exec test -e {} \; -print

--- a/scripts/get-distro.sh
+++ b/scripts/get-distro.sh
@@ -5,18 +5,26 @@
 
 set -euo pipefail
 
-if [ "$(uname -s)" = 'Darwin' ]; then
-    DIST='macos'
-    VERSION_ID=$(sw_vers | gsed -n '/^ProductVersion:/p' | gsed -r 's/ProductVersion:(.*)/\1/g' | gsed -r 's/([0-9]+).*/\1/g' | gsed 's/^[ \t]*//g')
-    SYSTEM="$(echo "${DIST}${VERSION_ID}" | gsed -r 's/([a-zA-Z]*)-.*/\1/g')"
-elif [ "$(uname -s)" = 'Linux' ]; then
-    if grep -q -i 'rhel' /etc/*-release; then
-        DIST='el'
-        VERSION_ID="$(rpm --eval '%{rhel}')"
-    else
-        DIST="$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')"
-        VERSION_ID="$(sed -n '/^VERSION_ID=/p' /etc/os-release | sed -r 's/VERSION_ID=(.*)/\1/g' | sed 's/"//g')"
-    fi
-    SYSTEM="$(echo "${DIST}${VERSION_ID}" | sed -r 's/([a-zA-Z]*)-.*/\1/g')"
-fi
+UNAME="$(uname -s)"
+
+case "$UNAME" in
+    Darwin)
+        DIST='macos'
+        VERSION_ID=$(sw_vers | gsed -n '/^ProductVersion:/p' | gsed -r 's/ProductVersion:(.*)/\1/g' | gsed -r 's/([0-9]+).*/\1/g' | gsed 's/^[ \t]*//g')
+        SYSTEM="$(echo "${DIST}${VERSION_ID}" | gsed -r 's/([a-zA-Z]*)-.*/\1/g')"
+        ;;
+    Linux)
+        if grep -q -i 'rhel' /etc/*-release; then
+            DIST='el'
+            VERSION_ID="$(rpm --eval '%{rhel}')"
+        else
+            DIST="$(sed -n '/^ID=/p' /etc/os-release | sed -r 's/ID=(.*)/\1/g' | sed 's/"//g')"
+            VERSION_ID="$(sed -n '/^VERSION_ID=/p' /etc/os-release | sed -r 's/VERSION_ID=(.*)/\1/g' | sed 's/"//g')"
+        fi
+        SYSTEM="$(echo "${DIST}${VERSION_ID}" | sed -r 's/([a-zA-Z]*)-.*/\1/g')"
+        ;;
+    CYGWIN*|MSYS*|MINGW*)
+        SYSTEM="windows"
+        ;;
+esac
 echo "$SYSTEM"

--- a/scripts/pkg-full-vsn.sh
+++ b/scripts/pkg-full-vsn.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+## This script print the package full vsn based on current build environment
+
+## Arg 1 is either 'vsn_exact' (default) or 'vsn_matcher'
+## when 'vsn_exact' is given, the version number is the output of pkg-vsn.sh
+## otherwise '*' is used for 'find' command to find old versions (as upgrade base)
+
+set -euo pipefail
+
+VSN_MATCH="${1:-vsn_exact}"
+
+case "${VSN_MATCH}" in
+    vsn_exact)
+        PKG_VSN="${PKG_VSN:-$(./pkg-vsn.sh)}"
+        ;;
+    vsn_matcher)
+        PKG_VSN='*'
+        ;;
+    *)
+        echo "$0 ERROR: second arg must "
+        exit 1
+        ;;
+esac
+
+# ensure dir
+cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+
+OTP_VSN="${OTP_VSN:-$(./scripts/get-otp-vsn.sh)}"
+SYSTEM="$(./scripts/get-distro.sh)"
+
+UNAME="$(uname -m)"
+case "$UNAME" in
+    x86_64)
+        ARCH='amd64'
+        ;;
+    aarch64)
+        ARCH='arm64'
+        ;;
+    arm*)
+        ARCH=arm
+        ;;
+esac
+
+echo "${PKG_VSN}-otp${OTP_VSN}-${SYSTEM}-${ARCH}"


### PR DESCRIPTION
* fix various issues for windows build
  - find command clash with window's find
  - zip command not found, changed to use 7z so we do not have use powershell apis
  - absolute paths are tricky to work with in windows, so the make_zip is changed to use relative path 
* added a `scripts/get-full-vsn.sh` to print out the full version string like `4.4.0-otp24.1.5-4-el8-amd64`.
* fixed windows upload artifacts upload group
* changed to create .sha256 immediately when building packages 
