### PR TITLE
0421 refactor delete unused schema field

### DIFF
--- a/apps/emqx_authn/src/emqx_authn.app.src
+++ b/apps/emqx_authn/src/emqx_authn.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authn, [
     {description, "EMQX Authentication"},
-    {vsn, "0.1.18"},
+    {vsn, "0.1.19"},
     {modules, []},
     {registered, [emqx_authn_sup, emqx_authn_registry]},
     {applications, [kernel, stdlib, emqx_resource, emqx_connector, ehttpc, epgsql, mysql, jose]},

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -100,7 +100,6 @@ common_fields() ->
         maps:to_list(
             maps:without(
                 [
-                    base_url,
                     pool_type
                 ],
                 maps:from_list(emqx_connector_http:fields(config))

--- a/apps/emqx_authz/src/emqx_authz_api_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_schema.erl
@@ -114,7 +114,6 @@ authz_http_common_fields() ->
         maps:to_list(
             maps:without(
                 [
-                    base_url,
                     pool_type
                 ],
                 maps:from_list(emqx_connector_http:fields(config))

--- a/apps/emqx_authz/src/emqx_authz_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_schema.erl
@@ -230,7 +230,6 @@ http_common_fields() ->
         maps:to_list(
             maps:without(
                 [
-                    base_url,
                     pool_type
                 ],
                 maps:from_list(connector_fields(http))

--- a/apps/emqx_bridge/src/schema/emqx_bridge_webhook_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_webhook_schema.erl
@@ -68,7 +68,7 @@ basic_config() ->
             )}
     ] ++ webhook_creation_opts() ++
         proplists:delete(
-            max_retries, proplists:delete(base_url, emqx_connector_http:fields(config))
+            max_retries, emqx_connector_http:fields(config)
         ).
 
 request_config() ->

--- a/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
@@ -29,6 +29,10 @@
 -compile(nowarn_export_all).
 -compile(export_all).
 
+-type url() :: emqx_http_lib:uri_map().
+-reflect_type([url/0]).
+-typerefl_from_string({url/0, emqx_http_lib, uri_parse}).
+
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
@@ -314,7 +318,7 @@ t_sub_fields(_Config) ->
     ok.
 
 t_complicated_type(_Config) ->
-    Path = "/ref/complicated_type",
+    Path = "/ref/complex_type",
     Object = #{
         <<"content">> => #{
             <<"application/json">> =>
@@ -633,14 +637,14 @@ schema("/error") ->
             }
         }
     };
-schema("/ref/complicated_type") ->
+schema("/ref/complex_type") ->
     #{
         operationId => test,
         post => #{
             responses => #{
                 200 => [
                     {no_neg_integer, hoconsc:mk(non_neg_integer(), #{})},
-                    {url, hoconsc:mk(emqx_connector_http:url(), #{})},
+                    {url, hoconsc:mk(url(), #{})},
                     {server, hoconsc:mk(emqx_schema:ip_port(), #{})},
                     {connect_timeout, hoconsc:mk(emqx_connector_http:connect_timeout(), #{})},
                     {pool_type, hoconsc:mk(emqx_connector_http:pool_type(), #{})},

--- a/rel/i18n/emqx_connector_http.hocon
+++ b/rel/i18n/emqx_connector_http.hocon
@@ -1,14 +1,5 @@
 emqx_connector_http {
 
-base_url.desc:
-"""The base URL is the URL includes only the scheme, host and port.<br/>
-When send an HTTP request, the real URL to be used is the concatenation of the base URL and the
-path parameter<br/>
-For example: `http://localhost:9901/`"""
-
-base_url.label:
-"""Base Url"""
-
 body.desc:
 """HTTP request body."""
 

--- a/rel/i18n/zh/emqx_connector_http.hocon
+++ b/rel/i18n/zh/emqx_connector_http.hocon
@@ -1,13 +1,5 @@
 emqx_connector_http {
 
-base_url.desc:
-"""base URL 只包含host和port。<br/>
-发送HTTP请求时，真实的URL是由base URL 和 path parameter连接而成。<br/>
-示例：`http://localhost:9901/`"""
-
-base_url.label:
-"""Base Url"""
-
 body.desc:
 """HTTP请求报文主体。"""
 


### PR DESCRIPTION
Fixes: EMQX-9791
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a5f4d11</samp>

Removed the `base_url` field from the HTTP connector and related modules and files. Replaced it with the `url` field, which simplifies the configuration and validation of the HTTP scheme and SSL options. Updated the internationalization messages accordingly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [~] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [~] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [~] Change log has been added to `changes/` dir for user-facing artifacts update
