### PR TITLE
ci: release only the default packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -320,15 +320,9 @@ jobs:
       run: sudo apt-get update && sudo apt install -y dos2unix
     - name: get packages
       run: |
-        DEFAULT_BEAM_PLATFORM='otp24.3.4.2-1'
         set -e -u
         cd packages/${{ matrix.profile }}
-        # Make a copy of the default OTP version package to a file without OTP version infix
-        while read -r fname; do
-          default_fname=$(echo "$fname" | sed "s/-${DEFAULT_BEAM_PLATFORM}//g")
-          echo "$fname -> $default_fname"
-          cp "$fname" "$default_fname"
-        done < <(find . -maxdepth 1 -type f | grep -E "emqx(-enterprise)?-5\.[0-9]+\.[0-9]+.*-${DEFAULT_BEAM_PLATFORM}" | grep -v elixir)
+        # fix the .sha256 file format
         for var in $(ls | grep emqx | grep -v sha256); do
           dos2unix $var.sha256
           echo "$(cat $var.sha256) $var" | sha256sum -c || exit 1

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -11,11 +11,10 @@ help() {
     echo "$0 PROFILE [options]"
     echo
     echo "-h|--help:       To display this usage information"
-    echo "--default:       Print default vsn number. e.g. e.g. 5.0.0-ubuntu20.04-amd64"
-    echo "--long:          Print long vsn number. e.g. 5.0.0-otp24.2.1-1-ubuntu20.04-amd64"
+    echo "--long:          Print long vsn number. e.g. 5.0.0-ubuntu20.04-amd64"
     echo "                 Otherwise short e.g. 5.0.0"
     echo "--elixir:        Include elixir version in the long version string"
-    echo "                 e.g. 5.0.0-elixir1.13.4-otp24.2.1-1-ubuntu20.04-amd64"
+    echo "                 e.g. 5.0.0-elixir-ubuntu20.04-amd64"
     echo "--vsn_matcher:   For --long option, replace the EMQX version with '*'"
     echo "                 so it can be used in find commands"
 }
@@ -33,10 +32,6 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
         help
         exit 0
-        ;;
-    --default)
-        IS_DEFAULT_RELEASE='yes'
-        shift 1
         ;;
     --long)
         LONG_VERSION='yes'
@@ -123,18 +118,7 @@ if [ "${IS_MATCHER:-}" = 'yes' ]; then
     PKG_VSN='*'
 fi
 
-OTP_VSN="${OTP_VSN:-$(./scripts/get-otp-vsn.sh)}"
 SYSTEM="$(./scripts/get-distro.sh)"
-
-case "$SYSTEM" in
-    windows*)
-        # directly build the default package for windows
-        IS_DEFAULT_RELEASE='yes'
-        ;;
-    *)
-        true
-        ;;
-esac
 
 UNAME_M="$(uname -m)"
 case "$UNAME_M" in
@@ -149,15 +133,10 @@ case "$UNAME_M" in
         ;;
 esac
 
-if [ "${IS_DEFAULT_RELEASE:-not-default-release}" = 'yes' ]; then
-    # when it's the default release, we do not add elixir or otp version
-    infix=''
+if [ "${IS_ELIXIR:-}" = "yes" ]; then
+    infix='-elixir'
 else
-    infix="-otp${OTP_VSN}"
-    if [ "${IS_ELIXIR:-}" = "yes" ]; then
-        ELIXIR_VSN="${ELIXIR_VSN:-$(./scripts/get-elixir-vsn.sh)}"
-        infix="-elixir${ELIXIR_VSN}${infix}"
-    fi
+    infix=''
 fi
 
 echo "${PKG_VSN}${infix}-${SYSTEM}-${ARCH}"


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-8239
We no longer need to 'flavour' the packages with otp or elixir version numbers since we found a way forward for hot-upgrading 

Based this on v5.0.10 because we want to merge it to e5.0.0-beta.5
Will add release note change in the next PR after merge.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

~~- [ ] Added tests for the changes~~
~~- [ ] Changed lines covered in coverage report~~
- [ ] Change log has been added to `changes/` dir
~~- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change
~~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
~~- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in~~ **Backward Compatibility** section

## Backward Compatibility

## More information
