### PR TITLE
build: copy example config to etc dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -247,3 +247,4 @@ $(foreach tt,$(ALL_ELIXIR_TGZS),$(eval $(call gen-elixir-tgz-target,$(tt))))
 .PHONY: fmt
 fmt: $(REBAR)
 	@./scripts/erlfmt -w '{apps,lib-ee}/*/{src,include,test}/**/*.{erl,hrl,app.src}'
+	@./scripts/erlfmt -w 'rebar.config.erl'

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -393,7 +393,9 @@ etc_overlay(ReleaseType, Edition) ->
     Templates = emqx_etc_overlay(ReleaseType, Edition),
     [
         {mkdir, "etc/"},
-        {copy, "{{base_dir}}/lib/emqx/etc/certs", "etc/"}
+        {copy, "{{base_dir}}/lib/emqx/etc/certs", "etc/"},
+        {copy, "{{base_dir}}/lib/emqx_dashboard/etc/emqx-en.conf.example", "etc/"},
+        {copy, "{{base_dir}}/lib/emqx_dashboard/etc/emqx-zh.conf.example", "etc/"}
     ] ++
         lists:map(
             fun


### PR DESCRIPTION
we don't have a frontend to display the example configs yet.
and having it in `emqx_dashboard` application's priv dir (and 3 level deeper) is not easy for uses to find.

This PR adds a copy of the generated files to EMQX's etc dir