### PR TITLE
fix(pulsar): use a binary duration as default `health_check_interval`

### DIFF
--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
@@ -140,7 +140,7 @@ fields(producer_resource_opts) ->
     lists:filtermap(
         fun
             ({health_check_interval = Field, MetaFn}) ->
-                {true, {Field, override_default(MetaFn, 1_000)}};
+                {true, {Field, override_default(MetaFn, <<"1s">>)}};
             ({Field, _Meta}) ->
                 lists:member(Field, SupportedOpts)
         end,


### PR DESCRIPTION
# Targeting `release-50`

Port of #10707 to e5.0.4

Fixes https://emqx.atlassian.net/browse/EMQX-9885

The frontend needs the default value to match the duration (binary) type to display correctly.



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4df4859</samp>

Changed the default `health_check_interval` option for the Pulsar bridge plugin to use seconds instead of milliseconds. Updated the `emqx_bridge_pulsar.erl` file to handle binary values for this option.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
