### PR TITLE
feature: batch kicking out clients

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -2374,6 +2374,15 @@ broker.sys_heartbeat = 30s
 ## - all
 broker.session_locking_strategy = quorum
 
+## How to handle logins with the same client ID.
+##
+## Value: Enum
+## - takeover_older_session:
+##   accept the newer connection and takeover/ kick out the older sesion
+## - reject_newer_connection:
+##   reject the newer connection once the clientid conected before
+#broker.clientid_duplicated_strategy = takeover_older_session
+
 ## Dispatch strategy for shared subscription
 ##
 ## Value: Enum

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2499,6 +2499,11 @@ end}.
   {datatype, {enum, [local,leader,quorum,all]}}
 ]}.
 
+{mapping, "broker.clientid_duplicated_strategy", "emqx.clientid_duplicated_strategy", [
+  {default, takeover_older_session},
+  {datatype, {enum, [takeover_older_session,reject_newer_connection]}}
+]}.
+
 %% @doc Default shared Subscription Dispatch Strategy.
 {mapping, "broker.shared_subscription_strategy", "emqx.shared_subscription_strategy", [
   {default, round_robin},


### PR DESCRIPTION
This PR contained the following new features:
- Add  option to deny client with the same clientid
```properties
## How to handle logins with the same client ID.
##
## Value: Enum
## - takeover_older_session:
##   accept the newer connection and takeover/ kick out the older sesion
## - reject_newer_connection:
##   reject the newer connection once the clientid conected before
#broker.clientid_duplicated_strategy = takeover_older_session
```
- batch kicking out clients