### PR TITLE
test(buffer_worker): add assertion for inflight count after batch expiration

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1256,6 +1256,13 @@ handle_async_batch_reply2([Inflight], ReplyContext, Result, Now) ->
             %% some queries are not expired, put them back to the inflight batch
             %% so it can be either acked now or retried later
             ok = update_inflight_item(InflightTID, Ref, RealNotExpired, NumExpired),
+            ?tp_ignore_side_effects_in_prod(
+                handle_async_reply_partially_expired,
+                #{
+                    inflight_count => inflight_count(InflightTID),
+                    num_inflight_messages => inflight_num_msgs(InflightTID)
+                }
+            ),
             do_handle_async_batch_reply(ReplyContext#{min_batch := RealNotExpired}, Result)
     end.
 

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -2248,6 +2248,15 @@ do_t_expiration_async_after_reply(IsBatch) ->
                             }
                         ],
                         ?of_kind(handle_async_reply_expired, Trace)
+                    ),
+                    ?assertMatch(
+                        [
+                            #{
+                                inflight_count := 1,
+                                num_inflight_messages := 1
+                            }
+                        ],
+                        ?of_kind(handle_async_reply_partially_expired, Trace)
                     );
                 single ->
                     ?assertMatch(


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9829

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at db60dcb</samp>

Add a trace point and a test case for resource buffer worker handling partially expired async replies. This is to improve the performance and reliability of the resource buffer feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
