### PR TITLE
refactor(cookie): Warning message when boot with default Erlang cookie

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -9,6 +9,7 @@
 
 ## Enhancements
 
+* Print a warning message when boot with the default (insecure) Erlang cookie. [#8905](https://github.com/emqx/emqx/pull/8905)
 * Change the `/gateway` API path to plural form. [#8823](https://github.com/emqx/emqx/pull/8823)
 * Remove `node.etc_dir` from emqx.conf, because it is never used.
   Also allow user to customize the logging directory [#8892](https://github.com/emqx/emqx/pull/8892)

--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -10,7 +10,7 @@
 
 node {
   name = "emqx@127.0.0.1"
-  cookie = emqxsecretcookie
+  cookie = "{{ emqx_default_erlang_cookie }}"
   data_dir = "{{ platform_data_dir }}"
 }
 

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -400,7 +400,7 @@ fields("node") ->
                 string(),
                 #{
                     mapping => "vm_args.-setcookie",
-                    default => "emqxsecretcookie",
+                    required => true,
                     'readOnly' => true,
                     sensitive => true,
                     desc => ?DESC(node_cookie)

--- a/bin/emqx
+++ b/bin/emqx
@@ -600,7 +600,7 @@ is_down() {
         if ps -p "$PID" | grep -q 'defunct'; then
             # zombie state, print parent pid
             parent="$(ps -o ppid= -p "$PID" | tr -d ' ')"
-            echo "WARN: $PID is marked <defunct>, parent:"
+            echo "WARNING: $PID is marked <defunct>, parent:"
             ps -p "$parent"
             return 0
         fi
@@ -748,8 +748,9 @@ export ESCRIPT_NAME="$SHORT_NAME"
 
 PIPE_DIR="${PIPE_DIR:-/$DATA_DIR/${WHOAMI}_erl_pipes/$NAME/}"
 
-## make EMQX_NODE_COOKIE right
+## Resolve Erlang cookie.
 if [ -n "${EMQX_NODE_COOKIE:-}" ]; then
+    ## To be backward compatible, read EMQX_NODE_COOKIE
     export EMQX_NODE__COOKIE="${EMQX_NODE_COOKIE}"
     unset EMQX_NODE_COOKIE
 fi
@@ -762,9 +763,13 @@ if [ -z "$COOKIE" ]; then
         COOKIE="$(grep -E '^-setcookie' "${vm_args_file}" | awk '{print $2}')"
     fi
 fi
-
-if [ -z "$COOKIE" ]; then
-    die "Please set node.cookie in $EMQX_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE__COOKIE"
+[ -z "$COOKIE" ] && COOKIE="$EMQX_DEFAULT_ERLANG_COOKIE"
+if [ $IS_BOOT_COMMAND = 'yes' ] && [ "$COOKIE" = "$EMQX_DEFAULT_ERLANG_COOKIE" ]; then
+    echoerr "!!!!!!"
+    echoerr "WARNING: Default (insecure) Erlang cookie is in use."
+    echoerr "WARNING: Configure node.cookie in $EMQX_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE__COOKIE"
+    echoerr "NOTE: Use the same config value for all nodes in the cluster."
+    echoerr "!!!!!!"
 fi
 
 ## check if OTP version has mnesia_hook feature; if not, fallback to

--- a/build
+++ b/build
@@ -157,6 +157,7 @@ make_relup() {
     local name_pattern
     name_pattern="${PROFILE}-$(./pkg-vsn.sh "$PROFILE" --vsn_matcher --long)"
     local releases=()
+    mkdir -p _upgrade_base
     while read -r tgzfile ; do
         local base_vsn
         base_vsn="$(echo "$tgzfile" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta|rc)\.[0-9])?(-[0-9a-f]{8})?" | head -1)"

--- a/mix.exs
+++ b/mix.exs
@@ -547,6 +547,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp template_vars(release, release_type, :bin = _package_type, edition_type) do
     [
+      emqx_default_erlang_cookie: default_cookie(),
       platform_data_dir: "data",
       platform_etc_dir: "etc",
       platform_log_dir: "log",
@@ -569,6 +570,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp template_vars(release, release_type, :pkg = _package_type, edition_type) do
     [
+      emqx_default_erlang_cookie: default_cookie(),
       platform_data_dir: "/var/lib/emqx",
       platform_etc_dir: "/etc/emqx",
       platform_log_dir: "/var/log/emqx",
@@ -587,6 +589,10 @@ defmodule EMQXUmbrella.MixProject do
       is_elixir: "yes",
       is_enterprise: if(edition_type == :enterprise, do: "yes", else: "no")
     ] ++ build_info()
+  end
+
+  defp default_cookie() do
+    "emqx50elixir"
   end
 
   defp emqx_description(release_type, edition_type) do

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -298,13 +298,12 @@ relform() ->
 emqx_description(cloud, ee) -> "EMQX Enterprise";
 emqx_description(cloud, ce) -> "EMQX".
 
-overlay_vars(RelType, PkgType, Edition) ->
-    overlay_vars_rel(RelType) ++
+overlay_vars(cloud, PkgType, Edition) ->
+    [
+        {emqx_default_erlang_cookie, "emqxsecretcookie"}
+    ] ++
         overlay_vars_pkg(PkgType) ++
         overlay_vars_edition(Edition).
-
-overlay_vars_rel(cloud) ->
-    [{vm_args_file, "vm.args"}].
 
 overlay_vars_edition(ce) ->
     [

--- a/rel/emqx_vars
+++ b/rel/emqx_vars
@@ -9,19 +9,17 @@ ERL_OPTS="{{ erl_opts }}"
 RUNNER_BIN_DIR="{{ runner_bin_dir }}"
 RUNNER_LIB_DIR="{{ runner_lib_dir }}"
 IS_ELIXIR="${IS_ELIXIR:-{{ is_elixir }}}"
-
 ## Allow users to pre-set `RUNNER_LOG_DIR` because it only affects boot commands like `start` and `console`,
 ## but not other commands such as `ping` and `ctl`.
 RUNNER_LOG_DIR="${RUNNER_LOG_DIR:-{{ runner_log_dir }}}"
-
 EMQX_ETC_DIR="{{ emqx_etc_dir }}"
 RUNNER_USER="{{ runner_user }}"
 SCHEMA_MOD="{{ emqx_schema_mod }}"
 IS_ENTERPRISE="{{ is_enterprise }}"
-
-export EMQX_DESCRIPTION='{{ emqx_description }}'
-
-## computed vars
+## Do not change EMQX_DEFAULT_ERLANG_COOKIE.
+## Configure EMQX_NODE_COOKIE instead
+EMQX_DEFAULT_ERLANG_COOKIE='{{ emqx_default_erlang_cookie }}'
 REL_NAME="emqx"
+export EMQX_DESCRIPTION='{{ emqx_description }}'
 
 ## updated vars here

--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -42,7 +42,7 @@ curl -L --silent --show-error \
      --output "${RELEASE_ASSET_FILE}" \
      "$DIRECT_DOWNLOAD_URL"
 
-unzip -q "$RELEASE_ASSET_FILE" -d "$DASHBOARD_PATH"
+unzip -o -q "$RELEASE_ASSET_FILE" -d "$DASHBOARD_PATH"
 rm -rf "$DASHBOARD_PATH/www"
 mv "$DASHBOARD_PATH/dist" "$DASHBOARD_PATH/www"
 rm -f "$RELEASE_ASSET_FILE"


### PR DESCRIPTION
```
$ env EMQX_NODE_COOKIE='' ./_build/emqx/rel/emqx/bin/emqx console
!!!!!!
WARNING: Default (insecure) Erlang cookie is in use.
WARNING: Configure node.cookie in /mnt/code/src/emqx/0/_build/emqx/rel/emqx/etc/emqx.conf or override from environment variable EMQX_NODE__COOKIE
NOTE: Use the same config value for all nodes in the cluster.
!!!!!!
log.file_handlers.default.enable = EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE = false
log.console_handler.enable = EMQX_LOG__CONSOLE_HANDLER__ENABLE = true
```