### PR TITLE
feat(crl): register CRL URLs when starting TLS listeners

### DIFF
--- a/src/emqx_crl_cache.erl
+++ b/src/emqx_crl_cache.erl
@@ -143,7 +143,8 @@ http_get(URL, HTTPTimeout) ->
      ).
 
 do_http_fetch_and_cache(URL) ->
-    %% FIXME
+    ?tp(crl_http_fetch, #{crl_url => URL}),
+    %% FIXME: read from config
     Resp = ?MODULE:http_get(URL, ?HTTP_TIMEOUT),
     case Resp of
         {ok, {{_, 200, _}, _, Body}} ->

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -139,6 +139,7 @@ start_listener(Proto, ListenOn, Options0) when Proto == ssl; Proto == tls ->
     ListenerID = proplists:get_value(listener_id, Options0),
     Options1 = proplists:delete(listener_id, Options0),
     Options = emqx_ocsp_cache:inject_sni_fun(ListenerID, Options1),
+    ok = maybe_register_crl_urls(Options),
     start_mqtt_listener('mqtt:ssl', ListenOn, Options);
 
 %% Start MQTT/WS listener
@@ -299,4 +300,22 @@ find_by_id(Id, [L | Rest]) ->
     case identifier(L) =:= Id of
         true -> L;
         false -> find_by_id(Id, Rest)
+    end.
+
+-spec maybe_register_crl_urls([esockd:option()]) -> ok.
+maybe_register_crl_urls(Options) ->
+    CRLOptions = proplists:get_value(crl_options, Options, []),
+    case proplists:get_bool(crl_cache_enabled, CRLOptions) of
+        false ->
+            ok;
+        true ->
+            URLs =
+                lists:usort(
+                  [URL
+                   || URL <- proplists:get_value(crl_cache_urls, CRLOptions, [])]),
+            lists:foreach(
+              fun(URL) ->
+                emqx_crl_cache:refresh(URL)
+              end,
+              URLs)
     end.

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -302,6 +302,7 @@ find_by_id(Id, [L | Rest]) ->
         false -> find_by_id(Id, Rest)
     end.
 
+%% @doc Called by Enterprise edition to dynamically reload configs.
 -spec maybe_register_crl_urls([esockd:option()]) -> ok.
 maybe_register_crl_urls(Options) ->
     CRLOptions = proplists:get_value(crl_options, Options, []),


### PR DESCRIPTION
Will be used for hot-configuration (EE downstream) as well.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
