### PR TITLE
fix: change the defualt value of `max_topic_levels` to 128

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -399,7 +399,7 @@ fields("mqtt") ->
             sc(
                 range(1, 65535),
                 #{
-                    default => 65535,
+                    default => 128,
                     desc => ?DESC(mqtt_max_topic_levels)
                 }
             )},

--- a/changes/v5.0.11-en.md
+++ b/changes/v5.0.11-en.md
@@ -19,6 +19,7 @@
 
 - Improve node name generation rules to avoid potential atom table overflow risk [#9387](https://github.com/emqx/emqx/pull/9387).
 
+- Set the default value for the maximum level of a topic to 128 [#9406](https://github.com/emqx/emqx/pull/9406).
 
 ## Bug fixes
 

--- a/changes/v5.0.11-zh.md
+++ b/changes/v5.0.11-zh.md
@@ -17,6 +17,8 @@
 
 - 改进了节点名称生成规则，以避免潜在的原子表溢出风险 [#9387](https://github.com/emqx/emqx/pull/9387)。
 
+- 将主题的最大层级限制的默认值设置为128 [#9406](https://github.com/emqx/emqx/pull/9406)。
+
 ## 修复
 
 - 修复 helm chart 的 `ssl.existingName` 选项不起作用 [#9307](https://github.com/emqx/emqx/issues/9307)。


### PR DESCRIPTION
This default value in v4.x is 128 but 65535 in v5. If the value is too large then the memory may be run out when parsing topic

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] ~~Added tests for the changes~~
- [x] ~~Changed lines covered in coverage report~~
- [x] Change log has been added to `changes/` dir
- [x] ~~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change
     [ EMQX-8120](https://emqx.atlassian.net/browse/EMQX-8120)
- [x] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] ~~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~~

## Backward Compatibility

## More information
