### PR TITLE
feat(banned): kick session when it is banned by clientid

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -3,7 +3,7 @@
     {id, "emqx"},
     {description, "EMQX Core"},
     % strict semver, bump manually!
-    {vsn, "5.0.10"},
+    {vsn, "5.0.11"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/changes/v5.0.11-en.md
+++ b/changes/v5.0.11-en.md
@@ -7,6 +7,9 @@
 
 - Security enhancement for the `subscribe` API [#9355](https://github.com/emqx/emqx/pull/9355).
 
+- Enhance the `banned` feature [#9367](https://github.com/emqx/emqx/pull/9367).
+  Now the corresponding session will be kicked when client is banned by `clientid`.
+
 ## Bug fixes
 
 - Return 404 for status of unknown authenticator in `/authenticator/{id}/status` [#9328](https://github.com/emqx/emqx/pull/9328).

--- a/changes/v5.0.11-zh.md
+++ b/changes/v5.0.11-zh.md
@@ -7,6 +7,9 @@
 
 - 增强订阅 API 的安全性 [#9355](https://github.com/emqx/emqx/pull/9355)。
 
+- 增加 `封禁` 功能 [#9367](https://github.com/emqx/emqx/pull/9367)。
+  现在客户端通过 `clientid` 被封禁时将会踢掉对应的会话。
+
 ## 修复
 
 - 通过 `/authenticator/{id}/status` 请求未知认证器的状态时，将会返回 404。


### PR DESCRIPTION
A banned client shouldn't continue to publish/receive, so it's better to kick its session when it is banned.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change
      [EMQX-8109](https://emqx.atlassian.net/browse/EMQX-8109)
- [x] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] ~~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~~

## Backward Compatibility

## More information
