### PR TITLE
EMQX 8754 test function return 500 of data integration google pubsub

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -251,7 +251,9 @@ maybe_clear_certs(TmpPath, #{ssl := SslConf} = Conf) ->
     case is_tmp_path_conf(TmpPath, SslConf) of
         true -> emqx_connector_ssl:clear_certs(TmpPath, Conf);
         false -> ok
-    end.
+    end;
+maybe_clear_certs(_TmpPath, _ConfWithoutSsl) ->
+    ok.
 
 is_tmp_path_conf(TmpPath, #{certfile := Certfile}) ->
     is_tmp_path(TmpPath, Certfile);

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -86,6 +86,7 @@ init_per_testcase(_, Config) ->
     {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
     {Port, Sock, Acceptor} = start_http_server(fun handle_fun_200_ok/2),
     [{port, Port}, {sock, Sock}, {acceptor, Acceptor} | Config].
+
 end_per_testcase(_, Config) ->
     Sock = ?config(sock, Config),
     Acceptor = ?config(acceptor, Config),

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -171,7 +171,7 @@ create_dry_run(ResourceType, Config) ->
     ok = emqx_resource_manager_sup:ensure_child(
         MgrId, ResId, <<"dry_run">>, ResourceType, Config, #{}
     ),
-    case wait_for_ready(ResId, 15000) of
+    case wait_for_ready(ResId, 5000) of
         ok ->
             remove(ResId);
         {error, Reason} ->

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_gcp_pubsub.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_gcp_pubsub.erl
@@ -149,31 +149,31 @@ values(get) ->
     maps:merge(values(post), ?METRICS_EXAMPLE);
 values(post) ->
     #{
-        <<"pubsub_topic">> => <<"mytopic">>,
-        <<"service_account_json">> =>
+        pubsub_topic => <<"mytopic">>,
+        service_account_json =>
             #{
-                <<"auth_provider_x509_cert_url">> =>
+                auth_provider_x509_cert_url =>
                     <<"https://www.googleapis.com/oauth2/v1/certs">>,
-                <<"auth_uri">> =>
+                auth_uri =>
                     <<"https://accounts.google.com/o/oauth2/auth">>,
-                <<"client_email">> =>
+                client_email =>
                     <<"test@myproject.iam.gserviceaccount.com">>,
-                <<"client_id">> => <<"123812831923812319190">>,
-                <<"client_x509_cert_url">> =>
+                client_id => <<"123812831923812319190">>,
+                client_x509_cert_url =>
                     <<
                         "https://www.googleapis.com/robot/v1/"
                         "metadata/x509/test%40myproject.iam.gserviceaccount.com"
                     >>,
-                <<"private_key">> =>
+                private_key =>
                     <<
                         "-----BEGIN PRIVATE KEY-----\n"
                         "MIIEvQI..."
                     >>,
-                <<"private_key_id">> => <<"kid">>,
-                <<"project_id">> => <<"myproject">>,
-                <<"token_uri">> =>
+                private_key_id => <<"kid">>,
+                project_id => <<"myproject">>,
+                token_uri =>
                     <<"https://oauth2.googleapis.com/token">>,
-                <<"type">> => <<"service_account">>
+                type => <<"service_account">>
             }
     };
 values(put) ->

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
@@ -196,13 +196,17 @@ create_bridge_http(Config, GCPPubSubConfigOverrides) ->
     Params = GCPPubSubConfig#{<<"type">> => TypeBin, <<"name">> => Name},
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    ProbePath = emqx_mgmt_api_test_util:api_path(["bridges_probe"]),
+    ProbeResult = emqx_mgmt_api_test_util:request_api(post, ProbePath, "", AuthHeader, Params),
     ct:pal("creating bridge (via http): ~p", [Params]),
+    ct:pal("probe result: ~p", [ProbeResult]),
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
             {ok, Res0} -> {ok, emqx_json:decode(Res0, [return_maps])};
             Error -> Error
         end,
     ct:pal("bridge creation result: ~p", [Res]),
+    ?assertEqual(element(1, ProbeResult), element(1, Res)),
     Res.
 
 create_rule_and_action_http(Config) ->
@@ -672,7 +676,7 @@ t_create_via_http(Config) ->
         create_bridge_http(Config),
         fun(Res, Trace) ->
             ?assertMatch({ok, _}, Res),
-            ?assertMatch([_], ?of_kind(gcp_pubsub_bridge_jwt_created, Trace)),
+            ?assertMatch([_, _], ?of_kind(gcp_pubsub_bridge_jwt_created, Trace)),
             ok
         end
     ),


### PR DESCRIPTION
Bridges that don't have an ssl conf in their schema (like `gcp_pubsub`) cause a crash.

Fixes [EMQX-8754](https://emqx.atlassian.net/browse/EMQX-8754).

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] ~Change log has been added to `changes/<version>/(feat|fix)-<PR-id>.en.md` and `.zh.md` files~
- [X] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~Schema changes are backward compatible~