### PR TITLE
chore: bump ehttpc -> 0.4.8

### DIFF
--- a/changes/ce/fix-10548.en.md
+++ b/changes/ce/fix-10548.en.md
@@ -1,0 +1,2 @@
+Fixed a race condition in the HTTP driver that would result in an error rather than a retry of the request.
+Related fix in the driver: https://github.com/emqx/ehttpc/pull/45

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule EMQXUmbrella.MixProject do
       {:redbug, "2.0.8"},
       {:covertool, github: "zmstone/covertool", tag: "2.0.4.1", override: true},
       {:typerefl, github: "ieQu1/typerefl", tag: "0.9.1", override: true},
-      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.7", override: true},
+      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.8", override: true},
       {:gproc, github: "uwiger/gproc", tag: "0.8.0", override: true},
       {:jiffy, github: "emqx/jiffy", tag: "1.0.5", override: true},
       {:cowboy, github: "emqx/cowboy", tag: "2.9.0", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -56,7 +56,7 @@
     , {gpb, "4.19.5"} %% gpb only used to build, but not for release, pin it here to avoid fetching a wrong version due to rebar plugins scattered in all the deps
     , {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}}
     , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.9"}}}
-    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.7"}}}
+    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.8"}}}
     , {gproc, {git, "https://github.com/uwiger/gproc", {tag, "0.8.0"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}


### PR DESCRIPTION
# Targeting `release-50`

Fixes https://emqx.atlassian.net/browse/EMQX-9656

See also https://github.com/emqx/ehttpc/pull/45

This fixes a race condition where the remote server would close the connection before or during requests, and, depending on timing, an `{error, normal}` response would be returned.  In those cases, we should just retry the request without using up "retry credits".

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 207f081</samp>

This pull request fixes a race condition in the HTTP client library `ehttpc` that could cause EMQ X to crash. It updates the `ehttpc` dependency in `mix.exs` and adds a changelog entry in `changes/ce/fix-10548.en.md`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
