### PR TITLE
Upgrade ehttpc to 0.2.0

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -39,7 +39,7 @@
 
 {deps,
     [ {gpb, "4.11.2"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
-    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.1.15"}}}
+    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.2.0"}}}
     , {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.7.1"}}}
     , {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}


### PR DESCRIPTION
In ehttpc v0.2.0, we have optimized the implementation for request collection
to reduce resource consumption. see: https://github.com/emqx/ehttpc/pull/31

