### PR TITLE
chore(charts): fix object to list

### DIFF
--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -207,7 +207,7 @@ ssl:
   enabled: false
   useExisting: false
   existingName: emqx-tls
-  dnsnames: {}
+  dnsnames: []
   issuer:
     name: letsencrypt-dns
     kind: ClusterIssuer


### PR DESCRIPTION
Leaving default value ```{}``` makes error when trying to install chart. need to be a list to work properly with certificate names list.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
