### PR TITLE
docs: make clickhouse config label for Server URL more concise

### DIFF
--- a/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_clickhouse.conf
+++ b/lib-ee/emqx_ee_bridge/i18n/emqx_ee_bridge_clickhouse.conf
@@ -60,7 +60,7 @@ https://clickhouse.com/docs/en/interfaces/formats#formats 了解更多关于
             }
         label {
             en: "Batch Value Separator"
-            zh: "批量值分离器"
+            zh: "分隔符"
         }
     }
     config_enable {

--- a/lib-ee/emqx_ee_connector/i18n/emqx_ee_connector_clickhouse.conf
+++ b/lib-ee/emqx_ee_connector/i18n/emqx_ee_connector_clickhouse.conf
@@ -7,8 +7,8 @@ emqx_ee_connector_clickhouse {
           zh: """你想连接到的Clickhouse服务器的HTTP URL（例如http://myhostname:8123）。"""
         }
         label: {
-              en: "URL to clickhouse server"
-              zh: "到clickhouse服务器的URL"
+              en: "Server URL"
+              zh: "服务器 URL"
             }
     }
 


### PR DESCRIPTION
As the title says. This is just a small documentation change so I don't think a change log entry is needed.