### PR TITLE
feat(helm): possibility to add `minReadySeconds` in helm chart for the stateful set

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
@@ -32,6 +32,9 @@ spec:
   {{- end }}
   updateStrategy:
     type: RollingUpdate
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -35,6 +35,9 @@ serviceAccount:
 ## Forces the recreation of pods during helm upgrades. This can be useful to update configuration values even if the container image did not change.
 recreatePods: false
 
+## Sets the minReadySeconds parameter on the stateful set. This can be used to add delay between restart / updates between the single pods.
+minReadySeconds:
+
 clusterDomain: cluster.local
 
 podAnnotations: {}

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -32,6 +32,9 @@ spec:
   {{- end }}
   updateStrategy:
     type: RollingUpdate
+  {{- if .Values.minReadySeconds }}
+  minReadySeconds: {{ .Values.minReadySeconds }}
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -35,6 +35,9 @@ serviceAccount:
 ## Forces the recreation of pods during helm upgrades. This can be useful to update configuration values even if the container image did not change.
 recreatePods: false
 
+## Sets the minReadySeconds parameter on the stateful set. This can be used to add delay between restart / updates between the single pods.
+minReadySeconds:
+
 clusterDomain: cluster.local
 
 podAnnotations: {}


### PR DESCRIPTION
This change allows to set the `minReadySeconds` for the StatefulSet. This allow to add a gap between the restarts of each pod by upgrade or restart command. 

Our use case is, that some of our mqtt-clients can't handle it well when they are disconnected multiple times in a short amount of time. But this can happen when they are disconnected for the pod restart and are connected to the next pod that will restart next.

Due to this feature is only available for kubernetes <= 1.25, the tag is not added with a default value but insead only added if it is set in the values configuration.

see: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#minimum-ready-seconds
