### PR TITLE
fix(ft): restrict max filename length in transfers

### DIFF
--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -110,8 +110,8 @@ decode_filemeta(Map) when is_map(Map) ->
         Meta = hocon_tconf:check_plain(Schema, Map, #{atom_key => true, required => false}),
         {ok, Meta}
     catch
-        throw:Error ->
-            {error, {invalid_filemeta, Error}}
+        throw:{_Schema, Errors} ->
+            {error, {invalid_filemeta, Errors}}
     end.
 
 encode_filemeta(Meta = #{}) ->
@@ -381,7 +381,7 @@ do_validate([{filemeta, Payload} | Rest], Parsed) ->
         {ok, Meta} ->
             do_validate(Rest, [Meta | Parsed]);
         {error, Reason} ->
-            {error, {invalid_filemeta, Reason}}
+            {error, Reason}
     end;
 do_validate([{offset, Offset} | Rest], Parsed) ->
     case string:to_integer(Offset) of

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -184,8 +184,17 @@ t_invalid_filename(Config) ->
         emqtt:publish(C, mk_init_topic(<<"f3">>), encode_meta(meta("/etc/passwd", <<>>)), 1)
     ),
     ?assertRCName(
+        unspecified_error,
+        emqtt:publish(
+            C,
+            mk_init_topic(<<"f4">>),
+            encode_meta(meta(lists:duplicate(1000, $A), <<>>)),
+            1
+        )
+    ),
+    ?assertRCName(
         success,
-        emqtt:publish(C, mk_init_topic(<<"f4">>), encode_meta(meta("146%", <<>>)), 1)
+        emqtt:publish(C, mk_init_topic(<<"f5">>), encode_meta(meta("146%", <<>>)), 1)
     ).
 
 t_simple_transfer(Config) ->

--- a/apps/emqx_s3/src/emqx_s3_schema.erl
+++ b/apps/emqx_s3/src/emqx_s3_schema.erl
@@ -12,6 +12,7 @@
 -export([roots/0, fields/1, namespace/0, tags/0, desc/1]).
 
 -export([translate/1]).
+-export([translate/2]).
 
 roots() ->
     [s3].
@@ -36,7 +37,8 @@ fields(s3) ->
                 string(),
                 #{
                     desc => ?DESC("secret_access_key"),
-                    required => false
+                    required => false,
+                    sensitive => true
                 }
             )},
         {bucket,
@@ -142,7 +144,10 @@ desc(transport_options) ->
     "Options for the HTTP transport layer used by the S3 client".
 
 translate(Conf) ->
-    Options = #{atom_key => true},
+    translate(Conf, #{}).
+
+translate(Conf, OptionsIn) ->
+    Options = maps:merge(#{atom_key => true}, OptionsIn),
     #{s3 := TranslatedConf} = hocon_tconf:check_plain(
         emqx_s3_schema, #{<<"s3">> => Conf}, Options, [s3]
     ),

--- a/apps/emqx_s3/test/emqx_s3_schema_SUITE.erl
+++ b/apps/emqx_s3/test/emqx_s3_schema_SUITE.erl
@@ -108,6 +108,25 @@ t_full_config(_Config) ->
         })
     ).
 
+t_sensitive_config_hidden(_Config) ->
+    ?assertMatch(
+        #{
+            access_key_id := "access_key_id",
+            secret_access_key := <<"******">>
+        },
+        emqx_s3_schema:translate(
+            #{
+                <<"bucket">> => <<"bucket">>,
+                <<"host">> => <<"s3.us-east-1.endpoint.com">>,
+                <<"port">> => 443,
+                <<"access_key_id">> => <<"access_key_id">>,
+                <<"secret_access_key">> => <<"secret_access_key">>
+            },
+            % NOTE: this is what Config API handler is doing
+            #{obfuscate_sensitive_values => true}
+        )
+    ).
+
 t_invalid_limits(_Config) ->
     ?assertException(
         throw,


### PR DESCRIPTION
Reject transfers with too long filenames right away, during `init` handling, to avoid having to deal with filesystem errors later.

Fixes [EMQX-9517](https://emqx.atlassian.net/browse/EMQX-9517), [EMQX-9630](https://emqx.atlassian.net/browse/EMQX-9630).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04523b3</samp>

This pull request improves the file metadata validation and error handling in the `emqx_ft` module and adds a new test case to verify the filename length limit. This enhances the robustness and compatibility of the file storage feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible

