### PR TITLE
Restart dashboard crash

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_sup.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_sup.erl
@@ -22,7 +22,7 @@
 
 -export([init/1]).
 
--define(CHILD(I), {I, {I, start_link, []}, permanent, 5000, worker, [I]}).
+-define(CHILD(I, ShutDown), {I, {I, start_link, []}, permanent, ShutDown, worker, [I]}).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
@@ -30,7 +30,7 @@ start_link() ->
 init([]) ->
     {ok,
         {{one_for_one, 5, 100}, [
-            ?CHILD(emqx_dashboard_listener),
-            ?CHILD(emqx_dashboard_token),
-            ?CHILD(emqx_dashboard_monitor)
+            ?CHILD(emqx_dashboard_listener, brutal_kill),
+            ?CHILD(emqx_dashboard_token, 5000),
+            ?CHILD(emqx_dashboard_monitor, 5000)
         ]}}.

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule EMQXUmbrella.MixProject do
       {:esockd, github: "emqx/esockd", tag: "5.9.3", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.13.0", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.3.4", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.5", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.3"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.13.0"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.4"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.5"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}


### PR DESCRIPTION
1. https://github.com/emqx/minirest/pull/97 fix crash log if emqx_dashboard restart.
2. don't log emqx_dashboard_listener killed.  mute the blew log by update shutdown time to brutal_kill
```
2022-06-16T23:53:24.022827+08:00 [error] Supervisor: {local,emqx_dashboard_sup}. Context: shutdown_error. Reason: killed. Offender: id=emqx_dashboard_listener,pid=<0.2198.0>.
Stop listener dashboard:http:18083 on :18083 successfully.
```
