### PR TITLE
fix: keep alive check

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -708,8 +708,6 @@ handle_timeout(
     TRef,
     keepalive,
     State = #state{
-        transport = Transport,
-        socket = Socket,
         channel = Channel
     }
 ) ->
@@ -717,12 +715,9 @@ handle_timeout(
         disconnected ->
             {ok, State};
         _ ->
-            case Transport:getstat(Socket, [recv_oct]) of
-                {ok, [{recv_oct, RecvOct}]} ->
-                    handle_timeout(TRef, {keepalive, RecvOct}, State);
-                {error, Reason} ->
-                    handle_info({sock_error, Reason}, State)
-            end
+            %% recv_pkt: valid MQTT message
+            RecvCnt = emqx_pd:get_counter(recv_pkt),
+            handle_timeout(TRef, {keepalive, RecvCnt}, State)
     end;
 handle_timeout(TRef, Msg, State) ->
     with_channel(handle_timeout, [TRef, Msg], State).

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -316,11 +316,6 @@ t_handle_timeout(_) ->
         emqx_connection:handle_timeout(TRef, keepalive, State)
     ),
 
-    ok = meck:expect(emqx_transport, getstat, fun(_Sock, _Options) -> {error, for_testing} end),
-    ?assertMatch(
-        {stop, {shutdown, for_testing}, _NState},
-        emqx_connection:handle_timeout(TRef, keepalive, State)
-    ),
     ?assertMatch({ok, _NState}, emqx_connection:handle_timeout(TRef, undefined, State)).
 
 t_parse_incoming(_) ->


### PR DESCRIPTION
According to MQTT spec, MQTT Server should check a complete MQTT message
recv in last keep-alive time frame instead of the number of received bytes
from the socket.

This commit change to check the recv pkt counter from process dict
instead.

Also it could save some calls to erlang port.

