### PR TITLE
fix(emqx_mgmt_auth): better randomisation of app secrets

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -182,4 +182,5 @@ trans(Fun) ->
     end.
 
 generate_api_secret() ->
-    emqx_guid:to_base62(emqx_guid:gen()).
+    Random = crypto:strong_rand_bytes(32),
+    emqx_base62:encode(Random).


### PR DESCRIPTION
change from timestamp seeded hash (uuid) to crypto:strong_rand_bytes

