### PR TITLE
feat(emqx_prometheus): expose live_connections stats to prometheus

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.0.4"},
+    {vsn, "5.0.5"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -219,6 +219,10 @@ emqx_collect(emqx_connections_count, Stats) ->
     gauge_metric(?C('connections.count', Stats));
 emqx_collect(emqx_connections_max, Stats) ->
     gauge_metric(?C('connections.max', Stats));
+emqx_collect(emqx_live_connections_count, Stats) ->
+    gauge_metric(?C('live_connections.count', Stats));
+emqx_collect(emqx_live_connections_max, Stats) ->
+    gauge_metric(?C('live_connections.max', Stats));
 %% sessions
 emqx_collect(emqx_sessions_count, Stats) ->
     gauge_metric(?C('sessions.count', Stats));
@@ -460,6 +464,8 @@ emqx_stats() ->
     [
         emqx_connections_count,
         emqx_connections_max,
+        emqx_live_connections_count,
+        emqx_live_connections_max,
         emqx_sessions_count,
         emqx_sessions_max,
         emqx_topics_count,

--- a/changes/v5.0.17/feat-9930.en.md
+++ b/changes/v5.0.17/feat-9930.en.md
@@ -1,0 +1,1 @@
+Expose the stats `live_connections.count` and `live_connections.max` to Prometheus.

--- a/changes/v5.0.17/feat-9930.zh.md
+++ b/changes/v5.0.17/feat-9930.zh.md
@@ -1,0 +1,1 @@
+将统计数据 `live_connections.count` 和 `live_connections.max` 公开给 Prometheus.


### PR DESCRIPTION
This PR exposes the stats live_connections.count and live_connections.max to Prometheus.

Sister to https://github.com/emqx/emqx/pull/9929 for v4.4.

Fixes EMQX-8852.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes (no, we don't test exposing individual metrics in `emqx_prometheus`)
- [ ] Changed lines covered in coverage report
- [X] Change log has been added to `changes/<version>/(feat|fix)-<PR-id>.en.md` and `.zh.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible
