### PR TITLE
feat(telemetry): add cluster uuid

### DIFF
--- a/apps/emqx_modules/src/proto/emqx_telemetry_proto_v1.erl
+++ b/apps/emqx_modules/src/proto/emqx_telemetry_proto_v1.erl
@@ -20,7 +20,8 @@
 
 -export([
     introduced_in/0,
-    get_uuid/1
+    get_node_uuid/1,
+    get_cluster_uuid/1
 ]).
 
 -include_lib("emqx/include/bpapi.hrl").
@@ -28,6 +29,10 @@
 introduced_in() ->
     "5.0.0".
 
--spec get_uuid(node()) -> {ok, binary()} | emqx_rpc:badrpc().
-get_uuid(Node) ->
-    rpc:call(Node, emqx_telemetry, get_uuid, []).
+-spec get_node_uuid(node()) -> {ok, binary()} | emqx_rpc:badrpc().
+get_node_uuid(Node) ->
+    rpc:call(Node, emqx_telemetry, get_node_uuid, []).
+
+-spec get_cluster_uuid(node()) -> {ok, binary()} | emqx_rpc:badrpc().
+get_cluster_uuid(Node) ->
+    rpc:call(Node, emqx_telemetry, get_cluster_uuid, []).

--- a/apps/emqx_modules/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_api_SUITE.erl
@@ -59,6 +59,7 @@ init_per_testcase(t_status_fail, Config) ->
 init_per_testcase(t_status, Config) ->
     meck:new(emqx_telemetry, [non_strict, passthrough]),
     meck:expect(emqx_telemetry, official_version, 1, true),
+    meck:expect(emqx_telemetry, enable, fun() -> ok end),
     Config;
 init_per_testcase(_TestCase, Config) ->
     Config.


### PR DESCRIPTION
Each node already has its own UUID, and now we want to add a cluster UUID that is the same for all nodes.