### PR TITLE
chore: use zmstone/base16 fork

### DIFF
--- a/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/lib-ce/emqx_dashboard/src/emqx_dashboard.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard,
  [{description, "EMQX Web Dashboard"},
-  {vsn, "4.4.15"}, % strict semver, bump manually!
+  {vsn, "4.4.16"}, % strict semver, bump manually!
   {modules, []},
   {registered, [emqx_dashboard_sup]},
   {applications, [kernel,stdlib,mnesia,minirest]},

--- a/rebar.config
+++ b/rebar.config
@@ -39,6 +39,7 @@
 
 {deps,
     [ {gpb, "4.11.2"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
+    , {base16, {git, "https://github.com/zmstone/base16", {tag, "1.0.0"}}}
     , {redbug, "2.0.7"}
     , {covertool, {git, "https://github.com/zmstone/covertool", {tag, "2.0.4.1"}}}
     , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.4"}}}

--- a/src/emqx.app.src
+++ b/src/emqx.app.src
@@ -6,7 +6,7 @@
   %% the emqx `release' version, which in turn is comprised of several
   %% apps, one of which is this.  See `emqx_release.hrl' for more
   %% info.
-  {vsn, "4.4.16"}, % strict semver, bump manually!
+  {vsn, "4.4.17"}, % strict semver, bump manually!
   {modules, []},
   {registered, []},
   {applications, [ kernel


### PR DESCRIPTION
Use a fork of base16 dependency which has no non-permissive license.
The original repo had test code in non-permissive license which caused some unnecessary concerns.

Absolutely no code change at all.