### PR TITLE
freat: add date_to_unix_ts/3 function to the rule engine

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -227,6 +227,7 @@
     now_timestamp/1,
     format_date/3,
     format_date/4,
+    date_to_unix_ts/3,
     date_to_unix_ts/4
 ]).
 
@@ -1083,6 +1084,14 @@ format_date(TimeUnit, Offset, FormatString, TimeEpoch) ->
             emqx_plugin_libs_rule:str(FormatString),
             TimeEpoch
         )
+    ).
+
+date_to_unix_ts(TimeUnit, FormatString, InputString) ->
+    emqx_rule_date:parse_date(
+        time_unit(TimeUnit),
+        "Z",
+        emqx_plugin_libs_rule:str(FormatString),
+        emqx_plugin_libs_rule:str(InputString)
     ).
 
 date_to_unix_ts(TimeUnit, Offset, FormatString, InputString) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -1087,12 +1087,7 @@ format_date(TimeUnit, Offset, FormatString, TimeEpoch) ->
     ).
 
 date_to_unix_ts(TimeUnit, FormatString, InputString) ->
-    emqx_rule_date:parse_date(
-        time_unit(TimeUnit),
-        "Z",
-        emqx_plugin_libs_rule:str(FormatString),
-        emqx_plugin_libs_rule:str(InputString)
-    ).
+    date_to_unix_ts(TimeUnit, "Z", FormatString, InputString).
 
 date_to_unix_ts(TimeUnit, Offset, FormatString, InputString) ->
     emqx_rule_date:parse_date(

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1003,6 +1003,24 @@ prop_format_date_fun() ->
                         )
                     ]
             )
+    ),
+    %% When no offset is specified, the offset should be taken from the formatted time string
+    ArgsNoOffset = [<<"second">>, <<"%y-%m-%d-%H:%M:%S%Z">>],
+    ArgsOffset = [<<"second">>, <<"+08:00">>, <<"%y-%m-%d-%H:%M:%S%Z">>],
+    ?FORALL(
+        S,
+        erlang:system_time(second),
+        S ==
+            apply_func(
+                date_to_unix_ts,
+                ArgsNoOffset ++
+                    [
+                        apply_func(
+                            format_date,
+                            ArgsOffset ++ [S]
+                        )
+                    ]
+            )
     ).
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -959,7 +959,7 @@ prop_format_date_fun() ->
     Args1 = [<<"second">>, <<"+07:00">>, <<"%m--%d--%y---%H:%M:%S%Z">>],
     ?FORALL(
         S,
-        erlang:system_time(second),
+        range(0, 4000000000),
         S ==
             apply_func(
                 date_to_unix_ts,
@@ -975,7 +975,7 @@ prop_format_date_fun() ->
     Args2 = [<<"millisecond">>, <<"+04:00">>, <<"--%m--%d--%y---%H:%M:%S%Z">>],
     ?FORALL(
         S,
-        erlang:system_time(millisecond),
+        range(0, 4000000000),
         S ==
             apply_func(
                 date_to_unix_ts,
@@ -991,7 +991,7 @@ prop_format_date_fun() ->
     Args = [<<"second">>, <<"+08:00">>, <<"%y-%m-%d-%H:%M:%S%Z">>],
     ?FORALL(
         S,
-        erlang:system_time(second),
+        range(0, 4000000000),
         S ==
             apply_func(
                 date_to_unix_ts,
@@ -1009,7 +1009,7 @@ prop_format_date_fun() ->
     ArgsOffset = [<<"second">>, <<"+08:00">>, <<"%y-%m-%d-%H:%M:%S%Z">>],
     ?FORALL(
         S,
-        erlang:system_time(second),
+        range(0, 4000000000),
         S ==
             apply_func(
                 date_to_unix_ts,

--- a/changes/ce/feat-10392.en.md
+++ b/changes/ce/feat-10392.en.md
@@ -1,0 +1,1 @@
+A new function to convert a formatted date to an integer timestamp has been added: date_to_unix_ts/3


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9245

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8435571</samp>

Add a new rule engine function `date_to_unix_ts/3` to convert date strings to unix timestamps and a test case for it in `emqx_rule_funcs_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [X] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [X] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [X] Schema changes are backward compatible
