### PR TITLE
test: fix flaky influxdb test

### DIFF
--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
@@ -990,9 +990,7 @@ t_write_failure(Config) ->
                     ?assertMatch([_ | _], Trace),
                     [#{result := Result} | _] = Trace,
                     ?assert(
-                        {error, {error, {closed, "The connection was lost."}}} =:= Result orelse
-                            {error, {error, closed}} =:= Result orelse
-                            {error, {recoverable_error, econnrefused}} =:= Result,
+                        not emqx_ee_connector_influxdb:is_unrecoverable_error(Result),
                         #{got => Result}
                     );
                 async ->
@@ -1000,11 +998,7 @@ t_write_failure(Config) ->
                     ?assertMatch([#{action := nack} | _], Trace),
                     [#{result := Result} | _] = Trace,
                     ?assert(
-                        {error, {recoverable_error, {closed, "The connection was lost."}}} =:=
-                            Result orelse
-                            {error, {error, closed}} =:= Result orelse
-                            {error, {recoverable_error, econnrefused}} =:= Result orelse
-                            {error, {recoverable_error, noproc}} =:= Result,
+                        not emqx_ee_connector_influxdb:is_unrecoverable_error(Result),
                         #{got => Result}
                     )
             end,

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_influxdb.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_influxdb.erl
@@ -35,6 +35,9 @@
     desc/1
 ]).
 
+%% only for test
+-export([is_unrecoverable_error/1]).
+
 -type ts_precision() :: ns | us | ms | s.
 
 %% influxdb servers don't need parse
@@ -655,12 +658,6 @@ str(S) when is_list(S) ->
 
 is_unrecoverable_error({error, {unrecoverable_error, _}}) ->
     true;
-is_unrecoverable_error({error, {recoverable_error, _}}) ->
-    false;
-is_unrecoverable_error({error, {error, econnrefused}}) ->
-    false;
-is_unrecoverable_error({error, econnrefused}) ->
-    false;
 is_unrecoverable_error(_) ->
     false.
 


### PR DESCRIPTION
```
2023-03-30T13:15:30.8273178Z "check stage" failed: error
2023-03-30T13:15:30.8273446Z {assert,[{module,emqx_ee_bridge_influxdb_SUITE},
2023-03-30T13:15:30.8273704Z          {line,995},
2023-03-30T13:15:30.8273956Z          {comment,#{got => {error,{recoverable_error,noproc}}}},
2023-03-30T13:15:30.8274426Z          {expression,"{ error , { error , { closed , \"The connection was lost.\" } } } =:= Result orelse { error , { error , closed } } =:= Result orelse { error , { recoverable_error , econnrefused } } =:= Result"},
2023-03-30T13:15:30.8274917Z          {expected,true},
2023-03-30T13:15:30.8275134Z          {value,false}]}
2023-03-30T13:15:30.8275507Z Stacktrace: [{emqx_ee_bridge_influxdb_SUITE,'-t_write_failure/1-fun-4-',2,
2023-03-30T13:15:30.8275791Z                  [{file,
2023-03-30T13:15:30.8276169Z                       "/emqx/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl"},
2023-03-30T13:15:30.8276439Z                   {line,995}]},
2023-03-30T13:15:30.8276697Z              {emqx_ee_bridge_influxdb_SUITE,t_write_failure,1,
2023-03-30T13:15:30.8276939Z                  [{file,
2023-03-30T13:15:30.8277309Z                       "/emqx/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl"},
2023-03-30T13:15:30.8277580Z                   {line,965}]}]
```