### PR TITLE
fix(elixir): set locale for docker images (docker)

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -20,6 +20,10 @@ RUN export PROFILE="$EMQX_NAME" \
 
 FROM $RUN_FROM
 
+# Elixir complains if runs without UTF-8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
 COPY deploy/docker/docker-entrypoint.sh /usr/bin/
 COPY --from=builder /emqx-rel/emqx /opt/emqx
 


### PR DESCRIPTION
Elixir wants to run under UTF-8 locales.  Since we changed the base
runner image to Debian, we have to set those variables for it to pick
them up.

