### PR TITLE
fix: non_neg_integer() translated to minimum = 1 in bridge-api-en.json

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -311,7 +311,7 @@ typename_to_spec("float()", _Mod) ->
 typename_to_spec("integer()", _Mod) ->
     #{type => number};
 typename_to_spec("non_neg_integer()", _Mod) ->
-    #{type => number, minimum => 1};
+    #{type => number, minimum => 0};
 typename_to_spec("number()", _Mod) ->
     #{type => number};
 typename_to_spec("string()", _Mod) ->

--- a/changes/ce/fix-10636.md
+++ b/changes/ce/fix-10636.md
@@ -1,0 +1,1 @@
+An issue with the MongoDB connector related to the "Max Overflow" parameter has been fixed. Previously, the minimum limit for the parameter was incorrectly set to 1 instead of allowing a minimum value of 0. This issue has been fixed, and the "Max Overflow" parameter now correctly supports a minimum value of 0.


### PR DESCRIPTION
The schema type non_neg_integer() should be translated to minimum 0 and not 1 when generating the bridge-api-en.json file.

Fixes https://emqx.atlassian.net/browse/EMQX-9714

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a711ee2</samp>

Fix a bug in `emqx_conf` that caused incorrect JSON schema validation for `non_neg_integer()` type. Update the `typename_to_spec` function to map `non_neg_integer()` to a JSON schema with a minimum of 0.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible
