### PR TITLE
feat(telemetry): enable/disable even in non-official versions

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -488,8 +488,9 @@ is_tcp_server_available(Host, Port, Timeout) ->
 start_ekka() ->
     try mnesia_hook:module_info() of
         _ -> ekka:start()
-    catch _:_ ->
-        %% Falling back to using Mnesia DB backend.
-        application:set_env(mria, db_backend, mnesia),
-        ekka:start()
+    catch
+        _:_ ->
+            %% Falling back to using Mnesia DB backend.
+            application:set_env(mria, db_backend, mnesia),
+            ekka:start()
     end.

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -223,7 +223,9 @@ t_callback_crash(_Config) ->
     Opts = #{rawconf_with_defaults => true},
     ok = emqx_config_handler:add_handler(CrashPath, ?MODULE),
     Old = emqx:get_raw_config(CrashPath),
-    ?assertMatch({error, {config_update_crashed, _}}, emqx:update_config(CrashPath, <<"89%">>, Opts)),
+    ?assertMatch(
+        {error, {config_update_crashed, _}}, emqx:update_config(CrashPath, <<"89%">>, Opts)
+    ),
     New = emqx:get_raw_config(CrashPath),
     ?assertEqual(Old, New),
     ok = emqx_config_handler:remove_handler(CrashPath),

--- a/apps/emqx_modules/src/emqx_modules_conf.erl
+++ b/apps/emqx_modules/src/emqx_modules_conf.erl
@@ -84,7 +84,8 @@ remove_topic_metrics(Topic) ->
 
 -spec is_telemetry_enabled() -> boolean().
 is_telemetry_enabled() ->
-    emqx:get_config([telemetry, enable], true).
+    IsOfficial = emqx_telemetry:official_version(emqx_release:version()),
+    emqx:get_config([telemetry, enable], IsOfficial).
 
 -spec set_telemetry_status(boolean()) -> ok | {error, term()}.
 set_telemetry_status(Status) ->

--- a/apps/emqx_modules/src/emqx_telemetry_api.erl
+++ b/apps/emqx_modules/src/emqx_telemetry_api.erl
@@ -215,7 +215,7 @@ status(put, #{body := Body}) ->
             Reason =
                 case Enable of
                     true -> <<"Telemetry status is already enabled">>;
-                    false -> <<"Telemetry status is already disable">>
+                    false -> <<"Telemetry status is already disabled">>
                 end,
             {400, #{code => 'BAD_REQUEST', message => Reason}};
         false ->

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -242,7 +242,18 @@ t_official_version(_) ->
     false = emqx_telemetry:official_version("1.1-alpha.0"),
     true = emqx_telemetry:official_version("1.1-beta.1"),
     true = emqx_telemetry:official_version("1.1-rc.1"),
-    false = emqx_telemetry:official_version("1.1-alpha.a").
+    false = emqx_telemetry:official_version("1.1-alpha.a"),
+    true = emqx_telemetry:official_version("5.0.0"),
+    true = emqx_telemetry:official_version("5.0.0-alpha.1"),
+    true = emqx_telemetry:official_version("5.0.0-beta.4"),
+    true = emqx_telemetry:official_version("5.0-rc.1"),
+    true = emqx_telemetry:official_version("5.0.0-rc.1"),
+    false = emqx_telemetry:official_version("5.0.0-alpha.a"),
+    false = emqx_telemetry:official_version("5.0.0-beta.a"),
+    false = emqx_telemetry:official_version("5.0.0-rc.a"),
+    false = emqx_telemetry:official_version("5.0.0-foo"),
+    false = emqx_telemetry:official_version("5.0.0-rc.1-ccdf7920"),
+    ok.
 
 t_get_telemetry(_Config) ->
     {ok, TelemetryData} = emqx_telemetry:get_telemetry(),

--- a/apps/emqx_modules/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_api_SUITE.erl
@@ -52,19 +52,18 @@ end_per_suite(_Config) ->
     ]),
     ok.
 
-init_per_testcase(t_status_fail, Config) ->
+init_per_testcase(t_status_non_official, Config) ->
     meck:new(emqx_telemetry, [non_strict, passthrough]),
     meck:expect(emqx_telemetry, official_version, 1, false),
     Config;
 init_per_testcase(t_status, Config) ->
     meck:new(emqx_telemetry, [non_strict, passthrough]),
-    meck:expect(emqx_telemetry, official_version, 1, true),
     meck:expect(emqx_telemetry, enable, fun() -> ok end),
     Config;
 init_per_testcase(_TestCase, Config) ->
     Config.
 
-end_per_testcase(t_status_fail, _Config) ->
+end_per_testcase(t_status_non_official, _Config) ->
     meck:unload(emqx_telemetry);
 end_per_testcase(t_status, _Config) ->
     meck:unload(emqx_telemetry);
@@ -138,9 +137,9 @@ t_status(_) ->
         )
     ).
 
-t_status_fail(_) ->
+t_status_non_official(_) ->
     ?assertMatch(
-        {ok, 400, _},
+        {ok, 200, _},
         request(
             put,
             uri(["telemetry", "status"]),


### PR DESCRIPTION
- Makes telemetry enabled by default on official versions.
- Allow enabling/disabling telemetry even on non-official versions.

