### PR TITLE
fix(test): use a real copy of BUILD_INFO for testing

### DIFF
--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -47,7 +47,7 @@ init_per_testcase(t_get_telemetry, Config) ->
         emqx_telemetry,
         read_raw_build_info,
         fun() ->
-            {ok, Path} = file:read_link(filename:join([DataDir, "BUILD_INFO"])),
+            Path = filename:join([DataDir, "BUILD_INFO"]),
             {ok, Template} = file:read_file(Path),
             Vars0 = [
                 {build_info_arch, "arch"},

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE_data/BUILD_INFO
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE_data/BUILD_INFO
@@ -1,1 +1,6 @@
-../../../../rel/BUILD_INFO
+arch: "{{ build_info_arch }}"
+wordsize: {{ build_info_wordsize }}
+os: "{{ build_info_os }}"
+erlang: "{{ build_info_erlang }}"
+elixir: "{{ build_info_elixir }}"
+relform: "{{ build_info_relform }}"


### PR DESCRIPTION
On macOS, apparently symlinks can cause problems when rebar3 tries to
copy files to the `_build` directory.  So we now use a copy of
`rel/BUILD_INFO`.  Unfortunately, this has the downside of this copy
possibly going stale over time.

## Note

Please run `rm _build/test/lib/emqx_modules/test/emqx_telemetry_SUITE_data/BUILD_INFO` if the following error is encountered:

```
+ env LOGLEVEL=debug make ct-suite SUITE=apps/emqx_modules/test/emqx_telemetry_SUITE
/home/thales/dev/emqx/emqx/rebar3 ct -v --readable=false --name 'test@127.0.0.1' --suite apps/emqx_modules/test/emqx_telemetry_SUITE
===> Plugin er_coap_client does not export init/1. It will not be used.
===> Verifying dependencies...
cp: not writing through dangling symlink '/home/thales/dev/emqx/emqx/_build/test/lib/emqx_modules/test/emqx_telemetry_SUITE_data/BUILD_INFO'
===> sh(cp -Rp /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_modules_conf_SUITE.erl /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_rewrite_SUITE.erl /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_event_message_SUITE.erl /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_telemetry_SUITE_data /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_telemetry_SUITE.erl /home/thales/dev/emqx/emqx/apps/emqx_modules/test/emqx_delayed_SUITE.erl "/home/thales/dev/emqx/emqx/_build/test/lib/emqx_modules/test")
failed with return code 1 and the following output:
cp: not writing through dangling symlink '/home/thales/dev/emqx/emqx/_build/test/lib/emqx_modules/test/emqx_telemetry_SUITE_data/BUILD_INFO'
```