### PR TITLE
chore: deprecate statsd

### DIFF
--- a/apps/emqx_statsd/src/emqx_statsd_api.erl
+++ b/apps/emqx_statsd/src/emqx_statsd_api.erl
@@ -49,6 +49,7 @@ schema("/statsd") ->
         'operationId' => statsd,
         get =>
             #{
+                deprecated => true,
                 description => ?DESC(get_statsd_config_api),
                 tags => ?API_TAG_STATSD,
                 responses =>
@@ -56,6 +57,7 @@ schema("/statsd") ->
             },
         put =>
             #{
+                deprecated => true,
                 description => ?DESC(update_statsd_config_api),
                 tags => ?API_TAG_STATSD,
                 'requestBody' => statsd_config_schema(),

--- a/apps/emqx_statsd/src/emqx_statsd_schema.erl
+++ b/apps/emqx_statsd/src/emqx_statsd_schema.erl
@@ -32,7 +32,8 @@
 
 namespace() -> "statsd".
 
-roots() -> ["statsd"].
+roots() ->
+    [{"statsd", hoconsc:mk(hoconsc:ref(?MODULE, "statsd"), #{importance => ?IMPORTANCE_HIDDEN})}].
 
 fields("statsd") ->
     [


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9313

We have decided to abolish this feature, so in version 5.0 we have hidden the configuration document and marked the related HTTP API as deprecated.


<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
