### PR TITLE
fix: load bootstrap file when no bootstrap user

### DIFF
--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -1,6 +1,6 @@
 {application, emqx_management,
  [{description, "EMQ X Management API and CLI"},
-  {vsn, "4.4.10"}, % strict semver, bump manually!
+  {vsn, "4.4.11"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_management_sup]},
   {applications, [kernel,stdlib,emqx_plugin_libs,minirest]},

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -36,6 +36,8 @@
         , del_app/1
         , list_apps/0
         , init_bootstrap_apps/0
+        , need_bootstrap/0
+        , clear_bootstrap_apps/0
         ]).
 
 %% APP Auth/ACL API
@@ -81,13 +83,31 @@ add_default_app() ->
     end.
 
 init_bootstrap_apps() ->
-    Bootstrap = application:get_env(emqx_management, bootstrap_apps_file, undefined),
-    Size = mnesia:table_info(mqtt_app, size),
-    init_bootstrap_apps(Bootstrap, Size).
+    case need_bootstrap() of
+        true ->
+            Bootstrap = application:get_env(emqx_management, bootstrap_apps_file, undefined),
+            init_bootstrap_apps(Bootstrap);
+        false ->
+            ok
+    end.
 
-init_bootstrap_apps(undefined, _) -> ok;
-init_bootstrap_apps(_File, Size)when Size > 0 -> ok;
-init_bootstrap_apps(File, 0) ->
+need_bootstrap() ->
+    {atomic, Res} = mnesia:transaction(fun() -> bootstrap_apps() =:= [] end),
+    Res.
+
+clear_bootstrap_apps() ->
+    {atomic, ok} =
+        mnesia:transaction(fun() ->
+            DeleteFun = fun(A) -> mnesia:delete_object(A) end,
+            lists:foreach(DeleteFun, bootstrap_apps())
+                           end),
+    ok.
+
+bootstrap_apps() ->
+    mnesia:match_object(mqtt_app, #mqtt_app{desc = ?BOOTSTRAP_TAG, _ = '_'}, read).
+
+init_bootstrap_apps(undefined) -> ok;
+init_bootstrap_apps(File) ->
     case file:open(File, [read, binary]) of
         {ok, Dev} ->
             {ok, MP} = re:compile(<<"(\.+):(\.+$)">>, [ungreedy]),
@@ -95,7 +115,7 @@ init_bootstrap_apps(File, 0) ->
                 ok -> ok;
                 Error ->
                     %% if failed add bootstrap users, we should clear all bootstrap apps
-                    {atomic, ok} = mnesia:clear_table(mqtt_app),
+                    clear_bootstrap_apps(),
                     Error
             end;
         {error, Reason} = Error ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -241,6 +241,7 @@ init_per_testcase(Test, Config)
     | Config];
 init_per_testcase(t_rule_api_unicode_ids, Config) ->
     ok = emqx_dashboard_admin:mnesia(boot),
+    ok = emqx_mgmt_auth:mnesia(boot),
     emqx_ct_helpers:start_apps([emqx_management, emqx_dashboard]),
     Config;
 init_per_testcase(_TestCase, Config) ->

--- a/changes/v4.4.12-en.md
+++ b/changes/v4.4.12-en.md
@@ -1,3 +1,7 @@
 ### Enhancements
 
 - Upgrade http client library `ehttpc` from `0.2.1` to `0.4.2` [#9456](https://github.com/emqx/emqx/pull/9456).
+
+### Bug Fixes
+
+- Fixed load bootstrap file when no bootstrap user in `mqtt_app` [#9474](https://github.com/emqx/emqx-enterprise/pull/9474).

--- a/changes/v4.4.12-zh.md
+++ b/changes/v4.4.12-zh.md
@@ -1,3 +1,8 @@
 ### 增强
 
 - HTTP 客户端库 `ehttpc` 从 `0.2.1` 升级到 `0.4.2` [#9456](https://github.com/emqx/emqx/pull/9456)。
+
+
+### 修复
+
+- 修复 mqtt_app 表内没有 boostrap user 里未导入用户的问题 [#9474](https://github.com/emqx/emqx-enterprise/pull/9474).


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->

When doing a hot upgrade or rolling upgrade, the `mqtt_app` table is not empty, Leading to skip import bootstrap users.

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
