### PR TITLE
0108 refactor authn schema union member selector

### DIFF
--- a/apps/emqx/src/emqx_authentication.erl
+++ b/apps/emqx/src/emqx_authentication.erl
@@ -759,9 +759,10 @@ maybe_unhook(State) ->
     State.
 
 do_create_authenticator(AuthenticatorID, #{enable := Enable} = Config, Providers) ->
-    case maps:get(authn_type(Config), Providers, undefined) of
+    Type = authn_type(Config),
+    case maps:get(Type, Providers, undefined) of
         undefined ->
-            {error, no_available_provider};
+            {error, {no_available_provider_for, Type}};
         Provider ->
             case Provider:create(AuthenticatorID, Config) of
                 {ok, State} ->

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -366,13 +366,6 @@ schema_default(Schema) ->
     case hocon_schema:field_schema(Schema, type) of
         ?ARRAY(_) ->
             [];
-        ?LAZY(?ARRAY(_)) ->
-            [];
-        ?LAZY(?UNION(Members)) ->
-            case [A || ?ARRAY(A) <- hoconsc:union_members(Members)] of
-                [_ | _] -> [];
-                _ -> #{}
-            end;
         _ ->
             #{}
     end.
@@ -407,8 +400,7 @@ merge_envs(SchemaMod, RawConf) ->
     Opts = #{
         required => false,
         format => map,
-        apply_override_envs => true,
-        check_lazy => true
+        apply_override_envs => true
     },
     hocon_tconf:merge_env_overrides(SchemaMod, RawConf, all, Opts).
 
@@ -451,9 +443,7 @@ compact_errors(Schema, Errors) ->
 do_check_config(SchemaMod, RawConf, Opts0) ->
     Opts1 = #{
         return_plain => true,
-        format => map,
-        %% Don't check lazy types, such as authenticate
-        check_lazy => false
+        format => map
     },
     Opts = maps:merge(Opts0, Opts1),
     {AppEnvs, CheckedConf} =

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -413,8 +413,8 @@ check_config(SchemaMod, RawConf, Opts0) ->
     try
         do_check_config(SchemaMod, RawConf, Opts0)
     catch
-        throw:{Schema, Errors} ->
-            compact_errors(Schema, Errors)
+        throw:Errors:Stacktrace ->
+            throw(emqx_hocon:compact_errors(Errors, Stacktrace))
     end.
 
 %% HOCON tries to be very informative about all the detailed errors
@@ -425,8 +425,8 @@ compact_errors(Schema, [Error0 | More]) when is_map(Error0) ->
         case length(More) of
             0 ->
                 Error0;
-            _ ->
-                Error0#{unshown_errors => length(More)}
+            N ->
+                Error0#{unshown_errors => N}
         end,
     Error =
         case is_atom(Schema) of

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -414,31 +414,9 @@ check_config(SchemaMod, RawConf, Opts0) ->
         do_check_config(SchemaMod, RawConf, Opts0)
     catch
         throw:Errors:Stacktrace ->
-            throw(emqx_hocon:compact_errors(Errors, Stacktrace))
+            {error, Reason} = emqx_hocon:compact_errors(Errors, Stacktrace),
+            erlang:raise(throw, Reason, Stacktrace)
     end.
-
-%% HOCON tries to be very informative about all the detailed errors
-%% it's maybe too much when reporting to the user
--spec compact_errors(any(), any()) -> no_return().
-compact_errors(Schema, [Error0 | More]) when is_map(Error0) ->
-    Error1 =
-        case length(More) of
-            0 ->
-                Error0;
-            N ->
-                Error0#{unshown_errors => N}
-        end,
-    Error =
-        case is_atom(Schema) of
-            true ->
-                Error1#{schema_module => Schema};
-            false ->
-                Error1
-        end,
-    throw(Error);
-compact_errors(Schema, Errors) ->
-    %% unexpected, we need the stacktrace reported, hence error
-    error({Schema, Errors}).
 
 do_check_config(SchemaMod, RawConf, Opts0) ->
     Opts1 = #{

--- a/apps/emqx/src/emqx_hocon.erl
+++ b/apps/emqx/src/emqx_hocon.erl
@@ -20,6 +20,7 @@
 -export([
     format_path/1,
     check/2,
+    check/3,
     compact_errors/2,
     format_error/1,
     format_error/2,
@@ -37,20 +38,23 @@ format_path([Name | Rest]) -> [iol(Name), "." | format_path(Rest)].
 %% Always return plain map with atom keys.
 -spec check(module(), hocon:config() | iodata()) ->
     {ok, hocon:config()} | {error, any()}.
-check(SchemaModule, Conf) when is_map(Conf) ->
+check(SchemaModule, Conf) ->
     %% TODO: remove required
     %% fields should state required or not in their schema
     Opts = #{atom_key => true, required => false},
+    check(SchemaModule, Conf, Opts).
+
+check(SchemaModule, Conf, Opts) when is_map(Conf) ->
     try
         {ok, hocon_tconf:check_plain(SchemaModule, Conf, Opts)}
     catch
         throw:Errors:Stacktrace ->
             compact_errors(Errors, Stacktrace)
     end;
-check(SchemaModule, HoconText) ->
+check(SchemaModule, HoconText, Opts) ->
     case hocon:binary(HoconText, #{format => map}) of
         {ok, MapConfig} ->
-            check(SchemaModule, MapConfig);
+            check(SchemaModule, MapConfig, Opts);
         {error, Reason} ->
             {error, Reason}
     end.

--- a/apps/emqx/src/emqx_hocon.erl
+++ b/apps/emqx/src/emqx_hocon.erl
@@ -119,8 +119,8 @@ compact_errors(SchemaModule, [Error0 | More], _Stacktrace) when is_map(Error0) -
         end,
     {error, Error};
 compact_errors(SchemaModule, Error, Stacktrace) ->
-    %% unexpected, we need the stacktrace reported, hence error
-    %% if this happens i'ts a bug in hocon_tconf
+    %% unexpected, we need the stacktrace reported
+    %% if this happens it's a bug in hocon_tconf
     {error, #{
         schema_module => SchemaModule,
         exception => Error,

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2363,7 +2363,12 @@ authentication(Which) ->
             Module ->
                 Module:root_type()
         end,
-    hoconsc:mk(Type, #{desc => Desc}).
+    hoconsc:mk(Type, #{desc => Desc, converter => fun ensure_array/1}).
+
+%% the older version schema allows individual element (instead of a chain) in config
+ensure_array(undefined) -> undefined;
+ensure_array(L) when is_list(L) -> L;
+ensure_array(M) when is_map(M) -> [M].
 
 -spec qos() -> typerefl:type().
 qos() ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2352,25 +2352,18 @@ authentication(Which) ->
             global -> ?DESC(global_authentication);
             listener -> ?DESC(listener_authentication)
         end,
-    %% The runtime module injection
-    %% from EMQX_AUTHENTICATION_SCHEMA_MODULE_PT_KEY
-    %% is for now only affecting document generation.
-    %% maybe in the future, we can find a more straightforward way to support
-    %% * document generation (at compile time)
-    %% * type checks before boot (in bin/emqx config generation)
-    %% * type checks at runtime (when changing configs via management API)
-    Type0 =
+    %% poor man's dependency injection
+    %% this is due to the fact that authn is implemented outside of 'emqx' app.
+    %% so it can not be a part of emqx_schema since 'emqx' app is supposed to
+    %% work standalone.
+    Type =
         case persistent_term:get(?EMQX_AUTHENTICATION_SCHEMA_MODULE_PT_KEY, undefined) of
-            undefined -> hoconsc:array(typerefl:map());
-            Module -> Module:root_type()
+            undefined ->
+                hoconsc:array(typerefl:map());
+            Module ->
+                Module:root_type()
         end,
-    %% It is a lazy type because when handling runtime update requests
-    %% the config is not checked by emqx_schema, but by the injected schema
-    Type = hoconsc:lazy(Type0),
-    #{
-        type => Type,
-        desc => Desc
-    }.
+    hoconsc:mk(Type, #{desc => Desc}).
 
 -spec qos() -> typerefl:type().
 qos() ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2363,12 +2363,12 @@ authentication(Which) ->
             Module ->
                 Module:root_type()
         end,
-    hoconsc:mk(Type, #{desc => Desc, converter => fun ensure_array/1}).
+    hoconsc:mk(Type, #{desc => Desc, converter => fun ensure_array/2}).
 
 %% the older version schema allows individual element (instead of a chain) in config
-ensure_array(undefined) -> undefined;
-ensure_array(L) when is_list(L) -> L;
-ensure_array(M) when is_map(M) -> [M].
+ensure_array(undefined, _) -> undefined;
+ensure_array(L, _) when is_list(L) -> L;
+ensure_array(M, _) -> [M].
 
 -spec qos() -> typerefl:type().
 qos() ->

--- a/apps/emqx/test/emqx_authentication_SUITE.erl
+++ b/apps/emqx/test/emqx_authentication_SUITE.erl
@@ -53,48 +53,8 @@
 ).
 
 %%------------------------------------------------------------------------------
-%% Hocon Schema
-%%------------------------------------------------------------------------------
-
-roots() ->
-    [
-        {config, #{
-            type => hoconsc:union([
-                hoconsc:ref(?MODULE, type1),
-                hoconsc:ref(?MODULE, type2)
-            ])
-        }}
-    ].
-
-fields(type1) ->
-    [
-        {mechanism, {enum, [password_based]}},
-        {backend, {enum, [built_in_database]}},
-        {enable, fun enable/1}
-    ];
-fields(type2) ->
-    [
-        {mechanism, {enum, [password_based]}},
-        {backend, {enum, [mysql]}},
-        {enable, fun enable/1}
-    ].
-
-enable(type) -> boolean();
-enable(default) -> true;
-enable(_) -> undefined.
-
-%%------------------------------------------------------------------------------
 %% Callbacks
 %%------------------------------------------------------------------------------
-
-check_config(C) ->
-    #{config := R} =
-        hocon_tconf:check_plain(
-            ?MODULE,
-            #{<<"config">> => C},
-            #{atom_key => true}
-        ),
-    R.
 
 create(_AuthenticatorID, _Config) ->
     {ok, #{mark => 1}}.
@@ -200,7 +160,7 @@ t_authenticator(Config) when is_list(Config) ->
     % Create an authenticator when the provider does not exist
 
     ?assertEqual(
-        {error, no_available_provider},
+        {error, {no_available_provider_for, {password_based, built_in_database}}},
         ?AUTHN:create_authenticator(ChainName, AuthenticatorConfig1)
     ),
 
@@ -335,14 +295,14 @@ t_update_config(Config) when is_list(Config) ->
     ok = register_provider(?config("auth2"), ?MODULE),
     Global = ?config(global),
     AuthenticatorConfig1 = #{
-        <<"mechanism">> => <<"password_based">>,
-        <<"backend">> => <<"built_in_database">>,
-        <<"enable">> => true
+        mechanism => password_based,
+        backend => built_in_database,
+        enable => true
     },
     AuthenticatorConfig2 = #{
-        <<"mechanism">> => <<"password_based">>,
-        <<"backend">> => <<"mysql">>,
-        <<"enable">> => true
+        mechanism => password_based,
+        backend => mysql,
+        enable => true
     },
     ID1 = <<"password_based:built_in_database">>,
     ID2 = <<"password_based:mysql">>,

--- a/apps/emqx_authn/src/emqx_authn.app.src
+++ b/apps/emqx_authn/src/emqx_authn.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authn, [
     {description, "EMQX Authentication"},
-    {vsn, "0.1.12"},
+    {vsn, "0.1.13"},
     {modules, []},
     {registered, [emqx_authn_sup, emqx_authn_registry]},
     {applications, [kernel, stdlib, emqx_resource, emqx_connector, ehttpc, epgsql, mysql, jose]},

--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -20,7 +20,6 @@
     providers/0,
     check_config/1,
     check_config/2,
-    check_configs/1,
     %% for telemetry information
     get_enabled_authns/0
 ]).
@@ -38,16 +37,6 @@ providers() ->
         {jwt, emqx_authn_jwt},
         {{scram, built_in_database}, emqx_enhanced_authn_scram_mnesia}
     ].
-
-check_configs(CM) when is_map(CM) ->
-    check_configs([CM]);
-check_configs(CL) ->
-    check_configs(CL, 1).
-
-check_configs([], _Nth) ->
-    [];
-check_configs([Config | Configs], Nth) ->
-    [check_config(Config, #{id_for_log => Nth}) | check_configs(Configs, Nth + 1)].
 
 check_config(Config) ->
     check_config(Config, #{}).
@@ -67,14 +56,20 @@ do_check_config(#{<<"mechanism">> := Mec0} = Config, Opts) ->
         end,
     case lists:keyfind(Key, 1, providers()) of
         false ->
-            throw(#{error => unknown_authn_provider, which => Key});
+            Reason =
+                case Key of
+                    {M, B} ->
+                        #{mechanism => M, backend => B};
+                    M ->
+                        #{mechanism => M}
+                end,
+            throw(Reason#{error => unknown_authn_provider});
         {_, ProviderModule} ->
             do_check_config_maybe_throw(ProviderModule, Config, Opts)
     end;
-do_check_config(Config, Opts) when is_map(Config) ->
+do_check_config(Config, _Opts) when is_map(Config) ->
     throw(#{
         error => invalid_config,
-        which => maps:get(id_for_log, Opts, unknown),
         reason => "mechanism_field_required"
     }).
 

--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -69,7 +69,7 @@ do_check_config(#{<<"mechanism">> := Mec0} = Config, Opts) ->
         false ->
             throw(#{error => unknown_authn_provider, which => Key});
         {_, ProviderModule} ->
-            hocon_tconf:check_plain(
+            emqx_hocon:check(
                 ProviderModule,
                 #{?CONF_NS_BINARY => Config},
                 Opts#{atom_key => true}

--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -1232,15 +1232,10 @@ serialize_error({unknown_authn_type, Type}) ->
         code => <<"BAD_REQUEST">>,
         message => binfmt("Unknown type '~p'", [Type])
     }};
-serialize_error({bad_authenticator_config, Reason}) ->
-    {400, #{
-        code => <<"BAD_REQUEST">>,
-        message => binfmt("Bad authenticator config ~p", [Reason])
-    }};
 serialize_error(Reason) ->
     {400, #{
         code => <<"BAD_REQUEST">>,
-        message => binfmt("~p", [Reason])
+        message => binfmt("~0p", [Reason])
     }}.
 
 parse_position(<<"front">>) ->

--- a/apps/emqx_authn/src/emqx_authn_app.erl
+++ b/apps/emqx_authn/src/emqx_authn_app.erl
@@ -35,6 +35,9 @@
 %%------------------------------------------------------------------------------
 
 start(_StartType, _StartArgs) ->
+    %% required by test cases, ensure the injection of
+    %% EMQX_AUTHENTICATION_SCHEMA_MODULE_PT_KEY
+    _ = emqx_conf_schema:roots(),
     ok = mria_rlog:wait_for_shards([?AUTH_SHARD], infinity),
     {ok, Sup} = emqx_authn_sup:start_link(),
     case initialize() of
@@ -43,8 +46,7 @@ start(_StartType, _StartArgs) ->
     end.
 
 stop(_State) ->
-    ok = deinitialize(),
-    ok.
+    ok = deinitialize().
 
 %%------------------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_authn/src/emqx_authn_app.erl
+++ b/apps/emqx_authn/src/emqx_authn_app.erl
@@ -53,26 +53,17 @@ stop(_State) ->
 %%------------------------------------------------------------------------------
 
 initialize() ->
-    try
-        ok = ?AUTHN:register_providers(emqx_authn:providers()),
-
-        lists:foreach(
-            fun({ChainName, RawAuthConfigs}) ->
-                AuthConfig = emqx_authn:check_configs(RawAuthConfigs),
-                ?AUTHN:initialize_authentication(
-                    ChainName,
-                    AuthConfig
-                )
-            end,
-            chain_configs()
-        )
-    of
-        ok -> ok
-    catch
-        throw:Reason ->
-            ?SLOG(error, #{msg => "failed_to_initialize_authentication", reason => Reason}),
-            {error, {failed_to_initialize_authentication, Reason}}
-    end.
+    ok = ?AUTHN:register_providers(emqx_authn:providers()),
+    lists:foreach(
+        fun({ChainName, RawAuthConfigs}) ->
+            AuthConfig = emqx_authn:check_configs(RawAuthConfigs),
+            ?AUTHN:initialize_authentication(
+                ChainName,
+                AuthConfig
+            )
+        end,
+        chain_configs()
+    ).
 
 deinitialize() ->
     ok = ?AUTHN:deregister_providers(provider_types()),

--- a/apps/emqx_authn/src/emqx_authn_app.erl
+++ b/apps/emqx_authn/src/emqx_authn_app.erl
@@ -55,8 +55,7 @@ stop(_State) ->
 initialize() ->
     ok = ?AUTHN:register_providers(emqx_authn:providers()),
     lists:foreach(
-        fun({ChainName, RawAuthConfigs}) ->
-            AuthConfig = emqx_authn:check_configs(RawAuthConfigs),
+        fun({ChainName, AuthConfig}) ->
             ?AUTHN:initialize_authentication(
                 ChainName,
                 AuthConfig
@@ -73,12 +72,12 @@ chain_configs() ->
     [global_chain_config() | listener_chain_configs()].
 
 global_chain_config() ->
-    {?GLOBAL, emqx:get_raw_config([?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY], [])}.
+    {?GLOBAL, emqx:get_config([?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_BINARY], [])}.
 
 listener_chain_configs() ->
     lists:map(
         fun({ListenerID, _}) ->
-            {ListenerID, emqx:get_raw_config(auth_config_path(ListenerID), [])}
+            {ListenerID, emqx:get_config(auth_config_path(ListenerID), [])}
         end,
         emqx_listeners:list()
     ).

--- a/apps/emqx_authn/src/emqx_authn_schema.erl
+++ b/apps/emqx_authn/src/emqx_authn_schema.erl
@@ -105,8 +105,12 @@ select_union_member(Value, _Providers) ->
     throw(#{reason => "not_a_struct", value => Value}).
 
 try_select_union_member(Module, Value) ->
-    %% some modules have union_member_selector/1 exported to help selectin the sub-types
-    %% emqx_authn_http, emqx_authn_jwt, emqx_authn_mongodb and emqx_authn_redis
+    %% some modules have `union_member_selector/1' exported to help selecting
+    %% the sub-types, they are:
+    %%   emqx_authn_http
+    %%   emqx_authn_jwt
+    %%   emqx_authn_mongodb
+    %%   emqx_authn_redis
     try
         Module:union_member_selector({value, Value})
     catch

--- a/apps/emqx_authn/src/emqx_authn_schema.erl
+++ b/apps/emqx_authn/src/emqx_authn_schema.erl
@@ -105,13 +105,10 @@ select_union_member(Value, _Providers) ->
     throw(#{reason => "not_a_struct", value => Value}).
 
 try_select_union_member(Module, Value) ->
-    %% some modules have refs/1 exported to help selectin the sub-types
+    %% some modules have union_member_selector/1 exported to help selectin the sub-types
     %% emqx_authn_http, emqx_authn_jwt, emqx_authn_mongodb and emqx_authn_redis
-    try Module:refs(Value) of
-        {ok, Type} ->
-            [Type];
-        {error, Reason} ->
-            throw(Reason)
+    try
+        Module:union_member_selector({value, Value})
     catch
         error:undef ->
             %% otherwise expect only one member from this module

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -40,6 +40,7 @@
 
 -export([
     refs/0,
+    refs/1,
     create/2,
     update/2,
     authenticate/2,
@@ -66,12 +67,12 @@ roots() ->
 
 fields(get) ->
     [
-        {method, #{type => get, required => true, default => get, desc => ?DESC(method)}},
+        {method, #{type => get, required => true, desc => ?DESC(method)}},
         {headers, fun headers_no_content_type/1}
     ] ++ common_fields();
 fields(post) ->
     [
-        {method, #{type => post, required => true, default => post, desc => ?DESC(method)}},
+        {method, #{type => post, required => true, desc => ?DESC(method)}},
         {headers, fun headers/1}
     ] ++ common_fields().
 
@@ -158,6 +159,13 @@ refs() ->
         hoconsc:ref(?MODULE, get),
         hoconsc:ref(?MODULE, post)
     ].
+
+refs(#{<<"method">> := <<"get">>}) ->
+    {ok, hoconsc:ref(?MODULE, get)};
+refs(#{<<"method">> := <<"post">>}) ->
+    {ok, hoconsc:ref(?MODULE, post)};
+refs(_) ->
+    {error, "'http' auth backend must have get|post as 'method'"}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -165,7 +165,10 @@ refs(#{<<"method">> := <<"get">>}) ->
 refs(#{<<"method">> := <<"post">>}) ->
     {ok, hoconsc:ref(?MODULE, post)};
 refs(_) ->
-    {error, "'http' auth backend must have get|post as 'method'"}.
+    {error, #{
+        field_name => method,
+        expected => "get | post"
+    }}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -40,7 +40,7 @@
 
 -export([
     refs/0,
-    refs/1,
+    union_member_selector/1,
     create/2,
     update/2,
     authenticate/2,
@@ -60,7 +60,7 @@ roots() ->
     [
         {?CONF_NS,
             hoconsc:mk(
-                hoconsc:union(refs()),
+                hoconsc:union(fun union_member_selector/1),
                 #{}
             )}
     ].
@@ -160,15 +160,20 @@ refs() ->
         hoconsc:ref(?MODULE, post)
     ].
 
+union_member_selector(all_union_members) ->
+    refs();
+union_member_selector({value, Value}) ->
+    refs(Value).
+
 refs(#{<<"method">> := <<"get">>}) ->
-    {ok, hoconsc:ref(?MODULE, get)};
+    [hoconsc:ref(?MODULE, get)];
 refs(#{<<"method">> := <<"post">>}) ->
-    {ok, hoconsc:ref(?MODULE, post)};
+    [hoconsc:ref(?MODULE, post)];
 refs(_) ->
-    {error, #{
+    throw(#{
         field_name => method,
         expected => "get | post"
-    }}.
+    }).
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -187,7 +187,10 @@ select_ref(false, #{<<"public_key">> := _}) ->
 select_ref(false, _) ->
     {ok, hoconsc:ref(?MODULE, 'hmac-based')};
 select_ref(_, _) ->
-    {error, "use_jwks must be set to true or false"}.
+    {error, #{
+        field_name => use_jwks,
+        expected => "true | false"
+    }}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_jwt.erl
@@ -171,7 +171,14 @@ refs() ->
 
 refs(#{<<"mechanism">> := <<"jwt">>} = V) ->
     UseJWKS = maps:get(<<"use_jwks">>, V, undefined),
-    select_ref(UseJWKS, V).
+    select_ref(boolean(UseJWKS), V).
+
+%% this field is technically a boolean type,
+%% but union member selection is done before type casting (by typrefl),
+%% so we have to allow strings too
+boolean(<<"true">>) -> true;
+boolean(<<"false">>) -> false;
+boolean(Other) -> Other.
 
 select_ref(true, _) ->
     {ok, hoconsc:ref(?MODULE, 'jwks')};
@@ -180,7 +187,7 @@ select_ref(false, #{<<"public_key">> := _}) ->
 select_ref(false, _) ->
     {ok, hoconsc:ref(?MODULE, 'hmac-based')};
 select_ref(_, _) ->
-    {error, "use_jwks must be set"}.
+    {error, "use_jwks must be set to true or false"}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
@@ -33,6 +33,7 @@
 
 -export([
     refs/0,
+    refs/1,
     create/2,
     update/2,
     authenticate/2,
@@ -129,6 +130,15 @@ refs() ->
         hoconsc:ref(?MODULE, 'replica-set'),
         hoconsc:ref(?MODULE, 'sharded-cluster')
     ].
+
+refs(#{<<"mongo_type">> := <<"single">>}) ->
+    {ok, hoconsc:ref(?MODULE, standalone)};
+refs(#{<<"mongo_type">> := <<"rs">>}) ->
+    {ok, hoconsc:ref(?MODULE, 'replica-set')};
+refs(#{<<"mongo_type">> := <<"sharded">>}) ->
+    {ok, hoconsc:ref(?MODULE, 'sharded-cluster')};
+refs(_) ->
+    {error, "unknown 'mongo_type'"}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mongodb.erl
@@ -138,7 +138,10 @@ refs(#{<<"mongo_type">> := <<"rs">>}) ->
 refs(#{<<"mongo_type">> := <<"sharded">>}) ->
     {ok, hoconsc:ref(?MODULE, 'sharded-cluster')};
 refs(_) ->
-    {error, "unknown 'mongo_type'"}.
+    {error, #{
+        field_name => mongo_type,
+        expected => "single | rs | sharded"
+    }}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
@@ -33,7 +33,7 @@
 
 -export([
     refs/0,
-    refs/1,
+    union_member_selector/1,
     create/2,
     update/2,
     authenticate/2,
@@ -53,7 +53,7 @@ roots() ->
     [
         {?CONF_NS,
             hoconsc:mk(
-                hoconsc:union(refs()),
+                hoconsc:union(fun union_member_selector/1),
                 #{}
             )}
     ].
@@ -98,17 +98,22 @@ refs() ->
         hoconsc:ref(?MODULE, sentinel)
     ].
 
+union_member_selector(all_union_members) ->
+    refs();
+union_member_selector({value, Value}) ->
+    refs(Value).
+
 refs(#{<<"redis_type">> := <<"single">>}) ->
-    {ok, hoconsc:ref(?MODULE, standalone)};
+    [hoconsc:ref(?MODULE, standalone)];
 refs(#{<<"redis_type">> := <<"cluster">>}) ->
-    {ok, hoconsc:ref(?MODULE, cluster)};
+    [hoconsc:ref(?MODULE, cluster)];
 refs(#{<<"redis_type">> := <<"sentinel">>}) ->
-    {ok, hoconsc:ref(?MODULE, sentinel)};
+    [hoconsc:ref(?MODULE, sentinel)];
 refs(_) ->
-    {error, #{
+    throw(#{
         field_name => redis_type,
         expected => "single | cluster | sentinel"
-    }}.
+    }).
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
@@ -105,7 +105,10 @@ refs(#{<<"redis_type">> := <<"cluster">>}) ->
 refs(#{<<"redis_type">> := <<"sentinel">>}) ->
     {ok, hoconsc:ref(?MODULE, sentinel)};
 refs(_) ->
-    {error, "unknown 'redis_type'"}.
+    {error, #{
+        field_name => redis_type,
+        expected => "single | cluster | sentinel"
+    }}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_redis.erl
@@ -33,6 +33,7 @@
 
 -export([
     refs/0,
+    refs/1,
     create/2,
     update/2,
     authenticate/2,
@@ -96,6 +97,15 @@ refs() ->
         hoconsc:ref(?MODULE, cluster),
         hoconsc:ref(?MODULE, sentinel)
     ].
+
+refs(#{<<"redis_type">> := <<"single">>}) ->
+    {ok, hoconsc:ref(?MODULE, standalone)};
+refs(#{<<"redis_type">> := <<"cluster">>}) ->
+    {ok, hoconsc:ref(?MODULE, cluster)};
+refs(#{<<"redis_type">> := <<"sentinel">>}) ->
+    {ok, hoconsc:ref(?MODULE, sentinel)};
+refs(_) ->
+    {error, "unknown 'redis_type'"}.
 
 create(_AuthenticatorID, Config) ->
     create(Config).

--- a/apps/emqx_authn/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_mnesia_SUITE.erl
@@ -49,56 +49,6 @@ end_per_testcase(_Case, Config) ->
 %% Tests
 %%------------------------------------------------------------------------------
 
--define(CONF(Conf), #{?CONF_NS_BINARY => Conf}).
-
-t_check_schema(_Config) ->
-    Check = fun(C) -> emqx_config:check_config(emqx_schema, ?CONF(C)) end,
-    ConfigOk = #{
-        <<"mechanism">> => <<"password_based">>,
-        <<"backend">> => <<"built_in_database">>,
-        <<"user_id_type">> => <<"username">>,
-        <<"password_hash_algorithm">> => #{
-            <<"name">> => <<"bcrypt">>,
-            <<"salt_rounds">> => <<"6">>
-        }
-    },
-    _ = Check(ConfigOk),
-
-    ConfigNotOk = #{
-        <<"mechanism">> => <<"password_based">>,
-        <<"backend">> => <<"built_in_database">>,
-        <<"user_id_type">> => <<"username">>,
-        <<"password_hash_algorithm">> => #{
-            <<"name">> => <<"md6">>
-        }
-    },
-    ?assertThrow(
-        #{
-            path := "authentication.1.password_hash_algorithm.name",
-            matched_type := "authn-builtin_db:authentication/authn-hash:simple",
-            reason := unable_to_convert_to_enum_symbol
-        },
-        Check(ConfigNotOk)
-    ),
-
-    ConfigMissingAlgoName = #{
-        <<"mechanism">> => <<"password_based">>,
-        <<"backend">> => <<"built_in_database">>,
-        <<"user_id_type">> => <<"username">>,
-        <<"password_hash_algorithm">> => #{
-            <<"foo">> => <<"bar">>
-        }
-    },
-
-    ?assertThrow(
-        #{
-            path := "authentication.1.password_hash_algorithm",
-            reason := "algorithm_name_missing",
-            matched_type := "authn-builtin_db:authentication"
-        },
-        Check(ConfigMissingAlgoName)
-    ).
-
 t_create(_) ->
     Config0 = config(),
 

--- a/apps/emqx_authn/test/emqx_authn_pgsql_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_pgsql_SUITE.erl
@@ -105,17 +105,12 @@ t_update_with_invalid_config(_Config) ->
     AuthConfig = raw_pgsql_auth_config(),
     BadConfig = maps:without([<<"server">>], AuthConfig),
     ?assertMatch(
-        {error,
-            {bad_authenticator_config, #{
-                reason :=
-                    {emqx_authn_pgsql, [
-                        #{
-                            kind := validation_error,
-                            path := "authentication.server",
-                            reason := required_field
-                        }
-                    ]}
-            }}},
+        {error, #{
+            kind := validation_error,
+            matched_type := "authn-postgresql:authentication",
+            path := "authentication.1.server",
+            reason := required_field
+        }},
         emqx:update_config(
             ?PATH,
             {create_authenticator, ?GLOBAL, BadConfig}

--- a/apps/emqx_authn/test/emqx_authn_redis_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_redis_SUITE.erl
@@ -160,10 +160,12 @@ t_create_invalid_config(_Config) ->
     Config0 = raw_redis_auth_config(),
     Config = maps:without([<<"server">>], Config0),
     ?assertMatch(
-        {error,
-            {bad_authenticator_config, #{
-                reason := {emqx_authn_redis, [#{kind := validation_error}]}
-            }}},
+        {error, #{
+            kind := validation_error,
+            matched_type := "authn-redis:standalone",
+            path := "authentication.1.server",
+            reason := required_field
+        }},
         emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, Config})
     ),
     ?assertMatch([], emqx_config:get_raw([authentication])),

--- a/apps/emqx_authn/test/emqx_authn_schema_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_schema_SUITE.erl
@@ -1,0 +1,190 @@
+-module(emqx_authn_schema_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("emqx_authn.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    _ = application:load(emqx_conf),
+    emqx_common_test_helpers:start_apps([emqx_authn]),
+    Config.
+
+end_per_suite(_) ->
+    emqx_common_test_helpers:stop_apps([emqx_authn]),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
+    mria:clear_table(emqx_authn_mnesia),
+    Config.
+
+end_per_testcase(_Case, Config) ->
+    Config.
+
+-define(CONF(Conf), #{?CONF_NS_BINARY => Conf}).
+
+t_check_schema(_Config) ->
+    Check = fun(C) -> emqx_config:check_config(emqx_schema, ?CONF(C)) end,
+    ConfigOk = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"built_in_database">>,
+        <<"user_id_type">> => <<"username">>,
+        <<"password_hash_algorithm">> => #{
+            <<"name">> => <<"bcrypt">>,
+            <<"salt_rounds">> => <<"6">>
+        }
+    },
+    _ = Check(ConfigOk),
+
+    ConfigNotOk = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"built_in_database">>,
+        <<"user_id_type">> => <<"username">>,
+        <<"password_hash_algorithm">> => #{
+            <<"name">> => <<"md6">>
+        }
+    },
+    ?assertThrow(
+        #{
+            path := "authentication.1.password_hash_algorithm.name",
+            matched_type := "authn-builtin_db:authentication/authn-hash:simple",
+            reason := unable_to_convert_to_enum_symbol
+        },
+        Check(ConfigNotOk)
+    ),
+
+    ConfigMissingAlgoName = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"built_in_database">>,
+        <<"user_id_type">> => <<"username">>,
+        <<"password_hash_algorithm">> => #{
+            <<"foo">> => <<"bar">>
+        }
+    },
+
+    ?assertThrow(
+        #{
+            path := "authentication.1.password_hash_algorithm",
+            reason := "algorithm_name_missing",
+            matched_type := "authn-builtin_db:authentication"
+        },
+        Check(ConfigMissingAlgoName)
+    ).
+
+t_union_member_selector(_) ->
+    ?assertMatch(#{authentication := undefined}, check(undefined)),
+    C1 = #{<<"backend">> => <<"built_in_database">>},
+    ?assertThrow(
+        #{
+            path := "authentication.1",
+            reason := "missing_mechanism_field"
+        },
+        check(C1)
+    ),
+    C2 = <<"foobar">>,
+    ?assertThrow(
+        #{
+            path := "authentication.1",
+            reason := "not_a_struct",
+            value := <<"foobar">>
+        },
+        check(C2)
+    ),
+    Base = #{
+        <<"user_id_type">> => <<"username">>,
+        <<"password_hash_algorithm">> => #{
+            <<"name">> => <<"plain">>
+        }
+    },
+    BadBackend = Base#{<<"mechanism">> => <<"password_based">>, <<"backend">> => <<"bar">>},
+    ?assertThrow(
+        #{
+            reason := "unknown_backend",
+            backend := <<"bar">>
+        },
+        check(BadBackend)
+    ),
+    BadMechanism = Base#{<<"mechanism">> => <<"foo">>, <<"backend">> => <<"built_in_database">>},
+    ?assertThrow(
+        #{
+            reason := "unsupported_mechanism",
+            mechanism := <<"foo">>,
+            backend := <<"built_in_database">>
+        },
+        check(BadMechanism)
+    ),
+    BadCombination = Base#{<<"mechanism">> => <<"scram">>, <<"backend">> => <<"http">>},
+    ?assertThrow(
+        #{
+            reason := "unsupported_mechanism",
+            mechanism := <<"scram">>,
+            backend := <<"http">>
+        },
+        check(BadCombination)
+    ),
+    ok.
+
+t_http_auth_selector(_) ->
+    C1 = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"http">>
+    },
+    ?assertThrow(
+        #{
+            field_name := method,
+            expected := "get | post"
+        },
+        check(C1)
+    ),
+    ok.
+
+t_mongo_auth_selector(_) ->
+    C1 = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"mongodb">>
+    },
+    ?assertThrow(
+        #{
+            field_name := mongo_type,
+            expected := "single | rs | sharded"
+        },
+        check(C1)
+    ),
+    ok.
+
+t_redis_auth_selector(_) ->
+    C1 = #{
+        <<"mechanism">> => <<"password_based">>,
+        <<"backend">> => <<"redis">>
+    },
+    ?assertThrow(
+        #{
+            field_name := redis_type,
+            expected := "single | cluster | sentinel"
+        },
+        check(C1)
+    ),
+    ok.
+
+t_redis_jwt_selector(_) ->
+    C1 = #{
+        <<"mechanism">> => <<"jwt">>
+    },
+    ?assertThrow(
+        #{
+            field_name := use_jwks,
+            expected := "true | false"
+        },
+        check(C1)
+    ),
+    ok.
+
+check(C) ->
+    {_Mappings, Checked} = emqx_config:check_config(emqx_schema, ?CONF(C)),
+    Checked.

--- a/apps/emqx_authn/test/emqx_authn_schema_tests.erl
+++ b/apps/emqx_authn/test/emqx_authn_schema_tests.erl
@@ -1,0 +1,135 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_authn_schema_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%% schema error
+-define(ERR(Reason), {error, Reason}).
+
+union_member_selector_mongo_test_() ->
+    Check = fun(Txt) -> check(emqx_authn_mongodb, Txt) end,
+    [
+        {"unknown", fun() ->
+            ?assertMatch(
+                ?ERR(#{field_name := mongo_type, expected := _}),
+                Check("{mongo_type: foobar}")
+            )
+        end},
+        {"single", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-mongodb:standalone"}),
+                Check("{mongo_type: single}")
+            )
+        end},
+        {"replica-set", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-mongodb:replica-set"}),
+                Check("{mongo_type: rs}")
+            )
+        end},
+        {"sharded", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-mongodb:sharded-cluster"}),
+                Check("{mongo_type: sharded}")
+            )
+        end}
+    ].
+
+union_member_selector_jwt_test_() ->
+    Check = fun(Txt) -> check(emqx_authn_jwt, Txt) end,
+    [
+        {"unknown", fun() ->
+            ?assertMatch(
+                ?ERR(#{field_name := use_jwks, expected := "true | false"}),
+                Check("{use_jwks = 1}")
+            )
+        end},
+        {"jwks", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-jwt:jwks"}),
+                Check("{use_jwks = true}")
+            )
+        end},
+        {"publick-key", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-jwt:public-key"}),
+                Check("{use_jwks = false, public_key = 1}")
+            )
+        end},
+        {"hmac-based", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-jwt:hmac-based"}),
+                Check("{use_jwks = false}")
+            )
+        end}
+    ].
+
+union_member_selector_redis_test_() ->
+    Check = fun(Txt) -> check(emqx_authn_redis, Txt) end,
+    [
+        {"unknown", fun() ->
+            ?assertMatch(
+                ?ERR(#{field_name := redis_type, expected := _}),
+                Check("{redis_type = 1}")
+            )
+        end},
+        {"single", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-redis:standalone"}),
+                Check("{redis_type = single}")
+            )
+        end},
+        {"cluster", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-redis:cluster"}),
+                Check("{redis_type = cluster}")
+            )
+        end},
+        {"sentinel", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-redis:sentinel"}),
+                Check("{redis_type = sentinel}")
+            )
+        end}
+    ].
+
+union_member_selector_http_test_() ->
+    Check = fun(Txt) -> check(emqx_authn_http, Txt) end,
+    [
+        {"unknown", fun() ->
+            ?assertMatch(
+                ?ERR(#{field_name := method, expected := _}),
+                Check("{method = 1}")
+            )
+        end},
+        {"get", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-http:get"}),
+                Check("{method = get}")
+            )
+        end},
+        {"post", fun() ->
+            ?assertMatch(
+                ?ERR(#{matched_type := "authn-http:post"}),
+                Check("{method = post}")
+            )
+        end}
+    ].
+
+check(Module, HoconConf) ->
+    emqx_hocon:check(Module, ["authentication= ", HoconConf]).

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.11"},
+    {vsn, "0.1.12"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -296,8 +296,6 @@ hocon_schema_to_spec(Type, LocalModule) when ?IS_TYPEREFL(Type) ->
 hocon_schema_to_spec(?ARRAY(Item), LocalModule) ->
     {Schema, Refs} = hocon_schema_to_spec(Item, LocalModule),
     {#{type => array, items => Schema}, Refs};
-hocon_schema_to_spec(?LAZY(Item), LocalModule) ->
-    hocon_schema_to_spec(Item, LocalModule);
 hocon_schema_to_spec(?ENUM(Items), _LocalModule) ->
     {#{type => enum, symbols => Items}, []};
 hocon_schema_to_spec(?MAP(Name, Type), LocalModule) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -609,8 +609,6 @@ hocon_schema_to_spec(Type, LocalModule) when ?IS_TYPEREFL(Type) ->
 hocon_schema_to_spec(?ARRAY(Item), LocalModule) ->
     {Schema, Refs} = hocon_schema_to_spec(Item, LocalModule),
     {#{type => array, items => Schema}, Refs};
-hocon_schema_to_spec(?LAZY(Item), LocalModule) ->
-    hocon_schema_to_spec(Item, LocalModule);
 hocon_schema_to_spec(?ENUM(Items), _LocalModule) ->
     {#{type => string, enum => Items}, []};
 hocon_schema_to_spec(?MAP(Name, Type), LocalModule) ->

--- a/bin/emqx
+++ b/bin/emqx
@@ -911,7 +911,7 @@ fi
 if [ $IS_BOOT_COMMAND = 'yes' ] && [ "$COOKIE" = "$EMQX_DEFAULT_ERLANG_COOKIE" ]; then
     logwarn "Default (insecure) Erlang cookie is in use."
     logwarn "Configure node.cookie in $EMQX_ETC_DIR/emqx.conf or override from environment variable EMQX_NODE__COOKIE"
-    logwarn "Use the same config value for all nodes in the cluster."
+    logwarn "NOTE: Use the same cookie for all nodes in the cluster."
 fi
 
 ## check if OTP version has mnesia_hook feature; if not, fallback to


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-8657

Also got rid of the `lazy` type which forced us to validate the config during node boot sequence, but not before.

Verified with below test script:
```
env EMQX_AUTHENTICATION__1='{mechanism="password_based",backend="mysql",server="localhost:3306",database="emqx",username="emqx",password="emqx",query="SELECT password_hash, salt, is_superuser FROM mqtt_user WHERE username = ${username} LIMIT 1",password_hash_algorithm={name=sha256,salt_position=prefix},enable=true}' \
    EMQX_DASHBOARD__default_password='ppp***' \
    EMQX_AUTHENTICATION__1__backend=yoursql \
    EMQX_NODE__COOKIE=foobar \
    ./_build/emqx/rel/emqx/bin/emqx check_config
```
## before the fix

`check_config` command does not find the error,
instead, it will crash when starting with quite a few lines of  rather big crash logs like:

```
Erlang/OTP 24 [erts-12.3.2.2] [emqx] [64-bit] [smp:20:20] [ds:20:20:8] [async-threads:4] [jit]

Listener ssl:default on 0.0.0.0:8883 started.
Listener tcp:default on 0.0.0.0:1883 started.
Listener ws:default on 0.0.0.0:8083 started.
Listener wss:default on 0.0.0.0:8084 started.
Listener http:dashboard on :18083 started.
2023-01-11T19:20:14.501565+01:00 [error] line: 71, mfa: emqx_authn_app:initialize/0, msg: failed_to_initialize_authentication, reason: #{error => unknown_backend,value => <<"yoursql">>}
2023-01-11T19:20:14.502160+01:00 [error] crasher: initial call: application_master:init/4, pid: <0.2513.0>, registered_name: [], exit: {{{failed_to_initialize_authentication,#{error => unknown_backend,value => <<"yoursql">>}},{emqx_authn_app,start,[normal,[]]}},[{application_master,init,4,[{file,"application_master.erl"},{line,142}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [<0.2512.0>], message_queue_len: 1, messages: [{'EXIT',<0.2514.0>,normal}], links: [<0.2512.0>,<0.1705.0>], dictionary: [], trap_exit: true, status: running, heap_size: 376, stack_size: 29, reductions: 167; neighbours:
2023-01-11T19:20:14.502623+01:00 [critical] app: emqx_authn, line: 88, mfa: emqx_machine_boot:start_one_app/1, msg: failed_to_start_app, reason: {emqx_authn,{{failed_to_initialize_authentication,#{error => unknown_backend,value => <<"yoursql">>}},{emqx_authn_app,start,[normal,[]]}}}
......a lot of lines ....
stack_size: 29, reductions: 170; neighbours:
Stop listener http:dashboard on :18083 successfully.
Listener ssl:default on 0.0.0.0:8883 stopped.
Listener tcp:default on 0.0.0.0:1883 stopped.
Listener ws:default on 0.0.0.0:8083 stopped.
Listener wss:default on 0.0.0.0:8084 stopped.
[os_mon] memory supervisor port (memsup): Erlang has closed
[os_mon] cpu supervisor port (cpu_sup): Erlang has closed
{"Kernel pid terminated",application_controller,"{application_start_failure,emqx_machine,{{shutdown,....
.... a lot of lines ....
Crash dump is being written to: log/erl_crash.dump...done
```

## after fix:

```
2023-01-13T14:25:14.768426+01:00 [error] failed_to_check_schema: emqx_conf_schema
2023-01-13T14:25:14.771508+01:00 [error] #{backend => <<"yoursql">>,kind => validation_error,path => "authentication.1",reason => "unknown_backend"}
ERROR: call_hocon_failed: -v -t 2023.01.13.14.25.14 -s emqx_conf_schema -c /mnt/code/src/emqx/0/_build/emqx/rel/emqx/etc/emqx.conf -d /mnt/code/src/emqx/0/_build/emqx/rel/emqx/data/configs generate
```


## This PR also sunsets the never-documented, over-engineered authn extension mechanism

Develop a new Erlang app which
  * must use HOCON for configs
  * implement a `check_config/` callback for config validation
  * implement `create/2` callback called at boot
  * implement `update/2` callback to handle runtime config updates
  * register itself with authn providers at boot time

With all the above complexity, the gains are:
* Be able to configure the extended authn provider as a part of an authn chain
* Be able to re-configure from the HTTP API
* Maybe after some new feature to be add to dashboard, it's possible to configure the chain from UI

NOTE: the old way of extending authn is always supported: implement a plugin with hooks to 'client.authenticate' hook-point.