### PR TITLE
fix(dashboard): use atom for `verify` tls option in dashboard listener

### DIFF
--- a/lib-ce/emqx_dashboard/priv/emqx_dashboard.schema
+++ b/lib-ce/emqx_dashboard/priv/emqx_dashboard.schema
@@ -83,7 +83,7 @@
 ]}.
 
 {mapping, "dashboard.listener.https.verify", "emqx_dashboard.listeners", [
-  {datatype, string}
+  {datatype, atom}
 ]}.
 
 {mapping, "dashboard.listener.https.fail_if_no_peer_cert", "emqx_dashboard.listeners", [
@@ -149,4 +149,3 @@
         end
       end, [http, https]))
 end}.
-


### PR DESCRIPTION
```
2022-05-19T10:47:34.262135-04:00 [error] Failed to start Ranch
listener 'https:dashboard' in ranch_ssl:listen <snip> for reason {options,{verify,"verify_none"}} (unknown POSIX error)
```

