### PR TITLE
chore: Don't display primary example, we should show default if no example found

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -133,7 +133,7 @@ current_rate(Node) when Node == node() ->
     try
         {ok, Rate} = do_call(current_rate),
         {ok, Rate}
-    catch _E:R:_S ->
+    catch _E:R ->
         ?SLOG(warning, #{msg => "Dashboard monitor error", reason => R}),
         %% Rate map 0, ensure api will not crash.
         %% When joining cluster, dashboard monitor restart.

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -572,25 +572,25 @@ hocon_schema_to_spec(Atom, _LocalModule) when is_atom(Atom) ->
 typename_to_spec("user_id_type()", _Mod) ->
     #{type => string, enum => [clientid, username]};
 typename_to_spec("term()", _Mod) ->
-    #{type => string, example => "any"};
+    #{type => string};
 typename_to_spec("boolean()", _Mod) ->
-    #{type => boolean, example => true};
+    #{type => boolean};
 typename_to_spec("binary()", _Mod) ->
-    #{type => string, example => <<"binary-example">>};
+    #{type => string};
 typename_to_spec("float()", _Mod) ->
-    #{type => number, example => 3.14159};
+    #{type => number};
 typename_to_spec("integer()", _Mod) ->
-    #{type => integer, example => 100};
+    #{type => integer};
 typename_to_spec("non_neg_integer()", _Mod) ->
-    #{type => integer, minimum => 0, example => 100};
+    #{type => integer, minimum => 0};
 typename_to_spec("pos_integer()", _Mod) ->
-    #{type => integer, minimum => 1, example => 100};
+    #{type => integer, minimum => 1};
 typename_to_spec("number()", _Mod) ->
-    #{type => number, example => 42};
+    #{type => number};
 typename_to_spec("string()", _Mod) ->
-    #{type => string, example => <<"string-example">>};
+    #{type => string};
 typename_to_spec("atom()", _Mod) ->
-    #{type => string, example => atom};
+    #{type => string};
 typename_to_spec("epoch_second()", _Mod) ->
     #{
         <<"oneOf">> => [
@@ -627,7 +627,7 @@ typename_to_spec("timeout()", _Mod) ->
     #{
         <<"oneOf">> => [
             #{type => string, example => infinity},
-            #{type => integer, example => 100}
+            #{type => integer}
         ],
         example => infinity
     };
@@ -640,7 +640,7 @@ typename_to_spec("map()", _Mod) ->
 typename_to_spec("#{" ++ _, Mod) ->
     typename_to_spec("map()", Mod);
 typename_to_spec("qos()", _Mod) ->
-    #{type => string, enum => [0, 1, 2], example => 0};
+    #{type => string, enum => [0, 1, 2]};
 typename_to_spec("{binary(), binary()}", _Mod) ->
     #{type => object, example => #{}};
 typename_to_spec("comma_separated_list()", _Mod) ->
@@ -648,7 +648,7 @@ typename_to_spec("comma_separated_list()", _Mod) ->
 typename_to_spec("comma_separated_atoms()", _Mod) ->
     #{type => string, example => <<"item1,item2">>};
 typename_to_spec("pool_type()", _Mod) ->
-    #{type => string, enum => [random, hash], example => hash};
+    #{type => string, enum => [random, hash]};
 typename_to_spec("log_level()", _Mod) ->
     #{
         type => string,
@@ -716,7 +716,7 @@ typerefl_array(Spec, _Name, _Mod) ->
 %% integer(1)
 integer(nomatch, Name) ->
     case string:to_integer(Name) of
-        {Int, []} -> #{type => integer, enum => [Int], example => Int, default => Int};
+        {Int, []} -> #{type => integer, enum => [Int], default => Int};
         _ -> nomatch
     end;
 integer(Spec, _Name) ->
@@ -725,7 +725,7 @@ integer(Spec, _Name) ->
 add_integer_prop(Schema, Key, Value) ->
     case string:to_integer(Value) of
         {error, no_integer} -> Schema;
-        {Int, []} when Key =:= minimum -> Schema#{Key => Int, example => Int};
+        {Int, []} when Key =:= minimum -> Schema#{Key => Int};
         {Int, []} -> Schema#{Key => Int}
     end.
 

--- a/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
@@ -62,9 +62,9 @@ t_in_query(_Config) ->
     Expect =
         [#{description => <<"results per page (max 100)">>,
             example => 1, in => query, name => per_page,
-            schema => #{example => 1, maximum => 100, minimum => 1, type => integer}},
+            schema => #{maximum => 100, minimum => 1, type => integer}},
             #{description => <<"QOS">>, in => query, name => qos,
-                schema => #{enum => [0, 1, 2], example => 0, type => string}}],
+                schema => #{enum => [0, 1, 2], type => string}}],
     validate("/test/in/query", Expect),
     ok.
 
@@ -96,12 +96,12 @@ t_public_ref(_Config) ->
     ], Refs),
     ExpectRefs = [
         #{<<"public.limit">> => #{description => <<"Results per page(max 1000)">>,
-            example => 50,in => query,name => limit,
-            schema => #{default => 100,example => 1,maximum => 1000,
+            in => query,name => limit, example => 50,
+            schema => #{default => 100,maximum => 1000,
                 minimum => 1,type => integer}}},
         #{<<"public.page">> => #{description => <<"Page number of the results to fetch.">>,
-            example => 1,in => query,name => page,
-            schema => #{default => 1,example => 100,minimum => 1,type => integer}}}],
+            in => query,name => page,example => 1,
+            schema => #{default => 1,minimum => 1,type => integer}}}],
     ?assertEqual(ExpectRefs, emqx_dashboard_swagger:components(Refs,#{})),
     ok.
 
@@ -114,11 +114,11 @@ t_in_mix(_Config) ->
                 example => <<"12m">>,in => path,name => state,required => true,
                 schema => #{example => <<"1h">>,type => string}},
             #{example => 10,in => query,name => per_page, required => false,
-                schema => #{default => 5,example => 1,maximum => 50,minimum => 1, type => integer}},
-            #{in => query,name => is_admin, schema => #{example => true,type => boolean}},
+                schema => #{default => 5,maximum => 50,minimum => 1, type => integer}},
+            #{in => query,name => is_admin, schema => #{type => boolean}},
             #{in => query,name => timeout,
                 schema => #{<<"oneOf">> => [#{enum => [infinity],type => string},
-                    #{example => 30,maximum => 60,minimum => 30, type => integer}]}}],
+                    #{maximum => 60,minimum => 30, type => integer}]}}],
     ExpectMeta = #{
             tags => [tags, good],
             description => <<"good description">>,
@@ -138,15 +138,15 @@ t_without_in(_Config) ->
 t_require(_Config) ->
     ExpectSpec = [#{
         in => query,name => userid, required => false,
-        schema => #{example => <<"binary-example">>, type => string}}],
+        schema => #{type => string}}],
     validate("/required/false", ExpectSpec),
     ok.
 
 t_nullable(_Config) ->
     NullableFalse = [#{in => query,name => userid, required => true,
-        schema => #{example => <<"binary-example">>, type => string}}],
+        schema => #{type => string}}],
     NullableTrue = [#{in => query,name => userid,
-        schema => #{example => <<"binary-example">>, type => string}, required => false}],
+        schema => #{type => string}, required => false}],
     validate("/nullable/false", NullableFalse),
     validate("/nullable/true", NullableTrue),
     ok.

--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -43,7 +43,7 @@ t_object(_Config) ->
             #{required => [<<"timeout">>, <<"per_page">>],
                 <<"properties">> =>[
                     {<<"per_page">>, #{description => <<"good per page desc">>,
-                        example => 1, maximum => 100, minimum => 1, type => integer}},
+                        maximum => 100, minimum => 1, type => integer}},
                     {<<"timeout">>, #{default => 5, <<"oneOf">> =>
                     [#{example => <<"1h">>, type => string},
                         #{enum => [infinity], type => string}]}},
@@ -64,13 +64,13 @@ t_nest_object(_Config) ->
             #{required => [<<"timeout">>],
                 <<"properties">> =>
                 [{<<"per_page">>, #{description => <<"good per page desc">>,
-                    example => 1, maximum => 100, minimum => 1, type => integer}},
+                    maximum => 100, minimum => 1, type => integer}},
                     {<<"timeout">>, #{default => 5, <<"oneOf">> =>
                     [#{example => <<"1h">>, type => string},
                         #{enum => [infinity], type => string}]}},
                     {<<"nest_object">>,
                         #{<<"properties">> =>
-                        [{<<"good_nest_1">>, #{example => 100, type => integer}},
+                        [{<<"good_nest_1">>, #{type => integer}},
                             {<<"good_nest_2">>, #{<<"$ref">> =>
                             <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>}}],
                             <<"type">> => object}},
@@ -105,7 +105,7 @@ t_remote_ref(_Config) ->
     {_, Components} = validate("/ref/remote", Spec, Refs),
     ExpectComponents = [
         #{<<"emqx_swagger_remote_schema.ref2">> => #{<<"properties">> => [
-            {<<"page">>, #{description => <<"good page">>,example => 1,
+            {<<"page">>, #{description => <<"good page">>,
                 maximum => 100,minimum => 1,type => integer}},
         {<<"another_ref">>, #{<<"$ref">> =>
         <<"#/components/schemas/emqx_swagger_remote_schema.ref3">>}}], <<"type">> => object}},
@@ -136,8 +136,7 @@ t_nest_ref(_Config) ->
             {<<"webhook-host">>, #{default => <<"127.0.0.1:80">>,
                 example => <<"127.0.0.1:80">>,type => string}},
             {<<"log_dir">>, #{example => <<"var/log/emqx">>,type => string}},
-            {<<"tag">>, #{description => <<"tag">>,
-                example => <<"binary-example">>,type => string}}],
+            {<<"tag">>, #{description => <<"tag">>,type => string}}],
             <<"type">> => object}}]),
     {_, Components} = validate("/ref/nest/ref", Spec, Refs),
     ?assertEqual(ExpectComponents, Components),
@@ -181,7 +180,7 @@ t_ref_array_with_key(_Config) ->
                 <<"type">> => object, <<"properties">> =>
                 [
                     {<<"per_page">>, #{description => <<"good per page desc">>,
-                        example => 1, maximum => 100, minimum => 1, type => integer}},
+                        maximum => 100, minimum => 1, type => integer}},
                     {<<"timeout">>, #{default => 5, <<"oneOf">> =>
                     [#{example => <<"1h">>, type => string},
                         #{enum => [infinity], type => string}]}},

--- a/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
@@ -50,7 +50,7 @@ t_object(_config) ->
         #{<<"schema">> => #{required => [<<"timeout">>, <<"per_page">>],
             <<"properties">> => [
                 {<<"per_page">>, #{description => <<"good per page desc">>,
-                    example => 1, maximum => 100, minimum => 1, type => integer}},
+                    maximum => 100, minimum => 1, type => integer}},
                 {<<"timeout">>, #{default => 5, <<"oneOf">> =>
                 [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
                 {<<"inner_ref">>, #{<<"$ref">> =>
@@ -92,12 +92,12 @@ t_nest_object(_Config) ->
     Object =
         #{<<"content">> => #{<<"application/json">> => #{<<"schema">> =>
         #{required => [<<"timeout">>], <<"type">> => object, <<"properties">> => [
-            {<<"per_page">>, #{description => <<"good per page desc">>, example => 1,
+            {<<"per_page">>, #{description => <<"good per page desc">>,
                 maximum => 100, minimum => 1, type => integer}},
             {<<"timeout">>, #{default => 5, <<"oneOf">> =>
             [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
             {<<"nest_object">>, #{<<"type">> => object, <<"properties">> => [
-                {<<"good_nest_1">>, #{example => 100, type => integer}},
+                {<<"good_nest_1">>, #{type => integer}},
                 {<<"good_nest_2">>, #{<<"$ref">> =>
                 <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}
                 }]}},
@@ -185,16 +185,15 @@ t_complicated_type(_Config) ->
     Object = #{<<"content">> => #{<<"application/json">> =>
     #{<<"schema">> => #{<<"properties">> =>
     [
-        {<<"no_neg_integer">>, #{example => 100, minimum => 0, type => integer}},
+        {<<"no_neg_integer">>, #{minimum => 0, type => integer}},
         {<<"url">>, #{example => <<"http://127.0.0.1">>, type => string}},
         {<<"server">>, #{example => <<"127.0.0.1:80">>, type => string}},
         {<<"connect_timeout">>, #{example => infinity, <<"oneOf">> => [
             #{example => infinity, type => string},
-            #{example => 100, type => integer}]}},
-        {<<"pool_type">>, #{enum => [random, hash], example => hash, type => string}},
+            #{type => integer}]}},
+        {<<"pool_type">>, #{enum => [random, hash], type => string}},
         {<<"timeout">>, #{example => infinity,
-            <<"oneOf">> =>
-            [#{example => infinity, type => string}, #{example => 100, type => integer}]}},
+            <<"oneOf">> => [#{example => infinity, type => string}, #{type => integer}]}},
         {<<"bytesize">>, #{example => <<"32MB">>, type => string}},
         {<<"wordsize">>, #{example => <<"1024KB">>, type => string}},
         {<<"maps">>, #{example => #{}, type => object}},
@@ -203,7 +202,7 @@ t_complicated_type(_Config) ->
         {<<"log_level">>,
             #{enum => [debug, info, notice, warning, error, critical, alert, emergency, all],
                 type => string}},
-        {<<"fix_integer">>, #{default => 100, enum => [100], example => 100,type => integer}}
+        {<<"fix_integer">>, #{default => 100, enum => [100],type => integer}}
     ],
         <<"type">> => object}}}},
     {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
@@ -219,17 +218,16 @@ t_ref_array_with_key(_Config) ->
     Object = #{<<"content">> => #{<<"application/json">> => #{<<"schema">> => #{
         required => [<<"timeout">>], <<"type">> => object, <<"properties">> => [
             {<<"per_page">>, #{description => <<"good per page desc">>,
-                example => 1, maximum => 100, minimum => 1, type => integer}},
+                maximum => 100, minimum => 1, type => integer}},
             {<<"timeout">>, #{default => 5, <<"oneOf">> =>
             [#{example => <<"1h">>, type => string}, #{enum => [infinity], type => string}]}},
-            {<<"assert">>, #{description => <<"money">>, example => 3.14159, type => number}},
-            {<<"number_ex">>, #{description => <<"number example">>,
-                example => 42, type => number}},
+            {<<"assert">>, #{description => <<"money">>, type => number}},
+            {<<"number_ex">>, #{description => <<"number example">>, type => number}},
             {<<"percent_ex">>, #{description => <<"percent example">>,
                 example => <<"12%">>, type => number}},
             {<<"duration_ms_ex">>, #{description => <<"duration ms example">>,
                 example => <<"32s">>, type => string}},
-            {<<"atom_ex">>, #{description => <<"atom ex">>, example => atom, type => string}},
+            {<<"atom_ex">>, #{description => <<"atom ex">>, type => string}},
             {<<"array_refs">>, #{items => #{<<"$ref">> =>
             <<"#/components/schemas/emqx_swagger_response_SUITE.good_ref">>}, type => array}}
         ]}
@@ -254,12 +252,12 @@ t_hocon_schema_function(_Config) ->
         #{<<"emqx_swagger_remote_schema.ref1">> => #{<<"type">> => object,
             <<"properties">> => [
                 {<<"protocol">>, #{enum => [http, https], type => string}},
-                {<<"port">>, #{default => 18083, example => 100, type => integer}}]
+                {<<"port">>, #{default => 18083, type => integer}}]
         }},
         #{<<"emqx_swagger_remote_schema.ref2">> => #{<<"type">> => object,
             <<"properties">> => [
                 {<<"page">>, #{description => <<"good page">>,
-                    example => 1, maximum => 100, minimum => 1, type => integer}},
+                    maximum => 100, minimum => 1, type => integer}},
                 {<<"another_ref">>, #{<<"$ref">> =>
                 <<"#/components/schemas/emqx_swagger_remote_schema.ref3">>}}
             ]
@@ -279,9 +277,9 @@ t_hocon_schema_function(_Config) ->
                 #{<<"$ref">> => <<"#/components/schemas/emqx_swagger_remote_schema.ref1">>}]},
                 type => array}},
                 {<<"default_username">>,
-                    #{default => <<"admin">>, example => <<"string-example">>, type => string}},
+                    #{default => <<"admin">>, type => string}},
                 {<<"default_password">>,
-                    #{default => <<"public">>, example => <<"string-example">>, type => string}},
+                    #{default => <<"public">>, type => string}},
                 {<<"sample_interval">>,
                     #{default => <<"10s">>, example => <<"1h">>, type => string}},
                 {<<"token_expired_time">>,


### PR DESCRIPTION
If you don't provide an example for the primary type, use the default value instead of generating a meaningless example yourself.
such as "binary-example",  "string-example", "atom-example".