### PR TITLE
chore: Add more PR templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/ci.md
+++ b/.github/PULL_REQUEST_TEMPLATE/ci.md
@@ -1,0 +1,7 @@
+Fixes <issue-or-jira-number>
+
+## PR Checklist
+Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:
+
+- [ ] If changed package build ci, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
+- [ ] Change log has been added to `changes/` dir for user-facing artifacts update

--- a/.github/PULL_REQUEST_TEMPLATE/doc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/doc.md
@@ -1,0 +1,1 @@
+Fixes <issue-or-jira-number>

--- a/.github/PULL_REQUEST_TEMPLATE/v4.md
+++ b/.github/PULL_REQUEST_TEMPLATE/v4.md
@@ -1,7 +1,4 @@
-<!-- Please describe the current behavior and link to a relevant issue. -->
-Fixes <issue-number>
-
-**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/emqx/emqx/blob/master/CONTRIBUTING.md.
+Fixes <issue-or-jira-number>
 
 ## PR Checklist
 Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:
@@ -9,11 +6,7 @@ Please convert it to a draft if any of the following conditions are not met. Rev
 - [ ] Added tests for the changes
 - [ ] Changed lines covered in coverage report
 - [ ] Change log has been added to `changes/` dir
-- [ ] For EMQX 4.x: `appup` files updated (execute `scripts/update-appup.sh emqx`)
+- [ ] `appup` files updated (execute `scripts/update-appup.sh emqx`)
 - [ ] For internal contributor: there is a jira ticket to track this change
 - [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
 - [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section
-
-## Backward Compatibility
-
-## More information

--- a/.github/PULL_REQUEST_TEMPLATE/v5.md
+++ b/.github/PULL_REQUEST_TEMPLATE/v5.md
@@ -1,0 +1,11 @@
+Fixes <issue-or-jira-number>
+
+## PR Checklist
+Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:
+
+- [ ] Added tests for the changes
+- [ ] Changed lines covered in coverage report
+- [ ] Change log has been added to `changes/` dir
+- [ ] For internal contributor: there is a jira ticket to track this change
+- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
+- [ ] Schema changes are backward compatible


### PR DESCRIPTION
Now there are 4 different kinds of PRs

* doc, nothing to fill
* ci, two check boxes
* v4, the old template
* v5, slightly different from v4 (no appup)