### PR TITLE
fix(emqx_authn_api): return 404 for status of unknown authenticator

### DIFF
--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -40,7 +40,7 @@ init_per_suite(Config) ->
         ?wait_async_action(
             emqx_common_test_helpers:start_apps([]),
             #{?snk_kind := listener_started, bind := 1883},
-            timer:seconds(10)
+            timer:seconds(100)
         ),
         fun(Trace) ->
             %% more than one listener

--- a/apps/emqx_authn/src/emqx_authn.app.src
+++ b/apps/emqx_authn/src/emqx_authn.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authn, [
     {description, "EMQX Authentication"},
-    {vsn, "0.1.8"},
+    {vsn, "0.1.9"},
     {modules, []},
     {registered, [emqx_authn_sup, emqx_authn_registry]},
     {applications, [kernel, stdlib, emqx_resource, ehttpc, epgsql, mysql, jose]},

--- a/changes/v5.0.11-en.md
+++ b/changes/v5.0.11-en.md
@@ -7,3 +7,4 @@
 
 ## Bug fixes
 
+- Return 404 for status of unknown authenticator in `/authenticator/{id}/status` [#9328](https://github.com/emqx/emqx/pull/9328).

--- a/changes/v5.0.11-zh.md
+++ b/changes/v5.0.11-zh.md
@@ -5,5 +5,6 @@
 - 增强 `保留消息` 的安全性 [#9332](https://github.com/emqx/emqx/pull/9332)。
   现在投递保留消息前，会先过滤掉来源客户端被封禁了的那些消息。
 
-## Bug fixes
+## 修复
 
+- 通过 `/authenticator/{id}/status` 请求未知认证器的状态时，将会返回 404。


### PR DESCRIPTION
This also makes sure we call the same code everytime we access an authenticator. Moreover we return a 500 in case a remote call fails due to technical issues.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [EMQX-7821](https://emqx.atlassian.net/browse/EMQX-7821)


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~

## Backward Compatibility

## More information
