### PR TITLE
EMQX 8945 crash for bad param value to mqtt delayed messages api call

### DIFF
--- a/apps/emqx_modules/src/emqx_delayed_api.erl
+++ b/apps/emqx_modules/src/emqx_delayed_api.erl
@@ -52,7 +52,7 @@
 -define(INVALID_NODE, 'INVALID_NODE').
 
 api_spec() ->
-    emqx_dashboard_swagger:spec(?MODULE).
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
     [

--- a/apps/emqx_modules/src/emqx_delayed_api.erl
+++ b/apps/emqx_modules/src/emqx_delayed_api.erl
@@ -202,9 +202,9 @@ delayed_message(get, #{bindings := #{node := NodeBin, msgid := HexId}}) ->
                             {200, Message#{payload => base64:encode(Payload)}}
                     end;
                 {error, not_found} ->
-                    {404, generate_http_code_map(not_found, Id)};
+                    {404, generate_http_code_map(not_found, HexId)};
                 {badrpc, _} ->
-                    {400, generate_http_code_map(invalid_node, Id)}
+                    {400, generate_http_code_map(invalid_node, NodeBin)}
             end
         end
     );
@@ -271,19 +271,19 @@ generate_http_code_map(id_schema_error, Id) ->
     #{
         code => ?MESSAGE_ID_SCHEMA_ERROR,
         message =>
-            iolist_to_binary(io_lib:format("Message ID ~p schema error", [Id]))
+            iolist_to_binary(io_lib:format("Message ID ~s schema error", [Id]))
     };
 generate_http_code_map(not_found, Id) ->
     #{
         code => ?MESSAGE_ID_NOT_FOUND,
         message =>
-            iolist_to_binary(io_lib:format("Message ID ~p not found", [Id]))
+            iolist_to_binary(io_lib:format("Message ID ~s not found", [Id]))
     };
 generate_http_code_map(invalid_node, Node) ->
     #{
         code => ?INVALID_NODE,
         message =>
-            iolist_to_binary(io_lib:format("The node name ~p is invalid", [Node]))
+            iolist_to_binary(io_lib:format("The node name ~s is invalid", [Node]))
     }.
 
 make_maybe(X, Error, Fun) ->

--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.11"},
+    {vsn, "5.0.12"},
     {modules, []},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},
     {mod, {emqx_modules_app, []}},

--- a/changes/ce/fix-10315.en.md
+++ b/changes/ce/fix-10315.en.md
@@ -1,0 +1,1 @@
+Fix crash checking `limit` and `page` parameters in `/mqtt/delayed/messages` API call.


### PR DESCRIPTION
Fixes [EMQX-8945](https://emqx.atlassian.net/browse/EMQX-8945)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0efa9c7</samp>

This pull request enhances the `emqx_delayed_api` module with better validation, error handling, and consistency. It also bumps the version of the `emqx_modules` application to 5.0.12.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [-] Added tests for the changes
- [-] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [-] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [-] Schema changes are backward compatible

