### PR TITLE
fix: install plugins timeout by deadlock

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -648,7 +648,8 @@ put_config(Key, Value) when is_atom(Key) ->
     put_config([Key], Value);
 put_config(Path, Values) when is_list(Path) ->
     Opts = #{rawconf_with_defaults => true, override_to => cluster},
-    case emqx_conf:update([?CONF_ROOT | Path], bin_key(Values), Opts) of
+    %% Already in cluster_rpc, don't use emqx_conf:update, dead calls
+    case emqx:update_config([?CONF_ROOT | Path], bin_key(Values), Opts) of
         {ok, _} -> ok;
         Error -> Error
     end.

--- a/apps/emqx_plugins/test/emqx_plugins_tests.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_tests.erl
@@ -125,8 +125,8 @@ purge_test() ->
 meck_emqx() ->
     meck:new(emqx, [unstick, passthrough]),
     meck:expect(
-        emqx_conf,
-        update,
+        emqx,
+        update_config,
         fun(Path, Values, _Opts) ->
             emqx_config:put(Path, Values)
         end


### PR DESCRIPTION
2022-06-17T09:51:59.579406+08:00 [warning] exception: exit, line: 116, mfa: minirest_handler:apply_callback/3, path: /plugins/:name/:action, reason: {timeout,{gen_server,call,[emqx_cluster_rpc,{initiate,{emqx_mgmt_api_plugins,ensure_action,[<<"emqx_plugin_template-5.0-rc.1">>,start]}},10000]}}, stacktrace: [{gen_server,call,3,[{file,"gen_server.erl"},{line,247}]},{emqx_cluster_rpc,do_multicall,5,[{file,"emqx_cluster_rpc.erl"},{line,160}]},{emqx_cluster_rpc,multicall,5,[{file,"emqx_cluster_rpc.erl"},{line,133}]},{emqx_mgmt_api_plugins,update_plugin,2,[{file,"emqx_mgmt_api_plugins.erl"},{line,378}]},{minirest_handler,apply_callback,3,[{file,"minirest_handler.erl"},{line,111}]},{minirest_handler,handle,2,[{file,"minirest_handler.erl"},{line,44}]},{minirest_handler,init,2,[{file,"minirest_handler.erl"},{line,27}]},{cowboy_handler,execute,2,[{file,"cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]