### PR TITLE
fix: get subscriptions crash when subid is undefined

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -122,7 +122,7 @@ format({_Subscriber, Topic, Options = #{share := Group}}) ->
     #{node => node(), topic => filename:join([<<"$share">>, Group, Topic]), clientid => maps:get(subid, Options), qos => QoS};
 format({_Subscriber, Topic, Options}) ->
     QoS = maps:get(qos, Options),
-    #{node => node(), topic => Topic, clientid => maps:get(subid, Options), qos => QoS}.
+    #{node => node(), topic => Topic, clientid => maps:get(subid, Options, ""), qos => QoS}.
 
 %%--------------------------------------------------------------------
 %% Query Function


### PR DESCRIPTION
2022-07-06T14:22:33.481334+08:00 [error] GET /api/v4/subscriptions error: badarg, stacktrace:, [{erlang,length,[{badrpc,{'EXIT',{{badkey,subid},[{erlang,map_get,[subid,#{nl => 0,qos => 0,rap => 0,rh => 0}],[{error_info,#{module => erl_erts_errors}}]},{emqx_mgmt_api_subscriptions,format,1,[{file,"emqx_mgmt_api_subscriptions.erl"},{line,125}]},{lists,map,2,[{file,"lists.erl"},{line,1243}]},{lists,map,2,[{file,"lists.erl"},{line,1243}]},{emqx_mgmt_api,select_table,5,[{file,"emqx_mgmt_api.erl"},{line,220}]},{emqx_mgmt_api,do_query,5,[]}]}}}],[{error_info,#{module => erl_erts_errors}}]},{emqx_mgmt_api,do_cluster_query,6,[{file,"emqx_mgmt_api.erl"},{line,174}]},{emqx_mgmt_api,cluster_query,3,[{file,"emqx_mgmt_api.erl"},{line,161}]},{emqx_mgmt_api_subscriptions,list,2,[{file,"emqx_mgmt_api_subscriptions.erl"},{line,66}]},{minirest_handler,dispatch,2,[{file,"minirest_handler.erl"},{line,90}]},{minirest,handle_request,2,[{file,"minirest.erl"},{line,116}]},{minirest,init,2,[{file,"minirest.erl"},{line,108}]},{cowboy_handler,execute,2,[{file,"cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]


If we use GB/T 32960 plugins， the dashboard‘s get subscription will crash.