### PR TITLE
Fix(exproto): start idle timer to avoid client leaking

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -10,6 +10,12 @@ File format:
 - One list item per change topic
   Change log ends with a list of github PRs
 
+## v4.3.19
+
+### Bug fixes
+
+- Add a idle timer for ExProto UDP client to avoid client leaking [#8628]
+
 ## v4.3.18
 
 ### Enhancements

--- a/apps/emqx_exproto/src/emqx_exproto.app.src
+++ b/apps/emqx_exproto/src/emqx_exproto.app.src
@@ -1,6 +1,6 @@
 {application, emqx_exproto,
  [{description, "EMQ X Extension for Protocol"},
-  {vsn, "4.3.9"}, %% 4.3.3 is used by ee
+  {vsn, "4.3.10"}, %% 4.3.3 is used by ee
   {modules, []},
   {registered, []},
   {mod, {emqx_exproto_app, []}},

--- a/apps/emqx_exproto/src/emqx_exproto.appup.src
+++ b/apps/emqx_exproto/src/emqx_exproto.appup.src
@@ -1,7 +1,9 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{<<"4\\.3\\.[2-8]">>,
+  [{"4.3.9",
+    [{load_module,emqx_exproto_channel,brutal_purge,soft_purge,[]}]},
+   {<<"4\\.3\\.[2-8]">>,
     [{load_module,emqx_exproto_conn,brutal_purge,soft_purge,[]},
      {load_module,emqx_exproto_channel,brutal_purge,soft_purge,[]}]},
    {<<"4\\.3\\.[0-1]">>,
@@ -10,7 +12,9 @@
      {load_module,emqx_exproto_conn,brutal_purge,soft_purge,[]},
      {load_module,emqx_exproto_channel,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
-  [{<<"4\\.3\\.[2-8]">>,
+  [{"4.3.9",
+    [{load_module,emqx_exproto_channel,brutal_purge,soft_purge,[]}]},
+   {<<"4\\.3\\.[2-8]">>,
     [{load_module,emqx_exproto_conn,brutal_purge,soft_purge,[]},
      {load_module,emqx_exproto_channel,brutal_purge,soft_purge,[]}]},
    {<<"4\\.3\\.[0-1]">>,


### PR DESCRIPTION
- chore(exproto): start idle timer for udp clients
- chore: update app.src & appup.src
