### PR TITLE
fix: use binary_to_existing_atom to replace some risky binary_to_atom

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -59,9 +59,10 @@ bridge_id(BridgeType, BridgeName) ->
     Type = bin(BridgeType),
     <<Type/binary, ":", Name/binary>>.
 
+-spec parse_bridge_id(list() | binary() | atom()) -> {atom(), binary()}.
 parse_bridge_id(BridgeId) ->
     case string:split(bin(BridgeId), ":", all) of
-        [Type, Name] -> {binary_to_atom(Type, utf8), binary_to_atom(Name, utf8)};
+        [Type, Name] -> {binary_to_atom(Type, utf8), Name};
         _ -> error({invalid_bridge_id, BridgeId})
     end.
 

--- a/apps/emqx_connector/src/emqx_connector.erl
+++ b/apps/emqx_connector/src/emqx_connector.erl
@@ -78,9 +78,10 @@ connector_id(Type0, Name0) ->
     Name = bin(Name0),
     <<Type/binary, ":", Name/binary>>.
 
+-spec parse_connector_id(binary() | list() | atom()) -> {atom(), binary()}.
 parse_connector_id(ConnectorId) ->
     case string:split(bin(ConnectorId), ":", all) of
-        [Type, Name] -> {binary_to_atom(Type, utf8), binary_to_atom(Name, utf8)};
+        [Type, Name] -> {binary_to_atom(Type, utf8), Name};
         _ -> error({invalid_connector_id, ConnectorId})
     end.
 

--- a/apps/emqx_gateway/src/coap/handler/emqx_coap_pubsub_handler.erl
+++ b/apps/emqx_gateway/src/coap/handler/emqx_coap_pubsub_handler.erl
@@ -121,7 +121,13 @@ apply_publish_opts(Msg, MQTTMsg) ->
             maps:fold(
                 fun
                     (<<"retain">>, V, Acc) ->
-                        Val = erlang:binary_to_atom(V),
+                        Val =
+                            case emqx_misc:safe_to_existing_atom(V) of
+                                {ok, true} ->
+                                    true;
+                                _ ->
+                                    false
+                            end,
                         emqx_message:set_flag(retain, Val, Acc);
                     (<<"expiry">>, V, Acc) ->
                         Val = erlang:binary_to_integer(V),

--- a/apps/emqx_gateway/src/emqx_gateway_api_clients.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_clients.erl
@@ -113,15 +113,19 @@ clients(get, #{
                         ?QUERY_FUN
                     );
                 Node0 ->
-                    Node1 = binary_to_atom(Node0, utf8),
-                    QStringWithoutNode = maps:without([<<"node">>], QString),
-                    emqx_mgmt_api:node_query(
-                        Node1,
-                        QStringWithoutNode,
-                        TabName,
-                        ?CLIENT_QSCHEMA,
-                        ?QUERY_FUN
-                    )
+                    case emqx_misc:safe_to_existing_atom(Node0) of
+                        {ok, Node1} ->
+                            QStringWithoutNode = maps:without([<<"node">>], QString),
+                            emqx_mgmt_api:node_query(
+                                Node1,
+                                QStringWithoutNode,
+                                TabName,
+                                ?CLIENT_QSCHEMA,
+                                ?QUERY_FUN
+                            );
+                        {error, _} ->
+                            {error, Node0, {badrpc, <<"invalid node">>}}
+                    end
             end,
         case Result of
             {error, page_limit_invalid} ->

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -648,15 +648,19 @@ list_clients(QString) ->
                     ?QUERY_FUN
                 );
             Node0 ->
-                Node1 = binary_to_atom(Node0, utf8),
-                QStringWithoutNode = maps:without([<<"node">>], QString),
-                emqx_mgmt_api:node_query(
-                    Node1,
-                    QStringWithoutNode,
-                    ?CLIENT_QTAB,
-                    ?CLIENT_QSCHEMA,
-                    ?QUERY_FUN
-                )
+                case emqx_misc:safe_to_existing_atom(Node0) of
+                    {ok, Node1} ->
+                        QStringWithoutNode = maps:without([<<"node">>], QString),
+                        emqx_mgmt_api:node_query(
+                            Node1,
+                            QStringWithoutNode,
+                            ?CLIENT_QTAB,
+                            ?CLIENT_QSCHEMA,
+                            ?QUERY_FUN
+                        );
+                    {error, _} ->
+                        {error, Node0, {badrpc, <<"invalid node">>}}
+                end
         end,
     case Result of
         {error, page_limit_invalid} ->

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -145,13 +145,18 @@ subscriptions(get, #{query_string := QString}) ->
                     ?QUERY_FUN
                 );
             Node0 ->
-                emqx_mgmt_api:node_query(
-                    binary_to_atom(Node0, utf8),
-                    QString,
-                    ?SUBS_QTABLE,
-                    ?SUBS_QSCHEMA,
-                    ?QUERY_FUN
-                )
+                case emqx_misc:safe_to_existing_atom(Node0) of
+                    {ok, Node1} ->
+                        emqx_mgmt_api:node_query(
+                            Node1,
+                            QString,
+                            ?SUBS_QTABLE,
+                            ?SUBS_QSCHEMA,
+                            ?QUERY_FUN
+                        );
+                    {error, _} ->
+                        {error, Node0, {badrpc, <<"invalid node">>}}
+                end
         end,
     case Response of
         {error, page_limit_invalid} ->

--- a/changes/v5.0.10-en.md
+++ b/changes/v5.0.10-en.md
@@ -15,6 +15,7 @@
 - Now it is possible to opt out VM internal metrics in prometheus stats [#9222](https://github.com/emqx/emqx/pull/9222).
   When system load is high, reporting too much metrics data may cause the prometheus stats API timeout.
 
+- Improve security when converting types such as `binary` `lists` to `atom` types [#9279](https://github.com/emqx/emqx/pull/9279).
 
 ## Bug fixes
 

--- a/changes/v5.0.10-zh.md
+++ b/changes/v5.0.10-zh.md
@@ -14,6 +14,7 @@
 
 - 可通过配置关闭 prometheus 中的部分内部指标，如果遇到机器负载过高 prometheus 接口返回超时可考虑关闭部分不关心指标，以提高响应速度 [#9222](https://github.com/emqx/emqx/pull/9222）。
 
+- 提升 `binary` 、`list` 等类型转换为 `atom` 类型时的安全性 [#9279](https://github.com/emqx/emqx/pull/9279)。
 
 ## Bug fixes
 


### PR DESCRIPTION
1.  emqx_bridge_resource
After investigation, it was confirmed that there was no need to convert the bridge name to atom.
We can keep it binary, whether the API, configuration or emqx_bridge all of these are supports names in binary format

2. emqx_bridge_api
When we use one API to send a request to a Node, it means that the Node is known, so it is better to use the `binary_to_existing_atom`
 And due to the maximum limit of the nested of the elvis, I had to adjust the function indent

3. emqx_connector
After investigation, it was confirmed that there was no need to convert the bridge name to atom.
We can keep it binary, whether the API, configuration both of these are supports names in binary format

4. Ensure that the node name is known

- emqx_dashboard_monitor_api
- emqx_gateway_api_clients
- emqx_mgmt_api_clients
- emqx_mgmt_api_subscriptions
When we use one API to send a request to a Node, it means that the Node is known, so it is better to use the `binary_to_existing_atom`

5. emqx_coap_pubsub_handler
The flag  for retain can only be true/false, which are two existing atoms


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

~~- [ ] Added tests for the changes~~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
~~- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
       EMQX-8026
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
This is one of a series of fixes for the atom attack risk, and there may be other PRs to follow, a PR per modification maybe could helps to describe in more detail why the change was made