### PR TITLE
feat(emqx_prometheus): expose live_connections stats to prometheus

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -1,6 +1,6 @@
 {application, emqx_prometheus,
  [{description, "Prometheus for EMQ X"},
-  {vsn, "4.3.1"}, % strict semver, bump manually!
+  {vsn, "4.3.2"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_prometheus_sup]},
   {applications, [kernel,stdlib,prometheus]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.appup.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.appup.src
@@ -1,9 +1,9 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"4.3.0",
-    [{load_module,emqx_prometheus,brutal_purge,soft_purge,[]}]},
+  [{"4.3.1",[{load_module,emqx_prometheus,brutal_purge,soft_purge,[]}]},
+   {"4.3.0",[{load_module,emqx_prometheus,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
-  [{"4.3.0",
-    [{load_module,emqx_prometheus,brutal_purge,soft_purge,[]}]},
+  [{"4.3.1",[{load_module,emqx_prometheus,brutal_purge,soft_purge,[]}]},
+   {"4.3.0",[{load_module,emqx_prometheus,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}]}.

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -185,6 +185,10 @@ emqx_collect(emqx_connections_count, Stats) ->
     gauge_metric(?C('connections.count', Stats));
 emqx_collect(emqx_connections_max, Stats) ->
     gauge_metric(?C('connections.max', Stats));
+emqx_collect(emqx_live_connections_count, Stats) ->
+    gauge_metric(?C('live_connections.count', Stats));
+emqx_collect(emqx_live_connections_max, Stats) ->
+    gauge_metric(?C('live_connections.max', Stats));
 
 %% sessions
 emqx_collect(emqx_sessions_count, Stats) ->
@@ -471,6 +475,8 @@ emqx_collect(emqx_cluster_nodes_stopped, ClusterData) ->
 emqx_stats() ->
     [ emqx_connections_count
     , emqx_connections_max
+    , emqx_live_connections_count
+    , emqx_live_connections_max
     , emqx_sessions_count
     , emqx_sessions_max
     , emqx_topics_count

--- a/changes/v4.4.15-en.md
+++ b/changes/v4.4.15-en.md
@@ -16,6 +16,8 @@
 
 - Add more debug logs for authentication and ACL [#9943](https://github.com/emqx/emqx/pull/9943).
 
+- Expose the stats `live_connections.count` and `live_connections.max` to Prometheus [#9929](https://github.com/emqx/emqx/pull/9929).
+
 ## Bug fixes
 
 - Fixed an error when forward MQTT messages with User-Property using the `republish` action [#9942](https://github.com/emqx/emqx/pull/9942).

--- a/changes/v4.4.15-zh.md
+++ b/changes/v4.4.15-zh.md
@@ -16,6 +16,8 @@
 
 - 为认证和授权添加了更多调试日志 [#9943](https://github.com/emqx/emqx/pull/9943)。
 
+- 将统计数据 `live_connections.count` 和 `live_connections.max` 公开给 Prometheus [#9929](https://github.com/emqx/emqx/pull/9929).
+
 ## 修复
 
 - 修复使用 `消息重发布` 动作转发带 User-Property 的 MQTT 消息时出错的问题 [#9942](https://github.com/emqx/emqx/pull/9942)。


### PR DESCRIPTION
This exposes the stats `live_connections.count` and `live_connections.max` to Prometheus.

Sister to https://github.com/emqx/emqx/pull/9930 for v5.

Fixes EMQX-8852.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes (no: there is no test coverage of the prometheus code)
- [ ] Changed lines covered in coverage report
- [X] Change log has been added to `changes/` dir
- [X] `appup` files updated (execute `scripts/update-appup.sh emqx`)
- [X] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] In case of non-backward compatible changes, reviewer should check this item as a write-off, and add details in **Backward Compatibility** section
