### PR TITLE
fix ssl options

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1824,13 +1824,7 @@ common_ssl_opts_schema(Defaults) ->
 %% @doc Make schema for SSL listener options.
 %% When it's for ranch listener, an extra field `handshake_timeout' is added.
 -spec server_ssl_opts_schema(map(), boolean()) -> hocon_schema:field_schema().
-server_ssl_opts_schema(Defaults1, IsRanchListener) ->
-    Defaults0 = #{
-        cacertfile => emqx:cert_file("cacert.pem"),
-        certfile => emqx:cert_file("cert.pem"),
-        keyfile => emqx:cert_file("key.pem")
-    },
-    Defaults = maps:merge(Defaults0, Defaults1),
+server_ssl_opts_schema(Defaults, IsRanchListener) ->
     D = fun(Field) -> maps:get(to_atom(Field), Defaults, undefined) end,
     Df = fun(Field, Default) -> maps:get(to_atom(Field), Defaults, Default) end,
     common_ssl_opts_schema(Defaults) ++
@@ -1883,15 +1877,7 @@ server_ssl_opts_schema(Defaults1, IsRanchListener) ->
 
 %% @doc Make schema for SSL client.
 -spec client_ssl_opts_schema(map()) -> hocon_schema:field_schema().
-client_ssl_opts_schema(Defaults1) ->
-    %% assert
-    true = lists:all(fun(K) -> is_atom(K) end, maps:keys(Defaults1)),
-    Defaults0 = #{
-        cacertfile => emqx:cert_file("cacert.pem"),
-        certfile => emqx:cert_file("client-cert.pem"),
-        keyfile => emqx:cert_file("client-key.pem")
-    },
-    Defaults = maps:merge(Defaults0, Defaults1),
+client_ssl_opts_schema(Defaults) ->
     common_ssl_opts_schema(Defaults) ++
         [
             {"server_name_indication",

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -476,7 +476,7 @@ to_client_opts(Opts) ->
     CertFile = ensure_str(Get(certfile)),
     CAFile = ensure_str(Get(cacertfile)),
     Verify = GetD(verify, verify_none),
-    SNI = ensure_str(Get(server_name_indication)),
+    SNI = ensure_sni(Get(server_name_indication)),
     Versions = integral_versions(Get(versions)),
     Ciphers = integral_ciphers(Versions, Get(ciphers)),
     filter([
@@ -504,6 +504,11 @@ fuzzy_map_get(Key, Options, Default) ->
         error ->
             Default
     end.
+
+ensure_sni(disable) -> disable;
+ensure_sni(undefined) -> undefined;
+ensure_sni(L) when is_list(L) -> L;
+ensure_sni(B) when is_binary(B) -> unicode:characters_to_list(B, utf8).
 
 ensure_str(undefined) -> undefined;
 ensure_str(L) when is_list(L) -> L;

--- a/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
@@ -22,14 +22,14 @@
 -compile(export_all).
 
 -define(CLUSTER_RPC_SHARD, emqx_cluster_rpc_shard).
--define(CONF_DEFAULT,
-    <<"\n"
+-define(CONF_DEFAULT, <<
+    "\n"
     "prometheus {\n"
     "  push_gateway_server = \"http://127.0.0.1:9091\"\n"
     "  interval = \"1s\"\n"
     "  enable = true\n"
-    "}\n">>
-).
+    "}\n"
+>>).
 
 %%--------------------------------------------------------------------
 %% Setups


### PR DESCRIPTION
For ssl options, the `sni` should be an atom `'disable'` or string for hostname.
See [type-sni](https://www.erlang.org/doc/man/ssl.html#type-sni)

And code style fmt fixed here: https://github.com/emqx/emqx/pull/7772