### PR TITLE
chore: remove /configs/listeners, use /listeners/ API instead

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -17,7 +17,8 @@
 ## Enhancements
 
 * Improve the dashboard listener startup log, the listener name is no longer spliced with port information,
-  and the colon(:) is no longer displayed when IP is not specified.[#8480](https://github.com/emqx/emqx/pull/8480)
+  and the colon(:) is no longer displayed when IP is not specified. [#8480](https://github.com/emqx/emqx/pull/8480)
+* Remove `/configs/listeners` API, use `/listeners/` instead. [#8485](https://github.com/emqx/emqx/pull/8485)
 
 # 5.0.3
 

--- a/apps/emqx_dashboard/src/emqx_dashboard.appup.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.appup.src
@@ -1,13 +1,7 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"5.0.0",
-    [{load_module,emqx_dashboard,brutal_purge,soft_purge,[]},
-     {load_module,emqx_dashboard_api,brutal_purge,soft_purge,[]},
-     {load_module,emqx_dashboard_token,brutal_purge,soft_purge,[]}]},
-   {<<".*">>,[]}],
-  [{"5.0.0",
-    [{load_module,emqx_dashboard,brutal_purge,soft_purge,[]},
-     {load_module,emqx_dashboard_api,brutal_purge,soft_purge,[]},
-     {load_module,emqx_dashboard_token,brutal_purge,soft_purge,[]}]},
-   {<<".*">>,[]}]}.
+  %% we should always restart dashboard to make sure api rules/swagger is updated
+  [{<<".*">>,[{restart_application, emqx_dashboard}]}],
+  [{<<".*">>,[{restart_application, emqx_dashboard}]}]
+}.

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -62,7 +62,8 @@
         <<"prometheus">>,
         <<"telemetry">>,
         <<"sys_topics">>,
-        <<"limiter">>
+        <<"limiter">>,
+        <<"listeners">>
     ] ++ global_zone_roots()
 ).
 


### PR DESCRIPTION
1. Remove `/configs/listeners`, use `/listeners/` API instead. `/configs/listeners` is introduced by accident, and the design does not make sense. To be able to handle the listeners more effectively, you can use `/listeners`.
2. Restart the dashboard application in the emqx_dashboard's appup to generate the latest routing rules and swagger.