### PR TITLE
fix: only report enable authn/authz in telemetry

### DIFF
--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -106,7 +106,7 @@ get_enabled_authns() ->
     AuthnTypes = lists:usort([
         Type
      || #{authenticators := As} <- Chains,
-        #{id := Type} <- As
+        #{id := Type, enable := true} <- As
     ]),
     OverriddenListeners =
         lists:foldl(

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -417,7 +417,7 @@ do_authorize(
     end.
 
 get_enabled_authzs() ->
-    lists:usort([Type || #{type := Type} <- lookup()]).
+    lists:usort([Type || #{type := Type, enable := true} <- lookup()]).
 
 %%--------------------------------------------------------------------
 %% Internal function

--- a/apps/emqx_authz/test/emqx_authz_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_SUITE.erl
@@ -366,7 +366,7 @@ t_get_enabled_authzs_none_enabled(_Config) ->
     ?assertEqual([], emqx_authz:get_enabled_authzs()).
 
 t_get_enabled_authzs_some_enabled(_Config) ->
-    {ok, _} = emqx_authz:update(?CMD_REPLACE, [?SOURCE4]),
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [?SOURCE4, ?SOURCE5#{<<"enable">> := false}]),
     ?assertEqual([postgresql], emqx_authz:get_enabled_authzs()).
 
 t_subscribe_deny_disconnect_publishes_last_will_testament(_Config) ->

--- a/changes/ce/fix-10833.en.md
+++ b/changes/ce/fix-10833.en.md
@@ -1,0 +1,1 @@
+Only include enabled authenticators and authorizers in telemetry report, not all of them.


### PR DESCRIPTION
Fixes [EMQX-10002](https://emqx.atlassian.net/browse/EMQX-10002)

Telemtry report only enabled authenticators and authorizers.

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae42309</samp>

This pull request fixes a bug that caused disabled authenticators and authorization sources to be applied to the listeners and topics, respectively. It adds conditions to filter out the disabled ones when getting the enabled types, and updates a test case to reflect the change.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
