### PR TITLE
Fix status code for lwm2m clients in api

### DIFF
--- a/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_api.erl
+++ b/apps/emqx_gateway/src/lwm2m/emqx_lwm2m_api.erl
@@ -81,7 +81,7 @@ schema(?PATH("/observe")) ->
             ],
             'requestBody' => [],
             responses => #{
-                200 => <<"No Content">>,
+                204 => <<"No Content">>,
                 404 => error_codes(['CLIENT_NOT_FOUND'], <<"Clientid not found">>)
             }
         }
@@ -98,7 +98,7 @@ schema(?PATH("/read")) ->
                 {path, mk(binary(), #{in => query, required => true, example => "/3/0/7"})}
             ],
             responses => #{
-                200 => <<"No Content">>,
+                204 => <<"No Content">>,
                 404 => error_codes(['CLIENT_NOT_FOUND'], <<"clientid not found">>)
             }
         }
@@ -121,7 +121,7 @@ schema(?PATH("/write")) ->
                 {value, mk(binary(), #{in => query, required => true, example => 123})}
             ],
             responses => #{
-                200 => <<"No Content">>,
+                204 => <<"No Content">>,
                 404 => error_codes(['CLIENT_NOT_FOUND'], <<"Clientid not found">>)
             }
         }
@@ -275,7 +275,7 @@ send_cmd(ClientId, Cmd) ->
     case emqx_gateway_cm_registry:lookup_channels(lwm2m, ClientId) of
         [Channel | _] ->
             ok = emqx_lwm2m_channel:send_cmd(Channel, Cmd),
-            {200};
+            {204};
         _ ->
             {404, #{code => 'CLIENT_NOT_FOUND'}}
     end.

--- a/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
@@ -354,7 +354,7 @@ call_deprecated_send_api(ClientId, Cmd, Query) ->
 call_send_api(ClientId, Cmd, Query, API) ->
     ApiPath = emqx_mgmt_api_test_util:api_path([API, ClientId, Cmd]),
     Auth = emqx_mgmt_api_test_util:auth_header_(),
-    Opts = #{return_body => true},
+    Opts = #{return_all => true},
     {ok, {{"HTTP/1.1", StatusCode, _}, _Headers, Response}} = emqx_mgmt_api_test_util:request_api(
         post, ApiPath, Query, Auth, [], Opts
     ),

--- a/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_lwm2m_api_SUITE.erl
@@ -253,7 +253,7 @@ t_read(Config) ->
     test_recv_mqtt_response(RespTopic),
 
     %% step2, call Read API
-    call_send_api(Epn, "read", "path=/3/0/0"),
+    ?assertMatch({204, []}, call_send_api(Epn, "read", "path=/3/0/0")),
     timer:sleep(100),
     #coap_message{type = Type, method = Method, options = Opts} = test_recv_coap_request(UdpSock),
     ?assertEqual(con, Type),
@@ -289,7 +289,7 @@ t_write(Config) ->
     test_recv_mqtt_response(RespTopic),
 
     %% step2, call write API
-    call_send_api(Epn, "write", "path=/3/0/13&type=Integer&value=123"),
+    ?assertMatch({204, []}, call_send_api(Epn, "write", "path=/3/0/13&type=Integer&value=123")),
     timer:sleep(100),
     #coap_message{type = Type, method = Method, options = Opts} = test_recv_coap_request(UdpSock),
     ?assertEqual(con, Type),
@@ -326,7 +326,7 @@ t_observe(Config) ->
     test_recv_mqtt_response(RespTopic),
 
     %% step2, call observe API
-    call_deprecated_send_api(Epn, "observe", "path=/3/0/1&enable=false"),
+    ?assertMatch({204, []}, call_deprecated_send_api(Epn, "observe", "path=/3/0/1&enable=false")),
     timer:sleep(100),
     #coap_message{type = Type, method = Method, options = Opts} = test_recv_coap_request(UdpSock),
     ?assertEqual(con, Type),
@@ -354,9 +354,12 @@ call_deprecated_send_api(ClientId, Cmd, Query) ->
 call_send_api(ClientId, Cmd, Query, API) ->
     ApiPath = emqx_mgmt_api_test_util:api_path([API, ClientId, Cmd]),
     Auth = emqx_mgmt_api_test_util:auth_header_(),
-    {ok, Response} = emqx_mgmt_api_test_util:request_api(post, ApiPath, Query, Auth),
+    Opts = #{return_body => true},
+    {ok, {{"HTTP/1.1", StatusCode, _}, _Headers, Response}} = emqx_mgmt_api_test_util:request_api(
+        post, ApiPath, Query, Auth, [], Opts
+    ),
     ?LOGT("rest api response:~ts~n", [Response]),
-    Response.
+    {StatusCode, Response}.
 
 no_received_request(ClientId, Path, Action) ->
     Response = call_lookup_api(ClientId, Path, Action),

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -264,6 +264,7 @@ get_configs(Node, Opts) ->
         end,
     URI = emqx_mgmt_api_test_util:api_path(Path),
     case emqx_mgmt_api_test_util:request_api(get, URI, [], [], [], Opts) of
+        {ok, {_, _, Res}} -> {ok, emqx_json:decode(Res, [return_maps])};
         {ok, Res} -> {ok, emqx_json:decode(Res, [return_maps])};
         Error -> Error
     end.

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -228,10 +228,10 @@ t_configs_node({'end', _}) ->
 t_configs_node(_) ->
     Node = atom_to_list(node()),
 
-    ?assertEqual({ok, <<"self">>}, get_configs(Node, #{return_body => true})),
-    ?assertEqual({ok, <<"other">>}, get_configs("other_node", #{return_body => true})),
+    ?assertEqual({ok, <<"self">>}, get_configs(Node, #{return_all => true})),
+    ?assertEqual({ok, <<"other">>}, get_configs("other_node", #{return_all => true})),
 
-    {ExpType, ExpRes} = get_configs("unknown_node", #{return_body => true}),
+    {ExpType, ExpRes} = get_configs("unknown_node", #{return_all => true}),
     ?assertEqual(error, ExpType),
     ?assertMatch({{_, 404, _}, _, _}, ExpRes),
     {_, _, Body} = ExpRes,

--- a/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
@@ -163,7 +163,7 @@ t_publish_too_large(Config) ->
             "",
             Auth,
             Body,
-            #{return_body => true}
+            #{return_all => true}
         ),
     ?assertMatch({_, 400, _}, Summary),
     ?assertMatch(
@@ -286,7 +286,7 @@ t_publish_bulk_dispatch_one_message_invalid_topic(Config) when is_list(Config) -
             "",
             Auth,
             Body,
-            #{return_body => true}
+            #{return_all => true}
         ),
     ?assertMatch({_, 400, _}, Summary),
     ?assertMatch(
@@ -325,7 +325,7 @@ t_publish_bulk_dispatch_failure(Config) when is_list(Config) ->
             "",
             Auth,
             Body,
-            #{return_body => true}
+            #{return_all => true}
         ),
     ?assertMatch({_, 503, _}, Summary),
     ?assertMatch(

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -94,10 +94,14 @@ do_request_api(Method, Request, Opts) ->
     case httpc:request(Method, Request, [], []) of
         {error, socket_closed_remotely} ->
             {error, socket_closed_remotely};
-        {ok, {{"HTTP/1.1", Code, _}, _, Return}} when
+        {ok, {{"HTTP/1.1", Code, _} = Reason, Headers, Body}} when
+            Code >= 200 andalso Code =< 299 andalso ReturnBody
+        ->
+            {ok, {Reason, Headers, Body}};
+        {ok, {{"HTTP/1.1", Code, _}, _, Body}} when
             Code >= 200 andalso Code =< 299
         ->
-            {ok, Return};
+            {ok, Body};
         {ok, {Reason, Headers, Body}} when ReturnBody ->
             {error, {Reason, Headers, Body}};
         {ok, {Reason, _Headers, _Body}} ->

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -89,20 +89,20 @@ request_api(Method, Url, QueryParams, AuthOrHeaders, Body, Opts) when
     ).
 
 do_request_api(Method, Request, Opts) ->
-    ReturnBody = maps:get(return_body, Opts, false),
+    ReturnAll = maps:get(return_all, Opts, false),
     ct:pal("Method: ~p, Request: ~p", [Method, Request]),
     case httpc:request(Method, Request, [], []) of
         {error, socket_closed_remotely} ->
             {error, socket_closed_remotely};
         {ok, {{"HTTP/1.1", Code, _} = Reason, Headers, Body}} when
-            Code >= 200 andalso Code =< 299 andalso ReturnBody
+            Code >= 200 andalso Code =< 299 andalso ReturnAll
         ->
             {ok, {Reason, Headers, Body}};
         {ok, {{"HTTP/1.1", Code, _}, _, Body}} when
             Code >= 200 andalso Code =< 299
         ->
             {ok, Body};
-        {ok, {Reason, Headers, Body}} when ReturnBody ->
+        {ok, {Reason, Headers, Body}} when ReturnAll ->
             {error, {Reason, Headers, Body}};
         {ok, {Reason, _Headers, _Body}} ->
             {error, Reason}

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -34,6 +34,8 @@ Please note, the request body of `/bridges` API to configure MQTT brdige is chan
 
 - Users can define the `externalTrafficPolicy` of service in EMQX Helm Chart [#9527](https://github.com/emqx/emqx/pull/9527).
 
+- Return `204` instead of `200` for `POST /gateway/lwm2m/clients/{clientid}/{read,write,observe}` [#9480](https://github.com/emqx/emqx/pull/9480).
+
 ## Bug fixes
 
 - Fix that the obsolete SSL files aren't deleted after the ExHook config update [#9432](https://github.com/emqx/emqx/pull/9432).

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -33,6 +33,8 @@ v5.0.11 或更早版本创建的配置文件，在新版本中会被自动转换
 
 - 用户可以在 EMQX Helm Chart 中自定义 service 资源的 `externalTrafficPolicy` [#9527](https://github.com/emqx/emqx/pull/9527)。
 
+- Return `204` instead of `200` for `POST /gateway/lwm2m/clients/{clientid}/{read,write,observe}` [#9480](https://github.com/emqx/emqx/pull/9480).
+
 ## 修复
 
 - 修复 ExHook 更新 SSL 相关配置后，过时的 SSL 文件没有被删除的问题 [#9432](https://github.com/emqx/emqx/pull/9432)。

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -33,7 +33,7 @@ v5.0.11 或更早版本创建的配置文件，在新版本中会被自动转换
 
 - 用户可以在 EMQX Helm Chart 中自定义 service 资源的 `externalTrafficPolicy` [#9527](https://github.com/emqx/emqx/pull/9527)。
 
-- Return `204` instead of `200` for `POST /gateway/lwm2m/clients/{clientid}/{read,write,observe}` [#9480](https://github.com/emqx/emqx/pull/9480).
+- 现在调用 `POST /gateway/lwm2m/clients/{clientid}/{read,write,observe}` 时，将会返回 204，而不再是 200 [#9480](https://github.com/emqx/emqx/pull/9480)。
 
 ## 修复
 


### PR DESCRIPTION
Doing a HTTP POST to `/gateway/lwm2m/clients/{clientid}/read` returned 200 without a response body. This PR changes this so that `read`, `write` and `observe` all return 204 - No Content since they all share the same semantics.

Fixes EMQX-7983.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [X] Changed lines covered in coverage report
- [X] Change log has been added to `changes/` dir
- [X] For internal contributor: there is a jira ticket to track this change

## Backward Compatibility

## More information
