### PR TITLE
refactor: rename Field to Struct for ref type create function

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2094,9 +2094,9 @@ sc(Type, Meta) -> hoconsc:mk(Type, Meta).
 
 map(Name, Type) -> hoconsc:map(Name, Type).
 
-ref(Field) -> hoconsc:ref(?MODULE, Field).
+ref(StructName) -> hoconsc:ref(?MODULE, StructName).
 
-ref(Module, Field) -> hoconsc:ref(Module, Field).
+ref(Module, StructName) -> hoconsc:ref(Module, StructName).
 
 mk_duration(Desc, OverrideMeta) ->
     DefaultMeta = #{


### PR DESCRIPTION
    HOCON type reference is actually a child-struct's struct name
    not necessarily the same name as the parent-sutrct's field name

    This commit changes the variable name for more clarity