### PR TITLE
fix: bad default plugins

### DIFF
--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -31,11 +31,12 @@ all() -> emqx_ct:all(?MODULE).
 %%--------------------------------------------------------------------
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([emqx_retainer]),
+    emqx_retainer_ct_helper:ensure_start(),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_retainer]).
+    emqx_retainer_ct_helper:ensure_stop(),
+    ok.
 
 init_per_testcase(TestCase, Config) ->
     emqx_retainer:clean(<<"#">>),
@@ -207,4 +208,3 @@ receive_messages(Count, Msgs) ->
     after 2000 ->
             Msgs
     end.
-

--- a/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
@@ -24,11 +24,12 @@
 all() -> emqx_ct:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_ct_helpers:start_apps([emqx_retainer]),
+    emqx_retainer_ct_helper:ensure_start(),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_ct_helpers:stop_apps([emqx_retainer]).
+    emqx_retainer_ct_helper:ensure_stop(),
+    ok.
 
 init_per_testcase(_TestCase, Config) ->
     Config.

--- a/apps/emqx_retainer/test/emqx_retainer_ct_helper.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_ct_helper.erl
@@ -1,0 +1,46 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_retainer_ct_helper).
+
+
+%% API
+-export([ensure_start/0, ensure_stop/0]).
+-ifdef(EMQX_ENTERPRISE).
+ensure_start() ->
+    application:stop(emqx_modules),
+    init_conf(),
+    emqx_ct_helpers:start_apps([emqx_retainer]),
+    ok.
+
+-else.
+
+ensure_start() ->
+    init_conf(),
+    emqx_ct_helpers:start_apps([emqx_retainer]),
+    ok.
+
+-endif.
+
+ensure_stop() ->
+    emqx_ct_helpers:stop_apps([emqx_retainer]).
+
+
+init_conf() ->
+    application:set_env(emqx_retainer, expiry_interval, 0),
+    application:set_env(emqx_retainer, max_payload_size, 1024000),
+    application:set_env(emqx_retainer, max_retained_messages, 0),
+    application:set_env(emqx_retainer, storage_type, ram),
+    ok.

--- a/apps/emqx_retainer/test/mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx_retainer/test/mqtt_protocol_v5_SUITE.erl
@@ -27,12 +27,13 @@ init_per_suite(Config) ->
     %% Meck emqtt
     ok = meck:new(emqtt, [non_strict, passthrough, no_history, no_link]),
     %% Start Apps
-    emqx_ct_helpers:start_apps([emqx_retainer]),
+    emqx_retainer_ct_helper:ensure_start(),
     Config.
 
 end_per_suite(_Config) ->
     ok = meck:unload(emqtt),
-    emqx_ct_helpers:stop_apps([emqx_retainer]).
+    emqx_retainer_ct_helper:ensure_stop().
+
 
 %%--------------------------------------------------------------------
 %% Helpers
@@ -107,7 +108,7 @@ t_publish_message_expiry_interval(_) ->
     Msgs = receive_messages(4),
     ?assertEqual(2, length(Msgs)),  %% [MQTT-3.3.2-5]
 
-    L = lists:map(fun(Msg) -> MessageExpiryInterval = maps:get('Message-Expiry-Interval', maps:get(properties, Msg)), MessageExpiryInterval < 10 end, Msgs), 
+    L = lists:map(fun(Msg) -> MessageExpiryInterval = maps:get('Message-Expiry-Interval', maps:get(properties, Msg)), MessageExpiryInterval < 10 end, Msgs),
     ?assertEqual(2, length(L)),  %% [MQTT-3.3.2-6]
 
     ok = emqtt:disconnect(Client1),

--- a/src/emqx_plugins.erl
+++ b/src/emqx_plugins.erl
@@ -217,21 +217,49 @@ load_plugin_conf(AppName, PluginDir) ->
 ensure_file(File) ->
     case filelib:is_file(File) of
         false ->
-            DefaultPlugins = [ {emqx_management, true}
-                             , {emqx_dashboard, true}
-                             , {emqx_modules, true}
-                             , {emqx_recon, true}
-                             , {emqx_retainer, true}
-                             , {emqx_telemetry, true}
-                             , {emqx_rule_engine, true}
-                             , {emqx_bridge_mqtt, false}
-                             , {emqx_eviction_agent, true}
-                             , {emqx_node_rebalance, true}
-                             ],
+            DefaultPlugins = default_plugins(),
             write_loaded(DefaultPlugins);
         true ->
             ok
     end.
+
+-ifndef(EMQX_ENTERPRISE).
+%% default plugins see rebar.config.erl
+default_plugins() ->
+    [
+        {emqx_management, true},
+        {emqx_dashboard, true},
+        %% emqx_modules is not a plugin, but a normal application starting when boots.
+        {emqx_modules, false},
+        {emqx_retainer, true},
+        {emqx_recon, true},
+        {emqx_telemetry, true},
+        {emqx_rule_engine, true},
+        {emqx_bridge_mqtt, false},
+        {emqx_eviction_agent, true},
+        {emqx_node_rebalance, true}
+    ].
+
+-else.
+
+default_plugins() ->
+    [
+        {emqx_management, true},
+        {emqx_dashboard, true},
+        %% enterprise version of emqx_modules is a plugin
+        {emqx_modules, true},
+        %% retainer is managed by emqx_modules.
+        %% default is true in data/load_modules. **NOT HERE**
+        {emqx_retainer, false},
+        {emqx_recon, true},
+        {emqx_telemetry, true},
+        {emqx_rule_engine, true},
+        {emqx_bridge_mqtt, false},
+        {emqx_eviction_agent, true},
+        {emqx_node_rebalance, true}
+    ].
+
+-endif.
 
 with_loaded_file(File, SuccFun) ->
     case read_loaded(File) of

--- a/test/emqx_plugins_SUITE.erl
+++ b/test/emqx_plugins_SUITE.erl
@@ -89,6 +89,38 @@ t_load(_) ->
     ?assertEqual(ignore, emqx_plugins:load()),
     ?assertEqual(ignore, emqx_plugins:unload()).
 
+-ifndef(EMQX_ENTERPRISE).
+default_plugins() ->
+    [
+        {emqx_bridge_mqtt, false},
+        {emqx_dashboard, true},
+        {emqx_eviction_agent, true},
+        {emqx_management, true},
+        {emqx_modules, false},
+        {emqx_node_rebalance, true},
+        {emqx_recon, true},
+        {emqx_retainer, true},
+        {emqx_rule_engine, true},
+        {emqx_telemetry, true}
+    ].
+
+-else.
+
+default_plugins() ->
+    [
+        {emqx_bridge_mqtt, false},
+        {emqx_dashboard, true},
+        {emqx_eviction_agent, true},
+        {emqx_management, true},
+        {emqx_modules, true},
+        {emqx_node_rebalance, true},
+        {emqx_recon, true},
+        {emqx_retainer, false},
+        {emqx_rule_engine, true},
+        {emqx_telemetry, true}
+    ].
+
+-endif.
 t_ensure_default_loaded_plugins_file(Config) ->
     %% this will trigger it to write the default plugins to the
     %% inexistent file; but it won't truly load them in this test
@@ -96,19 +128,8 @@ t_ensure_default_loaded_plugins_file(Config) ->
     TmpFilepath = ?config(tmp_filepath, Config),
     ok = emqx_plugins:load(),
     {ok, Contents} = file:consult(TmpFilepath),
-    ?assertEqual(
-       [ {emqx_bridge_mqtt, false}
-       , {emqx_dashboard, true}
-       , {emqx_eviction_agent, true}
-       , {emqx_management, true}
-       , {emqx_modules, true}
-       , {emqx_node_rebalance, true}
-       , {emqx_recon, true}
-       , {emqx_retainer, true}
-       , {emqx_rule_engine, true}
-       , {emqx_telemetry, true}
-       ],
-       lists:sort(Contents)),
+    DefaultPlugins = default_plugins(),
+    ?assertEqual(DefaultPlugins, lists:sort(Contents)),
     ok.
 
 t_init_config(_) ->


### PR DESCRIPTION
## CE
emqx_modules is not a plugin, but a permanent application when emqx boots. emqx_retainer is a normal plugin.
So we don't need to start emqx_modules as plugins, setting `{emqx_modules, false}` in `data/load_plugins`

## EE
emqx_modules is a plugin, it manages all modules, so it must enable when emqx boots, otherwise all modules are abnormal. 
We must make sure `{emqx_modules, true}` in `data/load_plugins`.
the `emqx_retainer` is a normal module, we should set  `{emqx_retainer, false}` in `data/load_plugins` and make sure
it is enabled at `data/load_modules`.

So `emqx_modules` and `emqx_retainer` need diff default values between EE and CE.

BTW: we can see diff default in EE's `rebar.config.erl` 
