### PR TITLE
feat: remove $queue in favor of $share

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -40,14 +40,11 @@
 -define(ERTS_MINIMUM_REQUIRED, "10.0").
 
 %%--------------------------------------------------------------------
-%% Topics' prefix: $SYS | $queue | $share
+%% Topics' prefix: $SYS | $share
 %%--------------------------------------------------------------------
 
 %% System topic
 -define(SYSTOP, <<"$SYS/">>).
-
-%% Queue topic
--define(QUEUE, <<"$queue/">>).
 
 %%--------------------------------------------------------------------
 %% alarms

--- a/apps/emqx/src/emqx_topic.erl
+++ b/apps/emqx/src/emqx_topic.erl
@@ -210,12 +210,8 @@ parse({TopicFilter, Options}) when is_binary(TopicFilter) ->
     parse(TopicFilter, Options).
 
 -spec parse(topic(), map()) -> {topic(), map()}.
-parse(TopicFilter = <<"$queue/", _/binary>>, #{share := _Group}) ->
-    error({invalid_topic_filter, TopicFilter});
 parse(TopicFilter = <<"$share/", _/binary>>, #{share := _Group}) ->
     error({invalid_topic_filter, TopicFilter});
-parse(<<"$queue/", TopicFilter/binary>>, Options) ->
-    parse(TopicFilter, Options#{share => <<"$queue">>});
 parse(TopicFilter = <<"$share/", Rest/binary>>, Options) ->
     case binary:split(Rest, <<"/">>) of
         [_Any] ->

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -424,7 +424,7 @@ systopic_mon() ->
 sharetopic() ->
     ?LET(
         {Type, Grp, T},
-        {oneof([<<"$queue">>, <<"$share">>]), list(latin_char()), normal_topic()},
+        {oneof([<<"$share">>]), list(latin_char()), normal_topic()},
         <<Type/binary, "/", (iolist_to_binary(Grp))/binary, "/", T/binary>>
     ).
 

--- a/apps/emqx/test/emqx_topic_SUITE.erl
+++ b/apps/emqx/test/emqx_topic_SUITE.erl
@@ -187,10 +187,6 @@ t_systop(_) ->
 
 t_feed_var(_) ->
     ?assertEqual(
-        <<"$queue/client/clientId">>,
-        feed_var(<<"$c">>, <<"clientId">>, <<"$queue/client/$c">>)
-    ),
-    ?assertEqual(
         <<"username/test/client/x">>,
         feed_var(
             ?PH_USERNAME,
@@ -212,10 +208,6 @@ long_topic() ->
 
 t_parse(_) ->
     ?assertError(
-        {invalid_topic_filter, <<"$queue/t">>},
-        parse(<<"$queue/t">>, #{share => <<"g">>})
-    ),
-    ?assertError(
         {invalid_topic_filter, <<"$share/g/t">>},
         parse(<<"$share/g/t">>, #{share => <<"g">>})
     ),
@@ -229,11 +221,9 @@ t_parse(_) ->
     ),
     ?assertEqual({<<"a/b/+/#">>, #{}}, parse(<<"a/b/+/#">>)),
     ?assertEqual({<<"a/b/+/#">>, #{qos => 1}}, parse({<<"a/b/+/#">>, #{qos => 1}})),
-    ?assertEqual({<<"topic">>, #{share => <<"$queue">>}}, parse(<<"$queue/topic">>)),
     ?assertEqual({<<"topic">>, #{share => <<"group">>}}, parse(<<"$share/group/topic">>)),
     %% The '$local' and '$fastlane' topics have been deprecated.
     ?assertEqual({<<"$local/topic">>, #{}}, parse(<<"$local/topic">>)),
-    ?assertEqual({<<"$local/$queue/topic">>, #{}}, parse(<<"$local/$queue/topic">>)),
     ?assertEqual({<<"$local/$share/group/a/b/c">>, #{}}, parse(<<"$local/$share/group/a/b/c">>)),
     ?assertEqual({<<"$fastlane/topic">>, #{}}, parse(<<"$fastlane/topic">>)).
 

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -183,7 +183,7 @@ format({_Subscriber, Topic, Options}) ->
     ).
 
 get_topic(Topic, #{share := Group}) ->
-    filename:join([<<"$share">>, Group, Topic]);
+    emqx_topic:join([<<"$share">>, Group, Topic]);
 get_topic(Topic, _) ->
     Topic.
 

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -182,8 +182,6 @@ format({_Subscriber, Topic, Options}) ->
         maps:with([qos, nl, rap, rh], Options)
     ).
 
-get_topic(Topic, #{share := <<"$queue">> = Group}) ->
-    filename:join([Group, Topic]);
 get_topic(Topic, #{share := Group}) ->
     filename:join([<<"$share">>, Group, Topic]);
 get_topic(Topic, _) ->

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -8,4 +8,7 @@
 
 - Start building MacOS packages for Apple Silicon hadrdware [#9423](https://github.com/emqx/emqx/pull/9423).
 
+- Remove support for setting shared subscriptions using the non-standard `$queue` feature [#9412](https://github.com/emqx/emqx/pull/9412).
+  Shared subscriptions are now part of the MQTT spec. Use `$shared` instead.
+
 ## Bug fixes

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -9,6 +9,6 @@
 - Start building MacOS packages for Apple Silicon hadrdware [#9423](https://github.com/emqx/emqx/pull/9423).
 
 - Remove support for setting shared subscriptions using the non-standard `$queue` feature [#9412](https://github.com/emqx/emqx/pull/9412).
-  Shared subscriptions are now part of the MQTT spec. Use `$shared` instead.
+  Shared subscriptions are now part of the MQTT spec. Use `$share` instead.
 
 ## Bug fixes

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -4,8 +4,8 @@
 
 - 通过 `node.global_gc_interval = disabled` 来禁用全局垃圾回收 [#9418](https://github.com/emqx/emqx/pull/9418)。
 
-- Remove support for setting shared subscriptions using the non-standard `$queue` feature [#9412](https://github.com/emqx/emqx/pull/9412).
-  Shared subscriptions are now part of the MQTT spec. Use `$shared` instead.
+- 删除了老的共享订阅支持方式， 不再使用 `$queue` 前缀 [#9412](https://github.com/emqx/emqx/pull/9412)。
+  共享订阅自 MQTT v5.0 开始已成为协议标准，可以使用 `$share` 前缀代替 `$queue`。
 
 ## 修复
 

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -4,6 +4,9 @@
 
 - 通过 `node.global_gc_interval = disabled` 来禁用全局垃圾回收 [#9418](https://github.com/emqx/emqx/pull/9418)。
 
+- Remove support for setting shared subscriptions using the non-standard `$queue` feature [#9412](https://github.com/emqx/emqx/pull/9412).
+  Shared subscriptions are now part of the MQTT spec. Use `$shared` instead.
+
 ## 修复
 
 - 优化命令行实现, 避免输入错误指令时, 产生不必要的原子表消耗 [#9416](https://github.com/emqx/emqx/pull/9416)。


### PR DESCRIPTION
This PR removes support for setting shared subscriptions with the non-standard $queue feature. Shared subscriptions is now part of the MQTT spec (using $share) and we will only support that from now on.

Fixes EMQX-8010.

PR to docs repo: https://github.com/emqx/emqx-docs/pull/1510

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [X] For internal contributor: there is a jira ticket to track this change
- [X] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
