### PR TITLE
fix: remove the default value of webhook body field

### DIFF
--- a/apps/emqx_bridge/i18n/emqx_bridge_webhook_schema.conf
+++ b/apps/emqx_bridge/i18n/emqx_bridge_webhook_schema.conf
@@ -93,11 +93,20 @@ HTTP 请求的标头。<br/>
                    desc {
                          en: """
 The body of the HTTP request.<br/>
+If not provided, the body will be a JSON object of all the available fields.<br/>
+There, 'all the available fields' means the context of a MQTT message when
+this webhook is triggered by receiving a MQTT message (the `local_topic` is set),
+or the context of the event when this webhook is triggered by a rule (i.e. this
+webhook is used as an action of a rule).<br/>
 Template with variables is allowed.
 """
                          zh: """
 HTTP 请求的正文。<br/>
-允许使用带有变量的模板。"""
+如果没有设置该字段，请求正文将是包含所有可用字段的 JSON object。<br/>
+如果该 webhook 是由于收到 MQTT 消息触发的，'所有可用字段' 将是 MQTT 消息的
+上下文信息；如果该 webhook 是由于规则触发的，'所有可用字段' 则为触发事件的上下文信息。<br/>
+允许使用带有变量的模板。
+"""
                         }
                    label: {
                            en: "HTTP Body"

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -274,7 +274,6 @@ parse_confs(
     #{
         url := Url,
         method := Method,
-        body := Body,
         headers := Headers,
         request_timeout := ReqTimeout,
         max_retries := Retry
@@ -288,7 +287,7 @@ parse_confs(
             #{
                 path => Path,
                 method => Method,
-                body => Body,
+                body => maps:get(body, Conf, undefined),
                 headers => Headers,
                 request_timeout => ReqTimeout,
                 max_retries => Retry

--- a/apps/emqx_bridge/src/schema/emqx_bridge_webhook_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_webhook_schema.erl
@@ -115,7 +115,7 @@ request_config() ->
             mk(
                 binary(),
                 #{
-                    default => <<"${payload}">>,
+                    default => undefined,
                     desc => ?DESC("config_body")
                 }
             )},

--- a/apps/emqx_connector/src/emqx_connector_http.erl
+++ b/apps/emqx_connector/src/emqx_connector_http.erl
@@ -431,14 +431,13 @@ preprocess_request(
     #{
         method := Method,
         path := Path,
-        body := Body,
         headers := Headers
     } = Req
 ) ->
     #{
         method => emqx_plugin_libs_rule:preproc_tmpl(bin(Method)),
         path => emqx_plugin_libs_rule:preproc_tmpl(Path),
-        body => emqx_plugin_libs_rule:preproc_tmpl(Body),
+        body => maybe_preproc_tmpl(body, Req),
         headers => preproc_headers(Headers),
         request_timeout => maps:get(request_timeout, Req, 30000),
         max_retries => maps:get(max_retries, Req, 2)
@@ -469,6 +468,12 @@ preproc_headers(Headers) when is_list(Headers) ->
         Headers
     ).
 
+maybe_preproc_tmpl(Key, Conf) ->
+    case maps:get(Key, Conf, undefined) of
+        undefined -> undefined;
+        Val -> emqx_plugin_libs_rule:preproc_tmpl(Val)
+    end.
+
 process_request(
     #{
         method := MethodTks,
@@ -487,7 +492,7 @@ process_request(
         request_timeout => ReqTimeout
     }.
 
-process_request_body([], Msg) ->
+process_request_body(undefined, Msg) ->
     emqx_json:encode(Msg);
 process_request_body(BodyTks, Msg) ->
     emqx_plugin_libs_rule:proc_tmpl(BodyTks, Msg).

--- a/changes/v5.0.14/fix-9705.en.md
+++ b/changes/v5.0.14/fix-9705.en.md
@@ -1,0 +1,8 @@
+Remove the default value of Webhook.
+Before this repair, the default value of the `body` field of Webhook is `${payload}`,
+but there is no `payload` field in the available fields of other events except message
+publishing in the rule, so in this case, the webhook will send a string with the
+message body as "undefined" to the HTTP service.
+This fix removes the default value of the `body` field. When the `body` field is
+not configured, Webhook will send all available fields of the current event in
+the format of JSON object.

--- a/changes/v5.0.14/fix-9705.zh.md
+++ b/changes/v5.0.14/fix-9705.zh.md
@@ -1,0 +1,5 @@
+删除 Webhook 的默认值。
+在此修复之前，Webhook 的 `body` 字段的默认值为 `${payload}`，但规则中除了消息发布之外的其他事件的可用字段中
+都没有 `payload` 字段，所以这种情况下 Webhook 将发送消息正文为 "undefined" 的字符串到 HTTP 服务。
+此修复移除了 `body` 字段的默认值，当未配置 `body` 字段的时候，Webhook 将以 JSON object 的格式发送
+当前事件的全部可用字段。


### PR DESCRIPTION
- if the default value is set to "", then we send "" as the http body.
- if the default value is not set, then we send all the available fields as the http body.