### PR TITLE
feat(config): Filter unnecessary HTTP APIs

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -53,6 +53,7 @@
 %%--------------------------------------------------------------------
 -define(ACTIVATED_ALARM, emqx_activated_alarm).
 -define(DEACTIVATED_ALARM, emqx_deactivated_alarm).
+-define(TRIE, emqx_trie).
 
 %%--------------------------------------------------------------------
 %% Message and Delivery

--- a/apps/emqx/src/emqx_alarm.erl
+++ b/apps/emqx/src/emqx_alarm.erl
@@ -164,7 +164,7 @@ to_rfc3339(Timestamp) ->
 %%--------------------------------------------------------------------
 
 init([]) ->
-    ok = mria:wait_for_tables([?ACTIVATED_ALARM, ?DEACTIVATED_ALARM]),
+    ok = mria:wait_for_tables([?ACTIVATED_ALARM, ?DEACTIVATED_ALARM, ?TRIE]),
     deactivate_all_alarms(),
     {ok, #{}, get_validity_period()}.
 

--- a/apps/emqx/src/emqx_trie.erl
+++ b/apps/emqx/src/emqx_trie.erl
@@ -47,7 +47,6 @@
 -compile(nowarn_export_all).
 -endif.
 
--define(TRIE, emqx_trie).
 -define(SESSION_DISC_TRIE, emqx_session_trie_disc).
 -define(SESSION_RAM_TRIE, emqx_session_trie_ram).
 -define(PREFIX(Prefix), {Prefix, 0}).

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -30,18 +30,27 @@
 -define(PREFIX_RESET, "/configs_reset/").
 -define(ERR_MSG(MSG), list_to_binary(io_lib:format("~p", [MSG]))).
 -define(EXCLUDES, [
-    exhook,
-    gateway,
-    plugins,
-    bridges,
-    "rule_engine",
-    "authorization",
-    "authentication",
-    "rpc",
-    "db",
-    "connectors",
-    "slow_subs",
-    "psk_authentication"
+    <<"exhook">>,
+    <<"gateway">>,
+    <<"plugins">>,
+    <<"bridges">>,
+    <<"rule_engine">>,
+    <<"authorization">>,
+    <<"authentication">>,
+    <<"rpc">>,
+    <<"db">>,
+    <<"connectors">>,
+    <<"slow_subs">>,
+    <<"psk_authentication">>,
+    <<"topic_metrics">>,
+    <<"rewrite">>,
+    <<"auto_subscribe">>,
+    <<"retainer">>,
+    <<"statsd">>,
+    <<"delayed">>,
+    <<"event_message">>,
+    <<"prometheus">>,
+    <<"telemetry">>
 ]).
 
 api_spec() ->
@@ -51,7 +60,7 @@ namespace() -> "configuration".
 
 paths() ->
     ["/configs", "/configs_reset/:rootname"] ++
-    lists:map(fun({Name, _Type}) -> ?PREFIX ++ to_list(Name) end, config_list(?EXCLUDES)).
+    lists:map(fun({Name, _Type}) -> ?PREFIX ++ binary_to_list(Name) end, config_list()).
 
 schema("/configs") ->
     #{
@@ -66,15 +75,12 @@ schema("/configs") ->
                         desc =>
  <<"Node's name: If you do not fill in the fields, this node will be used by default.">>})}],
             responses => #{
-                200 => config_list(?EXCLUDES)
+                200 => lists:map(fun({_, Schema}) -> Schema end, config_list())
             }
         }
     };
 schema("/configs_reset/:rootname") ->
-    Paths = lists:map(
-        fun({Path, _})when is_atom(Path) -> Path;
-           ({Path, _}) when is_list(Path) -> list_to_atom(Path)
-        end, config_list(?EXCLUDES)),
+    Paths = lists:map(fun({Path, _}) -> binary_to_atom(Path) end, config_list()),
     #{
         'operationId' => config_reset,
         post => #{
@@ -88,9 +94,9 @@ schema("/configs_reset/:rootname") ->
             %% `conf_path`, it cannot be defined here.
             parameters => [
                 {rootname, hoconsc:mk( hoconsc:enum(Paths)
-                                     , #{in => path, example => <<"authorization">>})},
+                                     , #{in => path, example => <<"sysmon">>})},
                 {conf_path, hoconsc:mk(typerefl:binary(),
-                    #{in => query, required => false, example => <<"cache.enable">>,
+                    #{in => query, required => false, example => <<"os.sysmem_high_watermark">>,
                         desc => <<"The config path separated by '.' character">>})}],
             responses => #{
                 200 => <<"Rest config successfully">>,
@@ -99,13 +105,13 @@ schema("/configs_reset/:rootname") ->
         }
     };
 schema(Path) ->
-    {Root, Schema} = find_schema(Path),
+    {RootKey, {_Root, Schema}} = find_schema(Path),
     #{
         'operationId' => config,
         get => #{
             tags => [conf],
             description => iolist_to_binary([ <<"Get the sub-configurations under *">>
-                                            , Root
+                                            , RootKey
                                             , <<"*">>]),
             responses => #{
                 200 => Schema,
@@ -115,7 +121,7 @@ schema(Path) ->
         put => #{
             tags => [conf],
             description => iolist_to_binary([ <<"Update the sub-configurations under *">>
-                                            , Root
+                                            , RootKey
                                             , <<"*">>]),
             'requestBody' => Schema,
             responses => #{
@@ -127,13 +133,8 @@ schema(Path) ->
 
 find_schema(Path) ->
     [_, _Prefix, Root | _] = string:split(Path, "/", all),
-    Configs = config_list(?EXCLUDES),
-    case lists:keyfind(Root, 1, Configs) of
-        {Root, Schema} -> {Root, Schema};
-        false ->
-            RootAtom = list_to_existing_atom(Root),
-            {Root, element(2, lists:keyfind(RootAtom, 1, Configs))}
-    end.
+    Configs = config_list(),
+    lists:keyfind(list_to_binary(Root), 1, Configs).
 
 %% we load all configs from emqx_conf_schema, some of them are defined as local ref
 %% we need redirect to emqx_conf_schema.
@@ -148,7 +149,8 @@ config(get, _Params, Req) ->
         {ok, Conf} ->
             {200, Conf};
         {not_found, _, _} ->
-            {404, #{code => 'NOT_FOUND', message => <<"Config cannot found">>}}
+            {404, #{code => 'NOT_FOUND',
+                message => <<(list_to_binary(Path))/binary, " not found">>}}
     end;
 
 config(put, #{body := Body}, Req) ->
@@ -201,12 +203,10 @@ conf_path_from_querystr(Req) ->
         Path -> string:lexemes(Path, ". ")
     end.
 
-config_list(Exclude) ->
-    Roots = emqx_conf_schema:roots(),
+config_list() ->
+    Exclude = ?EXCLUDES,
+    Roots = hocon_schema:roots(emqx_conf_schema),
     lists:foldl(fun(Key, Acc) -> lists:keydelete(Key, 1, Acc) end, Roots, Exclude).
-
-to_list(L) when is_list(L) -> L;
-to_list(Atom) when is_atom(Atom) -> atom_to_list(Atom).
 
 conf_path(Req) ->
     <<"/api/v5", ?PREFIX, Path/binary>> = cowboy_req:path(Req),

--- a/apps/emqx_modules/src/emqx_rewrite_api.erl
+++ b/apps/emqx_modules/src/emqx_rewrite_api.erl
@@ -27,12 +27,6 @@
 
 -define(EXCEED_LIMIT, 'EXCEED_LIMIT').
 
--import(emqx_mgmt_util, [ object_array_schema/1
-                        , object_array_schema/2
-                        , error_schema/2
-                        , properties/1
-                        ]).
-
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE).
 


### PR DESCRIPTION
- fix alarm crash when safe_publish is not ready.
```erlang
[error] exception: error, line: 231, mfa: emqx_broker:safe_publish/1, msg: publishing_error, payload: #{extra => [],flags => 
#{sys => true},from => emqx_alarm,headers => #{properties => #{'Content-Type' => <<"application/json">>}},id => 
<<0,5,217,171,204,123,235,194,244,67,0,0,8,13,0,0>>,qos => 0,timestamp => 1646706776861,topic => 
<<"$SYS/brokers/emqx@127.0.0.1/alarms/activate">>}, reason: badarg, stacktrace: [{ets,first,[emqx_trie],[{error_info,#
{cause => id,module => erl_stdlib_errors}}]},{emqx_trie,empty,1,[{file,"emqx_trie.erl"},{line,171}]},
{emqx_router,match_trie,1,[{file,"emqx_router.erl"},{line,138}]},{emqx_router,match_routes,1,[{file,"emqx_router.erl"},
{line,130}]},{emqx_broker,publish,1,[{file,"emqx_broker.erl"},{line,214}]},{emqx_broker,safe_publish,1,
[{file,"emqx_broker.erl"},{line,221}]},{emqx_alarm,do_actions,3,[{file,"emqx_alarm.erl"},{line,351}]},
{emqx_alarm,handle_call,3,[{file,"emqx_alarm.erl"},{line,177}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},
{line,721}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,750}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},
{line,226}]}], topic: $SYS/brokers/emqx@127.0.0.1/alarms/activate

```
-  filter more config API.