### PR TITLE
chore: improve the dashboard listener startup log

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -14,6 +14,11 @@
 * Fix AuthN JWKS SSL schema. Using schema in `emqx_schema`. [#8458](https://github.com/emqx/emqx/pull/8458)
 * `sentinel` field should be required when AuthN/AuthZ Redis using sentinel mode. [#8458](https://github.com/emqx/emqx/pull/8458)
 
+## Enhancements
+
+* Improve the dashboard listener startup log, the listener name is no longer spliced with port information,
+  and the colon(:) is no longer displayed when IP is not specified.[#8480](https://github.com/emqx/emqx/pull/8480)
+
 # 5.0.3
 
 ## Bug fixes

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -493,7 +493,7 @@ merge_default(Options) ->
     end.
 
 format_addr(Port) when is_integer(Port) ->
-    io_lib:format(":~w", [Port]);
+    io_lib:format("~w", [Port]);
 %% Print only the port number when bound on all interfaces
 format_addr({{0, 0, 0, 0}, Port}) ->
     format_addr(Port);

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -159,7 +159,7 @@ listeners(Listeners) ->
             maps:get(enable, Conf) andalso
                 begin
                     {Conf1, Bind} = ip_port(Conf),
-                    {true, {listener_name(Protocol, Conf1), Protocol, Bind, ranch_opts(Conf1)}}
+                    {true, {listener_name(Protocol), Protocol, Bind, ranch_opts(Conf1)}}
                 end
         end,
         maps:to_list(Listeners)
@@ -208,19 +208,8 @@ ranch_opts(Options) ->
 filter_false(_K, false, S) -> S;
 filter_false(K, V, S) -> [{K, V} | S].
 
-listener_name(Protocol, #{port := Port, ip := IP}) ->
-    Name =
-        "dashboard:" ++
-            atom_to_list(Protocol) ++ ":" ++
-            inet:ntoa(IP) ++ ":" ++
-            integer_to_list(Port),
-    list_to_atom(Name);
-listener_name(Protocol, #{port := Port}) ->
-    Name =
-        "dashboard:" ++
-            atom_to_list(Protocol) ++ ":" ++
-            integer_to_list(Port),
-    list_to_atom(Name).
+listener_name(Protocol) ->
+    list_to_atom(atom_to_list(Protocol) ++ ":dashboard").
 
 authorize(Req) ->
     case cowboy_req:parse_header(<<"authorization">>, Req) of


### PR DESCRIPTION
Starting from 5.0, the dashboard listener only supports one listener port for each listener type. For example, HTTP can only be configured with 18083, and it no longer supports configuring multiple HTTP ports. So we remove the port information from the listener name. Keep the same format as the other listeners.

### without IP or with (0.0.0.0)
```
Listener ssl:default on 8883 started.
Listener tcp:default on 1883 started.
Listener ws:default on 8083 started.
Listener wss:default on 8084 started.
Listener http:dashboard on 18083 started.
```
### with IP
```
Listener ssl:default on 127.0.0.1:8883 started.
Listener tcp:default on 127.0.0.1:1883 started.
Listener ws:default on 127.0.0.1:8083 started.
Listener wss:default on 127.0.0.1:8084 started.
Listener http:dashboard on 127.0.0.1:18083 started.
```