### PR TITLE
docs: clarify description of bridge username and password

### DIFF
--- a/changes/ce/fix-10708.md
+++ b/changes/ce/fix-10708.md
@@ -1,0 +1,1 @@
+Enhanced clarity of the descriptions for the bridge configuration fields (username and password) to better guide users during setup.

--- a/rel/i18n/emqx_connector_schema_lib.hocon
+++ b/rel/i18n/emqx_connector_schema_lib.hocon
@@ -13,7 +13,7 @@ database_desc.label:
 """Database Name"""
 
 password.desc:
-"""EMQX's password in the external database."""
+"""The password associated with the bridge, used for authentication with the external database."""
 
 password.label:
 """Password"""
@@ -37,7 +37,7 @@ ssl.label:
 """Enable SSL"""
 
 username.desc:
-"""EMQX's username in the external database."""
+"""The username associated with the bridge in the external database used for authentication or identification purposes."""
 
 username.label:
 """Username"""


### PR DESCRIPTION
Fixes:
https://emqx.atlassian.net/browse/EMQX-9613
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 46f0505</samp>

Improved the descriptions of bridge credentials in `emqx_connector_schema_lib.hocon`. This change clarifies the difference between the bridge's `password` and `username` fields and the EMQX's own credentials.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [] Schema changes are backward compatible
