### PR TITLE
fix: default max_connections in raw config should be binary not atom

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1647,7 +1647,7 @@ base_listener(Bind) ->
             sc(
                 hoconsc:union([infinity, pos_integer()]),
                 #{
-                    default => infinity,
+                    default => <<"infinity">>,
                     desc => ?DESC(base_listener_max_connections)
                 }
             )},

--- a/changes/v5.0.15/fix-9748-en.md
+++ b/changes/v5.0.15/fix-9748-en.md
@@ -1,0 +1,1 @@
+Listeners not configured with `max_connections` will cause the cluster `/listeners` API to return 500 error.

--- a/changes/v5.0.15/fix-9748-zh.md
+++ b/changes/v5.0.15/fix-9748-zh.md
@@ -1,0 +1,1 @@
+监听器不配置 `max_connections` 时会导致集群 `/listeners` 接口返回 500 错误。


### PR DESCRIPTION
Fix: https://github.com/emqx/emqx/issues/9733
When we don't set the `max_connections` of the listener, he will use the default value.
```
listeners.tcp.demo {
     bind = "0.0.0.0:2883"
}
```
we fill the raw config with the default value in `emqx_listener:do_list_raw/0`.
```erlang
Key = <<"listeners">>,
Raw = emqx_config:get_raw([Key], #{}),
SchemaMod = emqx_config:get_schema_mod(Key),
#{Key := RawWithDefault} = emqx_config:fill_defaults(SchemaMod, #{Key => Raw}, #{}),
```
The default value should not be an atom, but binary.

