### PR TITLE
refactor: return `204` instead of `200` for `PUT /authenticator/:id`

### DIFF
--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -1006,11 +1006,10 @@ update_authenticator(ConfKeyPath, ChainName, AuthenticatorID, Config) ->
         )
     of
         {ok, #{
-            post_config_update := #{emqx_authentication := #{id := ID}},
-            raw_config := AuthenticatorsConfig
+            post_config_update := #{emqx_authentication := #{id := _ID}},
+            raw_config := _AuthenticatorsConfig
         }} ->
-            {ok, AuthenticatorConfig} = find_config(ID, AuthenticatorsConfig),
-            {200, maps:put(id, ID, convert_certs(fill_defaults(AuthenticatorConfig)))};
+            {204};
         {error, {_PrePostConfigUpdate, emqx_authentication, Reason}} ->
             serialize_error(Reason);
         {error, Reason} ->

--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -22,7 +22,6 @@
 
 -include("emqx_authn.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("common_test/include/ct.hrl").
 
 -define(TCP_DEFAULT, 'tcp:default').
 
@@ -42,7 +41,7 @@ groups() ->
 init_per_testcase(t_authenticator_fail, Config) ->
     meck:expect(emqx_authn_proto_v1, lookup_from_all_nodes, 3, [{error, {exception, badarg}}]),
     init_per_testcase(default, Config);
-init_per_testcase(_, Config) ->
+init_per_testcase(_Case, Config) ->
     {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
     emqx_authn_test_lib:delete_authenticators(
         [?CONF_NS_ATOM],
@@ -213,7 +212,7 @@ test_authenticators(PathPrefix) ->
         method => <<"get">>,
         headers => #{<<"content-type">> => <<"application/json">>}
     },
-    {ok, 200, _} = request(
+    {ok, 204, _} = request(
         put,
         uri(PathPrefix ++ [?CONF_NS, "password_based:http"]),
         ValidConfig1
@@ -302,14 +301,14 @@ test_authenticator(PathPrefix) ->
         method => <<"get">>,
         headers => #{<<"content-type">> => <<"application/json">>}
     },
-    {ok, 200, _} = request(
+    {ok, 204, _} = request(
         put,
         uri(PathPrefix ++ [?CONF_NS, "password_based:http"]),
         ValidConfig1
     ),
 
     ValidConfig2 = ValidConfig0#{pool_size => 9},
-    {ok, 200, _} = request(
+    {ok, 204, _} = request(
         put,
         uri(PathPrefix ++ [?CONF_NS, "password_based:http"]),
         ValidConfig2

--- a/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
@@ -448,7 +448,7 @@ t_jwt_not_allow_empty_claim_name(_) ->
     ),
 
     ?assertMatch(
-        {200, _},
+        {204},
         emqx_authn_api:authenticator(
             put, #{
                 bindings => #{id => <<"jwt">>},

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -14,6 +14,8 @@
 - Refactor authn API by replacing `POST /authentication/{id}/move` with `PUT /authentication/{id}/position/{position}`. [#9419](https://github.com/emqx/emqx/pull/9419).
   Same is done for `/listeners/{listener_id}/authentication/id/...`.
 
+- Return `204` instead of `200` for `PUT /authenticator/:id` [#9434](https://github.com/emqx/emqx/pull/9434/).
+
 ## Bug fixes
 
 - Fix that the obsolete SSL files aren't deleted after the ExHook config update [#9432](https://github.com/emqx/emqx/pull/9432).

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -4,6 +4,8 @@
 
 - 通过 `node.global_gc_interval = disabled` 来禁用全局垃圾回收 [#9418](https://github.com/emqx/emqx/pull/9418)。
 
+- 现在，`PUT /authenticator/:id` 将会返回 204 而不再是 200 [#9434](https://github.com/emqx/emqx/pull/9434/)。
+
 - 优化命令行实现, 避免输入错误指令时, 产生不必要的原子表消耗 [#9416](https://github.com/emqx/emqx/pull/9416)。
 
 - 支持在 Apple Silicon 架构下编译苹果系统的发行版本 [#9423](https://github.com/emqx/emqx/pull/9423)。


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [EMQX-7982](https://emqx.atlassian.net/browse/EMQX-7982)


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~
- [x] Sync with dashboard team 

## Backward Compatibility

## More information
