### PR TITLE
fix: count all msg size of `event_message` for mqtt bridge

### DIFF
--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_msg.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_msg.erl
@@ -142,11 +142,14 @@ from_binary(Bin) -> binary_to_term(Bin).
 
 %% @doc Estimate the size of a message.
 %% Count only the topic length + payload size
+%% There is no topic and payload for event message. So count all `Msg` term
 -spec estimate_size(msg()) -> integer().
 estimate_size(#message{topic = Topic, payload = Payload}) ->
     size(Topic) + size(Payload);
 estimate_size(#{topic := Topic, payload := Payload}) ->
-    size(Topic) + size(Payload).
+    size(Topic) + size(Payload);
+estimate_size(Term) ->
+    erlang:external_size(Term).
 
 set_headers(undefined, Msg) ->
     Msg;


### PR DESCRIPTION
fix https://github.com/emqx/emqx/issues/8494