### PR TITLE
fix: run emqx in docker with 'emqx' as node name by default

### DIFF
--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -19,7 +19,7 @@ LOCAL_IP=$(hostname -i | grep -oE '((25[0-5]|(2[0-4]|1[0-9]|[1-9]|)[0-9])\.){3}(
 if [[ -z "$EMQX_NODE_NAME" ]]; then
 
     if [[ -z "$EMQX_NAME" ]]; then
-        EMQX_NAME="$(hostname)"
+        EMQX_NAME='emqx'
     fi
 
     if [[ -z "$EMQX_HOST" ]]; then


### PR DESCRIPTION
Prior to this commit (also 4.x), the docker entrypoint script
sets default node name to $(hostname), which is typically a hash
like '6ec088117e14' and the erlang distribution port (ekka_epmd)
and gen_rpc port becomes non-deterministic.

After this commit, docker nodes start by default as name `emqx`,
so that the ports are static unless name is specifically set by
user. (4370 for erlang distribution and 5370 for gen_rpc)

