### PR TITLE
docs: delete local-override.conf from config template

### DIFF
--- a/rel/emqx_conf.template.en.md
+++ b/rel/emqx_conf.template.en.md
@@ -4,13 +4,12 @@ and a superset of JSON.
 
 ## Layered
 
-EMQX configuration consists of 3 layers.
+EMQX configuration consists of two layers.
 From bottom up:
 
 1. Immutable base: `emqx.conf` + `EMQX_` prefixed environment variables.<br/>
    Changes in this layer require a full node restart to take effect.
 1. Cluster overrides: `$EMQX_NODE__DATA_DIR/configs/cluster-override.conf`
-1. Local node overrides: `$EMQX_NODE__DATA_DIR/configs/local-override.conf`
 
 When environment variable `$EMQX_NODE__DATA_DIR` is not set, config `node.data_dir`
 is used.

--- a/rel/emqx_conf.template.zh.md
+++ b/rel/emqx_conf.template.zh.md
@@ -3,12 +3,11 @@ HOCON（Human-Optimized Config Object Notation）是一个JSON的超集，非常
 
 ## 分层结构
 
-EMQX的配置文件可分为三层，自底向上依次是：
+EMQX的配置文件可分为二层，自底向上依次是：
 
 1. 不可变的基础层 `emqx.conf` 加上 `EMQX_` 前缀的环境变量。<br/>
    修改这一层的配置之后，需要重启节点来使之生效。
 1. 集群范围重载层：`$EMQX_NODE__DATA_DIR/configs/cluster-override.conf`
-1. 节点本地重载层：`$EMQX_NODE__DATA_DIR/configs/local-override.conf`
 
 如果环境变量 `$EMQX_NODE__DATA_DIR` 没有设置，那么该目录会从 `emqx.conf` 的 `node.data_dir` 配置中读取。
 


### PR DESCRIPTION
The config overriding order is subject to a refactoring.
Here is what going to happen somewhere in v5.0.x or v5.1.0

* There will be a `cluster.hocon` added to data dir, and it will become the bottom of the overlaying order.
* For backward compatibility reasons `cluster-override.conf` will stay (if it exists) but will not be documented.
