### PR TITLE
build: drop relup for edge edition

### DIFF
--- a/build
+++ b/build
@@ -182,6 +182,9 @@ make_zip() {
     local target_zip="${pkgpath}/${pkgname}"
     tar zxf "${tarball}" -C "${tard}/emqx"
     has_relup='yes'
+    if [[ "$PROFILE" = *edge* ]]; then
+        has_relup='no'
+    fi
     case "$SYSTEM" in
         windows*)
             # no relup support for windows


### PR DESCRIPTION
* the edge edition is completely dropped in v5
* typically reboot is acceptable for edge brokers
* we do not know how many users are using it
* we never really seriously tested relup for edge edition
* now there is an issue in relup which will fail edge edition not worth the investment to fix