### PR TITLE
fix(mgmt_api): remove possibility to set clientid in /publish API

### DIFF
--- a/apps/emqx_management/i18n/emqx_mgmt_api_publish_i18n.conf
+++ b/apps/emqx_management/i18n/emqx_mgmt_api_publish_i18n.conf
@@ -63,12 +63,6 @@ result of each individual message in the batch.
             zh: "MQTT 消息的 QoS"
         }
     }
-    clientid {
-        desc {
-            en: "Each message can be published as if it is done on behalf of an MQTT client whos ID can be specified in this field."
-            zh: "每个消息都可以带上一个 MQTT 客户端 ID，用于模拟 MQTT 客户端的发布行为。"
-        }
-    }
     payload {
         desc {
             en: "The MQTT message payload."

--- a/apps/emqx_management/src/emqx_mgmt_api_publish.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_publish.erl
@@ -102,6 +102,10 @@ fields(message) ->
                 required => false,
                 default => 0
             })},
+        {clientid,
+            hoconsc:mk(binary(), #{
+                deprecated => {since, "v5.0.14"}
+            })},
         {payload,
             hoconsc:mk(binary(), #{
                 desc => ?DESC(payload),

--- a/changes/v5.0.14/fix-9667.en.md
+++ b/changes/v5.0.14/fix-9667.en.md
@@ -1,0 +1,1 @@
+Remove possibility to set `clientid` for `/publish` and `/publish/bulk` HTTP APIs. This is to reduce the risk for security confusion.

--- a/changes/v5.0.14/fix-9667.zh.md
+++ b/changes/v5.0.14/fix-9667.zh.md
@@ -1,0 +1,1 @@
+从 HTTP API /publish 和 /publish/bulk 中移除 clientid, 降低安全风险


### PR DESCRIPTION
To avoid security confusion, we remove the possibility to specify the client ID in the request body for `/publish` and `/publish/bulk`.

Fixes EMQX-8385.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [X] Change log has been added to `changes/` dir
- [X] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible
