### PR TITLE
chore: show more error msg when check_erlang_start failed

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -37,15 +37,15 @@ assert_node_alive() {
     fi
 }
 
-check_eralng_start() {
-    "$BINDIR/$PROGNAME" -noshell -boot "$REL_DIR/start_clean" -s crypto start -s init stop
+check_erlang_start() {
+    "$BINDIR/$PROGNAME" -boot "$REL_DIR/start_clean" -eval "crypto:start(),halt()"
 }
 
-if ! check_eralng_start >/dev/null 2>&1; then
+if ! check_erlang_start >/dev/null 2>&1; then
     BUILT_ON="$(head -1 "${REL_DIR}/BUILT_ON")"
     ## failed to start, might be due to missing libs, try to be portable
     export LD_LIBRARY_PATH="$DYNLIBS_DIR:$LD_LIBRARY_PATH"
-    if ! check_eralng_start; then
+    if ! check_erlang_start; then
         ## it's hopeless
         echoerr "FATAL: Unable to start Erlang."
         echoerr "Please make sure openssl-1.1.1 (libcrypto) and libncurses are installed."


### PR DESCRIPTION
Before, if erlang is not satisfy with the openssl verison. only show a `undef` stacktrace.
```
[root]# ./erts-12.1.5/bin/erl -noshell -boot releases/4.4.3/start_clean -s crypto start -s init stop
Erlang/OTP 24 [erts-12.1.5] [emqx] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:1] [jit]

{"init terminating in do_boot",{undef,[{crypto,start,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({undef,[{crypto,start,[],[]},{init,start_em,1,[]},{init,do_boot,3,[]}]})

Crash dump is being written to: erl_crash.dump...done

```
Then we delete `-noshell` option and replace `-s` with `-eval`. to show loading nif failed msg.
```
[root]# ./erts-12.1.5/bin/erl -boot releases/4.4.3/start_clean -eval "crypto:start(),halt()"
\Erlang/OTP 24 [erts-12.1.5] [emqx] [64-bit] [smp:1:1] [ds:1:1:10] [async-threads:1] [jit]

Eshell V12.1.5  (abort with ^G)
1> \=ERROR REPORT==== 18-May-2022::21:51:37.915020 ===
Unable to load crypto library. Failed with error:
"load_failed, Failed to load NIF library: '/root/emqx/lib/crypto-5.0.4/priv/lib/crypto.so: undefined symbol: EC_GROUP_new_curve_GF2m, version OPENSSL_1_1_0'"
OpenSSL might not be installed on this system.

{"init terminating in do_boot",{undef,[{crypto,start,[],[]},{erl_eval,do_apply,6,[{file,"erl_eval.erl"},{line,685}]},{erl_eval,exprs,5,[{file,"erl_eval.erl"},{line,123}]},{init,start_it,1,[]},{init,start_em,1,[]},{init,do_boot,3,[]}]}}
init terminating in do_boot ({undef,[{crypto,start,[],[]},{erl_eval,do_apply,6,[{_},{_}]},{erl_eval,exprs,5,[{_},{_}]},{init,start_it,1,[]},{init,start_em,1,[]},{init,do_boot,3,[]}]})
```