### PR TITLE
fix: rm non-portable `env` option

### DIFF
--- a/scripts/emqx_rel_otp_app_overwrite.escript
+++ b/scripts/emqx_rel_otp_app_overwrite.escript
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S escript -c
+#!/usr/bin/env escript
 %% This script is part of 'relup' process to overwrite the OTP app versions (incl. ERTS) in rel files from upgrade base
 %% so that 'rebar relup' call will not generate instructions for restarting OTP apps or restarting the emulator.
 %%
@@ -7,6 +7,7 @@
 %%
 %% note, we use NEW to overwrite OLD is because the modified NEW rel file will be overwritten by next 'rebar relup'
 %%
+-mode(compile).
 
 main([Dir, RelVsn, BASE_VERSIONS]) ->
     {ErtsVsn, Overwrites} = get_otp_apps(rel_file(Dir, RelVsn), RelVsn),

--- a/scripts/fail-on-old-otp-version.escript
+++ b/scripts/fail-on-old-otp-version.escript
@@ -1,4 +1,6 @@
-#!/usr/bin/env -S escript -c
+#!/usr/bin/env escript
+
+-mode(compile).
 
 main(_) ->
     OtpRelease = list_to_integer(erlang:system_info(otp_release)),
@@ -9,4 +11,3 @@ main(_) ->
         false ->
             ok
     end.
-

--- a/scripts/update_appup.escript
+++ b/scripts/update_appup.escript
@@ -1,5 +1,7 @@
-#!/usr/bin/env -S escript -c
+#!/usr/bin/env escript
 %% -*- erlang-indent-level:4 -*-
+
+-mode(compile).
 
 usage() ->
 "A script that fills in boilerplate for appup files.


### PR DESCRIPTION
On some systems, like `centos7`, `env` does not have a `-S` option.

