### PR TITLE
fix(rule_engine): count referenced bridges in `from` clauses as dependencies (rv5.0)

### DIFF
--- a/apps/emqx_bridge/include/emqx_bridge_resource.hrl
+++ b/apps/emqx_bridge/include/emqx_bridge_resource.hrl
@@ -1,0 +1,22 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-ifndef(EMQX_BRIDGE_RESOURCE_HRL).
+-define(EMQX_BRIDGE_RESOURCE_HRL, true).
+
+-define(BRIDGE_HOOKPOINT(BridgeId), <<"$bridges/", BridgeId/binary>>).
+
+-endif.

--- a/apps/emqx_bridge/test/emqx_bridge_resource_tests.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_resource_tests.erl
@@ -1,0 +1,33 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_resource_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+bridge_hookpoint_test_() ->
+    BridgeId = emqx_bridge_resource:bridge_id(type, name),
+    BridgeHookpoint = emqx_bridge_resource:bridge_hookpoint(BridgeId),
+    [
+        ?_assertEqual(<<"$bridges/type:name">>, BridgeHookpoint),
+        ?_assertEqual(
+            {ok, BridgeId},
+            emqx_bridge_resource:bridge_hookpoint_to_bridge_id(BridgeHookpoint)
+        ),
+        ?_assertEqual(
+            {error, bad_bridge_hookpoint},
+            emqx_bridge_resource:bridge_hookpoint_to_bridge_id(BridgeId)
+        )
+    ].

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -20,6 +20,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_bridge/include/emqx_bridge_resource.hrl").
 
 -export([
     reload/0,
@@ -1011,7 +1012,7 @@ hook_fun_name(HookPoint) ->
     HookFunName.
 
 %% return static function references to help static code checks
-hook_fun(<<"$bridges/", _/binary>>) -> fun ?MODULE:on_bridge_message_received/2;
+hook_fun(?BRIDGE_HOOKPOINT(_)) -> fun ?MODULE:on_bridge_message_received/2;
 hook_fun('client.connected') -> fun ?MODULE:on_client_connected/3;
 hook_fun('client.disconnected') -> fun ?MODULE:on_client_disconnected/4;
 hook_fun('client.connack') -> fun ?MODULE:on_client_connack/4;
@@ -1034,7 +1035,7 @@ ntoa(undefined) -> undefined;
 ntoa({IpAddr, Port}) -> iolist_to_binary([inet:ntoa(IpAddr), ":", integer_to_list(Port)]);
 ntoa(IpAddr) -> iolist_to_binary(inet:ntoa(IpAddr)).
 
-event_name(<<"$bridges/", _/binary>> = Bridge) -> Bridge;
+event_name(?BRIDGE_HOOKPOINT(_) = Bridge) -> Bridge;
 event_name(<<"$events/client_connected">>) -> 'client.connected';
 event_name(<<"$events/client_disconnected">>) -> 'client.disconnected';
 event_name(<<"$events/client_connack">>) -> 'client.connack';
@@ -1047,7 +1048,7 @@ event_name(<<"$events/message_dropped">>) -> 'message.dropped';
 event_name(<<"$events/delivery_dropped">>) -> 'delivery.dropped';
 event_name(_) -> 'message.publish'.
 
-event_topic(<<"$bridges/", _/binary>> = Bridge) -> Bridge;
+event_topic(?BRIDGE_HOOKPOINT(_) = Bridge) -> Bridge;
 event_topic('client.connected') -> <<"$events/client_connected">>;
 event_topic('client.disconnected') -> <<"$events/client_disconnected">>;
 event_topic('client.connack') -> <<"$events/client_connack">>;

--- a/changes/ce/fix-10251.en.md
+++ b/changes/ce/fix-10251.en.md
@@ -1,0 +1,3 @@
+Consider bridges referenced in `FROM` rule clauses as dependencies.
+
+Before this fix, when one tried to delete an ingress rule referenced in an action like `select * from "$bridges/mqtt:ingress"`, the UI would not trigger a warning about dependent rule actions.


### PR DESCRIPTION
## Note: targetting `release-50`

Fixes https://emqx.atlassian.net/browse/EMQX-9325

Currently, ingress bridges referenced in the `FROM` clause of rules are not being accounted as dependencies.

When we try to delete an ingress bridge that's referenced in a rule like `select * from "$bridges/mqtt:ingress"`, that bridge does not trigger an UI warning about dependent actions.

Fixes <issue-or-jira-number>

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
