### PR TITLE
Shared redispatch fix

### DIFF
--- a/src/emqx_shared_sub.erl
+++ b/src/emqx_shared_sub.erl
@@ -229,7 +229,9 @@ is_ack_required(Msg) -> ?NO_ACK =/= get_group_ack(Msg).
 maybe_nack_dropped(Msg) ->
     case get_group_ack(Msg) of
         ?NO_ACK -> false;
-        {_Group, Sender, Ref} -> ok == nack(Sender, Ref, dropped)
+        {_Group, Sender, Ref} -> ok == nack(Sender, Ref, dropped);
+        %% Backward compatability
+        {Sender, Ref} -> ok == nack(Sender, Ref, dropped)
     end.
 
 %% @doc Negative ack message due to connection down.
@@ -251,6 +253,10 @@ maybe_ack(Msg) ->
         ?NO_ACK ->
             Msg;
         {_Group, Sender, Ref} ->
+            Sender ! {Ref, ?ACK},
+            without_group_ack(Msg);
+        %% Backward compatability
+        {Sender, Ref} ->
             Sender ! {Ref, ?ACK},
             without_group_ack(Msg)
     end.

--- a/src/emqx_shared_sub.erl
+++ b/src/emqx_shared_sub.erl
@@ -217,8 +217,8 @@ get_group_ack(Msg) ->
 -spec(get_group(emqx_types:message()) -> {ok, any()} | error).
 get_group(Msg) ->
     case get_group_ack(Msg) of
-        ?NO_ACK -> error;
-        {Group, _Sender, _Ref} -> {ok, Group}
+        {Group, _Sender, _Ref} -> {ok, Group};
+        _ -> error
     end.
 
 -spec(is_ack_required(emqx_types:message()) -> boolean()).


### PR DESCRIPTION
As was pointed out [here](https://github.com/emqx/emqx/pull/7984#discussion_r878981942), changes to shared ack header are backward incompatible in cluster. This PR fixes it, by making calls to `emqx_shared_sub:get_group` compatible with old structure