### PR TITLE
fix: Config API can't get the default values from raw config

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -268,7 +268,7 @@ config(put, #{body := Body}, Req) ->
 global_zone_configs(get, _Params, _Req) ->
     Paths = global_zone_roots(),
     Zones = lists:foldl(
-        fun(Path, Acc) -> Acc#{Path => get_config_with_default([Path])} end,
+        fun(Path, Acc) -> maps:merge(Acc, get_config_with_default(Path)) end,
         #{},
         Paths
     ),
@@ -343,7 +343,7 @@ get_full_config() ->
     ).
 
 get_config_with_default(Path) ->
-    emqx_config:fill_defaults(emqx:get_raw_config(Path)).
+    emqx_config:fill_defaults(#{Path => emqx:get_raw_config([Path])}).
 
 conf_path_from_querystr(Req) ->
     case proplists:get_value(<<"conf_path">>, cowboy_req:parse_qs(Req)) of

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -133,6 +133,18 @@ t_global_zone(_Config) ->
 
     BadZones = emqx_map_lib:deep_put([<<"mqtt">>, <<"max_qos_allowed">>], Zones, 3),
     ?assertMatch({error, {"HTTP/1.1", 400, _}}, update_global_zone(BadZones)),
+
+    %% Remove max_qos_allowed from raw config, but we still get default value(2).
+    Mqtt0 = emqx_conf:get_raw([<<"mqtt">>]),
+    ?assertEqual(1, emqx_map_lib:deep_get([<<"max_qos_allowed">>], Mqtt0)),
+    Mqtt1 = maps:remove(<<"max_qos_allowed">>, Mqtt0),
+    ok = emqx_config:put_raw([<<"mqtt">>], Mqtt1),
+    Mqtt2 = emqx_conf:get_raw([<<"mqtt">>]),
+    ?assertNot(maps:is_key(<<"max_qos_allowed">>, Mqtt2), Mqtt2),
+    {ok, #{<<"mqtt">> := Mqtt3}} = get_global_zone(),
+    %% the default value is 2
+    ?assertEqual(2, emqx_map_lib:deep_get([<<"max_qos_allowed">>], Mqtt3)),
+    ok = emqx_config:put_raw([<<"mqtt">>], Mqtt0),
     ok.
 
 get_global_zone() ->

--- a/changes/v5.0.11-en.md
+++ b/changes/v5.0.11-en.md
@@ -20,3 +20,5 @@
 - Return 404 for status of unknown authenticator in `/authenticator/{id}/status` [#9328](https://github.com/emqx/emqx/pull/9328).
 
 - Fix that JWT ACL rules are only applied if an `exp` claim is set [#9368](https://github.com/emqx/emqx/pull/9368).
+
+- Fix that `/configs/global_zone` API cannot get the default value of the configuration [#9392](https://github.com/emqx/emqx/pull/9392).

--- a/changes/v5.0.11-zh.md
+++ b/changes/v5.0.11-zh.md
@@ -18,3 +18,5 @@
 - 通过 `/authenticator/{id}/status` 请求未知认证器的状态时，将会返回 404。
 
 - 修复 JWT ACL 规则只在设置了超期时间时才生效的问题 [#9368](https://github.com/emqx/emqx/pull/9368)。
+
+- 修复 `/configs/global_zone` API 无法正确获取配置的默认值问题 [#9392](https://github.com/emqx/emqx/pull/9392)。


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
[Fixes 9210](https://github.com/emqx/emqx/issues/9201)

If we define mqtt in emqx.conf as:
```
mqtt {
  max_qos_allowed = 1 
}
```
then GET `/configs/global_zones` will return `...mqtt {max_qos_allowed: 1}...`, the mqtt's other field is missing.

This PR tries to get the disappearing defaults back.
```
mqtt {
  await_rel_timeout = "300s"
  exclusive_subscription = false
  idle_timeout = "15s"
  ignore_loop_deliver = false
  keepalive_backoff = 0.75
  max_awaiting_rel = 100
  max_clientid_len = 65535
  max_inflight = 32
  max_mqueue_len = 2000
  max_packet_size = "11MB"
  max_qos_allowed = 1
  max_subscriptions = "infinity"
  max_topic_alias = 65535
  max_topic_levels = 65535
  mqueue_default_priority = "lowest"
  mqueue_priorities = "disabled"
  "mqueue_store_qos0" = true
  peer_cert_as_clientid = "disabled"
  peer_cert_as_username = "disabled"
  response_information = ""
  retain_available = true
  retry_interval = "30s"
  server_keepalive = "disabled"
  session_expiry_interval = "2h"
  shared_subscription = true
  strict_mode = false
  upgrade_qos = false
  use_username_as_clientid = false
  wildcard_subscription = true
}
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
