### PR TITLE
feat(helm): user can define service account by userself

### DIFF
--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -40,6 +40,9 @@ Parameter  | Description | Default Value
 `image.pullPolicy`  | The image pull policy  | `IfNotPresent`
 `image.pullSecrets `  | The image pull secrets (does not add image pull secrets to deployed pods)  |``[]``
 `recreatePods` | Forces the recreation of pods during upgrades, which can be useful to always apply the most recent configuration. | `false`
+`serviceAccount.create` | If `true`, create a new service account | `true`
+`serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |
+`serviceAccount.annotations` | Annotations to add to the service account |
 `podAnnotations ` | Annotations for pod | `{}`
 `podManagementPolicy`| To redeploy a chart with existing PVC(s), the value must be set to Parallel to avoid deadlock | `Parallel`
 `persistence.enabled` | Enable EMQX persistence using PVC | `false`

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -64,6 +64,7 @@ spec:
         checksum/config: {{ $configData | sha256sum | quote }}
       {{- end }}
     spec:
+      serviceAccountName:  {{ include "emqx.serviceAccountName" . }}
       volumes:
       {{- if .Values.emqxLoadedPlugins }}
       - name: emqx-loaded-plugins
@@ -106,9 +107,6 @@ spec:
       - name: emqx-license
         secret:
           secretName: {{ $licenseSecretName }}
-      {{- end }}
-      {{- if eq (.Values.emqxConfig.EMQX_CLUSTER__DISCOVERY | default "k8s") "k8s"  }}
-      serviceAccountName:  {{ include "emqx.fullname" . }}
       {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}

--- a/deploy/charts/emqx/templates/_helpers.tpl
+++ b/deploy/charts/emqx/templates/_helpers.tpl
@@ -30,3 +30,14 @@ Create chart name and version as used by the chart label.
 {{- define "emqx.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "emqx.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "emqx.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/emqx/templates/rbac.yaml
+++ b/deploy/charts/emqx/templates/rbac.yaml
@@ -1,10 +1,23 @@
-{{- if eq (.Values.emqxConfig.EMQX_CLUSTER__DISCOVERY | default "k8s") "k8s"  }}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   namespace: {{ .Release.Namespace }}
-  name: {{ include "emqx.fullname" . }}
+  name: {{ include "emqx.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}
+
 ---
+{{- if .Values.serviceAccount.create }}
+{{- if eq (.Values.emqxConfig.EMQX_CLUSTER__DISCOVERY | default "k8s") "k8s"  }}
 kind: Role
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -23,7 +36,12 @@ rules:
   - get
   - watch
   - list
+{{- end }}
+{{- end }}
+
 ---
+{{- if .Values.serviceAccount.create }}
+{{- if eq (.Values.emqxConfig.EMQX_CLUSTER__DISCOVERY | default "k8s") "k8s"  }}
 kind: RoleBinding
 {{- if semverCompare ">=1.17-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,10 +53,11 @@ metadata:
   name: {{ include "emqx.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "emqx.fullname" . }}
+    name: {{ include "emqx.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
   name: {{ include "emqx.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -14,6 +14,16 @@ image:
   # pullSecrets:
   # - myRegistryKeySecretName
 
+serviceAccount:
+  # Specifies whether a service account should be created
+  # If set false, means you need create service account by yourself
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+  # Annotations to add to the service account
+  annotations: {}
+
 ## Forces the recreation of pods during helm upgrades. This can be useful to update configuration values even if the container image did not change.
 recreatePods: false
 


### PR DESCRIPTION
Sometimes, in order to use certain secrets and provide access to the kubernetes cluster user need to provide specifies service account to the EMQX deployment