### PR TITLE
fix (emqx_mgmt): call emqx_alarm:delete_all_deactivated_alarms for remote nodes

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -499,7 +499,7 @@ delete_all_deactivated_alarms() ->
 delete_all_deactivated_alarms(Node) when Node =:= node() ->
     emqx_alarm:delete_all_deactivated_alarms();
 delete_all_deactivated_alarms(Node) ->
-    rpc_call(Node, delete_deactivated_alarms, [Node]).
+    rpc_call(Node, emqx_alarm, delete_all_deactivated_alarms, []).
 
 add_duration_field(Alarms) ->
     Now = erlang:system_time(microsecond),
@@ -574,7 +574,10 @@ item(route, {Topic, Node}) ->
 %%--------------------------------------------------------------------
 
 rpc_call(Node, Fun, Args) ->
-    case rpc:call(Node, ?MODULE, Fun, Args) of
+    rpc_call(Node, ?MODULE, Fun, Args).
+
+rpc_call(Node, Mod, Fun, Args) ->
+    case rpc:call(Node, Mod, Fun, Args) of
         {badrpc, Reason} -> {error, Reason};
         Res -> Res
     end.


### PR DESCRIPTION

Old call was calling a non-existant function on current module, instead we make call directly into `emqx_alarm` on remote node.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes EMQX-7665

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
