### PR TITLE
fix: systemctl stop don't stop port in the desired order

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_terminator.erl
+++ b/apps/emqx_machine/src/emqx_machine_terminator.erl
@@ -41,7 +41,7 @@
 -define(DO_IT, graceful_shutdown).
 
 %% @doc This API is called to shutdown the Erlang VM by RPC call from remote shell node.
-%% The shutown of apps is delegated to a to a process instead of doing it in the RPC spawned
+%% The shutdown of apps is delegated to a to a process instead of doing it in the RPC spawned
 %% process which has a remote group leader.
 start_link() ->
     {ok, _} = gen_server:start_link({local, ?TERMINATOR}, ?MODULE, [], []).
@@ -87,8 +87,9 @@ handle_cast(_Cast, State) ->
 
 handle_call(?DO_IT, _From, State) ->
     try
-        emqx_machine_boot:stop_apps(),
-        emqx_machine_boot:stop_port_apps()
+        %% stop port apps before stopping other apps.
+        emqx_machine_boot:stop_port_apps(),
+        emqx_machine_boot:stop_apps()
     catch
         C:E:St ->
             Apps = [element(1, A) || A <- application:which_applications()],

--- a/deploy/packages/emqx.service
+++ b/deploy/packages/emqx.service
@@ -22,8 +22,10 @@ LimitNOFILE=1048576
 
 # ExecStop is commented out so systemd will send a SIGTERM when 'systemctl stop'.
 # SIGTERM is handled by EMQX and it then performs a graceful shutdown
-# It's better than command 'emqx stop' because it needs to ping the node
-# ExecStop=/bin/bash /usr/bin/emqx stop
+# emqx stop will ping node, always return 0 to make sure next command will be executed
+ExecStop=/bin/bash -c '/usr/bin/emqx stop; exit 0'
+# If the process is still running, force kill it
+ExecStop=/bin/sh -c 'if [ ps -p $MAINPID >/dev/null 2>&1 ]; then /bin/kill -15 $MAINPID; fi'
 
 # Wait long enough before force kill for graceful shutdown
 TimeoutStopSec=120s

--- a/deploy/packages/emqx.service
+++ b/deploy/packages/emqx.service
@@ -25,7 +25,7 @@ LimitNOFILE=1048576
 # emqx stop will ping node, always return 0 to make sure next command will be executed
 ExecStop=/bin/bash -c '/usr/bin/emqx stop; exit 0'
 # If the process is still running, force kill it
-ExecStop=/bin/sh -c 'if [ ps -p $MAINPID >/dev/null 2>&1 ]; then /bin/kill -15 $MAINPID; fi'
+ExecStop=/bin/bash -c 'if [ ps -p $MAINPID >/dev/null 2>&1 ]; then kill -15 $MAINPID; fi'
 
 # Wait long enough before force kill for graceful shutdown
 TimeoutStopSec=120s


### PR DESCRIPTION
Fixes [EMQX-9393](https://emqx.atlassian.net/browse/EMQX-9393)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->
```
2023-03-29T16:43:25.915761+08:00 [error] Generic server memsup terminating. Reason: {port_died,normal}. Last message: {'EXIT',<0.2117.0>,{port_died,normal}}. State: [{data,[{"Timeout",60000}]},{items,{"Memory Usage",[{"Allocated",929959936},{"Total",3832242176}]}},{items,{"Worst Memory User",[{"Pid",<0.2031.0>},{"Memory",4720472}]}}].
2023-03-29T16:43:25.924764+08:00 [error] crasher: initial call: memsup:init/1, pid: <0.2116.0>, registered_name: memsup, exit: {{port_died,normal},[{gen_server,handle_common_reply,8,[{file,"gen_server.erl"},{line,811}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,226}]}]}, ancestors: [os_mon_sup,<0.2114.0>], message_queue_len: 0, messages: [], links: [<0.2115.0>], dictionary: [], trap_exit: true, status: running, heap_size: 4185, stack_size: 29, reductions: 187637; neighbours:
2023-03-29T16:43:25.924979+08:00 [error] Supervisor: {local,os_mon_sup}. Context: child_terminated. Reason: {port_died,normal}. Offender: id=memsup,pid=<0.2116.0>.
```
### Before: 
if we don't provide `ExecStop` in emqx.service, systemd will automatically send a kill signal to all processes in the emqx cgroup, including the ports, which will be killed by systemd. This is why the crash log was printed. This PR attempts to first call "emqx stop" to try to shut down normally. If the shutdown is not successful, then a sigterm signal will be sent to force a shutdown.
```
[ ~]# systemctl status emqx
● emqx.service - emqx daemon
     Loaded: loaded (/usr/lib/systemd/system/emqx.service; enabled; vendor preset: disabled)
     Active: active (running) since Thu 2023-04-06 16:17:56 CST; 15s ago
   Main PID: 19893 (beam.smp)
      Tasks: 32 (limit: 23156)
     Memory: 212.6M
        CPU: 5.837s
     CGroup: /system.slice/emqx.service
             ├─19893 emqx -Bd -spp true -A 4 -IOt 4 -SDio 8 -e 262144 -zdbbl 8192 -Q 1048576 -P 2097152 -- -root /usr/lib/emqx -progname /usr/bin/emqx -- -home /var/lib/emq>
             ├─20163 erl_child_setup 1048576
             ├─20187 /usr/lib/emqx/lib/os_mon-2.7.1/priv/bin/memsup
             └─20188 /usr/lib/emqx/lib/os_mon-2.7.1/priv/bin/cpu_sup
```
We can see 20163/20187/20188 port is in emqx's CGroup, if we don't provide `ExecStop` in emqx.service, systemd will kill them at the same time.

### After 
```
[~]# time systemctl status emqx
○ emqx.service - emqx daemon
     Loaded: loaded (/usr/lib/systemd/system/emqx.service; enabled; vendor preset: disabled)
     Active: inactive (dead) since Thu 2023-04-06 16:40:33 CST; 10s ago
   Duration: 22min 33.530s
    Process: 19893 ExecStart=/bin/bash /usr/bin/emqx foreground (code=exited, status=0/SUCCESS)
    Process: 20195 ExecStop=/bin/bash -c /usr/bin/emqx stop; exit 0 (code=exited, status=0/SUCCESS)
    Process: 20331 ExecStop=/bin/sh -c C=0; while [ $C -lt 10 ] && [ ps -p $MAIN_PID >/dev/null 2>&1 ]; do sleep 1; C=$(($C+1)); done (code=exited, status=0/SUCCESS)
    Process: 20332 ExecStop=/bin/sh -c if [ ps -p $MAINPID >/dev/null 2>&1 ]; then /bin/kill -15 $MAINPID; fi (code=exited, status=0/SUCCESS)
   Main PID: 19893 (code=exited, status=0/SUCCESS)
        CPU: 11.088s

Apr 06 16:40:31 emqx-os-compatible-testing bash[19893]: Stop listener http:dashboard on :18083 successfully.
Apr 06 16:40:31 emqx-os-compatible-testing bash[19893]: Listener ssl:default on 0.0.0.0:8883 stopped.
Apr 06 16:40:31 emqx-os-compatible-testing bash[19893]: Listener tcp:default on 0.0.0.0:1883 stopped.
Apr 06 16:40:31 emqx-os-compatible-testing bash[19893]: Listener ws:default on 0.0.0.0:8083 stopped.
Apr 06 16:40:31 emqx-os-compatible-testing bash[19893]: Listener wss:default on 0.0.0.0:8084 stopped.
Apr 06 16:40:33 emqx-os-compatible-testing emqx[20330]: STOP: OK
Apr 06 16:40:33 emqx-os-compatible-testing systemd[1]: emqx.service: Deactivated successfully.
Apr 06 16:40:33 emqx-os-compatible-testing systemd[1]: Stopped emqx daemon.
Apr 06 16:40:33 emqx-os-compatible-testing systemd[1]: emqx.service: Consumed 11.088s CPU time.

real	0m2.008s
user	0m0.004s
sys	0m0.003s
```

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2a8270</samp>

Fix a typo in `emqx_machine_terminator.erl` and improve the graceful shutdown process of EMQX in `emqx.service`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
