### PR TITLE
refactor(crl): rename `s/enable_crl_cache/enable_crl_check/g`

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1554,7 +1554,7 @@ listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 ##
 ## Value: boolean
 ## Default: false
-## listener.ssl.external.enable_crl_cache = true
+## listener.ssl.external.enable_crl_check = true
 
 ## Comma-separated URL list for CRL servers to fetch and cache CRLs
 ## from.  Must include the path to the CRL file(s).

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1702,7 +1702,7 @@ end}.
   {datatype, {duration, ms}}
 ]}.
 
-{mapping, "listener.ssl.$name.enable_crl_cache", "emqx.listeners", [
+{mapping, "listener.ssl.$name.enable_crl_check", "emqx.listeners", [
   {default, false},
   {datatype, {enum, [true, false]}}
 ]}.
@@ -2337,7 +2337,7 @@ end}.
                       undefined -> undefined;
                       _ -> {fun emqx_psk:lookup/3, <<>>}
                     end,
-                  CRLCheck = case cuttlefish:conf_get(Prefix ++ ".enable_crl_cache", Conf, false) of
+                  CRLCheck = case cuttlefish:conf_get(Prefix ++ ".enable_crl_check", Conf, false) of
                                true ->
                                  HTTPTimeout = cuttlefish:conf_get(Prefix ++ ".crl_cache_http_timeout", Conf, timer:seconds(15)),
                                  %% {crl_check, true} doesn't work
@@ -2374,7 +2374,7 @@ end}.
                     undefined -> undefined;
                     URLs -> string:tokens(URLs, ", ")
                   end,
-        Filter([ {crl_cache_enabled, cuttlefish:conf_get(Prefix ++ ".enable_crl_cache", Conf, false)}
+        Filter([ {crl_check_enabled, cuttlefish:conf_get(Prefix ++ ".enable_crl_check", Conf, false)}
                , {crl_cache_urls, CRLURLs}
                ])
       end,

--- a/src/emqx_crl_cache.erl
+++ b/src/emqx_crl_cache.erl
@@ -187,7 +187,7 @@ collect_urls(Listeners) ->
     CRLOpts1 =
         lists:filter(
           fun(CRLOpts) ->
-            proplists:get_bool(crl_cache_enabled, CRLOpts)
+            proplists:get_bool(crl_check_enabled, CRLOpts)
           end,
           CRLOpts0),
     CRLURLs =

--- a/src/emqx_listeners.erl
+++ b/src/emqx_listeners.erl
@@ -306,7 +306,7 @@ find_by_id(Id, [L | Rest]) ->
 -spec maybe_register_crl_urls([esockd:option()]) -> ok.
 maybe_register_crl_urls(Options) ->
     CRLOptions = proplists:get_value(crl_options, Options, []),
-    case proplists:get_bool(crl_cache_enabled, CRLOptions) of
+    case proplists:get_bool(crl_check_enabled, CRLOptions) of
         false ->
             ok;
         true ->

--- a/test/emqx_crl_cache_SUITE.erl
+++ b/test/emqx_crl_cache_SUITE.erl
@@ -80,7 +80,7 @@ end_per_testcase(TestCase, Config)
     emqx_crl_cache_http_server:stop(ServerPid),
     emqx_ct_helpers:stop_apps([]),
     emqx_ct_helpers:change_emqx_opts(
-      ssl_twoway, [ {crl_options, [ {crl_cache_enabled, false}
+      ssl_twoway, [ {crl_options, [ {crl_check_enabled, false}
                                   , {crl_cache_urls, []}
                                   ]}
                   ]),
@@ -90,7 +90,7 @@ end_per_testcase(TestCase, Config)
 end_per_testcase(t_not_cached_and_unreachable, _Config) ->
     emqx_ct_helpers:stop_apps([]),
     emqx_ct_helpers:change_emqx_opts(
-      ssl_twoway, [ {crl_options, [ {crl_cache_enabled, false}
+      ssl_twoway, [ {crl_options, [ {crl_check_enabled, false}
                                   , {crl_cache_urls, []}
                                   ]}
                   ]),
@@ -194,7 +194,7 @@ setup_crl_options(Config, #{is_cached := IsCached}) ->
                                               , {crl_cache,
                                                  {ssl_crl_cache, {internal, [{http, timer:seconds(15)}]}}}
                                               ]}
-                              , {crl_options, [ {crl_cache_enabled, true}
+                              , {crl_options, [ {crl_check_enabled, true}
                                               , {crl_cache_urls, URLs}
                                               ]}
                               ]),


### PR DESCRIPTION
To avoid some confusion that may arise from the `enable_crl_cache` name.  Enabling this option is actually the way to enable the CRL check itself, and caching should always be on in that case.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
