### PR TITLE
fix(rule_action): fix metrics for bridges returning `async_return`

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -508,8 +508,6 @@ nested_put(Alias, Val, Columns0) ->
     emqx_rule_maps:nested_put(Alias, Val, Columns).
 
 -define(IS_RES_DOWN(R), R == stopped; R == not_connected; R == not_found).
-inc_action_metrics(ok, RuleId) ->
-    emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.success');
 inc_action_metrics({error, {recoverable_error, _}}, RuleId) ->
     emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.failed.out_of_service');
 inc_action_metrics(?RESOURCE_ERROR_M(R, _), RuleId) when ?IS_RES_DOWN(R) ->
@@ -525,6 +523,10 @@ inc_action_metrics(R, RuleId) ->
             emqx_metrics_worker:inc(rule_metrics, RuleId, 'actions.success')
     end.
 
+is_ok_result(ok) ->
+    true;
+is_ok_result({async_return, R}) ->
+    is_ok_result(R);
 is_ok_result(R) when is_tuple(R) ->
     ok == erlang:element(1, R);
 is_ok_result(_) ->


### PR DESCRIPTION
Port of #10344 to `release-50`

Kafka Producer, when called asynchronously, will return `{async_return, {ok, pid()}}`, which currently counts as an unknown failure.

This bug may have been masked by [this previous bug](https://github.com/emqx/emqx/pull/10258), and there were no tests to avoid this regression prior to this fix.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c24b08</samp>

This pull request refactors the rule action metrics update logic in `emqx_rule_runtime.erl` and enhances the test case for the Kafka bridge producer in `emqx_bridge_impl_kafka_producer_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
