### PR TITLE
chore: improve the emqx_cm

### DIFF
--- a/apps/emqx/src/emqx_cm_locker.erl
+++ b/apps/emqx/src/emqx_cm_locker.erl
@@ -29,9 +29,13 @@
     unlock/1
 ]).
 
+%% The takeover timeout (T_TAKEOVER) in emqx_cm is 15s, we should use a sufficent expiration
+%% time to avoid being killed by the ekka_locker before completing the entire takeover task.
+-define(EXPIRY_TIMEOUT, 60_000).
+
 -spec start_link() -> startlink_ret().
 start_link() ->
-    ekka_locker:start_link(?MODULE).
+    ekka_locker:start_link(?MODULE, ?EXPIRY_TIMEOUT).
 
 -spec trans(emqx_types:clientid(), fun(([node()]) -> any())) -> any().
 trans(ClientId, Fun) ->


### PR DESCRIPTION
- change the timeout of the emqx_cm_locker to 60s to avoid being killed by the ekka_locker before completing the entire takeover task.
- move the `cast({registered, Chan})` before inserting ETS tables to prevent ETS leakage in case the process dies before being monitored.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 585df13</samp>

This pull request fixes a bug in `emqx_cm` and adjusts the lock expiration time in `emqx_cm_locker` to improve the reliability and consistency of channel management across nodes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
