### PR TITLE
fix(emqx_telemety): use total_memory memsup key

### DIFF
--- a/apps/emqx_modules/src/emqx_telemetry.erl
+++ b/apps/emqx_modules/src/emqx_telemetry.erl
@@ -408,7 +408,7 @@ vm_specs() ->
     SysMemData = memsup:get_system_memory_data(),
     [
         {num_cpus, erlang:system_info(logical_processors)},
-        {total_memory, proplists:get_value(available_memory, SysMemData)}
+        {total_memory, proplists:get_value(total_memory, SysMemData)}
     ].
 
 -spec mqtt_runtime_insights(state()) -> {map(), state()}.


### PR DESCRIPTION
`available_memory` seems to be a linux specific concept (smwt like `free` + `cache`).
On e.g. macos we do not have such a key:

Linux:
```
5.0.0-rc.1-7b6a71c1(emqx@127.0.0.1)1> memsup:get_system_memory_data().
[{available_memory,6347300864},
 {buffered_memory,514732032},
 {cached_memory,4329361408},
 {free_memory,2232246272},
 {free_swap,1073737728},
 {system_total_memory,8597819392},
 {total_memory,8597819392},
 {total_swap,1073737728}]
```

Mac Os:
```
5.0.0-rc.1-e9ce91b6(emqx@127.0.0.1)1> memsup:get_system_memory_data().
[{free_memory,105984000},
 {system_total_memory,17179869184},
 {total_memory,17179869184}]
```