### PR TITLE
fix: for connection used ecpool, let worker do health check fun

### DIFF
--- a/apps/emqx_plugin_libs/src/emqx_plugin_libs_pool.erl
+++ b/apps/emqx_plugin_libs/src/emqx_plugin_libs_pool.erl
@@ -67,13 +67,14 @@ stop_pool(Name) ->
 health_check_ecpool_workers(PoolName, CheckFunc) ->
     health_check_ecpool_workers(PoolName, CheckFunc, ?HEALTH_CHECK_TIMEOUT).
 
-health_check_ecpool_workers(PoolName, CheckFunc, Timeout) when is_function(CheckFunc) ->
+health_check_ecpool_workers(PoolName, CheckFunc, Timeout) ->
     Workers = [Worker || {_WorkerName, Worker} <- ecpool:workers(PoolName)],
     DoPerWorker =
         fun(Worker) ->
             case ecpool_worker:client(Worker) of
                 {ok, Conn} ->
-                    erlang:is_process_alive(Conn) andalso CheckFunc(Conn);
+                    erlang:is_process_alive(Conn) andalso
+                        ecpool_worker:exec(Worker, CheckFunc, Timeout);
                 _ ->
                     false
             end

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_dynamo.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_dynamo.erl
@@ -31,8 +31,7 @@
     connect/1,
     do_get_status/1,
     do_async_reply/2,
-    worker_do_query/4,
-    worker_do_get_status/1
+    worker_do_query/4
 ]).
 
 -import(hoconsc, [mk/2, enum/1, ref/2]).
@@ -165,17 +164,13 @@ on_get_status(_InstanceId, #{poolname := Pool}) ->
     Health = emqx_plugin_libs_pool:health_check_ecpool_workers(Pool, fun ?MODULE:do_get_status/1),
     status_result(Health).
 
-do_get_status(Conn) ->
+do_get_status(_Conn) ->
     %% because the dynamodb driver connection process is the ecpool worker self
     %% so we must call the checker function inside the worker
-    ListTables = ecpool_worker:exec(Conn, {?MODULE, worker_do_get_status, []}, infinity),
-    case ListTables of
+    case erlcloud_ddb2:list_tables() of
         {ok, _} -> true;
         _ -> false
     end.
-
-worker_do_get_status(_) ->
-    erlcloud_ddb2:list_tables().
 
 status_result(_Status = true) -> connected;
 status_result(_Status = false) -> connecting.


### PR DESCRIPTION
let it be same with `ecpool:pick_and_do/3` for checkfun use format as {M,F,A}

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] ~Added~ tests for the changes. **the tests will be run in all `connector` SUITEs.**

~- [ ] Changed lines covered in coverage report~
~- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files~
~- [ ] For internal contributor: there is a jira ticket to track this change~
~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
~- [ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

~- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
~- [ ] Change log has been added to `changes/` dir for user-facing artifacts update~
