### PR TITLE
build: compatibility to make 4.4+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,6 @@ SCRIPTS = $(CURDIR)/scripts
 export EMQX_RELUP ?= true
 export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.0-28:1.13.4-24.3.4.2-2-debian11
 export EMQX_DEFAULT_RUNNER = debian:11-slim
-export OTP_VSN ?= $(shell $(CURDIR)/scripts/get-otp-vsn.sh)
-export ELIXIR_VSN ?= $(shell $(CURDIR)/scripts/get-elixir-vsn.sh)
-
-export EMQX_DASHBOARD_VERSION ?= v1.2.4
-export EMQX_EE_DASHBOARD_VERSION ?= e1.0.6
-
 export EMQX_REL_FORM ?= tgz
 export QUICER_DOWNLOAD_FROM_RELEASE = 1
 ifeq ($(OS),Windows_NT)
@@ -17,6 +11,22 @@ ifeq ($(OS),Windows_NT)
 	FIND=/usr/bin/find
 else
 	FIND=find
+endif
+
+# Dashbord version
+# from https://github.com/emqx/emqx-dashboard5
+export EMQX_DASHBOARD_VERSION ?= v1.2.4
+export EMQX_EE_DASHBOARD_VERSION ?= e1.0.6
+
+# `:=` should be used here, otherwise the `$(shell ...)` will be executed every time when the variable is used
+# In make 4.4+, for backward-compatibility the value from the original environment is used.
+# so the shell script will be executed tons of times.
+# https://github.com/emqx/emqx/pull/10627
+ifeq ($(strip $(OTP_VSN)),)
+	export OTP_VSN := $(shell $(SCRIPTS)/get-otp-vsn.sh)
+endif
+ifeq ($(strip $(ELIXIR_VSN)),)
+	export ELIXIR_VSN := $(shell $(SCRIPTS)/get-elixir-vsn.sh)
 endif
 
 PROFILE ?= emqx


### PR DESCRIPTION
#### *More details:*

https://lists.gnu.org/archive/html/info-gnu/2022-10/msg00008.html

> * WARNING: Backward-incompatibility!
    Previously makefile variables marked as export were not exported to commands
    started by the $(shell ...) function.  Now, all exported variables are
    exported to $(shell ...).  If this leads to recursion during expansion, then
    for backward-compatibility the value from the original environment is used.
    To detect this change search for 'shell-export' in the .FEATURES variable.

---

#### *Why this change:*

Variables assigned with `?=` in the makefile will be evaluated each time they are used. However, due to changes in `make 4.4+`, it will cause the shell script to be executed every time the var has been used, which is not necessary for the current case (OTP and ELIXIR versions generally do not change during the build process).

---
### Test:

#### add these lines into `Makefile` and build with make 4.4+
```Makefile
DT_SEMICOLON := $(shell date) # `date` will be executed once
DT__QUESTION ?= $(shell date) # `date` will be executed each time when using the var

dt:
	@echo SEMICOLON: $(DT_SEMICOLON)
	@echo _QUESTION: $(DT__QUESTION)
	@echo "sleep 2"
	$(shell sleep 2)
	@echo SEMICOLON: $(DT_SEMICOLON)
	@echo _QUESTION: $(DT__QUESTION)
```
#### Result:

*Even an unrelated make target still leads to variables evaluated.*

```bash
$ make --debug=all dt
GNU Make 4.4.1
Built for x86_64-pc-linux-gnu
Copyright (C) 1988-2023 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Reading makefiles...
Reading makefile 'Makefile'...
Makefile:20: not recursively expanding ELIXIR_VSN to export to shell function
Makefile:20: not recursively expanding ELIXIR_VSN to export to shell function
Makefile:19: not recursively expanding OTP_VSN to export to shell function
Makefile:20: not recursively expanding ELIXIR_VSN to export to shell function
Makefile:19: not recursively expanding OTP_VSN to export to shell function
Makefile:19: not recursively expanding OTP_VSN to export to shell function
Makefile:20: not recursively expanding ELIXIR_VSN to export to shell function
Makefile:20: not recursively expanding ELIXIR_VSN to export to shell function
Makefile:19: not recursively expanding OTP_VSN to export to shell function
Makefile:20: not recursively expanding ELIXIR_VSN to export to shell function
...
```


---

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f32bf20</samp>

Allow overriding OTP and Elixir versions in `Makefile`. Move export commands inside conditionals and use `SCRIPTS` variable for scripts directory.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
