### PR TITLE
fix(bridge-api): unflatten nodes' bridge lists back

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -71,8 +71,8 @@
 
 -define(BRIDGE_NOT_FOUND(BRIDGE_TYPE, BRIDGE_NAME),
     ?NOT_FOUND(
-        <<"Bridge lookup failed: bridge named '", BRIDGE_NAME/binary, "' of type ",
-            (atom_to_binary(BRIDGE_TYPE))/binary, " does not exist.">>
+        <<"Bridge lookup failed: bridge named '", (BRIDGE_NAME)/binary, "' of type ",
+            (bin(BRIDGE_TYPE))/binary, " does not exist.">>
     )
 ).
 
@@ -507,10 +507,10 @@ schema("/bridges_probe") ->
     case is_ok(NodeReplies) of
         {ok, NodeBridges} ->
             AllBridges = [
-                format_resource(Data, Node)
-             || {Node, Bridges} <- lists:zip(Nodes, NodeBridges), Data <- Bridges
+                [format_resource(Data, Node) || Data <- Bridges]
+             || {Node, Bridges} <- lists:zip(Nodes, NodeBridges)
             ],
-            ?OK(zip_bridges([AllBridges]));
+            ?OK(zip_bridges(AllBridges));
         {error, Reason} ->
             ?INTERNAL_ERROR(Reason)
     end.

--- a/changes/ce/fix-10190.en.md
+++ b/changes/ce/fix-10190.en.md
@@ -1,0 +1,1 @@
+Fix the issue where nodes responses to the list bridges RPC were incorrectly flattened, which caused List Bridges API HTTP handler to crash when there was more than 1 node in the cluster.


### PR DESCRIPTION
Bridge lists were erroneously flattened in cad6492c. This causes bridge listing fail in emqx clusters consisting of more than 1 node.

Fixes [EMQX-9269](https://emqx.atlassian.net/browse/EMQX-9269)

## PR Checklist

Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
