### PR TITLE
ci(mac): drop macos 10.15

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -143,7 +143,6 @@ jobs:
           - 24.2.1-1
         os:
           - macos-11
-          - macos-10.15
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/download-artifact@v2

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -133,7 +133,6 @@ jobs:
         - 24.2.1-1
         macos:
         - macos-11
-        - macos-10.15
 
     runs-on: ${{ matrix.macos }}
 


### PR DESCRIPTION
Github is dropping support for macos 10.15 in its CI at 2022-08-30.

