### PR TITLE
fix: save app's env when bootstrapping and reloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ mix.lock
 apps/emqx/test/emqx_static_checks_data/master.bpapi
 # rendered configurations
 *.conf.rendered
+*.conf.rendered.*
 lux_logs/
 /.prepare
 bom.json

--- a/apps/emqx/src/config/emqx_config_logger.erl
+++ b/apps/emqx/src/config/emqx_config_logger.erl
@@ -37,9 +37,14 @@ remove_handler() ->
 %% so we need to refresh the logger config after this node starts.
 %% It will not affect the logger config when cluster-override.conf is unchanged.
 refresh_config() ->
-    Log = emqx:get_raw_config(?LOG),
-    {ok, _} = emqx:update_config(?LOG, Log),
-    ok.
+    case emqx:get_raw_config(?LOG, undefined) of
+        %% no logger config when CT is running.
+        undefined ->
+            ok;
+        Log ->
+            {ok, _} = emqx:update_config(?LOG, Log),
+            ok
+    end.
 
 post_config_update(?LOG, _Req, _NewConf, _OldConf, AppEnvs) ->
     Kernel = proplists:get_value(kernel, AppEnvs),

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -582,6 +582,7 @@ save_to_override_conf(RawConf, Opts) ->
 add_handlers() ->
     ok = emqx_config_logger:add_handler(),
     emqx_sys_mon:add_handler(),
+    emqx_config_logger:refresh_config(),
     ok.
 
 remove_handlers() ->

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -542,6 +542,8 @@ save_configs(AppEnvs, Conf, RawConf, OverrideConf, Opts) ->
     save_to_app_env(AppEnvs),
     save_to_config_map(Conf, RawConf).
 
+%% we ignore kernel app env,
+%% because the old app env will be used in emqx_config_logger:post_config_update/5
 -define(IGNORE_APPS, [kernel]).
 
 -spec save_to_app_env([tuple()]) -> ok.

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -409,7 +409,7 @@ catch_call(F) ->
             {crashed, {C, E, S}}
     end.
 force_set_config_file_paths(emqx_conf, [Path] = Paths) ->
-    Bin = iolist_to_binary(io_lib:format("node.config_files = [~p]", [Path])),
+    Bin = iolist_to_binary(io_lib:format("node.config_files = [~p]~n", [Path])),
     ok = file:write_file(Path, Bin, [append]),
     application:set_env(emqx, config_files, Paths);
 force_set_config_file_paths(emqx, Paths) ->

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -408,7 +408,9 @@ catch_call(F) ->
         C:E:S ->
             {crashed, {C, E, S}}
     end.
-force_set_config_file_paths(emqx_conf, Paths) ->
+force_set_config_file_paths(emqx_conf, [Path] = Paths) ->
+    Bin = iolist_to_binary(io_lib:format("node.config_files = [~p]", [Path])),
+    ok = file:write_file(Path, Bin, [append]),
     application:set_env(emqx, config_files, Paths);
 force_set_config_file_paths(emqx, Paths) ->
     application:set_env(emqx, config_files, Paths);

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -463,7 +463,7 @@ fields("node") ->
             )},
         {"config_files",
             sc(
-                list(string()),
+                hoconsc:array(string()),
                 #{
                     mapping => "emqx.config_files",
                     default => undefined,

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -92,6 +92,14 @@ set_data_dir_env() ->
     Node = atom_to_list(node()),
     %% will create certs and authz dir
     ok = filelib:ensure_dir(Node ++ "/configs/"),
+    {ok, [ConfigFile]} = application:get_env(emqx, config_files),
+    NewConfigFile = ConfigFile ++ "." ++ Node,
+    {ok, _} = file:copy(ConfigFile, NewConfigFile),
+    Bin = iolist_to_binary(io_lib:format("node.config_files = [~p]~n", [NewConfigFile])),
+    ok = file:write_file(NewConfigFile, Bin, [append]),
+    DataDir = iolist_to_binary(io_lib:format("node.data_dir = ~p~n", [Node])),
+    ok = file:write_file(NewConfigFile, DataDir, [append]),
+    application:set_env(emqx, config_files, [NewConfigFile]),
     application:set_env(emqx, data_dir, Node),
     application:set_env(emqx, cluster_override_conf_file, Node ++ "/configs/cluster-override.conf"),
     ok.

--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [


### PR DESCRIPTION
If we configure `logger` and `prometheus`  in `cluster-override.conf`
```
log {
  file_handlers {
    default {
      burst_limit {
        enable = true
        max_count = 10000
        window_time = "1s"
      ...
    }
prometheus {
  enable = true
  interval = "151s"
  job_name = "${name}/instance/${name}~${host}"
  mnesia_collector = "enabled"
  push_gateway_server = "http://127.0.0.1:9091"
  vm_dist_collector = "enabled"
  vm_memory_collector = "enabled"
  vm_msacc_collector = "enabled"
  vm_statistics_collector = "enabled"
  vm_system_info_collector = "enabled"
}
```
These configurations will have no effect. This is because `log` is an environment variable for `kernal` applications.
`*_collector` are the environment variable for the `prometheus` application.

we need to save those two applications' env after init_load.

close https://github.com/emqx/emqx/pull/8895
