### PR TITLE
ci: pass down `$SYSTEM` for relup base versions escript

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -84,6 +84,7 @@ jobs:
         PYTHON: python
         DIAGNOSTIC: 1
         PROFILE: emqx
+        SYSTEM: windows
       working-directory: source
       run: |
         erl -eval "erlang:display(crypto:info_lib())" -s init stop

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -259,6 +259,7 @@ jobs:
           --profile "${PROFILE}" \
           --pkgtype "${PACKAGE}" \
           --arch "${ARCH}" \
+          --system "${SYSTEM}" \
           --builder "ghcr.io/emqx/emqx-builder/4.4-19:${OTP}-${SYSTEM}"
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -79,6 +79,7 @@ jobs:
       env:
         PYTHON: python
         DIAGNOSTIC: 1
+        SYSTEM: windows
       run: |
         erl -eval "erlang:display(crypto:info_lib())" -s init stop
         make ${{ matrix.profile }}-zip

--- a/scripts/relup-base-vsns.escript
+++ b/scripts/relup-base-vsns.escript
@@ -161,6 +161,9 @@ fetch_version(Vsn, VsnMap) ->
 filter_froms(Froms0, AvailableVersionsIndex) ->
     Froms1 =
         case os:getenv("SYSTEM") of
+            %% we do not support relup for windows
+            "windows" ->
+                [];
             %% debian11 is introduced since v4.4.2 and e4.4.2
             %% exclude tags before them
             "debian11" ->


### PR DESCRIPTION
`relup-base-versions.escript` needs to know the system the package is
being built for to correctly enumerate the base versions for relup.

