### PR TITLE
fix: don't drop input ssl options even if invalid

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_ssl.erl
+++ b/apps/emqx_connector/src/emqx_connector_ssl.erl
@@ -22,7 +22,7 @@
 ]).
 
 convert_certs(RltvDir, NewConfig) ->
-    NewSSL = drop_invalid_certs(map_get_oneof([<<"ssl">>, ssl], NewConfig, undefined)),
+    NewSSL = map_get_oneof([<<"ssl">>, ssl], NewConfig, undefined),
     case emqx_tls_lib:ensure_ssl_files(RltvDir, NewSSL) of
         {ok, NewSSL1} ->
             {ok, new_ssl_config(NewConfig, NewSSL1)};
@@ -31,15 +31,12 @@ convert_certs(RltvDir, NewConfig) ->
     end.
 
 clear_certs(RltvDir, Config) ->
-    OldSSL = drop_invalid_certs(map_get_oneof([<<"ssl">>, ssl], Config, undefined)),
+    OldSSL = map_get_oneof([<<"ssl">>, ssl], Config, undefined),
     ok = emqx_tls_lib:delete_ssl_files(RltvDir, undefined, OldSSL).
 
 new_ssl_config(Config, undefined) -> Config;
 new_ssl_config(Config, #{<<"enable">> := _} = SSL) -> Config#{<<"ssl">> => SSL};
 new_ssl_config(Config, #{enable := _} = SSL) -> Config#{ssl => SSL}.
-
-drop_invalid_certs(undefined) -> undefined;
-drop_invalid_certs(SSL) -> emqx_tls_lib:drop_invalid_certs(SSL).
 
 map_get_oneof([], _Map, Default) ->
     Default;


### PR DESCRIPTION
Before this fix, testing the connector using a already created SSL cert file (file path), the file is deleted after testing!