### PR TITLE
build(docker): change docker base image to debian

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -344,7 +344,8 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - alpine3.15.1
+          - [alpine3.15.1, "alpine:3.15.1", "deploy/docker/Dockerfile.alpine"]
+          - [debian11, "debian:11-slim", "deploy/docker/Dockerfile"]
         profile: ${{ fromJson(needs.prepare.outputs.BUILD_PROFILES) }}
         # NOTE: for docker, only support latest otp and elixir
         # versions, not a matrix
@@ -368,7 +369,7 @@ jobs:
           - arch: amd64
             build_machine: aws-arm64
         include:
-          - os: alpine3.15.1
+          - os: [debian11, "debian:11-slim", "deploy/docker/Dockerfile"]
             profile: emqx
             otp: 24.2.1-1
             elixir: 1.13.4
@@ -376,7 +377,7 @@ jobs:
             build_elixir: no_elixir
             build_machine: ubuntu-20.04
             registry: public.ecr.aws
-          - os: alpine3.15.1
+          - os: [debian11, "debian:11-slim", "deploy/docker/Dockerfile"]
             profile: emqx
             otp: 24.2.1-1
             elixir: 1.13.4
@@ -402,7 +403,7 @@ jobs:
         path: |
           source/_build/default/lib/quicer/
           source/deps/quicer/
-        key: ${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ needs.prepare.outputs.DEP_QUICER_REF }}
+        key: ${{ matrix.os[0] }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ needs.prepare.outputs.DEP_QUICER_REF }}
 
     - name: Login for docker.
       uses: docker/login-action@v1
@@ -423,7 +424,6 @@ jobs:
     - name: prepare for docker-action-parms
       id: pre-meta
       run: |
-        img=$(echo ${{ matrix.os }} | sed 's#\([0-9.]\+\)$#:\1#g')
         emqx_name=${{ matrix.profile }}
         img_suffix=${{ matrix.arch }}
         img_labels="org.opencontainers.image.otp.version=${{ matrix.otp }}"
@@ -433,7 +433,9 @@ jobs:
           img_suffix="elixir-${{ matrix.arch }}"
           img_labels="org.opencontainers.image.elixir.version=${{ matrix.elixir }}\n${img_labels}"
         fi
-        echo "::set-output name=img::${img}"
+        if [[ ${{ matrix.os[0] }} =~ "alpine" ]]; then
+          img_suffix="${img_suffix}-alpine"
+        fi
         echo "::set-output name=emqx_name::${emqx_name}"
         echo "::set-output name=img_suffix::${img_suffix}"
         echo "::set-output name=img_labels::${img_labels}"
@@ -465,10 +467,10 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          BUILD_FROM=ghcr.io/emqx/emqx-builder/5.0-16:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
-          RUN_FROM=${{ steps.pre-meta.outputs.img }}
+          BUILD_FROM=ghcr.io/emqx/emqx-builder/5.0-16:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os[0] }}
+          RUN_FROM=${{ matrix.os[1] }}
           EMQX_NAME=${{ steps.pre-meta.outputs.emqx_name }}
-        file: source/deploy/docker/Dockerfile
+        file: source/${{ matrix.os[2] }}
         context: source
 
   docker-push-multi-arch-manifest:
@@ -483,6 +485,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        os:
+          - [alpine3.15.1, "alpine:3.15.1", "deploy/docker/Dockerfile.alpine"]
+          - [debian11, "debian:11-slim", "deploy/docker/Dockerfile"]
         profile: ${{ fromJson(needs.prepare.outputs.BUILD_PROFILES) }}
         # NOTE: for docker, only support latest otp version, not a matrix
         otp:
@@ -506,7 +511,7 @@ jobs:
           - arch: amd64
             build_machine: aws-arm64
         include:
-          - os: alpine3.15.1
+          - os: [debian11, "debian:11-slim", "deploy/docker/Dockerfile"]
             profile: emqx
             otp: 24.2.1-1
             elixir: 1.13.4
@@ -514,7 +519,7 @@ jobs:
             build_elixir: no_elixir
             build_machine: ubuntu-20.04
             registry: public.ecr.aws
-          - os: alpine3.15.1
+          - os: [debian11, "debian:11-slim", "deploy/docker/Dockerfile"]
             profile: emqx
             otp: 24.2.1-1
             elixir: 1.13.4
@@ -551,7 +556,6 @@ jobs:
       - name: prepare for docker-action-parms
         id: pre-meta
         run: |
-          img=$(echo ${{ matrix.os }} | sed 's#\([0-9.]\+\)$#:\1#g')
           emqx_name=${{ matrix.profile }}
           img_suffix=${{ matrix.arch }}
           img_labels="org.opencontainers.image.otp.version=${{ matrix.otp }}"
@@ -560,6 +564,9 @@ jobs:
             emqx_name="emqx-elixir"
             img_suffix="elixir-${{ matrix.arch }}"
             img_labels="org.opencontainers.image.elixir.version=${{ matrix.elixir }}\n$img_labels"
+          fi
+          if [[ ${{ matrix.os[0] }} =~ "alpine" ]]; then
+            img_suffix="${img_suffix}-alpine"
           fi
           echo "::set-output name=img::${img}"
           echo "::set-output name=emqx_name::${emqx_name}"

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -47,7 +47,7 @@ jobs:
           - mnesia
           - rlog
         os:
-          - alpine3.15.1
+          - ["alpine3.15.1", "alpine:3.15.1"]
         otp:
           - 24.2.1-1
         elixir:
@@ -78,12 +78,13 @@ jobs:
         path: |
           source/_build/default/lib/quicer/
           source/deps/quicer/
-        key: ${{ matrix.os }}-${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
+        key: ${{ matrix.os[0] }}-${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
 
     - name: make docker image
       working-directory: source
       env:
-        EMQX_BUILDER: ghcr.io/emqx/emqx-builder/5.0-16:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+        EMQX_BUILDER: ghcr.io/emqx/emqx-builder/5.0-16:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os[0] }}
+        EMQX_RUNNER: ${{ matrix.os[1] }}
       run: |
         make ${{ matrix.profile }}-docker
     - name: run emqx
@@ -128,7 +129,7 @@ jobs:
         profile:
         - emqx
         os:
-          - alpine3.15.1
+          - ["debian11", "debian:11-slim"]
         otp:
           - 24.2.1-1
         elixir:
@@ -158,12 +159,13 @@ jobs:
       uses: actions/cache@v2
       with:
         path: source/_build/default/lib/quicer/
-        key: ${{ matrix.os }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
+        key: ${{ matrix.os[0] }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ steps.deps-refs.outputs.DEP_QUICER_REF }}
 
     - name: make docker image
       working-directory: source
       env:
-        EMQX_BUILDER: ghcr.io/emqx/emqx-builder/5.0-16:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}
+        EMQX_BUILDER: ghcr.io/emqx/emqx-builder/5.0-16:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os[0] }}
+        EMQX_RUNNER: ${{ matrix.os[1] }}
       run: |
         make ${{ matrix.profile }}-docker
         echo "TARGET=emqx/${{ matrix.profile }}" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,11 @@ REBAR = $(CURDIR)/rebar3
 BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts
 export EMQX_RELUP ?= true
-export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.0-16:1.13.4-24.2.1-1-alpine3.15.1
-export EMQX_DEFAULT_RUNNER = alpine:3.15.1
+export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.0-16:1.13.4-24.2.1-1-debian11
+export EMQX_DEFAULT_RUNNER = debian:11-slim
 export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export ELIXIR_VSN ?= $(shell $(CURDIR)/scripts/get-elixir-vsn.sh)
 export EMQX_DASHBOARD_VERSION ?= v0.35.0
-export DOCKERFILE := deploy/docker/Dockerfile
 export EMQX_REL_FORM ?= tgz
 ifeq ($(OS),Windows_NT)
 	export REBAR_COLOR=none

--- a/build
+++ b/build
@@ -209,13 +209,18 @@ make_tgz() {
     log "Tarball sha256sum: $(cat "${target}.sha256")"
 }
 
-## This function builds the default docker image based on alpine:3.15.1 (by default)
+## This function builds the default docker image based on debian 11
 make_docker() {
     EMQX_BUILDER="${EMQX_BUILDER:-${EMQX_DEFAULT_BUILDER}}"
     EMQX_RUNNER="${EMQX_RUNNER:-${EMQX_DEFAULT_RUNNER}}"
-
-    if [[ "$PROFILE" = *-elixir ]]
-    then
+    if [ -z "${EMQX_DOCKERFILE:-}" ]; then
+        if [[ "$EMQX_BUILDER" =~ "alpine" ]]; then
+            EMQX_DOCKERFILE='deploy/docker/Dockerfile.alpine'
+        else
+            EMQX_DOCKERFILE='deploy/docker/Dockerfile'
+        fi
+    fi
+    if [[ "$PROFILE" = *-elixir ]]; then
       PKG_VSN="$PKG_VSN-elixir"
     fi
 
@@ -225,7 +230,7 @@ make_docker() {
        --build-arg RUN_FROM="${EMQX_RUNNER}" \
        --build-arg EMQX_NAME="$PROFILE" \
        --tag "emqx/${PROFILE%%-elixir}:${PKG_VSN}" \
-       -f "${DOCKERFILE}" .
+       -f "${EMQX_DOCKERFILE}" .
 }
 
 function join {

--- a/deploy/docker/Dockerfile.alpine
+++ b/deploy/docker/Dockerfile.alpine
@@ -1,6 +1,27 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.0-16:1.13.4-24.2.1-1-debian11
-ARG RUN_FROM=debian:11-slim
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.0-15:1.13.3-24.2.1-1-alpine3.15.1
+ARG RUN_FROM=alpine:3.15.1
 FROM ${BUILD_FROM} AS builder
+
+RUN apk add --no-cache \
+    autoconf \
+    automake \
+    bash \
+    bison \
+    bsd-compat-headers \
+    coreutils \
+    curl \
+    flex \
+    g++ \
+    gcc \
+    git \
+    jq \
+    libc-dev \
+    libstdc++ \
+    libtool \
+    make \
+    ncurses-dev \
+    openssl-dev \
+    perl
 
 COPY . /emqx
 
@@ -24,18 +45,15 @@ COPY deploy/docker/docker-entrypoint.sh /usr/bin/
 COPY --from=builder /emqx-rel/emqx /opt/emqx
 
 RUN ln -s /opt/emqx/bin/* /usr/local/bin/
-
-RUN apt-get update; \
-    apt-get install -y --no-install-recommends ca-certificates procps; \
-    rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache curl ncurses-libs openssl sudo libstdc++ bash
 
 WORKDIR /opt/emqx
 
-RUN groupadd -r -g 1000 emqx; \
-    useradd -r -m -u 1000 -g emqx emqx; \
-    chgrp -Rf emqx /opt/emqx; \
-    chmod -Rf g+w /opt/emqx; \
-    chown -Rf emqx /opt/emqx
+RUN adduser -D -u 1000 emqx \
+    && echo "emqx ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+
+RUN chgrp -Rf emqx /opt/emqx && chmod -Rf g+w /opt/emqx \
+    && chown -Rf emqx /opt/emqx
 
 USER emqx
 


### PR DESCRIPTION
And add new tag for alpine image

## Why do it

1. The docker official image uses debian, and `emqx/emqx` can be unified with it
2. Debian has an advantage over alpine in terms of sysctl and daily toolsets
3. We have emqx debian zip package, so debian image can use hot upgrade