### PR TITLE
fix(limiter): change 'bucket name' to 'bucket_name'

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -161,7 +161,7 @@ fields(limiter_opts) ->
                         " This value + rate = the maximum limit that can be achieved when limiter burst."
                 }
             )},
-        {bucket, sc(map("bucket name", ref(bucket_opts)), #{desc => "Buckets config"})}
+        {bucket, sc(map("bucket_name", ref(bucket_opts)), #{desc => "Buckets config"})}
     ];
 fields(bucket_opts) ->
     [


### PR DESCRIPTION
the space in name field will make some problems in frontend

