### PR TITLE
feat: start dashboard listener asynchronously

### DIFF
--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -100,7 +100,7 @@ all_ciphers(['tlsv1.3']) ->
 all_ciphers(Versions) ->
     %% assert non-empty
     List = lists:append([ssl:cipher_suites(all, V, openssl) || V <- Versions]),
-    dedup(List).
+    [_ | _] = dedup(List).
 
 %% @doc All Pre-selected TLS ciphers.
 %% ssl:cipher_suites(all, V, openssl) is too slow. so we cache default ciphers.

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -27,9 +27,6 @@
     all_ciphers/0
 ]).
 
--compile(export_all).
--compile(nowarn_export_all).
-
 %% SSL files
 -export([
     ensure_ssl_files/2,
@@ -219,19 +216,18 @@ default_versions(_) ->
 %% Deduplicate a list without re-ordering the elements.
 dedup([]) ->
     [];
-dedup(List) ->
-    lists:reverse(
-        lists:foldl(
-            fun(L, Acc) ->
-                case lists:member(L, Acc) of
-                    false -> [L | Acc];
-                    true -> Acc
-                end
-            end,
-            [],
-            List
-        )
-    ).
+dedup(List0) ->
+    List = lists:foldl(
+        fun(L, Acc) ->
+            case lists:member(L, Acc) of
+                false -> [L | Acc];
+                true -> Acc
+            end
+        end,
+        [],
+        List0
+    ),
+    lists:reverse(List).
 
 %% parse comma separated tls version strings
 parse_versions(Versions) ->

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -193,8 +193,11 @@ start_app(App, Schema, ConfigFile, SpecAppConfig) ->
     copy_certs(App, RenderedConfigFile),
     SpecAppConfig(App),
     case application:ensure_all_started(App) of
-        {ok, _} -> ok;
-        {error, Reason} -> error({failed_to_start_app, App, Reason})
+        {ok, _} ->
+            ok = ensure_dashboard_listeners_started(App),
+            ok;
+        {error, Reason} ->
+            error({failed_to_start_app, App, Reason})
     end.
 
 render_config_file(ConfigFile, Vars0) ->
@@ -494,3 +497,9 @@ start_ekka() ->
             application:set_env(mria, db_backend, mnesia),
             ekka:start()
     end.
+
+ensure_dashboard_listeners_started(emqx_dashboard) ->
+    ok = gen_server:call(emqx_dashboard_listener, sync),
+    ok;
+ensure_dashboard_listeners_started(_App) ->
+    ok.

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -443,6 +443,7 @@ fields("node") ->
                 #{
                     mapping => "vm_args.-env ERL_CRASH_DUMP",
                     desc => ?DESC(node_crash_dump_file),
+                    default => "log/erl_crash.dump",
                     'readOnly' => true
                 }
             )},

--- a/apps/emqx_connector/src/emqx_connector_ssl.erl
+++ b/apps/emqx_connector/src/emqx_connector_ssl.erl
@@ -30,6 +30,8 @@ convert_certs(RltvDir, NewConfig) ->
             {error, {bad_ssl_config, Reason}}
     end.
 
+clear_certs(_RltvDir, undefined) ->
+    ok;
 clear_certs(RltvDir, Config) ->
     OldSSL = map_get_oneof([<<"ssl">>, ssl], Config, undefined),
     ok = emqx_tls_lib:delete_ssl_files(RltvDir, undefined, OldSSL).

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -22,7 +22,8 @@
     start_listeners/0,
     start_listeners/1,
     stop_listeners/1,
-    stop_listeners/0
+    stop_listeners/0,
+    list_listeners/0
 ]).
 
 -export([
@@ -54,7 +55,6 @@ stop_listeners() ->
 
 start_listeners(Listeners) ->
     {ok, _} = application:ensure_all_started(minirest),
-    init_i18n(),
     Authorization = {?MODULE, authorize},
     GlobalSpec = #{
         openapi => "3.0.0",
@@ -101,7 +101,6 @@ start_listeners(Listeners) ->
             [],
             listeners(Listeners)
         ),
-    clear_i18n(),
     case Res of
         [] -> ok;
         _ -> {error, Res}
@@ -163,6 +162,9 @@ listeners(Listeners) ->
         end,
         maps:to_list(Listeners)
     ).
+
+list_listeners() ->
+    listeners(listeners()).
 
 ip_port(Opts) -> ip_port(maps:take(bind, Opts), Opts).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -81,7 +81,7 @@ start_listeners(Listeners) ->
         security => [#{'basicAuth' => []}, #{'bearerAuth' => []}],
         swagger_global_spec => GlobalSpec,
         dispatch => Dispatch,
-        middlewares => [cowboy_router, ?EMQX_MIDDLE, cowboy_handler]
+        middlewares => [?EMQX_MIDDLE, cowboy_router, cowboy_handler]
     },
     Res =
         lists:foldl(

--- a/apps/emqx_dashboard/src/emqx_dashboard_app.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_app.erl
@@ -26,19 +26,18 @@
 -include("emqx_dashboard.hrl").
 
 start(_StartType, _StartArgs) ->
-    {ok, Sup} = emqx_dashboard_sup:start_link(),
     ok = mria_rlog:wait_for_shards([?DASHBOARD_SHARD], infinity),
+    {ok, Sup} = emqx_dashboard_sup:start_link(),
     case emqx_dashboard:start_listeners() of
         ok ->
             emqx_dashboard_cli:load(),
-            {ok, _Result} = emqx_dashboard_admin:add_default_user(),
-            ok = emqx_dashboard_config:add_handler(),
+            {ok, _} = emqx_dashboard_admin:add_default_user(),
             {ok, Sup};
         {error, Reason} ->
             {error, Reason}
     end.
 
 stop(_State) ->
-    ok = emqx_dashboard_config:remove_handler(),
+    ok = emqx_dashboard:stop_listeners(),
     emqx_dashboard_cli:unload(),
-    emqx_dashboard:stop_listeners().
+    ok.

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
@@ -75,7 +75,7 @@ regenerate_minirest_dispatch() ->
         emqx_dashboard:init_i18n(),
         lists:foreach(
             fun(Listener) ->
-                minirest:regenerate_dispatch(element(1, Listener))
+                minirest:update_dispatch(element(1, Listener))
             end,
             emqx_dashboard:list_listeners()
         )

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
@@ -21,6 +21,7 @@
 %% API
 -export([add_handler/0, remove_handler/0]).
 -export([pre_config_update/3, post_config_update/5]).
+-export([regenerate_minirest_dispatch/0]).
 
 -behaviour(gen_server).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
@@ -25,7 +25,7 @@
 
 -behaviour(gen_server).
 
--export([start_link/0, is_ready/0]).
+-export([start_link/0, is_ready/1]).
 
 -export([
     init/1,
@@ -37,8 +37,8 @@
     code_change/3
 ]).
 
-is_ready() ->
-    ready =:= gen_server:call(?MODULE, get_state, 10000).
+is_ready(Timeout) ->
+    ready =:= gen_server:call(?MODULE, get_state, Timeout).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
@@ -80,7 +80,9 @@ regenerate_minirest_dispatch() ->
             emqx_dashboard:list_listeners()
         )
     catch
-        _:_ -> emqx_dashboard:clear_i18n()
+        _:_ -> ok
+    after
+        emqx_dashboard:clear_i18n()
     end.
 
 add_handler() ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_sup.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_sup.erl
@@ -29,8 +29,8 @@ start_link() ->
 
 init([]) ->
     {ok,
-        {{one_for_one, 10, 100}, [
+        {{one_for_one, 5, 100}, [
+            ?CHILD(emqx_dashboard_listener),
             ?CHILD(emqx_dashboard_token),
-            ?CHILD(emqx_dashboard_monitor),
-            ?CHILD(emqx_dashboard_config)
+            ?CHILD(emqx_dashboard_monitor)
         ]}}.

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -35,26 +35,7 @@ end_per_suite(_) ->
     ok.
 
 set_special_configs(emqx_dashboard) ->
-    Config = #{
-        default_username => <<"admin">>,
-        default_password => <<"public">>,
-        listeners =>
-            #{
-                http =>
-                    #{
-                        backlog => 512,
-                        bind => 18083,
-                        enable => true,
-                        inet6 => false,
-                        ipv6_v6only => false,
-                        max_connections => 512,
-                        num_acceptors => 4,
-                        send_timeout => 5000
-                    }
-            }
-    },
-    emqx_config:put([dashboard], Config),
-    ok;
+    emqx_dashboard_api_test_helpers:set_default_config();
 set_special_configs(_App) ->
     ok.
 

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule EMQXUmbrella.MixProject do
       {:mria, github: "emqx/mria", tag: "0.2.4", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.12.5", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.3.0", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.1", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule EMQXUmbrella.MixProject do
       {:mria, github: "emqx/mria", tag: "0.2.4", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.12.5", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.3.1", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.2", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule EMQXUmbrella.MixProject do
       {:mria, github: "emqx/mria", tag: "0.2.4", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.12.5", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.2.13", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.0", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.4"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.5"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.13"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.0"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.4"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.5"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.0"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.1"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.4"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.5"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.1"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.2"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}


### PR DESCRIPTION
The dashboard start_listeners is slowing down due to too much API router(dispatch) generation.
we need to update ranch's dispatch async.

https://github.com/emqx/minirest/pull/90
https://github.com/emqx/minirest/pull/91