### PR TITLE
feat: validate tls_versions value

### DIFF
--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -3,6 +3,8 @@
 ## Enhancements
 
 
+- Make sure listener's tls_versions is `[tlsv1,tlsv1.1,tlsv1.2,tlsv1.3]` [#9260](https://github.com/emqx/emqx/pull/9260).
+
 - Remove useless information from the dashboard listener failure log [#9260](https://github.com/emqx/emqx/pull/9260).
 
 - We now trigger the `'message.acked'` hook after the CoAP gateway sends a message to the device and receives the ACK from the device [#9264](https://github.com/emqx/emqx/pull/9264).

--- a/changes/v4.3.22-en.md
+++ b/changes/v4.3.22-en.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 
-- Make sure listener's tls_versions is `[tlsv1,tlsv1.1,tlsv1.2,tlsv1.3]` [#9260](https://github.com/emqx/emqx/pull/9260).
+- Make sure listener's `tls_versions` config value is one or more of `tlsv1`, `tlsv1.1`, `tlsv1.2`, `tlsv1.3` [#9260](https://github.com/emqx/emqx/pull/9260).
 
 - Remove useless information from the dashboard listener failure log [#9260](https://github.com/emqx/emqx/pull/9260).
 

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -2,6 +2,8 @@
 
 ## 增强
 
+- 确证监听器的 tls_versions 为 `[tlsv1,tlsv1.1,tlsv1.2,tlsv1.3]` [#9260](https://github.com/emqx/emqx/pull/9260).
+
 - 删除 Dashboard 监听器失败时日志中的无用信息 [#9260](https://github.com/emqx/emqx/pull/9260).
 
 - 当 CoAP 网关给设备投递消息并收到设备发来的确认之后，回调 `'message.acked'` 钩子 [#9264](https://github.com/emqx/emqx/pull/9264)。

--- a/changes/v4.3.22-zh.md
+++ b/changes/v4.3.22-zh.md
@@ -2,7 +2,7 @@
 
 ## 增强
 
-- 确证监听器的 tls_versions 为 `[tlsv1,tlsv1.1,tlsv1.2,tlsv1.3]` [#9260](https://github.com/emqx/emqx/pull/9260).
+- 检查监听器的 `tls_versions` 配置值是 `tlsv1`，`tlsv1.1`，`tlsv1.2`，`tlsv1.3` 中的一个或多个组合 [#9260](https://github.com/emqx/emqx/pull/9260)。
 
 - 删除 Dashboard 监听器失败时日志中的无用信息 [#9260](https://github.com/emqx/emqx/pull/9260).
 

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -2203,7 +2203,16 @@ end}.
     SslOpts = fun(Prefix) ->
                   Versions = case SplitFun(cuttlefish:conf_get(Prefix ++ ".tls_versions", Conf, undefined)) of
                                 undefined -> undefined;
-                                L -> [list_to_atom(V) || V <- L]
+                                L ->
+                                  Versions0 = [list_to_atom(V) || V <- L],
+                                  SupportVersions = ['tlsv1', 'tlsv1.1', 'tlsv1.2', 'tlsv1.3'],
+                                  case lists:all(fun(V) -> lists:member(V, SupportVersions) end, Versions0) of
+                                     false ->
+                                        cuttlefish:invalid(
+                                        lists:flatten(io_lib:format("tls_versions: only support ~p", [SupportVersions])));
+                                      true ->
+                                        Versions0
+                                  end
                             end,
                   TLSCiphers = cuttlefish:conf_get(Prefix++".ciphers", Conf, undefined),
                   PSKCiphers = cuttlefish:conf_get(Prefix++".psk_ciphers", Conf, undefined),


### PR DESCRIPTION
Make sure listener's tls_versions is `[tlsv1,tlsv1.1,tlsv1.2,tlsv1.3]`

- [x] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change

## Backward Compatibility

## More information
