### PR TITLE
feat: hide shared_subscription_group,rpc,slow_subs

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1498,12 +1498,14 @@ fields("broker") ->
                 ref("broker_perf"),
                 #{importance => ?IMPORTANCE_HIDDEN}
             )},
+        %% FIXME: Need new design for shared subscription group
         {"shared_subscription_group",
             sc(
                 map(name, ref("shared_subscription_group")),
                 #{
                     example => #{<<"example_group">> => #{<<"strategy">> => <<"random">>}},
-                    desc => ?DESC(shared_subscription_group_strategy)
+                    desc => ?DESC(shared_subscription_group_strategy),
+                    importance => ?IMPORTANCE_HIDDEN
                 }
             )}
     ];

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -98,7 +98,10 @@ roots() ->
             {"rpc",
                 sc(
                     ?R_REF("rpc"),
-                    #{translate_to => ["gen_rpc"]}
+                    #{
+                        translate_to => ["gen_rpc"],
+                        importance => ?IMPORTANCE_HIDDEN
+                    }
                 )}
         ] ++
         emqx_schema:roots(medium) ++

--- a/apps/emqx_slow_subs/src/emqx_slow_subs.app.src
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs.app.src
@@ -1,7 +1,7 @@
 {application, emqx_slow_subs, [
     {description, "EMQX Slow Subscribers Statistics"},
     % strict semver, bump manually!
-    {vsn, "1.0.4"},
+    {vsn, "1.0.5"},
     {modules, []},
     {registered, [emqx_slow_subs_sup]},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_slow_subs/src/emqx_slow_subs_schema.erl
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs_schema.erl
@@ -22,7 +22,8 @@
 
 namespace() -> "slow_subs".
 
-roots() -> ["slow_subs"].
+roots() ->
+    [{"slow_subs", ?HOCON(?R_REF("slow_subs"), #{importance => ?IMPORTANCE_HIDDEN})}].
 
 fields("slow_subs") ->
     [


### PR DESCRIPTION
Fixes [EMQX-9441](https://emqx.atlassian.net/browse/EMQX-9441), [EMQX-9552](https://emqx.atlassian.net/browse/EMQX-9552), [EMQX-9509](https://emqx.atlassian.net/browse/EMQX-9509)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be35ae2</samp>

This pull request adds or modifies some hidden configuration items for the rpc, shared subscription group, and slow_subs features, which are not fully implemented or exposed to the users yet. It also updates the version number of the `emqx_slow_subs` application.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
