### PR TITLE
fix: remove outdated cert store from packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -94,6 +94,11 @@ jobs:
         }
         make ensure-rebar3
         make ${{ matrix.profile }}
+        ## Delete certifi cert store
+        $Cert = Get-ChildItem "_build/${{ matrix.profile }}/rel/emqx/lib/certifi*/priv/cacerts.pem"
+        if (Test-Path $Cert) {
+            Remove-Item $Cert
+        }
         mkdir -p _packages/${{ matrix.profile }}
         Compress-Archive -Path _build/${{ matrix.profile }}/rel/emqx -DestinationPath _build/${{ matrix.profile }}/rel/$pkg_name
         mv _build/${{ matrix.profile }}/rel/$pkg_name _packages/${{ matrix.profile }}

--- a/build
+++ b/build
@@ -61,9 +61,20 @@ log() {
     echo "===< $msg"
 }
 
+delete_unwanted_file() {
+    if [ -e "${1}" ]; then
+        log "Deleting file: ${1}"
+        rm -f "${1}"
+    else
+        log "Cannot delete file: ${1} -- file not found"
+    fi
+}
+
 make_rel() {
-    # shellcheck disable=SC1010
-    ./rebar3 as "$PROFILE" do release,tar
+    ./rebar3 as "$PROFILE" release
+    # delete outdated cert store
+    delete_unwanted_file _build/"${PROFILE}"/rel/emqx/lib/certifi*/priv/cacerts.pem
+    ./rebar3 as "$PROFILE" tar
 }
 
 ## unzip previous version .zip files to _build/$PROFILE/rel/emqx/releases before making relup


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes EEC-636

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
