### PR TITLE
ci(cross-packages): fix scheduled build of elixir packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -234,6 +234,7 @@ jobs:
           build_machine: aws-arm64
         include:
           - profile: emqx
+            builder: 5.0-26
             otp: 24.3.4.2-1
             elixir: 1.13.4
             build_elixir: with_elixir
@@ -241,6 +242,7 @@ jobs:
             os: ubuntu20.04
             build_machine: ubuntu-20.04
           - profile: emqx
+            builder: 5.0-26
             otp: 24.3.4.2-1
             elixir: 1.13.4
             build_elixir: with_elixir


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/3792053154/jobs/6447962507

```
Warning: Docker pull failed with exit code 1, back off 7.423 seconds before retry.
  /usr/bin/docker --config /home/runner/work/_temp/.docker_3e093c11-b66a-46be-a2f0-b127d4f98058 pull ghcr.io/emqx/emqx-builder/:1.13.4-24.3.4.2-1-ubuntu20.04
  invalid reference format
  Error: Docker pull failed with exit code 1
```