### PR TITLE
fix(delayed): Improve time precision of delayed messages

### DIFF
--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -1,3 +1,9 @@
+# 5.0.10
+
+## Enhancements
+
+* Use milliseconds internally in emqx_delayed to store the publish time, improving precision.[#9060](https://github.com/emqx/emqx/pull/9060)
+
 # 5.0.9
 
 ## Enhancements

--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -1,14 +1,9 @@
-# 5.0.10
-
-## Enhancements
-
-* Use milliseconds internally in emqx_delayed to store the publish time, improving precision.[#9060](https://github.com/emqx/emqx/pull/9060)
-
 # 5.0.9
 
 ## Enhancements
 
 * Add `cert_common_name` and `cert_subject` placeholder support for authz_http and authz_mongo.[#8973](https://github.com/emqx/emqx/pull/8973)
+* Use milliseconds internally in emqx_delayed to store the publish time, improving precision.[#9060](https://github.com/emqx/emqx/pull/9060)
 
 ## Bug fixes
 

--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.4"},
+    {vsn, "5.0.5"},
     {modules, []},
     {applications, [kernel, stdlib, emqx]},
     {mod, {emqx_modules_app, []}},


### PR DESCRIPTION
Use milliseconds internally in emqx_delayed to store the publish time, improving precision

