### PR TITLE
perf(TLS): set default sndbuf and recbuf to 4K

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -15,7 +15,9 @@ File format:
 
 - TLS listener memory usage optimization
   new option 'hibernate_after' to hibernate TLS process after idling
-
+- TLS listener default buffer size to 4KB
+  Eliminate uncertainty that the buffer size is set by OS default
+  
 ## v4.3.20
 
 ### Bug fixes

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1609,14 +1609,14 @@ listener.ssl.external.ciphers = TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TL
 ## See: listener.tcp.$name.recbuf
 ##
 ## Value: Bytes
-## listener.ssl.external.recbuf = 4KB
+listener.ssl.external.recbuf = 4KB
 
 ## The TCP send buffer(os kernel) for internal MQTT connections.
 ##
 ## See: listener.tcp.$name.sndbuf
 ##
 ## Value: Bytes
-## listener.ssl.external.sndbuf = 4KB
+listener.ssl.external.sndbuf = 4KB
 
 ## The size of the user-level software buffer used by the driver.
 ##


### PR DESCRIPTION
Without using default values, sockets will be opened with OS default buffer sizes. OS default is set by linux aligning to the host memory size that large memory has larger OS default.

Now more and more user run EMQX in container which has large OS memory but the container max memory is limited by cgroup that could be very small amount compared to the OS total memory size.

To eliminate uncertainty, it is better to have the default value set.

