### PR TITLE
fix: avoid crashing telemetry if bridge app is not ready

### DIFF
--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -120,21 +120,45 @@ t_listener_authenticator_import_users(_) ->
     test_authenticator_import_users(["listeners", ?TCP_DEFAULT]).
 
 t_aggregate_metrics(_) ->
-    Metrics = #{ 'emqx@node1.emqx.io' => #{metrics =>
-                                               #{failed => 0,matched => 1,rate => 0.0,
-                                                 rate_last5m => 0.0,rate_max => 0.1,
-                                                 success => 1}
-                                          },
-                 'emqx@node2.emqx.io' => #{metrics =>
-                                               #{failed => 0,matched => 1,rate => 0.0,
-                                                 rate_last5m => 0.0,rate_max => 0.1,
-                                                 success => 1}
-                                          }
-               },
+    Metrics = #{
+        'emqx@node1.emqx.io' => #{
+            metrics =>
+                #{
+                    failed => 0,
+                    matched => 1,
+                    rate => 0.0,
+                    rate_last5m => 0.0,
+                    rate_max => 0.1,
+                    success => 1
+                }
+        },
+        'emqx@node2.emqx.io' => #{
+            metrics =>
+                #{
+                    failed => 0,
+                    matched => 1,
+                    rate => 0.0,
+                    rate_last5m => 0.0,
+                    rate_max => 0.1,
+                    success => 1
+                }
+        }
+    },
     Res = emqx_authn_api:aggregate_metrics(maps:values(Metrics)),
-    ?assertEqual(#{metrics =>
-                       #{failed => 0,matched => 2,rate => 0.0,rate_last5m => 0.0,
-                         rate_max => 0.2,success => 2}}, Res).
+    ?assertEqual(
+        #{
+            metrics =>
+                #{
+                    failed => 0,
+                    matched => 2,
+                    rate => 0.0,
+                    rate_last5m => 0.0,
+                    rate_max => 0.2,
+                    success => 2
+                }
+        },
+        Res
+    ).
 
 test_authenticators(PathPrefix) ->
     ValidConfig = emqx_authn_test_lib:http_example(),

--- a/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
@@ -449,21 +449,45 @@ t_move_source(_) ->
     ok.
 
 t_aggregate_metrics(_) ->
-    Metrics = #{ 'emqx@node1.emqx.io' => #{metrics =>
-                                               #{failed => 0,matched => 1,rate => 0.0,
-                                                 rate_last5m => 0.0,rate_max => 0.1,
-                                                 success => 1}
-                                          },
-                 'emqx@node2.emqx.io' => #{metrics =>
-                                               #{failed => 0,matched => 1,rate => 0.0,
-                                                 rate_last5m => 0.0,rate_max => 0.1,
-                                                 success => 1}
-                                          }
-               },
+    Metrics = #{
+        'emqx@node1.emqx.io' => #{
+            metrics =>
+                #{
+                    failed => 0,
+                    matched => 1,
+                    rate => 0.0,
+                    rate_last5m => 0.0,
+                    rate_max => 0.1,
+                    success => 1
+                }
+        },
+        'emqx@node2.emqx.io' => #{
+            metrics =>
+                #{
+                    failed => 0,
+                    matched => 1,
+                    rate => 0.0,
+                    rate_last5m => 0.0,
+                    rate_max => 0.1,
+                    success => 1
+                }
+        }
+    },
     Res = emqx_authn_api:aggregate_metrics(maps:values(Metrics)),
-    ?assertEqual(#{metrics =>
-                       #{failed => 0,matched => 2,rate => 0.0,rate_last5m => 0.0,
-                         rate_max => 0.2,success => 2}}, Res).
+    ?assertEqual(
+        #{
+            metrics =>
+                #{
+                    failed => 0,
+                    matched => 2,
+                    rate => 0.0,
+                    rate_last5m => 0.0,
+                    rate_max => 0.2,
+                    success => 2
+                }
+        },
+        Res
+    ).
 
 get_sources(Result) ->
     maps:get(<<"sources">>, jsx:decode(Result), []).

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -367,7 +367,15 @@ t_send_after_enable(_) ->
     ok = snabbkaffe:start_trace(),
     try
         ok = emqx_telemetry:enable(),
-        ?assertMatch({ok, _}, ?block_until(#{?snk_kind := telemetry_data_reported}, 2000, 100)),
+        Timeout = 12_000,
+        ?assertMatch(
+            {ok, _},
+            ?wait_async_action(
+                ok = emqx_telemetry:enable(),
+                #{?snk_kind := telemetry_data_reported},
+                Timeout
+            )
+        ),
         receive
             {request, post, _URL, _Headers, Body} ->
                 {ok, Decoded} = emqx_json:safe_decode(Body, [return_maps]),


### PR DESCRIPTION
- Avoid crashing telemetry app if it tries to report data when the bridge app is not ready yet.
- Avoid hanging `emqx_module` app initialization by deferring the first report after a few seconds, instead of being synchronous.