### PR TITLE
feat(ft-api): provide configuration API

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -118,7 +118,7 @@
 -type route_path() :: string() | binary().
 -type route_methods() :: map().
 -type route_handler() :: atom().
--type route_options() :: #{filter => filter() | undefined}.
+-type route_options() :: #{filter => filter()}.
 
 -type api_spec_entry() :: {route_path(), route_methods(), route_handler(), route_options()}.
 -type api_spec_component() :: map().
@@ -137,10 +137,9 @@ spec(Module, Options) ->
     {ApiSpec, AllRefs} =
         lists:foldl(
             fun(Path, {AllAcc, AllRefsAcc}) ->
-                {OperationId, Specs, Refs} = parse_spec_ref(Module, Path, Options),
-                Opts = #{filter => filter(Options)},
+                {OperationId, Specs, Refs, RouteOpts} = parse_spec_ref(Module, Path, Options),
                 {
-                    [{filename:join("/", Path), Specs, OperationId, Opts} | AllAcc],
+                    [{filename:join("/", Path), Specs, OperationId, RouteOpts} | AllAcc],
                     Refs ++ AllRefsAcc
                 }
             end,
@@ -350,6 +349,7 @@ parse_spec_ref(Module, Path, Options) ->
                 ),
                 error({failed_to_generate_swagger_spec, Module, Path})
         end,
+    OperationId = maps:get('operationId', Schema),
     {Specs, Refs} = maps:fold(
         fun(Method, Meta, {Acc, RefsAcc}) ->
             (not lists:member(Method, ?METHODS)) andalso
@@ -358,9 +358,13 @@ parse_spec_ref(Module, Path, Options) ->
             {Acc#{Method => Spec}, SubRefs ++ RefsAcc}
         end,
         {#{}, []},
-        maps:without(['operationId'], Schema)
+        maps:without(['operationId', 'filter'], Schema)
     ),
-    {maps:get('operationId', Schema), Specs, Refs}.
+    RouteOpts = generate_route_opts(Schema, Options),
+    {OperationId, Specs, Refs, RouteOpts}.
+
+generate_route_opts(Schema, Options) ->
+    #{filter => compose_filters(filter(Options), custom_filter(Schema))}.
 
 check_parameters(Request, Spec, Module) ->
     #{bindings := Bindings, query_string := QueryStr} = Request,

--- a/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_parameter_SUITE.erl
@@ -108,8 +108,12 @@ t_ref(_Config) ->
     LocalPath = "/test/in/ref/local",
     Path = "/test/in/ref",
     Expect = [#{<<"$ref">> => <<"#/components/parameters/emqx_swagger_parameter_SUITE.page">>}],
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, LocalPath, #{}),
+    {OperationId, Spec, Refs, RouteOpts} = emqx_dashboard_swagger:parse_spec_ref(
+        ?MODULE, Path, #{}
+    ),
+    {OperationId, Spec, Refs, RouteOpts} = emqx_dashboard_swagger:parse_spec_ref(
+        ?MODULE, LocalPath, #{}
+    ),
     ?assertEqual(test, OperationId),
     Params = maps:get(parameters, maps:get(post, Spec)),
     ?assertEqual(Expect, Params),
@@ -122,7 +126,7 @@ t_public_ref(_Config) ->
         #{<<"$ref">> => <<"#/components/parameters/public.page">>},
         #{<<"$ref">> => <<"#/components/parameters/public.limit">>}
     ],
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
+    {OperationId, Spec, Refs, #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
     ?assertEqual(test, OperationId),
     Params = maps:get(parameters, maps:get(post, Spec)),
     ?assertEqual(Expect, Params),
@@ -264,7 +268,7 @@ t_nullable(_Config) ->
 t_method(_Config) ->
     PathOk = "/method/ok",
     PathError = "/method/error",
-    {test, Spec, []} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, PathOk, #{}),
+    {test, Spec, [], #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, PathOk, #{}),
     ?assertEqual(lists:sort(?METHODS), lists:sort(maps:keys(Spec))),
     ?assertThrow(
         {error, #{module := ?MODULE, path := PathError, method := bar}},
@@ -393,7 +397,7 @@ assert_all_filters_equal(Spec, Filter) ->
     ).
 
 validate(Path, ExpectParams) ->
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
+    {OperationId, Spec, Refs, #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
     ?assertEqual(test, OperationId),
     Params = maps:get(parameters, maps:get(post, Spec)),
     ?assertEqual(ExpectParams, Params),

--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -717,7 +717,7 @@ t_object_trans_error(_Config) ->
     ok.
 
 validate(Path, ExpectSpec, ExpectRefs) ->
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
+    {OperationId, Spec, Refs, #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
     ?assertEqual(test, OperationId),
     ?assertEqual(ExpectSpec, Spec),
     ?assertEqual(ExpectRefs, Refs),

--- a/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
@@ -125,7 +125,7 @@ t_error(_Config) ->
                 }
             }
     },
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
+    {OperationId, Spec, Refs, #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
     ?assertEqual(test, OperationId),
     Response = maps:get(responses, maps:get(get, Spec)),
     ?assertEqual(Error400, maps:get(<<"400">>, Response)),
@@ -371,7 +371,7 @@ t_complicated_type(_Config) ->
                 }
         }
     },
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
+    {OperationId, Spec, Refs, #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
     ?assertEqual(test, OperationId),
     Response = maps:get(responses, maps:get(post, Spec)),
     ?assertEqual(Object, maps:get(<<"200">>, Response)),
@@ -660,7 +660,7 @@ schema("/fields/sub") ->
     to_schema(hoconsc:ref(sub_fields)).
 
 validate(Path, ExpectObject, ExpectRefs) ->
-    {OperationId, Spec, Refs} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
+    {OperationId, Spec, Refs, #{}} = emqx_dashboard_swagger:parse_spec_ref(?MODULE, Path, #{}),
     ?assertEqual(test, OperationId),
     Response = maps:get(responses, maps:get(post, Spec)),
     ?assertEqual(ExpectObject, maps:get(<<"200">>, Response)),

--- a/apps/emqx_ft/src/emqx_ft_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_api.erl
@@ -39,27 +39,30 @@
 %% API callbacks
 -export([
     '/file_transfer/files'/2,
-    '/file_transfer/files/:clientid/:fileid'/2
+    '/file_transfer/files/:clientid/:fileid'/2,
+    '/file_transfer'/2
 ]).
 
 -import(hoconsc, [mk/2, ref/1, ref/2]).
 
+-define(SCHEMA_CONFIG, ref(emqx_ft_schema, file_transfer)).
+
 namespace() -> "file_transfer".
 
 api_spec() ->
-    emqx_dashboard_swagger:spec(?MODULE, #{
-        check_schema => true, filter => fun ?MODULE:check_ft_enabled/2
-    }).
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
     [
         "/file_transfer/files",
-        "/file_transfer/files/:clientid/:fileid"
+        "/file_transfer/files/:clientid/:fileid",
+        "/file_transfer"
     ].
 
 schema("/file_transfer/files") ->
     #{
         'operationId' => '/file_transfer/files',
+        filter => fun ?MODULE:check_ft_enabled/2,
         get => #{
             tags => [<<"file_transfer">>],
             summary => <<"List all uploaded files">>,
@@ -82,6 +85,7 @@ schema("/file_transfer/files") ->
 schema("/file_transfer/files/:clientid/:fileid") ->
     #{
         'operationId' => '/file_transfer/files/:clientid/:fileid',
+        filter => fun ?MODULE:check_ft_enabled/2,
         get => #{
             tags => [<<"file_transfer">>],
             summary => <<"List files uploaded in a specific transfer">>,
@@ -100,6 +104,36 @@ schema("/file_transfer/files/:clientid/:fileid") ->
                 )
             }
         }
+    };
+schema("/file_transfer") ->
+    #{
+        'operationId' => '/file_transfer',
+        get => #{
+            tags => [<<"file_transfer">>],
+            summary => <<"Get current File Transfer configuration">>,
+            description => ?DESC("file_transfer_get_config"),
+            responses => #{
+                200 => ?SCHEMA_CONFIG,
+                503 => emqx_dashboard_swagger:error_codes(
+                    ['SERVICE_UNAVAILABLE'], error_desc('SERVICE_UNAVAILABLE')
+                )
+            }
+        },
+        put => #{
+            tags => [<<"file_transfer">>],
+            summary => <<"Update File Transfer configuration">>,
+            description => ?DESC("file_transfer_update_config"),
+            'requestBody' => ?SCHEMA_CONFIG,
+            responses => #{
+                200 => ?SCHEMA_CONFIG,
+                400 => emqx_dashboard_swagger:error_codes(
+                    ['INVALID_CONFIG'], error_desc('INVALID_CONFIG')
+                ),
+                503 => emqx_dashboard_swagger:error_codes(
+                    ['SERVICE_UNAVAILABLE'], error_desc('SERVICE_UNAVAILABLE')
+                )
+            }
+        }
     }.
 
 check_ft_enabled(Params, _Meta) ->
@@ -107,7 +141,7 @@ check_ft_enabled(Params, _Meta) ->
         true ->
             {ok, Params};
         false ->
-            {503, error_msg('SERVICE_UNAVAILABLE', <<"Service unavailable">>)}
+            {503, error_msg('SERVICE_UNAVAILABLE')}
     end.
 
 '/file_transfer/files'(get, #{
@@ -146,6 +180,18 @@ check_ft_enabled(Params, _Meta) ->
             {503, error_msg('SERVICE_UNAVAILABLE')}
     end.
 
+'/file_transfer'(get, _Meta) ->
+    {200, format_config(emqx_ft_conf:get())};
+'/file_transfer'(put, #{body := ConfigIn}) ->
+    case emqx_ft_conf:update(ConfigIn) of
+        {ok, #{config := Config}} ->
+            {200, format_config(Config)};
+        {error, Error = #{kind := validation_error}} ->
+            {400, error_msg('INVALID_CONFIG', format_validation_error(Error))};
+        {error, Error} ->
+            {400, error_msg('INVALID_CONFIG', emqx_utils:format(Error))}
+    end.
+
 format_page(#{items := Files, cursor := Cursor}) ->
     #{
         <<"files">> => lists:map(fun format_file_info/1, Files),
@@ -156,14 +202,23 @@ format_page(#{items := Files}) ->
         <<"files">> => lists:map(fun format_file_info/1, Files)
     }.
 
+format_config(Config) ->
+    Schema = emqx_hocon:make_schema(emqx_ft_schema:fields(file_transfer)),
+    hocon_tconf:make_serializable(Schema, emqx_utils_maps:binary_key_map(Config), #{}).
+
+format_validation_error(Error) ->
+    emqx_logger_jsonfmt:best_effort_json(Error).
+
 error_msg(Code) ->
     #{code => Code, message => error_desc(Code)}.
 
 error_msg(Code, Msg) ->
-    #{code => Code, message => emqx_utils:readable_error_msg(Msg)}.
+    #{code => Code, message => Msg}.
 
 error_desc('FILES_NOT_FOUND') ->
     <<"Files requested for this transfer could not be found">>;
+error_desc('INVALID_CONFIG') ->
+    <<"Provided configuration is invalid">>;
 error_desc('SERVICE_UNAVAILABLE') ->
     <<"Service unavailable">>.
 

--- a/apps/emqx_ft/src/emqx_ft_app.erl
+++ b/apps/emqx_ft/src/emqx_ft_app.erl
@@ -18,13 +18,16 @@
 
 -behaviour(application).
 
--export([start/2, stop/1]).
+-export([start/2, prep_stop/1, stop/1]).
 
 start(_StartType, _StartArgs) ->
     {ok, Sup} = emqx_ft_sup:start_link(),
     ok = emqx_ft_conf:load(),
     {ok, Sup}.
 
-stop(_State) ->
+prep_stop(State) ->
     ok = emqx_ft_conf:unload(),
+    State.
+
+stop(_State) ->
     ok.

--- a/apps/emqx_ft/src/emqx_ft_storage.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage.erl
@@ -16,6 +16,8 @@
 
 -module(emqx_ft_storage).
 
+-include_lib("emqx/include/types.hrl").
+
 -export(
     [
         store_filemeta/2,
@@ -29,7 +31,7 @@
         with_storage_type/3,
 
         backend/0,
-        on_config_update/2
+        update_config/2
     ]
 ).
 
@@ -94,10 +96,10 @@
 -callback files(storage(), query(Cursor)) ->
     {ok, page(file_info(), Cursor)} | {error, term()}.
 
--callback start(emqx_config:config()) -> any().
--callback stop(emqx_config:config()) -> any().
+-callback start(storage()) -> any().
+-callback stop(storage()) -> any().
 
--callback on_config_update(_OldConfig :: emqx_config:config(), _NewConfig :: emqx_config:config()) ->
+-callback update_config(_OldConfig :: maybe(storage()), _NewConfig :: maybe(storage())) ->
     any().
 
 %%--------------------------------------------------------------------
@@ -157,9 +159,9 @@ with_storage_type(Type, Fun, Args) ->
 backend() ->
     backend(emqx_ft_conf:storage()).
 
--spec on_config_update(_Old :: emqx_maybe:t(config()), _New :: emqx_maybe:t(config())) ->
+-spec update_config(_Old :: emqx_maybe:t(config()), _New :: emqx_maybe:t(config())) ->
     ok.
-on_config_update(ConfigOld, ConfigNew) ->
+update_config(ConfigOld, ConfigNew) ->
     on_backend_update(
         emqx_maybe:apply(fun backend/1, ConfigOld),
         emqx_maybe:apply(fun backend/1, ConfigNew)
@@ -168,13 +170,13 @@ on_config_update(ConfigOld, ConfigNew) ->
 on_backend_update({Type, _} = Backend, {Type, _} = Backend) ->
     ok;
 on_backend_update({Type, StorageOld}, {Type, StorageNew}) ->
-    ok = (mod(Type)):on_config_update(StorageOld, StorageNew);
+    ok = (mod(Type)):update_config(StorageOld, StorageNew);
 on_backend_update(BackendOld, BackendNew) when
     (BackendOld =:= undefined orelse is_tuple(BackendOld)) andalso
         (BackendNew =:= undefined orelse is_tuple(BackendNew))
 ->
-    _ = emqx_maybe:apply(fun on_storage_stop/1, BackendOld),
-    _ = emqx_maybe:apply(fun on_storage_start/1, BackendNew),
+    _ = emqx_maybe:apply(fun stop_backend/1, BackendOld),
+    _ = emqx_maybe:apply(fun start_backend/1, BackendNew),
     ok.
 
 %%--------------------------------------------------------------------
@@ -185,10 +187,10 @@ on_backend_update(BackendOld, BackendNew) when
 backend(#{local := Storage}) ->
     {local, Storage}.
 
-on_storage_start({Type, Storage}) ->
+start_backend({Type, Storage}) ->
     (mod(Type)):start(Storage).
 
-on_storage_stop({Type, Storage}) ->
+stop_backend({Type, Storage}) ->
     (mod(Type)):stop(Storage).
 
 mod(local) ->

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter.erl
@@ -31,7 +31,7 @@
 -export([list/2]).
 
 %% Lifecycle API
--export([on_config_update/2]).
+-export([update_config/2]).
 
 %% Internal API
 -export([exporter/1]).
@@ -81,7 +81,7 @@
 -callback stop(exporter_conf()) ->
     ok.
 
--callback update(exporter_conf(), exporter_conf()) ->
+-callback update_config(exporter_conf(), exporter_conf()) ->
     ok | {error, _Reason}.
 
 %%------------------------------------------------------------------------------
@@ -141,8 +141,8 @@ list(Storage, Query) ->
 
 %% Lifecycle
 
--spec on_config_update(storage(), storage()) -> ok | {error, term()}.
-on_config_update(StorageOld, StorageNew) ->
+-spec update_config(storage(), storage()) -> ok | {error, term()}.
+update_config(StorageOld, StorageNew) ->
     on_exporter_update(
         emqx_maybe:apply(fun exporter/1, StorageOld),
         emqx_maybe:apply(fun exporter/1, StorageNew)
@@ -151,7 +151,7 @@ on_config_update(StorageOld, StorageNew) ->
 on_exporter_update(Config, Config) ->
     ok;
 on_exporter_update({ExporterMod, ConfigOld}, {ExporterMod, ConfigNew}) ->
-    ExporterMod:update(ConfigOld, ConfigNew);
+    ExporterMod:update_config(ConfigOld, ConfigNew);
 on_exporter_update(ExporterOld, ExporterNew) ->
     _ = emqx_maybe:apply(fun stop/1, ExporterOld),
     _ = emqx_maybe:apply(fun start/1, ExporterNew),

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
@@ -31,7 +31,7 @@
 -export([
     start/1,
     stop/1,
-    update/2
+    update_config/2
 ]).
 
 %% Internal API for RPC
@@ -150,8 +150,8 @@ start(_Options) -> ok.
 -spec stop(options()) -> ok.
 stop(_Options) -> ok.
 
--spec update(options(), options()) -> ok.
-update(_OldOptions, _NewOptions) -> ok.
+-spec update_config(options(), options()) -> ok.
+update_config(_OldOptions, _NewOptions) -> ok.
 
 %%--------------------------------------------------------------------
 %% Internal API

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_s3.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_s3.erl
@@ -28,7 +28,12 @@
 -export([
     start/1,
     stop/1,
-    update/2
+    update_config/2
+]).
+
+-export([
+    pre_config_update/3,
+    post_config_update/3
 ]).
 
 -type options() :: emqx_s3:profile_config().
@@ -111,11 +116,21 @@ start(Options) ->
 
 -spec stop(options()) -> ok.
 stop(_Options) ->
-    ok = emqx_s3:stop_profile(?S3_PROFILE_ID).
+    emqx_s3:stop_profile(?S3_PROFILE_ID).
 
--spec update(options(), options()) -> ok.
-update(_OldOptions, NewOptions) ->
+-spec update_config(options(), options()) -> ok.
+update_config(_OldOptions, NewOptions) ->
     emqx_s3:update_profile(?S3_PROFILE_ID, NewOptions).
+
+%%--------------------------------------------------------------------
+%% Config update hooks
+%%--------------------------------------------------------------------
+
+pre_config_update(_ConfKey, NewOptions, OldOptions) ->
+    emqx_s3:pre_config_update(?S3_PROFILE_ID, NewOptions, OldOptions).
+
+post_config_update(_ConfKey, NewOptions, OldOptions) ->
+    emqx_s3:post_config_update(?S3_PROFILE_ID, NewOptions, OldOptions).
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -48,9 +48,9 @@
 
 -export([files/2]).
 
--export([on_config_update/2]).
 -export([start/1]).
 -export([stop/1]).
+-export([update_config/2]).
 
 -export_type([storage/0]).
 -export_type([filefrag/1]).
@@ -229,10 +229,10 @@ files(Storage, Query) ->
 
 %%
 
-on_config_update(StorageOld, StorageNew) ->
+update_config(StorageOld, StorageNew) ->
     % NOTE: this will reset GC timer, frequent changes would postpone GC indefinitely
     ok = emqx_ft_storage_fs_gc:reset(StorageNew),
-    emqx_ft_storage_exporter:on_config_update(StorageOld, StorageNew).
+    emqx_ft_storage_exporter:update_config(StorageOld, StorageNew).
 
 start(Storage) ->
     ok = lists:foreach(
@@ -241,11 +241,11 @@ start(Storage) ->
         end,
         child_spec(Storage)
     ),
-    ok = emqx_ft_storage_exporter:on_config_update(undefined, Storage),
+    ok = emqx_ft_storage_exporter:update_config(undefined, Storage),
     ok.
 
 stop(Storage) ->
-    ok = emqx_ft_storage_exporter:on_config_update(Storage, undefined),
+    ok = emqx_ft_storage_exporter:update_config(Storage, undefined),
     ok = lists:foreach(
         fun(#{id := ChildId}) ->
             _ = supervisor:terminate_child(emqx_ft_sup, ChildId),

--- a/apps/emqx_ft/test/emqx_ft_conf_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_conf_SUITE.erl
@@ -31,15 +31,21 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(_Case, Config) ->
+init_per_testcase(TC, Config) ->
     _ = emqx_config:save_schema_mod_and_names(emqx_ft_schema),
     ok = emqx_common_test_helpers:start_apps(
-        [emqx_conf, emqx_ft], fun
+        [emqx_conf, emqx_ft],
+        fun
             (emqx_ft) ->
                 emqx_ft_test_helpers:load_config(#{});
             (_) ->
                 ok
-        end
+        end,
+        #{
+            extra_mustache_vars => #{
+                platform_data_dir => filename:join(?config(priv_dir, Config), TC)
+            }
+        }
     ),
     {ok, _} = emqx:update_config([rpc, port_discovery], manual),
     Config.
@@ -55,16 +61,13 @@ end_per_testcase(_Case, _Config) ->
 t_update_config(_Config) ->
     ?assertMatch(
         {error, #{kind := validation_error}},
-        emqx_conf:update(
-            [file_transfer],
-            #{<<"storage">> => #{<<"unknown">> => #{<<"foo">> => 42}}},
-            #{}
+        emqx_ft_conf:update(
+            #{<<"storage">> => #{<<"unknown">> => #{<<"foo">> => 42}}}
         )
     ),
     ?assertMatch(
         {ok, _},
-        emqx_conf:update(
-            [file_transfer],
+        emqx_ft_conf:update(
             #{
                 <<"enable">> => true,
                 <<"storage">> => #{
@@ -82,8 +85,7 @@ t_update_config(_Config) ->
                         }
                     }
                 }
-            },
-            #{}
+            }
         )
     ),
     ?assertEqual(
@@ -102,10 +104,8 @@ t_update_config(_Config) ->
 t_disable_restore_config(Config) ->
     ?assertMatch(
         {ok, _},
-        emqx_conf:update(
-            [file_transfer],
-            #{<<"enable">> => true, <<"storage">> => #{<<"local">> => #{}}},
-            #{}
+        emqx_ft_conf:update(
+            #{<<"enable">> => true, <<"storage">> => #{<<"local">> => #{}}}
         )
     ),
     ?assertEqual(
@@ -117,11 +117,7 @@ t_disable_restore_config(Config) ->
     % Verify that clearing storage settings reverts config to defaults
     ?assertMatch(
         {ok, _},
-        emqx_conf:update(
-            [file_transfer],
-            #{<<"enable">> => false, <<"storage">> => undefined},
-            #{}
-        )
+        emqx_ft_conf:update(#{<<"enable">> => false, <<"storage">> => undefined})
     ),
     ?assertEqual(
         false,
@@ -153,8 +149,7 @@ t_disable_restore_config(Config) ->
     Root = iolist_to_binary(emqx_ft_test_helpers:root(Config, node(), [segments])),
     ?assertMatch(
         {ok, _},
-        emqx_conf:update(
-            [file_transfer],
+        emqx_ft_conf:update(
             #{
                 <<"enable">> => true,
                 <<"storage">> => #{
@@ -165,8 +160,7 @@ t_disable_restore_config(Config) ->
                         }
                     }
                 }
-            },
-            #{}
+            }
         )
     ),
     % Verify that GC is getting triggered eventually
@@ -190,11 +184,7 @@ t_disable_restore_config(Config) ->
 t_switch_exporter(_Config) ->
     ?assertMatch(
         {ok, _},
-        emqx_conf:update(
-            [file_transfer],
-            #{<<"enable">> => true},
-            #{}
-        )
+        emqx_ft_conf:update(#{<<"enable">> => true})
     ),
     ?assertMatch(
         #{local := #{exporter := #{local := _}}},
@@ -245,5 +235,96 @@ t_switch_exporter(_Config) ->
     % Verify that transfers work
     ok = emqx_ft_test_helpers:upload_file(gen_clientid(), <<"f1">>, "f1", <<?MODULE_STRING>>).
 
+t_persist_ssl_certfiles(Config) ->
+    ?assertMatch(
+        {ok, _},
+        emqx_ft_conf:update(mk_storage(true))
+    ),
+    ?assertEqual(
+        [],
+        list_ssl_certfiles(Config)
+    ),
+    S3Config = #{
+        <<"bucket">> => <<"emqx">>,
+        <<"host">> => <<"https://localhost">>,
+        <<"port">> => 9000
+    },
+    ?assertMatch(
+        {error, {pre_config_update, _, {bad_ssl_config, #{}}}},
+        emqx_ft_conf:update(
+            mk_storage(true, #{
+                <<"s3">> => S3Config#{
+                    <<"transport_options">> => #{
+                        <<"ssl">> => #{
+                            <<"certfile">> => <<"cert.pem">>,
+                            <<"keyfile">> => <<"key.pem">>
+                        }
+                    }
+                }
+            })
+        )
+    ),
+    ?assertMatch(
+        {ok, _},
+        emqx_ft_conf:update(
+            mk_storage(false, #{
+                <<"s3">> => S3Config#{
+                    <<"transport_options">> => #{
+                        <<"ssl">> => #{
+                            <<"certfile">> => emqx_ft_test_helpers:pem_privkey(),
+                            <<"keyfile">> => emqx_ft_test_helpers:pem_privkey()
+                        }
+                    }
+                }
+            })
+        )
+    ),
+    ?assertMatch(
+        #{
+            local := #{
+                exporter := #{
+                    s3 := #{
+                        transport_options := #{
+                            ssl := #{
+                                certfile := <<"/", _CertFilepath/binary>>,
+                                keyfile := <<"/", _KeyFilepath/binary>>
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        emqx_ft_conf:storage()
+    ),
+    ?assertMatch(
+        [_Certfile, _Keyfile],
+        list_ssl_certfiles(Config)
+    ),
+    ?assertMatch(
+        {ok, _},
+        emqx_ft_conf:update(mk_storage(true))
+    ),
+    ?assertEqual(
+        [],
+        list_ssl_certfiles(Config)
+    ).
+
+mk_storage(Enabled) ->
+    mk_storage(Enabled, #{<<"local">> => #{}}).
+
+mk_storage(Enabled, Exporter) ->
+    #{
+        <<"enable">> => Enabled,
+        <<"storage">> => #{
+            <<"local">> => #{
+                <<"exporter">> => Exporter
+            }
+        }
+    }.
+
 gen_clientid() ->
     emqx_base62:encode(emqx_guid:gen()).
+
+list_ssl_certfiles(_Config) ->
+    CertDir = emqx:mutable_certs_dir(),
+    filelib:fold_files(CertDir, ".*", true, fun(Filepath, Acc) -> [Filepath | Acc] end, []).

--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -126,3 +126,13 @@ upload_file(ClientId, FileId, Name, Data, Node) ->
 
 aws_config() ->
     emqx_s3_test_helpers:aws_config(tcp, binary_to_list(?S3_HOST), ?S3_PORT).
+
+pem_privkey() ->
+    <<
+        "\n"
+        "-----BEGIN EC PRIVATE KEY-----\n"
+        "MHQCAQEEICKTbbathzvD8zvgjL7qRHhW4alS0+j0Loo7WeYX9AxaoAcGBSuBBAAK\n"
+        "oUQDQgAEJBdF7MIdam5T4YF3JkEyaPKdG64TVWCHwr/plC0QzNVJ67efXwxlVGTo\n"
+        "ju0VBj6tOX1y6C0U+85VOM0UU5xqvw==\n"
+        "-----END EC PRIVATE KEY-----\n"
+    >>.

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -54,7 +54,8 @@
     safe_to_existing_atom/1,
     safe_to_existing_atom/2,
     pub_props_to_packet/1,
-    safe_filename/1
+    safe_filename/1,
+    format/1
 ]).
 
 -export([
@@ -481,6 +482,9 @@ safe_to_existing_atom(Atom, _Encoding) when is_atom(Atom) ->
 safe_to_existing_atom(_Any, _Encoding) ->
     {error, invalid_type}.
 
+format(Term) ->
+    iolist_to_binary(io_lib:format("~0p", [Term])).
+
 %%------------------------------------------------------------------------------
 %% Internal Functions
 %%------------------------------------------------------------------------------
@@ -562,7 +566,7 @@ to_hr_error({not_authorized, _}) ->
 to_hr_error({malformed_username_or_password, _}) ->
     <<"Bad username or password">>;
 to_hr_error(Error) ->
-    iolist_to_binary(io_lib:format("~0p", [Error])).
+    format(Error).
 
 try_to_existing_atom(Convert, Data, Encoding) ->
     try Convert(Data, Encoding) of

--- a/rel/i18n/emqx_ft_api.hocon
+++ b/rel/i18n/emqx_ft_api.hocon
@@ -6,6 +6,12 @@ file_list.desc:
 file_list_transfer.desc
 """List a file uploaded during specified transfer, identified by client id and file id."""
 
+file_transfer_get_config.desc:
+"""Show current File Transfer configuration."""
+
+file_transfer_update_config.desc:
+"""Replace File Transfer configuration."""
+
 }
 
 emqx_ft_storage_exporter_fs_api {


### PR DESCRIPTION
Fixes [EMQX-9523](https://emqx.atlassian.net/browse/EMQX-9523)

This PR implements conversion of raw TLS certificate / key data into files in the file system during config update but not the other way around, because:
* This isn't usually needed to API consumers (i.e. dashboard) and currently works the same with most of the bridges / connectors.
* Exposing back TLS key material sounds as risky as exposing passwords.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 277a0eb</samp>

This pull request adds a new API route for getting and updating the file transfer configuration, improves the SSL certfiles management for the S3 exporter module, and refactors some functions and types to follow the `emqx_config_handler` behaviour and avoid conflicts. It also updates the tests and the i18n descriptions for the file transfer API.

## PR Checklist

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
