### PR TITLE
test: attempt to fix inter-suite flakiness

### DIFF
--- a/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl
+++ b/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl
@@ -186,6 +186,8 @@ end_per_testcase(TestCase, Config)
  when TestCase =:= t_available_acl_query_timeout;
       TestCase =:= t_acl_superuser_timeout;
       TestCase =:= t_authn_no_connection;
+      TestCase =:= t_available_authn_query_timeout;
+      TestCase =:= t_authn_timeout;
       TestCase =:= t_available_acl_query_no_connection ->
     ProxyHost = ?config(proxy_host, Config),
     ProxyPort = ?config(proxy_port, Config),

--- a/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl
+++ b/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl
@@ -115,7 +115,7 @@ init_per_suite(Config) ->
 end_per_suite(_Cfg) ->
     deinit_mongo_data(),
     %% avoid inter-suite flakiness
-    ok = emqx_mod_acl_internal:load([]),
+    emqx_mod_acl_internal:load([]),
     emqx_ct_helpers:stop_apps([emqx_auth_mongo]).
 
 set_special_confs(emqx) ->


### PR DESCRIPTION
Ex:
https://github.com/emqx/emqx-enterprise/actions/runs/3124750818/jobs/5068407612#step:7:769

```
%%% undefined ==> end_per_suite: FAILED
%%% undefined ==> {{badmatch,{error,enoent}},
 [{emqx_auth_mongo_SUITE,end_per_suite,1,
                         [{file,"/emqx/apps/emqx_auth_mongo/test/emqx_auth_mongo_SUITE.erl"},
                          {line,62}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1784}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1381}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1225}]}]}
Testing lib.emqx_auth_mongo: TEST COMPLETE, 3 ok, 0 failed of 3 test cases
```

