### PR TITLE
fix(retainer): don't translate config content, keep it in raw

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer_api.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_api.erl
@@ -38,7 +38,7 @@
 namespace() -> "retainer".
 
 api_spec() ->
-    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
     [?PREFIX, ?PREFIX ++ "/messages", ?PREFIX ++ "/message/:topic"].

--- a/apps/emqx_retainer/src/emqx_retainer_api.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_api.erl
@@ -44,7 +44,7 @@ paths() ->
     [?PREFIX, ?PREFIX ++ "/messages", ?PREFIX ++ "/message/:topic"].
 
 schema(?PREFIX) ->
-    #{operationId => config,
+    #{'operationId' => config,
       get => #{tags => ?TAGS,
                description => <<"Get retainer config">>,
                responses => #{200 => mk(conf_schema(), #{desc => "The config content"}),
@@ -61,7 +61,7 @@ schema(?PREFIX) ->
      };
 
 schema(?PREFIX ++ "/messages") ->
-    #{operationId => lookup_retained_warp,
+    #{'operationId' => lookup_retained_warp,
       get => #{tags => ?TAGS,
                description => <<"List retained messages">>,
                parameters => page_params(),
@@ -72,7 +72,7 @@ schema(?PREFIX ++ "/messages") ->
         };
 
 schema(?PREFIX ++ "/message/:topic") ->
-    #{operationId => with_topic_warp,
+    #{'operationId' => with_topic_warp,
       get => #{tags => ?TAGS,
                description => <<"Lookup a message by a topic without wildcards">>,
                parameters => parameters(),


### PR DESCRIPTION
The front-end expects to get the raw config content, not the translated one