### PR TITLE
fix: lookup topic without force percent decode

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_topics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_topics.erl
@@ -139,9 +139,9 @@ lookup(#{topic := Topic}) ->
 %%%==============================================================================================
 %% internal
 generate_topic(Params = #{<<"topic">> := Topic}) ->
-    Params#{<<"topic">> => uri_string:percent_decode(Topic)};
+    Params#{<<"topic">> => Topic};
 generate_topic(Params = #{topic := Topic}) ->
-    Params#{topic => uri_string:percent_decode(Topic)};
+    Params#{topic => Topic};
 generate_topic(Params) ->
     Params.
 

--- a/changes/ce/fix-10801.en.md
+++ b/changes/ce/fix-10801.en.md
@@ -1,0 +1,1 @@
+Avoid duplicated percent decode the topic name in API `/topics/{topic}` and `/topics`.


### PR DESCRIPTION
* the minirest handler would do it

Fixes [EMQX-9825](https://emqx.atlassian.net/browse/EMQX-9825)

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c923f52</samp>

Fixed a topic filter bug in `emqx_mgmt_api_topics.erl` by removing percent decoding of the topic parameter. This improved the accuracy and consistency of the management API.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- [x] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
