### PR TITLE
fix(connector): fix previous incorrectly fixes

### DIFF
--- a/apps/emqx_connector/src/emqx_connector.app.src
+++ b/apps/emqx_connector/src/emqx_connector.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_connector, [
     {description, "An OTP application"},
-    {vsn, "0.1.8"},
+    {vsn, "0.1.9"},
     {registered, []},
     {mod, {emqx_connector_app, []}},
     {applications, [

--- a/apps/emqx_connector/src/emqx_connector_ssl.erl
+++ b/apps/emqx_connector/src/emqx_connector_ssl.erl
@@ -70,14 +70,11 @@ try_clear_certs(RltvDir, NewConf, OldConf) ->
     ).
 
 try_clear_certs2(RltvDir, #{<<"connector">> := NewConnector}, #{<<"connector">> := OldConnector}) ->
-    NewSSL = maps:get(<<"ssl">>, NewConnector, undefined),
-    OldSSL = maps:get(<<"ssl">>, OldConnector, undefined),
-    try_clear_certs2(RltvDir, NewSSL, OldSSL);
-try_clear_certs2(RltvDir, NewSSL, OldSSL) when is_map(NewSSL) andalso is_map(OldSSL) ->
-    ok = emqx_tls_lib:delete_ssl_files(RltvDir, NewSSL, OldSSL);
+    try_clear_certs2(RltvDir, NewConnector, OldConnector);
 try_clear_certs2(RltvDir, NewConf, OldConf) ->
-    ?SLOG(debug, #{msg => "unexpected_conf", path => RltvDir, new => NewConf, OldConf => OldConf}),
-    ok.
+    NewSSL = try_map_get(<<"ssl">>, NewConf, undefined),
+    OldSSL = try_map_get(<<"ssl">>, OldConf, undefined),
+    ok = emqx_tls_lib:delete_ssl_files(RltvDir, NewSSL, OldSSL).
 
 new_ssl_config(RltvDir, Config, SSL) ->
     case emqx_tls_lib:ensure_ssl_files(RltvDir, SSL) of
@@ -100,3 +97,8 @@ new_ssl_config(Config, _NewSSL) ->
 
 normalize_key_to_bin(Map) ->
     emqx_map_lib:binary_key_map(Map).
+
+try_map_get(Key, Map, Default) when is_map(Map) ->
+    maps:get(Key, Map, Default);
+try_map_get(_Key, undefined, Default) ->
+    Default.


### PR DESCRIPTION
There was an error in the try_clear_certs2/3 clause that the argument isn't the ssl field but including it.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
