### PR TITLE
0202 fix flaky tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ test-compile: $(REBAR) merge-config
 ct: $(REBAR) merge-config
 	@ENABLE_COVER_COMPILE=1 $(REBAR) ct --name $(CT_NODE_NAME) -c -v --cover_export_name $(CT_COVER_EXPORT_PREFIX)-ct
 
+## only check bpapi for enterprise profile because it's a super-set.
 .PHONY: static_checks
 static_checks:
 	@$(REBAR) as check do dialyzer, xref

--- a/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
@@ -720,7 +720,8 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
 
     %% verify the metrics of the bridge, the message should be queued
     ?assertMatch(
-        #{<<"status">> := Status} when Status == <<"connecting">>; Status == <<"disconnected">>,
+        #{<<"status">> := Status} when
+            Status == <<"connecting">> orelse Status == <<"disconnected">>,
         request_bridge(BridgeIDEgress)
     ),
     %% matched >= 3 because of possible retries.
@@ -797,7 +798,8 @@ t_mqtt_conn_bridge_egress_async_reconnect(_) ->
     ok = emqx_listeners:stop_listener('tcp:default'),
     ct:sleep(1500),
     ?assertMatch(
-        #{<<"status">> := Status} when Status == <<"connecting">>; Status == <<"disconnected">>,
+        #{<<"status">> := Status} when
+            Status == <<"connecting">> orelse Status == <<"disconnected">>,
         request_bridge(BridgeIDEgress)
     ),
 


### PR DESCRIPTION
The test case which appends new config to the end of emqx.conf.all might contaminate other test cases after it.
This PR changes to use "include" derivative from HOCON which can tolerate files to be included being missing -- this allows us to safely delete the temp config file after the test, so it won't contaminate other tests even when the "include" is left behind.