### PR TITLE
refactor: stop releasing edge edition

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -47,14 +47,14 @@ jobs:
           tag=${{ github.ref }}
           case $tag in
             refs/tags/v*)
-              echo "::set-output name=BUILD_PROFILES::[\"emqx\",\"emqx-edge\"]"
+              echo "::set-output name=BUILD_PROFILES::[\"emqx\"]"
               ;;
             refs/tags/e*)
               echo "::set-output name=BUILD_PROFILES::[\"emqx-enterprise\"]"
               ;;
             *)
               # this is for testing ?
-              echo "::set-output name=BUILD_PROFILES::[\"emqx-edge\",\"emqx\",\"emqx-enterprise\"]"
+              echo "::set-output name=BUILD_PROFILES::[\"emqx\",\"emqx-enterprise\"]"
               ;;
           esac
       - name: get_all_deps
@@ -126,8 +126,6 @@ jobs:
         os:
           - macos-11
           - macos-10.15
-        exclude:
-          - profile: emqx-edge
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/download-artifact@v2
@@ -638,8 +636,6 @@ jobs:
             s3dir='emqx-ce'
         elif [ $PROFILE = 'emqx-enterprise' ]; then
             s3dir='emqx-ee'
-        elif [ $PROFILE = 'emqx-edge' ]; then
-            s3dir='emqx-edge'
         else
             echo "unknown profile $PROFILE"
             exit 1

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -29,7 +29,6 @@ jobs:
       fail-fast: false
       matrix:
         profile:
-        - emqx-edge
         - emqx
         - emqx-enterprise
         otp:
@@ -227,7 +226,6 @@ jobs:
     strategy:
       matrix:
         profile:
-        - emqx-edge
         - emqx
         - emqx-enterprise
     runs-on: aws-amd64

--- a/.github/workflows/elixir_apps_check.yaml
+++ b/.github/workflows/elixir_apps_check.yaml
@@ -15,20 +15,12 @@ jobs:
       matrix:
         release_type:
           - cloud
-          - edge
         package_type:
           - bin
           - pkg
         edition_type:
           - community
           - enterprise
-        exclude:
-          - release_type: edge
-            package_type: bin
-            edition_type: enterprise
-          - release_type: edge
-            package_type: pkg
-            edition_type: enterprise
 
     steps:
       - name: fix_git_permission

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         profile:
-          - emqx-edge
           - emqx
           - emqx-enterprise
 
@@ -28,8 +27,6 @@ jobs:
               s3dir='emqx-ce'
           elif [ $PROFILE = 'emqx-enterprise' ]; then
               s3dir='emqx-ee'
-          elif [ $PROFILE = 'emqx-edge' ]; then
-              s3dir='emqx-edge'
           else
               echo "unknown profile $PROFILE"
               exit 1

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -41,7 +41,6 @@ jobs:
       matrix:
         profile:
           - emqx
-          - emqx-edge
           - emqx-enterprise
           - emqx-elixir
         cluster_db_backend:
@@ -55,9 +54,6 @@ jobs:
           - 1.13.3
         arch:
           - amd64
-        exclude:
-          - profile: emqx-edge
-            cluster_db_backend: rlog
     steps:
     - uses: actions/download-artifact@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ else
 endif
 
 PROFILE ?= emqx
-REL_PROFILES := emqx emqx-edge emqx-enterprise
-PKG_PROFILES := emqx-pkg emqx-edge-pkg emqx-enterprise-pkg
+REL_PROFILES := emqx emqx-enterprise
+PKG_PROFILES := emqx-pkg emqx-enterprise-pkg
 PROFILES := $(REL_PROFILES) $(PKG_PROFILES) default
 
 CT_NODE_NAME ?= 'test@127.0.0.1'

--- a/apps/emqx/src/emqx_release.erl
+++ b/apps/emqx/src/emqx_release.erl
@@ -26,14 +26,12 @@
 
 -define(EMQX_DESCS, #{
     ee => "EMQX Enterprise",
-    ce => "EMQX",
-    edge => "EMQX Edge"
+    ce => "EMQX"
 }).
 
 -define(EMQX_REL_VSNS, #{
     ee => ?EMQX_RELEASE_EE,
-    ce => ?EMQX_RELEASE_CE,
-    edge => ?EMQX_RELEASE_CE
+    ce => ?EMQX_RELEASE_CE
 }).
 
 %% @doc Return EMQX description.
@@ -43,7 +41,7 @@ description() ->
 %% @doc Return EMQX edition info.
 %% Read info from persistent_term at runtime.
 %% Or meck this function to run tests for another edition.
--spec edition() -> ce | ee | edge.
+-spec edition() -> ce | ee.
 -ifdef(EMQX_RELEASE_EDITION).
 edition() -> ?EMQX_RELEASE_EDITION.
 -else.

--- a/apps/emqx/test/emqx_pool_SUITE.erl
+++ b/apps/emqx/test/emqx_pool_SUITE.erl
@@ -41,6 +41,7 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
+    _ = application:stop(grpoc),
     ok = emqx_logger:set_log_level(emergency),
     application:ensure_all_started(gproc),
     Config.

--- a/apps/emqx_rule_engine/rebar.config
+++ b/apps/emqx_rule_engine/rebar.config
@@ -10,7 +10,6 @@
     warn_unused_import,
     warn_obsolete_guard,
     no_debug_info,
-    %% for edge
     compressed,
     {parse_transform}
 ]}.

--- a/build
+++ b/build
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # This script helps to build release artifacts.
-# arg1: profile, e.g. emqx | emqx-edge | emqx-pkg | emqx-edge-pkg
+# arg1: profile, e.g. emqx | emqx-pkg
 # arg2: artifact, e.g. rel | relup | tgz | pkg
 
 if [[ -n "$DEBUG" ]]; then
@@ -237,10 +237,10 @@ function join {
 export_release_vars() {
   local profile="$1"
   case "$profile" in
-    emqx|emqx-edge|emqx-enterprise)
+    emqx|emqx-enterprise)
       export ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-no}
       ;;
-    emqx-pkg|emqx-edge-pkg|emqx-enterprise-pkg)
+    emqx-pkg|emqx-enterprise-pkg)
       export ELIXIR_MAKE_TAR=${ELIXIR_MAKE_TAR:-yes}
       ;;
     *)
@@ -254,9 +254,6 @@ export_release_vars() {
   case "$profile" in
     *enterprise*)
       erl_opts+=( "{d, 'EMQX_RELEASE_EDITION', ee}" )
-      ;;
-    *edge*)
-      erl_opts+=( "{d, 'EMQX_RELEASE_EDITION', edge}" )
       ;;
     *)
       erl_opts+=( "{d, 'EMQX_RELEASE_EDITION', ce}" )

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 help() {
     echo
     echo "-h|--help:                 To display this usage information"
-    echo "--profile <PROFILE>:       EMQX profile to build (emqx|emqx-edge|emqx-enterprise)"
+    echo "--profile <PROFILE>:       EMQX profile to build (emqx|emqx-enterprise)"
     echo "--pkgtype tgz|pkg:         Specify which package to build, tgz for .tar.gz,"
     echo "                           pkg for .rpm or .deb"
     echo "--elixir:                  Specify if the release should be built with Elixir, "

--- a/scripts/check-elixir-applications.exs
+++ b/scripts/check-elixir-applications.exs
@@ -22,7 +22,7 @@ defmodule CheckElixirApplications do
       env: [{"DEBUG", "1"}]
     )
 
-    mix_apps = mix_applications(inputs.release_type, inputs.edition_type)
+    mix_apps = mix_applications(inputs.edition_type)
     rebar_apps = rebar_applications(profile)
     results = diff_apps(mix_apps, rebar_apps)
 
@@ -70,8 +70,8 @@ defmodule CheckElixirApplications do
     end
   end
 
-  defp mix_applications(release_type, edition_type) do
-    EMQXUmbrella.MixProject.applications(release_type, edition_type)
+  defp mix_applications(edition_type) do
+    EMQXUmbrella.MixProject.applications(edition_type)
   end
 
   defp rebar_applications(profile) do

--- a/scripts/pkg-tests.sh
+++ b/scripts/pkg-tests.sh
@@ -9,9 +9,6 @@ case "${MAKE_TARGET}" in
     emqx-enterprise-*)
         EMQX_NAME='emqx-enterprise'
         ;;
-    emqx-edge-*)
-        EMQX_NAME='emqx-edge'
-        ;;
     emqx-*)
         EMQX_NAME='emqx'
         ;;

--- a/scripts/relup-base-packages.sh
+++ b/scripts/relup-base-packages.sh
@@ -21,10 +21,6 @@ case $PROFILE in
         DIR='enterprise'
         EDITION='enterprise'
         ;;
-    "emqx-edge")
-        DIR='edge'
-        EDITION='edge'
-        ;;
     *)
         echo "Unknown profile $PROFILE"
         exit 1


### PR DESCRIPTION
Prior to EMQX 5.0, the edge edition's main difference comaring
to standard edition are:
* Less number of plugins in the release (smaller package size)
* Smaller number is vm.args (for lower memory usage)

Starting from 5.0 most of the plugins are included as features,
the tuned vm.args arguments does not justify a special release edition.

Also as nanomq is getting mature,
EMQ's recommendtation for MQTT broker in edge is https://nanomq.io/

