### PR TITLE
fix: bad best fmt json []

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -3,7 +3,7 @@
     {id, "emqx"},
     {description, "EMQX Core"},
     % strict semver, bump manually!
-    {vsn, "5.0.13"},
+    {vsn, "5.0.14"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -221,7 +221,7 @@ best_effort_json_obj(Map, Config) ->
     end.
 
 json([], _) ->
-    "[]";
+    "";
 json(<<"">>, _) ->
     "\"\"";
 json(A, _) when is_atom(A) -> atom_to_binary(A, utf8);
@@ -375,5 +375,20 @@ p_config() ->
             {single_line, proper_types:boolean()}
         ]
     ).
+
+best_effort_json_test() ->
+    ?assertEqual(
+        <<"{}">>,
+        emqx_logger_jsonfmt:best_effort_json([])
+    ),
+    ?assertEqual(
+        <<"{\n    \"key\": []\n}">>,
+        emqx_logger_jsonfmt:best_effort_json(#{key => []})
+    ),
+    ?assertEqual(
+        <<"[\n    {\n        \"key\": []\n    }\n]">>,
+        emqx_logger_jsonfmt:best_effort_json([#{key => []}])
+    ),
+    ok.
 
 -endif.


### PR DESCRIPTION
before:
```
./bin/emqx_ctl cluster status --json
{
    "running_nodes": [
        "emqx1@127.0.0.1"
    ],
    "stopped_nodes": [91,93]
}
```
after:
```
./bin/emqx_ctl cluster status --json
{
    "running_nodes": [
        "emqx1@127.0.0.1"
    ],
    "stopped_nodes": []
}
```