### PR TITLE
chore: update ekka to 0.7.11

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
   {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
   {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.7.1"}}},
   {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.7.6"}}},
-  {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.7.10"}}},
+  {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.7.11"}}},
   {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.0"}}},
   {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.0.0"}}}
  ]}.


### PR DESCRIPTION
In order to print the stacktrace of the killed process by holding ekka_locker too long

diffs: https://github.com/emqx/ekka/commit/41618485655a13de8af16f48d0f193477df9b1dd
