### PR TITLE
chore: Hide config shared_dispatch_ack_enabled

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1489,10 +1489,8 @@ fields("broker") ->
             sc(
                 boolean(),
                 #{
-                    %% TODO: deprecated => {since, "5.1.0"}
-                    %% in favor of session message re-dispatch at termination
-                    %% we will stop supporting dispatch acks for shared
-                    %% subscriptions.
+                    deprecated => {since, "5.1.0"},
+                    importance => ?IMPORTANCE_HIDDEN,
                     default => false,
                     desc => ?DESC(broker_shared_dispatch_ack_enabled)
                 }

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -165,7 +165,7 @@ strategy(Group) ->
 
 -spec ack_enabled() -> boolean().
 ack_enabled() ->
-    emqx:get_config([broker, shared_dispatch_ack_enabled]).
+    emqx:get_config([broker, shared_dispatch_ack_enabled], false).
 
 do_dispatch(SubPid, _Group, Topic, Msg, _Type) when SubPid =:= self() ->
     %% Deadlock otherwise
@@ -181,7 +181,7 @@ do_dispatch(SubPid, _Group, Topic, Msg, retry) ->
 do_dispatch(SubPid, Group, Topic, Msg, fresh) ->
     case ack_enabled() of
         true ->
-            %% FIXME: replace with `emqx_shared_sub_proto:dispatch_with_ack' in 5.2
+            %% TODO: delete this clase after 5.1.0
             do_dispatch_with_ack(SubPid, Group, Topic, Msg);
         false ->
             send(SubPid, Topic, {deliver, Topic, Msg})

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -50,7 +50,6 @@ t_fill_default_values(_) ->
                         },
                     <<"route_batch_clean">> := false,
                     <<"session_locking_strategy">> := quorum,
-                    <<"shared_dispatch_ack_enabled">> := false,
                     <<"shared_subscription_strategy">> := round_robin
                 }
         },

--- a/changes/ce/fix-10462.en.md
+++ b/changes/ce/fix-10462.en.md
@@ -1,0 +1,4 @@
+Deprecate config `broker.shared_dispatch_ack_enabled`.
+This was designed to avoid dispatching messages to a shared-subscription session which has the client disconnected.
+However since v5.0.9, this feature is no longer useful because the shared-subscrption messages in a expired session will be redispatched to other sessions in the group.
+See also: https://github.com/emqx/emqx/pull/9104

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1373,9 +1373,9 @@ persistent_session_store_message_gc_interval.label:
 """Message GC interval"""
 
 broker_shared_dispatch_ack_enabled.desc:
-"""Deprecated, will be removed in 5.1.
-Enable/disable shared dispatch acknowledgement for QoS 1 and QoS 2 messages.
-This should allow messages to be dispatched to a different subscriber in the group in case the picked (based on `shared_subscription_strategy`) subscriber is offline."""
+"""Deprecated.
+This was designed to avoid dispatching messages to a shared-subscription session which has the client disconnected.
+However it's no longer useful because the shared-subscrption messages in a expired session will be redispatched to other sessions in the group."""
 
 base_listener_enable_authn.desc:
 """Set <code>true</code> (default) to enable client authentication on this listener, the authentication

--- a/rel/i18n/zh/emqx_schema.hocon
+++ b/rel/i18n/zh/emqx_schema.hocon
@@ -1313,9 +1313,10 @@ persistent_session_store_message_gc_interval.label:
 """消息清理间隔"""
 
 broker_shared_dispatch_ack_enabled.desc:
-"""该配置项已废弃，会在 5.1 中移除。
+"""该配置项已废弃。
 启用/禁用 QoS 1 和 QoS 2 消息的共享派发确认。
-开启后，允许将消息从未及时回复 ACK 的订阅者 （例如，客户端离线） 重新派发给另外一个订阅者。"""
+该配置最初设计用于避免将消息派发给客户端离线状态下的会话中去。
+但新版本中，已做增强：在一个会话结束时，会话中的消息会重新派发到组内的其他会话中 -- 使这个老配置失去存在的意义。"""
 
 base_listener_enable_authn.desc:
 """配置 <code>true</code> （默认值）启用客户端进行身份认证，通过检查认配置的认认证器链来决定是否允许接入。


### PR DESCRIPTION
Fixes EMQX-8434

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 701a1f6</samp>

Deprecated and hid the `broker_shared_dispatch_ack_enabled` option from the schema and updated the shared subscription dispatching logic and the related descriptions and tests. This option is no longer needed as the broker handles the re-dispatching of messages in expired sessions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
