### PR TITLE
Improve EMQX startup sequence

### DIFF
--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -354,8 +354,10 @@ handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
 
-handle_info({mnesia_table_event, {write, NewRecord, _}}, State = #state{pmon = PMon}) ->
-    #emqx_shared_subscription{subpid = SubPid} = NewRecord,
+handle_info(
+    {mnesia_table_event, {write, #emqx_shared_subscription{subpid = SubPid}, _}},
+    State = #state{pmon = PMon}
+) ->
     {noreply, update_stats(State#state{pmon = emqx_pmon:monitor(SubPid, PMon)})};
 %% The subscriber may have subscribed multiple topics, so we need to keep monitoring the PID until
 %% it `unsubscribed` the last topic.

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -57,7 +57,7 @@ overrides() ->
 %% Temporary workaround for a rebar3 erl_opts duplication
 %% bug. Ideally, we want to set this define globally
 snabbkaffe_overrides() ->
-    Apps = [snabbkaffe, ekka, mria],
+    Apps = [snabbkaffe, ekka, mria, gen_rpc],
     [{add, App, [{erl_opts, [{d, snk_kind, msg}]}]} || App <- Apps].
 
 config() ->


### PR DESCRIPTION
1. Make some essential applications permanent, so the node doesn't remain in the zombie state if any of these apps crash (it may hide errors)
2. Make initialization of some non-essential applications async
3. Fix crash in `emqx_shared_sub` process that is unable to handle table schema change 