### PR TITLE
fix: add new sensitive keywords to redact checklist

### DIFF
--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -581,6 +581,15 @@ is_sensitive_key(<<"password">>) -> true;
 is_sensitive_key(secret) -> true;
 is_sensitive_key("secret") -> true;
 is_sensitive_key(<<"secret">>) -> true;
+is_sensitive_key(secret_key) -> true;
+is_sensitive_key("secret_key") -> true;
+is_sensitive_key(<<"secret_key">>) -> true;
+is_sensitive_key(security_token) -> true;
+is_sensitive_key("security_token") -> true;
+is_sensitive_key(<<"security_token">>) -> true;
+is_sensitive_key(aws_secret_access_key) -> true;
+is_sensitive_key("aws_secret_access_key") -> true;
+is_sensitive_key(<<"aws_secret_access_key">>) -> true;
 is_sensitive_key(_) -> false.
 
 redact(Term) ->

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_dynamo.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_dynamo.erl
@@ -48,7 +48,11 @@ fields(config) ->
         {aws_secret_access_key,
             mk(
                 binary(),
-                #{required => true, desc => ?DESC("aws_secret_access_key")}
+                #{
+                    required => true,
+                    desc => ?DESC("aws_secret_access_key"),
+                    sensitive => true
+                }
             )},
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {auto_reconnect, fun emqx_connector_schema_lib:auto_reconnect/1}

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_rocketmq.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_rocketmq.erl
@@ -52,9 +52,10 @@ fields(config) ->
         {secret_key,
             mk(
                 binary(),
-                #{default => <<>>, desc => ?DESC("secret_key")}
+                #{default => <<>>, desc => ?DESC("secret_key"), sensitive => true}
             )},
-        {security_token, mk(binary(), #{default => <<>>, desc => ?DESC(security_token)})},
+        {security_token,
+            mk(binary(), #{default => <<>>, desc => ?DESC(security_token), sensitive => true})},
         {sync_timeout,
             mk(
                 emqx_schema:duration(),


### PR DESCRIPTION
Fixes [EMQX-9684](https://emqx.atlassian.net/browse/EMQX-9684)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 277deee</samp>

This pull request adds a new utility function `is_sensitive_key/1` to check for confidential keys and updates the schemas of the DynamoDB and RocketMQ connectors to mark some fields as `sensitive`. This improves the security and privacy of the connector configurations and logs.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
