### PR TITLE
fix(helm-charts): add home volume when container uses readonly filesystem

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
@@ -74,6 +74,10 @@ spec:
         secret:
           secretName: {{ .Values.emqxLicenseSecretName }}
       {{- end }}
+      {{- if and (.Values.containerSecurityContext.enabled) (.Values.containerSecurityContext.readOnlyRootFilesystem) }}
+      - name: emqx-home
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
@@ -138,6 +142,10 @@ spec:
             subPath: "emqx.lic"
             readOnly: true
           {{- end }}
+          {{- if and (.Values.containerSecurityContext.enabled) (.Values.containerSecurityContext.readOnlyRootFilesystem) }}
+          - name: emqx-home
+            mountPath: "/home/emqx"
+          {{- end}}
           readinessProbe:
             httpGet:
               path: /status

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -74,6 +74,10 @@ spec:
         secret:
           secretName: {{ .Values.emqxLicenseSecretName }}
       {{- end }}
+      {{- if and (.Values.containerSecurityContext.enabled) (.Values.containerSecurityContext.readOnlyRootFilesystem) }}
+      - name: emqx-home
+        emptyDir: {}
+      {{- end }}
       {{- if .Values.podSecurityContext.enabled }}
       securityContext: {{- omit .Values.podSecurityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}
@@ -138,6 +142,10 @@ spec:
             subPath: "emqx.lic"
             readOnly: true
           {{- end }}
+          {{- if and (.Values.containerSecurityContext.enabled) (.Values.containerSecurityContext.readOnlyRootFilesystem) }}
+          - name: emqx-home
+            mountPath: "/home/emqx"
+          {{- end}}
           readinessProbe:
             httpGet:
               path: /status


### PR DESCRIPTION
When an EMQX container runs with readonly filesystem, it needs a writable home directory to save the Erlang cookie