### PR TITLE
chore: skip downloading upgrade base images for windows

### DIFF
--- a/scripts/relup-base-packages.sh
+++ b/scripts/relup-base-packages.sh
@@ -44,6 +44,10 @@ esac
 
 
 case "$SYSTEM" in
+    windows*)
+        echo "WARNING: skipped downloading relup base for windows because we do not support relup for windows yet."
+        exit 0
+        ;;
     macos*)
         SHASUM="shasum -a 256"
         ;;


### PR DESCRIPTION
because we do not support relup for windows for now

