### PR TITLE
build: do not skip downloading relup base package

### DIFF
--- a/scripts/relup-base-packages.sh
+++ b/scripts/relup-base-packages.sh
@@ -57,15 +57,17 @@ for tag in $(../scripts/relup-base-vsns.sh $EDITION | xargs echo -n); do
     filename="$PROFILE-$SYSTEM-${tag#[e|v]}-$ARCH.zip"
     url="https://packages.emqx.io/$DIR/$tag/$filename"
     echo "downloading base package from ${url} ..."
-    if [ ! -f "$filename" ] && curl -L -I -m 10 -o /dev/null -s -w "%{http_code}" "${url}" | grep -q -oE "^[23]+" ; then
-        curl -L -o "${filename}" "${url}"
-        if [ "$SYSTEM" != "centos6" ]; then
-            curl -L -o "${filename}.sha256" "${url}.sha256"
-            SUMSTR=$(cat "${filename}.sha256")
-            echo "got sha265sum: ${SUMSTR}"
-            ## https://askubuntu.com/questions/1202208/checking-sha256-checksum
-            echo "${SUMSTR}  ${filename}" | $SHASUM -c || exit 1
-        fi
+    if [ -f "$filename" ]; then
+        echo "file $filename already downloaded; skikpped"
+        continue
+    fi
+    curl -L -o "${filename}" "${url}"
+    if [ "$SYSTEM" != "centos6" ]; then
+        curl -L -o "${filename}.sha256" "${url}.sha256"
+        SUMSTR=$(cat "${filename}.sha256")
+        echo "got sha265sum: ${SUMSTR}"
+        ## https://askubuntu.com/questions/1202208/checking-sha256-checksum
+        echo "${SUMSTR}  ${filename}" | $SHASUM -c || exit 1
     fi
 done
 

--- a/scripts/relup-base-vsns.sh
+++ b/scripts/relup-base-vsns.sh
@@ -58,7 +58,13 @@ case "${EDITION}" in
         ;;
 esac
 
+SYSTEM="${SYSTEM:-$(./scripts/get-distro.sh)}"
+
 while read -r git_tag; do
+    if [ "$SYSTEM" = 'centos8' ] && [ "$git_tag" = 'v4.3.13' ]; then
+        # This version for centos8 was broken and deleted from archive
+        continue
+    fi
     # shellcheck disable=SC2207
     semver=($(parse_semver "$git_tag"))
     if [ "${#semver[@]}" -eq 3 ] && [ "${semver[2]}" -le "${CUR_SEMVER[2]}" ]; then


### PR DESCRIPTION
do not skip downloading only because of curl error.
for known missing base packages, we should list them in the script

