### PR TITLE
chore(pgsql): restart emqx_auth_pgsql due to the egpsql upgraded

### DIFF
--- a/apps/emqx_auth_pgsql/src/emqx_auth_pgsql.appup.src
+++ b/apps/emqx_auth_pgsql/src/emqx_auth_pgsql.appup.src
@@ -1,25 +1,11 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{<<"4\\.3\\.[1-2]">>,
-    %% epgsql 4.4.0 -> 4.6.0.
-    %% epgsql has no appup ,so we can only restart it.
-    [{restart_application,epgsql},
-     {load_module,emqx_auth_pgsql_app,brutal_purge,soft_purge,[]},
-     {load_module,emqx_auth_pgsql,brutal_purge,soft_purge,[]}]},
-   {"4.3.0",
-    [{restart_application,epgsql},
-     {load_module,emqx_auth_pgsql_app,brutal_purge,soft_purge,[]},
-     {load_module,emqx_auth_pgsql,brutal_purge,soft_purge,[]},
-     {load_module,emqx_acl_pgsql,brutal_purge,soft_purge,[]}]},
+  [{<<"4\\.3\\.[0-2]">>,
+    %% restart it due to epgsql upgraded from 4.4.0 to 4.6.0
+    %% in emqx_auth_pgsql:v4.3.3
+    [{restart_application,emqx_auth_pgsql}]},
    {<<".*">>,[]}],
-  [{<<"4\\.3\\.[1-2]">>,
-    [{restart_application,epgsql},
-     {load_module,emqx_auth_pgsql_app,brutal_purge,soft_purge,[]},
-     {load_module,emqx_auth_pgsql,brutal_purge,soft_purge,[]}]},
-   {"4.3.0",
-    [{load_module,emqx_auth_pgsql,brutal_purge,soft_purge,[]},
-     {restart_application,epgsql},
-     {load_module,emqx_auth_pgsql_app,brutal_purge,soft_purge,[]},
-     {load_module,emqx_acl_pgsql,brutal_purge,soft_purge,[]}]},
+  [{<<"4\\.3\\.[0-2]">>,
+    [{restart_application,emqx_auth_pgsql}]},
    {<<".*">>,[]}]}.


### PR DESCRIPTION
We have to restart the emqx_auth_pgsql because epgsql has upgraded 4.4.0 to 4.6.0
see: #8001

