### PR TITLE
perf(config): eliminate make_ref() calls in config get calls

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -103,6 +103,8 @@
 -define(ZONE_CONF_PATH(ZONE, PATH), [zones, ZONE | PATH]).
 -define(LISTENER_CONF_PATH(TYPE, LISTENER, PATH), [listeners, TYPE, LISTENER | PATH]).
 
+-define(CONFIG_NOT_FOUND_MAGIC, '$0tFound').
+
 -export_type([
     update_request/0,
     raw_config/0,
@@ -164,9 +166,8 @@ get(KeyPath, Default) -> do_get(?CONF, KeyPath, Default).
 -spec find(emqx_utils_maps:config_key_path()) ->
     {ok, term()} | {not_found, emqx_utils_maps:config_key_path(), term()}.
 find([]) ->
-    Ref = make_ref(),
-    case do_get(?CONF, [], Ref) of
-        Ref -> {not_found, []};
+    case do_get(?CONF, [], ?CONFIG_NOT_FOUND_MAGIC) of
+        ?CONFIG_NOT_FOUND_MAGIC -> {not_found, []};
         Res -> {ok, Res}
     end;
 find(KeyPath) ->
@@ -179,9 +180,8 @@ find(KeyPath) ->
 -spec find_raw(emqx_utils_maps:config_key_path()) ->
     {ok, term()} | {not_found, emqx_utils_maps:config_key_path(), term()}.
 find_raw([]) ->
-    Ref = make_ref(),
-    case do_get_raw([], Ref) of
-        Ref -> {not_found, []};
+    case do_get_raw([], ?CONFIG_NOT_FOUND_MAGIC) of
+        ?CONFIG_NOT_FOUND_MAGIC -> {not_found, []};
         Res -> {ok, Res}
     end;
 find_raw(KeyPath) ->
@@ -666,11 +666,9 @@ do_get_raw(Path, Default) ->
     do_get(?RAW_CONF, Path, Default).
 
 do_get(Type, KeyPath) ->
-    Ref = make_ref(),
-    Res = do_get(Type, KeyPath, Ref),
-    case Res =:= Ref of
-        true -> error({config_not_found, KeyPath});
-        false -> Res
+    case do_get(Type, KeyPath, ?CONFIG_NOT_FOUND_MAGIC) of
+        ?CONFIG_NOT_FOUND_MAGIC -> error({config_not_found, KeyPath});
+        Res -> Res
     end.
 
 do_get(Type, [], Default) ->

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.0.0"},
+    {vsn, "5.0.1"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/src/emqx_utils_maps.erl
+++ b/apps/emqx_utils/src/emqx_utils_maps.erl
@@ -41,14 +41,13 @@
 -type config_key_path() :: [config_key()].
 -type convert_fun() :: fun((...) -> {K1 :: any(), V1 :: any()} | drop).
 
+-define(CONFIG_NOT_FOUND_MAGIC, '$0tFound').
 %%-----------------------------------------------------------------
 -spec deep_get(config_key_path(), map()) -> term().
 deep_get(ConfKeyPath, Map) ->
-    Ref = make_ref(),
-    Res = deep_get(ConfKeyPath, Map, Ref),
-    case Res =:= Ref of
-        true -> error({config_not_found, ConfKeyPath});
-        false -> Res
+    case deep_get(ConfKeyPath, Map, ?CONFIG_NOT_FOUND_MAGIC) of
+        ?CONFIG_NOT_FOUND_MAGIC -> error({config_not_found, ConfKeyPath});
+        Res -> Res
     end.
 
 -spec deep_get(config_key_path(), map(), term()) -> term().

--- a/changes/ce/perf-10417.en.md
+++ b/changes/ce/perf-10417.en.md
@@ -1,4 +1,1 @@
-Improve get config performance
-
-eliminate make_ref calls
-
+Improve get config performance by eliminating temporary references.

--- a/changes/ce/perf-10417.en.md
+++ b/changes/ce/perf-10417.en.md
@@ -1,0 +1,4 @@
+Improve get config performance
+
+eliminate make_ref calls
+


### PR DESCRIPTION
Fixes EMQX-9615

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e462b7f</samp>

This pull request refactors the `emqx_config` module to use a macro for handling missing configuration keys, and moves some code from the `emqx_utils_maps` module to the `emqx_config` module to improve code quality and performance.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
~- [ ] Schema changes are backward compatible~

