### PR TITLE
perf(config): avoid build new map in emqx_mgmt_caps:get_caps

### DIFF
--- a/.ci/docker-compose-file/scripts/run-emqx.sh
+++ b/.ci/docker-compose-file/scripts/run-emqx.sh
@@ -20,8 +20,8 @@ esac
 
 {
   echo "HOCON_ENV_OVERRIDE_PREFIX=EMQX_"
-  echo "EMQX_ZONES__DEFAULT__MQTT__RETRY_INTERVAL=2s"
-  echo "EMQX_ZONES__DEFAULT__MQTT__MAX_TOPIC_ALIAS=10"
+  echo "EMQX_MQTT__RETRY_INTERVAL=2s"
+  echo "EMQX_MQTT__MAX_TOPIC_ALIAS=10"
   echo "EMQX_AUTHORIZATION__SOURCES=[]"
   echo "EMQX_AUTHORIZATION__NO_MATCH=allow"
 } >> .ci/docker-compose-file/conf.cluster.env

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -167,8 +167,8 @@ jobs:
             --set image.pullPolicy=Never \
             --set image.tag=$EMQX_TAG \
             --set emqxAclConfig="" \
-            --set emqxConfig.EMQX_ZONES__DEFAULT__MQTT__RETRY_INTERVAL=2s \
-            --set emqxConfig.EMQX_ZONES__DEFAULT__MQTT__MAX_TOPIC_ALIAS=10 \
+            --set emqxConfig.EMQX_MQTT__RETRY_INTERVAL=2s \
+            --set emqxConfig.EMQX_MQTT__MAX_TOPIC_ALIAS=10 \
             --set emqxConfig.EMQX_AUTHORIZATION__SOURCES=[] \
             --set emqxConfig.EMQX_AUTHORIZATION__NO_MATCH=allow \
             deploy/charts/${{ matrix.profile }} \
@@ -185,8 +185,8 @@ jobs:
             --set image.pullPolicy=Never \
             --set image.tag=$EMQX_TAG \
             --set emqxAclConfig="" \
-            --set emqxConfig.EMQX_ZONES__DEFAULT__MQTT__RETRY_INTERVAL=2s \
-            --set emqxConfig.EMQX_ZONES__DEFAULT__MQTT__MAX_TOPIC_ALIAS=10 \
+            --set emqxConfig.EMQX_MQTT__RETRY_INTERVAL=2s \
+            --set emqxConfig.EMQX_MQTT__MAX_TOPIC_ALIAS=10 \
             --set emqxConfig.EMQX_AUTHORIZATION__SOURCES=[] \
             --set emqxConfig.EMQX_AUTHORIZATION__NO_MATCH=allow \
             deploy/charts/${{ matrix.profile }} \

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -3,7 +3,7 @@
     {id, "emqx"},
     {description, "EMQX Core"},
     % strict semver, bump manually!
-    {vsn, "5.0.24"},
+    {vsn, "5.0.25"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_mqtt_caps.erl
+++ b/apps/emqx/src/emqx_mqtt_caps.erl
@@ -88,7 +88,7 @@ check_pub(Zone, Flags) when is_map(Flags) ->
             error ->
                 Flags
         end,
-        maps:with(?PUBCAP_KEYS, get_caps(Zone))
+        get_caps(?PUBCAP_KEYS, Zone)
     ).
 
 do_check_pub(#{topic_levels := Levels}, #{max_topic_levels := Limit}) when
@@ -111,7 +111,7 @@ do_check_pub(_Flags, _Caps) ->
 ) ->
     ok_or_error(emqx_types:reason_code()).
 check_sub(ClientInfo = #{zone := Zone}, Topic, SubOpts) ->
-    Caps = maps:with(?SUBCAP_KEYS, get_caps(Zone)),
+    Caps = get_caps(?SUBCAP_KEYS, Zone),
     Flags = lists:foldl(
         fun
             (max_topic_levels, Map) ->
@@ -152,10 +152,12 @@ do_check_sub(_Flags, _Caps, _, _) ->
     ok.
 
 get_caps(Zone) ->
-    lists:foldl(
-        fun({K, V}, Acc) ->
-            Acc#{K => emqx_config:get_zone_conf(Zone, [mqtt, K], V)}
-        end,
-        #{},
-        maps:to_list(?DEFAULT_CAPS)
+    get_caps(maps:keys(?DEFAULT_CAPS), Zone).
+get_caps(Keys, Zone) ->
+    maps:with(
+        Keys,
+        maps:merge(
+            ?DEFAULT_CAPS,
+            emqx_config:get_zone_conf(Zone, [mqtt])
+        )
     ).

--- a/apps/emqx/src/emqx_mqtt_caps.erl
+++ b/apps/emqx/src/emqx_mqtt_caps.erl
@@ -58,18 +58,18 @@
     exclusive_subscription
 ]).
 
--define(DEFAULT_CAPS, #{
-    max_packet_size => ?MAX_PACKET_SIZE,
-    max_clientid_len => ?MAX_CLIENTID_LEN,
-    max_topic_alias => ?MAX_TOPIC_AlIAS,
-    max_topic_levels => ?MAX_TOPIC_LEVELS,
-    max_qos_allowed => ?QOS_2,
-    retain_available => true,
-    wildcard_subscription => true,
-    subscription_identifiers => true,
-    shared_subscription => true,
-    exclusive_subscription => false
-}).
+-define(DEFAULT_CAPS_KEYS, [
+    max_packet_size,
+    max_clientid_len,
+    max_topic_alias,
+    max_topic_levels,
+    max_qos_allowed,
+    retain_available,
+    wildcard_subscription,
+    subscription_identifiers,
+    shared_subscription,
+    exclusive_subscription
+]).
 
 -spec check_pub(
     emqx_types:zone(),
@@ -152,12 +152,12 @@ do_check_sub(_Flags, _Caps, _, _) ->
     ok.
 
 get_caps(Zone) ->
-    get_caps(maps:keys(?DEFAULT_CAPS), Zone).
+    get_caps(?DEFAULT_CAPS_KEYS, Zone).
 get_caps(Keys, Zone) ->
     maps:with(
         Keys,
         maps:merge(
-            ?DEFAULT_CAPS,
+            emqx_config:get([mqtt]),
             emqx_config:get_zone_conf(Zone, [mqtt])
         )
     ).

--- a/apps/emqx/src/emqx_mqtt_caps.erl
+++ b/apps/emqx/src/emqx_mqtt_caps.erl
@@ -37,7 +37,6 @@
     max_qos_allowed => emqx_types:qos(),
     retain_available => boolean(),
     wildcard_subscription => boolean(),
-    subscription_identifiers => boolean(),
     shared_subscription => boolean(),
     exclusive_subscription => boolean()
 }.
@@ -66,7 +65,6 @@
     max_qos_allowed,
     retain_available,
     wildcard_subscription,
-    subscription_identifiers,
     shared_subscription,
     exclusive_subscription
 ]).

--- a/apps/emqx/src/emqx_zone_schema.erl
+++ b/apps/emqx/src/emqx_zone_schema.erl
@@ -61,6 +61,9 @@ hidden() ->
         "flapping_detect"
     ].
 
+%% optimized for mqtt field
+fields("mqtt") ->
+    emqx_schema:fields("mqtt");
 %% zone schemas are clones from the same name from root level
 %% only not allowed to have default values.
 fields(Name) ->

--- a/apps/emqx/src/emqx_zone_schema.erl
+++ b/apps/emqx/src/emqx_zone_schema.erl
@@ -61,9 +61,6 @@ hidden() ->
         "flapping_detect"
     ].
 
-%% optimized for mqtt field
-fields("mqtt") ->
-    emqx_schema:fields("mqtt");
 %% zone schemas are clones from the same name from root level
 %% only not allowed to have default values.
 fields(Name) ->

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -275,7 +275,6 @@ t_chan_caps(_) ->
             max_topic_levels := Level,
             retain_available := true,
             shared_subscription := true,
-            subscription_identifiers := true,
             wildcard_subscription := true
         } when is_integer(Level),
         emqx_channel:caps(channel())

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -267,6 +267,8 @@ t_chan_info(_) ->
 t_chan_caps(_) ->
     ?assertMatch(
         #{
+            exclusive_subscription := false,
+            max_packet_size := 1048576,
             max_clientid_len := 65535,
             max_qos_allowed := 2,
             max_topic_alias := 65535,

--- a/changes/ce/perf-10525.en.md
+++ b/changes/ce/perf-10525.en.md
@@ -1,0 +1,2 @@
+Reduce resource usage per MQTT packet handling.
+


### PR DESCRIPTION
Fixes [EMQX-9617](https://emqx.atlassian.net/browse/EMQX-9617)



<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d29f76e</samp>

Refactor `emqx_mqtt_caps.erl` to use a common function for getting MQTT capabilities. This improves code readability and reduces duplication. The default cap is fetched from the global mqtt config instead of module hardcoded macros.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~Added tests for the changes~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [ ] ~Schema changes are backward compatible~


