### PR TITLE
fix: create consistent interface 'with_node' for API access

### DIFF
--- a/apps/emqx/include/emqx_api_lib.hrl
+++ b/apps/emqx/include/emqx_api_lib.hrl
@@ -1,0 +1,36 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-ifndef(EMQX_API_LIB_HRL).
+-define(EMQX_API_LIB_HRL, true).
+
+-define(ERROR_MSG(CODE, REASON), #{code => CODE, message => emqx_misc:readable_error_msg(REASON)}).
+
+-define(OK(CONTENT), {200, CONTENT}).
+
+-define(NO_CONTENT, 204).
+
+-define(BAD_REQUEST(CODE, REASON), {400, ?ERROR_MSG(CODE, REASON)}).
+-define(BAD_REQUEST(REASON), ?BAD_REQUEST('BAD_REQUEST', REASON)).
+
+-define(NOT_FOUND(REASON), {404, ?ERROR_MSG('NOT_FOUND', REASON)}).
+
+-define(INTERNAL_ERROR(REASON), {500, ?ERROR_MSG('INTERNAL_ERROR', REASON)}).
+
+-define(NOT_IMPLEMENTED, 501).
+
+-define(SERVICE_UNAVAILABLE(REASON), {503, ?ERROR_MSG('SERVICE_UNAVAILABLE', REASON)}).
+-endif.

--- a/apps/emqx/src/emqx_api_lib.erl
+++ b/apps/emqx/src/emqx_api_lib.erl
@@ -1,0 +1,69 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_api_lib).
+
+-export([
+    with_node/2,
+    with_node_or_cluster/2
+]).
+
+-include("emqx_api_lib.hrl").
+
+-define(NODE_NOT_FOUND(NODE), ?NOT_FOUND(<<"Node not found: ", NODE/binary>>)).
+
+%%--------------------------------------------------------------------
+%% exported API
+%%--------------------------------------------------------------------
+-spec with_node(binary(), fun((atom()) -> {ok, term()} | {error, term()})) ->
+    ?OK(term()) | ?NOT_FOUND(binary()) | ?BAD_REQUEST(term()).
+with_node(BinNode, Fun) ->
+    case lookup_node(BinNode) of
+        {ok, Node} ->
+            handle_result(Fun(Node));
+        not_found ->
+            ?NODE_NOT_FOUND(BinNode)
+    end.
+
+-spec with_node_or_cluster(binary(), fun((atom()) -> {ok, term()} | {error, term()})) ->
+    ?OK(term()) | ?NOT_FOUND(iolist()) | ?BAD_REQUEST(term()).
+with_node_or_cluster(<<"all">>, Fun) ->
+    handle_result(Fun(all));
+with_node_or_cluster(Node, Fun) ->
+    with_node(Node, Fun).
+
+%%--------------------------------------------------------------------
+%% Internal
+%%--------------------------------------------------------------------
+
+-spec lookup_node(binary()) -> {ok, atom()} | not_found.
+lookup_node(BinNode) ->
+    case emqx_misc:safe_to_existing_atom(BinNode, utf8) of
+        {ok, Node} ->
+            case lists:member(Node, mria:running_nodes()) of
+                true ->
+                    {ok, Node};
+                false ->
+                    not_found
+            end;
+        _Error ->
+            not_found
+    end.
+
+handle_result({ok, Result}) ->
+    ?OK(Result);
+handle_result({error, Reason}) ->
+    ?BAD_REQUEST(Reason).

--- a/apps/emqx/test/emqx_api_lib_SUITE.erl
+++ b/apps/emqx/test/emqx_api_lib_SUITE.erl
@@ -1,0 +1,101 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_api_lib_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include("emqx_api_lib.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+-define(DUMMY, dummy_module).
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    emqx_common_test_helpers:boot_modules(all),
+    emqx_common_test_helpers:start_apps([]),
+    Config.
+
+end_per_suite(_Config) ->
+    emqx_common_test_helpers:stop_apps([]).
+
+init_per_testcase(_Case, Config) ->
+    meck:new(?DUMMY, [non_strict]),
+    meck:expect(?DUMMY, expect_not_called, 1, fun(Node) -> throw({blow_this_up, Node}) end),
+    meck:expect(?DUMMY, expect_success, 1, {ok, success}),
+    meck:expect(?DUMMY, expect_error, 1, {error, error}),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    meck:unload(?DUMMY).
+
+t_with_node(_) ->
+    test_with(fun emqx_api_lib:with_node/2, [<<"all">>]).
+
+t_with_node_or_cluster(_) ->
+    test_with(fun emqx_api_lib:with_node_or_cluster/2, []),
+    meck:reset(?DUMMY),
+    ?assertEqual(
+        ?OK(success),
+        emqx_api_lib:with_node_or_cluster(
+            <<"all">>,
+            fun ?DUMMY:expect_success/1
+        )
+    ),
+    ?assertMatch([{_, {?DUMMY, expect_success, [all]}, {ok, success}}], meck:history(?DUMMY)).
+
+%% helpers
+test_with(TestFun, ExtraBadNodes) ->
+    % make sure this is an atom
+    'unknownnode@unknownnohost',
+    BadNodes =
+        [
+            <<"undefined">>,
+            <<"this_should_not_be_an_atom">>,
+            <<"unknownnode@unknownnohost">>
+        ] ++ ExtraBadNodes,
+    [ensure_not_found(TestFun(N, fun ?DUMMY:expect_not_called/1)) || N <- BadNodes],
+    ensure_not_called(?DUMMY, expect_not_called),
+    ensure_not_existing_atom(<<"this_should_not_be_an_atom">>),
+
+    GoodNode = node(),
+
+    ?assertEqual(
+        ?OK(success),
+        TestFun(GoodNode, fun ?DUMMY:expect_success/1)
+    ),
+
+    ?assertEqual(
+        ?BAD_REQUEST(error),
+        TestFun(GoodNode, fun ?DUMMY:expect_error/1)
+    ),
+    ok.
+
+ensure_not_found(Result) ->
+    ?assertMatch({404, _}, Result).
+
+ensure_not_called(Mod, Fun) ->
+    ?assert(not meck:called(Mod, Fun, '_')).
+
+ensure_not_existing_atom(Bin) ->
+    try binary_to_existing_atom(Bin) of
+        _ -> throw(is_atom)
+    catch
+        error:badarg ->
+            ok
+    end.

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -20,6 +20,7 @@
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_api_lib.hrl").
 -include_lib("emqx_bridge/include/emqx_bridge.hrl").
 
 -import(hoconsc, [mk/2, array/1, enum/1]).
@@ -46,13 +47,9 @@
 
 -export([lookup_from_local_node/2]).
 
--define(BAD_REQUEST(Reason), {400, error_msg('BAD_REQUEST', Reason)}).
-
 -define(BRIDGE_NOT_ENABLED,
     ?BAD_REQUEST(<<"Forbidden operation, bridge not enabled">>)
 ).
-
--define(NOT_FOUND(Reason), {404, error_msg('NOT_FOUND', Reason)}).
 
 -define(BRIDGE_NOT_FOUND(BridgeType, BridgeName),
     ?NOT_FOUND(

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.15"},
+    {vsn, "5.0.16"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [kernel, stdlib, mnesia, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.0.16"},
+    {vsn, "5.0.17"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [kernel, stdlib, emqx_plugins, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -68,7 +68,7 @@ t_nodes_api(_) ->
 
     BadNodePath = emqx_mgmt_api_test_util:api_path(["nodes", "badnode"]),
     ?assertMatch(
-        {error, {_, 400, _}},
+        {error, {_, 404, _}},
         emqx_mgmt_api_test_util:request_api(get, BadNodePath)
     ).
 
@@ -94,7 +94,7 @@ t_node_stats_api(_) ->
 
     BadNodePath = emqx_mgmt_api_test_util:api_path(["nodes", "badnode", "stats"]),
     ?assertMatch(
-        {error, {_, 400, _}},
+        {error, {_, 404, _}},
         emqx_mgmt_api_test_util:request_api(get, BadNodePath)
     ).
 
@@ -112,7 +112,7 @@ t_node_metrics_api(_) ->
 
     BadNodePath = emqx_mgmt_api_test_util:api_path(["nodes", "badnode", "metrics"]),
     ?assertMatch(
-        {error, {_, 400, _}},
+        {error, {_, 404, _}},
         emqx_mgmt_api_test_util:request_api(get, BadNodePath)
     ).
 

--- a/changes/ce/fix-10237.en.md
+++ b/changes/ce/fix-10237.en.md
@@ -1,0 +1,1 @@
+Ensure we return `404` status code for unknown node names in `/nodes/:node[/metrics|/stats]` API.


### PR DESCRIPTION
This is just a copy of https://github.com/emqx/emqx/pull/10237 but targets release-50 instead of master to be included in the next release.
