### PR TITLE
refactor(pgsql): move pgsql && matrix && timescale bridges into their own app

### DIFF
--- a/apps/emqx_bridge_matrix/rebar.config
+++ b/apps/emqx_bridge_matrix/rebar.config
@@ -1,0 +1,7 @@
+{erl_opts, [debug_info]}.
+
+{deps, [
+    {emqx_connector, {path, "../../apps/emqx_connector"}},
+    {emqx_resource, {path, "../../apps/emqx_resource"}},
+    {emqx_bridge, {path, "../../apps/emqx_bridge"}}
+]}.

--- a/apps/emqx_bridge_matrix/src/emqx_bridge_matrix.app.src
+++ b/apps/emqx_bridge_matrix/src/emqx_bridge_matrix.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_matrix, [
     {description, "EMQX Enterprise MatrixDB Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},

--- a/apps/emqx_bridge_matrix/src/emqx_bridge_matrix.erl
+++ b/apps/emqx_bridge_matrix/src/emqx_bridge_matrix.erl
@@ -1,7 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_ee_bridge_matrix).
+-module(emqx_bridge_matrix).
 
 -export([
     conn_bridge_examples/1
@@ -22,7 +22,7 @@ conn_bridge_examples(Method) ->
         #{
             <<"matrix">> => #{
                 summary => <<"Matrix Bridge">>,
-                value => emqx_ee_bridge_pgsql:values(Method, matrix)
+                value => emqx_bridge_pgsql:values(Method, matrix)
             }
         }
     ].
@@ -34,9 +34,9 @@ namespace() -> "bridge_matrix".
 roots() -> [].
 
 fields("post") ->
-    emqx_ee_bridge_pgsql:fields("post", matrix);
+    emqx_bridge_pgsql:fields("post", matrix);
 fields(Method) ->
-    emqx_ee_bridge_pgsql:fields(Method).
+    emqx_bridge_pgsql:fields(Method).
 
 desc(_) ->
     undefined.

--- a/apps/emqx_bridge_pgsql/docker-ct
+++ b/apps/emqx_bridge_pgsql/docker-ct
@@ -1,0 +1,2 @@
+toxiproxy
+pgsql

--- a/apps/emqx_bridge_pgsql/rebar.config
+++ b/apps/emqx_bridge_pgsql/rebar.config
@@ -1,0 +1,7 @@
+{erl_opts, [debug_info]}.
+
+{deps, [
+    {emqx_connector, {path, "../../apps/emqx_connector"}},
+    {emqx_resource, {path, "../../apps/emqx_resource"}},
+    {emqx_bridge, {path, "../../apps/emqx_bridge"}}
+]}.

--- a/apps/emqx_bridge_pgsql/src/emqx_bridge_pgsql.app.src
+++ b/apps/emqx_bridge_pgsql/src/emqx_bridge_pgsql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pgsql, [
     {description, "EMQX Enterprise PostgreSQL Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},

--- a/apps/emqx_bridge_pgsql/src/emqx_bridge_pgsql.erl
+++ b/apps/emqx_bridge_pgsql/src/emqx_bridge_pgsql.erl
@@ -1,7 +1,7 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2022 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_ee_bridge_pgsql).
+-module(emqx_bridge_pgsql).
 
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").

--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_ee_bridge_pgsql_SUITE).
+-module(emqx_bridge_pgsql_SUITE).
 
 -compile(nowarn_export_all).
 -compile(export_all).

--- a/apps/emqx_bridge_timescale/rebar.config
+++ b/apps/emqx_bridge_timescale/rebar.config
@@ -1,0 +1,7 @@
+{erl_opts, [debug_info]}.
+
+{deps, [
+    {emqx_connector, {path, "../../apps/emqx_connector"}},
+    {emqx_resource, {path, "../../apps/emqx_resource"}},
+    {emqx_bridge, {path, "../../apps/emqx_bridge"}}
+]}.

--- a/apps/emqx_bridge_timescale/src/emqx_bridge_timescale.app.src
+++ b/apps/emqx_bridge_timescale/src/emqx_bridge_timescale.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_timescale, [
     {description, "EMQX Enterprise TimescaleDB Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib]},
     {env, []},

--- a/apps/emqx_bridge_timescale/src/emqx_bridge_timescale.erl
+++ b/apps/emqx_bridge_timescale/src/emqx_bridge_timescale.erl
@@ -1,7 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_ee_bridge_timescale).
+-module(emqx_bridge_timescale).
 
 -export([
     conn_bridge_examples/1
@@ -22,7 +22,7 @@ conn_bridge_examples(Method) ->
         #{
             <<"timescale">> => #{
                 summary => <<"Timescale Bridge">>,
-                value => emqx_ee_bridge_pgsql:values(Method, timescale)
+                value => emqx_bridge_pgsql:values(Method, timescale)
             }
         }
     ].
@@ -34,9 +34,9 @@ namespace() -> "bridge_timescale".
 roots() -> [].
 
 fields("post") ->
-    emqx_ee_bridge_pgsql:fields("post", timescale);
+    emqx_bridge_pgsql:fields("post", timescale);
 fields(Method) ->
-    emqx_ee_bridge_pgsql:fields(Method).
+    emqx_bridge_pgsql:fields(Method).
 
 desc(_) ->
     undefined.

--- a/changes/ee/feat-10662.en.md
+++ b/changes/ee/feat-10662.en.md
@@ -1,0 +1,1 @@
+Refactor the directory structure of the PostgreSQL && Matrix && Timescale data bridges.

--- a/lib-ee/emqx_ee_bridge/docker-ct
+++ b/lib-ee/emqx_ee_bridge/docker-ct
@@ -5,6 +5,5 @@ mongo_rs_sharded
 mysql
 redis
 redis_cluster
-pgsql
 clickhouse
 dynamo

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
@@ -19,7 +19,7 @@ api_schemas(Method) ->
         ref(emqx_bridge_kafka, Method ++ "_producer"),
         ref(emqx_bridge_cassandra, Method),
         ref(emqx_ee_bridge_mysql, Method),
-        ref(emqx_ee_bridge_pgsql, Method),
+        ref(emqx_bridge_pgsql, Method),
         ref(emqx_ee_bridge_mongodb, Method ++ "_rs"),
         ref(emqx_ee_bridge_mongodb, Method ++ "_sharded"),
         ref(emqx_ee_bridge_mongodb, Method ++ "_single"),
@@ -29,8 +29,8 @@ api_schemas(Method) ->
         ref(emqx_ee_bridge_redis, Method ++ "_single"),
         ref(emqx_ee_bridge_redis, Method ++ "_sentinel"),
         ref(emqx_ee_bridge_redis, Method ++ "_cluster"),
-        ref(emqx_ee_bridge_timescale, Method),
-        ref(emqx_ee_bridge_matrix, Method),
+        ref(emqx_bridge_timescale, Method),
+        ref(emqx_bridge_matrix, Method),
         ref(emqx_bridge_tdengine, Method),
         ref(emqx_ee_bridge_clickhouse, Method),
         ref(emqx_ee_bridge_dynamo, Method),
@@ -53,9 +53,9 @@ schema_modules() ->
         emqx_ee_bridge_mongodb,
         emqx_ee_bridge_mysql,
         emqx_ee_bridge_redis,
-        emqx_ee_bridge_pgsql,
-        emqx_ee_bridge_timescale,
-        emqx_ee_bridge_matrix,
+        emqx_bridge_pgsql,
+        emqx_bridge_timescale,
+        emqx_bridge_matrix,
         emqx_bridge_tdengine,
         emqx_ee_bridge_clickhouse,
         emqx_ee_bridge_dynamo,
@@ -280,7 +280,7 @@ pgsql_structs() ->
     [
         {Type,
             mk(
-                hoconsc:map(name, ref(emqx_ee_bridge_pgsql, "config")),
+                hoconsc:map(name, ref(emqx_bridge_pgsql, "config")),
                 #{
                     desc => <<Name/binary, " Bridge Config">>,
                     required => false

--- a/rel/i18n/emqx_bridge_pgsql.hocon
+++ b/rel/i18n/emqx_bridge_pgsql.hocon
@@ -1,4 +1,4 @@
-emqx_ee_bridge_pgsql {
+emqx_bridge_pgsql {
 
 config_enable.desc:
 """Enable or disable this bridge"""

--- a/rel/i18n/zh/emqx_bridge_pgsql.hocon
+++ b/rel/i18n/zh/emqx_bridge_pgsql.hocon
@@ -1,4 +1,4 @@
-emqx_ee_bridge_pgsql {
+emqx_bridge_pgsql {
 
 config_enable.desc:
 """启用/禁用桥接"""


### PR DESCRIPTION

Fixes [EMQX-9537](https://emqx.atlassian.net/browse/EMQX-9537)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 716bdc0</samp>

This pull request refactors the enterprise edition bridge modules to use the open source naming convention and directory structure. It renames and moves the `emqx_ee_bridge_pgsql`, `emqx_ee_bridge_timescale`, and `emqx_ee_bridge_matrix` apps to `emqx_bridge_pgsql`, `emqx_bridge_timescale`, and `emqx_bridge_matrix` respectively, and updates their dependencies, configurations, and tests accordingly. It also adds the `erl_opts` and `deps` options to the `rebar.config` files of the bridge apps to enable `rebar3` compilation and dependency management.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
