### PR TITLE
buffer work refactoring follow up (part 1)

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -65,7 +65,7 @@ load() ->
         fun({Type, NamedConf}) ->
             lists:foreach(
                 fun({Name, Conf}) ->
-                    %% fetch opts for `emqx_resource_worker`
+                    %% fetch opts for `emqx_resource_buffer_worker`
                     ResOpts = emqx_resource:fetch_creation_opts(Conf),
                     safe_load_bridge(Type, Name, Conf, ResOpts)
                 end,

--- a/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
@@ -886,9 +886,9 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
     {ok, SRef} =
         snabbkaffe:subscribe(
             fun
-                (#{?snk_kind := resource_worker_retry_inflight_failed}) ->
+                (#{?snk_kind := buffer_worker_retry_inflight_failed}) ->
                     true;
-                (#{?snk_kind := resource_worker_flush_nack}) ->
+                (#{?snk_kind := buffer_worker_flush_nack}) ->
                     true;
                 (_) ->
                     false

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -255,7 +255,7 @@ reset_metrics(ResId) ->
 query(ResId, Request) ->
     query(ResId, Request, #{}).
 
--spec query(resource_id(), Request :: term(), emqx_resource_worker:query_opts()) ->
+-spec query(resource_id(), Request :: term(), emqx_resource_buffer_worker:query_opts()) ->
     Result :: term().
 query(ResId, Request, Opts) ->
     case emqx_resource_manager:ets_lookup(ResId) of
@@ -263,11 +263,11 @@ query(ResId, Request, Opts) ->
             IsBufferSupported = is_buffer_supported(Module),
             case {IsBufferSupported, QM} of
                 {true, _} ->
-                    emqx_resource_worker:simple_sync_query(ResId, Request);
+                    emqx_resource_buffer_worker:simple_sync_query(ResId, Request);
                 {false, sync} ->
-                    emqx_resource_worker:sync_query(ResId, Request, Opts);
+                    emqx_resource_buffer_worker:sync_query(ResId, Request, Opts);
                 {false, async} ->
-                    emqx_resource_worker:async_query(ResId, Request, Opts)
+                    emqx_resource_buffer_worker:async_query(ResId, Request, Opts)
             end;
         {error, not_found} ->
             ?RESOURCE_ERROR(not_found, "resource not found")
@@ -275,7 +275,7 @@ query(ResId, Request, Opts) ->
 
 -spec simple_sync_query(resource_id(), Request :: term()) -> Result :: term().
 simple_sync_query(ResId, Request) ->
-    emqx_resource_worker:simple_sync_query(ResId, Request).
+    emqx_resource_buffer_worker:simple_sync_query(ResId, Request).
 
 -spec start(resource_id()) -> ok | {error, Reason :: term()}.
 start(ResId) ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
@@ -13,7 +13,7 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--module(emqx_resource_worker_sup).
+-module(emqx_resource_buffer_worker_sup).
 -behaviour(supervisor).
 
 %%%=============================================================================
@@ -99,7 +99,7 @@ ensure_worker_added(ResId, Idx) ->
 
 -define(CHILD_ID(MOD, RESID, INDEX), {MOD, RESID, INDEX}).
 ensure_worker_started(ResId, Idx, Opts) ->
-    Mod = emqx_resource_worker,
+    Mod = emqx_resource_buffer_worker,
     Spec = #{
         id => ?CHILD_ID(Mod, ResId, Idx),
         start => {Mod, start_link, [ResId, Idx, Opts]},
@@ -116,7 +116,7 @@ ensure_worker_started(ResId, Idx, Opts) ->
     end.
 
 ensure_worker_removed(ResId, Idx) ->
-    ChildId = ?CHILD_ID(emqx_resource_worker, ResId, Idx),
+    ChildId = ?CHILD_ID(emqx_resource_buffer_worker, ResId, Idx),
     case supervisor:terminate_child(?SERVER, ChildId) of
         ok ->
             Res = supervisor:delete_child(?SERVER, ChildId),
@@ -129,7 +129,7 @@ ensure_worker_removed(ResId, Idx) ->
     end.
 
 ensure_disk_queue_dir_absent(ResourceId, Index) ->
-    ok = emqx_resource_worker:clear_disk_queue_dir(ResourceId, Index),
+    ok = emqx_resource_buffer_worker:clear_disk_queue_dir(ResourceId, Index),
     ok.
 
 ensure_worker_pool_removed(ResId) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -150,7 +150,7 @@ create(MgrId, ResId, Group, ResourceType, Config, Opts) ->
             %% buffer, so there is no need for resource workers
             ok;
         false ->
-            ok = emqx_resource_worker_sup:start_workers(ResId, Opts),
+            ok = emqx_resource_buffer_worker_sup:start_workers(ResId, Opts),
             case maps:get(start_after_created, Opts, ?START_AFTER_CREATED) of
                 true ->
                     wait_for_ready(ResId, maps:get(start_timeout, Opts, ?START_TIMEOUT));
@@ -473,7 +473,7 @@ retry_actions(Data) ->
 
 handle_remove_event(From, ClearMetrics, Data) ->
     stop_resource(Data),
-    ok = emqx_resource_worker_sup:stop_workers(Data#data.id, Data#data.opts),
+    ok = emqx_resource_buffer_worker_sup:stop_workers(Data#data.id, Data#data.opts),
     case ClearMetrics of
         true -> ok = emqx_metrics_worker:clear_metrics(?RES_METRICS, Data#data.id);
         false -> ok
@@ -587,9 +587,9 @@ maybe_alarm(_Status, ResId) ->
 maybe_resume_resource_workers(connected) ->
     lists:foreach(
         fun({_, Pid, _, _}) ->
-            emqx_resource_worker:resume(Pid)
+            emqx_resource_buffer_worker:resume(Pid)
         end,
-        supervisor:which_children(emqx_resource_worker_sup)
+        supervisor:which_children(emqx_resource_buffer_worker_sup)
     );
 maybe_resume_resource_workers(_) ->
     ok.

--- a/apps/emqx_resource/src/emqx_resource_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_sup.erl
@@ -39,8 +39,8 @@ init([]) ->
             modules => [emqx_resource_manager_sup]
         },
     WorkerSup = #{
-        id => emqx_resource_worker_sup,
-        start => {emqx_resource_worker_sup, start_link, []},
+        id => emqx_resource_buffer_worker_sup,
+        start => {emqx_resource_buffer_worker_sup, start_link, []},
         restart => permanent,
         shutdown => infinity,
         type => supervisor

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -414,7 +414,7 @@ t_query_counter_async_inflight(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(WindowSize, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 1_000
             ),
         fun(Trace) ->
@@ -439,7 +439,7 @@ t_query_counter_async_inflight(_) ->
             emqx_resource:query(?ID, {inc_counter, 99}, #{
                 async_reply_fun => {Insert, [Tab0, tmp_query]}
             }),
-            #{?snk_kind := resource_worker_appended_to_queue},
+            #{?snk_kind := buffer_worker_appended_to_queue},
             1_000
         ),
     tap_metrics(?LINE),
@@ -490,7 +490,7 @@ t_query_counter_async_inflight(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(WindowSize, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 1_000
             ),
         fun(Trace) ->
@@ -596,7 +596,7 @@ t_query_counter_async_inflight_batch(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(NumMsgs, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 5_000
             ),
         fun(Trace) ->
@@ -623,7 +623,7 @@ t_query_counter_async_inflight_batch(_) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:query(?ID, {inc_counter, 2}),
-                    #{?snk_kind := resource_worker_flush_but_inflight_full},
+                    #{?snk_kind := buffer_worker_flush_but_inflight_full},
                     5_000
                 ),
             ?assertMatch(0, ets:info(Tab0, size)),
@@ -646,7 +646,7 @@ t_query_counter_async_inflight_batch(_) ->
             emqx_resource:query(?ID, {inc_counter, 3}, #{
                 async_reply_fun => {Insert, [Tab0, tmp_query]}
             }),
-            #{?snk_kind := resource_worker_appended_to_queue},
+            #{?snk_kind := buffer_worker_appended_to_queue},
             1_000
         ),
     tap_metrics(?LINE),
@@ -706,7 +706,7 @@ t_query_counter_async_inflight_batch(_) ->
         {_, {ok, _}} =
             ?wait_async_action(
                 inc_counter_in_parallel(NumMsgs, ReqOpts),
-                #{?snk_kind := resource_worker_flush_but_inflight_full},
+                #{?snk_kind := buffer_worker_flush_but_inflight_full},
                 5_000
             ),
         fun(Trace) ->
@@ -1055,7 +1055,7 @@ t_retry_batch(_Config) ->
                         end,
                         Payloads
                     ),
-                    #{?snk_kind := resource_worker_enter_blocked},
+                    #{?snk_kind := buffer_worker_enter_blocked},
                     5_000
                 ),
             %% now the individual messages should have been counted
@@ -1066,7 +1066,7 @@ t_retry_batch(_Config) ->
             %% batch shall remain enqueued.
             {ok, _} =
                 snabbkaffe:block_until(
-                    ?match_n_events(2, #{?snk_kind := resource_worker_retry_inflight_failed}),
+                    ?match_n_events(2, #{?snk_kind := buffer_worker_retry_inflight_failed}),
                     5_000
                 ),
             %% should not have increased the matched count with the retries
@@ -1078,7 +1078,7 @@ t_retry_batch(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ok = emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_retry_inflight_succeeded},
+                    #{?snk_kind := buffer_worker_retry_inflight_succeeded},
                     5_000
                 ),
             %% 1 more because of the `resume' call
@@ -1140,7 +1140,7 @@ t_delete_and_re_create_with_same_name(_Config) ->
             ?assertMatch(ok, emqx_resource:simple_sync_query(?ID, block)),
             NumRequests = 10,
             {ok, SRef} = snabbkaffe:subscribe(
-                ?match_event(#{?snk_kind := resource_worker_enter_blocked}),
+                ?match_event(#{?snk_kind := buffer_worker_enter_blocked}),
                 NumBufferWorkers,
                 _Timeout = 5_000
             ),
@@ -1189,7 +1189,7 @@ t_delete_and_re_create_with_same_name(_Config) ->
                             resume_interval => 1_000
                         }
                     ),
-                    #{?snk_kind := resource_worker_enter_running},
+                    #{?snk_kind := buffer_worker_enter_running},
                     5_000
                 ),
 
@@ -1271,13 +1271,13 @@ t_retry_sync_inflight(_Config) ->
                         Res = emqx_resource:query(?ID, {big_payload, <<"a">>}, QueryOpts),
                         TestPid ! {res, Res}
                     end),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ok = emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_retry_inflight_succeeded},
+                    #{?snk_kind := buffer_worker_retry_inflight_succeeded},
                     ResumeInterval * 3
                 ),
             receive
@@ -1322,13 +1322,13 @@ t_retry_sync_inflight_batch(_Config) ->
                         Res = emqx_resource:query(?ID, {big_payload, <<"a">>}, QueryOpts),
                         TestPid ! {res, Res}
                     end),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
             {ok, {ok, _}} =
                 ?wait_async_action(
                     ok = emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_retry_inflight_succeeded},
+                    #{?snk_kind := buffer_worker_retry_inflight_succeeded},
                     ResumeInterval * 3
                 ),
             receive
@@ -1368,7 +1368,7 @@ t_retry_async_inflight(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:query(?ID, {big_payload, <<"b">>}, QueryOpts),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
 
@@ -1376,7 +1376,7 @@ t_retry_async_inflight(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_enter_running},
+                    #{?snk_kind := buffer_worker_enter_running},
                     ResumeInterval * 2
                 ),
             ok
@@ -1411,7 +1411,7 @@ t_retry_async_inflight_batch(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:query(?ID, {big_payload, <<"b">>}, QueryOpts),
-                    #{?snk_kind := resource_worker_retry_inflight_failed},
+                    #{?snk_kind := buffer_worker_retry_inflight_failed},
                     ResumeInterval * 2
                 ),
 
@@ -1419,7 +1419,7 @@ t_retry_async_inflight_batch(_Config) ->
             {ok, {ok, _}} =
                 ?wait_async_action(
                     emqx_resource:simple_sync_query(?ID, resume),
-                    #{?snk_kind := resource_worker_enter_running},
+                    #{?snk_kind := buffer_worker_enter_running},
                     ResumeInterval * 2
                 ),
             ok
@@ -1459,7 +1459,7 @@ t_async_pool_worker_death(_Config) ->
             NumReqs = 10,
             {ok, SRef0} =
                 snabbkaffe:subscribe(
-                    ?match_event(#{?snk_kind := resource_worker_appended_to_inflight}),
+                    ?match_event(#{?snk_kind := buffer_worker_appended_to_inflight}),
                     NumReqs,
                     1_000
                 ),
@@ -1472,7 +1472,7 @@ t_async_pool_worker_death(_Config) ->
             %% grab one of the worker pids and kill it
             {ok, SRef1} =
                 snabbkaffe:subscribe(
-                    ?match_event(#{?snk_kind := resource_worker_worker_down_update}),
+                    ?match_event(#{?snk_kind := buffer_worker_worker_down_update}),
                     NumBufferWorkers,
                     10_000
                 ),
@@ -1568,8 +1568,8 @@ assert_sync_retry_fail_then_succeed_inflight(Trace) ->
     ct:pal("  ~p", [Trace]),
     ?assert(
         ?strict_causality(
-            #{?snk_kind := resource_worker_flush_nack, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_flush_nack, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
             Trace
         )
     ),
@@ -1577,8 +1577,8 @@ assert_sync_retry_fail_then_succeed_inflight(Trace) ->
     %% before restoring the resource health.
     ?assert(
         ?causality(
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_succeeded, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
             Trace
         )
     ),
@@ -1588,8 +1588,8 @@ assert_async_retry_fail_then_succeed_inflight(Trace) ->
     ct:pal("  ~p", [Trace]),
     ?assert(
         ?strict_causality(
-            #{?snk_kind := resource_worker_reply_after_query, action := nack, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_reply_after_query, action := nack, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
             Trace
         )
     ),
@@ -1597,8 +1597,8 @@ assert_async_retry_fail_then_succeed_inflight(Trace) ->
     %% before restoring the resource health.
     ?assert(
         ?causality(
-            #{?snk_kind := resource_worker_retry_inflight_failed, ref := _Ref},
-            #{?snk_kind := resource_worker_retry_inflight_succeeded, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
             Trace
         )
     ),

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mysql.erl
@@ -95,7 +95,8 @@ fields("config") ->
                 }
             )}
     ] ++
-        emqx_connector_mysql:fields(config) -- emqx_connector_schema_lib:prepare_statement_fields();
+        (emqx_connector_mysql:fields(config) --
+            emqx_connector_schema_lib:prepare_statement_fields());
 fields("creation_opts") ->
     Opts = emqx_resource_schema:fields("creation_opts"),
     [O || {Field, _} = O <- Opts, not is_hidden_opts(Field)];

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_pgsql.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_pgsql.erl
@@ -97,7 +97,8 @@ fields("config") ->
                 }
             )}
     ] ++
-        emqx_connector_pgsql:fields(config) -- emqx_connector_schema_lib:prepare_statement_fields();
+        (emqx_connector_pgsql:fields(config) --
+            emqx_connector_schema_lib:prepare_statement_fields());
 fields("creation_opts") ->
     Opts = emqx_resource_schema:fields("creation_opts"),
     [O || {Field, _} = O <- Opts, not is_hidden_opts(Field)];

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
@@ -914,7 +914,7 @@ t_write_failure(Config) ->
         fun(Trace0) ->
             case QueryMode of
                 sync ->
-                    Trace = ?of_kind(resource_worker_flush_nack, Trace0),
+                    Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
                     ?assertMatch([_ | _], Trace),
                     [#{result := Result} | _] = Trace,
                     ?assert(

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_mysql_SUITE.erl
@@ -413,7 +413,7 @@ t_write_failure(Config) ->
         end),
         fun(Trace0) ->
             ct:pal("trace: ~p", [Trace0]),
-            Trace = ?of_kind(resource_worker_flush_nack, Trace0),
+            Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,
             case Error of

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_pgsql_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_pgsql_SUITE.erl
@@ -431,7 +431,7 @@ t_write_failure(Config) ->
         end),
         fun(Trace0) ->
             ct:pal("trace: ~p", [Trace0]),
-            Trace = ?of_kind(resource_worker_flush_nack, Trace0),
+            Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,
             case Error of


### PR DESCRIPTION
Renaming `emqx_resource_worker` to `emqx_resource_buffer_worker` for clarity of purpose.