### PR TITLE
fix: stop port apps when emqx_machine_terminator shutdown

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_terminator.erl
+++ b/apps/emqx_machine/src/emqx_machine_terminator.erl
@@ -87,7 +87,8 @@ handle_cast(_Cast, State) ->
 
 handle_call(?DO_IT, _From, State) ->
     try
-        emqx_machine_boot:stop_apps()
+        emqx_machine_boot:stop_apps(),
+        emqx_machine_boot:stop_port_apps()
     catch
         C:E:St ->
             Apps = [element(1, A) || A <- application:which_applications()],

--- a/changes/ce/fix-10132.en.md
+++ b/changes/ce/fix-10132.en.md
@@ -1,0 +1,1 @@
+Fix `systemctl stop emqx` command not stopping jq, os_mon application properly, generating some error logs.

--- a/changes/ce/fix-10132.zh.md
+++ b/changes/ce/fix-10132.zh.md
@@ -1,0 +1,1 @@
+修复`systemctl stop emqx` 命令没有正常停止 jq, os_mon 组件，产生一些错误日志。


### PR DESCRIPTION
Fix: `systemctl stop emqx ` don't stop port apps.
```
2023-03-14T02:37:36.935887+00:00 [error] Generic server disksup terminating. Reason: {port_died,normal}. Last message: {'EXIT',#Port<0.7>,normal}. State: [{data,[{"OS",{unix,linux}},{"Timeout",1800000},{"Threshold",80},{"DiskData",[{"/dev",470372,0},{"/run",100004,1},{"/",20464340,24},{"/dev/shm",500000,0},{"/run/lock",5120,0},{"/sys/fs/cgroup",500000,0},{"/run/user/1000",100000,0}]}]}].
2023-03-14T02:37:36.936066+00:00 [error] Generic server memsup terminating. Reason: {port_died,normal}. Last message: {'EXIT',<0.1816.0>,{port_died,normal}}. State: [{data,[{"Timeout",60000}]},{items,{"Memory Usage",[{"Allocated",903290880},{"Total",1024004096}]}},{items,{"Worst Memory User",[{"Pid",<0.1731.0>},{"Memory",5091856}]}}].
2023-03-14T02:37:36.939582+00:00 [error] crasher: initial call: memsup:init/1, pid: <0.1815.0>, registered_name: memsup, exit: {{port_died,normal},[{gen_server,handle_common_reply,8,[{file,"gen_server.erl"},{line,811}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [os_mon_sup,<0.1812.0>], message_queue_len: 0, messages: [], links: [<0.1813.0>], dictionary: [{system_memory_high_watermark,set}], trap_exit: true, status: running, heap_size: 2586, stack_size: 29, reductions: 272495; neighbours:
2023-03-14T02:37:36.947804+00:00 [error] Supervisor: {local,os_mon_sup}. Context: child_terminated. Reason: {port_died,normal}. Offender: id=memsup,pid=<0.1815.0>.
2023-03-14T02:37:36.940614+00:00 [error] crasher: initial call: disksup:init/1, pid: <0.1814.0>, registered_name: disksup, exit: {{port_died,normal},[{gen_server,handle_common_reply,8,[{file,"gen_server.erl"},{line,811}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [os_mon_sup,<0.1812.0>], message_queue_len: 0, messages: [], links: [<0.1813.0>], dictionary: [], trap_exit: true, status: running, heap_size: 6772, stack_size: 29, reductions: 11113; neighbours:
2023-03-14T02:37:36.948367+00:00 [error] Supervisor: {local,os_mon_sup}. Context: child_terminated. Reason: {port_died,normal}. Offender: id=disksup,pid=<0.1814.0>.
2023-03-14T02:37:37.000212+00:00 [error] jq port program has died unexpectedly for reason normal (state = #{id => 0, port =>, #
Port<0.37>, processed_json_calls =>, 0, restart_period =>, 1000000}) , Trying to restart...
```