### PR TITLE
fix: infinite recursion in mysql connector and improve mysql EE bridge tests

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_mysql.erl
+++ b/apps/emqx_connector/src/emqx_connector_mysql.erl
@@ -419,7 +419,7 @@ on_sql_query(
     {ok, Conn} = ecpool_worker:client(Worker),
     ?tp(
         mysql_connector_send_query,
-        #{sql_or_key => SQLOrKey, data => Data}
+        #{sql_func => SQLFunc, sql_or_key => SQLOrKey, data => Data}
     ),
     try mysql:SQLFunc(Conn, SQLOrKey, Data, Timeout) of
         {error, disconnected} = Result ->
@@ -431,6 +431,10 @@ on_sql_query(
             _ = exit(Conn, restart),
             Result;
         {error, not_prepared} = Error ->
+            ?tp(
+                mysql_connector_prepare_query_failed,
+                #{error => not_prepared}
+            ),
             ?SLOG(
                 warning,
                 LogMeta#{msg => "mysql_connector_prepare_query_failed", reason => not_prepared}

--- a/apps/emqx_connector/src/emqx_connector_mysql.erl
+++ b/apps/emqx_connector/src/emqx_connector_mysql.erl
@@ -263,7 +263,7 @@ init_prepare(State = #{prepare_statement := Prepares, poolname := PoolName}) ->
 maybe_prepare_sql(SQLOrKey, Prepares, PoolName) ->
     case maps:is_key(SQLOrKey, Prepares) of
         true -> prepare_sql(Prepares, PoolName);
-        false -> {error, prepared_statement_is_unprepared}
+        false -> {error, prepared_statement_invalid}
     end.
 
 prepare_sql(Prepares, PoolName) when is_map(Prepares) ->

--- a/changes/v5.0.13-en.md
+++ b/changes/v5.0.13-en.md
@@ -20,3 +20,5 @@
 
 - Fix shared subscription 'sticky' strategy [#9578](https://github.com/emqx/emqx/pull/9578).
   Prior to this change, a 'sticky' subscriber may continue to receive messages after unsubscribing.
+
+- Add check to ensure that a given key is among the prepared statements on query in the mysql connector [#9571](https://github.com/emqx/emqx/pull/9571).

--- a/changes/v5.0.13-zh.md
+++ b/changes/v5.0.13-zh.md
@@ -20,3 +20,5 @@
 
 - 修复共享订阅的 'sticky' 策略 [#9578](https://github.com/emqx/emqx/pull/9578)。
   在此修复前，使用 'sticky' 策略的订阅客户端可能在取消订阅后继续收到消息。
+
+- Add check to ensure that a given key is among the prepared statements on query in the mysql connector [#9571](https://github.com/emqx/emqx/pull/9571).

--- a/changes/v5.0.13-zh.md
+++ b/changes/v5.0.13-zh.md
@@ -21,4 +21,4 @@
 - 修复共享订阅的 'sticky' 策略 [#9578](https://github.com/emqx/emqx/pull/9578)。
   在此修复前，使用 'sticky' 策略的订阅客户端可能在取消订阅后继续收到消息。
 
-- Add check to ensure that a given key is among the prepared statements on query in the mysql connector [#9571](https://github.com/emqx/emqx/pull/9571).
+- 增强 mysql 查询流程，确保给定的查询语句在 mysql 连接器的预编译语句中 [#9571](https://github.com/emqx/emqx/pull/9571)。

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
@@ -421,15 +421,12 @@ t_write_timeout(Config) ->
     Val = integer_to_binary(erlang:unique_integer()),
     SentData = #{payload => Val, timestamp => 1668602148000},
     Timeout = 10,
-    ?check_trace(
-        emqx_common_test_helpers:with_failure(timeout, ProxyName, ProxyHost, ProxyPort, fun() ->
+    emqx_common_test_helpers:with_failure(timeout, ProxyName, ProxyHost, ProxyPort, fun() ->
+        ?assertMatch(
+            {error, {resource_error, _}},
             query_resource(Config, {send_message, SentData, [], Timeout})
-        end),
-        fun(Result, _Trace) ->
-            ?assertMatch({error, {resource_error, _}}, Result),
-            ok
-        end
-    ),
+        )
+    end),
     ok.
 
 t_simple_sql_query(Config) ->

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
@@ -480,7 +480,7 @@ t_unprepared_statement_query(Config) ->
     Result = query_resource(Config, Request),
     case ?config(enable_batch, Config) of
         true -> ?assertEqual({error, invalid_request}, Result);
-        false -> ?assertEqual({error, prepared_statement_is_unprepared}, Result)
+        false -> ?assertEqual({error, prepared_statement_invalid}, Result)
     end,
     ok.
 


### PR DESCRIPTION
This is a continuation of EMQX-7923 and implements further EE mysql bridge tests covering:

- prepared statements
- batching
- driver behavior with timeout failures

A bug was found while implementing tests regarding prepared statements. An infinite loop was triggered in the mysql connector when a query used a prepared statement key that was not among the defined prepared statements on start. We now check that the key is defined among the prepared statements before recursing. It seems that this bug was never
triggered in any production code.

Fixes EMQX-8414.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [X] Changed lines covered in coverage report
- [x] Change log has been added to `changes/` dir
- [X] For internal contributor: there is a jira ticket to track this change
