### PR TITLE
chore: add copilot markers to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,9 @@
 Fixes <issue-or-jira-number>
 
-Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate.
+<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->
+
+## Summary
+copilot:summary
 
 ## PR Checklist
 Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:


### PR DESCRIPTION
<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary

<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 634d003</samp>

Updated the pull request template to hide the release-50 branch comment and add a summary placeholder. This improves the readability and clarity of the PR descriptions.
