### PR TITLE
fix(rule_engine): support Tuple types as arrays

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -852,25 +852,52 @@ jq(FilterProgram, JSONBin) ->
 %%------------------------------------------------------------------------------
 
 nth(N, L) when is_integer(N), is_list(L) ->
-    lists:nth(N, L).
+    lists:nth(N, L);
+nth(N, Tuple) when is_integer(N), is_tuple(Tuple) ->
+    element(N, Tuple).
 
 length(List) when is_list(List) ->
-    erlang:length(List).
+    erlang:length(List);
+length(Tuple) when is_tuple(Tuple) ->
+    tuple_size(Tuple).
 
 sublist(Len, List) when is_integer(Len), is_list(List) ->
-    lists:sublist(List, Len).
+    lists:sublist(List, Len);
+sublist(Len, Tuple) when is_integer(Len), is_tuple(Tuple), Len =< tuple_size(Tuple), Len > 0 ->
+    [element(N, Tuple) || N <- lists:seq(1, Len)];
+sublist(_, {}) ->
+    [].
 
 sublist(Start, Len, List) when is_integer(Start), is_integer(Len), is_list(List) ->
-    lists:sublist(List, Start, Len).
+    lists:sublist(List, Start, Len);
+sublist(Start, Len, Tuple) when is_integer(Start), is_integer(Len), is_tuple(Tuple), Start > 0 ->
+    End = min(tuple_size(Tuple), Start + Len - 1),
+    [element(N, Tuple) || N <- lists:seq(Start, End)];
+sublist(_, _, {}) ->
+    [].
 
 first(List) when is_list(List) ->
-    hd(List).
+    hd(List);
+first(Tuple) when is_tuple(Tuple) ->
+    element(1, Tuple).
 
 last(List) when is_list(List) ->
-    lists:last(List).
+    lists:last(List);
+last(Tuple) when is_tuple(Tuple) ->
+    element(tuple_size(Tuple), Tuple).
 
 contains(Elm, List) when is_list(List) ->
-    lists:member(Elm, List).
+    lists:member(Elm, List);
+contains(_, {}) -> false;
+contains(Elm, Tuple) when is_tuple(Tuple) ->
+    contains(Elm, Tuple, 1, tuple_size(Tuple)).
+
+contains(Elm, Tuple, Index, Size) when Index =< Size ->
+    case element(Index, Tuple) of
+        Elm -> true;
+        _ -> contains(Elm, Tuple, Index+1, Size)
+    end;
+contains(_, _, _, _) -> false.
 
 map_new() ->
     #{}.

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -701,11 +701,15 @@ bin(S) -> iolist_to_binary(S).
 
 t_nth(_) ->
     ?assertEqual(2, apply_func(nth, [2, [1, 2, 3, 4]])),
-    ?assertEqual(4, apply_func(nth, [4, [1, 2, 3, 4]])).
+    ?assertEqual(4, apply_func(nth, [4, [1, 2, 3, 4]])),
+    ?assertEqual(2, apply_func(nth, [2, {1, 2, 3, 4}])),
+    ?assertEqual(4, apply_func(nth, [4, {1, 2, 3, 4}])).
 
 t_length(_) ->
     ?assertEqual(4, apply_func(length, [[1, 2, 3, 4]])),
-    ?assertEqual(0, apply_func(length, [[]])).
+    ?assertEqual(0, apply_func(length, [[]])),
+    ?assertEqual(4, apply_func(length, [{1, 2, 3, 4}])),
+    ?assertEqual(0, apply_func(length, [{}])).
 
 t_slice(_) ->
     ?assertEqual([1, 2, 3, 4], apply_func(sublist, [4, [1, 2, 3, 4]])),
@@ -714,11 +718,20 @@ t_slice(_) ->
     ?assertEqual([4], apply_func(sublist, [4, 2, [1, 2, 3, 4]])),
     ?assertEqual([], apply_func(sublist, [5, 2, [1, 2, 3, 4]])),
     ?assertEqual([2, 3], apply_func(sublist, [2, 2, [1, 2, 3, 4]])),
-    ?assertEqual([1], apply_func(sublist, [1, 1, [1, 2, 3, 4]])).
+    ?assertEqual([1], apply_func(sublist, [1, 1, [1, 2, 3, 4]])),
+    ?assertEqual([1, 2, 3, 4], apply_func(sublist, [4, {1, 2, 3, 4}])),
+    ?assertEqual([1, 2], apply_func(sublist, [2, {1, 2, 3, 4}])),
+    ?assertEqual([4], apply_func(sublist, [4, 1, {1, 2, 3, 4}])),
+    ?assertEqual([4], apply_func(sublist, [4, 2, {1, 2, 3, 4}])),
+    ?assertEqual([], apply_func(sublist, [5, 2, {1, 2, 3, 4}])),
+    ?assertEqual([2, 3], apply_func(sublist, [2, 2, {1, 2, 3, 4}])),
+    ?assertEqual([1], apply_func(sublist, [1, 1, {1, 2, 3, 4}])).
 
 t_first_last(_) ->
     ?assertEqual(1, apply_func(first, [[1, 2, 3, 4]])),
-    ?assertEqual(4, apply_func(last, [[1, 2, 3, 4]])).
+    ?assertEqual(4, apply_func(last, [[1, 2, 3, 4]])),
+    ?assertEqual(1, apply_func(first, [{1, 2, <<"three">>, 4}])),
+    ?assertEqual(4, apply_func(last, [{1, 2, <<"three">>, 4}])).
 
 t_contains(_) ->
     ?assertEqual(true, apply_func(contains, [1, [1, 2, 3, 4]])),
@@ -727,7 +740,14 @@ t_contains(_) ->
     ?assertEqual(true, apply_func(contains, [#{a => b}, [#{a => 1}, #{a => b}]])),
     ?assertEqual(false, apply_func(contains, [#{a => b}, [#{a => 1}]])),
     ?assertEqual(false, apply_func(contains, [3, [1, 2]])),
-    ?assertEqual(false, apply_func(contains, [<<"c">>, [<<>>, <<"ab">>, 3, <<"a">>]])).
+    ?assertEqual(false, apply_func(contains, [<<"c">>, [<<>>, <<"ab">>, 3, <<"a">>]])),
+    ?assertEqual(true, apply_func(contains, [1, {1, 2, 3, 4}])),
+    ?assertEqual(true, apply_func(contains, [3, {1, 2, 3, 4}])),
+    ?assertEqual(true, apply_func(contains, [<<"a">>, {<<>>, <<"ab">>, 3, <<"a">>}])),
+    ?assertEqual(true, apply_func(contains, [#{a => b}, {#{a => 1}, #{a => b}}])),
+    ?assertEqual(false, apply_func(contains, [#{a => b}, {#{a => 1}}])),
+    ?assertEqual(false, apply_func(contains, [3, {1, 2}])),
+    ?assertEqual(false, apply_func(contains, [<<"c">>, {<<>>, <<"ab">>, 3, <<"a">>}])).
 
 t_map_get(_) ->
     ?assertEqual(1, apply_func(map_get, [<<"a">>, #{a => 1}])),


### PR DESCRIPTION
SQL array functions such as nth or last was working on lists only. This adds Tuple support for array functions.

Fixes #9891


## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
