### PR TITLE
fix(windows): set EMQX_LOG_DIR env variable

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -102,9 +102,16 @@ jobs:
     - name: run emqx
       timeout-minutes: 5
       run: |
+        $ErrorActionPreference = "Stop"
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx start
-        Start-Sleep -s 5
-        echo "EMQX started"
+        Start-Sleep -s 10
+        $pingOutput = ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx ping
+        if ($pingOutput = 'pong') {
+          echo "EMQX started OK"
+        } else {
+          echo "Failed to ping EMQX $pingOutput"
+          Exit 1
+        }
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx stop
         echo "EMQX stopped"
         ./_build/${{ matrix.profile }}/rel/emqx/bin/emqx install

--- a/bin/emqx.cmd
+++ b/bin/emqx.cmd
@@ -46,6 +46,7 @@
 @set "RUNNER_ROOT_DIR=%rel_root_dir%"
 :: hard code etc dir
 @set "EMQX_ETC_DIR=%rel_root_dir%\etc"
+@set "EMQX_LOG_DIR=%rel_root_dir%\log"
 @set "etc_dir=%rel_root_dir%\etc"
 @set "lib_dir=%rel_root_dir%\lib"
 @set "emqx_conf=%etc_dir%\emqx.conf"

--- a/changes/ce/fix-10785.en.md
+++ b/changes/ce/fix-10785.en.md
@@ -1,0 +1,3 @@
+Ensure `EMQX_LOG_DIR` is set by Windows boot script.
+
+The environment variable `EMQX_LOG_DIR` was missing in v5.0.25, caused EMQX Windows package fail to boot unless set by sysadmin.


### PR DESCRIPTION
Fixes https://askemq.com/t/topic/4892/4 and [EMQX-9904](https://emqx.atlassian.net/browse/EMQX-9904)


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5e1bc4</samp>

Improve error handling and verification for Windows build workflow. Use `emqx ping` to check EMQX status and exit on failure.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [~] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
