### PR TITLE
Fix HTTP APIs for getting rule events and testing rule SQLs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.0-8:1.13.3-24.2.1-1-al
 export EMQX_DEFAULT_RUNNER = alpine:3.14
 export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export ELIXIR_VSN ?= $(shell $(CURDIR)/scripts/get-elixir-vsn.sh)
-export EMQX_DASHBOARD_VERSION ?= v0.21.0
+export EMQX_DASHBOARD_VERSION ?= v0.23.0
 export DOCKERFILE := deploy/docker/Dockerfile
 export EMQX_REL_FORM ?= tgz
 ifeq ($(OS),Windows_NT)

--- a/apps/emqx/include/http_api.hrl
+++ b/apps/emqx/include/http_api.hrl
@@ -16,8 +16,9 @@
 
 %% Bad Request
 -define(BAD_REQUEST,              'BAD_REQUEST').
+-define(NOT_MATCH,                'NOT_MATCH').
 
--define(ALREADY_EXISTS,          'ALREADY_EXISTS').
+-define(ALREADY_EXISTS,           'ALREADY_EXISTS').
 -define(BAD_CONFIG_SCHEMA,        'BAD_CONFIG_SCHEMA').
 -define(BAD_LISTENER_ID,          'BAD_LISTENER_ID').
 -define(BAD_NODE_NAME,            'BAD_NODE_NAME').
@@ -49,7 +50,8 @@
 %% All codes
 -define(ERROR_CODES,
     [ {'BAD_REQUEST',               <<"Request parameters are not legal">>}
-    , {'ALREADY_EXISTS',           <<"Resource already existed">>}
+    , {'NOT_MATCH',                 <<"Conditions are not matched">>}
+    , {'ALREADY_EXISTS',            <<"Resource already existed">>}
     , {'BAD_CONFIG_SCHEMA',         <<"Configuration data is not legal">>}
     , {'BAD_LISTENER_ID',           <<"Bad listener ID">>}
     , {'BAD_NODE_NAME',             <<"Bad Node Name">>}

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs_metrics.erl
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs_metrics.erl
@@ -58,13 +58,13 @@
 -export_type([metrics/0, handler_name/0, metric_id/0]).
 
 -type rate() :: #{
-    current => float(),
-    max => float(),
-    last5m => float()
+    current := float(),
+    max := float(),
+    last5m := float()
 }.
 -type metrics() :: #{
-    counters => #{atom() => integer()},
-    rate => #{atom() => rate()}
+    counters := #{atom() => integer()},
+    rate := #{atom() => rate()}
 }.
 -type handler_name() :: atom().
 -type metric_id() :: binary().
@@ -158,10 +158,10 @@ init(Name) ->
     {ok, #state{}}.
 
 handle_call({get_rate, _Id}, _From, State = #state{rates = undefined}) ->
-    {reply, #{}, State};
+    {reply, make_rate(0, 0, 0), State};
 handle_call({get_rate, Id}, _From, State = #state{rates = Rates}) ->
     {reply, case maps:get(Id, Rates, undefined) of
-                undefined -> #{};
+                undefined -> make_rate(0, 0, 0);
                 RatesPerId -> format_rates_of_id(RatesPerId)
             end, State};
 
@@ -303,7 +303,13 @@ format_rates_of_id(RatesPerId) ->
         end, RatesPerId).
 
 format_rate(#rate{max = Max, current = Current, last5m = Last5Min}) ->
-    #{max => precision(Max, 2), current => precision(Current, 2), last5m => precision(Last5Min, 2)}.
+    make_rate(Current, Max, Last5Min).
+
+make_rate(Current, Max, Last5Min) ->
+    #{ current => precision(Current, 2)
+     , max => precision(Max, 2)
+     , last5m => precision(Last5Min, 2)
+     }.
 
 precision(Float, N) ->
     Base = math:pow(10, N),

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -72,6 +72,7 @@ fields("rule_test") ->
                                    , ref("ctx_dropped")
                                    , ref("ctx_connected")
                                    , ref("ctx_disconnected")
+                                   , ref("ctx_bridge_mqtt")
                                    ]),
         #{desc => "The context of the event for testing",
           default => #{}})}
@@ -204,7 +205,20 @@ fields("ctx_disconnected") ->
     , {"sockname", sc(binary(), #{desc => "The IP Address and Port of the Local Listener"})}
     , {"disconnected_at", sc(integer(), #{
         desc => "The Time that this Client is Disconnected"})}
-    ].
+    ];
+
+fields("ctx_bridge_mqtt") ->
+    [ {"event_type", sc('$bridges/mqtt:*', #{desc => "Event Type", required => true})}
+    , {"id", sc(binary(), #{desc => "Message ID"})}
+    , {"payload", sc(binary(), #{desc => "The Message Payload"})}
+    , {"topic", sc(binary(), #{desc => "Message Topic"})}
+    , {"server", sc(binary(), #{desc => "The IP address (or hostname) and port of the MQTT broker,"
+        " in IP:Port format"})}
+    , {"dup", sc(binary(), #{desc => "The DUP flag of the MQTT message"})}
+    , {"retain", sc(binary(), #{desc => "If is a retain message"})}
+    , {"message_received_at", sc(integer(), #{
+        desc => "The Time that this Message is Received"})}
+    ] ++ [qos()].
 
 qos() ->
     {"qos", sc(emqx_schema:qos(), #{desc => "The Message QoS"})}.

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -15,10 +15,11 @@
 -spec check_params(map(), tag()) -> {ok, map()} | {error, term()}.
 check_params(Params, Tag) ->
     BTag = atom_to_binary(Tag),
-    case emqx_hocon:check(?MODULE, #{BTag => Params}) of
-        {ok, #{Tag := Checked}} ->
-            {ok, Checked};
-        {error, Reason} ->
+    Opts = #{atom_key => true, required => false},
+    try hocon_tconf:check_plain(?MODULE, #{BTag => Params}, Opts, [Tag]) of
+        #{Tag := Checked} -> {ok, Checked}
+    catch
+        throw : Reason ->
             ?SLOG(error, #{msg => "check_rule_params_failed",
                            reason => Reason
                           }),

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -41,7 +41,7 @@
         {ok, CheckedParams} ->
             EXPR;
         {error, REASON} ->
-            {400, #{code => 'BAD_ARGS', message => ?ERR_BADARGS(REASON)}}
+            {400, #{code => 'BAD_REQUEST', message => ?ERR_BADARGS(REASON)}}
     end).
 -define(METRICS(MATCH, PASS, FAIL, FAIL_EX, FAIL_NORES, O_TOTAL, O_FAIL, O_FAIL_OOS,
         O_FAIL_UNKNOWN, O_SUCC, RATE, RATE_MAX, RATE_5),
@@ -85,10 +85,8 @@ api_spec() ->
 
 paths() -> ["/rule_events", "/rule_test", "/rules", "/rules/:id"].
 
-error_schema(Code, Message) ->
-    [ {code, mk(string(), #{example => Code})}
-    , {message, mk(string(), #{example => Message})}
-    ].
+error_schema(Code, Message) when is_atom(Code) ->
+    emqx_dashboard_swagger:error_codes([Code], Message).
 
 rule_creation_schema() ->
     ref(emqx_rule_api_schema, "rule_creation").
@@ -115,7 +113,7 @@ schema("/rules") ->
             summary => <<"Create a Rule">>,
             requestBody => rule_creation_schema(),
             responses => #{
-                400 => error_schema('BAD_ARGS', "Invalid Parameters"),
+                400 => error_schema('BAD_REQUEST', "Invalid Parameters"),
                 201 => rule_info_schema()
             }}
     };
@@ -153,7 +151,7 @@ schema("/rules/:id") ->
             parameters => param_path_id(),
             requestBody => rule_creation_schema(),
             responses => #{
-                400 => error_schema('BAD_ARGS', "Invalid Parameters"),
+                400 => error_schema('BAD_REQUEST', "Invalid Parameters"),
                 200 => rule_info_schema()
             }
         },
@@ -177,7 +175,7 @@ schema("/rule_test") ->
             summary => <<"Test a Rule">>,
             requestBody => rule_test_schema(),
             responses => #{
-                400 => error_schema('BAD_ARGS', "Invalid Parameters"),
+                400 => error_schema('BAD_REQUEST', "Invalid Parameters"),
                 412 => error_schema('NOT_MATCH', "SQL Not Match"),
                 200 => <<"Rule Test Pass">>
             }
@@ -201,13 +199,13 @@ param_path_id() ->
 '/rules'(post, #{body := Params0}) ->
     case maps:get(<<"id">>, Params0, list_to_binary(emqx_misc:gen_id(8))) of
         <<>> ->
-            {400, #{code => 'BAD_ARGS', message => <<"empty rule id is not allowed">>}};
+            {400, #{code => 'BAD_REQUEST', message => <<"empty rule id is not allowed">>}};
         Id ->
             Params = filter_out_request_body(Params0),
             ConfPath = emqx_rule_engine:config_key_path() ++ [Id],
             case emqx_rule_engine:get_rule(Id) of
                 {ok, _Rule} ->
-                    {400, #{code => 'BAD_ARGS', message => <<"rule id already exists">>}};
+                    {400, #{code => 'BAD_REQUEST', message => <<"rule id already exists">>}};
                 not_found ->
                     case emqx_conf:update(ConfPath, Params, #{}) of
                         {ok, #{post_config_update := #{emqx_rule_engine := AllRules}}} ->
@@ -216,7 +214,7 @@ param_path_id() ->
                         {error, Reason} ->
                             ?SLOG(error, #{msg => "create_rule_failed",
                                         id => Id, reason => Reason}),
-                            {400, #{code => 'BAD_ARGS', message => ?ERR_BADARGS(Reason)}}
+                            {400, #{code => 'BAD_REQUEST', message => ?ERR_BADARGS(Reason)}}
                     end
             end
     end.
@@ -224,6 +222,8 @@ param_path_id() ->
 '/rule_test'(post, #{body := Params}) ->
     ?CHECK_PARAMS(Params, rule_test, case emqx_rule_sqltester:test(CheckedParams) of
         {ok, Result} -> {200, Result};
+        {error, {parse_error, Reason}} ->
+            {400, #{code => 'BAD_REQUEST', message => err_msg(Reason)}};
         {error, nomatch} -> {412, #{code => 'NOT_MATCH', message => <<"SQL Not Match">>}}
     end).
 
@@ -245,7 +245,7 @@ param_path_id() ->
         {error, Reason} ->
             ?SLOG(error, #{msg => "update_rule_failed",
                            id => Id, reason => Reason}),
-            {400, #{code => 'BAD_ARGS', message => ?ERR_BADARGS(Reason)}}
+            {400, #{code => 'BAD_REQUEST', message => ?ERR_BADARGS(Reason)}}
     end;
 
 '/rules/:id'(delete, #{bindings := #{id := Id}}) ->
@@ -255,7 +255,7 @@ param_path_id() ->
         {error, Reason} ->
             ?SLOG(error, #{msg => "delete_rule_failed",
                            id => Id, reason => Reason}),
-            {500, #{code => 'BAD_ARGS', message => ?ERR_BADARGS(Reason)}}
+            {500, #{code => 'INTERNAL_ERROR', message => ?ERR_BADARGS(Reason)}}
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -86,7 +86,7 @@ api_spec() ->
 paths() -> ["/rule_events", "/rule_test", "/rules", "/rules/:id"].
 
 error_schema(Code, Message) when is_atom(Code) ->
-    emqx_dashboard_swagger:error_codes([Code], Message).
+    emqx_dashboard_swagger:error_codes([Code], list_to_binary(Message)).
 
 rule_creation_schema() ->
     ref(emqx_rule_api_schema, "rule_creation").

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -607,7 +607,7 @@ columns_with_exam(<<"$bridges/mqtt", _/binary>> = EventName) ->
     [ {<<"event">>, EventName}
     , {<<"id">>, emqx_guid:to_hexstr(emqx_guid:gen())}
     , {<<"payload">>, <<"{\"msg\": \"hello\"}">>}
-    , {<<"peerhost">>, <<"192.168.0.10">>}
+    , {<<"server">>, <<"192.168.0.10:1883">>}
     , {<<"topic">>, <<"t/a">>}
     , {<<"qos">>, 1}
     , {<<"dup">>, false}

--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -22,7 +22,7 @@
         , get_selected_data/3
         ]).
 
--spec test(#{sql := binary(), context := map()}) -> {ok, map() | list()} | {error, nomatch}.
+-spec test(#{sql := binary(), context := map()}) -> {ok, map() | list()} | {error, term()}.
 test(#{sql := Sql, context := Context}) ->
     case emqx_rule_sqlparser:parse(Sql) of
         {ok, Select} ->


### PR DESCRIPTION

- Add `server` field to the events of the MQTT Bridge source.
- Fix the issue that POST `rule_test` crashes.