### PR TITLE
Change trace timestrap to microsecond

### DIFF
--- a/apps/emqx/src/emqx_trace/emqx_trace_formatter.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_formatter.erl
@@ -27,7 +27,7 @@ format(
     #{level := debug, meta := Meta = #{trace_tag := Tag}, msg := Msg},
     #{payload_encode := PEncode}
 ) ->
-    Time = calendar:system_time_to_rfc3339(erlang:system_time(second)),
+    Time = calendar:system_time_to_rfc3339(erlang:system_time(microsecond), [{unit, microsecond}]),
     ClientId = to_iolist(maps:get(clientid, Meta, "")),
     Peername = maps:get(peername, Meta, ""),
     MetaBin = format_meta(Meta, PEncode),

--- a/changes/ce/feat-10588.en.md
+++ b/changes/ce/feat-10588.en.md
@@ -1,0 +1,2 @@
+Increase the time precision of trace logs from second to microsecond.
+For example, change from `2023-05-02T08:43:50+00:00` to `2023-05-02T08:43:50.237945+00:00`.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

```
2023-05-04T11:28:49.613197+08:00 [MQTT] test@127.0.0.1:53184 msg: mqtt_packet_received, packet: CONNECT(Q0, R0, D0, ClientId=test, ProtoName=MQTT, ProtoVsn=5, CleanStart=true, KeepAlive=100, Username=test, Password=******)
2023-05-04T11:28:49.613594+08:00 [MQTT] test@127.0.0.1:53184 msg: mqtt_packet_sent, packet: CONNACK(Q0, R0, D0, AckFlags=0, ReasonCode=0)
2023-05-04T11:28:49.699356+08:00 [MQTT] test@127.0.0.1:53184 msg: mqtt_packet_received, packet: SUBSCRIBE(Q1, R0, D0, PacketId=52380 TopicFilters=[wwww/1(#{nl => 0,qos => 0,rap => 0,rh => 0})])
2023-05-04T11:28:49.699626+08:00 [SUBSCRIBE] test@127.0.0.1:53184 msg: subscribe, sub_id: test, sub_opts: [nl: 0, qos: 0, rap: 0, rh: 0, sub_props: []], topic: wwww/1
2023-05-04T11:28:49.699796+08:00 [MQTT] test@127.0.0.1:53184 msg: mqtt_packet_sent, packet: SUBACK(Q0, R0, D0, PacketId=52380, ReasonCodes=[0])
```
<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e42e73e</samp>

Increased the time precision of trace logs from seconds to microseconds. Added a `changes/ce/feat-10588.en.md` file to document the feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
