### PR TITLE
fix: return 503 instead of crash when dashboard generate router timeout

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
@@ -38,7 +38,12 @@
 ]).
 
 is_ready(Timeout) ->
-    ready =:= gen_server:call(?MODULE, is_ready, Timeout).
+    try
+        ready =:= gen_server:call(?MODULE, is_ready, Timeout)
+    catch
+        exit:{timeout, _} ->
+            false
+    end.
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).

--- a/apps/emqx_dashboard/src/emqx_dashboard_middleware.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_middleware.erl
@@ -43,5 +43,6 @@ check_dispatch_ready(Env) ->
             true;
         true ->
             %% dashboard should always ready, if not, is_ready/1 will block until ready.
-            emqx_dashboard_listener:is_ready(timer:seconds(15))
+            %% if not ready, dashboard will return 503.
+            emqx_dashboard_listener:is_ready(timer:seconds(20))
     end.

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule EMQXUmbrella.MixProject do
       {:ekka, github: "emqx/ekka", tag: "0.13.2", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.6", override: true},
-      {:minirest, github: "emqx/minirest", tag: "1.3.5", override: true},
+      {:minirest, github: "emqx/minirest", tag: "1.3.6", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},
       {:replayq, "0.3.4", override: true},
       {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,7 @@
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.13.2"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
     , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.6"}}}
-    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.5"}}}
+    , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.6"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}
     , {replayq, "0.3.4"}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}


### PR DESCRIPTION
fix:
2022-07-29T05:45:39.832860+00:00 [error] crasher: initial call: cowboy_stream_h:request_process/3, pid: <0.2724.0>,
 registered_name: [], exit: {{{timeout,{gen_server,call,[emqx_dashboard_listener,is_ready,15000]}},[{gen_server,call,3,
[{file,"gen_server.erl"},{line,247}]},{emqx_dashboard_listener,is_ready,1,[{file,"emqx_dashboard_listener.erl"},{line,41}]},
{emqx_dashboard_middleware,execute,2,[{file,"emqx_dashboard_middleware.erl"},{line,24}]},
{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,
[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]},[{gen_server,call,3,
[{file,"gen_server.erl"},{line,247}]},{emqx_dashboard_listener,is_ready,1,[{file,"emqx_dashboard_listener.erl"},{line,41}]},
{emqx_dashboard_middleware,execute,2,[{file,"emqx_dashboard_middleware.erl"},{line,24}]},
{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,
[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: 
[<0.2723.0>,<0.2409.0>,<0.2408.0>,ranch_sup,<0.1902.0>], message_queue_len: 0, messages: [], links: [<0.2723.0>], 
dictionary: [], trap_exit: false, status: running, heap_size: 1598, stack_size: 29, reductions: 259; neighbours:
