### PR TITLE
ci: enable running test cases and cover for main-v4.x

### DIFF
--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -59,7 +59,7 @@ jobs:
       with:
         name: rebar3.crashdump
         path: ./rebar3.crashdump
-    - name: pakcages test
+    - name: packages test
       run: |
         export CODE_PATH=$GITHUB_WORKSPACE
         .ci/build_packages/tests.sh

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -5,6 +5,8 @@ on:
     tags:
       - v*
       - e*
+    branches:
+      - 'main-v4.?'
   pull_request:
 
 jobs:
@@ -26,6 +28,7 @@ jobs:
     run_common_test:
         runs-on: ${{ matrix.runs-on }}
         strategy:
+          fail-fast: false
           matrix:
             runs-on:
               - aws-amd64
@@ -110,6 +113,7 @@ jobs:
         - name: run cover
           run: |
             printenv > .env
+            docker exec -i erlang bash -c "git config --global --add safe.directory /emqx"
             docker exec -i erlang bash -c "make cover"
             docker exec --env-file .env -i erlang bash -c "make coveralls"
         - name: cat rebar.crashdump

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -103,7 +103,7 @@ plugins(HasElixir) ->
 
 test_plugins() ->
     [ rebar3_proper,
-      {coveralls, {git, "https://github.com/emqx/coveralls-erl", {branch, "fix-git-info"}}}
+      {coveralls, {git, "https://github.com/emqx/coveralls-erl", {tag, "v2.2.0-emqx-1"}}}
     ].
 
 test_deps() ->


### PR DESCRIPTION
An attempt to make Coveralls bot to identify and report coverage
changes in `main-v4.{3,4}`-based PRs.

Currently, `master`-based PRs get their reports correctly.  When one
checks such a report, e.g.: https://coveralls.io/builds/52535695 , it
identifies if coverage increased or decreased relative to the base
branch.

`main-v4.x`-based PRs, however, always seem to report as "first
builds", so it doesn't report if coverage increased or
decreased. E.g.: https://coveralls.io/builds/52541065 .

The reason _could be_ that, currently, `main-v4.x` branches do not
build themselves.  That is, PRs run the test + cover analysis, as
usual, but once they're merged, tests (and thus coverage analysis) do
not run.  And that _could be_ why the tool can't see if coverage
increased or decreased with such PR.
