### PR TITLE
ci: delete duplicated sha256 file creation

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -266,18 +266,6 @@ jobs:
           --pkgtype "${PACKAGE}" \
           --arch "${ARCH}" \
           --builder "ghcr.io/emqx/emqx-builder/4.4-5:${OTP}-${SYSTEM}"
-    - name: create sha256
-      working-directory: source
-      env:
-        PROFILE: ${{ matrix.profile}}
-      run: |
-        if [ -d _packages/$PROFILE ]; then
-          cd _packages/$PROFILE
-            for var in $(ls emqx-* ); do
-              sudo bash -c "echo $(sha256sum $var | awk '{print $1}') > $var.sha256"
-            done
-          cd -
-        fi
     - uses: actions/upload-artifact@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REL_PROFILES := emqx emqx-edge
 PKG_PROFILES := emqx-pkg emqx-edge-pkg
 PROFILES := $(REL_PROFILES) $(PKG_PROFILES) default
 
-export REBAR_GIT_CLONE_OPTIONS += --depth=1
+export REBAR_GIT_CLONE_OPTIONS += --depth=1 --quiet
 
 .PHONY: default
 default: $(REBAR) $(PROFILE)


### PR DESCRIPTION
the latest build commands create sha256 sum right after the build
e.g. command `make emqx-zip` creates two files:
- emqx-\<version>.zip
- emqx-\<version>.zip.sha256