### PR TITLE
fix: centos8 has reached the end of its life cycle. But centos7 is st…

### DIFF
--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -20,7 +20,7 @@ jobs:
           - 24.3.4.2-1
         os:
           - ubuntu20.04
-          - el8
+          - el7
         runs-on:
           - aws-amd64
           - ubuntu-20.04


### PR DESCRIPTION
Centos8 has reached the end of its life cycle. But centos7 is still being updated until 2024.6.30.
The vast majority of commercial users, still using centos7.

<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes <issue-number>

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
