### PR TITLE
fix(lwm2m): better logging for unknown object IDs

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -9,6 +9,7 @@
 * The license is now copied to all nodes in the cluster when it's reloaded. [#8598](https://github.com/emqx/emqx/pull/8598)
 * Added a HTTP API to manage licenses. [#8610](https://github.com/emqx/emqx/pull/8610)
 * Updated `/nodes` API node_status from `Running/Stopped` to `running/stopped`. [#8642](https://github.com/emqx/emqx/pull/8642)
+* Better logging on unknown object IDs. [#8670](https://github.com/emqx/emqx/pull/8670)
 
 # 5.0.4
 

--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
     {applications, [kernel, stdlib, grpc, emqx, emqx_authn]},

--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_cmd.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_cmd.erl
@@ -221,14 +221,16 @@ read_resp_to_mqtt({ok, SuccessCode}, CoapPayload, Format, Ref) ->
         Result = content_to_mqtt(CoapPayload, Format, Ref),
         make_response(SuccessCode, Ref, Format, Result)
     catch
-        error:not_implemented ->
-            make_response(not_implemented, Ref);
-        _:Ex:_ST ->
+        throw:{bad_request, Reason} ->
+            ?SLOG(error, #{msg => "bad_request", payload => CoapPayload, reason => Reason}),
+            make_response(bad_request, Ref);
+        E:R:ST ->
             ?SLOG(error, #{
-                msg => "bad_payload_format",
+                msg => "bad_request",
                 payload => CoapPayload,
-                reason => Ex,
-                stacktrace => _ST
+                exception => E,
+                reason => R,
+                stacktrace => ST
             }),
             make_response(bad_request, Ref)
     end.

--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_message.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_message.erl
@@ -29,7 +29,7 @@
 tlv_to_json(BaseName, TlvData) ->
     DecodedTlv = emqx_lwm2m_tlv:parse(TlvData),
     ObjectId = object_id(BaseName),
-    ObjDefinition = emqx_lwm2m_xml_object:get_obj_def(ObjectId, true),
+    ObjDefinition = emqx_lwm2m_xml_object:get_obj_def_assertive(ObjectId, true),
     case DecodedTlv of
         [#{tlv_resource_with_value := Id, value := Value}] ->
             TrueBaseName = basename(BaseName, undefined, undefined, Id, 3),
@@ -318,7 +318,7 @@ path([H | T], Acc) ->
 
 text_to_json(BaseName, Text) ->
     {ObjectId, ResourceId} = object_resource_id(BaseName),
-    ObjDefinition = emqx_lwm2m_xml_object:get_obj_def(ObjectId, true),
+    ObjDefinition = emqx_lwm2m_xml_object:get_obj_def_assertive(ObjectId, true),
     Val = text_value(Text, ResourceId, ObjDefinition),
     [#{path => BaseName, value => Val}].
 

--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_xml_object.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_xml_object.erl
@@ -21,6 +21,7 @@
 
 -export([
     get_obj_def/2,
+    get_obj_def_assertive/2,
     get_object_id/1,
     get_object_name/1,
     get_object_and_resource_id/2,
@@ -29,7 +30,13 @@
     get_resource_operations/2
 ]).
 
-% This module is for future use. Disabled now.
+get_obj_def_assertive(ObjectId, IsInt) ->
+    case get_obj_def(ObjectId, IsInt) of
+        {error, no_xml_definition} ->
+            erlang:throw({bad_request, {unknown_object_id, ObjectId}});
+        Xml ->
+            Xml
+    end.
 
 get_obj_def(ObjectIdInt, true) ->
     emqx_lwm2m_xml_object_db:find_objectid(ObjectIdInt);

--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_xml_object_db.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_xml_object_db.erl
@@ -76,12 +76,9 @@ find_name(Name) ->
         end,
     case ets:lookup(?LWM2M_OBJECT_NAME_TO_ID_TAB, NameBinary) of
         [] ->
-            undefined;
+            {error, no_xml_definition};
         [{NameBinary, ObjectId}] ->
-            case ets:lookup(?LWM2M_OBJECT_DEF_TAB, ObjectId) of
-                [] -> undefined;
-                [{ObjectId, Xml}] -> Xml
-            end
+            find_objectid(ObjectId)
     end.
 
 stop() ->


### PR DESCRIPTION
Prior to this change, unknown object IDs would result in a tuple
{error, no_xml_definition}, and this tuple is passed down to xmerl
lib to get XML node data and eventually crash with function_clause.

With this fix, the unknown object ID exception is caught and logged
properly.

port from: https://github.com/emqx/emqx/pull/8654