### PR TITLE
fix: emqx start failed after uninstalling old version

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -8,6 +8,10 @@ RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
 # shellcheck disable=SC1090
 . "$RUNNER_ROOT_DIR"/releases/emqx_vars
 
+EMQX_LICENSE_CONF=''
+REL_NAME="emqx"
+ERTS_PATH="$RUNNER_ROOT_DIR/erts-$ERTS_VSN/bin"
+
 RUNNER_SCRIPT="$RUNNER_BIN_DIR/$REL_NAME"
 CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
 REL_DIR="$RUNNER_ROOT_DIR/releases/$REL_VSN"

--- a/data/emqx_vars
+++ b/data/emqx_vars
@@ -12,12 +12,10 @@ RUNNER_LIB_DIR="{{ runner_lib_dir }}"
 RUNNER_ETC_DIR="{{ runner_etc_dir }}"
 RUNNER_DATA_DIR="{{ runner_data_dir }}"
 RUNNER_USER="{{ runner_user }}"
+EMQX_DESCRIPTION='{{ emqx_description }}'
 
-EMQX_LICENSE_CONF=''
-export EMQX_DESCRIPTION='{{ emqx_description }}'
+## Warning: DO NOT create new variables using the above vars in this file,
+## as the vars above can be overwritten by the relup scripts later, like:
+## REL_VSN="new_version"
 
-## computed vars
-REL_NAME="emqx"
-ERTS_PATH="$RUNNER_ROOT_DIR/erts-$ERTS_VSN/bin"
-
-## updated vars here
+## overwritten vars here


### PR DESCRIPTION
Move all the ENV variables that not related to the compiled vars to `emqx` script.