### PR TITLE
Gateway restart won't make built-in-database data lost

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_redis.erl
+++ b/apps/emqx_connector/src/emqx_connector_redis.erl
@@ -90,7 +90,6 @@ fields(sentinel) ->
         }},
         {sentinel, #{
             type => string(),
-            required => true,
             desc => ?DESC("sentinel_desc")
         }}
     ] ++

--- a/apps/emqx_connector/src/emqx_connector_redis.erl
+++ b/apps/emqx_connector/src/emqx_connector_redis.erl
@@ -88,7 +88,11 @@ fields(sentinel) ->
             required => true,
             desc => ?DESC("sentinel")
         }},
-        {sentinel, #{type => string(), desc => ?DESC("sentinel_desc")}}
+        {sentinel, #{
+            type => string(),
+            required => true,
+            desc => ?DESC("sentinel_desc")
+        }}
     ] ++
         redis_fields() ++
         emqx_connector_schema_lib:ssl_fields().

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -304,13 +304,19 @@ do_listeners_cluster_status(Listeners) ->
                 Id => #{
                     node => Node,
                     current_connections => Curr,
-                    max_connections => Max
+                    %% XXX: Since it is taken from raw-conf, it is possible a string
+                    max_connections => int(Max)
                 }
             }
         end,
         #{},
         Listeners
     ).
+
+int(B) when is_binary(B) ->
+    binary_to_integer(B);
+int(I) when is_integer(I) ->
+    I.
 
 %%--------------------------------------------------------------------
 %% Swagger defines

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -292,7 +292,14 @@ do_listeners_cluster_status(Listeners) ->
         fun({Id, ListenOn}, Acc) ->
             BinId = erlang:atom_to_binary(Id),
             {ok, #{<<"max_connections">> := Max}} = emqx_gateway_conf:listener(BinId),
-            Curr = esockd:get_current_connections({Id, ListenOn}),
+            Curr =
+                try esockd:get_current_connections({Id, ListenOn}) of
+                    Int -> Int
+                catch
+                    %% not started
+                    error:not_found ->
+                        0
+                end,
             Acc#{
                 Id => #{
                     node => Node,

--- a/apps/emqx_gateway/src/emqx_gateway_insta_sup.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_insta_sup.erl
@@ -173,14 +173,14 @@ handle_info(
 ) ->
     case lists:member(Pid, Pids) of
         true ->
-            ?SLOG(error, #{
+            ?SLOG(info, #{
                 msg => "child_process_exited",
                 child => Pid,
                 reason => Reason
             }),
             case Pids -- [Pid] of
                 [] ->
-                    ?SLOG(error, #{
+                    ?SLOG(info, #{
                         msg => "gateway_all_children_process_existed",
                         gateway_name => Name
                     }),
@@ -193,7 +193,7 @@ handle_info(
                     {noreply, State#state{child_pids = RemainPids}}
             end;
         _ ->
-            ?SLOG(error, #{
+            ?SLOG(info, #{
                 msg => "gateway_catch_a_unknown_process_exited",
                 child => Pid,
                 reason => Reason,

--- a/apps/emqx_gateway/test/emqx_exproto_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_exproto_SUITE.erl
@@ -72,7 +72,6 @@ init_per_group(GrpName, Cfg) ->
     put(grpname, GrpName),
     Svrs = emqx_exproto_echo_svr:start(),
     emqx_common_test_helpers:start_apps([emqx_gateway], fun set_special_cfg/1),
-    emqx_logger:set_log_level(debug),
     [{servers, Svrs}, {listener_type, GrpName} | Cfg].
 
 end_per_group(_, Cfg) ->

--- a/apps/emqx_gateway/test/emqx_gateway_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_SUITE.erl
@@ -34,7 +34,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 init_per_suite(Conf) ->
     emqx_config:erase(gateway),
     emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
-    emqx_common_test_helpers:start_apps([emqx_gateway]),
+    emqx_common_test_helpers:start_apps([emqx_authn, emqx_gateway]),
     Conf.
 
 end_per_suite(_Conf) ->
@@ -44,7 +44,7 @@ end_per_suite(_Conf) ->
 
 init_per_testcase(t_get_basic_usage_info_2, Config) ->
     DataDir = ?config(data_dir, Config),
-    emqx_common_test_helpers:stop_apps([emqx_gateway]),
+    application:stop(emqx_gateway),
     ok = setup_fake_usage_data(DataDir),
     Config;
 init_per_testcase(_TestCase, Config) ->

--- a/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_sn_protocol_SUITE.erl
@@ -1914,8 +1914,6 @@ t_register_subs_resume_on(_) ->
     _ = emqx:publish(emqx_message:make(test, ?QOS_1, <<"topic-b">>, <<"m2">>)),
     _ = emqx:publish(emqx_message:make(test, ?QOS_2, <<"topic-b">>, <<"m3">>)),
 
-    emqx_logger:set_log_level(debug),
-
     {ok, NSocket} = gen_udp:open(0, [binary]),
     send_connect_msg(NSocket, <<"test">>, 0),
     ?assertMatch(
@@ -2087,8 +2085,6 @@ t_register_skip_failure_topic_name_and_reach_max_retry_times(_) ->
     send_disconnect_msg(Socket, undefined),
     ?assertMatch(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
     gen_udp:close(Socket),
-
-    emqx_logger:set_log_level(debug),
 
     {ok, NSocket} = gen_udp:open(0, [binary]),
     send_connect_msg(NSocket, <<"test">>, 0),


### PR DESCRIPTION
- fix(redis): make sentinel required
- fix(gw): fix list listeners failed if gateway disabled
- feat(gw): keep authenticator resource after gateway disabled
- fix(gw): not updating the authenticator using re-creation
