### PR TITLE
fix(ft): require final size in `fin` packet

### DIFF
--- a/apps/emqx/src/emqx_maybe.erl
+++ b/apps/emqx/src/emqx_maybe.erl
@@ -34,9 +34,40 @@ from_list([]) ->
 from_list([Term]) ->
     Term.
 
+%% @doc Apply a function to a maybe argument.
 -spec apply(fun((maybe(A)) -> maybe(A)), maybe(A)) ->
     maybe(A).
 apply(_Fun, undefined) ->
     undefined;
 apply(Fun, Term) when is_function(Fun) ->
     erlang:apply(Fun, [Term]).
+
+%%
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+to_list_test_() ->
+    [
+        ?_assertEqual([], to_list(undefined)),
+        ?_assertEqual([42], to_list(42))
+    ].
+
+from_list_test_() ->
+    [
+        ?_assertEqual(undefined, from_list([])),
+        ?_assertEqual(3.1415, from_list([3.1415])),
+        ?_assertError(_, from_list([1, 2, 3]))
+    ].
+
+apply_test_() ->
+    [
+        ?_assertEqual(<<"42">>, ?MODULE:apply(fun erlang:integer_to_binary/1, 42)),
+        ?_assertEqual(undefined, ?MODULE:apply(fun erlang:integer_to_binary/1, undefined)),
+        ?_assertEqual(undefined, ?MODULE:apply(fun crash/1, undefined))
+    ].
+
+crash(_) ->
+    erlang:error(crashed).
+
+-endif.

--- a/apps/emqx/src/emqx_maybe.erl
+++ b/apps/emqx/src/emqx_maybe.erl
@@ -1,0 +1,42 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2017-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_maybe).
+
+-include_lib("emqx/include/types.hrl").
+
+-export([to_list/1]).
+-export([from_list/1]).
+-export([apply/2]).
+
+-spec to_list(maybe(A)) -> [A].
+to_list(undefined) ->
+    [];
+to_list(Term) ->
+    [Term].
+
+-spec from_list([A]) -> maybe(A).
+from_list([]) ->
+    undefined;
+from_list([Term]) ->
+    Term.
+
+-spec apply(fun((maybe(A)) -> maybe(A)), maybe(A)) ->
+    maybe(A).
+apply(_Fun, undefined) ->
+    undefined;
+apply(Fun, Term) when is_function(Fun) ->
+    erlang:apply(Fun, [Term]).

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -16,7 +16,7 @@
 
 -module(emqx_ft_assembler).
 
--export([start_link/2]).
+-export([start_link/3]).
 
 -behaviour(gen_statem).
 -export([callback_mode/0]).
@@ -36,11 +36,11 @@
 
 %%
 
-start_link(Storage, Transfer) ->
+start_link(Storage, Transfer, Size) ->
     %% TODO
     %% Additional callbacks? They won't survive restarts by the supervisor, which brings a
     %% question if we even need to retry with the help of supervisor.
-    gen_statem:start_link(?REF(Transfer), ?MODULE, {Storage, Transfer}, []).
+    gen_statem:start_link(?REF(Transfer), ?MODULE, {Storage, Transfer, Size}, []).
 
 %%
 
@@ -49,11 +49,11 @@ start_link(Storage, Transfer) ->
 callback_mode() ->
     handle_event_function.
 
-init({Storage, Transfer}) ->
+init({Storage, Transfer, Size}) ->
     St = #st{
         storage = Storage,
         transfer = Transfer,
-        assembly = emqx_ft_assembly:new(),
+        assembly = emqx_ft_assembly:new(Size),
         hash = crypto:hash_init(sha256)
     },
     {ok, idle, St}.

--- a/apps/emqx_ft/src/emqx_ft_assembler_sup.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler_sup.erl
@@ -17,7 +17,7 @@
 -module(emqx_ft_assembler_sup).
 
 -export([start_link/0]).
--export([ensure_child/2]).
+-export([ensure_child/3]).
 
 -behaviour(supervisor).
 -export([init/1]).
@@ -25,10 +25,10 @@
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
-ensure_child(Storage, Transfer) ->
+ensure_child(Storage, Transfer, Size) ->
     Childspec = #{
         id => Transfer,
-        start => {emqx_ft_assembler, start_link, [Storage, Transfer]},
+        start => {emqx_ft_assembler, start_link, [Storage, Transfer, Size]},
         restart => temporary
     },
     case supervisor:start_child(?MODULE, Childspec) of

--- a/apps/emqx_ft/src/emqx_ft_storage.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage.erl
@@ -20,7 +20,7 @@
     [
         store_filemeta/2,
         store_segment/2,
-        assemble/1,
+        assemble/2,
 
         ready_transfers/0,
         get_ready_transfer/1,
@@ -53,7 +53,7 @@
     ok | {async, pid()} | {error, term()}.
 -callback store_segment(storage(), emqx_ft:transfer(), emqx_ft:segment()) ->
     ok | {async, pid()} | {error, term()}.
--callback assemble(storage(), emqx_ft:transfer()) ->
+-callback assemble(storage(), emqx_ft:transfer(), _Size :: emqx_ft:bytes()) ->
     ok | {async, pid()} | {error, term()}.
 -callback ready_transfers(storage()) ->
     {ok, [{ready_transfer_id(), ready_transfer_info()}]} | {error, term()}.
@@ -76,11 +76,11 @@ store_segment(Transfer, Segment) ->
     Mod = mod(),
     Mod:store_segment(storage(), Transfer, Segment).
 
--spec assemble(emqx_ft:transfer()) ->
+-spec assemble(emqx_ft:transfer(), emqx_ft:bytes()) ->
     ok | {async, pid()} | {error, term()}.
-assemble(Transfer) ->
+assemble(Transfer, Size) ->
     Mod = mod(),
-    Mod:assemble(storage(), Transfer).
+    Mod:assemble(storage(), Transfer, Size).
 
 -spec ready_transfers() -> {ok, [{ready_transfer_id(), ready_transfer_info()}]} | {error, term()}.
 ready_transfers() ->

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -24,7 +24,7 @@
 -export([store_segment/3]).
 -export([list/3]).
 -export([pread/5]).
--export([assemble/2]).
+-export([assemble/3]).
 
 -export([transfers/1]).
 
@@ -167,12 +167,12 @@ pread(_Storage, _Transfer, Frag, Offset, Size) ->
             {error, Reason}
     end.
 
--spec assemble(storage(), transfer()) ->
+-spec assemble(storage(), transfer(), emqx_ft:bytes()) ->
     % {ok, _Assembler :: pid()} | {error, incomplete} | {error, badrpc} | {error, _TODO}.
     {async, _Assembler :: pid()} | {error, _TODO}.
-assemble(Storage, Transfer) ->
+assemble(Storage, Transfer, Size) ->
     % TODO: ask cluster if the transfer is already assembled
-    {ok, Pid} = emqx_ft_assembler_sup:ensure_child(Storage, Transfer),
+    {ok, Pid} = emqx_ft_assembler_sup:ensure_child(Storage, Transfer, Size),
     {async, Pid}.
 
 get_ready_transfer(_Storage, ReadyTransferId) ->

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -37,8 +37,14 @@ all() ->
 
 groups() ->
     [
-        {single_node, [sequence], emqx_common_test_helpers:all(?MODULE) -- [t_switch_node]},
-        {cluster, [sequence], [t_switch_node]}
+        {single_node, [sequence], emqx_common_test_helpers:all(?MODULE) -- group_cluster()},
+        {cluster, [sequence], group_cluster()}
+    ].
+
+group_cluster() ->
+    [
+        t_switch_node,
+        t_unreliable_migrating_client
     ].
 
 init_per_suite(Config) ->
@@ -61,24 +67,60 @@ set_special_configs(Config) ->
 
 init_per_testcase(Case, Config) ->
     ClientId = atom_to_binary(Case),
-    {ok, C} = emqtt:start_link([{proto_ver, v5}, {clientid, ClientId}]),
-    {ok, _} = emqtt:connect(C),
-    [{client, C}, {clientid, ClientId} | Config].
+    case ?config(group, Config) of
+        cluster ->
+            [{clientid, ClientId} | Config];
+        _ ->
+            {ok, C} = emqtt:start_link([{proto_ver, v5}, {clientid, ClientId}]),
+            {ok, _} = emqtt:connect(C),
+            [{client, C}, {clientid, ClientId} | Config]
+    end.
 end_per_testcase(_Case, Config) ->
-    C = ?config(client, Config),
-    ok = emqtt:stop(C),
+    _ = [ok = emqtt:stop(C) || {client, C} <- Config],
     ok.
 
-init_per_group(cluster, Config) ->
-    Node = emqx_ft_test_helpers:start_additional_node(Config, emqx_ft1),
-    [{additional_node, Node} | Config];
-init_per_group(_Group, Config) ->
-    Config.
+init_per_group(Group = cluster, Config) ->
+    Cluster = mk_cluster_specs(Config),
+    ct:pal("Starting ~p", [Cluster]),
+    Nodes = [
+        emqx_common_test_helpers:start_slave(Name, Opts#{join_to => node()})
+     || {Name, Opts} <- Cluster
+    ],
+    [{group, Group}, {cluster_nodes, Nodes} | Config];
+init_per_group(Group, Config) ->
+    [{group, Group} | Config].
 
 end_per_group(cluster, Config) ->
-    ok = emqx_ft_test_helpers:stop_additional_node(Config);
+    ok = lists:foreach(
+        fun emqx_ft_test_helpers:stop_additional_node/1,
+        ?config(cluster_nodes, Config)
+    );
 end_per_group(_Group, _Config) ->
     ok.
+
+mk_cluster_specs(Config) ->
+    Specs = [
+        {core, emqx_ft_SUITE1, #{listener_ports => [{tcp, 2883}]}},
+        {core, emqx_ft_SUITE2, #{listener_ports => [{tcp, 3883}]}}
+    ],
+    CommOpts = [
+        {env, [{emqx, boot_modules, [broker, listeners]}]},
+        {apps, [emqx_ft]},
+        {conf, [{[listeners, Proto, default, enabled], false} || Proto <- [ssl, ws, wss]]},
+        {env_handler, fun
+            (emqx_ft) ->
+                ok = emqx_config:put([file_transfer, storage], #{
+                    type => local,
+                    root => emqx_ft_test_helpers:ft_root(Config, node())
+                });
+            (_) ->
+                ok
+        end}
+    ],
+    emqx_common_test_helpers:emqx_cluster(
+        Specs,
+        CommOpts
+    ).
 
 %%--------------------------------------------------------------------
 %% Tests
@@ -125,7 +167,7 @@ t_simple_transfer(Config) ->
 
     Data = [<<"first">>, <<"second">>, <<"third">>],
 
-    Meta = meta(Filename, Data),
+    Meta = #{size := Filesize} = meta(Filename, Data),
     MetaPayload = emqx_json:encode(Meta),
 
     MetaTopic = <<"$file/", FileId/binary, "/init">>,
@@ -145,7 +187,7 @@ t_simple_transfer(Config) ->
         with_offsets(Data)
     ),
 
-    FinTopic = <<"$file/", FileId/binary, "/fin">>,
+    FinTopic = <<"$file/", FileId/binary, "/fin/", (integer_to_binary(Filesize))/binary>>,
     ?assertRCName(
         success,
         emqtt:publish(C, FinTopic, <<>>, 1)
@@ -194,7 +236,7 @@ t_no_meta(Config) ->
         emqtt:publish(C, SegmentTopic, Data, 1)
     ),
 
-    FinTopic = <<"$file/", FileId/binary, "/fin">>,
+    FinTopic = <<"$file/", FileId/binary, "/fin/42">>,
     ?assertRCName(
         unspecified_error,
         emqtt:publish(C, FinTopic, <<>>, 1)
@@ -208,7 +250,7 @@ t_no_segment(Config) ->
 
     Data = [<<"first">>, <<"second">>, <<"third">>],
 
-    Meta = meta(Filename, Data),
+    Meta = #{size := Filesize} = meta(Filename, Data),
     MetaPayload = emqx_json:encode(Meta),
 
     MetaTopic = <<"$file/", FileId/binary, "/init">>,
@@ -229,7 +271,7 @@ t_no_segment(Config) ->
         tl(with_offsets(Data))
     ),
 
-    FinTopic = <<"$file/", FileId/binary, "/fin">>,
+    FinTopic = <<"$file/", FileId/binary, "/fin/", (integer_to_binary(Filesize))/binary>>,
     ?assertRCName(
         unspecified_error,
         emqtt:publish(C, FinTopic, <<>>, 1)
@@ -264,7 +306,7 @@ t_invalid_checksum(Config) ->
 
     Data = [<<"first">>, <<"second">>, <<"third">>],
 
-    Meta = meta(Filename, Data),
+    Meta = #{size := Filesize} = meta(Filename, Data),
     MetaPayload = emqx_json:encode(Meta#{checksum => sha256hex(<<"invalid">>)}),
 
     MetaTopic = <<"$file/", FileId/binary, "/init">>,
@@ -284,14 +326,15 @@ t_invalid_checksum(Config) ->
         with_offsets(Data)
     ),
 
-    FinTopic = <<"$file/", FileId/binary, "/fin">>,
+    FinTopic = <<"$file/", FileId/binary, "/fin/", (integer_to_binary(Filesize))/binary>>,
     ?assertRCName(
         unspecified_error,
         emqtt:publish(C, FinTopic, <<>>, 1)
     ).
 
 t_switch_node(Config) ->
-    AdditionalNodePort = emqx_ft_test_helpers:tcp_port(?config(additional_node, Config)),
+    [Node | _] = ?config(cluster_nodes, Config),
+    AdditionalNodePort = emqx_ft_test_helpers:tcp_port(Node),
 
     ClientId = <<"t_switch_node-migrating_client">>,
 
@@ -306,7 +349,7 @@ t_switch_node(Config) ->
 
     %% First, publist metadata and the first segment to the additional node
 
-    Meta = meta(Filename, Data),
+    Meta = #{size := Filesize} = meta(Filename, Data),
     MetaPayload = emqx_json:encode(Meta),
 
     MetaTopic = <<"$file/", FileId/binary, "/init">>,
@@ -335,7 +378,7 @@ t_switch_node(Config) ->
         emqtt:publish(C2, <<"$file/", FileId/binary, "/", Offset2/binary>>, Data2, 1)
     ),
 
-    FinTopic = <<"$file/", FileId/binary, "/fin">>,
+    FinTopic = <<"$file/", FileId/binary, "/fin/", (integer_to_binary(Filesize))/binary>>,
     ?assertRCName(
         success,
         emqtt:publish(C2, FinTopic, <<>>, 1)
@@ -360,12 +403,133 @@ t_assemble_crash(Config) ->
     C = ?config(client, Config),
 
     meck:new(emqx_ft_storage_fs),
-    meck:expect(emqx_ft_storage_fs, assemble, fun(_, _) -> meck:exception(error, oops) end),
+    meck:expect(emqx_ft_storage_fs, assemble, fun(_, _, _) -> meck:exception(error, oops) end),
 
     ?assertRCName(
         unspecified_error,
         emqtt:publish(C, <<"$file/someid/fin">>, <<>>, 1)
     ).
+
+t_unreliable_migrating_client(Config) ->
+    NodeSelf = node(),
+    [Node1, Node2] = ?config(cluster_nodes, Config),
+
+    ClientId = ?config(clientid, Config),
+    FileId = emqx_guid:to_hexstr(emqx_guid:gen()),
+    Filename = "migratory-birds-in-southern-hemisphere-2013.pdf",
+    Filesize = 1000,
+    Gen = emqx_ft_content_gen:new({{ClientId, FileId}, Filesize}, 16),
+    Payload = iolist_to_binary(emqx_ft_content_gen:consume(Gen, fun({Chunk, _, _}) -> Chunk end)),
+    Meta = meta(Filename, Payload),
+
+    Context = #{
+        clientid => ClientId,
+        fileid => FileId,
+        filesize => Filesize,
+        payload => Payload
+    },
+    Commands = [
+        {fun connect_mqtt_client/2, [NodeSelf]},
+        {fun send_filemeta/2, [Meta]},
+        {fun send_segment/3, [0, 100]},
+        {fun send_segment/3, [100, 100]},
+        {fun send_segment/3, [200, 100]},
+        {fun stop_mqtt_client/1, []},
+        {fun connect_mqtt_client/2, [Node1]},
+        {fun connect_mqtt_client/2, [Node2]},
+        {fun send_filemeta/2, [Meta]},
+        {fun send_segment/3, [0, 200]},
+        {fun send_segment/3, [200, 200]},
+        {fun send_segment/3, [400, 100]},
+        {fun connect_mqtt_client/2, [Node2]},
+        {fun send_segment/3, [200, 200]},
+        {fun send_segment/3, [400, 200]},
+        {fun connect_mqtt_client/2, [Node1]},
+        {fun send_segment/3, [400, 200]},
+        {fun send_segment/3, [600, eof]},
+        {fun send_finish/1, []},
+        {fun connect_mqtt_client/2, [NodeSelf]},
+        {fun send_finish/1, []}
+    ],
+    _Context = run_commands(Commands, Context),
+
+    {ok, ReadyTransfers} = emqx_ft_storage:ready_transfers(),
+    ReadyTransferIds =
+        [Id || {#{<<"clientid">> := CId} = Id, _Info} <- ReadyTransfers, CId == ClientId],
+
+    Node1Bin = atom_to_binary(Node1),
+    NodeSelfBin = atom_to_binary(NodeSelf),
+    ?assertMatch(
+        [#{<<"node">> := Node1Bin}, #{<<"node">> := NodeSelfBin}],
+        lists:sort(ReadyTransferIds)
+    ),
+
+    [
+        begin
+            {ok, TableQH} = emqx_ft_storage:get_ready_transfer(Id),
+            ?assertEqual(
+                Payload,
+                iolist_to_binary(qlc:eval(TableQH))
+            )
+        end
+     || Id <- ReadyTransferIds
+    ].
+
+run_commands(Commands, Context) ->
+    lists:foldl(fun run_command/2, Context, Commands).
+
+run_command({Command, Args}, Context) ->
+    ct:pal("COMMAND ~p ~p", [erlang:fun_info(Command, name), Args]),
+    erlang:apply(Command, Args ++ [Context]).
+
+connect_mqtt_client(Node, ContextIn) ->
+    Context = #{clientid := ClientId} = disown_mqtt_client(ContextIn),
+    NodePort = emqx_ft_test_helpers:tcp_port(Node),
+    {ok, Client} = emqtt:start_link([{proto_ver, v5}, {clientid, ClientId}, {port, NodePort}]),
+    {ok, _} = emqtt:connect(Client),
+    Context#{client => Client}.
+
+stop_mqtt_client(Context = #{client := Client}) ->
+    _ = emqtt:stop(Client),
+    maps:remove(client, Context).
+
+disown_mqtt_client(Context = #{client := Client}) ->
+    _ = erlang:unlink(Client),
+    maps:remove(client, Context);
+disown_mqtt_client(Context = #{}) ->
+    Context.
+
+send_filemeta(Meta, Context = #{client := Client, fileid := FileId}) ->
+    Topic = <<"$file/", FileId/binary, "/init">>,
+    MetaPayload = emqx_json:encode(Meta),
+    ?assertRCName(
+        success,
+        emqtt:publish(Client, Topic, MetaPayload, 1)
+    ),
+    Context.
+
+send_segment(Offset, Size, Context = #{client := Client, fileid := FileId, payload := Payload}) ->
+    Topic = <<"$file/", FileId/binary, "/", (integer_to_binary(Offset))/binary>>,
+    Data =
+        case Size of
+            eof ->
+                binary:part(Payload, Offset, byte_size(Payload) - Offset);
+            N ->
+                binary:part(Payload, Offset, N)
+        end,
+    ?assertRCName(
+        success,
+        emqtt:publish(Client, Topic, Data, 1)
+    ),
+    Context.
+
+send_finish(Context = #{client := Client, fileid := FileId, filesize := Filesize}) ->
+    Topic = <<"$file/", FileId/binary, "/fin/", (integer_to_binary(Filesize))/binary>>,
+    ?assertRCName(
+        success,
+        emqtt:publish(Client, Topic, <<>>, 1)
+    ),
+    Context.
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -136,8 +136,8 @@ t_download_transfer(Config) ->
     ),
 
     ?assertEqual(
-        Response,
-        <<"data">>
+        <<"data">>,
+        Response
     ).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
@@ -67,7 +67,7 @@ init_per_group(_Group, Config) ->
     Config.
 
 end_per_group(cluster, Config) ->
-    ok = emqx_ft_test_helpers:stop_additional_node(Config);
+    ok = emqx_ft_test_helpers:stop_additional_node(?config(additional_node, Config));
 end_per_group(_Group, _Config) ->
     ok.
 


### PR DESCRIPTION
Otherwise there are situations when it's not entirely clear if a transfer is really ready to be assembled. Since the `size` field in a filemeta is not required (and rightly so), we need client to tell us the final transfer size at the end of the process.

Also synthesize a testcase to show why it's needed.

Also worth noting that right now `fin` packets require final size, even if a client already told us the size through filemeta. The latter is regarded as serving informational purposes only (which means that, for example, it might differ from the final size, or some tranfer progress might show >100% somewhere because of that).

---

[EMQX-8916](https://emqx.atlassian.net/browse/EMQX-8916)