### PR TITLE
fix: remove enable from server_ssl_opts_schema

### DIFF
--- a/apps/emqx/i18n/emqx_schema_i18n.conf
+++ b/apps/emqx/i18n/emqx_schema_i18n.conf
@@ -1316,7 +1316,7 @@ Specifies the size of the compression context for the client.
     }
 }
 
-common_ssl_opts_schema_enable {
+client_ssl_opts_schema_enable {
     desc {
         en: """
 Enable TLS.

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -493,10 +493,7 @@ limiter(Opts) ->
 ssl_opts(Opts) ->
     maps:to_list(
         emqx_tls_lib:drop_tls13_for_old_otp(
-            maps:without(
-                [enable],
-                maps:get(ssl, Opts, #{})
-            )
+            maps:get(ssl, Opts, #{})
         )
     ).
 

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1690,14 +1690,6 @@ common_ssl_opts_schema(Defaults) ->
     D = fun(Field) -> maps:get(to_atom(Field), Defaults, undefined) end,
     Df = fun(Field, Default) -> maps:get(to_atom(Field), Defaults, Default) end,
     [
-        {"enable",
-            sc(
-                boolean(),
-                #{
-                    default => Df("enable", false),
-                    desc => ?DESC(common_ssl_opts_schema_enable)
-                }
-            )},
         {"cacertfile",
             sc(
                 binary(),
@@ -1846,6 +1838,14 @@ server_ssl_opts_schema(Defaults, IsRanchListener) ->
 client_ssl_opts_schema(Defaults) ->
     common_ssl_opts_schema(Defaults) ++
         [
+            {"enable",
+                sc(
+                    boolean(),
+                    #{
+                        default => false,
+                        desc => ?DESC(client_ssl_opts_schema_enable)
+                    }
+                )},
             {"server_name_indication",
                 sc(
                     hoconsc:union([disable, string()]),

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -87,7 +87,7 @@ fields("https") ->
         bind(18804)
         | common_listener_fields() ++
             exclude_fields(
-                ["enable", "fail_if_no_peer_cert"],
+                ["fail_if_no_peer_cert"],
                 emqx_schema:server_ssl_opts_schema(#{}, true)
             )
     ].


### PR DESCRIPTION
if we choose ssl listener(emqx as server), we always enable ssl options.
if we use tls option to connect others(emqx as client), then we should have this enable in client_ssl_opts_schema.