### PR TITLE
fix(schema): allow `false` as a value for `rpc.enable_ssl`

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -385,8 +385,8 @@ end}.
 
 %% RPC SSL server port.
 {mapping, "rpc.enable_ssl", "gen_rpc.ssl_server_port", [
-  {default, 5369},
-  {datatype, integer}
+  {default, "5369"},
+  {datatype, string}
 ]}.
 
 %% RPC SSL certificates
@@ -408,6 +408,18 @@ end}.
   {datatype, integer},
   {validators, ["range:gt_0_lt_256"]}
 ]}.
+
+{translation, "gen_rpc.ssl_server_port", fun(Conf) ->
+  case cuttlefish:conf_get("rpc.enable_ssl", Conf) of
+    "false" -> false;
+    Str ->
+        try list_to_integer(Str) of
+            N -> N
+        catch
+            _ : _ -> error({not_integer_or_false, Str})
+        end
+  end
+end}.
 
 {translation, "gen_rpc.tcp_client_num", fun(Conf) ->
   case cuttlefish:conf_get("rpc.tcp_client_num", Conf) of

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -385,7 +385,7 @@ end}.
 
 %% RPC SSL server port.
 {mapping, "rpc.enable_ssl", "gen_rpc.ssl_server_port", [
-  {default, "5369"},
+  {default, "false"},
   {datatype, string}
 ]}.
 


### PR DESCRIPTION
To disable a driver module `DRV` in `gen_rpc`, `DRV_server_port` must
be set to `false`.  Currently if one tries to build EMQX with `make
emqx` and then run it without creating some certificates for
`gen_rpc`:

```
2022-02-24T13:46:19.132263-03:00 [error] event=failed_to_setup_server driver=ssl reason="{options,{cacertfile,[]}}"
2022-02-24T13:46:19.132391-03:00 [error] Supervisor: {local,gen_rpc_sup}. Context: start_error. Reason: {options,{cacertfile,[]}}. Offender: id=gen_rpc_server_ssl,pid=undefined.
2022-02-24T13:46:19.132711-03:00 [error] crasher: initial call: application_master:init/4, pid: <0.2147.0>, registered_name: [], exit: {{{shutdown,{failed_to_start_child,gen_rpc_server_ssl,{options,{cacertfile,[]}}}},{gen_rpc_app,start,[normal,[]]}},[{application_master,init,4,[{file,"application_master.erl"},{line,142}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.2146.0>], message_queue_len: 1, messages: [{'EXIT',<0.2148.0>,normal}], links: [<0.2146.0>,<0.2029.0>], dictionary: [], trap_exit: true, status: running, heap_size: 610, stack_size: 29, reductions: 215; neighbours:
[os_mon] memory supervisor port (memsup): Erlang has closed
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
{"Kernel pid terminated",application_controller,"{application_start_failure,gen_rpc,{{shutdown,{failed_to_start_child,gen_rpc_server_ssl,{options,{cacertfile,[]}}}},{gen_rpc_app,start,[normal,[]]}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,gen_rpc,{{shutdown,{failed_to_start_child,gen_rpc_server_ssl,{options,{cacertfile,[]}}}},{gen_rpc_app,start,[normal,[]]}}})
```

