### PR TITLE
chore(git-hook): don't fail commit hook when no mix

### DIFF
--- a/scripts/git-hook-pre-commit.sh
+++ b/scripts/git-hook-pre-commit.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 OPT="${1:--c}"
 
 # mix format check is quite fast
-mix format --check-formatted
+which mix && mix format --check-formatted
 
 files_dirty="$(git diff --name-only | grep -E '.*\.erl' || true)"
 files_cached="$(git diff --cached --name-only | grep -E '.*\.erl' || true)"


### PR DESCRIPTION
I am working with a emqx repo locally with many work trees from different branches (5.0, 4.4).
The commit hook is shared by all the work trees. 

It is inconvenient to force local env to have mix format check.
This PR skip mix format checks if the mix is not present.