### PR TITLE
fix: add 2 seconds delay penalty for bad logins

### DIFF
--- a/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -183,12 +183,20 @@ check(Username, Password) ->
     case lookup_user(Username) of
         [#mqtt_admin{password = PwdHash}] ->
             case is_valid_pwd(PwdHash, Password) of
-                true  -> ok;
-                false -> {error, <<"Username/Password error">>}
+                true  ->
+                    ok;
+                false ->
+                    ok = bad_login_penalty(),
+                    {error, <<"Username/Password error">>}
             end;
         [] ->
+            ok = bad_login_penalty(),
             {error, <<"Username/Password error">>}
     end.
+
+bad_login_penalty() ->
+    timer:sleep(2000),
+    ok.
 
 is_valid_pwd(<<Salt:4/binary, Hash/binary>>, Password) ->
     Hash =:= md5_hash(Salt, Password).


### PR DESCRIPTION
Clarification:
This is a least-effort attempt to avoid brutal forcing without external dependencies.
elegant solutions are

* 2FA (or multi FA) -- this is something already solved by SSO solutions
* Prove of work from clients -- not sure how many people are using it


by default, there are 512 concurrent connections limit to management APIs,
so a malicious client may technically eat up all the connections by starting a lot of http clients concurrently.
however, at the current stage, there is no DDoS protection implemented in EMQX itself anyway,
so we'll consider that a different issue and maybe follow up in a different thread.