### PR TITLE
0702 no relup for opensource edition

### DIFF
--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -18,7 +18,6 @@ jobs:
     runs-on: ubuntu-20.04
     container: "ghcr.io/emqx/emqx-builder/5.0-17:1.13.4-24.2.1-1-ubuntu20.04"
     outputs:
-      CUR_CE_VSN: ${{ steps.find-versions.outputs.CUR_CE_VSN }}
       CUR_EE_VSN: ${{ steps.find-versions.outputs.CUR_EE_VSN }}
       OLD_VERSIONS: ${{ steps.find-versions.outputs.OLD_VERSIONS }}
     defaults:
@@ -35,12 +34,9 @@ jobs:
       run: |
         set -x
         cd emqx
-        ce_vsn="$(./pkg-vsn.sh opensource)"
         ee_vsn="$(./pkg-vsn.sh enterprise)"
-        old_ce_vsns="$(./scripts/relup-build/base-vsns.sh opensource | xargs)"
         old_ee_vsns="$(./scripts/relup-build/base-vsns.sh enterprise | xargs)"
-        old_vsns=$(echo -n "${old_ce_vsns} ${old_ee_vsns}" | sed 's/ $//g' | jq -R -s -c 'split(" ")')
-        echo "::set-output name=CUR_CE_VSN::$ce_vsn"
+        old_vsns=$(echo -n "${old_ee_vsns}" | sed 's/ $//g' | jq -R -s -c 'split(" ")')
         echo "::set-output name=CUR_EE_VSN::$ee_vsn"
         echo "::set-output name=OLD_VERSIONS::$old_vsns"
     - name: build emqx
@@ -69,7 +65,6 @@ jobs:
         old_vsn: ${{ fromJson(needs.relup_test_plan.outputs.OLD_VERSIONS) }}
     env:
       OLD_VSN: "${{ matrix.old_vsn }}"
-      CUR_CE_VSN: "${{ needs.relup_test_plan.outputs.CUR_CE_VSN }}"
       CUR_EE_VSN: "${{ needs.relup_test_plan.outputs.CUR_EE_VSN }}"
     defaults:
       run:
@@ -106,9 +101,6 @@ jobs:
         case "$OLD_VSN" in
           e*)
             export CUR_VSN="$CUR_EE_VSN"
-            ;;
-          v*)
-            export CUR_VSN="$CUR_CE_VSN"
             ;;
           *)
             echo "unknown old version $OLD_VSN"

--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -1,4 +1,43 @@
+# 5.0.2
+
+Announcemnet: EMQX team has decided to stop supporting relup for opensouce edition.
+Going forward, it will be an enterprise only feature.
+
+Main reason: relup requires carefully crafted upgrade instructions from ALL previous versions.
+
+For example, 4.3 is now at 4.3.16, we have `4.3.0->4.3.16`, `4.3.1->4.3.16`, ... 16 such upgrade paths in total to maintain.
+This had been the biggest obstacle for EMQX team to act agile enought in deliverying enhancements and fixes.
+
+## Enhancements
+
+## Bug fixes
+
+* Fixed a typo in `bin/emqx` which affects MacOs release when trying to enable Erlang distribution over TLS [8398](https://github.com/emqx/emqx/pull/8398)
+
 # 5.0.1
+
+5.0.1 is built on [Erlang/OTP 24.2.1-1](https://github.com/emqx/otp/tree/OTP-24.2.1-1). Same as 5.0.0.
+
+5.0.0 (like 4.4.x) had Erlang/OTP version number in the package name.
+This is because we wanted to release different flavor packages (on different Elixir/Erlang/OTP platforms).
+
+However the long package names also causes confusion, as users may not know which to choose if there were more than
+one presented at the same time.
+
+Going forward, (starting from 5.0.1), packages will be released in both default (short) and flavored (long) package names.
+
+For example: `emqx-5.0.1-otp24.2.1-1-ubuntu20.04-amd64.tar.gz`,
+but only the default one is presented to the users: `emqx-5.0.1-ubuntu20.04-amd64.tar.gz`.
+
+In case anyone wants to try a different flavor package, it can be downlowded from the public s3 bucket,
+for example:
+https://s3.us-west-2.amazonaws.com/packages.emqx/emqx-ce/v5.0.1/emqx-5.0.1-otp24.2.1-1-ubuntu20.04-arm64.tar.gz
+
+Exceptions:
+
+* Windows package is always presented with short name (currently on Erlang/OTP 24.2.1).
+* Elixir package name is flavored with both Elixir and Erlang/OTP version numbers,
+  for example: `emqx-5.0.1-elixir1.13.4-otp24.2.1-1-ubuntu20.04-amd64.tar.gz`
 
 ## Enhancements
 

--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -32,7 +32,7 @@
 %% `apps/emqx/src/bpapi/README.md'
 
 %% Community edition
--define(EMQX_RELEASE_CE, "5.0.1").
+-define(EMQX_RELEASE_CE, "5.0.2").
 
 %% Enterprise edition
 -define(EMQX_RELEASE_EE, "5.0.0-alpha.1").

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -3,7 +3,7 @@
     {id, "emqx"},
     {description, "EMQX Core"},
     % strict semver, bump manually!
-    {vsn, "5.0.1"},
+    {vsn, "5.0.2"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -130,8 +130,8 @@ case "$SYSTEM" in
         ;;
 esac
 
-UNAME="$(uname -m)"
-case "$UNAME" in
+UNAME_M="$(uname -m)"
+case "$UNAME_M" in
     x86_64)
         ARCH='amd64'
         ;;

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -120,19 +120,15 @@ fi
 OTP_VSN="${OTP_VSN:-$(./scripts/get-otp-vsn.sh)}"
 SYSTEM="$(./scripts/get-distro.sh)"
 
-if [ "${PKG_VSN:-}" = 'v5.0.0' ]; then
-    # 5.0.0 is released only with a full name package
-    # e.g. 5.0.0-otp24.2.1-1-ubuntu20.04-amd64
-    case "$SYSTEM" in
-        windows*)
-            ## alway directly build the default package for windows
-            IS_DEFAULT_RELEASE='yes'
-            ;;
-        *)
-            true
-            ;;
-    esac
-fi
+case "$SYSTEM" in
+    windows*)
+        # directly build the default package for windows
+        IS_DEFAULT_RELEASE='yes'
+        ;;
+    *)
+        true
+        ;;
+esac
 
 UNAME="$(uname -m)"
 case "$UNAME" in

--- a/scripts/apps-version-check.sh
+++ b/scripts/apps-version-check.sh
@@ -24,6 +24,7 @@ while read -r app; do
     if [ "$old_app_version" = "$now_app_version" ]; then
         changed_lines="$(git diff "$latest_release"...HEAD --ignore-blank-lines -G "$no_comment_re" \
                              -- "$app_path/src" \
+                             -- "$app_path/include" \
                              -- ":(exclude)"$app_path/src/*.appup.src"" \
                              -- "$app_path/priv" \
                              -- "$app_path/c_src" | wc -l ) "

--- a/scripts/relup-build/download-base-packages.sh
+++ b/scripts/relup-build/download-base-packages.sh
@@ -27,9 +27,13 @@ case $PROFILE in
         ;;
 esac
 
-UNAME="$(uname -s)"
-case "$UNAME" in
-    Darwin)
+SYSTEM="$(./scripts/get-distro.sh)"
+case "$SYSTEM" in
+    windows*)
+        echo "NOTE: no_relup_for_windows"
+        exit 0
+        ;;
+    macos*)
         SHASUM="shasum -a 256"
         ;;
     *)

--- a/scripts/relup-build/download-base-packages.sh
+++ b/scripts/relup-build/download-base-packages.sh
@@ -9,17 +9,17 @@ set -euo pipefail
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.."
 ROOT_DIR="$(pwd)"
 
-PROFILE="${1:-emqx}"
+PROFILE="${1:-emqx-enterprise}"
 export PROFILE
 
 case $PROFILE in
-    "emqx")
-        DIR='broker'
-        EDITION='opensource'
-        ;;
     "emqx-enterprise")
         DIR='enterprise'
         EDITION='enterprise'
+        ;;
+    "emqx")
+        echo "No relup for opensource edition"
+        exit 0
         ;;
     *)
         echo "Unknown profile $PROFILE"


### PR DESCRIPTION
Announcemnet: EMQX team has decided to stop supporting relup for opensouce edition.
Going forward, it will be an enterprise only feature.

Main reason: relup requires carefully crafted upgrade instructions from ALL previous versions.

For example, 4.3 is now at 4.3.16, we have `4.3.0->4.3.16`, `4.3.1->4.3.16`, ... 16 such upgrade paths in total to maintain.
This had been the biggest obstacle for EMQX team to act agile enought in deliverying enhancements and fixes.
