### PR TITLE
Fix mqtt bridge hangs on msg sending

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -208,8 +208,8 @@ info_example_basic(webhook) ->
             auto_restart_interval => 15000,
             query_mode => async,
             async_inflight_window => 100,
-            enable_queue => true,
-            max_queue_bytes => 1024 * 1024 * 1024
+            enable_queue => false,
+            max_queue_bytes => 100 * 1024 * 1024
         }
     };
 info_example_basic(mqtt) ->

--- a/apps/emqx_connector/src/emqx_connector_mqtt.erl
+++ b/apps/emqx_connector/src/emqx_connector_mqtt.erl
@@ -187,8 +187,7 @@ on_stop(_InstId, #{name := InstanceId}) ->
 
 on_query(_InstId, {send_message, Msg}, #{name := InstanceId}) ->
     ?TRACE("QUERY", "send_msg_to_remote_node", #{message => Msg, connector => InstanceId}),
-    emqx_connector_mqtt_worker:send_to_remote(InstanceId, Msg),
-    ok.
+    emqx_connector_mqtt_worker:send_to_remote(InstanceId, Msg).
 
 on_query_async(
     _InstId,
@@ -197,8 +196,7 @@ on_query_async(
     #{name := InstanceId}
 ) ->
     ?TRACE("QUERY", "async_send_msg_to_remote_node", #{message => Msg, connector => InstanceId}),
-    emqx_connector_mqtt_worker:send_to_remote_async(InstanceId, Msg, {ReplayFun, Args}),
-    ok.
+    emqx_connector_mqtt_worker:send_to_remote_async(InstanceId, Msg, {ReplayFun, Args}).
 
 on_get_status(_InstId, #{name := InstanceId, bridge_conf := Conf}) ->
     AutoReconn = maps:get(auto_reconnect, Conf, true),

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
@@ -276,7 +276,7 @@ idle({call, From}, ensure_started, State) ->
         {error, Reason, _State} ->
             {keep_state_and_data, [{reply, From, {error, Reason}}]}
     end;
-idle({call, From}, send_to_remote, _State) ->
+idle({call, From}, {send_to_remote, _}, _State) ->
     {keep_state_and_data, [{reply, From, {error, {recoverable_error, not_connected}}}]};
 %% @doc Standing by for manual start.
 idle(info, idle, #{start_type := manual}) ->
@@ -342,7 +342,7 @@ common(_StateName, {call, From}, get_forwards, #{connect_opts := #{forwards := F
 common(_StateName, {call, From}, get_subscriptions, #{connection := Connection}) ->
     {keep_state_and_data, [{reply, From, maps:get(subscriptions, Connection, #{})}]};
 common(_StateName, {call, From}, Req, _State) ->
-    {keep_state_and_data, [{reply, From, {error, {unsuppored_request, Req}}}]};
+    {keep_state_and_data, [{reply, From, {error, {unsupported_request, Req}}}]};
 common(_StateName, info, {'EXIT', _, _}, State) ->
     {keep_state, State};
 common(StateName, Type, Content, #{name := Name} = State) ->

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
@@ -342,7 +342,7 @@ common(_StateName, {call, From}, get_forwards, #{connect_opts := #{forwards := F
 common(_StateName, {call, From}, get_subscriptions, #{connection := Connection}) ->
     {keep_state_and_data, [{reply, From, maps:get(subscriptions, Connection, #{})}]};
 common(_StateName, {call, From}, Req, _State) ->
-    {keep_state_and_data, [{reply, From, {unsuppored_request, Req}}]};
+    {keep_state_and_data, [{reply, From, {error, {unsuppored_request, Req}}}]};
 common(_StateName, info, {'EXIT', _, _}, State) ->
     {keep_state, State};
 common(StateName, Type, Content, #{name := Name} = State) ->

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -84,15 +84,15 @@
 -define(DEFAULT_QUEUE_SEG_SIZE, 10 * 1024 * 1024).
 -define(DEFAULT_QUEUE_SEG_SIZE_RAW, <<"10MB">>).
 
--define(DEFAULT_QUEUE_SIZE, 100 * 1024 * 1024 * 1024).
--define(DEFAULT_QUEUE_SIZE_RAW, <<"100GB">>).
+-define(DEFAULT_QUEUE_SIZE, 100 * 1024 * 1024).
+-define(DEFAULT_QUEUE_SIZE_RAW, <<"100MB">>).
 
 %% count
 -define(DEFAULT_BATCH_SIZE, 100).
 
 %% milliseconds
--define(DEFAULT_BATCH_TIME, 10).
--define(DEFAULT_BATCH_TIME_RAW, <<"10ms">>).
+-define(DEFAULT_BATCH_TIME, 20).
+-define(DEFAULT_BATCH_TIME_RAW, <<"20ms">>).
 
 %% count
 -define(DEFAULT_INFLIGHT, 100).

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -525,7 +525,7 @@ handle_connecting_health_check(Data) ->
             (connected, UpdatedData) ->
                 {next_state, connected, UpdatedData};
             (connecting, UpdatedData) ->
-                Actions = [{state_timeout, ?HEALTHCHECK_INTERVAL, health_check}],
+                Actions = [{state_timeout, health_check_interval(Data#data.opts), health_check}],
                 {keep_state, UpdatedData, Actions};
             (disconnected, UpdatedData) ->
                 {next_state, disconnected, UpdatedData}

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -467,11 +467,11 @@ retry_actions(Data) ->
 
 handle_remove_event(From, ClearMetrics, Data) ->
     stop_resource(Data),
+    ok = emqx_resource_worker_sup:stop_workers(Data#data.id, Data#data.opts),
     case ClearMetrics of
         true -> ok = emqx_metrics_worker:clear_metrics(?RES_METRICS, Data#data.id);
         false -> ok
     end,
-    ok = emqx_resource_worker_sup:stop_workers(Data#data.id, Data#data.opts),
     {stop_and_reply, normal, [{reply, From, ok}]}.
 
 start_resource(Data, From) ->

--- a/apps/emqx_resource/src/emqx_resource_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_worker.erl
@@ -133,6 +133,7 @@ init({Id, Index, Opts}) ->
         end,
     emqx_metrics_worker:inc(?RES_METRICS, Id, 'queuing', queue_count(Queue)),
     ok = inflight_new(Name),
+    HCItvl = maps:get(health_check_interval, Opts, ?HEALTHCHECK_INTERVAL),
     St = #{
         id => Id,
         index => Index,
@@ -142,7 +143,7 @@ init({Id, Index, Opts}) ->
         batch_size => BatchSize,
         batch_time => maps:get(batch_time, Opts, ?DEFAULT_BATCH_TIME),
         queue => Queue,
-        resume_interval => maps:get(resume_interval, Opts, ?HEALTHCHECK_INTERVAL),
+        resume_interval => maps:get(resume_interval, Opts, HCItvl),
         acc => [],
         acc_left => BatchSize,
         tref => undefined

--- a/apps/emqx_resource/src/emqx_resource_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_worker.erl
@@ -585,7 +585,12 @@ assert_ok_result(ok) ->
 assert_ok_result({async_return, R}) ->
     assert_ok_result(R);
 assert_ok_result(R) when is_tuple(R) ->
-    ok = erlang:element(1, R);
+    try
+        ok = erlang:element(1, R)
+    catch
+        error:{badmatch, _} ->
+            error({not_ok_result, R})
+    end;
 assert_ok_result(R) ->
     error({not_ok_result, R}).
 

--- a/apps/emqx_resource/src/schema/emqx_resource_schema.erl
+++ b/apps/emqx_resource/src/schema/emqx_resource_schema.erl
@@ -82,7 +82,7 @@ query_mode(_) -> undefined.
 
 enable_batch(type) -> boolean();
 enable_batch(required) -> false;
-enable_batch(default) -> false;
+enable_batch(default) -> true;
 enable_batch(desc) -> ?DESC("enable_batch");
 enable_batch(_) -> undefined.
 

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_influxdb.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_influxdb.erl
@@ -93,8 +93,8 @@ values(common, Protocol, SupportUint, TypeOpts) ->
         precision => ms,
         resource_opts => #{
             enable_batch => false,
-            batch_size => 5,
-            batch_time => <<"1m">>
+            batch_size => 100,
+            batch_time => <<"20ms">>
         },
         server => <<"127.0.0.1:8086">>,
         ssl => #{enable => false}

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
@@ -58,7 +58,7 @@ values(post) ->
             worker_pool_size => 1,
             health_check_interval => ?HEALTHCHECK_INTERVAL_RAW,
             auto_restart_interval => ?AUTO_RESTART_INTERVAL_RAW,
-            enable_batch => false,
+            enable_batch => true,
             batch_size => ?DEFAULT_BATCH_SIZE,
             batch_time => ?DEFAULT_BATCH_TIME,
             query_mode => async,


### PR DESCRIPTION
1. setup an egress MQTT Bridge on local broker B, to a remote broker A.
2. restart the remote broker A.
3. send message to the MQTT Bridge.
4. the bridge hangs, all messages will be queued in the mailbox of `emqx_resource_worker`.

```
ee-5.0.0-beta.3-g477d4b0b(emqx@127.0.0.1)57> process_info(<0.3403.0>).
[{registered_name,'emqx_resource_worker:bridge:mqtt:mqtt_example:1'},
 {current_function,{gen,do_call,4}},
 {initial_call,{proc_lib,init_p,5}},
 {status,waiting},
 {message_queue_len,205},
 {links,[<0.2411.0>]},
 {dictionary,[{'$initial_call',{emqx_resource_worker,init,1}},
              {'$ancestors',[emqx_resource_worker_sup,emqx_resource_sup,
                             <0.2407.0>]}]},
 {trap_exit,true},
 {error_handler,error_handler},
 {priority,normal},
 {group_leader,<0.2406.0>},
 {total_heap_size,17731},
 {heap_size,17731},
 {stack_size,42},
 {reductions,42154},
 {garbage_collection,[{max_heap_size,#{error_logger => true,kill => true,size => 0}},
                      {min_bin_vheap_size,46422},
                      {min_heap_size,233},
                      {fullsweep_after,1000},
                      {minor_gcs,0}]},
 {suspending,[]}]
ee-5.0.0-beta.3-g477d4b0b(emqx@127.0.0.1)58> process_info(<0.3403.0>, monitors).
{monitors,[{process,<0.5527.0>}]}
ee-5.0.0-beta.3-g477d4b0b(emqx@127.0.0.1)59> process_info(<0.5527.0>).
[{registered_name,'bridge:mqtt:mqtt_example:44'},
 {current_function,{gen_statem,loop_receive,3}},
 {initial_call,{proc_lib,init_p,5}},
 {status,waiting},
 {message_queue_len,0},
 {links,[<0.2442.0>]},
 {dictionary,
     [{'$initial_call',{emqx_connector_mqtt_worker,init,1}},
      {'$ancestors',
          [emqx_connector_mqtt,emqx_connector_sup,<0.2440.0>]}]},
 {trap_exit,true},
 {error_handler,error_handler},
 {priority,normal},
 {group_leader,<0.2439.0>},
 {total_heap_size,610},
 {heap_size,610},
 {stack_size,11},
 {reductions,36330},
 {garbage_collection,
     [{max_heap_size,
          #{error_logger => true,kill => true,size => 0}},
      {min_bin_vheap_size,46422},
      {min_heap_size,233},
      {fullsweep_after,1000},
      {minor_gcs,0}]},
 {suspending,[]}]
``` 