### PR TITLE
chore: update-appup.sh always rebuild baseline

### DIFF
--- a/.github/workflows/apps_version_check.yaml
+++ b/.github/workflows/apps_version_check.yaml
@@ -16,12 +16,14 @@ jobs:
     container: emqx/build-env:${{ matrix.erl_otp }}-${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v1
-      - name: Check apps version
-        run: ./scripts/apps-version-check.sh
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # need full history
       - name: Check relup (ce)
         if: endsWith(github.repository, 'emqx')
         run: ./scripts/update-appup.sh emqx --check
       - name: Check relup (ee)
         if: endsWith(github.repository, 'enterprise')
         run: ./scripts/update-appup.sh emqx-ee --check
+      - name: Check apps version
+        run: ./scripts/apps-version-check.sh

--- a/scripts/apps-version-check.sh
+++ b/scripts/apps-version-check.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-latest_release=$(git describe --abbrev=0 --tags)
+latest_release=$(git describe --abbrev=0 --tags --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*')
 
 bad_app_count=0
 

--- a/scripts/update-appup.sh
+++ b/scripts/update-appup.sh
@@ -34,8 +34,12 @@ case "$PROFILE" in
         ;;
 esac
 
-PREV_TAG="$(git describe --tag --match "${TAG_PREFIX}*" | grep -oE "${TAG_PREFIX}4\.[0-9]+\.[0-9]+")"
-PREV_VERSION="${PREV_TAG#[e|v]}"
+## possible tags:
+##  v4.3.11
+##  e4.3.11
+##  rel-v4.4.3
+##  rel-e4.4.3
+PREV_TAG="$(git describe --tag --abbrev=0 --match "[${TAG_PREFIX}|rel-]*" --exclude '*rc*' --exclude '*alpha*' --exclude '*beta*')"
 
 shift 1
 # bash 3.2 treat empty array as unbound, so we can't use 'ESCRIPT_ARGS=()' here,
@@ -74,36 +78,20 @@ if [ "${SKIP_BUILD:-}" != 'yes' ]; then
     make "${PROFILE}"
 fi
 
-SYSTEM="${SYSTEM:-$(./scripts/get-distro.sh)}"
-if [ -z "${ARCH:-}" ]; then
-    UNAME="$(uname -m)"
-    case "$UNAME" in
-        x86_64)
-            ARCH='amd64'
-            ;;
-        aarch64)
-            ARCH='arm64'
-            ;;
-        arm*)
-            ARCH='arm'
-            ;;
-    esac
-fi
-
-PACKAGE_NAME="${PROFILE}-${SYSTEM}-${PREV_VERSION}-${ARCH}.zip"
-DOWNLOAD_URL="https://www.emqx.com/downloads/${DIR}/v${PREV_VERSION}/${PACKAGE_NAME}"
-
-PREV_DIR_BASE="/tmp/emqx-appup-base"
+PREV_DIR_BASE="/tmp/emqx-appup-build"
 mkdir -p "${PREV_DIR_BASE}"
-pushd "${PREV_DIR_BASE}"
-if [ ! -f "${PACKAGE_NAME}" ]; then
-    echo "Download: ${PACKAGE_NAME}"
-    curl -f -L -o "${PACKAGE_NAME}" "${DOWNLOAD_URL}"
+if [ ! -d "${PREV_TAG}" ]; then
+    cp -R . "${PREV_DIR_BASE}/${PREV_TAG}"
 fi
-if [ ! -d "${PREV_TAG}"  ]; then
-    unzip -q -n -d "${PREV_TAG}" "${PACKAGE_NAME}"
-fi
+
+pushd "${PREV_DIR_BASE}/${PREV_TAG}"
+git reset --hard
+git checkout ${PREV_TAG}
+make clean-all
+make $PROFILE
 popd
+
+PREV_REL_DIR="${PREV_DIR_BASE}/${PREV_TAG}/_build/${PROFILE}/lib"
 
 # bash 3.2 does not allow empty array, so we had to add an empty string in the ESCRIPT_ARGS array,
 # this in turn makes quoting "${ESCRIPT_ARGS[@]}" problematic, hence disable SC2068 check here
@@ -111,9 +99,9 @@ popd
 ./scripts/update_appup.escript \
     --src-dirs "${SRC_DIRS}/**" \
     --release-dir "_build/${PROFILE}/lib" \
-    --prev-release-dir "${PREV_DIR_BASE}/${PREV_TAG}/emqx/lib" \
+    --prev-release-dir "${PREV_REL_DIR}" \
     --skip-build \
-    ${ESCRIPT_ARGS[@]} "$PREV_VERSION"
+    ${ESCRIPT_ARGS[@]} "$PREV_TAG"
 
 if [ "${IS_CHECK:-}" = 'yes' ]; then
     diffs="$(git diff --name-only | grep -E '\.appup\.src' || true)"

--- a/scripts/update-appup.sh
+++ b/scripts/update-appup.sh
@@ -16,15 +16,12 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 PROFILE="${1:-}"
 case "$PROFILE" in
     emqx-ee)
-        DIR='enterprise'
         TAG_PREFIX='e'
         ;;
     emqx)
-        DIR='broker'
         TAG_PREFIX='v'
         ;;
     emqx-edge)
-        DIR='edge'
         TAG_PREFIX='v'
         ;;
     *)
@@ -86,9 +83,9 @@ fi
 
 pushd "${PREV_DIR_BASE}/${PREV_TAG}"
 git reset --hard
-git checkout ${PREV_TAG}
+git checkout "${PREV_TAG}"
 make clean-all
-make $PROFILE
+make "$PROFILE"
 popd
 
 PREV_REL_DIR="${PREV_DIR_BASE}/${PREV_TAG}/_build/${PROFILE}/lib"


### PR DESCRIPTION
Reasons
* OTP version might be different in developer's env and build env
* For some tags, we do not build release. e.g. rel-v4.4.X

