### PR TITLE
fix(deps): use tags for dependencies

### DIFF
--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,8 +19,8 @@ IsQuicSupp = fun() ->
                     )
              end,
 
-Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {branch, "0.6.0"}}},
-Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {branch, "0.0.9"}}},
+Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.0"}}},
+Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.9"}}},
 
 ExtraDeps = fun(C) ->
                 {deps, Deps0} = lists:keyfind(deps, 1, C),

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -30,7 +30,7 @@ assert_otp() ->
     end.
 
 bcrypt() ->
-    {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {branch, "0.6.0"}}}.
+    {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.0"}}}.
 
 quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.9"}}}.


### PR DESCRIPTION
Some dependencies, like `bcrypt` and `quic`, have their references
declared as `branch`, yet there are no branches with those names, but
tags.  Despite rebar3 managing somehow to handle that, if a project
managed by Mix tries to declare EMQX as its dependency, it's not able
to fetch those dependencies.

```
$ mix deps.get
* Updating emqx (https://github.com/emqx/emqx - v5.0-beta.3)
* Updating lc (https://github.com/qzhuyan/lc.git - 0.1.2)
* Updating gproc (https://github.com/uwiger/gproc - 0.8.0)
* Updating typerefl (https://github.com/k32/typerefl - 0.8.6)
* Updating jiffy (https://github.com/emqx/jiffy - 1.0.5)
* Updating cowboy (https://github.com/emqx/cowboy - 2.9.0)
* Updating esockd (https://github.com/emqx/esockd - 5.9.0)
* Updating ekka (https://github.com/emqx/ekka - 0.11.1)
* Updating gen_rpc (https://github.com/emqx/gen_rpc - 2.5.1)
* Updating hocon (https://github.com/emqx/hocon.git - 0.22.1)
* Updating pbkdf2 (https://github.com/emqx/erlang-pbkdf2.git - 2.0.4)
* Updating recon (https://github.com/ferd/recon - 2.5.1)
* Updating snabbkaffe (https://github.com/kafka4beam/snabbkaffe.git - 0.16.0)
* Updating bcrypt (https://github.com/emqx/erlang-bcrypt.git - origin/0.6.0)
error: pathspec 'origin/0.6.0' did not match any file(s) known to git
** (Mix) Command "git --git-dir=.git checkout --quiet origin/0.6.0" failed
```

Therefore, we change them to `tag`s.

