### PR TITLE
fix(telemetry): Ensure verify_none for http client

### DIFF
--- a/lib-ce/emqx_telemetry/src/emqx_telemetry.app.src
+++ b/lib-ce/emqx_telemetry/src/emqx_telemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_telemetry,
  [{description, "EMQ X Telemetry"},
-  {vsn, "4.3.2"}, % strict semver, bump manually!
+  {vsn, "4.3.3"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_telemetry_sup]},
   {applications, [kernel,stdlib]},

--- a/lib-ce/emqx_telemetry/src/emqx_telemetry.appup.src
+++ b/lib-ce/emqx_telemetry/src/emqx_telemetry.appup.src
@@ -1,13 +1,13 @@
 %% -*- mode: erlang -*-
 {VSN,
  [
-   {<<"4\\.3\\.[0-1]">>, [
+   {<<"4\\.3\\.[0-2]">>, [
      {load_module, emqx_telemetry, brutal_purge, soft_purge, []}
    ]},
    {<<".*">>, []}
  ],
  [
-   {<<"4\\.3\\.[0-1]">>, [
+   {<<"4\\.3\\.[0-2]">>, [
      {load_module, emqx_telemetry, brutal_purge, soft_purge, []}
    ]},
    {<<".*">>, []}

--- a/lib-ce/emqx_telemetry/src/emqx_telemetry.erl
+++ b/lib-ce/emqx_telemetry/src/emqx_telemetry.erl
@@ -367,7 +367,9 @@ report_telemetry(State = #state{url = URL}) ->
     end.
 
 httpc_request(Method, URL, Headers, Body) ->
-    httpc:request(Method, {URL, Headers, "application/json", Body}, [], []).
+    HTTPOptions = [{timeout, timer:seconds(10)}, {ssl, [{verify, verify_none}]}],
+    Options = [],
+    httpc:request(Method, {URL, Headers, "application/json", Body}, HTTPOptions, Options).
 
 ignore_lib_apps(Apps) ->
     LibApps = [kernel, stdlib, sasl, appmon, eldap, erts,


### PR DESCRIPTION
fixes: https://github.com/emqx/emqx/issues/7875

This issue was reported on 4.4 where the default OTP version had the warning introduced.
but the fix is applied to `main-v4.3`, which will be forward merged to `main-v4.4`