### PR TITLE
feat(ft): properly propagate config updates

### DIFF
--- a/apps/emqx/src/emqx_maybe.erl
+++ b/apps/emqx/src/emqx_maybe.erl
@@ -23,6 +23,9 @@
 -export([define/2]).
 -export([apply/2]).
 
+-type t(T) :: maybe(T).
+-export_type([t/1]).
+
 -spec to_list(maybe(A)) -> [A].
 to_list(undefined) ->
     [];

--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -301,8 +301,8 @@ store_filemeta(Transfer, Segment) ->
         emqx_ft_storage:store_filemeta(Transfer, Segment)
     catch
         C:E:S ->
-            ?SLOG(error, #{
-                msg => "start_store_filemeta_failed", class => C, reason => E, stacktrace => S
+            ?tp(error, "start_store_filemeta_failed", #{
+                class => C, reason => E, stacktrace => S
             }),
             {error, {internal_error, E}}
     end.
@@ -312,8 +312,8 @@ store_segment(Transfer, Segment) ->
         emqx_ft_storage:store_segment(Transfer, Segment)
     catch
         C:E:S ->
-            ?SLOG(error, #{
-                msg => "start_store_segment_failed", class => C, reason => E, stacktrace => S
+            ?tp(error, "start_store_segment_failed", #{
+                class => C, reason => E, stacktrace => S
             }),
             {error, {internal_error, E}}
     end.
@@ -323,8 +323,8 @@ assemble(Transfer, FinalSize) ->
         emqx_ft_storage:assemble(Transfer, FinalSize)
     catch
         C:E:S ->
-            ?SLOG(error, #{
-                msg => "start_assemble_failed", class => C, reason => E, stacktrace => S
+            ?tp(error, "start_assemble_failed", #{
+                class => C, reason => E, stacktrace => S
             }),
             {error, {internal_error, E}}
     end.
@@ -334,8 +334,7 @@ transfer(Msg, FileId) ->
     {clientid_to_binary(ClientId), FileId}.
 
 on_complete(Op, {ChanPid, PacketId}, Transfer, Result) ->
-    ?SLOG(debug, #{
-        msg => "on_complete",
+    ?tp(debug, "on_complete", #{
         operation => Op,
         packet_id => PacketId,
         transfer => Transfer
@@ -344,15 +343,13 @@ on_complete(Op, {ChanPid, PacketId}, Transfer, Result) ->
         {Mode, ok} when Mode == ack orelse Mode == down ->
             erlang:send(ChanPid, {puback, PacketId, [], ?RC_SUCCESS});
         {Mode, {error, _} = Reason} when Mode == ack orelse Mode == down ->
-            ?SLOG(error, #{
-                msg => Op ++ "_failed",
+            ?tp(error, Op ++ "_failed", #{
                 transfer => Transfer,
                 reason => Reason
             }),
             erlang:send(ChanPid, {puback, PacketId, [], ?RC_UNSPECIFIED_ERROR});
         timeout ->
-            ?SLOG(error, #{
-                msg => Op ++ "_timed_out",
+            ?tp(error, Op ++ "_timed_out", #{
                 transfer => Transfer
             }),
             erlang:send(ChanPid, {puback, PacketId, [], ?RC_UNSPECIFIED_ERROR})

--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -198,8 +198,7 @@ on_file_command(PacketId, FileId, Msg, FileCommand) ->
     end.
 
 on_init(PacketId, Msg, Transfer, Meta) ->
-    ?SLOG(info, #{
-        msg => "on_init",
+    ?tp(info, "file_transfer_init", #{
         mqtt_msg => Msg,
         packet_id => PacketId,
         transfer => Transfer,
@@ -229,8 +228,7 @@ on_abort(_Msg, _FileId) ->
     ?RC_SUCCESS.
 
 on_segment(PacketId, Msg, Transfer, Offset, Checksum) ->
-    ?SLOG(info, #{
-        msg => "on_segment",
+    ?tp(info, "file_transfer_segment", #{
         mqtt_msg => Msg,
         packet_id => PacketId,
         transfer => Transfer,
@@ -255,8 +253,7 @@ on_segment(PacketId, Msg, Transfer, Offset, Checksum) ->
     end).
 
 on_fin(PacketId, Msg, Transfer, FinalSize, Checksum) ->
-    ?SLOG(info, #{
-        msg => "on_fin",
+    ?tp(info, "file_transfer_fin", #{
         mqtt_msg => Msg,
         packet_id => PacketId,
         transfer => Transfer,

--- a/apps/emqx_ft/src/emqx_ft_app.erl
+++ b/apps/emqx_ft/src/emqx_ft_app.erl
@@ -22,11 +22,9 @@
 
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_ft_sup:start_link(),
-    ok = emqx_ft:hook(),
     ok = emqx_ft_conf:load(),
     {ok, Sup}.
 
 stop(_State) ->
     ok = emqx_ft_conf:unload(),
-    ok = emqx_ft:unhook(),
     ok.

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -159,7 +159,7 @@ handle_event(internal, _, {assemble, []}, St = #{}) ->
     {next_state, complete, St, ?internal([])};
 handle_event(internal, _, complete, St = #{export := Export}) ->
     Result = emqx_ft_storage_exporter:complete(Export),
-    ok = maybe_garbage_collect(Result, St),
+    _ = maybe_garbage_collect(Result, St),
     {stop, {shutdown, Result}, maps:remove(export, St)}.
 
 -spec terminate(_Reason, state(), stdata()) -> _.

--- a/apps/emqx_ft/src/emqx_ft_schema.erl
+++ b/apps/emqx_ft/src/emqx_ft_schema.erl
@@ -55,6 +55,15 @@ roots() -> [file_transfer].
 
 fields(file_transfer) ->
     [
+        {enable,
+            mk(
+                boolean(),
+                #{
+                    desc => ?DESC("enable"),
+                    required => false,
+                    default => false
+                }
+            )},
         {init_timeout,
             mk(
                 emqx_schema:duration_ms(),
@@ -87,22 +96,19 @@ fields(file_transfer) ->
                 hoconsc:union(
                     fun
                         (all_union_members) ->
-                            [
-                                % NOTE: by default storage is disabled
-                                undefined,
-                                ref(local_storage)
-                            ];
+                            [ref(local_storage)];
                         ({value, #{<<"type">> := <<"local">>}}) ->
                             [ref(local_storage)];
                         ({value, #{<<"type">> := _}}) ->
                             throw(#{field_name => type, expected => "local"});
-                        (_) ->
-                            [undefined]
+                        ({value, _}) ->
+                            [ref(local_storage)]
                     end
                 ),
                 #{
                     required => false,
-                    desc => ?DESC("storage")
+                    desc => ?DESC("storage"),
+                    default => #{<<"type">> => <<"local">>}
                 }
             )}
     ];

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -98,6 +98,7 @@
 }.
 
 -type storage() :: #{
+    type := 'local',
     segments := segments(),
     exporter := emqx_ft_storage_exporter:exporter()
 }.

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -47,6 +47,8 @@
 
 -export([files/1]).
 
+-export([on_config_update/2]).
+
 -export_type([storage/0]).
 -export_type([filefrag/1]).
 -export_type([filefrag/0]).
@@ -216,6 +218,13 @@ assemble(Storage, Transfer, Size) ->
 
 files(Storage) ->
     emqx_ft_storage_exporter:list(Storage).
+
+%%
+
+on_config_update(StorageOld, StorageNew) ->
+    % NOTE: this will reset GC timer, frequent changes would postpone GC indefinitely
+    ok = emqx_ft_storage_fs_gc:reset(StorageNew),
+    emqx_ft_storage_exporter:on_config_update(StorageOld, StorageNew).
 
 %%
 

--- a/apps/emqx_ft/src/emqx_ft_sup.erl
+++ b/apps/emqx_ft/src/emqx_ft_sup.erl
@@ -61,5 +61,5 @@ init([]) ->
         modules => [emqx_ft_responder_sup]
     },
 
-    ChildSpecs = [Responder, AssemblerSup, FileReaderSup | emqx_ft_storage:child_spec()],
+    ChildSpecs = [Responder, AssemblerSup, FileReaderSup],
     {ok, {SupFlags, ChildSpecs}}.

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -63,6 +63,7 @@ set_special_configs(Config) ->
                 % NOTE
                 % Inhibit local fs GC to simulate it isn't fast enough to collect
                 % complete transfers.
+                enable => true,
                 storage => emqx_utils_maps:deep_merge(
                     Storage,
                     #{segments => #{gc => #{interval => 0}}}

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -30,23 +30,13 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
     ok = emqx_mgmt_api_test_util:init_suite(
-        [emqx_conf, emqx_ft], set_special_configs(Config)
+        [emqx_conf, emqx_ft], emqx_ft_test_helpers:env_handler(Config)
     ),
     {ok, _} = emqx:update_config([rpc, port_discovery], manual),
     Config.
 end_per_suite(_Config) ->
     ok = emqx_mgmt_api_test_util:end_suite([emqx_ft, emqx_conf]),
     ok.
-
-set_special_configs(Config) ->
-    fun
-        (emqx_ft) ->
-            emqx_ft_test_helpers:load_config(#{
-                storage => emqx_ft_test_helpers:local_storage(Config)
-            });
-        (_) ->
-            ok
-    end.
 
 init_per_testcase(Case, Config) ->
     [{tc, Case} | Config].

--- a/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
@@ -46,8 +46,8 @@ init_per_testcase(TC, Config) ->
     ok = snabbkaffe:start_trace(),
     {ok, Pid} = emqx_ft_assembler_sup:start_link(),
     [
-        {storage_root, "file_transfer_root"},
-        {exports_root, "file_transfer_exports"},
+        {storage_root, <<"file_transfer_root">>},
+        {exports_root, <<"file_transfer_exports">>},
         {file_id, atom_to_binary(TC)},
         {assembler_sup, Pid}
         | Config
@@ -246,13 +246,17 @@ exporter(Config) ->
     emqx_ft_storage_exporter:exporter(storage(Config)).
 
 storage(Config) ->
-    #{
-        type => local,
-        segments => #{
-            root => ?config(storage_root, Config)
-        },
-        exporter => #{
-            type => local,
-            root => ?config(exports_root, Config)
-        }
-    }.
+    maps:get(
+        storage,
+        emqx_ft_schema:translate(#{
+            <<"storage">> => #{
+                <<"type">> => <<"local">>,
+                <<"segments">> => #{
+                    <<"root">> => ?config(storage_root, Config)
+                },
+                <<"exporter">> => #{
+                    <<"root">> => ?config(exports_root, Config)
+                }
+            }
+        })
+    ).

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
@@ -35,21 +35,11 @@ groups() ->
     ].
 
 init_per_suite(Config) ->
-    ok = emqx_common_test_helpers:start_apps([emqx_ft], set_special_configs(Config)),
+    ok = emqx_common_test_helpers:start_apps([emqx_ft], emqx_ft_test_helpers:env_handler(Config)),
     Config.
 end_per_suite(_Config) ->
     ok = emqx_common_test_helpers:stop_apps([emqx_ft]),
     ok.
-
-set_special_configs(Config) ->
-    fun
-        (emqx_ft) ->
-            emqx_ft_test_helpers:load_config(#{
-                storage => emqx_ft_test_helpers:local_storage(Config)
-            });
-        (_) ->
-            ok
-    end.
 
 init_per_testcase(Case, Config) ->
     [{tc, Case} | Config].

--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -41,7 +41,7 @@ stop_additional_node(Node) ->
 env_handler(Config) ->
     fun
         (emqx_ft) ->
-            load_config(#{storage => local_storage(Config)});
+            load_config(#{enable => true, storage => local_storage(Config)});
         (_) ->
             ok
     end.

--- a/apps/emqx_s3/src/emqx_s3_client.erl
+++ b/apps/emqx_s3/src/emqx_s3_client.erl
@@ -57,7 +57,7 @@
     port := part_number(),
     bucket := string(),
     headers := headers(),
-    acl := emqx_s3:acl(),
+    acl := emqx_s3:acl() | undefined,
     url_expire_time := pos_integer(),
     access_key_id := string() | undefined,
     secret_access_key := string() | undefined,

--- a/apps/emqx_s3/src/emqx_s3_schema.erl
+++ b/apps/emqx_s3/src/emqx_s3_schema.erl
@@ -105,7 +105,6 @@ fields(s3) ->
                     bucket_owner_full_control
                 ]),
                 #{
-                    default => private,
                     desc => ?DESC("acl"),
                     required => false
                 }

--- a/apps/emqx_s3/test/emqx_s3_schema_SUITE.erl
+++ b/apps/emqx_s3/test/emqx_s3_schema_SUITE.erl
@@ -23,7 +23,6 @@ t_minimal_config(_Config) ->
             bucket := "bucket",
             host := "s3.us-east-1.endpoint.com",
             port := 443,
-            acl := private,
             min_part_size := 5242880,
             transport_options :=
                 #{

--- a/rel/i18n/emqx_ft_schema.hocon
+++ b/rel/i18n/emqx_ft_schema.hocon
@@ -1,5 +1,11 @@
 emqx_ft_schema {
 
+enable.desc:
+"""Enable the File Transfer feature.<br/>
+Enabling File Transfer implies reserving special MQTT topics in order to serve the protocol.<br/>
+This toggle does not have an effect neither on the availability of the File Transfer REST API, nor
+on storage-dependent background activities (e.g. garbage collection)."""
+
 init_timeout.desc:
 """Timeout for initializing the file transfer.<br/>
 After reaching the timeout, `init` message will be acked with an error"""


### PR DESCRIPTION
Fixes [EMQX-9521](https://emqx.atlassian.net/browse/EMQX-9521).

## Summary
Ensure that:
* Storage config might be removed.
* Local FS GC process is set up when Local FS storage is configured.
* Local FS GC process gets its timer reset on config updates.
* Storage / exporter gets chosen based on `type` only.
* Exporter config updates propagated as before.

Also employ `emqx_ft_schema:translate/1` instead of duplicating defaults where applicable.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [ ] ~~Schema changes are backward compatible~~
