### PR TITLE
fix(api): add limiter API back which deleted by mistake

### DIFF
--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.0.19"},
+    {vsn, "5.0.20"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [kernel, stdlib, emqx_plugins, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -42,6 +42,7 @@
     <<"alarm">>,
     <<"sys_topics">>,
     <<"sysmon">>,
+    <<"limiter">>,
     <<"log">>,
     <<"persistent_session_store">>,
     <<"zones">>

--- a/changes/ce/fix-10495.en.md
+++ b/changes/ce/fix-10495.en.md
@@ -1,0 +1,1 @@
+Add the limiter API `/configs/limiter` which was deleted by mistake back. 


### PR DESCRIPTION
This API was mistakenly deleted by PR #10431.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at feeb3df</samp>

Add rate limiting support to management API. Update `emqx_mgmt_api_configs.erl` to include `<<"limiter">>` key in config fields.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
