### PR TITLE
fix(rocketmq): expose the driver parameter `sync_timeout` into the RocketMQ bridge configuration

### DIFF
--- a/rel/i18n/emqx_ee_connector_rocketmq.hocon
+++ b/rel/i18n/emqx_ee_connector_rocketmq.hocon
@@ -1,6 +1,6 @@
 emqx_ee_connector_rocketmq {
 
-    server {
+    servers {
         desc {
           en: """The IPv4 or IPv6 address or the hostname to connect to.<br/>
 A host entry has the following form: `Host[:Port]`.<br/>
@@ -23,6 +23,17 @@ The RocketMQ default port 9876 is used if `[:Port]` is not specified."""
         label: {
               en: "RocketMQ Topic"
               zh: "RocketMQ 主题"
+            }
+    }
+
+    sync_timeout {
+        desc {
+          en: """Timeout of RocketMQ driver synchronous call."""
+          zh: """RocketMQ 驱动同步调用的超时时间。"""
+        }
+        label: {
+              en: "Sync Timeout"
+              zh: "同步调用超时时间"
             }
     }
 


### PR DESCRIPTION
Fixes [EMQX-9651](https://emqx.atlassian.net/browse/EMQX-9651)

Before this fix, RocketMQ backend shared the `request_timeout` configuration with resource workers, but in fact, the `request_timeout` is different between them. 

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7704995</samp>

This pull request enhances the RocketMQ connector by adding a `sync_timeout` option to control the driver call timeout and improving the i18n of the connector options in `emqx_ee_connector_rocketmq.hocon`. It also fixes some minor issues in the code and documentation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
