### PR TITLE
fix(plugins): attempt to extract plugin from current node on startup

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -764,6 +764,7 @@ setup_node(Node, Opts) when is_map(Opts) ->
                 load_apps => LoadApps,
                 apps => Apps,
                 env => Env,
+                join_to => JoinTo,
                 start_apps => StartApps
             }
         ]

--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/changes/ce/fix-10422.en.md
+++ b/changes/ce/fix-10422.en.md
@@ -1,0 +1,1 @@
+Fixed a bug where external plugins could not be configured via environment variables in a lone-node cluster.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9605

Fixes https://github.com/emqx/emqx-elixir-plugin/issues/25

If an user happens to configure a plugin in a lone-node cluster via environment variables, it would fail to start up as there are no other nodes to copy the plugin from.  Here, we attempt to check if the package is present in the current node but not yet extracted.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fb9eb6e</samp>

This pull request enhances the `emqx_plugins` module and its test suite. It adds a test case for starting a plugin on a single node, updates the version number, improves the plugin extraction and cluster copy logic, and adds a new field to the cluster helper function.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
