### PR TITLE
fix(limiter): adjust type for compatibility

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -61,7 +61,7 @@
 -type limiter_id() :: atom().
 -type bucket_name() :: atom().
 -type rate() :: infinity | float().
--type burst_rate() :: 0 | float().
+-type burst_rate() :: number().
 %% this is a compatible type for the deprecated field and type `capacity`.
 -type burst() :: burst_rate().
 %% the capacity of the token bucket


### PR DESCRIPTION
Fixes <issue-or-jira-number>

this type used to be `0 | float`,  but here https://github.com/emqx/emqx/blob/d1089fa4603fddd7035a8487515fcabe496acdfa/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl#LL144C68-L144C68, we set a default value of 1000 to the capacity, it should have been stored as a string, but in some configuration files it is a number which will not trigger a `typerefl_from_string` call and directly pass to the hocon validator, obviously, the 1000 either 0 or float, so the type must be changed to `number()`.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95a67f3</samp>

Changed the type of `burst_rate` in `emqx_limiter_schema.erl` to support negative values. This allows the rate limiter to borrow tokens from the future.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
