### PR TITLE
fix: can't start dashboard if default_username is missing

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -31,6 +31,7 @@ File format:
 - Fixed issue in Lua hook that didn't prevent a topic from being
   subscribed to. [#8288]
 - Ensuring that exhook dispatches the client events are sequential. [#8311]
+- Ensure start dashboard ok event if default_username is missing.
 
 ## v4.3.15
 

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -293,7 +293,6 @@ initial_default_user_passwd_hashed() ->
 %% use this persistent_term for a copy of the value in mnesia database
 %% so that after the node leaves a cluster, db gets purged,
 %% we can still find the changed password back from PT
-ensure_default_user_passwd_hashed_in_pt(<<>>) -> ok;
 ensure_default_user_passwd_hashed_in_pt(Hashed) ->
     ok = persistent_term:put({?MODULE, default_user_passwd_hashed}, Hashed).
 


### PR DESCRIPTION
FIX: https://github.com/emqx/emqx/issues/8126

If we remove default_username/password from `emqx_dashboard.conf`, 
We should make sure the dashboard starts successfully.