### PR TITLE
fix: make sure swagger.json is fully generated

### DIFF
--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -55,6 +55,10 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
+    %% Load all applications to ensure swagger.json is fully generated.
+    Apps = emqx_machine_boot:reboot_apps(),
+    ct:pal("load apps:~p~n", [Apps]),
+    lists:foreach(fun(App) -> application:load(App) end, Apps),
     emqx_mgmt_api_test_util:init_suite([emqx_management]),
     Config.
 

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -26,7 +26,7 @@
 -dialyzer({no_match, [basic_reboot_apps/0]}).
 
 -ifdef(TEST).
--export([sorted_reboot_apps/1]).
+-export([sorted_reboot_apps/1, reboot_apps/0]).
 -endif.
 
 %% these apps are always (re)started by emqx_machine
@@ -120,7 +120,7 @@ restart_type(App) ->
 
 %% the list of (re)started apps depends on release type/edition
 reboot_apps() ->
-    {ok, ConfigApps0} = application:get_env(emqx_machine, applications),
+    ConfigApps0 = application:get_env(emqx_machine, applications, []),
     BaseRebootApps = basic_reboot_apps(),
     ConfigApps = lists:filter(fun(App) -> not lists:member(App, BaseRebootApps) end, ConfigApps0),
     BaseRebootApps ++ ConfigApps.


### PR DESCRIPTION
Fixes <issue-or-jira-number>
minirest only generate loaded apps's swagger.json. so we make sure the dashboard_SUITE is loaded all apps to generate fully swagger.json.
Only change in CI test.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
