### PR TITLE
fix: cluster/local-override.conf does not take effect at vm.args/app.config

### DIFF
--- a/apps/emqx/src/config/emqx_config_logger.erl
+++ b/apps/emqx/src/config/emqx_config_logger.erl
@@ -37,9 +37,14 @@ remove_handler() ->
 %% so we need to refresh the logger config after this node starts.
 %% It will not affect the logger config when cluster-override.conf is unchanged.
 refresh_config() ->
-    Log = emqx:get_raw_config(?LOG),
-    {ok, _} = emqx:update_config(?LOG, Log),
-    ok.
+    case emqx:get_raw_config(?LOG, undefined) of
+        %% no logger config when CT is running.
+        undefined ->
+            ok;
+        Log ->
+            {ok, _} = emqx:update_config(?LOG, Log),
+            ok
+    end.
 
 post_config_update(?LOG, _Req, _NewConf, _OldConf, AppEnvs) ->
     Kernel = proplists:get_value(kernel, AppEnvs),

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -558,6 +558,7 @@ save_to_override_conf(RawConf, Opts) ->
 add_handlers() ->
     ok = emqx_config_logger:add_handler(),
     emqx_sys_mon:add_handler(),
+    emqx_config_logger:refresh_config(),
     ok.
 
 remove_handlers() ->

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -40,6 +40,7 @@
 
 -export([namespace/0, roots/0, fields/1, translations/0, translation/1, validations/0, desc/1]).
 -export([conf_get/2, conf_get/3, keys/2, filter/1]).
+-export([parse_data_dir/1]).
 
 %% Static apps which merge their configs into the merged emqx.conf
 %% The list can not be made a dynamic read at run-time as it is used
@@ -452,6 +453,7 @@ fields("node") ->
                     required => true,
                     'readOnly' => true,
                     mapping => "emqx.data_dir",
+                    converter => fun ?MODULE:parse_data_dir/1,
                     desc => ?DESC(node_data_dir)
                 }
             )},
@@ -1407,3 +1409,9 @@ validator_string_re(Val, RE, Error) ->
     catch
         _:_ -> {error, Error}
     end.
+
+parse_data_dir(Dir) ->
+    Dir1 = string:trim(Dir, both, " "),
+    Dir2 = string:trim(Dir1, trailing, "/"),
+    ok = filelib:ensure_dir(Dir2),
+    Dir2.

--- a/bin/emqx
+++ b/bin/emqx
@@ -440,6 +440,11 @@ call_hocon() {
         || die "call_hocon_failed: $*" $?
 }
 
+get_boot_config() {
+    path_to_value="$1"
+    echo -e "$EMQX_BOOT_CONFIGS" | grep "$path_to_value=" | sed -e "s/$path_to_value=//g" | tr -d \"
+}
+
 ## Resolve boot configs in a batch
 ## This is because starting the Erlang beam with all modules loaded
 ## and parsing HOCON config + environment variables is a non-trivial task
@@ -448,11 +453,20 @@ if [ "$IS_ENTERPRISE" = 'yes' ]; then
     CONF_KEYS+=( 'license.key' )
 fi
 
+get_configs() {
+    CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
+    NODE_DATA_DIR=$(echo -e "$CONFIGS" | grep 'node.data_dir=' | sed -e "s/node.data_dir=//g" | tr -d \")
+    CLUSTER_OVERRIDE_CONF_FILE="$NODE_DATA_DIR/configs/cluster-override.conf"
+    LOCAL_OVERRIDE_CONF_FILE="$NODE_DATA_DIR/configs/local-override.conf"
+    if [ -s "$CLUSTER_OVERRIDE_CONF_FILE" ] || [ -s "$LOCAL_OVERRIDE_CONF_FILE" ]; then
+       CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get -c "$CLUSTER_OVERRIDE_CONF_FILE" -c "$LOCAL_OVERRIDE_CONF_FILE" "${CONF_KEYS[@]}")"
+    fi
+    echo "$CONFIGS"
+}
+
 if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
     if [ "${EMQX_BOOT_CONFIGS:-}" = '' ]; then
-        EMQX_BOOT_CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
-        ## export here so the 'console' command recursively called from
-        ## 'start' command does not have to parse the configs again
+        EMQX_BOOT_CONFIGS="$(get_configs)"
         export EMQX_BOOT_CONFIGS
     fi
 else
@@ -476,14 +490,9 @@ else
         fi
     else
         ## None or more than one node is running, resolve from boot config
-        EMQX_BOOT_CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
+        EMQX_BOOT_CONFIGS="$(get_configs)"
     fi
 fi
-
-get_boot_config() {
-    path_to_value="$1"
-    echo -e "$EMQX_BOOT_CONFIGS" | grep "$path_to_value=" | sed -e "s/$path_to_value=//g" | tr -d \"
-}
 
 EPMD_ARGS="-start_epmd false -epmd_module ekka_epmd -proto_dist ekka"
 PROTO_DIST="$(get_boot_config 'cluster.proto_dist' || true)"
@@ -573,9 +582,7 @@ generate_config() {
 
     ## this command populates two files: app.<time>.config and vm.<time>.args
     ## NOTE: the generate command merges environment variables to the base config (emqx.conf),
-    ## but does not include the cluster-override.conf and local-override.conf
-    ## meaning, certain overrides will not be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -d "$DATA_DIR"/configs generate
+    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "$DATA_DIR"/configs/cluster-override.conf -c "$DATA_DIR"/configs/local-override.conf -d "$DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"

--- a/bin/emqx
+++ b/bin/emqx
@@ -455,7 +455,7 @@ fi
 
 resolve_data_dir() {
     DIR=$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf get "node.data_dir")
-    echo -e "$DIR" | sed 's/\"//g'
+    echo -e "$DIR" | tr -d \"
 }
 get_boot_configs() {
     NODE_DATA_DIR=$(resolve_data_dir)

--- a/bin/emqx
+++ b/bin/emqx
@@ -459,6 +459,11 @@ resolve_data_dir() {
 }
 get_boot_configs() {
     NODE_DATA_DIR=$(resolve_data_dir)
+    NODE_DATA_DIR="${NODE_DATA_DIR%/}"
+    if [[ $NODE_DATA_DIR != /* ]]; then
+        # relative path
+        NODE_DATA_DIR="${RUNNER_ROOT_DIR}/${NODE_DATA_DIR}"
+    fi
     CLUSTER_OVERRIDE_CONF_FILE="$NODE_DATA_DIR"/configs/cluster-override.conf
     LOCAL_OVERRIDE_CONF_FILE="$NODE_DATA_DIR"/configs/local-override.conf
     CONFIGS=$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "${CLUSTER_OVERRIDE_CONF_FILE}" -c "${LOCAL_OVERRIDE_CONF_FILE}" multi_get "${CONF_KEYS[@]}")

--- a/bin/emqx
+++ b/bin/emqx
@@ -448,25 +448,26 @@ get_boot_config() {
 ## Resolve boot configs in a batch
 ## This is because starting the Erlang beam with all modules loaded
 ## and parsing HOCON config + environment variables is a non-trivial task
-CONF_KEYS=( 'node.data_dir' 'node.name' 'node.cookie' 'node.db_backend' 'cluster.proto_dist' )
+CONF_KEYS=('node.name' 'node.cookie' 'node.db_backend' 'cluster.proto_dist' )
 if [ "$IS_ENTERPRISE" = 'yes' ]; then
     CONF_KEYS+=( 'license.key' )
 fi
 
-get_configs() {
-    CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
-    NODE_DATA_DIR=$(echo -e "$CONFIGS" | grep 'node.data_dir=' | sed -e "s/node.data_dir=//g" | tr -d \")
-    CLUSTER_OVERRIDE_CONF_FILE="$NODE_DATA_DIR/configs/cluster-override.conf"
-    LOCAL_OVERRIDE_CONF_FILE="$NODE_DATA_DIR/configs/local-override.conf"
-    if [ -s "$CLUSTER_OVERRIDE_CONF_FILE" ] || [ -s "$LOCAL_OVERRIDE_CONF_FILE" ]; then
-       CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get -c "$CLUSTER_OVERRIDE_CONF_FILE" -c "$LOCAL_OVERRIDE_CONF_FILE" "${CONF_KEYS[@]}")"
-    fi
-    echo "$CONFIGS"
+resolve_data_dir() {
+    DIR=$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf get "node.data_dir")
+    echo -e "$DIR" | sed 's/\"//g'
+}
+get_boot_configs() {
+    NODE_DATA_DIR=$(resolve_data_dir)
+    CLUSTER_OVERRIDE_CONF_FILE="$NODE_DATA_DIR"/configs/cluster-override.conf
+    LOCAL_OVERRIDE_CONF_FILE="$NODE_DATA_DIR"/configs/local-override.conf
+    CONFIGS=$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -c "${CLUSTER_OVERRIDE_CONF_FILE}" -c "${LOCAL_OVERRIDE_CONF_FILE}" multi_get "${CONF_KEYS[@]}")
+    echo -e "node.data_dir=$NODE_DATA_DIR\n$CONFIGS"
 }
 
 if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
     if [ "${EMQX_BOOT_CONFIGS:-}" = '' ]; then
-        EMQX_BOOT_CONFIGS="$(get_configs)"
+        EMQX_BOOT_CONFIGS="$(get_boot_configs)"
         export EMQX_BOOT_CONFIGS
     fi
 else
@@ -490,7 +491,7 @@ else
         fi
     else
         ## None or more than one node is running, resolve from boot config
-        EMQX_BOOT_CONFIGS="$(get_configs)"
+        EMQX_BOOT_CONFIGS="$(get_boot_configs)"
     fi
 fi
 
@@ -564,7 +565,15 @@ relx_start_command() {
 # Function to check configs without generating them
 check_config() {
     ## this command checks the configs without generating any files
-    call_hocon -v -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf check_schema
+    EMQX_CONF="$EMQX_ETC_DIR/emqx.conf"
+    CLUSTER_OVERRIDE_CONF="$DATA_DIR/configs/cluster-override.conf"
+    LOCAL_OVERRIDE_CONF="$DATA_DIR/configs/local-override.conf"
+    echo "Checking configs..."
+    echo "$EMQX_CONF"
+    echo "$CLUSTER_OVERRIDE_CONF"
+    echo "$LOCAL_OVERRIDE_CONF"
+    call_hocon -v -s "$SCHEMA_MOD" -c "$EMQX_CONF" -c "$CLUSTER_OVERRIDE_CONF" -c "$LOCAL_OVERRIDE_CONF" check_schema
+    echo "All configuration format are ok."
 }
 
 # Function to generate app.config and vm.args

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -68,3 +68,5 @@ Please note, the request body of `/bridges` API to configure MQTT brdige is chan
 - Fix bridging function, when both ingress and egress bridges are configured, egress bridge does not work [#9523](https://github.com/emqx/emqx/pull/9523).
 
 - Fix EMQX Helm Chart using incorrect secret values when custom credentials are provided [#9536](https://github.com/emqx/emqx/pull/9536).
+
+- Fix `cluster/local-override.conf` does not take effect at vm.args/app.config. [#8895](https://github.com/emqx/emqx/pull/8895)

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -66,3 +66,5 @@ v5.0.11 或更早版本创建的配置文件，在新版本中会被自动转换
 - 桥接功能修复，当同时配置了2个桥，方向为入桥和出桥时，出桥不工作的问题。[#9523](https://github.com/emqx/emqx/pull/9523).
 
 - 修复了 EMQX Helm Chart 中当用户使用自定义的用户名和密码时，创建的 Secret 资源不正确问题 [#9536](https://github.com/emqx/emqx/pull/9536)。
+
+- 修复 `cluster/local-override.conf` 不会生效的问题 [#8895](https://github.com/emqx/emqx/pull/8895)。


### PR DESCRIPTION
Config changes such as log levels etc can be applied from dashboard in realtime.
However due to the sys.config (or app.config) generation did not take cluster-override (nor local-override) into account.
such config change are not persisted.

This PR tries to include both cluster and local overrides into config generation stage.

- [x] Verify space is allowed in data_dir config (and env override)

Fix `emqx.cmd` for Windows in another PR.