### PR TITLE
fix(rule_action): fix metrics for bridges returning `async_return`

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -525,6 +525,8 @@ inc_action_metrics(R, RuleId) ->
 
 is_ok_result(ok) ->
     true;
+is_ok_result({async_return, R}) ->
+    is_ok_result(R);
 is_ok_result(R) when is_tuple(R) ->
     ok == erlang:element(1, R);
 is_ok_result(_) ->


### PR DESCRIPTION
Kafka Producer, when called asynchronously, will return `{async_return, {ok, pid()}}`, which currently counts as an unknown failure.


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8685477</samp>

This pull request improves the test coverage and the error handling of the rule engine when sending messages to Kafka. It adds assertions to the `emqx_bridge_impl_kafka_producer_SUITE.erl` test module and handles the `async_return` result from asynchronous rule actions in `emqx_rule_runtime.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
