### PR TITLE
chore: more detail about crash dump config

### DIFF
--- a/apps/emqx/etc/vm.args.cloud
+++ b/apps/emqx/etc/vm.args.cloud
@@ -24,9 +24,6 @@
 ## Sets the maximum number of atoms the virtual machine can handle.
 #+t 1048576
 
-## Set the location of crash dumps
-#-env ERL_CRASH_DUMP {{ platform_log_dir }}/crash.dump
-
 ## Set how many times generational garbages collections can be done without
 ## forcing a fullsweep collection.
 -env ERL_FULLSWEEP_AFTER 1000
@@ -39,11 +36,6 @@
 ## In this mode, the shell evaluates a function call only if allowed.
 ## Prevent user from accidentally calling a function from the prompt that could harm a running system.
 -stdlib restricted_shell emqx_restricted_shell
-
-## Specifies the net_kernel tick time in seconds.
-## This is the approximate time a connected node may be unresponsive until
-## it is considered down and thereby disconnected.
--kernel net_ticktime 120
 
 ## Sets the distribution buffer busy limit (dist_buf_busy_limit).
 ## Preferably set in `emqx.conf`,

--- a/apps/emqx_conf/i18n/emqx_conf_schema.conf
+++ b/apps/emqx_conf/i18n/emqx_conf_schema.conf
@@ -480,8 +480,16 @@ the old dir should be deleted first.<br/>
 
   node_crash_dump_seconds {
     desc {
-      en: """The number of seconds that the broker is allowed to spend writing a crash dump."""
-      zh: """保存崩溃文件最大允许时间，如果文件太大，在规则时间内没有保存完成，则会直接结束。"""
+      en: """This variable gives the number of seconds that the emulator is allowed to spend writing a crash dump. When the given number of seconds have elapsed, the emulator is terminated.
+- If setting to 0 seconds, the runtime system does not even attempt to write the crash dump file. It only terminates.
+- If setting to a positive value S, wait for S seconds to complete the crash dump file and then terminates the runtime system with a SIGALRM signal.
+- A negative value causes the termination of the runtime system to wait indefinitely until the crash dump file has been completely written.
+ """
+      zh: """该配置给出了运行时系统允许花费的写入崩溃转储的秒数。当给定的秒数已经过去，运行时系统将被终止。
+- 如果设置为0秒，运行时会立即终止，不会尝试写入崩溃转储文件。
+- 如果设置为一个正数 S，节点会等待 S 秒来完成崩溃转储文件，然后用SIGALRM信号终止运行时系统。
+- 如果设置为一个负值导致运行时系统的终止等待无限期地直到崩溃转储文件已经完全写入。
+"""
     }
     label {
       en: "Crash Dump Seconds"
@@ -491,10 +499,14 @@ the old dir should be deleted first.<br/>
 
   node_crash_dump_bytes {
     desc {
-      en: """The maximum size of a crash dump file in bytes."""
+      en: """This variable sets the maximum size of a crash dump file in bytes.
+The crash dump will be truncated if this limit is exceeded.
+If setting it to 0, the runtime system does not even attempt to write a crash dump file.
+"""
       zh: """限制崩溃文件的大小，当崩溃时节点内存太大，
 如果为了保存现场，需要全部存到崩溃文件中，此处限制最多能保存多大的文件。
-          """
+如果超过此限制，崩溃转储将被截断。如果设置为0，系统不会尝试写入崩溃转储文件。
+"""
     }
     label {
       en: "Crash Dump Bytes"

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -487,7 +487,7 @@ fields("node") ->
                 #{
                     mapping => "vm_args.-env ERL_CRASH_DUMP",
                     desc => ?DESC(node_crash_dump_file),
-                    default => "log/erl_crash.dump",
+                    default => crash_dump_file_default(),
                     'readOnly' => true
                 }
             )},
@@ -1295,6 +1295,15 @@ sort_log_levels(Levels) ->
         end,
         Levels
     ).
+
+crash_dump_file_default() ->
+    case os:getenv("RUNNER_LOG_DIR") of
+        false ->
+            %% testing, or running emqx app as deps
+            "log/erl_crash.dump";
+        Dir ->
+            [filename:join([Dir, "erl_crash.dump"])]
+    end.
 
 %% utils
 -spec conf_get(string() | [string()], hocon:config()) -> term().

--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_machine/src/user_default.erl
+++ b/apps/emqx_machine/src/user_default.erl
@@ -26,6 +26,14 @@
 
 %% API
 -export([lock/0, unlock/0]).
+-export([t/1, t2/1, t/2, t2/2, t/3, t2/3]).
 
 lock() -> emqx_restricted_shell:lock().
 unlock() -> emqx_restricted_shell:unlock().
+
+t(M) -> recon_trace:calls({M, '_', return_trace}, 300).
+t2(M) -> recon_trace:calls({M, '_', return_trace}, 300, [{args, arity}]).
+t(M, F) -> recon_trace:calls({M, F, return_trace}, 300).
+t2(M, F) -> recon_trace:calls({M, F, return_trace}, 300, [{args, arity}]).
+t(M, F, A) -> recon_trace:calls({M, F, A}, 300).
+t2(M, F, A) -> recon_trace:calls({M, F, A}, 300, [{args, arity}]).


### PR DESCRIPTION
- Fix bad `node.crash_dump_file` default value in rpm.
- More detail about `node.crash_dump_seconds` and `node_crash_dump_bytes`. we can set this to 0 to prevent the generation of crash-dump file.
- Remove `ERL_CRASH_DUMP` from `vm.args.cloud`. we configure this from `node.crash_dump_file`.  so we remove this comment from `vm.args.cloud`.
- Remove `-kernel net_ticktime` from `vm.args.cloud`. we configure this from `node.dist_net_ticktime`.If the user modifies both(`node.dist_net_ticktime` and `etc/vm.args`), this can be confusing as to which one is in effect. so we remove it from vm.args.
- Add some alias trace fun to user_default.