### PR TITLE
build: add strict-semver version bump check for apps

### DIFF
--- a/scripts/apps-version-check.sh
+++ b/scripts/apps-version-check.sh
@@ -8,6 +8,10 @@ bad_app_count=0
 no_comment_re='(^[^\s?%])'
 ## TODO: c source code comments re (in $app_path/c_src dirs)
 
+parse_semver() {
+    echo "$1" | tr '.|-' ' '
+}
+
 while read -r app; do
     if [ "$app" != "emqx" ]; then
         app_path="$app"
@@ -15,7 +19,7 @@ while read -r app; do
         app_path="."
     fi
     src_file="$app_path/src/$(basename "$app").app.src"
-    old_app_version="$(git show "$latest_release":"$src_file" | grep vsn | grep -oE '"[0-9]+.[0-9]+.[0-9]+"' | tr -d '"')"
+    old_app_version="$(git show "$latest_release":"$src_file" | grep vsn | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"')"
     now_app_version=$(grep -E 'vsn' "$src_file" | grep -oE '"[0-9]+\.[0-9]+\.[0-9]+"' | tr -d '"')
     if [ "$old_app_version" = "$now_app_version" ]; then
         changed_lines="$(git diff "$latest_release"...HEAD --ignore-blank-lines -G "$no_comment_re" \
@@ -34,6 +38,19 @@ while read -r app; do
             ## for safty, we just force a dashboard version bump for each and every release
             ## even if there is nothing changed in the app
             echo "$src_file needs a vsn bump to ensure plugins loaded after upgrade"
+            bad_app_count=$(( bad_app_count + 1))
+        fi
+    else
+        # shellcheck disable=SC2207
+        old_app_version_semver=($(parse_semver "$old_app_version"))
+        # shellcheck disable=SC2207
+        now_app_version_semver=($(parse_semver "$now_app_version"))
+        if  [ "${old_app_version_semver[0]}" = "${now_app_version_semver[0]}" ] && \
+            [ "${old_app_version_semver[1]}" = "${now_app_version_semver[1]}" ] && \
+            [ "$(( "${old_app_version_semver[2]}" + 1 ))" = "${now_app_version_semver[2]}" ]; then
+            true
+        else
+            echo "$src_file: non-strict semver version bump from $old_app_version to $now_app_version"
             bad_app_count=$(( bad_app_count + 1))
         fi
     fi


### PR DESCRIPTION
Often we forget that an app version is already bumped and end up bumping it twice.