### PR TITLE
Do not complain on nonexisting ets while `emqx_topic_metrics` stops

### DIFF
--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.13"},
+    {vsn, "5.0.14"},
     {modules, []},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},
     {mod, {emqx_modules_app, []}},

--- a/apps/emqx_modules/src/emqx_topic_metrics.erl
+++ b/apps/emqx_modules/src/emqx_topic_metrics.erl
@@ -179,7 +179,12 @@ deregister_all() ->
     gen_server:call(?MODULE, {deregister, all}).
 
 is_registered(Topic) ->
-    ets:member(?TAB, Topic).
+    try
+        ets:member(?TAB, Topic)
+    catch
+        error:badarg ->
+            false
+    end.
 
 all_registered_topics() ->
     [Topic || {Topic, _} <- ets:tab2list(?TAB)].

--- a/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_topic_metrics_SUITE.erl
@@ -42,6 +42,9 @@ init_per_testcase(_Case, Config) ->
     emqx_topic_metrics:deregister_all(),
     Config.
 
+end_per_testcase(t_metrics_not_started, _Config) ->
+    _ = supervisor:restart_child(emqx_modules_sup, emqx_topic_metrics),
+    ok;
 end_per_testcase(_Case, _Config) ->
     emqx_topic_metrics:deregister_all(),
     emqx_config:put([topic_metrics], []),
@@ -181,3 +184,10 @@ t_unknown_messages(_) ->
         OldPid,
         whereis(emqx_topic_metrics)
     ).
+
+t_metrics_not_started(_Config) ->
+    _ = emqx_topic_metrics:register(<<"a/b/c">>),
+    ?assert(emqx_topic_metrics:is_registered(<<"a/b/c">>)),
+    ok = supervisor:terminate_child(emqx_modules_sup, emqx_topic_metrics),
+    ?assertNot(emqx_topic_metrics:is_registered(<<"a/b/c">>)),
+    {ok, _} = supervisor:restart_child(emqx_modules_sup, emqx_topic_metrics).

--- a/changes/ce/feat-10571.en.md
+++ b/changes/ce/feat-10571.en.md
@@ -1,0 +1,2 @@
+Do not emit useless crash report when EMQX stops.
+Previously, when EMQX (and `emqx_topic_metrics` in particular) stopped and removed underlying tables, some messages were still being handled and crashed.


### PR DESCRIPTION
Fixes [EMQX-9798](https://emqx.atlassian.net/browse/EMQX-9798)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 07e2443</samp>

Fixed a bug in the `is_registered` function of the `emqx_topic_metrics` module and added a testcase for it. Bumped the version number of the `emqx_modules` application.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
~- [ ] Schema changes are backward compatible~
