### PR TITLE
buid: fix make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ $(REL_PROFILES:%=%): $(COMMON_DEPS)
 clean: $(PROFILES:%=clean-%)
 $(PROFILES:%=clean-%):
 	@if [ -d _build/$(@:clean-%=%) ]; then \
-		rm rebar.lock \
+		rm -f rebar.lock; \
 		rm -rf _build/$(@:clean-%=%)/rel; \
 		$(FIND) _build/$(@:clean-%=%) -name '*.beam' -o -name '*.so' -o -name '*.app' -o -name '*.appup' -o -name '*.o' -o -name '*.d' -type f | xargs rm -f; \
 		$(FIND) _build/$(@:clean-%=%) -type l -delete; \


### PR DESCRIPTION
without semicolon `rm` considers all tokens on line 136 as separate files