### PR TITLE
fix: change timeout of gen_server:calls for emqx_telemetry to infinity

### DIFF
--- a/lib-ce/emqx_telemetry/src/emqx_telemetry.app.src
+++ b/lib-ce/emqx_telemetry/src/emqx_telemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_telemetry,
  [{description, "EMQ X Telemetry"},
-  {vsn, "4.3.4"}, % strict semver, bump manually!
+  {vsn, "4.3.5"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_telemetry_sup]},
   {applications, [kernel,stdlib]},

--- a/lib-ce/emqx_telemetry/src/emqx_telemetry.appup.src
+++ b/lib-ce/emqx_telemetry/src/emqx_telemetry.appup.src
@@ -1,11 +1,9 @@
 %% -*- mode: erlang -*-
 %% Unless you know what you are doing, DO NOT edit manually!!
 {VSN,
-  [{"4.3.3",[{load_module,emqx_telemetry,brutal_purge,soft_purge,[]}]},
-   {<<"4\\.3\\.[0-2]">>,
+  [{<<"4\\.3\\.[0-4]">>,
     [{load_module,emqx_telemetry,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}],
-  [{"4.3.3",[{load_module,emqx_telemetry,brutal_purge,soft_purge,[]}]},
-   {<<"4\\.3\\.[0-2]">>,
+  [{<<"4\\.3\\.[0-4]">>,
     [{load_module,emqx_telemetry,brutal_purge,soft_purge,[]}]},
    {<<".*">>,[]}]}.

--- a/lib-ce/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/lib-ce/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -42,7 +42,7 @@ t_uuid(_) ->
     {ok, UUID2} = emqx_telemetry:get_uuid(),
     emqx_telemetry:stop(),
     emqx_telemetry:start_link([{enabled, true},
-                               {url, "https://telemetry.emqx.io/api/telemetry"},
+                               {url, undefined},
                                {report_interval, 7 * 24 * 60 * 60}]),
     {ok, UUID3} = emqx_telemetry:get_uuid(),
     ?assertEqual(UUID2, UUID3).
@@ -80,7 +80,7 @@ t_send_after_enable(_) ->
     ok = snabbkaffe:start_trace(),
     try
         ok = emqx_telemetry:enable(),
-        ?assertMatch({ok, _}, ?block_until(#{?snk_kind := telemetry_data_reported}, 2000, 100))
+        ?assertMatch({ok, _}, ?block_until(#{?snk_kind := telemetry_data_reported}, 15000, 100))
     after
         ok = snabbkaffe:stop()
     end.


### PR DESCRIPTION
The CI failed if telemetry spent too much time on sending HTTP request. So I changed the timeout of the gen_server:call to infinity.