### PR TITLE
feat: hide data items from configuration files and documentation.

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -163,7 +163,7 @@ roots(high) ->
         {?EMQX_AUTHORIZATION_CONFIG_ROOT_NAME,
             sc(
                 ref(?EMQX_AUTHORIZATION_CONFIG_ROOT_NAME),
-                #{}
+                #{importance => ?IMPORTANCE_HIDDEN}
             )}
     ];
 roots(medium) ->
@@ -2760,7 +2760,11 @@ authentication(Which) ->
             Module ->
                 Module:root_type()
         end,
-    hoconsc:mk(Type, #{desc => Desc, converter => fun ensure_array/2}).
+    hoconsc:mk(Type, #{
+        desc => Desc,
+        converter => fun ensure_array/2,
+        importance => ?IMPORTANCE_HIDDEN
+    }).
 
 %% the older version schema allows individual element (instead of a chain) in config
 ensure_array(undefined, _) -> undefined;

--- a/apps/emqx_bridge/src/schema/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_schema.erl
@@ -137,7 +137,7 @@ namespace() -> "bridge".
 tags() ->
     [<<"Bridge">>].
 
-roots() -> [bridges].
+roots() -> [{bridges, ?HOCON(?R_REF(bridges), #{importance => ?IMPORTANCE_HIDDEN})}].
 
 fields(bridges) ->
     [

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1278,7 +1278,10 @@ emqx_schema_high_prio_roots() ->
         {"authorization",
             sc(
                 ?R_REF("authorization"),
-                #{desc => ?DESC(authorization)}
+                #{
+                    desc => ?DESC(authorization),
+                    importance => ?IMPORTANCE_HIDDEN
+                }
             )},
     lists:keyreplace("authorization", 1, Roots, Authz).
 

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -38,7 +38,7 @@ namespace() -> rule_engine.
 tags() ->
     [<<"Rule Engine">>].
 
-roots() -> ["rule_engine"].
+roots() -> [{"rule_engine", ?HOCON(?R_REF("rule_engine"), #{importance => ?IMPORTANCE_HIDDEN})}].
 
 fields("rule_engine") ->
     rule_engine_settings() ++

--- a/changes/ce/feat-10385.en.md
+++ b/changes/ce/feat-10385.en.md
@@ -1,0 +1,1 @@
+Hide data items(rule_engine/bridge/authz/authn) from configuration files and documentation.


### PR DESCRIPTION
Fixes [EMQX-9561](https://emqx.atlassian.net/browse/EMQX-9561),[EMQX-9560](https://emqx.atlassian.net/browse/EMQX-9560),[EMQX-9504](https://emqx.atlassian.net/browse/EMQX-9504),[EMQX-9559](https://emqx.atlassian.net/browse/EMQX-9559)
Hide data items(rule_engine/bridge/authz/authn) from configuration files and document.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc2beda</samp>

Refactor the configuration file schemas to hide some sections by default and support HOCON syntax. Move the `bridges` and `rule_engine` schemas from their respective apps to the `emqx` app, and add the `importance` attribute to the `authorization`, `plugins`, `bridges`, and `rule_engine` schemas. Use the `?HOCON` macro to wrap the schemas that need HOCON syntax.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
