### PR TITLE
fix: can't shutdown emqx_config_handler process.

### DIFF
--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -139,6 +139,9 @@ handle_cast(_Msg, State) ->
 handle_info(_Info, State) ->
     {noreply, State}.
 
+%% application shutdown, we can't call application_controller here.
+terminate(shutdown, _) ->
+    ok;
 terminate(_Reason, #{handlers := Handlers}) ->
     save_handlers(Handlers),
     ok.


### PR DESCRIPTION
fix: `./bin/emqx stop`
```erlang
2022-04-14T13:36:17.765414+08:00 [error] Supervisor: {local,emqx_kernel_sup}. Context: shutdown_error. 
Reason: killed. Offender: id=emqx_config_handler,pid=<0.2010.0>.
```