### PR TITLE
fix(bridge-api): unflatten nodes' bridge lists back

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -56,8 +56,8 @@
 
 -define(BRIDGE_NOT_FOUND(BridgeType, BridgeName),
     ?NOT_FOUND(
-        <<"Bridge lookup failed: bridge named '", BridgeName/binary, "' of type ",
-            (atom_to_binary(BridgeType))/binary, " does not exist.">>
+        <<"Bridge lookup failed: bridge named '", (BridgeName)/binary, "' of type ",
+            (bin(BridgeType))/binary, " does not exist.">>
     )
 ).
 
@@ -475,10 +475,10 @@ schema("/bridges_probe") ->
     case is_ok(NodeReplies) of
         {ok, NodeBridges} ->
             AllBridges = [
-                format_resource(Data, Node)
-             || {Node, Bridges} <- lists:zip(Nodes, NodeBridges), Data <- Bridges
+                [format_resource(Data, Node) || Data <- Bridges]
+             || {Node, Bridges} <- lists:zip(Nodes, NodeBridges)
             ],
-            {200, zip_bridges([AllBridges])};
+            {200, zip_bridges(AllBridges)};
         {error, Reason} ->
             {500, error_msg('INTERNAL_ERROR', Reason)}
     end.


### PR DESCRIPTION
Bridge lists were erroneously flattened in https://github.com/emqx/emqx/commit/cad6492c990c4f694878fda8a1b64ed3bc776741. This causes bridge listing fail in emqx clusters consisting of more than 1 node.

Fixes [EMQX-9269](https://emqx.atlassian.net/browse/EMQX-9269)

## PR Checklist

Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible

See also #10190.