### PR TITLE
fix(coap): to better handle coap requests in connection mode

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.1.18"},
+    {vsn, "0.1.19"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
     {applications, [kernel, stdlib, emqx, emqx_authn, emqx_ctl]},

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -33,6 +33,7 @@
 -export([
     open_session/5,
     open_session/6,
+    discard_session/2,
     kick_session/2,
     kick_session/3,
     takeover_session/2,

--- a/apps/emqx_gateway_coap/src/emqx_gateway_coap.app.src
+++ b/apps/emqx_gateway_coap/src/emqx_gateway_coap.app.src
@@ -1,6 +1,6 @@
 {application, emqx_gateway_coap, [
     {description, "CoAP Gateway"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/changes/ce/fix-10871.en.md
+++ b/changes/ce/fix-10871.en.md
@@ -1,0 +1,2 @@
+Fixes for connection deletion and message publishing requests not taking effect
+issues once the connection has been created in a different UDP port first.


### PR DESCRIPTION
Fixes for connection deletion and message publishing requests not taking effect issues once the connection has been created in a different UDP port first.

Fixes https://emqx.atlassian.net/browse/EMQX-9803

<!-- Make sure to target release-50 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38ac427</samp>

This pull request adds connection mode support for the CoAP gateway, which enables persistent and secure connections for clients using tokens. It also updates the version numbers of the `emqx_gateway_coap` and `emqx_gateway` applications, and exports a new function in the `emqx_gateway_cm` module to discard sessions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
