### PR TITLE
ci: add elixir support to `dev` / `make quickrun` scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,10 @@ compile: $(PROFILES:%=compile-%)
 $(PROFILES:%=compile-%):
 	@$(BUILD) $(@:compile-%=%) apps
 
+.PHONY: $(PROFILES:%=compile-%-elixir)
+$(PROFILES:%=compile-%-elixir):
+	@env IS_ELIXIR=yes $(BUILD) $(@:compile-%-elixir=%) apps
+
 ## Not calling rebar3 clean because
 ## 1. rebar3 clean relies on rebar3, meaning it reads config, fetches dependencies etc.
 ## 2. it's slow

--- a/build
+++ b/build
@@ -145,6 +145,16 @@ just_compile() {
     make_docs
 }
 
+just_compile_elixir() {
+    ./scripts/pre-compile.sh "$PROFILE"
+    rm -f rebar.lock
+    # shellcheck disable=SC1010
+    env MIX_ENV="$PROFILE" mix do local.hex --if-missing --force, \
+        local.rebar rebar3 "${PWD}/rebar3" --if-missing --force, \
+        deps.get
+    env MIX_ENV="$PROFILE" mix compile
+}
+
 make_rel() {
     local release_or_tar="${1}"
     just_compile
@@ -395,7 +405,11 @@ log "building artifact=$ARTIFACT for profile=$PROFILE"
 
 case "$ARTIFACT" in
     apps)
-        just_compile
+        if [ "${IS_ELIXIR:-}" = "yes" ]; then
+            just_compile_elixir
+        else
+            just_compile
+        fi
         ;;
     doc|docs)
         make_docs

--- a/dev
+++ b/dev
@@ -2,6 +2,10 @@
 
 set -euo pipefail
 
+if [ -n "${DEBUG:-}" ]; then
+  set -x
+fi
+
 UNAME="$(uname -s)"
 
 PROJ_ROOT="$(git rev-parse --show-toplevel)"
@@ -123,6 +127,14 @@ case "${PROFILE}" in
     ee|emqx-enterprise)
         PROFILE='emqx-enterprise'
         ;;
+    ce-ex|emqx-elixir)
+        export IS_ELIXIR=yes
+        PROFILE='emqx'
+        ;;
+    ee-ex|emqx-enterprise-elixir)
+        export IS_ELIXIR=yes
+        PROFILE='emqx-enterprise'
+        ;;
     *)
         echo "Unknown profile $PROFILE"
         exit 1
@@ -131,10 +143,10 @@ esac
 export PROFILE
 
 case "${PROFILE}" in
-    emqx)
+    emqx|emqx-elixir)
         export SCHEMA_MOD='emqx_conf_schema'
         ;;
-    emqx-enterprise)
+    emqx-enterprise|emqx-enterprise-elixir)
         export SCHEMA_MOD='emqx_enterprise_schema'
         ;;
 esac
@@ -177,6 +189,17 @@ prepare_erl_libs() {
             erl_libs="${app}"
         fi
     done
+    if [ "${IS_ELIXIR:-}" = "yes" ]; then
+        local elixir_libs_root_dir
+        elixir_libs_root_dir=$(realpath "$(elixir -e ':code.lib_dir(:elixir) |> IO.puts()')"/..)
+        for app in "${elixir_libs_root_dir}"/*; do
+            if [ -n "$erl_libs" ]; then
+                erl_libs="${erl_libs}${sep}${app}"
+            else
+                erl_libs="${app}"
+            fi
+        done
+    fi
     export ERL_LIBS="$erl_libs"
 }
 
@@ -342,21 +365,45 @@ boot() {
     append_args_file
     APPS="$(apps_to_load)"
 
-    BOOT_SEQUENCE="
-        Apps=[${APPS}],
-        ok=lists:foreach(fun application:load/1, Apps),
-        io:format(user, \"~nLoaded: ~p~n\", [Apps]),
-        {ok, _} = application:ensure_all_started(emqx_machine).
-    "
+    if [ "${IS_ELIXIR:-}" = "yes" ]; then
+        BOOT_SEQUENCE='
+          apps = System.get_env("APPS") |> String.split(",") |> Enum.map(&String.to_atom/1)
+          Enum.each(apps, &Application.load/1)
+          IO.inspect(apps, label: :loaded, limit: :infinity)
+          {:ok, _} = Application.ensure_all_started(:emqx_machine)
+        '
+        if [ -n "${EPMD_ARGS:-}" ]; then
+            EPMD_ARGS_ELIXIR="--erl $EPMD_ARGS"
+        else
+            EPMD_ARGS_ELIXIR=""
+        fi
 
-    # shellcheck disable=SC2086
-    erl -name "$EMQX_NODE_NAME" \
-        $EPMD_ARGS \
-        -proto_dist ekka \
-        -args_file "$ARGS_FILE" \
-        -config "$CONF_FILE" \
-        -s emqx_restricted_shell set_prompt_func \
-        -eval "$BOOT_SEQUENCE"
+        # shellcheck disable=SC2086
+        env APPS="$APPS" iex \
+          --name "$EMQX_NODE_NAME" \
+          $EPMD_ARGS_ELIXIR \
+          --erl '-user Elixir.IEx.CLI' \
+          --erl '-proto_dist ekka' \
+          --vm-args "$ARGS_FILE" \
+          --erl-config "$CONF_FILE" \
+          -e "$BOOT_SEQUENCE"
+    else
+        BOOT_SEQUENCE="
+            Apps=[${APPS}],
+            ok=lists:foreach(fun application:load/1, Apps),
+            io:format(user, \"~nLoaded: ~p~n\", [Apps]),
+            {ok, _} = application:ensure_all_started(emqx_machine).
+        "
+
+        # shellcheck disable=SC2086
+        erl -name "$EMQX_NODE_NAME" \
+            $EPMD_ARGS \
+            -proto_dist ekka \
+            -args_file "$ARGS_FILE" \
+            -config "$CONF_FILE" \
+            -s emqx_restricted_shell set_prompt_func \
+            -eval "$BOOT_SEQUENCE"
+    fi
 }
 
 # Generate a random id


### PR DESCRIPTION
```sh
ͳ ./dev -p emqx-enterprise-elixir
Running from code in _build/emqx-enterprise/lib
EMQX_LOG__CONSOLE__ENABLE [log.console.enable]: true
Erlang/OTP 25 [erts-13.1.2] [emqx] [64-bit] [smp:24:24] [ds:24:24:8] [async-threads:4] [jit:ns]

loaded: [:emqx_slow_subs, :emqx_bridge_timescale, :emqx_gateway, :emqx_bridge_opents,
 :emqx_bridge_influxdb, :emqx_plugins, :emqx_ctl, :emqx_s3,
 :emqx_bridge_rabbitmq, :emqx_bridge_pulsar, :emqx_exhook,
 :emqx_bridge_clickhouse, :emqx_auto_subscribe, :emqx_oracle,
 :emqx_gateway_stomp, :emqx_bridge_pgsql, :emqx_bridge_dynamo,
 :emqx_gateway_coap, :emqx_gateway_mqttsn, :emqx_enterprise, :emqx_management,
 :emqx_rule_engine, :emqx_bridge_hstreamdb, :emqx_node_rebalance, :emqx_machine,
 :emqx_bridge_sqlserver, :emqx_gateway_exproto, :emqx_connector, :emqx_bridge,
 :emqx_conf, :emqx_gateway_lwm2m, :emqx_prometheus, :emqx_bridge_oracle,
 :emqx_bridge_rocketmq, :emqx_modules, :emqx_eviction_agent, :emqx_bridge_iotdb,
 :emqx, :emqx_psk, :emqx_retainer, :emqx_ft, :emqx_bridge_gcp_pubsub,
 :emqx_authn, :emqx_plugin_libs, :emqx_bridge_mysql, :emqx_bridge_redis,
 :emqx_dashboard, :emqx_bridge_matrix, :emqx_authz, :emqx_bridge_kafka,
 :emqx_bridge_cassandra, :emqx_bridge_tdengine, :emqx_utils,
 :emqx_bridge_mongodb, :emqx_resource, :emqx_ee_connector, :emqx_ee_bridge,
 :emqx_license, :emqx_ee_schema_registry]
Listener ssl:default on 0.0.0.0:8883 started.
Listener tcp:default on 0.0.0.0:1883 started.
Listener ws:default on 0.0.0.0:8083 started.
Listener wss:default on 0.0.0.0:8084 started.
Listener http:dashboard on :18083 started.

========================================================================
Using an evaluation license limited to 100 concurrent connections.
Apply for a license at https://emqx.com/apply-licenses/emqx.
Or contact EMQ customer services.
========================================================================
EMQX Enterprise 5.0.4-alpha.2-gfe81e952 is running now!
Interactive Elixir (1.13.4) - press Ctrl+C to exit (type h() ENTER for help)
iex(emqx@127.0.0.1)1> 
```

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
