### PR TITLE
Revert "fix: remove outdated cert store from packages"

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -94,11 +94,6 @@ jobs:
         }
         make ensure-rebar3
         make ${{ matrix.profile }}
-        ## Delete certifi cert store
-        $Cert = Get-ChildItem "_build/${{ matrix.profile }}/rel/emqx/lib/certifi*/priv/cacerts.pem"
-        if (Test-Path $Cert) {
-            Remove-Item $Cert
-        }
         mkdir -p _packages/${{ matrix.profile }}
         Compress-Archive -Path _build/${{ matrix.profile }}/rel/emqx -DestinationPath _build/${{ matrix.profile }}/rel/$pkg_name
         mv _build/${{ matrix.profile }}/rel/$pkg_name _packages/${{ matrix.profile }}

--- a/build
+++ b/build
@@ -61,20 +61,9 @@ log() {
     echo "===< $msg"
 }
 
-delete_unwanted_file() {
-    if [ -e "${1}" ]; then
-        log "Deleting file: ${1}"
-        rm -f "${1}"
-    else
-        log "Cannot delete file: ${1} -- file not found"
-    fi
-}
-
 make_rel() {
-    ./rebar3 as "$PROFILE" release
-    # delete outdated cert store
-    delete_unwanted_file _build/"${PROFILE}"/rel/emqx/lib/certifi*/priv/cacerts.pem
-    ./rebar3 as "$PROFILE" tar
+    # shellcheck disable=SC1010
+    ./rebar3 as "$PROFILE" do release,tar
 }
 
 ## unzip previous version .zip files to _build/$PROFILE/rel/emqx/releases before making relup


### PR DESCRIPTION
Reverts emqx/emqx#9321

The cert file is copied again to rel dir at the `tar` step.