### PR TITLE
Start EMQX in foreground mode in systemd

### DIFF
--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -544,6 +544,7 @@ log {
   ##----------------------------------------------------------------
   ## file_handlers.<name>
   file_handlers.default {
+    enable = true
     ## The log level filter of this handler
     ## All the log messages with levels lower than this level will
     ## be dropped.

--- a/bin/emqx
+++ b/bin/emqx
@@ -540,6 +540,48 @@ latest_vm_args() {
     fi
 }
 
+# backward compabible with 4.x
+tr_log_to_env() {
+    local log_to=${EMQX_LOG__TO:-undefined}
+    # unset because it's unknown to 5.0
+    unset EMQX_LOG__TO
+    case "${log_to}" in
+        console)
+            export EMQX_LOG__CONSOLE_HANDLER__ENABLE='true'
+            export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE='false'
+            ;;
+        file)
+            export EMQX_LOG__CONSOLE_HANDLER__ENABLE='false'
+            export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE='true'
+            ;;
+        both)
+            export EMQX_LOG__CONSOLE_HANDLER__ENABLE='true'
+            export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE='true'
+            ;;
+        default)
+            # want to use config file defaults, do nothing
+            ;;
+        undefined)
+            # value not set, do nothing
+            ;;
+        *)
+            echoerr "Unknown environment value for EMQX_LOG__TO=${log_to} discarded"
+            ;;
+    esac
+}
+
+maybe_log_to_console() {
+    if [ "${EMQX_LOG__TO:-}" = 'default' ]; then
+        # want to use config file defaults, do nothing
+        unset EMQX_LOG__TO
+    else
+        tr_log_to_env
+        # ensure defaults
+        export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-true}"
+        export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE="${EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE:-false}"
+    fi
+}
+
 ## IS_BOOT_COMMAND is set for later to inspect node name and cookie from hocon config (or env variable)
 case "${COMMAND}" in
     start|console|console_clean|foreground)
@@ -621,7 +663,7 @@ case "${COMMAND}" in
 
         # this flag passes down to console mode
         # so we know it's intended to be run in daemon mode
-        export _EMQX_START_MODE="$COMMAND"
+        export _EMQX_START_DAEMON_MODE=1
 
         case "$COMMAND" in
             start)
@@ -764,8 +806,10 @@ case "${COMMAND}" in
         esac
 
         # set before generate_config
-        if [ "${_EMQX_START_MODE:-}" = '' ]; then
-            export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-true}"
+        if [ "${_EMQX_START_DAEMON_MODE:-}" = 1 ]; then
+            tr_log_to_env
+        else
+            maybe_log_to_console
         fi
 
         #generate app.config and vm.args
@@ -815,8 +859,7 @@ case "${COMMAND}" in
         # start up the release in the foreground for use by runit
         # or other supervision services
 
-        # set before generate_config
-        export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-true}"
+        maybe_log_to_console
 
         #generate app.config and vm.args
         generate_config "$NAME_TYPE" "$NAME"

--- a/deploy/packages/emqx.service
+++ b/deploy/packages/emqx.service
@@ -5,13 +5,34 @@ After=network.target
 [Service]
 User=emqx
 Group=emqx
-Type=forking
+
+# The ExecStart= is foreground, so 'simple' here
+Type=simple
 Environment=HOME=/var/lib/emqx
-ExecStart=/usr/bin/emqx start
+
+# Enable logging to file
+Environment=EMQX_LOG__TO=default
+
+# Start 'foregroun' but not 'start' (daemon) mode.
+# Because systemd monitor/restarts 'simple' services
+ExecStart=/usr/bin/emqx foreground
+
+# Give EMQX enough file descriptors
 LimitNOFILE=1048576
-ExecStop=/usr/bin/emqx stop
+
+# ExecStop is commented out so systemd will send a SIGTERM when 'systemctl stop'.
+# SIGTERM is handled by EMQX and it then performs a graceful shutdown
+# It's better than command 'emqx stop' because it needs to ping the node
+# ExecStop=/usr/bin/emqx stop
+
+# Wait long enough before force kill for graceful shutdown
+TimeoutStopSec=120s
+
 Restart=on-failure
-RestartSec=5s
+
+# Do not restart immediately so the peer nodes in the cluster have
+# enough time to handle the 'DOWN' events of this node
+RestartSec=120s
 
 [Install]
 WantedBy=multi-user.target

--- a/deploy/packages/rpm/emqx.service
+++ b/deploy/packages/rpm/emqx.service
@@ -1,17 +1,1 @@
-[Unit]
-Description=emqx daemon
-After=network.target
-
-[Service]
-User=emqx
-Group=emqx
-Type=forking
-Environment=HOME=/var/lib/emqx
-ExecStart=/usr/bin/emqx start
-LimitNOFILE=1048576
-ExecStop=/usr/bin/emqx stop
-Restart=on-failure
-RestartSec=5s
-
-[Install]
-WantedBy=multi-user.target
+../emqx.service


### PR DESCRIPTION
This PR includes two changes.
1. Start EMQX in foreground mode in systemd (`simple` type instead of `fork`)
3. Support `EMQX_LOG__TO` for backward compatibility 
  * If `EMQX_LOG__TO=default`, EMQX respects the config file
  * if `MEQX_LOG__TO` is set to `console`, `file` or `both`, environment variable overrides will effect
  * In `foreground` mode, EMQX logs to console by default (as if `EMQX_LOG__TO=console`)

start log:
```
Mar 11 10:00:27 ip-10-0-1-35 systemd[1]: Started emqx daemon.
Mar 11 10:00:32 ip-10-0-1-35 emqx[5644]: EXEC: /usr/lib/emqx/erts-12.2.1/bin/erlexec -noshell -noinput +Bd -boot /usr/lib/emqx/releases/5.0.0-beta.3-1cf24248/start -mode embedded -boot_var ERTS_LIB_DIR />
Mar 11 10:00:34 ip-10-0-1-35 emqx[5417]: Listener quic:default on :14567 started.
Mar 11 10:00:34 ip-10-0-1-35 emqx[5417]: Listener ssl:default on :8883 started.
Mar 11 10:00:34 ip-10-0-1-35 emqx[5417]: Listener tcp:default on :1883 started.
Mar 11 10:00:34 ip-10-0-1-35 emqx[5417]: Listener ws:default on :8083 started.
Mar 11 10:00:34 ip-10-0-1-35 emqx[5417]: Listener wss:default on :8084 started.
Mar 11 10:00:35 ip-10-0-1-35 emqx[5417]: Start listener dashboard:http:18083 on :18083 successfully.
Mar 11 10:00:35 ip-10-0-1-35 emqx[5417]: EMQX 5.0.0-beta.3-1cf24248 is running now!
```
stop log:
```
Mar 11 10:00:50 ip-10-0-1-35 systemd[1]: Stopping emqx daemon...
Mar 11 10:00:50 ip-10-0-1-35 emqx[5417]: Stop listener dashboard:http:18083 on :18083 successfully.
Mar 11 10:00:50 ip-10-0-1-35 emqx[5417]: Listener quic:default on :14567 stopped.
Mar 11 10:00:50 ip-10-0-1-35 emqx[5417]: Listener ssl:default on :8883 stopped.
Mar 11 10:00:50 ip-10-0-1-35 emqx[5417]: Listener tcp:default on :1883 stopped.
Mar 11 10:00:50 ip-10-0-1-35 emqx[5417]: Listener ws:default on :8083 stopped.
Mar 11 10:00:50 ip-10-0-1-35 emqx[5417]: Listener wss:default on :8084 stopped.
Mar 11 10:00:50 ip-10-0-1-35 emqx[5707]: [os_mon] memory supervisor port (memsup): Erlang has closed
Mar 11 10:00:52 ip-10-0-1-35 systemd[1]: emqx.service: Succeeded.
Mar 11 10:00:52 ip-10-0-1-35 systemd[1]: Stopped emqx daemon.
```