### PR TITLE
Fix bridge api

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -532,6 +532,17 @@ lookup_from_local_node(BridgeType, BridgeName) ->
                                 {200};
                             {error, timeout} ->
                                 {503, error_msg('SERVICE_UNAVAILABLE', <<"request timeout">>)};
+                            {error, {start_pool_failed, Name, Reason}} ->
+                                {503,
+                                    error_msg(
+                                        'SERVICE_UNAVAILABLE',
+                                        bin(
+                                            io_lib:format(
+                                                "failed to start ~p pool for reason ~p",
+                                                [Name, Reason]
+                                            )
+                                        )
+                                    )};
                             {error, Reason} ->
                                 {500, error_msg('INTERNAL_ERROR', Reason)}
                         end

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs_pool.erl
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs_pool.erl
@@ -40,12 +40,13 @@ start_pool(Name, Mod, Options) ->
             stop_pool(Name),
             start_pool(Name, Mod, Options);
         {error, Reason} ->
+            NReason = parse_reason(Reason),
             ?SLOG(error, #{
                 msg => "start_ecpool_error",
                 pool_name => Name,
-                reason => Reason
+                reason => NReason
             }),
-            {error, {start_pool_failed, Name, Reason}}
+            {error, {start_pool_failed, Name, NReason}}
     end.
 
 stop_pool(Name) ->
@@ -86,3 +87,11 @@ health_check_ecpool_workers(PoolName, CheckFunc, Timeout) when is_function(Check
         exit:timeout ->
             false
     end.
+
+parse_reason({
+    {shutdown, {failed_to_start_child, _, {shutdown, {failed_to_start_child, _, Reason}}}},
+    _
+}) ->
+    Reason;
+parse_reason(Reason) ->
+    Reason.

--- a/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_influxdb.conf
+++ b/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_influxdb.conf
@@ -65,7 +65,7 @@ TLDR: </br>
     desc_type {
         desc {
             en: """The Bridge Type."""
-            zh: """Bridge 类型。"""
+            zh: """桥接类型。"""
         }
         label {
             en: "Bridge Type"
@@ -75,12 +75,12 @@ TLDR: </br>
 
     desc_name {
         desc {
-            en: """Bridge name, used as a human-readable description of the bridge."""
-            zh: """桥接名字，人类可读的描述信息。"""
+            en: """Bridge name."""
+            zh: """桥接名称。"""
         }
         label {
             en: "Bridge Name"
-            zh: "桥接名字"
+            zh: "桥接名称"
         }
     }
 


### PR DESCRIPTION
- for connectors using ecpool, parse connect error `Reason` when start pool failed.
- Refine InfluxDB bridge desc.