### PR TITLE
fix(update_appup): clean untracked nested git directories

### DIFF
--- a/scripts/update-appup.sh
+++ b/scripts/update-appup.sh
@@ -101,7 +101,7 @@ else
         git fetch "$REMOTE"
     fi
     git reset --hard
-    git clean -fdx
+    git clean -ffdx
     git checkout "${PREV_TAG}"
     make "$PROFILE"
     popd


### PR DESCRIPTION
Since the script copies the current workdir into the temporary
directory for the previous build, when we latter try to clean the
directory, `git clean -fdx` refuses to clean the folders of some
dependencies:

```
+ git clean -fdx
Skipping repository _build/default/lib/lc
```

So, if the branch contains a dependency with changed version, it'll
not be picked up by the script, as both versions will be identical and
hence have no `.appup` difference.

