### PR TITLE
fix: missing default value for qos field of API /clients/:clientid/subscribe

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -549,7 +549,7 @@ fields(keepalive) ->
     ];
 fields(subscribe) ->
     [
-        {topic, hoconsc:mk(binary(), #{desc => <<"Topic">>})},
+        {topic, hoconsc:mk(binary(), #{required => true, desc => <<"Topic">>})},
         {qos, hoconsc:mk(emqx_schema:qos(), #{default => 0, desc => <<"QoS">>})},
         {nl, hoconsc:mk(integer(), #{default => 0, desc => <<"No Local">>})},
         {rap, hoconsc:mk(integer(), #{default => 0, desc => <<"Retain as Published">>})},

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -550,7 +550,7 @@ fields(keepalive) ->
 fields(subscribe) ->
     [
         {topic, hoconsc:mk(binary(), #{desc => <<"Topic">>})},
-        {qos, hoconsc:mk(emqx_schema:qos(), #{desc => <<"QoS">>})},
+        {qos, hoconsc:mk(emqx_schema:qos(), #{default => 0, desc => <<"QoS">>})},
         {nl, hoconsc:mk(integer(), #{default => 0, desc => <<"No Local">>})},
         {rap, hoconsc:mk(integer(), #{default => 0, desc => <<"Retain as Published">>})},
         {rh, hoconsc:mk(integer(), #{default => 0, desc => <<"Retain Handling">>})}

--- a/changes/v5.0.14/fix-9703.en.md
+++ b/changes/v5.0.14/fix-9703.en.md
@@ -1,0 +1,3 @@
+Set the default value of the `qos` field of the HTTP API `/clients/:clientid/subscribe` to 0.
+Before this fix, the `qos` field have no default value, which leads to a `function_clause` error
+when querying this API.

--- a/changes/v5.0.14/fix-9703.zh.md
+++ b/changes/v5.0.14/fix-9703.zh.md
@@ -1,0 +1,2 @@
+将 HTTP 接口 `/clients/:clientid/subscribe` 的 `qos` 字段的默认值设置为 0。
+在此修复之前，`qos` 字段没有默认值，调用订阅接口的时候将导致 `function_clause` 错误。


### PR DESCRIPTION
Set the default value of qos to 0, which is the default value of the API `/mqtt/subscribe` and `/mqtt/subscribe_batch` in emqx 4.x.