### PR TITLE
feat(tls-partial-chains): update schema

### DIFF
--- a/changes/v4.4.19-en.md
+++ b/changes/v4.4.19-en.md
@@ -18,7 +18,6 @@
   ```
 
 - Adds a new feature to enable partial certificate chain validation for TLS listeners[#10553](https://github.com/emqx/emqx/pull/10553).
-  If partial_chain is set to 'true', the last certificate in cacertfile is treated as the terminal of the certificate trust-chain. That is, the TLS handshake does not require full trust-chain, and EMQX will not try to validate the chain all the way up to the root CA.
 
 - Adds a new feature to enable client certificate extended key usage validation for TLS listeners[#10669](https://github.com/emqx/emqx/pull/10669).
 

--- a/changes/v4.4.19-zh.md
+++ b/changes/v4.4.19-zh.md
@@ -17,8 +17,7 @@
   2023-04-20T18:10:17.205436+08:00 [error] [esockd_proxy_protocol] The listener 127.0.0.1:8883 is working in proxy protocol mode, but timed out while waiting for proxy_protocol header
   ```
 
-- 增加了一个新的功能，为 TLS 监听器启用部分证书链验证[#10553](https://github.com/emqx/emqx/pull/10553)。
-  如果 partial_chain 设置为“true”，cacertfile 中的最后一个证书将被视为证书信任链的顶端证书。 也就是说，TLS 握手不需要完整的链，并且 EMQX 不会尝试一直验证链直到根 CA。
+- 增加了一个新功能，为 TLS 监听器启用部分证书链验证[#10553](https://github.com/emqx/emqx/pull/10553)。
   
 - 增加了一个新功能，为 TLS 监听器启用客户端证书扩展密钥使用验证 [#10669](https://github.com/emqx/emqx/pull/10669)。
 

--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -1647,7 +1647,7 @@ end}.
 ]}.
 
 {mapping, "listener.ssl.$name.partial_chain", "emqx.listeners", [
-  {datatype, atom}
+  {datatype, {enum, [true, false, two_cacerts_from_cacertfile, cacert_from_cacertfile]}}
 ]}.
 
 {mapping, "listener.ssl.$name.verify_peer_ext_key_usage", "emqx.listeners", [

--- a/src/emqx_tls_lib.erl
+++ b/src/emqx_tls_lib.erl
@@ -200,7 +200,7 @@ opt_partial_chain(SslOpts) ->
         undefined ->
             SslOpts;
         false ->
-            SslOpts;
+            proplists:delete(partial_chain, SslOpts);
         V when V =:= cacert_from_cacertfile orelse V == true ->
             replace(SslOpts, partial_chain, rootfun_trusted_ca_from_cacertfile(1, SslOpts));
         V when V =:= two_cacerts_from_cacertfile -> %% for certificate rotations

--- a/test/emqx_listener_tls_verify_partial_chain_SUITE.erl
+++ b/test/emqx_listener_tls_verify_partial_chain_SUITE.erl
@@ -400,6 +400,22 @@ t_conn_fail_with_server_two_IA_bundle_and_client_root_chain(Config) ->
   fail_when_no_ssl_alert(Socket, unknown_ca),
   ok = ssl:close(Socket).
 
+t_conn_fail_with_server_partial_chain_false_intermediate_cacert_and_client_cert(Config) ->
+  Port = emqx_test_tls_certs_helper:select_free_port(ssl),
+  DataDir = ?config(data_dir, Config),
+  Options = [{ssl_options, [ {cacertfile, filename:join(DataDir, "intermediate1.pem")}
+                           , {certfile, filename:join(DataDir, "server1.pem")}
+                           , {keyfile, filename:join(DataDir, "server1.key")}
+                           , {partial_chain, false}
+                           | ?config(ssl_config, Config)
+                           ]}],
+  emqx_listeners:start_listener(ssl, Port, Options),
+  {ok, Socket} = ssl:connect({127, 0, 0, 1}, Port, [{keyfile,  filename:join(DataDir, "client1.key")},
+                                                    {certfile,  filename:join(DataDir, "client1.pem")}
+                                                   ], 1000),
+  fail_when_no_ssl_alert(Socket, unknown_ca),
+  ssl:close(Socket).
+
 t_error_handling_invalid_cacertfile(Config) ->
   Port = emqx_test_tls_certs_helper:select_free_port(ssl),
   DataDir = ?config(data_dir, Config),


### PR DESCRIPTION
followup review comments in #10673 

Since we now support cacert refresh and makes the logic a little complicated, 
detailed description of the feature is moved to emqx-docs PR:  https://github.com/emqx/emqx-docs/pull/1893