### PR TITLE
fix: primary logger level not update

### DIFF
--- a/apps/emqx/src/config/emqx_config_logger.erl
+++ b/apps/emqx/src/config/emqx_config_logger.erl
@@ -67,12 +67,16 @@ post_config_update(_ConfPath, _Req, _NewConf, _OldConf, _AppEnvs) ->
     ok.
 
 maybe_update_log_level(NewLevel) ->
-    OldLevel = application:get_env(kernel, logger_level, warning),
+    OldLevel = emqx_logger:get_primary_log_level(),
     case OldLevel =:= NewLevel of
         true ->
             %% no change
             ok;
         false ->
+            ok = emqx_logger:set_primary_log_level(NewLevel),
+            %% also update kernel's logger_level for troubleshooting
+            %% what is actually in effect is the logger's primary log level
+            ok = application:set_env(kernel, logger_level, NewLevel),
             log_to_console("Config override: log level is set to '~p'~n", [NewLevel])
     end.
 
@@ -97,7 +101,7 @@ update_log_handlers(NewHandlers) ->
     end,
     AddsAndUpdates = lists:filtermap(MapFn, NewHandlers),
     lists:foreach(fun update_log_handler/1, Removes ++ AddsAndUpdates),
-    _ = application:set_env(kernel, logger, NewHandlers),
+    ok = application:set_env(kernel, logger, NewHandlers),
     ok.
 
 update_log_handler({removed, Id}) ->
@@ -115,7 +119,7 @@ id_for_log(Other) -> "log.file_handlers." ++ atom_to_list(Other).
 atom(Id) when is_binary(Id) -> binary_to_atom(Id, utf8);
 atom(Id) when is_atom(Id) -> Id.
 
-%% @doc Translate raw config to app-env conpatible log handler configs list.
+%% @doc Translate raw config to app-env compatible log handler configs list.
 tr_handlers(Conf) ->
     %% mute the default handler
     tr_console_handler(Conf) ++

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -42,7 +42,6 @@
 start(_Type, _Args) ->
     ok = maybe_load_config(),
     ok = emqx_persistent_session:init_db_backend(),
-    ok = emqx_config_logger:refresh_config(),
     ok = maybe_start_quicer(),
     ok = emqx_bpapi:start(),
     wait_boot_shards(),

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -29,6 +29,7 @@
 
 start(_StartType, _StartArgs) ->
     init_conf(),
+    ok = emqx_config_logger:refresh_config(),
     emqx_conf_sup:start_link().
 
 stop(_State) ->

--- a/deploy/packages/emqx.service
+++ b/deploy/packages/emqx.service
@@ -13,7 +13,7 @@ Environment=HOME=/var/lib/emqx
 # Enable logging to file
 Environment=EMQX_LOG__TO=default
 
-# Start 'foregroun' but not 'start' (daemon) mode.
+# Start 'foreground' but not 'start' (daemon) mode.
 # Because systemd monitor/restarts 'simple' services
 ExecStart=/bin/bash /usr/bin/emqx foreground
 


### PR DESCRIPTION
1. Refresh log-config as soon as you get the `override.conf` configuration.
2. Update the primary log level when refreshing log-config.
3. Don't crash if add_handler failed.

This PR is related https://github.com/emqx/emqx/pull/9876, so it doesn't have the relevant tickets.