### PR TITLE
Add info about default dashboard user name and password to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Or change to the installation root directory if emqx is installed from a release
 ./bin/emqx stop
 ```
 
-To view the dashboard after running, use your browser to open: http://localhost:18083
+To view the dashboard after running, use your browser to open: http://localhost:18083 (default user/password = admin/public)
 
 ## Test
 


### PR DESCRIPTION
It makes sense to provide information about the default username and
password in the README file together with the information about how
to reach the web dashboard. New users reading the "Quick Start"
section would otherwise get struck wondering how to log in.

