### PR TITLE
fix(retainer): fix that EMQX can't start when the retainer is disabled

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -7,6 +7,7 @@
 * Avoid publishing will message when client fails to auhtenticate. [#8887](https://github.com/emqx/emqx/pull/8887)
 * Speed up dispatching of shared subscription messages in a cluster [#8893](https://github.com/emqx/emqx/pull/8893)
 * Speed up updating the configuration, When some nodes in the cluster are down. [#8857](https://github.com/emqx/emqx/pull/8857)
+* Fix that EMQX can't start when the retainer is disabled [#8911](https://github.com/emqx/emqx/pull/8911)
 
 ## Enhancements
 

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.4"},
+    {vsn, "5.0.5"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -348,16 +348,12 @@ enable_retainer(
     #{context_id := ContextId} = State,
     #{
         msg_clear_interval := ClearInterval,
-        backend := BackendCfg,
-        flow_control := FlowControl
+        backend := BackendCfg
     }
 ) ->
     NewContextId = ContextId + 1,
     Context = create_resource(new_context(NewContextId), BackendCfg),
     load(Context),
-    emqx_limiter_server:add_bucket(
-        ?APP, internal, maps:get(batch_deliver_limiter, FlowControl, undefined)
-    ),
     State#{
         enable := true,
         context_id := NewContextId,
@@ -373,7 +369,6 @@ disable_retainer(
     } = State
 ) ->
     unload(),
-    emqx_limiter_server:del_bucket(?APP, internal),
     ok = close_resource(Context),
     State#{
         enable := false,


### PR DESCRIPTION

Reproduce steps:
1. Start an emqx and disable the Retainer
2. Restarting emqx will report the following error
<img width="1438" alt="image" src="https://user-images.githubusercontent.com/13825269/189092250-d0688a0c-e6e3-4c6f-bfef-ebfdb1b23827.png">