### PR TITLE
0228 fix ssl dist optfile

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -525,11 +525,11 @@ else
         ## only one emqx node is running, get running args from 'ps -ef' output
         tmp_nodename=$(echo -e "$PS_LINE" | $GREP -oE "\s\-s?name.*" | awk '{print $2}' || true)
         tmp_cookie=$(echo -e "$PS_LINE" | $GREP -oE "\s\-setcookie.*" | awk '{print $2}' || true)
-        tmp_dist="$(echo -e "$PS_LINE" | $GREP -oE '\-ssl_dist_optfile\s.+\s' | awk '{print $2}' || true)"
+        SSL_DIST_OPTFILE="$(echo -e "$PS_LINE" | $GREP -oE '\-ssl_dist_optfile\s.+\s' | awk '{print $2}' || true)"
         tmp_ticktime="$(echo -e "$PS_LINE" | $GREP -oE '\s\-kernel\snet_ticktime\s.+\s' | awk '{print $3}' || true)"
         # data_dir is actually not needed, but kept anyway
         tmp_datadir="$(echo -e "$PS_LINE" | $GREP -oE "\-emqx_data_dir.*" | sed -E 's#.+emqx_data_dir[[:blank:]]##g' | sed -E 's#[[:blank:]]--$##g' || true)"
-        if [ -z "$tmp_dist" ]; then
+        if [ -z "$SSL_DIST_OPTFILE" ]; then
             tmp_proto='inet_tcp'
         else
             tmp_proto='inet_tls'

--- a/bin/emqx
+++ b/bin/emqx
@@ -945,7 +945,7 @@ if [ -n "${EMQX_NODE_COOKIE:-}" ]; then
 fi
 COOKIE="${EMQX_NODE__COOKIE:-}"
 COOKIE_IN_USE="$(get_boot_config 'node.cookie')"
-if [ -n "$COOKIE_IN_USE" ] && [ -n "$COOKIE" ] && [ "$COOKIE" != "$COOKIE_IN_USE" ]; then
+if [ "$IS_BOOT_COMMAND" != 'yes' ] && [ -n "$COOKIE_IN_USE" ] && [ -n "$COOKIE" ] && [ "$COOKIE" != "$COOKIE_IN_USE" ]; then
     die "EMQX_NODE__COOKIE is different from the cookie used by $NAME"
 fi
 [ -z "$COOKIE" ] && COOKIE="$COOKIE_IN_USE"

--- a/changes/ce/fix-10043.en.md
+++ b/changes/ce/fix-10043.en.md
@@ -1,0 +1,3 @@
+Fixed two bugs introduced in v5.0.18.
+* The environment varialbe `SSL_DIST_OPTFILE` was not set correctly for non-boot commands.
+* When cookie is overriden from environment variable, EMQX node is unable to start.

--- a/changes/ce/fix-10043.en.md
+++ b/changes/ce/fix-10043.en.md
@@ -1,3 +1,3 @@
 Fixed two bugs introduced in v5.0.18.
 * The environment varialbe `SSL_DIST_OPTFILE` was not set correctly for non-boot commands.
-* When cookie is overriden from environment variable, EMQX node is unable to start.
+* When cookie is overridden from environment variable, EMQX node is unable to start.

--- a/changes/ce/fix-10043.zh.md
+++ b/changes/ce/fix-10043.zh.md
@@ -1,0 +1,3 @@
+修复 v5.0.18 引入的 2 个bug。
+* 环境变量 `SSL_DIST_OPTFILE` 的值设置错误导致节点无法为 Erlang distribution 启用 SSL。
+* 当节点的 cookie 从环境变量重载 （而不是设置在配置文件中时），节点无法启动的问题。

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 ## this is why a docker network is created, and the containers's names have a dot.
 
 # ensure dir
-cd -P -- "$(dirname -- "$0")/.."
+cd -P -- "$(dirname -- "$0")/../../"
 
 IMAGE1="${1}"
 IMAGE2="${2:-${IMAGE1}}"
@@ -94,7 +94,7 @@ backend emqx_dashboard_back
     # Must use a consistent dispatch when EMQX is running on different versions
     # because the js files for the dashboard is chunked, having the backends sharing
     # load randomly will cause the browser fail to GET some chunks (or get bad chunks if names clash)
-    balance first
+    balance source
     mode http
     server emqx-1 $NODE1:18083
     server emqx-2 $NODE2:18083
@@ -146,7 +146,7 @@ wait_for_emqx() {
     container="$1"
     wait_limit="$2"
     wait_sec=0
-    while ! docker exec "$container" emqx_ctl status >/dev/null 2>&1; do
+    while ! docker exec "$container" emqx ctl status; do
         wait_sec=$(( wait_sec + 1 ))
         if [ $wait_sec -gt "$wait_limit" ]; then
             echo "timeout wait for EMQX"
@@ -182,4 +182,4 @@ wait_for_haproxy 10
 
 echo
 
-docker exec $NODE1 emqx_ctl cluster join "emqx@$NODE2"
+docker exec $NODE1 emqx ctl cluster join "emqx@$NODE2"


### PR DESCRIPTION
Fixes [EMQX-9046](https://emqx.atlassian.net/browse/EMQX-9046)

This PR fixes two issues, both introduced in v5.0.18
1. 
```
+ docker exec node2.emqx.io emqx ctl status
/usr/local/bin/emqx: line 592: SSL_DIST_OPTFILE: unbound variable
```

2.
when cookie is only set from environment variable, the boot command is unable to start the node
and complain that the set cookie is different from configured (the default).


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible
