### PR TITLE
feat: upgrade MongoDB library to support MongoDB 5.1+

### DIFF
--- a/apps/emqx_connector/rebar.config
+++ b/apps/emqx_connector/rebar.config
@@ -12,7 +12,7 @@
     {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.1"}}},
     {epgsql, {git, "https://github.com/emqx/epgsql", {tag, "4.7-emqx.2"}}},
     %% NOTE: mind poolboy version when updating mongodb-erlang version
-    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.13"}}},
+    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.18"}}},
     %% NOTE: mind poolboy version when updating eredis_cluster version
     {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.7.1"}}},
     %% mongodb-erlang uses a special fork https://github.com/comtihon/poolboy.git

--- a/changes/v5.0.14/feat-8329.en.md
+++ b/changes/v5.0.14/feat-8329.en.md
@@ -1,0 +1,1 @@
+The MongoDB library has been upgraded to support MongoDB 5.1+

--- a/changes/v5.0.14/feat-8329.zh.md
+++ b/changes/v5.0.14/feat-8329.zh.md
@@ -1,0 +1,1 @@
+MongoDB 的驱动现在已经升级到 MongoDB 5.1+ 了。


### PR DESCRIPTION
Question: Since the enterprise branch has other apps that depends on MongoDB, I guess the enterprise branch has to be updated as well, right?