### PR TITLE
chore: make sure topic_metrics/rewrite's default is []

### DIFF
--- a/apps/emqx_modules/src/emqx_modules_schema.erl
+++ b/apps/emqx_modules/src/emqx_modules_schema.erl
@@ -36,11 +36,13 @@ roots() ->
         "telemetry",
         array("rewrite", #{
             desc => "List of topic rewrite rules.",
-            importance => ?IMPORTANCE_HIDDEN
+            importance => ?IMPORTANCE_HIDDEN,
+            default => []
         }),
         array("topic_metrics", #{
             desc => "List of topics whose metrics are reported.",
-            importance => ?IMPORTANCE_HIDDEN
+            importance => ?IMPORTANCE_HIDDEN,
+            default => []
         })
     ].
 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

The root keys `topic_metrics/rewtire` is array, should give default as [], not a object.
Don't need changelog

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b09ee54</samp>

Fix configuration loading issues for `emqx_modules` by adding default values for arrays in `emqx_modules_schema.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
