### PR TITLE
fix: reboot `emqx_license` app for join cluster

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -24,6 +24,7 @@
 -export([stop_port_apps/0]).
 
 -dialyzer({no_match, [basic_reboot_apps/0]}).
+-dialyzer({no_match, [basic_reboot_apps_edition/1]}).
 
 -ifdef(TEST).
 -export([sorted_reboot_apps/1, reboot_apps/0]).

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -126,39 +126,40 @@ reboot_apps() ->
     BaseRebootApps ++ ConfigApps.
 
 basic_reboot_apps() ->
-    CE =
-        ?BASIC_REBOOT_APPS ++
-            [
-                emqx_prometheus,
-                emqx_modules,
-                emqx_dashboard,
-                emqx_connector,
-                emqx_gateway,
-                emqx_resource,
-                emqx_rule_engine,
-                emqx_bridge,
-                emqx_plugin_libs,
-                emqx_management,
-                emqx_retainer,
-                emqx_exhook,
-                emqx_authn,
-                emqx_authz,
-                emqx_slow_subs,
-                emqx_auto_subscribe,
-                emqx_plugins
-            ],
-    case emqx_release:edition() of
-        ce ->
-            CE ++ [emqx_telemetry];
-        ee ->
-            CE ++
-                [
-                    emqx_s3,
-                    emqx_ft,
-                    emqx_eviction_agent,
-                    emqx_node_rebalance
-                ]
-    end.
+    ?BASIC_REBOOT_APPS ++
+        [
+            emqx_prometheus,
+            emqx_modules,
+            emqx_dashboard,
+            emqx_connector,
+            emqx_gateway,
+            emqx_resource,
+            emqx_rule_engine,
+            emqx_bridge,
+            emqx_plugin_libs,
+            emqx_management,
+            emqx_retainer,
+            emqx_exhook,
+            emqx_authn,
+            emqx_authz,
+            emqx_slow_subs,
+            emqx_auto_subscribe,
+            emqx_plugins
+        ] ++ basic_reboot_apps_edition(emqx_release:edition()).
+
+basic_reboot_apps_edition(ce) ->
+    [emqx_telemetry];
+basic_reboot_apps_edition(ee) ->
+    [
+        emqx_license,
+        emqx_s3,
+        emqx_ft,
+        emqx_eviction_agent,
+        emqx_node_rebalance
+    ];
+%% unexcepted edition, should not happen
+basic_reboot_apps_edition(_) ->
+    [].
 
 sorted_reboot_apps() ->
     Apps = [{App, app_deps(App)} || App <- reboot_apps()],

--- a/changes/ce/fix-10820.en.md
+++ b/changes/ce/fix-10820.en.md
@@ -1,0 +1,6 @@
+In case the cluster updated license before the new node join in. The new node will not apply the updated license.
+After this change, the new joined node will use the cluster's license key.
+
+Sometimes the new node must start with a outdated license.
+e.g. use emqx-operator deployed and needed to scale up after license expired.
+At the time the cluster's license key already updated by API/CLI, but the new node won't use it.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ace04e8</samp>

Refactor `basic_reboot_apps` function to use a helper function for enterprise applications and add `emqx_license` to the list. This fixes the license check issue after upgrading.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- [x] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] ~Change log has been added to `changes/` dir for user-facing artifacts update~
