### PR TITLE
fix: websocket's max_connection not work

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1515,7 +1515,7 @@ base_listener() ->
             )},
         {"acceptors",
             sc(
-                integer(),
+                pos_integer(),
                 #{
                     default => 16,
                     desc => ?DESC(base_listener_acceptors)
@@ -1523,7 +1523,7 @@ base_listener() ->
             )},
         {"max_connections",
             sc(
-                hoconsc:union([infinity, integer()]),
+                hoconsc:union([infinity, pos_integer()]),
                 #{
                     default => infinity,
                     desc => ?DESC(base_listener_max_connections)


### PR DESCRIPTION
https://github.com/rabbitmq/rabbitmq-web-mqtt/issues/28#issuecomment-380833296

> In Cowboy it's only used to limit the number of HTTP connections. As soon as an HTTP connection becomes a Websocket connection, the connection is no longer counted and so you can have 1024 as a limit and still have 10k Websocket connections.

so we need to check max_connection by ourselves. otherwise the ws/wss's max_connection is not work as we expect.