### PR TITLE
fix: update the jq library to v0.3.6 to v0.3.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -616,7 +616,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.6", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.7", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -42,7 +42,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.16"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.6"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.7"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),


### PR DESCRIPTION
This update fixes a bug that could leave a long running jq program executing in a port program after the Erlang VM is shut down.

