### PR TITLE
chore: make sure swagger's tags always titlecase

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -33,14 +33,8 @@
 
 % Swagger
 
--define(API_TAGS_GLOBAL, [
-    ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY,
-    <<"authentication config(global)">>
-]).
--define(API_TAGS_SINGLE, [
-    ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY,
-    <<"authentication config(single listener)">>
-]).
+-define(API_TAGS_GLOBAL, [<<"authentication">>]).
+-define(API_TAGS_SINGLE, [<<"listener authentication">>]).
 
 -export([
     api_spec/0,

--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -33,8 +33,8 @@
 
 % Swagger
 
--define(API_TAGS_GLOBAL, [<<"authentication">>]).
--define(API_TAGS_SINGLE, [<<"listener authentication">>]).
+-define(API_TAGS_GLOBAL, [<<"Authentication">>]).
+-define(API_TAGS_SINGLE, [<<"Listener authentication">>]).
 
 -export([
     api_spec/0,

--- a/apps/emqx_authn/src/emqx_authn_user_import_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_user_import_api.erl
@@ -30,7 +30,7 @@
 
 % Swagger
 -define(API_TAGS_GLOBAL, [<<"authentication">>]).
--define(API_TAGS_SINGLE, [<<"listener authentication">>]).
+-define(API_TAGS_SINGLE, [<<"Listener authentication">>]).
 
 -export([
     api_spec/0,

--- a/apps/emqx_authn/src/emqx_authn_user_import_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_user_import_api.erl
@@ -29,7 +29,7 @@
 -define(NOT_FOUND, 'NOT_FOUND').
 
 % Swagger
--define(API_TAGS_GLOBAL, [<<"authentication">>]).
+-define(API_TAGS_GLOBAL, [<<"Authentication">>]).
 -define(API_TAGS_SINGLE, [<<"Listener authentication">>]).
 
 -export([

--- a/apps/emqx_authn/src/emqx_authn_user_import_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_user_import_api.erl
@@ -29,15 +29,8 @@
 -define(NOT_FOUND, 'NOT_FOUND').
 
 % Swagger
-
--define(API_TAGS_GLOBAL, [
-    ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY,
-    <<"authentication">>
-]).
--define(API_TAGS_SINGLE, [
-    ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY,
-    <<"listener authentication">>
-]).
+-define(API_TAGS_GLOBAL, [<<"authentication">>]).
+-define(API_TAGS_SINGLE, [<<"listener authentication">>]).
 
 -export([
     api_spec/0,

--- a/apps/emqx_authn/src/emqx_authn_user_import_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_user_import_api.erl
@@ -32,11 +32,11 @@
 
 -define(API_TAGS_GLOBAL, [
     ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY,
-    <<"authentication config(global)">>
+    <<"authentication">>
 ]).
 -define(API_TAGS_SINGLE, [
     ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY,
-    <<"authentication config(single listener)">>
+    <<"listener authentication">>
 ]).
 
 -export([

--- a/apps/emqx_authz/src/emqx_authz_api_sources.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_sources.erl
@@ -50,6 +50,8 @@
     aggregate_metrics/1
 ]).
 
+-define(TAGS, [<<"Authorization">>]).
+
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
@@ -70,6 +72,7 @@ schema("/authorization/sources") ->
         get =>
             #{
                 description => ?DESC(authorization_sources_get),
+                tags => ?TAGS,
                 responses =>
                     #{
                         200 => mk(
@@ -81,6 +84,7 @@ schema("/authorization/sources") ->
         post =>
             #{
                 description => ?DESC(authorization_sources_post),
+                tags => ?TAGS,
                 'requestBody' => mk(
                     hoconsc:union(authz_sources_type_refs()),
                     #{desc => ?DESC(source_config)}
@@ -101,6 +105,7 @@ schema("/authorization/sources/:type") ->
         get =>
             #{
                 description => ?DESC(authorization_sources_type_get),
+                tags => ?TAGS,
                 parameters => parameters_field(),
                 responses =>
                     #{
@@ -114,6 +119,7 @@ schema("/authorization/sources/:type") ->
         put =>
             #{
                 description => ?DESC(authorization_sources_type_put),
+                tags => ?TAGS,
                 parameters => parameters_field(),
                 'requestBody' => mk(hoconsc:union(authz_sources_type_refs())),
                 responses =>
@@ -125,6 +131,7 @@ schema("/authorization/sources/:type") ->
         delete =>
             #{
                 description => ?DESC(authorization_sources_type_delete),
+                tags => ?TAGS,
                 parameters => parameters_field(),
                 responses =>
                     #{
@@ -139,6 +146,7 @@ schema("/authorization/sources/:type/status") ->
         get =>
             #{
                 description => ?DESC(authorization_sources_type_status_get),
+                tags => ?TAGS,
                 parameters => parameters_field(),
                 responses =>
                     #{
@@ -159,6 +167,7 @@ schema("/authorization/sources/:type/move") ->
         post =>
             #{
                 description => ?DESC(authorization_sources_type_move_post),
+                tags => ?TAGS,
                 parameters => parameters_field(),
                 'requestBody' =>
                     emqx_dashboard_swagger:schema_with_examples(

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auto_subscribe, [
     {description, "An OTP application"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {mod, {emqx_auto_subscribe_app, []}},
     {applications, [

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_api.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_api.erl
@@ -44,12 +44,14 @@ schema("/mqtt/auto_subscribe") ->
         'operationId' => auto_subscribe,
         get => #{
             description => ?DESC(list_auto_subscribe_api),
+            tags => [<<"Auto subscribe">>],
             responses => #{
                 200 => hoconsc:ref(emqx_auto_subscribe_schema, "auto_subscribe")
             }
         },
         put => #{
             description => ?DESC(update_auto_subscribe_api),
+            tags => [<<"Auto subscribe">>],
             'requestBody' => hoconsc:ref(emqx_auto_subscribe_schema, "auto_subscribe"),
             responses => #{
                 200 => hoconsc:ref(emqx_auto_subscribe_schema, "auto_subscribe"),

--- a/apps/emqx_dashboard/src/emqx_dashboard_error_code_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_error_code_api.erl
@@ -51,6 +51,7 @@ schema("/error_codes") ->
         get => #{
             security => [],
             description => <<"API Error Codes">>,
+            tags => [<<"Error Codes">>],
             responses => #{
                 200 => hoconsc:array(hoconsc:ref(?MODULE, error_code))
             }
@@ -62,6 +63,7 @@ schema("/error_codes/:code") ->
         get => #{
             security => [],
             description => <<"API Error Codes">>,
+            tags => [<<"Error Codes">>],
             parameters => [
                 {code,
                     hoconsc:mk(hoconsc:enum(emqx_dashboard_error_code:all()), #{

--- a/apps/emqx_dashboard/src/emqx_dashboard_error_code_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_error_code_api.erl
@@ -51,7 +51,7 @@ schema("/error_codes") ->
         get => #{
             security => [],
             description => <<"API Error Codes">>,
-            tags => [<<"Error Codes">>],
+            tags => [<<"Error codes">>],
             responses => #{
                 200 => hoconsc:array(hoconsc:ref(?MODULE, error_code))
             }
@@ -63,7 +63,7 @@ schema("/error_codes/:code") ->
         get => #{
             security => [],
             description => <<"API Error Codes">>,
-            tags => [<<"Error Codes">>],
+            tags => [<<"Error codes">>],
             parameters => [
                 {code,
                     hoconsc:mk(hoconsc:enum(emqx_dashboard_error_code:all()), #{

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -37,7 +37,7 @@ schema("/monitor") ->
     #{
         'operationId' => monitor,
         get => #{
-            tags => [dashboard],
+            tags => [<<"metrics">>],
             desc => <<"List monitor data.">>,
             parameters => [parameter_latest()],
             responses => #{
@@ -50,7 +50,7 @@ schema("/monitor/nodes/:node") ->
     #{
         'operationId' => monitor,
         get => #{
-            tags => [dashboard],
+            tags => [<<"metrics">>],
             desc => <<"List the monitor data on the node.">>,
             parameters => [parameter_node(), parameter_latest()],
             responses => #{
@@ -63,7 +63,7 @@ schema("/monitor_current") ->
     #{
         'operationId' => monitor_current,
         get => #{
-            tags => [dashboard],
+            tags => [<<"metrics">>],
             desc => <<"Current status. Gauge and rate.">>,
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(sampler_current), #{})
@@ -74,7 +74,7 @@ schema("/monitor_current/nodes/:node") ->
     #{
         'operationId' => monitor_current,
         get => #{
-            tags => [dashboard],
+            tags => [<<"metrics">>],
             desc => <<"Node current status. Gauge and rate.">>,
             parameters => [parameter_node()],
             responses => #{

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -37,7 +37,7 @@ schema("/monitor") ->
     #{
         'operationId' => monitor,
         get => #{
-            tags => [<<"metrics">>],
+            tags => [<<"Metrics">>],
             desc => <<"List monitor data.">>,
             parameters => [parameter_latest()],
             responses => #{
@@ -50,7 +50,7 @@ schema("/monitor/nodes/:node") ->
     #{
         'operationId' => monitor,
         get => #{
-            tags => [<<"metrics">>],
+            tags => [<<"Metrics">>],
             desc => <<"List the monitor data on the node.">>,
             parameters => [parameter_node(), parameter_latest()],
             responses => #{
@@ -63,7 +63,7 @@ schema("/monitor_current") ->
     #{
         'operationId' => monitor_current,
         get => #{
-            tags => [<<"metrics">>],
+            tags => [<<"Metrics">>],
             desc => <<"Current status. Gauge and rate.">>,
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(sampler_current), #{})
@@ -74,7 +74,7 @@ schema("/monitor_current/nodes/:node") ->
     #{
         'operationId' => monitor_current,
         get => #{
-            tags => [<<"metrics">>],
+            tags => [<<"Metrics">>],
             desc => <<"Node current status. Gauge and rate.">>,
             parameters => [parameter_node()],
             responses => #{

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -338,10 +338,17 @@ to_spec(Meta, Params, RequestBody, Responses) ->
     maps:put('requestBody', RequestBody, Spec).
 
 generate_method_desc(Spec = #{desc := _Desc}) ->
-    trans_description(maps:remove(desc, Spec), Spec);
+    Spec1 = trans_description(maps:remove(desc, Spec), Spec),
+    trans_tags(Spec1);
 generate_method_desc(Spec = #{description := _Desc}) ->
-    trans_description(Spec, Spec);
+    Spec1 = trans_description(Spec, Spec),
+    trans_tags(Spec1);
 generate_method_desc(Spec) ->
+    trans_tags(Spec).
+
+trans_tags(Spec = #{tags := Tags}) ->
+    Spec#{tags => [string:titlecase(to_bin(Tag)) || Tag <- Tags]};
+trans_tags(Spec) ->
     Spec.
 
 parameters(Params, Module) ->

--- a/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
@@ -196,7 +196,7 @@ t_in_mix(_Config) ->
             }
         ],
     ExpectMeta = #{
-        tags => [tags, good],
+        tags => [<<"Tags">>, <<"Good">>],
         description => <<"good description">>,
         summary => <<"good summary">>,
         security => [],

--- a/apps/emqx_gateway/src/coap/emqx_coap_api.erl
+++ b/apps/emqx_gateway/src/coap/emqx_coap_api.erl
@@ -48,7 +48,7 @@ schema(?PREFIX ++ "/request") ->
     #{
         operationId => request,
         post => #{
-            tags => [<<"coap">>],
+            tags => [<<"CoAP gateway">>],
             desc => ?DESC(send_coap_request),
             parameters => request_parameters(),
             requestBody => request_body(),

--- a/apps/emqx_gateway/src/coap/emqx_coap_api.erl
+++ b/apps/emqx_gateway/src/coap/emqx_coap_api.erl
@@ -48,7 +48,7 @@ schema(?PREFIX ++ "/request") ->
     #{
         operationId => request,
         post => #{
-            tags => [<<"gateway|coap">>],
+            tags => [<<"coap">>],
             desc => ?DESC(send_coap_request),
             parameters => request_parameters(),
             requestBody => request_body(),

--- a/apps/emqx_management/src/emqx_mgmt_api_alarms.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_alarms.erl
@@ -26,7 +26,7 @@
 
 -export([alarms/2]).
 
--define(TAGS, [<<"alarms">>]).
+-define(TAGS, [<<"Alarms">>]).
 
 %% internal export (for query)
 -export([query/4]).

--- a/apps/emqx_management/src/emqx_mgmt_api_alarms.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_alarms.erl
@@ -26,6 +26,8 @@
 
 -export([alarms/2]).
 
+-define(TAGS, [<<"alarms">>]).
+
 %% internal export (for query)
 -export([query/4]).
 
@@ -40,6 +42,7 @@ schema("/alarms") ->
         'operationId' => alarms,
         get => #{
             description => ?DESC(list_alarms_api),
+            tags => ?TAGS,
             parameters => [
                 hoconsc:ref(emqx_dashboard_swagger, page),
                 hoconsc:ref(emqx_dashboard_swagger, limit),
@@ -59,6 +62,7 @@ schema("/alarms") ->
         },
         delete => #{
             description => ?DESC(delete_alarms_api),
+            tags => ?TAGS,
             responses => #{
                 204 => ?DESC(delete_alarms_api_response204)
             }

--- a/apps/emqx_management/src/emqx_mgmt_api_app.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_app.erl
@@ -22,6 +22,7 @@
 -export([api_spec/0, fields/1, paths/0, schema/1, namespace/0]).
 -export([api_key/2, api_key_by_name/2]).
 -export([validate_name/1]).
+-define(TAGS, [<<"API keys">>]).
 
 namespace() -> "api_key".
 
@@ -36,12 +37,14 @@ schema("/api_key") ->
         'operationId' => api_key,
         get => #{
             description => "Return api_key list",
+            tags => ?TAGS,
             responses => #{
                 200 => delete([api_secret], fields(app))
             }
         },
         post => #{
             description => "Create new api_key",
+            tags => ?TAGS,
             'requestBody' => delete([created_at, api_key, api_secret], fields(app)),
             responses => #{
                 200 => hoconsc:ref(app),
@@ -54,6 +57,7 @@ schema("/api_key/:name") ->
         'operationId' => api_key_by_name,
         get => #{
             description => "Return the specific api_key",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
                 200 => delete([api_secret], fields(app)),
@@ -62,6 +66,7 @@ schema("/api_key/:name") ->
         },
         put => #{
             description => "Update the specific api_key",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             'requestBody' => delete([created_at, api_key, api_secret, name], fields(app)),
             responses => #{
@@ -71,6 +76,7 @@ schema("/api_key/:name") ->
         },
         delete => #{
             description => "Delete the specific api_key",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
                 204 => <<"Delete successfully">>,

--- a/apps/emqx_management/src/emqx_mgmt_api_banned.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_banned.erl
@@ -39,6 +39,7 @@
 ]).
 
 -define(TAB, emqx_banned).
+-define(TAGS, [<<"Banned">>]).
 
 -define(BANNED_TYPES, [clientid, username, peerhost]).
 
@@ -55,6 +56,7 @@ schema("/banned") ->
         'operationId' => banned,
         get => #{
             description => ?DESC(list_banned_api),
+            tags => ?TAGS,
             parameters => [
                 hoconsc:ref(emqx_dashboard_swagger, page),
                 hoconsc:ref(emqx_dashboard_swagger, limit)
@@ -68,6 +70,7 @@ schema("/banned") ->
         },
         post => #{
             description => ?DESC(create_banned_api),
+            tags => ?TAGS,
             'requestBody' => hoconsc:mk(hoconsc:ref(ban)),
             responses => #{
                 200 => [{data, hoconsc:mk(hoconsc:array(hoconsc:ref(ban)), #{})}],
@@ -83,6 +86,7 @@ schema("/banned/:as/:who") ->
         'operationId' => delete_banned,
         delete => #{
             description => ?DESC(delete_banned_api),
+            tags => ?TAGS,
             parameters => [
                 {as,
                     hoconsc:mk(hoconsc:enum(?BANNED_TYPES), #{

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -54,6 +54,7 @@
 -export([do_subscribe/3]).
 
 -define(CLIENT_QTAB, emqx_channel_info).
+-define(TAGS, [<<"Clients">>]).
 
 -define(CLIENT_QSCHEMA, [
     {<<"node">>, atom},
@@ -100,6 +101,7 @@ schema("/clients") ->
         'operationId' => clients,
         get => #{
             description => <<"List clients">>,
+            tags => ?TAGS,
             parameters => [
                 hoconsc:ref(emqx_dashboard_swagger, page),
                 hoconsc:ref(emqx_dashboard_swagger, limit),
@@ -220,6 +222,7 @@ schema("/clients/:clientid") ->
         'operationId' => client,
         get => #{
             description => <<"Get clients info by client ID">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(?MODULE, client), #{}),
@@ -230,6 +233,7 @@ schema("/clients/:clientid") ->
         },
         delete => #{
             description => <<"Kick out client by client ID">>,
+            tags => ?TAGS,
             parameters => [
                 {clientid, hoconsc:mk(binary(), #{in => path})}
             ],
@@ -246,6 +250,7 @@ schema("/clients/:clientid/authorization/cache") ->
         'operationId' => authz_cache,
         get => #{
             description => <<"Get client authz cache in the cluster.">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(?MODULE, authz_cache), #{}),
@@ -256,6 +261,7 @@ schema("/clients/:clientid/authorization/cache") ->
         },
         delete => #{
             description => <<"Clean client authz cache in the cluster.">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             responses => #{
                 204 => <<"Kick out client successfully">>,
@@ -270,6 +276,7 @@ schema("/clients/:clientid/subscriptions") ->
         'operationId' => subscriptions,
         get => #{
             description => <<"Get client subscriptions">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             responses => #{
                 200 => hoconsc:mk(
@@ -286,6 +293,7 @@ schema("/clients/:clientid/subscribe") ->
         'operationId' => subscribe,
         post => #{
             description => <<"Subscribe">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             'requestBody' => hoconsc:mk(hoconsc:ref(?MODULE, subscribe)),
             responses => #{
@@ -301,6 +309,7 @@ schema("/clients/:clientid/subscribe/bulk") ->
         'operationId' => subscribe_batch,
         post => #{
             description => <<"Subscribe">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             'requestBody' => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, subscribe))),
             responses => #{
@@ -316,6 +325,7 @@ schema("/clients/:clientid/unsubscribe") ->
         'operationId' => unsubscribe,
         post => #{
             description => <<"Unsubscribe">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             'requestBody' => hoconsc:mk(hoconsc:ref(?MODULE, unsubscribe)),
             responses => #{
@@ -331,6 +341,7 @@ schema("/clients/:clientid/unsubscribe/bulk") ->
         'operationId' => unsubscribe_batch,
         post => #{
             description => <<"Unsubscribe">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             'requestBody' => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, unsubscribe))),
             responses => #{
@@ -346,6 +357,7 @@ schema("/clients/:clientid/keepalive") ->
         'operationId' => set_keepalive,
         put => #{
             description => <<"Set the online client keepalive by seconds">>,
+            tags => ?TAGS,
             parameters => [{clientid, hoconsc:mk(binary(), #{in => path})}],
             'requestBody' => hoconsc:mk(hoconsc:ref(?MODULE, keepalive)),
             responses => #{

--- a/apps/emqx_management/src/emqx_mgmt_api_cluster.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_cluster.erl
@@ -40,6 +40,7 @@ schema("/cluster") ->
         'operationId' => cluster_info,
         get => #{
             description => "Get cluster info",
+            tags => [<<"Cluster">>],
             responses => #{
                 200 => [
                     {name, ?HOCON(string(), #{desc => "Cluster name"})},
@@ -54,6 +55,7 @@ schema("/cluster/:node/invite") ->
         'operationId' => invite_node,
         put => #{
             description => "Invite node to cluster",
+            tags => [<<"Cluster">>],
             parameters => [hoconsc:ref(node)],
             responses => #{
                 200 => <<"ok">>,
@@ -66,6 +68,7 @@ schema("/cluster/:node/force_leave") ->
         'operationId' => force_leave,
         delete => #{
             description => "Force leave node from cluster",
+            tags => [<<"Cluster">>],
             parameters => [hoconsc:ref(node)],
             responses => #{
                 204 => <<"Delete successfully">>,

--- a/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_metrics.erl
@@ -22,7 +22,7 @@
 
 -import(hoconsc, [mk/2, ref/2]).
 
-%% minirest/dashbaord_swagger behaviour callbacks
+%% minirest/dashboard_swagger behaviour callbacks
 -export([
     api_spec/0,
     paths/0,
@@ -74,6 +74,7 @@ schema("/metrics") ->
         get =>
             #{
                 description => <<"EMQX metrics">>,
+                tags => [<<"Metrics">>],
                 parameters =>
                     [
                         {aggregate,

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -64,6 +64,7 @@ schema("/nodes") ->
         get =>
             #{
                 description => <<"List EMQX nodes">>,
+                tags => [<<"Nodes">>],
                 responses =>
                     #{
                         200 => mk(
@@ -79,6 +80,7 @@ schema("/nodes/:node") ->
         get =>
             #{
                 description => <<"Get node info">>,
+                tags => [<<"Nodes">>],
                 parameters => [ref(node_name)],
                 responses =>
                     #{
@@ -96,6 +98,7 @@ schema("/nodes/:node/metrics") ->
         get =>
             #{
                 description => <<"Get node metrics">>,
+                tags => [<<"Nodes">>],
                 parameters => [ref(node_name)],
                 responses =>
                     #{
@@ -113,6 +116,7 @@ schema("/nodes/:node/stats") ->
         get =>
             #{
                 description => <<"Get node stats">>,
+                tags => [<<"Nodes">>],
                 parameters => [ref(node_name)],
                 responses =>
                     #{

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -48,6 +48,7 @@
 ]).
 
 -define(NAME_RE, "^[A-Za-z]+[A-Za-z0-9-_.]*$").
+-define(TAGS, [<<"Plugins">>]).
 
 namespace() -> "plugins".
 
@@ -72,6 +73,7 @@ schema("/plugins") ->
                 "List all install plugins.</br>"
                 "Plugins are launched in top-down order.</br>"
                 "Using `POST /plugins/{name}/move` to change the boot order.",
+            tags => ?TAGS,
             responses => #{
                 200 => hoconsc:array(hoconsc:ref(plugin))
             }
@@ -85,6 +87,7 @@ schema("/plugins/install") ->
                 "Install a plugin(plugin-vsn.tar.gz)."
                 "Follow [emqx-plugin-template](https://github.com/emqx/emqx-plugin-template) "
                 "to develop plugin.",
+            tags => ?TAGS,
             'requestBody' => #{
                 content => #{
                     'multipart/form-data' => #{
@@ -111,6 +114,7 @@ schema("/plugins/:name") ->
         'operationId' => plugin,
         get => #{
             description => "Describe a plugin according `release.json` and `README.md`.",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
                 200 => hoconsc:ref(plugin),
@@ -119,6 +123,7 @@ schema("/plugins/:name") ->
         },
         delete => #{
             description => "Uninstall a plugin package.",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
                 204 => <<"Uninstall successfully">>,
@@ -134,6 +139,7 @@ schema("/plugins/:name/:action") ->
                 "start/stop a installed plugin.</br>"
                 "- **start**: start the plugin.</br>"
                 "- **stop**: stop the plugin.</br>",
+            tags => ?TAGS,
             parameters => [
                 hoconsc:ref(name),
                 {action, hoconsc:mk(hoconsc:enum([start, stop]), #{desc => "Action", in => path})}
@@ -149,6 +155,7 @@ schema("/plugins/:name/move") ->
         'operationId' => update_boot_order,
         post => #{
             description => "Setting the boot order of plugins.",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             'requestBody' => move_request_body(),
             responses => #{200 => <<"OK">>}

--- a/apps/emqx_management/src/emqx_mgmt_api_publish.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_publish.erl
@@ -43,6 +43,7 @@ schema("/publish") ->
         'operationId' => publish,
         post => #{
             description => <<"Publish Message">>,
+            tags => [<<"Mqtt">>],
             'requestBody' => hoconsc:mk(hoconsc:ref(?MODULE, publish_message)),
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(?MODULE, publish_message_info))
@@ -54,6 +55,7 @@ schema("/publish/bulk") ->
         'operationId' => publish_batch,
         post => #{
             description => <<"Publish Messages">>,
+            tags => [<<"Mqtt">>],
             'requestBody' => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, publish_message)), #{}),
             responses => #{
                 200 => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, publish_message_info)), #{})

--- a/apps/emqx_management/src/emqx_mgmt_api_publish.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_publish.erl
@@ -55,7 +55,7 @@ schema("/publish/bulk") ->
         'operationId' => publish_batch,
         post => #{
             description => <<"Publish Messages">>,
-            tags => [<<"Mqtt">>],
+            tags => [<<"Publish">>],
             'requestBody' => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, publish_message)), #{}),
             responses => #{
                 200 => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, publish_message_info)), #{})

--- a/apps/emqx_management/src/emqx_mgmt_api_publish.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_publish.erl
@@ -43,7 +43,7 @@ schema("/publish") ->
         'operationId' => publish,
         post => #{
             description => <<"Publish Message">>,
-            tags => [<<"Mqtt">>],
+            tags => [<<"Publish">>],
             'requestBody' => hoconsc:mk(hoconsc:ref(?MODULE, publish_message)),
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(?MODULE, publish_message_info))

--- a/apps/emqx_management/src/emqx_mgmt_api_stats.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_stats.erl
@@ -50,7 +50,7 @@ schema("/stats") ->
         get =>
             #{
                 description => <<"EMQX stats">>,
-                tags => [<<"metrics">>],
+                tags => [<<"Metrics">>],
                 parameters => [ref(aggregate)],
                 responses =>
                     #{

--- a/apps/emqx_management/src/emqx_mgmt_api_stats.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_stats.erl
@@ -50,7 +50,7 @@ schema("/stats") ->
         get =>
             #{
                 description => <<"EMQX stats">>,
-                tags => [<<"stats">>],
+                tags => [<<"metrics">>],
                 parameters => [ref(aggregate)],
                 responses =>
                     #{

--- a/apps/emqx_management/src/emqx_mgmt_api_status.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_status.erl
@@ -37,6 +37,7 @@ schema("/status") ->
         get =>
             #{
                 description => <<"Node running status">>,
+                tags => [<<"Status">>],
                 security => [],
                 responses =>
                     #{

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -60,6 +60,7 @@ schema("/subscriptions") ->
         'operationId' => subscriptions,
         get => #{
             description => <<"List subscriptions">>,
+            tags => [<<"Subscriptions">>],
             parameters => parameters(),
             responses => #{
                 200 => hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, subscription)), #{})

--- a/apps/emqx_management/src/emqx_mgmt_api_sys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_sys.erl
@@ -31,7 +31,7 @@
 
 -export([sys/2]).
 
--define(TAGS, [<<"system topics">>]).
+-define(TAGS, [<<"System topics">>]).
 
 namespace() -> "sys".
 

--- a/apps/emqx_management/src/emqx_mgmt_api_sys.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_sys.erl
@@ -31,7 +31,7 @@
 
 -export([sys/2]).
 
--define(TAGS, [<<"sys">>]).
+-define(TAGS, [<<"system topics">>]).
 
 namespace() -> "sys".
 

--- a/apps/emqx_management/src/emqx_mgmt_api_topics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_topics.erl
@@ -39,6 +39,7 @@
 -define(TOPIC_NOT_FOUND, 'TOPIC_NOT_FOUND').
 
 -define(TOPICS_QUERY_SCHEMA, [{<<"topic">>, binary}, {<<"node">>, atom}]).
+-define(TAGS, [<<"Topics">>]).
 
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
@@ -51,6 +52,7 @@ schema("/topics") ->
         'operationId' => topics,
         get => #{
             description => <<"Topics list">>,
+            tags => ?TAGS,
             parameters => [
                 topic_param(query),
                 node_param(),
@@ -70,6 +72,7 @@ schema("/topics/:topic") ->
         'operationId' => topic,
         get => #{
             description => <<"Lookup topic info by name">>,
+            tags => ?TAGS,
             parameters => [topic_param(path)],
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(topic), #{}),

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -47,6 +47,7 @@
 
 -define(TO_BIN(_B_), iolist_to_binary(_B_)).
 -define(NOT_FOUND(N), {404, #{code => 'NOT_FOUND', message => ?TO_BIN([N, " NOT FOUND"])}}).
+-define(TAGS, [<<"Trace">>]).
 
 namespace() -> "trace".
 
@@ -61,12 +62,14 @@ schema("/trace") ->
         'operationId' => trace,
         get => #{
             description => "List all trace",
+            tags => ?TAGS,
             responses => #{
                 200 => hoconsc:ref(trace)
             }
         },
         post => #{
             description => "Create new trace",
+            tags => ?TAGS,
             'requestBody' => delete([status, log_size], fields(trace)),
             responses => #{
                 200 => hoconsc:ref(trace),
@@ -82,6 +85,7 @@ schema("/trace") ->
         },
         delete => #{
             description => "Clear all traces",
+            tags => ?TAGS,
             responses => #{
                 204 => <<"No Content">>
             }
@@ -92,6 +96,7 @@ schema("/trace/:name") ->
         'operationId' => delete_trace,
         delete => #{
             description => "Delete trace by name",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
                 204 => <<"Delete successfully">>,
@@ -104,6 +109,7 @@ schema("/trace/:name/stop") ->
         'operationId' => update_trace,
         put => #{
             description => "Stop trace by name",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
                 200 => hoconsc:ref(trace),
@@ -116,6 +122,7 @@ schema("/trace/:name/download") ->
         'operationId' => download_trace_log,
         get => #{
             description => "Download trace log by name",
+            tags => ?TAGS,
             parameters => [hoconsc:ref(name), hoconsc:ref(node)],
             responses => #{
                 200 =>
@@ -134,6 +141,7 @@ schema("/trace/:name/log") ->
         'operationId' => stream_log_file,
         get => #{
             description => "view trace log",
+            tags => ?TAGS,
             parameters => [
                 hoconsc:ref(name),
                 hoconsc:ref(bytes),

--- a/apps/emqx_modules/src/emqx_telemetry_api.erl
+++ b/apps/emqx_modules/src/emqx_telemetry_api.erl
@@ -52,12 +52,14 @@ schema("/telemetry/status") ->
         get =>
             #{
                 description => ?DESC(get_telemetry_status_api),
+                tags => [<<"Telemetry">>],
                 responses =>
                     #{200 => status_schema(?DESC(get_telemetry_status_api))}
             },
         put =>
             #{
                 description => ?DESC(update_telemetry_status_api),
+                tags => [<<"Telemetry">>],
                 'requestBody' => status_schema(?DESC(update_telemetry_status_api)),
                 responses =>
                     #{
@@ -71,6 +73,7 @@ schema("/telemetry/data") ->
         get =>
             #{
                 description => ?DESC(get_telemetry_data_api),
+                tags => [<<"Telemetry">>],
                 responses =>
                     #{200 => mk(ref(?MODULE, telemetry), #{desc => ?DESC(get_telemetry_data_api)})}
             }

--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.0.1"},
+    {vsn, "5.0.2"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx]},

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -34,7 +34,7 @@
 ]).
 
 -define(SCHEMA_MODULE, emqx_prometheus_schema).
--define(TAGS, [<<"monitor">>]).
+-define(TAGS, [<<"Monitor">>]).
 
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).

--- a/apps/emqx_prometheus/src/emqx_prometheus_api.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_api.erl
@@ -34,6 +34,7 @@
 ]).
 
 -define(SCHEMA_MODULE, emqx_prometheus_schema).
+-define(TAGS, [<<"monitor">>]).
 
 api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
@@ -50,12 +51,14 @@ schema("/prometheus") ->
         get =>
             #{
                 description => <<"Get Prometheus config info">>,
+                tags => ?TAGS,
                 responses =>
                     #{200 => prometheus_config_schema()}
             },
         put =>
             #{
                 description => <<"Update Prometheus config">>,
+                tags => ?TAGS,
                 'requestBody' => prometheus_config_schema(),
                 responses =>
                     #{200 => prometheus_config_schema()}
@@ -67,6 +70,7 @@ schema("/prometheus/stats") ->
         get =>
             #{
                 description => <<"Get Prometheus Data">>,
+                tags => ?TAGS,
                 security => [],
                 responses =>
                     #{200 => prometheus_data_schema()}

--- a/apps/emqx_slow_subs/src/emqx_slow_subs.app.src
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs.app.src
@@ -1,7 +1,7 @@
 {application, emqx_slow_subs, [
     {description, "EMQX Slow Subscribers Statistics"},
     % strict semver, bump manually!
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {modules, []},
     {registered, [emqx_slow_subs_sup]},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_slow_subs/src/emqx_slow_subs_api.erl
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs_api.erl
@@ -25,6 +25,7 @@
 -export([api_spec/0, paths/0, schema/1, fields/1, namespace/0]).
 
 -export([slow_subs/2, get_history/0, settings/2]).
+-define(TAGS, [<<"Slow subscriptions">>]).
 
 -import(hoconsc, [mk/2, ref/1, ref/2]).
 -import(emqx_mgmt_util, [bad_request/0]).
@@ -44,14 +45,14 @@ schema(("/slow_subscriptions")) ->
     #{
         'operationId' => slow_subs,
         delete => #{
-            tags => [<<"slow subs">>],
+            tags => ?TAGS,
             description => ?DESC(clear_records_api),
             parameters => [],
             'requestBody' => [],
             responses => #{204 => <<"No Content">>}
         },
         get => #{
-            tags => [<<"slow subs">>],
+            tags => ?TAGS,
             description => ?DESC(get_records_api),
             parameters => [
                 ref(emqx_dashboard_swagger, page),
@@ -65,12 +66,12 @@ schema("/slow_subscriptions/settings") ->
     #{
         'operationId' => settings,
         get => #{
-            tags => [<<"slow subs">>],
+            tags => ?TAGS,
             description => ?DESC(get_setting_api),
             responses => #{200 => conf_schema()}
         },
         put => #{
-            tags => [<<"slow subs">>],
+            tags => ?TAGS,
             description => ?DESC(update_setting_api),
             'requestBody' => conf_schema(),
             responses => #{200 => conf_schema()}

--- a/apps/emqx_statsd/src/emqx_statsd.app.src
+++ b/apps/emqx_statsd/src/emqx_statsd.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_statsd, [
     {description, "An OTP application"},
-    {vsn, "5.0.0"},
+    {vsn, "5.0.1"},
     {registered, []},
     {mod, {emqx_statsd_app, []}},
     {applications, [

--- a/apps/emqx_statsd/src/emqx_statsd_api.erl
+++ b/apps/emqx_statsd/src/emqx_statsd_api.erl
@@ -32,7 +32,7 @@
     schema/1
 ]).
 
--define(API_TAG_STATSD, [<<"monitor">>]).
+-define(API_TAG_STATSD, [<<"Monitor">>]).
 -define(SCHEMA_MODULE, emqx_statsd_schema).
 
 -define(INTERNAL_ERROR, 'INTERNAL_ERROR').

--- a/apps/emqx_statsd/src/emqx_statsd_api.erl
+++ b/apps/emqx_statsd/src/emqx_statsd_api.erl
@@ -32,7 +32,7 @@
     schema/1
 ]).
 
--define(API_TAG_STATSD, [<<"statsd">>]).
+-define(API_TAG_STATSD, [<<"monitor">>]).
 -define(SCHEMA_MODULE, emqx_statsd_schema).
 
 -define(INTERNAL_ERROR, 'INTERNAL_ERROR').


### PR DESCRIPTION
1. make sure tags always `titlecase`.
2. Each API needs to be assigned a tags.