### PR TITLE
fix(install_upgrade): check target version when unpacking (v4.4)

### DIFF
--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -32,6 +32,7 @@ main(Args) ->
 unpack({RelName, NameTypeArg, NodeName, Cookie}, Opts) ->
     TargetNode = start_distribution(NodeName, NameTypeArg, Cookie),
     Version = proplists:get_value(version, Opts),
+    validate_target_version(Version, TargetNode),
     case unpack_release(RelName, TargetNode, Version) of
         {ok, Vsn} ->
             ?INFO("Unpacked successfully: ~p", [Vsn]);


### PR DESCRIPTION
We already have a check to avoid upgrading between minor versions, such as 4.3 <-> 4.4 (and 4.4 <-> 4.5):

```
  Cannot upgrade/downgrade to 4.4.11-rc.3 from 4.3.17
  We only support relup between patch versions
  escript: exception error: {relup_not_allowed,unsupported_target_version}
    in function  install_upgrade_escript__escript__1670__7364__537878__24:validate_target_version/2 (/usr/lib/emqx/bin/install_upgrade.escript, line 444)
    in call from install_upgrade_escript__escript__1670__7364__537878__24:install/2 (/usr/lib/emqx/bin/install_upgrade.escript, line 58)
    in call from escript:run/2 (escript.erl, line 758)
    in call from escript:start/1 (escript.erl, line 277)
    in call from init:start_em/1
    in call from init:do_boot/3
```

But such check is missing for `unpack`, which may result in an unusable node after just unpacking:

```
emqx@d70cfe0e8e62:~$ emqx ctl status
ERROR: node_is_not_running!
```

The issue apparently arises from `nodetool` trying to use the `compiler` lib from the newer version rather than the old one:

```
  + ERL_FLAGS=' -start_epmd false -epmd_module ekka_epmd -proto_dist ekka'
  + /usr/lib/emqx/erts-11.2.2.8/bin/escript /usr/lib/emqx/bin/nodetool -name emqx@127.0.0.1 -setcookie emqxsecretcookie ping
  + die 'node_is_not_running!' 1
  + set +x
  ERROR: node_is_not_running!

  emqx@d70cfe0e8e62:~$ /usr/lib/emqx/erts-11.2.2.8/bin/escript /usr/lib/emqx/bin/nodetool -name emqx@127.0.0.1 -setcookie emqxsecretcookie ping
  escript: Internal error: undef
  =ERROR REPORT==== 2-Dec-2022::19:02:39.150274 ===
  Loading of /usr/lib/emqx/lib/compiler-8.1.1/ebin/compile.beam failed: badfile

  =ERROR REPORT==== 2-Dec-2022::19:02:39.150271 ===
  beam/beam_load.c(1879): Error loading module compile:
    This BEAM file was compiled for a later version of the run-time system than 23.
    To fix this, please recompile this module with an 23 compiler.
    (Use of opcode 176; this emulator supports only up to 170.)
```

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [EMQX-8419](https://emqx.atlassian.net/browse/EMQX-8419)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
