### PR TITLE
WIP fix: unwrap result from multi node lookup (erpc)

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -877,7 +877,10 @@ lookup_from_local_node(ChainName, AuthenticatorID) ->
 
 lookup_from_all_nodes(ChainName, AuthenticatorID) ->
     Nodes = mria_mnesia:running_nodes(),
-    case is_ok(emqx_authn_proto_v1:lookup_from_all_nodes(Nodes, ChainName, AuthenticatorID)) of
+    LookupResult = emqx_rpc:unwrap_erpc(
+        emqx_authn_proto_v1:lookup_from_all_nodes(Nodes, ChainName, AuthenticatorID)
+    ),
+    case is_ok(LookupResult) of
         {ok, ResList} ->
             {StatusMap, MetricsMap, ResourceMetricsMap, ErrorMap} = make_result_map(ResList),
             AggregateStatus = aggregate_status(maps:values(StatusMap)),

--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -164,6 +164,13 @@ t_aggregate_metrics(_) ->
         Res
     ).
 
+t_authenticator_status(_) ->
+    {ok, 400, _} = request(
+        get,
+        uri([?CONF_NS, "xxx", "status"]),
+        []
+    ).
+
 test_authenticators(PathPrefix) ->
     ValidConfig = emqx_authn_test_lib:http_example(),
     {ok, 200, _} = request(


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes EMQX-7821

Calls to "/api/v5/authentication/xxx/status" always return an http status code of 200 as long as the underlying rpc call itself doesn't crash or is in error, i.e. results like `{error, foo}` are passed as `{ok, {error, foo}}`. 

With this fix it will return a 400 if one or more results are `error` tuples. 

----- 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
