### PR TITLE
Upgrade gen coap to v0.4.3

### DIFF
--- a/apps/emqx_coap/rebar.config
+++ b/apps/emqx_coap/rebar.config
@@ -1,4 +1,4 @@
 {deps,
  [
-  {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.4.2"}}}
+  {gen_coap, {git, "https://github.com/emqx/gen_coap", {tag, "v0.4.3"}}}
  ]}.

--- a/changes/v4.4.15-en.md
+++ b/changes/v4.4.15-en.md
@@ -21,3 +21,5 @@
   ```
   2023-01-29T13:40:36.567692+08:00 [debug] 127.0.0.1:50393 [MQTT] RECV CONNECT(Q0, R0, D0ClientId=test_client, ... Password=undefined)
   ```
+
+- Avoid crash logs in CoAP gateway when receiving liveness checking packets from Load Balancer [#9869](https://github.com/emqx/emqx/pull/9869).

--- a/changes/v4.4.15-zh.md
+++ b/changes/v4.4.15-zh.md
@@ -20,3 +20,5 @@
   ```
   2023-01-29T13:40:36.567692+08:00 [debug] 127.0.0.1:50393 [MQTT] RECV CONNECT(Q0, R0, D0ClientId=test_client, ... Password=undefined)
   ```
+
+- 修复 CoAP 网关在收到负载均衡的心跳检查报文时产生的崩溃日志 [#9869](https://github.com/emqx/emqx/pull/9869)。


### PR DESCRIPTION
Avoid crash logs in CoAP gateway when receiving liveness checking packets from Load Balancer


see: https://github.com/emqx/gen_coap/pull/20