### PR TITLE
refactor: flatten crl_cache config namespace into root

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1566,14 +1566,14 @@ listener.ssl.external.cacertfile = {{ platform_etc_dir }}/certs/cacert.pem
 ##
 ## Value: Duration
 ## Default: 15 s
-## crl_cache.http_timeout = 15s
+## crl_cache_http_timeout = 15s
 
 ## The period to refresh the CRLs from the servers.  This is global
 ## for all URLs and listeners.
 ##
 ## Value: Duration
 ## Default: 15 m
-## crl_cache.refresh_interval = 15m
+## crl_cache_refresh_interval = 15m
 
 ## The Ephemeral Diffie-Helman key exchange is a very effective way of
 ## ensuring Forward Secrecy by exchanging a set of keys that never hit

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1712,12 +1712,12 @@ end}.
   {datatype, string}
 ]}.
 
-{mapping, "crl_cache.http_timeout", "emqx.crl_cache_http_timeout", [
+{mapping, "crl_cache_http_timeout", "emqx.crl_cache_http_timeout", [
   {default, "15s"},
   {datatype, {duration, ms}}
 ]}.
 
-{mapping, "crl_cache.refresh_interval", "emqx.crl_cache_refresh_interval", [
+{mapping, "crl_cache_refresh_interval", "emqx.crl_cache_refresh_interval", [
   {default, "15m"},
   {datatype, {duration, ms}}
 ]}.
@@ -2339,7 +2339,7 @@ end}.
                     end,
                   CRLCheck = case cuttlefish:conf_get(Prefix ++ ".enable_crl_check", Conf, false) of
                                true ->
-                                 HTTPTimeout = cuttlefish:conf_get("crl_cache.http_timeout", Conf, timer:seconds(15)),
+                                 HTTPTimeout = cuttlefish:conf_get("crl_cache_http_timeout", Conf, timer:seconds(15)),
                                  %% {crl_check, true} doesn't work
                                  [ {crl_check, peer}
                                  , {crl_cache, {ssl_crl_cache, {internal, [{http, HTTPTimeout}]}}}

--- a/test/emqx_crl_cache_SUITE.erl
+++ b/test/emqx_crl_cache_SUITE.erl
@@ -124,6 +124,7 @@ end_per_testcase(t_not_cached_and_unreachable, _Config) ->
 end_per_testcase(t_refresh_config, Config) ->
     OldConfigs = ?config(old_configs, Config),
     meck:unload([emqx_crl_cache]),
+    clear_crl_cache(),
     emqx_ct_helpers:stop_apps([]),
     emqx_ct_helpers:change_emqx_opts(
       ssl_twoway, [ {crl_options, [ {crl_check_enabled, false}
@@ -140,7 +141,6 @@ end_per_testcase(t_refresh_config, Config) ->
       end,
       OldConfigs),
     application:stop(cowboy),
-    clear_crl_cache(),
     ok = snabbkaffe:stop(),
     ok;
 end_per_testcase(_TestCase, _Config) ->


### PR DESCRIPTION


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
