### PR TITLE
chore: add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,42 @@
+## MQTT
+/apps/emqx_connector/src/mqtt/ @qzhuyan
+/apps/emqx/*/*mqtt* @qzhuyan
+
+## apps
+/apps/emqx/                @lafirest @thalesmg @HJianBo @ieQu1
+/apps/emqx_authn/          @savonarola @JimMoen @HJianBo
+/apps/emqx_authz/          @savonarola @JimMoen @HJianBo
+/apps/emqx_auto_subscribe/ @thalesmg @HJianBo
+/apps/emqx_bridge/         @terry-xiaoyu @thalesmg
+/apps/emqx_conf/           @ieQu1 @thalesmg
+/apps/emqx_connector/      @terry-xiaoyu @JimMoen
+/apps/emqx_dashboard/      @lafirest @JimMoen
+/apps/emqx_exhook/         @lafirest @HJianBo @JimMoen
+/apps/emqx_gateway/        @HJianBo @lafirest
+/apps/emqx_machine/        @thalesmg @terry-xiaoyu @ieQu1
+/apps/emqx_management/     @HJianBo @lafirest @sstrigler
+/apps/emqx_modules/        @thalesmg @terry-xiaoyu @HJianBo
+/apps/emqx_plugin_libs/    @terry-xiaoyu @lafirest
+/apps/emqx_plugins/        @thalesmg @JimMoen @ieQu1
+/apps/emqx_prometheus/     @JimMoen @ieQu1
+/apps/emqx_psk/            @lafirest @thalesmg @terry-xiaoyu
+/apps/emqx_resource/       @terry-xiaoyu @thalesmg
+/apps/emqx_retainer/       @lafirest @ieQu1 @thalesmg
+/apps/emqx_rule_engine/    @terry-xiaoyu @HJianBo @kjellwinblad
+/apps/emqx_slow_subs/      @lafirest @HJianBo
+/apps/emqx_statsd/         @JimMoen @HJianBo
+
+## other
+/lib-ee/                   @thalesmg
+/bin/                      @zmstone @thalesmg @terry-xiaoyu @id
+/rel/                      @zmstone @thalesmg @id
+
+## CI
+/.github/ @id
+/.ci/     @id
+/scripts/ @id
+/build    @id
+/deploy/  @id
+
+## Default
+* @zmstone


### PR DESCRIPTION
# CODEOWNERS

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

Assigned people to apps and scripts based on number of commits over the last year.
Exceptions:
- excluded @zmstone from per-app reviewers - he's everywhere, and he's also default reviewer anyway
- excluded @zhongwencool
- excluded @DDDHuang 
- excluded ex-employees
- special handling for mqtt stuff

# Data collection

## authors rank per app
```
for app in apps/*; do \
  echo $app; \
  git log --pretty=format:'%ae' --since='1 year ago' -- $app | sort | uniq -c | sort -rnk1,1 | head -n10; \
done
```
## list of authors
```
git log --pretty=format:'%ae' --since='1 year ago' | sort | uniq -c | sort -rnk1,1 > authors.txt
```
## personal rank of most popular apps per author
```
for a in $(< authors.txt); do \
  echo $a; \
  for app in apps/*; do \
    printf "%d\t%s\n" $(git log --since='1 year ago' --author $a -- $app | wc -l | tr -d '\n') $app; \
  done | sort -rnk1,1; \
done
```