### PR TITLE
chore: remove <<>> when logging username

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -325,7 +325,7 @@ is_self_auth_token(Username, Token) ->
     end.
 
 change_pwd(post, #{bindings := #{username := Username}, body := Params}) ->
-    LogMeta = #{msg => "Dashboard change password", username => Username},
+    LogMeta = #{msg => "Dashboard change password", username => binary_to_list(Username)},
     OldPwd = maps:get(<<"old_pwd">>, Params),
     NewPwd = maps:get(<<"new_pwd">>, Params),
     case ?EMPTY(OldPwd) orelse ?EMPTY(NewPwd) of


### PR DESCRIPTION
Before:
2023-02-03T16:56:23.087811+08:00 [error] msg: Dashboard change password, mfa: emqx_dashboard_api:change_pwd/2, line: 344, reason: error old pwd, result: failed, username: <<"admin">>
After:
2023-02-03T16:57:24.081831+08:00 [error] msg: Dashboard change password, mfa: emqx_dashboard_api:change_pwd/2, line: 344, reason: error old pwd, result: failed, username: admin