### PR TITLE
fix(ci): bump to jq v0.3.9 with OTP-25 prebuilt binaries

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -233,7 +233,7 @@ jobs:
             elixir: 1.13.4
             release_with: elixir
           - profile: emqx
-            otp: 24.3.4.2-1 # TODO: 25.1.2-2
+            otp: 25.1.2-2
             arch: amd64
             os: amzn2
             build_machine: ubuntu-20.04

--- a/mix.exs
+++ b/mix.exs
@@ -640,7 +640,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.8", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.9", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -42,7 +42,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.16"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.8"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.9"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),


### PR DESCRIPTION
This should heal OTP-25 package builds targeting `amzn2`.

---

[EMQX-8617](https://emqx.atlassian.net/browse/EMQX-8617)