### PR TITLE
test: avoid inter-suite flakiness

### DIFF
--- a/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl
+++ b/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl
@@ -52,10 +52,14 @@ all() ->
 init_per_suite(Cfg) ->
     emqx_ct_helpers:start_apps([emqx_auth_mongo], fun set_special_confs/1),
     init_mongo_data(),
+    %% avoid inter-suite flakiness
+    ok = emqx_mod_acl_internal:unload([]),
     Cfg.
 
 end_per_suite(_Cfg) ->
     deinit_mongo_data(),
+    %% avoid inter-suite flakiness
+    ok = emqx_mod_acl_internal:load([]),
     emqx_ct_helpers:stop_apps([emqx_auth_mongo]).
 
 set_special_confs(emqx) ->


### PR DESCRIPTION
This test runs most of the time fine in CI.  But, if run alone locally, will fail consistently because the default `acl.conf` has a catch-all `{allow, all}` clause.  Probably another suite that runs before this in CI unloads that and everything seems fine.

