### PR TITLE
Add rule engine configuration option for changing the implementation of the jq function

### DIFF
--- a/apps/emqx_rule_engine/i18n/emqx_rule_engine_schema.conf
+++ b/apps/emqx_rule_engine/i18n/emqx_rule_engine_schema.conf
@@ -261,6 +261,17 @@ of the rule, then the string "undefined" is used.
       }
     }
 
+    rule_engine_jq_implementation_module {
+      desc {
+          en: "The implementation module for the jq rule engine function. The two options are jq_nif and jq_port. With the jq_nif option an Erlang NIF library is used while with the jq_port option an implementation based on Erlang port programs is used. The jq_nif option (the default option) is the fastest implementation of the two but jq_port is safer as the jq programs will not execute in the same process as the Erlang VM."
+          zh: "jq 规则引擎功能的实现模块。可用的两个选项是 jq_nif 和 jq_port。jq_nif 使用 Erlang NIF 库访问 jq 库，而 jq_port 使用基于 Erlang Port 的实现。jq_nif 方式（默认选项）是这两个选项中最快的实现，但 jq_port 方式更安全，因为这种情况下 jq 程序不会在 Erlang VM 进程中执行。"
+      }
+      label: {
+          en: "JQ Implementation Module"
+          zh: "JQ 实现模块"
+      }
+    }
+
     desc_rule_engine {
                    desc {
                          en: """Configuration for the EMQX Rule Engine."""

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.1"},
+    {vsn, "5.0.2"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -320,6 +320,10 @@ init([]) ->
         {write_concurrency, true},
         {read_concurrency, true}
     ]),
+    ok = emqx_config_handler:add_handler(
+        [rule_engine, jq_implementation_module],
+        emqx_rule_engine_schema
+    ),
     {ok, #{}}.
 
 handle_call({insert_rule, Rule}, _From, State) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -25,7 +25,8 @@
     namespace/0,
     roots/0,
     fields/1,
-    desc/1
+    desc/1,
+    post_config_update/5
 ]).
 
 -export([validate_sql/1]).
@@ -48,6 +49,15 @@ fields("rule_engine") ->
                 #{
                     default => "10s",
                     desc => ?DESC("rule_engine_jq_function_default_timeout")
+                }
+            )},
+        {jq_implementation_module,
+            ?HOCON(
+                hoconsc:enum([jq_nif, jq_port]),
+                #{
+                    default => jq_nif,
+                    mapping => "jq.jq_implementation_module",
+                    desc => ?DESC("rule_engine_jq_implementation_module")
                 }
             )}
     ];
@@ -209,3 +219,13 @@ validate_sql(Sql) ->
         {ok, _Result} -> ok;
         {error, Reason} -> {error, Reason}
     end.
+
+post_config_update(
+    [rule_engine, jq_implementation_module],
+    _Req,
+    NewSysConf,
+    _OldSysConf,
+    _AppEnvs
+) ->
+    jq:set_implementation_module(NewSysConf),
+    ok.

--- a/mix.exs
+++ b/mix.exs
@@ -616,7 +616,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.5", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.6", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -42,7 +42,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.16"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.5"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.6"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -263,3 +263,5 @@ hstreamdb
 SASL
 GSSAPI
 keytab
+jq
+nif


### PR DESCRIPTION
This commit adds a rule engine configuration option for changing the implementation module used for the rule engine function jq. The two options are `jq_port` (uses Erlang port programs to interact with jq) and `jq_nif` (uses an Erlang NIF library to interact with jq).

**Things needed before merge:**

* Chinese translation for the description of the config option
* Bump the jq library version after [this PR](https://github.com/emqx/jq/pull/36) has been merged (the config option has no effect before that PR)