### PR TITLE
feat(ft): add GC logic and process for the FS storage backend

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -25,6 +25,7 @@
     boot_modules/1,
     start_apps/1,
     start_apps/2,
+    start_app/2,
     stop_apps/1,
     reload/2,
     app_path/2,

--- a/apps/emqx_ft/i18n/emqx_ft_schema_i18n.conf
+++ b/apps/emqx_ft/i18n/emqx_ft_schema_i18n.conf
@@ -33,4 +33,39 @@ emqx_ft_schema {
         }
     }
 
+    local_storage_gc {
+        desc {
+            en: "Garbage collection settings for the intermediate and temporary files in the local file system."
+            zh: ""
+        }
+        label: {
+            en: "Local Storage GC"
+            zh: ""
+        }
+    }
+
+    storage_gc_interval {
+        desc {
+            en: "Interval of periodic garbage collection."
+            zh: ""
+        }
+        label: {
+            en: "GC Interval"
+            zh: ""
+        }
+    }
+
+    storage_gc_max_segments_ttl {
+        desc {
+            en: "Maximum TTL of a segment kept in the local file system.<br/>"
+                "This is a hard limit: no segment will outlive this TTL, even if some file transfer specifies a "
+                "TTL more than that."
+            zh: ""
+        }
+        label: {
+            en: "GC Interval"
+            zh: ""
+        }
+    }
+
 }

--- a/apps/emqx_ft/include/emqx_ft_storage_fs.hrl
+++ b/apps/emqx_ft/include/emqx_ft_storage_fs.hrl
@@ -1,0 +1,29 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-ifndef(EMQX_FT_STORAGE_FS_HRL).
+-define(EMQX_FT_STORAGE_FS_HRL, true).
+
+-record(gcstats, {
+    started_at :: integer(),
+    finished_at :: integer() | undefined,
+    files = 0 :: non_neg_integer(),
+    directories = 0 :: non_neg_integer(),
+    space = 0 :: non_neg_integer(),
+    errors = #{} :: #{_GCSubject => {error, _}}
+}).
+
+-endif.

--- a/apps/emqx_ft/src/emqx_ft_conf.erl
+++ b/apps/emqx_ft/src/emqx_ft_conf.erl
@@ -50,16 +50,24 @@ storage() ->
 
 -spec gc_interval(_Storage) -> milliseconds().
 gc_interval(_Storage) ->
-    % TODO: config wiring
-    application:get_env(emqx_ft, gc_interval, timer:minutes(10)).
+    Conf = assert_storage(local),
+    emqx_map_lib:deep_get([gc, interval], Conf).
 
 -spec segments_ttl(_Storage) -> {_Min :: seconds(), _Max :: seconds()}.
 segments_ttl(_Storage) ->
-    % TODO: config wiring
+    Conf = assert_storage(local),
     {
-        application:get_env(emqx_ft, min_segments_ttl, 60),
-        application:get_env(emqx_ft, max_segments_ttl, 72 * 3600)
+        emqx_map_lib:deep_get([gc, minimum_segments_ttl], Conf),
+        emqx_map_lib:deep_get([gc, maximum_segments_ttl], Conf)
     }.
+
+assert_storage(Type) ->
+    case storage() of
+        Conf = #{type := Type} ->
+            Conf;
+        Conf ->
+            error({inapplicable, Conf})
+    end.
 
 %%--------------------------------------------------------------------
 %% API

--- a/apps/emqx_ft/src/emqx_ft_conf.erl
+++ b/apps/emqx_ft/src/emqx_ft_conf.erl
@@ -20,6 +20,11 @@
 
 -behaviour(emqx_config_handler).
 
+%% Accessors
+-export([storage/0]).
+-export([gc_interval/1]).
+-export([segments_ttl/1]).
+
 %% Load/Unload
 -export([
     load/0,
@@ -31,6 +36,30 @@
     pre_config_update/3,
     post_config_update/5
 ]).
+
+-type milliseconds() :: non_neg_integer().
+-type seconds() :: non_neg_integer().
+
+%%--------------------------------------------------------------------
+%% Accessors
+%%--------------------------------------------------------------------
+
+-spec storage() -> _Storage | disabled.
+storage() ->
+    emqx_config:get([file_transfer, storage], disabled).
+
+-spec gc_interval(_Storage) -> milliseconds().
+gc_interval(_Storage) ->
+    % TODO: config wiring
+    application:get_env(emqx_ft, gc_interval, timer:minutes(10)).
+
+-spec segments_ttl(_Storage) -> {_Min :: seconds(), _Max :: seconds()}.
+segments_ttl(_Storage) ->
+    % TODO: config wiring
+    {
+        application:get_env(emqx_ft, min_segments_ttl, 60),
+        application:get_env(emqx_ft, max_segments_ttl, 72 * 3600)
+    }.
 
 %%--------------------------------------------------------------------
 %% API

--- a/apps/emqx_ft/src/emqx_ft_schema.erl
+++ b/apps/emqx_ft/src/emqx_ft_schema.erl
@@ -65,13 +65,44 @@ fields(local_storage) ->
             type => binary(),
             desc => ?DESC("local_storage_root"),
             required => false
+        }},
+        {gc, #{
+            type => hoconsc:ref(?MODULE, local_storage_gc),
+            desc => ?DESC("local_storage_gc"),
+            required => false
+        }}
+    ];
+fields(local_storage_gc) ->
+    [
+        {interval, #{
+            type => emqx_schema:duration_ms(),
+            desc => ?DESC("storage_gc_interval"),
+            required => false,
+            default => "1h"
+        }},
+        {maximum_segments_ttl, #{
+            type => emqx_schema:duration_s(),
+            desc => ?DESC("storage_gc_max_segments_ttl"),
+            required => false,
+            default => "24h"
+        }},
+        {minimum_segments_ttl, #{
+            type => emqx_schema:duration_s(),
+            % desc => ?DESC("storage_gc_min_segments_ttl"),
+            required => false,
+            default => "5m",
+            % NOTE
+            % This setting does not seem to be useful to an end-user.
+            hidden => true
         }}
     ].
 
 desc(file_transfer) ->
     "File transfer settings";
 desc(local_storage) ->
-    "File transfer local storage settings".
+    "File transfer local storage settings";
+desc(local_storage_gc) ->
+    "Garbage collection settings for the File transfer local storage backend".
 
 schema(filemeta) ->
     #{

--- a/apps/emqx_ft/src/emqx_ft_storage_fs_gc.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs_gc.erl
@@ -1,0 +1,337 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Filesystem storage GC
+%%
+%% This is conceptually a part of the Filesystem storage backend, even
+%% though it's tied to the backend module with somewhat narrow interface.
+
+-module(emqx_ft_storage_fs_gc).
+
+-include_lib("emqx_ft/include/emqx_ft_storage_fs.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/types.hrl").
+-include_lib("kernel/include/file.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
+-export([start_link/1]).
+
+-export([collect/1]).
+-export([collect/3]).
+-export([reset/1]).
+
+-behaviour(gen_server).
+-export([init/1]).
+-export([handle_call/3]).
+-export([handle_cast/2]).
+-export([handle_info/2]).
+
+-record(st, {
+    storage :: emqx_ft_storage_fs:storage(),
+    next_gc_timer :: maybe(reference()),
+    last_gc :: maybe(gcstats())
+}).
+
+-type gcstats() :: #gcstats{}.
+
+%%
+
+start_link(Storage) ->
+    gen_server:start_link(mk_server_ref(Storage), ?MODULE, Storage, []).
+
+-spec collect(emqx_ft_storage_fs:storage()) -> gcstats().
+collect(Storage) ->
+    gen_server:call(mk_server_ref(Storage), {collect, erlang:system_time()}, infinity).
+
+-spec reset(emqx_ft_storage_fs:storage()) -> ok.
+reset(Storage) ->
+    gen_server:cast(mk_server_ref(Storage), reset).
+
+collect(Storage, Transfer, Nodes) ->
+    gen_server:cast(mk_server_ref(Storage), {collect, Transfer, Nodes}).
+
+mk_server_ref(Storage) ->
+    % TODO
+    {via, gproc, {n, l, {?MODULE, get_storage_root(Storage)}}}.
+
+%%
+
+init(Storage) ->
+    St = #st{storage = Storage},
+    {ok, start_timer(St)}.
+
+handle_call({collect, CalledAt}, _From, St) ->
+    StNext = maybe_collect_garbage(CalledAt, St),
+    {reply, StNext#st.last_gc, StNext};
+handle_call(Call, From, St) ->
+    ?SLOG(error, #{msg => "unexpected_call", call => Call, from => From}),
+    {noreply, St}.
+
+% TODO
+% handle_cast({collect, Transfer, [Node | Rest]}, St) ->
+%     ok = do_collect_transfer(Transfer, Node, St),
+%     ok = collect(self(), Transfer, Rest),
+%     {noreply, St};
+handle_cast(reset, St) ->
+    {noreply, reset_timer(St)};
+handle_cast(Cast, St) ->
+    ?SLOG(error, #{msg => "unexpected_cast", cast => Cast}),
+    {noreply, St}.
+
+handle_info({timeout, TRef, collect}, St = #st{next_gc_timer = TRef}) ->
+    StNext = do_collect_garbage(St),
+    {noreply, start_timer(StNext#st{next_gc_timer = undefined})}.
+
+% do_collect_transfer(Transfer, Node, St = #st{storage = Storage}) when Node == node() ->
+%     Stats = try_collect_transfer(Storage, Transfer, complete, init_gcstats()),
+%     ok = maybe_report(Stats, St),
+%     ok.
+
+maybe_collect_garbage(_CalledAt, St = #st{last_gc = undefined}) ->
+    do_collect_garbage(St);
+maybe_collect_garbage(CalledAt, St = #st{last_gc = #gcstats{finished_at = FinishedAt}}) ->
+    case FinishedAt > CalledAt of
+        true ->
+            St;
+        false ->
+            reset_timer(do_collect_garbage(St))
+    end.
+
+do_collect_garbage(St = #st{storage = Storage}) ->
+    Stats = collect_garbage(Storage),
+    ok = maybe_report(Stats, St),
+    St#st{last_gc = Stats}.
+
+maybe_report(#gcstats{errors = Errors}, #st{storage = Storage}) when map_size(Errors) > 0 ->
+    ?tp(warning, "garbage_collection_errors", #{errors => Errors, storage => Storage});
+maybe_report(#gcstats{} = _Stats, #st{storage = _Storage}) ->
+    ?tp(garbage_collection, #{stats => _Stats, storage => _Storage}).
+
+start_timer(St = #st{next_gc_timer = undefined}) ->
+    Delay = emqx_ft_conf:gc_interval(St#st.storage),
+    St#st{next_gc_timer = emqx_misc:start_timer(Delay, collect)}.
+
+reset_timer(St = #st{next_gc_timer = undefined}) ->
+    start_timer(St);
+reset_timer(St = #st{next_gc_timer = TRef}) ->
+    ok = emqx_misc:cancel_timer(TRef),
+    start_timer(St#st{next_gc_timer = undefined}).
+
+%%
+
+collect_garbage(Storage) ->
+    Stats = init_gcstats(),
+    {ok, Transfers} = emqx_ft_storage_fs:transfers(Storage),
+    collect_garbage(Storage, Transfers, Stats).
+
+collect_garbage(Storage, Transfers, Stats) ->
+    finish_gcstats(
+        maps:fold(
+            fun(Transfer, TransferInfo, StatsAcc) ->
+                % TODO: throttling?
+                try_collect_transfer(Storage, Transfer, TransferInfo, StatsAcc)
+            end,
+            Stats,
+            Transfers
+        )
+    ).
+
+try_collect_transfer(Storage, Transfer, #{status := complete}, Stats) ->
+    % File transfer is complete.
+    % We should be good to delete fragments and temporary files with their respective
+    % directories altogether.
+    % TODO: file expiration
+    {_, Stats1} = collect_fragments(Storage, Transfer, Stats),
+    {_, Stats2} = collect_tempfiles(Storage, Transfer, Stats1),
+    Stats2;
+try_collect_transfer(Storage, Transfer, #{status := incomplete}, Stats) ->
+    % File transfer is still incomplete.
+    % Any outdated fragments and temporary files should be collectable. As a kind of
+    % heuristic we only delete transfer directory itself only if it is also outdated
+    % _and was empty at the start of GC_, as a precaution against races between
+    % writers and GCs.
+    TTL = get_segments_ttl(Storage, Transfer),
+    Cutoff = erlang:system_time(second) + TTL,
+    {FragCleaned, Stats1} = collect_outdated_fragments(Storage, Transfer, Cutoff, Stats),
+    {TempCleaned, Stats2} = collect_outdated_tempfiles(Storage, Transfer, Cutoff, Stats1),
+    % TODO: collect empty directories separately
+    case FragCleaned and TempCleaned of
+        true ->
+            collect_transfer_directory(Storage, Transfer, Stats2);
+        false ->
+            Stats2
+    end.
+
+collect_fragments(Storage, Transfer, Stats) ->
+    Dirname = emqx_ft_storage_fs:get_subdir(Storage, Transfer, fragment),
+    collect_filepath(Dirname, true, Stats).
+
+collect_tempfiles(Storage, Transfer, Stats) ->
+    Dirname = emqx_ft_storage_fs:get_subdir(Storage, Transfer, temporary),
+    collect_filepath(Dirname, true, Stats).
+
+collect_outdated_fragments(Storage, Transfer, Cutoff, Stats) ->
+    Dirname = emqx_ft_storage_fs:get_subdir(Storage, Transfer, fragment),
+    Filter = fun(_Filepath, #file_info{mtime = ModifiedAt}) -> ModifiedAt < Cutoff end,
+    collect_filepath(Dirname, Filter, Stats).
+
+collect_outdated_tempfiles(Storage, Transfer, Cutoff, Stats) ->
+    Dirname = emqx_ft_storage_fs:get_subdir(Storage, Transfer, temporary),
+    Filter = fun(_Filepath, #file_info{mtime = ModifiedAt}) -> ModifiedAt < Cutoff end,
+    collect_filepath(Dirname, Filter, Stats).
+
+collect_transfer_directory(Storage, Transfer, Stats) ->
+    Dirname = emqx_ft_storage_fs:get_subdir(Storage, Transfer),
+    StatsNext = collect_empty_directory(Dirname, Stats),
+    collect_parents(Dirname, StatsNext).
+
+collect_parents(Dirname, Stats) ->
+    Parent = filename:dirname(Dirname),
+    case file:del_dir(Parent) of
+        ok ->
+            collect_parents(Parent, account_gcstat_directory(Stats));
+        {error, enoent} ->
+            collect_parents(Parent, Stats);
+        {error, eexist} ->
+            Stats;
+        {error, Reason} ->
+            register_gcstat_error({directory, Parent}, Reason, Stats)
+    end.
+
+% collect_outdated_fragment(#{path := Filepath, fileinfo := Fileinfo}, Cutoff, Stats) ->
+%     case Fileinfo#file_info.mtime of
+%         ModifiedAt when ModifiedAt < Cutoff ->
+%             collect_filepath(Filepath, Fileinfo, Stats);
+%         _ ->
+%             Stats
+%     end.
+
+-spec collect_filepath(file:name(), Filter, gcstats()) -> {boolean(), gcstats()} when
+    Filter :: boolean() | fun((file:name(), file:file_info()) -> boolean()).
+collect_filepath(Filepath, Filter, Stats) ->
+    case file:read_file_info(Filepath) of
+        {ok, Fileinfo} ->
+            collect_filepath(Filepath, Fileinfo, Filter, Stats);
+        {error, enoent} ->
+            {true, Stats};
+        {error, Reason} ->
+            {false, register_gcstat_error({path, Filepath}, Reason, Stats)}
+    end.
+
+collect_filepath(Filepath, #file_info{type = directory} = Fileinfo, Filter, Stats) ->
+    collect_directory(Filepath, Fileinfo, Filter, Stats);
+collect_filepath(Filepath, #file_info{type = regular} = Fileinfo, Filter, Stats) ->
+    case filter_filepath(Filter, Filepath, Fileinfo) andalso file:delete(Filepath, [raw]) of
+        false ->
+            {false, Stats};
+        ok ->
+            {true, account_gcstat(Fileinfo, Stats)};
+        {error, enoent} ->
+            {true, Stats};
+        {error, Reason} ->
+            {false, register_gcstat_error({file, Filepath}, Reason, Stats)}
+    end;
+collect_filepath(Filepath, Fileinfo, _Filter, Stats) ->
+    {false, register_gcstat_error({file, Filepath}, {unexpected, Fileinfo}, Stats)}.
+
+collect_directory(Dirpath, Fileinfo, Filter, Stats) ->
+    case file:list_dir(Dirpath) of
+        {ok, Filenames} ->
+            {Clean, StatsNext} = collect_files(Dirpath, Filenames, Filter, Stats),
+            case Clean andalso filter_filepath(Filter, Dirpath, Fileinfo) of
+                true ->
+                    {true, collect_empty_directory(Dirpath, StatsNext)};
+                _ ->
+                    {false, StatsNext}
+            end;
+        {error, Reason} ->
+            {false, register_gcstat_error({directory, Dirpath}, Reason, Stats)}
+    end.
+
+collect_files(Dirname, Filenames, Filter, Stats) ->
+    lists:foldl(
+        fun(Filename, {Complete, StatsAcc}) ->
+            Filepath = filename:join(Dirname, Filename),
+            {Collected, StatsNext} = collect_filepath(Filepath, Filter, StatsAcc),
+            {Collected andalso Complete, StatsNext}
+        end,
+        {true, Stats},
+        Filenames
+    ).
+
+collect_empty_directory(Dirpath, Stats) ->
+    case file:del_dir(Dirpath) of
+        ok ->
+            account_gcstat_directory(Stats);
+        {error, enoent} ->
+            Stats;
+        {error, Reason} ->
+            register_gcstat_error({directory, Dirpath}, Reason, Stats)
+    end.
+
+filter_filepath(Filter, _, _) when is_boolean(Filter) ->
+    Filter;
+filter_filepath(Filter, Filepath, Fileinfo) when is_function(Filter) ->
+    Filter(Filepath, Fileinfo).
+
+get_segments_ttl(Storage, Transfer) ->
+    {MinTTL, MaxTTL} = emqx_ft_conf:segments_ttl(Storage),
+    clamp(MinTTL, MaxTTL, try_get_filemeta_ttl(Storage, Transfer)).
+
+try_get_filemeta_ttl(Storage, Transfer) ->
+    case emqx_ft_storage_fs:read_filemeta(Storage, Transfer) of
+        {ok, Filemeta} ->
+            maps:get(segments_ttl, Filemeta, undefined);
+        {error, _} ->
+            undefined
+    end.
+
+clamp(Min, Max, V) ->
+    min(Max, max(Min, V)).
+
+% try_collect(_Subject, ok = Result, Then, _Stats) ->
+%     Then(Result);
+% try_collect(_Subject, {ok, Result}, Then, _Stats) ->
+%     Then(Result);
+% try_collect(Subject, {error, _} = Error, _Then, Stats) ->
+%     register_gcstat_error(Subject, Error, Stats).
+
+%%
+
+init_gcstats() ->
+    #gcstats{started_at = erlang:system_time()}.
+
+finish_gcstats(Stats) ->
+    Stats#gcstats{finished_at = erlang:system_time()}.
+
+account_gcstat(Fileinfo, Stats = #gcstats{files = Files, space = Space}) ->
+    Stats#gcstats{
+        files = Files + 1,
+        space = Space + Fileinfo#file_info.size
+    }.
+
+account_gcstat_directory(Stats = #gcstats{directories = Directories}) ->
+    Stats#gcstats{
+        directories = Directories + 1
+    }.
+
+register_gcstat_error(Subject, Error, Stats = #gcstats{errors = Errors}) ->
+    Stats#gcstats{errors = Errors#{Subject => Error}}.
+
+%%
+
+get_storage_root(Storage) ->
+    maps:get(root, Storage, filename:join(emqx:data_dir(), "file_transfer")).

--- a/apps/emqx_ft/src/emqx_ft_sup.erl
+++ b/apps/emqx_ft/src/emqx_ft_sup.erl
@@ -61,5 +61,5 @@ init([]) ->
         modules => [emqx_ft_responder_sup]
     },
 
-    ChildSpecs = [Responder, AssemblerSup, FileReaderSup],
+    ChildSpecs = [Responder, AssemblerSup, FileReaderSup | emqx_ft_storage:child_spec()],
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -58,9 +58,8 @@ end_per_suite(_Config) ->
 set_special_configs(Config) ->
     fun
         (emqx_ft) ->
-            ok = emqx_config:put([file_transfer, storage], #{
-                type => local, root => emqx_ft_test_helpers:ft_root(Config, node())
-            });
+            Root = emqx_ft_test_helpers:ft_root(Config, node()),
+            emqx_ft_test_helpers:load_config(#{storage => #{type => local, root => Root}});
         (_) ->
             ok
     end.
@@ -109,10 +108,8 @@ mk_cluster_specs(Config) ->
         {conf, [{[listeners, Proto, default, enabled], false} || Proto <- [ssl, ws, wss]]},
         {env_handler, fun
             (emqx_ft) ->
-                ok = emqx_config:put([file_transfer, storage], #{
-                    type => local,
-                    root => emqx_ft_test_helpers:ft_root(Config, node())
-                });
+                Root = emqx_ft_test_helpers:ft_root(Config, node()),
+                emqx_ft_test_helpers:load_config(#{storage => #{type => local, root => Root}});
             (_) ->
                 ok
         end}

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -41,9 +41,8 @@ end_per_suite(_Config) ->
 set_special_configs(Config) ->
     fun
         (emqx_ft) ->
-            ok = emqx_config:put([file_transfer, storage], #{
-                type => local, root => emqx_ft_test_helpers:ft_root(Config, node())
-            });
+            Root = emqx_ft_test_helpers:ft_root(Config, node()),
+            emqx_ft_test_helpers:load_config(#{storage => #{type => local, root => Root}});
         (_) ->
             ok
     end.

--- a/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
@@ -109,7 +109,7 @@ t_assemble_complete_local_transfer(Config) ->
     ok = emqx_ft_storage_fs:store_filemeta(Storage, Transfer, Meta),
     _ = emqx_ft_content_gen:consume(
         Gen,
-        fun({Content, SegmentNum, _SegmentCount}) ->
+        fun({Content, SegmentNum, _Meta}) ->
             Offset = (SegmentNum - 1) * SegmentSize,
             ?assertEqual(
                 ok,

--- a/apps/emqx_ft/test/emqx_ft_content_gen.erl
+++ b/apps/emqx_ft/test/emqx_ft_content_gen.erl
@@ -42,7 +42,7 @@
 -type payload() :: {Seed :: term(), Size :: integer()}.
 
 -type binary_payload() :: {
-    binary(), _ChunkNum :: non_neg_integer(), _ChunkCnt :: non_neg_integer()
+    binary(), _ChunkNum :: non_neg_integer(), _Meta :: #{}
 }.
 
 -type cont(Data) ::
@@ -200,7 +200,10 @@ generate_chunk(Seed, Offset, ChunkSize, Size) ->
      || I <- lists:seq(Offset div 16, To div 16)
     ]),
     ChunkNum = Offset div ChunkSize + 1,
-    ChunkCnt = ceil(Size / ChunkSize),
+    Meta = #{
+        chunk_size => ChunkSize,
+        chunk_count => ceil(Size / ChunkSize)
+    },
     Chunk =
         case Offset + ChunkSize of
             NextOffset when NextOffset > Size ->
@@ -208,7 +211,7 @@ generate_chunk(Seed, Offset, ChunkSize, Size) ->
             _ ->
                 Payload
         end,
-    {Chunk, ChunkNum, ChunkCnt}.
+    {Chunk, ChunkNum, Meta}.
 
 %% @doc First argument is a chunk number, the second one is a seed.
 %% This implementation is hardly efficient, but it was chosen for

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
@@ -48,9 +48,8 @@ end_per_suite(_Config) ->
 set_special_configs(Config) ->
     fun
         (emqx_ft) ->
-            ok = emqx_config:put([file_transfer, storage], #{
-                type => local, root => emqx_ft_test_helpers:ft_root(Config, node())
-            });
+            Root = emqx_ft_test_helpers:ft_root(Config, node()),
+            emqx_ft_test_helpers:load_config(#{storage => #{type => local, root => Root}});
         (_) ->
             ok
     end.

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_gc_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_gc_SUITE.erl
@@ -40,19 +40,9 @@ init_per_testcase(TC, Config) ->
     ok = emqx_common_test_helpers:start_app(
         emqx_ft,
         fun(emqx_ft) ->
-            emqx_common_test_helpers:load_config(
-                emqx_ft_schema,
-                iolist_to_binary([
-                    "file_transfer {"
-                    "  storage = {"
-                    "    type = \"local\","
-                    "    root = \"",
-                    mk_root(TC, Config),
-                    "\""
-                    "  }"
-                    "}"
-                ])
-            )
+            emqx_ft_test_helpers:load_config(#{
+                storage => #{type => local, root => mk_root(TC, Config)}
+            })
         end
     ),
     Config.

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_gc_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_gc_SUITE.erl
@@ -1,0 +1,205 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_ft_storage_fs_gc_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("emqx_ft/include/emqx_ft_storage_fs.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("snabbkaffe/include/test_macros.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    _ = application:load(emqx_ft),
+    ok = emqx_common_test_helpers:start_apps([]),
+    Config.
+
+end_per_suite(_Config) ->
+    ok = emqx_common_test_helpers:stop_apps([]),
+    ok.
+
+init_per_testcase(TC, Config) ->
+    _ = application:unset_env(emqx_ft, gc_interval),
+    _ = application:unset_env(emqx_ft, min_segments_ttl),
+    _ = application:unset_env(emqx_ft, max_segments_ttl),
+    ok = emqx_common_test_helpers:start_app(
+        emqx_ft,
+        fun(emqx_ft) ->
+            ok = emqx_config:put([file_transfer, storage], #{
+                type => local,
+                root => mk_root(TC, Config)
+            })
+        end
+    ),
+    Config.
+
+end_per_testcase(_TC, _Config) ->
+    ok = application:stop(emqx_ft),
+    ok.
+
+mk_root(TC, Config) ->
+    filename:join([?config(priv_dir, Config), <<"file_transfer">>, TC, atom_to_binary(node())]).
+
+%%
+
+t_gc_triggers_periodically(_Config) ->
+    Interval = 1000,
+    ok = application:set_env(emqx_ft, gc_interval, Interval),
+    ok = emqx_ft_storage_fs_gc:reset(emqx_ft_conf:storage()),
+    ?check_trace(
+        timer:sleep(Interval * 3),
+        fun(Trace) ->
+            [Event, _ | _] = ?of_kind(garbage_collection, Trace),
+            ?assertMatch(
+                #{
+                    stats := #gcstats{
+                        files = 0,
+                        directories = 0,
+                        space = 0,
+                        errors = #{} = Errors
+                    }
+                } when map_size(Errors) == 0,
+                Event
+            )
+        end
+    ).
+
+t_gc_triggers_manually(_Config) ->
+    ?check_trace(
+        ?assertMatch(
+            #gcstats{files = 0, directories = 0, space = 0, errors = #{} = Errors} when
+                map_size(Errors) == 0,
+            emqx_ft_storage_fs_gc:collect(emqx_ft_conf:storage())
+        ),
+        fun(Trace) ->
+            [Event] = ?of_kind(garbage_collection, Trace),
+            ?assertMatch(
+                #{stats := #gcstats{}},
+                Event
+            )
+        end
+    ).
+
+t_gc_complete_transfers(_Config) ->
+    Storage = emqx_ft_conf:storage(),
+    Transfers = [
+        {
+            T1 = {<<"client1">>, mk_file_id()},
+            "cat.cur",
+            emqx_ft_content_gen:new({?LINE, S1 = 42}, SS1 = 16)
+        },
+        {
+            T2 = {<<"client2">>, mk_file_id()},
+            "cat.ico",
+            emqx_ft_content_gen:new({?LINE, S2 = 420}, SS2 = 64)
+        },
+        {
+            T3 = {<<"client42">>, mk_file_id()},
+            "cat.jpg",
+            emqx_ft_content_gen:new({?LINE, S3 = 42000}, SS3 = 1024)
+        }
+    ],
+    % 1. Start all transfers
+    TransferSizes = emqx_misc:pmap(
+        fun(Transfer) -> start_transfer(Storage, Transfer) end,
+        Transfers
+    ),
+    ?assertEqual([S1, S2, S3], TransferSizes),
+    ?assertMatch(
+        #gcstats{files = 0, directories = 0, errors = #{} = Es} when map_size(Es) == 0,
+        emqx_ft_storage_fs_gc:collect(Storage)
+    ),
+    % 2. Complete just the first transfer
+    ?assertEqual(
+        ok,
+        complete_transfer(Storage, T1, S1)
+    ),
+    GCFiles1 = ceil(S1 / SS1) + 1,
+    ?assertMatch(
+        #gcstats{
+            files = GCFiles1,
+            directories = 2,
+            space = Space,
+            errors = #{} = Es
+        } when Space > S1 andalso map_size(Es) == 0,
+        emqx_ft_storage_fs_gc:collect(Storage)
+    ),
+    % 3. Complete rest of transfers
+    ?assertEqual(
+        [ok, ok],
+        emqx_misc:pmap(
+            fun({Transfer, Size}) -> complete_transfer(Storage, Transfer, Size) end,
+            [{T2, S2}, {T3, S3}]
+        )
+    ),
+    GCFiles2 = ceil(S2 / SS2) + 1,
+    GCFiles3 = ceil(S3 / SS3) + 1,
+    ?assertMatch(
+        #gcstats{
+            files = Files,
+            directories = 4,
+            space = Space,
+            errors = #{} = Es
+        } when
+            Files == (GCFiles2 + GCFiles3) andalso
+                Space > (S2 + S3) andalso
+                map_size(Es) == 0,
+        emqx_ft_storage_fs_gc:collect(Storage)
+    ).
+
+start_transfer(Storage, {Transfer, Name, Gen}) ->
+    Meta = #{
+        name => Name,
+        segments_ttl => 10
+    },
+    ?assertEqual(
+        ok,
+        emqx_ft_storage_fs:store_filemeta(Storage, Transfer, Meta)
+    ),
+    emqx_ft_content_gen:fold(
+        fun({Content, SegmentNum, #{chunk_size := SegmentSize}}, _Transferred) ->
+            Offset = (SegmentNum - 1) * SegmentSize,
+            ?assertEqual(
+                ok,
+                emqx_ft_storage_fs:store_segment(Storage, Transfer, {Offset, Content})
+            ),
+            Offset + byte_size(Content)
+        end,
+        0,
+        Gen
+    ).
+
+complete_transfer(Storage, Transfer, Size) ->
+    complete_transfer(Storage, Transfer, Size, 100).
+
+complete_transfer(Storage, Transfer, Size, Timeout) ->
+    {async, Pid} = emqx_ft_storage_fs:assemble(Storage, Transfer, Size),
+    MRef = erlang:monitor(process, Pid),
+    Pid ! kickoff,
+    receive
+        {'DOWN', MRef, process, Pid, {shutdown, Result}} ->
+            Result
+    after Timeout ->
+        ct:fail("Assembler did not finish in time")
+    end.
+
+mk_file_id() ->
+    emqx_guid:to_hexstr(emqx_guid:gen()).

--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -30,9 +30,7 @@ start_additional_node(Config, Name) ->
             {configure_gen_rpc, true},
             {env_handler, fun
                 (emqx_ft) ->
-                    ok = emqx_config:put([file_transfer, storage], #{
-                        type => local, root => ft_root(Config, node())
-                    });
+                    load_config(#{storage => #{type => local, root => ft_root(Config, node())}});
                 (_) ->
                     ok
             end}
@@ -44,6 +42,9 @@ stop_additional_node(Node) ->
     ok = rpc:call(Node, emqx_common_test_helpers, stop_apps, [[emqx_ft]]),
     {ok, _} = emqx_common_test_helpers:stop_slave(Node),
     ok.
+
+load_config(Config) ->
+    emqx_common_test_helpers:load_config(emqx_ft_schema, #{file_transfer => Config}).
 
 tcp_port(Node) ->
     {_, Port} = rpc:call(Node, emqx_config, get, [[listeners, tcp, default, bind]]),


### PR DESCRIPTION
Implementation is straightforward, and is probably prone to some race conditions (e.g. collecting an incomplete transfer while there's another incoming segment). These conditions demand thorough testing.

Rough TODOs.
* [x] More basic tests
* [ ] ~~Filemeta preservation~~ (will be part of _exporters_ effort)
* [ ] ~~Collecting assembled transfers proactively (new BPAPI probably)~~ (followup)
* [ ] ~~Randomized concurrent testing for race conditions~~ (followup)
* [x] Proper GC config

---

[EMQX-8271](https://emqx.atlassian.net/browse/EMQX-8271)