### PR TITLE
build: support additional checks before cutting a release tag

### DIFF
--- a/scripts/rel/cut4x.sh
+++ b/scripts/rel/cut4x.sh
@@ -230,6 +230,16 @@ if [ "$HAS_RELUP_DB" = 'yes' ]; then
     ./scripts/relup-base-vsns.escript check-vsn-db "$PKG_VSN" "$RELUP_PATHS"
 fi
 
+## Run some additional checks (e.g. some for enterprise edition only)
+CHECKS_DIR="./scripts/rel/checks"
+if [ -d "${CHECKS_DIR}" ]; then
+    CHECKS="$(find "${CHECKS_DIR}" -name "*.sh" -print0 2>/dev/null | xargs -0)"
+    for c in $CHECKS; do
+        logmsg "Executing $c"
+        $c
+    done
+fi
+
 if [ "$DRYRUN" = 'yes' ]; then
     logmsg "Release tag is ready to be created with command: git tag $TAG"
 else


### PR DESCRIPTION
It happened to v4.3.20 and e4.3.15
some of the commits were not synced to enterprise before creating the e4.3.15 tag.

you may inspect the diff with command:

`git diff --name-only v4.3.20...e4.3.15 -- "src/" -- "apps/" -- ":(exclude)apps/emqx_management"`

This caused some troubles in appup generation.
lucky that there were no complex appup instructions, so the workaround is to add more `load_module`
for some unchanged modules in the next release (i.e. the union of changed modules from both ce and ee).

With the `scripts/rel/cut4x.sh`, it will force sync the remotes before creating the tag,
however there may still be divergence due to for example merge conflict resolution
-- which should ideally never happen if all changes are always made to the ce repo first, but we are humans, we make mistakes.

With this PR, we can add additional check scripts to prevent future divergence to happen.
so far, there is nothing to check in the ce repo.
the divergence check script will be added to the ee repo.