### PR TITLE
feat(kafka): ensure allocated resources are removed on failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,4 +297,4 @@ fmt: $(REBAR)
 
 .PHONY: clean-test-cluster-config
 clean-test-cluster-config:
-	@rm apps/emqx_conf/data/configs/cluster.hocon || true
+	@rm -f apps/emqx_conf/data/configs/cluster.hocon || true

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ APPS=$(shell $(SCRIPTS)/find-apps.sh)
 
 .PHONY: $(APPS:%=%-ct)
 define gen-app-ct-target
-$1-ct: $(REBAR) merge-config
+$1-ct: $(REBAR) merge-config clean-test-cluster-config
 	$(eval SUITES := $(shell $(SCRIPTS)/find-suites.sh $1))
 ifneq ($(SUITES),)
 		@ENABLE_COVER_COMPILE=1 $(REBAR) ct -c -v \
@@ -127,7 +127,7 @@ endef
 $(foreach app,$(APPS),$(eval $(call gen-app-prop-target,$(app))))
 
 .PHONY: ct-suite
-ct-suite: $(REBAR) merge-config
+ct-suite: $(REBAR) merge-config clean-test-cluster-config
 ifneq ($(TESTCASE),)
 ifneq ($(GROUP),)
 	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE) --group $(GROUP)
@@ -294,3 +294,7 @@ fmt: $(REBAR)
 	@$(SCRIPTS)/erlfmt -w '{apps,lib-ee}/*/{src,include,test}/**/*.{erl,hrl,app.src}'
 	@$(SCRIPTS)/erlfmt -w 'rebar.config.erl'
 	@mix format
+
+.PHONY: clean-test-cluster-config
+clean-test-cluster-config:
+	@rm apps/emqx_conf/data/configs/cluster.hocon || true

--- a/apps/emqx/test/emqx_authentication_SUITE.erl
+++ b/apps/emqx/test/emqx_authentication_SUITE.erl
@@ -98,6 +98,8 @@ init_per_suite(Config) ->
     LogLevel = emqx_logger:get_primary_log_level(),
     ok = emqx_logger:set_log_level(debug),
     application:set_env(ekka, strict_mode, true),
+    emqx_config:erase_all(),
+    emqx_common_test_helpers:stop_apps([]),
     emqx_common_test_helpers:boot_modules(all),
     emqx_common_test_helpers:start_apps([]),
     [{log_level, LogLevel} | Config].

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, [emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -997,36 +997,33 @@ reconstruct_assignments_from_events(KafkaTopic, Events0, Acc0) ->
         Assignments
     ).
 
-setup_group_subscriber_spy(Node) ->
+setup_group_subscriber_spy_fn() ->
     TestPid = self(),
-    ok = erpc:call(
-        Node,
-        fun() ->
-            ok = meck:new(brod_group_subscriber_v2, [
-                passthrough, no_link, no_history, non_strict
-            ]),
-            ok = meck:expect(
-                brod_group_subscriber_v2,
-                assignments_received,
-                fun(Pid, MemberId, GenerationId, TopicAssignments) ->
-                    ?tp(
-                        kafka_assignment,
-                        #{
-                            node => node(),
-                            pid => Pid,
-                            member_id => MemberId,
-                            generation_id => GenerationId,
-                            topic_assignments => TopicAssignments
-                        }
-                    ),
-                    TestPid !
-                        {kafka_assignment, node(), {Pid, MemberId, GenerationId, TopicAssignments}},
-                    meck:passthrough([Pid, MemberId, GenerationId, TopicAssignments])
-                end
-            ),
-            ok
-        end
-    ).
+    fun() ->
+        ok = meck:new(brod_group_subscriber_v2, [
+            passthrough, no_link, no_history, non_strict
+        ]),
+        ok = meck:expect(
+            brod_group_subscriber_v2,
+            assignments_received,
+            fun(Pid, MemberId, GenerationId, TopicAssignments) ->
+                ?tp(
+                    kafka_assignment,
+                    #{
+                        node => node(),
+                        pid => Pid,
+                        member_id => MemberId,
+                        generation_id => GenerationId,
+                        topic_assignments => TopicAssignments
+                    }
+                ),
+                TestPid !
+                    {kafka_assignment, node(), {Pid, MemberId, GenerationId, TopicAssignments}},
+                meck:passthrough([Pid, MemberId, GenerationId, TopicAssignments])
+            end
+        ),
+        ok
+    end.
 
 wait_for_cluster_rpc(Node) ->
     %% need to wait until the config handler is ready after
@@ -1070,6 +1067,7 @@ cluster(Config) ->
             _ ->
                 ct_slave
         end,
+    ExtraEnvHandlerHook = setup_group_subscriber_spy_fn(),
     Cluster = emqx_common_test_helpers:emqx_cluster(
         [core, core],
         [
@@ -1083,6 +1081,7 @@ cluster(Config) ->
             {env_handler, fun
                 (emqx) ->
                     application:set_env(emqx, boot_modules, [broker, router]),
+                    ExtraEnvHandlerHook(),
                     ok;
                 (emqx_conf) ->
                     ok;
@@ -1701,7 +1700,6 @@ t_cluster_group(Config) ->
                     Nodes
                 )
             end),
-            lists:foreach(fun setup_group_subscriber_spy/1, Nodes),
             {ok, SRef0} = snabbkaffe:subscribe(
                 ?match_event(#{?snk_kind := kafka_consumer_subscriber_started}),
                 length(Nodes),
@@ -1778,7 +1776,6 @@ t_node_joins_existing_cluster(Config) ->
                 ct:pal("stopping ~p", [N1]),
                 ok = emqx_common_test_helpers:stop_slave(N1)
             end),
-            setup_group_subscriber_spy(N1),
             {{ok, _}, {ok, _}} =
                 ?wait_async_action(
                     erpc:call(N1, fun() ->
@@ -1822,7 +1819,6 @@ t_node_joins_existing_cluster(Config) ->
                 ct:pal("stopping ~p", [N2]),
                 ok = emqx_common_test_helpers:stop_slave(N2)
             end),
-            setup_group_subscriber_spy(N2),
             Nodes = [N1, N2],
             wait_for_cluster_rpc(N2),
 
@@ -1923,7 +1919,6 @@ t_cluster_node_down(Config) ->
                     Nodes
                 )
             end),
-            lists:foreach(fun setup_group_subscriber_spy/1, Nodes),
             {ok, SRef0} = snabbkaffe:subscribe(
                 ?match_event(#{?snk_kind := kafka_consumer_subscriber_started}),
                 length(Nodes),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -335,6 +335,7 @@ init_per_testcase(TestCase, Config) ->
 common_init_per_testcase(TestCase, Config0) ->
     ct:timetrap(timer:seconds(60)),
     delete_all_bridges(),
+    emqx_config:delete_override_conf_files(),
     KafkaTopic =
         <<
             (atom_to_binary(TestCase))/binary,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -446,6 +446,8 @@ t_failed_creation_then_fix(Config) ->
     ?assertMatch(#kafka_message{key = BinTime}, KafkaMsg),
     %% TODO: refactor those into init/end per testcase
     ok = ?PRODUCER:on_stop(ResourceId, State),
+    ?assertEqual([], supervisor:which_children(wolff_client_sup)),
+    ?assertEqual([], supervisor:which_children(wolff_producers_sup)),
     ok = emqx_bridge_resource:remove(BridgeId),
     delete_all_bridges(),
     ok.

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
@@ -285,6 +285,11 @@ create_bridge(Config, Overrides) ->
     PulsarConfig = emqx_utils_maps:deep_merge(PulsarConfig0, Overrides),
     emqx_bridge:create(Type, Name, PulsarConfig).
 
+delete_bridge(Config) ->
+    Type = ?BRIDGE_TYPE_BIN,
+    Name = ?config(pulsar_name, Config),
+    emqx_bridge:remove(Type, Name).
+
 create_bridge_api(Config) ->
     create_bridge_api(Config, _Overrides = #{}).
 
@@ -1008,6 +1013,8 @@ t_resource_manager_crash_after_producers_started(Config) ->
                         Producers =/= undefined,
                     10_000
                 ),
+            ?assertMatch({ok, _}, delete_bridge(Config)),
+            ?assertEqual([], get_pulsar_producers()),
             ok
         end,
         []
@@ -1039,6 +1046,8 @@ t_resource_manager_crash_before_producers_started(Config) ->
                     #{?snk_kind := pulsar_bridge_stopped, pulsar_producers := undefined},
                     10_000
                 ),
+            ?assertMatch({ok, _}, delete_bridge(Config)),
+            ?assertEqual([], get_pulsar_producers()),
             ok
         end,
         []

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -533,7 +533,7 @@ clean_allocated_resources(ResourceId, ResourceMod) ->
         true ->
             %% The resource entries in the ETS table are erased inside
             %% `call_stop' if the call is successful.
-            ok = emqx_resource:call_stop(ResourceId, ResourceMod, _ResourceState = undefined),
+            ok = call_stop(ResourceId, ResourceMod, _ResourceState = undefined),
             ok;
         false ->
             ok

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -192,14 +192,13 @@ remove(ResId) when is_binary(ResId) ->
 %% @doc Stops a running resource_manager and optionally clears the metrics for the resource
 -spec remove(resource_id(), boolean()) -> ok | {error, Reason :: term()}.
 remove(ResId, ClearMetrics) when is_binary(ResId) ->
-    ResourceManagerPid = gproc:whereis_name(?NAME(ResId)),
     try
         safe_call(ResId, {remove, ClearMetrics}, ?T_OPERATION)
     after
         %% Ensure the supervisor has it removed, otherwise the immediate re-add will see a stale process
         %% If the 'remove' call babove had succeeded, this is mostly a no-op but still needed to avoid race condition.
         %% Otherwise this is a 'infinity' shutdown, so it may take arbitrary long.
-        emqx_resource_manager_sup:delete_child(ResourceManagerPid)
+        emqx_resource_manager_sup:delete_child(ResId)
     end.
 
 %% @doc Stops and then starts an instance that was already running

--- a/changes/ee/feat-10778.en.md
+++ b/changes/ee/feat-10778.en.md
@@ -1,1 +1,1 @@
-Refactored Pulsar Producer bridge to avoid leaking resources during crashes.
+Refactored Pulsar Producer bridge to avoid leaking resources during crashes at creation.

--- a/changes/ee/feat-10813.en.md
+++ b/changes/ee/feat-10813.en.md
@@ -1,0 +1,1 @@
+Refactored Kafka Producer and Consumer bridges to avoid leaking resources during crashes at creation.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9936

This also introduces the following changes that were uncovered during development:
- Improved Kafka Consumer logging when the node is shutting down to reduce noise.
- We now ensure the bridge resources are removed if an exception happens during its creation to avoid leaking resources.
- We changed the `emqx_resource_manager_sup` restart strategy from `simple_one_for_one` to `one_for_one`.

  Using `simple_one_for_one` has a potential race condition issue where we read the PID of the resource manager before trying to remove a resource, and then that PID changes because it was either dead at first, or it crashed and changed, and later we use this stale PID to try to remove it from the supervisor.  Under such circumstances, the restarting child might linger in the supervisor, leaking resources.

  By using the resource ID itself as a child ID (and using `one_for_one` restart strategy), we ensure the child is truly removed.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1f74d26</samp>

This pull request adds resource management and telemetry for the kafka and pulsar bridges using the `emqx_resource` module. It also updates the version numbers, the change logs, and the test cases for the bridge applications. The changes aim to improve the reliability and observability of the bridges.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
