### PR TITLE
chore: update Running/Stopped to running/stopped

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -8,6 +8,7 @@
 
 * The license is now copied to all nodes in the cluster when it's reloaded. [#8598](https://github.com/emqx/emqx/pull/8598)
 * Added a HTTP API to manage licenses. [#8610](https://github.com/emqx/emqx/pull/8610)
+* Updated `/nodes` API node_status from `Running/Stopped` to `running/stopped`. [#8642](https://github.com/emqx/emqx/pull/8642)
 
 # 5.0.4
 

--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.0.2"},
+    {vsn, "5.0.3"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [kernel, stdlib, emqx_plugins, minirest, emqx]},

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -138,7 +138,7 @@ node_info() ->
             max_fds, lists:usort(lists:flatten(erlang:system_info(check_io)))
         ),
         connections => ets:info(emqx_channel, size),
-        node_status => 'Running',
+        node_status => 'running',
         uptime => proplists:get_value(uptime, BrokerInfo),
         version => iolist_to_binary(proplists:get_value(version, BrokerInfo)),
         role => mria_rlog:role()
@@ -156,7 +156,7 @@ node_info(Node) ->
     wrap_rpc(emqx_management_proto_v2:node_info(Node)).
 
 stopped_node_info(Node) ->
-    #{name => Node, node_status => 'Stopped'}.
+    #{name => Node, node_status => 'stopped'}.
 
 %%--------------------------------------------------------------------
 %% Brokers

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -288,7 +288,7 @@ get_stats(Node) ->
 %% internal function
 
 format(_Node, Info = #{memory_total := Total, memory_used := Used}) ->
-    RootDir = code:root_dir(),
+    RootDir = list_to_binary(code:root_dir()),
     LogPath =
         case log_path() of
             undefined ->

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -189,8 +189,8 @@ fields(node_info) ->
             )},
         {node_status,
             mk(
-                enum(['Running', 'Stopped']),
-                #{desc => <<"Node status">>, example => "Running"}
+                enum(['running', 'stopped']),
+                #{desc => <<"Node status">>, example => "running"}
             )},
         {otp_release,
             mk(
@@ -288,19 +288,18 @@ get_stats(Node) ->
 %% internal function
 
 format(_Node, Info = #{memory_total := Total, memory_used := Used}) ->
-    {ok, SysPathBinary} = file:get_cwd(),
-    SysPath = list_to_binary(SysPathBinary),
+    RootDir = code:root_dir(),
     LogPath =
         case log_path() of
             undefined ->
                 <<"log.file_handler.default.enable is false,only log to console">>;
             Path ->
-                filename:join(SysPath, Path)
+                filename:join(RootDir, Path)
         end,
     Info#{
         memory_total := emqx_mgmt_util:kmg(Total),
         memory_used := emqx_mgmt_util:kmg(Used),
-        sys_path => SysPath,
+        sys_path => RootDir,
         log_path => LogPath
     }.
 


### PR DESCRIPTION
`/gateway`'s status is all lowercase. `running/unloaded`.
but `/nodes/`'s status is `Running/Stopped`.

To make all APIs more standardized.
we should keep the status enum as lowercase.

