### PR TITLE
chore: respect PKG_VSN in pkg-vsn.sh

### DIFF
--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -73,6 +73,12 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
+# return immediately if version is already set
+if [[ "${PKG_VSN:-novalue}" != novalue && "${LONG_VERSION:-novalue}" != 'yes' ]]; then
+    echo "$PKG_VSN"
+    exit 0
+fi
+
 case "${PROFILE}" in
     *enterprise*)
         RELEASE_EDITION="EMQX_RELEASE_EE"


### PR DESCRIPTION
No changes in logic. Right now the same happens on line #110 in the current version: if `PKG_VSN` is set, and `--long` is not given, we just return `PKG_VSN`.

In the current version though, even if you set `PKG_VSN`, the script will still attempt to extract version from git. This fails to produce correct version if one tries to build emqx from source code archive (with no `.git`), and consequently fails the build.