### PR TITLE
fix: add default&example for schema

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -78,7 +78,6 @@
 
 -export_type([limiter_type/0, bucket_path/0]).
 
--import(emqx_schema, [sc/2, map/2]).
 -define(UNIT_TIME_IN_MS, 1000).
 
 namespace() -> limiter.
@@ -87,28 +86,29 @@ roots() -> [limiter].
 
 fields(limiter) ->
     [
-        {Type, sc(ref(limiter_opts), #{desc => ?DESC(Type), default => #{<<"enable">> => false}})}
+        {Type,
+            ?HOCON(?R_REF(limiter_opts), #{
+                desc => ?DESC(Type),
+                default => #{<<"enable">> => false}
+            })}
      || Type <- types()
     ];
 fields(limiter_opts) ->
     [
-        {enable, sc(boolean(), #{desc => ?DESC(enable), default => true})},
-        {rate, sc(rate(), #{desc => ?DESC(rate), default => "infinity"})},
+        {enable, ?HOCON(boolean(), #{desc => ?DESC(enable), default => true})},
+        {rate, ?HOCON(rate(), #{desc => ?DESC(rate), default => "infinity"})},
         {burst,
-            sc(
-                burst_rate(),
-                #{
-                    desc => ?DESC(burst),
-                    default => 0
-                }
-            )},
+            ?HOCON(burst_rate(), #{
+                desc => ?DESC(burst),
+                default => 0
+            })},
         {bucket,
-            sc(
-                map("bucket_name", ref(bucket_opts)),
+            ?HOCON(
+                ?MAP("bucket_name", ?R_REF(bucket_opts)),
                 #{
                     desc => ?DESC(bucket_cfg),
                     default => #{<<"default">> => #{}},
-                    examples => #{
+                    example => #{
                         <<"mybucket-name">> => #{
                             <<"rate">> => <<"infinity">>,
                             <<"capcity">> => <<"infinity">>,
@@ -121,12 +121,12 @@ fields(limiter_opts) ->
     ];
 fields(bucket_opts) ->
     [
-        {rate, sc(rate(), #{desc => ?DESC(rate), default => "infinity"})},
-        {capacity, sc(capacity(), #{desc => ?DESC(capacity), default => "infinity"})},
-        {initial, sc(initial(), #{default => "0", desc => ?DESC(initial)})},
+        {rate, ?HOCON(rate(), #{desc => ?DESC(rate), default => "infinity"})},
+        {capacity, ?HOCON(capacity(), #{desc => ?DESC(capacity), default => "infinity"})},
+        {initial, ?HOCON(initial(), #{default => "0", desc => ?DESC(initial)})},
         {per_client,
-            sc(
-                ref(client_bucket),
+            ?HOCON(
+                ?R_REF(client_bucket),
                 #{
                     default => #{},
                     desc => ?DESC(per_client)
@@ -135,14 +135,14 @@ fields(bucket_opts) ->
     ];
 fields(client_bucket) ->
     [
-        {rate, sc(rate(), #{default => "infinity", desc => ?DESC(rate)})},
-        {initial, sc(initial(), #{default => "0", desc => ?DESC(initial)})},
+        {rate, ?HOCON(rate(), #{default => "infinity", desc => ?DESC(rate)})},
+        {initial, ?HOCON(initial(), #{default => "0", desc => ?DESC(initial)})},
         %% low_watermark add for emqx_channel and emqx_session
         %% both modules consume first and then check
         %% so we need to use this value to prevent excessive consumption
         %% (e.g, consumption from an empty bucket)
         {low_watermark,
-            sc(
+            ?HOCON(
                 initial(),
                 #{
                     desc => ?DESC(low_watermark),
@@ -150,12 +150,12 @@ fields(client_bucket) ->
                 }
             )},
         {capacity,
-            sc(capacity(), #{
+            ?HOCON(capacity(), #{
                 desc => ?DESC(client_bucket_capacity),
                 default => "infinity"
             })},
         {divisible,
-            sc(
+            ?HOCON(
                 boolean(),
                 #{
                     desc => ?DESC(divisible),
@@ -163,7 +163,7 @@ fields(client_bucket) ->
                 }
             )},
         {max_retry_time,
-            sc(
+            ?HOCON(
                 emqx_schema:duration(),
                 #{
                     desc => ?DESC(max_retry_time),
@@ -171,7 +171,7 @@ fields(client_bucket) ->
                 }
             )},
         {failure_strategy,
-            sc(
+            ?HOCON(
                 failure_strategy(),
                 #{
                     desc => ?DESC(failure_strategy),
@@ -212,7 +212,6 @@ types() ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
-ref(Field) -> hoconsc:ref(?MODULE, Field).
 
 to_burst_rate(Str) ->
     to_rate(Str, false, true).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -62,7 +62,7 @@ roots() ->
 
 fields(get) ->
     [
-        {method, #{type => get, required => true, default => post, desc => ?DESC(method)}},
+        {method, #{type => get, required => true, default => get, desc => ?DESC(method)}},
         {headers, fun headers_no_content_type/1}
     ] ++ common_fields();
 fields(post) ->

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -78,6 +78,7 @@ set_special_configs(_App) ->
     <<"enable">> => true,
     <<"url">> => <<"https://example.com:443/a/b?c=d">>,
     <<"headers">> => #{},
+    <<"ssl">> => #{<<"enable">> => true},
     <<"method">> => <<"get">>,
     <<"request_timeout">> => 5000
 }).

--- a/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_sources_SUITE.erl
@@ -33,6 +33,7 @@
     <<"type">> => <<"http">>,
     <<"enable">> => true,
     <<"url">> => <<"https://fake.com:443/acl?username=", ?PH_USERNAME/binary>>,
+    <<"ssl">> => #{<<"enable">> => true},
     <<"headers">> => #{},
     <<"method">> => <<"get">>,
     <<"request_timeout">> => <<"5s">>

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
@@ -36,36 +36,36 @@ roots() ->
 fields("auto_subscribe") ->
     [
         {topics,
-            hoconsc:mk(
-                hoconsc:array(hoconsc:ref(?MODULE, "topic")),
+            ?HOCON(
+                ?ARRAY(?R_REF("topic")),
                 #{desc => ?DESC(auto_subscribe), default => []}
             )}
     ];
 fields("topic") ->
     [
         {topic,
-            sc(binary(), #{
+            ?HOCON(binary(), #{
                 required => true,
                 example => topic_example(),
                 desc => ?DESC("topic")
             })},
         {qos,
-            sc(emqx_schema:qos(), #{
+            ?HOCON(emqx_schema:qos(), #{
                 default => 0,
                 desc => ?DESC("qos")
             })},
         {rh,
-            sc(range(0, 2), #{
+            ?HOCON(range(0, 2), #{
                 default => 0,
                 desc => ?DESC("rh")
             })},
         {rap,
-            sc(range(0, 1), #{
+            ?HOCON(range(0, 1), #{
                 default => 0,
                 desc => ?DESC("rap")
             })},
         {nl,
-            sc(range(0, 1), #{
+            ?HOCON(range(0, 1), #{
                 default => 0,
                 desc => ?DESC(nl)
             })}
@@ -78,10 +78,3 @@ desc(_) -> undefined.
 topic_example() ->
     <<"/clientid/", ?PH_S_CLIENTID, "/username/", ?PH_S_USERNAME, "/host/", ?PH_S_HOST, "/port/",
         ?PH_S_PORT>>.
-
-%%--------------------------------------------------------------------
-%% Internal functions
-%%--------------------------------------------------------------------
-
-sc(Type, Meta) ->
-    hoconsc:mk(Type, Meta).

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -341,6 +341,7 @@ fields(cluster_k8s) ->
             sc(
                 string(),
                 #{
+                    default => "http://10.110.111.204:8080",
                     desc => ?DESC(cluster_k8s_apiserver),
                     'readOnly' => true
                 }
@@ -358,6 +359,7 @@ fields(cluster_k8s) ->
             sc(
                 hoconsc:enum([ip, dns, hostname]),
                 #{
+                    default => ip,
                     desc => ?DESC(cluster_k8s_address_type),
                     'readOnly' => true
                 }
@@ -731,7 +733,7 @@ fields("rpc") ->
                 emqx_schema:duration_s(),
                 #{
                     mapping => "gen_rpc.socket_keepalive_idle",
-                    default => "7200s",
+                    default => "15m",
                     desc => ?DESC(rpc_socket_keepalive_idle)
                 }
             )},

--- a/apps/emqx_connector/src/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/emqx_connector_schema.erl
@@ -20,8 +20,6 @@
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 
--import(hoconsc, [mk/2, ref/2]).
-
 -export([namespace/0, roots/0, fields/1, desc/1]).
 
 -export([
@@ -46,8 +44,8 @@ post_request() ->
     http_schema("post").
 
 http_schema(Method) ->
-    Schemas = [ref(schema_mod(Type), Method) || Type <- ?CONN_TYPES],
-    hoconsc:union(Schemas).
+    Schemas = [?R_REF(schema_mod(Type), Method) || Type <- ?CONN_TYPES],
+    ?UNION(Schemas).
 
 %%======================================================================================
 %% Hocon Schema Definitions
@@ -61,11 +59,8 @@ fields(connectors) ->
 fields("connectors") ->
     [
         {mqtt,
-            mk(
-                hoconsc:map(
-                    name,
-                    ref(emqx_connector_mqtt_schema, "connector")
-                ),
+            ?HOCON(
+                ?MAP(name, ?R_REF(emqx_connector_mqtt_schema, "connector")),
                 #{desc => ?DESC("mqtt")}
             )}
     ].

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -30,14 +30,14 @@ roots() -> ["dashboard"].
 fields("dashboard") ->
     [
         {listeners,
-            sc(
-                ref("listeners"),
+            ?HOCON(
+                ?R_REF("listeners"),
                 #{desc => ?DESC(listeners)}
             )},
         {default_username, fun default_username/1},
         {default_password, fun default_password/1},
         {sample_interval,
-            sc(
+            ?HOCON(
                 emqx_schema:duration_s(),
                 #{
                     default => "10s",
@@ -46,7 +46,7 @@ fields("dashboard") ->
                 }
             )},
         {token_expired_time,
-            sc(
+            ?HOCON(
                 emqx_schema:duration(),
                 #{
                     default => "60m",
@@ -59,16 +59,16 @@ fields("dashboard") ->
 fields("listeners") ->
     [
         {"http",
-            sc(
-                ref("http"),
+            ?HOCON(
+                ?R_REF("http"),
                 #{
                     desc => "TCP listeners",
                     required => {false, recursively}
                 }
             )},
         {"https",
-            sc(
-                ref("https"),
+            ?HOCON(
+                ?R_REF("https"),
                 #{
                     desc => "SSL listeners",
                     required => {false, recursively}
@@ -78,13 +78,13 @@ fields("listeners") ->
 fields("http") ->
     [
         enable(true),
-        bind(18803)
+        bind(18083)
         | common_listener_fields()
     ];
 fields("https") ->
     [
         enable(false),
-        bind(18804)
+        bind(18084)
         | common_listener_fields() ++
             exclude_fields(
                 ["fail_if_no_peer_cert"],
@@ -104,7 +104,7 @@ exclude_fields([FieldName | Rest], Fields) ->
 common_listener_fields() ->
     [
         {"num_acceptors",
-            sc(
+            ?HOCON(
                 integer(),
                 #{
                     default => 4,
@@ -112,7 +112,7 @@ common_listener_fields() ->
                 }
             )},
         {"max_connections",
-            sc(
+            ?HOCON(
                 integer(),
                 #{
                     default => 512,
@@ -120,7 +120,7 @@ common_listener_fields() ->
                 }
             )},
         {"backlog",
-            sc(
+            ?HOCON(
                 integer(),
                 #{
                     default => 1024,
@@ -128,7 +128,7 @@ common_listener_fields() ->
                 }
             )},
         {"send_timeout",
-            sc(
+            ?HOCON(
                 emqx_schema:duration(),
                 #{
                     default => "5s",
@@ -136,7 +136,7 @@ common_listener_fields() ->
                 }
             )},
         {"inet6",
-            sc(
+            ?HOCON(
                 boolean(),
                 #{
                     default => false,
@@ -144,7 +144,7 @@ common_listener_fields() ->
                 }
             )},
         {"ipv6_v6only",
-            sc(
+            ?HOCON(
                 boolean(),
                 #{
                     default => false,
@@ -155,7 +155,7 @@ common_listener_fields() ->
 
 enable(Bool) ->
     {"enable",
-        sc(
+        ?HOCON(
             boolean(),
             #{
                 default => Bool,
@@ -166,12 +166,12 @@ enable(Bool) ->
 
 bind(Port) ->
     {"bind",
-        sc(
-            hoconsc:union([non_neg_integer(), emqx_schema:ip_port()]),
+        ?HOCON(
+            ?UNION([non_neg_integer(), emqx_schema:ip_port()]),
             #{
                 default => Port,
                 required => true,
-                extra => #{example => [Port, "0.0.0.0:" ++ integer_to_list(Port)]},
+                example => "0.0.0.0:" ++ integer_to_list(Port),
                 desc => ?DESC(bind)
             }
         )}.
@@ -222,7 +222,3 @@ validate_sample_interval(Second) ->
             Msg = "must be between 1 and 60 and be a divisor of 60.",
             {error, Msg}
     end.
-
-sc(Type, Meta) -> hoconsc:mk(Type, Meta).
-
-ref(Field) -> hoconsc:ref(?MODULE, Field).

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -667,6 +667,8 @@ typename_to_spec("{binary(), binary()}", _Mod) ->
     #{type => object, example => #{}};
 typename_to_spec("comma_separated_list()", _Mod) ->
     #{type => string, example => <<"item1,item2">>};
+typename_to_spec("comma_separated_binary()", _Mod) ->
+    #{type => string, example => <<"item1,item2">>};
 typename_to_spec("comma_separated_atoms()", _Mod) ->
     #{type => string, example => <<"item1,item2">>};
 typename_to_spec("pool_type()", _Mod) ->

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -215,7 +215,7 @@ fields(coap) ->
             )},
         {notify_type,
             sc(
-                hoconsc:union([non, con, qos]),
+                hoconsc:enum([non, con, qos]),
                 #{
                     default => qos,
                     desc => ?DESC(coap_notify_type)
@@ -291,9 +291,9 @@ fields(lwm2m) ->
         %% FIXME: not working now
         {update_msg_publish_condition,
             sc(
-                hoconsc:union([always, contains_object_list]),
+                hoconsc:enum([always, contains_object_list]),
                 #{
-                    default => "contains_object_list",
+                    default => contains_object_list,
                     desc => ?DESC(lwm2m_update_msg_publish_condition)
                 }
             )},

--- a/apps/emqx_modules/src/emqx_modules_schema.erl
+++ b/apps/emqx_modules/src/emqx_modules_schema.erl
@@ -39,33 +39,34 @@ roots() ->
     ].
 
 fields("telemetry") ->
-    [{enable, hoconsc:mk(boolean(), #{default => true, desc => "Enable telemetry."})}];
+    [{enable, ?HOCON(boolean(), #{default => true, desc => "Enable telemetry."})}];
 fields("delayed") ->
     [
-        {enable, hoconsc:mk(boolean(), #{default => true, desc => ?DESC(enable)})},
-        {max_delayed_messages, sc(integer(), #{desc => ?DESC(max_delayed_messages), default => 0})}
+        {enable, ?HOCON(boolean(), #{default => true, desc => ?DESC(enable)})},
+        {max_delayed_messages,
+            ?HOCON(integer(), #{desc => ?DESC(max_delayed_messages), default => 0})}
     ];
 fields("rewrite") ->
     [
         {action,
-            sc(
+            ?HOCON(
                 hoconsc:enum([subscribe, publish, all]),
                 #{required => true, desc => ?DESC(tr_action), example => publish}
             )},
         {source_topic,
-            sc(
+            ?HOCON(
                 binary(),
                 #{required => true, desc => ?DESC(tr_source_topic), example => "x/#"}
             )},
         {dest_topic,
-            sc(
+            ?HOCON(
                 binary(),
                 #{required => true, desc => ?DESC(tr_dest_topic), example => "z/y/$1"}
             )},
         {re, fun regular_expression/1}
     ];
 fields("topic_metrics") ->
-    [{topic, sc(binary(), #{desc => "Collect metrics for the topic."})}].
+    [{topic, ?HOCON(binary(), #{desc => "Collect metrics for the topic."})}].
 
 desc("telemetry") ->
     "Settings for the telemetry module.";
@@ -91,6 +92,4 @@ is_re(Bin) ->
         {error, Reason} -> {error, {Bin, Reason}}
     end.
 
-array(Name, Meta) -> {Name, hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, Name)), Meta)}.
-
-sc(Type, Meta) -> hoconsc:mk(Type, Meta).
+array(Name, Meta) -> {Name, ?HOCON(?ARRAY(?R_REF(Name)), Meta)}.

--- a/apps/emqx_plugins/src/emqx_plugins_schema.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_schema.erl
@@ -45,7 +45,7 @@ fields(state) ->
 state_fields() ->
     [
         {name_vsn,
-            hoconsc:mk(
+            ?HOCON(
                 string(),
                 #{
                     desc => ?DESC(name_vsn),
@@ -53,7 +53,7 @@ state_fields() ->
                 }
             )},
         {enable,
-            hoconsc:mk(
+            ?HOCON(
                 boolean(),
                 #{
                     desc => ?DESC(enable),
@@ -69,7 +69,7 @@ root_fields() ->
         {check_interval, fun check_interval/1}
     ].
 
-states(type) -> hoconsc:array(hoconsc:ref(?MODULE, state));
+states(type) -> ?ARRAY(?R_REF(state));
 states(required) -> false;
 states(default) -> [];
 states(desc) -> ?DESC(states);

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -34,7 +34,7 @@ roots() -> ["prometheus"].
 fields("prometheus") ->
     [
         {push_gateway_server,
-            sc(
+            ?HOCON(
                 string(),
                 #{
                     default => "http://127.0.0.1:9091",
@@ -43,7 +43,7 @@ fields("prometheus") ->
                 }
             )},
         {interval,
-            sc(
+            ?HOCON(
                 emqx_schema:duration_ms(),
                 #{
                     default => "15s",
@@ -52,7 +52,7 @@ fields("prometheus") ->
                 }
             )},
         {enable,
-            sc(
+            ?HOCON(
                 boolean(),
                 #{
                     default => false,
@@ -64,5 +64,3 @@ fields("prometheus") ->
 
 desc("prometheus") -> ?DESC(prometheus);
 desc(_) -> undefined.
-
-sc(Type, Meta) -> hoconsc:mk(Type, Meta).

--- a/apps/emqx_psk/src/emqx_psk_schema.erl
+++ b/apps/emqx_psk/src/emqx_psk_schema.erl
@@ -27,8 +27,6 @@
     fields/1
 ]).
 
--import(emqx_schema, [sc/2]).
-
 namespace() -> "authn-psk".
 
 roots() -> ["psk_authentication"].
@@ -42,33 +40,24 @@ fields("psk_authentication") ->
 fields() ->
     [
         {enable,
-            sc(boolean(), #{
+            ?HOCON(boolean(), #{
                 default => false,
                 require => true,
                 desc => ?DESC(enable)
             })},
         {init_file,
-            sc(
-                binary(),
-                #{
-                    required => false,
-                    desc => ?DESC(init_file)
-                }
-            )},
+            ?HOCON(binary(), #{
+                required => false,
+                desc => ?DESC(init_file)
+            })},
         {separator,
-            sc(
-                binary(),
-                #{
-                    default => <<":">>,
-                    desc => ?DESC(separator)
-                }
-            )},
+            ?HOCON(binary(), #{
+                default => <<":">>,
+                desc => ?DESC(separator)
+            })},
         {chunk_size,
-            sc(
-                integer(),
-                #{
-                    default => 50,
-                    desc => ?DESC(chunk_size)
-                }
-            )}
+            ?HOCON(integer(), #{
+                default => 50,
+                desc => ?DESC(chunk_size)
+            })}
     ].

--- a/apps/emqx_retainer/src/emqx_retainer_schema.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_schema.erl
@@ -52,10 +52,10 @@ fields("retainer") ->
     ];
 fields(mnesia_config) ->
     [
-        {type, sc(hoconsc:enum([built_in_database]), mnesia_config_type, built_in_database)},
+        {type, sc(built_in_database, mnesia_config_type, built_in_database)},
         {storage_type,
             sc(
-                hoconsc:union([ram, disc]),
+                hoconsc:enum([ram, disc]),
                 mnesia_config_storage_type,
                 ram
             )},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -37,13 +37,13 @@ roots() -> ["rule_engine"].
 fields("rule_engine") ->
     [
         {ignore_sys_message,
-            sc(boolean(), #{default => true, desc => ?DESC("rule_engine_ignore_sys_message")})},
+            ?HOCON(boolean(), #{default => true, desc => ?DESC("rule_engine_ignore_sys_message")})},
         {rules,
-            sc(hoconsc:map("id", ref("rules")), #{
+            ?HOCON(hoconsc:map("id", ?R_REF("rules")), #{
                 desc => ?DESC("rule_engine_rules"), default => #{}
             })},
         {jq_function_default_timeout,
-            sc(
+            ?HOCON(
                 emqx_schema:duration_ms(),
                 #{
                     default => "10s",
@@ -55,7 +55,7 @@ fields("rules") ->
     [
         rule_name(),
         {"sql",
-            sc(
+            ?HOCON(
                 binary(),
                 #{
                     desc => ?DESC("rules_sql"),
@@ -65,8 +65,8 @@ fields("rules") ->
                 }
             )},
         {"actions",
-            sc(
-                hoconsc:array(hoconsc:union(actions())),
+            ?HOCON(
+                ?ARRAY(?UNION(actions())),
                 #{
                     desc => ?DESC("rules_actions"),
                     default => [],
@@ -82,9 +82,9 @@ fields("rules") ->
                     ]
                 }
             )},
-        {"enable", sc(boolean(), #{desc => ?DESC("rules_enable"), default => true})},
+        {"enable", ?HOCON(boolean(), #{desc => ?DESC("rules_enable"), default => true})},
         {"description",
-            sc(
+            ?HOCON(
                 binary(),
                 #{
                     desc => ?DESC("rules_description"),
@@ -95,12 +95,12 @@ fields("rules") ->
     ];
 fields("builtin_action_republish") ->
     [
-        {function, sc(republish, #{desc => ?DESC("republish_function")})},
-        {args, sc(ref("republish_args"), #{default => #{}})}
+        {function, ?HOCON(republish, #{desc => ?DESC("republish_function")})},
+        {args, ?HOCON(?R_REF("republish_args"), #{default => #{}})}
     ];
 fields("builtin_action_console") ->
     [
-        {function, sc(console, #{desc => ?DESC("console_function")})}
+        {function, ?HOCON(console, #{desc => ?DESC("console_function")})}
         %% we may support some args for the console action in the future
         %, {args, sc(map(), #{desc => "The arguments of the built-in 'console' action",
         %    default => #{}})}
@@ -108,7 +108,7 @@ fields("builtin_action_console") ->
 fields("user_provided_function") ->
     [
         {function,
-            sc(
+            ?HOCON(
                 binary(),
                 #{
                     desc => ?DESC("user_provided_function_function"),
@@ -117,7 +117,7 @@ fields("user_provided_function") ->
                 }
             )},
         {args,
-            sc(
+            ?HOCON(
                 map(),
                 #{
                     desc => ?DESC("user_provided_function_args"),
@@ -128,7 +128,7 @@ fields("user_provided_function") ->
 fields("republish_args") ->
     [
         {topic,
-            sc(
+            ?HOCON(
                 binary(),
                 #{
                     desc => ?DESC("republish_args_topic"),
@@ -137,7 +137,7 @@ fields("republish_args") ->
                 }
             )},
         {qos,
-            sc(
+            ?HOCON(
                 qos(),
                 #{
                     desc => ?DESC("republish_args_qos"),
@@ -146,8 +146,8 @@ fields("republish_args") ->
                 }
             )},
         {retain,
-            sc(
-                hoconsc:union([binary(), boolean()]),
+            ?HOCON(
+                hoconsc:union([boolean(), binary()]),
                 #{
                     desc => ?DESC("republish_args_retain"),
                     default => <<"${retain}">>,
@@ -155,7 +155,7 @@ fields("republish_args") ->
                 }
             )},
         {payload,
-            sc(
+            ?HOCON(
                 binary(),
                 #{
                     desc => ?DESC("republish_args_payload"),
@@ -182,7 +182,7 @@ desc(_) ->
 
 rule_name() ->
     {"name",
-        sc(
+        ?HOCON(
             binary(),
             #{
                 desc => ?DESC("rules_name"),
@@ -195,19 +195,16 @@ rule_name() ->
 actions() ->
     [
         binary(),
-        ref("builtin_action_republish"),
-        ref("builtin_action_console"),
-        ref("user_provided_function")
+        ?R_REF("builtin_action_republish"),
+        ?R_REF("builtin_action_console"),
+        ?R_REF("user_provided_function")
     ].
 
 qos() ->
-    hoconsc:union([emqx_schema:qos(), binary()]).
+    ?UNION([emqx_schema:qos(), binary()]).
 
 validate_sql(Sql) ->
     case emqx_rule_sqlparser:parse(Sql) of
         {ok, _Result} -> ok;
         {error, Reason} -> {error, Reason}
     end.
-
-sc(Type, Meta) -> hoconsc:mk(Type, Meta).
-ref(Field) -> hoconsc:ref(?MODULE, Field).

--- a/apps/emqx_slow_subs/src/emqx_slow_subs_schema.erl
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs_schema.erl
@@ -32,7 +32,7 @@ fields("slow_subs") ->
             )},
         {stats_type,
             sc(
-                hoconsc:enum([whole, internal, response]),
+                ?ENUM([whole, internal, response]),
                 whole,
                 stats_type
             )}
@@ -47,4 +47,4 @@ desc(_) ->
 %% Internal functions
 %%--------------------------------------------------------------------
 sc(Type, Default, Desc) ->
-    hoconsc:mk(Type, #{default => Default, desc => ?DESC(Desc)}).
+    ?HOCON(Type, #{default => Default, desc => ?DESC(Desc)}).


### PR DESCRIPTION
1. Don't `-import(hoconsc, [mk/1, mk/2, ref/1, ref/2, array/1, enum/1]).` replace this with: macro https://github.com/emqx/hocon/pull/182
2. Add default/example for schema.