### PR TITLE
0404 block cluster prc util boot is done

### DIFF
--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -283,9 +283,6 @@ init([Node, RetryMs]) ->
 
 %% @private
 handle_continue(?CATCH_UP, State) ->
-    %% emqx app must be started before
-    %% trying to catch up the rpc commit logs
-    ok = wait_for_emqx_ready(),
     {noreply, State, catch_up(State)}.
 
 handle_call(reset, _From, State) ->
@@ -572,37 +569,3 @@ maybe_init_tnx_id(_Node, TnxId) when TnxId < 0 -> ok;
 maybe_init_tnx_id(Node, TnxId) ->
     {atomic, _} = transaction(fun ?MODULE:commit/2, [Node, TnxId]),
     ok.
-
-%% @priv Cannot proceed until emqx app is ready.
-%% Otherwise the committed transaction catch up may fail.
-wait_for_emqx_ready() ->
-    %% wait 10 seconds for emqx to start
-    ok = do_wait_for_emqx_ready(10).
-
-%% Wait for emqx app to be ready,
-%% write a log message every 1 second
-do_wait_for_emqx_ready(0) ->
-    timeout;
-do_wait_for_emqx_ready(N) ->
-    %% check interval is 100ms
-    %% makes the total wait time 1 second
-    case do_wait_for_emqx_ready2(10) of
-        ok ->
-            ok;
-        timeout ->
-            ?SLOG(warning, #{msg => "stil_waiting_for_emqx_app_to_be_ready"}),
-            do_wait_for_emqx_ready(N - 1)
-    end.
-
-%% Wait for emqx app to be ready,
-%% check interval is 100ms
-do_wait_for_emqx_ready2(0) ->
-    timeout;
-do_wait_for_emqx_ready2(N) ->
-    case emqx:is_running() of
-        true ->
-            ok;
-        false ->
-            timer:sleep(100),
-            do_wait_for_emqx_ready2(N - 1)
-    end.

--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -39,6 +39,8 @@ post_boot() ->
     ok = ensure_apps_started(),
     ok = print_vsn(),
     ok = start_autocluster(),
+    %% start conf syncer after boot
+    ok = emqx_conf_sup:start_syncer(),
     ignore.
 
 -ifdef(TEST).


### PR DESCRIPTION
Currently the cluster config syncer (which subscribes to config change commit logs and replays the MFAs) is started earlier than other apps (as a part of emqx_conf app's supervision tree).
When it takes long time for some apps to start, the chance of a race increases:
config changes arrived before the apps are ready hence config changes may fail to apply locally.

The failed actions are retried though.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 420fb85</samp>

This pull request moves the cluster configuration syncer's init from the `emqx_conf` app to the `emqx_machine` app, and starts it after the boot process is completed. 
This avoids the config change catch-up applied too soon (before the dependent processes are ready), e.g. the config handler process and the resource manager processes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
