### PR TITLE
feat: warning unknown config root key

### DIFF
--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -19,6 +19,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -77,3 +78,21 @@ t_init_load(_Config) ->
     ?assertEqual(ExpectRootNames, lists:sort(emqx_config:get_root_names())),
     ?assertMatch({ok, #{raw_config := 128}}, emqx:update_config([mqtt, max_topic_levels], 128)),
     ok = file:delete(DeprecatedFile).
+
+t_unknown_rook_keys(_) ->
+    ?check_trace(
+        #{timetrap => 1000},
+        begin
+            ok = emqx_config:init_load(
+                emqx_schema, <<"test_1 {}\n test_2 {sub = 100}\n listeners {}">>
+            ),
+            ?block_until(#{?snk_kind := unknown_config_keys})
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{unknown_config_keys := "test_1,test_2"}],
+                ?of_kind(unknown_config_keys, Trace)
+            )
+        end
+    ),
+    ok.


### PR DESCRIPTION
Fixes [EMQX-9496](https://emqx.atlassian.net/browse/EMQX-9496)
When configuring EMQX, it is possible to manually misspell configuration items, which can lead to configuration not taking effect. 
For example, if "log" is misspelled as "Log", we need to give a warning that this configuration item will not take effect.
Ignore bad config root key, and only give warning log.

`Hocon` will ignore the configuration of root keys that he doesn't recognize. I think it's a good chioce, we will not modify this behavior.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bcb66bb</samp>

Add a function and a test case to warn about unknown config keys in `emqx_config`. Use snabbkaffe for logging and tracing.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
