### PR TITLE
fix: Authorization header leak in log entries for webhook

### DIFF
--- a/apps/emqx/src/emqx_misc.erl
+++ b/apps/emqx/src/emqx_misc.erl
@@ -609,7 +609,11 @@ do_redact(K, V, Checker) ->
 
 -define(REDACT_VAL, "******").
 redact_v(V) when is_binary(V) -> <<?REDACT_VAL>>;
-redact_v(_V) -> ?REDACT_VAL.
+%% The HOCON schema system may generate sensitive values with this format
+redact_v([{str, Bin}]) when is_binary(Bin) ->
+    [{str, <<?REDACT_VAL>>}];
+redact_v(_V) ->
+    ?REDACT_VAL.
 
 is_redacted(K, V) ->
     do_is_redacted(K, V, fun is_sensitive_key/1).

--- a/changes/v5.0.16/fix-9839.en.md
+++ b/changes/v5.0.16/fix-9839.en.md
@@ -1,0 +1,1 @@
+Make sure that the content of an Authorization header that users have specified for a webhook bridge is not printed to log files.

--- a/changes/v5.0.16/fix-9839.zh.md
+++ b/changes/v5.0.16/fix-9839.zh.md
@@ -1,0 +1,1 @@
+确保用户为webhook-bridge指定的Authorization-HTTP-header的内容不会被打印到日志文件。


### PR DESCRIPTION
The Authorization header contains sensitive information (e.g., password) so one typically don't want to print this to log files. This PR makes sure that the content of a Authorization header that users have specified for a webhook bridge is not printed to log files.

Jira issue: https://emqx.atlassian.net/browse/EMQX-8791

I don't know if release-50 is the right branch for this to be merged to so let me know if another branch is better and I will rebase it to that branch instead.