### PR TITLE
chore(connector): schema validator throw error messages directly

### DIFF
--- a/apps/emqx_connector/include/emqx_connector.hrl
+++ b/apps/emqx_connector/include/emqx_connector.hrl
@@ -36,6 +36,4 @@
     "The " ++ TYPE ++ " default port " ++ DEFAULT_PORT ++ " is used if `[:Port]` is not specified."
 ).
 
--define(THROW_ERROR(Str), erlang:throw({error, Str})).
-
 -define(CONNECTOR_RESOURCE_GROUP, <<"emqx_connector">>).


### PR DESCRIPTION
The code was carefully crafted to catch all exceptions except that the `try xxxx of` does not catch exceptions in the clauses.
Also the wrapping tuple of `{error, Message}` is not necessary, `throw`s are caught by hocon and treated as a regular error reason. 