### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+## Default
+* @zmstone @ieQu1 @terry-xiaoyu @qzhuyan @HJianBo @zhongwencool
+
 ## MQTT
 /apps/emqx_connector/src/mqtt/ @qzhuyan
 /apps/emqx/*/*mqtt* @qzhuyan
@@ -37,6 +40,3 @@
 /scripts/ @id
 /build    @id
 /deploy/  @id
-
-## Default
-* @zmstone


### PR DESCRIPTION
- add all members of code review board as default reviewers
- fix the issue of Stone being responsible for all code as [the last matching pattern takes the most precedence](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file).