### PR TITLE
fix(resource): make sure resource will not crash when stopping

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker_sup.erl
@@ -141,9 +141,5 @@ ensure_disk_queue_dir_absent(ResourceId, Index) ->
     ok.
 
 ensure_worker_pool_removed(ResId) ->
-    try
-        gproc_pool:delete(ResId)
-    catch
-        error:badarg -> ok
-    end,
+    gproc_pool:force_delete(ResId),
     ok.


### PR DESCRIPTION
Fixes [EMQX-9655](https://emqx.atlassian.net/browse/EMQX-9655)

We should avoid the resource crash when stopping or we need to catch the crash and filter out sensitive data

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
