### PR TITLE
fix: dashboard_monitor crash

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -30,7 +30,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.1"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.3"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.26.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.26.4"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.18.0"}}}

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -328,14 +328,14 @@ all() ->
     ].
 
 %% @doc Get metric value
--spec val(metric_name()) -> maybe(non_neg_integer()).
+-spec val(metric_name()) -> non_neg_integer().
 val(Name) ->
     case ets:lookup(?TAB, Name) of
         [#metric{idx = Idx}] ->
             CRef = persistent_term:get(?MODULE),
             counters:get(CRef, Idx);
         [] ->
-            undefined
+            0
     end.
 
 %% @doc Increase counter

--- a/apps/emqx/src/emqx_stats.erl
+++ b/apps/emqx/src/emqx_stats.erl
@@ -164,11 +164,11 @@ getstats() ->
     end.
 
 %% @doc Get stats by name.
--spec getstat(atom()) -> maybe(non_neg_integer()).
+-spec getstat(atom()) -> non_neg_integer().
 getstat(Name) ->
     case ets:lookup(?TAB, Name) of
         [{Name, Val}] -> Val;
-        [] -> undefined
+        [] -> 0
     end.
 
 %% @doc Set stats

--- a/apps/emqx/test/emqx_stats_SUITE.erl
+++ b/apps/emqx/test/emqx_stats_SUITE.erl
@@ -36,7 +36,7 @@ t_get_error_state(_) ->
 
 t_get_state(_) ->
     with_proc(fun() ->
-        ?assertEqual(undefined, emqx_stats:getstat('notExist')),
+        ?assertEqual(0, emqx_stats:getstat('notExist')),
         SetConnsCount = emqx_stats:statsfun('connections.count'),
         SetConnsCount(1),
         ?assertEqual(1, emqx_stats:getstat('connections.count')),

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -243,8 +243,8 @@ format(TimeStamp, Data, All) ->
     [Data#{time_stamp => TimeStamp} | All].
 
 cal_rate(_Now, undefined) ->
-    AllSamples = ?GAUGE_SAMPLER_LIST ++ maps:keys(?DELTA_SAMPLER_RATE_MAP),
-    {ok, lists:foldl(fun(Key, Acc) -> Acc#{Key => 0} end, #{}, AllSamples)};
+    AllSamples = ?GAUGE_SAMPLER_LIST ++ maps:values(?DELTA_SAMPLER_RATE_MAP),
+    lists:foldl(fun(Key, Acc) -> Acc#{Key => 0} end, #{}, AllSamples);
 cal_rate( #emqx_monit{data = NowData, time = NowTime}
         , #emqx_monit{data = LastData, time = LastTime}) ->
     TimeDelta = NowTime - LastTime,

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -242,6 +242,9 @@ format(Data) ->
 format(TimeStamp, Data, All) ->
     [Data#{time_stamp => TimeStamp} | All].
 
+cal_rate(_Now, undefined) ->
+    AllSamples = ?GAUGE_SAMPLER_LIST ++ maps:keys(?DELTA_SAMPLER_RATE_MAP),
+    {ok, lists:foldl(fun(Key, Acc) -> Acc#{Key => 0} end, #{}, AllSamples)};
 cal_rate( #emqx_monit{data = NowData, time = NowTime}
         , #emqx_monit{data = LastData, time = LastTime}) ->
     TimeDelta = NowTime - LastTime,

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -4,7 +4,7 @@
  [ {emqx, {path, "../emqx"}},
    %% FIXME: tag this as v3.1.3
    {prometheus, {git, "https://github.com/deadtrickster/prometheus.erl", {tag, "v4.8.1"}}},
-   {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.26.3"}}}
+   {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.26.4"}}}
  ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/mix.exs
+++ b/mix.exs
@@ -68,7 +68,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "0.18.0", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.26.3", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.26.4", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.4.1", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -66,7 +66,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.2"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.18.0"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.26.3"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.26.4"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.4.1"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
```erlang
5.0.0-beta.4-a2559631(emqx@127.0.0.1)1> 2022-03-22T10:49:19.585313+01:00 [error] Generic server emqx_dashboard_monitor terminating. Reason: {function_clause,[{emqx_dashboard_monitor,cal_rate,
[{emqx_monit,1647942559585,#{connections => 0,dropped => 0,received => 0,received_bytes => 0,routes => 0,sent => 
0,sent_bytes => 0,subscriptions => 0}},undefined],[{file,"emqx_dashboard_monitor.erl"},{line,245}]},
{emqx_dashboard_monitor,handle_call,3,[{file,"emqx_dashboard_monitor.erl"},{line,154}]},{gen_server,try_handle_call,4,
[{file,"gen_server.erl"},{line,721}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,750}]},
{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}. Last message: current_rate. State: {state,undefined}. Client
 <0.2639.0> stacktrace: [{gen,do_call,4,[{file,"gen.erl"},{line,233}]},{gen_server,call,3,[{file,"gen_server.erl"},{line,243}]},
{emqx_dashboard_monitor,'-current_rate/0-fun-0-',2,[{file,"emqx_dashboard_monitor.erl"},{line,114}]},{lists,foldl,3,
[{file,"lists.erl"},{line,1267}]}].

2022-03-22T10:49:19.585632+01:00 [error] crasher: initial call: emqx_dashboard_monitor:init/1, pid: <0.2637.0>, 
registered_name: emqx_dashboard_monitor, error: {function_clause,[{emqx_dashboard_monitor,cal_rate,
[{emqx_monit,1647942559585,#{connections => 0,dropped => 0,received => 0,received_bytes => 0,routes => 0,sent =>
 0,sent_bytes => 0,subscriptions => 0}},undefined],[{file,"emqx_dashboard_monitor.erl"},{line,245}]},
{emqx_dashboard_monitor,handle_call,3,[{file,"emqx_dashboard_monitor.erl"},{line,154}]},{gen_server,try_handle_call,4,
[{file,"gen_server.erl"},{line,721}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,750}]},
{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [emqx_dashboard_sup,<0.2398.0>], 
message_queue_len: 0, messages: [], links: [<0.2399.0>], dictionary: [], trap_exit: false, status: running, heap_size: 6772, 
stack_size: 29, reductions: 13168; neighbours:

```