### PR TITLE
fix(emqx_rule_events): do not keep tuple-value message headers

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -693,5 +693,9 @@ printable_maps(Headers) ->
                         value => Value
                      } || {Key, Value} <- V0]
                 };
-            (K, V0, AccIn) -> AccIn#{K => V0}
+            (_K, V, AccIn) when is_tuple(V) ->
+                %% internal header
+                AccIn;
+            (K, V, AccIn) ->
+                AccIn#{K => V}
         end, #{}, Headers).

--- a/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
@@ -22,10 +22,16 @@ t_mod_hook_fun(_) ->
 t_printable_maps(_) ->
     Headers = #{peerhost => {127,0,0,1},
                 peername => {{127,0,0,1}, 9980},
-                sockname => {{127,0,0,1}, 1883}
+                sockname => {{127,0,0,1}, 1883},
+                redispatch_to => {<<"group">>, <<"sub/topic/+">>},
+                shared_dispatch_ack => {self(), ref}
                 },
+    Converted = emqx_rule_events:printable_maps(Headers),
     ?assertMatch(
         #{peerhost := <<"127.0.0.1">>,
           peername := <<"127.0.0.1:9980">>,
           sockname := <<"127.0.0.1:1883">>
-        }, emqx_rule_events:printable_maps(Headers)).
+        }, Converted),
+    ?assertNot(maps:is_key(redispatch_to, Converted)),
+    ?assertNot(maps:is_key(shared_dispatch_ack, Converted)),
+    ok.

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -1,4 +1,6 @@
-### Enhancements
+# v4.3.22
+
+## Enhancements
 
 - Asynchronously refresh the resources and rules during emqx boot-up [#9199](https://github.com/emqx/emqx/pull/9199).
   This is to avoid slowing down the boot if some resources spend long time establishing the connection.
@@ -8,7 +10,7 @@
 
 - JWT ACL claim supports `all` action to imply the rules applie to both `pub` and `sub` [#9044](https://github.com/emqx/emqx/pull/9044).
 
-### Bug fixes
+## Bug fixes
 
 - Improve the display of rule's 'Maximum Speed' counter to only reserve 2 decimal places. [#9185](https://github.com/emqx/emqx/pull/9185)
   This is to avoid displaying floats like `0.30000000000000004` on the dashboard.
@@ -21,5 +23,10 @@
 
 - Restore old `emqx_auth_jwt` module API, so the hook callback functions registered in older version will not be invalidated after hot-upgrade [#9144](https://github.com/emqx/emqx/pull/9144).
 
-- Fixed the response status code for the `/status` endpoint [#9210](https://github.com/emqx/emqx/pull/9210). 
+- Fixed the response status code for the `/status` endpoint [#9210](https://github.com/emqx/emqx/pull/9210).
   Before the fix, it always returned `200` even if the EMQX application was not running.  Now it returns `503` in that case.
+
+- Fix message delivery related event encoding [#9226](https://github.com/emqx/emqx/pull/9226)
+  For rule-engine's input events like `$events/message_delivered`, and `$events/message_dropped`,
+  if the message was delivered to a shared-subscription, the encoding (to JSON) of the event will fail.
+  Affected versions: `v4.3.21`, `v4.4.10`, `e4.3.16` and `e4.4.10`.

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -1,4 +1,6 @@
-### 增强
+# v4.3.22
+
+## 增强
 
 - 在 emqx 启动时，异步地刷新资源和规则 [#9199](https://github.com/emqx/emqx/pull/9199)。
   这个改动是为了避免因为一些资源连接建立过慢，而导致启动时间过长。
@@ -8,7 +10,7 @@
 
 - 基于 JWT 的 ACL 支持 `all` 动作，指定同时适用于 `pub` 和 `sub` 两个动作的规则列表 [#9044](https://github.com/emqx/emqx/pull/9044)。
 
-### 修复
+## 修复
 
 - 改进规则的 "最大执行速度" 的计数，只保留小数点之后 2 位 [#9185](https://github.com/emqx/emqx/pull/9185)
   避免在 dashboard 上展示类似这样的浮点数：`0.30000000000000004`。
@@ -23,3 +25,8 @@
 
 - 修正了 `/status` API 的响应状态代码 [#9210](https://github.com/emqx/emqx/pull/9210)。
   在修复之前，它总是返回 `200`，即使 EMQX 应用程序没有运行。 现在它在这种情况下返回 `503`。
+
+- 修复规则引擎的消息事件编码失败 [#9226](https://github.com/emqx/emqx/pull/9226)。
+  带消息的规则引擎事件，例如 `$events/message_delivered` 和 `$events/message_dropped`,
+  如果消息事件是共享订阅产生的，在编码（到 JSON 格式）过程中会失败。
+  影响到的版本：`v4.3.21`, `v4.4.10`, `e4.3.16` 和 `e4.4.10`。


### PR DESCRIPTION
the converted message is for JSON encoding, keeping the tuple-values will lead to encoding error.

