### PR TITLE
fix: bulk subscribe topics failed in the client.connected hook

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -718,15 +718,18 @@ subscribe(#{clientid := ClientID, topic := Topic} = Sub) ->
     end.
 
 subscribe_batch(#{clientid := ClientID, topics := Topics}) ->
-    case lookup(#{clientid => ClientID}) of
-        {200, _} ->
+    %% We use emqx_channel instead of emqx_channel_info (used by the emqx_mgmt:lookup_client/2),
+    %% as the emqx_channel_info table will only be populated after the hook `client.connected`
+    %% has returned. So if one want to subscribe topics in this hook, it will fail.
+    case ets:lookup(emqx_channel, ClientID) of
+        [] ->
+            {404, ?CLIENT_ID_NOT_FOUND};
+        _ ->
             ArgList = [
                 [ClientID, Topic, maps:with([qos, nl, rap, rh], Sub)]
              || #{topic := Topic} = Sub <- Topics
             ],
-            {200, emqx_mgmt_util:batch_operation(?MODULE, do_subscribe, ArgList)};
-        {404, ?CLIENT_ID_NOT_FOUND} ->
-            {404, ?CLIENT_ID_NOT_FOUND}
+            {200, emqx_mgmt_util:batch_operation(?MODULE, do_subscribe, ArgList)}
     end.
 
 unsubscribe(#{clientid := ClientID, topic := Topic}) ->

--- a/changes/v5.0.14/fix-9712.en.md
+++ b/changes/v5.0.14/fix-9712.en.md
@@ -1,0 +1,2 @@
+Fixed the problem of '404 Not Found' when calling the HTTP API '/clients/:clientid/subscribe/bulk'
+from the plug-ins and data-bridges on handling the 'client.connected' event.

--- a/changes/v5.0.14/fix-9712.zh.md
+++ b/changes/v5.0.14/fix-9712.zh.md
@@ -1,0 +1,2 @@
+修复了监听 `client.connected` 事件的插件和数据桥接在调用 `/clients/:clientid/subscribe/bulk`
+HTTP 接口时报 `404 Not Found` 的问题。


### PR DESCRIPTION
When bulk subscribing topics using HTTP API (`/clients/:clientid/subscribe/bulk`) in the `client.connected` hook (e.g. in an webhook action listen on the `client.connected` event), the subscription will fail because the `emqx_channel_info` has not yet populated with the clientid.

But the HTTP API subscribing a single topic (`/clients/:clientid/subscribe`) works.