### PR TITLE
Refactor mria running nodes

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -97,7 +97,7 @@ format_list(Listener) ->
 do_list_raw() ->
     %% GET /listeners from other nodes returns [] when init config is not loaded.
     %% FIXME This is a workaround for the issue:
-    %% mria:running_nodes() sometime return node which not ready to accept rpc call.
+    %% emqx:running_nodes() sometime return node which not ready to accept rpc call.
     case emqx_app:init_load_done() of
         true ->
             Key = <<"listeners">>,

--- a/apps/emqx/src/emqx_sys.erl
+++ b/apps/emqx/src/emqx_sys.erl
@@ -211,7 +211,7 @@ handle_info({timeout, TRef, heartbeat}, State = #state{heartbeat = TRef}) ->
 handle_info({timeout, TRef, tick}, State = #state{ticker = TRef, sysdescr = Descr}) ->
     publish_any(version, version()),
     publish_any(sysdescr, Descr),
-    publish_any(brokers, mria:running_nodes()),
+    publish_any(brokers, emqx:running_nodes()),
     publish_any(stats, emqx_stats:getstats()),
     publish_any(metrics, emqx_metrics:all()),
     {noreply, tick(State), hibernate};

--- a/apps/emqx/src/persistent_session/emqx_persistent_session.erl
+++ b/apps/emqx/src/persistent_session/emqx_persistent_session.erl
@@ -301,7 +301,7 @@ resume(ClientInfo = #{clientid := ClientID}, ConnInfo, Session) ->
     %% 3. Notify writers that we are resuming.
     %%    They will buffer new messages.
     ?tp(ps_notify_writers, #{sid => SessionID}),
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     NodeMarkers = resume_begin(Nodes, SessionID),
     ?tp(ps_node_markers, #{sid => SessionID, markers => NodeMarkers}),
 

--- a/apps/emqx/test/props/prop_emqx_sys.erl
+++ b/apps/emqx/test/props/prop_emqx_sys.erl
@@ -109,8 +109,8 @@ do_mock(emqx_broker) ->
     );
 do_mock(emqx_stats) ->
     meck:expect(emqx_stats, getstats, fun() -> [0] end);
-do_mock(mria) ->
-    meck:expect(mria, running_nodes, fun() -> [node()] end);
+do_mock(emqx) ->
+    meck:expect(emqx, running_nodes, fun() -> [node()] end);
 do_mock(emqx_metrics) ->
     meck:expect(emqx_metrics, all, fun() -> [{hello, 3}] end);
 do_mock(emqx_hooks) ->

--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -901,7 +901,7 @@ lookup_from_local_node(ChainName, AuthenticatorID) ->
     end.
 
 lookup_from_all_nodes(ChainName, AuthenticatorID) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     LookupResult = emqx_authn_proto_v1:lookup_from_all_nodes(Nodes, ChainName, AuthenticatorID),
     case is_ok(LookupResult) of
         {ok, ResList} ->

--- a/apps/emqx_authz/src/emqx_authz_api_sources.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_sources.erl
@@ -356,7 +356,7 @@ lookup_from_local_node(Type) ->
     end.
 
 lookup_from_all_nodes(Type) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case is_ok(emqx_authz_proto_v1:lookup_from_all_nodes(Nodes, Type)) of
         {ok, ResList} ->
             {StatusMap, MetricsMap, ResourceMetricsMap, ErrorMap} = make_result_map(ResList),

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -465,7 +465,7 @@ schema("/bridges_probe") ->
             create_bridge(BridgeType, BridgeName, Conf)
     end;
 '/bridges'(get, _Params) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     NodeReplies = emqx_bridge_proto_v4:list_bridges_on_nodes(Nodes),
     case is_ok(NodeReplies) of
         {ok, NodeBridges} ->
@@ -571,7 +571,7 @@ maybe_deobfuscate_bridge_probe(Params) ->
     Params.
 
 get_metrics_from_all_nodes(BridgeType, BridgeName) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     Result = do_bpapi_call(all, get_metrics_from_all_nodes, [Nodes, BridgeType, BridgeName]),
     case Result of
         Metrics when is_list(Metrics) ->
@@ -581,7 +581,7 @@ get_metrics_from_all_nodes(BridgeType, BridgeName) ->
     end.
 
 lookup_from_all_nodes(BridgeType, BridgeName, SuccCode) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case is_ok(emqx_bridge_proto_v4:lookup_from_all_nodes(Nodes, BridgeType, BridgeName)) of
         {ok, [{ok, _} | _] = Results} ->
             {SuccCode, format_bridge_info([R || {ok, R} <- Results])};
@@ -650,7 +650,7 @@ get_metrics_from_local_node(BridgeType, BridgeName) ->
                     false ->
                         ?BRIDGE_NOT_ENABLED;
                     true ->
-                        Nodes = mria:running_nodes(),
+                        Nodes = emqx:running_nodes(),
                         call_operation(all, OperFunc, [Nodes, BridgeType, BridgeName])
                 catch
                     throw:not_found ->
@@ -1027,7 +1027,7 @@ do_bpapi_call(all, Call, Args) ->
         do_bpapi_call_vsn(emqx_bpapi:supported_version(emqx_bridge), Call, Args)
     );
 do_bpapi_call(Node, Call, Args) ->
-    case lists:member(Node, mria:running_nodes()) of
+    case lists:member(Node, emqx:running_nodes()) of
         true ->
             do_bpapi_call_vsn(emqx_bpapi:supported_version(Node, emqx_bridge), Call, Args);
         false ->

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -577,7 +577,7 @@ do_alarm(Fun, Res, #{tnx_id := Id} = Meta) ->
 
 wait_for_all_nodes_commit(TnxId, Delay, Remain) ->
     Lagging = lagging_nodes(TnxId),
-    Stopped = Lagging -- mria:running_nodes(),
+    Stopped = Lagging -- emqx:running_nodes(),
     case Lagging -- Stopped of
         [] when Stopped =:= [] ->
             ok;
@@ -602,7 +602,7 @@ wait_for_nodes_commit(RequiredSyncs, TnxId, Delay, Remain) ->
                 [] ->
                     ok;
                 Lagging ->
-                    Stopped = Lagging -- mria:running_nodes(),
+                    Stopped = Lagging -- emqx:running_nodes(),
                     case Stopped of
                         [] -> {peers_lagging, Lagging};
                         _ -> {stopped_nodes, Stopped}

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -119,7 +119,7 @@ init_conf() ->
     ok.
 
 cluster_nodes() ->
-    mria:cluster_nodes(cores) -- [node()].
+    emqx:cluster_nodes(cores) -- [node()].
 
 %% @doc Try to sync the cluster config from other core nodes.
 sync_cluster_conf() ->

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -70,7 +70,7 @@ admins(["status"]) ->
     status();
 admins(["skip"]) ->
     status(),
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     lists:foreach(fun emqx_cluster_rpc:skip_failed_commit/1, Nodes),
     status();
 admins(["skip", Node0]) ->
@@ -83,13 +83,13 @@ admins(["tnxid", TnxId0]) ->
     print(emqx_cluster_rpc:query(TnxId));
 admins(["fast_forward"]) ->
     status(),
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     TnxId = emqx_cluster_rpc:latest_tnx_id(),
     lists:foreach(fun(N) -> emqx_cluster_rpc:fast_forward_to_commit(N, TnxId) end, Nodes),
     status();
 admins(["fast_forward", ToTnxId]) ->
     status(),
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     TnxId = list_to_integer(ToTnxId),
     lists:foreach(fun(N) -> emqx_cluster_rpc:fast_forward_to_commit(N, TnxId) end, Nodes),
     status();

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -49,15 +49,15 @@ init_per_suite(Config) ->
     meck:new(emqx_alarm, [non_strict, passthrough, no_link]),
     meck:expect(emqx_alarm, activate, 3, ok),
     meck:expect(emqx_alarm, deactivate, 3, ok),
-    meck:new(mria, [non_strict, passthrough, no_link]),
-    meck:expect(mria, running_nodes, 0, [?NODE1, {node(), ?NODE2}, {node(), ?NODE3}]),
+    meck:new(emqx, [non_strict, passthrough, no_link]),
+    meck:expect(emqx, running_nodes, 0, [?NODE1, {node(), ?NODE2}, {node(), ?NODE3}]),
     Config.
 
 end_per_suite(_Config) ->
     ok = emqx_common_test_helpers:stop_apps([]),
     ekka:stop(),
     mria:stop(),
-    meck:unload(mria),
+    meck:unload(emqx),
     mria_mnesia:delete_schema(),
     meck:unload(emqx_alarm),
     ok.

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -126,7 +126,7 @@ current_rate() ->
             (_Node, Error) ->
                 Error
         end,
-    case lists:foldl(Fun, #{}, mria:cluster_nodes(running)) of
+    case lists:foldl(Fun, #{}, emqx:cluster_nodes(running)) of
         {badrpc, Reason} ->
             {badrpc, Reason};
         Rate ->
@@ -205,7 +205,7 @@ do_call(Request) ->
     gen_server:call(?MODULE, Request, 5000).
 
 do_sample(all, Time) ->
-    do_sample(mria:cluster_nodes(running), Time, #{});
+    do_sample(emqx:cluster_nodes(running), Time, #{});
 do_sample(Node, Time) when Node == node() ->
     MS = match_spec(Time),
     internal_format(ets:select(?TAB, MS));

--- a/apps/emqx_exhook/src/emqx_exhook_api.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_api.erl
@@ -471,7 +471,7 @@ fill_server_hooks_info([], _Name, _Default, MetricsL) ->
 -spec call_cluster(fun(([node()]) -> emqx_rpc:erpc_multicall(A))) ->
     [{node(), A | {error, _Err}}].
 call_cluster(Fun) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     Ret = Fun(Nodes),
     lists:zip(Nodes, lists:map(fun emqx_rpc:unwrap_erpc/1, Ret)).
 

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -281,7 +281,7 @@ get_cluster_listeners_info(GwName) ->
     ).
 
 listeners_cluster_status(Listeners) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case emqx_gateway_api_listeners_proto_v1:listeners_cluster_status(Nodes, Listeners) of
         {Results, []} ->
             Results;

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -215,7 +215,7 @@ get_chan_info(GwName, ClientId, ChanPid) ->
 
 -spec lookup_by_clientid(gateway_name(), emqx_types:clientid()) -> [pid()].
 lookup_by_clientid(GwName, ClientId) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case
         emqx_gateway_cm_proto_v1:lookup_by_clientid(
             Nodes, GwName, ClientId

--- a/apps/emqx_gateway/src/emqx_gateway_http.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_http.erl
@@ -148,7 +148,7 @@ gateway_status(GwName) ->
     end.
 
 cluster_gateway_status(GwName) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case emqx_gateway_http_proto_v1:get_cluster_status(Nodes, GwName) of
         {Results, []} ->
             Results;

--- a/apps/emqx_modules/src/emqx_topic_metrics_api.erl
+++ b/apps/emqx_modules/src/emqx_topic_metrics_api.erl
@@ -321,7 +321,7 @@ operate_topic_metrics(delete, #{bindings := #{topic := Topic}}) ->
 %%--------------------------------------------------------------------
 
 cluster_accumulation_metrics() ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case emqx_topic_metrics_proto_v1:metrics(Nodes) of
         {SuccResList, []} ->
             {ok, accumulate_nodes_metrics(SuccResList)};
@@ -330,7 +330,7 @@ cluster_accumulation_metrics() ->
     end.
 
 cluster_accumulation_metrics(Topic) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case emqx_topic_metrics_proto_v1:metrics(Nodes, Topic) of
         {SuccResList, []} ->
             case
@@ -422,12 +422,12 @@ do_accumulation_metrics(MetricsIn, {MetricsAcc, _}) ->
     ).
 
 reset() ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     _ = emqx_topic_metrics_proto_v1:reset(Nodes),
     ok.
 
 reset(Topic) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case emqx_topic_metrics_proto_v1:reset(Nodes, Topic) of
         {SuccResList, []} ->
             case

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -497,7 +497,7 @@ ensure_exists_and_installed(NameVsn) ->
     end.
 
 do_get_from_cluster(NameVsn) ->
-    Nodes = [N || N <- mria:running_nodes(), N /= node()],
+    Nodes = [N || N <- emqx:running_nodes(), N /= node()],
     case get_from_any_node(Nodes, NameVsn, []) of
         {ok, TarContent} ->
             ok = file:write_file(pkg_file(NameVsn), TarContent),

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -37,8 +37,6 @@ init_per_suite(Config) ->
     ok = ekka:start(),
     ok = mria_rlog:wait_for_shards([?CLUSTER_RPC_SHARD], infinity),
 
-    meck:new(mria_rlog, [non_strict, passthrough, no_link]),
-
     emqx_prometheus_SUITE:load_config(),
     emqx_mgmt_api_test_util:init_suite([emqx_prometheus]),
 
@@ -48,8 +46,6 @@ end_per_suite(Config) ->
     ekka:stop(),
     mria:stop(),
     mria_mnesia:delete_schema(),
-
-    meck:unload(mria_rlog),
 
     emqx_mgmt_api_test_util:end_suite([emqx_prometheus]),
     Config.
@@ -109,9 +105,6 @@ t_stats_api(_) ->
     Data = emqx_utils_json:decode(Response, [return_maps]),
     ?assertMatch(#{<<"client">> := _, <<"delivery">> := _}, Data),
 
-    {ok, _} = emqx_mgmt_api_test_util:request_api(get, Path, "", Auth),
-
-    ok = meck:expect(mria_rlog, backend, fun() -> rlog end),
     {ok, _} = emqx_mgmt_api_test_util:request_api(get, Path, "", Auth),
 
     ok.

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -627,7 +627,7 @@ do_reindex_batch(QC, Done) ->
     {Status, Done + length(Topics)}.
 
 wait_dispatch_complete(Timeout) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     {Results, []} = emqx_retainer_proto_v2:wait_dispatch_complete(Nodes, Timeout),
     lists:all(
         fun(Result) -> Result =:= ok end,
@@ -650,7 +650,7 @@ active_indices() ->
     {dirty_indices(read), dirty_indices(write)}.
 
 are_indices_updated(Indices) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     case emqx_retainer_proto_v2:active_mnesia_indices(Nodes) of
         {Results, []} ->
             lists:all(

--- a/apps/emqx_slow_subs/src/emqx_slow_subs_api.erl
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs_api.erl
@@ -147,5 +147,5 @@ settings(put, #{body := Body}) ->
     end.
 
 rpc_call(Fun) ->
-    Nodes = mria:running_nodes(),
+    Nodes = emqx:running_nodes(),
     Fun(Nodes).

--- a/apps/emqx_telemetry/src/emqx_telemetry.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry.erl
@@ -273,7 +273,7 @@ uptime() ->
     element(1, erlang:statistics(wall_clock)).
 
 nodes_uuid() ->
-    Nodes = lists:delete(node(), mria:running_nodes()),
+    Nodes = lists:delete(node(), emqx:running_nodes()),
     lists:foldl(
         fun(Node, Acc) ->
             case emqx_telemetry_proto_v1:get_node_uuid(Node) of

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -857,7 +857,7 @@ stop_slave(Node) ->
     %emqx_cluster_rpc:fast_forward_to_commit(Node, 100),
     rpc:call(Node, ?MODULE, leave_cluster, []),
     ok = slave:stop(Node),
-    ?assertEqual([node()], mria:running_nodes()),
+    ?assertEqual([node()], emqx:running_nodes()),
     ?assertEqual([], nodes()),
     _ = application:stop(mria),
     ok = application:start(mria).

--- a/apps/emqx_utils/src/emqx_utils_api.erl
+++ b/apps/emqx_utils/src/emqx_utils_api.erl
@@ -62,7 +62,7 @@ lookup_node(Node) when is_atom(Node) ->
 
 -spec is_running_node(atom()) -> {ok, atom()} | not_found.
 is_running_node(Node) ->
-    case lists:member(Node, mria:running_nodes()) of
+    case lists:member(Node, emqx:running_nodes()) of
         true ->
             {ok, Node};
         false ->

--- a/changes/ce/fix-10437.en.md
+++ b/changes/ce/fix-10437.en.md
@@ -1,0 +1,2 @@
+Avoid calling certain mria APIs directly in EMQX code.
+This change lays the groundwork for improving robustness of remote procedure calls: mria doesn't have any information about the status of the EMQX application, and it can falsely report some node as running before it's fully started.

--- a/lib-ee/emqx_license/src/emqx_license_resources.erl
+++ b/lib-ee/emqx_license/src/emqx_license_resources.erl
@@ -127,7 +127,7 @@ ensure_timer(#{check_peer_interval := CheckInterval} = State) ->
     State#{timer => erlang:send_after(CheckInterval, self(), update_resources)}.
 
 remote_connection_count() ->
-    Nodes = mria:running_nodes() -- [node()],
+    Nodes = emqx:running_nodes() -- [node()],
     Results = emqx_license_proto_v2:remote_connection_counts(Nodes),
     Counts = [Count || {ok, Count} <- Results],
     lists:sum(Counts).


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9611

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at be76040</samp>

This pull request refactors the codebase to use `emqx:running_nodes()` and `emqx:cluster_nodes/1` as the single source of truth for the cluster node information, instead of using the `mria` module, which is a distributed database library. This improves the consistency, reliability, and simplicity of the cluster operations and the HTTP, CLI, and MQTT APIs that depend on them. The pull request also bumps the version of the `emqx_plugins` application and updates the test code to match the changes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
