### PR TITLE
Mria replicant manual join

### DIFF
--- a/apps/emqx/src/emqx_kernel_sup.erl
+++ b/apps/emqx/src/emqx_kernel_sup.erl
@@ -35,7 +35,6 @@ init([]) ->
             child_spec(emqx_hooks, worker),
             child_spec(emqx_stats, worker),
             child_spec(emqx_metrics, worker),
-            child_spec(emqx_ctl, worker),
             child_spec(emqx_authn_authz_metrics_sup, supervisor)
         ]
     }}.

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.12"},
+    {vsn, "0.1.13"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -3,7 +3,7 @@
     {vsn, "0.1.12"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, emqx_ctl]},
     {env, []},
     {modules, []}
 ]}.

--- a/apps/emqx_ctl/README.md
+++ b/apps/emqx_ctl/README.md
@@ -1,0 +1,4 @@
+emqx_ctl
+=====
+
+Backend module for `emqx_ctl` command.

--- a/apps/emqx_ctl/rebar.config
+++ b/apps/emqx_ctl/rebar.config
@@ -1,0 +1,2 @@
+{erl_opts, [debug_info]}.
+{deps, []}.

--- a/apps/emqx_ctl/src/emqx_ctl.app.src
+++ b/apps/emqx_ctl/src/emqx_ctl.app.src
@@ -1,0 +1,15 @@
+{application, emqx_ctl, [
+    {description, "Backend for emqx_ctl script"},
+    {vsn, "0.1.0"},
+    {registered, []},
+    {mod, {emqx_ctl_app, []}},
+    {applications, [
+        kernel,
+        stdlib
+    ]},
+    {env, []},
+    {modules, []},
+
+    {licenses, ["Apache-2.0"]},
+    {links, []}
+]}.

--- a/apps/emqx_ctl/src/emqx_ctl_app.erl
+++ b/apps/emqx_ctl/src/emqx_ctl_app.erl
@@ -1,0 +1,18 @@
+%%%-------------------------------------------------------------------
+%% @doc emqx_ctl public API
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(emqx_ctl_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    emqx_ctl_sup:start_link().
+
+stop(_State) ->
+    ok.
+
+%% internal functions

--- a/apps/emqx_ctl/src/emqx_ctl_sup.erl
+++ b/apps/emqx_ctl/src/emqx_ctl_sup.erl
@@ -1,0 +1,33 @@
+%%%-------------------------------------------------------------------
+%% @doc emqx_ctl top level supervisor.
+%% @end
+%%%-------------------------------------------------------------------
+
+-module(emqx_ctl_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{
+        strategy => one_for_all,
+        intensity => 0,
+        period => 1
+    },
+    ChildSpecs = [
+        #{
+            id => emqx_ctl,
+            start => {emqx_ctl, start_link, []},
+            type => worker,
+            restart => permanent
+        }
+    ],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/apps/emqx_ctl/test/emqx_ctl_SUITE.erl
+++ b/apps/emqx_ctl/test/emqx_ctl_SUITE.erl
@@ -22,12 +22,10 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
-all() -> emqx_common_test_helpers:all(?MODULE).
+all() -> [t_reg_unreg_command, t_run_commands, t_print, t_usage, t_unexpected].
 
 init_per_suite(Config) ->
-    %% ensure stopped, this suite tests emqx_ctl process independently
-    application:stop(emqx),
-    ok = emqx_logger:set_log_level(emergency),
+    application:stop(emqx_ctl),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -5,7 +5,7 @@
     {vsn, "5.0.13"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
-    {applications, [kernel, stdlib, mnesia, minirest, emqx]},
+    {applications, [kernel, stdlib, mnesia, minirest, emqx, emqx_ctl]},
     {mod, {emqx_dashboard_app, []}},
     {env, []},
     {licenses, ["Apache-2.0"]},

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.13"},
+    {vsn, "5.0.14"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [kernel, stdlib, mnesia, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,10 +1,10 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.1.11"},
+    {vsn, "0.1.12"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
-    {applications, [kernel, stdlib, grpc, emqx, emqx_authn]},
+    {applications, [kernel, stdlib, grpc, emqx, emqx_authn, emqx_ctl]},
     {env, []},
     {modules, []},
     {licenses, ["Apache 2.0"]},

--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,10 +3,10 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {modules, []},
     {registered, []},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, emqx_ctl]},
     {mod, {emqx_machine_app, []}},
     {env, []},
     {licenses, ["Apache-2.0"]},

--- a/apps/emqx_machine/src/emqx_machine.erl
+++ b/apps/emqx_machine/src/emqx_machine.erl
@@ -29,6 +29,7 @@
 
 %% @doc EMQX boot entrypoint.
 start() ->
+    emqx_mgmt_cli:load(),
     case os:type() of
         {win32, nt} ->
             ok;

--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -5,7 +5,7 @@
     {vsn, "5.0.15"},
     {modules, []},
     {registered, [emqx_management_sup]},
-    {applications, [kernel, stdlib, emqx_plugins, minirest, emqx]},
+    {applications, [kernel, stdlib, emqx_plugins, minirest, emqx, emqx_ctl]},
     {mod, {emqx_mgmt_app, []}},
     {env, []},
     {licenses, ["Apache-2.0"]},

--- a/apps/emqx_management/src/emqx_mgmt_app.erl
+++ b/apps/emqx_management/src/emqx_mgmt_app.erl
@@ -31,9 +31,7 @@ start(_Type, _Args) ->
     ok = mria_rlog:wait_for_shards([?MANAGEMENT_SHARD], infinity),
     case emqx_mgmt_auth:init_bootstrap_file() of
         ok ->
-            {ok, Sup} = emqx_mgmt_sup:start_link(),
-            ok = emqx_mgmt_cli:load(),
-            {ok, Sup};
+            emqx_mgmt_sup:start_link();
         {error, Reason} ->
             {error, Reason}
     end.

--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,9 +1,9 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.9"},
+    {vsn, "5.0.10"},
     {modules, []},
-    {applications, [kernel, stdlib, emqx]},
+    {applications, [kernel, stdlib, emqx, emqx_ctl]},
     {mod, {emqx_modules_app, []}},
     {registered, [emqx_modules_sup]},
     {env, []}

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.9"},
+    {vsn, "5.0.10"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -5,7 +5,7 @@
     {vsn, "5.0.9"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
-    {applications, [kernel, stdlib, emqx]},
+    {applications, [kernel, stdlib, emqx, emqx_ctl]},
     {mod, {emqx_retainer_app, []}},
     {env, []},
     {licenses, ["Apache-2.0"]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.8"},
+    {vsn, "5.0.9"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -5,7 +5,7 @@
     {vsn, "5.0.8"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
-    {applications, [kernel, stdlib, rulesql, getopt]},
+    {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl]},
     {mod, {emqx_rule_engine_app, []}},
     {env, []},
     {licenses, ["Apache-2.0"]},

--- a/lib-ee/emqx_license/src/emqx_license.app.src
+++ b/lib-ee/emqx_license/src/emqx_license.app.src
@@ -3,6 +3,6 @@
     {vsn, "5.0.5"},
     {modules, []},
     {registered, [emqx_license_sup]},
-    {applications, [kernel, stdlib]},
+    {applications, [kernel, stdlib, emqx_ctl]},
     {mod, {emqx_license_app, []}}
 ]}.

--- a/lib-ee/emqx_license/src/emqx_license.app.src
+++ b/lib-ee/emqx_license/src/emqx_license.app.src
@@ -1,6 +1,6 @@
 {application, emqx_license, [
     {description, "EMQX License"},
-    {vsn, "5.0.5"},
+    {vsn, "5.0.6"},
     {modules, []},
     {registered, [emqx_license_sup]},
     {applications, [kernel, stdlib, emqx_ctl]},


### PR DESCRIPTION
Start `emqx_ctl` process before `emqx_machine` application, to get the CLI working, even if the rest of the EMQX is down. It may happen when on replicant node when it can't join to any core node.

Sadly, because emqx bootstrapping is done in a separate application, and because `apps/emqx` may be used standalone, I had no other way, but to split emqx_ctl module to a separate app to make all static checks happy. This is, admittedly, a pretty hacky solution, since this new repo is useless on its own.