### PR TITLE
feat: add enabled for listeners

### DIFF
--- a/apps/emqx/i18n/emqx_schema_i18n.conf
+++ b/apps/emqx/i18n/emqx_schema_i18n.conf
@@ -1895,16 +1895,16 @@ QUIC listeners
     }
 }
 
-fields_mqtt_quic_listener_enabled {
+fields_listener_enabled {
     desc {
         en: """
-Enable QUIC listener.
+Enable listener.
 """
-        zh: """启用 QUIC 监听器"""
+        zh: """启停监听器"""
     }
     label: {
-        en: "Enable QUIC listener"
-        zh: "启用 QUIC 监听器"
+        en: "Enable listener"
+        zh: "启停监听器"
     }
 }
 

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -375,7 +375,10 @@ pre_config_update(_Path, _Request, RawConf) ->
 post_config_update([listeners, Type, Name], {create, _Request}, NewConf, undefined, _AppEnvs) ->
     start_listener(Type, Name, NewConf);
 post_config_update([listeners, Type, Name], {update, _Request}, NewConf, OldConf, _AppEnvs) ->
-    restart_listener(Type, Name, {OldConf, NewConf});
+    case NewConf of
+        #{<<"enabled">> := true} -> restart_listener(Type, Name, {OldConf, NewConf});
+        _ -> ok
+    end;
 post_config_update([listeners, _Type, _Name], '$remove', undefined, undefined, _AppEnvs) ->
     {error, not_found};
 post_config_update([listeners, Type, Name], '$remove', undefined, OldConf, _AppEnvs) ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -844,14 +844,6 @@ fields("mqtt_wss_listener") ->
         ];
 fields("mqtt_quic_listener") ->
     [
-        {"enabled",
-            sc(
-                boolean(),
-                #{
-                    default => true,
-                    desc => ?DESC(fields_mqtt_quic_listener_enabled)
-                }
-            )},
         %% TODO: ensure cacertfile is configurable
         {"certfile",
             sc(
@@ -1567,6 +1559,14 @@ mqtt_listener(Bind) ->
 
 base_listener(Bind) ->
     [
+        {"enabled",
+            sc(
+                boolean(),
+                #{
+                    default => true,
+                    desc => ?DESC(fields_listener_enabled)
+                }
+            )},
         {"bind",
             sc(
                 hoconsc:union([ip_port(), integer()]),

--- a/apps/emqx/src/proto/emqx_broker_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_broker_proto_v1.erl
@@ -24,11 +24,7 @@
     forward/3,
     forward_async/3,
     list_client_subscriptions/2,
-    list_subscriptions_via_topic/2,
-
-    start_listener/2,
-    stop_listener/2,
-    restart_listener/2
+    list_subscriptions_via_topic/2
 ]).
 
 -include("bpapi.hrl").
@@ -56,15 +52,3 @@ list_client_subscriptions(Node, ClientId) ->
 -spec list_subscriptions_via_topic(node(), emqx_types:topic()) -> [emqx_types:subopts()].
 list_subscriptions_via_topic(Node, Topic) ->
     rpc:call(Node, emqx_broker, subscriptions_via_topic, [Topic]).
-
--spec start_listener(node(), atom()) -> ok | {error, _} | {badrpc, _}.
-start_listener(Node, Id) ->
-    rpc:call(Node, emqx_listeners, start_listener, [Id]).
-
--spec stop_listener(node(), atom()) -> ok | {error, _} | {badrpc, _}.
-stop_listener(Node, Id) ->
-    rpc:call(Node, emqx_listeners, stop_listener, [Id]).
-
--spec restart_listener(node(), atom()) -> ok | {error, _} | {badrpc, _}.
-restart_listener(Node, Id) ->
-    rpc:call(Node, emqx_listeners, restart_listener, [Id]).

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule EMQXUmbrella.MixProject do
       {:esockd, github: "emqx/esockd", tag: "5.9.3", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.12.9", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.3.3", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.4", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.3"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.9"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.3"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.4"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}


### PR DESCRIPTION
We need to save the action status to enabled fields.
Before: if we stop listeners and reboot node,  the listener will start again.
After: the stopped listeners will not restart when the node reboot.
