### PR TITLE
Avoid urldecode clientid twice

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_api_clients.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_clients.erl
@@ -145,10 +145,9 @@ clients(get, #{
 clients_insta(get, #{
     bindings := #{
         name := Name0,
-        clientid := ClientId0
+        clientid := ClientId
     }
 }) ->
-    ClientId = emqx_mgmt_util:urldecode(ClientId0),
     with_gateway(Name0, fun(GwName, _) ->
         case
             emqx_gateway_http:lookup_client(
@@ -172,10 +171,9 @@ clients_insta(get, #{
 clients_insta(delete, #{
     bindings := #{
         name := Name0,
-        clientid := ClientId0
+        clientid := ClientId
     }
 }) ->
-    ClientId = emqx_mgmt_util:urldecode(ClientId0),
     with_gateway(Name0, fun(GwName, _) ->
         _ = emqx_gateway_http:kickout_client(GwName, ClientId),
         {204}
@@ -185,10 +183,9 @@ clients_insta(delete, #{
 subscriptions(get, #{
     bindings := #{
         name := Name0,
-        clientid := ClientId0
+        clientid := ClientId
     }
 }) ->
-    ClientId = emqx_mgmt_util:urldecode(ClientId0),
     with_gateway(Name0, fun(GwName, _) ->
         case emqx_gateway_http:list_client_subscriptions(GwName, ClientId) of
             {error, not_found} ->
@@ -203,11 +200,10 @@ subscriptions(get, #{
 subscriptions(post, #{
     bindings := #{
         name := Name0,
-        clientid := ClientId0
+        clientid := ClientId
     },
     body := Body
 }) ->
-    ClientId = emqx_mgmt_util:urldecode(ClientId0),
     with_gateway(Name0, fun(GwName, _) ->
         case {maps:get(<<"topic">>, Body, undefined), subopts(Body)} of
             {undefined, _} ->
@@ -231,12 +227,10 @@ subscriptions(post, #{
 subscriptions(delete, #{
     bindings := #{
         name := Name0,
-        clientid := ClientId0,
-        topic := Topic0
+        clientid := ClientId,
+        topic := Topic
     }
 }) ->
-    ClientId = emqx_mgmt_util:urldecode(ClientId0),
-    Topic = emqx_mgmt_util:urldecode(Topic0),
     with_gateway(Name0, fun(GwName, _) ->
         _ = emqx_gateway_http:client_unsubscribe(GwName, ClientId, Topic),
         {204}

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -110,14 +110,12 @@ listeners(post, #{bindings := #{name := Name0}, body := LConf}) ->
         end
     end).
 
-listeners_insta(delete, #{bindings := #{name := Name0, id := ListenerId0}}) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
+listeners_insta(delete, #{bindings := #{name := Name0, id := ListenerId}}) ->
     with_gateway(Name0, fun(_GwName, _) ->
         ok = emqx_gateway_http:remove_listener(ListenerId),
         {204}
     end);
-listeners_insta(get, #{bindings := #{name := Name0, id := ListenerId0}}) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
+listeners_insta(get, #{bindings := #{name := Name0, id := ListenerId}}) ->
     with_gateway(Name0, fun(_GwName, _) ->
         case emqx_gateway_conf:listener(ListenerId) of
             {ok, Listener} ->
@@ -130,9 +128,8 @@ listeners_insta(get, #{bindings := #{name := Name0, id := ListenerId0}}) ->
     end);
 listeners_insta(put, #{
     body := LConf,
-    bindings := #{name := Name0, id := ListenerId0}
+    bindings := #{name := Name0, id := ListenerId}
 }) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
     with_gateway(Name0, fun(_GwName, _) ->
         {ok, RespConf} = emqx_gateway_http:update_listener(ListenerId, LConf),
         {200, RespConf}
@@ -141,10 +138,9 @@ listeners_insta(put, #{
 listeners_insta_authn(get, #{
     bindings := #{
         name := Name0,
-        id := ListenerId0
+        id := ListenerId
     }
 }) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
     with_gateway(Name0, fun(GwName, _) ->
         try emqx_gateway_http:authn(GwName, ListenerId) of
             Authn -> {200, Authn}
@@ -157,10 +153,9 @@ listeners_insta_authn(post, #{
     body := Conf,
     bindings := #{
         name := Name0,
-        id := ListenerId0
+        id := ListenerId
     }
 }) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
     with_gateway(Name0, fun(GwName, _) ->
         {ok, Authn} = emqx_gateway_http:add_authn(GwName, ListenerId, Conf),
         {201, Authn}
@@ -169,10 +164,9 @@ listeners_insta_authn(put, #{
     body := Conf,
     bindings := #{
         name := Name0,
-        id := ListenerId0
+        id := ListenerId
     }
 }) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
     with_gateway(Name0, fun(GwName, _) ->
         {ok, Authn} = emqx_gateway_http:update_authn(
             GwName, ListenerId, Conf
@@ -182,10 +176,9 @@ listeners_insta_authn(put, #{
 listeners_insta_authn(delete, #{
     bindings := #{
         name := Name0,
-        id := ListenerId0
+        id := ListenerId
     }
 }) ->
-    ListenerId = emqx_mgmt_util:urldecode(ListenerId0),
     with_gateway(Name0, fun(GwName, _) ->
         ok = emqx_gateway_http:remove_authn(GwName, ListenerId),
         {204}

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -1791,14 +1791,14 @@ message_to_packet(
 handle_call({subscribe, Topic, SubOpts}, _From, Channel) ->
     case do_subscribe({?SN_INVALID_TOPIC_ID, Topic, SubOpts}, Channel) of
         {ok, {_, NTopicName, NSubOpts}, NChannel} ->
-            reply({ok, {NTopicName, NSubOpts}}, NChannel);
+            reply_and_update({ok, {NTopicName, NSubOpts}}, NChannel);
         {error, ?SN_RC2_EXCEED_LIMITATION} ->
             reply({error, exceed_limitation}, Channel)
     end;
 handle_call({unsubscribe, Topic}, _From, Channel) ->
     TopicFilters = [emqx_topic:parse(Topic)],
     {ok, _, NChannel} = do_unsubscribe(TopicFilters, Channel),
-    reply(ok, NChannel);
+    reply_and_update(ok, NChannel);
 handle_call(subscriptions, _From, Channel = #channel{session = Session}) ->
     reply({ok, maps:to_list(emqx_session:info(subscriptions, Session))}, Channel);
 handle_call(kick, _From, Channel) ->
@@ -2191,6 +2191,9 @@ terminate(_Reason, _Channel) ->
 
 reply(Reply, Channel) ->
     {reply, Reply, Channel}.
+
+reply_and_update(Reply, Channel) ->
+    {reply, Reply, [{event, updated}], Channel}.
 
 shutdown(Reason, Channel) ->
     {shutdown, Reason, Channel}.

--- a/changes/ce/fix-10737.en.md
+++ b/changes/ce/fix-10737.en.md
@@ -1,0 +1,2 @@
+Fix the issue where the HTTP API interface of Gateway cannot handle ClientIDs with
+special characters, such as: `!@#$%^&*()_+{}:"<>?/`.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9787 and https://emqx.atlassian.net/browse/EMQX-9783

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 26b69a5</samp>

This pull request improves the HTTP API for gateway clients and listeners, and adds more test cases for the MQTT-SN protocol. It changes the `reply` function to `reply_and_update` in `emqx_mqttsn_channel.erl` to update the client information after a subscription or unsubscription. It also removes redundant decoding of parameters in `emqx_gateway_api_clients.erl` and `emqx_gateway_api_listeners.erl`. It adds two test cases in `emqx_sn_protocol_SUITE.erl` to check the API for complex client ids and subscription updates.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
