### PR TITLE
fix(rocketmq): fix that the update of ACL info not working

### DIFF
--- a/rel/i18n/emqx_ee_connector_rocketmq.hocon
+++ b/rel/i18n/emqx_ee_connector_rocketmq.hocon
@@ -26,6 +26,28 @@ The RocketMQ default port 9876 is used if `[:Port]` is not specified."""
             }
     }
 
+    access_key {
+        desc {
+          en: """RocketMQ server `accessKey`."""
+          zh: """RocketMQ 服务器的 `accessKey`。"""
+        }
+        label: {
+             en: "AccessKey"
+             zh: "AccessKey"
+            }
+    }
+
+    secret_key {
+        desc {
+          en: """RocketMQ server `secretKey`."""
+          zh: """RocketMQ 服务器的 `secretKey`。"""
+        }
+        label: {
+              en: "SecretKey"
+              zh: "SecretKey"
+            }
+    }
+
     sync_timeout {
         desc {
           en: """Timeout of RocketMQ driver synchronous call."""


### PR DESCRIPTION
Fixes [EMQX-9686](https://emqx.atlassian.net/browse/EMQX-9686)

Changes:

1. `username` -> `access_key`
2. `password` -> `secret_key`
3.  pass correct ACL info to RocketMQ when the bridge starts (in `on_start`)
4.  release all producers when the bridge stops (in `on_stop`)

Add test cases for ACL need much time, it will be tracked by another standalone ticket([EMQX-9709](https://emqx.atlassian.net/browse/EMQX-9709)).

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 117d5d3</samp>

This pull request enhances the rocketmq connector to support the ACL feature, which allows users to authenticate and authorize their access to the rocketmq broker using `access_key` and `secret_key` fields. It also simplifies the connector configuration and improves the code quality and the internationalized UI.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
