### PR TITLE
chore: portable stdout coloring in scripts

### DIFF
--- a/scripts/rel/cut4x.sh
+++ b/scripts/rel/cut4x.sh
@@ -40,10 +40,10 @@ EOF
 }
 
 logerr() {
-    echo -e "\e[31mERROR: $1\e[39m"
+    echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
 }
 logmsg() {
-    echo -e "\e[33mINFO: $1\e[39m"
+    echo "INFO: $1"
 }
 
 REL_BRANCH_CE="${REL_BRANCH_CE:-release-v43}"

--- a/scripts/rel/sync-remotes.sh
+++ b/scripts/rel/sync-remotes.sh
@@ -45,11 +45,10 @@ EOF
 }
 
 logerr() {
-    echo -e "\e[31mERROR: $1\e[39m"
+    echo "$(tput setaf 1)ERROR: $1$(tput sgr0)"
 }
-
 logwarn() {
-    echo -e "\e[33mINFO: $1\e[39m"
+    echo "$(tput setaf 3)WARNING: $1$(tput sgr0)"
 }
 
 logmsg() {


### PR DESCRIPTION
BSD's (macos) version of echo does not support -e flag

Found out when testing https://github.com/emqx/emqx/pull/9108

The output looks like this (verbatim)
```
\e[33mINFO: Fetching from remote=emqx (force tag sync).\e[39m
```

Corresponding article: https://www.codequoi.com/en/coloring-terminal-text-tput-and-ansi-escape-sequences/