### PR TITLE
chore: upgrade mongodb-erlang to v3.0.19

### DIFF
--- a/apps/emqx_connector/rebar.config
+++ b/apps/emqx_connector/rebar.config
@@ -12,7 +12,7 @@
     {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.1"}}},
     {epgsql, {git, "https://github.com/emqx/epgsql", {tag, "4.7-emqx.2"}}},
     %% NOTE: mind poolboy version when updating mongodb-erlang version
-    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.18"}}},
+    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.19"}}},
     %% NOTE: mind poolboy version when updating eredis_cluster version
     {eredis_cluster, {git, "https://github.com/emqx/eredis_cluster", {tag, "0.7.5"}}},
     %% mongodb-erlang uses a special fork https://github.com/comtihon/poolboy.git


### PR DESCRIPTION
This upgrades mongodb-erlang from v3.0.18 to v3.0.19. This fixes a bug that occurred when one issued a command specified as a map*. This fix should not affect present EMQX as this functionality is currently not used by EMQX. However, I think it is good to do the upgrade anyway in case we will use the fixed functionality in the future. There is no need to update the changelog.

* https://github.com/emqx/mongodb-erlang/pull/36