### PR TITLE
fix: zones api default value

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.6"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.7"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -129,7 +129,7 @@ init(Opts = #{max_len := MaxLen0, store_qos0 := Qos0}) ->
     #mqueue{
         max_len = MaxLen,
         store_qos0 = Qos0,
-        p_table = get_opt(priorities, Opts, ?NO_PRIORITY_TABLE),
+        p_table = p_table(get_opt(priorities, Opts, ?NO_PRIORITY_TABLE)),
         default_p = get_priority_opt(Opts),
         shift_opts = get_shift_opt(Opts)
     }.
@@ -295,3 +295,18 @@ get_shift_opt(Opts) ->
         multiplier = Mult,
         base = Base
     }.
+
+%% topic from mqtt.mqueue_priorities(map()) is atom.
+p_table(PTab = #{}) ->
+    maps:fold(
+        fun
+            (Topic, Priority, Acc) when is_atom(Topic) ->
+                maps:put(atom_to_binary(Topic), Priority, Acc);
+            (Topic, Priority, Acc) when is_binary(Topic) ->
+                maps:put(Topic, Priority, Acc)
+        end,
+        #{},
+        PTab
+    );
+p_table(PTab) ->
+    PTab.

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -609,7 +609,7 @@ fields("mqtt") ->
             )},
         {"mqueue_priorities",
             sc(
-                hoconsc:union([map(), disabled]),
+                hoconsc:union([disabled, map()]),
                 #{
                     default => disabled,
                     desc => ?DESC(mqtt_mqueue_priorities)
@@ -657,7 +657,7 @@ fields("mqtt") ->
             )}
     ];
 fields("zone") ->
-    emqx_zone_schema:zone();
+    emqx_zone_schema:zones_without_default();
 fields("flapping_detect") ->
     [
         {"enable",

--- a/apps/emqx/src/emqx_zone_schema.erl
+++ b/apps/emqx/src/emqx_zone_schema.erl
@@ -18,7 +18,8 @@
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 
--export([namespace/0, roots/0, fields/1, desc/1, zone/0, zone_without_hidden/0]).
+-export([namespace/0, roots/0, fields/1, desc/1]).
+-export([zones_without_default/0, global_zone_with_default/0]).
 
 namespace() -> zone.
 
@@ -35,7 +36,7 @@ roots() ->
         "overload_protection"
     ].
 
-zone() ->
+zones_without_default() ->
     Fields = roots(),
     Hidden = hidden(),
     lists:map(
@@ -50,8 +51,8 @@ zone() ->
         Fields
     ).
 
-zone_without_hidden() ->
-    lists:map(fun(F) -> {F, ?HOCON(?R_REF(F), #{})} end, roots() -- hidden()).
+global_zone_with_default() ->
+    lists:map(fun(F) -> {F, ?HOCON(?R_REF(emqx_schema, F), #{})} end, roots() -- hidden()).
 
 hidden() ->
     [
@@ -69,9 +70,10 @@ fields(Name) ->
 desc(Name) ->
     emqx_schema:desc(Name).
 
-%% no default values for zone settings
+%% no default values for zone settings, don't required either.
 no_default(Sc) ->
     fun
         (default) -> undefined;
+        (required) -> false;
         (Other) -> hocon_schema:field_schema(Sc, Other)
     end.

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -132,7 +132,7 @@ schema("/configs/global_zone") ->
         },
         put => #{
             tags => ?TAGS,
-            description => ?DESC(update_globar_zone_configs),
+            description => ?DESC(update_global_zone_configs),
             'requestBody' => Schema,
             responses => #{
                 200 => Schema,
@@ -146,7 +146,7 @@ schema("/configs/limiter") ->
         'operationId' => limiter,
         get => #{
             tags => ?TAGS,
-            description => ?DESC(get_node_level_limiter_congigs),
+            description => ?DESC(get_node_level_limiter_configs),
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(emqx_limiter_schema, limiter)),
                 404 => emqx_dashboard_swagger:error_codes(['NOT_FOUND'], <<"config not found">>)
@@ -154,7 +154,7 @@ schema("/configs/limiter") ->
         },
         put => #{
             tags => ?TAGS,
-            description => ?DESC(update_node_level_limiter_congigs),
+            description => ?DESC(update_node_level_limiter_configs),
             'requestBody' => hoconsc:mk(hoconsc:ref(emqx_limiter_schema, limiter)),
             responses => #{
                 200 => hoconsc:mk(hoconsc:ref(emqx_limiter_schema, limiter)),
@@ -356,4 +356,4 @@ global_zone_roots() ->
     lists:map(fun({K, _}) -> list_to_binary(K) end, global_zone_schema()).
 
 global_zone_schema() ->
-    emqx_zone_schema:zone_without_hidden().
+    emqx_zone_schema:global_zone_with_default().

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -133,15 +133,24 @@ t_log(_Config) ->
 t_global_zone(_Config) ->
     {ok, Zones} = get_global_zone(),
     ZonesKeys = lists:map(
-        fun({K, _}) -> list_to_binary(K) end, emqx_zone_schema:zone_without_hidden()
+        fun({K, _}) -> list_to_binary(K) end, emqx_zone_schema:global_zone_with_default()
     ),
     ?assertEqual(lists:usort(ZonesKeys), lists:usort(maps:keys(Zones))),
     ?assertEqual(
         emqx_config:get_zone_conf(no_default, [mqtt, max_qos_allowed]),
         emqx_utils_maps:deep_get([<<"mqtt">>, <<"max_qos_allowed">>], Zones)
     ),
-    NewZones = emqx_utils_maps:deep_put([<<"mqtt">>, <<"max_qos_allowed">>], Zones, 1),
-    {ok, #{}} = update_global_zone(NewZones),
+    NewZones1 = emqx_utils_maps:deep_put([<<"mqtt">>, <<"max_qos_allowed">>], Zones, 1),
+    NewZones2 = emqx_utils_maps:deep_remove([<<"mqtt">>, <<"peer_cert_as_clientid">>], NewZones1),
+    {ok, #{<<"mqtt">> := Res}} = update_global_zone(NewZones2),
+    %% Make sure peer_cert_as_clientid is not removed(fill default)
+    ?assertMatch(
+        #{
+            <<"max_qos_allowed">> := 1,
+            <<"peer_cert_as_clientid">> := <<"disabled">>
+        },
+        Res
+    ),
     ?assertEqual(1, emqx_config:get_zone_conf(no_default, [mqtt, max_qos_allowed])),
     %% Make sure the override config is updated, and remove the default value.
     ?assertMatch(#{<<"max_qos_allowed">> := 1}, read_conf(<<"mqtt">>)),
@@ -184,9 +193,11 @@ update_global_zone(Change) ->
 t_zones(_Config) ->
     {ok, Zones} = get_config("zones"),
     {ok, #{<<"mqtt">> := OldMqtt} = Zone1} = get_global_zone(),
-    {ok, #{}} = update_config("zones", Zones#{<<"new_zone">> => Zone1}),
+    Mqtt1 = maps:remove(<<"max_subscriptions">>, OldMqtt),
+    {ok, #{}} = update_config("zones", Zones#{<<"new_zone">> => Zone1#{<<"mqtt">> => Mqtt1}}),
     NewMqtt = emqx_config:get_raw([zones, new_zone, mqtt]),
-    ?assertEqual(OldMqtt, NewMqtt),
+    %% we remove max_subscription from global zone, so the new zone should not have it.
+    ?assertEqual(Mqtt1, NewMqtt),
     %% delete the new zones
     {ok, #{}} = update_config("zones", Zones),
     ?assertEqual(undefined, emqx_config:get_raw([new_zone, mqtt], undefined)),

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.8", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.39.6", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.39.7", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.2", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -75,7 +75,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.8"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.6"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.7"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}

--- a/rel/i18n/emqx_mgmt_api_configs.hocon
+++ b/rel/i18n/emqx_mgmt_api_configs.hocon
@@ -22,19 +22,19 @@ get_global_zone_configs.desc:
 get_global_zone_configs.label:
 """Get the global zone configs"""
 
-update_globar_zone_configs.desc:
-"""Update globbal zone configs"""
-update_globar_zone_configs.label:
-"""Update globbal zone configs"""
+update_global_zone_configs.desc:
+"""Update global zone configs"""
+update_global_zone_configs.label:
+"""Update global zone configs"""
 
-get_node_level_limiter_congigs.desc:
+get_node_level_limiter_configs.desc:
 """Get the node-level limiter configs"""
-get_node_level_limiter_congigs.label:
+get_node_level_limiter_configs.label:
 """Get the node-level limiter configs"""
 
-update_node_level_limiter_congigs.desc:
+update_node_level_limiter_configs.desc:
 """Update the node-level limiter configs"""
-update_node_level_limiter_congigs.label:
+update_node_level_limiter_configs.label:
 """Update the node-level limiter configs"""
 
 }


### PR DESCRIPTION
Fixes [EMQX-9999](https://emqx.atlassian.net/browse/EMQX-9999)
1. Fixes `mqtt.mqueue_priorities = {"test/topic": 1}` not working.
2. Fixes saving `mqtt.mqueue_priorities = {"测试/topic": 1}` crash from http api.
3. Fixes put `/global_zone` should have no default. 
4. Fixes put `configs/zones` should have default.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b6da3f</samp>

This pull request fixes some typos and bugs in the configuration API and schema modules, and updates the hocon dependency to the latest version. It also refactors the emqx_zone_schema module to simplify the zone definitions and avoid unnecessary defaults. It adds a function to convert topics to binary in the mqueue priority table to prevent atom exhaustion.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
