### PR TITLE
fix: get trace list crash when trace not initialized

### DIFF
--- a/CHANGES-4.4.md
+++ b/CHANGES-4.4.md
@@ -1,16 +1,5 @@
 # EMQX 4.4 Changes
 
-## v4.4.11
-
-<<<<<<< HEAD
-
-### Bug fixes  (synced from v4.3.22)
-
-- Fix get trace list crash when trace not initialize. [#9156](https://github.com/emqx/emqx/pull/9156)
-- Fix create trace sometime failed by end_at time has already passed. [#9156](https://github.com/emqx/emqx/pull/9156)
-
-### Enhancements (synced from v4.3.22)
-
 ## v4.4.10
 
 ### Bug fixes  (synced from v4.3.21)

--- a/CHANGES-4.4.md
+++ b/CHANGES-4.4.md
@@ -2,11 +2,12 @@
 
 ## v4.4.11
 
+<<<<<<< HEAD
 
 ### Bug fixes  (synced from v4.3.22)
 
-- Fix get trace list crash when trace not initialize.
-- Fix create trace sometime failed by end_at time has already passed.
+- Fix get trace list crash when trace not initialize. [#9156](https://github.com/emqx/emqx/pull/9156)
+- Fix create trace sometime failed by end_at time has already passed. [#9156](https://github.com/emqx/emqx/pull/9156)
 
 ### Enhancements (synced from v4.3.22)
 

--- a/CHANGES-4.4.md
+++ b/CHANGES-4.4.md
@@ -2,7 +2,11 @@
 
 ## v4.4.11
 
+
 ### Bug fixes  (synced from v4.3.22)
+
+- Fix get trace list crash when trace not initialize.
+- Fix create trace sometime failed by end_at time has already passed.
 
 ### Enhancements (synced from v4.3.22)
 

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.app.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.app.src
@@ -1,6 +1,6 @@
 {application, emqx_plugin_libs,
  [{description, "EMQ X Plugin utility libs"},
-  {vsn, "4.4.5"},
+  {vsn, "4.4.6"},
   {modules, []},
   {applications, [kernel,stdlib]},
   {env, []}

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
@@ -2,14 +2,9 @@
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
   [
-  {"4.4.5",
-    [{load_module,emqx_trace,brutal_purge,soft_purge,[]}]},
-  {"4.4.4",
+  {<<"4\\.4\\.[3-5]">>,
     [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
     {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
-   {"4.4.3",
-    [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
-     {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
    {"4.4.2",[
    {load_module,emqx_plugin_libs_ssl,brutal_purge,soft_purge,[]},
    {load_module,emqx_trace,brutal_purge,soft_purge,[]},
@@ -26,9 +21,7 @@
      {load_module,emqx_slow_subs_api,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
   [
-  {"4.4.5",
-    [{load_module,emqx_trace,brutal_purge,soft_purge,[]}]},
-   {"4.4.4",
+  {<<"4\\.4\\.[3-5]">>,
     [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
      {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
    {"4.4.3",

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
@@ -2,6 +2,8 @@
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
   [
+  {"4.4.5",
+    [{load_module,emqx_trace,brutal_purge,soft_purge,[]}]},
   {"4.4.4",
     [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
     {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},
@@ -24,6 +26,8 @@
      {load_module,emqx_slow_subs_api,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
   [
+  {"4.4.5",
+    [{load_module,emqx_trace,brutal_purge,soft_purge,[]}]},
    {"4.4.4",
     [{load_module,emqx_trace,brutal_purge,soft_purge,[]},
      {load_module,emqx_trace_api,brutal_purge,soft_purge,[]}]},

--- a/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
@@ -156,7 +156,7 @@ update(Name, Enable) ->
             [] -> mnesia:abort(not_found);
             [#?TRACE{enable = Enable}] -> ok;
             [Rec] ->
-                case erlang:system_time(second) >= Rec#?TRACE.end_at of
+                case os:system_time(second) >= Rec#?TRACE.end_at of
                     false -> mnesia:write(?TRACE, Rec#?TRACE{enable = Enable}, write);
                     true -> mnesia:abort(finished)
                 end
@@ -291,7 +291,7 @@ insert_new_trace(Trace) ->
     transaction(Tran).
 
 update_trace(Traces) ->
-    Now = erlang:system_time(second),
+    Now = os:system_time(second),
     {_Waiting, Running, Finished} = classify_by_time(Traces, Now),
     disable_finished(Finished),
     Started = emqx_trace_handler:running(),
@@ -418,7 +418,7 @@ ensure_map(Trace) when is_list(Trace) ->
         end, #{}, Trace).
 
 fill_default(Trace = #?TRACE{start_at = undefined}) ->
-    fill_default(Trace#?TRACE{start_at = erlang:system_time(second)});
+    fill_default(Trace#?TRACE{start_at = os:system_time(second)});
 fill_default(Trace = #?TRACE{end_at = undefined, start_at = StartAt}) ->
     fill_default(Trace#?TRACE{end_at = StartAt + 10 * 60});
 fill_default(Trace) -> Trace.
@@ -454,7 +454,7 @@ to_trace(#{start_at := StartAt} = Trace, Rec) ->
         {error, Reason} -> {error, Reason}
     end;
 to_trace(#{end_at := EndAt} = Trace, Rec) ->
-    Now = erlang:system_time(second),
+    Now = os:system_time(second),
     case to_system_second(EndAt) of
         {ok, Sec} when Sec > Now ->
             to_trace(maps:remove(end_at, Trace), Rec#?TRACE{end_at = Sec});
@@ -481,7 +481,7 @@ validate_ip_address(IP) ->
 to_system_second(At) ->
     try
         Sec = calendar:rfc3339_to_system_time(binary_to_list(At), [{unit, second}]),
-        Now = erlang:system_time(second),
+        Now = os:system_time(second),
         {ok, erlang:max(Now, Sec)}
     catch error: {badmatch, _} ->
         {error, ["The rfc3339 specification not satisfied: ", At]}

--- a/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
@@ -36,6 +36,7 @@
         , delete/1
         , clear/0
         , update/2
+        , os_now/0
         ]).
 
 -export([ format/1
@@ -515,6 +516,6 @@ set_log_primary_level(NewLevel) ->
         false -> ok
     end.
 
-%% the dashboard use os time to create trace, donot use erlang:system_time/1
+%% the dashboard use os time to create trace, do not use erlang:system_time/1
 os_now() ->
     os:system_time(second).

--- a/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace.erl
@@ -104,7 +104,10 @@ start_link() ->
 
 -spec list() -> [tuple()].
 list() ->
-    ets:match_object(?TRACE, #?TRACE{_ = '_'}).
+    case ets:info(?TRACE) of
+        undefined -> [];
+        _ -> ets:match_object(?TRACE, #?TRACE{_ = '_'})
+    end.
 
 -spec is_enable() -> boolean().
 is_enable() ->

--- a/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace_api.erl
+++ b/apps/emqx_plugin_libs/src/emqx_trace/emqx_trace_api.erl
@@ -44,7 +44,7 @@ list_trace(_, _Params) ->
             Nodes = ekka_mnesia:running_nodes(),
             TraceSize = cluster_call(?MODULE, get_trace_size, [], 30000),
             AllFileSize = lists:foldl(fun(F, Acc) -> maps:merge(Acc, F) end, #{}, TraceSize),
-            Now = erlang:system_time(second),
+            Now = emqx_trace:os_now(),
             Traces =
                 lists:map(fun(Trace = #{name := Name, start_at := Start,
                     end_at := End, enable := Enable, type := Type, filter := Filter}) ->

--- a/changes/v4.4.11-en.md
+++ b/changes/v4.4.11-en.md
@@ -1,0 +1,7 @@
+### Enhancements
+
+### Bug fixes
+
+- Fix get trace list crash when trace not initialize. [#9156](https://github.com/emqx/emqx/pull/9156)
+
+- Fix create trace sometime failed by end_at time has already passed. [#9156](https://github.com/emqx/emqx/pull/9156)

--- a/changes/v4.4.11-zh.md
+++ b/changes/v4.4.11-zh.md
@@ -1,0 +1,8 @@
+### 增强
+
+
+### 修复
+
+- 修复日志追踪模块没开启时，GET Trace 列表接口报错的问题。[#9156](https://github.com/emqx/emqx/pull/9156)
+
+- 修复创建追踪日志时偶尔会报`end_at time has already passed`错误，导致创建失败。[#9156](https://github.com/emqx/emqx/pull/9156)


### PR DESCRIPTION
- We should not crash when the trace module is not initialized, return empty list instead.
- Sometimes erlang:system_time will have a big gap with the OS time(the os time is from the dashboard)…
Replacing it with os time would also fix the inconsistency.