### PR TITLE
ci: fix packages build for ee releases 

### DIFF
--- a/.github/actions/detect-profiles/action.yaml
+++ b/.github/actions/detect-profiles/action.yaml
@@ -1,8 +1,4 @@
 name: 'Detect profiles'
-inputs:
-  ci_git_token:
-    required: true
-    type: string
 outputs:
   profiles:
     description: 'Detected profiles'
@@ -15,11 +11,9 @@ runs:
       shell: bash
       run: |
         if make emqx-ee --dry-run > /dev/null 2>&1; then
-          echo "::set-output name=profiles::[\"emqx-ee\"]"
-          echo "https://ci%40emqx.io:${{ inputs.ci_git_token }}@github.com" > $HOME/.git-credentials
-          git config --global credential.helper store
+          echo "profiles=[\"emqx-ee\"]" >> $GITHUB_OUTPUT
           echo "EMQX_NAME=emqx-ee" >> $GITHUB_ENV
         else
-          echo "::set-output name=profiles::[\"emqx\", \"emqx-edge\"]"
+          echo "profiles=[\"emqx\", \"emqx-edge\"]" >> $GITHUB_OUTPUT
           echo "EMQX_NAME=emqx" >> $GITHUB_ENV
         fi

--- a/.github/actions/package-macos/action.yaml
+++ b/.github/actions/package-macos/action.yaml
@@ -27,27 +27,23 @@ runs:
       shell: bash
       run: |
         brew update
-        brew install curl zip unzip gnu-sed kerl coreutils unixodbc freetds openssl@1.1
+        brew install curl zip unzip gnu-sed coreutils unixodbc freetds openssl@1.1
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
         echo "/usr/local/bin" >> $GITHUB_PATH
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       id: cache
       with:
-        path: ~/.kerl/${{ inputs.otp }}
+        path: /opt/erlang/${{ inputs.otp }}
         key: otp-install-${{ inputs.otp }}-${{ inputs.os }}-static-ssl-disable-hipe-disable-jit
-        restore-keys: |
-          otp-install-${{ inputs.otp }}-${{ inputs.os }}
     - name: build erlang
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
-      env:
-        KERL_BUILD_BACKEND: git
-        OTP_GITHUB_URL: https://github.com/emqx/otp
-        KERL_CONFIGURE_OPTIONS: --disable-dynamic-ssl-lib --with-ssl=/usr/local/opt/openssl@1.1 --disable-hipe --disable-jit
       run: |
-        kerl update releases
-        kerl build ${{ inputs.otp }}
-        kerl install ${{ inputs.otp }} $HOME/.kerl/${{ inputs.otp }}
+        git clone --depth 1 --branch OTP-${{ inputs.otp }} https://github.com/emqx/otp.git $HOME/otp-${{ inputs.otp }}
+        cd $HOME/otp-${{ inputs.otp }}
+        ./configure --disable-dynamic-ssl-lib --with-ssl=/usr/local/opt/openssl@1.1 --disable-hipe --disable-jit --prefix=/opt/erlang/${{ inputs.otp }}
+        make -j$(nproc)
+        sudo make install
     - name: build
       env:
         AUTO_INSTALL_BUILD_DEPS: 1
@@ -60,7 +56,7 @@ runs:
         APPLE_DEVELOPER_ID_BUNDLE_PASSWORD: ${{ inputs.apple_developer_id_bundle_password }}
       shell: bash
       run: |
-        . $HOME/.kerl/${{ inputs.otp }}/activate
+        export PATH="/opt/erlang/${{ inputs.otp }}/bin:$PATH"
         make ensure-rebar3
         sudo cp rebar3 /usr/local/bin/rebar3
         make ${EMQX_NAME}-zip

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -26,14 +26,12 @@ jobs:
       profiles: ${{ steps.detect-profiles.outputs.profiles}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           path: source
-          fetch-depth: 0
-      - id: detect-profiles
+      - name: detect-profiles
+        id: detect-profiles
         uses: ./source/.github/actions/detect-profiles
-        with:
-          ci_git_token: ${{ secrets.CI_GIT_TOKEN }}
       - name: get_all_deps
         if: endsWith(github.repository, 'emqx')
         run: |
@@ -109,7 +107,7 @@ jobs:
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx stop
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx install
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx uninstall
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.profile }}
         path: source/_packages/${{ matrix.profile }}/.
@@ -126,7 +124,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: source
         path: .
@@ -135,10 +133,7 @@ jobs:
         ln -s . source
         unzip -q source.zip
         rm source source.zip
-    - id: detect-profiles
-      uses: ./.github/actions/detect-profiles
-      with:
-        ci_git_token: ${{ secrets.CI_GIT_TOKEN }}
+    - uses: ./.github/actions/detect-profiles
     - uses: ./.github/actions/package-macos
       with:
         otp: ${{ matrix.otp }}
@@ -147,7 +142,7 @@ jobs:
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
         apple_developer_id_bundle: ${{ secrets.APPLE_DEVELOPER_ID_BUNDLE }}
         apple_developer_id_bundle_password: ${{ secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: ${EMQX_NAME}-${{ matrix.otp }}
         path: _packages/${EMQX_NAME}/.

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -30,12 +30,15 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - uses: ./.github/actions/detect-profiles
-      with:
-        ci_git_token: ${{ secrets.CI_GIT_TOKEN }}
     - name: fix-git-unsafe-repository
       run: git config --global --add safe.directory /__w/emqx/emqx
-    - uses: actions/cache@v2
+    - uses: ./.github/actions/detect-profiles
+    - name: ensure access to github
+      if: endsWith(github.repository, 'enterprise')
+      run: |
+        echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
+        git config --global credential.helper store
+    - uses: actions/cache@v3
       with:
         # dialyzer PLTs
         path: ~/.cache/rebar3/
@@ -48,7 +51,7 @@ jobs:
       run: make ${EMQX_NAME}-zip
     - name: build deb/rpm packages
       run: make ${EMQX_NAME}-pkg
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: rebar3.crashdump
@@ -57,7 +60,7 @@ jobs:
       run: |
         export CODE_PATH=$GITHUB_WORKSPACE
         .ci/build_packages/tests.sh
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.os }}
         path: _packages/**/*.zip
@@ -71,10 +74,13 @@ jobs:
           - macos-11
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+    - name: ensure access to github
+      if: endsWith(github.repository, 'enterprise')
+      run: |
+        echo "https://ci%40emqx.io:${{ secrets.CI_GIT_TOKEN }}@github.com" > $HOME/.git-credentials
+        git config --global credential.helper store
     - uses: ./.github/actions/detect-profiles
-      with:
-        ci_git_token: ${{ secrets.CI_GIT_TOKEN }}
     - uses: ./.github/actions/package-macos
       with:
         otp: ${{ matrix.otp }}
@@ -83,12 +89,12 @@ jobs:
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
         apple_developer_id_bundle: ${{ secrets.APPLE_DEVELOPER_ID_BUNDLE }}
         apple_developer_id_bundle_password: ${{ secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: rebar3.crashdump
         path: ./rebar3.crashdump
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: macos
         path: _packages/**/*.zip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,14 +13,9 @@ jobs:
       profiles: ${{ steps.detect-profiles.outputs.profiles}}
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          path: source
-          fetch-depth: 0
+      - uses: actions/checkout@v3
       - id: detect-profiles
-        uses: ./source/.github/actions/detect-profiles
-        with:
-          ci_git_token: ${{ secrets.CI_GIT_TOKEN }}
+        uses: ./.github/actions/detect-profiles
 
   upload:
     runs-on: ubuntu-20.04
@@ -59,12 +54,10 @@ jobs:
                -X POST \
                -d "{\"repo\":\"emqx/emqx\", \"tag\": \"${{ github.ref_name }}\" }" \
                ${{ secrets.EMQX_IO_RELEASE_API }}
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
+      - uses: actions/checkout@v3
       - name: get version
         id: version
-        run: echo "::set-output name=version::$(./pkg-vsn.sh)"
+        run: echo "version=$(./pkg-vsn.sh)" >> $GITHUB_OUTPUT
       - uses: emqx/push-helm-action@v1
         if: github.event_name == 'release' && endsWith(github.repository, 'emqx') && matrix.profile == 'emqx'
         with:


### PR DESCRIPTION
- build otp manually instead of kerl
- bump versions on some actions
- fix deprecated way of setting step output in some cases