### PR TITLE
build: fix relup on amzn2

### DIFF
--- a/build
+++ b/build
@@ -195,6 +195,14 @@ make_zip() {
                     ;;
             esac
             ;;
+        amzn2)
+            case "$PKG_VSN" in
+                4.4.12*)
+                    # this is the first version for amzn2, no relup
+                    has_relup='no'
+                    ;;
+            esac
+            ;;
     esac
     # shellcheck disable=SC2207
     bases=($(relup_db base-vsns "$PKG_VSN"))

--- a/scripts/get-distro.sh
+++ b/scripts/get-distro.sh
@@ -14,7 +14,11 @@ case "$UNAME" in
         SYSTEM="${DIST}${VERSION_ID}"
         ;;
     Linux)
-        if grep -q -i 'rhel' /etc/*-release; then
+        # /etc/os-release on amazon linux 2 contains both rhel and centos strings
+        if grep -q -i 'amzn' /etc/*-release; then
+            DIST='amzn'
+            VERSION_ID="$(sed -n '/^VERSION_ID=/p' /etc/os-release | sed -r 's/VERSION_ID=(.*)/\1/g' | sed 's/"//g')"
+        elif grep -q -i 'rhel' /etc/*-release; then
             DIST='el'
             VERSION_ID="$(rpm --eval '%{rhel}')"
         elif grep -q -i 'centos' /etc/*-release; then

--- a/scripts/relup-base-vsns.escript
+++ b/scripts/relup-base-vsns.escript
@@ -171,6 +171,11 @@ filter_froms(Froms0, AvailableVersionsIndex) ->
                   fun(Vsn) ->
                           not lists:member(Vsn, [<<"4.4.0">>, <<"4.4.1">>])
                   end, Froms0);
+            %% amzn2 is introduced since v4.4.12 and e4.4.12
+            %% exclude tags before them
+            "amzn2" ->
+                Excluded = [list_to_binary(["4.4.", integer_to_list(X)]) || X <- lists:seq(0,11)],
+                lists:filter(fun(Vsn) -> not lists:member(Vsn, Excluded) end, Froms0);
             _ ->
                 Froms0
         end,


### PR DESCRIPTION
```
$ ./scripts/buildx.sh --profile emqx --pkgtype zip --arch arm64 --builder ghcr.io/emqx/emqx-builder/4.4-23:24.3.4.2-1-amzn2
...
$ ls _packages/emqx
emqx-4.4.12-alpha.1-efc98147-otp24.3.4.2-1-amzn2-arm64.zip
emqx-4.4.12-alpha.1-efc98147-otp24.3.4.2-1-amzn2-arm64.zip.sha256
```