### PR TITLE
feat: cache OTP_VERSION in a persistent term for performance.

### DIFF
--- a/apps/emqx/src/emqx_vm.erl
+++ b/apps/emqx/src/emqx_vm.erl
@@ -399,7 +399,7 @@ compat_windows(Fun) ->
             end
     end.
 
-%% @doc Return on which Eralng/OTP the current vm is running.
+%% @doc Return on which Erlang/OTP the current vm is running.
 %% NOTE: This API reads a file, do not use it in critical code paths.
 get_otp_version() ->
     read_otp_version().
@@ -416,6 +416,8 @@ read_otp_version() ->
             %% running tests etc.
             OtpMajor = erlang:system_info(otp_release),
             OtpVsnFile = filename:join([ReleasesDir, OtpMajor, "OTP_VERSION"]),
-            {ok, Vsn} = file:read_file(OtpVsnFile),
-            Vsn
+            case file:read_file(OtpVsnFile) of
+                {ok, Vsn} -> Vsn;
+                {error, enoent} -> list_to_binary(OtpMajor)
+            end
     end.


### PR DESCRIPTION
1. Cache OTP_VERSION in a persistent term for performance. The dashboard's `/api/nodes` API will call this function frequently. We should avoid reading the file every time.
2. Fix crash when the `OTP_VERSION` file is missing.

```
function_clause, [{emqx_mgmt_api_nodes,format,['emqx@127.0.0.1',{error,{'EXIT',
{{badmatch,{error,enoent}},[{emqx_vm,read_otp_version,0,[{file,"emqx_vm.erl"},{line,419}]},{emqx_mgmt,otp_rel,0,
[{file,"emqx_mgmt.erl"},{line,533}]},{emqx_mgmt,node_info,0,[{file,"emqx_mgmt.erl"},{line,131}]}]}}}],
[{file,"emqx_mgmt_api_nodes.erl"},{line,290}]},{emqx_mgmt_api_nodes,'-list_nodes/1-lc$^0/1-0-',1,
[{file,"emqx_mgmt_api_nodes.erl"},{line,260}]},{emqx_mgmt_api_nodes,list_nodes,1,[{file,"emqx_mgmt_api_nodes.erl"},
{line,260}]},{minirest_handler,apply_callback,3,[{file,"minirest_handler.erl"},{line,111}]},{minirest_handler,handle,2,
[{file,"minirest_handler.erl"},{line,44}]},{minirest_handler,init,2,[{file,"minirest_handler.erl"},{line,27}]},
{cowboy_handler,execute,2,[{file,"cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,
[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},
{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]

```
close https://github.com/emqx/emqx/issues/9197
Fixes https://emqx.atlassian.net/browse/EMQX-8800