### PR TITLE
chore: cherry pick pr(10626&10659) from master

### DIFF
--- a/apps/emqx/src/emqx_os_mon.erl
+++ b/apps/emqx/src/emqx_os_mon.erl
@@ -23,8 +23,6 @@
 -export([start_link/0]).
 
 -export([
-    get_mem_check_interval/0,
-    set_mem_check_interval/1,
     get_sysmem_high_watermark/0,
     set_sysmem_high_watermark/1,
     get_procmem_high_watermark/0,
@@ -46,6 +44,9 @@
     terminate/2,
     code_change/3
 ]).
+-ifdef(TEST).
+-export([is_sysmem_check_supported/0]).
+-endif.
 
 -include("emqx.hrl").
 
@@ -60,14 +61,6 @@ update(OS) ->
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
-
-get_mem_check_interval() ->
-    memsup:get_check_interval().
-
-set_mem_check_interval(Seconds) when Seconds < 60000 ->
-    memsup:set_check_interval(1);
-set_mem_check_interval(Seconds) ->
-    memsup:set_check_interval(Seconds div 60000).
 
 get_sysmem_high_watermark() ->
     gen_server:call(?OS_MON, ?FUNCTION_NAME, infinity).
@@ -103,11 +96,9 @@ init_os_monitor() ->
 init_os_monitor(OS) ->
     #{
         sysmem_high_watermark := SysHW,
-        procmem_high_watermark := PHW,
-        mem_check_interval := MCI
+        procmem_high_watermark := PHW
     } = OS,
     set_procmem_high_watermark(PHW),
-    set_mem_check_interval(MCI),
     ok = update_mem_alarm_status(SysHW),
     SysHW.
 

--- a/changes/ce/fix-10659.en.md
+++ b/changes/ce/fix-10659.en.md
@@ -1,0 +1,1 @@
+Fix the issue where emqx cannot start when `sysmon.os.mem_check_interval` is disabled.

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule EMQXUmbrella.MixProject do
       # maybe forbid to fetch quicer
       {:emqtt,
        github: "emqx/emqtt", tag: "1.8.5", override: true, system_env: maybe_no_quic_env()},
-      {:rulesql, github: "emqx/rulesql", tag: "0.1.5"},
+      {:rulesql, github: "emqx/rulesql", tag: "0.1.6"},
       {:observer_cli, "1.7.1"},
       {:system_monitor, github: "ieQu1/system_monitor", tag: "3.0.3"},
       {:telemetry, "1.1.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,7 @@
     , {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.7"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.8.5"}}}
-    , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.5"}}}
+    , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.6"}}}
     , {observer_cli, "1.7.1"} % NOTE: depends on recon 2.5.x
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Cherry Pick https://github.com/emqx/emqx/pull/10626 and https://github.com/emqx/emqx/pull/10659 from master to release-50, so that we can release v5.0.25 on release-50.

RP#10626 fixed crash when setting `sysmon.os.mem_check_interval=disabled`.
PR#10659 fixed introduce invalid utf8 char.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9ff901a</samp>

This pull request fixes an issue with memory monitoring on some platforms and improves the test coverage and configuration of the feature. It removes unused code and updates the `emqx_os_mon` and `emqx_os_mon_SUITE` modules, the `mix.exs` file, and the `changes/ce/fix-10659.en.md` file. It also upgrades the `rulesql` library dependency.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
