### PR TITLE
Fix flaky postgres test v50

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ endef
 $(foreach app,$(APPS),$(eval $(call gen-app-prop-target,$(app))))
 
 .PHONY: ct-suite
-ct-suite: $(REBAR)
+ct-suite: $(REBAR) merge-config
 ifneq ($(TESTCASE),)
 ifneq ($(GROUP),)
 	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE) --group $(GROUP)

--- a/apps/emqx_connector/src/emqx_connector_pgsql.erl
+++ b/apps/emqx_connector/src/emqx_connector_pgsql.erl
@@ -228,6 +228,10 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
     Result = ecpool:pick_and_do(PoolName, {?MODULE, Type, [NameOrSQL, Data]}, no_handover),
     case Result of
         {error, Reason} ->
+            ?tp(
+                pgsql_connector_query_error,
+                #{error => Reason}
+            ),
             ?SLOG(error, #{
                 msg => "postgresql connector do sql query failed",
                 connector => InstId,

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_pgsql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_pgsql_SUITE.erl
@@ -427,8 +427,10 @@ t_write_failure(Config) ->
                 ok;
             ({error, {recoverable_error, disconnected}}, _Trace) ->
                 ok;
-            (_, _Trace) ->
-                ?assert(false)
+            (Res, Trace) ->
+                ct:pal("unexpected result: ~p", [Res]),
+                ct:pal("trace: ~p", [Trace]),
+                ct:fail("unexpected result")
         end
     ),
     ok.


### PR DESCRIPTION
- When switching branches, configuration might change, and tests that
depend on the dashboard starting successfully will hang forever
because some translations are missing from schema.json
- print more info when flaky test fails