### PR TITLE
fix authz cluster update config

### DIFF
--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -142,12 +142,12 @@ do_pre_config_update({?CMD_MOVE, Type, ?CMD_MOVE_AFTER(After)}, Sources) ->
     {S1, Front1, Rear1} = take(Type, Sources),
     {S2, Front2, Rear2} = take(After, Front1 ++ Rear1),
     Front2 ++ [S2, S1] ++ Rear2;
-do_pre_config_update({?CMD_PREPEND, NewSources}, Sources) ->
-    NSources = NewSources ++ Sources,
+do_pre_config_update({?CMD_PREPEND, NewSource}, Sources) ->
+    NSources = [NewSource] ++ Sources,
     ok = check_dup_types(NSources),
     NSources;
-do_pre_config_update({?CMD_APPEND, NewSources}, Sources) ->
-    NSources = Sources ++ NewSources,
+do_pre_config_update({?CMD_APPEND, NewSource}, Sources) ->
+    NSources = Sources ++ [NewSource],
     ok = check_dup_types(NSources),
     NSources;
 do_pre_config_update({{?CMD_REPLACE, Type}, #{<<"enable">> := Enable} = Source}, Sources)
@@ -186,12 +186,12 @@ do_post_config_update({?CMD_MOVE, _Type, _Where} = Cmd, _NewSources) ->
     MovedSources = do_pre_config_update(Cmd, InitedSources),
     ok = emqx_hooks:put('client.authorize', {?MODULE, authorize, [MovedSources]}, -1),
     ok = emqx_authz_cache:drain_cache();
-do_post_config_update({?CMD_PREPEND, Sources}, _NewSources) ->
-    InitedSources = init_sources(check_sources(Sources)),
+do_post_config_update({?CMD_PREPEND, Source}, _NewSources) ->
+    InitedSources = init_sources(check_sources([Source])),
     ok = emqx_hooks:put('client.authorize', {?MODULE, authorize, [InitedSources ++ lookup()]}, -1),
     ok = emqx_authz_cache:drain_cache();
-do_post_config_update({?CMD_APPEND, Sources}, _NewSources) ->
-    InitedSources = init_sources(check_sources(Sources)),
+do_post_config_update({?CMD_APPEND, Source}, _NewSources) ->
+    InitedSources = init_sources(check_sources([Source])),
     emqx_hooks:put('client.authorize', {?MODULE, authorize, [lookup() ++ InitedSources]}, -1),
     ok = emqx_authz_cache:drain_cache();
 do_post_config_update({{?CMD_REPLACE, Type}, Source}, _NewSources) when is_map(Source) ->

--- a/apps/emqx_authz/src/emqx_authz_api_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_schema.erl
@@ -65,13 +65,12 @@ fields(redis_cluster) ->
     ++ emqx_connector_redis:fields(cluster);
 fields(file) ->
     authz_common_fields(file)
-    ++ [ {rules, #{ type => binary()
-                  , example =>
-                        <<"{allow,{username,\"^dashboard?\"},","subscribe,[\"$SYS/#\"]}.\n",
-                          "{allow,{ipaddr,\"127.0.0.1\"},all,[\"$SYS/#\",\"#\"]}.">>}}
-         %% The path will be deprecated, `acl.conf` will be fixed in subdir of `data`
-       , {path, #{ type => binary()
-                 , example => <<"acl.conf">>}}];
+    ++ [ { rules, #{ type => binary()
+                   , required => true
+                   , example =>
+                         <<"{allow,{username,\"^dashboard?\"},","subscribe,[\"$SYS/#\"]}.\n",
+                           "{allow,{ipaddr,\"127.0.0.1\"},all,[\"$SYS/#\",\"#\"]}.">>}}
+    ];
 fields(position) ->
     [ { position
       , mk( string()

--- a/apps/emqx_authz/src/emqx_authz_api_sources.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_sources.erl
@@ -95,7 +95,7 @@ schema("/authorization/sources/:type") ->
      , put =>
            #{ description => <<"Update source">>
             , parameters => parameters_field()
-            , 'requestBody' => mk( hoconsc:union(authz_sources_type_refs()))
+            , 'requestBody' => mk(hoconsc:union(authz_sources_type_refs()))
             , responses =>
                   #{ 204 => <<"Authorization source updated successfully">>
                    , 400 => emqx_dashboard_swagger:error_codes([?BAD_REQUEST], <<"Bad Request">>)
@@ -170,12 +170,12 @@ sources(get, _) ->
     {200, #{sources => Sources}};
 sources(post, #{body := #{<<"type">> := <<"file">>, <<"rules">> := Rules}}) ->
     {ok, Filename} = write_file(acl_conf_file(), Rules),
-    update_config(?CMD_PREPEND, [#{<<"type">> => <<"file">>,
-                                   <<"enable">> => true, <<"path">> => Filename}]);
+    update_config(?CMD_PREPEND, #{<<"type">> => <<"file">>,
+                                  <<"enable">> => true, <<"path">> => Filename});
 sources(post, #{body := Body}) when is_map(Body) ->
     case maybe_write_certs(Body) of
         Config when is_map(Config) ->
-            update_config(?CMD_PREPEND, [Config]);
+            update_config(?CMD_PREPEND, Config);
         {error, Reason} ->
             {400, #{code => <<"BAD_REQUEST">>,
                     message => bin(Reason)}}

--- a/apps/emqx_authz/src/emqx_authz_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_schema.erl
@@ -93,6 +93,7 @@ fields(file) ->
     , {enable, #{type => boolean(),
                  default => true}}
     , {path, #{type => string(),
+               required => true,
                desc => """
 Path to the file which contains the ACL rules.<br>
 If the file provisioned before starting EMQX node,

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -125,12 +125,13 @@ set_special_configs(_App) ->
 %%------------------------------------------------------------------------------
 
 t_update_source(_) ->
+    %% replace all
     {ok, _} = emqx_authz:update(?CMD_REPLACE, [?SOURCE3]),
-    {ok, _} = emqx_authz:update(?CMD_PREPEND, [?SOURCE2]),
-    {ok, _} = emqx_authz:update(?CMD_PREPEND, [?SOURCE1]),
-    {ok, _} = emqx_authz:update(?CMD_APPEND, [?SOURCE4]),
-    {ok, _} = emqx_authz:update(?CMD_APPEND, [?SOURCE5]),
-    {ok, _} = emqx_authz:update(?CMD_APPEND, [?SOURCE6]),
+    {ok, _} = emqx_authz:update(?CMD_PREPEND, ?SOURCE2),
+    {ok, _} = emqx_authz:update(?CMD_PREPEND, ?SOURCE1),
+    {ok, _} = emqx_authz:update(?CMD_APPEND, ?SOURCE4),
+    {ok, _} = emqx_authz:update(?CMD_APPEND, ?SOURCE5),
+    {ok, _} = emqx_authz:update(?CMD_APPEND, ?SOURCE6),
 
     ?assertMatch([ #{type := http,  enable := true}
                  , #{type := mongodb, enable := true}
@@ -170,7 +171,7 @@ t_delete_source(_) ->
     ?assertMatch([ #{type := http,  enable := true}
                  ], emqx_conf:get([authorization, sources], [])),
 
-    {ok, _} = emqx_authz:update({?CMD_DELETE, http},  #{}),
+    {ok, _} = emqx_authz:update({?CMD_DELETE, http}, #{}),
 
     ?assertMatch([], emqx_conf:get([authorization, sources], [])).
 

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -34,6 +34,10 @@ init_per_suite(Config) ->
     meck:expect(emqx_resource, create_local, fun(_, _, _, _) -> {ok, meck_data} end),
     meck:expect(emqx_resource, remove_local, fun(_) -> ok end),
     meck:expect(emqx_resource, create_dry_run_local, fun(_, _) -> ok end),
+    meck:expect(emqx_authz, acl_conf_file,
+                fun() ->
+                        emqx_common_test_helpers:deps_path(emqx_authz, "etc/acl.conf")
+                end),
 
     ok = emqx_common_test_helpers:start_apps(
            [emqx_connector, emqx_conf, emqx_authz],
@@ -116,7 +120,9 @@ set_special_configs(_App) ->
                   }).
 -define(SOURCE6, #{<<"type">> => <<"file">>,
                    <<"enable">> => true,
-                   <<"path">> => emqx_common_test_helpers:deps_path(emqx_authz, "etc/acl.conf")
+                   <<"rules">> =>
+<<"{allow,{username,\"^dashboard?\"},subscribe,[\"$SYS/#\"]}."
+  "\n{allow,{ipaddr,\"127.0.0.1\"},all,[\"$SYS/#\",\"#\"]}.">>
                   }).
 
 

--- a/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
@@ -230,16 +230,16 @@ t_api(_) ->
     {ok, 204, _} =
         request( put
                , uri(["authorization", "sources", "built_in_database"])
-               ,  #{<<"enable">> => true}),
+               , #{<<"enable">> => true, <<"type">> => <<"built_in_database">>}),
     %% test idempotence
     {ok, 204, _} =
         request( put
                , uri(["authorization", "sources", "built_in_database"])
-               ,  #{<<"enable">> => true}),
+               , #{<<"enable">> => true, <<"type">> => <<"built_in_database">>}),
     {ok, 204, _} =
         request( put
                , uri(["authorization", "sources", "built_in_database"])
-               ,  #{<<"enable">> => false}),
+               , #{<<"enable">> => false, <<"type">> => <<"built_in_database">>}),
     {ok, 204, _} =
         request( delete
                , uri(["authorization", "sources", "built_in_database", "purge-all"])

--- a/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
@@ -108,6 +108,10 @@ init_per_suite(Config) ->
                 end),
     meck:expect(emqx_resource, health_check, fun(St) -> {ok, St} end),
     meck:expect(emqx_resource, remove_local, fun(_) -> ok end ),
+    meck:expect(emqx_authz, acl_conf_file,
+                fun() ->
+                        emqx_common_test_helpers:deps_path(emqx_authz, "etc/acl.conf")
+                end),
 
     ok = emqx_common_test_helpers:start_apps(
            [emqx_conf, emqx_authz, emqx_dashboard],


### PR DESCRIPTION
The acl file and cert file should be writen after EMQX sync config to all nodes.
Rather than at the node that received the API request.
Otherwise other nodes will get an empty path with no specific content.