### PR TITLE
fix(crl): make http timeout global for all listeners

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1550,7 +1550,6 @@ listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 ## listener.ssl.external.ocsp_refresh_http_timeout = 15s
 
 ## Whether to enable CRL verification and caching for this listener.
-## If set to true, requires specifying the CRL server URLs.
 ##
 ## Value: boolean
 ## Default: false

--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1562,11 +1562,12 @@ listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 ## Value: String
 ## listener.ssl.external.crl_cache_urls = http://my.crl.server/intermediate.crl.pem, http://my.other.crl.server/another.crl.pem
 
-## The timeout for the HTTP request when fetching CRLs.
+## The timeout for the HTTP request when fetching CRLs.  This is
+## global for all listeners.
 ##
 ## Value: Duration
 ## Default: 15 s
-## listener.ssl.external.crl_cache_http_timeout = 15s
+## crl_cache.http_timeout = 15s
 
 ## The period to refresh the CRLs from the servers.  This is global
 ## for all URLs and listeners.

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1712,7 +1712,7 @@ end}.
   {datatype, string}
 ]}.
 
-{mapping, "listener.ssl.$name.crl_cache_http_timeout", "emqx.listeners", [
+{mapping, "crl_cache.http_timeout", "emqx.crl_cache_http_timeout", [
   {default, "15s"},
   {datatype, {duration, ms}}
 ]}.
@@ -2339,7 +2339,7 @@ end}.
                     end,
                   CRLCheck = case cuttlefish:conf_get(Prefix ++ ".enable_crl_check", Conf, false) of
                                true ->
-                                 HTTPTimeout = cuttlefish:conf_get(Prefix ++ ".crl_cache_http_timeout", Conf, timer:seconds(15)),
+                                 HTTPTimeout = cuttlefish:conf_get("crl_cache.http_timeout", Conf, timer:seconds(15)),
                                  %% {crl_check, true} doesn't work
                                  [ {crl_check, peer}
                                  , {crl_cache, {ssl_crl_cache, {internal, [{http, HTTPTimeout}]}}}

--- a/test/emqx_crl_cache_SUITE.erl
+++ b/test/emqx_crl_cache_SUITE.erl
@@ -257,6 +257,7 @@ t_init_refresh(Config) ->
     URL2 = "http://localhost/crl2.pem",
     Opts = #{ urls => [URL1, URL2]
             , refresh_interval => timer:minutes(15)
+            , http_timeout => timer:seconds(15)
             },
     ok = snabbkaffe:start_trace(),
     {ok, SubRef} = snabbkaffe:subscribe(


### PR DESCRIPTION
We make the CRL HTTP timeout the same for all listeners for simplicity
of understanding and implementation.

Based on top of #9347 

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
