### PR TITLE
fix(CI): remote .jtl files before every jemeter run

### DIFF
--- a/.github/workflows/run_automate_tests.yaml
+++ b/.github/workflows/run_automate_tests.yaml
@@ -6,7 +6,8 @@ on:
       - "v4.*"
   pull_request:
     branches:
-      - "main-v4.*"
+      - 'main-v4**'
+      - 'release-v4**'
 
 jobs:
   build:
@@ -132,16 +133,21 @@ jobs:
         ln -s /tmp/apache-jmeter-$JMETER_VERSION /opt/jmeter
     - name: run jmeter
       run: |
+        JTL_FILE="jmeter_logs/webhook_${{ matrix.webhook_type }}.jtl"
+        if [ -e "$JTL_FILE" ]
+        then
+          echo > $JTL_FILE
+        fi
         /opt/jmeter/bin/jmeter.sh \
           -Jjmeter.save.saveservice.output_format=xml -n \
           -t scripts/automate-test-suite/${{ matrix.webhook_type }}.jmx \
           -Demqx_ip=$HAPROXY_IP \
           -Dweb_ip=$WEB_IP \
-          -l jmeter_logs/webhook_${{ matrix.webhook_type }}.jtl \
+          -l $JTL_FILE \
           -j jmeter_logs/logs/webhook_${{ matrix.webhook_type }}.log
     - name: check logs
       run: |
-        if cat jmeter_logs/webhook_${{ matrix.webhook_type }}.jtl | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
+        if cat $JTL_FILE | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
           echo "check logs filed"
           exit 1
         fi
@@ -228,6 +234,11 @@ jobs:
         wget --no-verbose -O "/opt/jmeter/lib/mysql-connector-java-8.0.16.jar" https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar
     - name: run jmeter
       run: |
+        JTL_FILE="jmeter_logs/${{ matrix.mysql_type }}_${{ matrix.mysql_tag }}.jtl"
+        if [ -e "$JTL_FILE" ]
+        then
+          echo > $JTL_FILE
+        fi
         /opt/jmeter/bin/jmeter.sh \
           -Jjmeter.save.saveservice.output_format=xml -n \
           -t scripts/automate-test-suite/${{ matrix.mysql_type }}.jmx \
@@ -240,11 +251,11 @@ jobs:
           -Dmysql_pwd="public" \
           -Dconfig_path="/tmp/etc" \
           -Ddocker_path=".ci/docker-compose-file" \
-          -l jmeter_logs/${{ matrix.mysql_type }}_${{ matrix.mysql_tag }}.jtl \
+          -l $JTL_FILE \
           -j jmeter_logs/logs/${{ matrix.mysql_type }}_${{ matrix.mysql_tag }}.log
     - name: check logs
       run: |
-        if cat jmeter_logs/${{ matrix.mysql_type }}_${{ matrix.mysql_tag }}.jtl | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
+        if cat $JTL_FILE | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
           echo "check logs filed"
           exit 1
         fi
@@ -332,6 +343,11 @@ jobs:
         wget --no-verbose -O "/opt/jmeter/lib/postgresql-42.2.18.jar" https://repo1.maven.org/maven2/org/postgresql/postgresql/42.2.18/postgresql-42.2.18.jar
     - name: run jmeter
       run: |
+        JTL_FILE="jmeter_logs/${{ matrix.pgsql_type }}_${{ matrix.pgsql_tag }}.jtl"
+        if [ -e "$JTL_FILE" ]
+        then
+          echo > $JTL_FILE
+        fi
         sudo /opt/jmeter/bin/jmeter.sh \
           -Jjmeter.save.saveservice.output_format=xml -n \
           -t scripts/automate-test-suite/${{ matrix.pgsql_type }}.jmx \
@@ -349,11 +365,11 @@ jobs:
           -Dport="5432" \
           -Dconfig_path=$CONFIG_PATH \
           -Ddocker_path=".ci/docker-compose-file" \
-          -l jmeter_logs/${{ matrix.pgsql_type }}_${{ matrix.pgsql_tag }}.jtl \
+          -l $JTL_FILE \
           -j jmeter_logs/logs/${{ matrix.pgsql_type }}_${{ matrix.pgsql_tag }}.log
     - name: check logs
       run: |
-        if cat jmeter_logs/${{ matrix.pgsql_type }}_${{ matrix.pgsql_tag }}.jtl | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
+        if cat $JTL_FILE | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
           echo "check logs filed"
           exit 1
         fi
@@ -430,6 +446,11 @@ jobs:
         wget --no-verbose -O "/opt/jmeter/lib/mysql-connector-java-8.0.16.jar" https://repo1.maven.org/maven2/mysql/mysql-connector-java/8.0.16/mysql-connector-java-8.0.16.jar
     - name: run jmeter
       run: |
+        JTL_FILE="jmeter_logs/http_auth_acl.jtl"
+        if [ -e "$JTL_FILE" ]
+        then
+          echo > $JTL_FILE
+        fi
         sudo /opt/jmeter/bin/jmeter.sh \
           -Jjmeter.save.saveservice.output_format=xml -n \
           -t scripts/automate-test-suite/http_auth_acl.jmx \
@@ -438,11 +459,11 @@ jobs:
           -Dweb_server_ip=$HTTP_IP \
           -Dconfig_path=$CONFIG_PATH \
           -Ddocker_path=".ci/docker-compose-file" \
-          -l jmeter_logs/http_auth_acl.jtl \
+          -l $JTL_FILE \
           -j jmeter_logs/logs/http_auth_acl.log
     - name: check logs
       run: |
-        if cat jmeter_logs/http_auth_acl.jtl | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
+        if cat $JTL_FILE | grep -e '<failure>true</failure>' > /dev/null 2>&1; then
           echo "check logs filed"
           sudo cat /var/lib/docker/volumes/docker-compose-file_etc/_data/emqx.conf
           exit 1


### PR DESCRIPTION
Fixes jmeter CI

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 72002e8</samp>

Refactor JMeter log file name in `.github/workflows/run_automate_tests.yaml`. Use a variable `JTL_FILE` to dynamically assign the log file name based on the webhook type. Improve code readability and avoid potential conflicts.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
