### PR TITLE
ci: fix conf tests group concurrency key

### DIFF
--- a/.github/workflows/run_conf_tests.yaml
+++ b/.github/workflows/run_conf_tests.yaml
@@ -1,7 +1,7 @@
 name: Run Configuration tests
 
 concurrency:
-  group: test-${{ github.event_name }}-${{ github.ref }}
+  group: conftest-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
`run_test_cases.yaml` and `run_conf_tests.yaml` seem to be cancelling each other.

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
