### PR TITLE
refactor: change confs for dashboard listeners from array to map

### DIFF
--- a/apps/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/apps/emqx_dashboard/etc/emqx_dashboard.conf
@@ -10,34 +10,29 @@ dashboard {
     sample_interval = 10s
     ## JWT token expiration time.
     token_expired_time = 60m
-    listeners = [
-        {
-            protocol = http
-            num_acceptors = 4
-            max_connections = 512
-            bind = 18083
-            backlog = 512
-            send_timeout = 5s
-            inet6 = false
-            ipv6_v6only = false
-        }
-    #    ,
-    #     {
-    #         protocol = https
-    #         bind = "127.0.0.1:18084"
-    #         num_acceptors = 2
-    #         backlog = 512
-    #         send_timeout = 5s
-    #         inet6 = false
-    #         ipv6_v6only = false
-    #         certfile = "etc/certs/cert.pem"
-    #         keyfile = "etc/certs/key.pem"
-    #         cacertfile = "etc/certs/cacert.pem"
-    #         verify = verify_peer
-    #         versions = ["tlsv1.3","tlsv1.2","tlsv1.1","tlsv1"]
-    #         ciphers = ["TLS_AES_256_GCM_SHA384","TLS_AES_128_GCM_SHA256","TLS_CHACHA20_POLY1305_SHA256","TLS_AES_128_CCM_SHA256","TLS_AES_128_CCM_8_SHA256","ECDHE-ECDSA-AES256-GCM-SHA384","ECDHE-RSA-AES256-GCM-SHA384","ECDHE-ECDSA-AES256-SHA384","ECDHE-RSA-AES256-SHA384","ECDHE-ECDSA-DES-CBC3-SHA","ECDH-ECDSA-AES256-GCM-SHA384","ECDH-RSA-AES256-GCM-SHA384","ECDH-ECDSA-AES256-SHA384","ECDH-RSA-AES256-SHA384","DHE-DSS-AES256-GCM-SHA384","DHE-DSS-AES256-SHA256","AES256-GCM-SHA384","AES256-SHA256","ECDHE-ECDSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-GCM-SHA256","ECDHE-ECDSA-AES128-SHA256","ECDHE-RSA-AES128-SHA256","ECDH-ECDSA-AES128-GCM-SHA256","ECDH-RSA-AES128-GCM-SHA256","ECDH-ECDSA-AES128-SHA256","ECDH-RSA-AES128-SHA256","DHE-DSS-AES128-GCM-SHA256","DHE-DSS-AES128-SHA256","AES128-GCM-SHA256","AES128-SHA256","ECDHE-ECDSA-AES256-SHA","ECDHE-RSA-AES256-SHA","DHE-DSS-AES256-SHA","ECDH-ECDSA-AES256-SHA","ECDH-RSA-AES256-SHA","AES256-SHA","ECDHE-ECDSA-AES128-SHA","ECDHE-RSA-AES128-SHA","DHE-DSS-AES128-SHA","ECDH-ECDSA-AES128-SHA","ECDH-RSA-AES128-SHA","AES128-SHA"]
-    #     }
-    ]
+    listeners.http {
+        num_acceptors = 4
+        max_connections = 512
+        bind = 18083
+        backlog = 512
+        send_timeout = 5s
+        inet6 = false
+        ipv6_v6only = false
+    }
+    #listeners.https {
+    #   bind = "127.0.0.1:18084"
+    #   num_acceptors = 4
+    #   backlog = 512
+    #   send_timeout = 5s
+    #   inet6 = false
+    #   ipv6_v6only = false
+    #   certfile = "etc/certs/cert.pem"
+    #   keyfile = "etc/certs/key.pem"
+    #   cacertfile = "etc/certs/cacert.pem"
+    #   verify = verify_peer
+    #   versions = ["tlsv1.3","tlsv1.2","tlsv1.1","tlsv1"]
+    #   ciphers = ["TLS_AES_256_GCM_SHA384","TLS_AES_128_GCM_SHA256","TLS_CHACHA20_POLY1305_SHA256","TLS_AES_128_CCM_SHA256","TLS_AES_128_CCM_8_SHA256","ECDHE-ECDSA-AES256-GCM-SHA384","ECDHE-RSA-AES256-GCM-SHA384","ECDHE-ECDSA-AES256-SHA384","ECDHE-RSA-AES256-SHA384","ECDHE-ECDSA-DES-CBC3-SHA","ECDH-ECDSA-AES256-GCM-SHA384","ECDH-RSA-AES256-GCM-SHA384","ECDH-ECDSA-AES256-SHA384","ECDH-RSA-AES256-SHA384","DHE-DSS-AES256-GCM-SHA384","DHE-DSS-AES256-SHA256","AES256-GCM-SHA384","AES256-SHA256","ECDHE-ECDSA-AES128-GCM-SHA256","ECDHE-RSA-AES128-GCM-SHA256","ECDHE-ECDSA-AES128-SHA256","ECDHE-RSA-AES128-SHA256","ECDH-ECDSA-AES128-GCM-SHA256","ECDH-RSA-AES128-GCM-SHA256","ECDH-ECDSA-AES128-SHA256","ECDH-RSA-AES128-SHA256","DHE-DSS-AES128-GCM-SHA256","DHE-DSS-AES128-SHA256","AES128-GCM-SHA256","AES128-SHA256","ECDHE-ECDSA-AES256-SHA","ECDHE-RSA-AES256-SHA","DHE-DSS-AES256-SHA","ECDH-ECDSA-AES256-SHA","ECDH-RSA-AES256-SHA","AES256-SHA","ECDHE-ECDSA-AES128-SHA","ECDHE-RSA-AES128-SHA","DHE-DSS-AES128-SHA","ECDH-ECDSA-AES128-SHA","ECDH-RSA-AES128-SHA","AES128-SHA"]
+    #}
 
     ## CORS Support. don't set cors true if you don't know what it means.
     # cors = false

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -155,16 +155,10 @@ apps() ->
     ].
 
 listeners(Listeners) ->
-    [
-        begin
-            Protocol = maps:get(protocol, ListenerOption0, http),
-            {ListenerOption, Bind} = ip_port(ListenerOption0),
-            Name = listener_name(Protocol, ListenerOption),
-            RanchOptions = ranch_opts(maps:without([protocol], ListenerOption)),
-            {Name, Protocol, Bind, RanchOptions}
-        end
-     || ListenerOption0 <- Listeners
-    ].
+    lists:map(fun({Protocol, Conf}) ->
+            {Conf1, Bind} = ip_port(Conf),
+            {listener_name(Protocol, Conf1), Protocol, Bind, ranch_opts(Conf1)}
+        end, maps:to_list(Listeners)).
 
 ip_port(Opts) -> ip_port(maps:take(bind, Opts), Opts).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -147,6 +147,8 @@ fields("https") ->
 
 desc("dashboard") ->
     "Configuration for EMQX dashboard.";
+desc("listeners") ->
+    "Configuration for the dashboard listener.";
 desc("http") ->
     "Configuration for the dashboard listener (plaintext).";
 desc("https") ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -31,12 +31,7 @@ fields("dashboard") ->
     [
         {listeners,
             sc(
-                hoconsc:array(
-                    hoconsc:union([
-                        hoconsc:ref(?MODULE, "http"),
-                        hoconsc:ref(?MODULE, "https")
-                    ])
-                ),
+                ref("listeners"),
                 #{
                     desc =>
                         "HTTP(s) listeners are identified by their protocol type and are\n"
@@ -71,17 +66,27 @@ fields("dashboard") ->
         {cors, fun cors/1},
         {i18n_lang, fun i18n_lang/1}
     ];
-fields("http") ->
+fields("listeners") ->
     [
-        {"protocol",
+        {"http",
             sc(
-                hoconsc:enum([http, https]),
+                ref("http"),
                 #{
-                    desc => ?DESC("protocol"),
-                    required => true,
-                    default => http
+                    desc => "TCP listeners",
+                    required => {false, recursively}
                 }
             )},
+        {"https",
+            sc(
+                ref("https"),
+                #{
+                    desc => "SSL listeners",
+                    required => {false, recursively}
+                }
+            )}
+    ];
+fields("http") ->
+    [
         {"bind", fun bind/1},
         {"num_acceptors",
             sc(
@@ -201,3 +206,5 @@ i18n_lang(desc) -> "Internationalization language support.";
 i18n_lang(_) -> undefined.
 
 sc(Type, Meta) -> hoconsc:mk(Type, Meta).
+
+ref(Field) -> hoconsc:ref(?MODULE, Field).

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -75,7 +75,7 @@ end_per_suite(_Config) ->
     mria:stop().
 
 set_special_configs(emqx_management) ->
-    Listeners = [#{protocol => http, port => 8081}],
+    Listeners = #{http => #{port => 8081}},
     Config = #{listeners => Listeners,
                applications => [#{id => "admin", secret => "public"}]},
     emqx_config:put([emqx_management], Config),

--- a/apps/emqx_dashboard/test/emqx_dashboard_api_test_helpers.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_api_test_helpers.erl
@@ -32,8 +32,11 @@ set_default_config() ->
     set_default_config(<<"admin">>).
 
 set_default_config(DefaultUsername) ->
-    Config = #{listeners => [#{protocol => http,
-                               port => 18083}],
+    Config = #{listeners => #{
+                  http => #{
+                    port => 18083
+                  }
+               },
                default_username => DefaultUsername,
                default_password => <<"public">>,
                i18n_lang => en


### PR DESCRIPTION
Don't use arrays in the config path to make it easier to change
configs via environments varibles.

