### PR TITLE
fix(rocketmq): allow setting multiple addresses in RocketMQ bridge

### DIFF
--- a/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_rocketmq_SUITE.erl
+++ b/lib-ee/emqx_ee_bridge/test/emqx_ee_bridge_rocketmq_SUITE.erl
@@ -136,7 +136,7 @@ rocketmq_config(BridgeType, Config) ->
         io_lib:format(
             "bridges.~s.~s {\n"
             "  enable = true\n"
-            "  server = ~p\n"
+            "  servers = ~p\n"
             "  topic = ~p\n"
             "  resource_opts = {\n"
             "    request_timeout = 1500ms\n"


### PR DESCRIPTION
Fixes [EMQX-9641](https://emqx.atlassian.net/browse/EMQX-9641)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6e12abf</samp>

Support multiple RocketMQ servers in the connector config. Rename and update the `server` field and function to `servers` in `emqx_ee_connector_rocketmq.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
