### PR TITLE
fix(backup): accept files outside `data/dir` when importing

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -666,7 +666,10 @@ look_up_file(Filename) ->
         end,
     case lists:filter(Filter, backup_files()) of
         [] ->
-            {error, not_found};
+            case filelib:is_file(Filename) of
+                true -> {ok, Filename};
+                false -> {error, not_found}
+            end;
         List ->
             {ok, hd(List)}
     end.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/7990

Currently, when importing a data backup using `emqx_ctl data import
/some/data.json`, it'll only search in the `data/backup` directory and
fail if the file is not inside that dir.

