### PR TITLE
chore: improve UI error message when using bad conn parameters

### DIFF
--- a/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_consumer.erl
+++ b/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_consumer.erl
@@ -145,6 +145,16 @@ on_start(InstanceId, Config) ->
                 instance_id => InstanceId,
                 kafka_hosts => BootstrapHosts
             });
+        {error, already_present = Reason} ->
+            ?SLOG(error, #{
+                msg => "failed_to_start_kafka_consumer_client",
+                instance_id => InstanceId,
+                kafka_hosts => BootstrapHosts,
+                reason => emqx_misc:redact(Reason)
+            }),
+            throw(
+                "Kafka client failed to start properly.  Please check the connection parameters."
+            );
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "failed_to_start_kafka_consumer_client",

--- a/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_consumer.erl
+++ b/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_consumer.erl
@@ -153,7 +153,7 @@ on_start(InstanceId, Config) ->
                 reason => emqx_misc:redact(Reason)
             }),
             throw(
-                "Kafka client failed to start properly.  Please check the connection parameters."
+                "Failed to start Kafka client. Please check the connection parameters."
             );
         {error, Reason} ->
             ?SLOG(error, #{

--- a/lib-ee/emqx_ee_bridge/test/emqx_bridge_impl_kafka_consumer_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_bridge_impl_kafka_consumer_SUITE.erl
@@ -1635,7 +1635,11 @@ t_bridge_rule_action_source(Config) ->
                 },
                 emqx_json:decode(RawPayload, [return_maps])
             ),
-            ?assertEqual(1, emqx_resource_metrics:received_get(ResourceId)),
+            ?retry(
+                _Sleep0 = 100,
+                _Attempts0 = 50,
+                ?assertEqual(1, emqx_resource_metrics:received_get(ResourceId))
+            ),
             ok
         end
     ),


### PR DESCRIPTION
## Note: targeting `release-50`

Fixes https://emqx.atlassian.net/browse/EMQX-9350

Helps the user by hinting at possibly wrong connection parameters when clicking "Reconnect" for Kafka Consumer.

#### Before change

![2023-03-27_15-19](https://user-images.githubusercontent.com/16166434/228031321-6c0a2f68-426d-46f1-a938-5d62fdec39ef.png)


#### After change

![2023-03-27_15-18](https://user-images.githubusercontent.com/16166434/228031013-de145e49-878b-4bcd-880d-6c185052e644.png)


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [~] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [~] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [~] Change log has been added to `changes/` dir for user-facing artifacts update
