### PR TITLE
fix(helm): delete needless labels for support helm upgrade

### DIFF
--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -27,7 +27,6 @@ spec:
         namespace: {{ .Release.Namespace }}
         labels:
           app.kubernetes.io/name: {{ include "emqx.name" . }}
-          helm.sh/chart: {{ include "emqx.chart" . }}
           app.kubernetes.io/instance: {{ .Release.Name }}
           app.kubernetes.io/managed-by: {{ .Release.Service }}
         annotations:


### PR DESCRIPTION
As discussed, the specific helm chart issue and how to fix it:

--

The root of the issue is that StatefulSet.yaml > volumeClaimTemplates has:

[helm.sh/chart:](http://helm.sh/chart:) {{ include "emqx.chart" . }}

Which is not allowed, since a statefulset's volumeClaimTemplates template cannot change (and it will change when an upgrade is performed).

--

How to fix:

In the file SatefulSet.yaml > spec > volumeClaimTemplates > metadata > labels, the following line must be deleted:

[helm.sh/chart:](http://helm.sh/chart:) {{ include "emqx.chart" . }}

--