### PR TITLE
feat(mqtt): add option to customize clientid prefix for egress bridges

### DIFF
--- a/apps/emqx_connector/i18n/emqx_connector_mqtt_schema.conf
+++ b/apps/emqx_connector/i18n/emqx_connector_mqtt_schema.conf
@@ -337,4 +337,15 @@ Template with variables is allowed.
                           }
                   }
 
+    clientid_prefix {
+      desc {
+        en: """Optional prefix to prepend to the clientid used by egress bridges."""
+        zh: """可选的前缀，用于在出口网桥使用的clientid前加上前缀。"""
+      }
+      label: {
+        en: "Clientid Prefix"
+        zh: "客户ID前缀"
+      }
+    }
+
 }

--- a/apps/emqx_connector/src/emqx_connector_mqtt.erl
+++ b/apps/emqx_connector/src/emqx_connector_mqtt.erl
@@ -152,7 +152,7 @@ on_start(InstId, Conf) ->
     BasicConf = basic_config(Conf),
     BridgeConf = BasicConf#{
         name => InstanceId,
-        clientid => clientid(InstId),
+        clientid => clientid(InstId, Conf),
         subscriptions => make_sub_confs(maps:get(ingress, Conf, undefined), Conf, InstId),
         forwards => make_forward_confs(maps:get(egress, Conf, undefined))
     },
@@ -246,7 +246,7 @@ basic_config(
         ssl := #{enable := EnableSsl} = Ssl
     } = Conf
 ) ->
-    BaiscConf = #{
+    BasicConf = #{
         %% connection opts
         server => Server,
         %% 30s
@@ -268,7 +268,7 @@ basic_config(
         ssl_opts => maps:to_list(maps:remove(enable, Ssl)),
         if_record_metrics => true
     },
-    maybe_put_fields([username, password], Conf, BaiscConf).
+    maybe_put_fields([username, password], Conf, BasicConf).
 
 maybe_put_fields(Fields, Conf, Acc0) ->
     lists:foldl(
@@ -285,5 +285,7 @@ maybe_put_fields(Fields, Conf, Acc0) ->
 ms_to_s(Ms) ->
     erlang:ceil(Ms / 1000).
 
-clientid(Id) ->
+clientid(Id, _Conf = #{clientid_prefix := Prefix = <<_/binary>>}) ->
+    iolist_to_binary([Prefix, ":", Id, ":", atom_to_list(node())]);
+clientid(Id, _Conf) ->
     iolist_to_binary([Id, ":", atom_to_list(node())]).

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_schema.erl
@@ -75,6 +75,7 @@ fields("server_configs") ->
                     desc => ?DESC("server")
                 }
             )},
+        {clientid_prefix, mk(binary(), #{required => false, desc => ?DESC("clientid_prefix")})},
         {reconnect_interval,
             mk_duration(
                 "Reconnect interval. Delay for the MQTT bridge to retry establishing the connection "

--- a/changes/v5.0.13-en.md
+++ b/changes/v5.0.13-en.md
@@ -14,6 +14,8 @@
 
 - Return `204` instead of `200` for `PUT /authenticator/:id` [#9434](https://github.com/emqx/emqx/pull/9434/).
 
+- Added the option to customize the clientid prefix of egress MQTT bridges. [#9609](https://github.com/emqx/emqx/pull/9609)
+
 ## Bug fixes
 
 - Trigger `message.dropped` hook when QoS2 message is resend by client with a same packet id, or 'awaiting_rel' queue is full [#9487](https://github.com/emqx/emqx/pull/9487).

--- a/changes/v5.0.13-zh.md
+++ b/changes/v5.0.13-zh.md
@@ -14,6 +14,8 @@
 
 - 现在，`PUT /authenticator/:id` 将会返回 204 而不再是 200 [#9434](https://github.com/emqx/emqx/pull/9434/)。
 
+- 增加了自定义出口MQTT桥的clientid前缀的选项。[#9609](https://github.com/emqx/emqx/pull/9609)
+
 ## 修复
 
 - 当 QoS2 消息被重发(使用相同 Packet ID)，或当 'awaiting_rel' 队列已满时，触发消息丢弃钩子(`message.dropped`)及计数器 [#9487](https://github.com/emqx/emqx/pull/9487)。


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-8445

Currently the bridge client’s client ID is prefixed with the resource ID.

Sometimes it’s useful for users to have control of this prefix, e.g. prefix based ACL rules in the target broker.