### PR TITLE
fix: bad auto_subscribe api schema

### DIFF
--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auto_subscribe, [
-    {description, "An OTP application"},
-    {vsn, "0.1.2"},
+    {description, "Auto subscribe Application"},
+    {vsn, "0.1.3"},
     {registered, []},
     {mod, {emqx_auto_subscribe_app, []}},
     {applications, [

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.erl
@@ -51,8 +51,21 @@ max_limit() ->
 list() ->
     format(emqx_conf:get([auto_subscribe, topics], [])).
 
-update(Topics) ->
-    update_(Topics).
+update(Topics) when length(Topics) =< ?MAX_AUTO_SUBSCRIBE ->
+    case
+        emqx_conf:update(
+            [auto_subscribe, topics],
+            Topics,
+            #{rawconf_with_defaults => true, override_to => cluster}
+        )
+    of
+        {ok, #{raw_config := NewTopics}} ->
+            {ok, NewTopics};
+        {error, Reason} ->
+            {error, Reason}
+    end;
+update(_Topics) ->
+    {error, quota_exceeded}.
 
 post_config_update(_KeyPath, _Req, NewTopics, _OldConf, _AppEnvs) ->
     Config = emqx_conf:get([auto_subscribe], #{}),
@@ -94,22 +107,6 @@ format(Rule = #{topic := Topic}) when is_map(Rule) ->
         rap => maps:get(rap, Rule, 0),
         nl => maps:get(nl, Rule, 0)
     }.
-
-update_(Topics) when length(Topics) =< ?MAX_AUTO_SUBSCRIBE ->
-    case
-        emqx_conf:update(
-            [auto_subscribe, topics],
-            Topics,
-            #{rawconf_with_defaults => true, override_to => cluster}
-        )
-    of
-        {ok, #{raw_config := NewTopics}} ->
-            {ok, NewTopics};
-        {error, Reason} ->
-            {error, Reason}
-    end;
-update_(_Topics) ->
-    {error, quota_exceeded}.
 
 update_hook() ->
     update_hook(emqx_conf:get([auto_subscribe], #{})).

--- a/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
+++ b/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
@@ -151,6 +151,32 @@ t_update(_) ->
     ResponseMap = emqx_json:decode(Response, [return_maps]),
     ?assertEqual(1, erlang:length(ResponseMap)),
 
+    BadBody1 = #{topic => ?TOPIC_S},
+    ?assertMatch(
+        {error, {"HTTP/1.1", 400, "Bad Request"}},
+        emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, BadBody1)
+    ),
+    BadBody2 = [#{topic => ?TOPIC_S, qos => 3}],
+    ?assertMatch(
+        {error, {"HTTP/1.1", 400, "Bad Request"}},
+        emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, BadBody2)
+    ),
+    BadBody3 = [#{topic => ?TOPIC_S, rh => 10}],
+    ?assertMatch(
+        {error, {"HTTP/1.1", 400, "Bad Request"}},
+        emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, BadBody3)
+    ),
+    BadBody4 = [#{topic => ?TOPIC_S, rap => -1}],
+    ?assertMatch(
+        {error, {"HTTP/1.1", 400, "Bad Request"}},
+        emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, BadBody4)
+    ),
+    BadBody5 = [#{topic => ?TOPIC_S, nl => -1}],
+    ?assertMatch(
+        {error, {"HTTP/1.1", 400, "Bad Request"}},
+        emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, BadBody5)
+    ),
+
     {ok, Client} = emqtt:start_link(#{username => ?CLIENT_USERNAME, clientid => ?CLIENT_ID}),
     {ok, _} = emqtt:connect(Client),
     timer:sleep(100),

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -705,7 +705,7 @@ typename_to_spec("service_account_json()", _Mod) ->
 typename_to_spec("#{" ++ _, Mod) ->
     typename_to_spec("map()", Mod);
 typename_to_spec("qos()", _Mod) ->
-    #{type => string, enum => [0, 1, 2]};
+    #{type => integer, minimum => 0, maximum => 2, example => 0};
 typename_to_spec("{binary(), binary()}", _Mod) ->
     #{type => object, example => #{}};
 typename_to_spec("comma_separated_list()", _Mod) ->

--- a/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
@@ -112,7 +112,7 @@ t_in_query(_Config) ->
                 description => <<"QOS">>,
                 in => query,
                 name => qos,
-                schema => #{enum => [0, 1, 2], type => string}
+                schema => #{minimum => 0, maximum => 2, type => integer, example => 0}
             }
         ],
     validate("/test/in/query", Expect),

--- a/changes/v5.0.14/fix-9714.en.md
+++ b/changes/v5.0.14/fix-9714.en.md
@@ -1,0 +1,1 @@
+Fix `/mqtt/auto_subscribe` API's bad swagger schema, and make sure swagger always checks if the schema is correct.

--- a/changes/v5.0.14/fix-9714.zh.md
+++ b/changes/v5.0.14/fix-9714.zh.md
@@ -1,0 +1,1 @@
+修复 `/mqtt/auto_subscribe` API 错误的 swagger 格式，并且保证 swagger 总是检查格式是否正确。


### PR DESCRIPTION
Fix: `/mqtt/auto_subscribe` API
1.  Bad swagger schema format. 
2. We should always check schema in swagger with `#{check_schema => true}`.
3. QoS is an integer (not a string).
Before:
![image](https://user-images.githubusercontent.com/3116225/211570014-b96ce8d7-ec79-416a-a2b0-7f0b5fdae194.png)
After:
<img width="1094" alt="image" src="https://user-images.githubusercontent.com/3116225/211571433-093b1dc4-5a85-4da1-9c97-15072cc2f920.png">
