### PR TITLE
fix(http-api): using a fixed order when cluster query nodes

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -167,7 +167,7 @@ cluster_query(Params, {Tab, QsSchema}, QueryFun) ->
     Start = if Page > 1 -> (Page-1) * Limit;
                true -> 0
             end,
-    Nodes = ekka_mnesia:running_nodes(),
+    Nodes = lists:sort(ekka_mnesia:running_nodes()),
     Rows = do_cluster_query(Nodes, Qs, QueryFun, Start, Limit+1, []),
     Meta = #{page => Page, limit => Limit},
     NMeta = case CodCnt =:= 0 of

--- a/changes/v4.4.15-en.md
+++ b/changes/v4.4.15-en.md
@@ -14,6 +14,8 @@
 
 ## Bug fixes
 
+- The returned client lists of HTTP query `GET /api/v4/clients?_page=2&_limit=20` to different nodes might be inconsistent [#9926](https://github.com/emqx/emqx/pull/9926).
+
 - Fix the problem that new MQTT TLS connections failed to establish after release hot upgrade [#9810](https://github.com/emqx/emqx/pull/9810).
   For more detailed information please see: [emqx/esockd#170](https://github.com/emqx/esockd/pull/170).
 

--- a/changes/v4.4.15-zh.md
+++ b/changes/v4.4.15-zh.md
@@ -14,6 +14,8 @@
 
 ## 修复
 
+- 使用 HTTP API `GET /api/v4/clients?_page=2&_limit=20` 请求客户端列表时，请求发送到不同的 emqx 节点，返回的客户端列表可能不一致 [#9926](https://github.com/emqx/emqx/pull/9926)。
+
 - 修复版本热升级之后，新的 MQTT TLS 连接建立失败的问题 [#9810](https://github.com/emqx/emqx/pull/9810)。
   详情见：[emqx/esockd#170](https://github.com/emqx/esockd/pull/170)
 


### PR DESCRIPTION
The returned client lists of HTTP query `GET /api/v4/clients?_page=2&_limit=20` to different nodes are inconsistent.
We should rpc_call to emqx nodes in a determined order.