### PR TITLE
chore: add namespace to bridge schema

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_http_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_http_schema.erl
@@ -4,10 +4,12 @@
 
 -import(hoconsc, [mk/2, enum/1]).
 
--export([roots/0, fields/1]).
+-export([roots/0, fields/1, namespace/0]).
 
 %%======================================================================================
 %% Hocon Schema Definitions
+namespace() -> "bridge".
+
 roots() -> [].
 
 fields("config") ->

--- a/apps/emqx_bridge/src/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_schema.erl
@@ -4,7 +4,7 @@
 
 -import(hoconsc, [mk/2, ref/2]).
 
--export([roots/0, fields/1]).
+-export([roots/0, fields/1, namespace/0]).
 
 -export([ get_response/0
         , put_request/0
@@ -80,6 +80,9 @@ direction_field(Dir, Desc) ->
 
 %%======================================================================================
 %% For config files
+
+namespace() -> "bridge".
+
 roots() -> [bridges].
 
 fields(bridges) ->


### PR DESCRIPTION
the `config` struct without a proper namespace at root level is very much confusing.