### PR TITLE
chore: copy `.tool-versions` when calculating appups

### DIFF
--- a/scripts/update-appup.sh
+++ b/scripts/update-appup.sh
@@ -92,6 +92,8 @@ else
     NEW_COPY='no'
 fi
 
+TOOL_VERSIONS="$PWD/.tool-versions"
+
 if [ "${SKIP_BUILD_BASE:-no}" = 'yes' ]; then
     echo "not building relup base ${PREV_DIR_BASE}/${PREV_TAG}"
 else
@@ -103,6 +105,9 @@ else
     git reset --hard
     git clean -ffdx
     git checkout "${PREV_TAG}"
+    # copy current .tool-versions to ensure same OTP version, even if
+    # overridden.
+    cp "$TOOL_VERSIONS" ./
     make "$PROFILE"
     popd
 fi


### PR DESCRIPTION
This can make it simpler to ensure the same OTP version that builds
the current checkout will match the one that builds the appup base,
since one may change the version locally.

