### PR TITLE
docs: update docker documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,4 +35,4 @@
 /.ci/     @emqx/emqx-review-board @id
 /scripts/ @emqx/emqx-review-board @id
 /build    @emqx/emqx-review-board @id
-/deploy/  @emqx/emqx-review-board @id
+/deploy/  @emqx/emqx-review-board @id @Rory-Z

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -102,10 +102,9 @@ The following table lists the configurable [EMQX](https://www.emqx.io/)-specific
 default values.
 Parameter | Description | Default Value
 --- | --- | ---
-`emqxConfig` | Map of [configuration](https://www.emqx.io/docs/en/latest/configuration/configuration.html) items
-expressed as [environment variables](https://www.emqx.io/docs/en/v4.3/configuration/environment-variable.html) (prefix
-can be omitted) or using the configuration
-files [namespaced dotted notation](https://www.emqx.io/docs/en/latest/configuration/configuration.html) | `nil`
+`emqxConfig` | Map of [configuration](https://www.emqx.io/docs/en/v5.0/admin/cfg.html) items
+expressed as [environment variables](https://www.emqx.io/docs/en/v5.0/admin/cfg.html#environment-variables) (prefix `EMQX_` can be omitted) or using the configuration
+files [namespaced dotted notation](https://www.emqx.io/docs/en/v5.0/admin/cfg.html#syntax) | `nil`
 `emqxLicenseSecretName` | Name of the secret that holds the license information | `nil`
 
 ## SSL settings

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,7 +1,6 @@
 ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.0-26:1.13.4-24.3.4.2-1-debian11
 ARG RUN_FROM=debian:11-slim
-ARG BUILDPLATFORM=linux/amd64
-FROM --platform=$BUILDPLATFORM ${BUILD_FROM} AS builder
+FROM ${BUILD_FROM} AS builder
 
 COPY . /emqx
 

--- a/deploy/docker/Dockerfile.alpine
+++ b/deploy/docker/Dockerfile.alpine
@@ -1,7 +1,6 @@
 ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.0-26:1.13.4-24.3.4.2-1-alpine3.15.1
 ARG RUN_FROM=alpine:3.15.1
-ARG BUILDPLATFORM=linux/amd64
-FROM --platform=$BUILDPLATFORM ${BUILD_FROM} AS builder
+FROM ${BUILD_FROM} AS builder
 
 RUN apk add --no-cache \
     autoconf \


### PR DESCRIPTION
Fixes [EMQX-8523](https://emqx.atlassian.net/browse/EMQX-8523).

- loaded plugins and loaded modules are not applicable in 5.0
- add information on how to correctly persist configuration in `/etc/`
- remove --platform arg from Dockerfile
- update documentation links in charts readme