### PR TITLE
ci: For 4.4, release package on OTP 24 only

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -205,7 +205,6 @@ jobs:
           - zip
           - pkg
         otp:
-          - 23.3.4.9-3
           - 24.1.5-3
         arch:
           - amd64
@@ -221,8 +220,6 @@ jobs:
           - centos7
           - raspbian10
         exclude:
-        - package: pkg
-          otp: 23.3.4.9-3
         - os: raspbian9
           arch: amd64
         - os: raspbian10
@@ -376,7 +373,6 @@ jobs:
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         otp:
-          - 23.3.4.9-3
           - 24.1.5-3
         include:
           - profile: emqx

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -77,4 +77,4 @@ docker run -i --rm \
     --workdir /emqx \
     --platform="linux/$ARCH" \
     "$BUILDER" \
-    bash -euc "make ${PROFILE}-${PKGTYPE} && .ci/build_packages/tests.sh $PROFILE $PKGTYPE"
+    bash -euc "git config --global --add safe.directory /emqx && chown -R root:root ./_build && make ${PROFILE}-${PKGTYPE} && .ci/build_packages/tests.sh $PROFILE $PKGTYPE"


### PR DESCRIPTION
when 4.4 was created, OTP 24 was quite new and we were not entirely sure which one will be more stable,
so it was release on both 23 and 24.

now it's becoming clear that we'll not go back to OTP23, we can stop releasing the packages on it.