### PR TITLE
buffer worker refactoring follow up (part1) (v5.0)

### DIFF
--- a/apps/emqx/src/emqx_misc.erl
+++ b/apps/emqx/src/emqx_misc.erl
@@ -56,7 +56,8 @@
     safe_to_existing_atom/1,
     safe_to_existing_atom/2,
     pub_props_to_packet/1,
-    safe_filename/1
+    safe_filename/1,
+    list_find/2
 ]).
 
 -export([
@@ -717,3 +718,14 @@ safe_filename(Filename) when is_binary(Filename) ->
     binary:replace(Filename, <<":">>, <<"-">>, [global]);
 safe_filename(Filename) when is_list(Filename) ->
     string:replace(Filename, ":", "-", all).
+
+-spec list_find(function(), list()) -> {ok, term()} | error.
+list_find(_Predicate, []) ->
+    error;
+list_find(Predicate, [X | Xs]) ->
+    case Predicate(X) of
+        true ->
+            {ok, X};
+        false ->
+            list_find(Predicate, Xs)
+    end.

--- a/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_http_SUITE.erl
@@ -172,7 +172,7 @@ t_response_handling(_Config) ->
                 [
                     #{
                         ?snk_kind := authz_http_request_failure,
-                        error := {recoverable_error, econnrefused}
+                        error := econnrefused
                     }
                 ],
                 ?of_kind(authz_http_request_failure, Trace)

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -65,7 +65,7 @@ load() ->
         fun({Type, NamedConf}) ->
             lists:foreach(
                 fun({Name, Conf}) ->
-                    %% fetch opts for `emqx_resource_worker`
+                    %% fetch opts for `emqx_resource_buffer_worker`
                     ResOpts = emqx_resource:fetch_creation_opts(Conf),
                     safe_load_bridge(Type, Name, Conf, ResOpts)
                 end,

--- a/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
@@ -886,9 +886,9 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
     {ok, SRef} =
         snabbkaffe:subscribe(
             fun
-                (#{?snk_kind := resource_worker_retry_inflight_failed}) ->
+                (#{?snk_kind := buffer_worker_retry_inflight_failed}) ->
                     true;
-                (#{?snk_kind := resource_worker_flush_nack}) ->
+                (#{?snk_kind := buffer_worker_flush_nack}) ->
                     true;
                 (_) ->
                     false

--- a/apps/emqx_connector/src/emqx_connector_http.erl
+++ b/apps/emqx_connector/src/emqx_connector_http.erl
@@ -306,7 +306,7 @@ on_query(
                 reason => Reason,
                 connector => InstId
             }),
-            {error, {recoverable_error, Reason}};
+            {error, Reason};
         {error, Reason} = Result ->
             ?SLOG(error, #{
                 msg => "http_connector_do_request_failed",
@@ -549,7 +549,7 @@ bin(Atom) when is_atom(Atom) ->
 reply_delegator(ReplyFunAndArgs, Result) ->
     case Result of
         {error, Reason} when Reason =:= econnrefused; Reason =:= timeout ->
-            Result1 = {error, {recoverable_error, Reason}},
+            Result1 = {error, Reason},
             emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result1);
         _ ->
             emqx_resource:apply_reply_fun(ReplyFunAndArgs, Result)

--- a/apps/emqx_connector/src/emqx_connector_redis.erl
+++ b/apps/emqx_connector/src/emqx_connector_redis.erl
@@ -208,7 +208,7 @@ do_query(InstId, Query, #{poolname := PoolName, type := Type} = State) ->
                 query => Query,
                 reason => Reason
             }),
-            case is_unrecoverable_error(Reason) of
+            case is_unrecoverable_error(Result) of
                 true ->
                     {error, {unrecoverable_error, Reason}};
                 false ->

--- a/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
+++ b/apps/emqx_connector/src/mqtt/emqx_connector_mqtt_worker.erl
@@ -277,7 +277,7 @@ idle({call, From}, ensure_started, State) ->
             {keep_state_and_data, [{reply, From, {error, Reason}}]}
     end;
 idle({call, From}, {send_to_remote, _}, _State) ->
-    {keep_state_and_data, [{reply, From, {error, {recoverable_error, not_connected}}}]};
+    {keep_state_and_data, [{reply, From, {error, not_connected}}]};
 %% @doc Standing by for manual start.
 idle(info, idle, #{start_type := manual}) ->
     keep_state_and_data;

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -255,7 +255,7 @@ reset_metrics(ResId) ->
 query(ResId, Request) ->
     query(ResId, Request, #{}).
 
--spec query(resource_id(), Request :: term(), emqx_resource_worker:query_opts()) ->
+-spec query(resource_id(), Request :: term(), emqx_resource_buffer_worker:query_opts()) ->
     Result :: term().
 query(ResId, Request, Opts) ->
     case emqx_resource_manager:ets_lookup(ResId) of
@@ -263,11 +263,11 @@ query(ResId, Request, Opts) ->
             IsBufferSupported = is_buffer_supported(Module),
             case {IsBufferSupported, QM} of
                 {true, _} ->
-                    emqx_resource_worker:simple_sync_query(ResId, Request);
+                    emqx_resource_buffer_worker:simple_sync_query(ResId, Request);
                 {false, sync} ->
-                    emqx_resource_worker:sync_query(ResId, Request, Opts);
+                    emqx_resource_buffer_worker:sync_query(ResId, Request, Opts);
                 {false, async} ->
-                    emqx_resource_worker:async_query(ResId, Request, Opts)
+                    emqx_resource_buffer_worker:async_query(ResId, Request, Opts)
             end;
         {error, not_found} ->
             ?RESOURCE_ERROR(not_found, "resource not found")
@@ -275,7 +275,7 @@ query(ResId, Request, Opts) ->
 
 -spec simple_sync_query(resource_id(), Request :: term()) -> Result :: term().
 simple_sync_query(ResId, Request) ->
-    emqx_resource_worker:simple_sync_query(ResId, Request).
+    emqx_resource_buffer_worker:simple_sync_query(ResId, Request).
 
 -spec start(resource_id()) -> ok | {error, Reason :: term()}.
 start(ResId) ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_resource_worker_sup).
+-module(emqx_resource_buffer_worker_sup).
 -behaviour(supervisor).
 
 %%%=============================================================================
@@ -99,7 +99,7 @@ ensure_worker_added(ResId, Idx) ->
 
 -define(CHILD_ID(MOD, RESID, INDEX), {MOD, RESID, INDEX}).
 ensure_worker_started(ResId, Idx, Opts) ->
-    Mod = emqx_resource_worker,
+    Mod = emqx_resource_buffer_worker,
     Spec = #{
         id => ?CHILD_ID(Mod, ResId, Idx),
         start => {Mod, start_link, [ResId, Idx, Opts]},
@@ -116,7 +116,7 @@ ensure_worker_started(ResId, Idx, Opts) ->
     end.
 
 ensure_worker_removed(ResId, Idx) ->
-    ChildId = ?CHILD_ID(emqx_resource_worker, ResId, Idx),
+    ChildId = ?CHILD_ID(emqx_resource_buffer_worker, ResId, Idx),
     case supervisor:terminate_child(?SERVER, ChildId) of
         ok ->
             Res = supervisor:delete_child(?SERVER, ChildId),
@@ -129,7 +129,7 @@ ensure_worker_removed(ResId, Idx) ->
     end.
 
 ensure_disk_queue_dir_absent(ResourceId, Index) ->
-    ok = emqx_resource_worker:clear_disk_queue_dir(ResourceId, Index),
+    ok = emqx_resource_buffer_worker:clear_disk_queue_dir(ResourceId, Index),
     ok.
 
 ensure_worker_pool_removed(ResId) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -150,7 +150,7 @@ create(MgrId, ResId, Group, ResourceType, Config, Opts) ->
             %% buffer, so there is no need for resource workers
             ok;
         false ->
-            ok = emqx_resource_worker_sup:start_workers(ResId, Opts),
+            ok = emqx_resource_buffer_worker_sup:start_workers(ResId, Opts),
             case maps:get(start_after_created, Opts, ?START_AFTER_CREATED) of
                 true ->
                     wait_for_ready(ResId, maps:get(start_timeout, Opts, ?START_TIMEOUT));
@@ -473,7 +473,7 @@ retry_actions(Data) ->
 
 handle_remove_event(From, ClearMetrics, Data) ->
     stop_resource(Data),
-    ok = emqx_resource_worker_sup:stop_workers(Data#data.id, Data#data.opts),
+    ok = emqx_resource_buffer_worker_sup:stop_workers(Data#data.id, Data#data.opts),
     case ClearMetrics of
         true -> ok = emqx_metrics_worker:clear_metrics(?RES_METRICS, Data#data.id);
         false -> ok
@@ -587,9 +587,9 @@ maybe_alarm(_Status, ResId) ->
 maybe_resume_resource_workers(connected) ->
     lists:foreach(
         fun({_, Pid, _, _}) ->
-            emqx_resource_worker:resume(Pid)
+            emqx_resource_buffer_worker:resume(Pid)
         end,
-        supervisor:which_children(emqx_resource_worker_sup)
+        supervisor:which_children(emqx_resource_buffer_worker_sup)
     );
 maybe_resume_resource_workers(_) ->
     ok.

--- a/apps/emqx_resource/src/emqx_resource_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_sup.erl
@@ -39,8 +39,8 @@ init([]) ->
             modules => [emqx_resource_manager_sup]
         },
     WorkerSup = #{
-        id => emqx_resource_worker_sup,
-        start => {emqx_resource_worker_sup, start_link, []},
+        id => emqx_resource_buffer_worker_sup,
+        start => {emqx_resource_buffer_worker_sup, start_link, []},
         restart => permanent,
         shutdown => infinity,
         type => supervisor

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -414,7 +414,7 @@ t_query_counter_async_inflight(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(WindowSize, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 1_000
             ),
         fun(Trace) ->
@@ -439,7 +439,7 @@ t_query_counter_async_inflight(_) ->
             emqx_resource:query(?ID, {inc_counter, 99}, #{
                 async_reply_fun => {Insert, [Tab0, tmp_query]}
             }),
-            #{?snk_kind := resource_worker_appended_to_queue},
+            #{?snk_kind := buffer_worker_appended_to_queue},
             1_000
         ),
     tap_metrics(?LINE),
@@ -490,7 +490,7 @@ t_query_counter_async_inflight(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(WindowSize, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 1_000
             ),
         fun(Trace) ->
@@ -596,7 +596,7 @@ t_query_counter_async_inflight_batch(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(NumMsgs, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 5_000
             ),
         fun(Trace) ->
@@ -623,7 +623,7 @@ t_query_counter_async_inflight_batch(_) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:query(?ID, {inc_counter, 2}),
-                    #{?snk_kind := resource_worker_flush_but_inflight_full},
+                    #{?snk_kind := buffer_worker_flush_but_inflight_full},
                     5_000
                 ),
             ?assertMatch(0, ets:info(Tab0, size)),
@@ -646,7 +646,7 @@ t_query_counter_async_inflight_batch(_) ->
             emqx_resource:query(?ID, {inc_counter, 3}, #{
                 async_reply_fun => {Insert, [Tab0, tmp_query]}
             }),
-            #{?snk_kind := resource_worker_appended_to_queue},
+            #{?snk_kind := buffer_worker_appended_to_queue},
             1_000
         ),
     tap_metrics(?LINE),
@@ -706,7 +706,7 @@ t_query_counter_async_inflight_batch(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(NumMsgs, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 5_000
             ),
         fun(Trace) ->
@@ -1055,7 +1055,7 @@ t_retry_batch(_Config) ->
                         end,
                         Payloads
                     ),
-                    #{?snk_kind := resource_worker_enter_blocked},
+                    #{?snk_kind := buffer_worker_enter_blocked},
                     5_000
                 ),
             %% now the individual messages should have been counted
@@ -1066,7 +1066,7 @@ t_retry_batch(_Config) ->
             %% batch shall remain enqueued.
             {ok, _} =
                 snabbkaffe:block_until(
-                    ?match_n_events(2, #{?snk_kind := resource_worker_retry_inflight_failed}),
+                    ?match_n_events(2, #{?snk_kind := buffer_worker_retry_inflight_failed}),
                     5_000
                 ),
             %% should not have increased the matched count with the retries
@@ -1078,7 +1078,7 @@ t_retry_batch(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ok = emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_retry_inflight_succeeded},
+                    #{?snk_kind := buffer_worker_retry_inflight_succeeded},
                     5_000
                 ),
             %% 1 more because of the `resume' call
@@ -1140,7 +1140,7 @@ t_delete_and_re_create_with_same_name(_Config) ->
             ?assertMatch(ok, emqx_resource:simple_sync_query(?ID, block)),
             NumRequests = 10,
             {ok, SRef} = snabbkaffe:subscribe(
-                ?match_event(#{?snk_kind := resource_worker_enter_blocked}),
+                ?match_event(#{?snk_kind := buffer_worker_enter_blocked}),
                 NumBufferWorkers,
                 _Timeout = 5_000
             ),
@@ -1189,7 +1189,7 @@ t_delete_and_re_create_with_same_name(_Config) ->
                             resume_interval => 1_000
                         }
                     ),
-                    #{?snk_kind := resource_worker_enter_running},
+                    #{?snk_kind := buffer_worker_enter_running},
                     5_000
                 ),
 
@@ -1271,13 +1271,13 @@ t_retry_sync_inflight(_Config) ->
                         Res = emqx_resource:query(?ID, {big_payload, <<"a">>}, QueryOpts),
                         TestPid ! {res, Res}
                     end),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ok = emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_retry_inflight_succeeded},
+                    #{?snk_kind := buffer_worker_retry_inflight_succeeded},
                     ResumeInterval * 3
                 ),
             receive
@@ -1322,13 +1322,13 @@ t_retry_sync_inflight_batch(_Config) ->
                         Res = emqx_resource:query(?ID, {big_payload, <<"a">>}, QueryOpts),
                         TestPid ! {res, Res}
                     end),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ok = emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_retry_inflight_succeeded},
+                    #{?snk_kind := buffer_worker_retry_inflight_succeeded},
                     ResumeInterval * 3
                 ),
             receive
@@ -1368,7 +1368,7 @@ t_retry_async_inflight(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:query(?ID, {big_payload, <<"b">>}, QueryOpts),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
 
@@ -1376,7 +1376,7 @@ t_retry_async_inflight(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_enter_running},
+                    #{?snk_kind := buffer_worker_enter_running},
                     ResumeInterval * 2
                 ),
             ok
@@ -1411,7 +1411,7 @@ t_retry_async_inflight_batch(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:query(?ID, {big_payload, <<"b">>}, QueryOpts),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
 
@@ -1419,7 +1419,7 @@ t_retry_async_inflight_batch(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_enter_running},
+                    #{?snk_kind := buffer_worker_enter_running},
                     ResumeInterval * 2
                 ),
             ok
@@ -1459,7 +1459,7 @@ t_async_pool_worker_death(_Config) ->
             NumReqs = 10,
             {ok, SRef0} =
                 snabbkaffe:subscribe(
-                    ?match_event(#{?snk_kind := resource_worker_appended_to_inflight}),
+                    ?match_event(#{?snk_kind := buffer_worker_appended_to_inflight}),
                     NumReqs,
                     1_000
                 ),
@@ -1472,7 +1472,7 @@ t_async_pool_worker_death(_Config) ->
             %% grab one of the worker pids and kill it
             {ok, SRef1} =
                 snabbkaffe:subscribe(
-                    ?match_event(#{?snk_kind := resource_worker_worker_down_update}),
+                    ?match_event(#{?snk_kind := buffer_worker_worker_down_update}),
                     NumBufferWorkers,
                     10_000
                 ),
@@ -1568,8 +1568,8 @@ assert_sync_retry_fail_then_succeed_inflight(Trace) ->
     ct:pal("  ~p", [Trace]),
     ?assert(
         ?strict_causality(
-            #{?snk_kind := resource_worker_flush_nack, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_flush_nack, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
             Trace
         )
     ),
@@ -1577,8 +1577,8 @@ assert_sync_retry_fail_then_succeed_inflight(Trace) ->
     %% before restoring the resource health.
     ?assert(
         ?causality(
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_succeeded, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
             Trace
         )
     ),
@@ -1588,8 +1588,8 @@ assert_async_retry_fail_then_succeed_inflight(Trace) ->
     ct:pal("  ~p", [Trace]),
     ?assert(
         ?strict_causality(
-            #{?snk_kind := resource_worker_reply_after_query, action := nack, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_reply_after_query, action := nack, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
             Trace
         )
     ),
@@ -1597,8 +1597,8 @@ assert_async_retry_fail_then_succeed_inflight(Trace) ->
     %% before restoring the resource health.
     ?assert(
         ?causality(
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_succeeded, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
             Trace
         )
     ),

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -510,15 +510,15 @@ nested_put(Alias, Val, Columns0) ->
 -define(IS_RES_DOWN(R), R == stopped; R == not_connected; R == not_found).
 inc_action_metrics(ok, RuleId) ->
     emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.success');
-inc_action_metrics({error, {recoverable_error, _}}, RuleId) ->
-    emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed.out_of_service');
+inc_action_metrics({error, {unrecoverable_error, _}}, RuleId) ->
+    emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed'),
+    emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed.unknown');
 inc_action_metrics(?RESOURCE_ERROR_M(R, _), RuleId) when ?IS_RES_DOWN(R) ->
     emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed.out_of_service');
 inc_action_metrics(R, RuleId) ->
     case is_ok_result(R) of
         false ->
-            emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed'),
-            emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed.unknown');
+            emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed.out_of_service');
         true ->
             emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.success')
     end.

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
@@ -95,7 +95,8 @@ fields("config") ->
                 }
             )}
     ] ++
-        emqx_connector_mysql:fields(config) -- emqx_connector_schema_lib:prepare_statement_fields();
+        (emqx_connector_mysql:fields(config) --
+            emqx_connector_schema_lib:prepare_statement_fields());
 fields("creation_opts") ->
     Opts = emqx_resource_schema:fields("creation_opts"),
     [O || {Field, _} = O <- Opts, not is_hidden_opts(Field)];

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_pgsql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_pgsql.erl
@@ -97,7 +97,8 @@ fields("config") ->
                 }
             )}
     ] ++
-        emqx_connector_pgsql:fields(config) -- emqx_connector_schema_lib:prepare_statement_fields();
+        (emqx_connector_pgsql:fields(config) --
+            emqx_connector_schema_lib:prepare_statement_fields());
 fields("creation_opts") ->
     Opts = emqx_resource_schema:fields("creation_opts"),
     [O || {Field, _} = O <- Opts, not is_hidden_opts(Field)];

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
@@ -1028,7 +1028,7 @@ do_econnrefused_or_timeout_test(Config, Error) ->
                     {_, {ok, _}} =
                         ?wait_async_action(
                             emqx:publish(Message),
-                            #{?snk_kind := gcp_pubsub_request_failed, recoverable_error := true},
+                            #{?snk_kind := gcp_pubsub_request_failed, unrecoverable_error := false},
                             15_000
                         );
                 {async, econnrefused} ->
@@ -1047,7 +1047,7 @@ do_econnrefused_or_timeout_test(Config, Error) ->
                             #{
                                 ?snk_kind := gcp_pubsub_request_failed,
                                 query_mode := async,
-                                recoverable_error := true
+                                unrecoverable_error := false
                             },
                             15_000
                         );
@@ -1271,6 +1271,7 @@ t_failure_no_body(Config) ->
     ),
     ok.
 
+%% even if we kill the worker, the request should be retried later
 t_unrecoverable_error(Config) ->
     ResourceId = ?config(resource_id, Config),
     QueryMode = ?config(query_mode, Config),

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
@@ -914,7 +914,7 @@ t_write_failure(Config) ->
         fun(Trace0) ->
             case QueryMode of
                 sync ->
-                    Trace = ?of_kind(resource_worker_flush_nack, Trace0),
+                    Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
                     ?assertMatch([_ | _], Trace),
                     [#{result := Result} | _] = Trace,
                     ?assert(

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
@@ -228,7 +228,7 @@ query_resource(Config, Request) ->
     Name = ?config(mysql_name, Config),
     BridgeType = ?config(mysql_bridge_type, Config),
     ResourceID = emqx_bridge_resource:resource_id(BridgeType, Name),
-    emqx_resource:query(ResourceID, Request).
+    emqx_resource:query(ResourceID, Request, #{timeout => 500}).
 
 unprepare(Config, Key) ->
     Name = ?config(mysql_name, Config),
@@ -419,7 +419,7 @@ t_write_failure(Config) ->
             case Error of
                 {resource_error, _} ->
                     ok;
-                {recoverable_error, disconnected} ->
+                disconnected ->
                     ok;
                 _ ->
                     ct:fail("unexpected error: ~p", [Error])
@@ -535,7 +535,7 @@ t_uninitialized_prepared_statement(Config) ->
         fun(Trace) ->
             ?assert(
                 ?strict_causality(
-                    #{?snk_kind := mysql_connector_prepare_query_failed, error := not_prepared},
+                    #{?snk_kind := mysql_connector_query_failed, error := not_prepared},
                     #{
                         ?snk_kind := mysql_connector_on_query_prepared_sql,
                         type_or_key := send_message

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
@@ -413,7 +413,7 @@ t_write_failure(Config) ->
         end),
         fun(Trace0) ->
             ct:pal("trace: ~p", [Trace0]),
-            Trace = ?of_kind(resource_worker_flush_nack, Trace0),
+            Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,
             case Error of

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_pgsql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_pgsql_SUITE.erl
@@ -431,7 +431,7 @@ t_write_failure(Config) ->
         end),
         fun(Trace0) ->
             ct:pal("trace: ~p", [Trace0]),
-            Trace = ?of_kind(resource_worker_flush_nack, Trace0),
+            Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,
             case Error of

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_redis.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_redis.erl
@@ -111,7 +111,7 @@ on_batch_query(
 query(InstId, Query, RedisConnSt) ->
     case emqx_connector_redis:on_query(InstId, Query, RedisConnSt) of
         {ok, _} = Ok -> Ok;
-        {error, no_connection} -> {error, {recoverable_error, no_connection}};
+        {error, no_connection} -> {error, no_connection};
         {error, _} = Error -> Error
     end.
 


### PR DESCRIPTION
- Rename `emqx_resource_worker` to `emqx_resource_buffer_worker` (for clarity)
- Change the default error handling behavior of buffer workers to assume the error is recoverable.  This will make us retry more types of errors and avoid data loss due to unknown/unhandled errors. 