### PR TITLE
feat(schema_registry): use rocksdb as table type for protobuf cache

### DIFF
--- a/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.app.src
+++ b/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_schema_registry, [
     {description, "EMQX Schema Registry"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, [emqx_ee_schema_registry_sup]},
     {mod, {emqx_ee_schema_registry_app, []}},
     {applications, [

--- a/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.erl
+++ b/lib-ee/emqx_ee_schema_registry/src/emqx_ee_schema_registry.erl
@@ -179,7 +179,7 @@ create_tables() ->
     ok = mria:create_table(?PROTOBUF_CACHE_TAB, [
         {type, set},
         {rlog_shard, ?SCHEMA_REGISTRY_SHARD},
-        {storage, disc_only_copies},
+        {storage, rocksdb_copies},
         {record_name, protobuf_cache},
         {attributes, record_info(fields, protobuf_cache)}
     ]),


### PR DESCRIPTION
Small improvement for a new and unreleased feature.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 99f3965</samp>

Updated the emqx_ee_schema_registry application to version 0.1.2 and switched the protobuf_cache table storage to `rocksdb_copies`. These changes enhance the schema registry's functionality and performance.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
