### PR TITLE
refactor: return `204` instead of `200` for `PUT /authenticator/:id`

### DIFF
--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -92,7 +92,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
-        ref: broker-autotest-v1
+        ref: broker-autotest-v2
         path: scripts
     - uses: actions/setup-java@v3
       with:
@@ -191,7 +191,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
-        ref: broker-autotest-v1
+        ref: broker-autotest-v2
         path: scripts
     - uses: actions/setup-java@v3
       with:
@@ -297,7 +297,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
-        ref: broker-autotest-v1
+        ref: broker-autotest-v2
         path: scripts
     - uses: actions/setup-java@v3
       with:
@@ -396,7 +396,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
-        ref: broker-autotest-v1
+        ref: broker-autotest-v2
         path: scripts
     - name: run jwks_server
       timeout-minutes: 10
@@ -496,7 +496,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         repository: emqx/emqx-fvt
-        ref: broker-autotest-v1
+        ref: broker-autotest-v2
         path: scripts
     - uses: actions/setup-java@v3
       with:

--- a/apps/emqx_authn/src/emqx_authn.app.src
+++ b/apps/emqx_authn/src/emqx_authn.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authn, [
     {description, "EMQX Authentication"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {modules, []},
     {registered, [emqx_authn_sup, emqx_authn_registry]},
     {applications, [kernel, stdlib, emqx_resource, emqx_connector, ehttpc, epgsql, mysql, jose]},

--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -190,10 +190,7 @@ schema("/authentication/:id") ->
                 authenticator_examples()
             ),
             responses => #{
-                200 => emqx_dashboard_swagger:schema_with_examples(
-                    emqx_authn_schema:authenticator_type(),
-                    authenticator_examples()
-                ),
+                204 => <<"Authenticator updated">>,
                 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>),
                 404 => error_codes([?NOT_FOUND], <<"Not Found">>),
                 409 => error_codes([?ALREADY_EXISTS], <<"ALREADY_EXISTS">>)
@@ -282,10 +279,7 @@ schema("/listeners/:listener_id/authentication/:id") ->
                 authenticator_examples()
             ),
             responses => #{
-                200 => emqx_dashboard_swagger:schema_with_examples(
-                    emqx_authn_schema:authenticator_type(),
-                    authenticator_examples()
-                ),
+                204 => <<"Authenticator updated">>,
                 400 => error_codes([?BAD_REQUEST], <<"Bad Request">>),
                 404 => error_codes([?NOT_FOUND], <<"Not Found">>),
                 409 => error_codes([?ALREADY_EXISTS], <<"ALREADY_EXISTS">>)
@@ -1005,12 +999,8 @@ update_authenticator(ConfKeyPath, ChainName, AuthenticatorID, Config) ->
             {update_authenticator, ChainName, AuthenticatorID, Config}
         )
     of
-        {ok, #{
-            post_config_update := #{emqx_authentication := #{id := ID}},
-            raw_config := AuthenticatorsConfig
-        }} ->
-            {ok, AuthenticatorConfig} = find_config(ID, AuthenticatorsConfig),
-            {200, maps:put(id, ID, convert_certs(fill_defaults(AuthenticatorConfig)))};
+        {ok, _} ->
+            {204};
         {error, {_PrePostConfigUpdate, emqx_authentication, Reason}} ->
             serialize_error(Reason);
         {error, Reason} ->

--- a/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_api_SUITE.erl
@@ -22,7 +22,6 @@
 
 -include("emqx_authn.hrl").
 -include_lib("eunit/include/eunit.hrl").
--include_lib("common_test/include/ct.hrl").
 
 -define(TCP_DEFAULT, 'tcp:default').
 
@@ -42,7 +41,7 @@ groups() ->
 init_per_testcase(t_authenticator_fail, Config) ->
     meck:expect(emqx_authn_proto_v1, lookup_from_all_nodes, 3, [{error, {exception, badarg}}]),
     init_per_testcase(default, Config);
-init_per_testcase(_, Config) ->
+init_per_testcase(_Case, Config) ->
     {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
     emqx_authn_test_lib:delete_authenticators(
         [?CONF_NS_ATOM],
@@ -213,7 +212,7 @@ test_authenticators(PathPrefix) ->
         method => <<"get">>,
         headers => #{<<"content-type">> => <<"application/json">>}
     },
-    {ok, 200, _} = request(
+    {ok, 204, _} = request(
         put,
         uri(PathPrefix ++ [?CONF_NS, "password_based:http"]),
         ValidConfig1
@@ -302,14 +301,14 @@ test_authenticator(PathPrefix) ->
         method => <<"get">>,
         headers => #{<<"content-type">> => <<"application/json">>}
     },
-    {ok, 200, _} = request(
+    {ok, 204, _} = request(
         put,
         uri(PathPrefix ++ [?CONF_NS, "password_based:http"]),
         ValidConfig1
     ),
 
     ValidConfig2 = ValidConfig0#{pool_size => 9},
-    {ok, 200, _} = request(
+    {ok, 204, _} = request(
         put,
         uri(PathPrefix ++ [?CONF_NS, "password_based:http"]),
         ValidConfig2

--- a/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_jwt_SUITE.erl
@@ -448,7 +448,7 @@ t_jwt_not_allow_empty_claim_name(_) ->
     ),
 
     ?assertMatch(
-        {200, _},
+        {204},
         emqx_authn_api:authenticator(
             put, #{
                 bindings => #{id => <<"jwt">>},

--- a/changes/v5.0.13-en.md
+++ b/changes/v5.0.13-en.md
@@ -12,6 +12,8 @@
 
 - Add compression functions `zip`, `gzip`, `zip_compress` in Rule-Engine and corresponding decompression functions [#9573](https://github.com/emqx/emqx/pull/9573).
 
+- Return `204` instead of `200` for `PUT /authenticator/:id` [#9434](https://github.com/emqx/emqx/pull/9434/).
+
 ## Bug fixes
 
 - Trigger `message.dropped` hook when QoS2 message is resend by client with a same packet id, or 'awaiting_rel' queue is full [#9487](https://github.com/emqx/emqx/pull/9487).

--- a/changes/v5.0.13-zh.md
+++ b/changes/v5.0.13-zh.md
@@ -12,6 +12,8 @@
 
 - 规则引擎支持压缩函数 `zip`, `gzip`, `zip_compress` 及对应的解压缩函数 [#9573](https://github.com/emqx/emqx/pull/9573)。
 
+- 现在，`PUT /authenticator/:id` 将会返回 204 而不再是 200 [#9434](https://github.com/emqx/emqx/pull/9434/)。
+
 ## 修复
 
 - 当 QoS2 消息被重发(使用相同 Packet ID)，或当 'awaiting_rel' 队列已满时，触发消息丢弃钩子(`message.dropped`)及计数器 [#9487](https://github.com/emqx/emqx/pull/9487)。


### PR DESCRIPTION
<!-- Please describe the current behavior and link to a relevant issue. -->
Fixes [EMQX-7982](https://emqx.atlassian.net/browse/EMQX-7982)

Repost of https://github.com/emqx/emqx/pull/9434 after it has been reverted. 

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [x] For internal contributor: there is a jira ticket to track this change
