### PR TITLE
perf(ft-asm): express coverage through shortest path on graph

### DIFF
--- a/apps/emqx/src/emqx_maybe.erl
+++ b/apps/emqx/src/emqx_maybe.erl
@@ -20,6 +20,7 @@
 
 -export([to_list/1]).
 -export([from_list/1]).
+-export([define/2]).
 -export([apply/2]).
 
 -spec to_list(maybe(A)) -> [A].
@@ -32,6 +33,12 @@ to_list(Term) ->
 from_list([]) ->
     undefined;
 from_list([Term]) ->
+    Term.
+
+-spec define(maybe(A), B) -> A | B.
+define(undefined, Term) ->
+    Term;
+define(Term, _) ->
     Term.
 
 %% @doc Apply a function to a maybe argument.
@@ -58,6 +65,13 @@ from_list_test_() ->
         ?_assertEqual(undefined, from_list([])),
         ?_assertEqual(3.1415, from_list([3.1415])),
         ?_assertError(_, from_list([1, 2, 3]))
+    ].
+
+define_test_() ->
+    [
+        ?_assertEqual(42, define(42, undefined)),
+        ?_assertEqual(<<"default">>, define(undefined, <<"default">>)),
+        ?_assertEqual(undefined, define(undefined, undefined))
     ].
 
 apply_test_() ->

--- a/apps/emqx/src/emqx_wdgraph.erl
+++ b/apps/emqx/src/emqx_wdgraph.erl
@@ -1,0 +1,186 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Weighted directed graph.
+%%
+%% Purely functional, built on top of a single `gb_tree`.
+%% Weights are currently assumed to be non-negative numbers, hovewer
+%% presumably anything that is ≥ 0 should work (but won't typecheck 🥲).
+
+-module(emqx_wdgraph).
+
+-export([new/0]).
+-export([insert_edge/5]).
+-export([find_edge/3]).
+-export([get_edges/2]).
+
+-export([find_shortest_path/3]).
+
+-export_type([t/0]).
+-export_type([t/2]).
+-export_type([weight/0]).
+
+-type gnode() :: term().
+-type weight() :: _NonNegative :: number().
+-type label() :: term().
+
+-opaque t() :: t(gnode(), label()).
+-opaque t(Node, Label) :: gb_trees:tree({Node}, {Node, weight(), Label}).
+
+%%
+
+-spec new() -> t(_, _).
+new() ->
+    gb_trees:empty().
+
+%% Add an edge.
+%% Nodes are not expected to exist beforehand, and created lazily.
+%% There could be only one edge between each pair of nodes, this function
+%% replaces any existing edge in the graph.
+-spec insert_edge(Node, Node, weight(), Label, t(Node, Label)) -> t(Node, Label).
+insert_edge(From, To, Weight, EdgeLabel, G) ->
+    Edges = tree_lookup({From}, G, []),
+    EdgesNext = lists:keystore(To, 1, Edges, {To, Weight, EdgeLabel}),
+    tree_update({From}, EdgesNext, G).
+
+%% Find exising edge between two nodes, if any.
+-spec find_edge(Node, Node, t(Node, Label)) -> {weight(), Label} | false.
+find_edge(From, To, G) ->
+    Edges = tree_lookup({From}, G, []),
+    case lists:keyfind(To, 1, Edges) of
+        {To, Weight, Label} ->
+            {Weight, Label};
+        false ->
+            false
+    end.
+
+%% Get all edges from the given node.
+-spec get_edges(Node, t(Node, Label)) -> [{Node, weight(), Label}].
+get_edges(Node, G) ->
+    tree_lookup({Node}, G, []).
+
+% Find the shortest path between two nodes, if any. If the path exists, return list
+% of edge labels along that path.
+% This is a Dijkstra shortest path algorithm. It is one-way right now, for
+% simplicity sake.
+-spec find_shortest_path(Node, Node, t(Node, Label)) -> [Label] | {false, _StoppedAt :: Node}.
+find_shortest_path(From, To, G1) ->
+    % NOTE
+    % If `From` and `To` are the same node, then path is `[]` even if this
+    % node does not exist in the graph.
+    G2 = set_cost(From, 0, [], G1),
+    case find_shortest_path(From, 0, To, G2) of
+        {true, G3} ->
+            construct_path(From, To, [], G3);
+        {false, Last} ->
+            {false, Last}
+    end.
+
+find_shortest_path(Node, Cost, Target, G1) ->
+    Edges = get_edges(Node, G1),
+    G2 = update_neighbours(Node, Cost, Edges, G1),
+    case take_queued(G2) of
+        {Target, _NextCost, G3} ->
+            {true, G3};
+        {Next, NextCost, G3} ->
+            find_shortest_path(Next, NextCost, Target, G3);
+        none ->
+            {false, Node}
+    end.
+
+construct_path(From, From, Acc, _) ->
+    Acc;
+construct_path(From, To, Acc, G) ->
+    {Prev, Label} = get_label(To, G),
+    construct_path(From, Prev, [Label | Acc], G).
+
+update_neighbours(Node, NodeCost, Edges, G1) ->
+    lists:foldl(
+        fun(Edge, GAcc) -> update_neighbour(Node, NodeCost, Edge, GAcc) end,
+        G1,
+        Edges
+    ).
+
+update_neighbour(Node, NodeCost, {Neighbour, Weight, Label}, G) ->
+    case is_visited(G, Neighbour) of
+        false ->
+            CurrentCost = get_cost(Neighbour, G),
+            case NodeCost + Weight of
+                NeighCost when NeighCost < CurrentCost ->
+                    set_cost(Neighbour, NeighCost, {Node, Label}, G);
+                _ ->
+                    G
+            end;
+        true ->
+            G
+    end.
+
+get_cost(Node, G) ->
+    case tree_lookup({Node, cost}, G, inf) of
+        {Cost, _Label} ->
+            Cost;
+        inf ->
+            inf
+    end.
+
+get_label(Node, G) ->
+    {_Cost, Label} = gb_trees:get({Node, cost}, G),
+    Label.
+
+set_cost(Node, Cost, Label, G1) ->
+    G3 =
+        case tree_lookup({Node, cost}, G1, inf) of
+            {CostWas, _Label} ->
+                {true, G2} = gb_trees:take({queued, CostWas, Node}, G1),
+                gb_trees:insert({queued, Cost, Node}, true, G2);
+            inf ->
+                gb_trees:insert({queued, Cost, Node}, true, G1)
+        end,
+    G4 = tree_update({Node, cost}, {Cost, Label}, G3),
+    G4.
+
+take_queued(G1) ->
+    It = gb_trees:iterator_from({queued, 0, 0}, G1),
+    case gb_trees:next(It) of
+        {{queued, Cost, Node} = Index, true, _It} ->
+            {Node, Cost, gb_trees:delete(Index, G1)};
+        _ ->
+            none
+    end.
+
+is_visited(G, Node) ->
+    case tree_lookup({Node, cost}, G, inf) of
+        inf ->
+            false;
+        {Cost, _Label} ->
+            not tree_lookup({queued, Cost, Node}, G, false)
+    end.
+
+tree_lookup(Index, Tree, Default) ->
+    case gb_trees:lookup(Index, Tree) of
+        {value, V} ->
+            V;
+        none ->
+            Default
+    end.
+
+tree_update(Index, Value, Tree) ->
+    case gb_trees:is_defined(Index, Tree) of
+        true ->
+            gb_trees:update(Index, Value, Tree);
+        false ->
+            gb_trees:insert(Index, Value, Tree)
+    end.

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -43,11 +43,20 @@
     ip/0,
     port/0,
     limited_atom/0,
-    limited_latin_atom/0
+    limited_latin_atom/0,
+    printable_utf8/0,
+    printable_codepoint/0
+]).
+
+%% Generic Types
+-export([
+    scaled/2
 ]).
 
 %% Iterators
 -export([nof/1]).
+
+-type proptype() :: proper_types:raw_type().
 
 %%--------------------------------------------------------------------
 %% Types High level
@@ -606,6 +615,20 @@ limited_atom() ->
 limited_any_term() ->
     oneof([binary(), number(), string()]).
 
+printable_utf8() ->
+    ?SUCHTHAT(
+        String,
+        ?LET(L, list(printable_codepoint()), unicode:characters_to_binary(L)),
+        is_binary(String)
+    ).
+
+printable_codepoint() ->
+    frequency([
+        {7, range(16#20, 16#7E)},
+        {2, range(16#00A0, 16#D7FF)},
+        {1, range(16#E000, 16#FFFD)}
+    ]).
+
 %%--------------------------------------------------------------------
 %% Iterators
 %%--------------------------------------------------------------------
@@ -631,6 +654,14 @@ limited_list(N, T) ->
             [T || _ <- lists:seq(1, N2)]
         end
     ).
+
+%%--------------------------------------------------------------------
+%% Generic Types
+%%--------------------------------------------------------------------
+
+-spec scaled(number(), proptype()) -> proptype().
+scaled(F, T) when F > 0 ->
+    ?SIZED(S, resize(round(S * F), T)).
 
 %%--------------------------------------------------------------------
 %% Internal funcs

--- a/apps/emqx/test/emqx_wdgraph_tests.erl
+++ b/apps/emqx/test/emqx_wdgraph_tests.erl
@@ -1,0 +1,84 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_wdgraph_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+empty_test_() ->
+    G = emqx_wdgraph:new(),
+    [
+        ?_assertEqual([], emqx_wdgraph:get_edges(foo, G)),
+        ?_assertEqual(false, emqx_wdgraph:find_edge(foo, bar, G))
+    ].
+
+edges_nodes_test_() ->
+    G1 = emqx_wdgraph:new(),
+    G2 = emqx_wdgraph:insert_edge(foo, bar, 42, "fancy", G1),
+    G3 = emqx_wdgraph:insert_edge(bar, baz, 1, "cheapest", G2),
+    G4 = emqx_wdgraph:insert_edge(bar, foo, 0, "free", G3),
+    G5 = emqx_wdgraph:insert_edge(foo, bar, 100, "luxury", G4),
+    [
+        ?_assertEqual({42, "fancy"}, emqx_wdgraph:find_edge(foo, bar, G2)),
+        ?_assertEqual({100, "luxury"}, emqx_wdgraph:find_edge(foo, bar, G5)),
+        ?_assertEqual([{bar, 100, "luxury"}], emqx_wdgraph:get_edges(foo, G5)),
+
+        ?_assertEqual({1, "cheapest"}, emqx_wdgraph:find_edge(bar, baz, G5)),
+        ?_assertEqual([{baz, 1, "cheapest"}, {foo, 0, "free"}], emqx_wdgraph:get_edges(bar, G5))
+    ].
+
+nonexistent_nodes_path_test_() ->
+    G1 = emqx_wdgraph:new(),
+    G2 = emqx_wdgraph:insert_edge(foo, bar, 42, "fancy", G1),
+    G3 = emqx_wdgraph:insert_edge(bar, baz, 1, "cheapest", G2),
+    [
+        ?_assertEqual(
+            {false, nosuchnode},
+            emqx_wdgraph:find_shortest_path(nosuchnode, baz, G3)
+        ),
+        ?_assertEqual(
+            [],
+            emqx_wdgraph:find_shortest_path(nosuchnode, nosuchnode, G3)
+        )
+    ].
+
+nonexistent_path_test_() ->
+    G1 = emqx_wdgraph:new(),
+    G2 = emqx_wdgraph:insert_edge(foo, bar, 42, "fancy", G1),
+    G3 = emqx_wdgraph:insert_edge(baz, boo, 1, "cheapest", G2),
+    G4 = emqx_wdgraph:insert_edge(boo, last, 3.5, "change", G3),
+    [
+        ?_assertEqual(
+            {false, last},
+            emqx_wdgraph:find_shortest_path(baz, foo, G4)
+        ),
+        ?_assertEqual(
+            {false, bar},
+            emqx_wdgraph:find_shortest_path(foo, last, G4)
+        )
+    ].
+
+shortest_path_test() ->
+    G1 = emqx_wdgraph:new(),
+    G2 = emqx_wdgraph:insert_edge(foo, bar, 42, "fancy", G1),
+    G3 = emqx_wdgraph:insert_edge(bar, baz, 1, "cheapest", G2),
+    G4 = emqx_wdgraph:insert_edge(baz, last, 0, "free", G3),
+    G5 = emqx_wdgraph:insert_edge(bar, last, 100, "luxury", G4),
+    G6 = emqx_wdgraph:insert_edge(bar, foo, 0, "comeback", G5),
+    ?assertEqual(
+        ["fancy", "cheapest", "free"],
+        emqx_wdgraph:find_shortest_path(foo, last, G6)
+    ).

--- a/apps/emqx_ft/test/props/prop_emqx_ft_assembly.erl
+++ b/apps/emqx_ft/test/props/prop_emqx_ft_assembly.erl
@@ -1,0 +1,214 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(prop_emqx_ft_assembly).
+
+-include_lib("proper/include/proper.hrl").
+
+-import(emqx_proper_types, [scaled/2]).
+
+-define(COVERAGE_TIMEOUT, 5000).
+
+prop_coverage() ->
+    ?FORALL(
+        {Filesize, Segsizes},
+        {filesize_t(), segsizes_t()},
+        ?FORALL(
+            Fragments,
+            noshrink(fragments_t(Filesize, Segsizes)),
+            ?TIMEOUT(
+                ?COVERAGE_TIMEOUT,
+                begin
+                    ASM1 = append_fragments(mk_assembly(Filesize), Fragments),
+                    {Time, ASM2} = timer:tc(emqx_ft_assembly, update, [ASM1]),
+                    measure(
+                        #{"Fragments" => length(Fragments), "Time" => Time},
+                        case emqx_ft_assembly:status(ASM2) of
+                            complete ->
+                                Coverage = emqx_ft_assembly:coverage(ASM2),
+                                measure(
+                                    #{"CoverageLength" => length(Coverage)},
+                                    is_coverage_complete(Coverage)
+                                );
+                            {incomplete, {missing, {segment, _, _}}} ->
+                                measure("CoverageLength", 0, true)
+                        end
+                    )
+                end
+            )
+        )
+    ).
+
+prop_coverage_likely_incomplete() ->
+    ?FORALL(
+        {Filesize, Segsizes, Hole},
+        {filesize_t(), segsizes_t(), filesize_t()},
+        ?FORALL(
+            Fragments,
+            noshrink(fragments_t(Filesize, Segsizes, Hole)),
+            ?TIMEOUT(
+                ?COVERAGE_TIMEOUT,
+                begin
+                    ASM1 = append_fragments(mk_assembly(Filesize), Fragments),
+                    {Time, ASM2} = timer:tc(emqx_ft_assembly, update, [ASM1]),
+                    measure(
+                        #{"Fragments" => length(Fragments), "Time" => Time},
+                        case emqx_ft_assembly:status(ASM2) of
+                            complete ->
+                                % NOTE: this is still possible due to the nature of `SUCHTHATMAYBE`
+                                IsComplete = emqx_ft_assembly:coverage(ASM2),
+                                collect(complete, is_coverage_complete(IsComplete));
+                            {incomplete, {missing, {segment, _, _}}} ->
+                                collect(incomplete, true)
+                        end
+                    )
+                end
+            )
+        )
+    ).
+
+prop_coverage_complete() ->
+    ?FORALL(
+        {Filesize, Segsizes},
+        {filesize_t(), ?SUCHTHAT([BaseSegsize | _], segsizes_t(), BaseSegsize > 0)},
+        ?FORALL(
+            {Fragments, MaxCoverage},
+            noshrink({fragments_t(Filesize, Segsizes), coverage_t(Filesize, Segsizes)}),
+            begin
+                % Ensure that we have complete coverage
+                ASM1 = append_fragments(mk_assembly(Filesize), Fragments ++ MaxCoverage),
+                {Time, ASM2} = timer:tc(emqx_ft_assembly, update, [ASM1]),
+                measure(
+                    #{"CoverageMax" => length(MaxCoverage), "Time" => Time},
+                    case emqx_ft_assembly:status(ASM2) of
+                        complete ->
+                            Coverage = emqx_ft_assembly:coverage(ASM2),
+                            measure(
+                                #{"Coverage" => length(Coverage)},
+                                is_coverage_complete(Coverage)
+                            );
+                        {incomplete, _} ->
+                            false
+                    end
+                )
+            end
+        )
+    ).
+
+measure(NamedSamples, Test) ->
+    maps:fold(fun(Name, Sample, Acc) -> measure(Name, Sample, Acc) end, Test, NamedSamples).
+
+is_coverage_complete([]) ->
+    true;
+is_coverage_complete(Coverage = [_ | Tail]) ->
+    is_coverage_complete(Coverage, Tail).
+
+is_coverage_complete([_], []) ->
+    true;
+is_coverage_complete(
+    [{_Node1, #{fragment := {segment, #{offset := O1, size := S1}}}} | Rest],
+    [{_Node2, #{fragment := {segment, #{offset := O2}}}} | Tail]
+) ->
+    (O1 + S1 == O2) andalso is_coverage_complete(Rest, Tail).
+
+mk_assembly(Filesize) ->
+    emqx_ft_assembly:append(emqx_ft_assembly:new(Filesize), node(), mk_filemeta(Filesize)).
+
+append_fragments(ASMIn, Fragments) ->
+    lists:foldl(
+        fun({Node, Frag}, ASM) ->
+            emqx_ft_assembly:append(ASM, Node, Frag)
+        end,
+        ASMIn,
+        Fragments
+    ).
+
+mk_filemeta(Filesize) ->
+    #{
+        path => "MANIFEST.json",
+        fragment => {filemeta, #{name => ?MODULE_STRING, size => Filesize}}
+    }.
+
+mk_segment(Offset, Size) ->
+    #{
+        path => "SEG" ++ integer_to_list(Offset) ++ integer_to_list(Size),
+        fragment => {segment, #{offset => Offset, size => Size}}
+    }.
+
+fragments_t(Filesize, Segsizes = [BaseSegsize | _]) ->
+    NSegs = Filesize / max(1, BaseSegsize),
+    scaled(1 + NSegs, list({node_t(), fragment_t(Filesize, Segsizes)})).
+
+fragments_t(Filesize, Segsizes = [BaseSegsize | _], Hole) ->
+    NSegs = Filesize / max(1, BaseSegsize),
+    scaled(1 + NSegs, list({node_t(), fragment_t(Filesize, Segsizes, Hole)})).
+
+fragment_t(Filesize, Segsizes, Hole) ->
+    ?SUCHTHATMAYBE(
+        #{fragment := {segment, #{offset := Offset, size := Size}}},
+        fragment_t(Filesize, Segsizes),
+        (Hole rem Filesize) =< Offset orelse (Hole rem Filesize) > (Offset + Size)
+    ).
+
+fragment_t(Filesize, Segsizes) ->
+    ?LET(
+        Segsize,
+        oneof(Segsizes),
+        ?LET(
+            Index,
+            range(0, Filesize div max(1, Segsize)),
+            mk_segment(Index * Segsize, min(Segsize, Filesize - (Index * Segsize)))
+        )
+    ).
+
+coverage_t(Filesize, [Segsize | _]) ->
+    NSegs = Filesize div max(1, Segsize),
+    [
+        {remote_node_t(), mk_segment(I * Segsize, min(Segsize, Filesize - (I * Segsize)))}
+     || I <- lists:seq(0, NSegs)
+    ].
+
+filesize_t() ->
+    scaled(4000, non_neg_integer()).
+
+segsizes_t() ->
+    ?LET(
+        BaseSize,
+        segsize_t(),
+        oneof([
+            [BaseSize, BaseSize * 2],
+            [BaseSize, BaseSize * 2, BaseSize * 3],
+            [BaseSize, BaseSize * 2, BaseSize * 5]
+        ])
+    ).
+
+segsize_t() ->
+    scaled(50, non_neg_integer()).
+
+remote_node_t() ->
+    oneof([
+        'emqx42@emqx.local',
+        'emqx43@emqx.local',
+        'emqx44@emqx.local'
+    ]).
+
+node_t() ->
+    oneof([
+        node(),
+        'emqx42@emqx.local',
+        'emqx43@emqx.local',
+        'emqx44@emqx.local'
+    ]).


### PR DESCRIPTION
The current algorithm's complexity proved to be unacceptable with sufficiently large inputs (e.g. GiBs-worth files split into 100 KiB sized segments for example). Express and reimplement it as the shortest path problem on graph where nodes are offsets and edges are Erlang nodes' segments.

---

[EMQX-8916](https://emqx.atlassian.net/browse/EMQX-8916)