### PR TITLE
feat(mgmt): add alias endpoint for health check 

### DIFF
--- a/apps/emqx_management/i18n/emqx_mgmt_api_status_i18n.conf
+++ b/apps/emqx_management/i18n/emqx_mgmt_api_status_i18n.conf
@@ -1,0 +1,38 @@
+emqx_mgmt_api_status {
+  get_status_api {
+    desc {
+      en: "Serves as a health check for the node.  Returns a plain text response"
+          " describing the status of the node.  This endpoint requires no"
+          " authentication.\n"
+          "\n"
+          "Returns status code 200 if the EMQX application is up and running, "
+          "503 otherwise."
+          "\n"
+          "The GET `/status` endpoint (without the `/api/...` prefix) is also an alias"
+          " to this endpoint and works in the same way."
+      zh: "作为节点的健康检查。 返回一个纯文本的响应，描述节点的状态。\n"
+          "\n"
+          "如果 EMQX 应用程序已经启动并运行，返回状态代码 200，否则返回 503。\n"
+          "\n"
+          "GET `/status`端点（没有`/api/...`前缀）也是这个端点的一个别名，工作方式相同。"
+    }
+  }
+
+  get_status_response200 {
+    desc {
+      en: "Node emqx@127.0.0.1 is started\n"
+          "emqx is running"
+      zh: "Node emqx@127.0.0.1 is started\n"
+          "emqx is running"
+    }
+  }
+
+  get_status_response503 {
+    desc {
+      en: "Node emqx@127.0.0.1 is stopped\n"
+          "emqx is not_running"
+      zh: "Node emqx@127.0.0.1 is stopped\n"
+          "emqx is not_running"
+    }
+  }
+}


### PR DESCRIPTION
This allow use to reference `/status` in the API documentation without
manually editing the `swagger.json` file.

![image](https://user-images.githubusercontent.com/16166434/197866375-c0de38de-6c2d-4b98-9857-6d9ccf1962ee.png)
