### PR TITLE
fix: remove '$FROM_ENV_VAR' from raw conf

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -261,10 +261,10 @@ get_default_value([RootName | _] = KeyPath) ->
     end.
 
 -spec get_raw(emqx_map_lib:config_key_path()) -> term().
-get_raw(KeyPath) -> do_get(?RAW_CONF, KeyPath).
+get_raw(KeyPath) -> emqx_hocon:remove_env_meta(do_get(?RAW_CONF, KeyPath)).
 
 -spec get_raw(emqx_map_lib:config_key_path(), term()) -> term().
-get_raw(KeyPath, Default) -> do_get(?RAW_CONF, KeyPath, Default).
+get_raw(KeyPath, Default) -> emqx_hocon:remove_env_meta(do_get(?RAW_CONF, KeyPath, Default)).
 
 -spec put_raw(map()) -> ok.
 put_raw(Config) ->


### PR DESCRIPTION
Remove '$FROM_ENV_VAR' from get_raw config, otherwise it will crash json encode.


EMQX_NODE__NAME='emqx2@127.0.0.1' \
EMQX_STATSD__SERVER='127.0.0.1:8124' \
EMQX_LISTENERS__TCP__DEFAULT__BIND='0.0.0.0:1882' \
EMQX_LISTENERS__SSL__DEFAULT__BIND='0.0.0.0:8882' \
EMQX_LISTENERS__QUIC__DEFAULT__BIND='0.0.0.0:14566' \
EMQX_LISTENERS__WS__DEFAULT__BIND='0.0.0.0:8082' \
EMQX_LISTENERS__WSS__DEFAULT__BIND='0.0.0.0:8085' \
EMQX_DASHBOARD__LISTENERS__HTTP__BIND='0.0.0.0:18082' \
./bin/emqx console
```
5.0.0-rc.1-e8cead48(emqx2@127.0.0.1)4> emqx_config:get_raw([<<"dashboard">>], #{}).
#{<<"default_password">> => <<"public">>,
  <<"default_username">> => <<"admin">>,
  <<"listeners">> =>
      #{<<"http">> =>
            #{<<"backlog">> => 512,
              <<"bind">> =>
                  {'$FROM_ENV_VAR',"EMQX_DASHBOARD__LISTENERS__HTTP__BIND",
                                   "0.0.0.0:18082"},
              <<"inet6">> => false,<<"ipv6_v6only">> => false,
              <<"max_connections">> => 512,<<"num_acceptors">> => 4,
              <<"send_timeout">> => <<"5s">>}},
  <<"sample_interval">> => <<"10s">>,
  <<"token_expired_time">> => <<"60m">>}
```