### PR TITLE
Improve uptime/0

### DIFF
--- a/apps/emqx/src/emqx_os_mon.erl
+++ b/apps/emqx/src/emqx_os_mon.erl
@@ -159,7 +159,7 @@ ensure_system_memory_alarm(HW) ->
     case erlang:whereis(memsup) of
         undefined -> ok;
         _Pid ->
-            {Allocated, Total, _Worst} = memsup:get_memory_data(),
+            {Total, Allocated, _Worst} = memsup:get_memory_data(),
             case Total =/= 0 andalso Allocated/Total * 100 > HW of
                 true -> emqx_alarm:activate(high_system_memory_usage, #{high_watermark => HW});
                 false -> ok


### PR DESCRIPTION
1. Refactor uptime/0 function: no longer dependent on emqx_sys process.
Possible problems with previous implementations: if emqx_sys process restarts, the uptime is incorrect.

2. Don't cache version in emqx_sys process, otherwise, the version is incorrect after the upgrade.
3. fix wrong usage of `memsup:get_memory_data/0`

Port: https://github.com/emqx/emqx/pull/7137 and https://github.com/emqx/emqx/pull/7117