### PR TITLE
feat: add timezone_to_second/1 function to rule engine

### DIFF
--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.2.4"},
+    {vsn, "0.2.5"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -228,7 +228,9 @@
     format_date/3,
     format_date/4,
     date_to_unix_ts/3,
-    date_to_unix_ts/4
+    date_to_unix_ts/4,
+    timezone_to_second/1,
+    timezone_to_offset_seconds/1
 ]).
 
 %% MongoDB specific date functions. These functions return a date tuple. The
@@ -1103,6 +1105,12 @@ date_to_unix_ts(TimeUnit, Offset, FormatString, InputString) ->
     OffsetSecond = emqx_calendar:offset_second(Offset),
     OffsetDelta = erlang:convert_time_unit(OffsetSecond, second, Unit),
     date_to_unix_ts(Unit, FormatString, InputString) - OffsetDelta.
+
+timezone_to_second(TimeZone) ->
+    timezone_to_offset_seconds(TimeZone).
+
+timezone_to_offset_seconds(TimeZone) ->
+    emqx_calendar:offset_second(TimeZone).
 
 %% @doc This is for sql funcs that should be handled in the specific modules.
 %% Here the emqx_rule_funcs module acts as a proxy, forwarding

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1012,6 +1012,25 @@ prop_format_date_fun() ->
     Args3DTUS = [<<"second">>, <<"+04:00">>, <<"--%m--%d--%Y---%H:%M:%S">>, Formatters3],
     Second == apply_func(date_to_unix_ts, Args3DTUS).
 
+t_timezone_to_offset_seconds(_) ->
+    t_timezone_to_offset_seconds_helper(timezone_to_offset_seconds),
+    %% The timezone_to_second function is kept for compatibility with 4.X.
+    t_timezone_to_offset_seconds_helper(timezone_to_second).
+
+t_timezone_to_offset_seconds_helper(FunctionName) ->
+    ?assertEqual(120 * 60, apply_func(FunctionName, [<<"+02:00:00">>])),
+    ?assertEqual(-120 * 60, apply_func(FunctionName, [<<"-02:00:00">>])),
+    ?assertEqual(102, apply_func(FunctionName, [<<"+00:01:42">>])),
+    ?assertEqual(0, apply_func(FunctionName, [<<"z">>])),
+    ?assertEqual(0, apply_func(FunctionName, [<<"Z">>])),
+    ?assertEqual(42, apply_func(FunctionName, [42])),
+    ?assertEqual(0, apply_func(FunctionName, [undefined])),
+    %% Check that the following does not crash
+    apply_func(FunctionName, [<<"local">>]),
+    apply_func(FunctionName, ["local"]),
+    apply_func(FunctionName, [local]),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Utility functions
 %%------------------------------------------------------------------------------

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1013,11 +1013,11 @@ prop_format_date_fun() ->
     Second == apply_func(date_to_unix_ts, Args3DTUS).
 
 t_timezone_to_offset_seconds(_) ->
-    t_timezone_to_offset_seconds_helper(timezone_to_offset_seconds),
+    timezone_to_offset_seconds_helper(timezone_to_offset_seconds),
     %% The timezone_to_second function is kept for compatibility with 4.X.
-    t_timezone_to_offset_seconds_helper(timezone_to_second).
+    timezone_to_offset_seconds_helper(timezone_to_second).
 
-t_timezone_to_offset_seconds_helper(FunctionName) ->
+timezone_to_offset_seconds_helper(FunctionName) ->
     ?assertEqual(120 * 60, apply_func(FunctionName, [<<"+02:00:00">>])),
     ?assertEqual(-120 * 60, apply_func(FunctionName, [<<"-02:00:00">>])),
     ?assertEqual(102, apply_func(FunctionName, [<<"+00:01:42">>])),

--- a/changes/ce/feat-10858.en.md
+++ b/changes/ce/feat-10858.en.md
@@ -1,0 +1,1 @@
+A new utility function timezone_to_offset_seconds/1 has been added to the rule engine SQL language. This function converts a timezone string (for example, "+02:00", "Z" and "local") to the corresponding offset in seconds.


### PR DESCRIPTION
This commit adds the functions `timezone_to_offset_seconds` and its alias `timezone_to_second` to the rule engine. As the names suggests, these functions convert a timzone offset string such as "+02:00", "Z", "local" to an integer representing how many seconds that the given timezone differs from UTC. `timezone_to_offset_seconds` is the one of the two functions that should be advertised while `timezone_to_second` in kept for backwards compatibility with 4.X.

Fixes:
https://emqx.atlassian.net/browse/EMQX-10058

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 995025b</samp>

Added timezone conversion functions and tests to `emqx_rule_funcs` and updated `emqx_machine` version.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible