### PR TITLE
Simplify `emqx_conf` and `gen_rpc` cooperation

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -55,7 +55,6 @@
 ]).
 
 -export([
-    set_gen_rpc_stateless/0,
     emqx_cluster/1,
     emqx_cluster/2,
     start_epmd/0,
@@ -254,12 +253,7 @@ read_schema_configs(no_schema, _ConfigFile) ->
     ok;
 read_schema_configs(Schema, ConfigFile) ->
     NewConfig = generate_config(Schema, ConfigFile),
-    lists:foreach(
-        fun({App, Configs}) ->
-            [application:set_env(App, Par, Value) || {Par, Value} <- Configs]
-        end,
-        NewConfig
-    ).
+    application:set_env(NewConfig).
 
 generate_config(SchemaModule, ConfigFile) when is_atom(SchemaModule) ->
     {ok, Conf0} = hocon:load(ConfigFile, #{format => richmap}),
@@ -553,16 +547,6 @@ ensure_quic_listener(Name, UdpPort) ->
     %% - wss: base_port + 4
     listener_ports => [{Type :: tcp | ssl | ws | wss, inet:port_number()}]
 }.
-
--spec set_gen_rpc_stateless() -> ok.
-set_gen_rpc_stateless() ->
-    %% When many tests run in an obscure order, it may occur that
-    %% `gen_rpc` started with its default settings before `emqx_conf`.
-    %% `gen_rpc` and `emqx_conf` have different default `port_discovery` modes,
-    %% so we reinitialize `gen_rpc` explicitly.
-    ok = application:stop(gen_rpc),
-    ok = application:set_env(gen_rpc, port_discovery, stateless),
-    ok = application:start(gen_rpc).
 
 -spec emqx_cluster(cluster_spec()) -> [{shortname(), node_opts()}].
 emqx_cluster(Specs) ->

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -42,12 +42,11 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx_ft], set_special_configs(Config)),
-    ok = emqx_common_test_helpers:set_gen_rpc_stateless(),
+    ok = emqx_common_test_helpers:start_apps([emqx_ft], set_special_configs(Config)),
     Config.
 
 end_per_suite(_Config) ->
-    ok = emqx_common_test_helpers:stop_apps([emqx_ft, emqx_conf]),
+    ok = emqx_common_test_helpers:stop_apps([emqx_ft]),
     ok.
 
 set_special_configs(Config) ->

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -32,7 +32,7 @@ init_per_suite(Config) ->
     ok = emqx_mgmt_api_test_util:init_suite(
         [emqx_conf, emqx_ft], set_special_configs(Config)
     ),
-    ok = emqx_common_test_helpers:set_gen_rpc_stateless(),
+    {ok, _} = emqx:update_config([rpc, port_discovery], manual),
     Config.
 end_per_suite(_Config) ->
     ok = emqx_mgmt_api_test_util:end_suite([emqx_ft, emqx_conf]),

--- a/apps/emqx_ft/test/emqx_ft_conf_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_conf_SUITE.erl
@@ -26,6 +26,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx_ft]),
+    {ok, _} = emqx:update_config([rpc, port_discovery], manual),
     Config.
 
 end_per_suite(_Config) ->

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
@@ -39,11 +39,10 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx_ft], set_special_configs(Config)),
-    ok = emqx_common_test_helpers:set_gen_rpc_stateless(),
+    ok = emqx_common_test_helpers:start_apps([emqx_ft], set_special_configs(Config)),
     Config.
 end_per_suite(_Config) ->
-    ok = emqx_common_test_helpers:stop_apps([emqx_ft, emqx_conf]),
+    ok = emqx_common_test_helpers:stop_apps([emqx_ft]),
     ok.
 
 set_special_configs(Config) ->

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_reader_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_reader_SUITE.erl
@@ -25,12 +25,11 @@
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx_ft]),
-    ok = emqx_common_test_helpers:set_gen_rpc_stateless(),
+    ok = emqx_common_test_helpers:start_apps([emqx_ft]),
     Config.
 
 end_per_suite(_Config) ->
-    ok = emqx_common_test_helpers:stop_apps([emqx_ft, emqx_conf]),
+    ok = emqx_common_test_helpers:stop_apps([emqx_ft]),
     ok.
 
 init_per_testcase(_Case, Config) ->

--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -28,7 +28,7 @@ start_additional_node(Config, Node) ->
         [
             {apps, [emqx_ft]},
             {join_to, SelfNode},
-            {configure_gen_rpc, false},
+            {configure_gen_rpc, true},
             {env_handler, fun
                 (emqx_ft) ->
                     ok = emqx_config:put([file_transfer, storage], #{


### PR DESCRIPTION
`emqx` test helpers start some apps "manually" (like `ekka`, `mria`, `gen_rpc`) before all the other apps.

So when we start `emqx_conf`, its rendered and loaded configs do not influence already started things (like `gen_rpc` servers), but influence newly started things (like `gen_rpc` discovery and clients). 

So when we start `emqx_conf` we should sync some settings back.
