### PR TITLE
ci: check if given schema.json exists before running spellcheck

### DIFF
--- a/scripts/spellcheck/spellcheck.sh
+++ b/scripts/spellcheck/spellcheck.sh
@@ -12,6 +12,11 @@ else
     SCHEMA="$(realpath "$1")"
 fi
 
+if ! [ -f "$SCHEMA" ]; then
+  echo "Schema file $SCHEMA does not exist; did you forget to run 'make emqx{,-enterprise}' ?"
+  exit 1
+fi
+
 set +e
 docker run --rm -i --name spellcheck \
     -v "${PROJ_ROOT}"/scripts/spellcheck/dicts:/dicts \


### PR DESCRIPTION
Prints helpful message when schema.json does not exist, as otherwise the "file" will be mounted as an empty directory inside the spellchecker container.


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41350b6</samp>

Improve spellcheck script and documentation. Add a check for `schema` file in `spellcheck.sh` and fix some typos.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
