### PR TITLE
chore: upgrade app lc from 0.2.0 to 0.2.1

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.1
     , {getopt, "1.0.1"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "0.15.0"}}}
-    , {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.2.0"}}}
+    , {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.2.1"}}}
     , {mongodb, {git,"https://github.com/emqx/mongodb-erlang", {tag, "v3.0.13"}}}
     ]}.
 


### PR DESCRIPTION
0.2.1 contains a minior fix to avoid flag process getting
force killed if beam file force purged

