### PR TITLE
ci: no need to run ct with static profile matrix

### DIFF
--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -178,9 +178,6 @@ jobs:
           fail-fast: false
           matrix:
             app: ${{ fromJson(needs.prepare.outputs.fast_ct_apps) }}
-            profile:
-              - emqx
-              - emqx-enterprise
             runs-on:
               - aws-amd64
               - ubuntu-20.04


### PR DESCRIPTION
`matrix.profile` is useless, the `app` dimension is is an array, [0] is the app name, [1] is the profile.
