### PR TITLE
fix(authn-jwt): avoid to save empty claim name

### DIFF
--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -441,6 +441,11 @@ check_claim_name(iat) ->
     false;
 check_claim_name(nbf) ->
     false;
+check_claim_name(Name) when
+    Name == <<>>;
+    Name == ""
+->
+    false;
 check_claim_name(_) ->
     true.
 

--- a/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
@@ -342,6 +342,40 @@ t_jwt_authenticator_verify_claims(_) ->
     },
     ?assertMatch({ok, #{is_superuser := false}}, emqx_authn_jwt:authenticate(Credential3, State1)).
 
+t_jwt_not_allow_empty_claim_name(_) ->
+    Request = #{
+        <<"use_jwks">> => false,
+        <<"algorithm">> => <<"hmac-based">>,
+        <<"secret">> => <<"secret">>,
+        <<"mechanism">> => <<"jwt">>
+    },
+    ?assertMatch(
+        {200, _},
+        emqx_authn_api:authenticators(
+            post, #{body => Request}
+        )
+    ),
+
+    ?assertMatch(
+        {400, _},
+        emqx_authn_api:authenticator(
+            put, #{
+                bindings => #{id => <<"jwt">>},
+                body => Request#{<<"verify_claims">> => #{<<>> => <<>>}}
+            }
+        )
+    ),
+
+    ?assertMatch(
+        {200, _},
+        emqx_authn_api:authenticator(
+            put, #{
+                bindings => #{id => <<"jwt">>},
+                body => Request#{<<"verify_claims">> => #{<<"key">> => <<>>}}
+            }
+        )
+    ).
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
An empty claim_name has not a real meaning and will result in a
syntax error cluster_override.conf. i.e:
```
authentication {
  mechanism = "jwt"
  verify_claims { = "22"}
  ...
}
```
