### PR TITLE
fix(JWT): make the `exp` to be optional claim

### DIFF
--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -365,11 +365,11 @@ verify(JWT, JWKs, VerifyClaims, AclClaimName) ->
 acl(Claims, AclClaimName) ->
     Acl =
         case Claims of
-            #{<<"exp">> := Expire, AclClaimName := Rules} ->
+            #{AclClaimName := Rules} ->
                 #{
                     acl => #{
                         rules => Rules,
-                        expire => Expire
+                        expire => maps:get(<<"exp">>, Claims, undefined)
                     }
                 };
             _ ->

--- a/changes/v5.0.11-en.md
+++ b/changes/v5.0.11-en.md
@@ -10,3 +10,5 @@
 ## Bug fixes
 
 - Return 404 for status of unknown authenticator in `/authenticator/{id}/status` [#9328](https://github.com/emqx/emqx/pull/9328).
+
+- Fix that JWT ACL rules are only applied if an `exp` claim is set [#9368](https://github.com/emqx/emqx/pull/9368).

--- a/changes/v5.0.11-zh.md
+++ b/changes/v5.0.11-zh.md
@@ -10,3 +10,5 @@
 ## 修复
 
 - 通过 `/authenticator/{id}/status` 请求未知认证器的状态时，将会返回 404。
+
+- 修复 JWT ACL 规则只在设置了超期时间时才生效的问题 [#9368](https://github.com/emqx/emqx/pull/9368)。


### PR DESCRIPTION
Fix #9217 

According to [the spec](https://www.rfc-editor.org/rfc/rfc7519.html), the `exp` should be optional

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change
      [ EMQX-7924](https://emqx.atlassian.net/browse/EMQX-7924)
- [x] ~~ If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] ~~ In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~~

## Backward Compatibility

## More information
