### PR TITLE
fix: don't save cert/authz zip on disk when emqx start

### DIFF
--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -13,6 +13,8 @@
 
 - Add `limiter` update API [#9133](https://github.com/emqx/emqx/pull/9133).
 
+- Avoid creating temporary zip files when syncing data directory during cluster startup [#9429](https://github.com/emqx/emqx/pull/9429).
+
 ## Bug fixes
 
 - Fix that the obsolete SSL files aren't deleted after the ExHook config update [#9432](https://github.com/emqx/emqx/pull/9432).

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -13,6 +13,8 @@
 
 - 添加 `limiter` 更新 API [#9133](https://github.com/emqx/emqx/pull/9133)。
 
+- EMQX 集群启动时同步 data 目录不需要在磁盘上产生临时的zip文件 [#9429](https://github.com/emqx/emqx/pull/9429)。
+
 ## 修复
 
 - 修复 ExHook 更新 SSL 相关配置后，过时的 SSL 文件没有被删除的问题 [#9432](https://github.com/emqx/emqx/pull/9432)。


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [<9402>](https://github.com/emqx/emqx/issues/9402)

Make the data.zip file only in memory, don't need to save this on disk.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
