### PR TITLE
docs: better max_overflow field label and description for MongoDB bridge

### DIFF
--- a/rel/i18n/emqx_connector_mongo.hocon
+++ b/rel/i18n/emqx_connector_mongo.hocon
@@ -49,10 +49,10 @@ local_threshold.label:
 """Local Threshold"""
 
 max_overflow.desc:
-"""Max Overflow."""
+"""The maximum number of additional workers that can be created when all workers in the pool are busy. This helps to manage temporary spikes in workload by allowing more concurrent connections to the MongoDB server."""
 
 max_overflow.label:
-"""Max Overflow"""
+"""Max Overflow Workers"""
 
 min_heartbeat_period.desc:
 """Controls the minimum amount of time to wait between heartbeats."""


### PR DESCRIPTION
The new label and description for the max_overflow field clarifies the purpose of the field, which is to manage the maximum number of additional workers created when all workers in the pool are busy, allowing more concurrent connections to the MongoDB server during workload spikes.

Fixes https://emqx.atlassian.net/browse/EMQX-9714
(part of)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b7c7d40</samp>

Updated the description and label of the `max_overflow` option in `emqx_connector_mongo.hocon` to clarify its meaning and usage. This is part of a pull request to improve the i18n and docs of the emqx_connector_mongo plugin.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
