### PR TITLE
chore(pgsql): mapping ssl option from 'true' to 'required'

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_pgsql.erl
+++ b/apps/emqx_connector/src/emqx_connector_pgsql.erl
@@ -186,8 +186,13 @@ conn_opts([], Acc) ->
     Acc;
 conn_opts([Opt = {database, _} | Opts], Acc) ->
     conn_opts(Opts, [Opt | Acc]);
-conn_opts([Opt = {ssl, _} | Opts], Acc) ->
-    conn_opts(Opts, [Opt | Acc]);
+conn_opts([{ssl, Bool} | Opts], Acc) when is_boolean(Bool) ->
+    Flag =
+        case Bool of
+            true -> required;
+            false -> false
+        end,
+    conn_opts(Opts, [{ssl, Flag} | Acc]);
 conn_opts([Opt = {port, _} | Opts], Acc) ->
     conn_opts(Opts, [Opt | Acc]);
 conn_opts([Opt = {timeout, _} | Opts], Acc) ->


### PR DESCRIPTION
Once the pgsql client is configured with ssl, we should force ssl to be used to
avoid fallback to tcp connection.
