### PR TITLE
chore(mgmt): modify the API Key limit to 1024.

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -45,6 +45,7 @@
 -endif.
 
 -define(APP, emqx_app).
+-define(API_KEY_LIMIT, 1024).
 
 -record(?APP, {
     name = <<>> :: binary() | '_',
@@ -76,7 +77,7 @@ create(Name, Enable, ExpiredAt, Desc) ->
     create(Name, ApiSecret, Enable, ExpiredAt, Desc).
 
 create(Name, ApiSecret, Enable, ExpiredAt, Desc) ->
-    case mnesia:table_info(?APP, size) < 100 of
+    case mnesia:table_info(?APP, size) < ?API_KEY_LIMIT of
         true -> create_app(Name, ApiSecret, Enable, ExpiredAt, Desc);
         false -> {error, "Maximum ApiKey"}
     end.


### PR DESCRIPTION
fixes https://github.com/emqx/emqx/issues/10587

Fixes https://emqx.atlassian.net/browse/CI-123

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1c258c4</samp>

Use a macro for API key limit in `emqx_mgmt_auth`. This change refactors the `create` function to use a macro for the maximum number of API keys allowed per user, instead of a hard-coded value. This makes the code more consistent and easier to modify.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
