### PR TITLE
fix(gw): load emqx applications before hocon configs checking

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_app.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_app.erl
@@ -45,7 +45,7 @@ load_default_gateway_applications() ->
         fun(Def) ->
             load_gateway_application(Def)
         end,
-        emqx_gateway_utils:find_gateway_definations()
+        emqx_gateway_utils:find_gateway_definitions()
     ).
 
 load_gateway_application(

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -75,7 +75,7 @@ fields(gateway) ->
                     }
                 )}
         end,
-        emqx_gateway_utils:find_gateway_definations()
+        emqx_gateway_utils:find_gateway_definitions()
     );
 fields(clientinfo_override) ->
     [

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -47,7 +47,7 @@
     listener_chain/3,
     make_deprecated_paths/1,
     make_compatible_schema/2,
-    find_gateway_definations/0
+    find_gateway_definitions/0
 ]).
 
 -export([stringfy/1]).
@@ -564,8 +564,8 @@ make_compatible_schema2(Path, SchemaFun) ->
         Schema
     ).
 
--spec find_gateway_definations() -> list(gateway_def()).
-find_gateway_definations() ->
+-spec find_gateway_definitions() -> list(gateway_def()).
+find_gateway_definitions() ->
     lists:flatten(
         lists:map(
             fun(App) ->

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -362,6 +362,20 @@ add_libs_dir() ->
 add_lib_dir(RootDir, Name, Vsn) ->
     LibDir = filename:join([RootDir, lib, atom_to_list(Name) ++ "-" ++ Vsn, ebin]),
     case code:add_patha(LibDir) of
-        true -> ok;
+        true ->
+            %% load all applications into application controller, before performing
+            %% the configuration check of HOCON
+            %%
+            %% It helps to implement the feature of dynamically searching schema.
+            %% See `emqx_gateway_schema:fields(gateway)`
+            is_emqx_application(Name) andalso application:load(Name),
+            ok;
         {error, _} -> error(LibDir)
     end.
+
+is_emqx_application(Name) when is_atom(Name) ->
+    is_emqx_application(atom_to_list(Name));
+is_emqx_application("emqx_" ++ _Rest) ->
+    true;
+is_emqx_application(_) ->
+    false.


### PR DESCRIPTION
In the previous refactoring https://github.com/emqx/emqx/pull/10278, we added a feature to search all gateway implementations in other applications, see: 
https://github.com/emqx/emqx/blob/7df049331266764979f00e3217bb9da66181a52b/apps/emqx_gateway/src/emqx_gateway_schema.erl#L78

However, it required these gateway applications already being loaded into the application controller.

So, it introduces a problem that if  the `etc/emqx.conf` contains any gateway configurations, starting EMQX will be failed:
<img width="720" alt="image" src="https://user-images.githubusercontent.com/13825269/232224709-92a51379-aaa6-4e0a-81fe-fdead97d544d.png">

Since none of the gateway applications were in a loaded state during the hocon configuration check.

After, this PR we try to load all emqx applications to support the dynamic application searching feature.

Feel free if you have any suggestions :)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
