### PR TITLE
fix(emqx_rule_events): drop tuple-value from message headers

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -1054,8 +1054,11 @@ printable_maps(Headers) ->
                      || {Key, Value} <- V0
                     ]
                 };
-            (K, V0, AccIn) ->
-                AccIn#{K => V0}
+            (_K, V, AccIn) when is_tuple(V) ->
+                %% internal headers
+                AccIn;
+            (K, V, AccIn) ->
+                AccIn#{K => V}
         end,
         #{},
         Headers

--- a/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
@@ -26,13 +26,19 @@ t_printable_maps(_) ->
     Headers = #{
         peerhost => {127, 0, 0, 1},
         peername => {{127, 0, 0, 1}, 9980},
-        sockname => {{127, 0, 0, 1}, 1883}
+        sockname => {{127, 0, 0, 1}, 1883},
+        redispatch_to => {<<"group">>, <<"sub/topic/+">>},
+        shared_dispatch_ack => {self(), ref}
     },
+    Converted = emqx_rule_events:printable_maps(Headers),
     ?assertMatch(
         #{
             peerhost := <<"127.0.0.1">>,
             peername := <<"127.0.0.1:9980">>,
             sockname := <<"127.0.0.1:1883">>
         },
-        emqx_rule_events:printable_maps(Headers)
-    ).
+        Converted
+    ),
+    ?assertNot(maps:is_key(redispatch_to, Converted)),
+    ?assertNot(maps:is_key(shared_dispatch_ack, Converted)),
+    ok.

--- a/changes/v5.0.10-en.md
+++ b/changes/v5.0.10-en.md
@@ -19,3 +19,8 @@
 
 - Fixed the HTTP response status code for the `/status` endpoint [#9211](https://github.com/emqx/emqx/pull/9211).
   Before the fix, it always returned `200` even if the EMQX application was not running. Now it returns `503` in that case.
+
+- Fix message delivery related event encoding [#9228](https://github.com/emqx/emqx/pull/9228).
+  This bug was introduced in v5.0.9. For Rule-Engine's input events like `$events/message_delivered`
+  and `$events/message_dropped`, if the message was delivered to a shared-subscription,
+  the encoding (to JSON) of the event will fail.

--- a/changes/v5.0.10-zh.md
+++ b/changes/v5.0.10-zh.md
@@ -18,3 +18,7 @@
 
 - 修正了 `/status` 端点的响应状态代码 [#9211](https://github.com/emqx/emqx/pull/9211)。
   在此修复前，它总是返回 HTTP 状态码 `200`，即使 EMQX 没有完成启动或正在重启。 现在它在这些情况下会返回状态码 `503`。
+
+- 修复规则引擎的消息事件编码失败 [#9228](https://github.com/emqx/emqx/pull/9228)。
+  该问题在 v5.0.9 中引入：带消息的规则引擎事件，例如 `$events/message_delivered` 和
+  `$events/message_dropped`, 如果消息事件是共享订阅产生的，在编码（到 JSON 格式）过程中会失败。


### PR DESCRIPTION
the message headers are fed to a JSON ecnoder which may crash if the header value is a tuple

