### PR TITLE
fix(emqx_management): resolve plugin name clashes

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -48,6 +48,9 @@
 
 -define(NAME_RE, "^[A-Za-z]+[A-Za-z0-9-_.]*$").
 -define(TAGS, [<<"Plugins">>]).
+%% Plugin NameVsn must follow the pattern <app_name>-<vsn>,
+%% app_name must be a snake_case (no '-' allowed).
+-define(VSN_WILDCARD, "-*.tar.gz").
 
 namespace() -> "plugins".
 
@@ -334,7 +337,7 @@ upload_install(post, #{body := #{<<"plugin">> := Plugin}}) when is_map(Plugin) -
             case emqx_plugins:parse_name_vsn(FileName) of
                 {ok, AppName, _Vsn} ->
                     AppDir = filename:join(emqx_plugins:install_dir(), AppName),
-                    case filelib:wildcard(AppDir ++ "*.tar.gz") of
+                    case filelib:wildcard(AppDir ++ ?VSN_WILDCARD) of
                         [] ->
                             do_install_package(FileName, Bin);
                         OtherVsn ->

--- a/changes/ce/fix-10225.en.md
+++ b/changes/ce/fix-10225.en.md
@@ -1,0 +1,2 @@
+Allow installing a plugin if its name matches the beginning of another (already installed) plugin name.
+For example: if plugin "emqx_plugin_template_a" is installed, it must not block installing plugin "emqx_plugin_template".


### PR DESCRIPTION
Allow installing a plugin if its name matches the beginning of another (already installed) plugin name. 
For example: if plugin "emqx_plugin_template_a" is installed, it must not block installing plugin "emqx_plugin_template".

Fixes #10213, EMQX-9290

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
