### PR TITLE
chore(actions): v4.4 update git actions versions

### DIFF
--- a/.github/workflows/apps_version_check.yaml
+++ b/.github/workflows/apps_version_check.yaml
@@ -16,7 +16,7 @@ jobs:
     container: ghcr.io/emqx/emqx-builder/4.4-20:${{ matrix.erl_otp }}-${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # need full history
       - name: fix-git-unsafe-repository
@@ -41,7 +41,7 @@ jobs:
         run: ./scripts/check-apps-vsn.sh
       - name: Check chart versions
         run: ./scripts/check-chart-vsn.sh
-      - uses: actions/upload-artifact@v3.1.0
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: expected_appup_files

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -45,7 +45,7 @@ jobs:
           git config --global credential.helper store
           make -C source deps-all
           zip -ryq source.zip source/* source/.[^.]*
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: source
           path: source.zip
@@ -63,7 +63,7 @@ jobs:
         exclude:
           - profile: emqx-edge
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: source
         path: .
@@ -182,12 +182,12 @@ jobs:
         shell: bash
 
     steps:
-    - uses: docker/setup-buildx-action@v1
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-qemu-action@v2
       with:
         image: tonistiigi/binfmt:latest
         platforms: all
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: source
         path: .
@@ -207,7 +207,7 @@ jobs:
           --pkgtype "${PACKAGE}" \
           --arch "${ARCH}" \
           --builder "ghcr.io/emqx/emqx-builder/4.4-20:${OTP}-${SYSTEM}"
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       with:
         name: ${{ matrix.profile }}
         path: source/_packages/${{ matrix.profile }}/
@@ -233,18 +233,18 @@ jobs:
             registry: 'public.ecr.aws'
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: source
         path: .
     - name: unzip source code
       run: unzip -q source.zip
-    - uses: docker/setup-buildx-action@v1
-    - uses: docker/setup-qemu-action@v1
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/setup-qemu-action@v2
       with:
         image: tonistiigi/binfmt:latest
         platforms: all
-    - uses: aws-actions/configure-aws-credentials@v1
+    - uses: aws-actions/configure-aws-credentials@v1-node16
       if: matrix.registry == 'public.ecr.aws'
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -253,12 +253,12 @@ jobs:
     - name: Docker login to aws ecr
       if: matrix.registry == 'public.ecr.aws'
       run: aws ecr-public get-login-password --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws
-    - uses: docker/login-action@v1
+    - uses: docker/login-action@v2
       if: matrix.registry == 'docker.io'
       with:
         username: ${{ secrets.DOCKER_HUB_USER }}
         password: ${{ secrets.DOCKER_HUB_TOKEN }}
-    - uses: docker/metadata-action@v3
+    - uses: docker/metadata-action@v4
       id: meta
       with:
         images: ${{ matrix.registry }}/${{ github.repository_owner }}/${{ matrix.profile }}
@@ -287,7 +287,7 @@ jobs:
           EMQX_NAME=${{ matrix.profile }}
         file: source/deploy/docker/Dockerfile
         context: source
-    - uses: docker/build-push-action@v2
+    - uses: docker/build-push-action@v3
       if: matrix.profile == 'emqx-ee'
       with:
         ## only push when stable tag and rc tag
@@ -317,7 +317,7 @@ jobs:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
 
     steps:
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: ${{ matrix.profile }}
         path: packages/${{ matrix.profile }}
@@ -332,7 +332,7 @@ jobs:
           echo "$(cat $var.sha256) $var" | sha256sum -c || exit 1
         done
         cd -
-    - uses: aws-actions/configure-aws-credentials@v1
+    - uses: aws-actions/configure-aws-credentials@v1-node16
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -86,7 +86,7 @@ jobs:
         otp:
           - 24.3.4.2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1
     - uses: erlef/setup-beam@v1
       with:

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -8,6 +8,6 @@ jobs:
     container: ghcr.io/emqx/emqx-builder/4.4-20:24.3.4.2-1-ubuntu20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Run check-deps-integrity.escript
         run: ./scripts/check-deps-integrity.escript

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         profile: ${{fromJSON(needs.prepare.outputs.profiles)}}
 
     steps:
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -41,7 +41,7 @@ jobs:
               s3dir=${{ matrix.profile }}
           fi
           aws s3 cp --recursive  s3://${{ secrets.AWS_S3_BUCKET }}/$s3dir/${{ github.ref_name }} packages
-      - uses: alexellis/upload-assets@0.2.2
+      - uses: alexellis/upload-assets@0.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:

--- a/.github/workflows/run_acl_migration_tests.yaml
+++ b/.github/workflows/run_acl_migration_tests.yaml
@@ -11,7 +11,7 @@ jobs:
         env:
             BASE_VERSION: "4.3.0"
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             path: emqx
         - name: Prepare scripts

--- a/.github/workflows/run_automate_tests.yaml
+++ b/.github/workflows/run_automate_tests.yaml
@@ -22,11 +22,11 @@ jobs:
         JMETER_VERSION: 5.4.3
       run: |
         wget --no-verbose --no-check-certificate -O /tmp/apache-jmeter.tgz https://downloads.apache.org/jmeter/binaries/apache-jmeter-$JMETER_VERSION.tgz
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: apache-jmeter.tgz
         path: /tmp/apache-jmeter.tgz
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: erlef/setup-beam@v1
       with:
         otp-version: "24.3.4.2"
@@ -49,7 +49,7 @@ jobs:
       run: |
         make ${{ steps.prepare.outputs.imgname }}-docker
         docker save emqx/${{ steps.prepare.outputs.imgname }}:${{ steps.prepare.outputs.version }} -o image.tar.gz
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: image
         path: image.tar.gz
@@ -65,8 +65,8 @@ jobs:
 
     needs: build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: image
         path: /tmp
@@ -82,12 +82,12 @@ jobs:
         docker-compose \
           -f .ci/docker-compose-file/docker-compose-emqx-cluster.yaml \
           up -d --build
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-svt-web-server
         ref: web-server-1.0
         path: emqx-svt-web-server
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
     - name: run webserver in docker
       run: |
         cd ./emqx-svt-web-server/svtserver
@@ -105,17 +105,18 @@ jobs:
         docker ps -a
         echo HAPROXY_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' haproxy) >> $GITHUB_ENV
         echo WEB_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' webserver) >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
         ref: v1.6.0
         path: scripts
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
         java-version: '8.0.282' # The JDK version to make available on the path.
         java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
         architecture: x64 # (x64 or x86) - defaults to x64
-    - uses: actions/download-artifact@v2
+        distribution: 'zulu'
+    - uses: actions/download-artifact@v3
       with:
         name: apache-jmeter.tgz
         path: /tmp
@@ -144,7 +145,7 @@ jobs:
           echo "check logs filed"
           exit 1
         fi
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: jmeter_logs
@@ -164,8 +165,8 @@ jobs:
 
     needs: build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: image
         path: /tmp
@@ -197,17 +198,18 @@ jobs:
         docker ps -a
         echo HAPROXY_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' haproxy) >> $GITHUB_ENV
         echo MYSQL_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql) >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
         ref: v1.6.0
         path: scripts
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
         java-version: '8.0.282' # The JDK version to make available on the path.
         java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
         architecture: x64 # (x64 or x86) - defaults to x64
-    - uses: actions/download-artifact@v2
+        distribution: 'zulu'
+    - uses: actions/download-artifact@v3
       with:
         name: apache-jmeter.tgz
         path: /tmp
@@ -246,7 +248,7 @@ jobs:
           echo "check logs filed"
           exit 1
         fi
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: jmeter_logs
@@ -270,8 +272,8 @@ jobs:
 
     needs: build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: image
         path: /tmp
@@ -300,17 +302,18 @@ jobs:
         echo HAPROXY_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' haproxy) >> $GITHUB_ENV
         echo PGSQL_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' pgsql) >> $GITHUB_ENV
         echo CONFIG_PATH=$(docker inspect -f '{{ range .Mounts }}{{ if eq .Name "docker-compose-file_etc" }}{{ .Source }}{{ end }}{{ end }}' node1.emqx.io) >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
         ref: v1.6.0
         path: scripts
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
         java-version: '8.0.282' # The JDK version to make available on the path.
         java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
         architecture: x64 # (x64 or x86) - defaults to x64
-    - uses: actions/download-artifact@v2
+        distribution: 'zulu'
+    - uses: actions/download-artifact@v3
       with:
         name: apache-jmeter.tgz
         path: /tmp
@@ -354,7 +357,7 @@ jobs:
           echo "check logs filed"
           exit 1
         fi
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: jmeter_logs
@@ -365,8 +368,8 @@ jobs:
 
     needs: build
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: image
         path: /tmp
@@ -397,17 +400,18 @@ jobs:
         echo HTTP_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' Tomcat) >> $GITHUB_ENV
         echo MYSQL_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' mysql) >> $GITHUB_ENV
         echo CONFIG_PATH=$(docker inspect -f '{{ range .Mounts }}{{ if eq .Name "docker-compose-file_etc" }}{{ .Source }}{{ end }}{{ end }}' node1.emqx.io) >> $GITHUB_ENV
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
         ref: v1.6.0
         path: scripts
-    - uses: actions/setup-java@v1
+    - uses: actions/setup-java@v3
       with:
         java-version: '8.0.282' # The JDK version to make available on the path.
         java-package: jdk # (jre, jdk, or jdk+fx) - defaults to jdk
         architecture: x64 # (x64 or x86) - defaults to x64
-    - uses: actions/download-artifact@v2
+        distribution: 'zulu'
+    - uses: actions/download-artifact@v3
       with:
         name: apache-jmeter.tgz
         path: /tmp
@@ -443,7 +447,7 @@ jobs:
           sudo cat /var/lib/docker/volumes/docker-compose-file_etc/_data/emqx.conf
           exit 1
         fi
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: jmeter_logs

--- a/.github/workflows/run_cts_tests.yaml
+++ b/.github/workflows/run_cts_tests.yaml
@@ -23,7 +23,7 @@ jobs:
         - ipv6
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
         # to avoid dirty self-hosted runners
       - name: stop containers
         run: |
@@ -60,7 +60,7 @@ jobs:
             -e "CUTTLEFISH_ENV_OVERRIDE_PREFIX=EMQX_" \
             --env-file .env \
             erlang sh -c "make apps/emqx_auth_ldap-ct"
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs_ldap${{ matrix.ldap_tag }}_${{ matrix.network_type }}
@@ -83,7 +83,7 @@ jobs:
         - tcp
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: stop containers
         run: |
           docker rm -f $(docker ps -qa) || true
@@ -136,7 +136,7 @@ jobs:
             -e "CUTTLEFISH_ENV_OVERRIDE_PREFIX=EMQX_" \
             --env-file .env \
             erlang sh -c "make apps/emqx_auth_mongo-ct"
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs_mongo${{ matrix.mongo_tag }}_${{ matrix.network_type }}_${{ matrix.connect_type }}
@@ -159,7 +159,7 @@ jobs:
         - tcp
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: stop containers
         run: |
           docker rm -f $(docker ps -qa) || true
@@ -224,7 +224,7 @@ jobs:
             -e "CUTTLEFISH_ENV_OVERRIDE_PREFIX=EMQX_" \
             --env-file .env \
             erlang sh -c "make apps/emqx_auth_mysql-ct"
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs_mysql${{ matrix.mysql_tag }}_${{ matrix.network_type }}_${{ matrix.connect_type }}
@@ -249,7 +249,7 @@ jobs:
         - tls
         - tcp
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: stop containers
         run: |
           docker rm -f $(docker ps -qa) || true
@@ -304,7 +304,7 @@ jobs:
             -e "CUTTLEFISH_ENV_OVERRIDE_PREFIX=EMQX_" \
             --env-file .env \
             erlang sh -c "make apps/emqx_auth_pgsql-ct"
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs_pgsql${{ matrix.pgsql_tag }}_${{ matrix.network_type }}_${{ matrix.connect_type }}
@@ -334,7 +334,7 @@ jobs:
           connect_type: tls
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: stop containers
         run: |
           docker rm -f $(docker ps -qa) || true
@@ -431,7 +431,7 @@ jobs:
             -e "CUTTLEFISH_ENV_OVERRIDE_PREFIX=EMQX_" \
             --env-file .env \
             erlang sh -c "make apps/emqx_auth_redis-ct"
-      - uses: actions/upload-artifact@v1
+      - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs_redis${{ matrix.redis_tag }}_${{ matrix.node_type }}_${{ matrix.network_type }}_${{ matrix.connect_type }}

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-20.04
 
         steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
         - uses: erlef/setup-beam@v1
           with:
             otp-version: "24.1.5"
@@ -75,7 +75,7 @@ jobs:
               - dns
 
         steps:
-        - uses: actions/checkout@v1
+        - uses: actions/checkout@v3
         - uses: erlef/setup-beam@v1
           with:
             otp-version: "24.1.5"
@@ -175,7 +175,7 @@ jobs:
           run: |
             kubectl describe pods emqx-2
             kubectl logs emqx-2
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           with:
             repository: emqx/paho.mqtt.testing
             ref: develop-4.0
@@ -211,7 +211,7 @@ jobs:
           run:
             shell: bash
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           name: Checkout
           with:
             path: emqx
@@ -260,7 +260,7 @@ jobs:
           PROFILE: "${{ needs.relup_test_plan.outputs.profile }}"
           BROKER: "${{ needs.relup_test_plan.outputs.broker }}"
         steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           name: Checkout
           with:
             path: emqx
@@ -273,7 +273,7 @@ jobs:
             fi
         - name: Build emqx
           run: make -C emqx ${PROFILE}-zip
-        - uses: actions/upload-artifact@v2
+        - uses: actions/upload-artifact@v3
           name: Upload built emqx and test scenario
           with:
             name: emqx_built
@@ -302,12 +302,12 @@ jobs:
           run:
             shell: bash
         steps:
-        - uses: actions/download-artifact@v2
+        - uses: actions/download-artifact@v3
           name: Download built emqx and test scenario
           with:
             name: emqx_built
             path: emqx_built
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
           name: Checkout one_more_emqx
           with:
             repository: terry-xiaoyu/one_more_emqx
@@ -332,7 +332,7 @@ jobs:
             --var FROM_OTP_VSN="${old_otp_vsn}" \
             --var TO_OTP_VSN="24.3.4.2-1" \
             emqx_built/.ci/fvt_tests/relup.lux
-        - uses: actions/upload-artifact@v2
+        - uses: actions/upload-artifact@v3
           name: Save debug data
           if: failure()
           with:

--- a/.github/workflows/run_gitlint.yaml
+++ b/.github/workflows/run_gitlint.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Install gitlint
         run: |
           sudo apt-get update

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Install shellcheck
         run: |
           sudo apt-get update


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
GIT actions upgraded to their current latest versions, to mitigate [node12 support dro](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
