### PR TITLE
perf(config): ensure root keys of 'conf' config is atom

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -3,7 +3,7 @@
     {id, "emqx"},
     {description, "EMQX Core"},
     % strict semver, bump manually!
-    {vsn, "5.0.24"},
+    {vsn, "5.0.25"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -151,7 +151,7 @@ get_root([RootName | _]) ->
 %% @doc For the given path, get raw root value enclosed in a single-key map.
 %% key is ensured to be binary.
 get_root_raw([RootName | _]) ->
-    #{bin(RootName) => do_get_raw([RootName], #{})}.
+    #{bin(RootName) => get_raw([RootName], #{})}.
 
 %% @doc Get a config value for the given path.
 %% The path should at least include root config name.
@@ -288,9 +288,11 @@ get_default_value([RootName | _] = KeyPath) ->
     end.
 
 -spec get_raw(emqx_utils_maps:config_key_path()) -> term().
+get_raw([Root | T]) when is_atom(Root) -> get_raw([bin(Root) | T]);
 get_raw(KeyPath) -> do_get_raw(KeyPath).
 
 -spec get_raw(emqx_utils_maps:config_key_path(), term()) -> term().
+get_raw([Root | T], Default) when is_atom(Root) -> get_raw([bin(Root) | T], Default);
 get_raw(KeyPath, Default) -> do_get_raw(KeyPath, Default).
 
 -spec put_raw(map()) -> ok.

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -232,14 +232,14 @@ find_listener_conf(Type, Listener, KeyPath) ->
 put(Config) ->
     maps:fold(
         fun(RootName, RootValue, _) ->
-            ?MODULE:put([RootName], RootValue)
+            ?MODULE:put([atom(RootName)], RootValue)
         end,
         ok,
         Config
     ).
 
 erase(RootName) ->
-    persistent_term:erase(?PERSIS_KEY(?CONF, bin(RootName))),
+    persistent_term:erase(?PERSIS_KEY(?CONF, atom(RootName))),
     persistent_term:erase(?PERSIS_KEY(?RAW_CONF, bin(RootName))),
     ok.
 
@@ -689,9 +689,9 @@ do_get(Type, [], Default) ->
         false -> AllConf
     end;
 do_get(Type, [RootName], Default) ->
-    persistent_term:get(?PERSIS_KEY(Type, bin(RootName)), Default);
+    persistent_term:get(?PERSIS_KEY(Type, RootName), Default);
 do_get(Type, [RootName | KeyPath], Default) ->
-    RootV = persistent_term:get(?PERSIS_KEY(Type, bin(RootName)), #{}),
+    RootV = persistent_term:get(?PERSIS_KEY(Type, RootName), #{}),
     do_deep_get(Type, KeyPath, RootV, Default).
 
 do_put(Type, Putter, [], DeepValue) ->
@@ -705,7 +705,7 @@ do_put(Type, Putter, [], DeepValue) ->
 do_put(Type, Putter, [RootName | KeyPath], DeepValue) ->
     OldValue = do_get(Type, [RootName], #{}),
     NewValue = do_deep_put(Type, Putter, KeyPath, OldValue, DeepValue),
-    persistent_term:put(?PERSIS_KEY(Type, bin(RootName)), NewValue).
+    persistent_term:put(?PERSIS_KEY(Type, RootName), NewValue).
 
 do_deep_get(?CONF, KeyPath, Map, Default) ->
     atom_conf_path(

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -177,7 +177,9 @@ t_sub_key_update_remove(_Config) ->
         {ok, #{post_config_update => #{emqx_config_handler_SUITE => ok}}},
         emqx:remove_config(KeyPath)
     ),
-    ?assertError({config_not_found, KeyPath}, emqx:get_raw_config(KeyPath)),
+    ?assertError(
+        {config_not_found, [<<"sysmon">>, os, cpu_check_interval]}, emqx:get_raw_config(KeyPath)
+    ),
     OSKey = maps:keys(emqx:get_raw_config([sysmon, os])),
     ?assertEqual(false, lists:member(<<"cpu_check_interval">>, OSKey)),
     ?assert(length(OSKey) > 0),

--- a/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_conf_SUITE.erl
@@ -274,7 +274,7 @@ t_load_unload_gateway(_) ->
 
     ?assertException(
         error,
-        {config_not_found, [gateway, stomp]},
+        {config_not_found, [<<"gateway">>, stomp]},
         emqx:get_raw_config([gateway, stomp])
     ),
     ok.
@@ -307,7 +307,7 @@ t_load_remove_authn(_) ->
 
     ?assertException(
         error,
-        {config_not_found, [gateway, stomp, authentication]},
+        {config_not_found, [<<"gateway">>, stomp, authentication]},
         emqx:get_raw_config([gateway, stomp, authentication])
     ),
     ok.
@@ -352,7 +352,7 @@ t_load_remove_listeners(_) ->
 
     ?assertException(
         error,
-        {config_not_found, [gateway, stomp, listeners, tcp, default]},
+        {config_not_found, [<<"gateway">>, stomp, listeners, tcp, default]},
         emqx:get_raw_config([gateway, stomp, listeners, tcp, default])
     ),
     ok.
@@ -401,7 +401,7 @@ t_load_remove_listener_authn(_) ->
     Path = [gateway, stomp, listeners, tcp, default, authentication],
     ?assertException(
         error,
-        {config_not_found, Path},
+        {config_not_found, [<<"gateway">>, stomp, listeners, tcp, default, authentication]},
         emqx:get_raw_config(Path)
     ),
     ok.
@@ -421,7 +421,7 @@ t_load_gateway_with_certs_content(_) ->
     assert_ssl_confs_files_deleted(SslConf),
     ?assertException(
         error,
-        {config_not_found, [gateway, stomp]},
+        {config_not_found, [<<"gateway">>, stomp]},
         emqx:get_raw_config([gateway, stomp])
     ),
     ok.
@@ -489,7 +489,7 @@ t_add_listener_with_certs_content(_) ->
 
     ?assertException(
         error,
-        {config_not_found, [gateway, stomp, listeners, ssl, default]},
+        {config_not_found, [<<"gateway">>, stomp, listeners, ssl, default]},
         emqx:get_raw_config([gateway, stomp, listeners, ssl, default])
     ),
     ok.

--- a/changes/ce/perf-10528.en.md
+++ b/changes/ce/perf-10528.en.md
@@ -1,0 +1,1 @@
+Reduce memory footprint in hot code path.


### PR DESCRIPTION
Fixes EMQX-9614
<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1ead3ce</samp>

Use atoms as keys for configuration map storage in `emqx_config`. Refactor and optimize the module to improve efficiency and readability.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

~- [ ] Added tests for the changes~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [ ] Schema changes are backward compatible

