### PR TITLE
chore: upgrade dashboards

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.0-28:1.13.4-24.3.4.2-2
 export EMQX_DEFAULT_RUNNER = debian:11-slim
 export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
 export ELIXIR_VSN ?= $(shell $(CURDIR)/scripts/get-elixir-vsn.sh)
-export EMQX_DASHBOARD_VERSION ?= v1.1.7
-export EMQX_EE_DASHBOARD_VERSION ?= e1.0.3
+export EMQX_DASHBOARD_VERSION ?= v1.1.8
+export EMQX_EE_DASHBOARD_VERSION ?= e1.0.4-beta.3
 export EMQX_REL_FORM ?= tgz
 export QUICER_DOWNLOAD_FROM_RELEASE = 1
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
For Opensource edition:
https://github.com/emqx/emqx-dashboard-web-new/releases/tag/v1.1.8

For Entperprise edition:
https://github.com/emqx/emqx-dashboard-web-new/releases/tag/e1.0.4-beta.3