### PR TITLE
chore: stat to resolve script dir on macos and readlink -f otherwise

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -7,7 +7,11 @@ set -euo pipefail
 DEBUG="${DEBUG:-0}"
 [ "$DEBUG" -eq 1 ] && set -x
 
-RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
+if [ "$(uname -s)" == 'Darwin' ]; then
+    RUNNER_ROOT_DIR="$(cd "$(dirname "$(stat -f%R "$0" || echo "$0")")"/..; pwd -P)"
+else
+    RUNNER_ROOT_DIR="$(cd "$(dirname "$(realpath "$0" || echo "$0")")"/..; pwd -P)"
+fi
 
 # shellcheck disable=SC1090,SC1091
 . "$RUNNER_ROOT_DIR"/releases/emqx_vars


### PR DESCRIPTION
```
man stat
...
     -f format
             Display information using the specified format.  See the Formats section for a description of
             valid formats.
...
R       The absolute pathname corresponding to the file.
...
```
GNU stat and BSD stat are different again, GNU stat uses `-c` to specify format.

For the history, here is list of links I went through while trying to find a portable solution (none of them worked):
* https://stackoverflow.com/questions/3572030/bash-script-absolute-path-with-os-x
* https://unix.stackexchange.com/questions/136494/whats-the-difference-between-realpath-and-readlink-f/136527#136527
* https://stackoverflow.com/questions/284662/how-do-you-normalize-a-file-path-in-bash
* https://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
* https://stackoverflow.com/questions/3349105/how-can-i-set-the-current-working-directory-to-the-directory-of-the-script-in-ba/17744637
* https://stackoverflow.com/questions/4774054/reliable-way-for-a-bash-script-to-get-the-full-path-to-itself/20265654
