### PR TITLE
feat: add edition info to /nodes api

### DIFF
--- a/apps/emqx/src/emqx_release.erl
+++ b/apps/emqx/src/emqx_release.erl
@@ -18,6 +18,7 @@
 
 -export([
     edition/0,
+    edition_longstr/0,
     description/0,
     version/0
 ]).
@@ -44,8 +45,12 @@ description() ->
 -spec edition() -> ce | ee.
 -ifdef(EMQX_RELEASE_EDITION).
 edition() -> ?EMQX_RELEASE_EDITION.
+
+edition_longstr() -> <<"Enterprise">>.
 -else.
 edition() -> ce.
+
+edition_longstr() -> <<"Opensource">>.
 -endif.
 
 %% @doc Return the release version.

--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_machine/src/emqx_restricted_shell.erl
+++ b/apps/emqx_machine/src/emqx_restricted_shell.erl
@@ -45,9 +45,10 @@ set_prompt_func() ->
 prompt_func(PropList) ->
     Line = proplists:get_value(history, PropList, 1),
     Version = emqx_release:version(),
+    Edition = emqx_release:edition(),
     case is_alive() of
-        true -> io_lib:format(<<"~ts(~s)~w> ">>, [Version, node(), Line]);
-        false -> io_lib:format(<<"~ts ~w> ">>, [Version, Line])
+        true -> io_lib:format(<<"~ts-~ts(~s)~w> ">>, [Edition, Version, node(), Line]);
+        false -> io_lib:format(<<"~ts-~ts ~w> ">>, [Edition, Version, Line])
     end.
 
 local_allowed(MF, Args, State) ->

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -19,6 +19,7 @@
 -include("emqx_mgmt.hrl").
 -elvis([{elvis_style, invalid_dynamic_call, disable}]).
 -elvis([{elvis_style, god_modules, disable}]).
+-dialyzer({nowarn_function, edition/0}).
 
 -include_lib("stdlib/include/qlc.hrl").
 -include_lib("emqx/include/emqx.hrl").

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -141,6 +141,7 @@ node_info() ->
         node_status => 'running',
         uptime => proplists:get_value(uptime, BrokerInfo),
         version => iolist_to_binary(proplists:get_value(version, BrokerInfo)),
+        edition => edition(),
         role => mria_rlog:role()
     }.
 
@@ -553,3 +554,9 @@ max_row_limit() ->
     ?MAX_ROW_LIMIT.
 
 table_size(Tab) -> ets:info(Tab, size).
+
+edition() ->
+    case emqx_release:edition() of
+        ee -> <<"enterprise">>;
+        ce -> <<"community">>
+    end.

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -19,7 +19,6 @@
 -include("emqx_mgmt.hrl").
 -elvis([{elvis_style, invalid_dynamic_call, disable}]).
 -elvis([{elvis_style, god_modules, disable}]).
--dialyzer({nowarn_function, edition/0}).
 
 -include_lib("stdlib/include/qlc.hrl").
 -include_lib("emqx/include/emqx.hrl").
@@ -142,7 +141,7 @@ node_info() ->
         node_status => 'running',
         uptime => proplists:get_value(uptime, BrokerInfo),
         version => iolist_to_binary(proplists:get_value(version, BrokerInfo)),
-        edition => edition(),
+        edition => emqx_release:edition_longstr(),
         role => mria_rlog:role()
     }.
 
@@ -555,9 +554,3 @@ max_row_limit() ->
     ?MAX_ROW_LIMIT.
 
 table_size(Tab) -> ets:info(Tab, size).
-
-edition() ->
-    case emqx_release:edition() of
-        ee -> <<"enterprise">>;
-        ce -> <<"opensource">>
-    end.

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -558,5 +558,5 @@ table_size(Tab) -> ets:info(Tab, size).
 edition() ->
     case emqx_release:edition() of
         ee -> <<"enterprise">>;
-        ce -> <<"community">>
+        ce -> <<"opensource">>
     end.

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -219,8 +219,8 @@ fields(node_info) ->
             )},
         {edition,
             mk(
-                enum([community, enterprise]),
-                #{desc => <<"Release edition">>, example => "community"}
+                enum([opensource, enterprise]),
+                #{desc => <<"Release edition">>, example => "opensource"}
             )},
         {sys_path,
             mk(

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -219,8 +219,8 @@ fields(node_info) ->
             )},
         {edition,
             mk(
-                enum([opensource, enterprise]),
-                #{desc => <<"Release edition">>, example => "opensource"}
+                enum(['Opensource', 'Enterprise']),
+                #{desc => <<"Release edition">>, example => "Opensource"}
             )},
         {sys_path,
             mk(

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -215,7 +215,12 @@ fields(node_info) ->
         {version,
             mk(
                 string(),
-                #{desc => <<"Release version">>, example => "5.0.0-beat.3-00000000"}
+                #{desc => <<"Release version">>, example => "5.0.0"}
+            )},
+        {edition,
+            mk(
+                enum([community, enterprise]),
+                #{desc => <<"Release edition">>, example => "community"}
             )},
         {sys_path,
             mk(

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -57,6 +57,11 @@ t_nodes_api(_) ->
     LocalNodeInfo = hd(NodesResponse),
     Node = binary_to_atom(maps:get(<<"node">>, LocalNodeInfo), utf8),
     ?assertEqual(Node, node()),
+    Edition = maps:get(<<"edition">>, LocalNodeInfo),
+    case emqx_release:edition() of
+        ee -> ?assertEqual(<<"enterprise">>, Edition);
+        ce -> ?assertEqual(<<"community">>, Edition)
+    end,
 
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -58,10 +58,7 @@ t_nodes_api(_) ->
     Node = binary_to_atom(maps:get(<<"node">>, LocalNodeInfo), utf8),
     ?assertEqual(Node, node()),
     Edition = maps:get(<<"edition">>, LocalNodeInfo),
-    case emqx_release:edition() of
-        ee -> ?assertEqual(<<"enterprise">>, Edition);
-        ce -> ?assertEqual(<<"opensource">>, Edition)
-    end,
+    ?assertEqual(emqx_release:edition_longstr(), Edition),
 
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -60,7 +60,7 @@ t_nodes_api(_) ->
     Edition = maps:get(<<"edition">>, LocalNodeInfo),
     case emqx_release:edition() of
         ee -> ?assertEqual(<<"enterprise">>, Edition);
-        ce -> ?assertEqual(<<"community">>, Edition)
+        ce -> ?assertEqual(<<"opensource">>, Edition)
     end,
 
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),


### PR DESCRIPTION
Add `{edition: opensource|enterprise}` to /nodes API

We have returned edition information in the dashboard's  POST `/login` API, 
Now we return the edition for each node.