### PR TITLE
feat: bootstrap dashboard users from dashboard.bootstrap_users_file

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_acl_mnesia_cli.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_acl_mnesia_cli.erl
@@ -122,8 +122,8 @@ cli(_) ->
                    , {"acl list ", "List all acls"}
                    , {"acl show clientid <Clientid>", "Lookup clientid acl detail"}
                    , {"acl show username <Username>", "Lookup username acl detail"}
-                   , {"acl aad clientid <Clientid> <Topic> <Action> <Access>", "Add clientid acl"}
-                   , {"acl add Username <Username> <Topic> <Action> <Access>", "Add username acl"}
+                   , {"acl add clientid <Clientid> <Topic> <Action> <Access>", "Add clientid acl"}
+                   , {"acl add username <Username> <Topic> <Action> <Access>", "Add username acl"}
                    , {"acl add _all <Topic> <Action> <Access>", "Add $all acl"}
                    , {"acl delete clientid <Clientid> <Topic>", "Delete clientid acl"}
                    , {"acl delete username <Username> <Topic>", "Delete username acl"}

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
@@ -1,6 +1,6 @@
 {application, emqx_auth_mnesia,
  [{description, "EMQ X Authentication with Mnesia"},
-  {vsn, "4.3.9"}, % strict semver, bump manually
+  {vsn, "4.3.10"}, % strict semver, bump manually
   {modules, []},
   {registered, []},
   {applications, [kernel,stdlib,mnesia]},

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.appup.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.appup.src
@@ -1,7 +1,9 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"4.3.7",
+  [{<<"4\\.3\\.[8-9]">>,
+    [{load_module,emqx_acl_mnesia_cli,brutal_purge,soft_purge,[]}]},
+   {"4.3.7",
     [{load_module,emqx_auth_mnesia_api,brutal_purge,soft_purge,[]},
      {load_module,emqx_acl_mnesia_cli,brutal_purge,soft_purge,[]}]},
    {<<"4\\.3\\.[5-6]">>,
@@ -33,7 +35,9 @@
      {load_module,emqx_acl_mnesia_cli,brutal_purge,soft_purge,[]},
      {load_module,emqx_auth_mnesia_app,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
-  [{"4.3.7",
+  [{<<"4\\.3\\.[8-9]">>,
+    [{load_module,emqx_acl_mnesia_cli,brutal_purge,soft_purge,[]}]},
+   {"4.3.7",
     [{load_module,emqx_auth_mnesia_api,brutal_purge,soft_purge,[]},
      {load_module,emqx_acl_mnesia_cli,brutal_purge,soft_purge,[]}]},
    {<<"4\\.3\\.[5-6]">>,

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -17,6 +17,9 @@
 
 - Enhanced log security in ACL modules, sensitive data will be obscured. [#9242](https://github.com/emqx/emqx/pull/9242).
 
+- Add `dashboard.bootstrap_users_file` configuration to bulk import default user&password when EMQX first starts.
+
+
 ## Bug fixes
 
 - Fix that after uploading a backup file with an UTF8 filename, HTTP API `GET /data/export` fails with status code 500 [#9224](https://github.com/emqx/emqx/pull/9224).

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -17,8 +17,7 @@
 
 - Enhanced log security in ACL modules, sensitive data will be obscured. [#9242](https://github.com/emqx/emqx/pull/9242).
 
-- Add `dashboard.bootstrap_users_file` configuration to bulk import default user&password when EMQX first starts [#9256](https://github.com/emqx/emqx/pull/9256).
-
+- Add `dashboard.bootstrap_users_file` configuration to bulk import default administrative username and password when EMQX initializes the database [#9256](https://github.com/emqx/emqx/pull/9256).
 
 
 ## Bug fixes

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -17,7 +17,8 @@
 
 - Enhanced log security in ACL modules, sensitive data will be obscured. [#9242](https://github.com/emqx/emqx/pull/9242).
 
-- Add `dashboard.bootstrap_users_file` configuration to bulk import default user&password when EMQX first starts.
+- Add `dashboard.bootstrap_users_file` configuration to bulk import default user&password when EMQX first starts [#9256](https://github.com/emqx/emqx/pull/9256).
+
 
 
 ## Bug fixes

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -17,6 +17,9 @@
 
 - 增强 ACL 模块中的日志安全性，敏感数据将被模糊化。[#9242](https://github.com/emqx/emqx/pull/9242)。
 
+- 增加 `dashboard.bootstrap_users_file` 配置，可以在EMQX第一次启动时批量导入默认的用户/密码。
+
+
 ## 修复
 
 - 修复若上传的备份文件名中包含 UTF8 字符，`GET /data/export` HTTP 接口返回 500 错误 [#9224](https://github.com/emqx/emqx/pull/9224)。

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -17,7 +17,7 @@
 
 - 增强 ACL 模块中的日志安全性，敏感数据将被模糊化。[#9242](https://github.com/emqx/emqx/pull/9242)。
 
-- 增加 `dashboard.bootstrap_users_file` 配置，可以在EMQX第一次启动时批量导入默认的用户/密码。
+- 增加 `dashboard.bootstrap_users_file` 配置，可以在EMQX第一次启动时批量导入默认的用户/密码 [#9256](https://github.com/emqx/emqx/pull/9256)。
 
 
 ## 修复

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -17,7 +17,7 @@
 
 - 增强 ACL 模块中的日志安全性，敏感数据将被模糊化。[#9242](https://github.com/emqx/emqx/pull/9242)。
 
-- 增加 `dashboard.bootstrap_users_file` 配置，可以在EMQX第一次启动时批量导入默认的用户/密码 [#9256](https://github.com/emqx/emqx/pull/9256)。
+- 增加 `dashboard.bootstrap_users_file` 配置，可以让 EMQX 初始化数据库时，从该文件批量导入一些控制台用户的用户名 / 密码 [#9256](https://github.com/emqx/emqx/pull/9256)。
 
 
 ## 修复

--- a/lib-ce/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/lib-ce/emqx_dashboard/etc/emqx_dashboard.conf
@@ -17,6 +17,15 @@ dashboard.default_user.login = admin
 ## Value: String
 dashboard.default_user.password = public
 
+## Initialize users file
+## Is used to add an administrative user to Dashboard when emqx is first launched,
+## the format is:
+##  ```
+##username1:password1
+##username2:password2
+## ```
+dashboard.bootstrap_users_file = {{ platform_etc_dir }}/bootstrap_users.txt
+
 ##--------------------------------------------------------------------
 ## HTTP Listener
 

--- a/lib-ce/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/lib-ce/emqx_dashboard/etc/emqx_dashboard.conf
@@ -24,7 +24,7 @@ dashboard.default_user.password = public
 ##username1:password1
 ##username2:password2
 ## ```
-dashboard.bootstrap_users_file = {{ platform_etc_dir }}/bootstrap_users.txt
+# dashboard.bootstrap_users_file = {{ platform_etc_dir }}/bootstrap_users.txt
 
 ##--------------------------------------------------------------------
 ## HTTP Listener

--- a/lib-ce/emqx_dashboard/etc/emqx_dashboard.conf
+++ b/lib-ce/emqx_dashboard/etc/emqx_dashboard.conf
@@ -18,8 +18,9 @@ dashboard.default_user.login = admin
 dashboard.default_user.password = public
 
 ## Initialize users file
-## Is used to add an administrative user to Dashboard when emqx is first launched,
-## the format is:
+## Is used to add administrative dashboard users when EMQX is launched for the first time.
+## This config will not take any effect once EMQX database is populated with the provided users.
+## The file content format is as below:
 ##  ```
 ##username1:password1
 ##username2:password2

--- a/lib-ce/emqx_dashboard/priv/emqx_dashboard.schema
+++ b/lib-ce/emqx_dashboard/priv/emqx_dashboard.schema
@@ -10,6 +10,11 @@
   {override_env, "ADMIN_PASSWORD"}
 ]}.
 
+{mapping, "dashboard.bootstrap_users_file", "emqx_dashboard.bootstrap_users_file", [
+  {datatype, string},
+  hidden
+]}.
+
 {mapping, "dashboard.listener.http", "emqx_dashboard.listeners", [
   {datatype, [integer, ip]}
 ]}.

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard,
  [{description, "EMQ X Web Dashboard"},
-  {vsn, "4.3.19"}, % strict semver, bump manually!
+  {vsn, "4.3.18"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_dashboard_sup]},
   {applications, [kernel,stdlib,mnesia,minirest]},

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard,
  [{description, "EMQ X Web Dashboard"},
-  {vsn, "4.3.18"}, % strict semver, bump manually!
+  {vsn, "4.3.19"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_dashboard_sup]},
   {applications, [kernel,stdlib,mnesia,minirest]},

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -212,7 +212,7 @@ add_bootstrap_users(File, 0) ->
                 ok -> ok;
                 Error ->
                     %% if failed add bootstrap users, we should clear all bootstrap users
-                    mnesia:transaction(fun clear_bootstrap_users/0, []),
+                    {atomic, ok} = mnesia:transaction(fun clear_bootstrap_users/0, []),
                     Error
                     end;
         {error, Reason} = Error ->

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -23,7 +23,7 @@
 -include("emqx_dashboard.hrl").
 -include_lib("emqx/include/logger.hrl").
 -define(DEFAULT_PASSWORD, <<"public">>).
--define(BOOTSTRAP_USER_TAG, <<"bootstrap user">>).
+-define(BOOTSTRAP_USER_TAG, <<"bootstrapped">>).
 
 -boot_mnesia({mnesia, [boot]}).
 -copy_mnesia({mnesia, [copy]}).
@@ -242,7 +242,7 @@ add_bootstrap_user(File, Dev, MP, Line) ->
                     case add_user(Username, Password, ?BOOTSTRAP_USER_TAG) of
                         ok ->
                             add_bootstrap_user(File, Dev, MP, Line + 1);
-                        Reason ->
+                        {error, Reason} ->
                             throw(#{file => File, line => Line, content => Bin, reason => Reason})
                     end;
                 _ ->
@@ -254,7 +254,7 @@ add_bootstrap_user(File, Dev, MP, Line) ->
             end;
         eof ->
             ok;
-        Error ->
+        {error, Error} ->
             throw(#{file => File, line => Line, reason => Error})
     end.
 

--- a/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -212,9 +212,9 @@ add_bootstrap_users(File, 0) ->
                 ok -> ok;
                 Error ->
                     %% if failed add bootstrap users, we should clear all bootstrap users
-                    {atomic, ok} = mnesia:transaction(fun clear_bootstrap_users/0, []),
+                    {atomic, ok} = mnesia:clear_table(mqtt_admin),
                     Error
-                    end;
+            end;
         {error, Reason} = Error ->
             ?LOG(error,
                 "failed to open the dashboard bootstrap users file(~s) for ~p",
@@ -257,14 +257,6 @@ add_bootstrap_user(File, Dev, MP, Line) ->
         Error ->
             throw(#{file => File, line => Line, reason => Error})
     end.
-
-clear_bootstrap_users() ->
-    FoldFun =
-        fun(#mqtt_admin{tags = ?BOOTSTRAP_USER_TAG} = User, Acc) ->
-            mnesia:delete_object(User), Acc;
-            (_, Acc) -> Acc
-        end,
-    mnesia:foldl(FoldFun, ok, mqtt_admin).
 
 bad_login_penalty() ->
     timer:sleep(2000),

--- a/lib-ce/emqx_dashboard/test/emqx_dashboard_admin_bootstrap_user.erl
+++ b/lib-ce/emqx_dashboard/test/emqx_dashboard_admin_bootstrap_user.erl
@@ -1,0 +1,89 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_admin_bootstrap_user).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+-import(emqx_dashboard_SUITE, [http_post/2]).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx/include/emqx.hrl").
+
+%%--------------------------------------------------------------------
+%% Setups
+%%--------------------------------------------------------------------
+
+all() ->
+    emqx_ct:all(?MODULE).
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+t_load_ok(_) ->
+    Bin = <<"test-1:password-1\ntest-2:password-2">>,
+    File = "./bootstrap_users.txt",
+    ok = file:write_file(File, Bin),
+    _ = mnesia:clear_table(emqx_admin),
+    application:set_env(emqx_dashboard, bootstrap_users_file, File),
+    emqx_ct_helpers:start_apps([emqx_dashboard]),
+    ?assertEqual(#{<<"code">> => 0}, check_auth(<<"test-1">>, <<"password-1">>)),
+    ?assertEqual(#{<<"code">> => 0}, check_auth(<<"test-2">>, <<"password-2">>)),
+    ?assertEqual(#{<<"message">> => <<"Username/Password error">>},
+        check_auth(<<"test-2">>, <<"password-1">>)),
+    emqx_ct_helpers:stop_apps([emqx_dashboard]).
+
+t_bootstrap_user_file_not_found(_) ->
+    File = "./bootstrap_users_not_exist.txt",
+    check_load_failed(File),
+    ok.
+
+t_load_invalid_username_failed(_) ->
+    Bin = <<"test-1:password-1\ntest&2:password-2">>,
+    File = "./bootstrap_users.txt",
+    ok = file:write_file(File, Bin),
+    check_load_failed(File),
+    ok.
+
+t_load_invalid_format_failed(_) ->
+    Bin = <<"test-1:password-1\ntest-2password-2">>,
+    File = "./bootstrap_users.txt",
+    ok = file:write_file(File, Bin),
+    check_load_failed(File),
+    ok.
+
+check_load_failed(File) ->
+    _ = mnesia:clear_table(emqx_admin),
+    application:set_env(emqx_dashboard, bootstrap_users_file, File),
+    ?assertError(_, emqx_ct_helpers:start_apps([emqx_dashboard])),
+    ?assertNot(lists:member(emqx_dashboard, application:which_applications())),
+    ?assertEqual(0, mnesia:table_info(mqtt_admin, size)).
+
+
+check_auth(Username, Password) ->
+    {ok, Res} = http_post("auth", #{<<"username">> => Username, <<"password">> => Password}),
+    json(Res).
+
+json(Data) ->
+    {ok, Jsx} = emqx_json:safe_decode(Data, [return_maps]), Jsx.


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Add `dashboard.bootstrp_user_file ="etc/bootstrap_user_file.txt"` to bulk import default user&password when EMQX first starts

- emqx_dashboard start failed when importing bootstrap users error.
- Don't import any bootstrap users when there is invalid data in the file.

## PR Checklist

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
