### PR TITLE
fix(metrics): inc `connack.auth_error` when using MQTT 3.1 (5.0)

### DIFF
--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -484,8 +484,12 @@ inc_sent(Packet) ->
 
 do_inc_sent(?CONNACK_PACKET(ReasonCode)) ->
     (ReasonCode == ?RC_SUCCESS) orelse inc('packets.connack.error'),
-    (ReasonCode == ?RC_NOT_AUTHORIZED) andalso inc('packets.connack.auth_error'),
-    (ReasonCode == ?RC_BAD_USER_NAME_OR_PASSWORD) andalso inc('packets.connack.auth_error'),
+    ((ReasonCode == ?RC_NOT_AUTHORIZED) orelse
+        (ReasonCode == ?CONNACK_AUTH)) andalso
+        inc('packets.connack.auth_error'),
+    ((ReasonCode == ?RC_BAD_USER_NAME_OR_PASSWORD) orelse
+        (ReasonCode == ?CONNACK_CREDENTIALS)) andalso
+        inc('packets.connack.auth_error'),
     inc('packets.connack.sent');
 do_inc_sent(?PUBLISH_PACKET(QoS)) ->
     inc('messages.sent'),


### PR DESCRIPTION
Since MQTT 3.1 uses a different reason code for auth failures, it was
failing to increase the corresponding metric that works for MQTT 5.0.

