### PR TITLE
fix: change connector name to prevent race condition in tests

### DIFF
--- a/apps/emqx_connector/test/emqx_connector_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_SUITE.erl
@@ -31,7 +31,7 @@
     <<"ssl">> => #{<<"enable">> => false}
 }).
 -define(CONNECTOR_TYPE, <<"mqtt">>).
--define(CONNECTOR_NAME, <<"test_connector">>).
+-define(CONNECTOR_NAME, <<"test_connector_42">>).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).


### PR DESCRIPTION
No matter how many times I run things locally I don't get any test failures. However I think the problem is the introduction of a same named connector in the `emqx_connector_SUITE`.

Hopefully this rename will prevent a race condition and there will be no problems with "already created connectors" in the future.

Why 42? Because it's the answer to everything...