### PR TITLE
feat: change log.handlers default enable

### DIFF
--- a/apps/emqx/src/config/emqx_config_logger.erl
+++ b/apps/emqx/src/config/emqx_config_logger.erl
@@ -20,6 +20,7 @@
 %% API
 -export([add_handler/0, remove_handler/0, refresh_config/0]).
 -export([post_config_update/5]).
+-include("logger.hrl").
 
 -define(LOG, [log]).
 
@@ -67,7 +68,18 @@ update_log_handlers(NewHandlers) ->
     ),
     lists:foreach(
         fun({handler, HandlerId, Mod, Conf}) ->
-            logger:add_handler(HandlerId, Mod, Conf)
+            case logger:add_handler(HandlerId, Mod, Conf) of
+                ok ->
+                    ok;
+                {error, Reason} ->
+                    ?SLOG(error, #{
+                        msg => "add_logger_handler_failed",
+                        handler_id => HandlerId,
+                        module => Mod,
+                        config => Conf,
+                        reason => Reason
+                    })
+            end
         end,
         NewHandlers -- OldHandlers
     ),

--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -15,7 +15,13 @@ node {
 }
 
 log {
+  console_handler {
+    level = warning
+  }
   file_handlers.default {
+## It is enabled by default via ENV when starting with daemon(./bin/emqx start).
+## Uncomment if you want to log to file.
+  # enable = true
     level = warning
     file = "{{ platform_log_dir }}/emqx.log"
   }

--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -19,7 +19,7 @@ log {
     level = warning
   }
   file_handlers.default {
-## It is enabled by default via ENV when starting with daemon(./bin/emqx start).
+## It is disabled by default, but turned on via ENV variable when starting in daemon mode (./bin/emqx start).
 ## Uncomment if you want to log to file.
   # enable = true
     level = warning

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1109,7 +1109,8 @@ tr_logger(Conf) ->
     FileHandlers =
         [
             begin
-                {handler, to_atom(HandlerName), logger_disk_log_h, #{
+                HandlerName = to_atom(<<"file_for_", HandlerNameBin/binary>>),
+                {handler, HandlerName, logger_disk_log_h, #{
                     level => conf_get("level", SubConf),
                     config => (log_handler_conf(SubConf))#{
                         type =>
@@ -1126,9 +1127,9 @@ tr_logger(Conf) ->
                     filesync_repeat_interval => no_repeat
                 }}
             end
-         || {HandlerName, SubConf} <- logger_file_handlers(Conf)
+         || {HandlerNameBin, SubConf} <- logger_file_handlers(Conf)
         ],
-    [{handler, default, undefined}] ++ ConsoleHandler ++ FileHandlers.
+    ConsoleHandler ++ FileHandlers.
 
 log_handler_common_confs(Enable) ->
     [

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -841,7 +841,7 @@ fields("log") ->
             )}
     ];
 fields("console_handler") ->
-    log_handler_common_confs(false);
+    log_handler_common_confs(true);
 fields("log_file_handler") ->
     [
         {"file",
@@ -865,7 +865,7 @@ fields("log_file_handler") ->
                     desc => ?DESC("log_file_handler_max_size")
                 }
             )}
-    ] ++ log_handler_common_confs(true);
+    ] ++ log_handler_common_confs(false);
 fields("log_rotation") ->
     [
         {"enable",

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -97,7 +97,7 @@ t_log(_Config) ->
     Log1 = emqx_map_lib:deep_put([<<"file_handlers">>, <<"default">>, <<"enable">>], Log, true),
     Log2 = emqx_map_lib:deep_put([<<"file_handlers">>, <<"default">>, <<"file">>], Log1, File),
     {ok, #{}} = update_config(<<"log">>, Log2),
-    {ok, Log3} = logger:get_handler_config(default),
+    {ok, Log3} = logger:get_handler_config(file_for_default),
     ?assertMatch(#{config := #{file := File}}, Log3),
     ErrLog1 = emqx_map_lib:deep_put([<<"file_handlers">>, <<"default">>, <<"enable">>], Log, 1),
     ?assertMatch({error, {"HTTP/1.1", 400, _}}, update_config(<<"log">>, ErrLog1)),
@@ -110,13 +110,13 @@ t_log(_Config) ->
     NewLog1 = emqx_map_lib:deep_put([<<"file_handlers">>, <<"new">>], Log2, Handler),
     NewLog2 = emqx_map_lib:deep_put([<<"file_handlers">>, <<"new">>, <<"file">>], NewLog1, File1),
     {ok, #{}} = update_config(<<"log">>, NewLog2),
-    {ok, Log4} = logger:get_handler_config(new),
+    {ok, Log4} = logger:get_handler_config(file_for_new),
     ?assertMatch(#{config := #{file := File1}}, Log4),
 
     %% disable new handler
     Disable = emqx_map_lib:deep_put([<<"file_handlers">>, <<"new">>, <<"enable">>], NewLog2, false),
     {ok, #{}} = update_config(<<"log">>, Disable),
-    ?assertEqual({error, {not_found, new}}, logger:get_handler_config(new)),
+    ?assertEqual({error, {not_found, file_for_new}}, logger:get_handler_config(file_for_new)),
     ok.
 
 t_global_zone(_Config) ->

--- a/bin/emqx
+++ b/bin/emqx
@@ -1101,7 +1101,7 @@ case "${COMMAND}" in
         # set before generate_config
         if [ "${_EMQX_START_DAEMON_MODE:-}" = 1 ]; then
             tr_log_to_env
-            # Ensure console log default is enabled, file log default is disabled when daemon mode.
+            # Ensure logging to console is disabled and logging to file is enabled when in daemon mode.
             # This default is opposite to the default in emqx_conf_schema
             export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-false}"
             export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE="${EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE:-true}"

--- a/bin/emqx
+++ b/bin/emqx
@@ -1101,7 +1101,7 @@ case "${COMMAND}" in
         # set before generate_config
         if [ "${_EMQX_START_DAEMON_MODE:-}" = 1 ]; then
             tr_log_to_env
-            # Ensure console log default is enabled, file log default is disabled.
+            # Ensure console log default is enabled, file log default is disabled when daemon mode.
             # This default is opposite to the default in emqx_conf_schema
             export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-false}"
             export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE="${EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE:-true}"

--- a/bin/emqx
+++ b/bin/emqx
@@ -496,7 +496,7 @@ get_boot_config() {
 EPMD_ARGS="-start_epmd false -epmd_module ekka_epmd -proto_dist ekka"
 PROTO_DIST="$(get_boot_config 'cluster.proto_dist' || true)"
 # this environment variable is required by ekka_dist module
-# because proto_dist is overriden to ekka, and there is a lack of ekka_tls module
+# because proto_dist is overridden to ekka, and there is a lack of ekka_tls module
 export EKKA_PROTO_DIST_MOD="${PROTO_DIST:-inet_tcp}"
 if [ "$EKKA_PROTO_DIST_MOD" = 'inet_tls' ]; then
     if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
@@ -845,9 +845,9 @@ maybe_log_to_console() {
         unset EMQX_LOG__TO
     else
         tr_log_to_env
-        # ensure defaults
-        export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-true}"
-        export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE="${EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE:-false}"
+        # Don't ensure console/file handler's default here, we define them in emqx_conf_schema.erl
+        # Otherwise, it will override the default value in emqx.conf
+        # Ultimately, we can't change them via emqx.conf
     fi
 }
 
@@ -1101,6 +1101,10 @@ case "${COMMAND}" in
         # set before generate_config
         if [ "${_EMQX_START_DAEMON_MODE:-}" = 1 ]; then
             tr_log_to_env
+            # Ensure console log default is enabled, file log default is disabled.
+            # This default is opposite to the default in emqx_conf_schema
+            export EMQX_LOG__CONSOLE_HANDLER__ENABLE="${EMQX_LOG__CONSOLE_HANDLER__ENABLE:-false}"
+            export EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE="${EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE:-true}"
         else
             maybe_log_to_console
         fi


### PR DESCRIPTION
Since we already use foreground as a primary, `systemd` and `docker` both use it.
The daemon mode(`./bin/emqx start`)  is mostly used for testing. 

The foreground mode forces `EMQX_LOG__CONSOLE_HANDLER__ENABLE` and `EMQX_LOG__FILE_HANDLERS__DEFAULT__ENABLE`, which causes setting them again in `emqx.conf` to be invalid(**ENV will override emqx.conf**).
- To make it easier for the user to set them in `emqx.conf`, the default values are placed in emqx_conf_schema and are no longer forced in ENV.
- If we start with daemon mode, force set file_handlers.default to enable.
- We should also provide the console settings in `emqx.conf`, to make it easier for users to modify.