### PR TITLE
chore(mix): fix mix builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,7 @@ $(PROFILES:%=clean-%):
 .PHONY: clean-all
 clean-all:
 	@rm -f rebar.lock
+	@rm -rf deps
 	@rm -rf _build
 
 .PHONY: deps-all

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -59,4 +59,12 @@
     {statistics, true}
 ]}.
 
-{project_plugins, [erlfmt]}.
+{project_plugins, [
+    {erlfmt, [
+        {files, [
+            "{src,include,test}/*.{hrl,erl,app.src}",
+            "rebar.config",
+            "rebar.config.script"
+        ]}
+    ]}
+]}.

--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -27,17 +27,17 @@ Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.
 Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.113"}}}.
 
 Dialyzer = fun(Config) ->
-                   {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),
-                   {plt_extra_apps, OldExtra} = lists:keyfind(plt_extra_apps, 1, OldDialyzerConfig),
-                   Extra = OldExtra ++ [quicer || IsQuicSupp()],
-                   NewDialyzerConfig = [{plt_extra_apps, Extra} | OldDialyzerConfig],
-                   lists:keystore(
-                     dialyzer,
-                     1,
-                     Config,
-                     {dialyzer, NewDialyzerConfig}
-                    )
-           end.
+    {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),
+    {plt_extra_apps, OldExtra} = lists:keyfind(plt_extra_apps, 1, OldDialyzerConfig),
+    Extra = OldExtra ++ [quicer || IsQuicSupp()],
+    NewDialyzerConfig = [{plt_extra_apps, Extra} | OldDialyzerConfig],
+    lists:keystore(
+        dialyzer,
+        1,
+        Config,
+        {dialyzer, NewDialyzerConfig}
+    )
+end.
 
 ExtraDeps = fun(C) ->
     {deps, Deps0} = lists:keyfind(deps, 1, C),

--- a/build
+++ b/build
@@ -147,7 +147,7 @@ make_rel() {
 
 make_elixir_rel() {
   ./scripts/pre-compile.sh "$PROFILE"
-  export_release_vars "$PROFILE"
+  export_elixir_release_vars "$PROFILE"
   # for some reason, this has to be run outside "do"...
   mix local.rebar --if-missing --force
   # shellcheck disable=SC1010
@@ -362,7 +362,7 @@ function join {
 
 # used to control the Elixir Mix Release output
 # see docstring in `mix.exs`
-export_release_vars() {
+export_elixir_release_vars() {
   local profile="$1"
   case "$profile" in
     emqx|emqx-enterprise)
@@ -376,27 +376,6 @@ export_release_vars() {
       exit 1
   esac
   export MIX_ENV="$profile"
-
-  local erl_opts=()
-
-  case "$(is_enterprise "$profile")" in
-    'yes')
-      erl_opts+=( "{d, 'EMQX_RELEASE_EDITION', ee}" )
-      ;;
-    'no')
-      erl_opts+=( "{d, 'EMQX_RELEASE_EDITION', ce}" )
-      ;;
-  esac
-
-  # At this time, Mix provides no easy way to pass `erl_opts' to
-  # dependencies.  The workaround is to set this variable before
-  # compiling the project, so that `emqx_release.erl' picks up
-  # `emqx_vsn' as if it was compiled by rebar3.
-  erl_opts+=( "{compile_info,[{emqx_vsn,\"${PKG_VSN}\"}]}" )
-  erl_opts+=( "{d,snk_kind,msg}" )
-
-  ERL_COMPILER_OPTIONS="[$(join , "${erl_opts[@]}")]"
-  export ERL_COMPILER_OPTIONS
 }
 
 log "building artifact=$ARTIFACT for profile=$PROFILE"


### PR DESCRIPTION
Fixes [EMQX-9223](https://emqx.atlassian.net/browse/EMQX-9223)

The targeted issues were discovered when I tried to experiment with building some Elixir things that used `emqx` as a dependency.

* Make `mix` not fetch (and build) quicer dependencies if it is not enabled.

* Make the project "buildable" with `mix` only. After some updates emqx gradually lost its ability to be built as a "mix project". E.g. we can't simply add it as a mix dependancy for code reuse, like
```
{:emqx_mix, github: "emqx/emqx", env: :emqx, runtime: false}
```
We have to rely only on shell scripts that build the whole distribution artifact to build the code:
```
{:emqx_mix, github: "emqx/emqx", env: :emqx, compile: "make emqx-elixir", runtime: false}
```
This involves many unnecessary steps.

* (chore): try to avoid building erlang terms with shell



## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

~~- [ ] Added tests for the changes~~
~~- [ ] Changed lines covered in coverage report~~
~~- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
~~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger): https://github.com/emqx/emqx/actions/runs/4472206036
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
