### PR TITLE
fix(dashboard): fix swagger spec generation

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -417,12 +417,16 @@ init_prop(Keys, Init, Type) ->
         fun(Key, Acc) ->
             case hocon_schema:field_schema(Type, Key) of
                 undefined -> Acc;
-                Schema -> Acc#{Key => to_bin(Schema)}
+                Schema -> Acc#{Key => format_prop(Key, Schema)}
             end
         end,
         Init,
         Keys
     ).
+
+format_prop(deprecated, Value) when is_boolean(Value) -> Value;
+format_prop(deprecated, _) -> true;
+format_prop(_, Schema) -> to_bin(Schema).
 
 trans_required(Spec, true, _) -> Spec#{required => true};
 trans_required(Spec, _, path) -> Spec#{required => true};

--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -94,6 +94,30 @@ t_object(_Config) ->
     validate("/object", Spec, Refs),
     ok.
 
+t_deprecated(_Config) ->
+    ?assertMatch(
+        [
+            #{
+                <<"emqx_swagger_requestBody_SUITE.deprecated_ref">> :=
+                    #{
+                        <<"properties">> :=
+                            [
+                                {<<"tag1">>, #{
+                                    deprecated := true
+                                }},
+                                {<<"tag2">>, #{
+                                    deprecated := true
+                                }},
+                                {<<"tag3">>, #{
+                                    deprecated := false
+                                }}
+                            ]
+                    }
+            }
+        ],
+        emqx_dashboard_swagger:components([{?MODULE, deprecated_ref}], #{})
+    ).
+
 t_nest_object(_Config) ->
     GoodRef = <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>,
     Spec = #{
@@ -812,7 +836,13 @@ fields(sub_fields) ->
             {init_file, fun init_file/1}
         ],
         desc => <<"test sub fields">>
-    }.
+    };
+fields(deprecated_ref) ->
+    [
+        {tag1, mk(binary(), #{desc => <<"tag1">>, deprecated => {since, "4.3.0"}})},
+        {tag2, mk(binary(), #{desc => <<"tag2">>, deprecated => true})},
+        {tag3, mk(binary(), #{desc => <<"tag3">>, deprecated => false})}
+    ].
 
 enable(type) -> boolean();
 enable(desc) -> <<"Whether to enable tls psk support">>;

--- a/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_telemetry_SUITE.erl
@@ -858,7 +858,8 @@ stop_slave(Node) ->
     ok = slave:stop(Node),
     ?assertEqual([node()], mria_mnesia:running_nodes()),
     ?assertEqual([], nodes()),
-    ok.
+    _ = application:stop(mria),
+    ok = application:start(mria).
 
 leave_cluster() ->
     try mnesia_hook:module_info() of

--- a/changes/ce/fix-9997.en.md
+++ b/changes/ce/fix-9997.en.md
@@ -1,0 +1,1 @@
+Fix Swagger API schema generation. `deprecated` metadata field is now always boolean, as [Swagger specification](https://swagger.io/specification/) suggests.

--- a/changes/ce/fix-9997.zh.md
+++ b/changes/ce/fix-9997.zh.md
@@ -1,0 +1,1 @@
+修复 Swagger API 生成时，`deprecated` 元数据字段未按照[标准](https://swagger.io/specification/)建议的那样始终为布尔值的问题。


### PR DESCRIPTION
Swagger says `deprecated` metadata field should always be boolean https://swagger.io/specification/

But in `hocon` we also support values like`{since, "4.3.0"}`, which result in `"deprecated": "since(\"4.3.0\")"` metadata.
This incompatibility breaks some API client generators.
