### PR TITLE
test: attempt to fix flaky test

### DIFF
--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -1473,7 +1473,10 @@ do_t_receive_after_recovery(Config) ->
     ResourceId = resource_id(Config),
     ?check_trace(
         begin
-            {ok, _} = create_bridge(Config),
+            {ok, _} = create_bridge(
+                Config,
+                #{<<"kafka">> => #{<<"offset_reset_policy">> => <<"earliest">>}}
+            ),
             ping_until_healthy(Config, _Period = 1_500, _Timeout0 = 24_000),
             {ok, connected} = emqx_resource_manager:health_check(ResourceId),
             %% 0) ensure each partition commits its offset so it can


### PR DESCRIPTION
Example failure: https://github.com/emqx/emqx/actions/runs/4789177314/jobs/8517116154#step:7:503

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9fde12</samp>

Fixed a kafka bridge test case by setting `offset_reset_policy` to `earliest` in `emqx_bridge_kafka_impl_consumer_SUITE.erl`. This ensures that the kafka consumer can receive messages from the broker even if the offset is missing or outdated.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
