### PR TITLE
fix(node_dump): Don't collect information about modules

### DIFF
--- a/bin/node_dump
+++ b/bin/node_dump
@@ -56,7 +56,6 @@ done
     collect netstat -tnl
 
     collect "$RUNNER_BIN_DIR"/emqx_ctl plugins list
-    collect "$RUNNER_BIN_DIR"/emqx_ctl modules list
 
     collect "$RUNNER_BIN_DIR"/emqx_ctl vm all
     collect "$RUNNER_BIN_DIR"/emqx_ctl listeners


### PR DESCRIPTION
No longer relevant for 5.0