### PR TITLE
refactor(metrics): change gauge metrics to be scoped by worker id

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kafka.yaml
+++ b/.ci/docker-compose-file/docker-compose-kafka.yaml
@@ -13,7 +13,7 @@ services:
     image: fredrikhgrelland/alpine-jdk11-openssl
     container_name: ssl_cert_gen
     volumes:
-      - emqx-shared-secret:/var/lib/secret
+      - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
       - ./kafka/generate-certs.sh:/bin/generate-certs.sh
     entrypoint: /bin/sh
     command: /bin/generate-certs.sh
@@ -21,21 +21,24 @@ services:
     hostname: kdc.emqx.net
     image:  ghcr.io/emqx/emqx-builder/5.0-17:1.13.4-24.2.1-1-ubuntu20.04
     container_name: kdc.emqx.net
+    expose:
+      - 88 # kdc
+      - 749 # admin server
+    # ports:
+    #   - 88:88
+    #   - 749:749
     networks:
       emqx_bridge:
     volumes:
-      - emqx-shared-secret:/var/lib/secret
+      - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
       - ./kerberos/krb5.conf:/etc/kdc/krb5.conf
       - ./kerberos/krb5.conf:/etc/krb5.conf
       - ./kerberos/run.sh:/usr/bin/run.sh
     command: run.sh
   kafka_1:
     image: wurstmeister/kafka:2.13-2.7.0
-    ports:
-      - "9092:9092"
-      - "9093:9093"
-      - "9094:9094"
-      - "9095:9095"
+    # ports:
+    #   - "9192-9195:9192-9195"
     container_name: kafka-1.emqx.net
     hostname: kafka-1.emqx.net
     depends_on:
@@ -45,9 +48,9 @@ services:
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://:9092,SASL_PLAINTEXT://:9093,SSL://:9094,SASL_SSL://:9095
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1.emqx.net:9092,SASL_PLAINTEXT://kafka-1.emqx.net:9093,SSL://kafka-1.emqx.net:9094,SASL_SSL://kafka-1.emqx.net:9095
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,SSL:SSL,SASL_SSL:SASL_SSL
+      KAFKA_LISTENERS: PLAINTEXT://:9092,SASL_PLAINTEXT://:9093,SSL://:9094,SASL_SSL://:9095,LOCAL_PLAINTEXT://:9192,LOCAL_SASL_PLAINTEXT://:9193,LOCAL_SSL://:9194,LOCAL_SASL_SSL://:9195
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-1.emqx.net:9092,SASL_PLAINTEXT://kafka-1.emqx.net:9093,SSL://kafka-1.emqx.net:9094,SASL_SSL://kafka-1.emqx.net:9095,LOCAL_PLAINTEXT://localhost:9192,LOCAL_SASL_PLAINTEXT://localhost:9193,LOCAL_SSL://localhost:9194,LOCAL_SASL_SSL://localhost:9195
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,SASL_PLAINTEXT:SASL_PLAINTEXT,SSL:SSL,SASL_SSL:SASL_SSL,LOCAL_PLAINTEXT:PLAINTEXT,LOCAL_SASL_PLAINTEXT:SASL_PLAINTEXT,LOCAL_SSL:SSL,LOCAL_SASL_SSL:SASL_SSL
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_SASL_ENABLED_MECHANISMS: PLAIN,SCRAM-SHA-256,SCRAM-SHA-512,GSSAPI
       KAFKA_SASL_KERBEROS_SERVICE_NAME: kafka
@@ -64,10 +67,22 @@ services:
     networks:
       emqx_bridge:
     volumes:
-      - emqx-shared-secret:/var/lib/secret
+      - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
       - ./kafka/jaas.conf:/etc/kafka/jaas.conf
       - ./kafka/run_add_scram_users.sh:/bin/run_add_scram_users.sh
       - ./kerberos/krb5.conf:/etc/kdc/krb5.conf
       - ./kerberos/krb5.conf:/etc/krb5.conf
     command: run_add_scram_users.sh
 
+# networks:
+#   emqx_bridge:
+#     driver: bridge
+#     name: emqx_bridge
+#     enable_ipv6: true
+#     ipam:
+#       driver: default
+#       config:
+#         - subnet: 172.100.239.0/24
+#           gateway: 172.100.239.1
+#         - subnet: 2001:3200:3200::/64
+#           gateway: 2001:3200:3200::1

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - emqx_bridge
     volumes:
       - ../..:/emqx
-      - emqx-shared-secret:/var/lib/secret
+      - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret
       - ./kerberos/krb5.conf:/etc/kdc/krb5.conf
       - ./kerberos/krb5.conf:/etc/krb5.conf
     working_dir: /emqx
@@ -37,6 +37,3 @@ networks:
           gateway: 172.100.239.1
         - subnet: 2001:3200:3200::/64
           gateway: 2001:3200:3200::1
-
-volumes:   # add this section
-  emqx-shared-secret:    # does not need anything underneath this

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -67,7 +67,8 @@
 -export([clear_screen/0]).
 -export([with_mock/4]).
 -export([
-    on_exit/1
+    on_exit/1,
+    call_janitor/0
 ]).
 
 %% Toxiproxy API
@@ -940,6 +941,13 @@ latency_up_proxy(off, Name, ProxyHost, ProxyPort) ->
 %%-------------------------------------------------------------------------------
 %% Testcase teardown utilities
 %%-------------------------------------------------------------------------------
+
+%% stop the janitor gracefully to ensure proper cleanup order and less
+%% noise in the logs.
+call_janitor() ->
+    Janitor = get_or_spawn_janitor(),
+    exit(Janitor, normal),
+    ok.
 
 get_or_spawn_janitor() ->
     case get({?MODULE, janitor_proc}) of

--- a/apps/emqx/test/emqx_test_janitor.erl
+++ b/apps/emqx/test/emqx_test_janitor.erl
@@ -49,8 +49,7 @@ push_on_exit_callback(Server, Callback) when is_function(Callback, 0) ->
 
 init(Parent) ->
     process_flag(trap_exit, true),
-    Ref = monitor(process, Parent),
-    {ok, #{callbacks => [], owner => {Ref, Parent}}}.
+    {ok, #{callbacks => [], owner => Parent}}.
 
 terminate(_Reason, #{callbacks := Callbacks}) ->
     lists:foreach(fun(Fun) -> Fun() end, Callbacks).
@@ -63,7 +62,7 @@ handle_call(_Req, _From, State) ->
 handle_cast(_Req, State) ->
     {noreply, State}.
 
-handle_info({'DOWN', Ref, process, Parent, _Reason}, State = #{owner := {Ref, Parent}}) ->
+handle_info({'EXIT', Parent, _Reason}, State = #{owner := Parent}) ->
     {stop, normal, State};
 handle_info(_Msg, State) ->
     {noreply, State}.

--- a/apps/emqx_bridge/i18n/emqx_bridge_schema.conf
+++ b/apps/emqx_bridge/i18n/emqx_bridge_schema.conf
@@ -163,7 +163,7 @@ emqx_bridge_schema {
 
      metric_queuing {
                    desc {
-                         en: """Count of messages that are currently queuing."""
+                         en: """Count of batches of messages that are currently queuing."""
                          zh: """当前被缓存到磁盘队列的消息个数。"""
                         }
                    label: {
@@ -195,7 +195,7 @@ emqx_bridge_schema {
 
     metric_sent_inflight {
                    desc {
-                         en: """Count of messages that were sent asynchronously but ACKs are not received."""
+                         en: """Count of batches of messages that were sent asynchronously but ACKs are not yet received."""
                          zh: """已异步地发送但没有收到 ACK 的消息个数。"""
                         }
                    label: {

--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -2,7 +2,7 @@
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
     {vsn, "0.1.7"},
-    {registered, []},
+    {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [
         kernel,

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -54,6 +54,7 @@
     T == gcp_pubsub;
     T == influxdb_api_v1;
     T == influxdb_api_v2;
+    T == kafka_producer;
     T == redis_single;
     T == redis_sentinel;
     T == redis_cluster
@@ -115,11 +116,11 @@ load_hook(Bridges) ->
         maps:to_list(Bridges)
     ).
 
-do_load_hook(Type, #{local_topic := _}) when ?EGRESS_DIR_BRIDGES(Type) ->
+do_load_hook(Type, #{local_topic := LocalTopic}) when
+    ?EGRESS_DIR_BRIDGES(Type) andalso is_binary(LocalTopic)
+->
     emqx_hooks:put('message.publish', {?MODULE, on_message_publish, []}, ?HP_BRIDGE);
 do_load_hook(mqtt, #{egress := #{local := #{topic := _}}}) ->
-    emqx_hooks:put('message.publish', {?MODULE, on_message_publish, []}, ?HP_BRIDGE);
-do_load_hook(kafka, #{producer := #{mqtt := #{topic := _}}}) ->
     emqx_hooks:put('message.publish', {?MODULE, on_message_publish, []}, ?HP_BRIDGE);
 do_load_hook(_Type, _Conf) ->
     ok.
@@ -368,9 +369,7 @@ get_matched_bridge_id(BType, #{local_topic := Filter}, Topic, BName, Acc) when
 ->
     do_get_matched_bridge_id(Topic, Filter, BType, BName, Acc);
 get_matched_bridge_id(mqtt, #{egress := #{local := #{topic := Filter}}}, Topic, BName, Acc) ->
-    do_get_matched_bridge_id(Topic, Filter, mqtt, BName, Acc);
-get_matched_bridge_id(kafka, #{producer := #{mqtt := #{topic := Filter}}}, Topic, BName, Acc) ->
-    do_get_matched_bridge_id(Topic, Filter, kafka, BName, Acc).
+    do_get_matched_bridge_id(Topic, Filter, mqtt, BName, Acc).
 
 do_get_matched_bridge_id(Topic, Filter, BType, BName, Acc) ->
     case emqx_topic:match(Topic, Filter) of

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -686,7 +686,6 @@ format_resp(
 
 format_metrics(#{
     counters := #{
-        'batching' := Batched,
         'dropped' := Dropped,
         'dropped.other' := DroppedOther,
         'dropped.queue_full' := DroppedQueueFull,
@@ -694,17 +693,19 @@ format_metrics(#{
         'dropped.resource_not_found' := DroppedResourceNotFound,
         'dropped.resource_stopped' := DroppedResourceStopped,
         'matched' := Matched,
-        'queuing' := Queued,
         'retried' := Retried,
         'failed' := SentFailed,
-        'inflight' := SentInflight,
         'success' := SentSucc,
         'received' := Rcvd
     },
+    gauges := Gauges,
     rate := #{
         matched := #{current := Rate, last5m := Rate5m, max := RateMax}
     }
 }) ->
+    Batched = maps:get('batching', Gauges, 0),
+    Queued = maps:get('queuing', Gauges, 0),
+    SentInflight = maps:get('inflight', Gauges, 0),
     ?METRICS(
         Batched,
         Dropped,

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -44,7 +44,12 @@
 ]).
 
 %% bi-directional bridge with producer/consumer or ingress/egress configs
--define(IS_BI_DIR_BRIDGE(TYPE), TYPE =:= <<"mqtt">>; TYPE =:= <<"kafka">>).
+-define(IS_BI_DIR_BRIDGE(TYPE),
+    TYPE =:= <<"mqtt">>
+).
+-define(IS_INGRESS_BRIDGE(TYPE),
+    TYPE =:= <<"kafka_consumer">> orelse ?IS_BI_DIR_BRIDGE(TYPE)
+).
 
 -if(?EMQX_RELEASE_EDITION == ee).
 bridge_to_resource_type(<<"mqtt">>) -> emqx_connector_mqtt;
@@ -294,12 +299,14 @@ parse_confs(
                 max_retries => Retry
             }
     };
-parse_confs(Type, Name, Conf) when ?IS_BI_DIR_BRIDGE(Type) ->
+parse_confs(Type, Name, Conf) when ?IS_INGRESS_BRIDGE(Type) ->
     %% For some drivers that can be used as data-sources, we need to provide a
     %% hookpoint. The underlying driver will run `emqx_hooks:run/3` when it
     %% receives a message from the external database.
     BId = bridge_id(Type, Name),
     Conf#{hookpoint => <<"$bridges/", BId/binary>>, bridge_name => Name};
+parse_confs(<<"kafka_producer">> = _Type, Name, Conf) ->
+    Conf#{bridge_name => Name};
 parse_confs(_Type, _Name, Conf) ->
     Conf.
 

--- a/apps/emqx_bridge/src/emqx_bridge_sup.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_sup.erl
@@ -34,5 +34,3 @@ init([]) ->
     },
     ChildSpecs = [],
     {ok, {SupFlags, ChildSpecs}}.
-
-%% internal functions

--- a/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
@@ -19,6 +19,7 @@
 -compile(export_all).
 
 -import(emqx_dashboard_api_test_helpers, [request/4, uri/1]).
+-import(emqx_common_test_helpers, [on_exit/1]).
 
 -include("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -124,6 +125,7 @@ init_per_testcase(_, Config) ->
     Config.
 end_per_testcase(_, _Config) ->
     clear_resources(),
+    emqx_common_test_helpers:call_janitor(),
     ok.
 
 clear_resources() ->
@@ -630,6 +632,12 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
         <<"name">> := ?BRIDGE_NAME_EGRESS
     } = jsx:decode(Bridge),
     BridgeIDEgress = emqx_bridge_resource:bridge_id(?TYPE_MQTT, ?BRIDGE_NAME_EGRESS),
+    on_exit(fun() ->
+        %% delete the bridge
+        {ok, 204, <<>>} = request(delete, uri(["bridges", BridgeIDEgress]), []),
+        {ok, 200, <<"[]">>} = request(get, uri(["bridges"]), []),
+        ok
+    end),
     %% we now test if the bridge works as expected
     LocalTopic = <<?EGRESS_LOCAL_TOPIC, "/1">>,
     RemoteTopic = <<?EGRESS_REMOTE_TOPIC, "/", LocalTopic/binary>>,
@@ -691,15 +699,20 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
 
     %% verify the metrics of the bridge, the message should be queued
     {ok, 200, BridgeStr1} = request(get, uri(["bridges", BridgeIDEgress]), []),
+    Decoded1 = jsx:decode(BridgeStr1),
+    ?assertMatch(
+        Status when (Status == <<"connected">> orelse Status == <<"connecting">>),
+        maps:get(<<"status">>, Decoded1)
+    ),
     %% matched >= 3 because of possible retries.
     ?assertMatch(
         #{
-            <<"status">> := Status,
-            <<"metrics">> := #{
-                <<"matched">> := Matched, <<"success">> := 1, <<"failed">> := 0, <<"queuing">> := 2
-            }
-        } when Matched >= 3 andalso (Status == <<"connected">> orelse Status == <<"connecting">>),
-        jsx:decode(BridgeStr1)
+            <<"matched">> := Matched,
+            <<"success">> := 1,
+            <<"failed">> := 0,
+            <<"queuing">> := 2
+        } when Matched >= 3,
+        maps:get(<<"metrics">>, Decoded1)
     ),
 
     %% start the listener 1883 to make the bridge reconnected
@@ -724,9 +737,6 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
     %% also verify the 2 messages have been sent to the remote broker
     assert_mqtt_msg_received(RemoteTopic, Payload1),
     assert_mqtt_msg_received(RemoteTopic, Payload2),
-    %% delete the bridge
-    {ok, 204, <<>>} = request(delete, uri(["bridges", BridgeIDEgress]), []),
-    {ok, 200, <<"[]">>} = request(get, uri(["bridges"]), []),
     ok.
 
 assert_mqtt_msg_received(Topic, Payload) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -141,9 +141,6 @@ create(MgrId, ResId, Group, ResourceType, Config, Opts) ->
             'dropped.resource_not_found',
             'dropped.resource_stopped',
             'dropped.other',
-            'queuing',
-            'batching',
-            'inflight',
             'received'
         ],
         [matched]

--- a/apps/emqx_resource/src/emqx_resource_metrics.erl
+++ b/apps/emqx_resource/src/emqx_resource_metrics.erl
@@ -54,6 +54,7 @@
     matched_inc/1,
     matched_inc/2,
     matched_get/1,
+    received_get/1,
     retried_inc/1,
     retried_inc/2,
     retried_get/1,
@@ -283,6 +284,10 @@ failed_inc(ID, Val) ->
 
 failed_get(ID) ->
     emqx_metrics_worker:get(?RES_METRICS, ID, 'failed').
+
+%%% @doc Count of message received by the resource
+received_get(ID) ->
+    emqx_metrics_worker:get(?RES_METRICS, ID, 'received').
 
 %%% @doc Count of message sends that have failed after having been retried
 retried_failed_inc(ID) ->

--- a/apps/emqx_resource/src/emqx_resource_metrics.erl
+++ b/apps/emqx_resource/src/emqx_resource_metrics.erl
@@ -24,11 +24,12 @@
 ]).
 
 -export([
-    batching_change/2,
+    batching_set/3,
+    batching_shift/3,
     batching_get/1,
-    inflight_change/2,
+    inflight_set/3,
     inflight_get/1,
-    queuing_change/2,
+    queuing_set/3,
     queuing_get/1,
     dropped_inc/1,
     dropped_inc/2,
@@ -115,8 +116,6 @@ handle_telemetry_event(
     _HandlerConfig
 ) ->
     case Event of
-        batching ->
-            emqx_metrics_worker:inc(?RES_METRICS, ID, 'batching', Val);
         dropped_other ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'dropped', Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'dropped.other', Val);
@@ -134,12 +133,8 @@ handle_telemetry_event(
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'dropped.resource_stopped', Val);
         failed ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'failed', Val);
-        inflight ->
-            emqx_metrics_worker:inc(?RES_METRICS, ID, 'inflight', Val);
         matched ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'matched', Val);
-        queuing ->
-            emqx_metrics_worker:inc(?RES_METRICS, ID, 'queuing', Val);
         retried_failed ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried', Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'failed', Val),
@@ -153,6 +148,34 @@ handle_telemetry_event(
         _ ->
             ok
     end;
+handle_telemetry_event(
+    [?TELEMETRY_PREFIX, Event],
+    _Measurements = #{gauge_set := Val},
+    _Metadata = #{resource_id := ID, worker_id := WorkerID},
+    _HandlerConfig
+) ->
+    case Event of
+        batching ->
+            emqx_metrics_worker:set_gauge(?RES_METRICS, ID, WorkerID, 'batching', Val);
+        inflight ->
+            emqx_metrics_worker:set_gauge(?RES_METRICS, ID, WorkerID, 'inflight', Val);
+        queuing ->
+            emqx_metrics_worker:set_gauge(?RES_METRICS, ID, WorkerID, 'queuing', Val);
+        _ ->
+            ok
+    end;
+handle_telemetry_event(
+    [?TELEMETRY_PREFIX, Event],
+    _Measurements = #{gauge_shift := Val},
+    _Metadata = #{resource_id := ID, worker_id := WorkerID},
+    _HandlerConfig
+) ->
+    case Event of
+        batching ->
+            emqx_metrics_worker:shift_gauge(?RES_METRICS, ID, WorkerID, 'batching', Val);
+        _ ->
+            ok
+    end;
 handle_telemetry_event(_EventName, _Measurements, _Metadata, _HandlerConfig) ->
     ok.
 
@@ -161,26 +184,48 @@ handle_telemetry_event(_EventName, _Measurements, _Metadata, _HandlerConfig) ->
 
 %% @doc Count of messages that are currently accumulated in memory waiting for
 %% being sent in one batch
-batching_change(ID, Val) ->
-    telemetry:execute([?TELEMETRY_PREFIX, batching], #{counter_inc => Val}, #{resource_id => ID}).
+batching_set(ID, WorkerID, Val) ->
+    telemetry:execute(
+        [?TELEMETRY_PREFIX, batching],
+        #{gauge_set => Val},
+        #{resource_id => ID, worker_id => WorkerID}
+    ).
+
+batching_shift(_ID, _WorkerID = undefined, _Val) ->
+    ok;
+batching_shift(ID, WorkerID, Val) ->
+    telemetry:execute(
+        [?TELEMETRY_PREFIX, batching],
+        #{gauge_shift => Val},
+        #{resource_id => ID, worker_id => WorkerID}
+    ).
 
 batching_get(ID) ->
-    emqx_metrics_worker:get(?RES_METRICS, ID, 'batching').
+    emqx_metrics_worker:get_gauge(?RES_METRICS, ID, 'batching').
 
-%% @doc Count of messages that are currently queuing. [Gauge]
-queuing_change(ID, Val) ->
-    telemetry:execute([?TELEMETRY_PREFIX, queuing], #{counter_inc => Val}, #{resource_id => ID}).
+%% @doc Count of batches of messages that are currently
+%% queuing. [Gauge]
+queuing_set(ID, WorkerID, Val) ->
+    telemetry:execute(
+        [?TELEMETRY_PREFIX, queuing],
+        #{gauge_set => Val},
+        #{resource_id => ID, worker_id => WorkerID}
+    ).
 
 queuing_get(ID) ->
-    emqx_metrics_worker:get(?RES_METRICS, ID, 'queuing').
+    emqx_metrics_worker:get_gauge(?RES_METRICS, ID, 'queuing').
 
-%% @doc Count of messages that were sent asynchronously but ACKs are not
-%% received. [Gauge]
-inflight_change(ID, Val) ->
-    telemetry:execute([?TELEMETRY_PREFIX, inflight], #{counter_inc => Val}, #{resource_id => ID}).
+%% @doc Count of batches of messages that were sent asynchronously but
+%% ACKs are not yet received. [Gauge]
+inflight_set(ID, WorkerID, Val) ->
+    telemetry:execute(
+        [?TELEMETRY_PREFIX, inflight],
+        #{gauge_set => Val},
+        #{resource_id => ID, worker_id => WorkerID}
+    ).
 
 inflight_get(ID) ->
-    emqx_metrics_worker:get(?RES_METRICS, ID, 'inflight').
+    emqx_metrics_worker:get_gauge(?RES_METRICS, ID, 'inflight').
 
 %% Counters (value can only got up):
 %% --------------------------------------

--- a/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_kafka.conf
+++ b/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_kafka.conf
@@ -39,6 +39,16 @@ emqx_ee_bridge_kafka {
             zh: "桥接名字"
         }
     }
+    kafka_producer {
+        desc {
+            en: "Kafka Producer configuration."
+            zh: "Kafka Producer的配置。"
+        }
+        label {
+            en: "Kafka Producer"
+            zh: "卡夫卡制片人"
+        }
+    }
     producer_opts {
         desc {
             en: "Local MQTT data source and Kafka bridge configs."
@@ -47,16 +57,6 @@ emqx_ee_bridge_kafka {
         label {
             en: "MQTT to Kafka"
             zh: "MQTT 到 Kafka"
-        }
-    }
-    producer_mqtt_opts {
-        desc {
-            en: "MQTT data source. Optional when used as a rule-engine action."
-            zh: "需要桥接到 MQTT 源主题。"
-        }
-        label {
-            en: "MQTT Source Topic"
-            zh: "MQTT 源主题"
         }
     }
     mqtt_topic {
@@ -218,7 +218,7 @@ emqx_ee_bridge_kafka {
     }
     socket_nodelay {
         desc {
-            en: "When set to 'true', TCP buffer sent as soon as possible. "
+            en: "When set to 'true', TCP buffer is sent as soon as possible. "
                 "Otherwise, the OS kernel may buffer small TCP packets for a while (40 ms by default)."
             zh: "设置 ‘true' 让系统内核立即发送。否则当需要发送当内容很少时，可能会有一定延迟（默认 40 毫秒）。"
         }
@@ -466,6 +466,130 @@ emqx_ee_bridge_kafka {
         label {
             en: "GSSAPI/Kerberos"
             zh: "GSSAPI/Kerberos"
+        }
+    }
+
+    kafka_consumer {
+        desc {
+            en: "Kafka Consumer configuration."
+            zh: "Kafka Consumer的配置。"
+        }
+        label {
+            en: "Kafka Consumer"
+            zh: "卡夫卡消费者"
+        }
+    }
+    consumer_opts {
+        desc {
+            en: "Local MQTT data sink and Kafka bridge configs."
+            zh: "本地MQTT数据汇和Kafka桥配置。"
+        }
+        label {
+            en: "MQTT to Kafka"
+            zh: "MQTT 到 Kafka"
+        }
+    }
+    consumer_kafka_opts {
+        desc {
+            en: "Kafka consumer configs."
+            zh: "Kafka消费者配置。"
+        }
+        label {
+            en: "Kafka Consumer"
+            zh: "卡夫卡消费者"
+        }
+    }
+    consumer_mqtt_opts {
+        desc {
+            en: "MQTT data sink."
+            zh: "MQTT数据汇。"
+        }
+        label {
+            en: "MQTT data sink."
+            zh: "MQTT数据汇。"
+        }
+    }
+    consumer_mqtt_topic {
+        desc {
+            en: "Local topic to which consumed Kafka messages should be published to."
+            zh: "消耗的Kafka消息应该被发布到的本地主题。"
+        }
+        label {
+            en: "MQTT Topic"
+            zh: "MQTT主题"
+        }
+    }
+    consumer_mqtt_qos {
+        desc {
+            en: "MQTT QoS used to publish messages consumed from Kafka."
+            zh: "MQTT QoS用于发布从Kafka消耗的消息。"
+        }
+        label {
+            en: "MQTT Topic QoS"
+            zh: "MQTT 主题服务质量"
+        }
+    }
+    consumer_mqtt_payload {
+        desc {
+            en: "The payload of the MQTT message to be published.\n"
+                "<code>full_message</code> will encode all data available as a JSON object,"
+                "<code>message_value</code> will directly use the Kafka message value as the "
+                "MQTT message payload."
+            zh: "要发布的MQTT消息的有效载荷。"
+                "<code>full_message</code>将把所有可用数据编码为JSON对象，"
+                "<code>message_value</code>将直接使用Kafka消息值作为MQTT消息的有效载荷。"
+        }
+        label {
+            en: "MQTT Payload"
+            zh: "MQTT有效载荷"
+        }
+    }
+    consumer_pool_size {
+        desc {
+            en: "Consumer pool size."
+            zh: "消费者群体的规模。"
+        }
+        label {
+            en: "Pool Size"
+            zh: "池子大小"
+        }
+    }
+    consumer_kafka_topic {
+        desc {
+            en: "Kafka topic to consume from."
+            zh: "从Kafka主题消费。"
+        }
+        label {
+            en: "Kafka topic"
+            zh: "卡夫卡主题 "
+        }
+    }
+    consumer_max_batch_bytes {
+        desc {
+            en: "Maximum bytes to fetch in a batch of messages."
+                "NOTE: this value might be expanded to retry when "
+                "it is not enough to fetch even a single message, "
+                "then slowly shrink back to the given value."
+            zh: "在一批消息中要取的最大字节数。"
+                "注意：这个值可能会被扩大，"
+                "当它甚至不足以取到一条消息时，就会重试，"
+                "然后慢慢缩回到给定的值。"
+        }
+        label {
+            en: "Max Bytes"
+            zh: "最大字节数"
+        }
+    }
+    consumer_offset_reset_policy {
+        desc {
+            en: "Defines how the consumers should reset the start offset when "
+                "a topic partition has and invalid or no initial offset."
+            zh: "定义当一个主题分区的初始偏移量无效或没有初始偏移量时，"
+                "消费者应如何重置开始偏移量。"
+        }
+        label {
+            en: "Offset Reset Policy"
+            zh: "偏移重置政策"
         }
     }
 }

--- a/lib-ee/emqx_ee_bridge/rebar.config
+++ b/lib-ee/emqx_ee_bridge/rebar.config
@@ -1,6 +1,6 @@
 {erl_opts, [debug_info]}.
 {deps, [ {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.32.0"}}}
-       , {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "1.7.3"}}}
+       , {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "1.7.4-tmg0"}}}
        , {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.2"}}}
        , {brod_gssapi, {git, "https://github.com/kafka4beam/brod_gssapi.git", {tag, "v0.1.0-rc1"}}}
        , {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.16.7"}}}

--- a/lib-ee/emqx_ee_bridge/rebar.config
+++ b/lib-ee/emqx_ee_bridge/rebar.config
@@ -1,9 +1,9 @@
 {erl_opts, [debug_info]}.
 {deps, [ {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.32.0"}}}
-       , {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "1.7.0"}}}
-       , {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.0"}}}
+       , {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "1.7.3"}}}
+       , {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.2"}}}
        , {brod_gssapi, {git, "https://github.com/kafka4beam/brod_gssapi.git", {tag, "v0.1.0-rc1"}}}
-       , {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.16.4"}}}
+       , {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.16.7"}}}
        , {emqx_connector, {path, "../../apps/emqx_connector"}}
        , {emqx_resource, {path, "../../apps/emqx_resource"}}
        , {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
@@ -1,7 +1,7 @@
 {application, emqx_ee_bridge, [
     {description, "EMQX Enterprise data bridges"},
     {vsn, "0.1.1"},
-    {registered, []},
+    {registered, [emqx_ee_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,
         stdlib,

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
@@ -52,7 +52,8 @@ examples(Method) ->
     lists:foldl(Fun, #{}, schema_modules()).
 
 resource_type(Type) when is_binary(Type) -> resource_type(binary_to_atom(Type, utf8));
-resource_type(kafka) -> emqx_bridge_impl_kafka;
+resource_type(kafka_consumer) -> emqx_bridge_impl_kafka_consumer;
+resource_type(kafka_producer) -> emqx_bridge_impl_kafka_producer;
 resource_type(hstreamdb) -> emqx_ee_connector_hstreamdb;
 resource_type(gcp_pubsub) -> emqx_ee_connector_gcp_pubsub;
 resource_type(mongodb_rs) -> emqx_connector_mongo;
@@ -67,14 +68,6 @@ resource_type(redis_cluster) -> emqx_ee_connector_redis.
 
 fields(bridges) ->
     [
-        {kafka,
-            mk(
-                hoconsc:map(name, ref(emqx_ee_bridge_kafka, "config")),
-                #{
-                    desc => <<"Kafka Bridge Config">>,
-                    required => false
-                }
-            )},
         {hstreamdb,
             mk(
                 hoconsc:map(name, ref(emqx_ee_bridge_hstreamdb, "config")),
@@ -99,7 +92,7 @@ fields(bridges) ->
                     required => false
                 }
             )}
-    ] ++ mongodb_structs() ++ influxdb_structs() ++ redis_structs().
+    ] ++ kafka_structs() ++ mongodb_structs() ++ influxdb_structs() ++ redis_structs().
 
 mongodb_structs() ->
     [
@@ -112,6 +105,16 @@ mongodb_structs() ->
                 }
             )}
      || Type <- [mongodb_rs, mongodb_sharded, mongodb_single]
+    ].
+
+kafka_structs() ->
+    [
+        {Type,
+            mk(
+                hoconsc:map(name, ref(emqx_ee_bridge_kafka, Type)),
+                #{desc => <<"EMQX Enterprise Config">>, required => false}
+            )}
+     || Type <- [kafka_producer, kafka_consumer]
     ].
 
 influxdb_structs() ->

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_kafka.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_kafka.erl
@@ -64,6 +64,10 @@ fields("put") ->
     fields("config");
 fields("get") ->
     emqx_bridge_schema:metrics_status_fields() ++ fields("post");
+fields(kafka_producer) ->
+    fields("config") ++ fields(producer_opts);
+fields(kafka_consumer) ->
+    fields("config") ++ fields(consumer_opts);
 fields("config") ->
     [
         {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
@@ -90,8 +94,6 @@ fields("config") ->
             mk(hoconsc:union([none, ref(auth_username_password), ref(auth_gssapi_kerberos)]), #{
                 default => none, desc => ?DESC("authentication")
             })},
-        {producer, mk(hoconsc:union([none, ref(producer_opts)]), #{desc => ?DESC(producer_opts)})},
-        %{consumer, mk(hoconsc:union([none, ref(consumer_opts)]), #{desc => ?DESC(consumer_opts)})},
         {socket_opts, mk(ref(socket_opts), #{required => false, desc => ?DESC(socket_opts)})}
     ] ++ emqx_connector_schema_lib:ssl_fields();
 fields(auth_username_password) ->
@@ -137,15 +139,16 @@ fields(socket_opts) ->
     ];
 fields(producer_opts) ->
     [
-        {mqtt, mk(ref(producer_mqtt_opts), #{desc => ?DESC(producer_mqtt_opts)})},
+        %% Note: there's an implicit convention in `emqx_bridge' that,
+        %% for egress bridges with this config, the published messages
+        %% will be forwarded to such bridges.
+        {local_topic, mk(binary(), #{desc => ?DESC(mqtt_topic)})},
         {kafka,
             mk(ref(producer_kafka_opts), #{
                 required => true,
                 desc => ?DESC(producer_kafka_opts)
             })}
     ];
-fields(producer_mqtt_opts) ->
-    [{topic, mk(binary(), #{desc => ?DESC(mqtt_topic)})}];
 fields(producer_kafka_opts) ->
     [
         {topic, mk(string(), #{required => true, desc => ?DESC(kafka_topic)})},
@@ -223,23 +226,42 @@ fields(producer_buffer) ->
                 default => true,
                 desc => ?DESC(buffer_memory_overload_protection)
             })}
+    ];
+fields(consumer_opts) ->
+    [
+        {kafka,
+            mk(ref(consumer_kafka_opts), #{required => true, desc => ?DESC(consumer_kafka_opts)})},
+        {mqtt, mk(ref(consumer_mqtt_opts), #{required => true, desc => ?DESC(consumer_mqtt_opts)})},
+        {pool_size,
+            mk(pos_integer(), #{required => true, default => 3, desc => ?DESC(consumer_pool_size)})}
+    ];
+fields(consumer_mqtt_opts) ->
+    [
+        {topic,
+            mk(binary(), #{
+                required => true,
+                desc => ?DESC(consumer_mqtt_topic)
+            })},
+        {qos, mk(emqx_schema:qos(), #{default => 0, desc => ?DESC(consumer_mqtt_qos)})},
+        {payload,
+            mk(
+                enum([full_message, message_value]),
+                #{default => full_message, desc => ?DESC(consumer_mqtt_payload)}
+            )}
+    ];
+fields(consumer_kafka_opts) ->
+    [
+        {topic, mk(binary(), #{desc => ?DESC(consumer_kafka_topic)})},
+        {max_batch_bytes,
+            mk(emqx_schema:bytesize(), #{
+                default => "896KB", desc => ?DESC(consumer_max_batch_bytes)
+            })},
+        {offset_reset_policy,
+            mk(
+                enum([reset_to_latest, reset_to_earliest, reset_by_subscriber]),
+                #{default => reset_to_latest, desc => ?DESC(consumer_offset_reset_policy)}
+            )}
     ].
-
-% fields(consumer_opts) ->
-%     [
-%         {kafka, mk(ref(consumer_kafka_opts), #{required => true, desc => ?DESC(consumer_kafka_opts)})},
-%         {mqtt, mk(ref(consumer_mqtt_opts), #{required => true, desc => ?DESC(consumer_mqtt_opts)})}
-%     ];
-% fields(consumer_mqtt_opts) ->
-%     [ {topic, mk(string(), #{desc => ?DESC(consumer_mqtt_topic)})}
-%     ];
-
-% fields(consumer_mqtt_opts) ->
-%     [ {topic, mk(string(), #{desc => ?DESC(consumer_mqtt_topic)})}
-%     ];
-% fields(consumer_kafka_opts) ->
-%     [ {topic, mk(string(), #{desc => ?DESC(consumer_kafka_topic)})}
-%     ].
 
 desc("config") ->
     ?DESC("desc_config");
@@ -254,11 +276,15 @@ struct_names() ->
         auth_gssapi_kerberos,
         auth_username_password,
         kafka_message,
+        kafka_producer,
+        kafka_consumer,
         producer_buffer,
         producer_kafka_opts,
-        producer_mqtt_opts,
         socket_opts,
-        producer_opts
+        producer_opts,
+        consumer_opts,
+        consumer_kafka_opts,
+        consumer_mqtt_opts
     ].
 
 %% -------------------------------------------------------------------------------------------------

--- a/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_consumer.erl
+++ b/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_consumer.erl
@@ -1,0 +1,304 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_impl_kafka_consumer).
+
+-behaviour(emqx_resource).
+
+%% `emqx_resource' API
+-export([
+    callback_mode/0,
+    on_start/2,
+    on_stop/2,
+    on_get_status/2
+]).
+
+%% `brod_group_consumer' API
+-export([
+    init/2,
+    handle_message/2
+]).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+%% needed for the #kafka_message record definition
+-include_lib("brod/include/brod.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
+
+-type config() :: #{
+    authentication := term(),
+    bootstrap_hosts := binary(),
+    bridge_name := atom(),
+    kafka := #{
+        max_batch_bytes := emqx_schema:bytesize(),
+        offset_reset_policy := offset_reset_policy(),
+        topic := binary()
+    },
+    mqtt := #{
+        topic := emqx_types:topic(),
+        qos := emqx_types:qos(),
+        payload := mqtt_payload()
+    },
+    pool_size := pos_integer(),
+    ssl := _,
+    any() => term()
+}.
+-type kafka_client_id() :: atom().
+-type state() :: #{
+    children_ids := #{emqx_ee_bridge_kafka_consumer_sup:child_id() => pid()},
+    kafka_client_id := kafka_client_id()
+}.
+-type offset_reset_policy() :: reset_to_latest | reset_to_earliest | reset_by_subscriber.
+-type mqtt_payload() :: full_message | message_value.
+-type consumer_state() :: #{
+    resource_id := resource_id(),
+    mqtt := #{
+        payload := mqtt_payload(),
+        topic => emqx_types:topic(),
+        qos => emqx_types:qos()
+    },
+    kafka_topic => binary()
+}.
+
+%%-------------------------------------------------------------------------------------
+%% `emqx_resource' API
+%%-------------------------------------------------------------------------------------
+
+callback_mode() ->
+    async_if_possible.
+
+-spec on_start(manager_id(), config()) -> {ok, state()}.
+on_start(InstanceId, Config) ->
+    ensure_consumer_supervisor_started(),
+    #{
+        authentication := Auth,
+        bootstrap_hosts := BootstrapHosts0,
+        bridge_name := BridgeName,
+        kafka := #{
+            max_batch_bytes := MaxBatchBytes,
+            offset_reset_policy := OffsetResetPolicy,
+            topic := KafkaTopic
+        },
+        mqtt := #{topic := MQTTTopic, qos := MQTTQoS, payload := MQTTPayload},
+        pool_size := PoolSize,
+        ssl := SSL
+    } = Config,
+    BootstrapHosts = emqx_bridge_impl_kafka:hosts(BootstrapHosts0),
+    GroupConfig = [],
+    ConsumerConfig = [
+        {max_bytes, MaxBatchBytes},
+        {offset_reset_policy, OffsetResetPolicy}
+    ],
+    InitialState = #{
+        resource_id => emqx_bridge_resource:resource_id(kafka_consumer, BridgeName),
+        mqtt => #{
+            payload => MQTTPayload,
+            topic => MQTTTopic,
+            qos => MQTTQoS
+        },
+        kafka_topic => KafkaTopic
+    },
+    ClientID0 = emqx_bridge_impl_kafka:make_client_id(BridgeName),
+    ClientID = binary_to_atom(ClientID0),
+    ClientOpts0 =
+        case Auth of
+            none -> [];
+            Auth -> [{sasl, emqx_bridge_impl_kafka:sasl(Auth)}]
+        end,
+    ClientOpts = add_ssl_opts(ClientOpts0, SSL),
+    case brod:start_client(BootstrapHosts, ClientID, ClientOpts) of
+        ok ->
+            ?SLOG(info, #{
+                msg => "kafka_consumer_client_started",
+                instance_id => InstanceId,
+                kafka_hosts => BootstrapHosts
+            });
+        {error, Reason} ->
+            ?SLOG(error, #{
+                msg => "failed_to_start_kafka_consumer_client",
+                instance_id => InstanceId,
+                kafka_hosts => BootstrapHosts,
+                reason => Reason
+            }),
+            throw(failed_to_start_kafka_client)
+    end,
+    GroupID = ClientID0,
+    GroupSubscriberConfig =
+        #{
+            client => ClientID,
+            group_id => GroupID,
+            topics => [KafkaTopic],
+            cb_module => ?MODULE,
+            init_data => InitialState,
+            message_type => message,
+            consumer_config => ConsumerConfig,
+            group_config => GroupConfig
+        },
+    case start_pool(InstanceId, PoolSize, GroupSubscriberConfig) of
+        {ok, ChildrenIds} ->
+            ?tp(
+                kafka_consumer_start_pool_started,
+                #{
+                    pool => ChildrenIds,
+                    instance_id => InstanceId
+                }
+            ),
+            {ok, #{
+                children_ids => ChildrenIds,
+                kafka_client_id => ClientID
+            }};
+        {error, #{error := Reason2, started := Started}} ->
+            ?SLOG(error, #{
+                msg => "failed_to_start_kafka_consumer",
+                instance_id => InstanceId,
+                kafka_hosts => BootstrapHosts,
+                kafka_topic => KafkaTopic,
+                reason => Reason2
+            }),
+            stop_consumer_pool(Started),
+            stop_client(ClientID),
+            throw(failed_to_start_kafka_consumer)
+    end.
+
+-spec on_stop(manager_id(), state()) -> ok.
+on_stop(_InstanceID, State) ->
+    #{
+        children_ids := ChildrenIds,
+        kafka_client_id := ClientID
+    } = State,
+    stop_consumer_pool(ChildrenIds),
+    stop_client(ClientID),
+    ok.
+
+-spec on_get_status(manager_id(), state()) -> connected.
+on_get_status(_InstanceID, _State) ->
+    connected.
+
+%%-------------------------------------------------------------------------------------
+%% `brod_group_subscriber' API
+%%-------------------------------------------------------------------------------------
+
+-spec init(_, consumer_state()) -> {ok, consumer_state()}.
+init(_GroupID, State) ->
+    {ok, State}.
+
+-spec handle_message(#kafka_message{}, consumer_state()) -> {ok, ack, consumer_state()}.
+handle_message(Message, State) ->
+    ?tp(
+        kafka_consumer_handle_message_enter,
+        #{message => Message, state => State}
+    ),
+    #{
+        resource_id := ResourceId,
+        kafka_topic := KafkaTopic,
+        mqtt := #{
+            topic := MQTTTopic,
+            payload := MQTTPayload,
+            qos := MQTTQoS
+        }
+    } = State,
+    Payload =
+        case MQTTPayload of
+            full_message ->
+                #{
+                    offset => Message#kafka_message.offset,
+                    key => Message#kafka_message.key,
+                    value => Message#kafka_message.value,
+                    ts => Message#kafka_message.ts,
+                    ts_type => Message#kafka_message.ts_type,
+                    headers => maps:from_list(Message#kafka_message.headers),
+                    topic => KafkaTopic
+                };
+            message_value ->
+                Message#kafka_message.value
+        end,
+    EncodedPayload = emqx_json:encode(Payload),
+    MQTTMessage = emqx_message:make(ResourceId, MQTTQoS, MQTTTopic, EncodedPayload),
+    _ = emqx:publish(MQTTMessage),
+    emqx_resource:inc_received(ResourceId),
+    {ok, ack, State}.
+
+%%-------------------------------------------------------------------------------------
+%% Helper fns
+%%-------------------------------------------------------------------------------------
+
+add_ssl_opts(ClientOpts, #{enable := false}) ->
+    ClientOpts;
+add_ssl_opts(ClientOpts, SSL) ->
+    [{ssl, emqx_tls_lib:to_client_opts(SSL)} | ClientOpts].
+
+make_consumer_worker_id(InstanceId, N) ->
+    <<"kafka_consumer:", InstanceId/binary, ":", (integer_to_binary(N))/binary>>.
+
+ensure_consumer_supervisor_started() ->
+    Mod = emqx_ee_bridge_kafka_consumer_sup,
+    ChildSpec =
+        #{
+            id => Mod,
+            start => {Mod, start_link, []},
+            restart => permanent,
+            shutdown => infinity,
+            type => supervisor,
+            modules => [Mod]
+        },
+    case supervisor:start_child(emqx_bridge_sup, ChildSpec) of
+        {ok, _Pid} ->
+            ok;
+        {error, already_present} ->
+            ok;
+        {error, {already_started, _Pid}} ->
+            ok
+    end.
+
+start_pool(InstanceId, PoolSize, GroupSubscriberConfig) ->
+    do_start_pool(PoolSize, InstanceId, GroupSubscriberConfig, #{}).
+
+do_start_pool(N, _InstanceId, _GroupSubscriberConfig, Acc) when N =< 0 ->
+    {ok, Acc};
+do_start_pool(N, InstanceId, GroupSubscriberConfig, Acc) ->
+    ChildId = make_consumer_worker_id(InstanceId, N),
+    case emqx_ee_bridge_kafka_consumer_sup:start_child(ChildId, GroupSubscriberConfig) of
+        {ok, Pid} ->
+            do_start_pool(N - 1, InstanceId, GroupSubscriberConfig, Acc#{ChildId => Pid});
+        {error, Reason} ->
+            {error, #{error => Reason, started => Acc}}
+    end.
+
+stop_consumer_pool(Children) ->
+    lists:foreach(
+        fun(Id) ->
+            log_when_error(
+                fun() ->
+                    emqx_ee_bridge_kafka_consumer_sup:ensure_child_deleted(Id)
+                end,
+                #{
+                    msg => "failed_to_delete_kafka_consumer",
+                    consumer_id => Id
+                }
+            )
+        end,
+        maps:keys(Children)
+    ).
+
+stop_client(ClientID) ->
+    _ = log_when_error(
+        fun() ->
+            brod:stop_client(ClientID)
+        end,
+        #{
+            msg => "failed_to_delete_kafka_consumer_client",
+            client_id => ClientID
+        }
+    ),
+    ok.
+
+log_when_error(Fun, Log) ->
+    try
+        Fun()
+    catch
+        C:E ->
+            ?SLOG(error, Log#{
+                exception => C,
+                reason => E
+            })
+    end.

--- a/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_producer.erl
+++ b/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_producer.erl
@@ -266,11 +266,11 @@ handle_telemetry_event(
     emqx_resource_metrics:dropped_queue_full_inc(ID, Val);
 handle_telemetry_event(
     [wolff, queuing],
-    #{counter_inc := Val},
-    #{bridge_id := ID},
+    #{gauge_set := Val},
+    #{bridge_id := ID, partition_id := PartitionID},
     _HandlerConfig
 ) when is_integer(Val) ->
-    emqx_resource_metrics:queuing_change(ID, Val);
+    emqx_resource_metrics:queuing_set(ID, PartitionID, Val);
 handle_telemetry_event(
     [wolff, retried],
     #{counter_inc := Val},
@@ -287,11 +287,11 @@ handle_telemetry_event(
     emqx_resource_metrics:failed_inc(ID, Val);
 handle_telemetry_event(
     [wolff, inflight],
-    #{counter_inc := Val},
-    #{bridge_id := ID},
+    #{gauge_set := Val},
+    #{bridge_id := ID, partition_id := PartitionID},
     _HandlerConfig
 ) when is_integer(Val) ->
-    emqx_resource_metrics:inflight_change(ID, Val);
+    emqx_resource_metrics:inflight_set(ID, PartitionID, Val);
 handle_telemetry_event(
     [wolff, retried_failed],
     #{counter_inc := Val},

--- a/lib-ee/emqx_ee_bridge/src/kafka/emqx_ee_bridge_kafka_consumer_sup.erl
+++ b/lib-ee/emqx_ee_bridge/src/kafka/emqx_ee_bridge_kafka_consumer_sup.erl
@@ -1,0 +1,79 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_ee_bridge_kafka_consumer_sup).
+
+-behaviour(supervisor).
+
+%% `supervisor' API
+-export([init/1]).
+
+%% API
+-export([
+    start_link/0,
+    child_spec/2,
+    start_child/2,
+    ensure_child_deleted/1
+]).
+
+-type child_id() :: binary().
+-export_type([child_id/0]).
+
+%%--------------------------------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------------------------------
+
+start_link() ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-spec child_spec(child_id(), map()) -> supervisor:child_spec().
+child_spec(Id, GroupSubscriberConfig) ->
+    Mod = brod_group_subscriber_v2,
+    #{
+        id => Id,
+        start => {Mod, start_link, [GroupSubscriberConfig]},
+        restart => transient,
+        shutdown => 10_000,
+        type => worker,
+        modules => [Mod]
+    }.
+
+-spec start_child(child_id(), map()) -> {ok, pid()} | {error, term()}.
+start_child(Id, GroupSubscriberConfig) ->
+    ChildSpec = child_spec(Id, GroupSubscriberConfig),
+    case supervisor:start_child(?MODULE, ChildSpec) of
+        {ok, Pid} ->
+            {ok, Pid};
+        {ok, Pid, _Info} ->
+            {ok, Pid};
+        {error, already_present} ->
+            supervisor:restart_child(?MODULE, Id);
+        {error, {already_started, Pid}} ->
+            {ok, Pid};
+        {error, Error} ->
+            {error, Error}
+    end.
+
+-spec ensure_child_deleted(child_id()) -> ok.
+ensure_child_deleted(Id) ->
+    case supervisor:terminate_child(?MODULE, Id) of
+        ok ->
+            ok = supervisor:delete_child(?MODULE, Id),
+            ok;
+        {error, not_found} ->
+            ok
+    end.
+
+%%--------------------------------------------------------------------------------------------
+%% `supervisor' API
+%%--------------------------------------------------------------------------------------------
+
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 10
+    },
+    ChildSpecs = [],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/lib-ee/emqx_ee_bridge/test/emqx_bridge_impl_kafka_consumer_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_bridge_impl_kafka_consumer_SUITE.erl
@@ -1,0 +1,653 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_impl_kafka_consumer_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+-define(BRIDGE_TYPE_BIN, <<"kafka_consumer">>).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    [
+        {group, plain},
+        {group, ssl},
+        {group, sasl_plain},
+        {group, sasl_ssl}
+    ].
+
+groups() ->
+    TCs = emqx_common_test_helpers:all(?MODULE),
+    SASLAuths = [
+        sasl_auth_plain,
+        sasl_auth_scram256,
+        sasl_auth_scram512,
+        sasl_auth_kerberos
+    ],
+    SASLAuthGroups = [{group, Type} || Type <- SASLAuths],
+    SASLTests = [{Group, TCs} || Group <- SASLAuths],
+    [
+        {plain, TCs},
+        {ssl, TCs},
+        {sasl_plain, SASLAuthGroups},
+        {sasl_ssl, SASLAuthGroups}
+    ] ++ SASLTests.
+
+sasl_only_tests() ->
+    [t_failed_creation_then_fixed].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(_Config) ->
+    emqx_mgmt_api_test_util:end_suite(),
+    ok = emqx_common_test_helpers:stop_apps([emqx_conf]),
+    ok = emqx_connector_test_helpers:stop_apps([emqx_bridge, emqx_resource]),
+    _ = application:stop(emqx_connector),
+    ok.
+
+init_per_group(plain = Type, Config) ->
+    KafkaHost = os:getenv("KAFKA_PLAIN_HOST", "kafka-1.emqx.net"),
+    KafkaPort = list_to_integer(os:getenv("KAFKA_PLAIN_PORT", "9092")),
+    ProxyName = "kafka_plain",
+    case emqx_common_test_helpers:is_tcp_server_available(KafkaHost, KafkaPort) of
+        true ->
+            Config1 = common_init_per_group(),
+            [
+                {proxy_name, ProxyName},
+                {kafka_host, KafkaHost},
+                {kafka_port, KafkaPort},
+                {kafka_type, Type},
+                {use_sasl, false},
+                {use_tls, false}
+                | Config1 ++ Config
+            ];
+        false ->
+            {skip, no_kafka}
+    end;
+init_per_group(sasl_plain = Type, Config) ->
+    KafkaHost = os:getenv("KAFKA_SASL_PLAIN_HOST", "kafka-1.emqx.net"),
+    KafkaPort = list_to_integer(os:getenv("KAFKA_SASL_PLAIN_PORT", "9093")),
+    ProxyName = "kafka_sasl_plain",
+    case emqx_common_test_helpers:is_tcp_server_available(KafkaHost, KafkaPort) of
+        true ->
+            Config1 = common_init_per_group(),
+            [
+                {proxy_name, ProxyName},
+                {kafka_host, KafkaHost},
+                {kafka_port, KafkaPort},
+                {kafka_type, Type},
+                {use_sasl, true},
+                {use_tls, false}
+                | Config1 ++ Config
+            ];
+        false ->
+            {skip, no_kafka}
+    end;
+init_per_group(ssl = Type, Config) ->
+    KafkaHost = os:getenv("KAFKA_SSL_HOST", "kafka-1.emqx.net"),
+    KafkaPort = list_to_integer(os:getenv("KAFKA_SSL_PORT", "9094")),
+    ProxyName = "kafka_ssl",
+    case emqx_common_test_helpers:is_tcp_server_available(KafkaHost, KafkaPort) of
+        true ->
+            Config1 = common_init_per_group(),
+            [
+                {proxy_name, ProxyName},
+                {kafka_host, KafkaHost},
+                {kafka_port, KafkaPort},
+                {kafka_type, Type},
+                {use_sasl, false},
+                {use_tls, true}
+                | Config1 ++ Config
+            ];
+        false ->
+            {skip, no_kafka}
+    end;
+init_per_group(sasl_ssl = Type, Config) ->
+    KafkaHost = os:getenv("KAFKA_SASL_SSL_HOST", "kafka-1.emqx.net"),
+    KafkaPort = list_to_integer(os:getenv("KAFKA_SASL_SSL_PORT", "9095")),
+    ProxyName = "kafka_sasl_ssl",
+    case emqx_common_test_helpers:is_tcp_server_available(KafkaHost, KafkaPort) of
+        true ->
+            Config1 = common_init_per_group(),
+            [
+                {proxy_name, ProxyName},
+                {kafka_host, KafkaHost},
+                {kafka_port, KafkaPort},
+                {kafka_type, Type},
+                {use_sasl, true},
+                {use_tls, true}
+                | Config1 ++ Config
+            ];
+        false ->
+            {skip, no_kafka}
+    end;
+init_per_group(sasl_auth_plain, Config) ->
+    [{sasl_auth_mechanism, plain} | Config];
+init_per_group(sasl_auth_scram256, Config) ->
+    [{sasl_auth_mechanism, scram_sha_256} | Config];
+init_per_group(sasl_auth_scram512, Config) ->
+    [{sasl_auth_mechanism, scram_sha_512} | Config];
+init_per_group(sasl_auth_kerberos, Config) ->
+    [{sasl_auth_mechanism, kerberos} | Config];
+init_per_group(_Group, Config) ->
+    Config.
+
+common_init_per_group() ->
+    ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
+    ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
+    ensure_loaded(),
+    application:load(emqx_bridge),
+    ok = emqx_common_test_helpers:start_apps([emqx_conf]),
+    ok = emqx_connector_test_helpers:start_apps([emqx_resource, emqx_bridge]),
+    {ok, _} = application:ensure_all_started(emqx_connector),
+    emqx_mgmt_api_test_util:init_suite(),
+    [
+        {proxy_host, ProxyHost},
+        {proxy_port, ProxyPort},
+        {mqtt_topic, <<"mqtt/topic">>},
+        {mqtt_qos, 0},
+        {mqtt_payload, full_message},
+        {pool_size, 1},
+        {kafka_topic, <<"test-topic-three-partitions">>}
+    ].
+
+end_per_group(Group, Config) when
+    Group =:= plain;
+    Group =:= ssl;
+    Group =:= sasl_plain;
+    Group =:= sasl_ssl
+->
+    ProxyHost = ?config(proxy_host, Config),
+    ProxyPort = ?config(proxy_port, Config),
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
+    delete_all_bridges(),
+    ok;
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(TestCase, Config) when
+    TestCase =:= t_failed_creation_then_fixed
+->
+    KafkaType = ?config(kafka_type, Config),
+    AuthMechanism = ?config(sasl_auth_mechanism, Config),
+    IsSASL = lists:member(KafkaType, [sasl_plain, sasl_ssl]),
+    case {IsSASL, AuthMechanism} of
+        {true, kerberos} ->
+            {skip, does_not_apply};
+        {true, _} ->
+            common_init_per_testcase(TestCase, Config);
+        {false, _} ->
+            {skip, does_not_apply}
+    end;
+init_per_testcase(TestCase, Config) ->
+    common_init_per_testcase(TestCase, Config).
+
+common_init_per_testcase(TestCase, Config) ->
+    ct:timetrap(timer:seconds(60)),
+    delete_all_bridges(),
+    KafkaType = ?config(kafka_type, Config),
+    {Name, ConfigString, KafkaConfig} = kafka_config(
+        TestCase, KafkaType, Config
+    ),
+    #{
+        producers := Producers,
+        clientid := KafkaClientId
+    } = start_producer(TestCase, Config),
+    [
+        {kafka_name, Name},
+        {kafka_config_string, ConfigString},
+        {kafka_config, KafkaConfig},
+        {kafka_producers, Producers},
+        {kafka_clientid, KafkaClientId}
+        | Config
+    ].
+
+end_per_testcase(_Testcase, Config) ->
+    ProxyHost = ?config(proxy_host, Config),
+    ProxyPort = ?config(proxy_port, Config),
+    Producers = ?config(kafka_producers, Config),
+    KafkaClientId = ?config(kafka_clientid, Config),
+    ok = snabbkaffe:stop(),
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
+    delete_all_bridges(),
+    ok = wolff:stop_and_delete_supervised_producers(Producers),
+    ok = wolff:stop_and_delete_supervised_client(KafkaClientId),
+    emqx_common_test_helpers:call_janitor(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+ensure_loaded() ->
+    _ = application:load(emqx_ee_bridge),
+    _ = emqx_ee_bridge:module_info(),
+    ok.
+
+start_producer(TestCase, Config) ->
+    KafkaTopic = ?config(kafka_topic, Config),
+    KafkaClientId = <<"test-client-", (atom_to_binary(TestCase))/binary>>,
+    KafkaHost = ?config(kafka_host, Config),
+    KafkaPort = ?config(kafka_port, Config),
+    UseTLS = ?config(use_tls, Config),
+    UseSASL = ?config(use_sasl, Config),
+    Hosts = emqx_bridge_impl_kafka:hosts(KafkaHost ++ ":" ++ integer_to_list(KafkaPort)),
+    SSL =
+        case UseTLS of
+            true ->
+                %% hint: when running locally, need to
+                %% `chmod og+rw` those files to be readable.
+                emqx_tls_lib:to_client_opts(
+                    #{
+                        keyfile => shared_secret(client_keyfile),
+                        certfile => shared_secret(client_certfile),
+                        cacertfile => shared_secret(client_cacertfile),
+                        verify => verify_none,
+                        enable => true
+                    }
+                );
+            false ->
+                []
+        end,
+    SASL =
+        case UseSASL of
+            true -> {plain, <<"emqxuser">>, <<"password">>};
+            false -> undefined
+        end,
+    ClientConfig = #{
+        min_metadata_refresh_interval => 5_000,
+        connect_timeout => 5_000,
+        client_id => KafkaClientId,
+        request_timeout => 1_000,
+        sasl => SASL,
+        ssl => SSL
+    },
+    {ok, Clients} = wolff:ensure_supervised_client(KafkaClientId, Hosts, ClientConfig),
+    ProducerConfig =
+        #{
+            name => test_producer,
+            partitioner => random,
+            partition_count_refresh_interval_seconds => 1_000,
+            replayq_max_total_bytes => 10_000,
+            replayq_seg_bytes => 9_000,
+            drop_if_highmem => false,
+            required_acks => leader_only,
+            max_batch_bytes => 900_000,
+            max_send_ahead => 0,
+            compression => no_compression,
+            telemetry_meta_data => #{}
+        },
+    {ok, Producers} = wolff:ensure_supervised_producers(KafkaClientId, KafkaTopic, ProducerConfig),
+    #{
+        producers => Producers,
+        clients => Clients,
+        clientid => KafkaClientId
+    }.
+
+shared_secret_path() ->
+    os:getenv("CI_SHARED_SECRET_PATH", "/var/lib/secret").
+
+shared_secret(client_keyfile) ->
+    filename:join([shared_secret_path(), "client.key"]);
+shared_secret(client_certfile) ->
+    filename:join([shared_secret_path(), "client.crt"]);
+shared_secret(client_cacertfile) ->
+    filename:join([shared_secret_path(), "ca.crt"]);
+shared_secret(rig_keytab) ->
+    filename:join([shared_secret_path(), "rig.keytab"]).
+
+publish(Config, Messages) ->
+    Producers = ?config(kafka_producers, Config),
+    ct:pal("publishing: ~p", [Messages]),
+    {_Partition, _OffsetReply} = wolff:send_sync(Producers, Messages, 10_000).
+
+kafka_config(TestCase, _KafkaType, Config) ->
+    KafkaHost = ?config(kafka_host, Config),
+    KafkaPort = ?config(kafka_port, Config),
+    KafkaTopic = ?config(kafka_topic, Config),
+    AuthType = proplists:get_value(sasl_auth_mechanism, Config, none),
+    UseTLS = proplists:get_value(use_tls, Config, false),
+    Name = <<
+        (atom_to_binary(TestCase))/binary, (integer_to_binary(erlang:unique_integer()))/binary
+    >>,
+    MQTTTopic = proplists:get_value(mqtt_topic, Config, <<"mqtt/topic">>),
+    MQTTQoS = proplists:get_value(mqtt_qos, Config, 0),
+    MQTTPayload = proplists:get_value(mqtt_payload, Config, full_message),
+    PoolSize = proplists:get_value(pool_size, Config, 1),
+    ConfigString =
+        io_lib:format(
+            "bridges.kafka_consumer.~s {\n"
+            "  enable = true\n"
+            "  bootstrap_hosts = \"~p:~b\"\n"
+            "  connect_timeout = 5s\n"
+            "  min_metadata_refresh_interval = 3s\n"
+            "  metadata_request_timeout = 5s\n"
+            "~s"
+            "  kafka {\n"
+            "    topic = ~s\n"
+            "    max_batch_bytes = 896KB\n"
+            %% todo: matrix this
+            "    offset_reset_policy = reset_to_latest\n"
+            "  }\n"
+            "  mqtt {\n"
+            "    topic = \"~s\"\n"
+            "    qos = ~b\n"
+            "    payload = ~p\n"
+            "  }\n"
+            "  pool_size = ~b\n"
+            "  ssl {\n"
+            "    enable = ~p\n"
+            "    verify = verify_none\n"
+            "    server_name_indication = \"auto\"\n"
+            "  }\n"
+            "}\n",
+            [
+                Name,
+                KafkaHost,
+                KafkaPort,
+                authentication(AuthType),
+                KafkaTopic,
+                MQTTTopic,
+                MQTTQoS,
+                MQTTPayload,
+                PoolSize,
+                UseTLS
+            ]
+        ),
+    {Name, ConfigString, parse_and_check(ConfigString, Name)}.
+
+authentication(Type) when
+    Type =:= scram_sha_256;
+    Type =:= scram_sha_512;
+    Type =:= plain
+->
+    io_lib:format(
+        "  authentication = {\n"
+        "    mechanism = ~p\n"
+        "    username = emqxuser\n"
+        "    password = password\n"
+        "  }\n",
+        [Type]
+    );
+authentication(kerberos) ->
+    %% TODO: how to make this work locally outside docker???
+    io_lib:format(
+        "  authentication = {\n"
+        "    kerberos_principal = rig@KDC.EMQX.NET\n"
+        "    kerberos_keytab_file = \"~s\"\n"
+        "  }\n",
+        [shared_secret(rig_keytab)]
+    );
+authentication(_) ->
+    "  authentication = none\n".
+
+parse_and_check(ConfigString, Name) ->
+    {ok, RawConf} = hocon:binary(ConfigString, #{format => map}),
+    TypeBin = ?BRIDGE_TYPE_BIN,
+    hocon_tconf:check_plain(emqx_bridge_schema, RawConf, #{required => false, atom_key => false}),
+    #{<<"bridges">> := #{TypeBin := #{Name := Config}}} = RawConf,
+    Config.
+
+create_bridge(Config) ->
+    create_bridge(Config, _Overrides = #{}).
+
+create_bridge(Config, Overrides) ->
+    Type = ?BRIDGE_TYPE_BIN,
+    Name = ?config(kafka_name, Config),
+    KafkaConfig0 = ?config(kafka_config, Config),
+    KafkaConfig = emqx_map_lib:deep_merge(KafkaConfig0, Overrides),
+    emqx_bridge:create(Type, Name, KafkaConfig).
+
+delete_bridge(Config) ->
+    Type = ?BRIDGE_TYPE_BIN,
+    Name = ?config(kafka_name, Config),
+    emqx_bridge:remove(Type, Name).
+
+delete_all_bridges() ->
+    lists:foreach(
+        fun(#{name := Name, type := Type}) ->
+            emqx_bridge:remove(Type, Name)
+        end,
+        emqx_bridge:list()
+    ).
+
+update_bridge_api(Config) ->
+    update_bridge_api(Config, _Overrides = #{}).
+
+update_bridge_api(Config, Overrides) ->
+    TypeBin = ?BRIDGE_TYPE_BIN,
+    Name = ?config(kafka_name, Config),
+    KafkaConfig0 = ?config(kafka_config, Config),
+    KafkaConfig = emqx_map_lib:deep_merge(KafkaConfig0, Overrides),
+    BridgeId = emqx_bridge_resource:bridge_id(TypeBin, Name),
+    Params = KafkaConfig#{<<"type">> => TypeBin, <<"name">> => Name},
+    Path = emqx_mgmt_api_test_util:api_path(["bridges", BridgeId]),
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    ct:pal("updating bridge (via http): ~p", [Params]),
+    Res =
+        case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Params) of
+            {ok, Res0} -> {ok, emqx_json:decode(Res0, [return_maps])};
+            Error -> Error
+        end,
+    ct:pal("bridge creation result: ~p", [Res]),
+    Res.
+
+send_message(Config, Payload) ->
+    Name = ?config(kafka_name, Config),
+    Type = ?BRIDGE_TYPE_BIN,
+    BridgeId = emqx_bridge_resource:bridge_id(Type, Name),
+    emqx_bridge:send_message(BridgeId, Payload).
+
+resource_id(Config) ->
+    Type = ?BRIDGE_TYPE_BIN,
+    Name = ?config(kafka_name, Config),
+    emqx_bridge_resource:resource_id(Type, Name).
+
+instance_id(Config) ->
+    ResourceId = resource_id(Config),
+    [{_, InstanceId}] = ets:lookup(emqx_resource_manager, {owner, ResourceId}),
+    InstanceId.
+
+receive_published() ->
+    receive_published(#{}).
+
+receive_published(Opts0) ->
+    Default = #{n => 1, timeout => 10_000},
+    Opts = maps:merge(Default, Opts0),
+    receive_published(Opts, []).
+
+receive_published(#{n := N, timeout := _Timeout}, Acc) when N =< 0 ->
+    lists:reverse(Acc);
+receive_published(#{n := N, timeout := Timeout} = Opts, Acc) ->
+    receive
+        {publish, Msg} ->
+            receive_published(Opts#{n := N - 1}, [Msg | Acc])
+    after Timeout ->
+        error(
+            {timeout, #{
+                msgs_so_far => Acc,
+                mailbox => process_info(self(), messages),
+                expected_remaining => N
+            }}
+        )
+    end.
+
+ensure_connected(Config) ->
+    ?assertMatch({ok, _}, get_client_connection(Config)),
+    ok.
+
+get_client_connection(Config) ->
+    KafkaName = ?config(kafka_name, Config),
+    KafkaHost = ?config(kafka_host, Config),
+    KafkaPort = ?config(kafka_port, Config),
+    ClientID = binary_to_atom(emqx_bridge_impl_kafka:make_client_id(KafkaName)),
+    brod_client:get_connection(ClientID, KafkaHost, KafkaPort).
+
+%%------------------------------------------------------------------------------
+%% Testcases
+%%------------------------------------------------------------------------------
+
+t_start_and_consume_ok(Config) ->
+    MQTTTopic = ?config(mqtt_topic, Config),
+    MQTTQoS = ?config(mqtt_qos, Config),
+    KafkaTopic = ?config(kafka_topic, Config),
+    KafkaName = ?config(kafka_name, Config),
+    ResourceId = emqx_bridge_resource:resource_id(kafka_consumer, KafkaName),
+    ?assertMatch(
+        {ok, _},
+        create_bridge(Config)
+    ),
+    ensure_connected(Config),
+    %% FIXME: the consumer is tremendously flaky without this
+    %% sleep (rarely receives the published message, sometimes
+    %% it does), specially if TLS is used... why???
+    ct:sleep(5_000),
+    {ok, C} = emqtt:start_link(),
+    on_exit(fun() -> emqtt:stop(C) end),
+    {ok, _} = emqtt:connect(C),
+    {ok, _, [0]} = emqtt:subscribe(C, MQTTTopic),
+    Payload = emqx_guid:to_hexstr(emqx_guid:gen()),
+
+    ?check_trace(
+        begin
+            {Res, {ok, _}} =
+                ?wait_async_action(
+                    publish(Config, [
+                        #{
+                            key => <<"mykey">>,
+                            value => Payload,
+                            headers => [{<<"hkey">>, <<"hvalue">>}]
+                        }
+                    ]),
+                    #{?snk_kind := kafka_consumer_handle_message_enter},
+                    20_000
+                ),
+            Res
+        end,
+        fun({_Partition, OffsetReply}, Trace) ->
+            ?assertMatch([_], ?of_kind(kafka_consumer_handle_message_enter, Trace)),
+            Published = receive_published(),
+            ?assertMatch(
+                [
+                    #{
+                        qos := MQTTQoS,
+                        topic := MQTTTopic,
+                        payload := _
+                    }
+                ],
+                Published
+            ),
+            [#{payload := PayloadBin}] = Published,
+            ?assertMatch(
+                #{
+                    <<"value">> := Payload,
+                    <<"key">> := <<"mykey">>,
+                    <<"topic">> := KafkaTopic,
+                    <<"offset">> := OffsetReply,
+                    <<"headers">> := #{<<"hkey">> := <<"hvalue">>}
+                },
+                emqx_json:decode(PayloadBin, [return_maps]),
+                #{
+                    offset_reply => OffsetReply,
+                    kafka_topic => KafkaTopic,
+                    payload => Payload
+                }
+            ),
+            ?assertEqual(1, emqx_resource_metrics:received_get(ResourceId)),
+            ok
+        end
+    ),
+    ok.
+
+%% ensure that we can create and use the bridge successfully after
+%% creating it with bad config.
+t_failed_creation_then_fixed(Config) ->
+    MQTTTopic = ?config(mqtt_topic, Config),
+    MQTTQoS = ?config(mqtt_qos, Config),
+    KafkaTopic = ?config(kafka_topic, Config),
+    {ok, _} = create_bridge(Config, #{
+        <<"authentication">> => #{<<"password">> => <<"wrong password">>}
+    }),
+    ct:sleep(5_000),
+    ClientConn0 = get_client_connection(Config),
+    case ClientConn0 of
+        {error, client_down} ->
+            ok;
+        {error, {client_down, _Stacktrace}} ->
+            ok;
+        _ ->
+            error({client_should_be_down, ClientConn0})
+    end,
+    %% now, update with the correct configuration
+    ok = snabbkaffe:start_trace(),
+    ?assertMatch(
+        {{ok, _}, {ok, _}},
+        ?wait_async_action(
+            update_bridge_api(Config),
+            #{?snk_kind := kafka_consumer_start_pool_started},
+            10_000
+        )
+    ),
+    ensure_connected(Config),
+    %% FIXME: the consumer is tremendously flaky without this
+    %% sleep (rarely receives the published message, sometimes
+    %% it does), specially if TLS is used... why???
+    ct:sleep(5_000),
+
+    {ok, C} = emqtt:start_link(),
+    on_exit(fun() -> emqtt:stop(C) end),
+    {ok, _} = emqtt:connect(C),
+    {ok, _, [0]} = emqtt:subscribe(C, MQTTTopic),
+    Payload = emqx_guid:to_hexstr(emqx_guid:gen()),
+
+    {_, {ok, _}} =
+        ?wait_async_action(
+            publish(Config, [
+                #{
+                    key => <<"mykey">>,
+                    value => Payload,
+                    headers => [{<<"hkey">>, <<"hvalue">>}]
+                }
+            ]),
+            #{?snk_kind := kafka_consumer_handle_message_enter},
+            20_000
+        ),
+    Published = receive_published(),
+    ?assertMatch(
+        [
+            #{
+                qos := MQTTQoS,
+                topic := MQTTTopic,
+                payload := _
+            }
+        ],
+        Published
+    ),
+    [#{payload := PayloadBin}] = Published,
+    ?assertMatch(
+        #{
+            <<"value">> := Payload,
+            <<"key">> := <<"mykey">>,
+            <<"topic">> := KafkaTopic,
+            <<"offset">> := _,
+            <<"headers">> := #{<<"hkey">> := <<"hvalue">>}
+        },
+        emqx_json:decode(PayloadBin, [return_maps]),
+        #{
+            kafka_topic => KafkaTopic,
+            payload => Payload
+        }
+    ),
+    ok.

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
@@ -124,6 +124,7 @@ init_per_testcase(TestCase, Config0) when
             delete_all_bridges(),
             Tid = install_telemetry_handler(TestCase),
             Config = generate_config(Config0),
+            put(telemetry_table, Tid),
             [{telemetry_table, Tid} | Config];
         false ->
             {skip, no_batching}
@@ -133,6 +134,7 @@ init_per_testcase(TestCase, Config0) ->
     delete_all_bridges(),
     Tid = install_telemetry_handler(TestCase),
     Config = generate_config(Config0),
+    put(telemetry_table, Tid),
     [{telemetry_table, Tid} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
@@ -393,7 +395,11 @@ assert_metrics(ExpectedMetrics, ResourceId) ->
             maps:keys(ExpectedMetrics)
         ),
     CurrentMetrics = current_metrics(ResourceId),
-    ?assertEqual(ExpectedMetrics, Metrics, #{current_metrics => CurrentMetrics}),
+    TelemetryTable = get(telemetry_table),
+    RecordedEvents = ets:tab2list(TelemetryTable),
+    ?assertEqual(ExpectedMetrics, Metrics, #{
+        current_metrics => CurrentMetrics, recorded_events => RecordedEvents
+    }),
     ok.
 
 assert_empty_metrics(ResourceId) ->
@@ -554,6 +560,7 @@ t_publish_success(Config) ->
     ResourceId = ?config(resource_id, Config),
     ServiceAccountJSON = ?config(service_account_json, Config),
     TelemetryTable = ?config(telemetry_table, Config),
+    QueryMode = ?config(query_mode, Config),
     Topic = <<"t/topic">>,
     ?check_trace(
         create_bridge(Config),
@@ -582,6 +589,17 @@ t_publish_success(Config) ->
     ),
     %% to avoid test flakiness
     wait_telemetry_event(TelemetryTable, success, ResourceId),
+    ExpectedInflightEvents =
+        case QueryMode of
+            sync -> 1;
+            async -> 3
+        end,
+    wait_telemetry_event(
+        TelemetryTable,
+        inflight,
+        ResourceId,
+        #{n_events => ExpectedInflightEvents, timeout => 5_000}
+    ),
     assert_metrics(
         #{
             batching => 0,
@@ -601,6 +619,7 @@ t_publish_success_local_topic(Config) ->
     ResourceId = ?config(resource_id, Config),
     ServiceAccountJSON = ?config(service_account_json, Config),
     TelemetryTable = ?config(telemetry_table, Config),
+    QueryMode = ?config(query_mode, Config),
     LocalTopic = <<"local/topic">>,
     {ok, _} = create_bridge(Config, #{<<"local_topic">> => LocalTopic}),
     assert_empty_metrics(ResourceId),
@@ -619,6 +638,17 @@ t_publish_success_local_topic(Config) ->
     ),
     %% to avoid test flakiness
     wait_telemetry_event(TelemetryTable, success, ResourceId),
+    ExpectedInflightEvents =
+        case QueryMode of
+            sync -> 1;
+            async -> 3
+        end,
+    wait_telemetry_event(
+        TelemetryTable,
+        inflight,
+        ResourceId,
+        #{n_events => ExpectedInflightEvents, timeout => 5_000}
+    ),
     assert_metrics(
         #{
             batching => 0,
@@ -649,6 +679,7 @@ t_publish_templated(Config) ->
     ResourceId = ?config(resource_id, Config),
     ServiceAccountJSON = ?config(service_account_json, Config),
     TelemetryTable = ?config(telemetry_table, Config),
+    QueryMode = ?config(query_mode, Config),
     Topic = <<"t/topic">>,
     PayloadTemplate = <<
         "{\"payload\": \"${payload}\","
@@ -694,6 +725,17 @@ t_publish_templated(Config) ->
     ),
     %% to avoid test flakiness
     wait_telemetry_event(TelemetryTable, success, ResourceId),
+    ExpectedInflightEvents =
+        case QueryMode of
+            sync -> 1;
+            async -> 3
+        end,
+    wait_telemetry_event(
+        TelemetryTable,
+        inflight,
+        ResourceId,
+        #{n_events => ExpectedInflightEvents, timeout => 5_000}
+    ),
     assert_metrics(
         #{
             batching => 0,
@@ -1053,7 +1095,7 @@ do_econnrefused_or_timeout_test(Config, Error) ->
         %% response expired, this succeeds.
         {econnrefused, async, _} ->
             wait_telemetry_event(TelemetryTable, queuing, ResourceId, #{
-                timeout => 10_000, n_events => 2
+                timeout => 10_000, n_events => 1
             }),
             CurrentMetrics = current_metrics(ResourceId),
             RecordedEvents = ets:tab2list(TelemetryTable),
@@ -1290,6 +1332,17 @@ t_unrecoverable_error(Config) ->
         end
     ),
     wait_telemetry_event(TelemetryTable, failed, ResourceId),
+    ExpectedInflightEvents =
+        case QueryMode of
+            sync -> 1;
+            async -> 3
+        end,
+    wait_telemetry_event(
+        TelemetryTable,
+        inflight,
+        ResourceId,
+        #{n_events => ExpectedInflightEvents, timeout => 5_000}
+    ),
     assert_metrics(
         #{
             batching => 0,

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
@@ -139,6 +139,7 @@ end_per_testcase(_TestCase, _Config) ->
     ok = snabbkaffe:stop(),
     delete_all_bridges(),
     ok = emqx_connector_web_hook_server:stop(),
+    emqx_common_test_helpers:call_janitor(),
     ok.
 
 %%------------------------------------------------------------------------------

--- a/mix.exs
+++ b/mix.exs
@@ -131,10 +131,10 @@ defmodule EMQXUmbrella.MixProject do
     [
       {:hstreamdb_erl, github: "hstreamdb/hstreamdb_erl", tag: "0.2.5"},
       {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.4", override: true},
-      {:wolff, github: "kafka4beam/wolff", tag: "1.7.0"},
-      {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.0", override: true},
+      {:wolff, github: "kafka4beam/wolff", tag: "1.7.3"},
+      {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.2", override: true},
       {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.0-rc1"},
-      {:brod, github: "kafka4beam/brod", tag: "3.16.4"},
+      {:brod, github: "kafka4beam/brod", tag: "3.16.7"},
       {:snappyer, "1.2.8", override: true},
       {:supervisor3, "1.1.11", override: true}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -131,7 +131,7 @@ defmodule EMQXUmbrella.MixProject do
     [
       {:hstreamdb_erl, github: "hstreamdb/hstreamdb_erl", tag: "0.2.5"},
       {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.4", override: true},
-      {:wolff, github: "kafka4beam/wolff", tag: "1.7.3"},
+      {:wolff, github: "kafka4beam/wolff", tag: "1.7.4-tmg0"},
       {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.2", override: true},
       {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.0-rc1"},
       {:brod, github: "kafka4beam/brod", tag: "3.16.7"},

--- a/scripts/merge-i18n.escript
+++ b/scripts/merge-i18n.escript
@@ -10,8 +10,9 @@ main(_) ->
     Conf = [merge(Conf0, Cfgs1),
             io_lib:nl()
            ],
-    ok = filelib:ensure_dir("apps/emqx_dashboard/priv/i18n.conf"),
-    ok = file:write_file("apps/emqx_dashboard/priv/i18n.conf", Conf).
+    OutputFile = "apps/emqx_dashboard/priv/i18n.conf",
+    ok = filelib:ensure_dir(OutputFile),
+    ok = file:write_file(OutputFile, Conf).
 
 merge(BaseConf, Cfgs) ->
     lists:foldl(


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-8548

Currently, we face several issues trying to keep resource metrics
reasonable.  For example, when a resource is re-created and has its
metrics reset, but then its durable queue resumes its previous work
and leads to strange (often negative) metrics.

Instead using `counters` that are shared by more than one worker to
manage gauges, we introduce an ETS table whose key is not only scoped
by the Resource ID as before, but also by the worker ID.  This way,
when a worker starts/terminates, they should set their own gauges to
their values (often 0 or `replayq:count` when resuming off a queue).
With this scoping and initialization procedure, we'll hopefully avoid
hitting those strange metrics scenarios and have better control over
the gauges.

Related Wolff PR: https://github.com/kafka4beam/wolff/pull/41