### PR TITLE
fix: running nodes should not include replica nodes

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.14"},
+    {vsn, "0.1.15"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -90,13 +90,13 @@ init_conf() ->
     emqx_app:set_init_config_load_done().
 
 cluster_nodes() ->
-    maps:get(running_nodes, ekka_cluster:info()) -- [node()].
+    mria_mnesia:running_nodes() -- [node()].
 
 copy_override_conf_from_core_node() ->
     case cluster_nodes() of
         %% The first core nodes is self.
         [] ->
-            ?SLOG(debug, #{msg => "skip_copy_overide_conf_from_core_node"}),
+            ?SLOG(debug, #{msg => "skip_copy_override_conf_from_core_node"}),
             {ok, ?DEFAULT_INIT_TXN_ID};
         Nodes ->
             {Results, Failed} = emqx_conf_proto_v2:get_override_config_file(Nodes),
@@ -130,7 +130,7 @@ copy_override_conf_from_core_node() ->
                             %% finish the boot sequence and load the
                             %% config for other nodes to copy it.
                             ?SLOG(info, #{
-                                msg => "skip_copy_overide_conf_from_core_node",
+                                msg => "skip_copy_override_conf_from_core_node",
                                 loading_from_disk => true,
                                 nodes => Nodes,
                                 failed => Failed,
@@ -142,7 +142,7 @@ copy_override_conf_from_core_node() ->
                             Jitter = rand:uniform(2_000),
                             Timeout = 10_000 + Jitter,
                             ?SLOG(info, #{
-                                msg => "copy_overide_conf_from_core_node_retry",
+                                msg => "copy_override_conf_from_core_node_retry",
                                 timeout => Timeout,
                                 nodes => Nodes,
                                 failed => Failed,
@@ -155,7 +155,7 @@ copy_override_conf_from_core_node() ->
                     [{ok, Info} | _] = lists:sort(fun conf_sort/2, Ready),
                     #{node := Node, conf := RawOverrideConf, tnx_id := TnxId} = Info,
                     ?SLOG(debug, #{
-                        msg => "copy_overide_conf_from_core_node_success",
+                        msg => "copy_override_conf_from_core_node_success",
                         node => Node,
                         cluster_override_conf_file => application:get_env(
                             emqx, cluster_override_conf_file

--- a/changes/ce/fix-10313.en.md
+++ b/changes/ce/fix-10313.en.md
@@ -1,0 +1,2 @@
+Ensure that when the core or replicant node starting, the `cluster-override.conf` file is only copied from the core node.
+Previously, when sorting nodes by startup time, the core node may have copied this file from the replicant node.

--- a/changes/ce/fix-10313.zh.md
+++ b/changes/ce/fix-10313.zh.md
@@ -1,0 +1,2 @@
+确保当 core 或 replicant 节点启动时，仅从 core 节点复制 `cluster-override.conf` 文件。
+此前按照节点启动时间排序时，core 节点可能从 replicant 节点复制该文件。


### PR DESCRIPTION
Fixes [EMQX-9413](https://emqx.atlassian.net/browse/EMQX-9413)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 53712e6</samp>

Fixed a cluster configuration issue and updated the emqx_conf application and change logs. The fix uses `mria_mnesia:running_nodes` to get cluster nodes and prevents copying `cluster-override.conf` from a replica node.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
