### PR TITLE
chore(mongodb authn): add defaults for field names

### DIFF
--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
@@ -100,16 +100,19 @@ filter(_) ->
 password_hash_field(type) -> binary();
 password_hash_field(desc) -> ?DESC(?FUNCTION_NAME);
 password_hash_field(required) -> false;
+password_hash_field(default) -> <<"password_hash">>;
 password_hash_field(_) -> undefined.
 
 salt_field(type) -> binary();
 salt_field(desc) -> ?DESC(?FUNCTION_NAME);
 salt_field(required) -> false;
+salt_field(default) -> <<"salt">>;
 salt_field(_) -> undefined.
 
 is_superuser_field(type) -> binary();
 is_superuser_field(desc) -> ?DESC(?FUNCTION_NAME);
 is_superuser_field(required) -> false;
+is_superuser_field(default) -> <<"is_superuser">>;
 is_superuser_field(_) -> undefined.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
Since these fields are not required, it's reasonable to set defaults for them.