### PR TITLE
fix: update jq to v0.2.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -611,7 +611,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.2.0", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.2.2", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -41,7 +41,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.9"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.2.0"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.2.2"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),


### PR DESCRIPTION
This PR makes jq compile error reporting better and avoids a crash when the program contains an include expression.

