### PR TITLE
perf: improve demonitor performance

### DIFF
--- a/apps/emqx/include/emqx_mqtt.hrl
+++ b/apps/emqx/include/emqx_mqtt.hrl
@@ -662,9 +662,9 @@ end).
     end
 ).
 
--define(FRAME_PARSE_ERROR(Reason), {frame_parse_error, Reason}).
--define(FRAME_SERIALIZE_ERROR(Reason), {frame_serialize_error, Reason}).
--define(THROW_FRAME_ERROR(Reason), erlang:throw(?FRAME_PARSE_ERROR(Reason))).
--define(THROW_SERIALIZE_ERROR(Reason), erlang:throw(?FRAME_SERIALIZE_ERROR(Reason))).
+-define(FRAME_PARSE_ERROR, frame_parse_error).
+-define(FRAME_SERIALIZE_ERROR, frame_serialize_error).
+-define(THROW_FRAME_ERROR(Reason), erlang:throw({?FRAME_PARSE_ERROR, Reason})).
+-define(THROW_SERIALIZE_ERROR(Reason), erlang:throw({?FRAME_SERIALIZE_ERROR, Reason})).
 
 -endif.

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -765,7 +765,7 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
             NState = State#state{parse_state = NParseState},
             parse_incoming(Rest, [Packet | Packets], NState)
     catch
-        throw:?FRAME_PARSE_ERROR(Reason) ->
+        throw:{?FRAME_PARSE_ERROR, Reason} ->
             ?SLOG(info, #{
                 reason => Reason,
                 at_state => emqx_frame:describe_state(ParseState),
@@ -840,19 +840,19 @@ serialize_and_inc_stats_fun(#state{serialize = Serialize}) ->
                 Data
         catch
             %% Maybe Never happen.
-            throw:?FRAME_SERIALIZE_ERROR(Reason) ->
+            throw:{?FRAME_SERIALIZE_ERROR, Reason} ->
                 ?SLOG(info, #{
                     reason => Reason,
                     input_packet => Packet
                 }),
-                erlang:error(?FRAME_SERIALIZE_ERROR(Reason));
+                erlang:error({?FRAME_SERIALIZE_ERROR, Reason});
             error:Reason:Stacktrace ->
                 ?SLOG(error, #{
                     input_packet => Packet,
                     exception => Reason,
                     stacktrace => Stacktrace
                 }),
-                erlang:error(frame_serialize_error)
+                erlang:error(?FRAME_SERIALIZE_ERROR)
         end
     end.
 

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -191,7 +191,7 @@ dispatch_with_ack(SubPid, Topic, Msg) ->
             {error, timeout}
         end
     after
-        _ = erlang:demonitor(Ref, [flush])
+        ok = emqx_pmon:demonitor(Ref)
     end.
 
 with_ack_ref(Msg, SenderRef) ->

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -676,7 +676,7 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
             NState = State#state{parse_state = NParseState},
             parse_incoming(Rest, [{incoming, Packet} | Packets], NState)
     catch
-        throw:?FRAME_PARSE_ERROR(Reason) ->
+        throw:{?FRAME_PARSE_ERROR, Reason} ->
             ?SLOG(info, #{
                 reason => Reason,
                 at_state => emqx_frame:describe_state(ParseState),
@@ -791,19 +791,19 @@ serialize_and_inc_stats_fun(#state{serialize = Serialize}) ->
                 Data
         catch
             %% Maybe Never happen.
-            throw:?FRAME_SERIALIZE_ERROR(Reason) ->
+            throw:{?FRAME_SERIALIZE_ERROR, Reason} ->
                 ?SLOG(info, #{
                     reason => Reason,
                     input_packet => Packet
                 }),
-                erlang:error(?FRAME_SERIALIZE_ERROR(Reason));
+                erlang:error({?FRAME_SERIALIZE_ERROR, Reason});
             error:Reason:Stacktrace ->
                 ?SLOG(error, #{
                     input_packet => Packet,
                     exception => Reason,
                     stacktrace => Stacktrace
                 }),
-                erlang:error(frame_serialize_error)
+                erlang:error(?FRAME_SERIALIZE_ERROR)
         end
     end.
 

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -185,12 +185,12 @@ call(WsPid, Req, Timeout) when is_pid(WsPid) ->
     WsPid ! {call, {self(), Mref}, Req},
     receive
         {Mref, Reply} ->
-            erlang:demonitor(Mref, [flush]),
+            ok = emqx_pmon:demonitor(Mref),
             Reply;
         {'DOWN', Mref, _, _, Reason} ->
             exit(Reason)
     after Timeout ->
-        erlang:demonitor(Mref, [flush]),
+        ok = emqx_pmon:demonitor(Mref),
         exit(timeout)
     end.
 

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -24,7 +24,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(ASSERT_FRAME_THROW(Reason, Expr),
-    ?assertThrow(?FRAME_PARSE_ERROR(Reason), Expr)
+    ?assertThrow({?FRAME_PARSE_ERROR, Reason}, Expr)
 ).
 
 all() ->


### PR DESCRIPTION
`demonitor(Ref, [flush])` often will not be be able to get optimised
by the compiler hence fallback to a full mailbox scan to drain
the `DOWN` message.

This commit tries to avoid the 'flush' when it's for sure
that there is no `DOWN` message sent.

