### PR TITLE
feat(retainer): add a field `deliver_rate` to limit the maximum delivery rate

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.12"},
+    {vsn, "5.0.13"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/changes/ce/feat-10782.en.md
+++ b/changes/ce/feat-10782.en.md
@@ -1,0 +1,2 @@
+Added a new `deliver_rate` option to the retainer configuration, which can limit the maximum delivery rate per session in the retainer.
+

--- a/rel/i18n/emqx_retainer_schema.hocon
+++ b/rel/i18n/emqx_retainer_schema.hocon
@@ -46,4 +46,6 @@ whether to continue to publish the message.
 See:
 http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038"""
 
+deliver_rate.desc:
+"""The maximum rate of delivering retain messages"""
 }


### PR DESCRIPTION

Fixes [EMQX-9918](https://emqx.atlassian.net/browse/EMQX-9918)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3a0a84</samp>

Added a new `deliver_rate` option to the `retainer` section of the configuration, which allows users to adjust the performance and throughput of delivering retain messages. Updated the schema, the test suite, and the documentation files accordingly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
