### PR TITLE
feat(schema_registry): add support for protobuf schemas

### DIFF
--- a/build
+++ b/build
@@ -124,10 +124,7 @@ make_docs() {
 }
 
 assert_no_compile_time_only_deps() {
-    if [ "$("$FIND" "_build/$PROFILE/rel/emqx/lib/" -maxdepth 1 -name 'gpb-*' -type d)" != "" ]; then
-        echo "gpb should not be included in the release"
-        exit 1
-    fi
+    :
 }
 
 make_rel() {

--- a/changes/ee/feat-10409.en.md
+++ b/changes/ee/feat-10409.en.md
@@ -1,0 +1,1 @@
+Add support for [Protocol Buffers](https://protobuf.dev/) schemas in Schema Registry.

--- a/lib-ee/emqx_ee_schema_registry/include/emqx_ee_schema_registry.hrl
+++ b/lib-ee/emqx_ee_schema_registry/include/emqx_ee_schema_registry.hrl
@@ -10,14 +10,19 @@
 
 -define(SCHEMA_REGISTRY_SHARD, emqx_ee_schema_registry_shard).
 -define(SERDE_TAB, emqx_ee_schema_registry_serde_tab).
+-define(PROTOBUF_CACHE_TAB, emqx_ee_schema_registry_protobuf_cache_tab).
 
 -type schema_name() :: binary().
 -type schema_source() :: binary().
 
 -type encoded_data() :: iodata().
 -type decoded_data() :: map().
--type serializer() :: fun((decoded_data()) -> encoded_data()).
--type deserializer() :: fun((encoded_data()) -> decoded_data()).
+-type serializer() ::
+    fun((decoded_data()) -> encoded_data())
+    | fun((decoded_data(), term()) -> encoded_data()).
+-type deserializer() ::
+    fun((encoded_data()) -> decoded_data())
+    | fun((encoded_data(), term()) -> decoded_data()).
 -type destructor() :: fun(() -> ok).
 -type serde_type() :: avro.
 -type serde_opts() :: map().
@@ -29,6 +34,18 @@
     destructor :: destructor()
 }).
 -type serde() :: #serde{}.
+
+-record(protobuf_cache, {
+    fingerprint,
+    module,
+    module_binary
+}).
+-type protobuf_cache() :: #protobuf_cache{
+    fingerprint :: binary(),
+    module :: module(),
+    module_binary :: binary()
+}.
+
 -type serde_map() :: #{
     name := schema_name(),
     serializer := serializer(),

--- a/lib-ee/emqx_ee_schema_registry/rebar.config
+++ b/lib-ee/emqx_ee_schema_registry/rebar.config
@@ -4,7 +4,8 @@
 {deps, [
   {emqx, {path, "../../apps/emqx"}},
   {emqx_utils, {path, "../../apps/emqx_utils"}},
-  {erlavro, {git, "https://github.com/klarna/erlavro.git", {tag, "2.9.8"}}}
+  {erlavro, {git, "https://github.com/klarna/erlavro.git", {tag, "2.9.8"}}},
+  {gpb, "4.19.7"}
 ]}.
 
 {shell, [

--- a/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.app.src
+++ b/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.app.src
@@ -6,7 +6,8 @@
     {applications, [
         kernel,
         stdlib,
-        erlavro
+        erlavro,
+        gpb
     ]},
     {env, []},
     {modules, []},

--- a/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.erl
+++ b/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.erl
@@ -176,7 +176,14 @@ create_tables() ->
         {record_name, serde},
         {attributes, record_info(fields, serde)}
     ]),
-    ok = mria:wait_for_tables([?SERDE_TAB]),
+    ok = mria:create_table(?PROTOBUF_CACHE_TAB, [
+        {type, set},
+        {rlog_shard, ?SCHEMA_REGISTRY_SHARD},
+        {storage, disc_only_copies},
+        {record_name, protobuf_cache},
+        {attributes, record_info(fields, protobuf_cache)}
+    ]),
+    ok = mria:wait_for_tables([?SERDE_TAB, ?PROTOBUF_CACHE_TAB]),
     ok.
 
 do_build_serdes(Schemas) ->

--- a/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry_schema.erl
+++ b/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry_schema.erl
@@ -53,10 +53,20 @@ fields(avro) ->
             mk(emqx_schema:json_binary(), #{required => true, desc => ?DESC("schema_source")})},
         {description, mk(binary(), #{default => <<>>, desc => ?DESC("schema_description")})}
     ];
+fields(protobuf) ->
+    [
+        {type, mk(protobuf, #{required => true, desc => ?DESC("schema_type")})},
+        {source, mk(binary(), #{required => true, desc => ?DESC("schema_source")})},
+        {description, mk(binary(), #{default => <<>>, desc => ?DESC("schema_description")})}
+    ];
 fields("get_avro") ->
     [{name, mk(binary(), #{required => true, desc => ?DESC("schema_name")})} | fields(avro)];
+fields("get_protobuf") ->
+    [{name, mk(binary(), #{required => true, desc => ?DESC("schema_name")})} | fields(protobuf)];
 fields("put_avro") ->
     fields(avro);
+fields("put_protobuf") ->
+    fields(protobuf);
 fields("post_" ++ Type) ->
     fields("get_" ++ Type).
 
@@ -64,6 +74,8 @@ desc(?CONF_KEY_ROOT) ->
     ?DESC("schema_registry_root");
 desc(avro) ->
     ?DESC("avro_type");
+desc(protobuf) ->
+    ?DESC("protobuf_type");
 desc(_) ->
     undefined.
 
@@ -96,7 +108,7 @@ mk(Type, Meta) -> hoconsc:mk(Type, Meta).
 ref(Name) -> hoconsc:ref(?MODULE, Name).
 
 supported_serde_types() ->
-    [avro].
+    [avro, protobuf].
 
 refs() ->
     [ref(Type) || Type <- supported_serde_types()].
@@ -105,6 +117,8 @@ refs(#{<<"type">> := TypeAtom} = Value) when is_atom(TypeAtom) ->
     refs(Value#{<<"type">> := atom_to_binary(TypeAtom)});
 refs(#{<<"type">> := <<"avro">>}) ->
     [ref(avro)];
+refs(#{<<"type">> := <<"protobuf">>}) ->
+    [ref(protobuf)];
 refs(_) ->
     Expected = lists:join(" | ", [atom_to_list(T) || T <- supported_serde_types()]),
     throw(#{
@@ -113,12 +127,14 @@ refs(_) ->
     }).
 
 refs_get_api() ->
-    [ref("get_avro")].
+    [ref("get_avro"), ref("get_protobuf")].
 
 refs_get_api(#{<<"type">> := TypeAtom} = Value) when is_atom(TypeAtom) ->
     refs(Value#{<<"type">> := atom_to_binary(TypeAtom)});
 refs_get_api(#{<<"type">> := <<"avro">>}) ->
     [ref("get_avro")];
+refs_get_api(#{<<"type">> := <<"protobuf">>}) ->
+    [ref("get_protobuf")];
 refs_get_api(_) ->
     Expected = lists:join(" | ", [atom_to_list(T) || T <- supported_serde_types()]),
     throw(#{

--- a/mix.exs
+++ b/mix.exs
@@ -94,7 +94,7 @@ defmodule EMQXUmbrella.MixProject do
       {:ranch,
        github: "ninenines/ranch", ref: "a692f44567034dacf5efcaa24a24183788594eb7", override: true},
       # in conflict by grpc and eetcd
-      {:gpb, "4.19.5", override: true, runtime: false},
+      {:gpb, "4.19.7", override: true, runtime: false},
       {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true}
     ] ++
       emqx_apps(profile_info, version) ++

--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
     [ {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.2"}}}
     , {redbug, "2.0.8"}
     , {covertool, {git, "https://github.com/zmstone/covertool", {tag, "2.0.4.1"}}}
-    , {gpb, "4.19.5"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
+    , {gpb, "4.19.7"}
     , {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}}
     , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.9"}}}
     , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.7"}}}

--- a/rel/i18n/emqx_ee_schema_registry_schema.hocon
+++ b/rel/i18n/emqx_ee_schema_registry_schema.hocon
@@ -6,6 +6,12 @@ avro_type.desc:
 avro_type.label:
 """Apache Avro"""
 
+protobuf_type.desc:
+"""[Protocol Buffers](https://protobuf.dev/) serialization format."""
+
+protobuf_type.label:
+"""Protocol Buffers"""
+
 schema_description.desc:
 """A description for this schema."""
 

--- a/rel/i18n/zh/emqx_ee_schema_registry_schema.hocon
+++ b/rel/i18n/zh/emqx_ee_schema_registry_schema.hocon
@@ -6,6 +6,12 @@ avro_type.desc:
 avro_type.label:
 """阿帕奇-阿夫罗"""
 
+protobuf_type.desc:
+"""[协议缓冲器](https://protobuf.dev/) 序列化格式。"""
+
+protobuf_type.label:
+"""协议缓冲器"""
+
 schema_description.desc:
 """对该模式的描述。"""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9470

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8f7c584</samp>

This pull request adds support for protobuf schemas and serdes in the schema registry app, using the gpb library and dynamic module loading. It also updates the test suites, the HTTP API, the i18n file, and the build script to handle the new feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [X] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [X] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
