### PR TITLE
fix(pmap): try not to exit abnormal as much as possible

### DIFF
--- a/apps/emqx/test/emqx_misc_SUITE.erl
+++ b/apps/emqx/test/emqx_misc_SUITE.erl
@@ -194,8 +194,8 @@ t_pmap_timeout(_) ->
     ).
 
 t_pmap_exception(_) ->
-    ?assertExit(
-        {foobar, _},
+    ?assertError(
+        foobar,
         emqx_misc:pmap(
             fun
                 (error) -> error(foobar);


### PR DESCRIPTION
'as much as possible' here means `try Expr catch _:_ ` will not be 100% safe, because `Expr` may spawn another linked process and get itself killed abnormally.
