### PR TITLE
fix: RabbitMQ field not marked as required

### DIFF
--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_rabbitmq, [
     {description, "EMQX Enterprise RabbitMQ Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib, ecql, rabbit_common, amqp_client]},
     {env, []},

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector.erl
@@ -72,7 +72,7 @@ fields(config) ->
                     desc => ?DESC("username")
                 }
             )},
-        {password, fun emqx_connector_schema_lib:password/1},
+        {password, fun emqx_connector_schema_lib:password_required/1},
         {pool_size,
             hoconsc:mk(
                 typerefl:pos_integer(),

--- a/apps/emqx_connector/src/emqx_connector_schema_lib.erl
+++ b/apps/emqx_connector/src/emqx_connector_schema_lib.erl
@@ -30,6 +30,7 @@
     database/1,
     username/1,
     password/1,
+    password_required/1,
     auto_reconnect/1
 ]).
 
@@ -103,6 +104,14 @@ password(format) -> <<"password">>;
 password(sensitive) -> true;
 password(converter) -> fun emqx_schema:password_converter/2;
 password(_) -> undefined.
+
+password_required(type) -> binary();
+password_required(desc) -> ?DESC("password");
+password_required(required) -> true;
+password_required(format) -> <<"password">>;
+password_required(sensitive) -> true;
+password_required(converter) -> fun emqx_schema:password_converter/2;
+password_required(_) -> undefined.
 
 auto_reconnect(type) -> boolean();
 auto_reconnect(desc) -> ?DESC("auto_reconnect");


### PR DESCRIPTION
This PR makes sure that the RabbitMQ password filed is marked as required. This ensures that the user provides a password and that the bridge does not throw a function clause exception if the password filed is not set.

Fixes:
https://emqx.atlassian.net/browse/EMQX-9974

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea2fea7</samp>

Add a new `password_required` function to `emqx_connector_schema_lib` module and use it to validate and convert the password field for RabbitMQ connector. Bump the version of `emqx_bridge_rabbitmq` application to 0.1.1.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [] Schema changes are backward compatible