### PR TITLE
ci(cut): Don't generate Chinese changelog

### DIFF
--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -233,19 +233,19 @@ if [ -d "${CHECKS_DIR}" ]; then
 fi
 
 generate_changelog () {
-    local from_tag num_en num_zh
+    local from_tag
     from_tag="${PREV_TAG:-}"
     if [[ -z $from_tag ]]; then
         from_tag="$(./scripts/find-prev-rel-tag.sh "$PROFILE")"
     fi
-    num_en=$(git diff --name-only -a "${from_tag}...HEAD" "changes" | grep -c '.en.md')
-    num_zh=$(git diff --name-only -a "${from_tag}...HEAD" "changes" | grep -c '.zh.md')
-    if [ "$num_en" -ne "$num_zh" ]; then
-        echo "Number of English and Chinese changelog files added since ${from_tag} do not match."
-        exit 1
-    fi
+    # num_en=$(git diff --name-only -a "${from_tag}...HEAD" "changes" | grep -c '.en.md')
+    # num_zh=$(git diff --name-only -a "${from_tag}...HEAD" "changes" | grep -c '.zh.md')
+    # if [ "$num_en" -ne "$num_zh" ]; then
+    #     echo "Number of English and Chinese changelog files added since ${from_tag} do not match."
+    #     exit 1
+    # fi
     ./scripts/rel/format-changelog.sh -b "${from_tag}" -l 'en' -v "$TAG" > "changes/${TAG}.en.md"
-    ./scripts/rel/format-changelog.sh -b "${from_tag}" -l 'zh' -v "$TAG" > "changes/${TAG}.zh.md"
+    # ./scripts/rel/format-changelog.sh -b "${from_tag}" -l 'zh' -v "$TAG" > "changes/${TAG}.zh.md"
     git add changes/"${TAG}".*.md
     if [ -n "$(git diff --staged --stat)" ]; then
         git commit -m "docs: Generate changelog for ${TAG}"


### PR DESCRIPTION

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3605e42</samp>

Comment out Chinese changelog generation in `cut.sh`. This is a temporary measure to avoid inconsistencies and errors in the release process until the translation workflow is improved.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
