### PR TITLE
fix(jwt): fix the jwt ACL will return a wrong result when the token is expired

### DIFF
--- a/apps/emqx_auth_jwt/src/emqx_auth_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_auth_jwt.erl
@@ -67,7 +67,7 @@ check_acl(ClientInfo = #{jwt_claims := Claims},
             case is_expired(Exp) of
                 true ->
                     ?DEBUG("acl_deny_due_to_jwt_expired", []),
-                    deny;
+                    {stop, deny};
                 false ->
                     verify_acl(ClientInfo, Acl, PubSub, Topic)
             end;

--- a/apps/emqx_auth_jwt/test/emqx_auth_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_auth_jwt_SUITE.erl
@@ -462,6 +462,16 @@ t_check_jwt_acl_expire(_Config) ->
        {ok, #{}, [?RC_NOT_AUTHORIZED]},
        emqtt:subscribe(C, <<"a/b">>, 0)),
 
+    Default = emqx_zone:get_env(external, acl_nomatch, deny),
+    emqx_zone:set_env(external, acl_nomatch, allow),
+    try
+        ?assertMatch(
+           {ok, #{}, [?RC_NOT_AUTHORIZED]},
+           emqtt:subscribe(C, <<"a/b">>, 0))
+    after
+        emqx_zone:set_env(external, acl_nomatch, Default)
+    end,
+
     ok = emqtt:disconnect(C).
 
 t_check_jwt_acl_no_exp(init, _Config) ->

--- a/changes/v4.3.23-en.md
+++ b/changes/v4.3.23-en.md
@@ -5,3 +5,5 @@
 - Added topic validation for `emqx_mod_rewrite`. The dest topics contains wildcards are not allowed to publish [#9359](https://github.com/emqx/emqx/issues/9359).
 
 ## Bug fixes
+
+- Fix a bug where the JWT ACL would not short-circuit with a deny response when the token is expired [#9338](https://github.com/emqx/emqx/pull/9338).

--- a/changes/v4.3.23-zh.md
+++ b/changes/v4.3.23-zh.md
@@ -5,3 +5,5 @@
 - 为主题重写模块增加主题合法性检查，带有通配符的目标主题不允许被发布 [#9359](https://github.com/emqx/emqx/issues/9359)。
 
 ## 修复
+
+- 修复 JWT ACL 在令牌超期后授权检查不生效的问题 [#9338](https://github.com/emqx/emqx/pull/9338)。


### PR DESCRIPTION
The jwt ACL will return `deny` when the token is expired but it should return the `{stop, deny}` actually

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
        EMQX-8051
- [x] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] ~~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~~

## Backward Compatibility

## More information
