### PR TITLE
refactor: change ce | ee to v | prefix for shell prompt

### DIFF
--- a/apps/emqx_machine/src/emqx_restricted_shell.erl
+++ b/apps/emqx_machine/src/emqx_restricted_shell.erl
@@ -45,10 +45,14 @@ set_prompt_func() ->
 prompt_func(PropList) ->
     Line = proplists:get_value(history, PropList, 1),
     Version = emqx_release:version(),
-    Edition = emqx_release:edition(),
+    Prefix =
+        case emqx_release:edition() of
+            ce -> "v";
+            ee -> "e"
+        end,
     case is_alive() of
-        true -> io_lib:format(<<"~ts-~ts(~s)~w> ">>, [Edition, Version, node(), Line]);
-        false -> io_lib:format(<<"~ts-~ts ~w> ">>, [Edition, Version, Line])
+        true -> io_lib:format(<<"~ts~ts(~s)~w> ">>, [Prefix, Version, node(), Line]);
+        false -> io_lib:format(<<"~ts~ts ~w> ">>, [Prefix, Version, Line])
     end.
 
 local_allowed(MF, Args, State) ->


### PR DESCRIPTION
Reason: 'ce' (Community Edition) is only for internal use, when it comes to user/customer facing descriptions, we should use Opensource edition and Enterprise edition.

Similary, for user/customer facing shell prompt,
use `v` for Opensource edition and `e` for Enterprise