### PR TITLE
fix(docker): fix env conflict for `EMQX_NODE_NAME` and `EMQX_NODE__NAME`

### DIFF
--- a/deploy/docker/docker-entrypoint.sh
+++ b/deploy/docker/docker-entrypoint.sh
@@ -39,9 +39,8 @@ if [[ -z "$EMQX_HOST" ]]; then
     export EMQX_HOST
 fi
 
-if [[ -z "$EMQX_NODE_NAME" ]]; then
-    export EMQX_NODE_NAME="$EMQX_NAME@$EMQX_HOST"
-fi
+export EMQX_NODE_NAME=${EMQX_NODE__NAME:-$EMQX_NAME@$EMQX_HOST}
+echo "node.name = $EMQX_NODE_NAME" >> /opt/emqx/etc/emqx.conf
 
 # The default rpc port discovery 'stateless' is mostly for clusters
 # having static node names. So it's troulbe-free for multiple emqx nodes


### PR DESCRIPTION
`docker-entrypoint` will set `EMQX_NODE_NAME` in env, and `emqx forground` will use it. but when user running `./bin/emqx` in container, emqx maybe not found `EMQX_NODE_NAME`, because it just work in `docker-entrypount`, so print `node.name` to `emqx.conf` to resolve it.