### PR TITLE
feat: add check_conf cli to check config format

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -21,6 +21,7 @@ File format:
 
 ### Enhancements
 - HTTP API(GET /rules/) support for pagination and fuzzy filtering. [#8450]
+- Add check_conf cli to check config format. [#8486]
 
 ## v4.3.16
 

--- a/bin/emqx
+++ b/bin/emqx
@@ -196,7 +196,7 @@ usage() {
         echo "  Up/Down-grade: upgrade | downgrade | install | uninstall"
         echo "  Install info:  ertspath | root_dir | versions"
         echo "  Runtime info:  pid | ping | versions"
-        echo "  Config check: check_conf"
+        echo "  Config check:  check_conf"
         echo "  Advanced:      console_clean | escript | rpc | rpcterms | eval"
         echo ''
         echo "Execute '$REL_NAME COMMAND help' for more information"

--- a/bin/emqx
+++ b/bin/emqx
@@ -196,6 +196,7 @@ usage() {
         echo "  Up/Down-grade: upgrade | downgrade | install | uninstall"
         echo "  Install info:  ertspath | root_dir | versions"
         echo "  Runtime info:  pid | ping | versions"
+        echo "  Configure check: check_conf"
         echo "  Advanced:      console_clean | escript | rpc | rpcterms | eval"
         echo ''
         echo "Execute '$REL_NAME COMMAND help' for more information"
@@ -338,9 +339,12 @@ trim() {
 
 # Function to generate app.config and vm.args
 generate_config() {
-    ## Delete the *.siz files first or it cann't start after
-    ## changing the config 'log.rotation.size'
-    rm -rf "${RUNNER_LOG_DIR}"/*.siz
+    check_only="$1"
+    if [ "$check_only" != "check_only" ]; then
+      ## Delete the *.siz files first or it cann't start after
+      ## changing the config 'log.rotation.size'
+      rm -rf "${RUNNER_LOG_DIR}"/*.siz
+    fi
 
     set +e
     if [ "${EMQX_LICENSE_CONF:-}" = "" ]; then
@@ -392,15 +396,22 @@ generate_config() {
             fi
         fi
     done
-    mv -f "$TMP_ARG_FILE" "$CUTTLE_GEN_ARG_FILE"
 
     if ! relx_nodetool chkconfig -config "$CONFIG_FILE"; then
         echoerr "Error reading $CONFIG_FILE"
         exit 1
     fi
+
+    if [ "$check_only" = "check_only" ]; then
+        rm -rf "$TMP_ARG_FILE"
+        rm -rf "$CUTTLE_GEN_ARG_FILE"
+        rm -rf "$CONFIG_FILE"
+    else
+        mv -f "$TMP_ARG_FILE" "$CUTTLE_GEN_ARG_FILE"
+    fi
 }
 
-# Call bootstrapd for daemon commands like start/stop/console
+# Call bootstrap for daemon commands like start/stop/console
 bootstrapd() {
     if [ -e "$RUNNER_DATA_DIR/.erlang.cookie" ]; then
         chown "$RUNNER_USER" "$RUNNER_DATA_DIR"/.erlang.cookie
@@ -449,6 +460,9 @@ case "$1" in
         IS_BOOT_COMMAND='yes'
         ;;
     foreground)
+        IS_BOOT_COMMAND='yes'
+        ;;
+    check_conf)
         IS_BOOT_COMMAND='yes'
         ;;
 esac
@@ -818,6 +832,10 @@ case "$1" in
         ;;
     ertspath)
         echo "$ERTS_PATH"
+        ;;
+    check_conf)
+        generate_config "check_only"
+        echo "$RUNNER_ETC_DIR/emqx.conf is ok"
         ;;
 
     ctl)

--- a/bin/emqx
+++ b/bin/emqx
@@ -196,7 +196,7 @@ usage() {
         echo "  Up/Down-grade: upgrade | downgrade | install | uninstall"
         echo "  Install info:  ertspath | root_dir | versions"
         echo "  Runtime info:  pid | ping | versions"
-        echo "  Configure check: check_conf"
+        echo "  Config check: check_conf"
         echo "  Advanced:      console_clean | escript | rpc | rpcterms | eval"
         echo ''
         echo "Execute '$REL_NAME COMMAND help' for more information"

--- a/bin/emqx
+++ b/bin/emqx
@@ -403,9 +403,9 @@ generate_config() {
     fi
 
     if [ "$check_only" = "check_only" ]; then
-        rm -rf "$TMP_ARG_FILE"
-        rm -rf "$CUTTLE_GEN_ARG_FILE"
-        rm -rf "$CONFIG_FILE"
+        rm -f "$TMP_ARG_FILE"
+        rm -f "$CUTTLE_GEN_ARG_FILE"
+        rm -f "$CONFIG_FILE"
     else
         mv -f "$TMP_ARG_FILE" "$CUTTLE_GEN_ARG_FILE"
     fi

--- a/bin/emqx
+++ b/bin/emqx
@@ -411,7 +411,7 @@ generate_config() {
     fi
 }
 
-# Call bootstrap for daemon commands like start/stop/console
+# Call bootstrapd for daemon commands like start/stop/console
 bootstrapd() {
     if [ -e "$RUNNER_DATA_DIR/.erlang.cookie" ]; then
         chown "$RUNNER_USER" "$RUNNER_DATA_DIR"/.erlang.cookie


### PR DESCRIPTION
As a developer, I need to test the availability of the modified configuration with a test command via CLI to avoid EMQX reboot due to configuration error.
The test command is provided to check the legality of existing configuration files and configuration items, and the data type of the configuration before starting or at runtime.

```bash
> ./bin/emqx  check_conf
xxx/etc/emqx.conf is ok
```
or

```bash
> ./bin/emqx  check_conf
2022-07-14T17:23:10.364230+08:00 [error] Error generating configuration in phase transform_datatypes
2022-07-14T17:23:10.364353+08:00 [error] Error transforming datatype for: cluster.autoheal
2022-07-14T17:23:10.364608+08:00 [error] "o1n" is not a valid enum value, acceptable values are: on, off
```
