### PR TITLE
ci: get OS from builder image name

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -324,10 +324,7 @@ jobs:
             --profile "${PROFILE}" \
             --pkgtype "${PKGTYPE}" \
             --arch "${ARCH}" \
-            --otp "${OTP}" \
             --elixir "${IsElixir}" \
-            --elixir-vsn "${ELIXIR}" \
-            --system "${SYSTEM}" \
             --builder "ghcr.io/emqx/emqx-builder/5.0-10:${ELIXIR}-${OTP}-${SYSTEM}"
         done
     - uses: actions/upload-artifact@v1

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -118,7 +118,7 @@ else
 fi
 
 HOST_SYSTEM="$(./scripts/get-distro.sh)"
-BUILDER_SYSTEM="$(docker run --rm -v "$(pwd)":/emqx "$BUILDER" /emqx/scripts/get-distro.sh)"
+BUILDER_SYSTEM="$(echo "$BUILDER" | awk -F'-' '{print $NF}')"
 
 CMD_RUN="make ${MAKE_TARGET} && ./scripts/pkg-tests.sh ${MAKE_TARGET}"
 


### PR DESCRIPTION
cross build is running in container
can not run docker in dokcer

