### PR TITLE
fix(exhook): fix the error message of unknown hookpoint

### DIFF
--- a/apps/emqx_exhook/src/emqx_exhook.app.src
+++ b/apps/emqx_exhook/src/emqx_exhook.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_exhook, [
     {description, "EMQX Extension for Hook"},
-    {vsn, "5.0.2"},
+    {vsn, "5.0.3"},
     {modules, []},
     {registered, []},
     {mod, {emqx_exhook_app, []}},

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -231,7 +231,7 @@ resolve_hookspec(HookSpecs) when is_list(HookSpecs) ->
                         end,
                     case {lists:member(Name, AvailableHooks), lists:member(Name, MessageHooks)} of
                         {false, _} ->
-                            error({unknown_hookpoint, Name});
+                            error({unknown_hookpoint, Name0});
                         {true, false} ->
                             Acc#{Name => #{}};
                         {true, true} ->


### PR DESCRIPTION
Now if there is an unknown hookpoint, the error message is actually `{unknown_hookpoint,{error,badarg}}`,
the hookpoint name information is lost

