### PR TITLE
feat(authn): support disable salt

### DIFF
--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -39,7 +39,7 @@
 -type hash_type_simple() :: plain | md5 | sha | sha256 | sha512.
 -type hash_type() :: hash_type_simple() | bcrypt | pbkdf2.
 
--type salt_position() :: prefix | suffix.
+-type salt_position() :: disable | prefix | suffix.
 -type salt() :: binary().
 
 -type pbkdf2_mac_fun() :: md4 | md5 | ripemd160 | sha | sha224 | sha256 | sha384 | sha512.
@@ -91,6 +91,8 @@ hash({bcrypt, Salt}, Password) ->
         {error, Reason} ->
             error(Reason)
     end;
+hash({SimpleHash, _Salt, disable}, Password) when is_binary(Password) ->
+    hash_data(SimpleHash, Password);
 hash({SimpleHash, Salt, prefix}, Password) when is_binary(Password), is_binary(Salt) ->
     hash_data(SimpleHash, <<Salt/binary, Password/binary>>);
 hash({SimpleHash, Salt, suffix}, Password) when is_binary(Password), is_binary(Salt) ->

--- a/apps/emqx/test/emqx_passwd_SUITE.erl
+++ b/apps/emqx/test/emqx_passwd_SUITE.erl
@@ -65,16 +65,28 @@ t_hash(_) ->
     Md5 = emqx_passwd:hash({md5, Salt, prefix}, Password),
     true = emqx_passwd:check_pass({md5, Salt, prefix}, Md5, Password),
     false = emqx_passwd:check_pass({md5, Salt, prefix}, Md5, WrongPassword),
+    ?assertEqual(
+        emqx_passwd:hash_data(md5, Password),
+        emqx_passwd:hash({md5, Salt, disable}, Password)
+    ),
 
     Sha = <<"59b3e8d637cf97edbe2384cf59cb7453dfe30789">>,
     Sha = emqx_passwd:hash({sha, Salt, prefix}, Password),
     true = emqx_passwd:check_pass({sha, Salt, prefix}, Sha, Password),
     false = emqx_passwd:check_pass({sha, Salt, prefix}, Sha, WrongPassword),
+    ?assertEqual(
+        emqx_passwd:hash_data(sha, Password),
+        emqx_passwd:hash({sha, Salt, disable}, Password)
+    ),
 
     Sha256 = <<"7a37b85c8918eac19a9089c0fa5a2ab4dce3f90528dcdeec108b23ddf3607b99">>,
     Sha256 = emqx_passwd:hash({sha256, Salt, suffix}, Password),
     true = emqx_passwd:check_pass({sha256, Salt, suffix}, Sha256, Password),
     false = emqx_passwd:check_pass({sha256, Salt, suffix}, Sha256, WrongPassword),
+    ?assertEqual(
+        emqx_passwd:hash_data(sha256, Password),
+        emqx_passwd:hash({sha256, Salt, disable}, Password)
+    ),
 
     Sha512 = iolist_to_binary(
         [
@@ -85,6 +97,10 @@ t_hash(_) ->
     Sha512 = emqx_passwd:hash({sha512, Salt, suffix}, Password),
     true = emqx_passwd:check_pass({sha512, Salt, suffix}, Sha512, Password),
     false = emqx_passwd:check_pass({sha512, Salt, suffix}, Sha512, WrongPassword),
+    ?assertEqual(
+        emqx_passwd:hash_data(sha512, Password),
+        emqx_passwd:hash({sha512, Salt, disable}, Password)
+    ),
 
     BcryptSalt = <<"$2b$12$wtY3h20mUjjmeaClpqZVve">>,
     Bcrypt = <<"$2b$12$wtY3h20mUjjmeaClpqZVvehyw7F.V78F3rbK2xDkCzRTMi6pmfUB6">>,

--- a/apps/emqx_authn/test/emqx_authn_password_hashing_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_password_hashing_SUITE.erl
@@ -109,12 +109,12 @@ hash_examples() ->
             }
         },
         #{
-            password_hash => <<"9b4d0c43d206d48279e69b9ad7132e22">>,
+            password_hash => <<"1bc29b36f623ba82aaf6724fd3b16718">>,
             salt => <<"salt">>,
             password => <<"md5">>,
             password_hash_algorithm => #{
                 name => md5,
-                salt_position => suffix
+                salt_position => disable
             }
         },
         #{

--- a/apps/emqx_authn/test/emqx_authn_redis_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_redis_SUITE.erl
@@ -328,6 +328,27 @@ user_seeds() ->
         #{
             data => #{
                 password_hash =>
+                    <<"a3c7f6b085c3e5897ffb9b86f18a9d905063f8550a74444b5892e193c1b50428">>,
+                is_superuser => <<"1">>
+            },
+            credentials => #{
+                clientid => <<"sha256_no_salt">>,
+                password => <<"sha256_no_salt">>
+            },
+            key => <<"mqtt_user:sha256_no_salt">>,
+            config_params => #{
+                cmd => <<"HMGET mqtt_user:${clientid} password_hash is_superuser">>,
+                password_hash_algorithm => #{
+                    name => <<"sha256">>,
+                    salt_position => <<"disable">>
+                }
+            },
+            result => {ok, #{is_superuser => true}}
+        },
+
+        #{
+            data => #{
+                password_hash =>
                     <<"$2b$12$wtY3h20mUjjmeaClpqZVveDWGlHzCGsvuThMlneGHA7wVeFYyns2u">>,
                 salt => <<"$2b$12$wtY3h20mUjjmeaClpqZVve">>,
                 is_superuser => <<"0">>


### PR DESCRIPTION
In 4.x, it is optional for Password Hash to contain Salt or not. So, we need to make it compatible in 5.0