### PR TITLE
chore(i18n): improve config desc

### DIFF
--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -1190,7 +1190,7 @@ To flush events, the handler discards the buffered log messages without logging.
   log_overload_kill_restart_after {
     desc {
       en: """The handler restarts automatically after a delay in the event of termination, unless the value `infinity` is set, which blocks any subsequent restarts."""
-      zh: """处理进程停止后，会在该延迟时间后自动重新启动。除非该值设置为 <code>infinity</code>，这表示永不重新启动。"""
+      zh: """处理进程停止后，会在该延迟时间后自动重新启动。除非该值设置为 <code>infinity</code>，这会阻止任何后续的重启。"""
     }
     label {
       en: "Handler Restart Timer"

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -1190,11 +1190,11 @@ To flush events, the handler discards the buffered log messages without logging.
   log_overload_kill_restart_after {
     desc {
       en: """The handler restarts automatically after a delay in the event of termination, unless the value `infinity` is set, which blocks any subsequent restarts."""
-      zh: """如果处理进程终止，它会在以指定的时间后后自动重新启动。 `infinity` 不自动重启。"""
+      zh: """处理进程停止后，会在该延迟时间后自动重新启动。除非该值设置为 <code>infinity</code>，这表示永不重新启动。"""
     }
     label {
       en: "Handler Restart Timer"
-      zh: "处理进程重启机制"
+      zh: "处理进程重启延迟"
     }
   }
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9218 to improve the Chinese tranlation for `log_overload_kill_restart_after`

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

Now, it is:

![image](https://user-images.githubusercontent.com/13825269/231640707-a3391ce7-f5a8-4c12-9e92-e54f598b540a.png)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b57b964</samp>

Improved Chinese translation of `handler_restart_timer` option in `emqx_conf_schema.hocon`. Fixed some wording and formatting issues to make the configuration documentation clearer and more consistent.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- ~Changed lines covered in coverage report~
- ~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
