### PR TITLE
fix: update dashboard password validator

### DIFF
--- a/changes/v4.4.14-en.md
+++ b/changes/v4.4.14-en.md
@@ -1,11 +1,11 @@
 # v4.4.14
 
 ## Enhancements
-- Add a password complexity requirement when adding or modifying Dashboard users via the API. Now passwords must contain at least 2 of alphabetic, numeric and special characters, and must be 8 to 64 characters long [#1696](https://github.com/emqx/emqx-enterprise/pull/1696).
+- Add a password complexity requirement when adding or modifying Dashboard users via the API. Now passwords must contain at least 2 of alphabetic, numeric and special characters, and must be 8 to 64 characters long [#9696](https://github.com/emqx/emqx/pull/9696).
 
 ## Bug fixes
 
-- Fix dashboard password validator is too simple. Now dashboard password must contain at least two different kind of characters from groups of letters, numbers and special characters. [#1696](https://github.com/emqx/emqx-enterprise/pull/1696).
-- Fix the problem that adding or importing Dashboard users via the API fails to add complex passwords due to incorrect checksum of the passwords [#1696](https://github.com/emqx/emqx-enterprise/pull/1696).
+- Fix dashboard password validator is too simple. Now dashboard password must contain at least two different kind of characters from groups of letters, numbers and special characters. [#9696](https://github.com/emqx/emqx/pull/9696).
+- Fix the problem that adding or importing Dashboard users via the API fails to add complex passwords due to incorrect checksum of the passwords [#9692](https://github.com/emqx/emqx/pull/9692).
 
-- Fix load bootstrap_app_file's apps is not sync when reboot. [#1697](https://github.com/emqx/emqx-enterprise/pull/1697).
+- Fix load bootstrap_app_file's apps is not sync when reboot. [#9692](https://github.com/emqx/emqx/pull/9692).

--- a/changes/v4.4.14-zh.md
+++ b/changes/v4.4.14-zh.md
@@ -2,10 +2,10 @@
 
 ## 增强
 
-- 通过 API 添加、修改 Dashboard 用户时，增加对密码复杂度的要求。现在密码必须包含字母、数字以及特殊字符中的至少 2 种，并且长度范围必须是 8~64 个字符 [#1696](https://github.com/emqx/emqx-enterprise/pull/1696)。
+- 通过 API 添加、修改 Dashboard 用户时，增加对密码复杂度的要求。现在密码必须包含字母、数字以及特殊字符中的至少 2 种，并且长度范围必须是 8~64 个字符 [#9696](https://github.com/emqx/emqx/pull/9696)。
 
 ## 修复
 
-- 修复通过 API 添加或者导入 Dashboard 用户时，对密码进行了错误的校验，导致复杂密码添加失败的问题 [#1696](https://github.com/emqx/emqx-enterprise/pull/1696)。
+- 修复通过 API 添加或者导入 Dashboard 用户时，对密码进行了错误的校验，导致复杂密码添加失败的问题 [#9696](https://github.com/emqx/emqx/pull/9696)。
 
-- 修复 boostrap_apps_file 文件更新后没有同步更新至数据库导致文件中新加 apps 未生效 [#1697](https://github.com/emqx/emqx-enterprise/pull/1697)。
+- 修复 boostrap_apps_file 文件更新后未同步至数据库，导致变更的 apps 无法生效 [#9692](https://github.com/emqx/emqx/pull/9692)。

--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -13,7 +13,7 @@ case "${PKG_VSN}" in
         ;;
     4.4*)
         # keep the above 4.3 untouched, otherwise conflicts!
-        EMQX_CE_DASHBOARD_VERSION='v4.4.7'
+        EMQX_CE_DASHBOARD_VERSION='v4.4.8'
         EMQX_EE_DASHBOARD_VERSION='v4.4.18'
         ;;
     *)


### PR DESCRIPTION
Fix dashboard password validator is too simple. Now dashboard password must contain at least two different kind of characters from groups of letters, numbers and special characters.