### PR TITLE
perf(bridge-api): ask nodes' bridge listings in parallel

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -4,6 +4,7 @@
 {emqx_authz,1}.
 {emqx_bridge,1}.
 {emqx_bridge,2}.
+{emqx_bridge,3}.
 {emqx_broker,1}.
 {emqx_cm,1}.
 {emqx_conf,1}.

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -226,21 +226,21 @@ post_config_update(_, _Req, NewConf, OldConf, _AppEnv) ->
     Result.
 
 list() ->
-    lists:foldl(
-        fun({Type, NameAndConf}, Bridges) ->
-            lists:foldl(
-                fun({Name, RawConf}, Acc) ->
+    maps:fold(
+        fun(Type, NameAndConf, Bridges) ->
+            maps:fold(
+                fun(Name, RawConf, Acc) ->
                     case lookup(Type, Name, RawConf) of
                         {error, not_found} -> Acc;
                         {ok, Res} -> [Res | Acc]
                     end
                 end,
                 Bridges,
-                maps:to_list(NameAndConf)
+                NameAndConf
             )
         end,
         [],
-        maps:to_list(emqx:get_raw_config([bridges], #{}))
+        emqx:get_raw_config([bridges], #{})
     ).
 
 lookup(Id) ->

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -483,11 +483,18 @@ schema("/bridges_probe") ->
             end
     end;
 '/bridges'(get, _Params) ->
-    {200,
-        zip_bridges([
-            [format_resp(Data, Node) || Data <- emqx_bridge_proto_v1:list_bridges(Node)]
-         || Node <- mria:running_nodes()
-        ])}.
+    Nodes = mria:running_nodes(),
+    NodeReplies = emqx_bridge_proto_v3:list_bridges_on_nodes(Nodes),
+    case is_ok(NodeReplies) of
+        {ok, NodeBridges} ->
+            AllBridges = [
+                format_resource(Data, Node)
+             || {Node, Bridges} <- lists:zip(Nodes, NodeBridges), Data <- Bridges
+            ],
+            {200, zip_bridges([AllBridges])};
+        {error, Reason} ->
+            {500, error_msg('INTERNAL_ERROR', Reason)}
+    end.
 
 '/bridges/:id'(get, #{bindings := #{id := Id}}) ->
     ?TRY_PARSE_ID(Id, lookup_from_all_nodes(BridgeType, BridgeName, 200));
@@ -591,7 +598,7 @@ lookup_from_all_nodes_metrics(BridgeType, BridgeName, SuccCode) ->
 
 do_lookup_from_all_nodes(BridgeType, BridgeName, SuccCode, FormatFun) ->
     Nodes = mria:running_nodes(),
-    case is_ok(emqx_bridge_proto_v1:lookup_from_all_nodes(Nodes, BridgeType, BridgeName)) of
+    case is_ok(emqx_bridge_proto_v3:lookup_from_all_nodes(Nodes, BridgeType, BridgeName)) of
         {ok, [{ok, _} | _] = Results} ->
             {SuccCode, FormatFun([R || {ok, R} <- Results])};
         {ok, [{error, not_found} | _]} ->
@@ -602,7 +609,7 @@ do_lookup_from_all_nodes(BridgeType, BridgeName, SuccCode, FormatFun) ->
 
 lookup_from_local_node(BridgeType, BridgeName) ->
     case emqx_bridge:lookup(BridgeType, BridgeName) of
-        {ok, Res} -> {ok, format_resp(Res)};
+        {ok, Res} -> {ok, format_resource(Res, node())};
         Error -> Error
     end.
 
@@ -802,10 +809,7 @@ aggregate_metrics(
 aggregate_metrics(#{}, Metrics) ->
     Metrics.
 
-format_resp(Data) ->
-    format_resp(Data, node()).
-
-format_resp(
+format_resource(
     #{
         type := Type,
         name := BridgeName,
@@ -974,7 +978,7 @@ do_bpapi_call(Node, Call, Args) ->
 do_bpapi_call_vsn(SupportedVersion, Call, Args) ->
     case lists:member(SupportedVersion, supported_versions(Call)) of
         true ->
-            apply(emqx_bridge_proto_v2, Call, Args);
+            apply(emqx_bridge_proto_v3, Call, Args);
         false ->
             {error, not_implemented}
     end.
@@ -984,9 +988,9 @@ maybe_unwrap({error, not_implemented}) ->
 maybe_unwrap(RpcMulticallResult) ->
     emqx_rpc:unwrap_erpc(RpcMulticallResult).
 
-supported_versions(start_bridge_to_node) -> [2];
-supported_versions(start_bridges_to_all_nodes) -> [2];
-supported_versions(_Call) -> [1, 2].
+supported_versions(start_bridge_to_node) -> [2, 3];
+supported_versions(start_bridges_to_all_nodes) -> [2, 3];
+supported_versions(_Call) -> [1, 2, 3].
 
 to_hr_reason(nxdomain) ->
     <<"Host not found">>;

--- a/apps/emqx_bridge/src/proto/emqx_bridge_proto_v3.erl
+++ b/apps/emqx_bridge/src/proto/emqx_bridge_proto_v3.erl
@@ -14,15 +14,15 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_bridge_proto_v2).
+-module(emqx_bridge_proto_v3).
 
 -behaviour(emqx_bpapi).
 
 -export([
     introduced_in/0,
-    deprecated_since/0,
 
     list_bridges/1,
+    list_bridges_on_nodes/1,
     restart_bridge_to_node/3,
     start_bridge_to_node/3,
     stop_bridge_to_node/3,
@@ -37,14 +37,16 @@
 -define(TIMEOUT, 15000).
 
 introduced_in() ->
-    "5.0.17".
-
-deprecated_since() ->
     "5.0.21".
 
 -spec list_bridges(node()) -> list() | emqx_rpc:badrpc().
 list_bridges(Node) ->
     rpc:call(Node, emqx_bridge, list, [], ?TIMEOUT).
+
+-spec list_bridges_on_nodes([node()]) ->
+    emqx_rpc:erpc_multicall([emqx_resource:resource_data()]).
+list_bridges_on_nodes(Nodes) ->
+    erpc:multicall(Nodes, emqx_bridge, list, [], ?TIMEOUT).
 
 -type key() :: atom() | binary() | [byte()].
 

--- a/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_mqtt_SUITE.erl
@@ -19,7 +19,6 @@
 -compile(export_all).
 
 -import(emqx_dashboard_api_test_helpers, [request/4, uri/1]).
--import(emqx_common_test_helpers, [on_exit/1]).
 
 -include("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
@@ -164,9 +163,9 @@ init_per_testcase(_, Config) ->
     {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
     ok = snabbkaffe:start_trace(),
     Config.
+
 end_per_testcase(_, _Config) ->
     clear_resources(),
-    emqx_common_test_helpers:call_janitor(),
     snabbkaffe:stop(),
     ok.
 
@@ -710,13 +709,6 @@ t_mqtt_conn_bridge_egress_reconnect(_) ->
         }
     ),
 
-    on_exit(fun() ->
-        %% delete the bridge
-        {ok, 204, <<>>} = request(delete, uri(["bridges", BridgeIDEgress]), []),
-        {ok, 200, <<"[]">>} = request(get, uri(["bridges"]), []),
-        ok
-    end),
-
     %% we now test if the bridge works as expected
     LocalTopic = <<?EGRESS_LOCAL_TOPIC, "/1">>,
     RemoteTopic = <<?EGRESS_REMOTE_TOPIC, "/", LocalTopic/binary>>,
@@ -826,13 +818,6 @@ t_mqtt_conn_bridge_egress_async_reconnect(_) ->
             }
         }
     ),
-
-    on_exit(fun() ->
-        %% delete the bridge
-        {ok, 204, <<>>} = request(delete, uri(["bridges", BridgeIDEgress]), []),
-        {ok, 200, <<"[]">>} = request(get, uri(["bridges"]), []),
-        ok
-    end),
 
     Self = self(),
     LocalTopic = <<?EGRESS_LOCAL_TOPIC, "/1">>,

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -260,7 +260,7 @@ query(ResId, Request) ->
 -spec query(resource_id(), Request :: term(), query_opts()) ->
     Result :: term().
 query(ResId, Request, Opts) ->
-    case emqx_resource_manager:ets_lookup(ResId) of
+    case emqx_resource_manager:lookup_cached(ResId) of
         {ok, _Group, #{query_mode := QM, mod := Module}} ->
             IsBufferSupported = is_buffer_supported(Module),
             case {IsBufferSupported, QM} of
@@ -311,7 +311,7 @@ set_resource_status_connecting(ResId) ->
 -spec get_instance(resource_id()) ->
     {ok, resource_group(), resource_data()} | {error, Reason :: term()}.
 get_instance(ResId) ->
-    emqx_resource_manager:ets_lookup(ResId, [metrics]).
+    emqx_resource_manager:lookup_cached(ResId, [metrics]).
 
 -spec fetch_creation_opts(map()) -> creation_opts().
 fetch_creation_opts(Opts) ->

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -309,7 +309,7 @@ set_resource_status_connecting(ResId) ->
 -spec get_instance(resource_id()) ->
     {ok, resource_group(), resource_data()} | {error, Reason :: term()}.
 get_instance(ResId) ->
-    emqx_resource_manager:lookup(ResId).
+    emqx_resource_manager:ets_lookup(ResId, [metrics]).
 
 -spec fetch_creation_opts(map()) -> creation_opts().
 fetch_creation_opts(Opts) ->

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -112,6 +112,8 @@
 
 -export([apply_reply_fun/2]).
 
+-export_type([resource_data/0]).
+
 -optional_callbacks([
     on_query/3,
     on_batch_query/3,

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -885,7 +885,7 @@ handle_async_worker_down(Data0, Pid) ->
 
 call_query(QM0, Id, Index, Ref, Query, QueryOpts) ->
     ?tp(call_query_enter, #{id => Id, query => Query, query_mode => QM0}),
-    case emqx_resource_manager:ets_lookup(Id) of
+    case emqx_resource_manager:lookup_cached(Id) of
         {ok, _Group, #{status := stopped}} ->
             ?RESOURCE_ERROR(stopped, "resource stopped or disabled");
         {ok, _Group, Resource} ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -36,8 +36,8 @@
     lookup/1,
     list_all/0,
     list_group/1,
-    ets_lookup/1,
-    ets_lookup/2,
+    lookup_cached/1,
+    lookup_cached/2,
     get_metrics/1,
     reset_metrics/1
 ]).
@@ -231,21 +231,21 @@ set_resource_status_connecting(ResId) ->
 -spec lookup(resource_id()) -> {ok, resource_group(), resource_data()} | {error, not_found}.
 lookup(ResId) ->
     case safe_call(ResId, lookup, ?T_LOOKUP) of
-        {error, timeout} -> ets_lookup(ResId, [metrics]);
+        {error, timeout} -> lookup_cached(ResId, [metrics]);
         Result -> Result
     end.
 
 %% @doc Lookup the group and data of a resource from the cache
--spec ets_lookup(resource_id()) -> {ok, resource_group(), resource_data()} | {error, not_found}.
-ets_lookup(ResId) ->
-    ets_lookup(ResId, []).
+-spec lookup_cached(resource_id()) -> {ok, resource_group(), resource_data()} | {error, not_found}.
+lookup_cached(ResId) ->
+    lookup_cached(ResId, []).
 
 %% @doc Lookup the group and data of a resource from the cache
--spec ets_lookup(resource_id(), [Option]) ->
+-spec lookup_cached(resource_id(), [Option]) ->
     {ok, resource_group(), resource_data()} | {error, not_found}
 when
     Option :: metrics.
-ets_lookup(ResId, Options) ->
+lookup_cached(ResId, Options) ->
     NeedMetrics = lists:member(metrics, Options),
     case read_cache(ResId) of
         {Group, Data} when NeedMetrics ->

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -72,115 +72,156 @@ t_check_config(_) ->
     {error, _} = emqx_resource:check_config(?TEST_RESOURCE, #{invalid => config}).
 
 t_create_remove(_) ->
-    {error, _} = emqx_resource:check_and_create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{unknown => test_resource}
-    ),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {error, _},
+                emqx_resource:check_and_create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{unknown => test_resource}
+                )
+            ),
 
-    {ok, _} = emqx_resource:create(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{name => test_resource}
-    ),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:create(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{name => test_resource}
+                )
+            ),
 
-    {ok, _} = emqx_resource:recreate(
-        ?ID,
-        ?TEST_RESOURCE,
-        #{name => test_resource},
-        #{}
-    ),
-    {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:recreate(
+                    ?ID,
+                    ?TEST_RESOURCE,
+                    #{name => test_resource},
+                    #{}
+                )
+            ),
 
-    ?assert(is_process_alive(Pid)),
+            {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
 
-    ok = emqx_resource:remove(?ID),
-    {error, _} = emqx_resource:remove(?ID),
+            ?assert(is_process_alive(Pid)),
 
-    ?assertNot(is_process_alive(Pid)).
+            ?assertEqual(ok, emqx_resource:remove(?ID)),
+            ?assertMatch({error, _}, emqx_resource:remove(?ID)),
+
+            ?assertNot(is_process_alive(Pid))
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_create_remove_local(_) ->
-    {error, _} = emqx_resource:check_and_create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{unknown => test_resource}
-    ),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {error, _},
+                emqx_resource:check_and_create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{unknown => test_resource}
+                )
+            ),
 
-    {ok, _} = emqx_resource:create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{name => test_resource}
-    ),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{name => test_resource}
+                )
+            ),
 
-    emqx_resource:recreate_local(
-        ?ID,
-        ?TEST_RESOURCE,
-        #{name => test_resource},
-        #{}
-    ),
-    {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
+            emqx_resource:recreate_local(
+                ?ID,
+                ?TEST_RESOURCE,
+                #{name => test_resource},
+                #{}
+            ),
 
-    ?assert(is_process_alive(Pid)),
+            {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
 
-    emqx_resource:set_resource_status_connecting(?ID),
+            ?assert(is_process_alive(Pid)),
 
-    emqx_resource:recreate_local(
-        ?ID,
-        ?TEST_RESOURCE,
-        #{name => test_resource},
-        #{}
-    ),
+            emqx_resource:set_resource_status_connecting(?ID),
 
-    ok = emqx_resource:remove_local(?ID),
-    {error, _} = emqx_resource:remove_local(?ID),
+            emqx_resource:recreate_local(
+                ?ID,
+                ?TEST_RESOURCE,
+                #{name => test_resource},
+                #{}
+            ),
 
-    ?assertMatch(
-        ?RESOURCE_ERROR(not_found),
-        emqx_resource:query(?ID, get_state)
-    ),
-    ?assertNot(is_process_alive(Pid)).
+            ?assertEqual(ok, emqx_resource:remove_local(?ID)),
+            ?assertMatch({error, _}, emqx_resource:remove_local(?ID)),
+
+            ?assertMatch(
+                ?RESOURCE_ERROR(not_found),
+                emqx_resource:query(?ID, get_state)
+            ),
+
+            ?assertNot(is_process_alive(Pid))
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_do_not_start_after_created(_) ->
-    ct:pal("creating resource"),
-    {ok, _} = emqx_resource:create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{name => test_resource},
-        #{start_after_created => false}
-    ),
-    %% the resource should remain `disconnected` after created
-    timer:sleep(200),
-    ?assertMatch(
-        ?RESOURCE_ERROR(stopped),
-        emqx_resource:query(?ID, get_state)
-    ),
-    ?assertMatch(
-        {ok, _, #{status := stopped}},
-        emqx_resource:get_instance(?ID)
-    ),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{name => test_resource},
+                    #{start_after_created => false}
+                )
+            ),
+            %% the resource should remain `disconnected` after created
+            timer:sleep(200),
+            ?assertMatch(
+                ?RESOURCE_ERROR(stopped),
+                emqx_resource:query(?ID, get_state)
+            ),
+            ?assertMatch(
+                {ok, _, #{status := stopped}},
+                emqx_resource:get_instance(?ID)
+            ),
 
-    %% start the resource manually..
-    ct:pal("starting resource manually"),
-    ok = emqx_resource:start(?ID),
-    {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
-    ?assert(is_process_alive(Pid)),
+            %% start the resource manually..
+            ?assertEqual(ok, emqx_resource:start(?ID)),
+            {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
+            ?assert(is_process_alive(Pid)),
 
-    %% restart the resource
-    ct:pal("restarting resource"),
-    ok = emqx_resource:restart(?ID),
-    ?assertNot(is_process_alive(Pid)),
-    {ok, #{pid := Pid2}} = emqx_resource:query(?ID, get_state),
-    ?assert(is_process_alive(Pid2)),
+            %% restart the resource
+            ?assertEqual(ok, emqx_resource:restart(?ID)),
+            ?assertNot(is_process_alive(Pid)),
+            {ok, #{pid := Pid2}} = emqx_resource:query(?ID, get_state),
+            ?assert(is_process_alive(Pid2)),
 
-    ct:pal("removing resource"),
-    ok = emqx_resource:remove_local(?ID),
+            ?assertEqual(ok, emqx_resource:remove_local(?ID)),
 
-    ?assertNot(is_process_alive(Pid2)).
+            ?assertNot(is_process_alive(Pid2))
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_query(_) ->
     {ok, _} = emqx_resource:create_local(
@@ -771,153 +812,210 @@ t_query_counter_async_inflight_batch(_) ->
     ok = emqx_resource:remove_local(?ID).
 
 t_healthy_timeout(_) ->
-    {ok, _} = emqx_resource:create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{name => <<"bad_not_atom_name">>, register => true},
-        %% the ?TEST_RESOURCE always returns the `Mod:on_get_status/2` 300ms later.
-        #{health_check_interval => 200}
-    ),
-    ?assertMatch(
-        {error, {resource_error, #{reason := timeout}}},
-        emqx_resource:query(?ID, get_state, #{timeout => 1_000})
-    ),
-    ?assertMatch({ok, _Group, #{status := disconnected}}, emqx_resource_manager:ets_lookup(?ID)),
-    ok = emqx_resource:remove_local(?ID).
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{name => <<"bad_not_atom_name">>, register => true},
+                    %% the ?TEST_RESOURCE always returns the `Mod:on_get_status/2` 300ms later.
+                    #{health_check_interval => 200}
+                )
+            ),
+            ?assertMatch(
+                {error, {resource_error, #{reason := timeout}}},
+                emqx_resource:query(?ID, get_state, #{timeout => 1_000})
+            ),
+            ?assertMatch(
+                {ok, _Group, #{status := disconnected}}, emqx_resource_manager:lookup(?ID)
+            ),
+            ?assertEqual(ok, emqx_resource:remove_local(?ID))
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_healthy(_) ->
-    {ok, _} = emqx_resource:create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{name => test_resource}
-    ),
-    {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
-    timer:sleep(300),
-    emqx_resource:set_resource_status_connecting(?ID),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{name => test_resource}
+                )
+            ),
+            {ok, #{pid := Pid}} = emqx_resource:query(?ID, get_state),
+            timer:sleep(300),
+            emqx_resource:set_resource_status_connecting(?ID),
 
-    {ok, connected} = emqx_resource:health_check(?ID),
-    ?assertMatch(
-        [#{status := connected}],
-        emqx_resource:list_instances_verbose()
-    ),
+            ?assertEqual({ok, connected}, emqx_resource:health_check(?ID)),
+            ?assertMatch(
+                [#{status := connected}],
+                emqx_resource:list_instances_verbose()
+            ),
 
-    erlang:exit(Pid, shutdown),
+            erlang:exit(Pid, shutdown),
 
-    ?assertEqual({ok, disconnected}, emqx_resource:health_check(?ID)),
+            ?assertEqual({ok, disconnected}, emqx_resource:health_check(?ID)),
 
-    ?assertMatch(
-        [#{status := disconnected}],
-        emqx_resource:list_instances_verbose()
-    ),
+            ?assertMatch(
+                [#{status := disconnected}],
+                emqx_resource:list_instances_verbose()
+            ),
 
-    ok = emqx_resource:remove_local(?ID).
+            ?assertEqual(ok, emqx_resource:remove_local(?ID))
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_stop_start(_) ->
-    {error, _} = emqx_resource:check_and_create(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{unknown => test_resource}
-    ),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {error, _},
+                emqx_resource:check_and_create(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{unknown => test_resource}
+                )
+            ),
 
-    {ok, _} = emqx_resource:check_and_create(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{<<"name">> => <<"test_resource">>}
-    ),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:check_and_create(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{<<"name">> => <<"test_resource">>}
+                )
+            ),
 
-    %% add some metrics to test their persistence
-    WorkerID0 = <<"worker:0">>,
-    WorkerID1 = <<"worker:1">>,
-    emqx_resource_metrics:inflight_set(?ID, WorkerID0, 2),
-    emqx_resource_metrics:inflight_set(?ID, WorkerID1, 3),
-    ?assertEqual(5, emqx_resource_metrics:inflight_get(?ID)),
+            %% add some metrics to test their persistence
+            WorkerID0 = <<"worker:0">>,
+            WorkerID1 = <<"worker:1">>,
+            emqx_resource_metrics:inflight_set(?ID, WorkerID0, 2),
+            emqx_resource_metrics:inflight_set(?ID, WorkerID1, 3),
+            ?assertEqual(5, emqx_resource_metrics:inflight_get(?ID)),
 
-    {ok, _} = emqx_resource:check_and_recreate(
-        ?ID,
-        ?TEST_RESOURCE,
-        #{<<"name">> => <<"test_resource">>},
-        #{}
-    ),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:check_and_recreate(
+                    ?ID,
+                    ?TEST_RESOURCE,
+                    #{<<"name">> => <<"test_resource">>},
+                    #{}
+                )
+            ),
 
-    {ok, #{pid := Pid0}} = emqx_resource:query(?ID, get_state),
+            {ok, #{pid := Pid0}} = emqx_resource:query(?ID, get_state),
 
-    ?assert(is_process_alive(Pid0)),
+            ?assert(is_process_alive(Pid0)),
 
-    %% metrics are reset when recreating
-    %% depending on timing, might show the request we just did.
-    ct:sleep(500),
-    ?assertEqual(0, emqx_resource_metrics:inflight_get(?ID)),
+            %% metrics are reset when recreating
+            %% depending on timing, might show the request we just did.
+            ct:sleep(500),
+            ?assertEqual(0, emqx_resource_metrics:inflight_get(?ID)),
 
-    ok = emqx_resource:stop(?ID),
+            ok = emqx_resource:stop(?ID),
 
-    ?assertNot(is_process_alive(Pid0)),
+            ?assertNot(is_process_alive(Pid0)),
 
-    ?assertMatch(
-        ?RESOURCE_ERROR(stopped),
-        emqx_resource:query(?ID, get_state)
-    ),
+            ?assertMatch(
+                ?RESOURCE_ERROR(stopped),
+                emqx_resource:query(?ID, get_state)
+            ),
 
-    ok = emqx_resource:restart(?ID),
-    timer:sleep(300),
+            ?assertEqual(ok, emqx_resource:restart(?ID)),
+            timer:sleep(300),
 
-    {ok, #{pid := Pid1}} = emqx_resource:query(?ID, get_state),
+            {ok, #{pid := Pid1}} = emqx_resource:query(?ID, get_state),
 
-    ?assert(is_process_alive(Pid1)),
+            ?assert(is_process_alive(Pid1)),
 
-    %% now stop while resetting the metrics
-    ct:sleep(500),
-    emqx_resource_metrics:inflight_set(?ID, WorkerID0, 1),
-    emqx_resource_metrics:inflight_set(?ID, WorkerID1, 4),
-    ?assertEqual(5, emqx_resource_metrics:inflight_get(?ID)),
-    ok = emqx_resource:stop(?ID),
-    ?assertEqual(0, emqx_resource_metrics:inflight_get(?ID)),
+            %% now stop while resetting the metrics
+            ct:sleep(500),
+            emqx_resource_metrics:inflight_set(?ID, WorkerID0, 1),
+            emqx_resource_metrics:inflight_set(?ID, WorkerID1, 4),
+            ?assertEqual(5, emqx_resource_metrics:inflight_get(?ID)),
+            ?assertEqual(ok, emqx_resource:stop(?ID)),
+            ?assertEqual(0, emqx_resource_metrics:inflight_get(?ID))
+        end,
 
-    ok.
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_stop_start_local(_) ->
-    {error, _} = emqx_resource:check_and_create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{unknown => test_resource}
-    ),
+    ?check_trace(
+        begin
+            ?assertMatch(
+                {error, _},
+                emqx_resource:check_and_create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{unknown => test_resource}
+                )
+            ),
 
-    {ok, _} = emqx_resource:check_and_create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{<<"name">> => <<"test_resource">>}
-    ),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:check_and_create_local(
+                    ?ID,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{<<"name">> => <<"test_resource">>}
+                )
+            ),
 
-    {ok, _} = emqx_resource:check_and_recreate_local(
-        ?ID,
-        ?TEST_RESOURCE,
-        #{<<"name">> => <<"test_resource">>},
-        #{}
-    ),
+            ?assertMatch(
+                {ok, _},
+                emqx_resource:check_and_recreate_local(
+                    ?ID,
+                    ?TEST_RESOURCE,
+                    #{<<"name">> => <<"test_resource">>},
+                    #{}
+                )
+            ),
 
-    {ok, #{pid := Pid0}} = emqx_resource:query(?ID, get_state),
+            {ok, #{pid := Pid0}} = emqx_resource:query(?ID, get_state),
 
-    ?assert(is_process_alive(Pid0)),
+            ?assert(is_process_alive(Pid0)),
 
-    ok = emqx_resource:stop(?ID),
+            ?assertEqual(ok, emqx_resource:stop(?ID)),
 
-    ?assertNot(is_process_alive(Pid0)),
+            ?assertNot(is_process_alive(Pid0)),
 
-    ?assertMatch(
-        ?RESOURCE_ERROR(stopped),
-        emqx_resource:query(?ID, get_state)
-    ),
+            ?assertMatch(
+                ?RESOURCE_ERROR(stopped),
+                emqx_resource:query(?ID, get_state)
+            ),
 
-    ok = emqx_resource:restart(?ID),
+            ?assertEqual(ok, emqx_resource:restart(?ID)),
 
-    {ok, #{pid := Pid1}} = emqx_resource:query(?ID, get_state),
+            {ok, #{pid := Pid1}} = emqx_resource:query(?ID, get_state),
 
-    ?assert(is_process_alive(Pid1)).
+            ?assert(is_process_alive(Pid1))
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
+    ).
 
 t_list_filter(_) ->
     {ok, _} = emqx_resource:create_local(
@@ -1031,16 +1129,24 @@ t_auto_retry(_) ->
     ?assertEqual(ok, Res).
 
 t_health_check_disconnected(_) ->
-    _ = emqx_resource:create_local(
-        ?ID,
-        ?DEFAULT_RESOURCE_GROUP,
-        ?TEST_RESOURCE,
-        #{name => test_resource, create_error => true},
-        #{auto_retry_interval => 100}
-    ),
-    ?assertEqual(
-        {ok, disconnected},
-        emqx_resource:health_check(?ID)
+    ?check_trace(
+        begin
+            _ = emqx_resource:create_local(
+                ?ID,
+                ?DEFAULT_RESOURCE_GROUP,
+                ?TEST_RESOURCE,
+                #{name => test_resource, create_error => true},
+                #{auto_retry_interval => 100}
+            ),
+            ?assertEqual(
+                {ok, disconnected},
+                emqx_resource:health_check(?ID)
+            )
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind("inconsistent_state", Trace)),
+            ?assertEqual([], ?of_kind("inconsistent_cache", Trace))
+        end
     ).
 
 t_unblock_only_required_buffer_workers(_) ->

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -263,7 +263,11 @@ t_batch_query_counter(_) ->
         ?DEFAULT_RESOURCE_GROUP,
         ?TEST_RESOURCE,
         #{name => test_resource, register => true},
-        #{batch_size => BatchSize, query_mode => sync}
+        #{
+            batch_size => BatchSize,
+            batch_time => 100,
+            query_mode => sync
+        }
     ),
 
     ?check_trace(
@@ -622,6 +626,7 @@ t_query_counter_async_inflight_batch(_) ->
         #{
             query_mode => async,
             batch_size => BatchSize,
+            batch_time => 100,
             async_inflight_window => WindowSize,
             worker_pool_size => 1,
             resume_interval => 300
@@ -1157,7 +1162,8 @@ t_unblock_only_required_buffer_workers(_) ->
         #{name => test_resource},
         #{
             query_mode => async,
-            batch_size => 5
+            batch_size => 5,
+            batch_time => 100
         }
     ),
     lists:foreach(
@@ -1171,7 +1177,8 @@ t_unblock_only_required_buffer_workers(_) ->
         #{name => test_resource},
         #{
             query_mode => async,
-            batch_size => 5
+            batch_size => 5,
+            batch_time => 100
         }
     ),
     %% creation of `?ID1` should not have unblocked `?ID`'s buffer workers
@@ -1202,6 +1209,7 @@ t_retry_batch(_Config) ->
         #{
             query_mode => async,
             batch_size => 5,
+            batch_time => 100,
             worker_pool_size => 1,
             resume_interval => 1_000
         }
@@ -1571,7 +1579,6 @@ t_retry_async_inflight_full(_Config) ->
             query_mode => async,
             async_inflight_window => AsyncInflightWindow,
             batch_size => 1,
-            batch_time => 20,
             worker_pool_size => 1,
             resume_interval => ResumeInterval
         }
@@ -2086,7 +2093,6 @@ t_expiration_async_after_reply(_Config) ->
         #{
             query_mode => async,
             batch_size => 1,
-            batch_time => 100,
             worker_pool_size => 1,
             resume_interval => 1_000
         }
@@ -2309,7 +2315,6 @@ t_expiration_retry(_Config) ->
         #{
             query_mode => sync,
             batch_size => 1,
-            batch_time => 100,
             worker_pool_size => 1,
             resume_interval => 300
         }
@@ -2499,7 +2504,6 @@ t_recursive_flush(_Config) ->
         #{
             query_mode => async,
             batch_size => 1,
-            batch_time => 10_000,
             worker_pool_size => 1
         }
     ),


### PR DESCRIPTION
Also make sure to reply `emqx_resource:get_instance/1` from cache.

The resource manager may be busy at times, so this change ensures that getting resource instance state will not block. Currently, no users of `emqx_resource:get_instance/1` do seem to be relying on resource state being "as-actual-as-possible" guarantee it was providing.

---

[EMQX-9136](https://emqx.atlassian.net/browse/EMQX-9136)