### PR TITLE
refactor(rule): rename outputs -> actions

### DIFF
--- a/apps/emqx_bridge/etc/emqx_bridge.conf
+++ b/apps/emqx_bridge/etc/emqx_bridge.conf
@@ -28,8 +28,8 @@
 #    retain = false
 #}
 #
-## HTTP bridges to an HTTP server
-#bridges.http.my_http_bridge {
+## WebHook to an HTTP server
+#bridges.webhook.my_webhook {
 #    enable = true
 #    direction = egress
 #    ## NOTE: we cannot use placehodler variables in the `scheme://host:port` part of the url

--- a/apps/emqx_bridge/i18n/emqx_bridge_http_schema.conf
+++ b/apps/emqx_bridge/i18n/emqx_bridge_http_schema.conf
@@ -52,7 +52,7 @@ HTTP Bridge 的 URL。</br>
                          en: """
 The MQTT topic filter to be forwarded to the HTTP server. All MQTT 'PUBLISH' messages with the topic
 matching the local_topic will be forwarded.</br>
-NOTE: if this bridge is used as the output of a rule (EMQX rule engine), and also local_topic is
+NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded.
 """

--- a/apps/emqx_bridge/i18n/emqx_bridge_schema.conf
+++ b/apps/emqx_bridge/i18n/emqx_bridge_schema.conf
@@ -72,14 +72,14 @@ In config files, you can find the corresponding config entry for a connector by 
                           }
                   }
 
-    bridges_http {
+    bridges_webhook {
                    desc {
-                         en: """HTTP bridges to an HTTP server."""
-                         zh: """转发消息到 HTTP 服务器的 HTTP Bridge"""
+                         en: """WebHook to an HTTP server."""
+                         zh: """转发消息到 HTTP 服务器的 WebHook"""
                         }
                    label: {
-                           en: "HTTP Bridge"
-                           zh: "HTTP Bridge"
+                           en: "WebHook"
+                           zh: "WebHook"
                           }
                   }
 

--- a/apps/emqx_bridge/i18n/emqx_bridge_webhook_schema.conf
+++ b/apps/emqx_bridge/i18n/emqx_bridge_webhook_schema.conf
@@ -1,4 +1,4 @@
-emqx_bridge_http_schema {
+emqx_bridge_webhook_schema {
 
     config_enable {
                    desc {

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -263,7 +263,7 @@ get_matched_bridges(Topic) ->
                     (_BName, #{direction := ingress}, Acc1) ->
                         Acc1;
                     (BName, #{direction := egress} = Egress, Acc1) ->
-                        %% HTTP, MySQL bridges only have egress direction
+                        %% WebHook, MySQL bridges only have egress direction
                         get_matched_bridge_id(Egress, Topic, BType, BName, Acc1)
                 end,
                 Acc0,

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -42,8 +42,6 @@
 
 -export([lookup_from_local_node/2]).
 
--define(TYPES, [mqtt, http]).
-
 -define(CONN_TYPES, [mqtt]).
 
 -define(TRY_PARSE_ID(ID, EXPR),
@@ -148,7 +146,7 @@ param_path_id() ->
             #{
                 in => path,
                 required => true,
-                example => <<"http:my_http_bridge">>,
+                example => <<"webhook:my_webhook">>,
                 desc => ?DESC("desc_param_path_id")
             }
         )}.
@@ -158,9 +156,9 @@ bridge_info_array_example(Method) ->
 
 bridge_info_examples(Method) ->
     maps:merge(conn_bridge_examples(Method), #{
-        <<"http_bridge">> => #{
-            summary => <<"HTTP Bridge">>,
-            value => info_example(http, awesome, Method)
+        <<"my_webhook">> => #{
+            summary => <<"WebHook">>,
+            value => info_example(webhook, awesome, Method)
         }
     }).
 
@@ -196,7 +194,7 @@ method_example(Type, Direction, Method) when Method == get; Method == post ->
     SDir = atom_to_list(Direction),
     SName =
         case Type of
-            http -> "my_" ++ SType ++ "_bridge";
+            webhook -> "my_" ++ SType;
             _ -> "my_" ++ SDir ++ "_" ++ SType ++ "_bridge"
         end,
     TypeNameExamp = #{
@@ -220,7 +218,7 @@ maybe_with_metrics_example(TypeNameExamp, get) ->
 maybe_with_metrics_example(TypeNameExamp, _) ->
     TypeNameExamp.
 
-info_example_basic(http, _) ->
+info_example_basic(webhook, _) ->
     #{
         enable => true,
         url => <<"http://localhost:9901/messages/${topic}">>,
@@ -232,7 +230,7 @@ info_example_basic(http, _) ->
         pool_size => 4,
         enable_pipelining => true,
         ssl => #{enable => false},
-        local_topic => <<"emqx_http/#">>,
+        local_topic => <<"emqx_webhook/#">>,
         method => post,
         body => <<"${payload}">>
     };

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -43,8 +43,8 @@
 
 bridge_to_resource_type(<<"mqtt">>) -> emqx_connector_mqtt;
 bridge_to_resource_type(mqtt) -> emqx_connector_mqtt;
-bridge_to_resource_type(<<"http">>) -> emqx_connector_http;
-bridge_to_resource_type(http) -> emqx_connector_http.
+bridge_to_resource_type(<<"webhook">>) -> emqx_connector_http;
+bridge_to_resource_type(webhook) -> emqx_connector_http.
 
 resource_id(BridgeId) when is_binary(BridgeId) ->
     <<"bridge:", BridgeId/binary>>.
@@ -104,7 +104,7 @@ update(Type, Name, {OldConf, Conf}) ->
     %% - if the connection related configs like `servers` is updated, we should restart/start
     %% or stop bridges according to the change.
     %% - if the connection related configs are not update, only non-connection configs like
-    %% the `method` or `headers` of a HTTP bridge is changed, then the bridge can be updated
+    %% the `method` or `headers` of a WebHook is changed, then the bridge can be updated
     %% without restarting the bridge.
     %%
     case if_only_to_toggle_enable(OldConf, Conf) of
@@ -237,7 +237,7 @@ is_tmp_path(TmpPath, File) ->
     string:str(str(File), str(TmpPath)) > 0.
 
 parse_confs(
-    http,
+    webhook,
     _Name,
     #{
         url := Url,

--- a/apps/emqx_bridge/src/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_schema.erl
@@ -46,7 +46,7 @@ http_schema(Method) ->
         ?CONN_TYPES
     ),
     hoconsc:union([
-        ref(emqx_bridge_http_schema, Method)
+        ref(emqx_bridge_webhook_schema, Method)
         | Schemas
     ]).
 
@@ -108,10 +108,10 @@ roots() -> [bridges].
 
 fields(bridges) ->
     [
-        {http,
+        {webhook,
             mk(
-                hoconsc:map(name, ref(emqx_bridge_http_schema, "config")),
-                #{desc => ?DESC("bridges_http")}
+                hoconsc:map(name, ref(emqx_bridge_webhook_schema, "config")),
+                #{desc => ?DESC("bridges_webhook")}
             )}
     ] ++
         [

--- a/apps/emqx_bridge/src/emqx_bridge_webhook_schema.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_webhook_schema.erl
@@ -1,4 +1,4 @@
--module(emqx_bridge_http_schema).
+-module(emqx_bridge_webhook_schema).
 
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
@@ -81,7 +81,7 @@ fields("get") ->
 desc("config") ->
     ?DESC("desc_config");
 desc(Method) when Method =:= "get"; Method =:= "put"; Method =:= "post" ->
-    ["Configuration for HTTP bridge using `", string:to_upper(Method), "` method."];
+    ["Configuration for WebHook using `", string:to_upper(Method), "` method."];
 desc(_) ->
     undefined.
 
@@ -111,7 +111,7 @@ basic_config() ->
 type_field() ->
     {type,
         mk(
-            http,
+            webhook,
             #{
                 required => true,
                 desc => ?DESC("desc_type")

--- a/apps/emqx_bridge/test/emqx_bridge_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_SUITE.erl
@@ -54,8 +54,8 @@ end_per_testcase(t_get_basic_usage_info_1, _Config) ->
             {ok, _} = emqx_bridge:remove(BridgeType, BridgeName)
         end,
         [
-            {http, <<"basic_usage_info_http">>},
-            {http, <<"basic_usage_info_http_disabled">>},
+            {webhook, <<"basic_usage_info_webhook">>},
+            {webhook, <<"basic_usage_info_webhook_disabled">>},
             {mqtt, <<"basic_usage_info_mqtt">>}
         ]
     ),
@@ -81,7 +81,7 @@ t_get_basic_usage_info_1(_Config) ->
         #{
             num_bridges => 3,
             count_by_type => #{
-                http => 1,
+                webhook => 1,
                 mqtt => 2
             }
         },
@@ -119,7 +119,7 @@ setup_fake_telemetry_data() ->
         url => <<"http://localhost:9901/messages/${topic}">>,
         enable => true,
         direction => egress,
-        local_topic => "emqx_http/#",
+        local_topic => "emqx_webhook/#",
         method => post,
         body => <<"${payload}">>,
         headers => #{},
@@ -129,10 +129,10 @@ setup_fake_telemetry_data() ->
         #{
             <<"bridges">> =>
                 #{
-                    <<"http">> =>
+                    <<"webhook">> =>
                         #{
-                            <<"basic_usage_info_http">> => HTTPConfig,
-                            <<"basic_usage_info_http_disabled">> =>
+                            <<"basic_usage_info_webhook">> => HTTPConfig,
+                            <<"basic_usage_info_webhook_disabled">> =>
                                 HTTPConfig#{enable => false}
                         },
                     <<"mqtt">> =>

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -23,7 +23,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -define(CONF_DEFAULT, <<"bridges: {}">>).
--define(BRIDGE_TYPE, <<"http">>).
+-define(BRIDGE_TYPE, <<"webhook">>).
 -define(BRIDGE_NAME, <<"test_bridge">>).
 -define(URL(PORT, PATH),
     list_to_binary(
@@ -37,7 +37,7 @@
     <<"type">> => TYPE,
     <<"name">> => NAME,
     <<"url">> => URL,
-    <<"local_topic">> => <<"emqx_http/#">>,
+    <<"local_topic">> => <<"emqx_webhook/#">>,
     <<"method">> => <<"post">>,
     <<"ssl">> => #{<<"enable">> => false},
     <<"body">> => <<"${payload}">>,
@@ -158,7 +158,7 @@ t_http_crud_apis(_) ->
     %% assert we there's no bridges at first
     {ok, 200, <<"[]">>} = request(get, uri(["bridges"]), []),
 
-    %% then we add a http bridge, using POST
+    %% then we add a webhook bridge, using POST
     %% POST /bridges/ will create a bridge
     URL1 = ?URL(Port, "path1"),
     {ok, 201, Bridge} = request(
@@ -182,7 +182,7 @@ t_http_crud_apis(_) ->
     BridgeID = emqx_bridge_resource:bridge_id(?BRIDGE_TYPE, ?BRIDGE_NAME),
     %% send an message to emqx and the message should be forwarded to the HTTP server
     Body = <<"my msg">>,
-    emqx:publish(emqx_message:make(<<"emqx_http/1">>, Body)),
+    emqx:publish(emqx_message:make(<<"emqx_webhook/1">>, Body)),
     ?assert(
         receive
             {http_server, received, #{
@@ -254,7 +254,7 @@ t_http_crud_apis(_) ->
     ),
 
     %% send an message to emqx again, check the path has been changed
-    emqx:publish(emqx_message:make(<<"emqx_http/1">>, Body)),
+    emqx:publish(emqx_message:make(<<"emqx_webhook/1">>, Body)),
     ?assert(
         receive
             {http_server, received, #{path := <<"/path2">>}} ->

--- a/apps/emqx_connector/i18n/emqx_connector_mqtt_schema.conf
+++ b/apps/emqx_connector/i18n/emqx_connector_mqtt_schema.conf
@@ -350,7 +350,7 @@ Ingress 模式定义了这个 bridge 如何从远程 MQTT broker 接收消息，
                          en: """
 The egress config defines how this bridge forwards messages from the local broker to the remote broker.</br>
 Template with variables is allowed in 'remote_topic', 'qos', 'retain', 'payload'.</br>
-NOTE: if this bridge is used as the output of a rule (emqx rule engine), and also local_topic is configured, then both the data got from the rule and the MQTT messages that matches local_topic will be forwarded.
+NOTE: if this bridge is used as the action of a rule (emqx rule engine), and also local_topic is configured, then both the data got from the rule and the MQTT messages that matches local_topic will be forwarded.
 """
                          zh: """
 Egress 模式定义了 bridge 如何将消息从本地 broker 转发到远程 broker。</br>

--- a/apps/emqx_connector/src/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/emqx_connector_schema.erl
@@ -30,7 +30,7 @@
     post_request/0
 ]).
 
-%% the config for http bridges do not need connectors
+%% the config for webhook bridges do not need connectors
 -define(CONN_TYPES, [mqtt]).
 
 %%======================================================================================

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
@@ -296,7 +296,7 @@ egress_desc() ->
     "The egress config defines how this bridge forwards messages from the local broker to the remote\n"
     "broker.</br>\n"
     "Template with variables is allowed in 'remote_topic', 'qos', 'retain', 'payload'.</br>\n"
-    "NOTE: if this bridge is used as the output of a rule (emqx rule engine), and also local_topic\n"
+    "NOTE: if this bridge is used as the action of a rule (emqx rule engine), and also local_topic\n"
     "is configured, then both the data got from the rule and the MQTT messages that matches\n"
     "local_topic will be forwarded.\n".
 

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -610,7 +610,7 @@ t_ingress_mqtt_bridge_with_rules(_) ->
         #{
             <<"name">> => <<"A_rule_get_messages_from_a_source_mqtt_bridge">>,
             <<"enable">> => true,
-            <<"outputs">> => [#{<<"function">> => "emqx_connector_api_SUITE:inspect"}],
+            <<"actions">> => [#{<<"function">> => "emqx_connector_api_SUITE:inspect"}],
             <<"sql">> => <<"SELECT * from \"$bridges/", BridgeIDIngress/binary, "\"">>
         }
     ),
@@ -653,14 +653,14 @@ t_ingress_mqtt_bridge_with_rules(_) ->
             <<"matched.rate">> := _,
             <<"matched.rate.max">> := _,
             <<"matched.rate.last5m">> := _,
-            <<"outputs.total">> := 1,
-            <<"outputs.success">> := 1,
-            <<"outputs.failed">> := 0,
-            <<"outputs.failed.out_of_service">> := 0,
-            <<"outputs.failed.unknown">> := 0
+            <<"actions.total">> := 1,
+            <<"actions.success">> := 1,
+            <<"actions.failed">> := 0,
+            <<"actions.failed.out_of_service">> := 0,
+            <<"actions.failed.unknown">> := 0
         }
     } = jsx:decode(Rule1),
-    %% we also check if the outputs of the rule is triggered
+    %% we also check if the actions of the rule is triggered
     ?assertMatch(
         #{
             inspect := #{
@@ -709,7 +709,7 @@ t_egress_mqtt_bridge_with_rules(_) ->
         #{
             <<"name">> => <<"A_rule_send_messages_to_a_sink_mqtt_bridge">>,
             <<"enable">> => true,
-            <<"outputs">> => [BridgeIDEgress],
+            <<"actions">> => [BridgeIDEgress],
             <<"sql">> => <<"SELECT * from \"t/1\"">>
         }
     ),
@@ -760,11 +760,11 @@ t_egress_mqtt_bridge_with_rules(_) ->
             <<"matched.rate">> := _,
             <<"matched.rate.max">> := _,
             <<"matched.rate.last5m">> := _,
-            <<"outputs.total">> := 1,
-            <<"outputs.success">> := 1,
-            <<"outputs.failed">> := 0,
-            <<"outputs.failed.out_of_service">> := 0,
-            <<"outputs.failed.unknown">> := 0
+            <<"actions.total">> := 1,
+            <<"actions.success">> := 1,
+            <<"actions.failed">> := 0,
+            <<"actions.failed.out_of_service">> := 0,
+            <<"actions.failed.unknown">> := 0
         }
     } = jsx:decode(Rule1),
     %% we should receive a message on the "remote" broker, with specified topic

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -562,7 +562,7 @@ t_rule_engine_and_data_bridge_info(_Config) ->
         #{
             data_bridge =>
                 #{
-                    http => #{num => 1, num_linked_by_rules => 3},
+                    webhook => #{num => 1, num_linked_by_rules => 3},
                     mqtt => #{num => 2, num_linked_by_rules => 2}
                 },
             num_data_bridges => 3

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -741,7 +741,7 @@ setup_fake_rule_engine_data() ->
             #{
                 id => <<"rule:t_get_basic_usage_info:1">>,
                 sql => <<"select 1 from topic">>,
-                outputs =>
+                actions =>
                     [
                         #{function => <<"erlang:hibernate">>, args => #{}},
                         #{function => console},
@@ -755,7 +755,7 @@ setup_fake_rule_engine_data() ->
             #{
                 id => <<"rule:t_get_basic_usage_info:2">>,
                 sql => <<"select 1 from topic">>,
-                outputs =>
+                actions =>
                     [
                         <<"mqtt:my_mqtt_bridge">>,
                         <<"http:my_http_bridge">>
@@ -767,7 +767,7 @@ setup_fake_rule_engine_data() ->
             #{
                 id => <<"rule:t_get_basic_usage_info:3">>,
                 sql => <<"select 1 from \"$bridges/mqtt:mqtt_in\"">>,
-                outputs =>
+                actions =>
                     [
                         #{function => console}
                     ]

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -745,8 +745,8 @@ setup_fake_rule_engine_data() ->
                     [
                         #{function => <<"erlang:hibernate">>, args => #{}},
                         #{function => console},
-                        <<"http:my_http_bridge">>,
-                        <<"http:my_http_bridge">>
+                        <<"webhook:my_webhook">>,
+                        <<"webhook:my_webhook">>
                     ]
             }
         ),
@@ -758,7 +758,7 @@ setup_fake_rule_engine_data() ->
                 actions =>
                     [
                         <<"mqtt:my_mqtt_bridge">>,
-                        <<"http:my_http_bridge">>
+                        <<"webhook:my_webhook">>
                     ]
             }
         ),

--- a/apps/emqx_rule_engine/etc/emqx_rule_engine.conf
+++ b/apps/emqx_rule_engine/etc/emqx_rule_engine.conf
@@ -8,7 +8,7 @@ rule_engine {
     #    description = "A simple rule that republishs MQTT messages from topic 't/1' to 't/2'"
     #    enable = true
     #    sql = "SELECT * FROM \"t/1\""
-    #    outputs = [
+    #    actions = [
     #        {
     #            function = republish
     #            args = {

--- a/apps/emqx_rule_engine/i18n/emqx_rule_api_schema.conf
+++ b/apps/emqx_rule_engine/i18n/emqx_rule_api_schema.conf
@@ -451,57 +451,57 @@ emqx_rule_api_schema {
                           }
                   }
 
-    metrics_outputs_total {
+    metrics_actions_total {
                    desc {
-                         en: "How much times the outputs are called by the rule. This value may several times of 'matched', depending on the number of the outputs of the rule."
+                         en: "How much times the actions are called by the rule. This value may several times of 'matched', depending on the number of the actions of the rule."
                          zh: "规则调用输出的次数。 该值可能是“sql.matched”的几倍，具体取决于规则输出的数量。"
                         }
                    label: {
-                           en: "Output Total"
+                           en: "Action Total"
                            zh: "调用输出次数"
                           }
                   }
 
-    metrics_outputs_success {
+    metrics_actions_success {
                    desc {
-                         en: "How much times the rule success to call the outputs."
+                         en: "How much times the rule success to call the actions."
                          zh: "规则成功调用输出的次数。"
                         }
                    label: {
-                           en: "Success Output"
+                           en: "Success Action"
                            zh: "成功调用输出次数"
                           }
                   }
 
-    metrics_outputs_failed {
+    metrics_actions_failed {
                    desc {
-                         en: "How much times the rule failed to call the outputs."
+                         en: "How much times the rule failed to call the actions."
                          zh: "规则调用输出失败的次数。"
                         }
                    label: {
-                           en: "Failed Output"
+                           en: "Failed Action"
                            zh: "调用输出失败次数"
                           }
                   }
 
-    metrics_outputs_failed_out_of_service {
+    metrics_actions_failed_out_of_service {
                    desc {
-                         en: "How much times the rule failed to call outputs due to the output is out of service. For example, a bridge is disabled or stopped."
+                         en: "How much times the rule failed to call actions due to the action is out of service. For example, a bridge is disabled or stopped."
                          zh: "由于输出停止服务而导致规则调用输出失败的次数。 例如，桥接被禁用或停止。"
                         }
                    label: {
-                           en: "Fail Output"
+                           en: "Fail Action"
                            zh: "调用输出失败次数"
                           }
                   }
 
-    metrics_outputs_failed_unknown {
+    metrics_actions_failed_unknown {
                    desc {
-                         en: "How much times the rule failed to call outputs due to to an unknown error."
+                         en: "How much times the rule failed to call actions due to to an unknown error."
                          zh: "由于未知错误，规则调用输出失败的次数。"
                         }
                    label: {
-                           en: "Fail Output"
+                           en: "Fail Action"
                            zh: "调用输出失败次数"
                           }
                   }

--- a/apps/emqx_rule_engine/i18n/emqx_rule_engine_schema.conf
+++ b/apps/emqx_rule_engine/i18n/emqx_rule_engine_schema.conf
@@ -28,21 +28,21 @@ Example: <code>SELECT * FROM "test/topic" WHERE payload.x = 1</code>
                           }
                   }
 
-    rules_outputs {
+    rules_actions {
                    desc {
                          en: """
-A list of outputs of the rule.
-An output can be a string that refers to the channel ID of an EMQX bridge, or an object
+A list of actions of the rule.
+An action can be a string that refers to the channel ID of an EMQX bridge, or an object
 that refers to a function.
 There a some built-in functions like "republish" and "console", and we also support user
 provided functions in the format: "{module}:{function}".
-The outputs in the list are executed sequentially.
-This means that if one of the output is executing slowly, all the following outputs will not
+The actions in the list are executed sequentially.
+This means that if one of the action is executing slowly, all the following actions will not
 be executed until it returns.
-If one of the output crashed, all other outputs come after it will still be executed, in the
+If one of the action crashed, all other actions come after it will still be executed, in the
 original order.
-If there's any error when running an output, there will be an error message, and the 'failure'
-counter of the function output or the bridge channel will increase.
+If there's any error when running an action, there will be an error message, and the 'failure'
+counter of the function action or the bridge channel will increase.
 """
                          zh: """
 规则的动作列表。
@@ -94,7 +94,7 @@ counter of the function output or the bridge channel will increase.
 
     console_function {
                    desc {
-                         en: """Print the outputs to the console"""
+                         en: """Print the actions to the console"""
                          zh: "将输出打印到控制台"
                         }
                    label: {
@@ -111,12 +111,12 @@ Where {module} is the Erlang callback module and {function} is the Erlang functi
 
 To write your own function, checkout the function <code>console</code> and
 <code>republish</code> in the source file:
-<code>apps/emqx_rule_engine/src/emqx_rule_outputs.erl</code> as an example.
+<code>apps/emqx_rule_engine/src/emqx_rule_actions.erl</code> as an example.
 """
                          zh: """
 用户提供的函数。 格式应为：'{module}:{function}'。
 其中 {module} 是 Erlang 回调模块， {function} 是 Erlang 函数。
-要编写自己的函数，请检查源文件：<code>apps/emqx_rule_engine/src/emqx_rule_outputs.erl</code> 中的示例函数 <code>console</code> 和<code>republish</code> 。
+要编写自己的函数，请检查源文件：<code>apps/emqx_rule_engine/src/emqx_rule_actions.erl</code> 中的示例函数 <code>console</code> 和<code>republish</code> 。
 """
                         }
                    label: {
@@ -130,11 +130,11 @@ To write your own function, checkout the function <code>console</code> and
                          en: """
 The args will be passed as the 3rd argument to module:function/3,
 checkout the function <code>console</code> and <code>republish</code> in the source file:
-<code>apps/emqx_rule_engine/src/emqx_rule_outputs.erl</code> as an example.
+<code>apps/emqx_rule_engine/src/emqx_rule_actions.erl</code> as an example.
 """
                          zh: """
 用户提供的参数将作为函数 module:function/3 的第三个参数，
-请检查源文件：<code>apps/emqx_rule_engine/src/emqx_rule_outputs.erl</code> 中的示例函数 <code>console</code> 和<code>republish</code> 。
+请检查源文件：<code>apps/emqx_rule_engine/src/emqx_rule_actions.erl</code> 中的示例函数 <code>console</code> 和<code>republish</code> 。
 """
                         }
                    label: {
@@ -272,9 +272,9 @@ of the rule, then the string "undefined" is used.
                           }
                   }
 
-    desc_builtin_output_republish {
+    desc_builtin_action_republish {
                    desc {
-                         en: """Configuration for a built-in output."""
+                         en: """Configuration for a built-in action."""
                          zh: """配置重新发布。"""
                         }
                    label: {
@@ -283,20 +283,20 @@ of the rule, then the string "undefined" is used.
                           }
                   }
 
-    desc_builtin_output_console {
+    desc_builtin_action_console {
                    desc {
-                         en: """Configuration for a built-in output."""
+                         en: """Configuration for a built-in action."""
                          zh: """配置打印到控制台"""
                         }
                    label: {
-                           en: "Output Console Configuration"
+                           en: "Action Console Configuration"
                            zh: "配置打印到控制台"
                           }
                   }
 
     desc_user_provided_function {
                    desc {
-                         en: """Configuration for a built-in output."""
+                         en: """Configuration for a built-in action."""
                          zh: """配置用户函数"""
                         }
                    label: {
@@ -307,7 +307,7 @@ of the rule, then the string "undefined" is used.
 
     desc_republish_args {
                    desc {
-                         en: """The arguments of the built-in 'republish' output.One can use variables in the args.
+                         en: """The arguments of the built-in 'republish' action.One can use variables in the args.
 The variables are selected by the rule. For example, if the rule SQL is defined as following:
 <code>
     SELECT clientid, qos, payload FROM "t/1"

--- a/apps/emqx_rule_engine/include/rule_engine.hrl
+++ b/apps/emqx_rule_engine/include/rule_engine.hrl
@@ -31,16 +31,16 @@
 -type selected_data() :: map().
 -type envs() :: map().
 
--type builtin_output_func() :: republish | console.
--type builtin_output_module() :: emqx_rule_outputs.
+-type builtin_action_func() :: republish | console.
+-type builtin_action_module() :: emqx_rule_actions.
 -type bridge_channel_id() :: binary().
--type output_fun_args() :: map().
+-type action_fun_args() :: map().
 
--type output() ::
+-type action() ::
     #{
-        mod := builtin_output_module() | module(),
-        func := builtin_output_func() | atom(),
-        args => output_fun_args()
+        mod := builtin_action_module() | module(),
+        func := builtin_action_func() | atom(),
+        args => action_fun_args()
     }
     | bridge_channel_id().
 
@@ -49,7 +49,7 @@
         id := rule_id(),
         name := binary(),
         sql := binary(),
-        outputs := [output()],
+        actions := [action()],
         enable := boolean(),
         description => binary(),
         %% epoch in millisecond precision

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -124,25 +124,25 @@ fields("metrics") ->
             sc(non_neg_integer(), #{
                 desc => ?DESC("metrics_sql_failed_unknown")
             })},
-        {"outputs.total",
+        {"actions.total",
             sc(non_neg_integer(), #{
-                desc => ?DESC("metrics_outputs_total")
+                desc => ?DESC("metrics_actions_total")
             })},
-        {"outputs.success",
+        {"actions.success",
             sc(non_neg_integer(), #{
-                desc => ?DESC("metrics_outputs_success")
+                desc => ?DESC("metrics_actions_success")
             })},
-        {"outputs.failed",
+        {"actions.failed",
             sc(non_neg_integer(), #{
-                desc => ?DESC("metrics_outputs_failed")
+                desc => ?DESC("metrics_actions_failed")
             })},
-        {"outputs.failed.out_of_service",
+        {"actions.failed.out_of_service",
             sc(non_neg_integer(), #{
-                desc => ?DESC("metrics_outputs_failed_out_of_service")
+                desc => ?DESC("metrics_actions_failed_out_of_service")
             })},
-        {"outputs.failed.unknown",
+        {"actions.failed.unknown",
             sc(non_neg_integer(), #{
-                desc => ?DESC("metrics_outputs_failed_unknown")
+                desc => ?DESC("metrics_actions_failed_unknown")
             })}
     ];
 fields("node_metrics") ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -65,11 +65,11 @@ end).
         'failed' => FAIL,
         'failed.exception' => FAIL_EX,
         'failed.no_result' => FAIL_NORES,
-        'outputs.total' => O_TOTAL,
-        'outputs.failed' => O_FAIL,
-        'outputs.failed.out_of_service' => O_FAIL_OOS,
-        'outputs.failed.unknown' => O_FAIL_UNKNOWN,
-        'outputs.success' => O_SUCC,
+        'actions.total' => O_TOTAL,
+        'actions.failed' => O_FAIL,
+        'actions.failed.out_of_service' => O_FAIL_OOS,
+        'actions.failed.unknown' => O_FAIL_UNKNOWN,
+        'actions.success' => O_SUCC,
         'matched.rate' => RATE,
         'matched.rate.max' => RATE_MAX,
         'matched.rate.last5m' => RATE_5
@@ -96,11 +96,11 @@ end).
         'failed' := FAIL,
         'failed.exception' := FAIL_EX,
         'failed.no_result' := FAIL_NORES,
-        'outputs.total' := O_TOTAL,
-        'outputs.failed' := O_FAIL,
-        'outputs.failed.out_of_service' := O_FAIL_OOS,
-        'outputs.failed.unknown' := O_FAIL_UNKNOWN,
-        'outputs.success' := O_SUCC,
+        'actions.total' := O_TOTAL,
+        'actions.failed' := O_FAIL,
+        'actions.failed.out_of_service' := O_FAIL_OOS,
+        'actions.failed.unknown' := O_FAIL_UNKNOWN,
+        'actions.success' := O_SUCC,
         'matched.rate' := RATE,
         'matched.rate.max' := RATE_MAX,
         'matched.rate.last5m' := RATE_5
@@ -362,7 +362,7 @@ format_rule_resp(#{
     name := Name,
     created_at := CreatedAt,
     from := Topics,
-    outputs := Output,
+    actions := Action,
     sql := SQL,
     enable := Enable,
     description := Descr
@@ -372,7 +372,7 @@ format_rule_resp(#{
         id => Id,
         name => Name,
         from => Topics,
-        outputs => format_output(Output),
+        actions => format_action(Action),
         sql => SQL,
         metrics => aggregate_metrics(NodeMetrics),
         node_metrics => NodeMetrics,
@@ -384,18 +384,18 @@ format_rule_resp(#{
 format_datetime(Timestamp, Unit) ->
     list_to_binary(calendar:system_time_to_rfc3339(Timestamp, [{unit, Unit}])).
 
-format_output(Outputs) ->
-    [do_format_output(Out) || Out <- Outputs].
+format_action(Actions) ->
+    [do_format_action(Act) || Act <- Actions].
 
-do_format_output(#{mod := Mod, func := Func, args := Args}) ->
+do_format_action(#{mod := Mod, func := Func, args := Args}) ->
     #{
         function => printable_function_name(Mod, Func),
         args => maps:remove(preprocessed_tmpl, Args)
     };
-do_format_output(BridgeChannelId) when is_binary(BridgeChannelId) ->
+do_format_action(BridgeChannelId) when is_binary(BridgeChannelId) ->
     BridgeChannelId.
 
-printable_function_name(emqx_rule_outputs, Func) ->
+printable_function_name(emqx_rule_actions, Func) ->
     Func;
 printable_function_name(Mod, Func) ->
     list_to_binary(lists:concat([Mod, ":", Func])).
@@ -411,11 +411,11 @@ get_rule_metrics(Id) ->
                     'failed' := Failed,
                     'failed.exception' := FailedEx,
                     'failed.no_result' := FailedNoRes,
-                    'outputs.total' := OTotal,
-                    'outputs.failed' := OFailed,
-                    'outputs.failed.out_of_service' := OFailedOOS,
-                    'outputs.failed.unknown' := OFailedUnknown,
-                    'outputs.success' := OFailedSucc
+                    'actions.total' := OTotal,
+                    'actions.failed' := OFailed,
+                    'actions.failed.out_of_service' := OFailedOOS,
+                    'actions.failed.unknown' := OFailedUnknown,
+                    'actions.success' := OFailedSucc
                 },
             rate :=
                 #{

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -64,11 +64,11 @@ fields("rules") ->
                     validator => fun ?MODULE:validate_sql/1
                 }
             )},
-        {"outputs",
+        {"actions",
             sc(
-                hoconsc:array(hoconsc:union(outputs())),
+                hoconsc:array(hoconsc:union(actions())),
                 #{
-                    desc => ?DESC("rules_outputs"),
+                    desc => ?DESC("rules_actions"),
                     default => [],
                     example => [
                         <<"http:my_http_bridge">>,
@@ -93,16 +93,16 @@ fields("rules") ->
                 }
             )}
     ];
-fields("builtin_output_republish") ->
+fields("builtin_action_republish") ->
     [
         {function, sc(republish, #{desc => ?DESC("republish_function")})},
         {args, sc(ref("republish_args"), #{default => #{}})}
     ];
-fields("builtin_output_console") ->
+fields("builtin_action_console") ->
     [
         {function, sc(console, #{desc => ?DESC("console_function")})}
-        %% we may support some args for the console output in the future
-        %, {args, sc(map(), #{desc => "The arguments of the built-in 'console' output",
+        %% we may support some args for the console action in the future
+        %, {args, sc(map(), #{desc => "The arguments of the built-in 'console' action",
         %    default => #{}})}
     ];
 fields("user_provided_function") ->
@@ -169,10 +169,10 @@ desc("rule_engine") ->
     ?DESC("desc_rule_engine");
 desc("rules") ->
     ?DESC("desc_rules");
-desc("builtin_output_republish") ->
-    ?DESC("desc_builtin_output_republish");
-desc("builtin_output_console") ->
-    ?DESC("desc_builtin_output_console");
+desc("builtin_action_republish") ->
+    ?DESC("desc_builtin_action_republish");
+desc("builtin_action_console") ->
+    ?DESC("desc_builtin_action_console");
 desc("user_provided_function") ->
     ?DESC("desc_user_provided_function");
 desc("republish_args") ->
@@ -207,11 +207,11 @@ validate_rule_name(Name) ->
             {error, Reason}
     end.
 
-outputs() ->
+actions() ->
     [
         binary(),
-        ref("builtin_output_republish"),
-        ref("builtin_output_console"),
+        ref("builtin_action_republish"),
+        ref("builtin_action_console"),
         ref("user_provided_function")
     ].
 

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -71,7 +71,7 @@ fields("rules") ->
                     desc => ?DESC("rules_actions"),
                     default => [],
                     example => [
-                        <<"http:my_http_bridge">>,
+                        <<"webhook:my_webhook">>,
                         #{
                             function => republish,
                             args => #{

--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -51,7 +51,7 @@ test_rule(Sql, Select, Context, EventTopics) ->
         id => RuleId,
         sql => Sql,
         from => EventTopics,
-        outputs => [#{mod => ?MODULE, func => get_selected_data, args => #{}}],
+        actions => [#{mod => ?MODULE, func => get_selected_data, args => #{}}],
         enable => true,
         is_foreach => emqx_rule_sqlparser:select_is_foreach(Select),
         fields => emqx_rule_sqlparser:select_fields(Select),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -35,6 +35,7 @@ all() ->
         {group, registry},
         {group, runtime},
         {group, events},
+        {group, telemetry},
         {group, bugs}
     ].
 
@@ -91,6 +92,10 @@ groups() ->
             t_sqlparse_invalid_json
         ]},
         {events, [], [t_events]},
+        {telemetry, [], [
+            t_get_basic_usage_info_0,
+            t_get_basic_usage_info_1
+        ]},
         {bugs, [], [
             t_sqlparse_payload_as,
             t_sqlparse_nested_get
@@ -2297,7 +2302,7 @@ t_get_basic_usage_info_1(_Config) ->
             referenced_bridges =>
                 #{
                     mqtt => 1,
-                    http => 3
+                    webhook => 3
                 }
         },
         emqx_rule_engine:get_basic_usage_info()

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -2274,8 +2274,8 @@ t_get_basic_usage_info_1(_Config) ->
                     [
                         #{function => <<"erlang:hibernate">>, args => #{}},
                         #{function => console},
-                        <<"http:my_http_bridge">>,
-                        <<"http:my_http_bridge">>
+                        <<"webhook:my_webhook">>,
+                        <<"webhook:my_webhook">>
                     ]
             }
         ),
@@ -2287,7 +2287,7 @@ t_get_basic_usage_info_1(_Config) ->
                 actions =>
                     [
                         <<"mqtt:my_mqtt_bridge">>,
-                        <<"http:my_http_bridge">>
+                        <<"webhook:my_webhook">>
                     ]
             }
         ),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
@@ -33,7 +33,7 @@ t_crud_rule_api(_Config) ->
         <<"description">> => <<"A simple rule">>,
         <<"enable">> => true,
         <<"id">> => RuleID,
-        <<"outputs">> => [#{<<"function">> => <<"console">>}],
+        <<"actions">> => [#{<<"function">> => <<"console">>}],
         <<"sql">> => <<"SELECT * from \"t/1\"">>,
         <<"name">> => <<"test_rule">>
     },


### PR DESCRIPTION
- rename `output` -> `action` from all APIs, configs and codes (emqx_rule_engine).
- rename http_bridge to webhook, and rename the type of webhook bridge `http` -> `webhook` from all APIs, configs and codes (emqx_bridge).