### PR TITLE
feat: enable upgrading release from 4.4.X to 4.5.Y

### DIFF
--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -1,6 +1,6 @@
 {application, emqx_management,
  [{description, "EMQ X Management API and CLI"},
-  {vsn, "4.4.6"}, % strict semver, bump manually!
+  {vsn, "4.4.7"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_management_sup]},
   {applications, [kernel,stdlib,emqx_plugin_libs,minirest]},

--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -939,6 +939,8 @@ is_version_supported2("4.3") ->
     true;
 is_version_supported2("4.4") ->
     true;
+is_version_supported2("4.5") ->
+    true;
 is_version_supported2(Version) ->
     case re:run(Version, "^4.[02].\\d+$", [{capture, none}]) of
         match ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -1,6 +1,6 @@
 {application, emqx_rule_engine,
  [{description, "EMQ X Rule Engine"},
-  {vsn, "4.4.7"}, % strict semver, bump manually!
+  {vsn, "4.4.8"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_rule_engine_sup, emqx_rule_registry]},
   {applications, [kernel,stdlib,rulesql,getopt]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.appup.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.appup.src
@@ -1,7 +1,8 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"4.4.6",[{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]}]},
+  [{"4.4.7",[{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]}]},
+   {"4.4.6",[{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]}]},
    {"4.4.5",
     [{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]},
      {load_module,emqx_rule_validator,brutal_purge,soft_purge,[]},
@@ -72,7 +73,8 @@
      {load_module,emqx_rule_runtime,brutal_purge,soft_purge,[]},
      {load_module,emqx_rule_engine_api,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
-  [{"4.4.6",[{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]}]},
+  [{"4.4.7",[{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]}]},
+   {"4.4.6",[{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]}]},
    {"4.4.5",
     [{load_module,emqx_rule_registry,brutal_purge,soft_purge,[]},
      {load_module,emqx_rule_validator,brutal_purge,soft_purge,[]},

--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -437,6 +437,8 @@ validate_target_version(TargetVersion, TargetNode) ->
     CurrentVersion = current_release_version(TargetNode),
     case {get_major_minor_vsn(CurrentVersion), get_major_minor_vsn(TargetVersion)} of
         {{Major, Minor}, {Major, Minor}} -> ok;
+        {{<<"4">>, <<"5">>}, {<<"4">>, <<"4">>}} -> ok;
+        {{<<"4">>, <<"4">>}, {<<"4">>, <<"5">>}} -> ok;
         _ ->
             ?INFO("Cannot upgrade/downgrade to ~s from ~s~n"
                   "We only support relup between patch versions",

--- a/include/emqx_release.hrl
+++ b/include/emqx_release.hrl
@@ -29,7 +29,7 @@
 
 -ifndef(EMQX_ENTERPRISE).
 
--define(EMQX_RELEASE, {opensource, "4.4.7"}).
+-define(EMQX_RELEASE, {opensource, "4.4.8"}).
 
 -else.
 

--- a/src/emqx.app.src
+++ b/src/emqx.app.src
@@ -6,7 +6,7 @@
   %% the emqx `release' version, which in turn is comprised of several
   %% apps, one of which is this.  See `emqx_release.hrl' for more
   %% info.
-  {vsn, "4.4.7"}, % strict semver, bump manually!
+  {vsn, "4.4.8"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [ kernel

--- a/src/emqx.appup.src
+++ b/src/emqx.appup.src
@@ -1,7 +1,10 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"4.4.6",
+  [{"4.4.7",
+    [{load_module,emqx_app,brutal_purge,soft_purge,[]},
+     {load_module,emqx_relup,brutal_purge,soft_purge,[]}]},
+   {"4.4.6",
     [{load_module,emqx_app,brutal_purge,soft_purge,[]},
      {load_module,emqx_relup,brutal_purge,soft_purge,[]}]},
    {"4.4.5",
@@ -162,7 +165,10 @@
      {load_module,emqx_message,brutal_purge,soft_purge,[]},
      {load_module,emqx_limiter,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
-  [{"4.4.6",
+  [{"4.4.7",
+    [{load_module,emqx_app,brutal_purge,soft_purge,[]},
+     {load_module,emqx_relup,brutal_purge,soft_purge,[]}]},
+   {"4.4.6",
     [{load_module,emqx_app,brutal_purge,soft_purge,[]},
      {load_module,emqx_relup,brutal_purge,soft_purge,[]}]},
    {"4.4.5",


### PR DESCRIPTION
When upgrading from 4.4.X, the `install_upgrade` script from 4.4.X
is used, which forbids such transition.

The problem is that the `install_upgrade.escript` for the older versions are already released.  So, a new 4.4.FIX release containing this fix would need to be cut to allow upgrading 4.4.X -> 4.4.FIX -> 4.5.0.