### PR TITLE
fix: show ref's desc in hot-config-schema.json

### DIFF
--- a/apps/emqx_conf/i18n/emqx_conf_schema.conf
+++ b/apps/emqx_conf/i18n/emqx_conf_schema.conf
@@ -944,8 +944,8 @@ until the RPC connection is considered lost."""
       zh: """需要持久化到文件的日志处理进程列表。默认只有 default 一个处理进程。"""
     }
     label {
-      en: "File Handlers"
-      zh: "File Handlers"
+      en: "File Handler"
+      zh: "File Handler"
     }
   }
 
@@ -1389,8 +1389,8 @@ Each sink is represented by a _log handler_, which can be configured independent
       zh: """日志处理进程将日志事件打印到 EMQX 控制台。"""
     }
     label {
-      en: "Console Log Handler"
-      zh: "控制台日志处理进程"
+      en: "Console Handler"
+      zh: "Console Handler"
     }
   }
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -431,22 +431,20 @@ desc_struct(Hocon) ->
     case hocon_schema:field_schema(Hocon, desc) of
         undefined ->
             case hocon_schema:field_schema(Hocon, description) of
-                undefined ->
-                    case Hocon of
-                        ?R_REF(Mod, Name) ->
-                            case erlang:function_exported(Mod, desc, 1) of
-                                true -> Mod:desc(Name);
-                                false -> undefined
-                            end;
-                        _ ->
-                            undefined
-                    end;
-                Struct1 ->
-                    Struct1
+                undefined -> get_ref_desc(Hocon);
+                Struct1 -> Struct1
             end;
         Struct ->
             Struct
     end.
+
+get_ref_desc(?R_REF(Mod, Name)) ->
+    case erlang:function_exported(Mod, desc, 1) of
+        true -> Mod:desc(Name);
+        false -> undefined
+    end;
+get_ref_desc(_) ->
+    undefined.
 
 request_body(#{content := _} = Content, _Module, _Options) ->
     {Content, []};

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -429,8 +429,23 @@ trans_label(Spec, Hocon, Default) ->
 
 desc_struct(Hocon) ->
     case hocon_schema:field_schema(Hocon, desc) of
-        undefined -> hocon_schema:field_schema(Hocon, description);
-        Struct -> Struct
+        undefined ->
+            case hocon_schema:field_schema(Hocon, description) of
+                undefined ->
+                    case Hocon of
+                        ?R_REF(Mod, Name) ->
+                            case erlang:function_exported(Mod, desc, 1) of
+                                true -> Mod:desc(Name);
+                                false -> undefined
+                            end;
+                        _ ->
+                            undefined
+                    end;
+                Struct1 ->
+                    Struct1
+            end;
+        Struct ->
+            Struct
     end.
 
 request_body(#{content := _} = Content, _Module, _Options) ->

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule EMQXUmbrella.MixProject do
       {:mria, github: "emqx/mria", tag: "0.2.5", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.12.6", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.3.2", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.3", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,7 @@
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.5"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.6"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.2"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.3"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}


### PR DESCRIPTION
1. Display ref's desc in schema.json.
2. Bump minirest(1.3.3) to force generate dispatch rule.