### PR TITLE
test(fix): fix flaky prop

### DIFF
--- a/apps/emqx/test/emqx_hooks_SUITE.erl
+++ b/apps/emqx/test/emqx_hooks_SUITE.erl
@@ -55,8 +55,9 @@ add_hook_order_prop() ->
                              (Prio1 =:= Prio2 andalso {M1, F1} =< {M2, F2})
                  end,
     ?FORALL(
-       Hooks, list({range(-1, 5), atom(), atom()}),
+       Hooks0, list({range(-1, 5), atom(), atom()}),
        try
+           Hooks = sets:to_list(sets:from_list(Hooks0)),
            {ok, _} = emqx_hooks:start_link(),
            [emqx:hook(prop_hook, {M, F, []}, Prio) || {Prio, M, F} <- Hooks],
            Callbacks = emqx_hooks:lookup(prop_hook),


### PR DESCRIPTION
Failing when duplicate elements were being generated.

```
 An exception was raised: error:{assertEqual,
                                [{module,emqx_hooks_SUITE},
                                 {line,65},
                                 {expression,"Order"},
                                 {expected,
                                  [{5,'',''},
                                   {5,'',''},
                                   {4,'\223',''},
                                   {2,'}Ijrµ\036',''}]},
                                 {value,
                                  [{5,'',''},
                                   {4,'\223',''},
                                   {2,'}Ijrµ\036',''}]}]}.
```

