### PR TITLE
feat: rename max_message_queue_len to max_mailbox_size

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -687,12 +687,13 @@ fields("force_shutdown") ->
                     desc => ?DESC(force_shutdown_enable)
                 }
             )},
-        {"max_message_queue_len",
+        {"max_mailbox_size",
             sc(
                 range(0, inf),
                 #{
                     default => 1000,
-                    desc => ?DESC(force_shutdown_max_message_queue_len)
+                    aliases => [max_message_queue_len],
+                    desc => ?DESC(force_shutdown_max_mailbox_size)
                 }
             )},
         {"max_heap_size",

--- a/apps/emqx/src/emqx_types.erl
+++ b/apps/emqx/src/emqx_types.erl
@@ -238,7 +238,7 @@
 -type stats() :: [{atom(), term()}].
 
 -type oom_policy() :: #{
-    max_message_queue_len => non_neg_integer(),
+    max_mailbox_size => non_neg_integer(),
     max_heap_size => non_neg_integer(),
     enable => boolean()
 }.

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -31,7 +31,7 @@ force_gc_conf() ->
     #{bytes => 16777216, count => 16000, enable => true}.
 
 force_shutdown_conf() ->
-    #{enable => true, max_heap_size => 4194304, max_message_queue_len => 1000}.
+    #{enable => true, max_heap_size => 4194304, max_mailbox_size => 1000}.
 
 rpc_conf() ->
     #{

--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.1.15"},
+    {vsn, "0.1.16"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
     {applications, [kernel, stdlib, emqx, emqx_authn, emqx_ctl]},

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -78,7 +78,7 @@
 -define(DEFAULT_GC_OPTS, #{count => 1000, bytes => 1024 * 1024}).
 -define(DEFAULT_OOM_POLICY, #{
     max_heap_size => 4194304,
-    max_message_queue_len => 32000
+    max_mailbox_size => 32000
 }).
 
 -elvis([{elvis_style, god_modules, disable}]).

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -230,7 +230,7 @@ check_oom(Policy) ->
 check_oom(_Pid, #{enable := false}) ->
     ok;
 check_oom(Pid, #{
-    max_message_queue_len := MaxQLen,
+    max_mailbox_size := MaxQLen,
     max_heap_size := MaxHeapSize
 }) ->
     case process_info(Pid, [message_queue_len, total_heap_size]) of

--- a/apps/emqx_utils/test/emqx_utils_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_utils_SUITE.erl
@@ -140,7 +140,7 @@ t_index_of(_) ->
 
 t_check(_) ->
     Policy = #{
-        max_message_queue_len => 10,
+        max_mailbox_size => 10,
         max_heap_size => 1024 * 1024 * 8,
         enable => true
     },

--- a/changes/ce/feat-10623.en.md
+++ b/changes/ce/feat-10623.en.md
@@ -1,0 +1,1 @@
+Renamed `max_message_queue_len` to `max_mailbox_size` in the `force_shutdown` configuration. Old name is kept as an alias, so this change is backward compatible.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -337,11 +337,11 @@ fields_mqtt_quic_listener_retry_memory_limit.desc:
 fields_mqtt_quic_listener_retry_memory_limit.label:
 """Retry memory limit"""
 
-force_shutdown_max_message_queue_len.desc:
-"""Maximum message queue length."""
+force_shutdown_max_mailbox_size.desc:
+"""In EMQX, each online client corresponds to an individual Erlang process. The configuration value establishes a mailbox size limit for these processes. If the mailbox size surpasses this limit, the client will be automatically terminated."""
 
-force_shutdown_max_message_queue_len.label:
-"""Maximum mailbox queue length of process."""
+force_shutdown_max_mailbox_size.label:
+"""Maximum mailbox size."""
 
 sys_heartbeat_interval.desc:
 """Time interval for publishing following heartbeat messages:

--- a/rel/i18n/zh/emqx_schema.hocon
+++ b/rel/i18n/zh/emqx_schema.hocon
@@ -324,11 +324,11 @@ fields_mqtt_quic_listener_retry_memory_limit.desc:
 fields_mqtt_quic_listener_retry_memory_limit.label:
 """重试内存限制"""
 
-force_shutdown_max_message_queue_len.desc:
-"""消息队列的最大长度。"""
+force_shutdown_max_mailbox_size.desc:
+"""每个在线客户端在 EMQX 服务器中都是独立的一个进程。该配置可以设为单个进程的邮箱消息队列设置最大长度，当超过该上限时，客户端会被强制下线。"""
 
-force_shutdown_max_message_queue_len.label:
-"""进程邮箱消息队列的最大长度"""
+force_shutdown_max_mailbox_size.label:
+"""进程邮箱消息数上限"""
 
 sys_heartbeat_interval.desc:
 """发送心跳系统消息的间隔时间，它包括：


### PR DESCRIPTION
Fixes [EMQX-9677](https://emqx.atlassian.net/browse/EMQX-9677)

Now we have two configuration items, one is `mqtt.max_mqueue_len`, the other is `force_shutdown.max_message_queue_len`, they are both called message queues. 

But in fact, one is the queue of MQTT messages, and the other is the message mailbox of the Erlang process.

This is very misleading, it is better to use two different names instead.

The dashboard currently cannot update the `force_shutdown` configuration.  This changes don't impact dashboard.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 77dccf3</samp>

Renamed `max_message_queue_len` to `max_mailbox_size` in the configuration schema and updated the translations. This improves the clarity and consistency of the configuration option and its documentation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
