### PR TITLE
fix: swagger crash/ copy conf failed from core node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.0-10:1.13.3-24.2.1-1-a
 export EMQX_DEFAULT_RUNNER = alpine:3.15.1
 export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export ELIXIR_VSN ?= $(shell $(CURDIR)/scripts/get-elixir-vsn.sh)
-export EMQX_DASHBOARD_VERSION ?= v0.29.0
+export EMQX_DASHBOARD_VERSION ?= v0.30.0
 export DOCKERFILE := deploy/docker/Dockerfile
 export EMQX_REL_FORM ?= tgz
 ifeq ($(OS),Windows_NT)

--- a/apps/emqx/i18n/emqx_schema_i18n.conf
+++ b/apps/emqx/i18n/emqx_schema_i18n.conf
@@ -618,7 +618,7 @@ mqtt 下所有的配置作为全局的默认值存在，它可以被 <code>zone<
 
     mqtt_max_clientid_len {
         desc {
-            en: """"Maximum allowed length of MQTT clientId."""
+            en: """Maximum allowed length of MQTT clientId."""
             zh: """允许的最大 MQTT Client ID 长度"""
         }
     }
@@ -824,7 +824,7 @@ Only works for the TLS connection."""
 
     broker {
         desc {
-            en: """"Message broker options."""
+            en: """Message broker options."""
             zh: """Broker 相关配置项。"""
         }
     }

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -86,7 +86,7 @@ roots() -> [limiter].
 fields(limiter) ->
     [
         {bytes_in, sc(ref(limiter_opts), #{desc => ?DESC(bytes_in)})},
-        {message_in, sc(ref(limiter_opts), #{description => ?DESC(message_in)})},
+        {message_in, sc(ref(limiter_opts), #{desc => ?DESC(message_in)})},
         {connection, sc(ref(limiter_opts), #{desc => ?DESC(connection)})},
         {message_routing, sc(ref(limiter_opts), #{desc => ?DESC(message_routing)})},
         {batch, sc(ref(limiter_opts), #{desc => ?DESC(batch)})}

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -63,7 +63,12 @@ id_example() -> 'tcp:default'.
 %% @doc List configured listeners.
 -spec list_raw() -> [{ListenerId :: atom(), Type :: binary(), ListenerConf :: map()}].
 list_raw() ->
-    [{listener_id(Type, LName), Type, LConf} || {Type, LName, LConf} <- do_list_raw()].
+    [
+        {listener_id(Type, LName), Type, LConf}
+     || %% FIXME: quic is not supported update vi dashboard yet
+        {Type, LName, LConf} <- do_list_raw(),
+        Type =/= <<"quic">>
+    ].
 
 list() ->
     Listeners = maps:to_list(emqx:get_config([listeners], #{})),

--- a/apps/emqx_authz/i18n/emqx_authz_api_cache_i18n.conf
+++ b/apps/emqx_authz/i18n/emqx_authz_api_cache_i18n.conf
@@ -1,6 +1,8 @@
 emqx_authz_api_cache {
   authorization_cache_delete {
-    en: """Clean all authorization cache in the cluster."""
-    zh: """清除集群中所有鉴权数据缓存"""
+    desc {
+      en: """Clean all authorization cache in the cluster."""
+      zh: """清除集群中所有鉴权数据缓存"""
+    }
   }
 }

--- a/apps/emqx_authz/i18n/emqx_authz_api_settings_i18n.conf
+++ b/apps/emqx_authz/i18n/emqx_authz_api_settings_i18n.conf
@@ -1,11 +1,15 @@
 emqx_authz_api_settings {
   authorization_settings_get {
-    en: """Get authorization settings"""
-    zh: """获取鉴权配置"""
+    desc {
+      en: """Get authorization settings"""
+      zh: """获取鉴权配置"""
+    }
   }
 
   authorization_settings_put {
-    en: """Update authorization settings"""
-    zh: """更新鉴权配置"""
+    desc {
+      en: """Update authorization settings"""
+      zh: """更新鉴权配置"""
+    }
   }
 }

--- a/apps/emqx_authz/i18n/emqx_authz_schema_i18n.conf
+++ b/apps/emqx_authz/i18n/emqx_authz_schema_i18n.conf
@@ -20,18 +20,35 @@ NOTE:
 The source elements are identified by their 'type'.
 It is NOT allowed to configure two or more sources of the same type.
 """
-      zh: """"""
+      zh: """
+鉴权数据源.<br>
+鉴权(ACL)数据源的列表.
+它被设计为一个数组,而不是一个散列映射,
+所以可以作为链式访问控制.<br>
+
+当授权一个 'publish' 或 'subscribe' 行为时,
+该配置列表中的所有数据源将按顺序进行检查。
+如果在某个客户端未找到时(使用 ClientID 或 Username),
+将会移动到下一个数据源. 直至得到 'allow' 或 'deny' 的结果.<br>
+
+如果在任何数据源中都未找到对应的客户端信息,
+配置的默认行为 ('authorization.no_match') 将生效.<br>
+
+注意:
+数据源使用 'type' 进行标识.
+使用同一类型的数据源多于一次不被允许.
+"""
     }
     label {
       en: """sources"""
-      zh: """"""
+      zh: """数据源"""
     }
   }
 
   authorization {
     desc {
       en: """Configuration related to the client authorization."""
-      zh: """"""
+      zh: """客户端授权相关配置"""
     }
     label {
       en: """authorization"""

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -39,7 +39,7 @@ init_conf() ->
     emqx_app:set_init_config_load_done().
 
 copy_override_conf_from_core_node() ->
-    case nodes() of
+    case mria_mnesia:running_nodes() -- [node()] of
         [] -> %% The first core nodes is self.
             ?SLOG(debug, #{msg => "skip_copy_overide_conf_from_core_node"}),
             {ok, -1};

--- a/apps/emqx_dashboard/i18n/emqx_dashboard_schema.conf
+++ b/apps/emqx_dashboard/i18n/emqx_dashboard_schema.conf
@@ -17,7 +17,7 @@ but use the same port."""
   }
   sample_interval {
     desc {
-      en: """How often to update metrics displayed in the dashboard.<br/>"
+      en: """How often to update metrics displayed in the dashboard.<br/>
 Note: `sample_interval` should be a divisor of 60."""
       zh: """更新仪表板中显示的指标的时间间隔。"""
     }
@@ -154,7 +154,7 @@ Note: `sample_interval` should be a divisor of 60."""
   }
   default_password {
     desc {
-      en: """The initial default password for dashboard 'admin' user.<br>"
+      en: """The initial default password for dashboard 'admin' user.<br>
 For safety, it should be changed as soon as possible."""
       zh: """默认的仪表板用户密码<br>
 为了安全，应该尽快修改密码。"""

--- a/apps/emqx_gateway/i18n/emqx_coap_api_i18n.conf
+++ b/apps/emqx_gateway/i18n/emqx_coap_api_i18n.conf
@@ -16,7 +16,7 @@ emqx_coap_api {
 
     method {
         desc {
-            en: """"Request method type"""
+            en: """Request method type"""
             zh: """请求 Method 类型"""
         }
     }
@@ -30,7 +30,7 @@ emqx_coap_api {
 
     content_type {
         desc {
-            en: """"Payload type" """
+            en: """Payload type"""
             zh: """Payload 类型"""
         }
     }

--- a/apps/emqx_gateway/i18n/emqx_gateway_schema_i18n.conf
+++ b/apps/emqx_gateway/i18n/emqx_gateway_schema_i18n.conf
@@ -220,7 +220,7 @@ For example, after receiving an update message from a client, any messages withi
 
     lwm2m_update_msg_publish_condition {
         desc {
-            en: """"Policy for publishing UPDATE event message.
+            en: """Policy for publishing UPDATE event message.
   - always: send update events as long as the UPDATE request is received.
   - contains_object_list: send update events only if the UPDATE request carries any Object List
 """


### PR DESCRIPTION
fix:
```
[error] failed: [], line: 61, mfa: emqx_conf_app:copy_override_conf_from_core_node/0, msg: 
copy_overide_conf_from_core_node_failed, nodes: ['emqx@node1.emqx.io'], not_ready: [{error,#{msg => 
"init_conf_load_not_done",node => 'emqx@node1.emqx.io'}}]

[node2.emqx.io](http://node2.emqx.io/) | 2022-03-16T02:11:56.285025+00:00 [error] crasher: initial call: 
application_master:init/4, pid: <0.2025.0>, registered_name: [], exit: {{bad_return,{{emqx_conf_app,start,[normal,[]]},
{'EXIT',{{badmatch,{error,"core node not ready"}},[{emqx_conf_app,init_conf,0,[{file,"emqx_conf_app.erl"},{line,36}]},
{emqx_conf_app,start,2,[{file,"emqx_conf_app.erl"},{line,28}]},{application_master,start_it_old,4,
[{file,"application_master.erl"},{line,293}]}]}}}},[{application_master,init,4,[{file,"application_master.erl"},{line,142}]},
{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.2024.0>], message_queue_len: 1, messages:
 [{'EXIT',<0.2027.0>,normal}], links: [<0.2024.0>,<0.1646.0>], dictionary: [],

```