### PR TITLE
fix(emqx_rule_monitor): sleep before retry but not after

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -79,8 +79,6 @@
              , action_instance_params/0
              ]).
 
--define(T_RETRY, 60000).
-
 %% redefine this macro to confine the appup scope
 -undef(RAISE).
 -define(RAISE(_EXP_, _ERROR_CONTEXT_),
@@ -684,8 +682,7 @@ init_resource_with_retrier(Module, OnCreate, ResId, Config) ->
                                     status = #{is_alive => true}},
         emqx_rule_registry:add_resource_params(ResParams)
     catch Class:Reason:ST ->
-        Interval = persistent_term:get({emqx_rule_engine, resource_restart_interval}, ?T_RETRY),
-        emqx_rule_monitor:ensure_resource_retrier(ResId, Interval),
+        emqx_rule_monitor:ensure_resource_retrier(ResId),
         erlang:raise(Class, {init_resource, Reason}, ST)
     end.
 

--- a/apps/emqx_rule_engine/src/emqx_rule_monitor.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_monitor.erl
@@ -32,9 +32,17 @@
 -export([ start_link/0
         , stop/0
         , async_refresh_resources_rules/0
-        , ensure_resource_retrier/2
+        , ensure_resource_retrier/1
         , retry_loop/3
         ]).
+
+%% fot test
+-export([ put_retry_interval/1
+        , get_retry_interval/0
+        , erase_retry_interval/0
+        ]).
+
+-define(T_RETRY, 60000).
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
@@ -46,10 +54,22 @@ init([]) ->
     _ = erlang:process_flag(trap_exit, true),
     {ok, #{retryers => #{}}}.
 
+put_retry_interval(I) when is_integer(I) andalso I >= 10 ->
+    _ = persistent_term:put({?MODULE, resource_restart_interval}, I),
+    ok.
+
+erase_retry_interval() ->
+    _ = persistent_term:erase({?MODULE, resource_restart_interval}),
+    ok.
+
+get_retry_interval() ->
+    persistent_term:get({?MODULE, resource_restart_interval}, ?T_RETRY).
+
 async_refresh_resources_rules() ->
     gen_server:cast(?MODULE, async_refresh).
 
-ensure_resource_retrier(ResId, Interval) ->
+ensure_resource_retrier(ResId) ->
+    Interval = get_retry_interval(),
     gen_server:cast(?MODULE, {create_restart_handler, resource, ResId, Interval}).
 
 handle_call(_Msg, _From, State) ->
@@ -111,11 +131,12 @@ update_object(Tag, Obj, Retryer, State) ->
     }.
 
 create_restart_handler(Tag, Obj, Interval) ->
-    ?LOG(info, "keep restarting ~p ~p, interval: ~p", [Tag, Obj, Interval]),
+    ?LOG(info, "starting_a_retry_loop for ~p ~p, with delay interval: ~p", [Tag, Obj, Interval]),
     %% spawn a dedicated process to handle the restarting asynchronously
     spawn_link(?MODULE, retry_loop, [Tag, Obj, Interval]).
 
 retry_loop(resource, ResId, Interval) ->
+    timer:sleep(Interval),
     case emqx_rule_registry:find_resource(ResId) of
         {ok, #resource{type = Type, config = Config}} ->
             try
@@ -124,10 +145,15 @@ retry_loop(resource, ResId, Interval) ->
                 ok = emqx_rule_engine:init_resource(M, F, ResId, Config),
                 refresh_and_enable_rules_of_resource(ResId)
             catch
-                Err:Reason:ST ->
-                    ?LOG(warning, "init_resource failed: ~p, ~0p",
-                        [{Err, Reason}, ST]),
-                    timer:sleep(Interval),
+                Err:Reason:Stacktrace ->
+                    %% do not log stacktrace if it's a throw
+                    LogContext =
+                        case Err of
+                            throw -> Reason;
+                            _ -> {Reason, Stacktrace}
+                        end,
+                    ?LOG_SENSITIVE(warning, "init_resource_retry_failed ~p, ~0p", [ResId, LogContext]),
+                    %% keep looping
                     ?MODULE:retry_loop(resource, ResId, Interval)
             end;
         not_found ->

--- a/apps/emqx_rule_engine/test/emqx_rule_monitor_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_monitor_SUITE.erl
@@ -48,7 +48,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(t_restart_resource, Config) ->
-    persistent_term:put({emqx_rule_engine, resource_restart_interval}, 100),
+    emqx_rule_monitor:put_retry_interval(100),
     Opts = [public, named_table, set, {read_concurrency, true}],
     _ = ets:new(?RES_PARAMS_TAB, [{keypos, #resource_params.id}|Opts]),
     ets:new(t_restart_resource, [named_table, public]),
@@ -77,7 +77,6 @@ init_per_testcase(_, Config) ->
     Config.
 
 end_per_testcase(t_restart_resource, Config) ->
-    persistent_term:put({emqx_rule_engine, resource_restart_interval}, 60000),
     ets:delete(t_restart_resource),
     common_end_per_testcases(),
     Config;
@@ -91,7 +90,9 @@ end_per_testcase(_, Config) ->
 
 common_init_per_testcase() ->
     {ok, _} = emqx_rule_monitor:start_link().
+
 common_end_per_testcases() ->
+    emqx_rule_monitor:erase_retry_interval(),
     emqx_rule_monitor:stop().
 
 t_restart_resource(_) ->

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -36,12 +36,14 @@
   For example: `acl_order = jwt,http`, this will make sure `jwt` is always checked before `http`,
   meaning if JWT is not found (or no `acl` cliam) for a client, then the ACL check will fallback to use the HTTP backend.
 
-
 - Added configurations to enable more `client.disconnected` events (and counter bumps) [#9267](https://github.com/emqx/emqx/pull/9267).
   Prior to this change, the `client.disconnected` event (and counter bump) is triggered when a client
   performs a 'normal' disconnect, or is 'kicked' by system admin, but NOT triggered when a
   stale connection had to be 'discarded' (for clean session) or 'takenover' (for non-clean session).
   Now it is possible to set configs `broker.client_disconnect_discarded` and `broker.client_disconnect_takenover` to `on` to enable the event in these scenarios.
+
+- For Rule-Engine resource creation failure, delay before the first retry [#9313](https://github.com/emqx/emqx/pull/9313).
+  Prior to this change, the retry delay was added *after* the retry failure.
 
 ## Bug fixes
 

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -37,6 +37,9 @@
   但不会在旧 session 被废弃 (clean_session = true) 或旧 session 被接管 (clean_session = false) 时被触发。
   可将 `broker.client_disconnect_discarded` 和 `broker.client_disconnect_takovered` 选项设置为 `on` 来启用此场景下的客户端断连事件。
 
+- 规则引擎资源创建失败后，第一次重试前增加一个延迟 [#9313](https://github.com/emqx/emqx/pull/9313)。
+  在此之前，重试的延迟发生在重试失败之后。
+
 ## 修复
 
 - 修复若上传的备份文件名中包含非 ASCII 字符，`GET /data/export` HTTP 接口返回 500 错误 [#9224](https://github.com/emqx/emqx/pull/9224)。


### PR DESCRIPTION
This was not in the release scope of v4.3.22 and v4.4.4,
however it's a blocking issue for enterprise test cases.

The in case of resource creation failure, e.g. when failed to connect to a remote webhook endpoint,
the retry loop is started immediately, causing it to log failures immediately.
This fix is to add the sleep to the beginning of the loop.

Example logs after the fix:
```
(emqx@127.0.0.1)1> 2022-11-05T17:59:30.209407+01:00 [error] check http_connectivity failed: <<"http://locahost:1111">>
2022-11-05T17:59:30.209626+01:00 [warning] create_resource failed: [#{func => init_resource,node => 'emqx@127.0.0.1',result => {throw,{init_resource,check_http_connectivity_failed}},rpc_type => multicall}]

(emqx@127.0.0.1)1>
(emqx@127.0.0.1)1> 2022-11-05T18:00:30.213588+01:00 [error] check http_connectivity failed: <<"http://locahost:1111">>
2022-11-05T18:00:30.213930+01:00 [warning] [Rule Monitor] init_resource_retry_failed <<"resource:518949">>, {{emqx_web_hook_actions,on_resource_create},check_http_connectivity_failed}
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir 
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change EMQX-8070
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
