### PR TITLE
fix: Handle obfuscated fields in bridges_probe API

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -546,7 +546,8 @@ schema("/bridges_probe") ->
     RequestMeta = #{module => ?MODULE, method => post, path => "/bridges_probe"},
     case emqx_dashboard_swagger:filter_check_request_and_translate_body(Request, RequestMeta) of
         {ok, #{body := #{<<"type">> := ConnType} = Params}} ->
-            case emqx_bridge_resource:create_dry_run(ConnType, maps:remove(<<"type">>, Params)) of
+            Params1 = maybe_deobfuscate_bridge_probe(Params),
+            case emqx_bridge_resource:create_dry_run(ConnType, maps:remove(<<"type">>, Params1)) of
                 ok ->
                     {204};
                 {error, Error} ->
@@ -555,6 +556,18 @@ schema("/bridges_probe") ->
         BadRequest ->
             BadRequest
     end.
+
+maybe_deobfuscate_bridge_probe(#{<<"type">> := BridgeType, <<"name">> := BridgeName} = Params) ->
+    case emqx_bridge:lookup(BridgeType, BridgeName) of
+        {ok, _} ->
+            RawConf = emqx:get_raw_config([bridges, BridgeType, BridgeName], #{}),
+            deobfuscate(Params, RawConf);
+        _ ->
+            %% A bridge may be probed before it's created, so not finding it here is fine
+            Params
+    end;
+maybe_deobfuscate_bridge_probe(Params) ->
+    Params.
 
 lookup_from_all_nodes(BridgeType, BridgeName, SuccCode) ->
     FormatFun = fun format_bridge_info_without_metrics/1,


### PR DESCRIPTION
Fixes: https://emqx.atlassian.net/browse/EMQX-9031

Examples:

**"test"** bridge exists, so bridge_prob with a hidden password is going to work:
```
curl -s http://localhost:18083/api/v5/bridges_probe -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2Nzc3MDAyNTIyNDksImlzcyI6IkVNUVgifQ.sN-8TBTLisuQvllmbSk2qei6jnAhWkgmg0BOwlauVIE'  -H 'Content-Type: application/json'  --data-binary '{"name":"test","type":"pgsql","database":"emqx","enable":true,"password":"******","pool_size":8,"resource_opts":{"auto_restart_interval":"60s","batch_size":1,"batch_time":"20ms","health_check_interval":"15s","max_queue_bytes":"100MB","query_mode":"sync","request_timeout":"15s","start_after_created":"true","start_timeout":"5s","worker_pool_size":16},"server":"127.0.0.1","sql":"insert into t_mqtt_msg(msgid, topic, qos, payload, arrived) values (${id}, ${topic}, ${qos}, ${payload}, TO_TIMESTAMP((${timestamp} :: bigint)/1000))","ssl":{"ciphers":[],"depth":10,"enable":false,"hibernate_after":"5s","reuse_sessions":true,"secure_renegotiate":true,"user_lookup_fun":"emqx_tls_psk:lookup","verify":"verify_none","versions":["tlsv1.3","tlsv1.2","tlsv1.1","tlsv1"]},"username":"admin"}' -w ' %{http_code}\n'
 204
```

**"test-not-found"** bridge doesn't exist, so hidden password is invalid (unless ****** is literally used as DB pass :slightly_smiling_face: )
```
curl -s http://localhost:18083/api/v5/bridges_probe -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2Nzc3MDAyNTIyNDksImlzcyI6IkVNUVgifQ.sN-8TBTLisuQvllmbSk2qei6jnAhWkgmg0BOwlauVIE'  -H 'Content-Type: application/json'  --data-binary '{"name":"test-not-found","type":"pgsql","database":"emqx","enable":true,"password":"******","pool_size":8,"resource_opts":{"auto_restart_interval":"60s","batch_size":1,"batch_time":"20ms","health_check_interval":"15s","max_queue_bytes":"100MB","query_mode":"sync","request_timeout":"15s","start_after_created":"true","start_timeout":"5s","worker_pool_size":16},"server":"127.0.0.1","sql":"insert into t_mqtt_msg(msgid, topic, qos, payload, arrived) values (${id}, ${topic}, ${qos}, ${payload}, TO_TIMESTAMP((${timestamp} :: bigint)/1000))","ssl":{"ciphers":[],"depth":10,"enable":false,"hibernate_after":"5s","reuse_sessions":true,"secure_renegotiate":true,"user_lookup_fun":"emqx_tls_psk:lookup","verify":"verify_none","versions":["tlsv1.3","tlsv1.2","tlsv1.1","tlsv1"]},"username":"admin"}' -w ' %{http_code}\n'
{"code":"TEST_FAILED","message":"{start_pool_failed,'_test_:442ba0e7fd72a756:39',invalid_password}"} 400
```
