### PR TITLE
 fix(mysql): fix the problem of data loss and bad match when mysql is disconnected

### DIFF
--- a/changes/v5.0.14-en.md
+++ b/changes/v5.0.14-en.md
@@ -10,3 +10,5 @@
 ## Bug Fixes
 
 - Fix an issue where testing the GCP PubSub could leak memory, and an issue where its JWT token would fail to refresh a second time. [#9641](https://github.com/emqx/emqx/pull/9641)
+
+- Fix the problem of data loss and bad match when the MySQL driver is disconnected [#9638](https://github.com/emqx/emqx/pull/9638).

--- a/changes/v5.0.14-zh.md
+++ b/changes/v5.0.14-zh.md
@@ -10,3 +10,5 @@
 ## 修复
 
 - 修复了测试GCP PubSub可能泄露内存的问题，以及其JWT令牌第二次刷新失败的问题。 [#9640](https://github.com/emqx/emqx/pull/9640)
+
+- 修复 MySQL 驱动断开连接时出现的数据丢失和匹配错误的问题 [#9638](https://github.com/emqx/emqx/pull/9638)。

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
@@ -404,9 +404,13 @@ t_write_failure(Config) ->
         emqx_common_test_helpers:with_failure(down, ProxyName, ProxyHost, ProxyPort, fun() ->
             send_message(Config, SentData)
         end),
-        fun(Result, _Trace) ->
-            ?assertMatch({error, {resource_error, _}}, Result),
-            ok
+        fun
+            ({error, {resource_error, _}}, _Trace) ->
+                ok;
+            ({error, {recoverable_error, disconnected}}, _Trace) ->
+                ok;
+            (_, _Trace) ->
+                ?assert(false)
         end
     ),
     ok.


### PR DESCRIPTION
fix [EMQX-8467](https://emqx.atlassian.net/browse/EMQX-8467)
~~1. fix incorrect metrics, including `Matched` `Sent Successfully` `Queuing` `Retried`~~
2. fix data loss issues
~~3. fix the problem that a message will be duplicated `batch size` times in `batch` mode~~
~~4.  simplify some data structure~~