### PR TITLE
chore: port ensure-rebar3.sh from 4.x

### DIFF
--- a/.github/workflows/elixir_apps_check.yaml
+++ b/.github/workflows/elixir_apps_check.yaml
@@ -36,7 +36,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: ensure rebar
-        run: ./scripts/ensure-rebar3.sh 3.16.1-emqx-1
+        run: ./scripts/ensure-rebar3.sh
       - name: check applications
         run: ./scripts/check-elixir-applications.exs
       - name: check applications started with emqx_machine

--- a/.github/workflows/elixir_deps_check.yaml
+++ b/.github/workflows/elixir_deps_check.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2.4.0
       - name: ensure rebar
-        run: ./scripts/ensure-rebar3.sh 3.16.1-emqx-1
+        run: ./scripts/ensure-rebar3.sh
       - name: setup mix
         run: |
           mix local.hex --force

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 $(shell $(CURDIR)/scripts/git-hooks-init.sh)
-REBAR_VERSION = 3.16.1-emqx-1
 REBAR = $(CURDIR)/rebar3
 BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts
@@ -36,7 +35,7 @@ all: $(REBAR) $(PROFILES)
 
 .PHONY: ensure-rebar3
 ensure-rebar3:
-	@$(SCRIPTS)/ensure-rebar3.sh $(REBAR_VERSION)
+	@$(SCRIPTS)/ensure-rebar3.sh
 
 .PHONY: ensure-hex
 ensure-hex:

--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 ## rebar3 tag 3.18.0-emqx-1 is compiled using otp24.1.5.
 ## we have to use an otp24-compiled rebar3 because the defination of record #application{}
 ## in systools.hrl is changed in otp24.
+OTP_VSN="${OTP_VSN:-$(./scripts/get-otp-vsn.sh)}"
 case ${OTP_VSN} in
     23*)
         VERSION="3.16.1-emqx-1"

--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -2,7 +2,21 @@
 
 set -euo pipefail
 
-VERSION="$1"
+## rebar3 tag 3.18.0-emqx-1 is compiled using otp24.1.5.
+## we have to use an otp24-compiled rebar3 because the defination of record #application{}
+## in systools.hrl is changed in otp24.
+case ${OTP_VSN} in
+    23*)
+        VERSION="3.16.1-emqx-1"
+        ;;
+    24*)
+        VERSION="3.18.0-emqx-1"
+        ;;
+    *)
+        echo "Unsupporetd Erlang/OTP version $OTP_VSN"
+        exit 1
+        ;;
+esac
 
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
@@ -10,7 +24,8 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 DOWNLOAD_URL='https://github.com/emqx/rebar3/releases/download'
 
 download() {
-    curl --silent --show-error -f -L "${DOWNLOAD_URL}/${VERSION}/rebar3" -o ./rebar3
+    echo "downloading rebar3 ${VERSION}"
+    curl -f -L "${DOWNLOAD_URL}/${VERSION}/rebar3" -o ./rebar3
 }
 
 # get the version number from the second line of the escript


### PR DESCRIPTION
```
===> Analyzing applications...
===> Compiling emqx
===> Running cross reference analysis...
escript: exception error: no match of right hand side value 
                 [{attribute,0,compile,{nowarn_unused_record,[[chain]]}},
                  {attribute,
                   {1,1},
                   file,
                   {"/__w/emqx/emqx/apps/emqx/src/emqx_authentication.erl",1}},
                  {attribute,{21,2},module,emqx_authentication},
                  {attribute,{23,2},behaviour,gen_server},
                  {attribute,
                   {1,1},
                   file,
                   {"/__w/emqx/emqx/apps/emqx/_build/default/lib/emqx/include/emqx.hrl",
                    1}},
                 {...}|...]
  in function  rebar_prv_xref:find_function_source_in_abstract_code/3 (rebar_prv_xref.erl, line 306)
  in call from rebar_prv_xref:format_mfa_source/1 (rebar_prv_xref.erl, line 265)
  in call from rebar_prv_xref:'-display_xref_result_fun/1-fun-0-'/2 (rebar_prv_xref.erl, line 228)
  in call from lists:map/2 (lists.erl, line 1243)
  in call from rebar_prv_xref:display_results/2 (rebar_prv_xref.erl, line 213)
  in call from rebar_prv_xref:format_error/1 (rebar_prv_xref.erl, line 60)
  in call from rebar3:handle_error/2 (rebar3.erl, line 347)
Error: Process completed with exit code 127.
```

The link to the failed CI: https://github.com/emqx/emqx/runs/6207537622?check_suite_focus=true