### PR TITLE
fix: on_get_status clickhouse just reporting connecting

### DIFF
--- a/lib-ee/emqx_ee_connector/i18n/emqx_ee_connector_clickhouse.conf
+++ b/lib-ee/emqx_ee_connector/i18n/emqx_ee_connector_clickhouse.conf
@@ -12,4 +12,15 @@ emqx_ee_connector_clickhouse {
             }
     }
 
+    connect_timeout {
+        desc {
+          en: "The timeout when connecting to the Clickhouse server."
+          zh: "连接HTTP服务器的超时时间。"
+        }
+        label: {
+              en: "Clickhouse Timeout"
+              zh: "连接超时"
+            }
+    }
+
 }

--- a/lib-ee/emqx_ee_connector/rebar.config
+++ b/lib-ee/emqx_ee_connector/rebar.config
@@ -3,7 +3,7 @@
   {hstreamdb_erl, {git, "https://github.com/hstreamdb/hstreamdb_erl.git", {tag, "0.2.5"}}},
   {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.9"}}},
   {tdengine, {git, "https://github.com/emqx/tdengine-client-erl", {tag, "0.1.5"}}},
-  {clickhouse, {git, "https://github.com/emqx/clickhouse-client-erl", {tag, "0.2"}}},
+  {clickhouse, {git, "https://github.com/emqx/clickhouse-client-erl", {tag, "0.3"}}},
   {erlcloud, {git, "https://github.com/emqx/erlcloud.git", {tag,"3.5.16-emqx-1"}}},
   {rocketmq, {git, "https://github.com/emqx/rocketmq-client-erl.git", {tag, "v0.5.1"}}},
   {emqx, {path, "../../apps/emqx"}}

--- a/lib-ee/emqx_ee_connector/test/ee_connector_clickhouse_SUITE.erl
+++ b/lib-ee/emqx_ee_connector/test/ee_connector_clickhouse_SUITE.erl
@@ -190,7 +190,8 @@ clickhouse_config() ->
                         ?CLICKHOUSE_DEFAULT_PORT
                     ]
                 )
-            )
+            ),
+            connect_timeout => 10000
         },
     #{<<"config">> => Config}.
 


### PR DESCRIPTION
The on_get_status callback for clickhouse just returned `connecting` without error information when the status check was unsuccessful. This is fixed by letting the callback return error information similarly to how the HTTP connector does it.

I think the schema changes are backwards compatible. I added a field with a default value so I guess old configs will automatically get the default value as value for the new field?

Fixes:
https://emqx.atlassian.net/browse/EMQX-9374
https://emqx.atlassian.net/browse/EMQX-9278


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [x ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [? ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
