### PR TITLE
chore: change node.data_dir from hidden to low

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -471,7 +471,7 @@ fields("node") ->
                     %% for now, it's tricky to use a different data_dir
                     %% otherwise data paths in cluster config may differ
                     %% TODO: change configurable data file paths to relative
-                    importance => ?IMPORTANCE_HIDDEN,
+                    importance => ?IMPORTANCE_LOW,
                     desc => ?DESC(node_data_dir)
                 }
             )},


### PR DESCRIPTION
Fixes [EMQX-9551](https://emqx.atlassian.net/browse/EMQX-9551)
`node.data_dir` is depended on `{{platform_data_dir }}`,  
Different packages will have different default values.
We can't hide this(delete it from etc/emqx.conf), So we changed it to a low priority level.

It's not release yet, don't need  changelog.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
