### PR TITLE
fix: return 404 for /telemetry/data in case it's disabled

### DIFF
--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.7"},
+    {vsn, "5.0.8"},
     {modules, []},
     {applications, [kernel, stdlib, emqx]},
     {mod, {emqx_modules_app, []}},

--- a/apps/emqx_modules/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_api_SUITE.erl
@@ -61,8 +61,20 @@ init_per_testcase(t_status_non_official, Config) ->
 init_per_testcase(t_status, Config) ->
     meck:new(emqx_telemetry, [non_strict, passthrough]),
     meck:expect(emqx_telemetry, enable, fun() -> ok end),
+    {ok, _, _} =
+        request(
+            put,
+            uri(["telemetry", "status"]),
+            #{<<"enable">> => true}
+        ),
     Config;
 init_per_testcase(_TestCase, Config) ->
+    {ok, _, _} =
+        request(
+            put,
+            uri(["telemetry", "status"]),
+            #{<<"enable">> => true}
+        ),
     Config.
 
 end_per_testcase(t_status_non_official, _Config) ->
@@ -169,4 +181,16 @@ t_data(_) ->
             <<"vm_specs">> := _
         },
         jsx:decode(Result)
-    ).
+    ),
+
+    {ok, 200, _} =
+        request(
+            put,
+            uri(["telemetry", "status"]),
+            #{<<"enable">> => false}
+        ),
+
+    {ok, 404, _} =
+        request(get, uri(["telemetry", "data"])),
+
+    ok.

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -21,3 +21,5 @@
 - Fix that the obsolete SSL files aren't deleted after the ExHook config update [#9432](https://github.com/emqx/emqx/pull/9432).
 
 - Fix doc and schema for `/trace` API [#9468](https://github.com/emqx/emqx/pull/9468).
+
+- Return `404` for `/telemetry/data` in case it's disabled [#9464](https://github.com/emqx/emqx/pull/9464).

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -20,3 +20,5 @@
 - 修复 ExHook 更新 SSL 相关配置后，过时的 SSL 文件没有被删除的问题 [#9432](https://github.com/emqx/emqx/pull/9432)。
 
 - 修复 /trace API 的返回值格式和相关文档 [#9468](https://github.com/emqx/emqx/pull/9468)。
+
+- 在遥测功能未开启时，通过 /telemetry/data 请求其数据，将会返回 404 [#9464](https://github.com/emqx/emqx/pull/9464)。


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [EMQX-7984](https://emqx.atlassian.net/browse/EMQX-7984)


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~

## Backward Compatibility

## More information
