### PR TITLE
feat(ft-conf): simplify schema of storage / exporter backends

### DIFF
--- a/apps/emqx_ft/src/emqx_ft_schema.erl
+++ b/apps/emqx_ft/src/emqx_ft_schema.erl
@@ -237,6 +237,10 @@ desc(s3_exporter) ->
     "S3 Exporter settings for the File transfer local storage backend";
 desc(local_storage_segments_gc) ->
     "Garbage collection settings for the File transfer local segments storage";
+desc(local_storage_exporter_backend) ->
+    "Exporter for the local file system storage backend";
+desc(storage_backend) ->
+    "Storage backend settings for file transfer";
 desc(_) ->
     undefined.
 

--- a/apps/emqx_ft/src/emqx_ft_storage.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage.erl
@@ -131,12 +131,8 @@ files(Query) ->
 
 -spec dispatch(atom(), list(term())) -> any().
 dispatch(Fun, Args) when is_atom(Fun) ->
-    case backend() of
-        {Type, Storage} ->
-            apply(mod(Type), Fun, [Storage | Args]);
-        _ ->
-            {error, disabled}
-    end.
+    {Type, Storage} = backend(),
+    apply(mod(Type), Fun, [Storage | Args]).
 
 %%
 
@@ -152,9 +148,7 @@ with_storage_type(Type, Fun, Args) ->
         {Type, Storage} when is_function(Fun) ->
             apply(Fun, [Storage | Args]);
         {_, _} = Backend ->
-            {error, {invalid_storage_backend, Backend}};
-        _ ->
-            {error, disabled}
+            {error, {invalid_storage_backend, Backend}}
     end.
 
 %%

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter.erl
@@ -169,14 +169,11 @@ stop({ExporterMod, ExporterOpts}) ->
 
 exporter(Storage) ->
     case maps:get(exporter, Storage) of
-        #{type := local} = Options ->
-            {emqx_ft_storage_exporter_fs, without_type(Options)};
-        #{type := s3} = Options ->
-            {emqx_ft_storage_exporter_s3, without_type(Options)}
+        #{local := Options} ->
+            {emqx_ft_storage_exporter_fs, Options};
+        #{s3 := Options} ->
+            {emqx_ft_storage_exporter_s3, Options}
     end.
-
-without_type(#{type := _} = Options) ->
-    maps:without([type], Options).
 
 init_checksum(#{checksum := {Algo, _}}) ->
     crypto:hash_init(Algo);

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
@@ -257,6 +257,9 @@ read_exportinfo(
     Transfer = dirnames_to_transfer(ClientId, FileId),
     Info = mk_exportinfo(Options, Filename, RelFilepath, Transfer, Fileinfo),
     [Info | Acc];
+read_exportinfo(_Options, {node, _Root = "", {error, enoent}, []}, Acc) ->
+    % NOTE: Root directory does not exist, this is not an error.
+    Acc;
 read_exportinfo(Options, Entry, Acc) ->
     ok = log_invalid_entry(Options, Entry),
     Acc.

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -58,16 +58,16 @@ end_per_suite(_Config) ->
 set_special_configs(Config) ->
     fun
         (emqx_ft) ->
-            Storage = emqx_ft_test_helpers:local_storage(Config),
+            % NOTE
+            % Inhibit local fs GC to simulate it isn't fast enough to collect
+            % complete transfers.
+            Storage = emqx_utils_maps:deep_merge(
+                emqx_ft_test_helpers:local_storage(Config),
+                #{<<"local">> => #{<<"segments">> => #{<<"gc">> => #{<<"interval">> => 0}}}}
+            ),
             emqx_ft_test_helpers:load_config(#{
-                % NOTE
-                % Inhibit local fs GC to simulate it isn't fast enough to collect
-                % complete transfers.
-                enable => true,
-                storage => emqx_utils_maps:deep_merge(
-                    Storage,
-                    #{segments => #{gc => #{interval => 0}}}
-                )
+                <<"enable">> => true,
+                <<"storage">> => Storage
             });
         (_) ->
             ok

--- a/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_assembler_SUITE.erl
@@ -246,16 +246,19 @@ exporter(Config) ->
     emqx_ft_storage_exporter:exporter(storage(Config)).
 
 storage(Config) ->
-    maps:get(
-        storage,
+    emqx_utils_maps:deep_get(
+        [storage, local],
         emqx_ft_schema:translate(#{
             <<"storage">> => #{
-                <<"type">> => <<"local">>,
-                <<"segments">> => #{
-                    <<"root">> => ?config(storage_root, Config)
-                },
-                <<"exporter">> => #{
-                    <<"root">> => ?config(exports_root, Config)
+                <<"local">> => #{
+                    <<"segments">> => #{
+                        <<"root">> => ?config(storage_root, Config)
+                    },
+                    <<"exporter">> => #{
+                        <<"local">> => #{
+                            <<"root">> => ?config(exports_root, Config)
+                        }
+                    }
                 }
             }
         })

--- a/apps/emqx_ft/test/emqx_ft_storage_exporter_s3_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_exporter_s3_SUITE.erl
@@ -111,7 +111,7 @@ t_upload_error(Config) ->
     Data = <<"data"/utf8>>,
 
     {ok, _} = emqx_conf:update(
-        [file_transfer, storage, exporter, bucket], <<"invalid-bucket">>, #{}
+        [file_transfer, storage, local, exporter, s3, bucket], <<"invalid-bucket">>, #{}
     ),
 
     ?assertEqual(

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
@@ -85,7 +85,7 @@ client_id(Config) ->
 
 storage(Config) ->
     RawConfig = #{<<"storage">> => emqx_ft_test_helpers:local_storage(Config)},
-    #{storage := Storage} = emqx_ft_schema:translate(RawConfig),
+    #{storage := #{local := Storage}} = emqx_ft_schema:translate(RawConfig),
     Storage.
 
 list_files(Config) ->

--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -54,20 +54,22 @@ local_storage(Config) ->
 
 local_storage(Config, Opts) ->
     #{
-        <<"type">> => <<"local">>,
-        <<"segments">> => #{<<"root">> => root(Config, node(), [segments])},
-        <<"exporter">> => exporter(Config, Opts)
+        <<"local">> => #{
+            <<"segments">> => #{<<"root">> => root(Config, node(), [segments])},
+            <<"exporter">> => exporter(Config, Opts)
+        }
     }.
 
 exporter(Config, #{exporter := local}) ->
-    #{<<"type">> => <<"local">>, <<"root">> => root(Config, node(), [exports])};
+    #{<<"local">> => #{<<"root">> => root(Config, node(), [exports])}};
 exporter(_Config, #{exporter := s3, bucket_name := BucketName}) ->
     BaseConfig = emqx_s3_test_helpers:base_raw_config(tcp),
-    BaseConfig#{
-        <<"bucket">> => list_to_binary(BucketName),
-        <<"type">> => <<"s3">>,
-        <<"host">> => ?S3_HOST,
-        <<"port">> => ?S3_PORT
+    #{
+        <<"s3">> => BaseConfig#{
+            <<"bucket">> => list_to_binary(BucketName),
+            <<"host">> => ?S3_HOST,
+            <<"port">> => ?S3_PORT
+        }
     }.
 
 load_config(Config) ->

--- a/rel/i18n/emqx_ft_schema.hocon
+++ b/rel/i18n/emqx_ft_schema.hocon
@@ -18,11 +18,11 @@ store_segment_timeout.desc:
 """Timeout for storing a file segment.<br/>
 After reaching the timeout, message with the segment will be acked with an error"""
 
-storage.desc:
+storage_backend.desc:
 """Storage settings for file transfer."""
 
-local_type.desc:
-"""Use local file system to store uploaded fragments and temporary data."""
+local_storage.desc:
+"""Local file system backend to store uploaded fragments and temporary data."""
 
 local_storage_segments.desc:
 """Settings for local segments storage, which include uploaded transfer fragments and temporary data."""
@@ -30,15 +30,15 @@ local_storage_segments.desc:
 local_storage_segments_root.desc:
 """File system path to keep uploaded fragments and temporary data."""
 
-local_storage_exporter.desc:
+local_storage_exporter_backend.desc:
 """Exporter for the local file system storage backend.<br/>
 Exporter defines where and how fully transferred and assembled files are stored."""
 
-local_storage_exporter_type.desc:
-"""Exporter type for the exporter to the local file system"""
+local_storage_exporter.desc:
+"""Exporter to the local file system."""
 
-s3_exporter_type.desc:
-"""Exporter type for the exporter to S3"""
+s3_exporter.desc:
+"""Exporter to the S3 API compatible object storage."""
 
 local_storage_exporter_root.desc:
 """File system path to keep uploaded files."""


### PR DESCRIPTION
~~Fixes [EMQX-9678](https://emqx.atlassian.net/browse/EMQX-9678)~~

Assumption is this changes will make `emqx_ft` config schema user-friendlier and also more future-proof.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4995741</samp>

Refactor and simplify the schema and logic for the storage and exporter backends of the file transfer feature. Use references, custom validators, and helper functions to reduce code duplication and improve error handling. Update the test cases and the i18n file to match the new schema.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [ ] ~~Schema changes are backward compatible~~
