### PR TITLE
docs: hide shard transport config from docs

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -567,6 +567,7 @@ fields("db") ->
                 hoconsc:enum([gen_rpc, distr]),
                 #{
                     mapping => "mria.shard_transport",
+                    hidden => true,
                     default => gen_rpc,
                     desc => ?DESC(db_default_shard_transport)
                 }
@@ -576,6 +577,7 @@ fields("db") ->
                 map(shard, hoconsc:enum([gen_rpc, distr])),
                 #{
                     desc => ?DESC(db_shard_transports),
+                    hidden => true,
                     mapping => "emqx_machine.custom_shard_transports",
                     default => #{}
                 }


### PR DESCRIPTION
Those configurations are too "magical" for the average user, and
keeping them in the docs might confuse users.

