### PR TITLE
fix: redact influxdb tokens in logs and reduce log level

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -255,7 +255,7 @@ create(BridgeType, BridgeName, RawConf) ->
         brige_action => create,
         bridge_type => BridgeType,
         bridge_name => BridgeName,
-        bridge_raw_config => RawConf
+        bridge_raw_config => emqx_misc:redact(RawConf)
     }),
     emqx_conf:update(
         emqx_bridge:config_key_path() ++ [BridgeType, BridgeName],

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -137,7 +137,7 @@ create(Type, Name, Conf, Opts0) ->
         msg => "create bridge",
         type => Type,
         name => Name,
-        config => Conf
+        config => emqx_misc:redact(Conf)
     }),
     Opts = override_start_after_created(Conf, Opts0),
     {ok, _Data} = emqx_resource:create_local(
@@ -172,7 +172,7 @@ update(Type, Name, {OldConf, Conf}, Opts0) ->
                 msg => "update bridge",
                 type => Type,
                 name => Name,
-                config => Conf
+                config => emqx_misc:redact(Conf)
             }),
             case recreate(Type, Name, Conf, Opts) of
                 {ok, _} ->
@@ -182,7 +182,7 @@ update(Type, Name, {OldConf, Conf}, Opts0) ->
                         msg => "updating_a_non_existing_bridge",
                         type => Type,
                         name => Name,
-                        config => Conf
+                        config => emqx_misc:redact(Conf)
                     }),
                     create(Type, Name, Conf, Opts);
                 {error, Reason} ->

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -495,15 +495,15 @@ log_and_alarm(IsSuccess, Res, #{kind := ?APPLY_KIND_INITIATE} = Meta) ->
     %% because nothing is committed
     case IsSuccess of
         true ->
-            ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_result", result => Res});
+            ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_result", result => emqx_misc:redact(Res)});
         false ->
-            ?SLOG(warning, Meta#{msg => "cluster_rpc_apply_result", result => Res})
+            ?SLOG(warning, Meta#{msg => "cluster_rpc_apply_result", result => emqx_misc:redact(Res)})
     end;
 log_and_alarm(true, Res, Meta) ->
-    ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_ok", result => Res}),
+    ?SLOG(debug, Meta#{msg => "cluster_rpc_apply_ok", result => emqx_misc:redact(Res)}),
     do_alarm(deactivate, Res, Meta);
 log_and_alarm(false, Res, Meta) ->
-    ?SLOG(error, Meta#{msg => "cluster_rpc_apply_failed", result => Res}),
+    ?SLOG(error, Meta#{msg => "cluster_rpc_apply_failed", result => emqx_misc:redact(Res)}),
     do_alarm(activate, Res, Meta).
 
 do_alarm(Fun, Res, #{tnx_id := Id} = Meta) ->

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -487,7 +487,7 @@ start_resource(Data, From) ->
             Actions = maybe_reply([{state_timeout, 0, health_check}], From, ok),
             {next_state, connecting, UpdatedData, Actions};
         {error, Reason} = Err ->
-            ?SLOG(error, #{
+            ?SLOG(warning, #{
                 msg => start_resource_failed,
                 id => Data#data.id,
                 reason => Reason
@@ -546,7 +546,7 @@ handle_connected_health_check(Data) ->
                 Actions = [{state_timeout, health_check_interval(Data#data.opts), health_check}],
                 {keep_state, UpdatedData, Actions};
             (Status, UpdatedData) ->
-                ?SLOG(error, #{
+                ?SLOG(warning, #{
                     msg => health_check_failed,
                     id => Data#data.id,
                     status => Status

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_influxdb.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_influxdb.erl
@@ -341,9 +341,10 @@ password(_) ->
 redact_auth(Term) ->
     emqx_misc:redact(Term, fun is_auth_key/1).
 
-is_auth_key(<<"Authorization">>) -> true;
-is_auth_key(<<"authorization">>) -> true;
-is_auth_key(_) -> false.
+is_auth_key(Key) when is_binary(Key) ->
+    string:equal("authorization", Key, true);
+is_auth_key(_) ->
+    false.
 
 %% -------------------------------------------------------------------------------------------------
 %% Query
@@ -627,6 +628,13 @@ is_unrecoverable_error(_) ->
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
+
+is_auth_key_test_() ->
+    [
+        ?_assert(is_auth_key(<<"Authorization">>)),
+        ?_assertNot(is_auth_key(<<"Something">>)),
+        ?_assertNot(is_auth_key(89))
+    ].
 
 %% for coverage
 desc_test_() ->

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_influxdb.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_influxdb.erl
@@ -208,7 +208,7 @@ start_client(InstId, Config) ->
     catch
         E:R:S ->
             ?tp(influxdb_connector_start_exception, #{error => {E, R}}),
-            ?SLOG(error, #{
+            ?SLOG(warning, #{
                 msg => "start influxdb connector error",
                 connector => InstId,
                 error => E,
@@ -242,7 +242,7 @@ do_start_client(
                     {ok, State};
                 false ->
                     ?tp(influxdb_connector_start_failed, #{error => influxdb_client_not_alive}),
-                    ?SLOG(error, #{
+                    ?SLOG(warning, #{
                         msg => "starting influxdb connector failed",
                         connector => InstId,
                         client => redact_auth(Client),
@@ -261,7 +261,7 @@ do_start_client(
             do_start_client(InstId, ClientConfig, Config);
         {error, Reason} ->
             ?tp(influxdb_connector_start_failed, #{error => Reason}),
-            ?SLOG(error, #{
+            ?SLOG(warning, #{
                 msg => "starting influxdb connector failed",
                 connector => InstId,
                 reason => Reason


### PR DESCRIPTION
Several places exposed InfluxDB tokens in log messages. These are now redacted. Some log messages were also reported on the `error` log level for connection failures. These should be warnings instead.

Fixes EMQX-8787 and EMQX-8788.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes (logs are not easily testable)
- [ ] Changed lines covered in coverage report
- [X] Change log has been added to `changes/<version>/(feat|fix)-<PR-id>.en.md` and `.zh.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [ ] ~Schema changes are backward compatible~
