### PR TITLE
feat: Support set keepalive via queryString & Body HTTP API.

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -22,8 +22,8 @@ File format:
 * CLI `emqx_ctl pem_cache clean` to force purge x509 certificate cache,
   to force an immediate reload of all certificates after the files are updated on disk.
 * Refactor the ExProto so that anonymous clients can also be displayed on the dashboard [#6983]
-* Force shutdown of processe that cannot answer takeover event [#7026]
-
+* Force shutdown of processes that cannot answer takeover event [#7026]
+* Support set keepalive via queryString & Body HTTP API.
 * `topic` parameter in bridge configuration can have `${node}` substitution (just like in `clientid` parameter)
 
 ### Bug fixes

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -257,7 +257,7 @@ set_keepalive(#{clientid := ClientId}, Params) ->
         undefined ->
             minirest:return({error, ?ERROR7, params_not_found});
         Interval0 ->
-            Interval = binary_to_integer(Interval0),
+            Interval = to_integer(Interval0),
             case emqx_mgmt:set_keepalive(emqx_mgmt_util:urldecode(ClientId), Interval) of
                 ok -> minirest:return();
                 {error, not_found} -> minirest:return({error, ?ERROR12, not_found});
@@ -265,6 +265,9 @@ set_keepalive(#{clientid := ClientId}, Params) ->
                 {error, Reason} -> minirest:return({error, ?ERROR1, Reason})
             end
     end.
+
+to_integer(Int)when is_integer(Int) -> Int;
+to_integer(Bin) when is_binary(Bin) -> binary_to_integer(Bin).
 
 %% @private
 %% S = 100,1s

--- a/src/emqx_channel.erl
+++ b/src/emqx_channel.erl
@@ -977,7 +977,9 @@ handle_call({quota, Policy}, Channel) ->
     reply(ok, Channel#channel{quota = Quota});
 
 handle_call({keepalive, Interval}, Channel = #channel{keepalive = KeepAlive,
-    conninfo = ConnInfo}) ->
+    conninfo = ConnInfo, timers = Timers}) ->
+    AliveTimer = maps:get(alive_timer, Timers, undefined),
+    emqx_misc:cancel_timer(AliveTimer),
     ClientId = info(clientid, Channel),
     NKeepalive = emqx_keepalive:set(interval, Interval * 1000, KeepAlive),
     NConnInfo = maps:put(keepalive, Interval, ConnInfo),


### PR DESCRIPTION
Passing it through querystring is a string.
if passed through body, it is an integer
add doc:https://github.com/emqx/emqx-docs/pull/1075