### PR TITLE
ci(appup): upload appup files when ci check fails

### DIFF
--- a/.github/workflows/apps_version_check.yaml
+++ b/.github/workflows/apps_version_check.yaml
@@ -29,3 +29,10 @@ jobs:
         run: ./scripts/update-appup.sh emqx-ee --check
       - name: Check apps version
         run: ./scripts/apps-version-check.sh
+      - uses: actions/upload-artifact@v3.1.0
+        if: failure()
+        with:
+          name: expected_appup_files
+          path: |
+            {src,apps}/**/*.appup.src
+          retention-days: 1


### PR DESCRIPTION
Often we have to remember to update both local tags and local
dependencies, and even so local results might differ from what the CI
check expects.  To help fixing expected appup file differences, we can
upload what CI produced to apply to our branch.

