### PR TITLE
chore(ocsp): hide ocsp from schema for now

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.4"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.14.5"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.37.0"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.37.2"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1285,6 +1285,8 @@ fields("listener_wss_opts") ->
     );
 fields("listener_quic_ssl_opts") ->
     %% Mark unsupported TLS options deprecated.
+    Schema0 = server_ssl_opts_schema(#{}, false),
+    Schema1 = lists:keydelete("ocsp", 1, Schema0),
     lists:map(
         fun({Name, Schema}) ->
             case is_quic_ssl_opts(Name) of
@@ -1294,7 +1296,7 @@ fields("listener_quic_ssl_opts") ->
                     {Name, Schema#{deprecated => {since, "5.0.20"}}}
             end
         end,
-        server_ssl_opts_schema(#{}, false)
+        Schema1
     );
 fields("ssl_client_opts") ->
     client_ssl_opts_schema(#{});
@@ -2258,6 +2260,8 @@ server_ssl_opts_schema(Defaults, IsRanchListener) ->
                         ref("ocsp"),
                         #{
                             required => false,
+                            %% TODO: remove after e5.0.2
+                            hidden => true,
                             validator => fun ocsp_inner_validator/1
                         }
                     )}

--- a/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
@@ -677,15 +677,9 @@ do_t_update_listener(Config) ->
     %% no ocsp at first
     ListenerId = "ssl:default",
     {ok, {{_, 200, _}, _, ListenerData0}} = get_listener_via_api(ListenerId),
-    ?assertMatch(
-        #{
-            <<"ssl_options">> :=
-                #{
-                    <<"ocsp">> :=
-                        #{<<"enable_ocsp_stapling">> := false}
-                }
-        },
-        ListenerData0
+    ?assertEqual(
+        undefined,
+        emqx_map_lib:deep_get([<<"ssl_options">>, <<"ocsp">>], ListenerData0, undefined)
     ),
     assert_no_http_get(),
 

--- a/mix.exs
+++ b/mix.exs
@@ -69,7 +69,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.7", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.37.0", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.37.2", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.2", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -69,7 +69,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.7"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.37.0"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.37.2"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
We're going to release it in a later version.  So, for now, we'll just hide it.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [~] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [~] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [X] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [~] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [~] Change log has been added to `changes/` dir for user-facing artifacts update
