### PR TITLE
build: fix git diff exclude pattern in app version check script

### DIFF
--- a/scripts/check-apps-vsn.sh
+++ b/scripts/check-apps-vsn.sh
@@ -42,7 +42,7 @@ check_apps() {
     if [ "$old_app_version" = "$now_app_version" ]; then
         changed_lines="$(git diff "$latest_release"...HEAD --ignore-blank-lines -G "$no_comment_re" \
                              -- "$app_path/src" \
-                             -- ":(exclude)'$app_path/src/*.appup.src'" \
+                             -- ":(exclude)$app_path/src/*.appup.src" \
                              -- "$app_path/priv" \
                              -- "$app_path/c_src" | wc -l ) "
         if [ "$changed_lines" -gt 0 ]; then


### PR DESCRIPTION
This quote in 4.3 seem to have already been changed to a double quote.
But that change was maybe lost during conflict resolution.