### PR TITLE
chore: bump ekka to 0.15.0

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -27,7 +27,7 @@
     {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.14.6"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.2"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},

--- a/changes/ce/fix-10500.en.md
+++ b/changes/ce/fix-10500.en.md
@@ -1,0 +1,12 @@
+Add several fixes, enhancements and features in Mria:
+  - protect `mria:join/1,2` with a global lock to prevent conflicts between
+    two nodes trying to join each other simultaneously
+    [Mria PR](https://github.com/emqx/mria/pull/137)
+  - implement new function `mria:sync_transaction/4,3,2`, which blocks the caller until
+    a transaction is imported to the local node (if the local node is a replicant, otherwise,
+    it behaves exactly the same as `mria:transaction/3,2`)
+    [Mria PR](https://github.com/emqx/mria/pull/136)
+  - optimize `mria:running_nodes/0`
+    [Mria PR](https://github.com/emqx/mria/pull/135)
+  - optimize `mria:ro_transaction/2` when called on a replicant node
+    [Mria PR](https://github.com/emqx/mria/pull/134).

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule EMQXUmbrella.MixProject do
       {:cowboy, github: "emqx/cowboy", tag: "2.9.0", override: true},
       {:esockd, github: "emqx/esockd", tag: "5.9.6", override: true},
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.7.2-emqx-9", override: true},
-      {:ekka, github: "emqx/ekka", tag: "0.14.6", override: true},
+      {:ekka, github: "emqx/ekka", tag: "0.15.0", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.7", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.3.8", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -62,7 +62,7 @@
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}}
     , {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.7.2-emqx-9"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.14.6"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.0"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
     , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.7"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.8"}}}


### PR DESCRIPTION
ekka 0.15.0 uses mria 0.5.0, which adds several fixes, enhancements and features:
  - protect `mria:join/1,2` with a global lock
  - implement new function `mria:sync_transaction/4,3,2`, which waits for a transaction replication to be ready on the local node (if the local node is a replicant)
  - optimize `mria:running_nodes/0`
  - optimize `mria:ro_transaction/2` when called on a replicant node.

Fixes: EMQX-9588 (#10380), EMQX-9102, EMQX-9152, EMQX-9213

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 453b261</samp>

Update `ekka` dependency to enable cluster discovery and autohealing in emqx 5.0.0.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
