### PR TITLE
fix: use list_to_existing_atom to replace some risky list_to_atom

### DIFF
--- a/apps/emqx/src/emqx_misc.erl
+++ b/apps/emqx/src/emqx_misc.erl
@@ -469,9 +469,9 @@ safe_to_existing_atom(In) ->
     safe_to_existing_atom(In, utf8).
 
 safe_to_existing_atom(Bin, Encoding) when is_binary(Bin) ->
-    try_to_existing_atom(fun erlang:binary_to_existing_atom/2, [Bin, Encoding]);
-safe_to_existing_atom(List, _Encoding) when is_list(List) ->
-    try_to_existing_atom(fun erlang:list_to_existing_atom/1, [List]);
+    try_to_existing_atom(fun erlang:binary_to_existing_atom/2, Bin, Encoding);
+safe_to_existing_atom(List, Encoding) when is_list(List) ->
+    try_to_existing_atom(fun(In, _) -> erlang:list_to_existing_atom(In) end, List, Encoding);
 safe_to_existing_atom(Atom, _Encoding) when is_atom(Atom) ->
     {ok, Atom};
 safe_to_existing_atom(_Any, _Encoding) ->
@@ -547,8 +547,8 @@ readable_error_msg(Error) ->
             end
     end.
 
-try_to_existing_atom(Fun, Args) ->
-    try erlang:apply(Fun, Args) of
+try_to_existing_atom(Convert, Data, Encoding) ->
+    try Convert(Data, Encoding) of
         Atom ->
             {ok, Atom}
     catch

--- a/apps/emqx_gateway/src/coap/handler/emqx_coap_pubsub_handler.erl
+++ b/apps/emqx_gateway/src/coap/handler/emqx_coap_pubsub_handler.erl
@@ -121,13 +121,7 @@ apply_publish_opts(Msg, MQTTMsg) ->
             maps:fold(
                 fun
                     (<<"retain">>, V, Acc) ->
-                        Val =
-                            case emqx_misc:safe_to_existing_atom(V) of
-                                {ok, true} ->
-                                    true;
-                                _ ->
-                                    false
-                            end,
+                        Val = V =:= <<"true">>,
                         emqx_message:set_flag(retain, Val, Acc);
                     (<<"expiry">>, V, Acc) ->
                         Val = erlang:binary_to_integer(V),

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -70,6 +70,8 @@
     default_subopts/0
 ]).
 
+-import(emqx_listeners, [esockd_access_rules/1]).
+
 -define(ACTIVE_N, 100).
 -define(DEFAULT_IDLE_TIMEOUT, 30000).
 -define(DEFAULT_GC_OPTS, #{count => 1000, bytes => 1024 * 1024}).
@@ -442,19 +444,6 @@ esockd_opts(Type, Opts0) ->
                 }
         end
     ).
-
-esockd_access_rules(StrRules) ->
-    Access = fun(S) ->
-        [A, CIDR] = string:tokens(S, " "),
-        {
-            list_to_atom(A),
-            case CIDR of
-                "all" -> all;
-                _ -> CIDR
-            end
-        }
-    end,
-    [Access(R) || R <- StrRules].
 
 ssl_opts(Name, Opts) ->
     Type =


### PR DESCRIPTION
1. emqx_listeners  emqx_gateway_utils
    esockd rules only use words 'allow' and 'deny', both are existing,
    so it is better to restrict the conversion and print a log when errors
2. emqx_misc  emqx_coap_pubsub_handler
    Fix the comments in #9279 
3. emqx_mgmt_cli
    The log level, the log handler id and the listener id  all of them already exist,
    so it's better to avoid the user creating a useless atom by mistake input

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

~~- [ ] Added tests for the changes~~
- [x] Changed lines covered in coverage report
~~- [ ] Change log has been added to `changes/` dir~~
~~- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change, and another jira tickt to track doc updates (if any)
      EMQX-8021
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
