### PR TITLE
fix(pgsql): fix ssl option for pgsql connector to match previous behavior (5.0)

### DIFF
--- a/.ci/docker-compose-file/pgsql/Dockerfile
+++ b/.ci/docker-compose-file/pgsql/Dockerfile
@@ -1,7 +1,7 @@
 ARG BUILD_FROM=postgres:13
 FROM ${BUILD_FROM}
 ARG POSTGRES_USER=postgres
-COPY --chown=$POSTGRES_USER ./pgsql/pg_hba.conf /var/lib/postgresql/pg_hba.conf
+COPY --chown=$POSTGRES_USER ./pgsql/pg_hba_tls.conf /var/lib/postgresql/pg_hba.conf
 COPY --chown=$POSTGRES_USER certs/server.key /var/lib/postgresql/server.key
 COPY --chown=$POSTGRES_USER certs/server.crt /var/lib/postgresql/server.crt
 COPY --chown=$POSTGRES_USER certs/ca.crt /var/lib/postgresql/root.crt

--- a/.ci/docker-compose-file/pgsql/pg_hba_tls.conf
+++ b/.ci/docker-compose-file/pgsql/pg_hba_tls.conf
@@ -1,0 +1,8 @@
+# TYPE DATABASE USER CIDR-ADDRESS METHOD
+local   all all trust
+# TODO: also test with `cert`? will require client certs
+hostssl all all 0.0.0.0/0 password
+hostssl all all ::/0      password
+
+hostssl all www-data 0.0.0.0/0 cert clientcert=1
+hostssl all postgres 0.0.0.0/0 cert clientcert=1

--- a/apps/emqx_connector/src/emqx_connector_pgsql.erl
+++ b/apps/emqx_connector/src/emqx_connector_pgsql.erl
@@ -100,7 +100,11 @@ on_start(
         case maps:get(enable, SSL) of
             true ->
                 [
-                    {ssl, required},
+                    %% note: this is converted to `required' in
+                    %% `conn_opts/2', and there's a boolean guard
+                    %% there; if this is set to `required' here,
+                    %% that'll require changing `conn_opts/2''s guard.
+                    {ssl, true},
                     {ssl_opts, emqx_tls_lib:to_client_opts(SSL)}
                 ];
             false ->

--- a/changes/v5.0.18/fix-9978.en.md
+++ b/changes/v5.0.18/fix-9978.en.md
@@ -1,0 +1,2 @@
+Fixed configuration issue when choosing to use SSL for a Postgres connection (`authn`, `authz` and bridge).
+The connection could fail to complete with a previously working configuration after an upgrade from 5.0.13 to newer EMQX versions.

--- a/changes/v5.0.18/fix-9978.zh.md
+++ b/changes/v5.0.18/fix-9978.zh.md
@@ -1,0 +1,2 @@
+修正了在Postgres连接中选择使用SSL时的配置问题（`authn`, `authz` 和 bridge）。
+从5.0.13升级到较新的EMQX版本后，连接可能无法完成之前的配置。


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/9907

At v5.0.14, we changed the `ssl` option for the Postgres connector from `true` to `required`, but there was another transformation in `conn_opts/2` that led to an incorrect configuration.  This change ended up preventing users from connecting to Postgres with their previous configurations after upgrading EMQX.