### PR TITLE
feat: use gen_rpc ordered cast for `emqx_rpc:cast/5`

### DIFF
--- a/apps/emqx/src/emqx_rpc.erl
+++ b/apps/emqx/src/emqx_rpc.erl
@@ -47,7 +47,7 @@
     ]}
 ).
 
--define(DefaultClientNum, 1).
+-define(DefaultClientNum, 10).
 
 -type badrpc() :: {badrpc, term()} | {badtcp, term()}.
 
@@ -86,11 +86,13 @@ multicall(Key, Nodes, Mod, Fun, Args) ->
 
 -spec cast(node(), module(), atom(), list()) -> cast_result().
 cast(Node, Mod, Fun, Args) ->
+    %% Note: using a non-ordered cast here, since the generated key is
+    %% random anyway:
     gen_rpc:cast(rpc_node(Node), Mod, Fun, Args).
 
 -spec cast(term(), node(), module(), atom(), list()) -> cast_result().
 cast(Key, Node, Mod, Fun, Args) ->
-    gen_rpc:cast(rpc_node({Key, Node}), Mod, Fun, Args).
+    gen_rpc:ordered_cast(rpc_node({Key, Node}), Mod, Fun, Args).
 
 rpc_node(Node) when is_atom(Node) ->
     {Node, rand:uniform(max_client_num())};

--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -780,8 +780,8 @@ rpc {
   ## @doc rpc.tcp_client_num
   ## ValueType: Integer
   ## Range: [1, 256]
-  ## Defaults: 1
-  tcp_client_num = 1
+  ## Defaults: 10
+  tcp_client_num = 10
 
   ## RCP Client connect timeout.
   ##

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -568,7 +568,7 @@ fields("rpc") ->
            })}
     , {"tcp_client_num",
        sc(range(1, 256),
-          #{ default => 1
+          #{ default => 10
            , desc => "Set the maximum number of RPC communication channels initiated by this node "
                      "to each remote node."
            })}


### PR DESCRIPTION
From: https://github.com/emqx/emqx/pull/6554

