### PR TITLE
fix: emqx can't start with systemctl

### DIFF
--- a/deploy/packages/rpm/Makefile
+++ b/deploy/packages/rpm/Makefile
@@ -16,12 +16,13 @@ TAR_PKG     := $(EMQX_REL)/$(TAR_PKG_DIR)/emqx-$(PKG_VSN).tar.gz
 SOURCE_PKG  := emqx-$(RPM_VSN)-$(RPM_REL).$(shell uname -m)
 TARGET_PKG  := $(EMQX_NAME)-$(shell $(EMQX_REL)/pkg-vsn.sh $(EMQX_NAME) --long)
 
-SYSTEMD := $(shell if command -v systemctl >/dev/null 2>&1; then echo yes; fi)
 # Not $(PWD) as it does not work for make -C
 CURDIR := $(shell pwd)
 
-POST_ADDITION := $(if $(SYSTEMD),%systemd_post %{_name}.service,echo post)
-PREUN_ADDITION := $(if $(SYSTEMD),%systemd_preun %{_name}.service,echo preun)
+POST_ADDITION := %systemd_post %{_name}.service
+PREUN_ADDITION := %systemd_preun %{_name}.service
+SERVICE_SRC := $(CURDIR)/emqx.service
+SERVICE_DST := %{_unitdir}/emqx.service
 
 .PHONY: all
 all: | $(BUILT)
@@ -36,6 +37,8 @@ all: | $(BUILT)
 		--define "_post_addition $(POST_ADDITION)" \
 		--define "_preun_addition $(PREUN_ADDITION)" \
 		--define "_sharedstatedir /var/lib" \
+		--define "_service_src $(SERVICE_SRC)" \
+		--define "_service_dst $(SERVICE_DST)" \
 		emqx.spec
 	mkdir -p $(EMQX_REL)/_packages/$(EMQX_NAME)
 	cp $(TOPDIR)/RPMS/$(shell uname -m)/$(SOURCE_PKG).rpm $(EMQX_REL)/_packages/$(EMQX_NAME)/$(TARGET_PKG).rpm

--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -47,6 +47,7 @@ cp -R %{_reldir}/releases %{buildroot}%{_lib_home}/
 cp -R %{_reldir}/bin %{buildroot}%{_lib_home}/
 cp -R %{_reldir}/etc/* %{buildroot}%{_conf_dir}/
 cp -R %{_reldir}/data/* %{buildroot}%{_var_home}/
+install -m644 %{_service_src} %{buildroot}%{_service_dst}
 
 %pre
 if [ $1 = 1 ]; then
@@ -84,6 +85,7 @@ exit 0
 
 %files
 %defattr(-,root,root)
+%{_service_dst}
 %attr(-,%{_user},%{_group}) %{_lib_home}/*
 %attr(-,%{_user},%{_group}) %dir %{_var_home}
 %attr(-,%{_user},%{_group}) %config(noreplace) %{_var_home}/*

--- a/scripts/pkg-tests.sh
+++ b/scripts/pkg-tests.sh
@@ -150,7 +150,11 @@ emqx_test(){
             fi
         ;;
         "rpm")
-            yum install -y "${PACKAGE_PATH}/${packagename}"
+            YUM_RES=$(yum install -y "${PACKAGE_PATH}/${packagename}"| tee /dev/null)
+            if [[ $YUM_RES =~ "Failed" ]]; then
+               echo "yum install failed"
+               exit 1
+            fi
             if ! rpm -q "${EMQX_NAME}" | grep -q "${EMQX_NAME}"; then
                 echo "package install error"
                 exit 1
@@ -189,7 +193,6 @@ EOF
         echo "Error: cannot locate emqx_vars"
         exit 1
     fi
-
     if ! emqx 'start'; then
         cat /var/log/emqx/erlang.log.1 || true
         cat /var/log/emqx/emqx.log.1 || true


### PR DESCRIPTION
Failed to manage emqx by systemctl because of missing `emqx.service`.
It happened in every build_slim_package action, such as:
https://github.com/emqx/emqx/runs/6434020470?check_suite_focus=true

```
yum install -y /__w/emqx/emqx/_packages/emqx-edge/emqx-edge-5.0.0-rc.2-c92e4b4e-otp24.2.1-1-el8-amd64.rpm
Rocky Linux 8 - AppStream                        13 kB/s | 4.8 kB     00:00    
Rocky Linux 8 - AppStream                       8.9 MB/s |  10 MB     00:01    
Rocky Linux 8 - BaseOS                           19 kB/s | 4.3 kB     00:00    
Rocky Linux 8 - BaseOS                          8.0 MB/s | 7.7 MB     00:00    
Rocky Linux 8 - Extras                           11 kB/s | 3.5 kB     00:00    
Rocky Linux 8 - Extras                           21 kB/s |  12 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64   39 kB/s |  19 kB     00:00    
Extra Packages for Enterprise Linux 8 - x86_64   12 MB/s |  11 MB     00:00    
Extra Packages for Enterprise Linux Modular 8 -  76 kB/s |  30 kB     00:00    
Extra Packages for Enterprise Linux Modular 8 - 1.3 MB/s | 1.0 MB     00:00    
Dependencies resolved.
================================================================================
 Package    Arch    Version                                 Repository     Size
================================================================================
Installing:
 emqx-edge  x86_64  5.0.0_rc.2_c92e4b4e-otp24.2.1_1.el8     @commandline   38 M

Transaction Summary
================================================================================
Install  1 Package

Total size: 38 M
Installed size: 82 M
Downloading Packages:
Running transaction check
Transaction check succeeded.
Running transaction test
Transaction test succeeded.
Running transaction
  Preparing        :                                                        1/1 
  Running scriptlet: emqx-edge-5.0.0_rc.2_c92e4b4e-otp24.2.1_1.el8.x86_64   1/1 
  Installing       : emqx-edge-5.0.0_rc.2_c92e4b4e-otp24.2.1_1.el8.x86_64   1/1 
  Running scriptlet: emqx-edge-5.0.0_rc.2_c92e4b4e-otp24.2.1_1.el8.x86_64   1/1 
Failed to enable unit, unit emqx.service does not exist.
```