### PR TITLE
refactor: remove the auto_reconnect field

### DIFF
--- a/apps/emqx_authz/README.md
+++ b/apps/emqx_authz/README.md
@@ -15,7 +15,6 @@ authz:{
               pool_size: 1
               username: root
               password: public
-              auto_reconnect: true
               ssl: {
                 enable: true
                 cacertfile:  "etc/certs/cacert.pem"
@@ -33,7 +32,6 @@ authz:{
               pool_size: 1
               username: root
               password: public
-              auto_reconnect: true
               ssl: {enable: false}
            }
            sql: "select ipaddress, username, clientid, action, permission, topic from mqtt_authz where ipaddr = ${peerhost} or username = ${username} or username = '$all' or clientid = ${clientid}"
@@ -45,7 +43,6 @@ authz:{
               database: 0
               pool_size: 1
               password: public
-              auto_reconnect: true
               ssl: {enable: false}
            }
            cmd: "HGETALL mqtt_authz:${username}"

--- a/apps/emqx_connector/README.md
+++ b/apps/emqx_connector/README.md
@@ -14,7 +14,7 @@ An MySQL connector can be used as following:
 ```
 (emqx@127.0.0.1)5> emqx_resource:list_instances_verbose().
 [#{config =>
-       #{auto_reconnect => true,cacertfile => [],certfile => [],
+       #{cacertfile => [],certfile => [],
          database => "mqtt",keyfile => [],password => "public",
          pool_size => 1,
          server => {{127,0,0,1},3306},

--- a/apps/emqx_connector/i18n/emqx_connector_schema_lib.conf
+++ b/apps/emqx_connector/i18n/emqx_connector_schema_lib.conf
@@ -68,13 +68,13 @@ emqx_connector_schema_lib {
 
     auto_reconnect {
         desc {
-          en: "Enable automatic reconnect to the database."
-          zh: "自动重连数据库。"
+          en: "Deprecated. Enable automatic reconnect to the database."
+          zh: "已弃用。自动重连数据库。"
         }
         label: {
-              en: "Auto Reconnect Database"
-              zh: "自动重连数据库"
-            }
+          en: "Deprecated. Auto Reconnect Database"
+          zh: "已弃用。自动重连数据库"
+        }
     }
 
 }

--- a/apps/emqx_connector/include/emqx_connector.hrl
+++ b/apps/emqx_connector/include/emqx_connector.hrl
@@ -24,6 +24,8 @@
 -define(REDIS_DEFAULT_PORT, 6379).
 -define(PGSQL_DEFAULT_PORT, 5432).
 
+-define(AUTO_RECONNECT_INTERVAL, 2).
+
 -define(SERVERS_DESC,
     "A Node list for Cluster to connect to. The nodes should be separated with commas, such as: `Node[,Node].`<br/>"
     "For each Node should be: "

--- a/apps/emqx_connector/src/emqx_connector_ldap.erl
+++ b/apps/emqx_connector/src/emqx_connector_ldap.erl
@@ -59,7 +59,6 @@ on_start(
         bind_password := BindPassword,
         timeout := Timeout,
         pool_size := PoolSize,
-        auto_reconnect := AutoReconn,
         ssl := SSL
     } = Config
 ) ->
@@ -86,11 +85,11 @@ on_start(
         {bind_password, BindPassword},
         {timeout, Timeout},
         {pool_size, PoolSize},
-        {auto_reconnect, reconn_interval(AutoReconn)}
+        {auto_reconnect, ?AUTO_RECONNECT_INTERVAL}
     ],
     PoolName = emqx_plugin_libs_pool:pool_name(InstId),
     case emqx_plugin_libs_pool:start_pool(PoolName, ?MODULE, Opts ++ SslOpts) of
-        ok -> {ok, #{poolname => PoolName, auto_reconnect => AutoReconn}};
+        ok -> {ok, #{poolname => PoolName}};
         {error, Reason} -> {error, Reason}
     end.
 
@@ -128,9 +127,6 @@ on_query(InstId, {search, Base, Filter, Attributes}, #{poolname := PoolName} = S
     Result.
 
 on_get_status(_InstId, _State) -> connected.
-
-reconn_interval(true) -> 15;
-reconn_interval(false) -> false.
 
 search(Conn, Base, Filter, Attributes) ->
     eldap2:search(Conn, [

--- a/apps/emqx_connector/src/emqx_connector_mysql.erl
+++ b/apps/emqx_connector/src/emqx_connector_mysql.erl
@@ -52,7 +52,6 @@
 -type state() ::
     #{
         poolname := atom(),
-        auto_reconnect := boolean(),
         prepare_statement := prepares(),
         params_tokens := params_tokens(),
         batch_inserts := sqls(),
@@ -84,8 +83,6 @@ on_start(
         server := Server,
         database := DB,
         username := User,
-        password := Password,
-        auto_reconnect := AutoReconn,
         pool_size := PoolSize,
         ssl := SSL
     } = Config
@@ -107,14 +104,14 @@ on_start(
         {host, Host},
         {port, Port},
         {user, User},
-        {password, Password},
+        {password, maps:get(password, Config, <<>>)},
         {database, DB},
-        {auto_reconnect, reconn_interval(AutoReconn)},
+        {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize}
     ],
     PoolName = emqx_plugin_libs_pool:pool_name(InstId),
     Prepares = parse_prepare_sql(Config),
-    State = maps:merge(#{poolname => PoolName, auto_reconnect => AutoReconn}, Prepares),
+    State = maps:merge(#{poolname => PoolName}, Prepares),
     case emqx_plugin_libs_pool:start_pool(PoolName, ?MODULE, Options ++ SslOpts) of
         ok ->
             {ok, init_prepare(State)};
@@ -194,7 +191,7 @@ mysql_function(prepared_query) ->
 mysql_function(_) ->
     mysql_function(prepared_query).
 
-on_get_status(_InstId, #{poolname := Pool, auto_reconnect := AutoReconn} = State) ->
+on_get_status(_InstId, #{poolname := Pool} = State) ->
     case emqx_plugin_libs_pool:health_check_ecpool_workers(Pool, fun ?MODULE:do_get_status/1) of
         true ->
             case do_check_prepares(State) of
@@ -205,10 +202,10 @@ on_get_status(_InstId, #{poolname := Pool, auto_reconnect := AutoReconn} = State
                     {connected, NState};
                 {error, _Reason} ->
                     %% do not log error, it is logged in prepare_sql_to_conn
-                    conn_status(AutoReconn)
+                    connecting
             end;
         false ->
-            conn_status(AutoReconn)
+            connecting
     end.
 
 do_get_status(Conn) ->
@@ -227,11 +224,6 @@ do_check_prepares(State = #{poolname := PoolName, prepare_statement := {error, P
     end.
 
 %% ===================================================================
-conn_status(_AutoReconn = true) -> connecting;
-conn_status(_AutoReconn = false) -> disconnected.
-
-reconn_interval(true) -> 15;
-reconn_interval(false) -> false.
 
 connect(Options) ->
     mysql:start_link(Options).

--- a/apps/emqx_connector/src/emqx_connector_pgsql.erl
+++ b/apps/emqx_connector/src/emqx_connector_pgsql.erl
@@ -56,7 +56,6 @@
 -type state() ::
     #{
         poolname := atom(),
-        auto_reconnect := boolean(),
         prepare_sql := prepares(),
         params_tokens := params_tokens(),
         prepare_statement := epgsql:statement()
@@ -87,8 +86,6 @@ on_start(
         server := Server,
         database := DB,
         username := User,
-        password := Password,
-        auto_reconnect := AutoReconn,
         pool_size := PoolSize,
         ssl := SSL
     } = Config
@@ -113,14 +110,14 @@ on_start(
         {host, Host},
         {port, Port},
         {username, User},
-        {password, emqx_secret:wrap(Password)},
+        {password, emqx_secret:wrap(maps:get(password, Config, ""))},
         {database, DB},
-        {auto_reconnect, reconn_interval(AutoReconn)},
+        {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize}
     ],
     PoolName = emqx_plugin_libs_pool:pool_name(InstId),
     Prepares = parse_prepare_sql(Config),
-    InitState = #{poolname => PoolName, auto_reconnect => AutoReconn, prepare_statement => #{}},
+    InitState = #{poolname => PoolName, prepare_statement => #{}},
     State = maps:merge(InitState, Prepares),
     case emqx_plugin_libs_pool:start_pool(PoolName, ?MODULE, Options ++ SslOpts) of
         ok ->
@@ -247,7 +244,7 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
     end,
     Result.
 
-on_get_status(_InstId, #{poolname := Pool, auto_reconnect := AutoReconn} = State) ->
+on_get_status(_InstId, #{poolname := Pool} = State) ->
     case emqx_plugin_libs_pool:health_check_ecpool_workers(Pool, fun ?MODULE:do_get_status/1) of
         true ->
             case do_check_prepares(State) of
@@ -258,10 +255,10 @@ on_get_status(_InstId, #{poolname := Pool, auto_reconnect := AutoReconn} = State
                     {connected, NState};
                 false ->
                     %% do not log error, it is logged in prepare_sql_to_conn
-                    conn_status(AutoReconn)
+                    connecting
             end;
         false ->
-            conn_status(AutoReconn)
+            connecting
     end.
 
 do_get_status(Conn) ->
@@ -280,11 +277,6 @@ do_check_prepares(State = #{poolname := PoolName, prepare_sql := {error, Prepare
     end.
 
 %% ===================================================================
-conn_status(_AutoReconn = true) -> connecting;
-conn_status(_AutoReconn = false) -> disconnected.
-
-reconn_interval(true) -> 15;
-reconn_interval(false) -> false.
 
 connect(Opts) ->
     Host = proplists:get_value(host, Opts),

--- a/apps/emqx_connector/src/emqx_connector_schema_lib.erl
+++ b/apps/emqx_connector/src/emqx_connector_schema_lib.erl
@@ -106,4 +106,5 @@ password(_) -> undefined.
 auto_reconnect(type) -> boolean();
 auto_reconnect(desc) -> ?DESC("auto_reconnect");
 auto_reconnect(default) -> true;
+auto_reconnect(deprecated) -> {since, "v5.0.15"};
 auto_reconnect(_) -> undefined.

--- a/changes/v5.0.15/feat-9725.en.md
+++ b/changes/v5.0.15/feat-9725.en.md
@@ -1,0 +1,11 @@
+Remove the config `auto_reconnect` from the emqx_authz, emqx_authn and data-bridge componets.
+This is because we have another config with similar functions: `resource_opts.auto_restart_interval`。
+
+The functions of these two config are difficult to distinguish, which will lead to confusion.
+After this change, `auto_reconnect` will not be configurable (always be true), and the underlying
+drivers that support this config will automatically reconnect the abnormally disconnected
+connection every `2s`.
+
+And the config `resource_opts.auto_restart_interval` is still available for user.
+It is the time interval that emqx restarts the resource when the connection cannot be
+established for some reason.

--- a/changes/v5.0.15/feat-9725.zh.md
+++ b/changes/v5.0.15/feat-9725.zh.md
@@ -1,0 +1,8 @@
+从认证、鉴权和数据桥接功能中，删除 `auto_reconnect` 配置项，因为我们还有另一个功能类似的配置项：
+`resource_opts.auto_restart_interval`。
+
+这两个配置项的功能难以区分，会导致困惑。此修改之后，`auto_reconnect` 将不可配置(永远为 true)，
+支持此配置的底层驱动将以 `2s` 为周期自动重连异常断开的连接。
+
+而 `resource_opts.auto_restart_interval` 配置项仍然开放给用户配置，它是资源因为某些原因
+无法建立连接的时候，emqx 重新启动该资源的时间间隔。

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
@@ -51,7 +51,6 @@ values(post) ->
         pool_size => 8,
         username => <<"root">>,
         password => <<"">>,
-        auto_reconnect => true,
         sql => ?DEFAULT_SQL,
         local_topic => <<"local/topic/#">>,
         resource_opts => #{

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_pgsql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_pgsql.erl
@@ -53,7 +53,6 @@ values(post, Type) ->
         pool_size => 8,
         username => <<"root">>,
         password => <<"public">>,
-        auto_reconnect => true,
         sql => ?DEFAULT_SQL,
         local_topic => <<"local/topic/#">>,
         resource_opts => #{

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_redis.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_redis.erl
@@ -79,7 +79,6 @@ values(common, RedisType, SpecificOpts) ->
         local_topic => <<"local/topic/#">>,
         pool_size => 8,
         password => <<"secret">>,
-        auto_reconnect => true,
         command_template => [<<"LPUSH">>, <<"MSGS">>, <<"${payload}">>],
         resource_opts => #{
             batch_size => 1,

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule EMQXUmbrella.MixProject do
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.0", override: true},
       {:hocon, github: "emqx/hocon", tag: "0.35.0", override: true},
-      {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.1", override: true},
+      {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.2", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},
       # in conflict by ehttpc and emqtt

--- a/rebar.config
+++ b/rebar.config
@@ -69,7 +69,7 @@
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.0"}}}
     , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.35.0"}}}
-    , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.1"}}}
+    , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}
     , {telemetry, "1.1.0"}


### PR DESCRIPTION
Remove the `auto_reconnect` config as we already have the `resource_opts.auto_restart_interval`.

We force the `auto_reconnect` to true (2s) for all the resources that use ecpool.