### PR TITLE
feat: rename etcd.ssl to etcd.ssl_options

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.17"},
+    {vsn, "0.1.18"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -335,11 +335,12 @@ fields(cluster_etcd) ->
                     desc => ?DESC(cluster_etcd_node_ttl)
                 }
             )},
-        {"ssl",
+        {"ssl_options",
             sc(
                 ?R_REF(emqx_schema, "ssl_client_opts"),
                 #{
                     desc => ?DESC(cluster_etcd_ssl),
+                    alias => [ssl],
                     'readOnly' => true
                 }
             )}

--- a/changes/ce/feat-10491.en.md
+++ b/changes/ce/feat-10491.en.md
@@ -1,0 +1,1 @@
+Rename `etcd.ssl` to `etcd.ssl_options` to keep all of SSL options consistent in the configuration file.


### PR DESCRIPTION
Fixes [EMQX-9671](https://emqx.atlassian.net/browse/EMQX-9671)
Keep all of SSL options consistent in the configuration file (not include the listener)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b1a2dd</samp>

Refactored SSL configuration for etcd cluster and bumped emqx_conf version. Renamed `ssl` field to `ssl_options` in `emqx_conf_schema.erl` and added an alias for backward compatibility.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
