### PR TITLE
fix(filename): ensure no absolute path in list when call `filename:join`

### DIFF
--- a/apps/emqx_lua_hook/src/emqx_lua_hook.app.src
+++ b/apps/emqx_lua_hook/src/emqx_lua_hook.app.src
@@ -1,6 +1,6 @@
 {application, emqx_lua_hook,
  [{description, "EMQ X Lua Hooks"},
-  {vsn, "4.3.2"}, % strict semver, bump manually!
+  {vsn, "4.3.3"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [kernel,stdlib]},

--- a/apps/emqx_lua_hook/src/emqx_lua_hook.appup.src
+++ b/apps/emqx_lua_hook/src/emqx_lua_hook.appup.src
@@ -1,7 +1,17 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"4.3.1",[{load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]},
-   {"4.3.0",[{load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]}],
-  [{"4.3.1",[{load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]},
-   {"4.3.0",[{load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]}]}.
+  [{"4.3.2",[{load_module,emqx_lua_hook_cli,brutal_purge,soft_purge,[]}]},
+   {"4.3.1",
+    [{load_module,emqx_lua_hook_cli,brutal_purge,soft_purge,[]},
+     {load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]},
+   {"4.3.0",
+    [{load_module,emqx_lua_hook_cli,brutal_purge,soft_purge,[]},
+     {load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]}],
+  [{"4.3.2",[{load_module,emqx_lua_hook_cli,brutal_purge,soft_purge,[]}]},
+   {"4.3.1",
+    [{load_module,emqx_lua_hook_cli,brutal_purge,soft_purge,[]},
+     {load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]},
+   {"4.3.0",
+    [{load_module,emqx_lua_hook_cli,brutal_purge,soft_purge,[]},
+     {load_module,emqx_lua_script,brutal_purge,soft_purge,[]}]}]}.

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.app.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.app.src
@@ -1,6 +1,6 @@
 {application, emqx_plugin_libs,
  [{description, "EMQ X Plugin utility libs"},
-  {vsn, "4.3.2"},
+  {vsn, "4.3.3"},
   {modules, []},
   {applications, [kernel,stdlib]},
   {env, []}

--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs.appup.src
@@ -1,16 +1,11 @@
-%% -*-: erlang -*-
-
+%% -*- mode: erlang -*-
+%% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [
-    {<<"4\\.3\\.[0-1]">>, [
-      {load_module, emqx_plugin_libs_ssl, brutal_purge, soft_purge, []}
-    ]},
-    {<<".*">>, []}
-  ],
-  [
-    {<<"4\\.3\\.[0-1]">>, [
-      {load_module, emqx_plugin_libs_ssl, brutal_purge, soft_purge, []}
-    ]},
-    {<<".*">>, []}
-  ]
-}.
+  [{"4.3.2",[{load_module,emqx_plugin_libs_ssl,brutal_purge,soft_purge,[]}]},
+   {<<"4\\.3\\.[0-1]">>,
+    [{load_module,emqx_plugin_libs_ssl,brutal_purge,soft_purge,[]}]},
+   {<<".*">>,[]}],
+  [{"4.3.2",[{load_module,emqx_plugin_libs_ssl,brutal_purge,soft_purge,[]}]},
+   {<<"4\\.3\\.[0-1]">>,
+    [{load_module,emqx_plugin_libs_ssl,brutal_purge,soft_purge,[]}]},
+   {<<".*">>,[]}]}.

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -45,6 +45,9 @@
 - For Rule-Engine resource creation failure, delay before the first retry [#9313](https://github.com/emqx/emqx/pull/9313).
   Prior to this change, the retry delay was added *after* the retry failure.
 
+- Enhanced security for file access [#9319](https://github.com/emqx/emqx/pull/9319).
+  Ensure that system files will not be accessed du to mistakes.
+
 ## Bug fixes
 
 - Fix that after uploading a backup file with an non-ASCII filename, HTTP API `GET /data/export` fails with status code 500 [#9224](https://github.com/emqx/emqx/pull/9224).

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -40,6 +40,9 @@
 - 规则引擎资源创建失败后，第一次重试前增加一个延迟 [#9313](https://github.com/emqx/emqx/pull/9313)。
   在此之前，重试的延迟发生在重试失败之后。
 
+- 增强文件访问的安全性 [#9319](https://github.com/emqx/emqx/pull/9319)。
+  确保不会因为意外访问到系统文件。
+
 ## 修复
 
 - 修复若上传的备份文件名中包含非 ASCII 字符，`GET /data/export` HTTP 接口返回 500 错误 [#9224](https://github.com/emqx/emqx/pull/9224)。

--- a/src/emqx_misc.erl
+++ b/src/emqx_misc.erl
@@ -534,8 +534,7 @@ redact_v(_V) -> ?REDACT_VAL.
 filename_join_safely([Abs | Path]) ->
     filename_join_safely(Abs, Path).
 
--spec filename_join_safely(file:name_all(), list(file:name_all())) -> _;
-                          (file:name_all(), file:name_all()) -> _.
+-spec filename_join_safely(file:name_all(), file:name_all()) -> _.
 filename_join_safely(Abs, Path) ->
     Abs2 = to_str(Abs),
     Path2 = to_str(ensure_to_path(Path)),


### PR DESCRIPTION
If there is one absolute path in the arguments of the `filename:join`, it will be returned as result, most of the time this is not what we want

This PR added a new function named `force_relative_filename_join` in the `emqx_misc` module which will force change the absolute path in the argument to relative.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
       EMQX-7978
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
