### PR TITLE
fix(emqx): emqx:shutdown should not log to remote node

### DIFF
--- a/src/emqx.erl
+++ b/src/emqx.erl
@@ -227,6 +227,7 @@ shutdown() ->
     shutdown(normal).
 
 shutdown(Reason) ->
+    ok = emqx_misc:maybe_mute_rpc_log(),
     ?LOG(critical, "emqx shutdown for ~s", [Reason]),
     on_shutdown(Reason),
     _ = emqx_plugins:unload(),

--- a/src/emqx_misc.erl
+++ b/src/emqx_misc.erl
@@ -23,6 +23,7 @@
 
 -export([ merge_opts/2
         , maybe_apply/2
+        , maybe_mute_rpc_log/0
         , compose/1
         , compose/2
         , run_fold/3
@@ -443,6 +444,27 @@ do_parallel_map(Fun, List) ->
         [],
         PidList
     ).
+
+%% @doc Call this function to avoid logs printed to RPC caller node.
+-spec maybe_mute_rpc_log() -> ok.
+maybe_mute_rpc_log() ->
+    GlNode = node(group_leader()),
+    maybe_mute_rpc_log(GlNode).
+
+maybe_mute_rpc_log(Node) when Node =:= node() ->
+    %% do nothing, this is a local call
+    ok;
+maybe_mute_rpc_log(Node) ->
+    case atom_to_list(Node) of
+        "remsh_" ++ _ ->
+            %% this is either an upgrade script or nodetool
+            %% do nothing, the log may go to the 'emqx' command line console
+            ok;
+        _ ->
+            %% otherwise set group leader to local node
+            _ = group_leader(whereis(init), self()),
+            ok
+    end.
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
When the call is issued from an rpc call of ekka:join(PeerNode), the logging to a remote group leader is very confusing when inviting a node to join

```
2022-10-04T10:18:57.304492+00:00 [critical] [EMQ X] emqx shutdown for join
2022-10-04T10:18:57.305534+00:00 [info] Importing modules from 'emqx@node1.emqx.io': internal_acl, presence, recon, retainer
2022-10-04T10:18:57.310668+00:00 [info] [Plugins] Stop plugin emqx_management successfully
2022-10-04T10:18:57.313849+00:00 [info] [Plugins] Stop plugin emqx_dashboard successfully
2022-10-04T10:18:57.316450+00:00 [info] [Plugins] Stop plugin emqx_modules successfully
2022-10-04T10:18:57.319311+00:00 [info] [Plugins] Stop plugin emqx_rule_engine successfully
2022-10-04T10:18:57.367801+00:00 [info] Ekka(Membership): Mnesia emqx@node2.emqx.io up
2022-10-04T10:18:57.966126+00:00 [info] No licenses to bootstrap from the cluster; ignoring
```

Before the change, when started in console mode, both nodes (inviting and invited) will log the above lines
After this change,  only the node which is joinning the cluster prints such logs.

## How to test it

* Start two EMQX nodes, say (node1, and node2) in console mode (`emqx console`)
* In the Erlang console of node1, execute `rpc:('emqx@node2.emqx.io', ekka, join, [node()]).`
* Observe the logs