### PR TITLE
refactor(exproto): support unary handler

### DIFF
--- a/apps/emqx_gateway/test/emqx_gateway_authn_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_authn_SUITE.erl
@@ -249,7 +249,7 @@ t_case_stomp(_) ->
 t_case_exproto(_) ->
     Mod = emqx_exproto_SUITE,
     SvrMod = emqx_exproto_echo_svr,
-    Svrs = SvrMod:start(),
+    Svrs = SvrMod:start(http),
     Login = fun(Username, Password, Expect) ->
         with_resource(
             ?FUNCTOR(Mod:open(tcp)),

--- a/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
@@ -332,7 +332,7 @@ t_case_sn_subscribe(_) ->
 t_case_exproto_publish(_) ->
     Mod = emqx_exproto_SUITE,
     SvrMod = emqx_exproto_echo_svr,
-    Svrs = SvrMod:start(),
+    Svrs = SvrMod:start(http),
     Payload = <<"publish with authz">>,
     Publish = fun(Topic, Checker) ->
         with_resource(
@@ -369,7 +369,7 @@ t_case_exproto_publish(_) ->
 t_case_exproto_subscribe(_) ->
     Mod = emqx_exproto_SUITE,
     SvrMod = emqx_exproto_echo_svr,
-    Svrs = SvrMod:start(),
+    Svrs = SvrMod:start(http),
     WaitTime = 5000,
     Sub = fun(Topic, ErrorCode) ->
         with_resource(

--- a/apps/emqx_gateway_exproto/.gitignore
+++ b/apps/emqx_gateway_exproto/.gitignore
@@ -22,3 +22,5 @@ src/emqx_exproto_v_1_connection_adapter_bhvr.erl
 src/emqx_exproto_v_1_connection_adapter_client.erl
 src/emqx_exproto_v_1_connection_handler_bhvr.erl
 src/emqx_exproto_v_1_connection_handler_client.erl
+src/emqx_exproto_v_1_connection_unary_handler_bhvr.erl
+src/emqx_exproto_v_1_connection_unary_handler_client.erl

--- a/apps/emqx_gateway_exproto/priv/protos/exproto.proto
+++ b/apps/emqx_gateway_exproto/priv/protos/exproto.proto
@@ -41,6 +41,8 @@ service ConnectionAdapter {
   rpc Subscribe(SubscribeRequest) returns (CodeResponse) {};
 
   rpc Unsubscribe(UnsubscribeRequest) returns (CodeResponse) {};
+
+  rpc RawPublish(RawPublishRequest) returns (CodeResponse) {};
 }
 
 // Deprecated service.
@@ -163,6 +165,15 @@ message PublishRequest {
   uint32 qos = 3;
 
   bytes payload = 4;
+}
+
+message RawPublishRequest {
+
+  string topic = 1;
+
+  uint32 qos = 2;
+
+  bytes payload = 3;
 }
 
 message SubscribeRequest {

--- a/apps/emqx_gateway_exproto/priv/protos/exproto.proto
+++ b/apps/emqx_gateway_exproto/priv/protos/exproto.proto
@@ -43,6 +43,8 @@ service ConnectionAdapter {
   rpc Unsubscribe(UnsubscribeRequest) returns (CodeResponse) {};
 }
 
+// Deprecated service.
+// Please using `ConnectionUnaryHandler` to replace it
 service ConnectionHandler {
 
   // -- socket layer
@@ -58,6 +60,32 @@ service ConnectionHandler {
   rpc OnTimerTimeout(stream TimerTimeoutRequest) returns (EmptySuccess) {};
 
   rpc OnReceivedMessages(stream ReceivedMessagesRequest) returns (EmptySuccess) {};
+}
+
+// This service is an optimization of `ConnectionHandler`.
+// In the initial version, we expected to use streams to improve the efficiency
+// of requests. But unfortunately, events between different streams are out of
+// order. it causes the `OnSocketCreated` event to may arrive later than `OnReceivedBytes`.
+//
+// So we added the `ConnectionUnaryHandler` service since v4.3.21/v4.4.10 and forced
+// the use of Unary in it to avoid ordering problems.
+//
+// Recommend using `ConnectionUnaryHandler` to replace `ConnectionHandler`
+service ConnectionUnaryHandler {
+
+  // -- socket layer
+
+  rpc OnSocketCreated(SocketCreatedRequest) returns (EmptySuccess) {};
+
+  rpc OnSocketClosed(SocketClosedRequest) returns (EmptySuccess) {};
+
+  rpc OnReceivedBytes(ReceivedBytesRequest) returns (EmptySuccess) {};
+
+  // -- pub/sub layer
+
+  rpc OnTimerTimeout(TimerTimeoutRequest) returns (EmptySuccess) {};
+
+  rpc OnReceivedMessages(ReceivedMessagesRequest) returns (EmptySuccess) {};
 }
 
 message EmptySuccess { }

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
@@ -33,6 +33,7 @@
     authenticate/2,
     start_timer/2,
     publish/2,
+    raw_publish/2,
     subscribe/2,
     unsubscribe/2
 ]).
@@ -128,6 +129,19 @@ publish(Req, Md) ->
         request => Req
     }),
     {ok, response({error, ?RESP_PARAMS_TYPE_ERROR}), Md}.
+
+-spec raw_publish(emqx_exproto_pb:raw_publish_request(), grpc:metadata()) ->
+    {ok, emqx_exproto_pb:code_response(), grpc:metadata()}
+    | {error, grpc_stream:error_response()}.
+raw_publish(Req = #{topic := Topic, qos := Qos, payload := Payload}, Md) ->
+    ?SLOG(debug, #{
+        msg => "recv_grpc_function_call",
+        function => ?FUNCTION_NAME,
+        request => Req
+    }),
+    Msg = emqx_message:make(exproto, Qos, Topic, Payload),
+    _ = emqx_broker:safe_publish(Msg),
+    {ok, response(ok), Md}.
 
 -spec subscribe(emqx_exproto_pb:subscribe_request(), grpc:metadata()) ->
     {ok, emqx_exproto_pb:code_response(), grpc:metadata()}

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
@@ -176,6 +176,8 @@ call(ConnStr, Req) ->
             {error, ?RESP_PARAMS_TYPE_ERROR, <<"The conn type error">>};
         exit:noproc ->
             {error, ?RESP_CONN_PROCESS_NOT_ALIVE, <<"Connection process is not alive">>};
+        exit:{noproc, _} ->
+            {error, ?RESP_CONN_PROCESS_NOT_ALIVE, <<"Connection process is not alive">>};
         exit:timeout ->
             {error, ?RESP_UNKNOWN, <<"Connection is not answered">>};
         Class:Reason:Stk ->

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_schema.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_schema.erl
@@ -74,6 +74,15 @@ fields(exproto_grpc_server) ->
 fields(exproto_grpc_handler) ->
     [
         {address, sc(binary(), #{required => true, desc => ?DESC(exproto_grpc_handler_address)})},
+        {service_name,
+            sc(
+                hoconsc:union(['ConnectionHandler', 'ConnectionUnaryHandler']),
+                #{
+                    required => true,
+                    default => 'ConnectionUnaryHandler',
+                    desc => ?DESC(exproto_grpc_handler_service_name)
+                }
+            )},
         {ssl_options,
             sc(
                 ref(emqx_schema, "ssl_client_opts"),

--- a/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.app.src
+++ b/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.app.src
@@ -1,6 +1,6 @@
 {application, emqx_gateway_exproto, [
     {description, "ExProto Gateway"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib, grpc, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_exproto/test/emqx_exproto_unary_echo_svr.erl
+++ b/apps/emqx_gateway_exproto/test/emqx_exproto_unary_echo_svr.erl
@@ -50,6 +50,7 @@
 -define(TYPE_UNSUBSCRIBE, 7).
 -define(TYPE_UNSUBACK, 8).
 -define(TYPE_DISCONNECT, 9).
+-define(TYPE_RAW_PUBLISH, 10).
 
 %%--------------------------------------------------------------------
 %% callbacks

--- a/apps/emqx_gateway_exproto/test/emqx_exproto_unary_echo_svr.erl
+++ b/apps/emqx_gateway_exproto/test/emqx_exproto_unary_echo_svr.erl
@@ -1,0 +1,97 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_exproto_unary_echo_svr).
+
+-behavior(emqx_exproto_v_1_connection_unary_handler_bhvr).
+
+-import(
+    emqx_exproto_echo_svr,
+    [
+        handle_in/3,
+        handle_out/2,
+        handle_out/3
+    ]
+).
+
+-export([
+    on_socket_created/2,
+    on_received_bytes/2,
+    on_socket_closed/2,
+    on_timer_timeout/2,
+    on_received_messages/2
+]).
+
+-define(LOG(Fmt, Args), ct:pal(Fmt, Args)).
+
+-define(CLIENT, emqx_exproto_v_1_connection_adapter_client).
+
+-define(close(Req), ?CLIENT:close(Req, #{channel => ct_test_channel})).
+
+-define(TYPE_CONNECT, 1).
+-define(TYPE_CONNACK, 2).
+-define(TYPE_PUBLISH, 3).
+-define(TYPE_PUBACK, 4).
+-define(TYPE_SUBSCRIBE, 5).
+-define(TYPE_SUBACK, 6).
+-define(TYPE_UNSUBSCRIBE, 7).
+-define(TYPE_UNSUBACK, 8).
+-define(TYPE_DISCONNECT, 9).
+
+%%--------------------------------------------------------------------
+%% callbacks
+%%--------------------------------------------------------------------
+
+-spec on_socket_created(emqx_exproto_pb:socket_created_request(), grpc:metadata()) ->
+    {ok, emqx_exproto_pb:empty_success(), grpc:metadata()}
+    | {error, grpc_stream:error_response()}.
+on_socket_created(_Req, _Md) ->
+    {ok, #{}, _Md}.
+
+-spec on_socket_closed(emqx_exproto_pb:socket_closed_request(), grpc:metadata()) ->
+    {ok, emqx_exproto_pb:empty_success(), grpc:metadata()}
+    | {error, grpc_stream:error_response()}.
+on_socket_closed(_Req, _Md) ->
+    {ok, #{}, _Md}.
+
+-spec on_received_bytes(emqx_exproto_pb:received_bytes_request(), grpc:metadata()) ->
+    {ok, emqx_exproto_pb:empty_success(), grpc:metadata()}
+    | {error, grpc_stream:error_response()}.
+on_received_bytes(#{conn := Conn, bytes := Bytes}, _Md) ->
+    #{<<"type">> := Type} = Params = emqx_utils_json:decode(Bytes, [return_maps]),
+    _ = handle_in(Conn, Type, Params),
+    {ok, #{}, _Md}.
+
+-spec on_timer_timeout(emqx_exproto_pb:timer_timeout_request(), grpc:metadata()) ->
+    {ok, emqx_exproto_pb:empty_success(), grpc:metadata()}
+    | {error, grpc_stream:error_response()}.
+on_timer_timeout(#{conn := Conn, type := 'KEEPALIVE'}, _Md) ->
+    ?LOG("Close this connection ~p due to keepalive timeout", [Conn]),
+    handle_out(Conn, ?TYPE_DISCONNECT),
+    ?close(#{conn => Conn}),
+    {ok, #{}, _Md}.
+
+-spec on_received_messages(emqx_exproto_pb:received_messages_request(), grpc:metadata()) ->
+    {ok, emqx_exproto_pb:empty_success(), grpc:metadata()}
+    | {error, grpc_stream:error_response()}.
+on_received_messages(#{conn := Conn, messages := Messages}, _Md) ->
+    lists:foreach(
+        fun(Message) ->
+            handle_out(Conn, ?TYPE_PUBLISH, Message)
+        end,
+        Messages
+    ),
+    {ok, #{}, _Md}.

--- a/changes/ce/feat-10598.en.md
+++ b/changes/ce/feat-10598.en.md
@@ -1,0 +1,1 @@
+Provide a callback method of Unary type in ExProto to avoid possible message disorder issues.

--- a/mix.exs
+++ b/mix.exs
@@ -57,7 +57,7 @@ defmodule EMQXUmbrella.MixProject do
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.7.2-emqx-11", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.15.2", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
-      {:grpc, github: "emqx/grpc-erl", tag: "0.6.7", override: true},
+      {:grpc, github: "emqx/grpc-erl", tag: "0.6.8", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.3.10", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.3", override: true},
       {:replayq, github: "emqx/replayq", tag: "0.3.7", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -64,7 +64,7 @@
     , {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.7.2-emqx-11"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.2"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
-    , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.7"}}}
+    , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.8"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.10"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.3"}}}
     , {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.7"}}}

--- a/rel/i18n/emqx_exproto_schema.hocon
+++ b/rel/i18n/emqx_exproto_schema.hocon
@@ -6,6 +6,16 @@ exproto.desc:
 exproto_grpc_handler_address.desc:
 """gRPC server address."""
 
+exproto_grpc_handler_service_name.desc:
+"""The service name to handle the connection events.
+In the initial version, we expected to use streams to improve the efficiency
+of requests in `ConnectionHandler`. But unfortunately, events between different
+streams are out of order. It causes the `OnSocketCreated` event to may arrive
+later than `OnReceivedBytes`.
+So we added the `ConnectionUnaryHandler` service since v5.0.25 and forced
+the use of Unary in it to avoid ordering problems.
+"""
+
 exproto_grpc_handler_ssl.desc:
 """SSL configuration for the gRPC client."""
 

--- a/rel/i18n/emqx_exproto_schema.hocon
+++ b/rel/i18n/emqx_exproto_schema.hocon
@@ -13,8 +13,7 @@ of requests in `ConnectionHandler`. But unfortunately, events between different
 streams are out of order. It causes the `OnSocketCreated` event to may arrive
 later than `OnReceivedBytes`.
 So we added the `ConnectionUnaryHandler` service since v5.0.25 and forced
-the use of Unary in it to avoid ordering problems.
-"""
+the use of Unary in it to avoid ordering problems."""
 
 exproto_grpc_handler_ssl.desc:
 """SSL configuration for the gRPC client."""


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9566

port from https://github.com/emqx/emqx/pull/10090

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 318e167</samp>

This pull request improves the external protocol gateway by deprecating the `ConnectionHandler` service and introducing a new `ConnectionUnaryHandler` service for gRPC requests. It also refactors and updates the gRPC client and server modules, the config schema, and the test suites to support the new service and the new gRPC implementation. It also bumps the version of `emqx_gateway_exproto` app and adds some documentation and translation for the new config field.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
