### PR TITLE
fix: text logger

### DIFF
--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -29,7 +29,7 @@ format(#{msg := {report, Report0}, meta := Meta} = Event, Config) when is_map(Re
     Report4 = enrich_report_topic(Report3, Meta),
     logger_formatter:format(Event#{msg := {report, Report4}}, Config);
 format(#{msg := {string, String}} = Event, Config) ->
-    format(Event#{msg => {"~ts ", String}}, Config);
+    format(Event#{msg => {"~ts ", [String]}}, Config);
 format(#{msg := Msg0, meta := Meta} = Event, Config) ->
     Msg1 = enrich_client_info(Msg0, Meta),
     Msg2 = enrich_mfa(Msg1, Meta),


### PR DESCRIPTION
Fix following "FORMAT ERROR"

 logger:warning(["line1\n", "line2\n","line3\n"]).

2022-04-06T18:44:07.412131+02:00 [warning] FORMAT ERROR: "~ts " - ["line1\n","line2\n","line3\n"]
ok

