### PR TITLE
chore(mix): patch mix version parser when it fails

### DIFF
--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -101,7 +101,7 @@ if [ "$GIT_EXACT_VSN" != '' ]; then
     fi
     SUFFIX=''
 else
-    SUFFIX="-$(git rev-parse HEAD | cut -b1-8)"
+    SUFFIX="-g$(git rev-parse HEAD | cut -b1-8)"
 fi
 
 PKG_VSN="${PKG_VSN:-${RELEASE}${SUFFIX}}"


### PR DESCRIPTION
Since upstream refuses to fix this issue:

https://github.com/elixir-lang/elixir/issues/12000

On rare occasions, our pre-release version, which is the prefix
of the git hash, might consist only of digits.  Even more rarely, it
might start with a `0`.  When that happens, Elixir will refuse to
parse that as a valid pre-release version (it wants it to be an
integer without a leading 0).

When that happens, we load our patched version that ignores this
check, since we want to interpret it as a string, not a number.

