### PR TITLE
fix: password log leak in RabbitMQ bridge

### DIFF
--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_rabbitmq, [
     {description, "EMQX Enterprise RabbitMQ Bridge"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [kernel, stdlib, ecql, rabbit_common, amqp_client]},
     {env, []},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.18"},
+    {vsn, "5.0.19"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl]},

--- a/changes/ee/fix-10878.en.md
+++ b/changes/ee/fix-10878.en.md
@@ -1,0 +1,1 @@
+A vulnerability in the RabbitMQ bridge, which could potentially expose passwords to log files, has been rectified


### PR DESCRIPTION
This fixes a vulnerability in the RabbitMQ bridge, which could potentially expose passwords to log files. This was accomplished by initializing the encryption library specifically designed for RabbitMQ's passwords. Consequently, passwords are no longer stored in unencrypted format. As a result, they will no longer be visible as plain text in log messages, thereby enhancing the system's security.

Fixes:
https://emqx.atlassian.net/browse/EMQX-9976

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 070bc99</samp>

This pull request adds encryption for the RabbitMQ password using the `credentials_obfuscation` library, supports file transfer over MQTT using the `emqx_ft` protocol, and updates the version numbers of the `emqx`, `emqx_bridge_rabbitmq`, and `emqx_ft` applications.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible