### PR TITLE
Format the listeners API fields

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -31,6 +31,8 @@
 * Remove `/configs/listeners` API, use `/listeners/` instead. [#8485](https://github.com/emqx/emqx/pull/8485)
 * Optimize performance of builtin database operations in processes with long message queue [#8439](https://github.com/emqx/emqx/pull/8439)
 * Improve authentication tracing. [#8554](https://github.com/emqx/emqx/pull/8554)
+* Standardize the '/listeners' and `/gateway/<name>/listeners` API fields.
+  It will introduce some incompatible updates, see [#8571](https://github.com/emqx/emqx/pull/8571)
 
 # 5.0.3
 

--- a/apps/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/apps/emqx_dashboard/etc/emqx_dashboard.conf
@@ -1,7 +1,7 @@
 dashboard {
     listeners.http {
-        bind: 18083
+        bind = 18083
     }
-    default_username: "admin"
-    default_password: "public"
+    default_username = "admin"
+    default_password = "public"
 }

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -92,7 +92,7 @@ start_listeners(Listeners) ->
                 case minirest:start(Name, RanchOptions, Minirest) of
                     {ok, _} ->
                         ?ULOG("Listener ~ts on ~ts started.~n", [
-                            Name, emqx_listeners:format_addr(Bind)
+                            Name, emqx_listeners:format_bind(Bind)
                         ]),
                         Acc;
                     {error, _Reason} ->
@@ -114,7 +114,7 @@ stop_listeners(Listeners) ->
             case minirest:stop(Name) of
                 ok ->
                     ?ULOG("Stop listener ~ts on ~ts successfully.~n", [
-                        Name, emqx_listeners:format_addr(Port)
+                        Name, emqx_listeners:format_bind(Port)
                     ]);
                 {error, not_found} ->
                     ?SLOG(warning, #{msg => "stop_listener_failed", name => Name, port => Port})

--- a/apps/emqx_gateway/i18n/emqx_gateway_api_listeners_i18n.conf
+++ b/apps/emqx_gateway/i18n/emqx_gateway_api_listeners_i18n.conf
@@ -112,6 +112,13 @@ emqx_gateway_api_listeners {
         }
     }
 
+    listener_status {
+        desc {
+            en: """listener status """
+            zh: """监听器状态"""
+        }
+    }
+
     listener_node_status {
         desc {
             en: """listener status of each node in the cluster"""

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -81,7 +81,7 @@ paths() ->
 
 listeners(get, #{bindings := #{name := Name0}}) ->
     with_gateway(Name0, fun(GwName, _) ->
-        Result = get_cluster_listeners_info(GwName),
+        Result = lists:map(fun bind2str/1, get_cluster_listeners_info(GwName)),
         {200, Result}
     end);
 listeners(post, #{bindings := #{name := Name0}, body := LConf}) ->
@@ -119,7 +119,7 @@ listeners_insta(get, #{bindings := #{name := Name0, id := ListenerId0}}) ->
     with_gateway(Name0, fun(_GwName, _) ->
         case emqx_gateway_conf:listener(ListenerId) of
             {ok, Listener} ->
-                {200, Listener};
+                {200, bind2str(Listener)};
             {error, not_found} ->
                 return_http_error(404, "Listener not found");
             {error, Reason} ->
@@ -266,11 +266,14 @@ get_cluster_listeners_info(GwName) ->
                 ClusterStatus
             ),
 
-            {MaxCons, CurrCons} = emqx_gateway_http:sum_cluster_connections(NodeStatus),
+            {MaxCons, CurrCons, Running} = aggregate_listener_status(NodeStatus),
 
             Listener#{
-                max_connections => MaxCons,
-                current_connections => CurrCons,
+                status => #{
+                    running => Running,
+                    max_connections => MaxCons,
+                    current_connections => CurrCons
+                },
                 node_status => NodeStatus
             }
         end,
@@ -292,20 +295,23 @@ do_listeners_cluster_status(Listeners) ->
         fun({Id, ListenOn}, Acc) ->
             BinId = erlang:atom_to_binary(Id),
             {ok, #{<<"max_connections">> := Max}} = emqx_gateway_conf:listener(BinId),
-            Curr =
+            {Running, Curr} =
                 try esockd:get_current_connections({Id, ListenOn}) of
-                    Int -> Int
+                    Int -> {true, Int}
                 catch
                     %% not started
                     error:not_found ->
-                        0
+                        {false, 0}
                 end,
             Acc#{
                 Id => #{
                     node => Node,
-                    current_connections => Curr,
-                    %% XXX: Since it is taken from raw-conf, it is possible a string
-                    max_connections => int(Max)
+                    status => #{
+                        running => Running,
+                        current_connections => Curr,
+                        %% XXX: Since it is taken from raw-conf, it is possible a string
+                        max_connections => int(Max)
+                    }
                 }
             }
         end,
@@ -317,6 +323,31 @@ int(B) when is_binary(B) ->
     binary_to_integer(B);
 int(I) when is_integer(I) ->
     I.
+aggregate_listener_status(NodeStatus) ->
+    aggregate_listener_status(NodeStatus, 0, 0, undefined).
+
+aggregate_listener_status(
+    [
+        #{status := #{running := Running, max_connections := Max, current_connections := Current}}
+        | T
+    ],
+    MaxAcc,
+    CurrAcc,
+    RunningAcc
+) ->
+    NRunning = aggregate_running(Running, RunningAcc),
+    aggregate_listener_status(T, MaxAcc + Max, Current + CurrAcc, NRunning);
+aggregate_listener_status([], MaxAcc, CurrAcc, RunningAcc) ->
+    {MaxAcc, CurrAcc, RunningAcc}.
+
+aggregate_running(R, R) -> R;
+aggregate_running(R, undefined) -> R;
+aggregate_running(_, _) -> inconsistent.
+
+bind2str(Listener = #{bind := Bind}) ->
+    Listener#{bind := iolist_to_binary(emqx_gateway_utils:format_listenon(Bind))};
+bind2str(Listener = #{<<"bind">> := Bind}) ->
+    Listener#{<<"bind">> := iolist_to_binary(emqx_gateway_utils:format_listenon(Bind))}.
 
 %%--------------------------------------------------------------------
 %% Swagger defines
@@ -590,22 +621,25 @@ params_paging_in_qs() ->
 roots() ->
     [listener].
 
-fields(listener_node_status) ->
+fields(listener_status) ->
     [
-        {current_connections, mk(non_neg_integer(), #{desc => ?DESC(current_connections)})},
+        {status,
+            mk(ref(emqx_mgmt_api_listeners, status), #{
+                desc => ?DESC(listener_status)
+            })},
         {node_status,
             mk(hoconsc:array(ref(emqx_mgmt_api_listeners, node_status)), #{
                 desc => ?DESC(listener_node_status)
             })}
     ];
 fields(tcp_listener) ->
-    emqx_gateway_api:fields(tcp_listener) ++ fields(listener_node_status);
+    emqx_gateway_api:fields(tcp_listener) ++ fields(listener_status);
 fields(ssl_listener) ->
-    emqx_gateway_api:fields(ssl_listener) ++ fields(listener_node_status);
+    emqx_gateway_api:fields(ssl_listener) ++ fields(listener_status);
 fields(udp_listener) ->
-    emqx_gateway_api:fields(udp_listener) ++ fields(listener_node_status);
+    emqx_gateway_api:fields(udp_listener) ++ fields(listener_status);
 fields(dtls_listener) ->
-    emqx_gateway_api:fields(dtls_listener) ++ fields(listener_node_status);
+    emqx_gateway_api:fields(dtls_listener) ++ fields(listener_status);
 fields(_) ->
     [].
 
@@ -623,12 +657,19 @@ listener_node_status_schema() ->
 examples_listener_list() ->
     Convert = fun(Cfg) ->
         Cfg#{
-            current_connections => 0,
+            status => #{
+                running => true,
+                max_connections => 1024000,
+                current_connections => 10
+            },
             node_status => [
                 #{
-                    node => <<"127.0.0.1">>,
-                    current_connections => 0,
-                    max_connections => 1024000
+                    node => <<"emqx@127.0.0.1">>,
+                    status => #{
+                        running => true,
+                        current_connections => 10,
+                        max_connections => 1024000
+                    }
                 }
             ]
         }

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -345,9 +345,9 @@ aggregate_running(R, undefined) -> R;
 aggregate_running(_, _) -> inconsistent.
 
 bind2str(Listener = #{bind := Bind}) ->
-    Listener#{bind := iolist_to_binary(emqx_gateway_utils:format_listenon(Bind))};
+    Listener#{bind := iolist_to_binary(emqx_listeners:format_bind(Bind))};
 bind2str(Listener = #{<<"bind">> := Bind}) ->
-    Listener#{<<"bind">> := iolist_to_binary(emqx_gateway_utils:format_listenon(Bind))}.
+    Listener#{<<"bind">> := iolist_to_binary(emqx_listeners:format_bind(Bind))}.
 
 %%--------------------------------------------------------------------
 %% Swagger defines

--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -181,24 +181,11 @@ do_convert_listener(GwName, LType, Conf) ->
 
 do_convert_listener2(GwName, LType, LName, LConf) ->
     ListenerId = emqx_gateway_utils:listener_id(GwName, LType, LName),
-    Running = emqx_gateway_utils:is_running(ListenerId, LConf),
-    bind2str(
-        LConf#{
-            id => ListenerId,
-            type => LType,
-            name => LName,
-            running => Running
-        }
-    ).
-
-bind2str(LConf = #{bind := Bind}) when is_integer(Bind) ->
-    maps:put(bind, integer_to_binary(Bind), LConf);
-bind2str(LConf = #{<<"bind">> := Bind}) when is_integer(Bind) ->
-    maps:put(<<"bind">>, integer_to_binary(Bind), LConf);
-bind2str(LConf = #{bind := Bind}) when is_binary(Bind) ->
-    LConf;
-bind2str(LConf = #{<<"bind">> := Bind}) when is_binary(Bind) ->
-    LConf.
+    LConf#{
+        id => ListenerId,
+        type => LType,
+        name => LName
+    }.
 
 get_bind(#{bind := Bind}) ->
     emqx_gateway_utils:parse_listenon(Bind);

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -287,12 +287,8 @@ apply(F, A2) when
 ->
     erlang:apply(F, A2).
 
-format_listenon(Port) when is_integer(Port) ->
-    io_lib:format("0.0.0.0:~w", [Port]);
-format_listenon({Addr, Port}) when is_list(Addr) ->
-    io_lib:format("~ts:~w", [Addr, Port]);
-format_listenon({Addr, Port}) when is_tuple(Addr) ->
-    io_lib:format("~ts:~w", [inet:ntoa(Addr), Port]).
+format_listenon(Term) ->
+    emqx_mgmt_util:format_listen_on(Term).
 
 parse_listenon(Port) when is_integer(Port) ->
     Port;

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -37,7 +37,6 @@
 
 -export([
     apply/2,
-    format_listenon/1,
     parse_listenon/1,
     unix_ts_to_rfc3339/1,
     unix_ts_to_rfc3339/2,
@@ -165,7 +164,7 @@ start_listener(
     {Type, LisName, ListenOn, SocketOpts, Cfg},
     ModCfg
 ) ->
-    ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
+    ListenOnStr = emqx_listeners:format_bind(ListenOn),
     ListenerId = emqx_gateway_utils:listener_id(GwName, Type, LisName),
 
     NCfg = maps:merge(Cfg, ModCfg),
@@ -243,7 +242,7 @@ stop_listeners(GwName, Listeners) ->
 -spec stop_listener(GwName :: atom(), Listener :: tuple()) -> ok.
 stop_listener(GwName, {Type, LisName, ListenOn, SocketOpts, Cfg}) ->
     StopRet = stop_listener(GwName, Type, LisName, ListenOn, SocketOpts, Cfg),
-    ListenOnStr = emqx_gateway_utils:format_listenon(ListenOn),
+    ListenOnStr = emqx_listeners:format_bind(ListenOn),
     case StopRet of
         ok ->
             console_print(
@@ -286,9 +285,6 @@ apply(F, A2) when
     is_list(A2)
 ->
     erlang:apply(F, A2).
-
-format_listenon(Term) ->
-    emqx_mgmt_util:format_listen_on(Term).
 
 parse_listenon(Port) when is_integer(Port) ->
     Port;

--- a/apps/emqx_gateway/src/exproto/emqx_exproto_impl.erl
+++ b/apps/emqx_gateway/src/exproto/emqx_exproto_impl.erl
@@ -167,7 +167,7 @@ start_grpc_server(GwName, Options = #{bind := ListenOn}) ->
                         )}
                 ]
         end,
-    ListenOnStr = emqx_listeners:format_addr(ListenOn),
+    ListenOnStr = emqx_listeners:format_bind(ListenOn),
     case grpc:start_server(GwName, ListenOn, Services, SvrOptions) of
         {ok, _SvrPid} ->
             console_print(

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -340,7 +340,7 @@ t_listeners_tcp(_) ->
     LisConf = #{
         name => <<"def">>,
         type => <<"tcp">>,
-        bind => <<"61613">>
+        bind => <<"127.0.0.1:61613">>
     },
     {201, _} = request(post, "/gateway/stomp/listeners", LisConf),
     {200, ConfResp} = request(get, "/gateway/stomp/listeners"),
@@ -348,7 +348,7 @@ t_listeners_tcp(_) ->
     {200, ConfResp1} = request(get, "/gateway/stomp/listeners/stomp:tcp:def"),
     assert_confs(LisConf, ConfResp1),
 
-    LisConf2 = maps:merge(LisConf, #{bind => <<"61614">>}),
+    LisConf2 = maps:merge(LisConf, #{bind => <<"127.0.0.1:61614">>}),
     {200, _} = request(
         put,
         "/gateway/stomp/listeners/stomp:tcp:def",
@@ -369,7 +369,7 @@ t_listeners_authn(_) ->
             #{
                 name => <<"def">>,
                 type => <<"tcp">>,
-                bind => <<"61613">>
+                bind => <<"127.0.0.1:61613">>
             }
         ]
     },
@@ -405,7 +405,7 @@ t_listeners_authn_data_mgmt(_) ->
             #{
                 name => <<"def">>,
                 type => <<"tcp">>,
-                bind => <<"61613">>
+                bind => <<"127.0.0.1:61613">>
             }
         ]
     },

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -543,7 +543,7 @@ format_status(Key, Node, Listener, Acc) ->
                     enable => Enabled,
                     ids => [Id],
                     acceptors => Acceptors,
-                    bind => format_raw_bind(Bind),
+                    bind => iolist_to_binary(emqx_listeners:format_bind(Bind)),
                     status => #{
                         running => Running,
                         max_connections => MaxConnections,
@@ -604,12 +604,6 @@ format_status(Key, Node, Listener, Acc) ->
 max_conn(_Int1, <<"infinity">>) -> <<"infinity">>;
 max_conn(<<"infinity">>, _Int) -> <<"infinity">>;
 max_conn(Int1, Int2) -> Int1 + Int2.
-
-%% @doc returning a uniform format (ip_port string) is more
-%% helpful to users
-format_raw_bind(Bind) when is_integer(Bind) ->
-    <<"0.0.0.0:", (integer_to_binary(Bind))/binary>>;
-format_raw_bind(Bind) when is_binary(Bind) -> Bind.
 
 update(Path, Conf) ->
     wrap(emqx_conf:update(Path, {update, Conf}, ?OPTS(cluster))).

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -582,7 +582,7 @@ listeners([]) ->
                 end,
             Info =
                 [
-                    {listen_on, {string, emqx_mgmt_util:format_listen_on(Port)}},
+                    {listen_on, {string, emqx_mgmt_util:format_listen_on(Bind)}},
                     {acceptors, Acceptors},
                     {proxy_protocol, ProxyProtocol},
                     {running, Running}

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -582,7 +582,7 @@ listeners([]) ->
                 end,
             Info =
                 [
-                    {listen_on, {string, emqx_mgmt_util:format_listen_on(Bind)}},
+                    {listen_on, {string, emqx_listeners:format_bind(Bind)}},
                     {acceptors, Acceptors},
                     {proxy_protocol, ProxyProtocol},
                     {running, Running}

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -582,7 +582,7 @@ listeners([]) ->
                 end,
             Info =
                 [
-                    {listen_on, {string, format_listen_on(Bind)}},
+                    {listen_on, {string, emqx_mgmt_util:format_listen_on(Port)}},
                     {acceptors, Acceptors},
                     {proxy_protocol, ProxyProtocol},
                     {running, Running}
@@ -801,15 +801,6 @@ indent_print({Key, {string, Val}}) ->
     emqx_ctl:print("  ~-16s: ~ts~n", [Key, Val]);
 indent_print({Key, Val}) ->
     emqx_ctl:print("  ~-16s: ~w~n", [Key, Val]).
-
-format_listen_on(Port) when is_integer(Port) ->
-    io_lib:format("0.0.0.0:~w", [Port]);
-format_listen_on({Addr, Port}) when is_list(Addr) ->
-    io_lib:format("~ts:~w", [Addr, Port]);
-format_listen_on({Addr, Port}) when is_tuple(Addr) andalso tuple_size(Addr) == 4 ->
-    io_lib:format("~ts:~w", [inet:ntoa(Addr), Port]);
-format_listen_on({Addr, Port}) when is_tuple(Addr) andalso tuple_size(Addr) == 8 ->
-    io_lib:format("[~ts]:~w", [inet:ntoa(Addr), Port]).
 
 name(Filter) ->
     iolist_to_binary(["CLI-", Filter]).

--- a/apps/emqx_management/src/emqx_mgmt_util.erl
+++ b/apps/emqx_management/src/emqx_mgmt_util.erl
@@ -43,10 +43,7 @@
     batch_schema/1
 ]).
 
--export([
-    urldecode/1,
-    format_listen_on/1
-]).
+-export([urldecode/1]).
 
 -define(KB, 1024).
 -define(MB, (1024 * 1024)).
@@ -88,25 +85,6 @@ merge_maps(Default, New) ->
 
 urldecode(S) ->
     emqx_http_lib:uri_decode(S).
-
--spec format_listen_on(
-    integer() | {tuple(), integer()} | string() | binary()
-) -> io_lib:chars().
-format_listen_on(Port) when is_integer(Port) ->
-    io_lib:format("0.0.0.0:~w", [Port]);
-format_listen_on({Addr, Port}) when is_list(Addr) ->
-    io_lib:format("~ts:~w", [Addr, Port]);
-format_listen_on({Addr, Port}) when is_tuple(Addr) ->
-    io_lib:format("~ts:~w", [inet:ntoa(Addr), Port]);
-format_listen_on(Str) when is_list(Str) ->
-    case emqx_schema:to_ip_port(Str) of
-        {ok, {Ip, Port}} ->
-            format_listen_on({Ip, Port});
-        {error, _} ->
-            format_listen_on(list_to_integer(Str))
-    end;
-format_listen_on(Bin) when is_binary(Bin) ->
-    format_listen_on(binary_to_list(Bin)).
 
 %%%==============================================================================================
 %% schema util

--- a/apps/emqx_management/src/emqx_mgmt_util.erl
+++ b/apps/emqx_management/src/emqx_mgmt_util.erl
@@ -43,7 +43,10 @@
     batch_schema/1
 ]).
 
--export([urldecode/1]).
+-export([
+    urldecode/1,
+    format_listen_on/1
+]).
 
 -define(KB, 1024).
 -define(MB, (1024 * 1024)).
@@ -85,6 +88,25 @@ merge_maps(Default, New) ->
 
 urldecode(S) ->
     emqx_http_lib:uri_decode(S).
+
+-spec format_listen_on(
+    integer() | {tuple(), integer()} | string() | binary()
+) -> io_lib:chars().
+format_listen_on(Port) when is_integer(Port) ->
+    io_lib:format("0.0.0.0:~w", [Port]);
+format_listen_on({Addr, Port}) when is_list(Addr) ->
+    io_lib:format("~ts:~w", [Addr, Port]);
+format_listen_on({Addr, Port}) when is_tuple(Addr) ->
+    io_lib:format("~ts:~w", [inet:ntoa(Addr), Port]);
+format_listen_on(Str) when is_list(Str) ->
+    case emqx_schema:to_ip_port(Str) of
+        {ok, {Ip, Port}} ->
+            format_listen_on({Ip, Port});
+        {error, _} ->
+            format_listen_on(list_to_integer(Str))
+    end;
+format_listen_on(Bin) when is_binary(Bin) ->
+    format_listen_on(binary_to_list(Bin)).
 
 %%%==============================================================================================
 %% schema util


### PR DESCRIPTION
There are some an incompatible changes, but we had to fix the incorrect API formatting as soon as possible. A summary changes:

1. Using the standard `status` and `node_status` data format for `GET /listeners` and `GET /gateway/<name>/listeners`.

    Before this changes, the MQTT  listener APIs returned these fields as:
    ```json
    "status": {
        "current_connections": 0,
        "max_connections": 4096000
     },
    "node_status": {
        "emqx@emqx-core-2.emqx-headless.default.svc.cluster.local": {
          "current_connections": 0,
          "max_connections": 512000
         }
    }
    ```
    The Gateway listener API returned as:
    ```json
    "node_status": [
       { "current_connections": 0,
          "max_connections": 1024000,
          "node": "emqx@emqx-core-2.emqx-headless.default.svc.cluster.local"
        },
     ]
    // No `status` field
    ```

   In this PR, we unify these fields both listeners API as:
   ```json
    "status": {
      "current_connections": 0,
      "max_connections": 102400,
      "running": true
    },
    "node_status": [ {
      "node": "emqx@127.0.0.1",
      "status": {
        "current_connections": 0,
        "max_connections": 102400,
        "running": true}
     }],
   ```

3.  Ensure the `bind` output style
    - Configured as `1883`, printed as `:1883`
    - Configured as `0.0.0.0:1883`, printed as `:1883`
    - Configured as `127.0.0.1:1883`, printed as `127.0.0.1:1883`
    - Configured as `::1:1883`, printed as `[::1]:1883`
    - Configured as `[::1]:1883`, printed as `[::1]:1883`
4.  Move `running` field into  `status` and `node_status` field for Gateway listeners API
5. Add `type`, `name` fields for MQTT listeners API