### PR TITLE
fix: can't get emqx's priv_dir when whitespace in install path

### DIFF
--- a/apps/emqx/etc/emqx_cloud/vm.args
+++ b/apps/emqx/etc/emqx_cloud/vm.args
@@ -120,7 +120,7 @@
 -shutdown_time 30000
 
 ## patches dir
--pa {{ platform_data_dir }}/patches
+-pa "{{ platform_data_dir }}/patches"
 
 ## Mnesia thresholds
 -mnesia dump_log_write_threshold 5000

--- a/apps/emqx/etc/emqx_edge/vm.args
+++ b/apps/emqx/etc/emqx_edge/vm.args
@@ -118,7 +118,7 @@
 -shutdown_time 10000
 
 ## patches dir
--pa {{ platform_data_dir }}/patches
+-pa "{{ platform_data_dir }}/patches"
 
 ## Mnesia thresholds
 -mnesia dump_log_write_threshold 5000

--- a/bin/emqx
+++ b/bin/emqx
@@ -289,7 +289,7 @@ compatiblity_info() {
     -eval "$COMPATIBILITY_CHECK"
 }
 
-# Collect Eralng/OTP runtime sanity and compatibility in one go
+# Collect Erlang/OTP runtime sanity and compatibility in one go
 if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
     # Read BUILD_INFO early as the next commands may mess up the shell
     BUILD_INFO="$(cat "${REL_DIR}/BUILD_INFO")"
@@ -514,7 +514,7 @@ generate_config() {
     TMP_ARG_FILE="$CONFIGS_DIR/vm.args.tmp"
     cp "$EMQX_ETC_DIR/vm.args" "$TMP_ARG_FILE"
     echo "" >> "$TMP_ARG_FILE"
-    echo "-pa ${REL_DIR}/consolidated" >> "$TMP_ARG_FILE"
+    echo "-pa \"${REL_DIR}/consolidated\"" >> "$TMP_ARG_FILE"
     ## read lines from generated vm.<time>.args file
     ## drop comment lines, and empty lines using sed
     ## pipe the lines to a while loop


### PR DESCRIPTION
if the install dir is "emqx test", crash on startup:
_crasher: initial call: application_master:init/4, pid: <0.1981.0>, registered_name: [], exit: {{bad_return,{{emqx_app,start,[normal,[]]},{'EXIT',{{badmatch,{error,enoent}},[{emqx_bpapi,announce,1,[{file,"emqx_bpapi.erl"},{line,79}]},{emqx_app,start,2,[{file,"emqx_app.erl"},{line,46}]},{application_master,start_it_old,4,[{file,"application_master.erl"},{line,293}]}]}}}},[{application_master,init,4,[{file,"application_master.erl"},{line,142}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.1980.0>], message_queue_len: 1, messages: [{'EXIT',<0.1982.0>,normal}], links: [<0.1980.0>,<0.1648.0>], dictionary: [], trap_exit: true, status: running, heap_size: 46422, stack_size: 29, reductions: 219; neighbours:_

the release paths is `-pa /Users/zhongwen/github/emqx/emqx-v5/_build/emqx/rel/emqx`
we need correct it to `-pa /Users/zhongwen/github/emqx/emqx-v5/_build/emqx/rel/emqx test/releases/5.0.0-rc.2-8ff552c9/consolidated`