### PR TITLE
fix(mix): do not include gpb in the release

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -90,7 +90,7 @@ defmodule EMQXUmbrella.MixProject do
       {:ranch,
        github: "ninenines/ranch", ref: "a692f44567034dacf5efcaa24a24183788594eb7", override: true},
       # in conflict by grpc and eetcd
-      {:gpb, "4.11.2", override: true}
+      {:gpb, "4.11.2", override: true, runtime: false}
     ] ++ umbrella_apps() ++ bcrypt_dep() ++ quicer_dep()
   end
 


### PR DESCRIPTION
Since `gpb` is a GPL compile-time-only dependency, we should not
include it in the release.

Note that adding `gpb: :none` to the release applications list *will*
make Mix include its files *and* reference them in the startup +
release scripts...

