### PR TITLE
fix(node_dump): define `RUNNER_ROOT_DIR` before sourcing vars

### DIFF
--- a/bin/node_dump
+++ b/bin/node_dump
@@ -2,13 +2,13 @@
 set -eu
 
 # shellcheck disable=SC1090,SC1091
-ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
-echo "Running node dump in ${ROOT_DIR}"
+RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
+echo "Running node dump in ${RUNNER_ROOT_DIR}"
 
 # shellcheck disable=SC1090,SC1091
-. "$ROOT_DIR"/releases/emqx_vars
+. "$RUNNER_ROOT_DIR"/releases/emqx_vars
 
-cd "${ROOT_DIR}"
+cd "${RUNNER_ROOT_DIR}"
 
 DUMP="$RUNNER_LOG_DIR/node_dump_$(date +"%Y%m%d_%H%M%S").tar.gz"
 CONF_DUMP="$RUNNER_LOG_DIR/conf.dump"


### PR DESCRIPTION
`emqx_vars` requires `RUNNER_ROOT_DIR` to be defined before being
sourced.

