### PR TITLE
ci: simplify dashboard download

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -48,7 +48,6 @@ jobs:
         run: |
           echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
           git config --global credential.helper store
-          echo "${{ secrets.CI_GIT_TOKEN }}" >> source/scripts/git-token
           make -C source deps-all
           zip -ryq source.zip source/* source/.[^.]*
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -25,7 +25,6 @@ jobs:
         if make emqx-ee --dry-run > /dev/null 2>&1; then
           echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
           git config --global credential.helper store
-          echo "${{ secrets.CI_GIT_TOKEN }}" >> ./scripts/git-token
           echo "EMQX_NAME=emqx-ee" >> $GITHUB_ENV
         else
           echo "EMQX_NAME=emqx" >> $GITHUB_ENV
@@ -63,7 +62,6 @@ jobs:
         if make emqx-ee --dry-run > /dev/null 2>&1; then
           echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
           git config --global credential.helper store
-          echo "${{ secrets.CI_GIT_TOKEN }}" >> ./scripts/git-token
           echo "EMQX_NAME=emqx-ee" >> $GITHUB_ENV
         else
           echo "EMQX_NAME=emqx" >> $GITHUB_ENV

--- a/.github/workflows/run_automate_tests.yaml
+++ b/.github/workflows/run_automate_tests.yaml
@@ -33,7 +33,6 @@ jobs:
         if [ -f EMQX_ENTERPRISE ]; then
           echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
           git config --global credential.helper store
-          echo "${{ secrets.CI_GIT_TOKEN }}" >> scripts/git-token
           make deps-emqx-ee
           make clean
           make emqx-ee-docker

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -22,7 +22,6 @@ jobs:
             if make emqx-ee --dry-run > /dev/null 2>&1; then
               echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
               git config --global credential.helper store
-              echo "${{ secrets.CI_GIT_TOKEN }}" >> scripts/git-token
               make deps-emqx-ee
               echo "TARGET=emqx/emqx-ee" >> $GITHUB_ENV
               echo "EMQX_TAG=$(./pkg-vsn.sh)" >> $GITHUB_ENV
@@ -76,7 +75,6 @@ jobs:
             if make emqx-ee --dry-run > /dev/null 2>&1; then
               echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
               git config --global credential.helper store
-              echo "${{ secrets.CI_GIT_TOKEN }}" >> scripts/git-token
               make deps-emqx-ee
               echo "TARGET=emqx/emqx-ee" >> $GITHUB_ENV
               make emqx-ee-docker
@@ -245,7 +243,6 @@ jobs:
             if [ "$PROFILE" = "emqx-ee" ]; then
               echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
               git config --global credential.helper store
-              echo "${{ secrets.CI_GIT_TOKEN }}" >> emqx/scripts/git-token
             fi
         - name: Build emqx
           run: make -C emqx ${PROFILE}-zip

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ export EMQX_RELUP ?= true
 export EMQX_DEFAULT_BUILDER = emqx/build-env:erl23.2.7.2-emqx-3-alpine
 export EMQX_DEFAULT_RUNNER = alpine:3.12
 export PKG_VSN ?= $(shell $(CURDIR)/pkg-vsn.sh)
-export EMQX_CE_DASHBOARD_VERSION ?= v4.3.5
 export DOCKERFILE := deploy/docker/Dockerfile
 ifeq ($(OS),Windows_NT)
 	export REBAR_COLOR=none

--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -5,6 +5,18 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 
+PKG_VSN="${PKG_VSN:-$(./pkg-vsn.sh)}"
+case "${PKG_VSN}" in
+    4.3*)
+        EMQX_CE_DASHBOARD_VERSION='v4.3.5'
+        EMQX_EE_DASHBOARD_VERSION='v4.3.15'
+        ;;
+    *)
+        echo "Unsupported version $PKG_VSN" >&2
+        exit 1
+        ;;
+esac
+
 RELEASE_ASSET_FILE="emqx-dashboard.zip"
 
 if [ -f 'EMQX_ENTERPRISE' ]; then


### PR DESCRIPTION
since EE dashboard repo is now [opensource](https://github.com/emqx/emqx-dashboard-web)
there is no need for the `git-token` file  