### PR TITLE
feat: add file to assist in formatting application

### DIFF
--- a/scripts/format_app.py
+++ b/scripts/format_app.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+# format_app.py
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+
+
+def handle_cli_args():
+  parser = argparse.ArgumentParser(description='A script for formatting a given app within emqx')
+  parser.add_argument("-a", "--application", required=True, help="The application which is to be formatted.")
+  parser.add_argument('-b', "--branch", help="The git branch to be switched to before formatting the code. Required unless the -f option is passed in which case the value will be ignored even if provided.")
+  parser.add_argument('-f', "--format_in_place", default=False, action="store_true", help="Pass the -f option to format on the current git branch, otherwise a branch name must be provided by passing the -b option.")
+  args = parser.parse_args()
+
+  if not args.format_in_place and not args.branch:
+    sys.exit("A new git branch name must be provided with the -b option unless the -f option is given to format the code in place.")
+
+  return args
+
+
+def get_app_path(application):
+  root_path = os.path.dirname(os.path.realpath(__file__))
+  full_path = f"{root_path}/../apps/{application}"
+  isdir = os.path.isdir(full_path) 
+
+  if isdir:
+    return full_path
+  
+  sys.exit(f"The application provided ({application}) does not appear at the expected location: {full_path}")
+
+
+def maybe_switch_git_branch(format_in_place, branch):
+  if not format_in_place:
+    PIPE = subprocess.PIPE
+    process = subprocess.Popen(["git", "status"], stdout=PIPE, text=True)
+    stdoutput, stderroutput = process.communicate()
+
+    if f"On branch {branch}" in stdoutput:
+      return
+    elif "working tree clean" in stdoutput:
+      subprocess.call(["git", "checkout", "-b", branch])
+    else:
+      sys.exit("Cannot switch git branches while there are changes waiting to be committed.")
+
+
+def maybe_add_rebar_plugin():
+  with open("rebar.config", "r+") as f:
+    text = f.read()
+    erlfmt_pattern = "\{project_plugins.+?erlfmt.+\}"
+    plugin_pattern = "\{project_plugins.+?\}"
+    
+    if not re.search(erlfmt_pattern, text) and not re.search(plugin_pattern, text):
+      f.write("\n{project_plugins, [erlfmt]}.\n")
+    elif not re.search(erlfmt_pattern, text) and re.search(plugin_pattern, text):
+      sys.exit("Could not find the erlfmt plugin but the 'project_plugins' declaration already exists. Please add 'erlfmt' to the plugins list manually and rerun the script.")
+
+
+def execute_formatting():
+  subprocess.call(["rebar3", "fmt", "-w"])
+
+
+def main():
+  args = handle_cli_args()
+  app_path = get_app_path(args.application)
+  os.chdir(app_path)
+  maybe_switch_git_branch(args.format_in_place, args.branch)
+  maybe_add_rebar_plugin()
+  execute_formatting()
+  
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
This added script file, which can be run from the root emqx directory or the scripts directory, aids in applying erlfmt formatting to an application.

It can be used on the first formatting, in which case it will add the required rebar3 plugin declaration to the `rebar.config` file, or on any subsequent formatting attempts.

Should be idempotent, and be able to be executed on any given application as many times as desired without adverse outcomes. So if you run into a case where there is an error during formatting, as will be the case in I think two of our sub apps due to the way we do some macros, you can fix the spots where there are errors and safely rerun the script and it should just work.

Result of calling the file with the `-h` option:

```
/bin/python3.9 scripts/format_app.py -h
usage: format_app.py [-h] [-a APPLICATION] [-b BRANCH] [-f]

A script for formatting a given app within emqx. Example Usage:
/bin/python3.9 scripts/format_app.py -a emqx_resource -b
format_resource_app

optional arguments:
  -h, --help            show this help message and exit
  -a APPLICATION, --application APPLICATION
                        The application which is to be
                        formatted.
  -b BRANCH, --branch BRANCH
                        The git branch to be switched to before
                        formatting the code. Required unless
                        the -f option is passed in which case
                        the value will be ignored even if
                        provided.
  -f, --format_in_place
                        Pass the -f option to format in place,
                        otherwise a branch name must be
                        provided by passing the -b option.
```