### PR TITLE
fix(dashboard): rename fields  for monitor_current APIs

### DIFF
--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -51,9 +51,9 @@
 
 -define(DELTA_SAMPLER_LIST,
     [ received
-    , received_bytes
+    %, received_bytes
     , sent
-    , sent_bytes
+    %, sent_bytes
     , dropped
     ]).
 
@@ -66,9 +66,10 @@
 -define(SAMPLER_LIST, ?GAUGE_SAMPLER_LIST ++ ?DELTA_SAMPLER_LIST).
 
 -define(DELTA_SAMPLER_RATE_MAP, #{
-    received        => received_rate,
-    received_bytes  => received_bytes_rate,
-    sent            => sent_rate,
-    sent_bytes      => sent_bytes_rate,
-    dropped         => dropped_rate
+    received        => received_msg_rate,
+    %% In 5.0.0, temporarily comment it to suppress bytes rate
+    %received_bytes  => received_bytes_rate,
+    %sent_bytes      => sent_bytes_rate,
+    sent            => sent_msg_rate,
+    dropped         => dropped_msg_rate
     }).

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -110,8 +110,9 @@ fields(sampler) ->
     [{time_stamp, hoconsc:mk(non_neg_integer(), #{desc => <<"Timestamp">>})} | Samplers];
 
 fields(sampler_current) ->
+    Names = maps:values(?DELTA_SAMPLER_RATE_MAP) ++ ?GAUGE_SAMPLER_LIST,
     [{SamplerName, hoconsc:mk(integer(), #{desc => swagger_desc(SamplerName)})}
-    || SamplerName <- maps:values(?DELTA_SAMPLER_RATE_MAP) ++ ?GAUGE_SAMPLER_LIST].
+    || SamplerName <- Names].
 
 %% -------------------------------------------------------------------------------------------------
 %% API
@@ -155,11 +156,11 @@ swagger_desc(connections) ->
     <<"Connections at the time of sampling."
     " Can only represent the approximate state">>;
 
-swagger_desc(received_rate)       -> swagger_desc_format("Dropped messages ", per);
-swagger_desc(received_bytes_rate) -> swagger_desc_format("Received bytes ", per);
-swagger_desc(sent_rate)           -> swagger_desc_format("Sent messages ", per);
-swagger_desc(sent_bytes_rate)     -> swagger_desc_format("Sent bytes ", per);
-swagger_desc(dropped_rate)        -> swagger_desc_format("Dropped messages ", per).
+swagger_desc(received_msg_rate)   -> swagger_desc_format("Dropped messages ", per);
+%swagger_desc(received_bytes_rate) -> swagger_desc_format("Received bytes ", per);
+swagger_desc(sent_msg_rate)       -> swagger_desc_format("Sent messages ", per);
+%swagger_desc(sent_bytes_rate)     -> swagger_desc_format("Sent bytes ", per);
+swagger_desc(dropped_msg_rate)    -> swagger_desc_format("Dropped messages ", per).
 
 swagger_desc_format(Format) ->
     swagger_desc_format(Format, last).


### PR DESCRIPTION
Rename the following fields:
- received_rate -> received_msg_rate
- sent_rate -> sent_msg_rate
- dropped_rate -> dropped_msg_rate

Remove:
- received_bytes_rate
- sent_bytes_rate


