### PR TITLE
fix: add clusterDomain in values

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/configmap.yaml
+++ b/deploy/charts/emqx-enterprise/templates/configmap.yaml
@@ -16,9 +16,9 @@ data:
   EMQX_CLUSTER__K8S__SERVICE_NAME:  {{ include "emqx.fullname" . }}-headless
   EMQX_CLUSTER__K8S__NAMESPACE: {{ .Release.Namespace }}
   EMQX_CLUSTER__K8S__ADDRESS_TYPE: "hostname"
-  EMQX_CLUSTER__K8S__SUFFIX: "svc.cluster.local"
+  EMQX_CLUSTER__K8S__SUFFIX: "svc.{{ .Values.clusterDomain }}"
   {{- else if eq (.Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY)  "dns"  }}
-  EMQX_CLUSTER__DNS__NAME: "{{  include "emqx.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local"
+  EMQX_CLUSTER__DNS__NAME: "{{  include "emqx.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
   EMQX_CLUSTER__DNS__RECORD_TYPE: "srv"
   {{- end -}}
   {{- range $index, $value := .Values.emqxConfig }}

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -35,6 +35,8 @@ serviceAccount:
 ## Forces the recreation of pods during helm upgrades. This can be useful to update configuration values even if the container image did not change.
 recreatePods: false
 
+clusterDomain: cluster.local
+
 podAnnotations: {}
 
 # Pod deployment policy

--- a/deploy/charts/emqx/templates/configmap.yaml
+++ b/deploy/charts/emqx/templates/configmap.yaml
@@ -16,9 +16,9 @@ data:
   EMQX_CLUSTER__K8S__SERVICE_NAME:  {{ include "emqx.fullname" . }}-headless
   EMQX_CLUSTER__K8S__NAMESPACE: {{ .Release.Namespace }}
   EMQX_CLUSTER__K8S__ADDRESS_TYPE: "hostname"
-  EMQX_CLUSTER__K8S__SUFFIX: "svc.cluster.local"
+  EMQX_CLUSTER__K8S__SUFFIX: "svc.{{ .Values.clusterDomain }}"
   {{- else if eq (.Values.emqxConfig.EMQX_CLUSTER__DISCOVERY_STRATEGY)  "dns"  }}
-  EMQX_CLUSTER__DNS__NAME: "{{  include "emqx.fullname" . }}-headless.{{ .Release.Namespace }}.svc.cluster.local"
+  EMQX_CLUSTER__DNS__NAME: "{{  include "emqx.fullname" . }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}"
   EMQX_CLUSTER__DNS__RECORD_TYPE: "srv"
   {{- end -}}
   {{- range $index, $value := .Values.emqxConfig }}

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -35,6 +35,8 @@ serviceAccount:
 ## Forces the recreation of pods during helm upgrades. This can be useful to update configuration values even if the container image did not change.
 recreatePods: false
 
+clusterDomain: cluster.local
+
 podAnnotations: {}
 
 # Pod deployment policy


### PR DESCRIPTION
It's not uncommon to use another clusterDomain in Kubernetes.
With this new config value, it's possible to avoid manually overriding some environment variables.