### PR TITLE
fix: remove password from info logs

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_http.erl
+++ b/apps/emqx_connector/src/emqx_connector_http.erl
@@ -209,7 +209,7 @@ on_start(
     ?SLOG(info, #{
         msg => "starting_http_connector",
         connector => InstId,
-        config => Config
+        config => emqx_misc:redact(Config)
     }),
     {Transport, TransportOpts} =
         case Scheme of

--- a/apps/emqx_connector/src/emqx_connector_ldap.erl
+++ b/apps/emqx_connector/src/emqx_connector_ldap.erl
@@ -65,7 +65,7 @@ on_start(
     ?SLOG(info, #{
         msg => "starting_ldap_connector",
         connector => InstId,
-        config => Config
+        config => emqx_misc:redact(Config)
     }),
     Servers = emqx_schema:parse_servers(Servers0, ?LDAP_HOST_OPTIONS),
     SslOpts =

--- a/apps/emqx_connector/src/emqx_connector_mongo.erl
+++ b/apps/emqx_connector/src/emqx_connector_mongo.erl
@@ -155,7 +155,7 @@ on_start(
             rs -> "starting_mongodb_replica_set_connector";
             sharded -> "starting_mongodb_sharded_connector"
         end,
-    ?SLOG(info, #{msg => Msg, connector => InstId, config => Config}),
+    ?SLOG(info, #{msg => Msg, connector => InstId, config => emqx_misc:redact(Config)}),
     NConfig = #{hosts := Hosts} = maybe_resolve_srv_and_txt_records(Config),
     SslOpts =
         case maps:get(enable, SSL) of

--- a/apps/emqx_connector/src/emqx_connector_mqtt.erl
+++ b/apps/emqx_connector/src/emqx_connector_mqtt.erl
@@ -149,7 +149,7 @@ on_start(InstId, Conf) ->
     ?SLOG(info, #{
         msg => "starting_mqtt_connector",
         connector => InstanceId,
-        config => Conf
+        config => emqx_misc:redact(Conf)
     }),
     BasicConf = basic_config(Conf),
     BridgeConf = BasicConf#{

--- a/apps/emqx_connector/src/emqx_connector_mysql.erl
+++ b/apps/emqx_connector/src/emqx_connector_mysql.erl
@@ -91,7 +91,7 @@ on_start(
     ?SLOG(info, #{
         msg => "starting_mysql_connector",
         connector => InstId,
-        config => Config
+        config => emqx_misc:redact(Config)
     }),
     SslOpts =
         case maps:get(enable, SSL) of

--- a/apps/emqx_connector/src/emqx_connector_pgsql.erl
+++ b/apps/emqx_connector/src/emqx_connector_pgsql.erl
@@ -94,7 +94,7 @@ on_start(
     ?SLOG(info, #{
         msg => "starting_postgresql_connector",
         connector => InstId,
-        config => Config
+        config => emqx_misc:redact(Config)
     }),
     SslOpts =
         case maps:get(enable, SSL) of

--- a/apps/emqx_connector/src/emqx_connector_redis.erl
+++ b/apps/emqx_connector/src/emqx_connector_redis.erl
@@ -123,7 +123,7 @@ on_start(
     ?SLOG(info, #{
         msg => "starting_redis_connector",
         connector => InstId,
-        config => Config
+        config => emqx_misc:redact(Config)
     }),
     ConfKey =
         case Type of

--- a/changes/v5.0.15/fix-8718-en.md
+++ b/changes/v5.0.15/fix-8718-en.md
@@ -1,0 +1,1 @@
+Password information has been removed from information log messages for http, ldap, mongo, mqtt, mysql, pgsql and redis.

--- a/changes/v5.0.15/fix-8718-zh.md
+++ b/changes/v5.0.15/fix-8718-zh.md
@@ -1,0 +1,1 @@
+密码信息已从http、ldap、mongo、mqtt、mysql、pgsql和redis的信息日志消息中删除。


### PR DESCRIPTION
Information log messages for several connectors contained sensitive password information. This commit fixes this by hiding the sensitive information from the log messages.

Fixes: https://emqx.atlassian.net/browse/EMQX-8718