### PR TITLE
refactor: move metrics out of /rules(/:id) to /rules/:id/metrics

### DIFF
--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -641,7 +641,7 @@ t_ingress_mqtt_bridge_with_rules(_) ->
         end
     ),
     %% and also the rule should be matched, with matched + 1:
-    {ok, 200, Rule1} = request(get, uri(["rules", RuleId]), []),
+    {ok, 200, Rule1} = request(get, uri(["rules", RuleId, "metrics"]), []),
     #{
         <<"id">> := RuleId,
         <<"metrics">> := #{
@@ -748,7 +748,7 @@ t_egress_mqtt_bridge_with_rules(_) ->
     timer:sleep(100),
     wait_for_resource_ready(BridgeIDEgress, 5),
     emqx:publish(emqx_message:make(RuleTopic, Payload2)),
-    {ok, 200, Rule1} = request(get, uri(["rules", RuleId]), []),
+    {ok, 200, Rule1} = request(get, uri(["rules", RuleId, "metrics"]), []),
     #{
         <<"id">> := RuleId,
         <<"metrics">> := #{

--- a/apps/emqx_rule_engine/i18n/emqx_rule_engine_api.conf
+++ b/apps/emqx_rule_engine/i18n/emqx_rule_engine_api.conf
@@ -84,6 +84,17 @@ emqx_rule_engine_api {
                           }
                   }
 
+    api4_1 {
+                   desc {
+                         en: "Get a rule's metrics by given Id"
+                         zh: "通过给定的 Id 获得规则的指标数据"
+                        }
+                   label: {
+                           en: "Get Metric"
+                           zh: "获得指标数据"
+                          }
+                  }
+
     api5 {
                    desc {
                          en: "Update a rule by given Id to all nodes in the cluster"

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -43,12 +43,6 @@ fields("rule_creation") ->
 fields("rule_info") ->
     [
         rule_id(),
-        {"metrics", sc(ref("metrics"), #{desc => ?DESC("ri_metrics")})},
-        {"node_metrics",
-            sc(
-                hoconsc:array(ref("node_metrics")),
-                #{desc => ?DESC("ri_node_metrics")}
-            )},
         {"from",
             sc(
                 hoconsc:array(binary()),
@@ -63,6 +57,16 @@ fields("rule_info") ->
                 }
             )}
     ] ++ fields("rule_creation");
+fields("rule_metrics") ->
+    [
+        rule_id(),
+        {"metrics", sc(ref("metrics"), #{desc => ?DESC("ri_metrics")})},
+        {"node_metrics",
+            sc(
+                hoconsc:array(ref("node_metrics")),
+                #{desc => ?DESC("ri_node_metrics")}
+            )}
+    ];
 %% TODO: we can delete this API if the Dashboard not depends on it
 fields("rule_events") ->
     ETopics = emqx_rule_events:event_topics_enum(),

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -14,6 +14,8 @@
 - Refactor authn API by replacing `POST /authentication/{id}/move` with `PUT /authentication/{id}/position/{position}`. [#9419](https://github.com/emqx/emqx/pull/9419).
   Same is done for `/listeners/{listener_id}/authentication/id/...`.
 
+- Redesign `/rules` API to make `metrics` a dedicated resources rather than being included with every response [#9461](https://github.com/emqx/emqx/pull/9461).
+
 ## Bug fixes
 
 - Fix that the obsolete SSL files aren't deleted after the ExHook config update [#9432](https://github.com/emqx/emqx/pull/9432).

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -8,10 +8,13 @@
 
 - 支持在 Apple Silicon 架构下编译苹果系统的发行版本 [#9423](https://github.com/emqx/emqx/pull/9423)。
 
+
 - 删除了老的共享订阅支持方式， 不再使用 `$queue` 前缀 [#9412](https://github.com/emqx/emqx/pull/9412)。
   共享订阅自 MQTT v5.0 开始已成为协议标准，可以使用 `$share` 前缀代替 `$queue`。
 
 - 重构认证 API，使用 `PUT /authentication/{id}/position/{position}` 代替了 `POST /authentication/{id}/move` [#9419](https://github.com/emqx/emqx/pull/9419)。
+
+- 重新设计了 `/rules` API，将  `metrics` 改为专用资源，而不再是包含在每个响应中 [#9461](https://github.com/emqx/emqx/pull/9461)。
 
 ## 修复
 


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [EMQX-7988](https://emqx.atlassian.net/browse/EMQX-7988)

Summary: 
 * you have to query `GET /rules/:id/metrics` explicitly in order to get metrics to a given rule. To reset metrics of a given you resource you `PUT /rules/:id/metrics/reset`. 
 * `/rules/:id/metrics/reset` now returns `204` instead of `200` to comply with rest of API
 * for all queries that include `:id` a `404` is returned in case rule does not exist

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~
- [x] Sync with dasboard team

## Backward Compatibility

## More information
