### PR TITLE
fix: fix newly found unsafe `binary_to_atom`

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "An OTP application"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -62,8 +62,15 @@ bridge_id(BridgeType, BridgeName) ->
 -spec parse_bridge_id(list() | binary() | atom()) -> {atom(), binary()}.
 parse_bridge_id(BridgeId) ->
     case string:split(bin(BridgeId), ":", all) of
-        [Type, Name] -> {binary_to_atom(Type, utf8), Name};
-        _ -> error({invalid_bridge_id, BridgeId})
+        [Type, Name] ->
+            case emqx_misc:safe_to_existing_atom(Type, utf8) of
+                {ok, Type1} ->
+                    {Type1, Name};
+                _ ->
+                    error({invalid_bridge_id, BridgeId})
+            end;
+        _ ->
+            error({invalid_bridge_id, BridgeId})
     end.
 
 reset_metrics(ResourceId) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.7"},
+    {vsn, "5.0.8"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [kernel, stdlib, mnesia, minirest, emqx]},


### PR DESCRIPTION
I just found some new unsafe `binary_to_atom` when I was investigating another issue. 

Maybe this PR doesn't need an update desc

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] ~~Change log has been added to `changes/` dir~~
- [x] ~~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] ~~For internal contributor: there is a jira ticket to track this change~~
- [x] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] ~~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~~

## Backward Compatibility

## More information
