### PR TITLE
fix: validate range for some bridge options

### DIFF
--- a/apps/emqx_resource/src/schema/emqx_resource_schema.erl
+++ b/apps/emqx_resource/src/schema/emqx_resource_schema.erl
@@ -23,6 +23,12 @@
 
 -export([namespace/0, roots/0, fields/1, desc/1]).
 
+%% range interval in ms
+-define(HEALTH_CHECK_INTERVAL_RANGE_MIN, 1).
+-define(HEALTH_CHECK_INTERVAL_RANGE_MAX, 3_600_000).
+-define(AUTO_RESTART_INTERVAL_RANGE_MIN, 1).
+-define(AUTO_RESTART_INTERVAL_RANGE_MAX, 3_600_000).
+
 %% -------------------------------------------------------------------------------------------------
 %% Hocon Schema Definitions
 
@@ -81,7 +87,21 @@ health_check_interval(type) -> emqx_schema:duration_ms();
 health_check_interval(desc) -> ?DESC("health_check_interval");
 health_check_interval(default) -> ?HEALTHCHECK_INTERVAL_RAW;
 health_check_interval(required) -> false;
+health_check_interval(validator) -> fun health_check_interval_range/1;
 health_check_interval(_) -> undefined.
+
+health_check_interval_range(HealthCheckInterval) when
+    is_integer(HealthCheckInterval) andalso
+        HealthCheckInterval >= ?HEALTH_CHECK_INTERVAL_RANGE_MIN andalso
+        HealthCheckInterval =< ?HEALTH_CHECK_INTERVAL_RANGE_MAX
+->
+    ok;
+health_check_interval_range(_HealthCheckInterval) ->
+    {error, #{
+        msg => <<"Health Check Interval out of range">>,
+        min => ?HEALTH_CHECK_INTERVAL_RANGE_MIN,
+        max => ?HEALTH_CHECK_INTERVAL_RANGE_MAX
+    }}.
 
 start_after_created(type) -> boolean();
 start_after_created(desc) -> ?DESC("start_after_created");
@@ -99,7 +119,21 @@ auto_restart_interval(type) -> hoconsc:union([infinity, emqx_schema:duration_ms(
 auto_restart_interval(desc) -> ?DESC("auto_restart_interval");
 auto_restart_interval(default) -> ?AUTO_RESTART_INTERVAL_RAW;
 auto_restart_interval(required) -> false;
+auto_restart_interval(validator) -> fun auto_restart_interval_range/1;
 auto_restart_interval(_) -> undefined.
+
+auto_restart_interval_range(AutoRestartInterval) when
+    is_integer(AutoRestartInterval) andalso
+        AutoRestartInterval >= ?AUTO_RESTART_INTERVAL_RANGE_MIN andalso
+        AutoRestartInterval =< ?AUTO_RESTART_INTERVAL_RANGE_MAX
+->
+    ok;
+auto_restart_interval_range(_AutoRestartInterval) ->
+    {error, #{
+        msg => <<"Auto Restart Interval out of range">>,
+        min => ?AUTO_RESTART_INTERVAL_RANGE_MIN,
+        max => ?AUTO_RESTART_INTERVAL_RANGE_MAX
+    }}.
 
 query_mode(type) -> enum([sync, async]);
 query_mode(desc) -> ?DESC("query_mode");

--- a/changes/ce/fix-10726.en.md
+++ b/changes/ce/fix-10726.en.md
@@ -1,0 +1,1 @@
+Validate Health Check Interval and Auto Restart Interval against the range from 1ms to 1 hour.


### PR DESCRIPTION
# targeting `release-50`

Fixes [EMQX-9864](https://emqx.atlassian.net/browse/EMQX-9864)

Schema changes are backward compatible if previous configured values for `auto_restart_interval` and `health_check_interval` are within range [1ms, 1h].


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4159015</samp>

Added validation and error messages for resource configuration parameters and updated the version number of `emqx_resource`. This enhances the resource management feature and prepares for a new release.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~Added tests for the changes~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [ ] ~Change log has been added to `changes/` dir for user-facing artifacts update~
