### PR TITLE
fix: newly created listeners have no limiter restrictions

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.app.src
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.app.src
@@ -2,7 +2,7 @@
 {application, emqx_limiter, [
     {description, "EMQX Hierarchical Limiter"},
     % strict semver, bump manually!
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {modules, []},
     {registered, [emqx_limiter_sup]},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1903,10 +1903,7 @@ base_listener(Bind) ->
                     listener_fields
                 ),
                 #{
-                    desc => ?DESC(base_listener_limiter),
-                    default => #{
-                        <<"connection">> => #{<<"rate">> => <<"1000/s">>, <<"capacity">> => 1000}
-                    }
+                    desc => ?DESC(base_listener_limiter)
                 }
             )},
         {"enable_authn",


### PR DESCRIPTION
Fixes [EMQX-9214](https://emqx.atlassian.net/browse/EMQX-9214)

Newly created listeners have no limiter restrictions
### Reproduction steps.
1. Create a new listener(demo) on the dashboard.
2. Check the listener's limiter connection status as 
```
6> emqx_config:get([listeners,tcp,demo,limiter,connection]).
#{capacity => 1099511627776,initial => 0,rate => infinity}
```
3. The default limiter status is
```
7> emqx_config:get([listeners,tcp,default,limiter,connection]).
#{capacity => 1000,initial => 0,rate => 100.0}
```
4. Restart EMQX, the new listener with the same limiter as the default one.
```
1> emqx_config:get([listeners,tcp,default,limiter,connection]).
#{capacity => 1000,initial => 0,rate => 100.0}
2> emqx_config:get([listeners,tcp,demo,limiter,connection]).
#{capacity => 1000,initial => 0,rate => 100.0}
```

### The cause.
The default value in the schema is overwritten.

So we reset the connection's bucket default value.
make sure  this default value always be 
```
#{capacity => 1000,initial => 0,rate => 100.0}
```
## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
