### PR TITLE
fix(telemetry): add verify_none ssl option

### DIFF
--- a/apps/emqx_modules/src/emqx_telemetry.erl
+++ b/apps/emqx_modules/src/emqx_telemetry.erl
@@ -355,7 +355,7 @@ report_telemetry(State0 = #state{url = URL}) ->
     State.
 
 httpc_request(Method, URL, Headers, Body) ->
-    HTTPOptions = [{timeout, 10_000}],
+    HTTPOptions = [{timeout, 10_000}, {ssl, [{verify, verify_none}]}],
     Options = [],
     httpc:request(Method, {URL, Headers, "application/json", Body}, HTTPOptions, Options).
 


### PR DESCRIPTION
To stop the "Authenticity is not established by certificate path
validation", Reason: "Option {verify, verify_peer} and
cacertfile/cacerts is missing" warning message

