### PR TITLE
fix: behavior of rule-engine when selection field does not exist

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_maps.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_maps.erl
@@ -44,8 +44,6 @@ do_nested_get([], Val, _OrgData, _Default) ->
 nested_put(Key, Val, Data) when not is_map(Data),
                                 not is_list(Data) ->
     nested_put(Key, Val, #{});
-nested_put(_, undefined, Map) ->
-    Map;
 nested_put({var, Key}, Val, Map) ->
     general_map_put({key, Key}, Val, Map, Map);
 nested_put({path, Path}, Val, Map) when is_list(Path) ->
@@ -65,8 +63,6 @@ general_map_get(Key, Map, OrgData, Default) ->
             (not_found) -> Default
         end).
 
-general_map_put(_Key, undefined, Map, _OrgData) ->
-    Map;
 general_map_put(Key, Val, Map, OrgData) ->
     general_find(Key, Map, OrgData,
         fun

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -1272,8 +1272,8 @@ t_sqlparse_undefined_variable(_Config) ->
             ,
     {ok, Res00} = emqx_rule_sqltester:test(
                     #{sql => Sql00, context => #{payload => <<"">>, topic => <<"t/a">>}}),
-    ?assertMatch(#{}, Res00),
-    ?assertEqual(0, map_size(Res00)),
+    ?assertEqual(#{<<"a">> => undefined, <<"b">> => undefined}, Res00),
+    ?assertEqual(2, map_size(Res00)),
     %% undefined compare to non-undefined variables should return false
     Sql01 = "select "
             "a, b "

--- a/apps/emqx_rule_engine/test/emqx_rule_maps_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_maps_SUITE.erl
@@ -42,6 +42,7 @@
 t_nested_put_map(_) ->
     ?assertEqual(#{a => 1}, nested_put(?path([a]), 1, #{})),
     ?assertEqual(#{a => a}, nested_put(?path([a]), a, #{})),
+    ?assertEqual(#{a => undefined}, nested_put(?path([a]), undefined, #{})),
     ?assertEqual(#{a => 1}, nested_put(?path([a]), 1, not_map)),
     ?assertEqual(#{a => #{b => b}}, nested_put(?path([a,b]), b, #{})),
     ?assertEqual(#{a => #{b => #{c => c}}}, nested_put(?path([a,b,c]), c, #{})),
@@ -172,4 +173,3 @@ all() ->
 
 suite() ->
     [{ct_hooks, [cth_surefire]}, {timetrap, {seconds, 30}}].
-


### PR DESCRIPTION
When the selection field does not exist, it should output `#{Field => undefined}`, not an empty map().

SQL:
```
SELECT  somefield
FROM
  "t/#"
```

Input:
```
{"msg": "hello"}
```

Before this fix, the output was:
```
{}
```

After this change, the output becomes:
```
{
  "somefield": "undefined"
}
```


