### PR TITLE
feat: add prometheus collectors config

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1021,10 +1021,10 @@ tr_vm_system_info_collector(Conf) ->
     metrics_enabled(conf_get("prometheus.vm_system_info_collector", Conf, enabled)).
 
 tr_vm_memory_collector(Conf) ->
-    metrics_enabled(conf_get("prometheus.vm_system_info_collector", Conf, enabled)).
+    metrics_enabled(conf_get("prometheus.vm_memory_collector", Conf, enabled)).
 
 tr_vm_msacc_collector(Conf) ->
-    metrics_enabled(conf_get("prometheus.vm_system_info_collector", Conf, enabled)).
+    metrics_enabled(conf_get("prometheus.vm_msacc_collector", Conf, enabled)).
 
 metrics_enabled(enabled) -> all;
 metrics_enabled(disabled) -> [].

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -980,7 +980,7 @@ desc("authorization") ->
 desc(_) ->
     undefined.
 
-translations() -> ["ekka", "kernel", "emqx", "gen_rpc"].
+translations() -> ["ekka", "kernel", "emqx", "gen_rpc", "prometheus"].
 
 translation("ekka") ->
     [{"cluster_discovery", fun tr_cluster_discovery/1}];
@@ -997,7 +997,37 @@ translation("emqx") ->
         {"local_override_conf_file", fun tr_local_override_conf_file/1}
     ];
 translation("gen_rpc") ->
-    [{"default_client_driver", fun tr_default_config_driver/1}].
+    [{"default_client_driver", fun tr_default_config_driver/1}];
+translation("prometheus") ->
+    [
+        {"vm_dist_collector_metrics", fun tr_vm_dist_collector/1},
+        {"mnesia_collector_metrics", fun tr_mnesia_collector/1},
+        {"vm_statistics_collector_metrics", fun tr_vm_statistics_collector/1},
+        {"vm_system_info_collector_metrics", fun tr_vm_system_info_collector/1},
+        {"vm_memory_collector_metrics", fun tr_vm_memory_collector/1},
+        {"vm_msacc_collector_metrics", fun tr_vm_msacc_collector/1}
+    ].
+
+tr_vm_dist_collector(Conf) ->
+    metrics_enabled(conf_get("prometheus.vm_dist_collector", Conf, enabled)).
+
+tr_mnesia_collector(Conf) ->
+    metrics_enabled(conf_get("prometheus.mnesia_collector", Conf, enabled)).
+
+tr_vm_statistics_collector(Conf) ->
+    metrics_enabled(conf_get("prometheus.vm_statistics_collector", Conf, enabled)).
+
+tr_vm_system_info_collector(Conf) ->
+    metrics_enabled(conf_get("prometheus.vm_system_info_collector", Conf, enabled)).
+
+tr_vm_memory_collector(Conf) ->
+    metrics_enabled(conf_get("prometheus.vm_system_info_collector", Conf, enabled)).
+
+tr_vm_msacc_collector(Conf) ->
+    metrics_enabled(conf_get("prometheus.vm_system_info_collector", Conf, enabled)).
+
+metrics_enabled(enabled) -> all;
+metrics_enabled(disabled) -> [].
 
 tr_default_config_driver(Conf) ->
     conf_get("rpc.driver", Conf).

--- a/apps/emqx_prometheus/i18n/emqx_prometheus_schema_i18n.conf
+++ b/apps/emqx_prometheus/i18n/emqx_prometheus_schema_i18n.conf
@@ -30,4 +30,41 @@ emqx_prometheus_schema {
       zh: """开启或关闭 Prometheus 数据推送"""
     }
   }
+  vm_dist_collector {
+    desc {
+      en: """Enable or disable VM distribution collector, collects information about the sockets and processes involved in the Erlang distribution mechanism."""
+      zh: """开启或关闭 VM 分布采集器，收集 Erlang 分布机制中涉及的套接字和进程的信息。"""
+    }
+  }
+  mnesia_collector {
+    desc {
+      en: """Enable or disable Mnesia collector, collects Mnesia metrics mainly using mnesia:system_info/1 ."""
+      zh: """开启或关闭 Mnesia 采集器, 使用 mnesia:system_info/1 收集 Mnesia 相关指标"""
+    }
+  }
+  vm_statistics_collector {
+    desc {
+      en: """Enable or disable VM statistics collector, collects Erlang VM metrics using erlang:statistics/1 ."""
+      zh: """开启或关闭 VM 统计采集器, 使用 erlang:statistics/1 收集 Erlang VM 相关指标"""
+    }
+  }
+
+  vm_system_info_collector {
+    desc {
+      en: """Enable or disable VM system info collector, collects Erlang VM metrics using erlang:system_info/1 ."""
+      zh: """开启或关闭 VM 系统信息采集器, 使用 erlang:system_info/1 收集 Erlang VM 相关指标"""
+    }
+  }
+  vm_memory_collector {
+    desc {
+      en: """Enable or disable VM memory collector, collects information about memory dynamically allocated by the Erlang emulator using erlang:memory/0 , also provides basic (D)ETS statistics ."""
+      zh: """开启或关闭 VM 内存采集器, 使用 erlang:memory/0 收集 Erlang 虚拟机动态分配的内存信息，同时提供基本的 (D)ETS 统计信息"""
+    }
+    }
+  vm_msacc_collector {
+    desc {
+      en: """Enable or disable VM msacc collector, collects microstate accounting metrics using erlang:statistics(microstate_accounting) ."""
+      zh: """开启或关闭 VM msacc 采集器, 使用 erlang:statistics(microstate_accounting) 收集微状态计数指标"""
+    }
+  }
 }

--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.0.2"},
+    {vsn, "5.0.3"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -147,7 +147,8 @@ handle_info({timeout, R, ?TIMER_MSG}, State = #state{timer = R, push_gateway = U
     Url = lists:concat([Uri, "/metrics/job/", Name, "/instance/", Name, "~", Ip]),
     Data = prometheus_text_format:format(),
     httpc:request(post, {Url, [], "text/plain", Data}, [{autoredirect, true}], []),
-    {noreply, ensure_timer(State)};
+    %% Data is too big, hibernate for saving memory and stop system monitor warning.
+    {noreply, ensure_timer(State), hibernate};
 handle_info(_Msg, State) ->
     {noreply, State}.
 

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -59,6 +59,66 @@ fields("prometheus") ->
                     required => true,
                     desc => ?DESC(enable)
                 }
+            )},
+        {vm_dist_collector,
+            ?HOCON(
+                hoconsc:enum([enabled, disabled]),
+                #{
+                    default => enabled,
+                    required => true,
+                    hidden => true,
+                    desc => ?DESC(vm_dist_collector)
+                }
+            )},
+        {mnesia_collector,
+            ?HOCON(
+                hoconsc:enum([enabled, disabled]),
+                #{
+                    default => enabled,
+                    required => true,
+                    hidden => true,
+                    desc => ?DESC(mnesia_collector)
+                }
+            )},
+        {vm_statistics_collector,
+            ?HOCON(
+                hoconsc:enum([enabled, disabled]),
+                #{
+                    default => enabled,
+                    required => true,
+                    hidden => true,
+                    desc => ?DESC(vm_statistics_collector)
+                }
+            )},
+        {vm_system_info_collector,
+            ?HOCON(
+                hoconsc:enum([enabled, disabled]),
+                #{
+                    default => enabled,
+                    required => true,
+                    hidden => true,
+                    desc => ?DESC(vm_system_info_collector)
+                }
+            )},
+        {vm_memory_collector,
+            ?HOCON(
+                hoconsc:enum([enabled, disabled]),
+                #{
+                    default => enabled,
+                    required => true,
+                    hidden => true,
+                    desc => ?DESC(vm_memory_collector)
+                }
+            )},
+        {vm_msacc_collector,
+            ?HOCON(
+                hoconsc:enum([enabled, disabled]),
+                #{
+                    default => enabled,
+                    required => true,
+                    hidden => true,
+                    desc => ?DESC(vm_msacc_collector)
+                }
             )}
     ].
 

--- a/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_SUITE.erl
@@ -28,6 +28,12 @@
     "  push_gateway_server = \"http://127.0.0.1:9091\"\n"
     "  interval = \"1s\"\n"
     "  enable = true\n"
+    "  vm_dist_collector = enabled\n"
+    "  mnesia_collector = enabled\n"
+    "  vm_statistics_collector = disabled\n"
+    "  vm_system_info_collector = disabled\n"
+    "  vm_memory_collector = enabled\n"
+    "  vm_msacc_collector = enabled\n"
     "}\n"
 >>).
 
@@ -71,7 +77,8 @@ t_start_stop(_) ->
     %% wait the interval timer tigger
     timer:sleep(2000).
 
-t_test(_) ->
+t_collector_no_crash_test(_) ->
+    prometheus_text_format:format(),
     ok.
 
 t_only_for_coverage(_) ->


### PR DESCRIPTION
Now we can turn off `vm_dist_collector/vm_dist_collector/mnesia_collector/vm_statistics_collector/vm_system_info_collector/vm_memory_collector/vm_msacc_collector` metrics.
These metrics are very slow to return after a single node exceeds 2.7M connections, causing fetching the prometheus/status API timeout. So add switches to turn them off.