### PR TITLE
chore: delete epmd related ports and settings

### DIFF
--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -76,32 +76,6 @@ node {
   ## Default: 2m
   dist_net_ticktime = 2m
 
-  ## Sets the port range for the listener socket of a distributed
-  ## Erlang node.
-  ## Note that if there are firewalls between clustered nodes, this
-  ## port segment for nodes’ communication should be allowed.
-  ##
-  ## See: http://www.erlang.org/doc/man/kernel_app.html
-  ##
-  ## @doc node.dist_listen_min
-  ## ValueType: Integer
-  ## Range: [1024,65535]
-  ## Default: 6369
-  dist_listen_min = 6369
-
-  ## Sets the port range for the listener socket of a distributed
-  ## Erlang node.
-  ## Note that if there are firewalls between clustered nodes, this
-  ## port segment for nodes’ communication should be allowed.
-  ##
-  ## See: http://www.erlang.org/doc/man/kernel_app.html
-  ##
-  ## @doc node.dist_listen_max
-  ## ValueType: Integer
-  ## Range: [1024,65535]
-  ## Default: 6369
-  dist_listen_max = 6369
-
   ## Sets the maximum depth of call stack back-traces in the exit
   ## reason element of 'EXIT' tuples.
   ## The flag also limits the stacktrace depth returned by

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -361,20 +361,6 @@ a crash dump"
            , desc => "This is the approximate time an EMQX node may be unresponsive "
                      "until it is considered down and thereby disconnected."
            })}
-    , {"dist_listen_min",
-       sc(range(1024, 65535),
-          #{ mapping => "kernel.inet_dist_listen_min"
-           , default => 6369
-           , desc => "Lower bound for the port range where EMQX broker "
-                     "listens for peer connections."
-           })}
-    , {"dist_listen_max",
-       sc(range(1024, 65535),
-          #{ mapping => "kernel.inet_dist_listen_max"
-           , default => 6369
-           , desc => "Upper bound for the port range where EMQX broker "
-                     "listens for peer connections."
-           })}
     , {"backtrace_depth",
        sc(integer(),
           #{ mapping => "emqx_machine.backtrace_depth"

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -62,11 +62,10 @@ VOLUME ["/opt/emqx/log", "/opt/emqx/data"]
 # - 8883 port for MQTT(SSL)
 # - 11883 port for internal MQTT/TCP
 # - 18083 for dashboard
-# - 4369 epmd (Erlang-distrbution port mapper daemon) listener (deprecated)
 # - 4370 default Erlang distrbution port
 # - 5369 for gen_rpc port mapping
 # - 6369 6370 for distributed node
-EXPOSE 1883 8081 8083 8084 8883 11883 18083 4369 4370 5369 6369 6370
+EXPOSE 1883 8081 8083 8084 8883 11883 18083 4370 5369 6369 6370
 
 ENTRYPOINT ["/usr/bin/docker-entrypoint.sh"]
 

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -168,7 +168,7 @@ Assume you are using redis auth plugin, for example:
 #EMQX_RETAINER__STORAGE_TYPE = "ram"
 #EMQX_RETAINER.MAX_PAYLOAD_SIZE = 1MB
 
-docker run -d --name emqx -p 18083:18083 -p 1883:1883 -p 4369:4369 \
+docker run -d --name emqx -p 18083:18083 -p 1883:1883 \
     -e EMQX_LISTENERS__TCP__DEFAULT=1883 \
     -e EMQX_LOADED_PLUGINS="emqx_retainer" \
     -e EMQX_RETAINER__STORAGE_TYPE = "ram" \
@@ -184,7 +184,7 @@ For numbered configuration options where the number is next to a ``.`` such as:
 You can configure an arbitrary number of them as long as each has a uniq unber for it's own configuration option:
 
 ```bash
-docker run -d --name emqx -p 18083:18083 -p 1883:1883 -p 4369:4369 \
+docker run -d --name emqx -p 18083:18083 -p 1883:1883 \
     -e EMQX_BACKEND_REDIS_POOL1__SERVER=127.0.0.1:6379
     [...]
     -e EMQX_BACKEND__REDIS__POOL5__SERVER=127.0.0.5:6379
@@ -294,7 +294,7 @@ If you want tune linux kernel by docker, you must ensure your docker is latest v
 
 ```bash
 
-docker run -d --name emqx -p 18083:18083 -p 1883:1883 -p 4369:4369 \
+docker run -d --name emqx -p 18083:18083 -p 1883:1883 \
     --sysctl fs.file-max=2097152 \
     --sysctl fs.nr_open=2097152 \
     --sysctl net.core.somaxconn=32768 \


### PR DESCRIPTION
Although 4.x supports using EPMD, but we really have not tested it for years.
Starting from 5.0, we'll always use `ekka` for Erlang distribution protocol.
