### PR TITLE
build: fix relup app overwrite escript

### DIFF
--- a/build
+++ b/build
@@ -100,7 +100,7 @@ make_relup() {
         if [ ! -f "${emqx_rel_file}" ]; then
             ./rebar3 as "${PROFILE}" release
         fi
-        scripts/emqx_rel_otp_app_overwrite.escript "${releases_dir}" "${PROFILE}" "${PKG_VSN}" "${RELX_BASE_VERSIONS}"
+        scripts/emqx_rel_otp_app_overwrite.escript "${releases_dir}" "${PKG_VSN}" "${RELX_BASE_VERSIONS}"
     fi
     ./rebar3 as "$PROFILE" relup --relname emqx --relvsn "${PKG_VSN}"
 

--- a/scripts/emqx_rel_otp_app_overwrite.escript
+++ b/scripts/emqx_rel_otp_app_overwrite.escript
@@ -1,4 +1,4 @@
-#!/usr/bin/env escript
+#!/usr/bin/env -S escript -c
 %% This script is part of 'relup' process to overwrite the OTP app versions (incl. ERTS) in rel files from upgrade base
 %% so that 'rebar relup' call will not generate instructions for restarting OTP apps or restarting the emulator.
 %%
@@ -7,6 +7,7 @@
 %%
 %% note, we use NEW to overwrite OLD is because the modified NEW rel file will be overwritten by next 'rebar relup'
 %%
+
 main([Dir, RelVsn, BASE_VERSIONS]) ->
     {ErtsVsn, Overwrites} = get_otp_apps(rel_file(Dir, RelVsn), RelVsn),
     lists:foreach(fun(BaseVer) ->

--- a/scripts/fail-on-old-otp-version.escript
+++ b/scripts/fail-on-old-otp-version.escript
@@ -1,4 +1,4 @@
-#!/usr/bin/env escript
+#!/usr/bin/env -S escript -c
 
 main(_) ->
     OtpRelease = list_to_integer(erlang:system_info(otp_release)),


### PR DESCRIPTION
the rel file name is always emqx.rel, has nothing to do with profile

