### PR TITLE
fix(shared): do not redispatch shared messages for certain shutdown

### DIFF
--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -802,8 +802,7 @@ replay(ClientInfo, Session = #session{inflight = Inflight}) ->
 -spec terminate(emqx_types:clientinfo(), Reason :: term(), session()) -> ok.
 terminate(ClientInfo, Reason, Session) ->
     run_terminate_hooks(ClientInfo, Reason, Session),
-    Reason =/= takenover andalso
-        redispatch_shared_messages(Session),
+    maybe_redispatch_shared_messages(Reason, Session),
     ok.
 
 run_terminate_hooks(ClientInfo, discarded, Session) ->
@@ -812,6 +811,13 @@ run_terminate_hooks(ClientInfo, takenover, Session) ->
     run_hook('session.takenover', [ClientInfo, info(Session)]);
 run_terminate_hooks(ClientInfo, Reason, Session) ->
     run_hook('session.terminated', [ClientInfo, Reason, info(Session)]).
+
+maybe_redispatch_shared_messages(takenover, _Session) ->
+    ok;
+maybe_redispatch_shared_messages(kicked, _Session) ->
+    ok;
+maybe_redispatch_shared_messages(_Reason, Session) ->
+    redispatch_shared_messages(Session).
 
 redispatch_shared_messages(#session{inflight = Inflight, mqueue = Q}) ->
     AllInflights = emqx_inflight:to_list(fun sort_fun/2, Inflight),


### PR DESCRIPTION
For takeover, there should be no message re-dispatch because the messages will be retried by the new session.

For kick, messages should not be re-dispatched for security reason. i.e. if admin has identified that there are malicious messages stored in persisted sessions, killing the session should not cause messages to be re-dispatched

