### PR TITLE
chore(bridges): add more helpful descriptions

### DIFF
--- a/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_redis.conf
+++ b/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_redis.conf
@@ -19,8 +19,13 @@ will be forwarded.
 
     command_template {
         desc {
-            en: """Redis Command Template"""
-            zh: """Redis Command 模板"""
+            en: """Redis command template used to export messages. Each list element stands for a command name or its argument.
+For example, to push payloads in a Redis list by key `msgs`, the elements should be the following:
+`rpush`, `msgs`, `${payload}`.
+"""
+            zh: """用于推送数据的 Redis 命令模板。 每个列表元素代表一个命令名称或其参数。
+例如，要通过键值 `msgs` 将消息体推送到 Redis 列表中，数组元素应该是： `rpush`, `msgs`, `${payload}`。
+"""
             }
         label {
             en: "Redis Command Template"


### PR DESCRIPTION
Add more helpful descriptions for `command_template` option of Redis bridge.