### PR TITLE
config: maxout max ports in emqx conf

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -422,7 +422,7 @@ fields("node") ->
                 #{
                     mapping => "vm_args.+Q",
                     desc => ?DESC(max_ports),
-                    default => 1048576,
+                    default => 134217727,
                     'readOnly' => true
                 }
             )},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -412,7 +412,7 @@ fields("node") ->
                 #{
                     mapping => "vm_args.+P",
                     desc => ?DESC(process_limit),
-                    default => 2097152,
+                    default => 134217727,
                     'readOnly' => true
                 }
             )},


### PR DESCRIPTION
We have a few reports from user that max number of conns are limited to `1048576`.
We have decided to max out it to up limit. 