### PR TITLE
feat(ft): make storage backend fully async-aware

### DIFF
--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -35,7 +35,7 @@
     decode_filemeta/1
 ]).
 
--export([on_assemble/2]).
+-export([on_complete/4]).
 
 -export_type([
     clientid/0,
@@ -76,7 +76,8 @@
 
 -type segment() :: {offset(), _Content :: binary()}.
 
--define(ASSEMBLE_TIMEOUT, 5000).
+-define(STORE_SEGMENT_TIMEOUT, 10000).
+-define(ASSEMBLE_TIMEOUT, 60000).
 
 %%--------------------------------------------------------------------
 %% API for app
@@ -143,52 +144,59 @@ on_message_puback(PacketId, #message{topic = Topic} = Msg, _PubRes, _RC) ->
 on_file_command(PacketId, Msg, FileCommand) ->
     case string:split(FileCommand, <<"/">>, all) of
         [FileId, <<"init">>] ->
-            on_init(Msg, FileId);
+            on_init(PacketId, Msg, transfer(Msg, FileId));
         [FileId, <<"fin">>] ->
-            on_fin(PacketId, Msg, FileId, undefined);
+            on_fin(PacketId, Msg, transfer(Msg, FileId), undefined);
         [FileId, <<"fin">>, Checksum] ->
-            on_fin(PacketId, Msg, FileId, Checksum);
+            on_fin(PacketId, Msg, transfer(Msg, FileId), Checksum);
         [FileId, <<"abort">>] ->
-            on_abort(Msg, FileId);
+            on_abort(Msg, transfer(Msg, FileId));
         [FileId, OffsetBin] ->
             validate([{offset, OffsetBin}], fun([Offset]) ->
-                on_segment(Msg, FileId, Offset, undefined)
+                on_segment(PacketId, Msg, transfer(Msg, FileId), Offset, undefined)
             end);
         [FileId, OffsetBin, ChecksumBin] ->
             validate([{offset, OffsetBin}, {checksum, ChecksumBin}], fun([Offset, Checksum]) ->
-                on_segment(Msg, FileId, Offset, Checksum)
+                on_segment(PacketId, Msg, transfer(Msg, FileId), Offset, Checksum)
             end);
         _ ->
             ?RC_UNSPECIFIED_ERROR
     end.
 
-on_init(Msg, FileId) ->
+on_init(PacketId, Msg, Transfer) ->
     ?SLOG(info, #{
         msg => "on_init",
         mqtt_msg => Msg,
-        file_id => FileId
+        packet_id => PacketId,
+        transfer => Transfer
     }),
     Payload = Msg#message.payload,
+    PacketKey = {self(), PacketId},
     % %% Add validations here
     case decode_filemeta(Payload) of
         {ok, Meta} ->
-            case emqx_ft_storage:store_filemeta(transfer(Msg, FileId), Meta) of
-                ok ->
-                    ?RC_SUCCESS;
-                {error, Reason} ->
-                    ?SLOG(warning, #{
-                        msg => "store_filemeta_failed",
-                        mqtt_msg => Msg,
-                        file_id => FileId,
-                        reason => Reason
-                    }),
-                    ?RC_UNSPECIFIED_ERROR
-            end;
+            Callback = fun(Result) ->
+                ?MODULE:on_complete("store_filemeta", PacketKey, Transfer, Result)
+            end,
+            with_responder(PacketKey, Callback, ?STORE_SEGMENT_TIMEOUT, fun() ->
+                case store_filemeta(Transfer, Meta) of
+                    % Stored, ack through the responder right away
+                    ok ->
+                        emqx_ft_responder:ack(PacketKey, ok);
+                    % Storage operation started, packet will be acked by the responder
+                    {async, Pid} ->
+                        ok = emqx_ft_responder:kickoff(PacketKey, Pid),
+                        ok;
+                    %% Storage operation failed, ack through the responder
+                    {error, _} = Error ->
+                        emqx_ft_responder:ack(PacketKey, Error)
+                end
+            end);
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "on_init: invalid filemeta",
                 mqtt_msg => Msg,
-                file_id => FileId,
+                transfer => Transfer,
                 reason => Reason
             }),
             ?RC_UNSPECIFIED_ERROR
@@ -198,48 +206,69 @@ on_abort(_Msg, _FileId) ->
     %% TODO
     ?RC_SUCCESS.
 
-on_segment(Msg, FileId, Offset, Checksum) ->
+on_segment(PacketId, Msg, Transfer, Offset, Checksum) ->
     ?SLOG(info, #{
         msg => "on_segment",
         mqtt_msg => Msg,
-        file_id => FileId,
+        packet_id => PacketId,
+        transfer => Transfer,
         offset => Offset,
         checksum => Checksum
     }),
     %% TODO: handle checksum
     Payload = Msg#message.payload,
     Segment = {Offset, Payload},
+    PacketKey = {self(), PacketId},
+    Callback = fun(Result) ->
+        ?MODULE:on_complete("store_segment", PacketKey, Transfer, Result)
+    end,
     %% Add offset/checksum validations
-    case emqx_ft_storage:store_segment(transfer(Msg, FileId), Segment) of
-        ok ->
-            ?RC_SUCCESS;
-        {error, _Reason} ->
-            ?RC_UNSPECIFIED_ERROR
-    end.
+    with_responder(PacketKey, Callback, ?STORE_SEGMENT_TIMEOUT, fun() ->
+        case store_segment(Transfer, Segment) of
+            ok ->
+                emqx_ft_responder:ack(PacketKey, ok);
+            {async, Pid} ->
+                ok = emqx_ft_responder:kickoff(PacketKey, Pid),
+                ok;
+            {error, _} = Error ->
+                emqx_ft_responder:ack(PacketKey, Error)
+        end
+    end).
 
-on_fin(PacketId, Msg, FileId, Checksum) ->
+on_fin(PacketId, Msg, Transfer, Checksum) ->
     ?SLOG(info, #{
         msg => "on_fin",
         mqtt_msg => Msg,
-        file_id => FileId,
-        checksum => Checksum,
-        packet_id => PacketId
+        packet_id => PacketId,
+        transfer => Transfer,
+        checksum => Checksum
     }),
     %% TODO: handle checksum? Do we need it?
     FinPacketKey = {self(), PacketId},
-    case emqx_ft_responder:start(FinPacketKey, fun ?MODULE:on_assemble/2, ?ASSEMBLE_TIMEOUT) of
-        %% We have new fin packet
+    Callback = fun(Result) ->
+        ?MODULE:on_complete("assemble", FinPacketKey, Transfer, Result)
+    end,
+    with_responder(FinPacketKey, Callback, ?ASSEMBLE_TIMEOUT, fun() ->
+        case assemble(Transfer) of
+            %% Assembling completed, ack through the responder right away
+            ok ->
+                emqx_ft_responder:ack(FinPacketKey, ok);
+            %% Assembling started, packet will be acked by the responder
+            {async, Pid} ->
+                ok = emqx_ft_responder:kickoff(FinPacketKey, Pid),
+                ok;
+            %% Assembling failed, ack through the responder
+            {error, _} = Error ->
+                emqx_ft_responder:ack(FinPacketKey, Error)
+        end
+    end).
+
+with_responder(Key, Callback, Timeout, CriticalSection) ->
+    case emqx_ft_responder:start(Key, Callback, Timeout) of
+        %% We have new packet
         {ok, _} ->
-            Callback = fun(Result) -> emqx_ft_responder:ack(FinPacketKey, Result) end,
-            case assemble(transfer(Msg, FileId), Callback) of
-                %% Assembling started, packet will be acked by the callback or the responder
-                {ok, _} ->
-                    ok;
-                %% Assembling failed, ack through the responder
-                {error, _} = Error ->
-                    emqx_ft_responder:ack(FinPacketKey, Error)
-            end;
-        %% Fin packet already received.
+            CriticalSection();
+        %% Packet already received.
         %% Since we are still handling the previous one,
         %% we probably have retransmit here
         {error, {already_started, _}} ->
@@ -247,13 +276,35 @@ on_fin(PacketId, Msg, FileId, Checksum) ->
     end,
     undefined.
 
-assemble(Transfer, Callback) ->
+store_filemeta(Transfer, Segment) ->
     try
-        emqx_ft_storage:assemble(Transfer, Callback)
+        emqx_ft_storage:store_filemeta(Transfer, Segment)
     catch
         C:E:S ->
-            ?SLOG(warning, #{
-                msg => "file_assemble_failed", class => C, reason => E, stacktrace => S
+            ?SLOG(error, #{
+                msg => "start_store_filemeta_failed", class => C, reason => E, stacktrace => S
+            }),
+            {error, {internal_error, E}}
+    end.
+
+store_segment(Transfer, Segment) ->
+    try
+        emqx_ft_storage:store_segment(Transfer, Segment)
+    catch
+        C:E:S ->
+            ?SLOG(error, #{
+                msg => "start_store_segment_failed", class => C, reason => E, stacktrace => S
+            }),
+            {error, {internal_error, E}}
+    end.
+
+assemble(Transfer) ->
+    try
+        emqx_ft_storage:assemble(Transfer)
+    catch
+        C:E:S ->
+            ?SLOG(error, #{
+                msg => "start_assemble_failed", class => C, reason => E, stacktrace => S
             }),
             {error, {internal_error, E}}
     end.
@@ -262,14 +313,28 @@ transfer(Msg, FileId) ->
     ClientId = Msg#message.from,
     {ClientId, FileId}.
 
-on_assemble({ChanPid, PacketId}, Result) ->
-    ?SLOG(debug, #{msg => "on_assemble", packet_id => PacketId, result => Result}),
+on_complete(Op, {ChanPid, PacketId}, Transfer, Result) ->
+    ?SLOG(debug, #{
+        msg => "on_complete",
+        operation => Op,
+        packet_id => PacketId,
+        transfer => Transfer
+    }),
     case Result of
-        {ack, ok} ->
+        {Mode, ok} when Mode == ack orelse Mode == down ->
             erlang:send(ChanPid, {puback, PacketId, [], ?RC_SUCCESS});
-        {ack, {error, _}} ->
+        {Mode, {error, _} = Reason} when Mode == ack orelse Mode == down ->
+            ?SLOG(error, #{
+                msg => Op ++ "_failed",
+                transfer => Transfer,
+                reason => Reason
+            }),
             erlang:send(ChanPid, {puback, PacketId, [], ?RC_UNSPECIFIED_ERROR});
         timeout ->
+            ?SLOG(error, #{
+                msg => Op ++ "_timed_out",
+                transfer => Transfer
+            }),
             erlang:send(ChanPid, {puback, PacketId, [], ?RC_UNSPECIFIED_ERROR})
     end.
 

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -18,36 +18,31 @@
 
 -include_lib("emqx/include/logger.hrl").
 
--export([start_link/3]).
+-export([start_link/2]).
 
 -behaviour(gen_statem).
 -export([callback_mode/0]).
 -export([init/1]).
-% -export([list_local_fragments/3]).
-% -export([list_remote_fragments/3]).
-% -export([start_assembling/3]).
 -export([handle_event/4]).
-
-% -export([handle_continue/2]).
-% -export([handle_call/3]).
-% -export([handle_cast/2]).
 
 -record(st, {
     storage :: _Storage,
     transfer :: emqx_ft:transfer(),
     assembly :: _TODO,
     file :: {file:filename(), io:device(), term()} | undefined,
-    hash,
-    callback :: fun((ok | {error, term()}) -> any())
+    hash
 }).
 
--define(RPC_LIST_TIMEOUT, 1000).
--define(RPC_READSEG_TIMEOUT, 5000).
+-define(NAME(Transfer), {n, l, {?MODULE, Transfer}}).
+-define(REF(Transfer), {via, gproc, ?NAME(Transfer)}).
 
 %%
 
-start_link(Storage, Transfer, Callback) ->
-    gen_statem:start_link(?MODULE, {Storage, Transfer, Callback}, []).
+start_link(Storage, Transfer) ->
+    %% TODO
+    %% Additional callbacks? They won't survive restarts by the supervisor, which brings a
+    %% question if we even need to retry with the help of supervisor.
+    gen_statem:start_link(?REF(Transfer), ?MODULE, {Storage, Transfer}, []).
 
 %%
 
@@ -56,16 +51,21 @@ start_link(Storage, Transfer, Callback) ->
 callback_mode() ->
     handle_event_function.
 
-init({Storage, Transfer, Callback}) ->
+init({Storage, Transfer}) ->
     St = #st{
         storage = Storage,
         transfer = Transfer,
         assembly = emqx_ft_assembly:new(),
-        hash = crypto:hash_init(sha256),
-        callback = Callback
+        hash = crypto:hash_init(sha256)
     },
-    {ok, list_local_fragments, St, ?internal([])}.
+    {ok, idle, St}.
 
+handle_event(info, kickoff, idle, St) ->
+    % NOTE
+    % Someone's told us to start the work, which usually means that it has set up a monitor.
+    % We could wait for this message and handle it at the end of the assembling rather than at
+    % the beginning, however it would make error handling much more messier.
+    {next_state, list_local_fragments, St, ?internal([])};
 handle_event(internal, _, list_local_fragments, St = #st{assembly = Asm}) ->
     % TODO: what we do with non-transients errors here (e.g. `eacces`)?
     {ok, Fragments} = emqx_ft_storage_fs:list(St#st.storage, St#st.transfer, fragment),
@@ -76,10 +76,10 @@ handle_event(internal, _, list_local_fragments, St = #st{assembly = Asm}) ->
             {next_state, start_assembling, NSt, ?internal([])};
         {incomplete, _} ->
             Nodes = mria_mnesia:running_nodes() -- [node()],
-            {next_state, {list_remote_fragments, Nodes}, NSt, ?internal([])}
+            {next_state, {list_remote_fragments, Nodes}, NSt, ?internal([])};
         % TODO: recovery?
-        % {error, _} = Reason ->
-        %     {stop, Reason}
+        {error, _} = Error ->
+            {stop, {shutdown, Error}}
     end;
 handle_event(internal, _, {list_remote_fragments, Nodes}, St) ->
     % TODO
@@ -107,12 +107,14 @@ handle_event(internal, _, {list_remote_fragments, Nodes}, St) ->
             {next_state, start_assembling, NSt, ?internal([])};
         % TODO: retries / recovery?
         {incomplete, _} = Status ->
-            {next_state, {failure, {error, Status}}, NSt, ?internal([])}
+            {stop, {shutdown, {error, Status}}};
+        {error, _} = Error ->
+            {stop, {shutdown, Error}}
     end;
 handle_event(internal, _, start_assembling, St = #st{assembly = Asm}) ->
     Filemeta = emqx_ft_assembly:filemeta(Asm),
     Coverage = emqx_ft_assembly:coverage(Asm),
-    % TODO: errors
+    % TODO: better error handling
     {ok, Handle} = emqx_ft_storage_fs:open_file(St#st.storage, St#st.transfer, Filemeta),
     {next_state, {assemble, Coverage}, St#st{file = Handle}, ?internal([])};
 handle_event(internal, _, {assemble, [{Node, Segment} | Rest]}, St = #st{}) ->
@@ -120,50 +122,16 @@ handle_event(internal, _, {assemble, [{Node, Segment} | Rest]}, St = #st{}) ->
     % Currently, race is possible between getting segment info from the remote node and
     % this node garbage collecting the segment itself.
     % TODO: pipelining
-    case pread(Node, Segment, St) of
-        {ok, Content} ->
-            case emqx_ft_storage_fs:write(St#st.file, Content) of
-                {ok, NHandle} ->
-                    {next_state, {assemble, Rest}, St#st{file = NHandle}, ?internal([])};
-                %% TODO: better error handling
-                {error, _} = Error ->
-                    {next_state, {failure, Error}, St, ?internal([])}
-            end;
-        {error, _} = Error ->
-            %% TODO: better error handling
-            {next_state, {failure, Error}, St, ?internal([])}
-    end;
+    % TODO: better error handling
+    {ok, Content} = pread(Node, Segment, St),
+    {ok, NHandle} = emqx_ft_storage_fs:write(St#st.file, Content),
+    {next_state, {assemble, Rest}, St#st{file = NHandle}, ?internal([])};
 handle_event(internal, _, {assemble, []}, St = #st{}) ->
     {next_state, complete, St, ?internal([])};
-handle_event(internal, _, complete, St = #st{assembly = Asm, file = Handle, callback = Callback}) ->
+handle_event(internal, _, complete, St = #st{assembly = Asm, file = Handle}) ->
     Filemeta = emqx_ft_assembly:filemeta(Asm),
     Result = emqx_ft_storage_fs:complete(St#st.storage, St#st.transfer, Filemeta, Handle),
-    _ = safe_apply(Callback, Result),
-    {stop, shutdown};
-handle_event(internal, _, {failure, Error}, #st{callback = Callback}) ->
-    _ = safe_apply(Callback, Error),
-    {stop, Error}.
-
-% handle_continue(list_local, St = #st{storage = Storage, transfer = Transfer, assembly = Asm}) ->
-%     % TODO: what we do with non-transients errors here (e.g. `eacces`)?
-%     {ok, Fragments} = emqx_ft_storage_fs:list(Storage, Transfer),
-%     NAsm = emqx_ft_assembly:update(emqx_ft_assembly:append(Asm, node(), Fragments)),
-%     NSt = St#st{assembly = NAsm},
-%     case emqx_ft_assembly:status(NAsm) of
-%         complete ->
-%             {noreply, NSt, {continue}};
-%         {more, _} ->
-%             error(noimpl);
-%         {error, _} ->
-%             error(noimpl)
-%     end,
-%     {noreply, St}.
-
-% handle_call(_Call, _From, St) ->
-%     {reply, {error, badcall}, St}.
-
-% handle_cast(_Cast, St) ->
-%     {noreply, St}.
+    {stop, {shutdown, Result}}.
 
 pread(Node, Segment, St) when Node =:= node() ->
     emqx_ft_storage_fs:pread(St#st.storage, St#st.transfer, Segment, 0, segsize(Segment));

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -16,8 +16,6 @@
 
 -module(emqx_ft_assembler).
 
--include_lib("emqx/include/logger.hrl").
-
 -export([start_link/2]).
 
 -behaviour(gen_statem).
@@ -142,16 +140,3 @@ pread(Node, Segment, St) ->
 
 segsize(#{fragment := {segment, Info}}) ->
     maps:get(size, Info).
-
-safe_apply(Callback, Result) ->
-    try apply(Callback, [Result]) of
-        _ -> ok
-    catch
-        Class:Reason:Stacktrace ->
-            ?SLOG(error, #{
-                msg => "safe_apply_failed",
-                class => Class,
-                reason => Reason,
-                stacktrace => Stacktrace
-            })
-    end.

--- a/apps/emqx_ft/src/emqx_ft_responder_sup.erl
+++ b/apps/emqx_ft/src/emqx_ft_responder_sup.erl
@@ -1,0 +1,48 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_ft_responder_sup).
+
+-export([start_link/0]).
+-export([start_child/3]).
+
+-behaviour(supervisor).
+-export([init/1]).
+
+-define(SUPERVISOR, ?MODULE).
+
+%%
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
+
+start_child(Key, RespFun, Timeout) ->
+    supervisor:start_child(?SUPERVISOR, [Key, RespFun, Timeout]).
+
+-spec init(_) -> {ok, {supervisor:sup_flags(), [supervisor:child_spec()]}}.
+init(_) ->
+    Flags = #{
+        strategy => simple_one_for_one,
+        intensity => 100,
+        period => 100
+    },
+    ChildSpec = #{
+        id => responder,
+        start => {emqx_ft_responder, start_link, []},
+        restart => temporary
+    },
+    {ok, {Flags, [ChildSpec]}}.

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -24,7 +24,7 @@
 -export([store_segment/3]).
 -export([list/3]).
 -export([pread/5]).
--export([assemble/3]).
+-export([assemble/2]).
 
 -export([transfers/1]).
 
@@ -168,11 +168,13 @@ pread(_Storage, _Transfer, Frag, Offset, Size) ->
             {error, Reason}
     end.
 
--spec assemble(storage(), transfer(), fun((ok | {error, term()}) -> any())) ->
+-spec assemble(storage(), transfer()) ->
     % {ok, _Assembler :: pid()} | {error, incomplete} | {error, badrpc} | {error, _TODO}.
-    {ok, _Assembler :: pid()} | {error, _TODO}.
-assemble(Storage, Transfer, Callback) ->
-    emqx_ft_assembler_sup:start_child(Storage, Transfer, Callback).
+    {async, _Assembler :: pid()} | {error, _TODO}.
+assemble(Storage, Transfer) ->
+    % TODO: ask cluster if the transfer is already assembled
+    {ok, Pid} = emqx_ft_assembler_sup:ensure_child(Storage, Transfer),
+    {async, Pid}.
 
 get_ready_transfer(_Storage, ReadyTransferId) ->
     case parse_ready_transfer_id(ReadyTransferId) of

--- a/apps/emqx_ft/src/emqx_ft_sup.erl
+++ b/apps/emqx_ft/src/emqx_ft_sup.erl
@@ -53,12 +53,12 @@ init([]) ->
     },
 
     Responder = #{
-        id => emqx_ft_responder,
-        start => {emqx_ft_responder, start_link, []},
+        id => emqx_ft_responder_sup,
+        start => {emqx_ft_responder_sup, start_link, []},
         restart => permanent,
         shutdown => infinity,
         type => worker,
-        modules => [emqx_ft_responder]
+        modules => [emqx_ft_responder_sup]
     },
 
     ChildSpecs = [Responder, AssemblerSup, FileReaderSup],

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -361,7 +361,7 @@ t_assemble_crash(Config) ->
     C = ?config(client, Config),
 
     meck:new(emqx_ft_storage_fs),
-    meck:expect(emqx_ft_storage_fs, assemble, fun(_, _, _) -> meck:exception(error, oops) end),
+    meck:expect(emqx_ft_storage_fs, assemble, fun(_, _) -> meck:exception(error, oops) end),
 
     ?assertRCName(
         unspecified_error,

--- a/apps/emqx_ft/test/emqx_ft_responder_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_responder_SUITE.erl
@@ -19,7 +19,6 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("emqx/include/asserts.hrl").
 
@@ -39,58 +38,58 @@ init_per_testcase(_Case, Config) ->
 end_per_testcase(_Case, _Config) ->
     ok.
 
-t_register_unregister(_Config) ->
+t_start_ack(_Config) ->
     Key = <<"test">>,
-    DefaultAction = fun(_) -> ok end,
-    ?assertEqual(
-        ok,
-        emqx_ft_responder:register(Key, DefaultAction, 1000)
+    DefaultAction = fun(_Key, {ack, Ref}) -> Ref end,
+    ?assertMatch(
+        {ok, _Pid},
+        emqx_ft_responder:start(Key, DefaultAction, 1000)
     ),
-    ?assertEqual(
-        {error, already_registered},
-        emqx_ft_responder:register(Key, DefaultAction, 1000)
+    ?assertMatch(
+        {error, {already_started, _Pid}},
+        emqx_ft_responder:start(Key, DefaultAction, 1000)
     ),
+    Ref = make_ref(),
     ?assertEqual(
-        ok,
-        emqx_ft_responder:unregister(Key)
+        Ref,
+        emqx_ft_responder:ack(Key, Ref)
     ),
-    ?assertEqual(
-        {error, not_found},
-        emqx_ft_responder:unregister(Key)
+    ?assertExit(
+        {noproc, _},
+        emqx_ft_responder:ack(Key, Ref)
     ).
 
 t_timeout(_Config) ->
     Key = <<"test">>,
     Self = self(),
-    DefaultAction = fun(K) -> Self ! {timeout, K} end,
-    ok = emqx_ft_responder:register(Key, DefaultAction, 20),
+    DefaultAction = fun(K, timeout) -> Self ! {timeout, K} end,
+    {ok, _Pid} = emqx_ft_responder:start(Key, DefaultAction, 20),
     receive
         {timeout, Key} ->
             ok
     after 100 ->
         ct:fail("emqx_ft_responder not called")
     end,
-    ?assertEqual(
-        {error, not_found},
-        emqx_ft_responder:unregister(Key)
+    ?assertExit(
+        {noproc, _},
+        emqx_ft_responder:ack(Key, oops)
     ).
 
-t_action_exception(_Config) ->
-    Key = <<"test">>,
-    DefaultAction = fun(K) -> error({oops, K}) end,
-
-    ?assertWaitEvent(
-        emqx_ft_responder:register(Key, DefaultAction, 10),
-        #{?snk_kind := ft_timeout_action_applied, key := <<"test">>},
-        1000
-    ),
-    ?assertEqual(
-        {error, not_found},
-        emqx_ft_responder:unregister(Key)
-    ).
+% t_action_exception(_Config) ->
+%     Key = <<"test">>,
+%     DefaultAction = fun(K) -> error({oops, K}) end,
+%     ?assertWaitEvent(
+%         emqx_ft_responder:start(Key, DefaultAction, 10),
+%         #{?snk_kind := ft_timeout_action_applied, key := <<"test">>},
+%         1000
+%     ),
+%     ?assertEqual(
+%         {error, not_found},
+%         emqx_ft_responder:ack(Key, oops)
+%     ).
 
 t_unknown_msgs(_Config) ->
-    Pid = whereis(emqx_ft_responder),
+    {ok, Pid} = emqx_ft_responder:start(make_ref(), fun(_, _) -> ok end, 100),
     Pid ! {unknown_msg, <<"test">>},
     ok = gen_server:cast(Pid, {unknown_msg, <<"test">>}),
     ?assertEqual(

--- a/apps/emqx_ft/test/emqx_ft_responder_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_responder_SUITE.erl
@@ -40,7 +40,7 @@ end_per_testcase(_Case, _Config) ->
 
 t_start_ack(_Config) ->
     Key = <<"test">>,
-    DefaultAction = fun(_Key, {ack, Ref}) -> Ref end,
+    DefaultAction = fun({ack, Ref}) -> Ref end,
     ?assertMatch(
         {ok, _Pid},
         emqx_ft_responder:start(Key, DefaultAction, 1000)
@@ -62,7 +62,7 @@ t_start_ack(_Config) ->
 t_timeout(_Config) ->
     Key = <<"test">>,
     Self = self(),
-    DefaultAction = fun(K, timeout) -> Self ! {timeout, K} end,
+    DefaultAction = fun(timeout) -> Self ! {timeout, Key} end,
     {ok, _Pid} = emqx_ft_responder:start(Key, DefaultAction, 20),
     receive
         {timeout, Key} ->
@@ -89,7 +89,7 @@ t_timeout(_Config) ->
 %     ).
 
 t_unknown_msgs(_Config) ->
-    {ok, Pid} = emqx_ft_responder:start(make_ref(), fun(_, _) -> ok end, 100),
+    {ok, Pid} = emqx_ft_responder:start(make_ref(), fun(_) -> ok end, 100),
     Pid ! {unknown_msg, <<"test">>},
     ok = gen_server:cast(Pid, {unknown_msg, <<"test">>}),
     ?assertEqual(

--- a/apps/emqx_ft/test/emqx_ft_responder_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_responder_SUITE.erl
@@ -20,7 +20,6 @@
 -compile(nowarn_export_all).
 
 -include_lib("stdlib/include/assert.hrl").
--include_lib("emqx/include/asserts.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -74,19 +73,6 @@ t_timeout(_Config) ->
         {noproc, _},
         emqx_ft_responder:ack(Key, oops)
     ).
-
-% t_action_exception(_Config) ->
-%     Key = <<"test">>,
-%     DefaultAction = fun(K) -> error({oops, K}) end,
-%     ?assertWaitEvent(
-%         emqx_ft_responder:start(Key, DefaultAction, 10),
-%         #{?snk_kind := ft_timeout_action_applied, key := <<"test">>},
-%         1000
-%     ),
-%     ?assertEqual(
-%         {error, not_found},
-%         emqx_ft_responder:ack(Key, oops)
-%     ).
 
 t_unknown_msgs(_Config) ->
     {ok, Pid} = emqx_ft_responder:start(make_ref(), fun(_) -> ok end, 100),


### PR DESCRIPTION
Introduce an ad-hoc concept of tasks that need to be kicked off manually. Rework filesystem backend to accommodate for this change. Adapt responder logic for that "kickoff" protocol.

---

[EMQX-8913](https://emqx.atlassian.net/browse/EMQX-8913)