### PR TITLE
fix pub api

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
@@ -447,6 +447,20 @@ t_pubsub(_) ->
                                    <<"payload">> => <<"hello">>}),
     ?assertEqual(?ERROR8, get(<<"code">>, BadClient2)),
 
+    {ok, BadParams} = request_api(post, api_path(["mqtt/publish"]), [], auth_header_(),
+                                  #{<<"clientid">> => 1,
+                                    <<"topics">> => <<"mytopic">>,
+                                    <<"qos">> => 1,
+                                    <<"payload">> => <<"hello">>,
+                                    <<"user_properties">> =>
+                                        #{<<"id">> => 10010,
+                                          <<"name">> => <<"emqx">>,
+                                          <<"foo">> => ["bad_properties1", "bad_properties2"],
+                                          <<"boolean">> => false
+                                         }
+                                   }),
+    ?assertEqual(?ERROR8, get(<<"code">>, BadParams)),
+
     {ok, BadClient3} = request_api(post, api_path(["mqtt/unsubscribe"]), [], auth_header_(),
                                  #{<<"clientid">> => 1,
                                    <<"topic">> => <<"mytopic">>}),


### PR DESCRIPTION
When an unsupported type value included in publish api params.
Such as integer/boolean/list/map/... as `User-Property` value will cause serialize packet error and crash, and then the clients who subscribed the target topic will disconnect.
e.g `10001`/`true`/`["v1", "v2"]`/`{"k1": "v1"}`