### PR TITLE
chore(mix): guard enterprise-only dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,22 +44,6 @@ all: $(REBAR) $(PROFILES)
 ensure-rebar3:
 	@$(SCRIPTS)/ensure-rebar3.sh
 
-.PHONY: ensure-hex
-ensure-hex:
-	@mix local.hex --if-missing --force
-
-.PHONY: ensure-mix-rebar3
-ensure-mix-rebar3: $(REBAR)
-	@mix local.rebar rebar3 $(CURDIR)/rebar3 --if-missing --force
-
-.PHONY: ensure-mix-rebar
-ensure-mix-rebar: $(REBAR)
-	@mix local.rebar --if-missing --force
-
-.PHONY: mix-deps-get
-mix-deps-get: $(ELIXIR_COMMON_DEPS)
-	@mix deps.get
-
 $(REBAR): prepare ensure-rebar3
 
 .PHONY: eunit
@@ -115,8 +99,6 @@ coveralls: $(REBAR)
 	@ENABLE_COVER_COMPILE=1 $(REBAR) as test coveralls send
 
 COMMON_DEPS := $(REBAR)
-
-ELIXIR_COMMON_DEPS := ensure-hex ensure-mix-rebar3 ensure-mix-rebar
 
 .PHONY: $(REL_PROFILES)
 $(REL_PROFILES:%=%): $(COMMON_DEPS)
@@ -226,13 +208,13 @@ conf-segs:
 
 ## elixir target is to create release packages using Elixir's Mix
 .PHONY: $(REL_PROFILES:%=%-elixir) $(PKG_PROFILES:%=%-elixir)
-$(REL_PROFILES:%=%-elixir) $(PKG_PROFILES:%=%-elixir): $(COMMON_DEPS) $(ELIXIR_COMMON_DEPS) mix-deps-get
+$(REL_PROFILES:%=%-elixir) $(PKG_PROFILES:%=%-elixir): $(COMMON_DEPS)
 	@env IS_ELIXIR=yes $(BUILD) $(subst -elixir,,$(@)) elixir
 
 .PHONY: $(REL_PROFILES:%=%-elixir-pkg)
 define gen-elixir-pkg-target
 # the Elixir places the tar in a different path than Rebar3
-$1-elixir-pkg: $(COMMON_DEPS) $(ELIXIR_COMMON_DEPS) mix-deps-get
+$1-elixir-pkg: $(COMMON_DEPS)
 	@env TAR_PKG_DIR=_build/$1-pkg \
 	     IS_ELIXIR=yes \
 	     $(BUILD) $1-pkg pkg
@@ -241,7 +223,7 @@ $(foreach pt,$(REL_PROFILES),$(eval $(call gen-elixir-pkg-target,$(pt))))
 
 .PHONY: $(REL_PROFILES:%=%-elixir-tgz)
 define gen-elixir-tgz-target
-$1-elixir-tgz: $(COMMON_DEPS) $(ELIXIR_COMMON_DEPS) mix-deps-get
+$1-elixir-tgz: $(COMMON_DEPS)
 	@env IS_ELIXIR=yes $(BUILD) $1 tgz
 endef
 ALL_ELIXIR_TGZS = $(REL_PROFILES)

--- a/build
+++ b/build
@@ -147,6 +147,12 @@ make_rel() {
 make_elixir_rel() {
   ./scripts/pre-compile.sh "$PROFILE"
   export_release_vars "$PROFILE"
+  # for some reason, this has to be run outside "do"...
+  mix local.rebar --if-missing --force
+  # shellcheck disable=SC1010
+  mix do local.hex --if-missing --force, \
+      local.rebar rebar3 "${PWD}/rebar3" --if-missing --force, \
+      deps.get
   mix release --overwrite
   assert_no_compile_time_only_deps
 }

--- a/mix.exs
+++ b/mix.exs
@@ -88,11 +88,11 @@ defmodule EMQXUmbrella.MixProject do
       {:ranch,
        github: "ninenines/ranch", ref: "a692f44567034dacf5efcaa24a24183788594eb7", override: true},
       # in conflict by grpc and eetcd
-      {:gpb, "4.11.2", override: true, runtime: false},
-      {:hstreamdb_erl, github: "hstreamdb/hstreamdb_erl", tag: "0.2.5"},
-      {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.3", override: true}
+      {:gpb, "4.11.2", override: true, runtime: false}
     ] ++
-      umbrella_apps() ++ enterprise_apps(profile_info) ++ bcrypt_dep() ++ jq_dep() ++ quicer_dep()
+      umbrella_apps() ++
+      enterprise_apps(profile_info) ++
+      enterprise_deps(profile_info) ++ bcrypt_dep() ++ jq_dep() ++ quicer_dep()
   end
 
   defp umbrella_apps() do
@@ -123,6 +123,17 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   defp enterprise_apps(_profile_info) do
+    []
+  end
+
+  defp enterprise_deps(_profile_info = %{edition_type: :enterprise}) do
+    [
+      {:hstreamdb_erl, github: "hstreamdb/hstreamdb_erl", tag: "0.2.5"},
+      {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.3", override: true}
+    ]
+  end
+
+  defp enterprise_deps(_profile_info) do
     []
   end
 


### PR DESCRIPTION
Avoid downloading enterprise-only dependencies in community edition.

