### PR TITLE
fix: keep eval command backward compatible with v4

### DIFF
--- a/.ci/docker-compose-file/scripts/run-emqx.sh
+++ b/.ci/docker-compose-file/scripts/run-emqx.sh
@@ -29,7 +29,7 @@ esac
 is_node_up() {
   local node="$1"
   docker exec -i "$node" \
-         bash -c "emqx eval-erl \"['emqx@node1.emqx.io','emqx@node2.emqx.io'] = maps:get(running_nodes, ekka_cluster:info()).\"" > /dev/null 2>&1
+         bash -c "emqx eval \"['emqx@node1.emqx.io','emqx@node2.emqx.io'] = maps:get(running_nodes, ekka_cluster:info()).\"" > /dev/null 2>&1
 }
 
 is_node_listening() {

--- a/bin/emqx
+++ b/bin/emqx
@@ -159,9 +159,6 @@ usage() {
         echo "Print EMQX installation root dir"
         ;;
     eval)
-        echo "Evaluate an Erlang or Elixir expression in the EMQX node"
-        ;;
-    eval-erl)
         echo "Evaluate an Erlang expression in the EMQX node, even on Elixir node"
         ;;
     eval-ex)
@@ -231,7 +228,7 @@ usage() {
         echo "  Install Info:     ertspath | root_dir"
         echo "  Runtime Status:   pid | ping"
         echo "  Validate Config:  check_config"
-        echo "  Advanced:         console_clean | escript | rpc | rpcterms | eval | eval-erl | eval-ex"
+        echo "  Advanced:         console_clean | escript | rpc | rpcterms | eval | eval-ex"
         echo ''
         echo "Execute '$REL_NAME COMMAND help' for more information"
     ;;
@@ -1263,25 +1260,6 @@ case "${COMMAND}" in
         relx_nodetool rpcterms "$@"
         ;;
     eval)
-        assert_node_alive
-
-        shift
-        if [ "$IS_ELIXIR" = "yes" ]
-        then
-          "$REL_DIR/elixir" \
-              --hidden \
-              --name "rand-$(relx_gen_id)-$NAME" \
-              --cookie "$COOKIE" \
-              --boot "$REL_DIR/start_clean" \
-              --boot-var RELEASE_LIB "$ERTS_LIB_DIR" \
-              --vm-args "$REL_DIR/remote.vm.args" \
-              --erl "-start_epmd false -epmd_module ekka_epmd" \
-              --rpc-eval "$NAME" "$@"
-        else
-          relx_nodetool "eval" "$@"
-        fi
-        ;;
-    eval-erl)
         assert_node_alive
 
         shift

--- a/bin/emqx
+++ b/bin/emqx
@@ -159,7 +159,7 @@ usage() {
         echo "Print EMQX installation root dir"
         ;;
     eval)
-        echo "Evaluate an Erlang expression in the EMQX node, even on Elixir node"
+        echo "Evaluate an Erlang expression in the EMQX node."
         ;;
     eval-ex)
         echo "Evaluate an Elixir expression in the EMQX node. Only applies to Elixir node"

--- a/bin/node_dump
+++ b/bin/node_dump
@@ -49,7 +49,7 @@ done
 # Collect system info:
 {
     collect "$RUNNER_BIN_DIR"/emqx_ctl broker
-    collect "$RUNNER_BIN_DIR"/emqx eval-erl "'emqx_node_dump:sys_info()'"
+    collect "$RUNNER_BIN_DIR"/emqx eval "'emqx_node_dump:sys_info()'"
 
     collect uname -a
     collect uptime
@@ -64,7 +64,7 @@ done
 
 # Collect information about the configuration:
 {
-    collect "$RUNNER_BIN_DIR"/emqx eval-erl "'emqx_node_dump:app_env_dump()'"
+    collect "$RUNNER_BIN_DIR"/emqx eval "'emqx_node_dump:app_env_dump()'"
 } > "${CONF_DUMP}"
 
 # Collect license info:

--- a/changes/ce/fix-10297.en.md
+++ b/changes/ce/fix-10297.en.md
@@ -1,0 +1,1 @@
+Keeps `eval` command backward compatible with v4 by evaluating only Erlang expressions, even on Elixir node. For Elixir expressions, use `eval-ex` command.


### PR DESCRIPTION
Keeps "eval" command evaluating only Erlang expressions, even on Elixir node.

Fixes https://emqx.atlassian.net/browse/EMQX-8947

Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~Added tests for the changes~
- [ ] ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [ ] ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- [ ] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [ ] ~Change log has been added to `changes/` dir for user-facing artifacts update~
