### PR TITLE
fix: run the 'message.acked' hook when ACK received from CoAP devices

### DIFF
--- a/apps/emqx_coap/src/emqx_coap.app.src
+++ b/apps/emqx_coap/src/emqx_coap.app.src
@@ -1,6 +1,6 @@
 {application, emqx_coap,
  [{description, "EMQ X CoAP Gateway"},
-  {vsn, "4.3.1"}, % strict semver, bump manually!
+  {vsn, "4.3.2"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [kernel,stdlib,gen_coap]},

--- a/apps/emqx_coap/src/emqx_coap.appup.src
+++ b/apps/emqx_coap/src/emqx_coap.appup.src
@@ -1,9 +1,15 @@
 %% -*-: erlang -*-
 {VSN,
-  [{"4.3.0",[
-    {load_module, emqx_coap_mqtt_adapter, brutal_purge, soft_purge, []}]},
+  [{<<"4\\.3\\.[0-1]">>,[
+    {load_module, emqx_coap_mqtt_adapter, brutal_purge, soft_purge, []},
+    {load_module, emqx_coap_pubsub_resource, brutal_purge, soft_purge, []},
+    {load_module, emqx_coap_resource, brutal_purge, soft_purge, []}
+   ]},
    {<<".*">>, []}],
-  [{"4.3.0",[
-    {load_module, emqx_coap_mqtt_adapter, brutal_purge, soft_purge, []}]},
+  [{<<"4\\.3\\.[0-1]">>,[
+    {load_module, emqx_coap_mqtt_adapter, brutal_purge, soft_purge, []},
+    {load_module, emqx_coap_pubsub_resource, brutal_purge, soft_purge, []},
+    {load_module, emqx_coap_resource, brutal_purge, soft_purge, []}
+   ]},
    {<<".*">>, []}]
 }.

--- a/apps/emqx_coap/src/emqx_coap_pubsub_resource.erl
+++ b/apps/emqx_coap/src/emqx_coap_pubsub_resource.erl
@@ -138,16 +138,32 @@ coap_unobserve({state, ChId, Prefix, TopicPath}) ->
     ok.
 
 handle_info({dispatch, Topic, Payload}, State) ->
+    %% This clause should never be matched any more. We keep it here to handle
+    %% the old format messages during the release upgrade.
+    %% In this case the second function clause of `coap_ack/2` will be called,
+    %% and the ACKs is discarded.
     ?LOG(debug, "dispatch Topic=~p, Payload=~p", [Topic, Payload]),
     {ok, Ret} = emqx_coap_pubsub_topics:reset_topic_info(Topic, Payload),
     ?LOG(debug, "Updated publish info of topic=~p, the Ret is ~p", [Topic, Ret]),
     {notify, [], #coap_content{format = <<"application/octet-stream">>, payload = Payload}, State};
+handle_info({dispatch, Msg}, State) ->
+    Payload = emqx_coap_mqtt_adapter:message_payload(Msg),
+    Topic = emqx_coap_mqtt_adapter:message_topic(Msg),
+    {ok, Ret} = emqx_coap_pubsub_topics:reset_topic_info(Topic, Payload),
+    ?LOG(debug, "Updated publish info of topic=~p, the Ret is ~p", [Topic, Ret]),
+    {notify, {pub, Msg}, #coap_content{format = <<"application/octet-stream">>, payload = Payload}, State};
 handle_info(Message, State) ->
     ?LOG(error, "Unknown Message ~p", [Message]),
     {noreply, State}.
 
-coap_ack(_Ref, State) -> {ok, State}.
-
+coap_ack({pub, Msg}, State) ->
+    ?LOG(debug, "received coap ack for publish msg: ~p", [Msg]),
+    Pid = get(mqtt_client_pid),
+    emqx_coap_mqtt_adapter:received_puback(Pid, Msg),
+    {ok, State};
+coap_ack(_Ref, State) ->
+    ?LOG(debug, "received coap ack: ~p", [_Ref]),
+    {ok, State}.
 
 %%--------------------------------------------------------------------
 %% Internal Functions

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -2,6 +2,11 @@
 
 ## Enhancements
 
+- We now trigger the `'message.acked'` hook after the CoAP gateway sends a message to the device and receives the ACK from the device [#9264](https://github.com/emqx/emqx/pull/9264).
+  With this change, the CoAP gateway can be combined with the offline message caching function (in the
+  emqx enterprise), so that CoAP devices are able to read the missed messages from the database when
+  it is online again.
+
 - Support to use placeholders like `${var}` in the HTTP `Headers` of rule-engine's Webhook actions [#9239](https://github.com/emqx/emqx/pull/9239).
 
 - Asynchronously refresh the resources and rules during emqx boot-up [#9199](https://github.com/emqx/emqx/pull/9199).

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -2,6 +2,9 @@
 
 ## 增强
 
+- 当 CoAP 网关给设备投递消息并收到设备发来的确认之后，回调 `'message.acked'` 钩子 [#9264](https://github.com/emqx/emqx/pull/9264)。
+  有了这个改动，CoAP 网关可以配合 EMQX (企业版)的离线消息缓存功能，让 CoAP 设备重新上线之后，从数据库读取其离线状态下错过的消息。
+
 - 支持在规则引擎的 Webhook 动作的 HTTP Headers 里使用 `${var}` 格式的占位符 [#9239](https://github.com/emqx/emqx/pull/9239)。
 
 - 在 emqx 启动时，异步地刷新资源和规则 [#9199](https://github.com/emqx/emqx/pull/9199)。


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->

We now trigger the `'message.acked'` hook after the CoAP gateway sends a message to the device and receives the ACK from the device.

With this change, the CoAP gateway can be combined with the offline message caching function (in the
emqx enterprise), so that CoAP devices are able to read the missed messages from the database when
it is online again.

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
