### PR TITLE
feat: add authn, authz status api

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_schema.erl
+++ b/apps/emqx_authn/src/emqx_authn_schema.erl
@@ -17,6 +17,7 @@
 -module(emqx_authn_schema).
 
 -include_lib("typerefl/include/types.hrl").
+-import(hoconsc, [mk/2, ref/2]).
 
 -export([ common_fields/0
         , roots/0
@@ -29,7 +30,6 @@
 
 roots() -> [].
 
-fields(_) -> [].
 
 common_fields() ->
     [ {enable, fun enable/1}
@@ -59,3 +59,40 @@ mechanism(Name) ->
 backend(Name) ->
     hoconsc:mk(hoconsc:enum([Name]),
                #{required => true}).
+
+fields("metrics_status_fields") ->
+    [ {"metrics", mk(ref(?MODULE, "metrics"), #{desc => "The metrics of the resource"})}
+    , {"node_metrics", mk(hoconsc:array(ref(?MODULE, "node_metrics")),
+                          #{ desc => "The metrics of the resource for each node"
+                           })}
+    , {"status", mk(status(), #{desc => "The status of the resource"})}
+    , {"node_status", mk(hoconsc:array(ref(?MODULE, "node_status")),
+                         #{ desc => "The status of the resource for each node"
+                          })}
+    ];
+
+fields("metrics") ->
+    [ {"matched", mk(integer(), #{desc => "Count of this resource is queried"})}
+    , {"success", mk(integer(), #{desc => "Count of query success"})}
+    , {"failed", mk(integer(), #{desc => "Count of query failed"})}
+    , {"rate", mk(float(), #{desc => "The rate of matched, times/second"})}
+    , {"rate_max", mk(float(), #{desc => "The max rate of matched, times/second"})}
+    , {"rate_last5m", mk(float(),
+           #{desc => "The average rate of matched in the last 5 minutes, times/second"})}
+    ];
+
+fields("node_metrics") ->
+    [ node_name()
+    , {"metrics", mk(ref(?MODULE, "metrics"), #{})}
+    ];
+
+fields("node_status") ->
+    [ node_name()
+    , {"status", mk(status(), #{})}
+    ].
+
+status() ->
+    hoconsc:enum([connected, disconnected, connecting]).
+
+node_name() ->
+    {"node", mk(binary(), #{desc => "The node name", example => "emqx@127.0.0.1"})}.

--- a/apps/emqx_authn/src/emqx_authn_schema.erl
+++ b/apps/emqx_authn/src/emqx_authn_schema.erl
@@ -16,6 +16,7 @@
 
 -module(emqx_authn_schema).
 
+-elvis([{elvis_style, invalid_dynamic_call, disable}]).
 -include_lib("typerefl/include/types.hrl").
 -import(hoconsc, [mk/2, ref/2]).
 

--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -167,30 +167,34 @@ test_authenticator(PathPrefix) ->
     {ok, 200, _} = request(
                      get,
                      uri(PathPrefix ++ [?CONF_NS, "password_based:http"])),
-    %% {ok, RList} = emqx_json:safe_decode(Res),
-    %% Snd = fun ({_, Val}) -> Val end,
-    %% LookupVal = fun LookupV(List, RestJson) ->
-    %%         case List of
-    %%             [Name] -> Snd(lists:keyfind(Name, 1, RestJson));
-    %%             [Name | NS] -> LookupV(NS, Snd(lists:keyfind(Name, 1, RestJson)))
-    %%         end
-    %%     end,
-    %% LookFun = fun (List) -> LookupVal(List, RList) end,
-    %% MetricsList = [{<<"failed">>, 0},
-    %%                {<<"matched">>, 0},
-    %%                {<<"rate">>, 0.0},
-    %%                {<<"rate_last5m">>, 0.0},
-    %%                {<<"rate_max">>, 0.0},
-    %%                {<<"success">>, 0}],
-    %% EqualFun = fun ({M, V}) ->
-    %%                ?assertEqual(V, LookFun([<<"metrics">>,
-    %%                                         M]
-    %%                                       )
-    %%                            ) end,
-    %% lists:map(EqualFun, MetricsList),
-    %% ?assertEqual(<<"connected">>,
-    %%              LookFun([<<"status">>
-    %%                      ])),
+
+    {ok, 200, Res} = request(
+                     get,
+                     uri(PathPrefix ++ [?CONF_NS, "password_based:http", "status"])),
+    {ok, RList} = emqx_json:safe_decode(Res),
+    Snd = fun ({_, Val}) -> Val end,
+    LookupVal = fun LookupV(List, RestJson) ->
+            case List of
+                [Name] -> Snd(lists:keyfind(Name, 1, RestJson));
+                [Name | NS] -> LookupV(NS, Snd(lists:keyfind(Name, 1, RestJson)))
+            end
+        end,
+    LookFun = fun (List) -> LookupVal(List, RList) end,
+    MetricsList = [{<<"failed">>, 0},
+                   {<<"matched">>, 0},
+                   {<<"rate">>, 0.0},
+                   {<<"rate_last5m">>, 0.0},
+                   {<<"rate_max">>, 0.0},
+                   {<<"success">>, 0}],
+    EqualFun = fun ({M, V}) ->
+                   ?assertEqual(V, LookFun([<<"metrics">>,
+                                            M]
+                                          )
+                               ) end,
+    lists:map(EqualFun, MetricsList),
+    ?assertEqual(<<"connected">>,
+                 LookFun([<<"status">>
+                         ])),
     {ok, 404, _} = request(
                      get,
                      uri(PathPrefix ++ [?CONF_NS, "password_based:redis"])),

--- a/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
@@ -176,32 +176,32 @@ t_api(_) ->
                            [?SOURCE2, ?SOURCE3, ?SOURCE4, ?SOURCE5, ?SOURCE6]),
     {ok, 204, _} = request(post, uri(["authorization", "sources"]), ?SOURCE1),
 
-    %% Snd = fun ({_, Val}) -> Val end,
-    %% LookupVal = fun LookupV(List, RestJson) ->
-    %%                     case List of
-    %%                         [Name] -> Snd(lists:keyfind(Name, 1, RestJson));
-    %%                         [Name | NS] -> LookupV(NS, Snd(lists:keyfind(Name, 1, RestJson)))
-    %%                     end
-    %%             end,
-    %% EqualFun = fun (RList) ->
-    %%                fun ({M, V}) ->
-    %%                    ?assertEqual(V,
-    %%                                 LookupVal([<<"metrics">>, M],
-    %%                                          RList)
-    %%                                )
-    %%                end
-    %%            end,
-    %% AssertFun =
-    %%     fun (ResultJson) ->
-    %%         {ok, RList} = emqx_json:safe_decode(ResultJson),
-    %%         MetricsList = [{<<"failed">>, 0},
-    %%                        {<<"matched">>, 0},
-    %%                        {<<"rate">>, 0.0},
-    %%                        {<<"rate_last5m">>, 0.0},
-    %%                        {<<"rate_max">>, 0.0},
-    %%                        {<<"success">>, 0}],
-    %%         lists:map(EqualFun(RList), MetricsList)
-    %%     end,
+    Snd = fun ({_, Val}) -> Val end,
+    LookupVal = fun LookupV(List, RestJson) ->
+                        case List of
+                            [Name] -> Snd(lists:keyfind(Name, 1, RestJson));
+                            [Name | NS] -> LookupV(NS, Snd(lists:keyfind(Name, 1, RestJson)))
+                        end
+                end,
+    EqualFun = fun (RList) ->
+                   fun ({M, V}) ->
+                       ?assertEqual(V,
+                                    LookupVal([<<"metrics">>, M],
+                                             RList)
+                                   )
+                   end
+               end,
+    AssertFun =
+        fun (ResultJson) ->
+            {ok, RList} = emqx_json:safe_decode(ResultJson),
+            MetricsList = [{<<"failed">>, 0},
+                           {<<"matched">>, 0},
+                           {<<"rate">>, 0.0},
+                           {<<"rate_last5m">>, 0.0},
+                           {<<"rate_max">>, 0.0},
+                           {<<"success">>, 0}],
+            lists:map(EqualFun(RList), MetricsList)
+        end,
 
     {ok, 200, Result2} = request(get, uri(["authorization", "sources"]), []),
     Sources = get_sources(Result2),
@@ -238,7 +238,8 @@ t_api(_) ->
                                          <<"verify">> => <<"verify_none">>
                                         }}),
     {ok, 200, Result4} = request(get, uri(["authorization", "sources", "mongodb"]), []),
-    %% AssertFun(Result4),
+    {ok, 200, Status4} = request(get, uri(["authorization", "sources", "mongodb", "status"]), []),
+    AssertFun(Status4),
     ?assertMatch(#{<<"type">> := <<"mongodb">>,
                    <<"ssl">> := #{<<"enable">> := <<"true">>,
                                   <<"cacertfile">> := ?MATCH_CERT,
@@ -261,7 +262,8 @@ t_api(_) ->
                                          <<"verify">> => <<"verify_none">>
                                         }}),
     {ok, 200, Result5} = request(get, uri(["authorization", "sources", "mongodb"]), []),
-    %% AssertFun(Result5),
+    {ok, 200, Status5} = request(get, uri(["authorization", "sources", "mongodb", "status"]), []),
+    AssertFun(Status5),
     ?assertMatch(#{<<"type">> := <<"mongodb">>,
                    <<"ssl">> := #{<<"enable">> := <<"true">>,
                                   <<"cacertfile">> := ?MATCH_CERT,


### PR DESCRIPTION
authn, authz get resource status.
add api：
/authentication/:id/status
/authentication/:id/authentication/:id/status
/authorization/sources/:type/status

status example
```erlang
    #{ metrics => #{  matched => 0,
                      success => 0,
                      failed => 0,
                      rate => 0.0,
                      rate_last5m => 0.0,
                      rate_max => 0.0
                   },
       node_metrics => [ #{node => node(),
                           metrics => #{  matched => 0,
                                          success => 0,
                                          failed => 0,
                                          rate => 0.0,
                                          rate_last5m => 0.0,
                                          rate_max => 0.0
                                       }
                           }
                       ],
       status => connected,
       node_status => [ #{node => node(),
                          status => connected
                         }
                      ]
     }
```
