### PR TITLE
chore: use `:rebar3` as `:gpb`'s manager

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -88,7 +88,7 @@ defmodule EMQXUmbrella.MixProject do
       {:ranch,
        github: "ninenines/ranch", ref: "a692f44567034dacf5efcaa24a24183788594eb7", override: true},
       # in conflict by grpc and eetcd
-      {:gpb, "4.11.2", override: true, runtime: false}
+      {:gpb, "4.19.5", override: true, runtime: false}
     ] ++
       umbrella_apps() ++ enterprise_apps(profile_info) ++ bcrypt_dep() ++ jq_dep() ++ quicer_dep()
   end

--- a/rebar.config
+++ b/rebar.config
@@ -46,7 +46,7 @@
 {deps,
     [ {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.1"}}}
     , {redbug, "2.0.7"}
-    , {gpb, "4.11.2"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
+    , {gpb, "4.19.5"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
     , {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}}
     , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.7"}}}
     , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.3.0"}}}


### PR DESCRIPTION
```
dependency :gpb is using Rebar 2, which is no longer maintained and no longer works in recent Erlang/OTP versions. Remove the :manager option or set it to :rebar3 instead
```

