### PR TITLE
chore: remove extra information from denied lwt log

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2130,11 +2130,7 @@ publish_will_msg(ClientInfo, Msg = #message{topic = Topic}) ->
             ?tp(
                 warning,
                 last_will_testament_publish_denied,
-                #{
-                    client_info => ClientInfo,
-                    topic => Topic,
-                    message => Msg
-                }
+                #{topic => Topic}
             ),
             ok
     end.


### PR DESCRIPTION
1. we already have client info (id and source IP) in logging metadata.
2. the payload can be potentially very large to log.

```
2022-09-26T15:51:30.981831-03:00 [warning] clientid: myclient, ipaddr: {127,0,0,1}, line: 356, mfa: emqx_authz:authorize_non_superuser/5, msg: authorization_permission_denied, peername: 127.0.0.1:35228, source: file, topic: some/topic, username: undefined
2022-09-26T15:51:30.981934-03:00 [warning] clientid: myclient, line: 662, mfa: emqx_channel:process_publish/2, msg: cannot_publish_to_topic, peername: 127.0.0.1:35228, reason: not_authorized, topic: some/topic
2022-09-26T15:51:30.982029-03:00 [warning] clientid: myclient, ipaddr: {127,0,0,1}, line: 356, mfa: emqx_authz:authorize_non_superuser/5, msg: authorization_permission_denied, peername: 127.0.0.1:35228, source: file, topic: $SYS/lwt, username: undefined
2022-09-26T15:51:30.982095-03:00 [warning] clientid: myclient, line: 662, mfa: emqx_channel:process_publish/2, msg: cannot_publish_to_topic, peername: 127.0.0.1:35228, reason: not_authorized, topic: $SYS/lwt
2022-09-26T15:51:30.982183-03:00 [warning] '$kind': last_will_testament_publish_denied, clientid: myclient, line: 2132, mfa: emqx_channel:publish_will_msg/2, peername: 127.0.0.1:35228, topic: $SYS/lwt
```