### PR TITLE
feat(helm): user can define service account by userself

### DIFF
--- a/deploy/charts/emqx-enterprise/README.md
+++ b/deploy/charts/emqx-enterprise/README.md
@@ -14,14 +14,14 @@ To install the chart with the release name `my-emqx`:
 + From github
   ```
   $ git clone https://github.com/emqx/emqx.git
-  $ cd emqx/deploy/charts/emqx
+  $ cd emqx/deploy/charts/emqx-enterprise
   $ helm install my-emqx .
   ```
 
 + From chart repos
   ```
   helm repo add emqx https://repos.emqx.io/charts
-  helm install my-emqx emqx/emqx
+  helm install my-emqx emqx/emqx-enterprise
   ```
   > If you want to install an unstable version, you need to add `--devel` when you execute the `helm install` command.
 
@@ -43,6 +43,9 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `image.repository` | EMQX Image name | `emqx/emqx-enterprise` |
 | `image.pullPolicy` | The image pull policy | IfNotPresent |
 | `image.pullSecrets ` | The image pull secrets | `[]` (does not add image pull secrets to deployed pods) |
+| `serviceAccount.create` | If `true`, create a new service account | `true` |
+| `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `serviceAccount.annotations` | Annotations to add to the service account |  |
 | `envFromSecret` | The name pull a secret in the same kubernetes namespace which contains values that will be added to the environment | nil |
 | `recreatePods` | Forces the recreation of pods during upgrades, which can be useful to always apply the most recent configuration. | false |
 | `podAnnotations ` | Annotations for pod | `{}` |
@@ -102,10 +105,9 @@ The following table lists the configurable [EMQX](https://www.emqx.io/)-specific
 default values.
 Parameter | Description | Default Value
 --- | --- | ---
-`emqxConfig` | Map of [configuration](https://www.emqx.io/docs/en/latest/configuration/configuration.html) items
-expressed as [environment variables](https://www.emqx.io/docs/en/v4.3/configuration/environment-variable.html) (prefix
-can be omitted) or using the configuration
-files [namespaced dotted notation](https://www.emqx.io/docs/en/latest/configuration/configuration.html) | `nil`
+`emqxConfig` | Map of [configuration](https://www.emqx.io/docs/en/v5.0/admin/cfg.html) items
+expressed as [environment variables](https://www.emqx.io/docs/en/v5.0/admin/cfg.html#environment-variables) (prefix `EMQX_` can be omitted) or using the configuration
+files [namespaced dotted notation](https://www.emqx.io/docs/en/v5.0/admin/cfg.html#syntax) | `nil`
 `emqxLicenseSecretName` | Name of the secret that holds the license information | `nil`
 
 ## SSL settings

--- a/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
@@ -52,6 +52,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "emqx.serviceAccountName" . }}
       volumes:
       {{- if .Values.ssl.enabled }}
       - name: ssl-cert
@@ -72,9 +73,6 @@ spec:
       - name: emqx-license
         secret:
           secretName: {{ .Values.emqxLicenseSecretName }}
-      {{- end }}
-      {{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s"}}
-      serviceAccountName:  {{ include "emqx.fullname" . }}
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}

--- a/deploy/charts/emqx-enterprise/templates/_helpers.tpl
+++ b/deploy/charts/emqx-enterprise/templates/_helpers.tpl
@@ -42,3 +42,14 @@ Get ssl secret name .
     {{ include "emqx.fullname" . }}-tls
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "emqx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "emqx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/emqx-enterprise/templates/rbac.yaml
+++ b/deploy/charts/emqx-enterprise/templates/rbac.yaml
@@ -1,10 +1,23 @@
-{{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s"}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ include "emqx.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-  name: {{ include "emqx.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
 ---
+{{- if .Values.serviceAccount.create }}
+{{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s" }}
 kind: Role
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +36,12 @@ rules:
   - get
   - watch
   - list
+{{- end }}
+{{- end }}
+
 ---
+{{- if .Values.serviceAccount.create }}
+{{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s" }}
 kind: RoleBinding
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,10 +53,11 @@ metadata:
   name: {{ include "emqx.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "emqx.fullname" . }}
+    name: {{ include "emqx.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "emqx.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -16,6 +16,15 @@ image:
   # pullSecrets:
   # - myRegistryKeySecretName
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  # If set false, means you need create service account by yourself
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Annotations to add to the service account
+  annotations: {}
 
 # The name of a secret in the same kubernetes namespace which contains values to
 # be added to the environment (must be manually created)

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -43,6 +43,9 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `image.repository` | EMQX Image name | emqx/emqx |
 | `image.pullPolicy` | The image pull policy | IfNotPresent |
 | `image.pullSecrets ` | The image pull secrets | `[]` (does not add image pull secrets to deployed pods) |
+| `serviceAccount.create` | If `true`, create a new service account | `true` |
+| `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `serviceAccount.annotations` | Annotations to add to the service account |  |
 | `envFromSecret` | The name pull a secret in the same kubernetes namespace which contains values that will be added to the environment | nil |
 | `recreatePods` | Forces the recreation of pods during upgrades, which can be useful to always apply the most recent configuration. | false |
 | `podAnnotations ` | Annotations for pod | `{}` |

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -52,6 +52,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | quote }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "emqx.serviceAccountName" . }}
       volumes:
       {{- if .Values.ssl.enabled }}
       - name: ssl-cert
@@ -72,9 +73,6 @@ spec:
       - name: emqx-license
         secret:
           secretName: {{ .Values.emqxLicenseSecretName }}
-      {{- end }}
-      {{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s"}}
-      serviceAccountName:  {{ include "emqx.fullname" . }}
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}

--- a/deploy/charts/emqx/templates/_helpers.tpl
+++ b/deploy/charts/emqx/templates/_helpers.tpl
@@ -42,3 +42,14 @@ Get ssl secret name .
     {{ include "emqx.fullname" . }}-tls
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "emqx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "emqx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/emqx/templates/rbac.yaml
+++ b/deploy/charts/emqx/templates/rbac.yaml
@@ -1,10 +1,23 @@
-{{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s"}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+  name: {{ include "emqx.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-  name: {{ include "emqx.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
 ---
+{{- if .Values.serviceAccount.create }}
+{{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s" }}
 kind: Role
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +36,12 @@ rules:
   - get
   - watch
   - list
+{{- end }}
+{{- end }}
+
 ---
+{{- if .Values.serviceAccount.create }}
+{{- if eq .Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY "k8s" }}
 kind: RoleBinding
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,10 +53,11 @@ metadata:
   name: {{ include "emqx.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "emqx.fullname" . }}
+    name: {{ include "emqx.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "emqx.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -16,6 +16,15 @@ image:
   # pullSecrets:
   # - myRegistryKeySecretName
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  # If set false, means you need create service account by yourself
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Annotations to add to the service account
+  annotations: {}
 
 # The name of a secret in the same kubernetes namespace which contains values to
 # be added to the environment (must be manually created)


### PR DESCRIPTION
Sometimes, in order to use certain secrets and provide access to the kubernetes cluster user need to provide specifies service account to the EMQX deployment