### PR TITLE
fix(tdengine): make password a required field (rv5.0)

### DIFF
--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -16,6 +16,9 @@ services:
       GITHUB_REF: ${GITHUB_REF}
     networks:
       - emqx_bridge
+    ports:
+      - 28083:18083
+      - 2883:1883
     volumes:
       - ../..:/emqx
       - /tmp/emqx-ci/emqx-shared-secret:/var/lib/secret

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_connector, [
     {description, "EMQX Enterprise connectors"},
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_tdengine.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_tdengine.erl
@@ -41,14 +41,16 @@ roots() ->
 fields(config) ->
     [
         {server, server()}
-        | add_default_username(emqx_connector_schema_lib:relational_db_fields())
+        | adjust_fields(emqx_connector_schema_lib:relational_db_fields())
     ].
 
-add_default_username(Fields) ->
+adjust_fields(Fields) ->
     lists:map(
         fun
             ({username, OrigUsernameFn}) ->
                 {username, add_default_fn(OrigUsernameFn, <<"root">>)};
+            ({password, OrigPasswordFn}) ->
+                {password, make_required_fn(OrigPasswordFn)};
             (Field) ->
                 Field
         end,
@@ -58,6 +60,12 @@ add_default_username(Fields) ->
 add_default_fn(OrigFn, Default) ->
     fun
         (default) -> Default;
+        (Field) -> OrigFn(Field)
+    end.
+
+make_required_fn(OrigFn) ->
+    fun
+        (required) -> true;
         (Field) -> OrigFn(Field)
     end.
 


### PR DESCRIPTION
## Note: targeting `release-50`

Fixes https://emqx.atlassian.net/browse/EMQX-9395

```
2023-03-29T09:59:02.655495+00:00 [warning] msg: start_resource_failed, mfa: emqx_resource_manager:start_resource/2, line: 524, id: <<"bridge:tdengine:jimmoen-test-trigger">>, reason: {error,function_clause,[{emqx_ee_connector_tdengine,on_start,[<<"bridge:tdengine:jimmoen-test-trigger:1076">>,#{database => <<"db">>,enable => true,pool_size => 8,resource_opts => #{auto_restart_interval => 60000,batch_size => 1,batch_time => 0,health_check_interval => 15000,max_queue_bytes => 104857600,query_mode => sync,request_timeout => 15000,start_after_created => true,start_timeout => 5000,worker_pool_size => 16},server => "127.0.0.1",sql => <<"insert into mqtt.t_mqtt_msg(ts, msgid, mqtt_topic, qos, payload, arrived) values (${ts}, ${id}, ${topic}, ${qos}, ${payload}, ${timestamp})">>,username => <<"root">>}],[{file,"emqx_ee_connector_tdengine.erl"},{line,76}]},{emqx_resource,call_start,3,[{file,"emqx_resource.erl"},{line,359}]},{emqx_resource_manager,start_resource,2,[{file,"emqx_resource_manager.erl"},{line,513}]},{gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1205}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}
```

![image](https://user-images.githubusercontent.com/16166434/228607704-8b6b88f8-3a5c-4b3b-9aab-5048aac809a5.png)

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
