### PR TITLE
chore: remove peercert from the state of connection processes

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -276,7 +276,9 @@ init(
     ),
     {NClientInfo, NConnInfo} = take_ws_cookie(ClientInfo, ConnInfo),
     #channel{
-        conninfo = NConnInfo,
+        %% We remove the peercert because it duplicates to what's stored in the socket,
+        %% Saving a copy here causes unnecessary wast of memory (about 1KB per connection).
+        conninfo = maps:put(peercert, undefined, NConnInfo),
         clientinfo = NClientInfo,
         topic_aliases = #{
             inbound => #{},

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -390,4 +390,10 @@ tls_certcn_as_clientid(TLSVsn, RequiredTLSVsn) ->
     {ok, _} = emqtt:connect(Client),
     #{clientinfo := #{clientid := CN}} = emqx_cm:get_chan_info(CN),
     confirm_tls_version(Client, RequiredTLSVsn),
+    %% verify that the peercert won't be stored in the conninfo
+    [ChannPid] = emqx_cm:lookup_channels(CN),
+    SysState = sys:get_state(ChannPid),
+    ChannelRecord = lists:keyfind(channel, 1, tuple_to_list(SysState)),
+    ConnInfo = lists:nth(2, tuple_to_list(ChannelRecord)),
+    ?assertMatch(#{peercert := undefined}, ConnInfo),
     emqtt:disconnect(Client).


### PR DESCRIPTION
Port https://github.com/emqx/emqx/pull/10221 from e4.4

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
