### PR TITLE
chore(bin/emqx): hide upgrade/downgrade from usage info

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -159,7 +159,7 @@ usage() {
         echo "Evaluate an Erlang expression in the EMQX node, even on Elixir node"
         ;;
     versions)
-        echo "List installed EMQX versions and their status"
+        echo "List installed EMQX release versions and their status"
         ;;
     unpack)
         echo "Usage: $REL_NAME unpack [VERSION]"
@@ -217,12 +217,12 @@ usage() {
         echo "  ctl:        Administration commands, execute '$REL_NAME ctl help' for more details"
         echo ''
         echo "More:"
-        echo "  Shell attach:  remote_console | attach"
-        echo "  Up/Down-grade: upgrade | downgrade | install | uninstall"
-        echo "  Install info:  ertspath | root_dir"
-        echo "  Runtime info:  pid | ping | versions"
+        echo "  Shell attach:     remote_console | attach"
+#       echo "  Up/Down-grade:    upgrade | downgrade | install | uninstall | versions" # TODO enable when supported
+        echo "  Install Info:     ertspath | root_dir"
+        echo "  Runtime Status:   pid | ping"
         echo "  Validate Config:  check_config"
-        echo "  Advanced:      console_clean | escript | rpc | rpcterms | eval | eval-erl"
+        echo "  Advanced:         console_clean | escript | rpc | rpcterms | eval | eval-erl"
         echo ''
         echo "Execute '$REL_NAME COMMAND help' for more information"
     ;;

--- a/bin/install_upgrade.escript
+++ b/bin/install_upgrade.escript
@@ -18,25 +18,16 @@ main([Command0, DistInfoStr | CommandArgs]) ->
     Opts = parse_arguments(CommandArgs),
     %% invoke the command passed as argument
     F = case Command0 of
-        %% "install" -> fun(A, B) -> install(A, B) end;
-        %% "unpack" -> fun(A, B) -> unpack(A, B) end;
-        %% "upgrade" -> fun(A, B) -> upgrade(A, B) end;
-        %% "downgrade" -> fun(A, B) -> downgrade(A, B) end;
-        %% "uninstall" -> fun(A, B) -> uninstall(A, B) end;
-        "versions" -> fun(A, B) -> versions(A, B) end;
-        _ -> fun fail_upgrade/2
+        "install" -> fun(A, B) -> install(A, B) end;
+        "unpack" -> fun(A, B) -> unpack(A, B) end;
+        "upgrade" -> fun(A, B) -> upgrade(A, B) end;
+        "downgrade" -> fun(A, B) -> downgrade(A, B) end;
+        "uninstall" -> fun(A, B) -> uninstall(A, B) end;
+        "versions" -> fun(A, B) -> versions(A, B) end
     end,
     F(DistInfo, Opts);
 main(Args) ->
     ?INFO("unknown args: ~p", [Args]),
-    erlang:halt(1).
-
-%% temporary block for hot-upgrades; next release will just remove
-%% this and the new script version shall be used instead of this
-%% current version.
-%% TODO: always deny relup for macos (unsupported)
-fail_upgrade(_DistInfo, _Opts) ->
-    ?ERROR("Unsupported upgrade path", []),
     erlang:halt(1).
 
 unpack({RelName, NameTypeArg, NodeName, Cookie}, Opts) ->


### PR DESCRIPTION
prior to this change, the `emqx versions` command emits a lot of "unsed function" compile warnings from the escript (because it's running in compile mode).

this PR tries to hide the upgrade commands from usage before it's supported.
