### PR TITLE
fix: dashboard monitor crash after badrpc

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -115,13 +115,16 @@ granularity_adapter(List) ->
 %% Get the current rate. Not the current sampler data.
 current_rate() ->
     Fun =
-        fun(Node, Cluster) ->
-            case current_rate(Node) of
-                {ok, CurrentRate} ->
-                    merge_cluster_rate(CurrentRate, Cluster);
-                {badrpc, Reason} ->
-                    {badrpc, {Node, Reason}}
-            end
+        fun
+            (Node, Cluster) when is_map(Cluster) ->
+                case current_rate(Node) of
+                    {ok, CurrentRate} ->
+                        merge_cluster_rate(CurrentRate, Cluster);
+                    {badrpc, Reason} ->
+                        {badrpc, {Node, Reason}}
+                end;
+            (_Node, Error) ->
+                Error
         end,
     case lists:foldl(Fun, #{}, mria_mnesia:cluster_nodes(running)) of
         {badrpc, Reason} ->


### PR DESCRIPTION
Accumulator becomes unusable after a `badrpc` error.

```
2022-07-21T15:22:17.825688-03:00 [warning] exception: error, line: 116, mfa: minirest_handler:apply_callback/3, path: /monitor_current, reason: {badmap,{badrpc,{'emqx@emqx-17.int.thales',{'emqx@emqx-17.int.thales',timeout}}}}, stacktrace: [{maps,get,[connections,{badrpc,{'emqx@emqx-17.int.thales',{'emqx@emqx-17.int.thales',timeout}}},0],[{file,"maps.erl"},{line,517},{error_info,#{module => erl_stdlib_errors}}]},{emqx_dashboard_monitor,'-merge_cluster_rate/2-fun-0-',3,[{file,"/emqx/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl"},{line,259}]},{maps,fold_1,3,[{file,"maps.erl"},{line,410}]},{lists,foldl,3,[{file,"lists.erl"},{line,1267}]},{emqx_dashboard_monitor,current_rate,0,[{file,"/emqx/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl"},{line,126}]},{emqx_dashboard_monitor_api,monitor_current,2,[{file,"/emqx/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl"},{line,135}]},{minirest_handler,apply_callback,3,[{file,"/emqx/deps/minirest/src/minirest_handler.erl"},{line,111}]},{minirest_handler,handle,2,[{file,"/emqx/deps/minirest/src/minirest_handler.erl"},{line,44}]},{minirest_handler,init,2,[{file,"/emqx/deps/minirest/src/minirest_handler.erl"},{line,27}]},{cowboy_handler,execute,2,[{file,"/emqx/deps/cowboy/src/cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,[{file,"/emqx/deps/cowboy/src/cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"/emqx/deps/cowboy/src/cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]
```

