### PR TITLE
feat(resource): stop adding uniqueness to manager ids

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_gcp_pubsub, [
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, [emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -114,8 +114,8 @@ callback_mode() ->
 is_buffer_supported() ->
     true.
 
--spec on_start(manager_id(), config()) -> {ok, state()}.
-on_start(InstanceId, Config) ->
+-spec on_start(resource_id(), config()) -> {ok, state()}.
+on_start(ResourceId, Config) ->
     #{
         authentication := Auth,
         bootstrap_hosts := BootstrapHosts0,
@@ -133,7 +133,7 @@ on_start(InstanceId, Config) ->
     BootstrapHosts = emqx_bridge_kafka_impl:hosts(BootstrapHosts0),
     KafkaType = kafka_consumer,
     %% Note: this is distinct per node.
-    ClientID = make_client_id(InstanceId, KafkaType, BridgeName),
+    ClientID = make_client_id(ResourceId, KafkaType, BridgeName),
     ClientOpts0 =
         case Auth of
             none -> [];
@@ -144,26 +144,26 @@ on_start(InstanceId, Config) ->
         ok ->
             ?tp(
                 kafka_consumer_client_started,
-                #{client_id => ClientID, instance_id => InstanceId}
+                #{client_id => ClientID, resource_id => ResourceId}
             ),
             ?SLOG(info, #{
                 msg => "kafka_consumer_client_started",
-                instance_id => InstanceId,
+                resource_id => ResourceId,
                 kafka_hosts => BootstrapHosts
             });
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "failed_to_start_kafka_consumer_client",
-                instance_id => InstanceId,
+                resource_id => ResourceId,
                 kafka_hosts => BootstrapHosts,
                 reason => emqx_utils:redact(Reason)
             }),
             throw(?CLIENT_DOWN_MESSAGE)
     end,
-    start_consumer(Config, InstanceId, ClientID).
+    start_consumer(Config, ResourceId, ClientID).
 
--spec on_stop(manager_id(), state()) -> ok.
-on_stop(_InstanceID, State) ->
+-spec on_stop(resource_id(), state()) -> ok.
+on_stop(_ResourceID, State) ->
     #{
         subscriber_id := SubscriberId,
         kafka_client_id := ClientID
@@ -172,8 +172,8 @@ on_stop(_InstanceID, State) ->
     stop_client(ClientID),
     ok.
 
--spec on_get_status(manager_id(), state()) -> connected | disconnected.
-on_get_status(_InstanceID, State) ->
+-spec on_get_status(resource_id(), state()) -> connected | disconnected.
+on_get_status(_ResourceID, State) ->
     #{
         subscriber_id := SubscriberId,
         kafka_client_id := ClientID,
@@ -271,8 +271,8 @@ ensure_consumer_supervisor_started() ->
             ok
     end.
 
--spec start_consumer(config(), manager_id(), brod:client_id()) -> {ok, state()}.
-start_consumer(Config, InstanceId, ClientID) ->
+-spec start_consumer(config(), resource_id(), brod:client_id()) -> {ok, state()}.
+start_consumer(Config, ResourceId, ClientID) ->
     #{
         bootstrap_hosts := BootstrapHosts0,
         bridge_name := BridgeName,
@@ -292,7 +292,7 @@ start_consumer(Config, InstanceId, ClientID) ->
     InitialState = #{
         key_encoding_mode => KeyEncodingMode,
         hookpoint => Hookpoint,
-        resource_id => emqx_bridge_resource:resource_id(kafka_consumer, BridgeName),
+        resource_id => ResourceId,
         topic_mapping => TopicMapping,
         value_encoding_mode => ValueEncodingMode
     },
@@ -337,7 +337,7 @@ start_consumer(Config, InstanceId, ClientID) ->
         {ok, _ConsumerPid} ->
             ?tp(
                 kafka_consumer_subscriber_started,
-                #{instance_id => InstanceId, subscriber_id => SubscriberId}
+                #{resource_id => ResourceId, subscriber_id => SubscriberId}
             ),
             {ok, #{
                 subscriber_id => SubscriberId,
@@ -347,7 +347,7 @@ start_consumer(Config, InstanceId, ClientID) ->
         {error, Reason2} ->
             ?SLOG(error, #{
                 msg => "failed_to_start_kafka_consumer",
-                instance_id => InstanceId,
+                resource_id => ResourceId,
                 kafka_hosts => emqx_bridge_kafka_impl:hosts(BootstrapHosts0),
                 reason => emqx_utils:redact(Reason2)
             }),
@@ -471,19 +471,19 @@ consumer_group_id(BridgeName0) ->
     BridgeName = to_bin(BridgeName0),
     <<"emqx-kafka-consumer-", BridgeName/binary>>.
 
--spec is_dry_run(manager_id()) -> boolean().
-is_dry_run(InstanceId) ->
-    TestIdStart = string:find(InstanceId, ?TEST_ID_PREFIX),
+-spec is_dry_run(resource_id()) -> boolean().
+is_dry_run(ResourceId) ->
+    TestIdStart = string:find(ResourceId, ?TEST_ID_PREFIX),
     case TestIdStart of
         nomatch ->
             false;
         _ ->
-            string:equal(TestIdStart, InstanceId)
+            string:equal(TestIdStart, ResourceId)
     end.
 
--spec make_client_id(manager_id(), kafka_consumer, atom() | binary()) -> atom().
-make_client_id(InstanceId, KafkaType, KafkaName) ->
-    case is_dry_run(InstanceId) of
+-spec make_client_id(resource_id(), kafka_consumer, atom() | binary()) -> atom().
+make_client_id(ResourceId, KafkaType, KafkaName) ->
+    case is_dry_run(ResourceId) of
         false ->
             ClientID0 = emqx_bridge_kafka_impl:make_client_id(KafkaType, KafkaName),
             binary_to_atom(ClientID0);

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_impl_producer.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_impl_producer.erl
@@ -70,7 +70,7 @@ callback_mode() -> async_if_possible.
 %% workers.
 is_buffer_supported() -> true.
 
--spec on_start(manager_id(), config()) -> {ok, state()}.
+-spec on_start(resource_id(), config()) -> {ok, state()}.
 on_start(InstanceId, Config) ->
     #{
         authentication := _Auth,
@@ -106,7 +106,7 @@ on_start(InstanceId, Config) ->
     end,
     start_producer(Config, InstanceId, ClientId, ClientOpts).
 
--spec on_stop(manager_id(), state()) -> ok.
+-spec on_stop(resource_id(), state()) -> ok.
 on_stop(_InstanceId, State) ->
     #{
         pulsar_client_id := ClientId,
@@ -117,7 +117,7 @@ on_stop(_InstanceId, State) ->
     ?tp(pulsar_bridge_stopped, #{instance_id => _InstanceId}),
     ok.
 
--spec on_get_status(manager_id(), state()) -> connected | disconnected.
+-spec on_get_status(resource_id(), state()) -> connected | disconnected.
 on_get_status(_InstanceId, State = #{}) ->
     #{
         pulsar_client_id := ClientId,
@@ -144,7 +144,7 @@ on_get_status(_InstanceId, _State) ->
     %% create the bridge is not quite finished, `State = undefined'.
     connecting.
 
--spec on_query(manager_id(), {send_message, map()}, state()) ->
+-spec on_query(resource_id(), {send_message, map()}, state()) ->
     {ok, term()}
     | {error, timeout}
     | {error, term()}.
@@ -163,7 +163,7 @@ on_query(_InstanceId, {send_message, Message}, State) ->
     end.
 
 -spec on_query_async(
-    manager_id(), {send_message, map()}, {ReplyFun :: function(), Args :: list()}, state()
+    resource_id(), {send_message, map()}, {ReplyFun :: function(), Args :: list()}, state()
 ) ->
     {ok, pid()}.
 on_query_async(_InstanceId, {send_message, Message}, AsyncReplyFn, State) ->
@@ -203,7 +203,7 @@ format_servers(Servers0) ->
         Servers1
     ).
 
--spec make_client_id(manager_id(), atom() | binary()) -> pulsar_client_id().
+-spec make_client_id(resource_id(), atom() | binary()) -> pulsar_client_id().
 make_client_id(InstanceId, BridgeName) ->
     case is_dry_run(InstanceId) of
         true ->
@@ -218,7 +218,7 @@ make_client_id(InstanceId, BridgeName) ->
             binary_to_atom(ClientIdBin)
     end.
 
--spec is_dry_run(manager_id()) -> boolean().
+-spec is_dry_run(resource_id()) -> boolean().
 is_dry_run(InstanceId) ->
     TestIdStart = string:find(InstanceId, ?TEST_ID_PREFIX),
     case TestIdStart of
@@ -255,7 +255,7 @@ producer_name(ClientId) ->
         ])
     ).
 
--spec start_producer(config(), manager_id(), pulsar_client_id(), map()) -> {ok, state()}.
+-spec start_producer(config(), resource_id(), pulsar_client_id(), map()) -> {ok, state()}.
 start_producer(Config, InstanceId, ClientId, ClientOpts) ->
     #{
         conn_opts := ConnOpts,

--- a/apps/emqx_connector/src/emqx_connector.app.src
+++ b/apps/emqx_connector/src/emqx_connector.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_connector, [
     {description, "EMQX Data Integration Connectors"},
-    {vsn, "0.1.21"},
+    {vsn, "0.1.22"},
     {registered, []},
     {mod, {emqx_connector_app, []}},
     {applications, [

--- a/apps/emqx_connector/src/emqx_connector_mqtt.erl
+++ b/apps/emqx_connector/src/emqx_connector_mqtt.erl
@@ -248,13 +248,12 @@ make_sub_confs(EmptyMap, _Conf, _) when map_size(EmptyMap) == 0 ->
     undefined;
 make_sub_confs(undefined, _Conf, _) ->
     undefined;
-make_sub_confs(SubRemoteConf, Conf, InstanceId) ->
-    ResId = emqx_resource_manager:manager_id_to_resource_id(InstanceId),
+make_sub_confs(SubRemoteConf, Conf, ResourceId) ->
     case maps:find(hookpoint, Conf) of
         error ->
             error({no_hookpoint_provided, Conf});
         {ok, HookPoint} ->
-            MFA = {?MODULE, on_message_received, [HookPoint, ResId]},
+            MFA = {?MODULE, on_message_received, [HookPoint, ResourceId]},
             SubRemoteConf#{on_message_received => MFA}
     end.
 

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -15,7 +15,6 @@
 %%--------------------------------------------------------------------
 -type resource_type() :: module().
 -type resource_id() :: binary().
--type manager_id() :: binary().
 -type raw_resource_config() :: binary() | raw_term_resource_config().
 -type raw_term_resource_config() :: #{binary() => term()} | [raw_term_resource_config()].
 -type resource_config() :: term().

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -113,7 +113,10 @@
 
 -export([apply_reply_fun/2]).
 
--export_type([resource_data/0]).
+-export_type([
+    resource_id/0,
+    resource_data/0
+]).
 
 -optional_callbacks([
     on_query/3,
@@ -362,7 +365,7 @@ is_buffer_supported(Module) ->
             false
     end.
 
--spec call_start(manager_id(), module(), resource_config()) ->
+-spec call_start(resource_id(), module(), resource_config()) ->
     {ok, resource_state()} | {error, Reason :: term()}.
 call_start(MgrId, Mod, Config) ->
     try
@@ -374,7 +377,7 @@ call_start(MgrId, Mod, Config) ->
             {error, #{exception => Kind, reason => Error, stacktrace => Stacktrace}}
     end.
 
--spec call_health_check(manager_id(), module(), resource_state()) ->
+-spec call_health_check(resource_id(), module(), resource_state()) ->
     resource_status()
     | {resource_status(), resource_state()}
     | {resource_status(), resource_state(), term()}
@@ -382,7 +385,7 @@ call_start(MgrId, Mod, Config) ->
 call_health_check(MgrId, Mod, ResourceState) ->
     ?SAFE_CALL(Mod:on_get_status(MgrId, ResourceState)).
 
--spec call_stop(manager_id(), module(), resource_state()) -> term().
+-spec call_stop(resource_id(), module(), resource_state()) -> term().
 call_stop(MgrId, Mod, ResourceState) ->
     ?SAFE_CALL(Mod:on_stop(MgrId, ResourceState)).
 

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -367,9 +367,9 @@ is_buffer_supported(Module) ->
 
 -spec call_start(resource_id(), module(), resource_config()) ->
     {ok, resource_state()} | {error, Reason :: term()}.
-call_start(MgrId, Mod, Config) ->
+call_start(ResId, Mod, Config) ->
     try
-        Mod:on_start(MgrId, Config)
+        Mod:on_start(ResId, Config)
     catch
         throw:Error ->
             {error, Error};
@@ -382,12 +382,12 @@ call_start(MgrId, Mod, Config) ->
     | {resource_status(), resource_state()}
     | {resource_status(), resource_state(), term()}
     | {error, term()}.
-call_health_check(MgrId, Mod, ResourceState) ->
-    ?SAFE_CALL(Mod:on_get_status(MgrId, ResourceState)).
+call_health_check(ResId, Mod, ResourceState) ->
+    ?SAFE_CALL(Mod:on_get_status(ResId, ResourceState)).
 
 -spec call_stop(resource_id(), module(), resource_state()) -> term().
-call_stop(MgrId, Mod, ResourceState) ->
-    ?SAFE_CALL(Mod:on_stop(MgrId, ResourceState)).
+call_stop(ResId, Mod, ResourceState) ->
+    ?SAFE_CALL(Mod:on_stop(ResId, ResourceState)).
 
 -spec check_config(resource_type(), raw_resource_config()) ->
     {ok, resource_config()} | {error, term()}.

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
@@ -52,6 +52,7 @@ init([]) ->
     ChildSpecs = [],
     {ok, {SupFlags, ChildSpecs}}.
 
+-spec start_workers(emqx_resource:resource_id(), _Opts :: #{atom() => _}) -> ok.
 start_workers(ResId, Opts) ->
     WorkerPoolSize = worker_pool_size(Opts),
     _ = ensure_worker_pool(ResId, hash, [{size, WorkerPoolSize}]),
@@ -63,6 +64,7 @@ start_workers(ResId, Opts) ->
         lists:seq(1, WorkerPoolSize)
     ).
 
+-spec stop_workers(emqx_resource:resource_id(), _Opts :: #{atom() => _}) -> ok.
 stop_workers(ResId, Opts) ->
     WorkerPoolSize = worker_pool_size(Opts),
     lists:foreach(
@@ -75,6 +77,7 @@ stop_workers(ResId, Opts) ->
     ensure_worker_pool_removed(ResId),
     ok.
 
+-spec worker_pids(emqx_resource:resource_id()) -> [pid()].
 worker_pids(ResId) ->
     lists:map(
         fun({_Name, Pid}) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -42,19 +42,18 @@
 ]).
 
 -export([
-    set_resource_status_connecting/1,
-    manager_id_to_resource_id/1
+    set_resource_status_connecting/1
 ]).
 
 % Server
--export([start_link/6]).
+-export([start_link/5]).
 
 % Behaviour
 -export([init/1, callback_mode/0, handle_event/4, terminate/3]).
 
 % State record
 -record(data, {
-    id, manager_id, group, mod, callback_mode, query_mode, config, opts, status, state, error, pid
+    id, group, mod, callback_mode, query_mode, config, opts, status, state, error, pid
 }).
 -type data() :: #data{}.
 
@@ -68,13 +67,6 @@
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
-
-make_manager_id(ResId) ->
-    emqx_resource:generate_id(ResId).
-
-manager_id_to_resource_id(MgrId) ->
-    [ResId, _Index] = string:split(MgrId, ":", trailing),
-    ResId.
 
 %% @doc Called from emqx_resource when starting a resource instance.
 %%
@@ -92,8 +84,7 @@ ensure_resource(ResId, Group, ResourceType, Config, Opts) ->
         {ok, _Group, Data} ->
             {ok, Data};
         {error, not_found} ->
-            MgrId = set_new_owner(ResId),
-            create_and_return_data(MgrId, ResId, Group, ResourceType, Config, Opts)
+            create_and_return_data(ResId, Group, ResourceType, Config, Opts)
     end.
 
 %% @doc Called from emqx_resource when recreating a resource which may or may not exist
@@ -103,23 +94,22 @@ recreate(ResId, ResourceType, NewConfig, Opts) ->
     case lookup(ResId) of
         {ok, Group, #{mod := ResourceType, status := _} = _Data} ->
             _ = remove(ResId, false),
-            MgrId = set_new_owner(ResId),
-            create_and_return_data(MgrId, ResId, Group, ResourceType, NewConfig, Opts);
+            create_and_return_data(ResId, Group, ResourceType, NewConfig, Opts);
         {ok, _, #{mod := Mod}} when Mod =/= ResourceType ->
             {error, updating_to_incorrect_resource_type};
         {error, not_found} ->
             {error, not_found}
     end.
 
-create_and_return_data(MgrId, ResId, Group, ResourceType, Config, Opts) ->
-    _ = create(MgrId, ResId, Group, ResourceType, Config, Opts),
+create_and_return_data(ResId, Group, ResourceType, Config, Opts) ->
+    _ = create(ResId, Group, ResourceType, Config, Opts),
     {ok, _Group, Data} = lookup(ResId),
     {ok, Data}.
 
 %% @doc Create a resource_manager and wait until it is running
-create(MgrId, ResId, Group, ResourceType, Config, Opts) ->
+create(ResId, Group, ResourceType, Config, Opts) ->
     % The state machine will make the actual call to the callback/resource module after init
-    ok = emqx_resource_manager_sup:ensure_child(MgrId, ResId, Group, ResourceType, Config, Opts),
+    ok = emqx_resource_manager_sup:ensure_child(ResId, Group, ResourceType, Config, Opts),
     ok = emqx_metrics_worker:create_metrics(
         ?RES_METRICS,
         ResId,
@@ -164,15 +154,12 @@ create(MgrId, ResId, Group, ResourceType, Config, Opts) ->
     ok | {error, Reason :: term()}.
 create_dry_run(ResourceType, Config) ->
     ResId = make_test_id(),
-    MgrId = set_new_owner(ResId),
     Opts =
         case is_map(Config) of
             true -> maps:get(resource_opts, Config, #{});
             false -> #{}
         end,
-    ok = emqx_resource_manager_sup:ensure_child(
-        MgrId, ResId, <<"dry_run">>, ResourceType, Config, Opts
-    ),
+    ok = emqx_resource_manager_sup:ensure_child(ResId, <<"dry_run">>, ResourceType, Config, Opts),
     case wait_for_ready(ResId, 5000) of
         ok ->
             remove(ResId);
@@ -283,10 +270,9 @@ health_check(ResId) ->
 %% Server start/stop callbacks
 
 %% @doc Function called from the supervisor to actually start the server
-start_link(MgrId, ResId, Group, ResourceType, Config, Opts) ->
+start_link(ResId, Group, ResourceType, Config, Opts) ->
     Data = #data{
         id = ResId,
-        manager_id = MgrId,
         group = Group,
         mod = ResourceType,
         callback_mode = emqx_resource:get_callback_mode(ResourceType),
@@ -320,7 +306,7 @@ terminate({shutdown, removed}, _State, _Data) ->
     ok;
 terminate(_Reason, _State, Data) ->
     _ = maybe_stop_resource(Data),
-    ok = delete_cache(Data#data.id, Data#data.manager_id),
+    ok = delete_cache(Data#data.id),
     ok.
 
 %% Behavior callback
@@ -345,9 +331,6 @@ handle_event({call, From}, start, State, Data) when
     start_resource(Data, From);
 handle_event({call, From}, start, _State, _Data) ->
     {keep_state_and_data, [{reply, From, ok}]};
-% Called when the resource received a `quit` message
-handle_event(info, quit, _State, _Data) ->
-    {stop, {shutdown, quit}};
 % Called when the resource is to be stopped
 handle_event({call, From}, stop, stopped, _Data) ->
     {keep_state_and_data, [{reply, From, ok}]};
@@ -429,20 +412,8 @@ log_cache_consistency({_, DataCached}, Data) ->
 %%------------------------------------------------------------------------------
 %% internal functions
 %%------------------------------------------------------------------------------
-insert_cache(ResId, Group, Data = #data{manager_id = MgrId}) ->
-    case get_owner(ResId) of
-        not_found ->
-            ets:insert(?ETS_TABLE, {ResId, Group, Data});
-        MgrId ->
-            ets:insert(?ETS_TABLE, {ResId, Group, Data});
-        _ ->
-            ?SLOG(error, #{
-                msg => get_resource_owner_failed,
-                resource_id => ResId,
-                action => quit_resource
-            }),
-            self() ! quit
-    end.
+insert_cache(ResId, Group, Data = #data{}) ->
+    ets:insert(?ETS_TABLE, {ResId, Group, Data}).
 
 read_cache(ResId) ->
     case ets:lookup(?ETS_TABLE, ResId) of
@@ -450,36 +421,13 @@ read_cache(ResId) ->
         [] -> not_found
     end.
 
-delete_cache(ResId, MgrId) ->
-    case get_owner(ResId) of
-        MgrIdNow when MgrIdNow == not_found; MgrIdNow == MgrId ->
-            do_delete_cache(ResId);
-        _ ->
-            ok
-    end.
-
-do_delete_cache(<<?TEST_ID_PREFIX, _/binary>> = ResId) ->
+delete_cache(<<?TEST_ID_PREFIX, _/binary>> = ResId) ->
     true = ets:delete(?ETS_TABLE, {owner, ResId}),
     true = ets:delete(?ETS_TABLE, ResId),
     ok;
-do_delete_cache(ResId) ->
+delete_cache(ResId) ->
     true = ets:delete(?ETS_TABLE, ResId),
     ok.
-
-set_new_owner(ResId) ->
-    MgrId = make_manager_id(ResId),
-    ok = set_owner(ResId, MgrId),
-    MgrId.
-
-set_owner(ResId, MgrId) ->
-    ets:insert(?ETS_TABLE, {{owner, ResId}, MgrId}),
-    ok.
-
-get_owner(ResId) ->
-    case ets:lookup(?ETS_TABLE, {owner, ResId}) of
-        [{_, MgrId}] -> MgrId;
-        [] -> not_found
-    end.
 
 retry_actions(Data) ->
     case maps:get(auto_restart_interval, Data#data.opts, ?AUTO_RESTART_INTERVAL) of
@@ -494,7 +442,7 @@ health_check_actions(Data) ->
 
 handle_remove_event(From, ClearMetrics, Data) ->
     _ = stop_resource(Data),
-    ok = delete_cache(Data#data.id, Data#data.manager_id),
+    ok = delete_cache(Data#data.id),
     ok = emqx_resource_buffer_worker_sup:stop_workers(Data#data.id, Data#data.opts),
     case ClearMetrics of
         true -> ok = emqx_metrics_worker:clear_metrics(?RES_METRICS, Data#data.id);
@@ -504,7 +452,7 @@ handle_remove_event(From, ClearMetrics, Data) ->
 
 start_resource(Data, From) ->
     %% in case the emqx_resource:call_start/2 hangs, the lookup/1 can read status from the cache
-    case emqx_resource:call_start(Data#data.manager_id, Data#data.mod, Data#data.config) of
+    case emqx_resource:call_start(Data#data.id, Data#data.mod, Data#data.config) of
         {ok, ResourceState} ->
             UpdatedData = Data#data{status = connecting, state = ResourceState},
             %% Perform an initial health_check immediately before transitioning into a connected state
@@ -535,7 +483,7 @@ stop_resource(#data{state = ResState, id = ResId} = Data) ->
     %% is returned.
     case ResState /= undefined of
         true ->
-            emqx_resource:call_stop(Data#data.manager_id, Data#data.mod, ResState);
+            emqx_resource:call_stop(Data#data.id, Data#data.mod, ResState);
         false ->
             ok
     end,
@@ -589,7 +537,7 @@ with_health_check(#data{state = undefined} = Data, Func) ->
     Func(disconnected, Data);
 with_health_check(#data{error = PrevError} = Data, Func) ->
     ResId = Data#data.id,
-    HCRes = emqx_resource:call_health_check(Data#data.manager_id, Data#data.mod, Data#data.state),
+    HCRes = emqx_resource:call_health_check(Data#data.id, Data#data.mod, Data#data.state),
     {Status, NewState, Err} = parse_health_check_result(HCRes, Data),
     _ = maybe_alarm(Status, ResId, Err, PrevError),
     ok = maybe_resume_resource_workers(ResId, Status),

--- a/apps/emqx_resource/src/emqx_resource_manager_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager_sup.erl
@@ -31,9 +31,6 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
-    TabOpts = [named_table, set, public, {read_concurrency, true}],
-    _ = ets:new(emqx_resource_manager, TabOpts),
-
     ChildSpecs = [
         #{
             id => emqx_resource_manager,
@@ -44,6 +41,5 @@ init([]) ->
             modules => [emqx_resource_manager]
         }
     ],
-
     SupFlags = #{strategy => simple_one_for_one, intensity => 10, period => 10},
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/emqx_resource/src/emqx_resource_manager_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager_sup.erl
@@ -17,14 +17,14 @@
 
 -behaviour(supervisor).
 
--export([ensure_child/6]).
+-export([ensure_child/5]).
 
 -export([start_link/0]).
 
 -export([init/1]).
 
-ensure_child(MgrId, ResId, Group, ResourceType, Config, Opts) ->
-    _ = supervisor:start_child(?MODULE, [MgrId, ResId, Group, ResourceType, Config, Opts]),
+ensure_child(ResId, Group, ResourceType, Config, Opts) ->
+    _ = supervisor:start_child(?MODULE, [ResId, Group, ResourceType, Config, Opts]),
     ok.
 
 start_link() ->

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_influxdb_SUITE.erl
@@ -502,11 +502,6 @@ resource_id(Config) ->
     Name = ?config(influxdb_name, Config),
     emqx_bridge_resource:resource_id(Type, Name).
 
-instance_id(Config) ->
-    ResourceId = resource_id(Config),
-    [{_, InstanceId}] = ets:lookup(emqx_resource_manager, {owner, ResourceId}),
-    InstanceId.
-
 %%------------------------------------------------------------------------------
 %% Testcases
 %%------------------------------------------------------------------------------
@@ -581,14 +576,14 @@ t_start_already_started(Config) ->
         {ok, _},
         create_bridge(Config)
     ),
-    InstanceId = instance_id(Config),
+    ResourceId = resource_id(Config),
     TypeAtom = binary_to_atom(Type),
     NameAtom = binary_to_atom(Name),
     {ok, #{bridges := #{TypeAtom := #{NameAtom := InfluxDBConfigMap}}}} = emqx_hocon:check(
         emqx_bridge_schema, InfluxDBConfigString
     ),
     ?check_trace(
-        emqx_ee_connector_influxdb:on_start(InstanceId, InfluxDBConfigMap),
+        emqx_ee_connector_influxdb:on_start(ResourceId, InfluxDBConfigMap),
         fun(Result, Trace) ->
             ?assertMatch({ok, _}, Result),
             ?assertMatch([_], ?of_kind(influxdb_connector_start_already_started, Trace)),

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_connector, [
     {description, "EMQX Enterprise connectors"},
-    {vsn, "0.1.11"},
+    {vsn, "0.1.12"},
     {registered, []},
     {applications, [
         kernel,

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_rocketmq.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_rocketmq.erl
@@ -267,9 +267,8 @@ apply_template([{Key, _} | _] = Reqs, Templates) ->
             [emqx_plugin_libs_rule:proc_tmpl(Template, Msg) || {_, Msg} <- Reqs]
     end.
 
-client_id(InstanceId) ->
-    Name = emqx_resource_manager:manager_id_to_resource_id(InstanceId),
-    erlang:binary_to_atom(Name, utf8).
+client_id(ResourceId) ->
+    erlang:binary_to_atom(ResourceId, utf8).
 
 redact(Msg) ->
     emqx_utils:redact(Msg, fun is_sensitive_key/1).


### PR DESCRIPTION
Fixes [EMQX-9257](https://emqx.atlassian.net/browse/EMQX-9257)

## Summary
Before this change, a separate `manager_id` / `instance_id` was used as a resource manager id, which made connector interface somewhat inconsistent: part of function calls to connector implementation used instance id as first argument while the rest used resource id itself.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [x] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
