### PR TITLE
fix: handle subscription list api when there are `emqx:subscribe` internal subscriptions

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -177,7 +177,7 @@ format(WhichNode, {{Topic, _Subscriber}, Options}) ->
     maps:merge(
         #{
             topic => get_topic(Topic, Options),
-            clientid => maps:get(subid, Options),
+            clientid => maps:get(subid, Options, null),
             node => WhichNode
         },
         maps:with([qos, nl, rap, rh], Options)

--- a/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
@@ -19,6 +19,7 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 -define(CLIENTID, <<"api_clientid">>).
 -define(USERNAME, <<"api_username">>).
@@ -141,6 +142,18 @@ t_subscription_fuzzy_search(Config) ->
         request_json(get, [{"page", "2"} | LimitMatchQuery], Headers),
     ?assertEqual(#{<<"page">> => 2, <<"limit">> => 3, <<"hasnext">> => false}, MatchMeta2P2),
     ?assertEqual(1, length(maps:get(<<"data">>, MatchData2P2))).
+
+%% checks that we can list when there are subscriptions made by
+%% `emqx:subscribe'.
+t_list_with_internal_subscription(_Config) ->
+    emqx:subscribe(<<"some/topic">>),
+    QS = [],
+    Headers = emqx_mgmt_api_test_util:auth_header_(),
+    ?assertMatch(
+        #{<<"data">> := [#{<<"clientid">> := null}]},
+        request_json(get, QS, Headers)
+    ),
+    ok.
 
 request_json(Method, Query, Headers) when is_list(Query) ->
     Qs = uri_string:compose_query(Query),


### PR DESCRIPTION
Before this fix, if there were any subscriptions made with `emqx:subscribe`, they would break the list subscriptions API as they don't have a clientid.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` and `.zh.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
