### PR TITLE
Fix: emqx bin does not work normal when erlang distribution over TLS

### DIFF
--- a/apps/emqx/etc/vm.args.cloud
+++ b/apps/emqx/etc/vm.args.cloud
@@ -35,6 +35,11 @@
 ## (Disabled by default..use with caution!)
 #-heart
 
+## The shell is started in a restricted mode.
+## In this mode, the shell evaluates a function call only if allowed.
+## Prevent user from accidentally calling a function from the prompt that could harm a running system.
+-stdlib restricted_shell emqx_restricted_shell
+
 ## Specifies the net_kernel tick time in seconds.
 ## This is the approximate time a connected node may be unresponsive until
 ## it is considered down and thereby disconnected.

--- a/bin/emqx
+++ b/bin/emqx
@@ -540,9 +540,10 @@ generate_config() {
 
     ## this command populates two files: app.<time>.config and vm.<time>.args
     ## NOTE: the generate command merges environment variables to the base config (emqx.conf),
-    ## but does not include the cluster-override.conf and local-override.conf
-    ## meaning, certain overrides will not be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -d "$DATA_DIR"/configs generate
+    ## also include the cluster-override.conf and local-override.conf
+    ## (User can update logger_handler from dashboard).
+    ## meaning, certain overrides will be mapped to app.<time>.config file
+    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "$DATA_DIR"/cluster-override.conf -c -c "$DATA_DIR"/local-override.conf -d "$DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"

--- a/bin/emqx
+++ b/bin/emqx
@@ -435,7 +435,7 @@ else
             die "node_is_not_running!" 1
         fi
         # get ssl_dist_optfile option
-        SSL_DIST_OPTFILE="$(echo -e "$PS_LINE" | grep -oE '+ssl_dist_optfile\s.+\s' | awk '{print $2}' || true)"
+        SSL_DIST_OPTFILE="$(echo -e "$PS_LINE" | grep -oE 'ssl_dist_optfile\s.+\s' | awk '{print $2}' || true)"
         if [ -z "$SSL_DIST_OPTFILE" ]; then
             EMQX_BOOT_CONFIGS="node.data_dir=${DATA_DIR}\ncluster.proto_dist=inet_tcp"
         else
@@ -475,8 +475,8 @@ if [ "$EKKA_PROTO_DIST_MOD" = 'inet_tls' ]; then
                 true
                 ;;
         esac
+        EPMD_ARGS="${EPMD_ARGS} -ssl_dist_optfile $SSL_DIST_OPTFILE"
     fi
-    EPMD_ARGS="${EPMD_ARGS} -ssl_dist_optfile $SSL_DIST_OPTFILE"
 fi
 
 DATA_DIR="$(get_boot_config 'node.data_dir')"
@@ -543,7 +543,7 @@ generate_config() {
     ## also include the cluster-override.conf and local-override.conf
     ## (User can update logger_handler from dashboard).
     ## meaning, certain overrides will be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "$DATA_DIR"/cluster-override.conf -c -c "$DATA_DIR"/local-override.conf -d "$DATA_DIR"/configs generate
+    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "$DATA_DIR"/cluster-override.conf -c "$DATA_DIR"/local-override.conf -d "$DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"

--- a/bin/emqx
+++ b/bin/emqx
@@ -543,7 +543,7 @@ generate_config() {
     ## also include the cluster-override.conf and local-override.conf
     ## (User can update logger_handler from dashboard).
     ## meaning, certain overrides will be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "$DATA_DIR"/cluster-override.conf -c "$DATA_DIR"/local-override.conf -d "$DATA_DIR"/configs generate
+    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "$DATA_DIR"/configs/cluster-override.conf -c "$DATA_DIR"/configs/local-override.conf -d "$DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"


### PR DESCRIPTION
1. Make `restricted_shell` work properly again.
2. App Env should always map override conf, otherwise, the user updates logger configuration from the dashboard, it does not take effect after reboot.
3. Fix `./bin/emqx xxxx` always prompt:
```shell
grep: repetition-operator operand invalid
```
It makes inet_tls mode not work correctly.
4. Fix `SSL_DIST_OPTFILE` unbond error.