### PR TITLE
feat(pulsar): ensure allocated resources are removed on failures (v5.0)

### DIFF
--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -121,3 +121,5 @@
 
 -define(TEST_ID_PREFIX, "_probe_:").
 -define(RES_METRICS, resource_metrics).
+
+-define(RESOURCE_ALLOCATION_TAB, emqx_resource_allocations).

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -500,8 +500,10 @@ stop_resource(#data{state = ResState, id = ResId} = Data) ->
     %% We don't care the return value of the Mod:on_stop/2.
     %% The callback mod should make sure the resource is stopped after on_stop/2
     %% is returned.
-    case ResState /= undefined of
+    HasAllocatedResources = emqx_resource:has_allocated_resources(ResId),
+    case ResState =/= undefined orelse HasAllocatedResources of
         true ->
+            %% we clear the allocated resources after stop is successful
             emqx_resource:call_stop(Data#data.id, Data#data.mod, ResState);
         false ->
             ok

--- a/apps/emqx_resource/src/emqx_resource_manager_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager_sup.erl
@@ -17,6 +17,8 @@
 
 -behaviour(supervisor).
 
+-include("emqx_resource.hrl").
+
 -export([ensure_child/5, delete_child/1]).
 
 -export([start_link/0]).
@@ -36,6 +38,12 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
+    %% Maps resource_id() to one or more allocated resources.
+    emqx_utils_ets:new(?RESOURCE_ALLOCATION_TAB, [
+        bag,
+        public,
+        {read_concurrency, true}
+    ]),
     ChildSpecs = [
         #{
             id => emqx_resource_manager,

--- a/changes/ee/feat-10778.en.md
+++ b/changes/ee/feat-10778.en.md
@@ -1,0 +1,1 @@
+Refactored Pulsar Producer bridge to avoid leaking resources during crashes.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9937

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44b87f0</samp>

This pull request adds a new feature to the `emqx_bridge_pulsar` module that uses the `emqx_resource` API to allocate and free resources for each bridge instance. This improves the reliability and robustness of the Pulsar connector. It also adds test cases and modifies some ETS table operations to support this feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
