### PR TITLE
Make FT fin command idempotent

### DIFF
--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -268,8 +268,8 @@ on_fin(PacketId, Msg, Transfer, FinalSize, Checksum) ->
     with_responder(FinPacketKey, Callback, emqx_ft_conf:assemble_timeout(), fun() ->
         case assemble(Transfer, FinalSize) of
             %% Assembling completed, ack through the responder right away
-            % ok ->
-            %     emqx_ft_responder:ack(FinPacketKey, ok);
+            ok ->
+                emqx_ft_responder:ack(FinPacketKey, ok);
             %% Assembling started, packet will be acked by the responder
             {async, Pid} ->
                 ok = emqx_ft_responder:kickoff(FinPacketKey, Pid),

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -24,6 +24,8 @@
 -export([handle_event/4]).
 -export([terminate/3]).
 
+-export([where/1]).
+
 -type stdata() :: #{
     storage := emqx_ft_storage_fs:storage(),
     transfer := emqx_ft:transfer(),
@@ -38,6 +40,9 @@
 
 start_link(Storage, Transfer, Size) ->
     gen_statem:start_link(?REF(Transfer), ?MODULE, {Storage, Transfer, Size}, []).
+
+where(Transfer) ->
+    gproc:where(?NAME(Transfer)).
 
 %%
 

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
@@ -324,7 +324,9 @@ list(_Options, Query = #{transfer := _Transfer}) ->
         #{items := Exports = [_ | _]} ->
             {ok, #{items => Exports}};
         #{items := [], errors := NodeErrors} ->
-            {error, NodeErrors}
+            {error, NodeErrors};
+        #{items := []} ->
+            {ok, #{items => []}}
     end;
 list(_Options, Query) ->
     Result = list(Query),

--- a/apps/emqx_ft/src/emqx_ft_storage_fs_proxy.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs_proxy.erl
@@ -22,7 +22,8 @@
 
 -export([
     list_local/2,
-    pread_local/4
+    pread_local/4,
+    lookup_local_assembler/1
 ]).
 
 list_local(Transfer, What) ->
@@ -30,3 +31,6 @@ list_local(Transfer, What) ->
 
 pread_local(Transfer, Frag, Offset, Size) ->
     emqx_ft_storage:with_storage_type(local, pread, [Transfer, Frag, Offset, Size]).
+
+lookup_local_assembler(Transfer) ->
+    emqx_ft_storage:with_storage_type(local, lookup_local_assembler, [Transfer]).

--- a/apps/emqx_ft/src/proto/emqx_ft_storage_fs_proto_v1.erl
+++ b/apps/emqx_ft/src/proto/emqx_ft_storage_fs_proto_v1.erl
@@ -22,6 +22,7 @@
 
 -export([multilist/3]).
 -export([pread/5]).
+-export([list_assemblers/2]).
 
 -type offset() :: emqx_ft:offset().
 -type transfer() :: emqx_ft:transfer().
@@ -41,3 +42,8 @@ multilist(Nodes, Transfer, What) ->
     {ok, [filefrag()]} | {error, term()} | no_return().
 pread(Node, Transfer, Frag, Offset, Size) ->
     erpc:call(Node, emqx_ft_storage_fs_proxy, pread_local, [Transfer, Frag, Offset, Size]).
+
+-spec list_assemblers([node()], transfer()) ->
+    emqx_rpc:erpc_multicall([pid()]).
+list_assemblers(Nodes, Transfer) ->
+    erpc:multicall(Nodes, emqx_ft_storage_fs_proxy, lookup_local_assembler, [Transfer]).


### PR DESCRIPTION
Fixes EMQX-9573

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 684e28a</samp>

This pull request improves the file transfer and assembly logic in the `emqx_ft` application. It adds functions to locate and communicate with the assembler processes across nodes, and to avoid duplicate or unnecessary file exports. It also fixes a bug that prevented the file transfer from being acknowledged, and updates the test cases and the protocol module accordingly.



