### PR TITLE
fix(limiter): fix precision issue

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_htb_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_htb_limiter.erl
@@ -374,7 +374,7 @@ return_pause(infinity, PauseType, Fun, Diff, Limiter) ->
     %% workaround when emqx_limiter_server's rate is infinity
     {PauseType, ?MINIMUM_PAUSE, make_retry_context(Fun, Diff), Limiter};
 return_pause(Rate, PauseType, Fun, Diff, Limiter) ->
-    Val = erlang:round(Diff * emqx_limiter_schema:minimum_period() / Rate),
+    Val = erlang:round(Diff * emqx_limiter_schema:default_period() / Rate),
     Pause = emqx_misc:clamp(Val, ?MINIMUM_PAUSE, ?MAXIMUM_PAUSE),
     {PauseType, Pause, make_retry_context(Fun, Diff), Limiter}.
 
@@ -408,5 +408,5 @@ may_return_or_pause(_, Limiter) ->
 
 %% @doc apply the elapsed time to the limiter
 apply_elapsed_time(Rate, Elapsed, Tokens, Capacity) ->
-    Inc = floor_div(mul(Elapsed, Rate), emqx_limiter_schema:minimum_period()),
+    Inc = floor_div(mul(Elapsed, Rate), emqx_limiter_schema:default_period()),
     erlang:min(add(Tokens, Inc), Capacity).

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -24,7 +24,7 @@
     fields/1,
     to_rate/1,
     to_capacity/1,
-    minimum_period/0,
+    default_period/0,
     to_burst_rate/1,
     to_initial/1,
     namespace/0,
@@ -191,8 +191,8 @@ desc(client_bucket) ->
 desc(_) ->
     undefined.
 
-%% minimum period is 100ms
-minimum_period() ->
+%% default period is 100ms
+default_period() ->
     100.
 
 to_rate(Str) ->
@@ -235,7 +235,7 @@ to_rate(Str, CanInfinity, CanZero) ->
         %% if time unit is 1s, it can be omitted
         {match, [QuotaStr]} ->
             Fun = fun(Quota) ->
-                {ok, Quota * minimum_period() / ?UNIT_TIME_IN_MS}
+                {ok, Quota * default_period() / ?UNIT_TIME_IN_MS}
             end,
             to_capacity(QuotaStr, Str, CanZero, Fun);
         {match, [QuotaStr, TimeVal, TimeUnit]} ->
@@ -250,7 +250,7 @@ to_rate(Str, CanInfinity, CanZero) ->
                 try
                     case emqx_schema:to_duration_ms(Interval) of
                         {ok, Ms} when Ms > 0 ->
-                            {ok, Quota * minimum_period() / Ms};
+                            {ok, Quota * default_period() / Ms};
                         {ok, 0} when CanZero ->
                             {ok, 0};
                         _ ->

--- a/apps/emqx/test/emqx_ratelimiter_SUITE.erl
+++ b/apps/emqx/test/emqx_ratelimiter_SUITE.erl
@@ -646,7 +646,7 @@ client_loop(
     } = State
 ) ->
     Now = ?NOW,
-    Period = emqx_limiter_schema:minimum_period(),
+    Period = emqx_limiter_schema:default_period(),
     MinPeriod = erlang:ceil(0.25 * Period),
     if
         Now >= EndTime ->


### PR DESCRIPTION
When the global rate is less than 1/s, the bad code produces a long period, this will make the rate not correct

