### PR TITLE
fix(authn-jwt): accept the pem conntet to create jwk authenticator

### DIFF
--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -215,7 +215,7 @@ create2(#{use_jwks := false,
           algorithm := 'public-key',
           certificate := Certificate,
           verify_claims := VerifyClaims}) ->
-    JWK = jose_jwk:from_pem_file(Certificate),
+    JWK = create_jwk_from_pem_or_file(Certificate),
     {ok, #{jwk => JWK,
            verify_claims => VerifyClaims}};
 
@@ -227,6 +227,16 @@ create2(#{use_jwks := true,
                    verify_claims => VerifyClaims}};
         {error, Reason} ->
             {error, Reason}
+    end.
+
+create_jwk_from_pem_or_file(CertfileOrFilePath)
+  when is_binary(CertfileOrFilePath);
+       is_list(CertfileOrFilePath) ->
+    case filelib:is_file(CertfileOrFilePath) of
+        true ->
+            jose_jwk:from_pem_file(CertfileOrFilePath);
+        false ->
+            jose_jwk:from_pem(iolist_to_binary(CertfileOrFilePath))
     end.
 
 connector_opts(#{ssl := #{enable := Enable} = SSL} = Config) ->


### PR DESCRIPTION
When creating a JWT authenticator using the HTTP-API, the JWT Public-Key cannot be stored as a file. So here we need to make compatibility to handle its public key