### PR TITLE
chore: upgrade hocon to 0.28.3 to speed up schema cache

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.3"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.13.1"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.28.2"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.28.3"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -4,7 +4,7 @@
     {emqx, {path, "../emqx"}},
     %% FIXME: tag this as v3.1.3
     {prometheus, {git, "https://github.com/deadtrickster/prometheus.erl", {tag, "v4.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.28.2"}}}
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.28.3"}}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.0", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.28.2", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.28.3", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.1", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -66,7 +66,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.28.2"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.28.3"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.1"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
https://github.com/emqx/hocon/pull/207
To fix:
```
022-07-07T03:05:59.583387+00:00 [error] line: 99, mfa: emqx_dashboard_listener:regenerate_minirest_dispatch/0,
 msg: regenerate_minirest_dispatch_failed, reason: [{error,{emqx_gateway_api,timeout}}], stacktrace: 
[{minirest_trails,assert_module_api_specs,1,[{file,"minirest_trails.erl"},{line,201}]},{minirest_trails,trails_schemas,1,
[{file,"minirest_trails.erl"},{line,28}]},{minirest,update_dispatch,1,[{file,"minirest.erl"},{line,44}]},{lists,foreach,2,
[{file,"lists.erl"},{line,1342}]},{emqx_dashboard_listener,regenerate_minirest_dispatch,0,
[{file,"emqx_dashboard_listener.erl"},{line,85}]},{emqx_dashboard_listener,handle_continue,2,
[{file,"emqx_dashboard_listener.erl"},{line,52}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,695}]},
{gen_server,loop,7,[{file,"gen_server.erl"},{line,437}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}], type: 
error
```