### PR TITLE
0114 boot log emqx.conf missing

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -456,6 +456,7 @@ if [ "$IS_ENTERPRISE" = 'yes' ]; then
 fi
 
 if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
+    [ -f "$EMQX_ETC_DIR"/emqx.conf ] || die "emqx.conf is not found in $EMQX_ETC_DIR" 1
     if [ "${EMQX_BOOT_CONFIGS:-}" = '' ]; then
         EMQX_BOOT_CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"
         ## export here so the 'console' command recursively called from


### PR DESCRIPTION
# after fix:
```
docker run --rm -it -v /tmp:/opt/emqx/etc emqx/emqx:5.0.14-g91c5a899
ERROR: emqx.conf is not found in /opt/emqx/etc
```
# comparing to:
```
docker run --rm -it -v /tmp:/opt/emqx/etc emqx/emqx:5.0.14
escript: exception throw: {emqx_conf_schema,[#{kind => validation_error,
                                      path => "node.cookie",
                                      reason => required_field,
                                      value => undefined},
                                    #{kind => validation_error,
                                      path => "node.data_dir",
                                      reason => required_field,
                                      value => undefined}]}
  in function  hocon_tconf:assert/2 (hocon_tconf.erl, line 1171)
  in call from hocon_tconf:map/4 (hocon_tconf.erl, line 308)
  in call from hocon_cli:get_values/3 (hocon_cli.erl, line 194)
  in call from hocon_cli:multi_get/2 (hocon_cli.erl, line 182)
  in call from escript:run/2 (escript.erl, line 750)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1
  in call from init:do_boot/3
```