### PR TITLE
chore: fix flaky test in emqx_ee_bridge_cassa_SUITE

### DIFF
--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_cassa_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_cassa_SUITE.erl
@@ -530,15 +530,16 @@ t_write_failure(Config) ->
         fun(Trace0) ->
             ct:pal("trace: ~p", [Trace0]),
             Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
-            ?assertMatch([#{result := {async_return, {error, _}}} | _], Trace),
-            [#{result := {async_return, {error, Error}}} | _] = Trace,
-            case Error of
-                {resource_error, _} ->
+            [#{result := Result} | _] = Trace,
+            case Result of
+                {async_return, {error, {resource_error, _}}} ->
                     ok;
-                {recoverable_error, disconnected} ->
+                {async_return, {error, {recoverable_error, disconnected}}} ->
+                    ok;
+                {error, {resource_error, _}} ->
                     ok;
                 _ ->
-                    ct:fail("unexpected error: ~p", [Error])
+                    ct:fail("unexpected error: ~p", [Result])
             end
         end
     ),


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/actions/runs/4729911432/jobs/8397694126

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 87c5170</samp>

Simplify and fix error handling in `emqx_ee_bridge_cassa_SUITE.erl`. Handle the new error format returned by the buffer worker when flushing messages to Cassandra.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
