### PR TITLE
fix: always check authn_http's header and ssl_option

### DIFF
--- a/apps/emqx_authn/src/emqx_authn.app.src
+++ b/apps/emqx_authn/src/emqx_authn.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authn, [
     {description, "EMQX Authentication"},
-    {vsn, "0.1.17"},
+    {vsn, "0.1.18"},
     {modules, []},
     {registered, [emqx_authn_sup, emqx_authn_registry]},
     {applications, [kernel, stdlib, emqx_resource, emqx_connector, ehttpc, epgsql, mysql, jose]},

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -38,6 +38,8 @@
     headers/1
 ]).
 
+-export([check_headers/1, check_ssl_opts/1]).
+
 -export([
     refs/0,
     union_member_selector/1,
@@ -107,8 +109,8 @@ common_fields() ->
 
 validations() ->
     [
-        {check_ssl_opts, fun check_ssl_opts/1},
-        {check_headers, fun check_headers/1}
+        {check_ssl_opts, fun ?MODULE:check_ssl_opts/1},
+        {check_headers, fun ?MODULE:check_headers/1}
     ].
 
 url(type) -> binary();
@@ -262,21 +264,39 @@ transform_header_name(Headers) ->
     ).
 
 check_ssl_opts(Conf) ->
-    {BaseUrl, _Path, _Query} = parse_url(get_conf_val("url", Conf)),
-    case BaseUrl of
-        <<"https://", _/binary>> ->
-            case get_conf_val("ssl.enable", Conf) of
-                true -> ok;
-                false -> false
-            end;
-        <<"http://", _/binary>> ->
-            ok
+    case get_conf_val("url", Conf) of
+        undefined ->
+            ok;
+        Url ->
+            {BaseUrl, _Path, _Query} = parse_url(Url),
+            case BaseUrl of
+                <<"https://", _/binary>> ->
+                    case get_conf_val("ssl.enable", Conf) of
+                        true ->
+                            ok;
+                        false ->
+                            <<"it's required to enable the TLS option to establish a https connection">>
+                    end;
+                <<"http://", _/binary>> ->
+                    ok
+            end
     end.
 
 check_headers(Conf) ->
-    Method = to_bin(get_conf_val("method", Conf)),
-    Headers = get_conf_val("headers", Conf),
-    Method =:= <<"post">> orelse (not maps:is_key(<<"content-type">>, Headers)).
+    case get_conf_val("headers", Conf) of
+        undefined ->
+            ok;
+        Headers ->
+            case to_bin(get_conf_val("method", Conf)) of
+                <<"post">> ->
+                    ok;
+                <<"get">> ->
+                    case maps:is_key(<<"content-type">>, Headers) of
+                        false -> ok;
+                        true -> <<"HTTP GET requests cannot include content-type header.">>
+                    end
+            end
+    end.
 
 parse_url(Url) ->
     case string:split(Url, "//", leading) of
@@ -311,7 +331,7 @@ parse_config(
         method => Method,
         path => Path,
         headers => ensure_header_name_type(Headers),
-        base_path_templete => emqx_authn_utils:parse_str(Path),
+        base_path_template => emqx_authn_utils:parse_str(Path),
         base_query_template => emqx_authn_utils:parse_deep(
             cow_qs:parse_qs(to_bin(Query))
         ),
@@ -324,7 +344,7 @@ parse_config(
 generate_request(Credential, #{
     method := Method,
     headers := Headers0,
-    base_path_templete := BasePathTemplate,
+    base_path_template := BasePathTemplate,
     base_query_template := BaseQueryTemplate,
     body_template := BodyTemplate
 }) ->

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -264,10 +264,9 @@ transform_header_name(Headers) ->
     ).
 
 check_ssl_opts(Conf) ->
-    case get_conf_val("url", Conf) of
-        undefined ->
-            ok;
-        Url ->
+    case is_backend_http(Conf) of
+        true ->
+            Url = get_conf_val("url", Conf),
             {BaseUrl, _Path, _Query} = parse_url(Url),
             case BaseUrl of
                 <<"https://", _/binary>> ->
@@ -279,14 +278,15 @@ check_ssl_opts(Conf) ->
                     end;
                 <<"http://", _/binary>> ->
                     ok
-            end
+            end;
+        false ->
+            ok
     end.
 
 check_headers(Conf) ->
-    case get_conf_val("headers", Conf) of
-        undefined ->
-            ok;
-        Headers ->
+    case is_backend_http(Conf) of
+        true ->
+            Headers = get_conf_val("headers", Conf),
             case to_bin(get_conf_val("method", Conf)) of
                 <<"post">> ->
                     ok;
@@ -295,7 +295,15 @@ check_headers(Conf) ->
                         false -> ok;
                         true -> <<"HTTP GET requests cannot include content-type header.">>
                     end
-            end
+            end;
+        false ->
+            ok
+    end.
+
+is_backend_http(Conf) ->
+    case get_conf_val("backend", Conf) of
+        http -> true;
+        _ -> false
     end.
 
 parse_url(Url) ->

--- a/apps/emqx_authn/test/emqx_authn_https_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_https_SUITE.erl
@@ -114,6 +114,22 @@ t_create_invalid_version(_Config) ->
         emqx_access_control:authenticate(?CREDENTIALS)
     ).
 
+t_create_disable_ssl_opts_when_https(_Config) ->
+    {ok, _} = create_https_auth_with_ssl_opts(
+        #{
+            <<"server_name_indication">> => <<"authn-server">>,
+            <<"verify">> => <<"verify_peer">>,
+            <<"versions">> => [<<"tlsv1.2">>],
+            <<"ciphers">> => [<<"ECDHE-RSA-AES256-GCM-SHA384">>],
+            <<"enable">> => <<"false">>
+        }
+    ),
+
+    ?assertEqual(
+        {error, not_authorized},
+        emqx_access_control:authenticate(?CREDENTIALS)
+    ).
+
 t_create_invalid_ciphers(_Config) ->
     {ok, _} = create_https_auth_with_ssl_opts(
         #{
@@ -135,6 +151,7 @@ t_create_invalid_ciphers(_Config) ->
 
 create_https_auth_with_ssl_opts(SpecificSSLOpts) ->
     AuthConfig = raw_https_auth_config(SpecificSSLOpts),
+    ct:pal("111:~p~n", [AuthConfig]),
     emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}).
 
 raw_https_auth_config(SpecificSSLOpts) ->

--- a/apps/emqx_authn/test/emqx_authn_https_SUITE.erl
+++ b/apps/emqx_authn/test/emqx_authn_https_SUITE.erl
@@ -114,22 +114,6 @@ t_create_invalid_version(_Config) ->
         emqx_access_control:authenticate(?CREDENTIALS)
     ).
 
-t_create_disable_ssl_opts_when_https(_Config) ->
-    {ok, _} = create_https_auth_with_ssl_opts(
-        #{
-            <<"server_name_indication">> => <<"authn-server">>,
-            <<"verify">> => <<"verify_peer">>,
-            <<"versions">> => [<<"tlsv1.2">>],
-            <<"ciphers">> => [<<"ECDHE-RSA-AES256-GCM-SHA384">>],
-            <<"enable">> => <<"false">>
-        }
-    ),
-
-    ?assertEqual(
-        {error, not_authorized},
-        emqx_access_control:authenticate(?CREDENTIALS)
-    ).
-
 t_create_invalid_ciphers(_Config) ->
     {ok, _} = create_https_auth_with_ssl_opts(
         #{
@@ -151,7 +135,6 @@ t_create_invalid_ciphers(_Config) ->
 
 create_https_auth_with_ssl_opts(SpecificSSLOpts) ->
     AuthConfig = raw_https_auth_config(SpecificSSLOpts),
-    ct:pal("111:~p~n", [AuthConfig]),
     emqx:update_config(?PATH, {create_authenticator, ?GLOBAL, AuthConfig}).
 
 raw_https_auth_config(SpecificSSLOpts) ->

--- a/apps/emqx_authz/src/emqx_authz.app.src
+++ b/apps/emqx_authz/src/emqx_authz.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authz, [
     {description, "An OTP application"},
-    {vsn, "0.1.17"},
+    {vsn, "0.1.18"},
     {registered, []},
     {mod, {emqx_authz_app, []}},
     {applications, [

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -5,27 +5,27 @@
 -module(emqx_conf_schema_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+-define(BASE_CONF,
+    ""
+    "\n"
+    "     node {\n"
+    "        name = \"emqx1@127.0.0.1\"\n"
+    "        cookie = \"emqxsecretcookie\"\n"
+    "        data_dir = \"data\"\n"
+    "     }\n"
+    "     cluster {\n"
+    "        name = emqxcl\n"
+    "        discovery_strategy = static\n"
+    "        static.seeds = ~p\n"
+    "        core_nodes = ~p\n"
+    "     }\n"
+    ""
+).
 array_nodes_test() ->
     ExpectNodes = ['emqx1@127.0.0.1', 'emqx2@127.0.0.1'],
-    BaseConf =
-        ""
-        "\n"
-        "     node {\n"
-        "        name = \"emqx1@127.0.0.1\"\n"
-        "        cookie = \"emqxsecretcookie\"\n"
-        "        data_dir = \"data\"\n"
-        "     }\n"
-        "     cluster {\n"
-        "        name = emqxcl\n"
-        "        discovery_strategy = static\n"
-        "        static.seeds = ~p\n"
-        "        core_nodes = ~p\n"
-        "     }\n"
-        "   "
-        "",
     lists:foreach(
         fun(Nodes) ->
-            ConfFile = iolist_to_binary(io_lib:format(BaseConf, [Nodes, Nodes])),
+            ConfFile = iolist_to_binary(io_lib:format(?BASE_CONF, [Nodes, Nodes])),
             {ok, Conf} = hocon:binary(ConfFile, #{format => richmap}),
             ConfList = hocon_tconf:generate(emqx_conf_schema, Conf),
             ClusterDiscovery = proplists:get_value(
@@ -43,6 +43,72 @@ array_nodes_test() ->
             )
         end,
         [["emqx1@127.0.0.1", "emqx2@127.0.0.1"], "emqx1@127.0.0.1, emqx2@127.0.0.1"]
+    ),
+    ok.
+
+authn_validations_test() ->
+    BaseConf = iolist_to_binary(io_lib:format(?BASE_CONF, ["emqx1@127.0.0.1", "emqx1@127.0.0.1"])),
+    DisableSSLWithHttps =
+        ""
+        "\n"
+        "authentication = [\n"
+        "{backend = \"http\"\n"
+        "body {password = \"${password}\", username = \"${username}\"}\n"
+        "connect_timeout = \"15s\"\n"
+        "enable_pipelining = 100\n"
+        "headers {\"content-type\" = \"application/json\"}\n"
+        "mechanism = \"password_based\"\n"
+        "method = \"post\"\n"
+        "pool_size = 8\n"
+        "request_timeout = \"5s\"\n"
+        "ssl {enable = false, verify = \"verify_peer\"}\n"
+        "url = \"https://127.0.0.1:8080\"\n"
+        "}\n"
+        "]\n"
+        "",
+    Conf = <<BaseConf/binary, (list_to_binary(DisableSSLWithHttps))/binary>>,
+    {ok, ConfMap} = hocon:binary(Conf, #{format => richmap}),
+    ?assertThrow(
+        {emqx_conf_schema, [
+            #{
+                kind := validation_error,
+                reason := integrity_validation_failure,
+                result := _,
+                validation_name := check_http_ssl_opts
+            }
+        ]},
+        hocon_tconf:generate(emqx_conf_schema, ConfMap)
+    ),
+    BadHeader =
+        ""
+        "\n"
+        "authentication = [\n"
+        "{backend = \"http\"\n"
+        "body {password = \"${password}\", username = \"${username}\"}\n"
+        "connect_timeout = \"15s\"\n"
+        "enable_pipelining = 100\n"
+        "headers {\"content-type\" = \"application/json\"}\n"
+        "mechanism = \"password_based\"\n"
+        "method = \"get\"\n"
+        "pool_size = 8\n"
+        "request_timeout = \"5s\"\n"
+        "ssl {enable = false, verify = \"verify_peer\"}\n"
+        "url = \"http://127.0.0.1:8080\"\n"
+        "}\n"
+        "]\n"
+        "",
+    Conf1 = <<BaseConf/binary, (list_to_binary(BadHeader))/binary>>,
+    {ok, ConfMap1} = hocon:binary(Conf1, #{format => richmap}),
+    ?assertThrow(
+        {emqx_conf_schema, [
+            #{
+                kind := validation_error,
+                reason := integrity_validation_failure,
+                result := _,
+                validation_name := check_http_headers
+            }
+        ]},
+        hocon_tconf:generate(emqx_conf_schema, ConfMap1)
     ),
     ok.
 

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -5,27 +5,28 @@
 -module(emqx_conf_schema_tests).
 
 -include_lib("eunit/include/eunit.hrl").
+
+%% erlfmt-ignore
 -define(BASE_CONF,
-    ""
-    "\n"
-    "     node {\n"
-    "        name = \"emqx1@127.0.0.1\"\n"
-    "        cookie = \"emqxsecretcookie\"\n"
-    "        data_dir = \"data\"\n"
-    "     }\n"
-    "     cluster {\n"
-    "        name = emqxcl\n"
-    "        discovery_strategy = static\n"
-    "        static.seeds = ~p\n"
-    "        core_nodes = ~p\n"
-    "     }\n"
-    ""
-).
+    """
+             node {
+                name = \"emqx1@127.0.0.1\"
+                cookie = \"emqxsecretcookie\"
+                data_dir = \"data\"
+             }
+             cluster {
+                name = emqxcl
+                discovery_strategy = static
+                static.seeds = ~p
+                core_nodes = ~p
+             }
+    """).
+
 array_nodes_test() ->
     ExpectNodes = ['emqx1@127.0.0.1', 'emqx2@127.0.0.1'],
     lists:foreach(
         fun(Nodes) ->
-            ConfFile = iolist_to_binary(io_lib:format(?BASE_CONF, [Nodes, Nodes])),
+            ConfFile = to_bin(?BASE_CONF, [Nodes, Nodes]),
             {ok, Conf} = hocon:binary(ConfFile, #{format => richmap}),
             ConfList = hocon_tconf:generate(emqx_conf_schema, Conf),
             ClusterDiscovery = proplists:get_value(
@@ -46,100 +47,72 @@ array_nodes_test() ->
     ),
     ok.
 
+%% erlfmt-ignore
+-define(BASE_AUTHN_ARRAY,
+    """
+        authentication = [
+          {backend = \"http\"
+          body {password = \"${password}\", username = \"${username}\"}
+          connect_timeout = \"15s\"
+          enable_pipelining = 100
+          headers {\"content-type\" = \"application/json\"}
+          mechanism = \"password_based\"
+          method = \"~p\"
+          pool_size = 8
+          request_timeout = \"5s\"
+          ssl {enable = ~p, verify = \"verify_peer\"}
+          url = \"~ts\"
+        }
+        ]
+    """
+).
+
+-define(ERROR(Reason),
+    {emqx_conf_schema, [
+        #{
+            kind := validation_error,
+            reason := integrity_validation_failure,
+            result := _,
+            validation_name := Reason
+        }
+    ]}
+).
+
 authn_validations_test() ->
-    BaseConf = iolist_to_binary(io_lib:format(?BASE_CONF, ["emqx1@127.0.0.1", "emqx1@127.0.0.1"])),
-    DisableSSLWithHttps =
-        ""
-        "\n"
-        "authentication = [\n"
-        "{backend = \"http\"\n"
-        "body {password = \"${password}\", username = \"${username}\"}\n"
-        "connect_timeout = \"15s\"\n"
-        "enable_pipelining = 100\n"
-        "headers {\"content-type\" = \"application/json\"}\n"
-        "mechanism = \"password_based\"\n"
-        "method = \"post\"\n"
-        "pool_size = 8\n"
-        "request_timeout = \"5s\"\n"
-        "ssl {enable = false, verify = \"verify_peer\"}\n"
-        "url = \"https://127.0.0.1:8080\"\n"
-        "}\n"
-        "]\n"
-        "",
-    Conf = <<BaseConf/binary, (list_to_binary(DisableSSLWithHttps))/binary>>,
-    {ok, ConfMap} = hocon:binary(Conf, #{format => richmap}),
-    ?assertThrow(
-        {emqx_conf_schema, [
-            #{
-                kind := validation_error,
-                reason := integrity_validation_failure,
-                result := _,
-                validation_name := check_http_ssl_opts
-            }
-        ]},
-        hocon_tconf:generate(emqx_conf_schema, ConfMap)
-    ),
-    BadHeader =
-        ""
-        "\n"
-        "authentication = [\n"
-        "{backend = \"http\"\n"
-        "body {password = \"${password}\", username = \"${username}\"}\n"
-        "connect_timeout = \"15s\"\n"
-        "enable_pipelining = 100\n"
-        "headers {\"content-type\" = \"application/json\"}\n"
-        "mechanism = \"password_based\"\n"
-        "method = \"get\"\n"
-        "pool_size = 8\n"
-        "request_timeout = \"5s\"\n"
-        "ssl {enable = false, verify = \"verify_peer\"}\n"
-        "url = \"http://127.0.0.1:8080\"\n"
-        "}\n"
-        "]\n"
-        "",
-    Conf1 = <<BaseConf/binary, (list_to_binary(BadHeader))/binary>>,
+    BaseConf = to_bin(?BASE_CONF, ["emqx1@127.0.0.1", "emqx1@127.0.0.1"]),
+
+    OKHttps = to_bin(?BASE_AUTHN_ARRAY, [post, true, <<"https://127.0.0.1:8080">>]),
+    Conf0 = <<BaseConf/binary, OKHttps/binary>>,
+    {ok, ConfMap0} = hocon:binary(Conf0, #{format => richmap}),
+    ?assert(is_list(hocon_tconf:generate(emqx_conf_schema, ConfMap0))),
+
+    OKHttp = to_bin(?BASE_AUTHN_ARRAY, [post, false, <<"http://127.0.0.1:8080">>]),
+    Conf1 = <<BaseConf/binary, OKHttp/binary>>,
     {ok, ConfMap1} = hocon:binary(Conf1, #{format => richmap}),
-    ?assertThrow(
-        {emqx_conf_schema, [
-            #{
-                kind := validation_error,
-                reason := integrity_validation_failure,
-                result := _,
-                validation_name := check_http_headers
-            }
-        ]},
-        hocon_tconf:generate(emqx_conf_schema, ConfMap1)
-    ),
-    BadHeader2 =
-        ""
-        "\n"
-        "authentication = \n"
-        "{backend = \"http\"\n"
-        "body {password = \"${password}\", username = \"${username}\"}\n"
-        "connect_timeout = \"15s\"\n"
-        "enable_pipelining = 100\n"
-        "headers {\"content-type\" = \"application/json\"}\n"
-        "mechanism = \"password_based\"\n"
-        "method = \"get\"\n"
-        "pool_size = 8\n"
-        "request_timeout = \"5s\"\n"
-        "ssl {enable = false, verify = \"verify_peer\"}\n"
-        "url = \"http://127.0.0.1:8080\"\n"
-        "}\n"
-        "\n"
-        "",
-    Conf2 = <<BaseConf/binary, (list_to_binary(BadHeader2))/binary>>,
+    ?assert(is_list(hocon_tconf:generate(emqx_conf_schema, ConfMap1))),
+
+    DisableSSLWithHttps = to_bin(?BASE_AUTHN_ARRAY, [post, false, <<"https://127.0.0.1:8080">>]),
+    Conf2 = <<BaseConf/binary, DisableSSLWithHttps/binary>>,
     {ok, ConfMap2} = hocon:binary(Conf2, #{format => richmap}),
     ?assertThrow(
-        {emqx_conf_schema, [
-            #{
-                kind := validation_error,
-                reason := integrity_validation_failure,
-                result := _,
-                validation_name := check_http_headers
-            }
-        ]},
+        ?ERROR(check_http_ssl_opts),
         hocon_tconf:generate(emqx_conf_schema, ConfMap2)
+    ),
+
+    BadHeader = to_bin(?BASE_AUTHN_ARRAY, [get, true, <<"https://127.0.0.1:8080">>]),
+    Conf3 = <<BaseConf/binary, BadHeader/binary>>,
+    {ok, ConfMap3} = hocon:binary(Conf3, #{format => richmap}),
+    ?assertThrow(
+        ?ERROR(check_http_headers),
+        hocon_tconf:generate(emqx_conf_schema, ConfMap3)
+    ),
+
+    BadHeaderWithTuple = binary:replace(BadHeader, [<<"[">>, <<"]">>], <<"">>, [global]),
+    Conf4 = <<BaseConf/binary, BadHeaderWithTuple/binary>>,
+    {ok, ConfMap4} = hocon:binary(Conf4, #{format => richmap}),
+    ?assertThrow(
+        ?ERROR(check_http_headers),
+        hocon_tconf:generate(emqx_conf_schema, ConfMap4)
     ),
     ok.
 
@@ -163,3 +136,6 @@ doc_gen_test() ->
             ok
         end
     }.
+
+to_bin(Format, Args) ->
+    iolist_to_binary(io_lib:format(Format, Args)).

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -110,6 +110,37 @@ authn_validations_test() ->
         ]},
         hocon_tconf:generate(emqx_conf_schema, ConfMap1)
     ),
+    BadHeader2 =
+        ""
+        "\n"
+        "authentication = \n"
+        "{backend = \"http\"\n"
+        "body {password = \"${password}\", username = \"${username}\"}\n"
+        "connect_timeout = \"15s\"\n"
+        "enable_pipelining = 100\n"
+        "headers {\"content-type\" = \"application/json\"}\n"
+        "mechanism = \"password_based\"\n"
+        "method = \"get\"\n"
+        "pool_size = 8\n"
+        "request_timeout = \"5s\"\n"
+        "ssl {enable = false, verify = \"verify_peer\"}\n"
+        "url = \"http://127.0.0.1:8080\"\n"
+        "}\n"
+        "\n"
+        "",
+    Conf2 = <<BaseConf/binary, (list_to_binary(BadHeader2))/binary>>,
+    {ok, ConfMap2} = hocon:binary(Conf2, #{format => richmap}),
+    ?assertThrow(
+        {emqx_conf_schema, [
+            #{
+                kind := validation_error,
+                reason := integrity_validation_failure,
+                result := _,
+                validation_name := check_http_headers
+            }
+        ]},
+        hocon_tconf:generate(emqx_conf_schema, ConfMap2)
+    ),
     ok.
 
 doc_gen_test() ->

--- a/apps/emqx_connector/src/emqx_connector.app.src
+++ b/apps/emqx_connector/src/emqx_connector.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_connector, [
     {description, "EMQX Data Integration Connectors"},
-    {vsn, "0.1.20"},
+    {vsn, "0.1.21"},
     {registered, []},
     {mod, {emqx_connector_app, []}},
     {applications, [

--- a/apps/emqx_prometheus/TODO
+++ b/apps/emqx_prometheus/TODO
@@ -1,2 +1,0 @@
-1. Add more VM Metrics
-2. Add more emqx Metrics

--- a/changes/ce/fix-10449.en.md
+++ b/changes/ce/fix-10449.en.md
@@ -1,2 +1,2 @@
 Validate the ssl_options and header configurations when creating authentication http (`authn_http`).
-Prior to this, incorrect ssl_options configuration could result in successful creation but the entire authn being unusable.
+Prior to this, incorrect `ssl` configuration could result in successful creation but the entire authn being unusable.

--- a/changes/ce/fix-10449.en.md
+++ b/changes/ce/fix-10449.en.md
@@ -1,0 +1,2 @@
+Validate the ssl_options and header configurations when creating authentication http (`authn_http`).
+Prior to this, incorrect ssl_options configuration could result in successful creation but the entire authn being unusable.


### PR DESCRIPTION
Fixes [EMQX-9631](https://emqx.atlassian.net/browse/EMQX-9631)

If the ssl_options and header configurations are set incorrectly when creating `authn_http`, it could result in the entire authn being unusable. 

### Before
we can create an `authn_http` with `{ssl_options.enable=false, url = "https://xxx"}`, but **https** must enable ssl_options.enable. 

### After
<img width="792" alt="image" src="https://user-images.githubusercontent.com/3116225/233023198-872a2455-b11c-4b73-9cb2-35c52e577503.png">


<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfb7bbf</samp>

Added and improved validation functions and tests for the http authentication backend in `emqx_authn`. Fixed some minor issues and updated the version number.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
