### PR TITLE
ci(elixir): use `MIX_ENV` profiles for machine boot checks

### DIFF
--- a/.github/workflows/elixir_apps_check.yaml
+++ b/.github/workflows/elixir_apps_check.yaml
@@ -13,14 +13,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release_type:
-          - cloud
-        package_type:
-          - bin
-          - pkg
-        edition_type:
-          - community
-          - enterprise
+        profile:
+          - emqx
+          - emqx-enterprise
+          - emqx-pkg
+          - emqx-enterprise-pkg
 
     steps:
       - name: fix_git_permission
@@ -36,11 +33,11 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: check applications
         run: ./scripts/check-elixir-applications.exs
+        env:
+          MIX_ENV: ${{ matrix.profile }}
       - name: check applications started with emqx_machine
         run: ./scripts/check-elixir-emqx-machine-boot-discrepancies.exs
         env:
-          EMQX_RELEASE_TYPE: ${{ matrix.release_type }}
-          EMQX_PACKAGE_TYPE: ${{ matrix.package_type }}
-          EMQX_EDITION_TYPE: ${{ matrix.edition_type }}
+          MIX_ENV: ${{ matrix.profile }}
 
 ...

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -248,13 +248,15 @@ end_per_testcase(t_num_clients, Config) ->
     meck:unload([httpc]),
     ok = snabbkaffe:stop(),
     Config;
-end_per_testcase(t_uuid_restored_from_file, _Config) ->
+end_per_testcase(t_uuid_restored_from_file, Config) ->
+    Node = ?config(n1, Config),
     DataDir = emqx:data_dir(),
     NodeUUIDFile = filename:join(DataDir, "node.uuid"),
     ClusterUUIDFile = filename:join(DataDir, "cluster.uuid"),
     ok = file:delete(NodeUUIDFile),
     ok = file:delete(ClusterUUIDFile),
     meck:unload([httpc]),
+    ok = stop_slave(Node),
     ok;
 end_per_testcase(_Testcase, _Config) ->
     meck:unload([httpc]),


### PR DESCRIPTION
With the change to using `MIX_ENV` for choosing a profile, the CI
check became out of date.

