### PR TITLE
build: more structured build info

### DIFF
--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -127,9 +127,9 @@ jobs:
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx stop
         echo "EMQX stopped"
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx install
-        echo "EQMX installed"
+        echo "EMQX installed"
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx uninstall
-        echo "EQMX uninstaled"
+        echo "EMQX uninstalled"
 
   mac:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export ELIXIR_VSN ?= $(shell $(CURDIR)/scripts/get-elixir-vsn.sh)
 export EMQX_DASHBOARD_VERSION ?= v0.21.0
 export DOCKERFILE := deploy/docker/Dockerfile
+export EMQX_REL_FORM ?= tgz
 ifeq ($(OS),Windows_NT)
 	export REBAR_COLOR=none
 	FIND=/usr/bin/find
@@ -192,7 +193,7 @@ $(foreach zt,$(ALL_TGZS),$(eval $(call gen-tgz-target,$(zt))))
 ## A pkg target depend on a regular release
 .PHONY: $(PKG_PROFILES)
 define gen-pkg-target
-$1: $1-rel
+$1:
 	@$(BUILD) $1 pkg
 endef
 $(foreach pt,$(PKG_PROFILES),$(eval $(call gen-pkg-target,$(pt))))
@@ -225,7 +226,7 @@ $(REL_PROFILES:%=%-elixir) $(PKG_PROFILES:%=%-elixir): $(COMMON_DEPS) $(ELIXIR_C
 .PHONY: $(REL_PROFILES:%=%-elixir-pkg)
 define gen-elixir-pkg-target
 # the Elixir places the tar in a different path than Rebar3
-$1-elixir-pkg: $1-pkg-elixir
+$1-elixir-pkg:
 	@env TAR_PKG_DIR=_build/$1-pkg \
 	     IS_ELIXIR=yes \
 	     $(BUILD) $1-pkg pkg

--- a/apps/emqx/src/emqx_vm.erl
+++ b/apps/emqx/src/emqx_vm.erl
@@ -368,27 +368,20 @@ compat_windows(Fun) ->
 %% @doc Return on which Eralng/OTP the current vm is running.
 %% NOTE: This API reads a file, do not use it in critical code paths.
 get_otp_version() ->
-    parse_built_on(read_otp_version()).
+    read_otp_version().
 
 read_otp_version() ->
     ReleasesDir = filename:join([code:root_dir(), "releases"]),
-    Filename = filename:join([ReleasesDir, emqx_app:get_release(), "BUILT_ON"]),
+    Filename = filename:join([ReleasesDir, emqx_app:get_release(), "BUILD_INFO"]),
     case file:read_file(Filename) of
-        {ok, BuiltOn} ->
-            %% running on EQM X release
-            BuiltOn;
+        {ok, BuildInfo} ->
+            %% running on EMQX release
+            {ok, Fields} = hocon:binary(BuildInfo),
+            hocon_maps:get("erlang", Fields);
         {error, enoent} ->
             %% running tests etc.
             OtpMajor = erlang:system_info(otp_release),
             OtpVsnFile = filename:join([ReleasesDir, OtpMajor, "OTP_VERSION"]),
             {ok, Vsn} = file:read_file(OtpVsnFile),
             Vsn
-    end.
-
-parse_built_on(BuiltOn) ->
-    case binary:split(BuiltOn, <<"-">>, [global]) of
-        [Vsn, <<"emqx">>, N | _] ->
-            binary_to_list(Vsn) ++ "-emqx-" ++ binary_to_list(N);
-        [Vsn | _] ->
-            string:trim(binary_to_list(Vsn))
     end.

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -146,7 +146,7 @@ node_info() ->
     Info = maps:from_list([{K, list_to_binary(V)} || {K, V} <- emqx_vm:loads()]),
     BrokerInfo = emqx_sys:info(),
     Info#{node              => node(),
-          otp_release       => iolist_to_binary(otp_rel()),
+          otp_release       => otp_rel(),
           memory_total      => proplists:get_value(allocated, Memory),
           memory_used       => proplists:get_value(used, Memory),
           process_available => erlang:system_info(process_limit),
@@ -179,7 +179,7 @@ lookup_broker(Node) ->
 
 broker_info() ->
     Info = maps:from_list([{K, iolist_to_binary(V)} || {K, V} <- emqx_sys:info()]),
-    Info#{node => node(), otp_release => iolist_to_binary(otp_rel()), node_status => 'Running'}.
+    Info#{node => node(), otp_release => otp_rel(), node_status => 'Running'}.
 
 broker_info(Node) ->
     wrap_rpc(emqx_management_proto_v1:broker_info(Node)).
@@ -574,7 +574,7 @@ wrap_rpc(Res) ->
     Res.
 
 otp_rel() ->
-    lists:concat([emqx_vm:get_otp_version(), "/", erlang:system_info(version)]).
+    iolist_to_binary([emqx_vm:get_otp_version(), "/", erlang:system_info(version)]).
 
 check_row_limit(Tables) ->
     check_row_limit(Tables, max_row_limit()).

--- a/bin/emqx
+++ b/bin/emqx
@@ -219,7 +219,7 @@ if [ "${2:-}" = 'help' ]; then
 fi
 
 if ! check_erlang_start >/dev/null 2>&1; then
-    BUILT_ON="$(head -1 "${REL_DIR}/BUILT_ON")"
+    BUILD_INFO="$(cat "${REL_DIR}/BUILD_INFO")"
     ## failed to start, might be due to missing libs, try to be portable
     export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-$DYNLIBS_DIR}"
     if [ "$LD_LIBRARY_PATH" != "$DYNLIBS_DIR" ]; then
@@ -229,8 +229,8 @@ if ! check_erlang_start >/dev/null 2>&1; then
         ## it's hopeless
         echoerr "FATAL: Unable to start Erlang."
         echoerr "Please make sure openssl-1.1.1 (libcrypto) and libncurses are installed."
-        echoerr "Also ensure it's running on the correct platform,"
-        echoerr "this EMQX release is built for $BUILT_ON"
+        echoerr "Also ensure it's running on the correct platform:"
+        echoerr "$BUILD_INFO"
         exit 1
     fi
     echoerr "WARNING: There seem to be missing dynamic libs from the OS. Using libs from ${DYNLIBS_DIR}"

--- a/build
+++ b/build
@@ -284,10 +284,17 @@ case "$ARTIFACT" in
             log "Skipped making deb/rpm package for $SYSTEM"
             exit 0
         fi
-        make -C "deploy/packages/${PKGERDIR}" clean
+        export EMQX_REL_FORM="$PKGERDIR"
+        if [ "${IS_ELIXIR:-}" = 'yes' ]; then
+            make_elixir_rel
+        else
+            make_rel
+        fi
         env EMQX_REL="$(pwd)" \
             EMQX_BUILD="${PROFILE}" \
-            SYSTEM="${SYSTEM}" \
+            make -C "deploy/packages/${PKGERDIR}" clean
+        env EMQX_REL="$(pwd)" \
+            EMQX_BUILD="${PROFILE}" \
             make -C "deploy/packages/${PKGERDIR}"
         ;;
     docker)

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -27,6 +27,7 @@ RUN export PROFILE="$EMQX_NAME" \
     && export EMQX_NAME=${EMQX_NAME%%-elixir} \
     && export EMQX_LIB_PATH="_build/$EMQX_NAME/lib" \
     && export EMQX_REL_PATH="/emqx/_build/$EMQX_NAME/rel/emqx" \
+    && export EMQX_REL_FORM='docker' \
     && cd /emqx \
     && rm -rf $EMQX_LIB_PATH \
     && make $PROFILE \

--- a/deploy/packages/deb/Makefile
+++ b/deploy/packages/deb/Makefile
@@ -1,4 +1,3 @@
-ARCH ?= amd64
 TOPDIR := /tmp/emqx
 # Keep this short to avoid bloating beam files with long file path info
 SRCDIR := $(TOPDIR)/$(PKG_VSN)

--- a/deploy/packages/rpm/Makefile
+++ b/deploy/packages/rpm/Makefile
@@ -9,11 +9,6 @@ space := $(none) $(none)
 RPM_VSN := $(subst -,_,$(PKG_VSN))
 RPM_REL := otp$(subst -,_,$(OTP_VSN))
 
-ARCH ?= amd64
-ifeq ($(ARCH),mips64)
-ARCH:=mips64el
-endif
-
 EMQX_NAME=$(subst -pkg,,$(EMQX_BUILD))
 
 TAR_PKG_DIR ?= _build/$(EMQX_BUILD)/rel/emqx

--- a/lib-ee/emqx_license/src/emqx_license_schema.erl
+++ b/lib-ee/emqx_license/src/emqx_license_schema.erl
@@ -21,7 +21,7 @@ roots() -> [{license,
 A license is either a `key` or a `file`.
 When `key` and `file` are both configured, `key` is used.
 
-EQMX by default starts with a trial license.  For a different license,
+EMQX by default starts with a trial license.  For a different license,
 visit https://www.emqx.com/apply-licenses/emqx to apply.
 "})}
            ].

--- a/rel/BUILD_INFO
+++ b/rel/BUILD_INFO
@@ -1,0 +1,6 @@
+arch: "{{ build_info_arch }}"
+wordsize: {{ build_info_wordsize }}
+os: "{{ build_info_os }}"
+erlang: "{{ build_info_erlang }}"
+elixir: "{{ build_info_elixir }}"
+relform: "{{ build_info_relform }}"

--- a/rel/BUILT_ON
+++ b/rel/BUILT_ON
@@ -1,1 +1,0 @@
-{{ built_on_arch }}


### PR DESCRIPTION
this information will be used to report in telemetry 
e.g.
```
arch: "x86_64-pc-linux-gnu"
wordsize: 64
os: "ubuntu20.04"
erlang: "24.2.1-1"
elixir: none
relform: "deb"
```