### PR TITLE
get trace file's detail via /trace/:name/log_detail

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 24.2.1-1
+erlang 24.3.4.2-1
 elixir 1.13.4-otp-24

--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -16,6 +16,7 @@
 * Fix empty variable interpolation in authentication and authorization. Placeholders for undefined variables are rendered now as empty strings and do not cause errors anymore. [#8963](https://github.com/emqx/emqx/pull/8963)
 * Fix the latency statistics error of the slow subscription module when `stats_type` is `internal` or `response`. [#8986](https://github.com/emqx/emqx/pull/8986)
 * Redispatch shared subscription messages. [#9104](https://github.com/emqx/emqx/pull/9104)
+* Ensure authentication type is an array, not struct. [#8923](https://github.com/emqx/emqx/pull/8923)
 
 # 5.0.8
 
@@ -27,6 +28,7 @@
 * Speed up dispatching of shared subscription messages in a cluster [#8893](https://github.com/emqx/emqx/pull/8893)
 * Fix the extra / prefix when CoAP gateway parsing client topics. [#8658](https://github.com/emqx/emqx/pull/8658)
 * Speed up updating the configuration, When some nodes in the cluster are down. [#8857](https://github.com/emqx/emqx/pull/8857)
+
 * Fix delayed publish inaccurate caused by os time change. [#8926](https://github.com/emqx/emqx/pull/8926)
 * Fix that EMQX can't start when the retainer is disabled [#8911](https://github.com/emqx/emqx/pull/8911)
 * Fix that redis authn will deny the unknown users [#8934](https://github.com/emqx/emqx/pull/8934)

--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -5,6 +5,9 @@
 * Add `cert_common_name` and `cert_subject` placeholder support for authz_http and authz_mongo.[#8973](https://github.com/emqx/emqx/pull/8973)
 * Use milliseconds internally in emqx_delayed to store the publish time, improving precision.[#9060](https://github.com/emqx/emqx/pull/9060)
 * More rigorous checking of flapping to improve stability of the system. [#9136](https://github.com/emqx/emqx/pull/9136)
+* No message(s) echo for the message publish APIs [#9155](https://github.com/emqx/emqx/pull/9155)
+  Prior to this fix, the message publish APIs (`api/v5/publish` and `api/v5/publish/bulk`) echos the message back to the client in HTTP body.
+  This change fixed it to only send back the message ID.
 
 ## Bug fixes
 

--- a/CHANGES-5.0.md
+++ b/CHANGES-5.0.md
@@ -8,6 +8,7 @@
 * No message(s) echo for the message publish APIs [#9155](https://github.com/emqx/emqx/pull/9155)
   Prior to this fix, the message publish APIs (`api/v5/publish` and `api/v5/publish/bulk`) echos the message back to the client in HTTP body.
   This change fixed it to only send back the message ID.
+* Add /trace/:name/log_detail HTTP API to return trace file's size and mtime [#9152](https://github.com/emqx/emqx/pull/9152)
 
 ## Bug fixes
 

--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -20,6 +20,7 @@
 {emqx_mgmt_api_plugins,1}.
 {emqx_mgmt_cluster,1}.
 {emqx_mgmt_trace,1}.
+{emqx_mgmt_trace,2}.
 {emqx_persistent_session,1}.
 {emqx_plugin_libs,1}.
 {emqx_prometheus,1}.

--- a/apps/emqx/src/emqx_authentication_config.erl
+++ b/apps/emqx/src/emqx_authentication_config.erl
@@ -64,7 +64,7 @@
 pre_config_update(_, UpdateReq, OldConfig) ->
     try do_pre_config_update(UpdateReq, to_list(OldConfig)) of
         {error, Reason} -> {error, Reason};
-        {ok, NewConfig} -> {ok, return_map(NewConfig)}
+        {ok, NewConfig} -> {ok, NewConfig}
     catch
         throw:Reason ->
             {error, Reason}
@@ -224,9 +224,6 @@ do_check_config(Type, Config, Module) ->
             }),
             throw({bad_authenticator_config, #{type => Type, reason => E}})
     end.
-
-return_map([L]) -> L;
-return_map(L) -> L.
 
 to_list(undefined) -> [];
 to_list(M) when M =:= #{} -> [];

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -414,9 +414,9 @@ check_config(SchemaMod, RawConf) ->
 check_config(SchemaMod, RawConf, Opts0) ->
     Opts1 = #{
         return_plain => true,
-        %% TODO: evil, remove, required should be declared in schema
-        required => false,
-        format => map
+        format => map,
+        %% Don't check lazy types, such as authenticate
+        check_lazy => false
     },
     Opts = maps:merge(Opts0, Opts1),
     {AppEnvs, CheckedConf} =

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2276,6 +2276,7 @@ validate_alarm_actions(Actions) ->
         Error -> {error, Error}
     end.
 
+parse_user_lookup_fun({Fun, _} = Lookup) when is_function(Fun, 3) -> Lookup;
 parse_user_lookup_fun(StrConf) ->
     [ModStr, FunStr] = string:tokens(str(StrConf), ": "),
     Mod = list_to_atom(ModStr),

--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -70,7 +70,9 @@ do_check_config(#{<<"mechanism">> := Mec} = Config, Opts) ->
                 #{?CONF_NS_BINARY => Config},
                 Opts#{atom_key => true}
             )
-    end.
+    end;
+do_check_config(_Config, _Opts) ->
+    throw({invalid_config, "mechanism_field_required"}).
 
 atom(Bin) ->
     try

--- a/apps/emqx_authn/src/emqx_authn_app.erl
+++ b/apps/emqx_authn/src/emqx_authn_app.erl
@@ -37,8 +37,10 @@
 start(_StartType, _StartArgs) ->
     ok = mria_rlog:wait_for_shards([?AUTH_SHARD], infinity),
     {ok, Sup} = emqx_authn_sup:start_link(),
-    ok = initialize(),
-    {ok, Sup}.
+    case initialize() of
+        ok -> {ok, Sup};
+        {error, Reason} -> {error, Reason}
+    end.
 
 stop(_State) ->
     ok = deinitialize(),
@@ -49,18 +51,26 @@ stop(_State) ->
 %%------------------------------------------------------------------------------
 
 initialize() ->
-    ok = ?AUTHN:register_providers(emqx_authn:providers()),
+    try
+        ok = ?AUTHN:register_providers(emqx_authn:providers()),
 
-    lists:foreach(
-        fun({ChainName, RawAuthConfigs}) ->
-            AuthConfig = emqx_authn:check_configs(RawAuthConfigs),
-            ?AUTHN:initialize_authentication(
-                ChainName,
-                AuthConfig
-            )
-        end,
-        chain_configs()
-    ).
+        lists:foreach(
+            fun({ChainName, RawAuthConfigs}) ->
+                AuthConfig = emqx_authn:check_configs(RawAuthConfigs),
+                ?AUTHN:initialize_authentication(
+                    ChainName,
+                    AuthConfig
+                )
+            end,
+            chain_configs()
+        )
+    of
+        ok -> ok
+    catch
+        throw:Reason ->
+            ?SLOG(error, #{msg => "failed_to_initialize_authentication", reason => Reason}),
+            {error, {failed_to_initialize_authentication, Reason}}
+    end.
 
 deinitialize() ->
     ok = ?AUTHN:deregister_providers(provider_types()),

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -34,7 +34,8 @@
     delete_trace/2,
     update_trace/2,
     download_trace_log/2,
-    stream_log_file/2
+    stream_log_file/2,
+    log_file_detail/2
 ]).
 
 -export([validate_name/1]).
@@ -55,7 +56,14 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
 
 paths() ->
-    ["/trace", "/trace/:name/stop", "/trace/:name/download", "/trace/:name/log", "/trace/:name"].
+    [
+        "/trace",
+        "/trace/:name/stop",
+        "/trace/:name/download",
+        "/trace/:name/log",
+        "/trace/:name/log_detail",
+        "/trace/:name"
+    ].
 
 schema("/trace") ->
     #{
@@ -95,7 +103,7 @@ schema("/trace/:name") ->
     #{
         'operationId' => delete_trace,
         delete => #{
-            description => "Delete trace by name",
+            description => "Delete specified trace",
             tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{
@@ -136,6 +144,19 @@ schema("/trace/:name/download") ->
             }
         }
     };
+schema("/trace/:name/log_detail") ->
+    #{
+        'operationId' => log_file_detail,
+        get => #{
+            description => "get trace log file's detail message, such as size, last update time",
+            tags => ?TAGS,
+            parameters => [hoconsc:ref(name)],
+            responses => #{
+                200 => hoconsc:array(hoconsc:ref(log_file_detail)),
+                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], <<"Trace Name Not Found">>)
+            }
+        }
+    };
 schema("/trace/:name/log") ->
     #{
         'operationId' => stream_log_file,
@@ -158,6 +179,13 @@ schema("/trace/:name/log") ->
         }
     }.
 
+fields(log_file_detail) ->
+    fields(node) ++
+        [
+            {size, hoconsc:mk(integer(), #{desc => "file size"})},
+            {mtime,
+                hoconsc:mk(integer(), #{desc => "the modification and last access times of a file"})}
+        ];
 fields(trace) ->
     [
         {name,
@@ -265,7 +293,8 @@ fields(node) ->
                 #{
                     desc => "Node name",
                     in => query,
-                    required => false
+                    required => false,
+                    example => "emqx@127.0.0.1"
                 }
             )}
     ];
@@ -323,7 +352,7 @@ trace(get, _Params) ->
                 emqx_trace:format(List0)
             ),
             Nodes = mria_mnesia:running_nodes(),
-            TraceSize = wrap_rpc(emqx_mgmt_trace_proto_v1:get_trace_size(Nodes)),
+            TraceSize = wrap_rpc(emqx_mgmt_trace_proto_v2:get_trace_size(Nodes)),
             AllFileSize = lists:foldl(fun(F, Acc) -> maps:merge(Acc, F) end, #{}, TraceSize),
             Now = erlang:system_time(second),
             Traces =
@@ -471,19 +500,43 @@ group_trace_file(ZipDir, TraceLog, TraceFiles) ->
     ).
 
 collect_trace_file(Nodes, TraceLog) ->
-    wrap_rpc(emqx_mgmt_trace_proto_v1:trace_file(Nodes, TraceLog)).
+    wrap_rpc(emqx_mgmt_trace_proto_v2:trace_file(Nodes, TraceLog)).
+
+collect_trace_file_detail(TraceLog) ->
+    Nodes = mria_mnesia:running_nodes(),
+    wrap_rpc(emqx_mgmt_trace_proto_v2:trace_file_detail(Nodes, TraceLog)).
 
 wrap_rpc({GoodRes, BadNodes}) ->
     BadNodes =/= [] andalso
         ?SLOG(error, #{msg => "rpc_call_failed", bad_nodes => BadNodes}),
     GoodRes.
 
+log_file_detail(get, #{bindings := #{name := Name}}) ->
+    case emqx_trace:get_trace_filename(Name) of
+        {ok, TraceLog} ->
+            TraceFiles = collect_trace_file_detail(TraceLog),
+            {200, group_trace_file_detail(TraceFiles)};
+        {error, not_found} ->
+            ?NOT_FOUND(Name)
+    end.
+
+group_trace_file_detail(TraceLogDetail) ->
+    GroupFun =
+        fun
+            ({ok, Info}, Acc) ->
+                [Info | Acc];
+            ({error, Error}, Acc) ->
+                ?SLOG(error, Error#{msg => "read_trace_file_failed"}),
+                Acc
+        end,
+    lists:foldl(GroupFun, [], TraceLogDetail).
+
 stream_log_file(get, #{bindings := #{name := Name}, query_string := Query}) ->
     Position = maps:get(<<"position">>, Query, 0),
     Bytes = maps:get(<<"bytes">>, Query, 1000),
     case parse_node(Query, node()) of
         {ok, Node} ->
-            case emqx_mgmt_trace_proto_v1:read_trace_file(Node, Name, Position, Bytes) of
+            case emqx_mgmt_trace_proto_v2:read_trace_file(Node, Name, Position, Bytes) of
                 {ok, Bin} ->
                     Meta = #{<<"position">> => Position + byte_size(Bin), <<"bytes">> => Bytes},
                     {200, #{meta => Meta, items => Bin}};

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -148,7 +148,7 @@ schema("/trace/:name/log_detail") ->
     #{
         'operationId' => log_file_detail,
         get => #{
-            description => "get trace log file's detail message, such as size, last update time",
+            description => "get trace log file's metadata, such as size, last update time",
             tags => ?TAGS,
             parameters => [hoconsc:ref(name)],
             responses => #{

--- a/apps/emqx_management/src/proto/emqx_mgmt_trace_proto_v2.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_trace_proto_v2.erl
@@ -1,0 +1,66 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_mgmt_trace_proto_v2).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    trace_file/2,
+    trace_file_detail/2,
+    get_trace_size/1,
+    read_trace_file/4
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+introduced_in() ->
+    "5.0.9".
+
+-spec get_trace_size([node()]) ->
+    emqx_rpc:multicall_result(#{{node(), file:name_all()} => non_neg_integer()}).
+get_trace_size(Nodes) ->
+    rpc:multicall(Nodes, emqx_mgmt_api_trace, get_trace_size, [], 30000).
+
+-spec trace_file([node()], file:name_all()) ->
+    emqx_rpc:multicall_result(
+        {ok, Node :: list(), Binary :: binary()}
+        | {error, Node :: list(), Reason :: term()}
+    ).
+trace_file(Nodes, File) ->
+    rpc:multicall(Nodes, emqx_trace, trace_file, [File], 60000).
+
+-spec trace_file_detail([node()], file:name_all()) ->
+    emqx_rpc:multicall_result(
+        {ok, #{
+            size => non_neg_integer(),
+            mtime => file:date_time() | non_neg_integer() | 'undefined',
+            node => atom()
+        }}
+        | {error, #{reason => term(), node => atom(), file => file:name_all()}}
+    ).
+trace_file_detail(Nodes, File) ->
+    rpc:multicall(Nodes, emqx_trace, trace_file_detail, [File], 25000).
+
+-spec read_trace_file(node(), binary(), non_neg_integer(), non_neg_integer()) ->
+    {ok, binary()}
+    | {error, _}
+    | {eof, non_neg_integer()}
+    | {badrpc, _}.
+read_trace_file(Node, Name, Position, Limit) ->
+    rpc:call(Node, emqx_mgmt_api_trace, read_trace_file, [Name, Position, Limit]).

--- a/apps/emqx_management/src/proto/emqx_mgmt_trace_proto_v2.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_trace_proto_v2.erl
@@ -63,4 +63,4 @@ trace_file_detail(Nodes, File) ->
     | {eof, non_neg_integer()}
     | {badrpc, _}.
 read_trace_file(Node, Name, Position, Limit) ->
-    rpc:call(Node, emqx_mgmt_api_trace, read_trace_file, [Name, Position, Limit]).
+    rpc:call(Node, emqx_mgmt_api_trace, read_trace_file, [Name, Position, Limit], 15000).

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -175,7 +175,7 @@ t_create_failed(_Config) ->
     emqx_trace:clear(),
     ok.
 
-t_download_log(_Config) ->
+t_log_file(_Config) ->
     ClientId = <<"client-test-download">>,
     Now = erlang:system_time(second),
     Name = <<"test_client_id">>,
@@ -191,6 +191,12 @@ t_download_log(_Config) ->
     ],
     ok = emqx_trace_handler_SUITE:filesync(Name, clientid),
     Header = auth_header_(),
+    ?assertMatch(
+        {error, {"HTTP/1.1", 404, "Not Found"}, _},
+        request_api(get, api_path("trace/test_client_not_found/log_detail"), Header)
+    ),
+    {ok, Detail} = request_api(get, api_path("trace/test_client_id/log_detail"), Header),
+    ?assertMatch([#{<<"mtime">> := _, <<"size">> := _, <<"node">> := _}], json(Detail)),
     {ok, Binary} = request_api(get, api_path("trace/test_client_id/download"), Header),
     {ok, [
         _Comment,


### PR DESCRIPTION
When users view the trace logs in the cluster, 
they generally look directly at the files on the nodes that have been updated recently, 
so we need a new API to return the trace file's size and modification times.

<img width="1181" alt="image" src="https://user-images.githubusercontent.com/3116225/195800141-79dd4d4e-6783-4be0-bd15-93249957cc9f.png">


