### PR TITLE
fix: emqx_schema: comma_separated_atoms() type cannot be configured as a list

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.14.6"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.1"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.2"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -135,7 +135,7 @@ fields("cluster") ->
             )},
         {"core_nodes",
             sc(
-                emqx_schema:comma_separated_atoms(),
+                node_array(),
                 #{
                     mapping => "mria.core_nodes",
                     default => [],
@@ -203,7 +203,7 @@ fields(cluster_static) ->
     [
         {"seeds",
             sc(
-                hoconsc:array(atom()),
+                node_array(),
                 #{
                     default => [],
                     desc => ?DESC(cluster_static_seeds),
@@ -1312,3 +1312,6 @@ validator_string_re(Val, RE, Error) ->
     catch
         _:_ -> {error, Error}
     end.
+
+node_array() ->
+    hoconsc:union([emqx_schema:comma_separated_atoms(), hoconsc:array(atom())]).

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -5,6 +5,46 @@
 -module(emqx_conf_schema_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+array_nodes_test() ->
+    ExpectNodes = ['emqx1@127.0.0.1', 'emqx2@127.0.0.1'],
+    BaseConf =
+        ""
+        "\n"
+        "     node {\n"
+        "        name = \"emqx1@127.0.0.1\"\n"
+        "        cookie = \"emqxsecretcookie\"\n"
+        "        data_dir = \"data\"\n"
+        "     }\n"
+        "     cluster {\n"
+        "        name = emqxcl\n"
+        "        discovery_strategy = static\n"
+        "        static.seeds = ~p\n"
+        "        core_nodes = ~p\n"
+        "     }\n"
+        "   "
+        "",
+    lists:foreach(
+        fun(Nodes) ->
+            ConfFile = iolist_to_binary(io_lib:format(BaseConf, [Nodes, Nodes])),
+            {ok, Conf} = hocon:binary(ConfFile, #{format => richmap}),
+            ConfList = hocon_tconf:generate(emqx_conf_schema, Conf),
+            ClusterDiscovery = proplists:get_value(
+                cluster_discovery, proplists:get_value(ekka, ConfList)
+            ),
+            ?assertEqual(
+                {static, [{seeds, ExpectNodes}]},
+                ClusterDiscovery,
+                Nodes
+            ),
+            ?assertEqual(
+                ExpectNodes,
+                proplists:get_value(core_nodes, proplists:get_value(mria, ConfList)),
+                Nodes
+            )
+        end,
+        [["emqx1@127.0.0.1", "emqx2@127.0.0.1"], "emqx1@127.0.0.1, emqx2@127.0.0.1"]
+    ),
+    ok.
 
 doc_gen_test() ->
     %% the json file too large to encode.

--- a/changes/ce/feat-10389.en.md
+++ b/changes/ce/feat-10389.en.md
@@ -1,2 +1,2 @@
 Unify the config formats for `cluster.core_nodes` and `cluster.statics.seeds`.
-Now they both support formats in arrays `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` or semicolon-separated strings `"emqx1@127.0.0.1,emqx2@127.0.0.1"`.
+Now they both support formats in array `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` or semicolon-separated string `"emqx1@127.0.0.1,emqx2@127.0.0.1"`.

--- a/changes/ce/feat-10389.en.md
+++ b/changes/ce/feat-10389.en.md
@@ -1,2 +1,2 @@
-Now `cluster.core_nodes` and `cluster.statics.seeds` are specified in the same way.
-Configuring them as `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` and `"emqx1@127.0.0.1,emqx2@127.0.0.1"` has the same effect.
+Unify the config formats for `cluster.core_nodes` and `cluster.statics.seeds`.
+Now they both support formats in arrays `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` or semicolon-separated strings `"emqx1@127.0.0.1,emqx2@127.0.0.1"`.

--- a/changes/ce/feat-10389.en.md
+++ b/changes/ce/feat-10389.en.md
@@ -1,2 +1,2 @@
 Now `cluster.core_nodes` and `cluster.statics.seeds` are specified in the same way.
-configure them as `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` and `"emqx1@127.0.0.1,emqx2@127.0.0.1"` has the same effect.
+Configuring them as `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` and `"emqx1@127.0.0.1,emqx2@127.0.0.1"` has the same effect.

--- a/changes/ce/feat-10389.en.md
+++ b/changes/ce/feat-10389.en.md
@@ -1,0 +1,2 @@
+Now `cluster.core_nodes` and `cluster.statics.seeds` are specified in the same way.
+configure them as `["emqx1@127.0.0.1", "emqx2@127.0.0.1"]` and `"emqx1@127.0.0.1,emqx2@127.0.0.1"` has the same effect.

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.7", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.39.1", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.39.2", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.2", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -75,7 +75,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.7"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.1"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.2"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
Fixes [EMQX-9005](https://emqx.atlassian.net/browse/EMQX-9005)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1472a37</samp>

This pull request updates the cluster configuration schema and tests to allow more flexible node name formats. It also updates the hocon dependency to enable this feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
