### PR TITLE
0126 reply caller for buffer overflow queue items

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -424,7 +424,13 @@ check_config(SchemaMod, RawConf, Opts0) ->
 %% it's maybe too much when reporting to the user
 -spec compact_errors(any(), any()) -> no_return().
 compact_errors(Schema, [Error0 | More]) when is_map(Error0) ->
-    Error1 = Error0#{discarded_errors_count => length(More)},
+    Error1 =
+        case length(More) of
+            0 ->
+                Error0;
+            _ ->
+                Error0#{unshown_errors => length(More)}
+        end,
     Error =
         case is_atom(Schema) of
             true ->

--- a/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_redis_SUITE.erl
@@ -188,8 +188,7 @@ t_create_invalid_config(_Config) ->
     ?assertMatch(
         {error, #{
             kind := validation_error,
-            path := "authorization.sources.1",
-            discarded_errors_count := 0
+            path := "authorization.sources.1"
         }},
         emqx_authz:update(?CMD_REPLACE, [C])
     ).

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1084,9 +1084,10 @@ estimate_size(QItem) ->
     erlang:external_size(QItem).
 
 -spec append_queue(id(), index(), replayq:q(), [queue_query()]) -> replayq:q().
-append_queue(Id, Index, Q, Queries) when not is_binary(Q) ->
-    %% we must not append a raw binary because the marshaller will get
-    %% lost.
+append_queue(Id, Index, Q, Queries) ->
+    %% this assertion is to ensure that we never append a raw binary
+    %% because the marshaller will get lost.
+    false = is_binary(hd(Queries)),
     Q0 = replayq:append(Q, Queries),
     Q2 =
         case replayq:overflow(Q0) of

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -243,7 +243,7 @@ blocked(cast, flush, Data) ->
 blocked(state_timeout, unblock, St) ->
     resume_from_blocked(St);
 blocked(info, ?SEND_REQ(_ReqFrom, {query, _Request, _Opts}) = Request0, Data0) ->
-    {_Queries, Data} = collect_and_enqueue_query_requests(Request0, Data0),
+    Data = collect_and_enqueue_query_requests(Request0, Data0),
     {keep_state, Data};
 blocked(info, {flush, _Ref}, _Data) ->
     keep_state_and_data;
@@ -412,7 +412,7 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
 -spec handle_query_requests(?SEND_REQ(request_from(), request()), data()) ->
     gen_statem:event_handler_result(state(), data()).
 handle_query_requests(Request0, Data0) ->
-    {_Queries, Data} = collect_and_enqueue_query_requests(Request0, Data0),
+    Data = collect_and_enqueue_query_requests(Request0, Data0),
     maybe_flush(Data).
 
 collect_and_enqueue_query_requests(Request0, Data0) ->
@@ -438,8 +438,7 @@ collect_and_enqueue_query_requests(Request0, Data0) ->
             Requests
         ),
     {_Overflow, NewQ} = append_queue(Id, Index, Q, Queries),
-    Data = Data0#{queue := NewQ},
-    {Queries, Data}.
+    Data0#{queue := NewQ}.
 
 maybe_flush(Data0) ->
     #{

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -1226,8 +1226,8 @@ t_always_overflow(_Config) ->
             Payload = binary:copy(<<"a">>, 100),
             %% since it's sync and it should never send a request, this
             %% errors with `timeout'.
-            ?assertError(
-                timeout,
+            ?assertEqual(
+                {error, buffer_overflow},
                 emqx_resource:query(
                     ?ID,
                     {big_payload, Payload},

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_gcp_pubsub_SUITE.erl
@@ -850,7 +850,6 @@ test_publish_success_batch(Config) ->
 t_not_a_json(Config) ->
     ?assertMatch(
         {error, #{
-            discarded_errors_count := 0,
             kind := validation_error,
             reason := #{exception := {error, {badmap, "not a json"}}},
             %% should be censored as it contains secrets
@@ -868,7 +867,6 @@ t_not_a_json(Config) ->
 t_not_of_service_account_type(Config) ->
     ?assertMatch(
         {error, #{
-            discarded_errors_count := 0,
             kind := validation_error,
             reason := {wrong_type, <<"not a service account">>},
             %% should be censored as it contains secrets
@@ -887,7 +885,6 @@ t_json_missing_fields(Config) ->
     GCPPubSubConfig0 = ?config(gcp_pubsub_config, Config),
     ?assertMatch(
         {error, #{
-            discarded_errors_count := 0,
             kind := validation_error,
             reason :=
                 {missing_keys, [


### PR DESCRIPTION
fixes:
https://emqx.atlassian.net/browse/EMQX-8782

For calls discarded due to buffer overflow, an error should replied immediately instead of waiting for timeout.