### PR TITLE
chore(helm): delete preStop command

### DIFF
--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -214,13 +214,6 @@ spec:
             initialDelaySeconds: 60
             periodSeconds: 30
             failureThreshold: 10
-          lifecycle:
-            preStop:
-              exec:
-                command:
-                  - "/opt/emqx/bin/emqx_ctl"
-                  - "cluster"
-                  - "leave"
     {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
There is a risk that preStop will fail. When persistence is enabled, preStop failure can lead to inconsistent emqx cluster data