### PR TITLE
Fix inconsistent replayq version

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -51,7 +51,7 @@
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.3.6"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "0.3.7"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
-    , {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.2"}}}
+    , {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.4"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {branch, "2.0.4"}}}
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.2.3.1"}}}
     , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.2"}}}


### PR DESCRIPTION
wolff 1.5.6 requires replayq 0.3.4

