### PR TITLE
fix(test): fix flaky test node setup

### DIFF
--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -662,7 +662,12 @@ host() ->
     Host.
 
 ebin_path() ->
-    string:join(["-pa" | lists:filter(fun is_lib/1, code:get_path())], " ").
+    string:join(["-pa" | paths()], " ").
 
-is_lib(Path) ->
-    string:prefix(Path, code:lib_dir()) =:= nomatch.
+paths() ->
+    [
+        Path
+     || Path <- code:get_path(),
+        string:prefix(Path, code:lib_dir()) =:= nomatch,
+        string:str(Path, "_build/default/plugins") =:= 0
+    ].


### PR DESCRIPTION
Due to a conflict in the typerefl version used by emqx and by the emqx_http_lib plugin, we have to avoid loading the version from the plugin when starting the test node.