### PR TITLE
0220 fail fast if cookie is obviously wrong

### DIFF
--- a/apps/emqx_ctl/src/emqx_ctl.erl
+++ b/apps/emqx_ctl/src/emqx_ctl.erl
@@ -149,7 +149,7 @@ help() ->
         [] ->
             print("No commands available.~n");
         Cmds ->
-            print("Usage: ~ts~n", [?MODULE]),
+            print("Usage: ~ts~n", ["emqx ctl"]),
             lists:foreach(
                 fun({_, {Mod, Cmd}, _}) ->
                     print("~110..-s~n", [""]),

--- a/bin/emqx
+++ b/bin/emqx
@@ -545,6 +545,10 @@ else
                 logerr "Make sure environment variable EMQX_NODE__NAME is set to indicate for which node this command is intended."
                 exit 1
             fi
+        else
+            if [ -n "${EMQX_NODE__NAME:-}" ]; then
+                die "Node $EMQX_NODE__NAME is not running?"
+            fi
         fi
         ## We have no choiece but to read the bootstrap config (with environment overrides available in the current shell)
         [ -f "$EMQX_ETC_DIR"/emqx.conf ] || die "emqx.conf is not found in $EMQX_ETC_DIR" 1
@@ -940,9 +944,11 @@ if [ -n "${EMQX_NODE_COOKIE:-}" ]; then
     unset EMQX_NODE_COOKIE
 fi
 COOKIE="${EMQX_NODE__COOKIE:-}"
-if [ -z "$COOKIE" ]; then
-    COOKIE="$(get_boot_config 'node.cookie')"
+COOKIE_IN_USE="$(get_boot_config 'node.cookie')"
+if [ -n "$COOKIE_IN_USE" ] && [ -n "$COOKIE" ] && [ "$COOKIE" != "$COOKIE_IN_USE" ]; then
+    die "EMQX_NODE__COOKIE is different from the cookie used by $NAME"
 fi
+[ -z "$COOKIE" ] && COOKIE="$COOKIE_IN_USE"
 [ -z "$COOKIE" ] && COOKIE="$EMQX_DEFAULT_ERLANG_COOKIE"
 
 maybe_warn_default_cookie() {

--- a/bin/emqx
+++ b/bin/emqx
@@ -550,7 +550,7 @@ else
                 die "Node $EMQX_NODE__NAME is not running?"
             fi
         fi
-        ## We have no choiece but to read the bootstrap config (with environment overrides available in the current shell)
+        ## We have no choice but to read the bootstrap config (with environment overrides available in the current shell)
         [ -f "$EMQX_ETC_DIR"/emqx.conf ] || die "emqx.conf is not found in $EMQX_ETC_DIR" 1
         maybe_use_portable_dynlibs
         EMQX_BOOT_CONFIGS="$(call_hocon -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf multi_get "${CONF_KEYS[@]}")"

--- a/changes/ce/fix-10015.en.md
+++ b/changes/ce/fix-10015.en.md
@@ -1,0 +1,7 @@
+To prevent errors caused by an incorrect EMQX node cookie provided from an environment variable,
+we have implemented a fail-fast mechanism.
+Previously, when an incorrect cookie was provided, the command would still attempt to ping the node,
+leading to the error message 'Node xxx not responding to pings'.
+With the new implementation, if a mismatched cookie is detected,
+a message will be logged to indicate that the cookie is incorrect,
+and the command will terminate with an error code of 1 without trying to ping the node.

--- a/changes/ce/fix-10015.zh.md
+++ b/changes/ce/fix-10015.zh.md
@@ -1,0 +1,4 @@
+在 cookie 给错时，快速失败。
+在此修复前，即使 cookie 配置错误，emqx 命令仍然会尝试去 ping EMQX 节点，
+并得到一个 "Node xxx not responding to pings" 的错误。
+修复后，如果发现 cookie 不一致，立即打印不一致的错误信息并退出。


### PR DESCRIPTION
A follow up improvement for [EMQX-8936](https://emqx.atlassian.net/browse/EMQX-8936)

When running more than one node in the host, one will need to set `EMQX_NODE__NAME` and `EMQX_NODE__COOKIE` to run the non-boot commands.
If the provided node name or cookie is obviously wrong, we should print out meaningful logs instead of just "Node xxx not responding to pings"

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [x] Change log has been added to `changes/<version>/(feat|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible
