### PR TITLE
feat(ft): add API

### DIFF
--- a/apps/emqx_ft/i18n/emqx_ft_api_i18n.conf
+++ b/apps/emqx_ft/i18n/emqx_ft_api_i18n.conf
@@ -1,0 +1,25 @@
+emqx_ft_api {
+
+    file_list {
+        desc {
+            en: "List all uploaded files."
+            zh: "列出所有上传的文件。"
+        }
+        label: {
+            en: "List all uploaded files"
+            zh: "列出所有上传的文件"
+        }
+    }
+
+    file_get {
+        desc {
+            en: "Get a file by its id."
+            zh: "根据文件 id 获取文件。"
+        }
+        label: {
+            en: "Get a file by its id"
+            zh: "根据文件 id 获取文件"
+        }
+    }
+
+}

--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -189,7 +189,7 @@ on_fin(PacketId, Msg, FileId, Checksum) ->
             %% We have new fin packet
             ok ->
                 Callback = callback(FinPacketKey, FileId),
-                case assemble(transfer(Msg, FileId), Callback) of
+                case emqx_ft_storage:assemble(transfer(Msg, FileId), Callback) of
                     %% Assembling started, packet will be acked by the callback or the responder
                     {ok, _} ->
                         undefined;
@@ -213,12 +213,6 @@ on_fin(PacketId, Msg, FileId, Checksum) ->
             {error, already_registered} ->
                 undefined
         end.
-
-assemble(Transfer, Callback) ->
-    emqx_ft_storage:assemble(
-        Transfer,
-        Callback
-    ).
 
 callback({ChanPid, PacketId} = Key, _FileId) ->
     fun(Result) ->

--- a/apps/emqx_ft/src/emqx_ft_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_api.erl
@@ -1,0 +1,163 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_ft_api).
+
+-behaviour(minirest_api).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx/include/logger.hrl").
+
+%% Swagger specs from hocon schema
+-export([
+    api_spec/0,
+    paths/0,
+    schema/1,
+    namespace/0
+]).
+
+-export([
+    fields/1,
+    roots/0
+]).
+
+%% API callbacks
+-export([
+    '/file_transfer/files'/2,
+    '/file_transfer/file'/2
+]).
+
+-import(hoconsc, [mk/2, ref/1, ref/2]).
+
+namespace() -> "file_transfer".
+
+api_spec() ->
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
+
+paths() ->
+    [
+        "/file_transfer/files",
+        "/file_transfer/file"
+    ].
+
+schema("/file_transfer/files") ->
+    #{
+        'operationId' => '/file_transfer/files',
+        get => #{
+            tags => [<<"file_transfer">>],
+            summary => <<"List all uploaded files">>,
+            description => ?DESC("file_list"),
+            responses => #{
+                200 => <<"Operation success">>,
+                503 => emqx_dashboard_swagger:error_codes(
+                    ['SERVICE_UNAVAILABLE'], <<"Service unavailable">>
+                )
+            }
+        }
+    };
+schema("/file_transfer/file") ->
+    #{
+        'operationId' => '/file_transfer/file',
+        get => #{
+            tags => [<<"file_transfer">>],
+            summary => <<"Download a particular file">>,
+            description => ?DESC("file_get"),
+            parameters => [
+                ref(file_node),
+                ref(file_clientid),
+                ref(file_id)
+            ],
+            responses => #{
+                200 => <<"Operation success">>,
+                404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], <<"Not found">>),
+                503 => emqx_dashboard_swagger:error_codes(
+                    ['SERVICE_UNAVAILABLE'], <<"Service unavailable">>
+                )
+            }
+        }
+    }.
+
+'/file_transfer/files'(get, #{}) ->
+    case emqx_ft_storage:ready_transfers() of
+        {ok, Transfers} ->
+            FormattedTransfers = lists:map(
+                fun({Id, Info}) ->
+                    #{id => Id, info => format_file_info(Info)}
+                end,
+                Transfers
+            ),
+            {200, #{<<"files">> => FormattedTransfers}};
+        {error, _} ->
+            {503, error_msg('SERVICE_UNAVAILABLE', <<"Service unavailable">>)}
+    end.
+
+'/file_transfer/file'(get, #{query_string := Query}) ->
+    case emqx_ft_storage:get_ready_transfer(Query) of
+        {ok, FileData} ->
+            {200, #{<<"content-type">> => <<"application/data">>}, FileData};
+        {error, enoent} ->
+            {404, error_msg('NOT_FOUND', <<"Not found">>)};
+        {error, _} ->
+            {503, error_msg('SERVICE_UNAVAILABLE', <<"Service unavailable">>)}
+    end.
+
+error_msg(Code, Msg) ->
+    #{code => Code, message => emqx_misc:readable_error_msg(Msg)}.
+
+-spec fields(hocon_schema:name()) -> hocon_schema:fields().
+fields(file_node) ->
+    Desc = <<"File Node">>,
+    Meta = #{
+        in => query, desc => Desc, example => <<"emqx@127.0.0.1">>, required => false
+    },
+    [{node, hoconsc:mk(binary(), Meta)}];
+fields(file_clientid) ->
+    Desc = <<"File ClientId">>,
+    Meta = #{
+        in => query, desc => Desc, example => <<"client1">>, required => false
+    },
+    [{clientid, hoconsc:mk(binary(), Meta)}];
+fields(file_id) ->
+    Desc = <<"File">>,
+    Meta = #{
+        in => query, desc => Desc, example => <<"file1">>, required => false
+    },
+    [{fileid, hoconsc:mk(binary(), Meta)}].
+
+roots() ->
+    [
+        file_node,
+        file_clientid,
+        file_id
+    ].
+
+%%--------------------------------------------------------------------
+%% Helpers
+%%--------------------------------------------------------------------
+
+format_file_info(#{path := Path, size := Size, timestamp := Timestamp}) ->
+    #{
+        path => Path,
+        size => Size,
+        timestamp => format_datetime(Timestamp)
+    }.
+
+format_datetime({{Year, Month, Day}, {Hour, Minute, Second}}) ->
+    iolist_to_binary(
+        io_lib:format("~4..0w-~2..0w-~2..0wT~2..0w:~2..0w:~2..0w", [
+            Year, Month, Day, Hour, Minute, Second
+        ])
+    ).

--- a/apps/emqx_ft/src/emqx_ft_storage_dummy.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_dummy.erl
@@ -21,7 +21,9 @@
 -export([
     store_filemeta/3,
     store_segment/3,
-    assemble/3
+    assemble/3,
+    ready_transfers/1,
+    get_ready_transfer/2
 ]).
 
 store_filemeta(_Storage, _Transfer, _Meta) ->
@@ -33,3 +35,9 @@ store_segment(_Storage, _Transfer, _Segment) ->
 assemble(_Storage, _Transfer, Callback) ->
     Pid = spawn(fun() -> Callback({error, not_implemented}) end),
     {ok, Pid}.
+
+ready_transfers(_Storage) ->
+    {ok, []}.
+
+get_ready_transfer(_Storage, _Id) ->
+    {error, not_implemented}.


### PR DESCRIPTION
```
>cat test-file.txt
aaaaaaaaaaaaaaaaaaaa
bbbbbbbbbbbbbbbbbbbb
cccccccccccccccccccc
dddddddddddddddddddd
eeeeeeeeeeeeeeeeeeee
ffffffffffffffffffff
gggggggggggggggggggg
hhhhhhhhhhhhhhhhhhhh

>emqx-ft --file test-file.txt --file-id f1 --client-id cl1
DEBUG:root:Sending CONNECT (u0, p0, wr0, wq0, wf0, c1, k60) client_id=b'cl1'
DEBUG:root:Sending PUBLISH (d0, q1, r0, m1), 'b'$file/f1/init'', ... (38 bytes)
DEBUG:root:Sending PUBLISH (d0, q1, r0, m2), 'b'$file/f1/0'', ... (168 bytes)
DEBUG:root:Sending PUBLISH (d0, q1, r0, m3), 'b'$file/f1/fin'' (NULL payload)
DEBUG:root:Received CONNACK (0, 0)
DEBUG:root:Received PUBACK (Mid: 1)
DEBUG:root:Received PUBACK (Mid: 2)
DEBUG:root:Received PUBACK (Mid: 3)
^CDEBUG:root:Sending DISCONNECT
Disconnected

>curl -s -u 'key:secret' 'http://127.0.0.1:18083/api/v5/file_transfer/files' | jq
{
  "files": [
    {
      "id": {
        "clientid": "cl1",
        "fileid": "f1",
        "node": "emqx@127.0.0.1"
      },
      "info": {
        "path": "data/file_transfer/cl1/f1/result/test-file.txt",
        "size": 168,
        "timestamp": "2023-02-06T01:41:57"
      }
    }
  ]
}

>curl -u 'key:secret' 'http://127.0.0.1:18083/api/v5/file_transfer/file?clientid=cl1&fileid=f1&node=emqx@127.0.0.1' -v
*   Trying 127.0.0.1:18083...
* Connected to 127.0.0.1 (127.0.0.1) port 18083 (#0)
* Server auth using Basic with user 'key'
> GET /api/v5/file_transfer/file?clientid=cl1&fileid=f1&node=emqx@127.0.0.1 HTTP/1.1
> Host: 127.0.0.1:18083
> Authorization: Basic a2V5OnNlY3JldA==
> User-Agent: curl/7.85.0
> Accept: */*
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< content-length: 168
< content-type: application/data
< date: Sun, 05 Feb 2023 23:42:20 GMT
< server: Cowboy
<
aaaaaaaaaaaaaaaaaaaa
bbbbbbbbbbbbbbbbbbbb
cccccccccccccccccccc
dddddddddddddddddddd
eeeeeeeeeeeeeeeeeeee
ffffffffffffffffffff
gggggggggggggggggggg
hhhhhhhhhhhhhhhhhhhh
* Connection #0 to host 127.0.0.1 left intact
```