### PR TITLE
fix(kafka_producer): add back `is_buffer_supported` callback

### DIFF
--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_bridge, [
     {description, "EMQX Enterprise data bridges"},
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {registered, [emqx_ee_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_producer.erl
+++ b/lib-ee/emqx_ee_bridge/src/kafka/emqx_bridge_impl_kafka_producer.erl
@@ -7,6 +7,7 @@
 
 %% callbacks of behaviour emqx_resource
 -export([
+    is_buffer_supported/0,
     callback_mode/0,
     on_start/2,
     on_stop/2,
@@ -25,6 +26,8 @@
 %% TODO: rename this to `kafka_producer' after alias support is added
 %% to hocon; keeping this as just `kafka' for backwards compatibility.
 -define(BRIDGE_TYPE, kafka).
+
+is_buffer_supported() -> true.
 
 callback_mode() -> async_if_possible.
 


### PR DESCRIPTION
## Note: targeting `release-50`

Fixes https://emqx.atlassian.net/browse/EMQX-9366

This callback was accidentally removed while adding another feature, which made the buffer workers to be used for this bridge while they shouldn’t be.



## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
