### PR TITLE
1214 upgrade to hocon 0.32.0

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.4"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.13.7"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.31.2"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.32.0"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -402,6 +402,7 @@ merge_envs(SchemaMod, RawConf) ->
         required => false,
         format => map,
         apply_override_envs => true,
+        remove_env_meta => true,
         check_lazy => true
     },
     hocon_tconf:merge_env_overrides(SchemaMod, RawConf, all, Opts).

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -575,10 +575,10 @@ load_hocon_file(FileName, LoadType) ->
     end.
 
 do_get_raw(Path) ->
-    hocon_tconf:remove_env_meta(do_get(?RAW_CONF, Path)).
+    do_get(?RAW_CONF, Path).
 
 do_get_raw(Path, Default) ->
-    hocon_tconf:remove_env_meta(do_get(?RAW_CONF, Path, Default)).
+    do_get(?RAW_CONF, Path, Default).
 
 do_get(Type, KeyPath) ->
     Ref = make_ref(),

--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -39,12 +39,15 @@ providers() ->
         {{scram, built_in_database}, emqx_enhanced_authn_scram_mnesia}
     ].
 
-check_configs(C) when is_map(C) ->
-    check_configs([C]);
-check_configs([]) ->
+check_configs(CM) when is_map(CM) ->
+    check_configs([CM]);
+check_configs(CL) ->
+    check_configs(CL, 1).
+
+check_configs([], _Nth) ->
     [];
-check_configs([Config | Configs]) ->
-    [check_config(Config) | check_configs(Configs)].
+check_configs([Config | Configs], Nth) ->
+    [check_config(Config, #{id_for_log => Nth}) | check_configs(Configs, Nth + 1)].
 
 check_config(Config) ->
     check_config(Config, #{}).
@@ -55,15 +58,16 @@ check_config(Config, Opts) ->
         #{?CONF_NS_BINARY := WithDefaults} -> WithDefaults
     end.
 
-do_check_config(#{<<"mechanism">> := Mec} = Config, Opts) ->
+do_check_config(#{<<"mechanism">> := Mec0} = Config, Opts) ->
+    Mec = atom(Mec0, #{error => unknown_mechanism}),
     Key =
         case maps:get(<<"backend">>, Config, false) of
-            false -> atom(Mec);
-            Backend -> {atom(Mec), atom(Backend)}
+            false -> Mec;
+            Backend -> {Mec, atom(Backend, #{error => unknown_backend})}
         end,
     case lists:keyfind(Key, 1, providers()) of
         false ->
-            throw({unknown_handler, Key});
+            throw(#{error => unknown_authn_provider, which => Key});
         {_, ProviderModule} ->
             hocon_tconf:check_plain(
                 ProviderModule,
@@ -71,22 +75,22 @@ do_check_config(#{<<"mechanism">> := Mec} = Config, Opts) ->
                 Opts#{atom_key => true}
             )
     end;
-do_check_config(Config, _Opts) when is_map(Config) ->
-    throw({invalid_config, "mechanism_field_required", Config});
-do_check_config(RawConf, Opts) ->
-    %% authentication conf is lazy type, when it comes from ENV, it is a string
-    %% EMQX_AUTHENTICATION__1="{mechanism=\"password_based\"...}"
-    case hocon:binary(RawConf, Opts) of
-        {ok, Conf} -> do_check_config(Conf, Opts);
-        {error, Reason} -> throw({invalid_config, Reason})
-    end.
+do_check_config(Config, Opts) when is_map(Config) ->
+    throw(#{
+        error => invalid_config,
+        which => maps:get(id_for_log, Opts, unknown),
+        reason => "mechanism_field_required"
+    }).
 
-atom(Bin) ->
+%% The atoms have to be loaded already,
+%% which might be an issue for plugins which are loaded after node boot
+%% but they should really manage their own configs in that case.
+atom(Bin, ErrorContext) ->
     try
         binary_to_existing_atom(Bin, utf8)
     catch
         _:_ ->
-            throw({unknown_auth_provider, Bin})
+            throw(ErrorContext#{value => Bin})
     end.
 
 -spec get_enabled_authns() ->

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -298,8 +298,8 @@ parse_confs(Type, Name, Conf) when ?IS_BI_DIR_BRIDGE(Type) ->
     %% For some drivers that can be used as data-sources, we need to provide a
     %% hookpoint. The underlying driver will run `emqx_hooks:run/3` when it
     %% receives a message from the external database.
-    BName = bridge_id(Type, Name),
-    Conf#{hookpoint => <<"$bridges/", BName/binary>>, bridge_name => Name};
+    BId = bridge_id(Type, Name),
+    Conf#{hookpoint => <<"$bridges/", BId/binary>>, bridge_name => Name};
 parse_confs(_Type, _Name, Conf) ->
     Conf.
 

--- a/lib-ee/emqx_ee_bridge/rebar.config
+++ b/lib-ee/emqx_ee_bridge/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
-{deps, [ {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.31.2"}}}
+{deps, [ {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.32.0"}}}
        , {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "1.7.0"}}}
        , {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.0"}}}
        , {brod_gssapi, {git, "https://github.com/kafka4beam/brod_gssapi.git", {tag, "v0.1.0-rc1"}}}

--- a/mix.exs
+++ b/mix.exs
@@ -67,7 +67,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.0", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.31.2", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.32.0", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.1", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -67,7 +67,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.31.2"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.32.0"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.1"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
this is a follow up fix for https://github.com/emqx/emqx/pull/9437

verified with:

```
env EMQX_AUTHENTICATION__1='{mechanism="password_based",backend="mysql",server="localhost:3306",database="emqx",username="emqx",password="******",query="SELECT password_hash, salt, is_superuser FROM mqtt_user WHERE username = ${username} LIMIT 1",password_hash_algorithm={name=sha256,salt_position=prefix},enable=true}' \
    EMQX_AUTHENTICATION__1__server='"localhost:3333"' \
    ./_build/emqx/rel/emqx/bin/emqx consol
```
```
v5.0.11-g375e3de0(emqx@127.0.0.1)1> emqx:get_config([authentication]).
[#{backend => <<"mysql">>,database => <<"emqx">>,
   enable => true,mechanism => <<"password_based">>,
   password => <<"******">>,
   password_hash_algorithm =>
       #{name => <<"sha256">>,salt_position => <<"prefix">>},
   query =>
       <<"SELECT password_hash, salt, is_superuser FROM mqtt_user WHERE username = ${username} LIMIT 1">>,
   server => <<"localhost:3333">>,username => <<"emqx">>}]
```