### PR TITLE
fix(time): replace os:system_time with erlang:system_time

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -8,6 +8,7 @@
 * Speed up dispatching of shared subscription messages in a cluster [#8893](https://github.com/emqx/emqx/pull/8893)
 * Fix the extra / prefix when CoAP gateway parsing client topics. [#8658](https://github.com/emqx/emqx/pull/8658)
 * Speed up updating the configuration, When some nodes in the cluster are down. [#8857](https://github.com/emqx/emqx/pull/8857)
+* Fix delayed publish inaccurate caused by os time change. [#8926](https://github.com/emqx/emqx/pull/8926)
 
 ## Enhancements
 

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -399,7 +399,7 @@ do_verify(JWT, [JWK | More], VerifyClaims) ->
     end.
 
 verify_claims(Claims, VerifyClaims0) ->
-    Now = os:system_time(seconds),
+    Now = erlang:system_time(seconds),
     VerifyClaims =
         [
             {<<"exp">>, fun(ExpireTime) ->

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -296,7 +296,7 @@ handle_cast(Msg, State) ->
 
 %% Do Publish...
 handle_info({timeout, TRef, do_publish}, State = #{publish_timer := TRef}) ->
-    DeletedKeys = do_publish(mnesia:dirty_first(?TAB), os:system_time(seconds)),
+    DeletedKeys = do_publish(mnesia:dirty_first(?TAB), erlang:system_time(seconds)),
     lists:foreach(fun(Key) -> mria:dirty_delete(?TAB, Key) end, DeletedKeys),
     {noreply, ensure_publish_timer(State#{publish_timer := undefined, publish_at := 0})};
 handle_info(stats, State = #{stats_fun := StatsFun}) ->
@@ -347,12 +347,12 @@ ensure_publish_timer(State) ->
 ensure_publish_timer('$end_of_table', State) ->
     State#{publish_timer := undefined, publish_at := 0};
 ensure_publish_timer({Ts, _Id}, State = #{publish_timer := undefined}) ->
-    ensure_publish_timer(Ts, os:system_time(seconds), State);
+    ensure_publish_timer(Ts, erlang:system_time(seconds), State);
 ensure_publish_timer({Ts, _Id}, State = #{publish_timer := TRef, publish_at := PubAt}) when
     Ts < PubAt
 ->
     ok = emqx_misc:cancel_timer(TRef),
-    ensure_publish_timer(Ts, os:system_time(seconds), State);
+    ensure_publish_timer(Ts, erlang:system_time(seconds), State);
 ensure_publish_timer(_Key, State) ->
     State.
 

--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.3"},
+    {vsn, "5.0.4"},
     {modules, []},
     {applications, [kernel, stdlib, emqx]},
     {mod, {emqx_modules_app, []}},


### PR DESCRIPTION
Avoid the problem of inaccurate timers caused by mixing erlang:system_time/0-1 and os:system_time/0-1

---
port https://github.com/emqx/emqx/pull/8908