### PR TITLE
ci: bump otp version to 23.3.4.18-1

### DIFF
--- a/.github/workflows/apps_version_check.yaml
+++ b/.github/workflows/apps_version_check.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         erl_otp:
-        - erl23.3.4.9-3
+        - erl23.3.4.18-1
         os:
         - ubuntu20.04
 

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -20,7 +20,7 @@ jobs:
     # avoid building when syncing to ee repo
     if: endsWith(github.repository, 'emqx')
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
 
     outputs:
       profiles: ${{ steps.detect-profiles.outputs.profiles}}
@@ -57,7 +57,7 @@ jobs:
       matrix:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
         otp:
-          - 23.3.4.13
+          - 23.3.4.17
         exclude:
           - profile: emqx-edge
 
@@ -118,7 +118,7 @@ jobs:
     strategy:
       matrix:
         otp:
-          - 23.3.4.9-3
+          - 23.3.4.18-1
         os:
           - macos-11
     runs-on: ${{ matrix.os }}
@@ -173,7 +173,7 @@ jobs:
           # - raspbian9
         otp_version:
           #- 23.2.7.2-emqx-3
-          - 23.3.4.9-3
+          - 23.3.4.18-1
         exclude:
         - os: centos6
           arch: arm64
@@ -329,7 +329,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          BUILD_FROM=emqx/build-env:erl23.3.4.9-3-alpine
+          BUILD_FROM=emqx/build-env:erl23.3.4.18-1-alpine
           RUN_FROM=alpine:3.12
           EMQX_NAME=${{ matrix.profile }}
         file: source/deploy/docker/Dockerfile
@@ -345,7 +345,7 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
-          BUILD_FROM=emqx/build-env:erl23.3.4.9-3-alpine
+          BUILD_FROM=emqx/build-env:erl23.3.4.18-1-alpine
           RUN_FROM=alpine:3.12
           EMQX_NAME=${{ matrix.profile }}
         file: source/deploy/docker/Dockerfile.enterprise

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         otp:
-          - erl23.3.4.9-3
+          - erl23.3.4.18-1
         os:
           - ubuntu20.04
           - centos7
@@ -69,7 +69,7 @@ jobs:
     strategy:
       matrix:
         otp:
-          - 23.3.4.9-3
+          - 23.3.4.18-1
         os:
           - macos-11
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   check_deps_integrity:
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
 
     outputs:
       profiles: ${{ steps.detect-profiles.outputs.profiles}}

--- a/.github/workflows/run_acl_migration_tests.yaml
+++ b/.github/workflows/run_acl_migration_tests.yaml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
     test:
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+        container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
         strategy:
             fail-fast: true
         env:

--- a/.github/workflows/run_automate_tests.yaml
+++ b/.github/workflows/run_automate_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: erlef/setup-beam@v1
       with:
-        otp-version: "23.3.4.13"
+        otp-version: "23.3.4.17"
     - name: build docker
       id: build_docker
       run: |

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -15,7 +15,7 @@ jobs:
         - uses: actions/checkout@v1
         - uses: erlef/setup-beam@v1
           with:
-            otp-version: "23.3.4.9"
+            otp-version: "23.3.4.17"
         - name: make docker
           run: |
             if make emqx-ee --dry-run > /dev/null 2>&1; then
@@ -67,7 +67,7 @@ jobs:
         - uses: actions/checkout@v1
         - uses: erlef/setup-beam@v1
           with:
-            otp-version: "23.3.4.9"
+            otp-version: "23.3.4.17"
         - name: prepare
           run: |
             if make emqx-ee --dry-run > /dev/null 2>&1; then
@@ -154,7 +154,7 @@ jobs:
 
     relup_test_plan:
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+        container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
         outputs:
           profile: ${{ steps.profile-and-versions.outputs.profile }}
           vsn: ${{ steps.profile-and-versions.outputs.vsn }}
@@ -200,7 +200,7 @@ jobs:
     relup_test_build:
         needs: relup_test_plan
         runs-on: ubuntu-20.04
-        container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+        container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
         defaults:
           run:
             shell: bash
@@ -235,7 +235,7 @@ jobs:
           - relup_test_plan
           - relup_test_build
         runs-on: ubuntu-20.04
-        container: emqx/relup-test-env:erl23.2.7.2-emqx-3-ubuntu20.04
+        container: emqx/relup-test-env:erl23.3.4.18-1-ubuntu20.04
         strategy:
           fail-fast: false
           matrix:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   prepare:
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
     outputs:
       ct_apps: ${{ steps.run_find_apps.outputs.ct_apps }}
     steps:
@@ -50,7 +50,7 @@ jobs:
   eunit_and_proper:
     needs: prepare
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +78,7 @@ jobs:
   emqx_ct:
     needs: prepare
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
     strategy:
       fail-fast: false
     steps:
@@ -224,7 +224,7 @@ jobs:
       - emqx_ct
       - ct
     runs-on: ubuntu-20.04
-    container: emqx/build-env:erl23.3.4.9-3-ubuntu20.04
+    container: emqx/build-env:erl23.3.4.18-1-ubuntu20.04
     steps:
       - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section