### PR TITLE
Add regression test for resource buffer worker flush

### DIFF
--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [


### PR DESCRIPTION
This PR adds a regression test for recursive flushing in `emqx_resource_buffer_worker`. The actual crash was fixed earlier in #9835.

Fixes EMQX-8784.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [X] Changed lines covered in coverage report
- [ ] ~Change log has been added to `changes/<version>/(feat|fix)-<PR-id>.en.md` and `.zh.md` files~ (no, it's just a test)
- [X] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [ ] ~Schema changes are backward compatible~
