### PR TITLE
ci: delete otp 24 from emqx app standalone job matrix

### DIFF
--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -14,7 +14,6 @@ jobs:
         builder:
           - 5.0-35
         otp:
-          - 24.3.4.2-3
           - 25.1.2-3
         # no need to use more than 1 version of Elixir, since tests
         # run using only Erlang code.  This is needed just to specify


### PR DESCRIPTION
I find the otp 24 build is quite flaky and otp 25 build is stable.
since we are going to leave otp 24 soon, let's just delete this check now.