### PR TITLE
fix(pulsar): mark whole auth struct as sensitive, update dashboard version and improve bridge type matching errors (r5.0)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ endif
 # Dashbord version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= v1.2.4-1
-export EMQX_EE_DASHBOARD_VERSION ?= e1.0.6
+export EMQX_EE_DASHBOARD_VERSION ?= e1.0.7-beta.3
 
 # `:=` should be used here, otherwise the `$(shell ...)` will be executed every time when the variable is used
 # In make 4.4+, for backward-compatibility the value from the original environment is used.

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
@@ -46,7 +46,14 @@ fields(config) ->
             )},
         {authentication,
             mk(hoconsc:union([none, ref(auth_basic), ref(auth_token)]), #{
-                default => none, desc => ?DESC("authentication")
+                default => none,
+                %% must mark this whole union as sensitive because
+                %% hocon ignores the `sensitive' metadata in struct
+                %% fields...  Also, when trying to type check a struct
+                %% that doesn't match the intended type, it won't have
+                %% sensitivity information from sibling types.
+                sensitive => true,
+                desc => ?DESC("authentication")
             })}
     ] ++ emqx_connector_schema_lib:ssl_fields();
 fields(producer_opts) ->

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
@@ -45,16 +45,19 @@ fields(config) ->
                 }
             )},
         {authentication,
-            mk(hoconsc:union([none, ref(auth_basic), ref(auth_token)]), #{
-                default => none,
-                %% must mark this whole union as sensitive because
-                %% hocon ignores the `sensitive' metadata in struct
-                %% fields...  Also, when trying to type check a struct
-                %% that doesn't match the intended type, it won't have
-                %% sensitivity information from sibling types.
-                sensitive => true,
-                desc => ?DESC("authentication")
-            })}
+            mk(
+                hoconsc:union(fun auth_union_member_selector/1),
+                #{
+                    default => none,
+                    %% must mark this whole union as sensitive because
+                    %% hocon ignores the `sensitive' metadata in struct
+                    %% fields...  Also, when trying to type check a struct
+                    %% that doesn't match the intended type, it won't have
+                    %% sensitivity information from sibling types.
+                    sensitive => true,
+                    desc => ?DESC("authentication")
+                }
+            )}
     ] ++ emqx_connector_schema_lib:ssl_fields();
 fields(producer_opts) ->
     [
@@ -232,4 +235,22 @@ override_default(OriginalFn, NewDefault) ->
     fun
         (default) -> NewDefault;
         (Field) -> OriginalFn(Field)
+    end.
+
+auth_union_member_selector(all_union_members) ->
+    [none, ref(auth_basic), ref(auth_token)];
+auth_union_member_selector({value, V}) ->
+    case V of
+        #{<<"password">> := _} ->
+            [ref(auth_basic)];
+        #{<<"jwt">> := _} ->
+            [ref(auth_token)];
+        <<"none">> ->
+            [none];
+        _ ->
+            Expected = "none | basic | token",
+            throw(#{
+                field_name => authentication,
+                expected => Expected
+            })
     end.

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_bridge, [
     {description, "EMQX Enterprise data bridges"},
-    {vsn, "0.1.12"},
+    {vsn, "0.1.13"},
     {registered, []},
     {applications, [
         kernel,

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.erl
@@ -14,33 +14,37 @@
 
 api_schemas(Method) ->
     [
-        ref(emqx_bridge_gcp_pubsub, Method),
-        ref(emqx_bridge_kafka, Method ++ "_consumer"),
-        ref(emqx_bridge_kafka, Method ++ "_producer"),
-        ref(emqx_bridge_cassandra, Method),
-        ref(emqx_ee_bridge_mysql, Method),
-        ref(emqx_bridge_pgsql, Method),
-        ref(emqx_ee_bridge_mongodb, Method ++ "_rs"),
-        ref(emqx_ee_bridge_mongodb, Method ++ "_sharded"),
-        ref(emqx_ee_bridge_mongodb, Method ++ "_single"),
-        ref(emqx_ee_bridge_hstreamdb, Method),
-        ref(emqx_bridge_influxdb, Method ++ "_api_v1"),
-        ref(emqx_bridge_influxdb, Method ++ "_api_v2"),
-        ref(emqx_ee_bridge_redis, Method ++ "_single"),
-        ref(emqx_ee_bridge_redis, Method ++ "_sentinel"),
-        ref(emqx_ee_bridge_redis, Method ++ "_cluster"),
-        ref(emqx_bridge_timescale, Method),
-        ref(emqx_bridge_matrix, Method),
-        ref(emqx_bridge_tdengine, Method),
-        ref(emqx_ee_bridge_clickhouse, Method),
-        ref(emqx_bridge_dynamo, Method),
-        ref(emqx_bridge_rocketmq, Method),
-        ref(emqx_bridge_sqlserver, Method),
-        ref(emqx_bridge_opents, Method),
-        ref(emqx_bridge_pulsar, Method ++ "_producer"),
-        ref(emqx_bridge_oracle, Method),
-        ref(emqx_bridge_iotdb, Method),
-        ref(emqx_bridge_rabbitmq, Method)
+        %% We need to map the `type' field of a request (binary) to a
+        %% bridge schema module.
+        api_ref(emqx_bridge_gcp_pubsub, <<"gcp_pubsub">>, Method),
+        api_ref(emqx_bridge_kafka, <<"kafka_consumer">>, Method ++ "_consumer"),
+        %% TODO: rename this to `kafka_producer' after alias support is added
+        %% to hocon; keeping this as just `kafka' for backwards compatibility.
+        api_ref(emqx_bridge_kafka, <<"kafka">>, Method ++ "_producer"),
+        api_ref(emqx_bridge_cassandra, <<"cassandra">>, Method),
+        api_ref(emqx_ee_bridge_mysql, <<"mysql">>, Method),
+        api_ref(emqx_bridge_pgsql, <<"pgsql">>, Method),
+        api_ref(emqx_ee_bridge_mongodb, <<"mongodb_rs">>, Method ++ "_rs"),
+        api_ref(emqx_ee_bridge_mongodb, <<"mongodb_sharded">>, Method ++ "_sharded"),
+        api_ref(emqx_ee_bridge_mongodb, <<"mongodb_single">>, Method ++ "_single"),
+        api_ref(emqx_ee_bridge_hstreamdb, <<"hstreamdb">>, Method),
+        api_ref(emqx_bridge_influxdb, <<"influxdb_api_v1">>, Method ++ "_api_v1"),
+        api_ref(emqx_bridge_influxdb, <<"influxdb_api_v2">>, Method ++ "_api_v2"),
+        api_ref(emqx_ee_bridge_redis, <<"redis_single">>, Method ++ "_single"),
+        api_ref(emqx_ee_bridge_redis, <<"redis_sentinel">>, Method ++ "_sentinel"),
+        api_ref(emqx_ee_bridge_redis, <<"redis_cluster">>, Method ++ "_cluster"),
+        api_ref(emqx_bridge_timescale, <<"timescale">>, Method),
+        api_ref(emqx_bridge_matrix, <<"matrix">>, Method),
+        api_ref(emqx_bridge_tdengine, <<"tdengine">>, Method),
+        api_ref(emqx_ee_bridge_clickhouse, <<"clickhouse">>, Method),
+        api_ref(emqx_bridge_dynamo, <<"dynamo">>, Method),
+        api_ref(emqx_bridge_rocketmq, <<"rocketmq">>, Method),
+        api_ref(emqx_bridge_sqlserver, <<"sqlserver">>, Method),
+        api_ref(emqx_bridge_opents, <<"opents">>, Method),
+        api_ref(emqx_bridge_pulsar, <<"pulsar_producer">>, Method ++ "_producer"),
+        api_ref(emqx_bridge_oracle, <<"oracle">>, Method),
+        api_ref(emqx_bridge_iotdb, <<"iotdb">>, Method),
+        api_ref(emqx_bridge_rabbitmq, <<"rabbitmq">>, Method)
     ].
 
 schema_modules() ->
@@ -338,3 +342,6 @@ rabbitmq_structs() ->
                 }
             )}
     ].
+
+api_ref(Module, Type, Method) ->
+    {Type, ref(Module, Method)}.


### PR DESCRIPTION
# targeting `release-50`

Fixes https://emqx.atlassian.net/browse/EMQX-9900

I tried to patch hocon itself to filter the sensitive data, but the
way it's currently structured doesn't seem to keep that field
metadata.  So, for now, we can just mark the whole auth union as
sensitive.

Dashboard `e1.0.7-beta.2` allowed username to be empty, which also gave rise to the reported issue.  Username is required in the latest dashboard version.

Also, this refactors the bridge API type resolving to also use an union member selector function to improve the error messages when a type does not match.

Bridge Probe API error after patch:

![image](https://github.com/emqx/emqx/assets/16166434/9e359e7c-0a25-485e-9404-b2e6ebf27865)

Bridge Update API error after patch:

![image](https://github.com/emqx/emqx/assets/16166434/11ad6467-7be2-4452-9ae9-5c0d474b6d01)

Bridge Create API error after patch:

![image](https://github.com/emqx/emqx/assets/16166434/6e53dad4-5b6d-456e-80c2-c27655ee61f0)



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dcccc09</samp>

This pull request adds support for pulsar token authentication and updates the emqx enterprise dashboard version. It also marks the `authentication` field in the `emqx_bridge_pulsar` schema as sensitive to prevent leaking credentials.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
