### PR TITLE
chore: bump deps versions with full OTP-25 compat

### DIFF
--- a/apps/emqx_connector/rebar.config
+++ b/apps/emqx_connector/rebar.config
@@ -14,7 +14,7 @@
     %% NOTE: mind poolboy version when updating mongodb-erlang version
     {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.13"}}},
     %% NOTE: mind poolboy version when updating eredis_cluster version
-    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.7.1"}}},
+    {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.7.5"}}},
     %% mongodb-erlang uses a special fork https://github.com/comtihon/poolboy.git
     %% (which has overflow_ttl feature added).
     %% However, it references `{branch, "master}` (commit 9c06a9a on 2021-04-07).

--- a/changes/v5.0.14/feat-9675.en.md
+++ b/changes/v5.0.14/feat-9675.en.md
@@ -1,0 +1,2 @@
+HTTP client library `ehttpc` upgraded from `0.4.2` to `0.4.3`.
+Library `eredis_cluster` which manages clients to redis clusters upgraded from `0.7.1` to `0.7.5`.

--- a/changes/v5.0.14/feat-9675.zh.md
+++ b/changes/v5.0.14/feat-9675.zh.md
@@ -1,0 +1,2 @@
+HTTP 客户端库 `ehttpc` 从 `0.4.2` 升级到 `0.4.3`
+Redis cluster 客户端库 `eredis_cluster` 从 `0.7.1` 升级到 `0.7.5`.

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule EMQXUmbrella.MixProject do
       {:lc, github: "emqx/lc", tag: "0.3.2", override: true},
       {:redbug, "2.0.8"},
       {:typerefl, github: "ieQu1/typerefl", tag: "0.9.1", override: true},
-      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.2", override: true},
+      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.3", override: true},
       {:gproc, github: "uwiger/gproc", tag: "0.8.0", override: true},
       {:jiffy, github: "emqx/jiffy", tag: "1.0.5", override: true},
       {:cowboy, github: "emqx/cowboy", tag: "2.9.0", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -49,7 +49,7 @@
     , {gpb, "4.19.5"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
     , {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}}
     , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.9"}}}
-    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.2"}}}
+    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.3"}}}
     , {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}


### PR DESCRIPTION
* https://github.com/emqx/ehttpc/compare/0.4.2...0.4.3
* https://github.com/emqx/eredis_cluster/compare/0.7.1...0.7.5
* https://github.com/emqx/eredis/compare/1.2.6...1.2.10 (transient)

Everything looks safe to upgrade except for [the missing `reconnect_loop/2` in `eredis`](https://github.com/emqx/eredis/compare/1.2.6...1.2.10#diff-4b609475abd2a5723f7d745ffa7048ae246ce6e385622aab08d328ff021aab3aL475) where some processes might be spinning during an upgrade (admittedly that's highly unlikely because it implies unstable redis cluster during an upgrade).

---

[EMQX-8562](https://emqx.atlassian.net/browse/EMQX-8562)