### PR TITLE
chore: warning default cookie used

### DIFF
--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -49,6 +49,7 @@ start(_Type, _Args) ->
     {ok, Sup} = emqx_sup:start_link(),
     ok = maybe_start_listeners(),
     emqx_config:add_handlers(),
+    warning_default_cookie(),
     register(emqx, self()),
     {ok, Sup}.
 
@@ -119,3 +120,19 @@ get_description() -> emqx_release:description().
 
 get_release() ->
     emqx_release:version().
+
+-define(DEFAULT_COOKIE, emqxsecretcookie).
+warning_default_cookie() ->
+    case erlang:get_cookie() =:= ?DEFAULT_COOKIE of
+        true ->
+            ?SLOG(
+                warning,
+                #{
+                    msg => "default_cookie_used",
+                    advices =>
+                        "Change default cookie via node.cookie in emqx.conf or EMQX_NODE__COOKIE env"
+                }
+            );
+        false ->
+            ok
+    end.

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -130,7 +130,7 @@ warning_default_cookie() ->
                 #{
                     msg => "default_cookie_used",
                     advices =>
-                        "Change default cookie via node.cookie in emqx.conf or EMQX_NODE__COOKIE env"
+                        "Change default Erlang cookie via node.cookie in emqx.conf or override with EMQX_NODE__COOKIE environment variable. NOTE: All nodes in the cluster should share the same config value."
                 }
             );
         false ->


### PR DESCRIPTION
For security reasons.