### PR TITLE
feat: don't override RUNNER_LOG_DIR env in emqx_vars

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -7,7 +7,8 @@
 
 ## Enhancements
 
-* change the `/gateway` API path to plural form. [#8823](https://github.com/emqx/emqx/pull/8823)
+* Change the `/gateway` API path to plural form. [#8823](https://github.com/emqx/emqx/pull/8823)
+* Remove `node.etc_dir` from emqx.conf. [#8892](https://github.com/emqx/emqx/pull/8892)
 
 # 5.0.7
 

--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -8,7 +8,8 @@
 ## Enhancements
 
 * Change the `/gateway` API path to plural form. [#8823](https://github.com/emqx/emqx/pull/8823)
-* Remove `node.etc_dir` from emqx.conf. [#8892](https://github.com/emqx/emqx/pull/8892)
+* Remove `node.etc_dir` from emqx.conf, because it is never used.
+  Also allow user to customize the logging directory [#8892](https://github.com/emqx/emqx/pull/8892)
 
 # 5.0.7
 

--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -12,7 +12,6 @@ node {
   name = "emqx@127.0.0.1"
   cookie = emqxsecretcookie
   data_dir = "{{ platform_data_dir }}"
-  etc_dir = "{{ platform_etc_dir }}"
 }
 
 log {

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -536,14 +536,6 @@ fields("node") ->
                     desc => ?DESC(node_applications)
                 }
             )},
-        {"etc_dir",
-            sc(
-                string(),
-                #{
-                    desc => ?DESC(node_etc_dir),
-                    'readOnly' => true
-                }
-            )},
         {"cluster_call",
             sc(
                 ?R_REF("cluster_call"),

--- a/rel/emqx_vars
+++ b/rel/emqx_vars
@@ -10,6 +10,8 @@ RUNNER_BIN_DIR="{{ runner_bin_dir }}"
 RUNNER_LIB_DIR="{{ runner_lib_dir }}"
 IS_ELIXIR="${IS_ELIXIR:-{{ is_elixir }}}"
 
+## Allow users to pre-set `RUNNER_LOG_DIR` because it only affects boot commands like `start` and `console`,
+## but not other commands such as `ping` and `ctl`.
 if [ -z "${RUNNER_LOG_DIR:-}" ]; then
     RUNNER_LOG_DIR="{{ runner_log_dir }}"
 fi

--- a/rel/emqx_vars
+++ b/rel/emqx_vars
@@ -13,8 +13,6 @@ IS_ELIXIR="${IS_ELIXIR:-{{ is_elixir }}}"
 ## Allow users to pre-set `RUNNER_LOG_DIR` because it only affects boot commands like `start` and `console`,
 ## but not other commands such as `ping` and `ctl`.
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-{{ runner_log_dir }}}"
-    RUNNER_LOG_DIR="{{ runner_log_dir }}"
-fi
 
 EMQX_ETC_DIR="{{ emqx_etc_dir }}"
 RUNNER_USER="{{ runner_user }}"

--- a/rel/emqx_vars
+++ b/rel/emqx_vars
@@ -12,7 +12,7 @@ IS_ELIXIR="${IS_ELIXIR:-{{ is_elixir }}}"
 
 ## Allow users to pre-set `RUNNER_LOG_DIR` because it only affects boot commands like `start` and `console`,
 ## but not other commands such as `ping` and `ctl`.
-if [ -z "${RUNNER_LOG_DIR:-}" ]; then
+RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-{{ runner_log_dir }}}"
     RUNNER_LOG_DIR="{{ runner_log_dir }}"
 fi
 

--- a/rel/emqx_vars
+++ b/rel/emqx_vars
@@ -7,11 +7,15 @@ REL_VSN="{{ release_version }}"
 ERTS_VSN="{{ erts_vsn }}"
 ERL_OPTS="{{ erl_opts }}"
 RUNNER_BIN_DIR="{{ runner_bin_dir }}"
-RUNNER_LOG_DIR="{{ runner_log_dir }}"
 RUNNER_LIB_DIR="{{ runner_lib_dir }}"
+IS_ELIXIR="${IS_ELIXIR:-{{ is_elixir }}}"
+
+if [ -z "${RUNNER_LOG_DIR:-}" ]; then
+    RUNNER_LOG_DIR="{{ runner_log_dir }}"
+fi
+
 EMQX_ETC_DIR="{{ emqx_etc_dir }}"
 RUNNER_USER="{{ runner_user }}"
-IS_ELIXIR="${IS_ELIXIR:-{{ is_elixir }}}"
 SCHEMA_MOD="{{ emqx_schema_mod }}"
 IS_ENTERPRISE="{{ is_enterprise }}"
 


### PR DESCRIPTION
Fix: can't override etc_dir  via ENV:
`RUNNER_LOG_DIR="/test/log" ./bin/emqx console`




