### PR TITLE
feat: optimize the log output format

### DIFF
--- a/apps/emqx/include/logger.hrl
+++ b/apps/emqx/include/logger.hrl
@@ -48,9 +48,9 @@
 -define(TRACE(Level, Tag, Msg, Meta), begin
     case persistent_term:get(?TRACE_FILTER, []) of
         [] -> ok;
-        %% We can't bind filter list to a variablebecause we pollute the calling scope with it.
+        %% We can't bind filter list to a variable because we pollute the calling scope with it.
         %% We also don't want to wrap the macro body in a fun
-        %% beacause this adds overhead to the happy path.
+        %% because this adds overhead to the happy path.
         %% So evaluate `persistent_term:get` twice.
         _ -> emqx_trace:log(persistent_term:get(?TRACE_FILTER, []), Msg, (Meta)#{trace_tag => Tag})
     end,

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -152,7 +152,7 @@ start_link() ->
 insert_channel_info(ClientId, Info, Stats) ->
     Chan = {ClientId, self()},
     true = ets:insert(?CHAN_INFO_TAB, {Chan, Info, Stats}),
-    ?tp(debug, insert_channel_info, #{client_id => ClientId}),
+    ?tp(debug, insert_channel_info, #{clientid => ClientId}),
     ok.
 
 %% @private

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -732,6 +732,12 @@ handle_timeout(TRef, Msg, State) ->
 %% Parse incoming data
 -compile({inline, [when_bytes_in/3]}).
 when_bytes_in(Oct, Data, State) ->
+    ?SLOG(debug, #{
+        msg => "raw_bin_received",
+        size => Oct,
+        bin => binary_to_list(binary:encode_hex(Data)),
+        type => "hex"
+    }),
     {Packets, NState} = parse_incoming(Data, [], State),
     Len = erlang:length(Packets),
     check_limiter(

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -550,6 +550,7 @@ handle_msg(
     },
     handle_incoming(Packet, NState);
 handle_msg({incoming, Packet}, State) ->
+    ?TRACE("MQTT", "mqtt_packet_received", #{packet => Packet}),
     handle_incoming(Packet, State);
 handle_msg({outgoing, Packets}, State) ->
     handle_outgoing(Packets, State);
@@ -783,7 +784,6 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
 
 handle_incoming(Packet, State) when is_record(Packet, mqtt_packet) ->
     ok = inc_incoming_stats(Packet),
-    ?TRACE("MQTT", "mqtt_packet_received", #{packet => Packet}),
     with_channel(handle_in, [Packet], State);
 handle_incoming(FrameError, State) ->
     with_channel(handle_in, [FrameError], State).

--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -101,4 +101,5 @@ enrich_topic({Fmt, Args}, #{topic := Topic}) when is_list(Fmt) ->
 enrich_topic(Msg, _) ->
     Msg.
 
+mfa(undefined) -> undefined;
 mfa({M, F, A}) -> atom_to_list(M) ++ ":" ++ atom_to_list(F) ++ "/" ++ integer_to_list(A).

--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -102,4 +102,4 @@ enrich_topic(Msg, _) ->
     Msg.
 
 mfa(undefined) -> undefined;
-mfa({M, F, A}) -> atom_to_list(M) ++ ":" ++ atom_to_list(F) ++ "/" ++ integer_to_list(A).
+mfa({M, F, A}) -> [atom_to_list(M), ":", atom_to_list(F), "/" ++ integer_to_list(A)].

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -477,8 +477,8 @@ format(Packet) -> format(Packet, emqx_trace_handler:payload_encode()).
 format(#mqtt_packet{header = Header, variable = Variable, payload = Payload}, PayloadEncode) ->
     HeaderIO = format_header(Header),
     case format_variable(Variable, Payload, PayloadEncode) of
-        "" -> HeaderIO;
-        VarIO -> [HeaderIO, ",", VarIO]
+        "" -> [HeaderIO, ")"];
+        VarIO -> [HeaderIO, ", ", VarIO, ")"]
     end.
 
 format_header(#mqtt_packet_header{
@@ -487,14 +487,14 @@ format_header(#mqtt_packet_header{
     qos = QoS,
     retain = Retain
 }) ->
-    io_lib:format("~ts(Q~p, R~p, D~p)", [type_name(Type), QoS, i(Retain), i(Dup)]).
+    io_lib:format("~ts(Q~p, R~p, D~p", [type_name(Type), QoS, i(Retain), i(Dup)]).
 
 format_variable(undefined, _, _) ->
     "";
 format_variable(Variable, undefined, PayloadEncode) ->
     format_variable(Variable, PayloadEncode);
 format_variable(Variable, Payload, PayloadEncode) ->
-    [format_variable(Variable, PayloadEncode), ",", format_payload(Payload, PayloadEncode)].
+    [format_variable(Variable, PayloadEncode), ", ", format_payload(Payload, PayloadEncode)].
 
 format_variable(
     #mqtt_packet_connect{

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -479,7 +479,11 @@ format(#mqtt_packet{header = Header, variable = Variable, payload = Payload}, Pa
     case format_variable(Variable, Payload, PayloadEncode) of
         "" -> [HeaderIO, ")"];
         VarIO -> [HeaderIO, ", ", VarIO, ")"]
-    end.
+    end;
+%% receive a frame error packet, such as {frame_error,frame_too_large} or
+%% {frame_error,#{expected => <<"'MQTT' or 'MQIsdp'">>,hint => invalid_proto_name,received => <<"bad_name">>}}
+format(FrameError, _PayloadEncode) ->
+    lists:flatten(io_lib:format("~tp", [FrameError])).
 
 format_header(#mqtt_packet_header{
     type = Type,

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -237,7 +237,7 @@ do_async_set_keepalive() ->
     {ok, _} = ?block_until(
         #{
             ?snk_kind := insert_channel_info,
-            client_id := ClientID
+            clientid := ClientID
         },
         2000,
         100


### PR DESCRIPTION
- Don't log CONNECT packet twice.
- Make the log output format order fixed. `msg, mfa, line, peername,clientid,topic`.
- Use brackets to wrap the MQTT packet when logging.

```
2023-01-30T16:39:24.889009+08:00 [debug] msg: raw_bin_received, mfa: emqx_connection:when_bytes_in/3, line: 740, peername: 127.0.0.1:62119, bin: 101E00044D51545405C2003C000004746573740003666F6F0006313233343536, size: 32, type: hex
2023-01-30T16:39:24.889361+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_channel:handle_in/2, line: 356, peername: 127.0.0.1:62119, clientid: test, packet: CONNECT(Q0, R0, D0, ClientId=test, ProtoName=MQTT, ProtoVsn=5, CleanStart=true, KeepAlive=60, Username=foo, Password=******), tag: MQTT
2023-01-30T16:39:24.889922+08:00 [debug] msg: insert_channel_info, mfa: emqx_cm:insert_channel_info/3, line: 155, peername: 127.0.0.1:62119, clientid: test
2023-01-30T16:39:24.890125+08:00 [debug] msg: mqtt_packet_sent, mfa: emqx_connection:serialize_and_inc_stats_fun/1, line: 838, peername: 127.0.0.1:62119, clientid: test, packet: CONNACK(Q0, R0, D0, AckFlags=0, ReasonCode=0), tag: MQTT
2023-01-30T16:39:25.079178+08:00 [debug] msg: raw_bin_received, mfa: emqx_connection:when_bytes_in/3, line: 740, peername: 127.0.0.1:62119, clientid: test, bin: 820A22480000047777777700, size: 12, type: hex
2023-01-30T16:39:25.079576+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_connection:handle_msg/2, line: 553, peername: 127.0.0.1:62119, clientid: test, packet: SUBSCRIBE(Q1, R0, D0, PacketId=8776 TopicFilters=[wwww(#{nl => 0,qos => 0,rap => 0,rh => 0})]), tag: MQTT
2023-01-30T16:39:25.080656+08:00 [info] msg: authorization_permission_allowed, mfa: emqx_authz:log_allowed/1, line: 375, peername: 127.0.0.1:62119, clientid: test, topic: wwww, ipaddr: {127,0,0,1}, source: file, username: <<"foo">>
2023-01-30T16:39:25.081140+08:00 [debug] msg: subscribe, mfa: emqx_trace:subscribe/3, line: 79, peername: 127.0.0.1:62119, clientid: test, topic: wwww, sub_id: <<"test">>, sub_opts: #{nl => 0,qos => 0,rap => 0,rh => 0,sub_props => #{}}, tag: SUBSCRIBE
2023-01-30T16:39:25.081743+08:00 [debug] msg: mqtt_packet_sent, mfa: emqx_connection:serialize_and_inc_stats_fun/1, line: 838, peername: 127.0.0.1:62119, clientid: test, packet: SUBACK(Q0, R0, D0, PacketId=8776, ReasonCodes=[0]), tag: MQTT
2023-01-30T16:39:25.082340+08:00 [debug] msg: insert_channel_info, mfa: emqx_cm:insert_channel_info/3, line: 155, peername: 127.0.0.1:62119, clientid: test
2023-01-30T16:39:25.262222+08:00 [debug] msg: raw_bin_received, mfa: emqx_connection:when_bytes_in/3, line: 740, peername: 127.0.0.1:62119, clientid: test, bin: 82092249000003742F3100, size: 11, type: hex
2023-01-30T16:39:25.262429+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_connection:handle_msg/2, line: 553, peername: 127.0.0.1:62119, clientid: test, packet: SUBSCRIBE(Q1, R0, D0, PacketId=8777 TopicFilters=[t/1(#{nl => 0,qos => 0,rap => 0,rh => 0})]), tag: MQTT
2023-01-30T16:39:25.262696+08:00 [info] msg: authorization_permission_allowed, mfa: emqx_authz:log_allowed/1, line: 375, peername: 127.0.0.1:62119, clientid: test, topic: t/1, ipaddr: {127,0,0,1}, source: file, username: <<"foo">>
2023-01-30T16:39:25.263222+08:00 [debug] msg: subscribe, mfa: emqx_trace:subscribe/3, line: 79, peername: 127.0.0.1:62119, clientid: test, topic: t/1, sub_id: <<"test">>, sub_opts: #{nl => 0,qos => 0,rap => 0,rh => 0,sub_props => #{}}, tag: SUBSCRIBE
2023-01-30T16:39:25.263635+08:00 [debug] msg: mqtt_packet_sent, mfa: emqx_connection:serialize_and_inc_stats_fun/1, line: 838, peername: 127.0.0.1:62119, clientid: test, packet: SUBACK(Q0, R0, D0, PacketId=8777, ReasonCodes=[0]), tag: MQTT
2023-01-30T16:39:25.264000+08:00 [debug] msg: insert_channel_info, mfa: emqx_cm:insert_channel_info/3, line: 155, peername: 127.0.0.1:62119, clientid: test
2023-01-30T16:39:25.367376+08:00 [debug] msg: raw_bin_received, mfa: emqx_connection:when_bytes_in/3, line: 740, peername: 127.0.0.1:62119, clientid: test, bin: 822B224A000025245359532F62726F6B6572732F656D7178403132372E302E302E312F636C69656E74732F2300, size: 45, type: hex
2023-01-30T16:39:25.367673+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_connection:handle_msg/2, line: 553, peername: 127.0.0.1:62119, clientid: test, packet: SUBSCRIBE(Q1, R0, D0, PacketId=8778 TopicFilters=[$SYS/brokers/emqx@127.0.0.1/clients/#(#{nl => 0,qos => 0,rap => 0,rh => 0})]), tag: MQTT
2023-01-30T16:39:25.367950+08:00 [info] msg: authorization_permission_allowed, mfa: emqx_authz:log_allowed/1, line: 375, peername: 127.0.0.1:62119, clientid: test, topic: $SYS/brokers/emqx@127.0.0.1/clients/#, ipaddr: {127,0,0,1}, source: file, username: <<"foo">>
2023-01-30T16:39:25.368706+08:00 [debug] msg: mqtt_packet_sent, mfa: emqx_connection:serialize_and_inc_stats_fun/1, line: 838, peername: 127.0.0.1:62119, clientid: test, packet: SUBACK(Q0, R0, D0, PacketId=8778, ReasonCodes=[0]), tag: MQTT
2023-01-30T16:39:25.369291+08:00 [debug] msg: insert_channel_info, mfa: emqx_cm:insert_channel_info/3, line: 155, peername: 127.0.0.1:62119, clientid: test
2023-01-30T16:39:29.599963+08:00 [debug] msg: raw_bin_received, mfa: emqx_connection:when_bytes_in/3, line: 740, peername: 127.0.0.1:62119, clientid: test, bin: 300D0003742F310031313231323231, size: 15, type: hex
2023-01-30T16:39:29.600265+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_connection:handle_msg/2, line: 553, peername: 127.0.0.1:62119, clientid: test, packet: PUBLISH(Q0, R0, D0, Topic=t/1, PacketId=undefined, Payload=1121221), tag: MQTT
2023-01-30T16:39:29.600490+08:00 [info] msg: authorization_permission_allowed, mfa: emqx_authz:log_allowed/1, line: 375, peername: 127.0.0.1:62119, clientid: test, topic: t/1, ipaddr: {127,0,0,1}, source: file, username: <<"foo">>
2023-01-30T16:39:29.601195+08:00 [debug] msg: publish_to, mfa: emqx_trace:publish/1, line: 74, peername: 127.0.0.1:62119, clientid: test, topic: t/1, payload: 1121221, tag: PUBLISH
2023-01-30T16:39:29.601585+08:00 [debug] msg: mqtt_packet_sent, mfa: emqx_connection:serialize_and_inc_stats_fun/1, line: 838, peername: 127.0.0.1:62119, clientid: test, packet: PUBLISH(Q0, R0, D0, Topic=t/1, PacketId=undefined, Payload=1121221), tag: MQTT
2023-01-30T16:40:29.594358+08:00 [debug] msg: raw_bin_received, mfa: emqx_connection:when_bytes_in/3, line: 740, peername: 127.0.0.1:62119, clientid: test, bin: C000, size: 2, type: hex
2023-01-30T16:40:29.594676+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_connection:handle_msg/2, line: 553, peername: 127.0.0.1:62119, clientid: test, packet: PINGREQ(Q0, R0, D0), tag: MQTT
2023-01-30T16:40:29.594891+08:00 [debug] msg: mqtt_packet_sent, mfa: emqx_connection:serialize_and_inc_stats_fun/1, line: 838, peername: 127.0.0.1:62119, clientid: test, packet: PINGRESP(Q0, R0, D0), tag: MQTT
```