### PR TITLE
fix: logger json formatter's config not working

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -14,6 +14,7 @@
 * Fix AuthN JWKS SSL schema. Using schema in `emqx_schema`. [#8458](https://github.com/emqx/emqx/pull/8458)
 * `sentinel` field should be required when AuthN/AuthZ Redis using sentinel mode. [#8458](https://github.com/emqx/emqx/pull/8458)
 * Fix bad swagger format. [#8517](https://github.com/emqx/emqx/pull/8517)
+* Fix `chars_limit` is not working when `formatter` is `json`. [#8518](http://github.com/emqx/emqx/pull/8518)
 
 ## Enhancements
 

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -69,9 +69,10 @@ best_effort_json(Input, Opts) ->
     jsx:encode(JsonReady, Opts).
 
 -spec format(logger:log_event(), config()) -> iodata().
-format(#{level := Level, msg := Msg, meta := Meta}, Config0) when is_map(Config0) ->
+format(#{level := Level, msg := Msg, meta := Meta} = Event, Config0) when is_map(Config0) ->
     Config = add_default_config(Config0),
-    [format(Msg, Meta#{level => Level}, Config), "\n"].
+    MsgBin = format(Msg, Meta#{level => Level}, Config),
+    logger_formatter:format(Event#{msg => {string, MsgBin}}, Config).
 
 format(Msg, Meta, Config) ->
     Data0 =

--- a/apps/emqx_conf/i18n/emqx_conf_schema.conf
+++ b/apps/emqx_conf/i18n/emqx_conf_schema.conf
@@ -1039,12 +1039,18 @@ Defaults to: <code>system</code>.
 
   common_handler_chars_limit {
     desc {
-      en: """Set the maximum length of a single log message. If this length is exceeded, the log message will be truncated."""
-      zh: """设置单个日志消息的最大长度。 如果超过此长度，则日志消息将被截断。最小可设置的长度为100。"""
+      en: """
+Set the maximum length of a single log message. If this length is exceeded, the log message will be truncated.
+NOTE: Restrict char limiter if formatter is json , it will get a truncated incomplete json data, which is not recommended.
+"""
+      zh: """
+设置单个日志消息的最大长度。 如果超过此长度，则日志消息将被截断。最小可设置的长度为100。
+注意：如果日志格式为 json，限制字符长度可能会导致截断不完整的 json 数据。
+"""
     }
     label {
       en: "Single Log Max Length"
-      zh: "单个日志最大长度"
+      zh: "单条日志长度限制"
     }
   }
 


### PR DESCRIPTION
The formatter configuration parameter is always ignored when using json schema.
However, restrict char limiter if used for JSON mode, it will get a truncated incomplete json data, which is not practical and not recommended.

