### PR TITLE
fix(hooks): return error on hook-removed subscription rather than deleting it

### DIFF
--- a/apps/emqx_lua_hook/src/emqx_lua_script.erl
+++ b/apps/emqx_lua_hook/src/emqx_lua_script.erl
@@ -171,7 +171,7 @@ on_client_subscribe(#{clientid := ClientId, username := Username}, _Properties, 
                         case on_client_subscribe_single(ClientId, Username, TopicFilter, LuaState) of
                             false ->
                                 {Topic, Opts} = TopicFilter,
-                                [{Topic, Opts#{delete => true}} | Acc];
+                                [{Topic, Opts#{deny_subscription => true}} | Acc];
                             NewTopicFilter ->
                                 [NewTopicFilter | Acc]
                         end

--- a/apps/emqx_lua_hook/test/emqx_lua_hook_SUITE.erl
+++ b/apps/emqx_lua_hook/test/emqx_lua_hook_SUITE.erl
@@ -711,7 +711,7 @@ t_stop_sub(_Config) ->
     OriginalTopicFilters = [{Topic = <<"u">>,
                              Opts = #{nl => 0,qos => 0,rap => 0,rh => 0}}],
     Props = #{},
-    Expected = [{Topic, Opts#{delete => true}}],
+    Expected = [{Topic, Opts#{deny_subscription => true}}],
     ?assertEqual(Expected, emqx_hooks:run_fold('client.subscribe',
                                          [ClientInfo, Props],
                                          OriginalTopicFilters)).

--- a/src/emqx_channel.erl
+++ b/src/emqx_channel.erl
@@ -425,9 +425,9 @@ handle_in(Packet = ?SUBSCRIBE_PACKET(PacketId, Properties, TopicFilters),
                                                                        Channel),
                     TupleTopicFilters2 =
                         lists:foldl(
-                          fun({{Topic, Opts = #{delete := true}}, _QoS}, Acc) ->
-                                  Key = {Topic, maps:without([delete], Opts)},
-                                  lists:keydelete(Key, 1, Acc);
+                          fun({{Topic, Opts = #{deny_subscription := true}}, _ReturnCode}, Acc) ->
+                                  Key = {Topic, maps:without([deny_subscription], Opts)},
+                                  lists:keyreplace(Key, 1, Acc, {Key, ?RC_UNSPECIFIED_ERROR});
                              (Tuple = {Key, _Value}, Acc) ->
                                   lists:keyreplace(Key, 1, Acc, Tuple)
                           end,

--- a/test/emqx_broker_SUITE.erl
+++ b/test/emqx_broker_SUITE.erl
@@ -315,7 +315,7 @@ t_handle_in_empty_client_subscribe_hook({'end', _Config}) ->
     ok;
 t_handle_in_empty_client_subscribe_hook(Config) when is_list(Config) ->
     Hook = fun(_ClientInfo, _Username, TopicFilter) ->
-                   EmptyFilters = [{T, Opts#{delete => true}} || {T, Opts} <- TopicFilter],
+                   EmptyFilters = [{T, Opts#{deny_subscription => true}} || {T, Opts} <- TopicFilter],
                    {stop, EmptyFilters}
            end,
     ok = emqx:hook('client.subscribe', Hook, []),
@@ -323,7 +323,7 @@ t_handle_in_empty_client_subscribe_hook(Config) when is_list(Config) ->
         {ok, C} = emqtt:start_link(),
         {ok, _} = emqtt:connect(C),
         {ok, _, RCs} = emqtt:subscribe(C, <<"t">>),
-        ?assertEqual([], RCs),
+        ?assertEqual([?RC_UNSPECIFIED_ERROR], RCs),
         ok
     after
         ok = emqx:unhook('client.subscribe', Hook)


### PR DESCRIPTION
Following https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901178

