### PR TITLE
ci: fix artifact upload path

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -110,7 +110,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.profile }}
-        path: source/_packages/${{ matrix.profile }}/.
+        path: source/_packages/${{ matrix.profile }}/
 
   mac:
     needs: prepare
@@ -145,7 +145,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: ${EMQX_NAME}-${{ matrix.otp }}
-        path: _packages/${EMQX_NAME}/.
+        path: _packages/${EMQX_NAME}/
 
   linux:
     runs-on: ubuntu-20.04
@@ -258,7 +258,7 @@ jobs:
     - uses: actions/upload-artifact@v1
       with:
         name: ${{ matrix.profile }}
-        path: /tmp/packages/${{ matrix.profile }}/.
+        path: /tmp/packages/${{ matrix.profile }}/
 
   docker:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
the upload-artifacts action does not allow relative paths
