### PR TITLE
fix(alarm): use gen_event:noifty/2 to generate alarm event

### DIFF
--- a/apps/emqx/src/emqx_alarm_handler.erl
+++ b/apps/emqx/src/emqx_alarm_handler.erl
@@ -61,7 +61,10 @@ handle_event({set_alarm, {system_memory_high_watermark, []}}, State) ->
     Message = to_bin("System memory usage is higher than ~p%", [HighWatermark]),
     emqx_alarm:activate(
         high_system_memory_usage,
-        #{high_watermark => HighWatermark},
+        #{
+            high_watermark => HighWatermark,
+            percent => emqx_os_mon:current_sysmem_percent()
+        },
         Message
     ),
     {ok, State};

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -45,9 +45,9 @@ start(_Type, _Args) ->
     ok = maybe_start_quicer(),
     ok = emqx_bpapi:start(),
     wait_boot_shards(),
+    ok = emqx_alarm_handler:load(),
     {ok, Sup} = emqx_sup:start_link(),
     ok = maybe_start_listeners(),
-    ok = emqx_alarm_handler:load(),
     emqx_config:add_handlers(),
     register(emqx, self()),
     {ok, Sup}.


### PR DESCRIPTION
Uniformly report high_system_memory_usage event by gen_event:notify/2 to
ensure generate a same alarm structure.


In the previous implement, the `ensure_system_memory_alarm/1` will generate a un-format alarm:
<img width="652" alt="image" src="https://user-images.githubusercontent.com/13825269/165229562-a1d13e71-e928-4668-b96e-8029354fab58.png">

