### PR TITLE
test: add test case for not publishing will msg when not authorized

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -23,6 +23,8 @@ File format:
   `SELECT topic =~ 't' as r FROM "$events/client_connected"`.
   The topic is a null value as there's no such field in event `$events/client_connected`, so it
   should return false if match it to a topic.
+- Added a test to prevent a last will testament message to be
+  published when a client is denied connection. [#8894](https://github.com/emqx/emqx/pull/8894)
 
 ## v4.3.19
 


### PR DESCRIPTION
4.3 was not affected in the first place, but this test can help prevent a regression.

Related issue: #8886 