### PR TITLE
build: stop running prepare on each build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ apps/emqx/test/emqx_static_checks_data/master.bpapi
 # rendered configurations
 *.conf.rendered
 lux_logs/
+/.prepare

--- a/Makefile
+++ b/Makefile
@@ -30,18 +30,19 @@ export REBAR_GIT_CLONE_OPTIONS += --depth=1
 .PHONY: default
 default: $(REBAR) $(PROFILE)
 
-.PHONY: prepare
-prepare: FORCE
+.prepare:
 	@$(SCRIPTS)/git-hooks-init.sh # this is no longer needed since 5.0 but we keep it anyway
 	@$(SCRIPTS)/prepare-build-deps.sh
-
-FORCE:
+	@touch .prepare
 
 .PHONY: all
 all: $(REBAR) $(PROFILES)
 
 .PHONY: ensure-rebar3
 ensure-rebar3:
+	@$(SCRIPTS)/ensure-rebar3.sh
+
+$(REBAR): .prepare
 	@$(SCRIPTS)/ensure-rebar3.sh
 
 .PHONY: ensure-hex
@@ -59,8 +60,6 @@ ensure-mix-rebar: $(REBAR)
 .PHONY: mix-deps-get
 mix-deps-get: $(ELIXIR_COMMON_DEPS)
 	@mix deps.get
-
-$(REBAR): prepare ensure-rebar3
 
 .PHONY: eunit
 eunit: $(REBAR) conf-segs

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,7 @@ all: $(REBAR) $(PROFILES)
 ensure-rebar3:
 	@$(SCRIPTS)/ensure-rebar3.sh
 
-$(REBAR): .prepare
-	@$(SCRIPTS)/ensure-rebar3.sh
+$(REBAR): .prepare ensure-rebar3
 
 .PHONY: ensure-hex
 ensure-hex:


### PR DESCRIPTION
Our default and main build targets depend on `$(REBAR)`, which is real file ./rebar3, but `$(REBAR)` target in turn depends on the phony target `prepare`. Accordingly, make executes `prepare` each time you run, e.g., `make emqx`. And it does not matter how many ages ago you installed dependencies.

This PR changes phony `prepare` target to real `.prepare` file to mark that the `prepare` has been run on this machine and to not run it again.

Wins:
- local repetitive builds should run a little faster (on macos especially)
- `make emqx` will work when installing emqx as homebrew package (right now it's impossible because when homebrew installs a package, `brew` command is not available and `prepare-build-deps.sh` script fails)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility
Not sure, please assist. There may be some automation depending on `make prepare`.

## More information
