### PR TITLE
refactor(gcp_pubsub): move GCP PubSub Bridge to its own app

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/rebar.config
+++ b/apps/emqx_bridge_gcp_pubsub/rebar.config
@@ -1,0 +1,10 @@
+%% -*- mode: erlang; -*-
+{erl_opts, [debug_info]}.
+{deps, [ {emqx_connector, {path, "../../apps/emqx_connector"}}
+       , {emqx_resource, {path, "../../apps/emqx_resource"}}
+       , {emqx_bridge, {path, "../../apps/emqx_bridge"}}
+       ]}.
+
+{shell, [
+    {apps, [emqx_bridge_gcp_pubsub]}
+]}.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -2,7 +2,11 @@
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
     {vsn, "0.1.0"},
     {registered, []},
-    {applications, [kernel, stdlib]},
+    {applications, [
+        kernel,
+        stdlib,
+        ehttpc
+    ]},
     {env, []},
     {modules, []},
     {links, []}

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_ee_bridge_gcp_pubsub).
+-module(emqx_bridge_gcp_pubsub).
 
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_connector.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_connector.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_ee_connector_gcp_pubsub).
+-module(emqx_bridge_gcp_pubsub_connector).
 
 -behaviour(emqx_resource).
 
@@ -27,7 +27,7 @@
 -export([reply_delegator/3]).
 
 -type jwt_worker() :: binary().
--type service_account_json() :: emqx_ee_bridge_gcp_pubsub:service_account_json().
+-type service_account_json() :: emqx_bridge_gcp_pubsub:service_account_json().
 -type config() :: #{
     connect_timeout := emqx_schema:duration_ms(),
     max_retries := non_neg_integer(),

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_SUITE.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_ee_bridge_gcp_pubsub_SUITE).
+-module(emqx_bridge_gcp_pubsub_SUITE).
 
 -compile(nowarn_export_all).
 -compile(export_all).

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
@@ -1,13 +1,14 @@
 {application, emqx_ee_bridge, [
     {description, "EMQX Enterprise data bridges"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {registered, []},
     {applications, [
         kernel,
         stdlib,
         emqx_ee_connector,
         telemetry,
-        emqx_bridge_kafka
+        emqx_bridge_kafka,
+        emqx_bridge_gcp_pubsub
     ]},
     {env, []},
     {modules, []},

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
@@ -14,7 +14,7 @@
 
 api_schemas(Method) ->
     [
-        ref(emqx_ee_bridge_gcp_pubsub, Method),
+        ref(emqx_bridge_gcp_pubsub, Method),
         ref(emqx_bridge_kafka, Method ++ "_consumer"),
         ref(emqx_bridge_kafka, Method ++ "_producer"),
         ref(emqx_ee_bridge_mysql, Method),
@@ -42,7 +42,7 @@ schema_modules() ->
     [
         emqx_bridge_kafka,
         emqx_ee_bridge_hstreamdb,
-        emqx_ee_bridge_gcp_pubsub,
+        emqx_bridge_gcp_pubsub,
         emqx_ee_bridge_influxdb,
         emqx_ee_bridge_mongodb,
         emqx_ee_bridge_mysql,
@@ -76,7 +76,7 @@ resource_type(kafka_consumer) -> emqx_bridge_kafka_impl_consumer;
 %% to hocon; keeping this as just `kafka' for backwards compatibility.
 resource_type(kafka) -> emqx_bridge_kafka_impl_producer;
 resource_type(hstreamdb) -> emqx_ee_connector_hstreamdb;
-resource_type(gcp_pubsub) -> emqx_ee_connector_gcp_pubsub;
+resource_type(gcp_pubsub) -> emqx_bridge_gcp_pubsub_connector;
 resource_type(mongodb_rs) -> emqx_ee_connector_mongodb;
 resource_type(mongodb_sharded) -> emqx_ee_connector_mongodb;
 resource_type(mongodb_single) -> emqx_ee_connector_mongodb;
@@ -108,7 +108,7 @@ fields(bridges) ->
             )},
         {gcp_pubsub,
             mk(
-                hoconsc:map(name, ref(emqx_ee_bridge_gcp_pubsub, "config")),
+                hoconsc:map(name, ref(emqx_bridge_gcp_pubsub, "config")),
                 #{
                     desc => <<"EMQX Enterprise Config">>,
                     required => false

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_connector, [
     {description, "EMQX Enterprise connectors"},
-    {vsn, "0.1.10"},
+    {vsn, "0.1.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/mix.exs
+++ b/mix.exs
@@ -154,7 +154,8 @@ defmodule EMQXUmbrella.MixProject do
   # need to remove those when listing `/apps/`...
   defp enterprise_umbrella_apps() do
     MapSet.new([
-      :emqx_bridge_kafka
+      :emqx_bridge_kafka,
+      :emqx_bridge_gcp_pubsub
     ])
   end
 
@@ -344,6 +345,7 @@ defmodule EMQXUmbrella.MixProject do
           emqx_ee_connector: :permanent,
           emqx_ee_bridge: :permanent,
           emqx_bridge_kafka: :permanent,
+          emqx_bridge_gcp_pubsub: :permanent,
           emqx_ee_schema_registry: :permanent
         ],
         else: []

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -79,6 +79,7 @@ is_enterprise(ce) -> false;
 is_enterprise(ee) -> true.
 
 is_community_umbrella_app("apps/emqx_bridge_kafka") -> false;
+is_community_umbrella_app("apps/emqx_bridge_gcp_pubsub") -> false;
 is_community_umbrella_app(_) -> true.
 
 is_jq_supported() ->
@@ -439,6 +440,7 @@ relx_apps_per_edition(ee) ->
         emqx_ee_connector,
         emqx_ee_bridge,
         emqx_bridge_kafka,
+        emqx_bridge_gcp_pubsub,
         emqx_ee_schema_registry
     ];
 relx_apps_per_edition(ce) ->

--- a/rel/i18n/emqx_bridge_gcp_pubsub.hocon
+++ b/rel/i18n/emqx_bridge_gcp_pubsub.hocon
@@ -1,4 +1,4 @@
-emqx_ee_bridge_gcp_pubsub {
+emqx_bridge_gcp_pubsub {
 
 connect_timeout.desc:
 """The timeout when connecting to the HTTP server."""

--- a/rel/i18n/zh/emqx_bridge_gcp_pubsub.hocon
+++ b/rel/i18n/zh/emqx_bridge_gcp_pubsub.hocon
@@ -1,4 +1,4 @@
-emqx_ee_bridge_gcp_pubsub {
+emqx_bridge_gcp_pubsub {
 
 connect_timeout.desc:
 """连接 HTTP 服务器的超时时间。"""

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -75,6 +75,9 @@ describe_app() {
         apps/emqx_bridge_kafka)
             profile='emqx-enterprise'
             ;;
+        apps/emqx_bridge_gcp_pubsub)
+            profile='emqx-enterprise'
+            ;;
         apps/*)
             profile='emqx'
             ;;

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -72,14 +72,12 @@ describe_app() {
         runner="docker"
     fi
     case "${app}" in
-        apps/emqx_bridge_kafka)
-            profile='emqx-enterprise'
-            ;;
-        apps/emqx_bridge_gcp_pubsub)
-            profile='emqx-enterprise'
-            ;;
         apps/*)
-            profile='emqx'
+            if [[ -f "${app}/BSL.txt" ]]; then
+              profile='emqx-enterprise'
+            else
+              profile='emqx'
+            fi
             ;;
         lib-ee/*)
             profile='emqx-enterprise'


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9536

Note: since GCP PubSub is not shared by any authn/authz backend, there's no need to separate its connector into another app.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 913a6dc</samp>

Moved the Google Cloud Pub/Sub bridge module from `emqx_ee_bridge` to a separate application `emqx_bridge_gcp_pubsub` and updated the related files and configurations. This change simplifies the naming and structure of the bridge and enables EMQ X to integrate with Google Cloud Pub/Sub as an enterprise feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
