### PR TITLE
fix(node_dump): define `RUNNER_ROOT_DIR` before sourcing vars

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -38,6 +38,7 @@ File format:
   startup. [#7876]
   [ekka-158](https://github.com/emqx/ekka/pull/158)
 * Add regular expression check ^[0-9A-Za-z_\-]+$ for node name [#7979]
+* Fix `node_dump` variable sourcing. [#8026]
 
 ## v4.3.14
 

--- a/bin/node_dump
+++ b/bin/node_dump
@@ -1,13 +1,13 @@
 #!/bin/sh
 set -eu
 
-ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
-echo "Running node dump in ${ROOT_DIR}"
+RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
+echo "Running node dump in ${RUNNER_ROOT_DIR}"
 
 # shellcheck disable=SC1090
-. "$ROOT_DIR"/releases/emqx_vars
+. "$RUNNER_ROOT_DIR"/releases/emqx_vars
 
-cd "${ROOT_DIR}"
+cd "${RUNNER_ROOT_DIR}"
 
 DUMP="$RUNNER_LOG_DIR/node_dump_$(date +"%Y%m%d_%H%M%S").tar.gz"
 CONF_DUMP="$RUNNER_LOG_DIR/conf.dump"


### PR DESCRIPTION
Port of https://github.com/emqx/emqx/pull/7733

`emqx_vars` requires `RUNNER_ROOT_DIR` to be defined before being
sourced.

