### PR TITLE
fix: remove emqx_telemetry from ee's default plugins

### DIFF
--- a/src/emqx_plugins.erl
+++ b/src/emqx_plugins.erl
@@ -250,7 +250,8 @@ default_plugins() ->
         %% default is true in data/load_modules. **NOT HERE**
         {emqx_retainer, false},
         {emqx_recon, true},
-        {emqx_telemetry, true},
+        %% emqx_telemetry is not exist in enterprise.
+        %% {emqx_telemetry, false},
         {emqx_rule_engine, true},
         {emqx_bridge_mqtt, false}
     ].


### PR DESCRIPTION
Remove `emqx_telemetry` from default plugins, it does not exist in the enterprise version.
Otherwise, it will report a WARNING when starting emqx.
```
 2022-08-22T09:34:57.619825+08:00 [alert] [Plugins] cannot_find_plugins: [emqx_telemetry]
```