### PR TITLE
fix: redact api request to hide auth token

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_bad_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_bad_api.erl
@@ -21,11 +21,12 @@
 -export([init/2]).
 
 init(Req0, State) ->
-    ?SLOG(warning, #{msg => "unexpected_api_access", request => Req0}),
+    RedactedReq = emqx_utils:redact(Req0),
+    ?SLOG(warning, #{msg => "unexpected_api_access", request => RedactedReq}),
     Req = cowboy_req:reply(
         404,
         #{<<"content-type">> => <<"application/json">>},
         <<"{\"code\": \"API_NOT_EXIST\", \"message\": \"Request Path Not Found\"}">>,
-        Req0
+        RedactedReq
     ),
     {ok, Req, State}.

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.0.1"},
+    {vsn, "5.0.2"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -575,6 +575,9 @@ try_to_existing_atom(Convert, Data, Encoding) ->
 is_sensitive_key(token) -> true;
 is_sensitive_key("token") -> true;
 is_sensitive_key(<<"token">>) -> true;
+is_sensitive_key(authorization) -> true;
+is_sensitive_key("authorization") -> true;
+is_sensitive_key(<<"authorization">>) -> true;
 is_sensitive_key(password) -> true;
 is_sensitive_key("password") -> true;
 is_sensitive_key(<<"password">>) -> true;

--- a/changes/ce/fix-10851.en.md
+++ b/changes/ce/fix-10851.en.md
@@ -1,0 +1,1 @@
+Obfuscated sensitive data in the bad API logging.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dcfe985</samp>

Fix the issue of exposing sensitive data in the log when accessing a non-existent API endpoint. Add a new function `emqx_utils:redact/1` to obfuscate sensitive data and use it in `emqx_dashboard_bad_api:init/1`. Bump the version of `emqx_utils` and update the change log.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
