### PR TITLE
feat: don't include emqx-entriprise.conf in opensource

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -373,9 +373,9 @@ defmodule EMQXUmbrella.MixProject do
 
     if edition_type == :enterprise do
       render_template(
-        "apps/emqx_conf/etc/emqx_enterprise.conf.all",
+        "apps/emqx_conf/etc/emqx-enterprise.conf.all",
         assigns,
-        Path.join(etc, "emqx_enterprise.conf")
+        Path.join(etc, "emqx-enterprise.conf")
       )
     end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -477,7 +477,7 @@ emqx_etc_overlay_per_edition(ce) ->
     ];
 emqx_etc_overlay_per_edition(ee) ->
     [
-        {"{{base_dir}}/lib/emqx_conf/etc/emqx_enterprise.conf.all", "etc/emqx_enterprise.conf"},
+        {"{{base_dir}}/lib/emqx_conf/etc/emqx-enterprise.conf.all", "etc/emqx-enterprise.conf"},
         {"{{base_dir}}/lib/emqx_conf/etc/emqx.conf.all", "etc/emqx.conf"}
     ].
 

--- a/scripts/merge-config.escript
+++ b/scripts/merge-config.escript
@@ -12,22 +12,25 @@
 -define(APPS, ["emqx", "emqx_dashboard", "emqx_authz"]).
 
 main(_) ->
+    Profile = os:getenv("PROFILE", "emqx"),
     {ok, BaseConf} = file:read_file("apps/emqx_conf/etc/emqx_conf.conf"),
-
     Cfgs = get_all_cfgs("apps/"),
+    Enterprise =
+        case Profile of
+            "emqx" -> [];
+            "emqx-enterprise" -> [io_lib:nl(), "include emqx-enterprise.conf", io_lib:nl()]
+        end,
     Conf = [
         merge(BaseConf, Cfgs),
         io_lib:nl(),
-        io_lib:nl(),
-        "include emqx_enterprise.conf",
-        io_lib:nl()
+        Enterprise
     ],
     ok = file:write_file("apps/emqx_conf/etc/emqx.conf.all", Conf),
 
     EnterpriseCfgs = get_all_cfgs("lib-ee/"),
     EnterpriseConf = merge("", EnterpriseCfgs),
 
-    ok = file:write_file("apps/emqx_conf/etc/emqx_enterprise.conf.all", EnterpriseConf).
+    ok = file:write_file("apps/emqx_conf/etc/emqx-enterprise.conf.all", EnterpriseConf).
 
 merge(BaseConf, Cfgs) ->
     lists:foldl(


### PR DESCRIPTION
- Rename `emqx_enterprise.conf` to `emqx-enterprise.conf`.
- Only append `include emqx-enterprise.conf` in enterprise's `emqx.conf`.