### PR TITLE
fix: deprecate unsupp quic TLS options

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1280,7 +1280,18 @@ fields("listener_wss_opts") ->
         true
     );
 fields("listener_quic_ssl_opts") ->
-    server_ssl_opts_schema(#{}, false);
+    %% Mark unsupported TLS options deprecated.
+    lists:map(
+        fun({Name, Schema}) ->
+            case is_quic_ssl_opts(Name) of
+                true ->
+                    {Name, Schema};
+                false ->
+                    {Name, Schema#{deprecated => {since, "5.0.20"}}}
+            end
+        end,
+        server_ssl_opts_schema(#{}, false)
+    );
 fields("ssl_client_opts") ->
     client_ssl_opts_schema(#{});
 fields("deflate_opts") ->
@@ -2841,3 +2852,18 @@ quic_lowlevel_settings_uint(Low, High, Desc) ->
             desc => Desc
         }
     ).
+
+-spec is_quic_ssl_opts(string()) -> boolean().
+is_quic_ssl_opts(Name) ->
+    lists:member(Name, [
+        "cacertfile",
+        "certfile",
+        "keyfile",
+        "verify"
+        %% Followings are planned
+        %% , "password"
+        %% , "hibernate_after"
+        %% , "fail_if_no_peer_cert"
+        %% , "handshake_timeout"
+        %% , "gc_after_handshake"
+    ]).

--- a/changes/ce/fix-10058.en.md
+++ b/changes/ce/fix-10058.en.md
@@ -1,0 +1,7 @@
+Deprecate unused QUIC TLS options.
+Only following TLS options are kept for the QUIC listeners: 
+
+- cacertfile
+- certfile
+- keyfile
+- verify

--- a/changes/ce/fix-10058.zh.md
+++ b/changes/ce/fix-10058.zh.md
@@ -1,0 +1,8 @@
+废弃未使用的 QUIC TLS 选项。
+QUIC 监听器只保留以下 TLS 选项:
+
+- cacertfile
+- certfile
+- keyfile
+- verify
+


### PR DESCRIPTION
The idea was to remove unsupp QUIC TLS options to avoid confusion.
But removing fields can cause schema backward compatible issues, so we decide to mark them deprecated. 

Manually checked that the Swagger spec file has these fields deprecated.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible
