### PR TITLE
feat: add new command for Elixir expression evaluation

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -164,6 +164,9 @@ usage() {
     eval-erl)
         echo "Evaluate an Erlang expression in the EMQX node, even on Elixir node"
         ;;
+    eval-ex)
+        echo "Evaluate an Elixir expression in the EMQX node. Only applies to Elixir node"
+        ;;
     versions)
         echo "List installed EMQX release versions and their status"
         ;;
@@ -228,7 +231,7 @@ usage() {
         echo "  Install Info:     ertspath | root_dir"
         echo "  Runtime Status:   pid | ping"
         echo "  Validate Config:  check_config"
-        echo "  Advanced:         console_clean | escript | rpc | rpcterms | eval | eval-erl"
+        echo "  Advanced:         console_clean | escript | rpc | rpcterms | eval | eval-erl | eval-ex"
         echo ''
         echo "Execute '$REL_NAME COMMAND help' for more information"
     ;;
@@ -1280,7 +1283,27 @@ case "${COMMAND}" in
         shift
         relx_nodetool "eval" "$@"
         ;;
+    eval-ex)
+        assert_node_alive
 
+        shift
+        if [ "$IS_ELIXIR" = "yes" ]
+        then
+          "$REL_DIR/elixir" \
+              --hidden \
+              --name "rand-$(relx_gen_id)-$NAME" \
+              --cookie "$COOKIE" \
+              --boot "$REL_DIR/start_clean" \
+              --boot-var RELEASE_LIB "$ERTS_LIB_DIR" \
+              --vm-args "$REL_DIR/remote.vm.args" \
+              --erl "-start_epmd false -epmd_module ekka_epmd" \
+              --rpc-eval "$NAME" "$@"
+        else
+            echo "EMQX node is not an Elixir node"
+            usage "$COMMAND"
+            exit 1
+        fi
+        ;;
     check_config)
         check_config
         ;;

--- a/changes/ce/feat-10263.en.md
+++ b/changes/ce/feat-10263.en.md
@@ -1,0 +1,1 @@
+Add command 'eval-ex' for Elixir expression evaluation.


### PR DESCRIPTION
Currently, Elixir expressions are evaluated on an EMQX node using the 'eval' command, which works for both Erlang and Elixir expressions. This commit adds the new command 'eval-ex' exclusively for evaluating Elixir expressions on Elixir nodes, similar to 'eval-erl' for Erlang.

Fixes https://emqx.atlassian.net/browse/EMQX-8947

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [X] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [X] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [~] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [~] Change log has been added to `changes/` dir for user-facing artifacts update
