### PR TITLE
chore: fix logging in bin/emqx on non-tty

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -54,11 +54,19 @@ export ERTS_LIB_DIR="$RUNNER_ROOT_DIR/lib"
 DYNLIBS_DIR="$RUNNER_ROOT_DIR/dynlibs"
 
 logerr() {
-    echo -e "$(tput setaf 1)ERROR: $*$(tput sgr0)" 1>&2
+    if [ "${TERM:-dumb}" = dumb ]; then
+        echo -e "ERROR: $*" 1>&2
+    else
+        echo -e "$(tput setaf 1)ERROR: $*$(tput sgr0)" 1>&2
+    fi
 }
 
 logwarn() {
-    echo "$(tput setaf 3)WARNING: $*$(tput sgr0)"
+    if [ "${TERM:-dumb}" = dumb ]; then
+        echo "WARNING: $*"
+    else
+        echo "$(tput setaf 3)WARNING: $*$(tput sgr0)"
+    fi
 }
 
 die() {


### PR DESCRIPTION
Fixes [EMQX-8577](https://emqx.atlassian.net/browse/EMQX-8577)
```
tput: No value for $TERM and no -T specified
tput: No value for $TERM and no -T specified
WARNING: Default (insecure) Erlang cookie is in use.
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/` dir
- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section

## Backward Compatibility

## More information
