### PR TITLE
fix(relup): release upgrade failed on symlink already exists

### DIFF
--- a/.ci/fvt_tests/relup.lux
+++ b/.ci/fvt_tests/relup.lux
@@ -18,8 +18,9 @@
     ?>
 
 [shell emqx]
+    !OLD_VSN=$(echo $OLD_VSN | sed  -r 's/[v|e]//g')
     !cd $PACKAGE_PATH
-    !unzip -q -o $PROFILE-ubuntu20.04-$(echo $OLD_VSN | sed  -r 's/[v|e]//g')-amd64.zip
+    !unzip -q -o $PROFILE-ubuntu20.04-$${OLD_VSN}-amd64.zip
     ?SH-PROMPT
 
     !cd emqx
@@ -30,6 +31,7 @@
     ?SH-PROMPT
 
 [shell emqx2]
+    !OLD_VSN=$(echo $OLD_VSN | sed  -r 's/[v|e]//g')
     !cd $PACKAGE_PATH
     !cp -f $ONE_MORE_EMQX_PATH/one_more_$(echo $PROFILE | sed 's/-/_/g').sh .
     !./one_more_$(echo $PROFILE | sed 's/-/_/g').sh emqx2
@@ -82,6 +84,27 @@
 
     !cp -f ../$PROFILE-ubuntu20.04-$VSN-amd64.zip releases/
 
+    ## upgrade to the new version
+    !./bin/emqx install $VSN
+    ?Made release permanent: "$VSN"
+    ?SH-PROMPT
+
+    !./bin/emqx versions |grep permanent
+    ?(.*)$VSN
+    ?SH-PROMPT
+
+    ## downgrade to the old version
+    !./bin/emqx install $${OLD_VSN}
+    ?Made release permanent:.*
+    ?SH-PROMPT
+
+    !./bin/emqx versions |grep permanent | grep -qs "$${OLD_VSN}"
+    ?SH-PROMPT:
+    !echo ==$$?==
+    ?^==0==
+    ?SH-PROMPT:
+
+    ## again, upgrade to the new version
     !./bin/emqx install $VSN
     ?Made release permanent: "$VSN"
     ?SH-PROMPT
@@ -107,6 +130,27 @@
 
     !cp -f ../$PROFILE-ubuntu20.04-$VSN-amd64.zip releases/
 
+    ## upgrade to the new version
+    !./bin/emqx install $VSN
+    ?Made release permanent: "$VSN"
+    ?SH-PROMPT
+
+    !./bin/emqx versions |grep permanent
+    ?(.*)$VSN
+    ?SH-PROMPT
+
+    ## downgrade to the old version
+    !./bin/emqx install $${OLD_VSN}
+    ?Made release permanent:.*
+    ?SH-PROMPT
+
+    !./bin/emqx versions |grep permanent | grep -qs "$${OLD_VSN}"
+    ?SH-PROMPT:
+    !echo ==$$?==
+    ?^==0==
+    ?SH-PROMPT:
+
+    ## again, upgrade to the new version
     !./bin/emqx install $VSN
     ?Made release permanent: "$VSN"
     ?SH-PROMPT

--- a/.ci/fvt_tests/relup.lux
+++ b/.ci/fvt_tests/relup.lux
@@ -136,17 +136,20 @@
     !./bin/emqx_ctl broker metrics | grep "messages.publish"
     ???SH-PROMPT
 
+## We don't guarantee not to lose a single message!
+## So even if we received 290~300 messages, we consider it as success
 [shell bench]
     !curl --user admin:public --silent --show-error http://localhost:8081/api/v4/rules | jq -M --raw-output ".data[0].metrics[] | select(.node==\"emqx@127.0.0.1\").matched"
-    ?300
+    ?(29[0-9])|(300)
     ?SH-PROMPT
 
     !curl --user admin:public --silent --show-error http://localhost:8081/api/v4/rules | jq -M --raw-output ".data[0].actions[0].metrics[] | select(.node==\"emqx@127.0.0.1\").success"
-    ?300
+    ?(29[0-9])|(300)
     ?SH-PROMPT
 
+    ## The /counter API is provided by .ci/fvt_test/http_server
     !curl http://127.0.0.1:8080/counter
-    ???{"data":300,"code":0}
+    ?\{"data":(29[0-9])|(300),"code":0\}
     ?SH-PROMPT
 
 [shell emqx2]

--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -25,6 +25,7 @@ File format:
 
 ### Bug fixes
 
+* Fix the `{error,eexist}` error when do release upgrade again if last run failed. [#7121]
 * Fix case where publishing to a non-existent topic alias would crash the connection [#6979]
 * Fix HTTP-API 500 error on querying the lwm2m client list on the another node [#7009]
 * Fix the ExProto connection registry is not released after the client process abnormally exits [#6983]


### PR DESCRIPTION
```
./bin/emqx install 4.4.1
unzip ["releases/emqx-ee-4.4.1-otp23.2.5-macos12-amd64.zip"]
escript: exception error: no case clause matching {error,eexist}
```