### PR TITLE
chore: pin gun 1.3.7

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -41,6 +41,7 @@
     [ {gpb, "4.11.2"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
     , {redbug, "2.0.7"}
     , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.2.0"}}}
+    , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}}
     , {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.7.3"}}}
     , {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}


### PR DESCRIPTION
`4.x ce` is using gun 1.3.7, but `4.x ee` is using gun 1.3.4

1.3.7 fix undef erlang:get_stacktrace/0. we should pin 1.3.7
https://github.com/emqx/gun/compare/1.3.4...emqx:gun:1.3.7

compile warning is EE
```bash
, Evaluated Version: "1.3.4"
, Deps versions: [
                  {<<"grpc">>,
                   {gun,{git,"https://github.com/emqx/gun",{tag,"1.3.7"}}}},
                  {<<"emqtt">>,
                   {gun,{git,"https://github.com/emqx/gun",{tag,"1.3.4"}}}},
                  {<<"ehttpc">>,
                   {gun,{git,"https://github.com/emqx/gun",{tag,"1.3.7"}}}}]
```
link: also pin 1.3.7 on emqtt(1.6.0) https://github.com/emqx/emqtt/pull/167