### PR TITLE
 feat(telemetry): report basic exhook usage

### DIFF
--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -231,6 +231,38 @@ t_misc_test(_) ->
     _ = emqx_exhook_server:format(#{name => <<"test">>, hookspec => #{}}),
     ok.
 
+t_get_basic_usage_info(_Config) ->
+    #{ num_servers := NumServers
+     , servers := Servers
+     } = emqx_exhook:get_basic_usage_info(),
+    ?assertEqual(1, NumServers),
+    ?assertMatch([_], Servers),
+    [#{driver := Driver, hooks := Hooks}] = Servers,
+    ?assertEqual(grpc, Driver),
+    ?assertEqual(
+       [
+        'client.authenticate',
+        'client.authorize',
+        'client.connack',
+        'client.connect',
+        'client.connected',
+        'client.disconnected',
+        'client.subscribe',
+        'client.unsubscribe',
+        'message.acked',
+        'message.delivered',
+        'message.dropped',
+        'message.publish',
+        'session.created',
+        'session.discarded',
+        'session.resumed',
+        'session.subscribed',
+        'session.takenover',
+        'session.terminated',
+        'session.unsubscribed'
+       ],
+       lists:sort(Hooks)).
+
 %%--------------------------------------------------------------------
 %% Utils
 %%--------------------------------------------------------------------

--- a/apps/emqx_modules/src/emqx_telemetry.erl
+++ b/apps/emqx_modules/src/emqx_telemetry.erl
@@ -349,7 +349,8 @@ get_telemetry(State0 = #state{uuid = UUID}) ->
         {authn_authz, get_authn_authz_info()},
         {gateway, get_gateway_info()},
         {rule_engine, RuleEngineInfo},
-        {bridge, BridgeInfo}
+        {bridge, BridgeInfo},
+        {exhook, get_exhook_info()}
     ]}.
 
 report_telemetry(State0 = #state{url = URL}) ->
@@ -504,6 +505,9 @@ get_rule_engine_and_bridge_info() ->
             data_bridge => BridgeInfo
         }
     }.
+
+get_exhook_info() ->
+    emqx_exhook:get_basic_usage_info().
 
 bin(L) when is_list(L) ->
     list_to_binary(L);


### PR DESCRIPTION
Example output:

```json
  "exhook": {
   "num_servers": 1
   "servers": [
      { "driver": "grpc",  // the only type now, maybe will add erlport 
        "hooks": ["client.authenticate", "message.publish"]  // the hooks enabled
      }
   ]
  }
```