### PR TITLE
build: imporove speed to local run

### DIFF
--- a/build
+++ b/build
@@ -125,6 +125,7 @@ assert_no_compile_time_only_deps() {
 }
 
 make_rel() {
+    local release_or_tar="${1}"
     ./scripts/pre-compile.sh "$PROFILE"
     # make_elixir_rel always create rebar.lock
     # delete it to make git clone + checkout work because we use shallow close for rebar deps
@@ -134,7 +135,7 @@ make_rel() {
     # generate docs (require beam compiled), generated to etc and priv dirs
     make_docs
     # now assemble the release tar
-    ./rebar3 as "$PROFILE" tar
+    ./rebar3 as "$PROFILE" "$release_or_tar"
     assert_no_compile_time_only_deps
 }
 
@@ -220,7 +221,7 @@ make_tgz() {
     else
       # build the src_tarball again to ensure relup is included
       # elixir does not have relup yet.
-      make_rel
+      make_rel tar
 
       local relpath="_build/${PROFILE}/rel/emqx"
       full_vsn="$(./pkg-vsn.sh "$PROFILE" --long)"
@@ -378,7 +379,7 @@ case "$ARTIFACT" in
         make_docs
         ;;
     rel)
-        make_rel
+        make_rel release
         ;;
     relup)
         make_relup
@@ -397,7 +398,7 @@ case "$ARTIFACT" in
         if [ "${IS_ELIXIR:-}" = 'yes' ]; then
             make_elixir_rel
         else
-            make_rel
+            make_rel tar
         fi
         env EMQX_REL="$(pwd)" \
             EMQX_BUILD="${PROFILE}" \

--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,7 @@
    emqx_ssl_crl_cache
  ]}.
 
-{provider_hooks, [{pre, [{release, {relup_helper, gen_appups}}]}]}.
+%{provider_hooks, [{pre, [{release, {relup_helper, gen_appups}}]}]}.
 
 {post_hooks,[]}.
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -156,7 +156,7 @@ project_app_dirs(Edition) ->
 
 plugins() ->
     [
-        {relup_helper, {git, "https://github.com/emqx/relup_helper", {tag, "2.1.0"}}},
+        %{relup_helper, {git, "https://github.com/emqx/relup_helper", {tag, "2.1.0"}}},
         %% emqx main project does not require port-compiler
         %% pin at root level for deterministic
         {pc, "v1.14.0"}
@@ -495,11 +495,8 @@ relx_overlay(ReleaseType, Edition) ->
         {copy, "bin/emqx_cluster_rescue", "bin/emqx_cluster_rescue"},
         {copy, "bin/node_dump", "bin/node_dump"},
         {copy, "bin/install_upgrade.escript", "bin/install_upgrade.escript"},
-        %% for relup
         {copy, "bin/emqx", "bin/emqx-{{release_version}}"},
-        %% for relup
         {copy, "bin/emqx_ctl", "bin/emqx_ctl-{{release_version}}"},
-        %% for relup
         {copy, "bin/install_upgrade.escript", "bin/install_upgrade.escript-{{release_version}}"},
         {copy, "apps/emqx_gateway_lwm2m/lwm2m_xml", "etc/lwm2m_xml"},
         {copy, "apps/emqx_authz/etc/acl.conf", "etc/acl.conf"},


### PR DESCRIPTION
prior to this change, 'make run' has to wait for the release tar ball to be created.
now it just builds the release and run from the `rel` dir.

relup helper plugin isn't quite ready to work with the rebar3 `release` command yet, so it's commented out for now.