### PR TITLE
test(evict): fix flapping testcase

### DIFF
--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
@@ -159,14 +159,14 @@ t_explicit_session_takeover(Config) ->
     ]),
     {ok, _, _} = emqtt:subscribe(C0, <<"t1">>),
 
-    ok = rpc:call(Node1, emqx_eviction_agent, enable, [test_eviction, undefined]),
-
     ?assertEqual(
         1,
         rpc:call(Node1, emqx_eviction_agent, connection_count, [])
     ),
 
     [ChanPid] = rpc:call(Node1, emqx_cm, lookup_channels, [<<"client_with_session">>]),
+
+    ok = rpc:call(Node1, emqx_eviction_agent, enable, [test_eviction, undefined]),
 
     ?assertWaitEvent(
         begin


### PR DESCRIPTION
Postpone enabling eviction agent so that target connection will not get evicted too early.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c11260</samp>

Fix test cases for eviction agent feature. Ensure that the eviction agent is enabled or disabled as expected in `t_eviction/1` and `t_eviction_with_shared_sub/1` in `emqx_eviction_agent_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
