### PR TITLE
fix(jwt auth): improve JWT handling

### DIFF
--- a/apps/emqx_authz/src/emqx_authz_jwt.erl
+++ b/apps/emqx_authz/src/emqx_authz_jwt.erl
@@ -69,26 +69,53 @@ verify(JWT) ->
     Now = erlang:system_time(second),
     VerifyClaims =
         [
-            {<<"exp">>, fun(ExpireTime) ->
-                is_integer(ExpireTime) andalso Now < ExpireTime
-            end},
-            {<<"iat">>, fun(IssueAt) ->
-                is_integer(IssueAt) andalso IssueAt =< Now
-            end},
-            {<<"nbf">>, fun(NotBefore) ->
-                is_integer(NotBefore) andalso NotBefore =< Now
-            end}
+            {<<"exp">>, required,
+                with_int_value(fun(ExpireTime) ->
+                    Now < ExpireTime
+                end)},
+            {<<"iat">>, optional,
+                with_int_value(fun(IssueAt) ->
+                    IssueAt =< Now
+                end)},
+            {<<"nbf">>, optional,
+                with_int_value(fun(NotBefore) ->
+                    NotBefore =< Now
+                end)}
         ],
     IsValid = lists:all(
-        fun({ClaimName, Validator}) ->
-            (not maps:is_key(ClaimName, JWT)) orelse
-                Validator(maps:get(ClaimName, JWT))
+        fun({ClaimName, Required, Validator}) ->
+            verify_claim(ClaimName, Required, JWT, Validator)
         end,
         VerifyClaims
     ),
     case IsValid of
         true -> {ok, JWT};
         false -> error
+    end.
+
+with_int_value(Fun) ->
+    fun(Value) ->
+        case Value of
+            Int when is_integer(Int) -> Fun(Int);
+            Bin when is_binary(Bin) ->
+                case string:to_integer(Bin) of
+                    {Int, <<>>} -> Fun(Int);
+                    _ -> false
+                end;
+            Str when is_list(Str) ->
+                case string:to_integer(Str) of
+                    {Int, ""} -> Fun(Int);
+                    _ -> false
+                end
+        end
+    end.
+
+verify_claim(ClaimName, Required, JWT, Validator) ->
+    case JWT of
+        #{ClaimName := Value} ->
+            Validator(Value);
+        #{} ->
+            Required =:= optional
     end.
 
 do_authorize(Client, PubSub, Topic, AclRules) ->

--- a/apps/emqx_authz/test/emqx_authz_jwt_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_jwt_SUITE.erl
@@ -241,6 +241,33 @@ t_check_no_acl_claim(_Config) ->
 
     ok = emqtt:disconnect(C).
 
+t_check_str_exp(_Config) ->
+    Payload = #{
+        <<"username">> => <<"username">>,
+        <<"exp">> => integer_to_binary(erlang:system_time(second) + 10),
+        <<"acl">> => #{<<"sub">> => [<<"a/b">>]}
+    },
+
+    JWT = generate_jws(Payload),
+
+    {ok, C} = emqtt:start_link(
+        [
+            {clean_start, true},
+            {proto_ver, v5},
+            {clientid, <<"clientid">>},
+            {username, <<"username">>},
+            {password, JWT}
+        ]
+    ),
+    {ok, _} = emqtt:connect(C),
+
+    ?assertMatch(
+        {ok, #{}, [0]},
+        emqtt:subscribe(C, <<"a/b">>, 0)
+    ),
+
+    ok = emqtt:disconnect(C).
+
 t_check_expire(_Config) ->
     Payload = #{
         <<"username">> => <<"username">>,


### PR DESCRIPTION
* Handle string values for `iat`, `nbf` and `exp` claims.
* Require `exp` claim for authn & authz