### PR TITLE
fix(psk): Add more PSK ciphers support

### DIFF
--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -166,7 +166,20 @@ all_ciphers(['tlsv1.3']) ->
 all_ciphers(Versions) ->
     %% assert non-empty
     List = lists:append([ssl:cipher_suites(all, V, openssl) || V <- Versions]),
-    [_ | _] = dedup(List).
+
+    %% Some PSK ciphers are both supported by OpenSSL and Erlang, but they need manual add here.
+    %% Found by this cmd
+    %% openssl ciphers -v|grep ^PSK| awk '{print $1}'| sed  "s/^/\"/;s/$/\"/" | tr "\n" ","
+    %% Then remove the ciphers that aren't supported by Erlang
+    PSK = [
+        "PSK-AES256-GCM-SHA384",
+        "PSK-AES128-GCM-SHA256",
+        "PSK-AES256-CBC-SHA384",
+        "PSK-AES256-CBC-SHA",
+        "PSK-AES128-CBC-SHA256",
+        "PSK-AES128-CBC-SHA"
+    ],
+    [_ | _] = dedup(List ++ PSK).
 
 %% @doc All Pre-selected TLS ciphers.
 default_ciphers() ->

--- a/changes/v5.0.12-en.md
+++ b/changes/v5.0.12-en.md
@@ -16,6 +16,8 @@
 
 - Redesign `/rules` API to make `metrics` a dedicated resources rather than being included with every response [#9461](https://github.com/emqx/emqx/pull/9461).
 
+- Add more PSK ciphers support [#9505](https://github.com/emqx/emqx/pull/9505).
+
 ## Bug fixes
 
 - Fix that the obsolete SSL files aren't deleted after the ExHook config update [#9432](https://github.com/emqx/emqx/pull/9432).

--- a/changes/v5.0.12-zh.md
+++ b/changes/v5.0.12-zh.md
@@ -16,6 +16,8 @@
 
 - 重新设计了 `/rules` API，将  `metrics` 改为专用资源，而不再是包含在每个响应中 [#9461](https://github.com/emqx/emqx/pull/9461)。
 
+- 支持更多的 PSK 密码套件[#9505](https://github.com/emqx/emqx/pull/9505)。
+
 ## 修复
 
 - 修复 ExHook 更新 SSL 相关配置后，过时的 SSL 文件没有被删除的问题 [#9432](https://github.com/emqx/emqx/pull/9432)。


### PR DESCRIPTION
There are some PSK ciphers both supported by OpenSSL and Erlang, but hidden in the `ssl:cipher_suites` so We need manually add them.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] ~~For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)~~
- [x] For internal contributor: there is a jira ticket to track this change
[EMQX-7235](https://emqx.atlassian.net/browse/EMQX-7235)
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] ~~In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section~~

## Backward Compatibility

## More information
