### PR TITLE
fix: check if trace is enabled when the file is not found

### DIFF
--- a/CHANGES-4.4.md
+++ b/CHANGES-4.4.md
@@ -1,5 +1,12 @@
 # EMQX 4.4 Changes
 
+## v4.4.7
+
+### Enhancements (synced from v4.3.18)
+
+### Bug fixes
+- Fix: Check if emqx_mod_trace is enabled when the trace file is not found.
+
 ## v4.4.5
 
 ### Enhancements (synced from v4.3.16)

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.app.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.app.src
@@ -1,6 +1,6 @@
 {application, emqx_plugin_libs,
  [{description, "EMQ X Plugin utility libs"},
-  {vsn, "4.4.4"},
+  {vsn, "4.4.5"},
   {modules, []},
   {applications, [kernel,stdlib]},
   {env, []}

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
@@ -2,6 +2,9 @@
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
   [
+  {"4.4.4",
+    [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
+    {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
    {"4.4.3",
     [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
      {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
@@ -21,6 +24,9 @@
      {load_module,emqx_slow_subs_api,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
   [
+   {"4.4.4",
+    [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
+     {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
    {"4.4.3",
      [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
       {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},

--- a/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
@@ -177,7 +177,13 @@ trace_file(File) ->
     Node = atom_to_list(node()),
     case file:read_file(FileName) of
         {ok, Bin} -> {ok, Node, Bin};
-        {error, Reason} -> {error, Node, Reason}
+        {error, enoent} ->
+            case emqx_trace:is_enable() of
+                false -> {error, Node, trace_disabled};
+                true -> {error, Node, enoent}
+            end;
+        {error, Reason} ->
+            {error, Node, Reason}
     end.
 
 delete_files_after_send(TraceLog, Zips) ->

--- a/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace_api.erl
+++ b/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace_api.erl
@@ -115,6 +115,9 @@ group_trace_file(ZipDir, TraceLog, TraceFiles) ->
                     ok -> [FileName | Acc];
                     _ -> Acc
                 end;
+            {error, Node, trace_disabled} ->
+                ?LOG(warning, "emqx_mod_trace modules is disabled on ~s ~s", [Node, TraceLog]),
+                Acc;
             {error, Node, Reason} ->
                 ?LOG(error, "download trace log error:~p", [{Node, TraceLog, Reason}]),
                 Acc


### PR DESCRIPTION
We allow `emqx_mod_trace` to be enabled on only some nodes in the cluster on 4.4.x
When the module is disabled, we need to correctly indicate that the module is not turned on.