### PR TITLE
fix: /listeners API crash when there are nodes still in initial conf

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -7,6 +7,7 @@
 ## Bug fixes
 
 * Check ACLs for last will testament topic before publishing the message. [#8930](https://github.com/emqx/emqx/pull/8930)
+* Fix GET /listeners API crash When some nodes still in initial configuration. [#9002](https://github.com/emqx/emqx/pull/9002)
 
 # 5.0.8
 

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -632,13 +632,13 @@ setup_node(Node, Opts) when is_map(Opts) ->
     %% Here we start the apps
     EnvHandlerForRpc =
         fun(App) ->
-            %% We load configuration, and than set the special enviroment variable
+            %% We load configuration, and than set the special environment variable
             %% which says that emqx shouldn't load configuration at startup
-            %% Otherwise, configuration get's loaded and all preset env in envhandler is lost
+            %% Otherwise, configuration gets loaded and all preset env in EnvHandler is lost
             LoadSchema andalso
                 begin
                     emqx_config:init_load(SchemaMod),
-                    application:set_env(emqx, init_config_load_done, true)
+                    application:set_env(emqx, init_config_load_done, false)
                 end,
 
             %% Need to set this otherwise listeners will conflict between each other

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -638,7 +638,7 @@ setup_node(Node, Opts) when is_map(Opts) ->
             LoadSchema andalso
                 begin
                     emqx_config:init_load(SchemaMod),
-                    application:set_env(emqx, init_config_load_done, false)
+                    application:set_env(emqx, init_config_load_done, true)
                 end,
 
             %% Need to set this otherwise listeners will conflict between each other

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -155,7 +155,13 @@ copy_override_conf_from_core_node() ->
                     ?SLOG(debug, #{
                         msg => "copy_overide_conf_from_core_node_success",
                         node => Node,
-                        envs => application:get_all_env(emqx)
+                        cluster_override_conf_file => application:get_env(
+                            emqx, cluster_override_conf_file
+                        ),
+                        local_override_conf_file => application:get_env(
+                            emqx, local_override_conf_file
+                        ),
+                        data_dir => emqx:data_dir()
                     }),
                     ok = emqx_config:save_to_override_conf(
                         RawOverrideConf,

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -152,11 +152,11 @@ copy_override_conf_from_core_node() ->
                 _ ->
                     [{ok, Info} | _] = lists:sort(fun conf_sort/2, Ready),
                     #{node := Node, conf := RawOverrideConf, tnx_id := TnxId} = Info,
-                    Msg = #{
+                    ?SLOG(debug, #{
                         msg => "copy_overide_conf_from_core_node_success",
-                        node => Node
-                    },
-                    ?SLOG(debug, Msg),
+                        node => Node,
+                        envs => application:get_all_env(emqx)
+                    }),
                     ok = emqx_config:save_to_override_conf(
                         RawOverrideConf,
                         #{override_to => cluster}


### PR DESCRIPTION

Fix GET /listeners API crashes when some nodes are still in init configuration.
```
{"code":"INTERNAL_ERROR","message":"error, {badmatch,{error,{'EXIT',{{badkey,<<\"listeners\">>},
[{erlang,map_get,[<<\"listeners\">>,#{}],[{error_info,#{module => erl_erts_errors}}]},{emqx_config,get_schema_mod,1,
[{file,\"emqx_config.erl\"},{line,505}]},{emqx_listeners,do_list_raw,0,[{file,\"emqx_listeners.erl\"},{line,92}]},
{emqx_listeners,list_raw,0,[{file,\"emqx_listeners.erl\"},{line,71}]},{emqx_mgmt_api_listeners,do_list_listeners,0,
[{file,\"emqx_mgmt_api_listeners.erl\"},{line,519}]}]}}}}, [{emqx_mgmt_api_listeners,listener_status_by_id,2,
[{file,\"emqx_mgmt_api_listeners.erl\"},{line,496}]},{emqx_mgmt_api_listeners,listener_status_by_id,1,
[{file,\"emqx_mgmt_api_listeners.erl\"},{line,472}]},{emqx_mgmt_api_listeners,list_listeners,2,
[{file,\"emqx_mgmt_api_listeners.erl\"},{line,342}]},{minirest_handler,apply_callback,3,[{file,\"minirest_handler.erl\"},
{line,111}]},{minirest_handler,handle,2,[{file,\"minirest_handler.erl\"},{line,44}]},{minirest_handler,init,2,
[{file,\"minirest_handler.erl\"},{line,27}]},{cowboy_handler,execute,2,[{file,\"cowboy_handler.erl\"},{line,41}]},
{cowboy_stream_h,execute,3,[{file,\"cowboy_stream_h.erl\"},{line,318}]},{cowboy_stream_h,request_process,3,
[{file,\"cowboy_stream_h.erl\"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,226}]}]"}
```