### PR TITLE
fix: upgrade jq lib to get rid of crash when space in path

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -8,6 +8,7 @@
   if it's a HTTPs server, we didn't check if TLS handshake was successful.
   [commits/6b45d2ea](https://github.com/emqx/emqx/commit/6b45d2ea9fde6d3b4a5b007f7a8c5a1c573d141e)
 * The `create_at` field of rules is missing after emqx restarts. [commits/5fc09e6b](https://github.com/emqx/emqx/commit/5fc09e6b950c340243d7be627a0ce1700691221c)
+* The rule engine's jq function now works even when the path to the EMQX install dir contains spaces
 
 # 5.0.3
 

--- a/mix.exs
+++ b/mix.exs
@@ -577,7 +577,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.4", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.5", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -41,7 +41,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.14"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.4"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.5"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),


### PR DESCRIPTION
This commit upgrades the jq library to a version that has fixed an issue that caused a crash when the port program had a space
in its path.

See: https://github.com/emqx/jq/commit/024719f3254ed944f0c208eba286e185ca4cca7b

