### PR TITLE
chore: improve the dashboard's configuration

### DIFF
--- a/apps/emqx_dashboard/i18n/emqx_dashboard_api_i18n.conf
+++ b/apps/emqx_dashboard/i18n/emqx_dashboard_api_i18n.conf
@@ -31,7 +31,7 @@ emqx_dashboard_api {
     license {
         desc {
             en: """EMQX License. opensource or enterprise"""
-            zh: """EMQX 许可。开源版本 或者企业版"""
+            zh: """EMQX 许可类型。可为 opensource 或 enterprise"""
         }
     }
 
@@ -44,15 +44,15 @@ emqx_dashboard_api {
 
     login_api {
         desc {
-            en: """Dashboard Auth. Get Token"""
-            zh: """Dashboard 认证。获取 Token"""
+            en: """Get Dashboard Auth Token."""
+            zh: """获取 Dashboard 认证 Token。"""
         }
     }
 
     login_success {
         desc {
-            en: """Dashboard Auth. Success"""
-            zh: """Dashboard 认证。成功"""
+            en: """Dashboard Auth Success"""
+            zh: """Dashboard 认证成功"""
         }
     }
 

--- a/apps/emqx_dashboard/i18n/emqx_dashboard_i18n.conf
+++ b/apps/emqx_dashboard/i18n/emqx_dashboard_i18n.conf
@@ -37,7 +37,7 @@ Note: `sample_interval` should be a divisor of 60, default is 10s."""
   }
   num_acceptors {
     desc {
-      en: "Socket acceptor pool size for TCP protocols. default is the number of schedulers online"
+      en: "Socket acceptor pool size for TCP protocols. Default is the number of schedulers online"
       zh: "TCP协议的Socket acceptor池大小, 默认设置在线的调度器数量（通常为 CPU 核数）"
     }
     label {

--- a/apps/emqx_dashboard/i18n/emqx_dashboard_i18n.conf
+++ b/apps/emqx_dashboard/i18n/emqx_dashboard_i18n.conf
@@ -8,7 +8,10 @@ For example, an HTTP listener can listen on all configured IP addresses
 on a given port for a machine by specifying the IP address 0.0.0.0.
 Alternatively, the HTTP listener can specify a unique IP address for each listener,
 but use the same port."""
-      zh: """仪表盘监听器设置。"""
+      zh: """Dashboard 监听器设置。监听器必须有唯一的端口号和IP地址的组合。
+例如，可以通过指定IP地址 0.0.0.0 来监听机器上给定端口上的所有配置的IP地址。
+或者，可以为每个监听器指定唯一的IP地址，但使用相同的端口。
+"""
     }
     label {
       en: "Listeners"
@@ -18,14 +21,14 @@ but use the same port."""
   sample_interval {
     desc {
       en: """How often to update metrics displayed in the dashboard.
-Note: `sample_interval` should be a divisor of 60."""
-      zh: """更新仪表板中显示的指标的时间间隔。必须小于60，且被60的整除。"""
+Note: `sample_interval` should be a divisor of 60, default is 10s."""
+      zh: """Dashboard 中图表指标的时间间隔。必须小于60，且被60的整除，默认设置 10s。"""
     }
   }
   token_expired_time {
     desc {
-      en: "JWT token expiration time."
-      zh: "JWT token 过期时间"
+      en: "JWT token expiration time. Default is 60 minutes"
+      zh: "JWT token 过期时间。默认设置为 60 分钟。"
     }
     label {
       en: "Token expired time"
@@ -34,8 +37,8 @@ Note: `sample_interval` should be a divisor of 60."""
   }
   num_acceptors {
     desc {
-      en: "Socket acceptor pool size for TCP protocols."
-      zh: "TCP协议的Socket acceptor池大小"
+      en: "Socket acceptor pool size for TCP protocols. default is the number of schedulers online"
+      zh: "TCP协议的Socket acceptor池大小, 默认设置在线的调度器数量（通常为 CPU 核数）"
     }
     label {
       en: "Number of acceptors"
@@ -45,7 +48,7 @@ Note: `sample_interval` should be a divisor of 60."""
   max_connections {
     desc {
       en: "Maximum number of simultaneous connections."
-      zh: "同时处理的最大连接数"
+      zh: "同时处理的最大连接数。"
     }
     label {
       en: "Maximum connections"
@@ -55,7 +58,7 @@ Note: `sample_interval` should be a divisor of 60."""
   backlog {
     desc {
       en: "Defines the maximum length that the queue of pending connections can grow to."
-      zh: "排队等待连接的队列的最大长度"
+      zh: "排队等待连接的队列的最大长度。"
     }
     label {
       en: "Backlog"
@@ -65,7 +68,7 @@ Note: `sample_interval` should be a divisor of 60."""
   send_timeout {
     desc {
       en: "Send timeout for the socket."
-      zh: "Socket发送超时时间"
+      zh: "Socket发送超时时间。"
     }
     label {
       en: "Send timeout"
@@ -75,7 +78,7 @@ Note: `sample_interval` should be a divisor of 60."""
   inet6 {
     desc {
       en: "Enable IPv6 support, default is false, which means IPv4 only."
-      zh: "启用IPv6， 如果机器不支持IPv6，请关闭此选项，否则会导致仪表盘无法使用。"
+      zh: "启用IPv6， 如果机器不支持IPv6，请关闭此选项，否则会导致 Dashboard 无法使用。"
     }
     label {
       en: "IPv6"
@@ -84,7 +87,8 @@ Note: `sample_interval` should be a divisor of 60."""
   }
   ipv6_v6only {
     desc {
-      en: "Disable IPv4-to-IPv6 mapping for the listener."
+      en: """Disable IPv4-to-IPv6 mapping for the listener.
+The configuration is only valid when the inet6 is true."""
       zh: "当开启 inet6 功能的同时禁用 IPv4-to-IPv6 映射。该配置仅在 inet6 功能开启时有效。"
     }
     label {
@@ -95,17 +99,17 @@ Note: `sample_interval` should be a divisor of 60."""
   desc_dashboard {
     desc {
       en: "Configuration for EMQX dashboard."
-      zh: "EMQX仪表板配置"
+      zh: "EMQX Dashboard 配置。"
     }
     label {
       en: "Dashboard"
-      zh: "仪表板"
+      zh: "Dashboard"
     }
   }
   desc_listeners {
     desc {
       en: "Configuration for the dashboard listener."
-      zh: "仪表板监听器配置"
+      zh: "Dashboard 监听器配置。"
     }
     label {
       en: "Listeners"
@@ -115,7 +119,7 @@ Note: `sample_interval` should be a divisor of 60."""
   desc_http {
     desc {
       en: "Configuration for the dashboard listener (plaintext)."
-      zh: "仪表板监听器(HTTP)配置"
+      zh: "Dashboard 监听器(HTTP)配置。"
     }
     label {
       en: "HTTP"
@@ -125,7 +129,7 @@ Note: `sample_interval` should be a divisor of 60."""
   desc_https {
     desc {
       en: "Configuration for the dashboard listener (TLS)."
-      zh: "仪表板监听器(HTTPS)配置"
+      zh: "Dashboard 监听器(HTTPS)配置。"
     }
     label {
       en: "HTTPS"
@@ -135,7 +139,7 @@ Note: `sample_interval` should be a divisor of 60."""
   listener_enable {
     desc {
         en: "Ignore or enable this listener"
-        zh: "忽略或启用该监听器配置"
+        zh: "忽略或启用该监听器。"
     }
     label {
         en: "Enable"
@@ -145,7 +149,7 @@ Note: `sample_interval` should be a divisor of 60."""
   bind {
     desc {
       en: "Port without IP(18083) or port with specified IP(127.0.0.1:18083)."
-      zh: "监听的地址与端口，在dashboard更新此配置时，会重启dashboard服务。"
+      zh: "监听地址和端口，热更新此配置时，会重启 Dashboard 服务。"
     }
     label {
       en: "Bind"
@@ -155,7 +159,7 @@ Note: `sample_interval` should be a divisor of 60."""
   default_username {
     desc {
       en: "The default username of the automatically created dashboard user."
-      zh: "默认的仪表板用户名"
+      zh: "Dashboard 的默认用户名。"
     }
     label {
       en: "Default username"
@@ -165,9 +169,12 @@ Note: `sample_interval` should be a divisor of 60."""
   default_password {
     desc {
       en: """The initial default password for dashboard 'admin' user.
-For safety, it should be changed as soon as possible."""
-      zh: """默认的仪表板用户密码
-为了安全，应该尽快修改密码。"""
+For safety, it should be changed as soon as possible.
+This value is not valid when you log in to Dashboard for the first time via the web
+and change to a complex password as prompted.
+"""
+      zh: """Dashboard 的默认密码，为了安全，应该尽快修改密码。
+当通过网页首次登录 Dashboard 并按提示修改成复杂密码后，此值就会失效。"""
     }
     label {
       en: "Default password"
@@ -179,7 +186,7 @@ For safety, it should be changed as soon as possible."""
       en: """Support Cross-Origin Resource Sharing (CORS).
 Allows a server to indicate any origins (domain, scheme, or port) other than
 its own from which a browser should permit loading resources."""
-      zh: """支持跨域资源共享(CORS)
+      zh: """支持跨域资源共享(CORS)，
 允许服务器指示任何来源(域名、协议或端口)，除了本服务器之外的任何浏览器应允许加载资源。"""
     }
     label {
@@ -190,7 +197,7 @@ its own from which a browser should permit loading resources."""
   i18n_lang {
     desc {
       en: "Internationalization language support."
-      zh: "swagger多语言支持"
+      zh: "设置 Swagger 多语言的版本，可为 en 或 zh。"
     }
     label {
       en: "I18n language"
@@ -199,8 +206,8 @@ its own from which a browser should permit loading resources."""
   }
   bootstrap_users_file {
     desc {
-      en: "Deprecated, use api_key.bootstrap_file"
-      zh: "已废弃，请使用 api_key.bootstrap_file"
+      en: "Deprecated, use api_key.bootstrap_file."
+      zh: "已废弃，请使用 api_key.bootstrap_file。"
     }
     label {
       en: """Deprecated"""

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -117,7 +117,7 @@ common_listener_fields() ->
             ?HOCON(
                 integer(),
                 #{
-                    default => 4,
+                    default => erlang:system_info(schedulers_online),
                     desc => ?DESC(num_acceptors)
                 }
             )},
@@ -141,7 +141,7 @@ common_listener_fields() ->
             ?HOCON(
                 emqx_schema:duration(),
                 #{
-                    default => "5s",
+                    default => "10s",
                     desc => ?DESC(send_timeout)
                 }
             )},


### PR DESCRIPTION
1. Change `send_timeout`'s default from `5s` to `10s`  to improve concurrency.
2. Change `num_acceptors`'s default from 4 to `erlang:system_info(schedulers_online)`.
3. Improve the dashboard's document.