### PR TITLE
test(ft): ensure no division by zero in coverage proptest

### DIFF
--- a/apps/emqx_ft/test/props/prop_emqx_ft_assembly.erl
+++ b/apps/emqx_ft/test/props/prop_emqx_ft_assembly.erl
@@ -58,7 +58,7 @@ prop_coverage_likely_incomplete() ->
         {filesize_t(), segsizes_t(), filesize_t()},
         ?FORALL(
             Fragments,
-            noshrink(segments_t(Filesize, Segsizes, Hole)),
+            noshrink(segments_t(Filesize, Segsizes, (Hole rem max(Filesize, 1)))),
             ?TIMEOUT(
                 ?COVERAGE_TIMEOUT,
                 begin
@@ -174,7 +174,7 @@ segment_t(Filesize, Segsizes, Hole) ->
     ?SUCHTHATMAYBE(
         {Offset, Size},
         segment_t(Filesize, Segsizes),
-        (Hole rem Filesize) =< Offset orelse (Hole rem Filesize) > (Offset + Size)
+        Hole =< Offset orelse Hole > (Offset + Size)
     ).
 
 segment_t(Filesize, Segsizes) ->


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98ce7e8</samp>

Improve property-based testing of `emqx_ft_assembly` by fixing offset bug and simplifying overlap check.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
