### PR TITLE
fix: use storageClassName instead of annotation

### DIFF
--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 4.4.0
+version: 4.4.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -23,7 +23,7 @@ spec:
           app.kubernetes.io/managed-by: {{ .Release.Service }}
       spec:
         {{- if .Values.persistence.storageClassName }}
-        storageClassName: {{ .Values.persistence.storageClassName | quote }} 
+        storageClassName: {{ .Values.persistence.storageClassName | quote }}
         {{- end }}
         accessModes:
           - {{ .Values.persistence.accessMode | quote }}

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -21,13 +21,10 @@ spec:
           helm.sh/chart: {{ include "emqx.chart" . }}
           app.kubernetes.io/instance: {{ .Release.Name }}
           app.kubernetes.io/managed-by: {{ .Release.Service }}
-        annotations:
-        {{- if .Values.persistence.storageClass }}
-          volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
-        {{- else }}
-          volume.alpha.kubernetes.io/storage-class: default
-        {{- end }}
       spec:
+        {{- if .Values.persistence.storageClassName }}
+        storageClassName: {{ .Values.persistence.storageClassName | quote }} 
+        {{- end }}
         accessModes:
           - {{ .Values.persistence.accessMode | quote }}
         resources:

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -32,9 +32,7 @@ podManagementPolicy: Parallel
 persistence:
   enabled: false
   size: 20Mi
-  ## If defined, volume.beta.kubernetes.io/storage-class: <storageClass>
-  ## Default: volume.alpha.kubernetes.io/storage-class: default
-  # storageClass: "-"
+  storageClassName: ""
   accessMode: ReadWriteOnce
   ## Existing PersistentVolumeClaims
   ## The value is evaluated as a template


### PR DESCRIPTION
[persistent-volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)

In the past, the annotation volume.beta.kubernetes.io/storage-class was used instead of the storageClassName attribute. This annotation is still working; however, it will become fully deprecated in a future Kubernetes release. 
