### PR TITLE
fix: default config should specify `cacert` file (4.3)

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1472,7 +1472,7 @@ listener.ssl.external.certfile = {{ platform_etc_dir }}/certs/cert.pem
 ## are used during server authentication and when building the client certificate chain.
 ##
 ## Value: File
-## listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
+listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 
 ## The Ephemeral Diffie-Helman key exchange is a very effective way of
 ## ensuring Forward Secrecy by exchanging a set of keys that never hit


### PR DESCRIPTION
The default configuration had the `cacert` option for the
`ssl.external` listener commented out.  If one is to set `verify =
verify_peer` in that listener without noticing that `cacert` is
unspecified, all connections will fail with:

```
2022-07-11T11:48:28.540807-03:00 [error] supervisor: 'esockd_connection_sup - <0.3971.0>', errorContext: connection_shutdown, reason: {ssl_error,{options,{cacertfile,[]}}}, offender: [{pid,<0.8225.13>},{name,connection},{mfargs,{emqx_connection,start_link,[[{deflate_options,[]},{max_conn_rate,10000},{active_n,100},{zone,external},{proxy_address_header,<<>>},{proxy_port_header,<<>>},{supported_subprotocols,[]}]]}}]
```

