### PR TITLE
feat(docs): generate config docs divided in subsections

### DIFF
--- a/apps/emqx_conf/src/doc_generation/emqx_conf_authn_section.erl
+++ b/apps/emqx_conf/src/doc_generation/emqx_conf_authn_section.erl
@@ -1,0 +1,59 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_authn_section).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx/include/emqx_authentication.hrl").
+
+-behaviour(hocon_schema).
+
+%% `hocon_schema' API
+-export([
+    namespace/0,
+    roots/0,
+    fields/1,
+    translations/0,
+    translation/1
+]).
+
+namespace() ->
+    undefined.
+
+roots() ->
+    %% this is needed to correctly load the authn modules and their
+    %% fields
+    PtKey = ?EMQX_AUTHENTICATION_SCHEMA_MODULE_PT_KEY,
+    case persistent_term:get(PtKey, undefined) of
+        undefined -> persistent_term:put(PtKey, emqx_authn_schema);
+        _ -> ok
+    end,
+    Roots = [
+        Entry
+     || Entry <- emqx_schema:roots(high),
+        element(1, Entry) =:= ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME
+    ],
+    Roots.
+
+fields(Name) ->
+    emqx_conf_schema:fields(Name).
+
+translations() ->
+    emqx_conf_schema:translations().
+
+translation(Name) ->
+    emqx_conf_schema:translation(Name).

--- a/apps/emqx_conf/src/doc_generation/emqx_conf_authz_section.erl
+++ b/apps/emqx_conf/src/doc_generation/emqx_conf_authz_section.erl
@@ -1,0 +1,52 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_authz_section).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
+
+-behaviour(hocon_schema).
+
+%% `hocon_schema' API
+-export([
+    namespace/0,
+    roots/0,
+    fields/1,
+    translations/0,
+    translation/1
+]).
+
+namespace() ->
+    undefined.
+
+roots() ->
+    Roots = [
+        Entry
+     || Entry <- emqx_conf_schema:emqx_roots(),
+        element(1, Entry) =:= ?EMQX_AUTHORIZATION_CONFIG_ROOT_NAME
+    ],
+    Roots.
+
+fields(Name) ->
+    emqx_conf_schema:fields(Name).
+
+translations() ->
+    emqx_conf_schema:translations().
+
+translation(Name) ->
+    emqx_conf_schema:translation(Name).

--- a/apps/emqx_conf/src/doc_generation/emqx_conf_emqx_section.erl
+++ b/apps/emqx_conf/src/doc_generation/emqx_conf_emqx_section.erl
@@ -1,0 +1,53 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_emqx_section).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx/include/emqx_authentication.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
+
+-behaviour(hocon_schema).
+
+%% `hocon_schema' API
+-export([
+    namespace/0,
+    roots/0,
+    fields/1,
+    translations/0,
+    translation/1
+]).
+
+namespace() ->
+    undefined.
+
+roots() ->
+    %% we need to remove authn and authz roots, as they have their own
+    %% special sections.
+    Roots0 = emqx_conf_schema:emqx_roots(),
+    Roots1 = lists:keydelete(?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME, 1, Roots0),
+    Roots2 = lists:keydelete(?EMQX_AUTHORIZATION_CONFIG_ROOT_NAME, 1, Roots1),
+    Roots2.
+
+fields(Name) ->
+    emqx_conf_schema:fields(Name).
+
+translations() ->
+    emqx_conf_schema:translations().
+
+translation(Name) ->
+    emqx_conf_schema:translation(Name).

--- a/apps/emqx_conf/src/doc_generation/emqx_conf_others_section.erl
+++ b/apps/emqx_conf/src/doc_generation/emqx_conf_others_section.erl
@@ -1,0 +1,60 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_conf_others_section).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+
+-behaviour(hocon_schema).
+
+%% `hocon_schema' API
+-export([
+    namespace/0,
+    roots/0,
+    fields/1,
+    translations/0,
+    translation/1
+]).
+
+namespace() ->
+    undefined.
+
+roots() ->
+    OtherSchemas = emqx_conf_schema:other_schemas() -- special_section_modules(),
+    lists:flatmap(fun roots/1, OtherSchemas).
+
+roots(Module) ->
+    lists:map(fun({_BinName, Root}) -> Root end, hocon_schema:roots(Module)).
+
+fields(Name) ->
+    emqx_conf_schema:fields(Name).
+
+translations() ->
+    emqx_conf_schema:translations().
+
+translation(Name) ->
+    emqx_conf_schema:translation(Name).
+
+%% modules from `emqx_conf_schema:other_schemas/0' that already have
+%% their special sections.
+special_section_modules() ->
+    [
+        emqx_authn_schema,
+        emqx_authz_schema,
+        emqx_bridge_schema,
+        emqx_rule_engine_schema
+    ].

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -41,6 +41,8 @@
 -export([namespace/0, roots/0, fields/1, translations/0, translation/1, validations/0, desc/1]).
 -export([conf_get/2, conf_get/3, keys/2, filter/1]).
 
+-export([emqx_roots/0, other_schemas/0]).
+
 %% Static apps which merge their configs into the merged emqx.conf
 %% The list can not be made a dynamic read at run-time as it is used
 %% by nodetool to generate app.<time>.config before EMQX is started
@@ -73,31 +75,7 @@ roots() ->
         undefined -> persistent_term:put(PtKey, emqx_authn_schema);
         _ -> ok
     end,
-    emqx_schema_high_prio_roots() ++
-        [
-            {"node",
-                sc(
-                    ?R_REF("node"),
-                    #{translate_to => ["emqx"]}
-                )},
-            {"cluster",
-                sc(
-                    ?R_REF("cluster"),
-                    #{translate_to => ["ekka"]}
-                )},
-            {"log",
-                sc(
-                    ?R_REF("log"),
-                    #{translate_to => ["kernel"]}
-                )},
-            {"rpc",
-                sc(
-                    ?R_REF("rpc"),
-                    #{translate_to => ["gen_rpc"]}
-                )}
-        ] ++
-        emqx_schema:roots(medium) ++
-        emqx_schema:roots(low) ++
+    emqx_roots() ++
         lists:flatmap(fun roots/1, ?MERGED_CONFIGS).
 
 validations() ->
@@ -1408,3 +1386,33 @@ validator_string_re(Val, RE, Error) ->
     catch
         _:_ -> {error, Error}
     end.
+
+emqx_roots() ->
+    emqx_schema_high_prio_roots() ++
+        [
+            {"node",
+                sc(
+                    ?R_REF("node"),
+                    #{translate_to => ["emqx"]}
+                )},
+            {"cluster",
+                sc(
+                    ?R_REF("cluster"),
+                    #{translate_to => ["ekka"]}
+                )},
+            {"log",
+                sc(
+                    ?R_REF("log"),
+                    #{translate_to => ["kernel"]}
+                )},
+            {"rpc",
+                sc(
+                    ?R_REF("rpc"),
+                    #{translate_to => ["gen_rpc"]}
+                )}
+        ] ++
+        emqx_schema:roots(medium) ++
+        emqx_schema:roots(low).
+
+other_schemas() ->
+    ?MERGED_CONFIGS.

--- a/rebar.config
+++ b/rebar.config
@@ -37,7 +37,16 @@
 
 {cover_opts, [verbose]}.
 {cover_export_enabled, true}.
-{cover_excl_mods, [emqx_exproto_pb, emqx_exhook_pb]}.
+{cover_excl_mods,
+  [ emqx_exproto_pb
+  , emqx_exhook_pb
+    %% thin wrappers around existing schemas, used only for organizing
+    %% docs into subsections.
+  , emqx_conf_authn_section
+  , emqx_conf_authz_section
+  , emqx_conf_emqx_section
+  , emqx_conf_others_section
+  ]}.
 
 {provider_hooks, [{pre, [{release, {relup_helper, gen_appups}}]}]}.
 


### PR DESCRIPTION
Instead of generating a single huge Markdown file with all the configurations, which is then manually copied over to `emqx-docs.git` as `admin/cfg.md`, here we split the docs in a few subsections:

- EMQX
- Authentication
- Authorization
- Bridges
- Rule Engine
- And the rest

Only the "EMQX" subsection contains the preamble that explains the configuration (Hocon, Layered structure, Syntax, etc.).

Fixes [EMQX-8330](https://emqx.atlassian.net/browse/EMQX-8330)

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
