### PR TITLE
fix(script): enable emqx.cmd to run from readonly root

### DIFF
--- a/bin/emqx_ctl.cmd
+++ b/bin/emqx_ctl.cmd
@@ -15,6 +15,12 @@
   set rel_root_dir=%%~fA
 )
 @set rel_dir=%rel_root_dir%\releases\%rel_vsn%
+:: hang onto the current dir so that we will reset to the proper location upon exit
+@set current_dir=%cd%
+:: cd into the root dir so that escript/werl will be able to find the ERTS using relative paths
+@echo off
+cd /d "%rel_root_dir%"
+@echo on
 @set emqx_conf=%rel_root_dir%\etc\emqx.conf
 
 @call :find_erts_dir
@@ -43,7 +49,14 @@
   copy "%rel_dir%\%rel_name%.boot" "%rel_dir%\start.boot" >nul
 )
 
+:exit
+@set err=%ERRORLEVEL%
+@cd %current_dir%
+@exit /b %err%
+@goto :eof
+
 @%escript% %nodetool% %node_type% "%node_name%" -setcookie "%node_cookie%" rpc emqx_ctl run_command %args%
+goto exit
 
 :: Find the ERTS dir
 :find_erts_dir


### PR DESCRIPTION
This commit updates emqx.cmd for Windows to:

1. Allow for erl.ini to use paths relative to the root of the EMQ X zip
2. Use user-provided data directory when set via the environment
   variable "EMQX_NODE__DATA_DIR"
3. Exit with proper exit code (instead of always 0) when running
   commands which may fail such as "ping" and "start"
4. Updates emqx_ctl.cmd with the same handling as 1 to handle relative
   paths in erl.ini

This commit does not include updating erl.ini to use a relative path by
default. However, if erl.ini does use a relative path and is readonly
then this change will work properly with that setup.

Closes #7092


I would also like to change the erl.ini which ships in the Windows ZIP by default to use relative paths which this change enables; however, I do not see a way to do that. So I would very much appreciate it if someone could point me in the right direction for making that happen.

