### PR TITLE
0308 stop releasing schema.json in rel package

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -146,8 +146,7 @@ dump_schema(Dir, SchemaModule, I18nFile) ->
         fun(Lang) ->
             gen_config_md(Dir, I18nFile, SchemaModule, Lang),
             gen_api_schema_json(Dir, I18nFile, Lang),
-            ExampleDir = filename:join(filename:dirname(filename:dirname(I18nFile)), "etc"),
-            gen_example_conf(ExampleDir, I18nFile, SchemaModule, Lang)
+            gen_example_conf(Dir, I18nFile, SchemaModule, Lang)
         end,
         [en, zh]
     ),

--- a/build
+++ b/build
@@ -112,9 +112,10 @@ make_docs() {
             SCHEMA_MODULE='emqx_conf_schema'
             ;;
     esac
+    mkdir -p _build/docgen
     # shellcheck disable=SC2086
     erl -noshell -pa $libs_dir1 $libs_dir2 $libs_dir3 -eval \
-        "Dir = filename:join([apps, emqx_dashboard, priv, www, static]), \
+        "Dir = filename:join(['_build', docgen]), \
          I18nFile = filename:join([apps, emqx_dashboard, priv, 'i18n.conf']), \
          ok = emqx_conf:dump_schema(Dir, $SCHEMA_MODULE, I18nFile), \
          halt(0)."

--- a/build
+++ b/build
@@ -112,13 +112,15 @@ make_docs() {
             SCHEMA_MODULE='emqx_conf_schema'
             ;;
     esac
-    mkdir -p _build/docgen
+    mkdir -p _build/docgen apps/emqx_dashboard/priv/www/static/
     # shellcheck disable=SC2086
     erl -noshell -pa $libs_dir1 $libs_dir2 $libs_dir3 -eval \
         "Dir = filename:join(['_build', docgen]), \
          I18nFile = filename:join([apps, emqx_dashboard, priv, 'i18n.conf']), \
          ok = emqx_conf:dump_schema(Dir, $SCHEMA_MODULE, I18nFile), \
          halt(0)."
+    cp _build/docgen/bridge-api-*.json apps/emqx_dashboard/priv/www/static/
+    cp _build/docgen/hot-config-schema-*.json apps/emqx_dashboard/priv/www/static/
 }
 
 assert_no_compile_time_only_deps() {

--- a/build
+++ b/build
@@ -92,7 +92,7 @@ log() {
 }
 
 make_docs() {
-    local libs_dir1 libs_dir2 libs_dir3
+    local libs_dir1 libs_dir2 libs_dir3 docdir dashboard_www_static
     libs_dir1="$("$FIND" "_build/$PROFILE/lib/" -maxdepth 2 -name ebin -type d)"
     if [ -d "_build/default/lib/" ]; then
         libs_dir2="$("$FIND" "_build/default/lib/" -maxdepth 2 -name ebin -type d)"
@@ -112,15 +112,16 @@ make_docs() {
             SCHEMA_MODULE='emqx_conf_schema'
             ;;
     esac
-    mkdir -p _build/docgen apps/emqx_dashboard/priv/www/static/
+    docdir="_build/docgen/$PROFILE"
+    dashboard_www_static='apps/emqx_dashboard/priv/www/static/'
+    mkdir -p "$docdir" "$dashboard_www_static"
     # shellcheck disable=SC2086
     erl -noshell -pa $libs_dir1 $libs_dir2 $libs_dir3 -eval \
-        "Dir = filename:join(['_build', docgen]), \
-         I18nFile = filename:join([apps, emqx_dashboard, priv, 'i18n.conf']), \
-         ok = emqx_conf:dump_schema(Dir, $SCHEMA_MODULE, I18nFile), \
+        "I18nFile = filename:join([apps, emqx_dashboard, priv, 'i18n.conf']), \
+         ok = emqx_conf:dump_schema('$docdir', $SCHEMA_MODULE, I18nFile), \
          halt(0)."
-    cp _build/docgen/bridge-api-*.json apps/emqx_dashboard/priv/www/static/
-    cp _build/docgen/hot-config-schema-*.json apps/emqx_dashboard/priv/www/static/
+    cp "$docdir"/bridge-api-*.json "$dashboard_www_static"
+    cp "$docdir"/hot-config-schema-*.json "$dashboard_www_static"
 }
 
 assert_no_compile_time_only_deps() {

--- a/mix.exs
+++ b/mix.exs
@@ -373,9 +373,11 @@ defmodule EMQXUmbrella.MixProject do
       Path.join(etc, "certs")
     )
 
+    profile = System.get_env("MIX_ENV")
+
     Mix.Generator.copy_file(
-      "apps/emqx_dashboard/etc/emqx.conf.en.example",
-      Path.join(etc, "emqx-example.conf"),
+      "_build/docgen/#{profile}/emqx.conf.en.example",
+      Path.join(etc, "emqx.conf.example"),
       force: overwrite?
     )
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -462,7 +462,8 @@ etc_overlay(ReleaseType, Edition) ->
     [
         {mkdir, "etc/"},
         {copy, "{{base_dir}}/lib/emqx/etc/certs", "etc/"},
-        {copy, "_build/docgen/emqx.conf.en.example", "etc/emqx.conf.example"}
+        {copy, "_build/docgen/" ++ name(Edition) ++ "/emqx.conf.en.example",
+            "etc/emqx.conf.example"}
     ] ++
         lists:map(
             fun
@@ -598,3 +599,6 @@ list_dir(Dir) ->
         false ->
             []
     end.
+
+name(ce) -> "emqx";
+name(ee) -> "emqx-enterprise".

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -462,7 +462,7 @@ etc_overlay(ReleaseType, Edition) ->
     [
         {mkdir, "etc/"},
         {copy, "{{base_dir}}/lib/emqx/etc/certs", "etc/"},
-        {copy, "apps/emqx_dashboard/etc/emqx.conf.en.example", "etc/emqx-example.conf"}
+        {copy, "_build/docgen/emqx.conf.en.example", "etc/emqx.conf.example"}
     ] ++
         lists:map(
             fun


### PR DESCRIPTION
Fixes [EMQX-8999](https://emqx.atlassian.net/browse/EMQX-8999)

Saying goodbye to the possibility of building self-contained releases which include the configuration documents.
We'll continue to generate the schema artifacts,
but not as a part of the `www/static` dir  of the web server (dashboard).

Find the new schema dump in `_build/docgen/{emqx,emqx-enterprise}`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [~] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
   this PR only removes some unused artifacts, which impacts no user experience.
- [x] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible
