### PR TITLE
feat: add option to gc after TLS/SSL handshake

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -34,6 +34,7 @@
 * Improve authentication tracing. [#8554](https://github.com/emqx/emqx/pull/8554)
 * Standardize the '/listeners' and `/gateway/<name>/listeners` API fields.
   It will introduce some incompatible updates, see [#8571](https://github.com/emqx/emqx/pull/8571)
+* Add option to perform GC on connection process after TLS/SSL handshake is performed. [#8637](https://github.com/emqx/emqx/pull/8637)
 
 # 5.0.3
 

--- a/apps/emqx/i18n/emqx_schema_i18n.conf
+++ b/apps/emqx/i18n/emqx_schema_i18n.conf
@@ -1841,6 +1841,23 @@ Maximum time duration allowed for the handshake to complete
     }
 }
 
+server_ssl_opts_schema_gc_after_handshake {
+    desc {
+        en: """
+Performance tuning.  If enabled, will immediately perform a GC after
+the TLS/SSL handshake is established.
+"""
+        zh: """
+性能调整。 如果启用，将在TLS/SSL握手建立后立即执行GC。
+TLS/SSL握手建立后立即进行GC。
+"""
+    }
+    label: {
+        en: "Perform GC after handshake"
+        zh: "握手后执行GC"
+    }
+}
+
 fields_listeners_tcp {
     desc {
         en: """

--- a/apps/emqx/i18n/emqx_schema_i18n.conf
+++ b/apps/emqx/i18n/emqx_schema_i18n.conf
@@ -1844,11 +1844,11 @@ Maximum time duration allowed for the handshake to complete
 server_ssl_opts_schema_gc_after_handshake {
     desc {
         en: """
-Performance tuning.  If enabled, will immediately perform a GC after
-the TLS/SSL handshake is established.
+Memory usage tuning. If enabled, will immediately perform a garbage collection after
+the TLS/SSL handshake.
 """
         zh: """
-性能调整。 如果启用，将在TLS/SSL握手建立后立即执行GC。
+内存使用调优。如果启用，将在TLS/SSL握手完成后立即执行垃圾回收。
 TLS/SSL握手建立后立即进行GC。
 """
     }

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -26,7 +26,7 @@
     {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}},
     {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}},
-    {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.3"}}},
+    {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.4"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.13.3"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.29.0"}}},

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1953,7 +1953,15 @@ server_ssl_opts_schema(Defaults, IsRanchListener) ->
                         }
                     )}
              || IsRanchListener
-            ]
+            ] ++
+                [
+                    {"gc_after_handshake",
+                        sc(boolean(), #{
+                            default => false,
+                            desc => ?DESC(server_ssl_opts_schema_gc_after_handshake)
+                        })}
+                 || not IsRanchListener
+                ]
         ].
 
 %% @doc Make schema for SSL client.

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -141,3 +141,38 @@ bad_tls_version_test() ->
         validate(Sc, #{<<"versions">> => [<<"foo">>]})
     ),
     ok.
+
+ssl_opts_gc_after_handshake_test_rancher_listener_test() ->
+    Sc = emqx_schema:server_ssl_opts_schema(
+        #{
+            gc_after_handshake => false
+        },
+        _IsRanchListener = true
+    ),
+    ?assertThrow(
+        {_Sc, [
+            #{
+                kind := validation_error,
+                reason := unknown_fields,
+                unknown := <<"gc_after_handshake">>
+            }
+        ]},
+        validate(Sc, #{<<"gc_after_handshake">> => true})
+    ),
+    ok.
+
+ssl_opts_gc_after_handshake_test_not_rancher_listener_test() ->
+    Sc = emqx_schema:server_ssl_opts_schema(
+        #{
+            gc_after_handshake => false
+        },
+        _IsRanchListener = false
+    ),
+    Checked = validate(Sc, #{<<"gc_after_handshake">> => <<"true">>}),
+    ?assertMatch(
+        #{
+            gc_after_handshake := true
+        },
+        Checked
+    ),
+    ok.

--- a/mix.exs
+++ b/mix.exs
@@ -51,7 +51,7 @@ defmodule EMQXUmbrella.MixProject do
       {:gproc, github: "uwiger/gproc", tag: "0.8.0", override: true},
       {:jiffy, github: "emqx/jiffy", tag: "1.0.5", override: true},
       {:cowboy, github: "emqx/cowboy", tag: "2.9.0", override: true},
-      {:esockd, github: "emqx/esockd", tag: "5.9.3", override: true},
+      {:esockd, github: "emqx/esockd", tag: "5.9.4", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.13.3", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.6", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
     , {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}
-    , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.3"}}}
+    , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.4"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.13.3"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
     , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.6"}}}


### PR DESCRIPTION

### Comparison

Connecting 1000 `emqtt-bench` subscribers with SSL.  Computing the difference of results of `erlang:memory()` before and after all clients are connected.

#### Without GC after handshake

|  | `processes_used` | `total` |
|--|------------------|---------|
| mem increase without gc after handshake (bytes) | `177894208` | `190032440` |
| mem increase with gc after handshake (bytes) | `108428752` | `113740224` |
| `mem(with gc) / mem(without gc)` | `0.662` | `0.728` |