### PR TITLE
chore: set channel info once

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -601,8 +601,7 @@ handle_msg({event, disconnected}, State = #state{channel = Channel}) ->
     {ok, State};
 handle_msg({event, _Other}, State = #state{channel = Channel}) ->
     ClientId = emqx_channel:info(clientid, Channel),
-    emqx_cm:set_chan_info(ClientId, info(State)),
-    emqx_cm:set_chan_stats(ClientId, stats(State)),
+    emqx_cm:insert_channel_info(ClientId, info(State), stats(State)),
     {ok, State};
 handle_msg({timeout, TRef, TMsg}, State) ->
     handle_timeout(TRef, TMsg, State);

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_impl.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_impl.erl
@@ -16,7 +16,7 @@
 
 -module(emqx_gateway_impl).
 
--include("include/emqx_gateway.hrl").
+-include("emqx_gateway.hrl").
 
 -type state() :: map().
 -type reason() :: any().


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
**Previous:**  Always update ets twice.
**Now         :** Only insert ets once.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [x] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/` dir~~
- [ ] ~~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [ ] ~~For internal contributor: there is a jira ticket to track this change~~
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
