### PR TITLE
fix(emqx_mgmt_auth): randomise all bytes in app secret

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -17,9 +17,10 @@ File format:
 * Made possible for EMQX to boot from a Linux directory which has white spaces in its path.
 * Add support for JWT authorization [#7596]
   Now MQTT clients may be authorized with respect to a specific claim containing publish/subscribe topic whitelists.
-  
+* Better randomisation of app screts (changed from timestamp seeded sha hash (uuid) to crypto:strong_rand_bytes)
+
 ### Bug fixes
-* List subscription topic (/api/v4/subscriptions), the result do not match with multiple conditions.  
+* List subscription topic (/api/v4/subscriptions), the result do not match with multiple conditions.
 
 
 ## v4.3.14

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -138,8 +138,11 @@ generate_appsecret_if_need(InSecrt) when is_binary(InSecrt), byte_size(InSecrt) 
 generate_appsecret_if_need(_) ->
     AppConf = application:get_env(?APP, application, []),
     case proplists:get_value(default_secret,  AppConf) of
-       undefined -> emqx_guid:to_base62(emqx_guid:gen());
-       Secret when is_binary(Secret) -> Secret
+       undefined ->
+            Random = crypto:strong_rand_bytes(32),
+            emqx_base62:encode(Random);
+       Secret when is_binary(Secret) ->
+            Secret
     end.
 
 -spec(get_appsecret(appid()) -> {appsecret() | undefined}).


### PR DESCRIPTION
prior to this change, app secrets are uuids which is not
completely random.

