### PR TITLE
chore(kafka_producer): rename `kafka` to `kafka_producer`

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -336,9 +336,7 @@ parse_confs(Type, Name, Conf) when ?IS_INGRESS_BRIDGE(Type) ->
     BId = bridge_id(Type, Name),
     BridgeHookpoint = bridge_hookpoint(BId),
     Conf#{hookpoint => BridgeHookpoint, bridge_name => Name};
-%% TODO: rename this to `kafka_producer' after alias support is added
-%% to hocon; keeping this as just `kafka' for backwards compatibility.
-parse_confs(<<"kafka">> = _Type, Name, Conf) ->
+parse_confs(<<"kafka_producer">> = _Type, Name, Conf) ->
     Conf#{bridge_name => Name};
 parse_confs(_Type, _Name, Conf) ->
     Conf.

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, [emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -37,10 +37,7 @@
 conn_bridge_examples(Method) ->
     [
         #{
-            %% TODO: rename this to `kafka_producer' after alias
-            %% support is added to hocon; keeping this as just `kafka'
-            %% for backwards compatibility.
-            <<"kafka">> => #{
+            <<"kafka_producer">> => #{
                 summary => <<"Kafka Producer Bridge">>,
                 value => values({Method, producer})
             }
@@ -416,10 +413,7 @@ struct_names() ->
 %% internal
 type_field() ->
     {type,
-        %% TODO: rename `kafka' to `kafka_producer' after alias
-        %% support is added to hocon; keeping this as just `kafka' for
-        %% backwards compatibility.
-        mk(enum([kafka_consumer, kafka]), #{required => true, desc => ?DESC("desc_type")})}.
+        mk(enum([kafka_consumer, kafka_producer]), #{required => true, desc => ?DESC("desc_type")})}.
 
 name_field() ->
     {name, mk(binary(), #{required => true, desc => ?DESC("desc_name")})}.

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -23,9 +23,7 @@
 
 -include_lib("emqx/include/logger.hrl").
 
-%% TODO: rename this to `kafka_producer' after alias support is added
-%% to hocon; keeping this as just `kafka' for backwards compatibility.
--define(BRIDGE_TYPE, kafka).
+-define(BRIDGE_TYPE, kafka_producer).
 
 is_buffer_supported() -> true.
 

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE_data/kafka_producer_legacy.hocon
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE_data/kafka_producer_legacy.hocon
@@ -1,0 +1,38 @@
+node.name = test@127.0.0.1
+node.cookie = emqxsecretcookie
+node.data_dir = "{{ test_priv_dir }}"
+
+dashboard.listeners.http.bind = "127.0.0.1:28083"
+
+# this was rename from `kafka` to `kafka_producer`
+bridges.kafka.kproducer {
+  authentication = "none"
+  bootstrap_hosts = "{{{ bootstrap_hosts }}}"
+  connect_timeout = "5s"
+  enable = true
+  kafka {
+    buffer {
+      memory_overload_protection = false
+      mode = "memory"
+      per_partition_limit = "2GB"
+      segment_bytes = "100MB"
+    }
+    compression = "no_compression"
+    max_batch_bytes = "896KB"
+    max_inflight = 10
+    message {
+      key = "${.clientid}"
+      timestamp = "${.timestamp}"
+      value = "${.}"
+    }
+    partition_count_refresh_interval = "60s"
+    partition_strategy = "random"
+    required_acks = "all_isr"
+    topic = "test-topic-three-partitions"
+  }
+  local_topic = "t/kafka_in_no_rules"
+  metadata_request_timeout = "5s"
+  min_metadata_refresh_interval = "3s"
+  socket_opts {recbuf = "1024KB", sndbuf = "1024KB"}
+  ssl {enable = false, verify = "verify_peer"}
+}

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -19,7 +19,7 @@ kafka_producer_test() ->
         #{
             <<"bridges">> :=
                 #{
-                    <<"kafka">> :=
+                    <<"kafka_producer">> :=
                         #{
                             <<"myproducer">> :=
                                 #{<<"kafka">> := #{}}
@@ -32,7 +32,7 @@ kafka_producer_test() ->
         #{
             <<"bridges">> :=
                 #{
-                    <<"kafka">> :=
+                    <<"kafka_producer">> :=
                         #{
                             <<"myproducer">> :=
                                 #{<<"local_topic">> := _}
@@ -45,7 +45,7 @@ kafka_producer_test() ->
         #{
             <<"bridges">> :=
                 #{
-                    <<"kafka">> :=
+                    <<"kafka_producer">> :=
                         #{
                             <<"myproducer">> :=
                                 #{
@@ -61,7 +61,7 @@ kafka_producer_test() ->
         #{
             <<"bridges">> :=
                 #{
-                    <<"kafka">> :=
+                    <<"kafka_producer">> :=
                         #{
                             <<"myproducer">> :=
                                 #{

--- a/changes/ee/feat-10517.en.md
+++ b/changes/ee/feat-10517.en.md
@@ -1,0 +1,3 @@
+Internally, the Kafka Producer bridge type has been renamed from `kafka` to `kafka_producer`.
+
+This is to improve consistency (compare to `kafka_consumer`). This should only concern users that write their configuration files by hand (`emqx.conf` or `cluster.hocon`), and is an otherwise transparent change.

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
@@ -74,9 +74,8 @@ examples(Method) ->
 
 resource_type(Type) when is_binary(Type) -> resource_type(binary_to_atom(Type, utf8));
 resource_type(kafka_consumer) -> emqx_bridge_kafka_impl_consumer;
-%% TODO: rename this to `kafka_producer' after alias support is added
-%% to hocon; keeping this as just `kafka' for backwards compatibility.
-resource_type(kafka) -> emqx_bridge_kafka_impl_producer;
+%% resource_type(kafka) -> emqx_bridge_kafka_impl_producer;
+resource_type(kafka_producer) -> emqx_bridge_kafka_impl_producer;
 resource_type(cassandra) -> emqx_bridge_cassandra_connector;
 resource_type(hstreamdb) -> emqx_ee_connector_hstreamdb;
 resource_type(gcp_pubsub) -> emqx_bridge_gcp_pubsub_connector;
@@ -183,13 +182,11 @@ mongodb_structs() ->
 
 kafka_structs() ->
     [
-        %% TODO: rename this to `kafka_producer' after alias support
-        %% is added to hocon; keeping this as just `kafka' for
-        %% backwards compatibility.
-        {kafka,
+        {kafka_producer,
             mk(
                 hoconsc:map(name, ref(emqx_bridge_kafka, kafka_producer)),
                 #{
+                    aliases => [kafka],
                     desc => <<"Kafka Producer Bridge Config">>,
                     required => false,
                     converter => fun emqx_bridge_kafka:kafka_producer_converter/2


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9717

# Note

This will require some change in the frontend, as it apparently defaults to Kafka Consumer when it receives a Kafka bridge of type `kafka_producer`.  https://github.com/emqx/emqx-dashboard5/pull/1293 seemed to work locally.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a32517</samp>

This pull request renames the `kafka` bridge type to `kafka_producer` in the `emqx_bridge_kafka` and `emqx_ee_bridge` applications, to distinguish it from the `kafka_consumer` type and to support Hocon aliases. It also updates the code, comments, tests, and configuration files accordingly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [X] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [X] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
