### PR TITLE
fix(rule_engine): rule id in path urlencoded

### DIFF
--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -28,6 +28,14 @@
 -include("emqx_rule_test.hrl").
 -import(emqx_rule_test_lib, [make_simple_resource_type/1]).
 
+%% API request funcs
+-import(emqx_rule_test_lib,
+        [ request_api/4
+        , request_api/5
+        , auth_header_/0
+        , api_path/1
+        ]).
+
 %%-define(PROPTEST(M,F), true = proper:quickcheck(M:F())).
 
 all() ->
@@ -62,6 +70,7 @@ groups() ->
       ]},
      {api, [],
       [t_crud_rule_api,
+       t_rule_api_unicode_ids,
        t_list_actions_api,
        t_show_action_api,
        t_crud_resources_api,
@@ -227,6 +236,10 @@ init_per_testcase(Test, Config)
      {conn_event, TriggerConnEvent},
      {connsql, SQL}
     | Config];
+init_per_testcase(t_rule_api_unicode_ids, Config) ->
+    ok = emqx_dashboard_admin:mnesia(boot),
+    emqx_ct_helpers:start_apps([emqx_management, emqx_dashboard]),
+    Config;
 init_per_testcase(_TestCase, Config) ->
     ok = emqx_rule_registry:register_resource_types(
             [make_simple_debug_resource_type()]),
@@ -249,6 +262,10 @@ end_per_testcase(Test, Config)
     emqtt:stop(?config(subclient, Config)),
     emqtt:stop(?config(connclient, Config)),
     Config;
+end_per_testcase(t_rule_api_unicode_ids, _Config) ->
+    application:stop(emqx_dashboard),
+    application:stop(emqx_management),
+    ok;
 end_per_testcase(_TestCase, _Config) ->
     ok.
 
@@ -522,6 +539,46 @@ t_crud_rule_api(_Config) ->
     %ct:pal("Show After Deleted: ~p", [NotFound]),
     ?assertMatch({ok, #{code := 404, message := _Message}}, NotFound),
     ok.
+
+-define(PRED(Elem), fun(Elem) -> true; (_) -> false end).
+
+t_rule_api_unicode_ids(_Config) ->
+    UData =
+        fun(Description) ->
+                #{<<"name">> => <<"debug-rule">>,
+                  <<"rawsql">> => <<"select * from \"t/a\"">>,
+                  <<"actions">> => [#{<<"name">> => <<"do_nothing">>,
+                                      <<"params">> => []}
+                                   ],
+                  <<"description">> => Description}
+        end,
+    CData = fun(Id, Description) ->  maps:put(<<"id">>, Id, UData(Description)) end,
+
+    CDes = <<"Creating rules description">>,
+    UDes = <<"Updating rules description">>,
+
+    %% create rule
+    CFun = fun(Id) -> {ok, Return} = request_api(post, api_path(["rules"]), [], auth_header_(), CData(Id, CDes)), Return end,
+    %% update rule
+    UFun = fun(Id) -> {ok, Return} = request_api(put, api_path(["rules", cow_uri:urlencode(Id)]), [], auth_header_(), UData(UDes)), Return end,
+    %% show rule
+    SFun = fun(Id) -> {ok, Return} = request_api(get, api_path(["rules", cow_uri:urlencode(Id)]), [], auth_header_()), Return end,
+    %% delete rule
+    DFun = fun(Id) -> {ok, Return} = request_api(delete, api_path(["rules", cow_uri:urlencode(Id)]), [], auth_header_()), Return end,
+
+    Ids = [unicode:characters_to_binary([Char]) || Char <- lists:seq(0, 1000) -- [46]] ++ [<<"%2e">>],
+
+    Ress = [begin
+                {?assertMatch(#{<<"code">> := 0, <<"data">> := #{<<"description">> := CDes}}, decode_to_map(CFun(Id))),
+                 ?assertMatch(#{<<"code">> := 0}, decode_to_map(UFun(Id))),
+                 ?assertMatch(#{<<"code">> := 0, <<"data">> := #{<<"description">> := UDes}}, decode_to_map(SFun(Id))),
+                 ?assertMatch(#{<<"code">> := 0}, decode_to_map(DFun(Id)))}
+           end || Id <- Ids],
+
+    ?assertEqual(true, lists:all(?PRED(true), [?PRED({ok, ok, ok, ok})(Res) || Res <- Ress ])).
+
+decode_to_map(ResponseBody) ->
+    jiffy:decode(list_to_binary(ResponseBody), [return_maps]).
 
 t_list_rule_api(_Config) ->
     AddIds =

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -35,3 +35,7 @@
   For rule-engine's input events like `$events/message_delivered`, and `$events/message_dropped`,
   if the message was delivered to a shared-subscription, the encoding (to JSON) of the event will fail.
   Affected versions: `v4.3.21`, `v4.4.10`, `e4.3.16` and `e4.4.10`.
+
+- Make sure Rule-Engine API supports Percent-encoding `rule_id` and `resource_id` in HTTP request path [#9190](https://github.com/emqx/emqx/pull/9190).
+  Note that the `id` in `POST /api/v4/rules` should be literals (not encoded) when creating a `rule` or `resource`.
+  See docs [Create Rule](https://www.emqx.io/docs/zh/v4.3/advanced/http-api.html#post-api-v4-rules) [Create Resource](https://www.emqx.io/docs/zh/v4.3/advanced/http-api.html#post-api-v4-resources).

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -35,3 +35,7 @@
   带消息的规则引擎事件，例如 `$events/message_delivered` 和 `$events/message_dropped`,
   如果消息事件是共享订阅产生的，在编码（到 JSON 格式）过程中会失败。
   影响到的版本：`v4.3.21`, `v4.4.10`, `e4.3.16` 和 `e4.4.10`。
+
+- 使规则引擎 API 在 HTTP 请求路径中支持百分号编码的 `rule_id` 及 `resource_id` [#9190](https://github.com/emqx/emqx/pull/9190)。
+  注意在创建规则或资源时，HTTP body 中的 `id` 字段仍为字面值，而不是编码之后的值。
+  详情请参考 [创建规则](https://www.emqx.io/docs/zh/v4.3/advanced/http-api.html#post-api-v4-rules) 和 [创建资源](https://www.emqx.io/docs/zh/v4.3/advanced/http-api.html#post-api-v4-resources)。


### PR DESCRIPTION
`rule_id` and `resource_id` could be any unicode character now.

#### Note:
EMQX Dashboard limited `rule_id` and `resource_id` with re `^([0-9a-zA-Z:_])*$`.
But user can still create rules/resources with any unicode character as id by manually request HTTP API.