### PR TITLE
fix(limiter): fix an error when setting `max_conn_rate` in a listener

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -286,7 +286,8 @@ default_client_config() ->
 default_bucket_config() ->
     #{
         rate => infinity,
-        burst => 0
+        burst => 0,
+        initial => 0
     }.
 
 get_listener_opts(Conf) ->


### PR DESCRIPTION
Fixes [EMQX-9853](https://emqx.atlassian.net/browse/EMQX-9853)

Although we hide the listener-level limiter configuration, we added some short paths for quick setup, so in fact, the listener-level still exists and we should use the converted limiter configuration for the listener not only the raw data

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b712625</samp>

This pull request improves the limiter configuration and functionality for the listeners. It allows disabling the limiter for some listeners, passing the limiter options to the WebSocket and quic modules, and setting different initial values for the limiter buckets. It also fixes some limiter bugs.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
