### PR TITLE
feat: hiden auto_subscribe conf

### DIFF
--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auto_subscribe, [
     {description, "Auto subscribe Application"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {mod, {emqx_auto_subscribe_app, []}},
     {applications, [

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
@@ -40,8 +40,7 @@ fields("auto_subscribe") ->
                 ?ARRAY(?R_REF("topic")),
                 #{
                     desc => ?DESC(auto_subscribe),
-                    default => [],
-                    importance => ?IMPORTANCE_HIDDEN
+                    default => []
                 }
             )}
     ];
@@ -51,31 +50,26 @@ fields("topic") ->
             ?HOCON(binary(), #{
                 required => true,
                 example => topic_example(),
-                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("topic")
             })},
         {qos,
             ?HOCON(emqx_schema:qos(), #{
                 default => 0,
-                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("qos")
             })},
         {rh,
             ?HOCON(range(0, 2), #{
                 default => 0,
-                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("rh")
             })},
         {rap,
             ?HOCON(range(0, 1), #{
                 default => 0,
-                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("rap")
             })},
         {nl,
             ?HOCON(range(0, 1), #{
                 default => 0,
-                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC(nl)
             })}
     ].

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe_schema.erl
@@ -31,14 +31,18 @@
 namespace() -> "auto_subscribe".
 
 roots() ->
-    ["auto_subscribe"].
+    [{"auto_subscribe", ?HOCON(?R_REF("auto_subscribe"), #{importance => ?IMPORTANCE_HIDDEN})}].
 
 fields("auto_subscribe") ->
     [
         {topics,
             ?HOCON(
                 ?ARRAY(?R_REF("topic")),
-                #{desc => ?DESC(auto_subscribe), default => []}
+                #{
+                    desc => ?DESC(auto_subscribe),
+                    default => [],
+                    importance => ?IMPORTANCE_HIDDEN
+                }
             )}
     ];
 fields("topic") ->
@@ -47,26 +51,31 @@ fields("topic") ->
             ?HOCON(binary(), #{
                 required => true,
                 example => topic_example(),
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("topic")
             })},
         {qos,
             ?HOCON(emqx_schema:qos(), #{
                 default => 0,
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("qos")
             })},
         {rh,
             ?HOCON(range(0, 2), #{
                 default => 0,
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("rh")
             })},
         {rap,
             ?HOCON(range(0, 1), #{
                 default => 0,
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC("rap")
             })},
         {nl,
             ?HOCON(range(0, 1), #{
                 default => 0,
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC(nl)
             })}
     ].

--- a/changes/ce/feat-10381.en.md
+++ b/changes/ce/feat-10381.en.md
@@ -1,1 +1,1 @@
-Hide the auto_subscribe configuration item so that it can be modified later only through the HTTP API.
+Hide the `auto_subscribe` configuration items so that they can be modified later only through the HTTP API.

--- a/changes/ce/feat-10381.en.md
+++ b/changes/ce/feat-10381.en.md
@@ -1,0 +1,1 @@
+Hide the auto_subscribe configuration item so that it can be modified later only through the HTTP API.


### PR DESCRIPTION
Fixes [EMQX-9505](https://emqx.atlassian.net/browse/EMQX-9505)

Hide the auto_subscribe in configuration file, so that it can be modified only through the HTTP API.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a70930f</samp>

The pull request hides the auto_subscribe configuration fields from the default view and updates the version of the `emqx_auto_subscribe` application. This improves the user experience and maintains the version consistency.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
