### PR TITLE
fix(listener): when update listener conf, should override limiter con…

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -320,7 +320,8 @@ crud_listeners_by_id(put, #{bindings := #{id := Id}, body := Body0}) ->
                 undefined ->
                     {404, #{code => 'BAD_LISTENER_ID', message => ?LISTENER_NOT_FOUND}};
                 PrevConf ->
-                    MergeConf = emqx_map_lib:deep_merge(PrevConf, Conf),
+                    MergeConfT = emqx_map_lib:deep_merge(PrevConf, Conf),
+                    MergeConf = emqx_listeners:ensure_override_limiter_conf(MergeConfT, Conf),
                     case update(Path, MergeConf) of
                         {ok, #{raw_config := _RawConf}} ->
                             crud_listeners_by_id(get, #{bindings => #{id => Id}});


### PR DESCRIPTION
if we always merge config, we will never delete some limiter settings
e.g. 
old config: #{limiter => #{connection => tcp}}
new config: #{limiter => #{}}
after merged: #{limiter => #{connection => tcp}}
but what we want to do is to delete the 'connection' limiter setting not keep it