### PR TITLE
fix(dynamo): fix terminology erros in the schema of the Dynamo bridge

### DIFF
--- a/changes/ee/fix-10438.en.md
+++ b/changes/ee/fix-10438.en.md
@@ -1,3 +1,5 @@
-Fix a configuration item name error in the DynamoDB data bridge.
+Fix some configuration item terminology errors in the DynamoDB data bridge:
 
-Changed `database` to `table`, because there is no term like `database` in DynamoDB, the correct concept should be `table`
+- Changed `database` to `table`
+- Changed `username` to `aws_access_key_id`
+- Changed `password` to `aws_secret_access_key`

--- a/changes/ee/fix-10438.en.md
+++ b/changes/ee/fix-10438.en.md
@@ -1,0 +1,3 @@
+Fix a configuration item name error in the DynamoDB data bridge.
+
+Changed `database` to `table`, because there is no term like `database` in DynamoDB, the correct concept should be `table`

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_dynamo.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_dynamo.erl
@@ -43,7 +43,7 @@ values(_Method) ->
         type => dynamo,
         name => <<"foo">>,
         url => <<"http://127.0.0.1:8000">>,
-        database => <<"mqtt">>,
+        table => <<"mqtt">>,
         pool_size => 8,
         username => <<"root">>,
         password => <<"******">>,

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_dynamo.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_dynamo.erl
@@ -45,8 +45,8 @@ values(_Method) ->
         url => <<"http://127.0.0.1:8000">>,
         table => <<"mqtt">>,
         pool_size => 8,
-        username => <<"root">>,
-        password => <<"******">>,
+        aws_access_key_id => <<"root">>,
+        aws_secret_access_key => <<"******">>,
         template => ?DEFAULT_TEMPLATE,
         local_topic => <<"local/topic/#">>,
         resource_opts => #{

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_dynamo_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_dynamo_SUITE.erl
@@ -14,8 +14,8 @@
 % DB defaults
 -define(TABLE, "mqtt").
 -define(TABLE_BIN, to_bin(?TABLE)).
--define(USERNAME, "root").
--define(PASSWORD, "public").
+-define(ACCESS_KEY_ID, "root").
+-define(SECRET_ACCESS_KEY, "public").
 -define(HOST, "dynamo").
 -define(PORT, 8000).
 -define(SCHEMA, "http://").
@@ -159,8 +159,8 @@ dynamo_config(BridgeType, Config) ->
             "  enable = true\n"
             "  url = ~p\n"
             "  table = ~p\n"
-            "  username = ~p\n"
-            "  password = ~p\n"
+            "  aws_access_key_id = ~p\n"
+            "  aws_secret_access_key = ~p\n"
             "  resource_opts = {\n"
             "    request_timeout = 500ms\n"
             "    batch_size = ~b\n"
@@ -172,8 +172,8 @@ dynamo_config(BridgeType, Config) ->
                 Name,
                 Url,
                 ?TABLE,
-                ?USERNAME,
-                ?PASSWORD,
+                ?ACCESS_KEY_ID,
+                ?SECRET_ACCESS_KEY,
                 BatchSize,
                 QueryMode
             ]
@@ -244,10 +244,10 @@ delete_table(_Config) ->
 setup_dynamo(Config) ->
     Host = ?GET_CONFIG(host, Config),
     Port = ?GET_CONFIG(port, Config),
-    erlcloud_ddb2:configure(?USERNAME, ?PASSWORD, Host, Port, ?SCHEMA).
+    erlcloud_ddb2:configure(?ACCESS_KEY_ID, ?SECRET_ACCESS_KEY, Host, Port, ?SCHEMA).
 
 directly_setup_dynamo() ->
-    erlcloud_ddb2:configure(?USERNAME, ?PASSWORD, ?HOST, ?PORT, ?SCHEMA).
+    erlcloud_ddb2:configure(?ACCESS_KEY_ID, ?SECRET_ACCESS_KEY, ?HOST, ?PORT, ?SCHEMA).
 
 directly_query(Query) ->
     directly_setup_dynamo(),

--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_dynamo_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_dynamo_SUITE.erl
@@ -158,7 +158,7 @@ dynamo_config(BridgeType, Config) ->
             "bridges.~s.~s {\n"
             "  enable = true\n"
             "  url = ~p\n"
-            "  database = ~p\n"
+            "  table = ~p\n"
             "  username = ~p\n"
             "  password = ~p\n"
             "  resource_opts = {\n"

--- a/rel/i18n/emqx_ee_connector_dynamo.hocon
+++ b/rel/i18n/emqx_ee_connector_dynamo.hocon
@@ -11,4 +11,10 @@ emqx_ee_connector_dynamo {
             }
     }
 
+table.desc:
+"""DynamoDB Table."""
+
+table.label:
+"""DynamoDB Table"""
+
 }

--- a/rel/i18n/emqx_ee_connector_dynamo.hocon
+++ b/rel/i18n/emqx_ee_connector_dynamo.hocon
@@ -11,10 +11,36 @@ emqx_ee_connector_dynamo {
             }
     }
 
-table.desc:
-"""DynamoDB Table."""
+    table {
+        desc {
+          en: """DynamoDB Table."""
+          zh: """DynamoDB 的表。"""
+        }
+        label: {
+              en: "Table "
+              zh: "表"
+            }
+    }
 
-table.label:
-"""DynamoDB Table"""
+    aws_access_key_id {
+        desc {
+          en: """Access Key ID for connecting to DynamoDB."""
+          zh: """DynamoDB 的访问 ID。"""
+        }
+        label: {
+             en: "AWS Access Key ID"
+             zh: "连接访问 ID"
+            }
+    }
 
+    aws_secret_access_key {
+        desc {
+          en: """AWS Secret Access Key for connecting to DynamoDB."""
+          zh: """DynamoDB 的访问密钥。"""
+        }
+        label: {
+              en: "AWS Secret Access Key"
+              zh: "连接访问密钥"
+            }
+    }
 }


### PR DESCRIPTION
- Changed `database` to `table`
- Changed `username` to `aws_access_key_id`
- Changed `password` to `aws_secret_access_key`

Fixes [EMQX-9612](https://emqx.atlassian.net/browse/EMQX-9612)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58a6b67</samp>

This pull request renames the `database` field to `table` in the DynamoDB connector and its related files. This makes the configuration and usage of the connector more consistent with the DynamoDB terminology and simplifies the query execution.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
