### PR TITLE
chore: move emqx API version (in generated doc) to emqx_release.hrl

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -36,3 +36,6 @@
 
 %% Enterprise edition
 -define(EMQX_RELEASE_EE, "5.0.0-alpha.1").
+
+%% the HTTP API version
+-define(EMQX_API_VERSION, "5.0").

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.1"},
+    {vsn, "5.0.2"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [kernel, stdlib, mnesia, minirest, emqx]},

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -39,6 +39,7 @@
 
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/http_api.hrl").
+-include_lib("emqx/include/emqx_release.hrl").
 
 -define(BASE_PATH, "/api/v5").
 
@@ -59,7 +60,7 @@ start_listeners(Listeners) ->
     Authorization = {?MODULE, authorize},
     GlobalSpec = #{
         openapi => "3.0.0",
-        info => #{title => "EMQX API", version => "5.0.0"},
+        info => #{title => "EMQX API", version => ?EMQX_API_VERSION},
         servers => [#{url => ?BASE_PATH}],
         components => #{
             schemas => #{},


### PR DESCRIPTION
So we have one place to bump all versions

