### PR TITLE
chore: un-hide ocsp stapling config

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2323,8 +2323,6 @@ server_ssl_opts_schema(Defaults, IsRanchListener) ->
                         ref("ocsp"),
                         #{
                             required => false,
-                            %% TODO: remove after e5.0.2
-                            importance => ?IMPORTANCE_HIDDEN,
                             validator => fun ocsp_inner_validator/1
                         }
                     )},
@@ -2333,6 +2331,7 @@ server_ssl_opts_schema(Defaults, IsRanchListener) ->
                         boolean(),
                         #{
                             default => false,
+                            importance => ?IMPORTANCE_MEDIUM,
                             desc => ?DESC("server_ssl_opts_schema_enable_crl_check")
                         }
                     )}

--- a/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
@@ -677,8 +677,12 @@ do_t_update_listener(Config) ->
     %% no ocsp at first
     ListenerId = "ssl:default",
     {ok, {{_, 200, _}, _, ListenerData0}} = get_listener_via_api(ListenerId),
-    ?assertEqual(
-        undefined,
+    ?assertMatch(
+        #{
+            <<"enable_ocsp_stapling">> := false,
+            <<"refresh_http_timeout">> := _,
+            <<"refresh_interval">> := _
+        },
         emqx_utils_maps:deep_get([<<"ssl_options">>, <<"ocsp">>], ListenerData0, undefined)
     ),
     assert_no_http_get(),


### PR DESCRIPTION
Undoing https://github.com/emqx/emqx/pull/10160

Port of https://github.com/emqx/emqx/pull/10439 to `release-50`.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 93f44b3</samp>

Updated the SSL configuration schema and the OCSP cache test case to improve the OCSP stapling feature. Bumped the EMQX Core version to 5.0.24.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
