### PR TITLE
feat: support kickout clients in batch

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -27,6 +27,7 @@
 {emqx_management,1}.
 {emqx_management,2}.
 {emqx_management,3}.
+{emqx_management,4}.
 {emqx_mgmt_api_plugins,1}.
 {emqx_mgmt_cluster,1}.
 {emqx_mgmt_trace,1}.

--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.0.23"},
+    {vsn, "5.0.24"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [kernel, stdlib, emqx_plugins, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -326,7 +326,7 @@ kickout_client(Node, ClientId) ->
 
 kickout_clients(ClientIds) when is_list(ClientIds) ->
     F = fun(Node) ->
-        emqx_management_proto_v3:kickout_clients(Node, ClientIds)
+        emqx_management_proto_v4:kickout_clients(Node, ClientIds)
     end,
     Results = lists:map(F, emqx:running_nodes()),
     case lists:filter(fun(Res) -> Res =/= ok end, Results) of

--- a/apps/emqx_management/src/proto/emqx_management_proto_v3.erl
+++ b/apps/emqx_management/src/proto/emqx_management_proto_v3.erl
@@ -32,7 +32,9 @@
 
     call_client/3,
 
-    get_full_config/1
+    get_full_config/1,
+
+    kickout_clients/2
 ]).
 
 -include_lib("emqx/include/bpapi.hrl").
@@ -78,3 +80,7 @@ call_client(Node, ClientId, Req) ->
 -spec get_full_config(node()) -> map() | list() | {badrpc, _}.
 get_full_config(Node) ->
     rpc:call(Node, emqx_mgmt_api_configs, get_full_config, []).
+
+-spec kickout_clients(node(), [emqx_types:clientid()]) -> ok | {badrpc, _}.
+kickout_clients(Node, ClientIds) ->
+    rpc:call(Node, emqx_mgmt, do_kickout_clients, [ClientIds]).

--- a/apps/emqx_management/src/proto/emqx_management_proto_v4.erl
+++ b/apps/emqx_management/src/proto/emqx_management_proto_v4.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_management_proto_v3).
+-module(emqx_management_proto_v4).
 
 -behaviour(emqx_bpapi).
 
@@ -32,13 +32,15 @@
 
     call_client/3,
 
-    get_full_config/1
+    get_full_config/1,
+
+    kickout_clients/2
 ]).
 
 -include_lib("emqx/include/bpapi.hrl").
 
 introduced_in() ->
-    "5.0.9".
+    "5.1.0".
 
 -spec unsubscribe_batch(node(), emqx_types:clientid(), [emqx_types:topic()]) ->
     {unsubscribe, _} | {error, _} | {badrpc, _}.
@@ -78,3 +80,7 @@ call_client(Node, ClientId, Req) ->
 -spec get_full_config(node()) -> map() | list() | {badrpc, _}.
 get_full_config(Node) ->
     rpc:call(Node, emqx_mgmt_api_configs, get_full_config, []).
+
+-spec kickout_clients(node(), [emqx_types:clientid()]) -> ok | {badrpc, _}.
+kickout_clients(Node, ClientIds) ->
+    rpc:call(Node, emqx_mgmt, do_kickout_clients, [ClientIds]).

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -202,7 +202,7 @@ t_kickout_clients(_) ->
     %% kickout clients
     KickoutPath = emqx_mgmt_api_test_util:api_path(["clients", "kickout", "bulk"]),
     KickoutBody = [ClientId1, ClientId2, ClientId3],
-    {ok, _} = emqx_mgmt_api_test_util:request_api_with_body(post, KickoutPath, KickoutBody),
+    {ok, 204, _} = emqx_mgmt_api_test_util:request_api_with_body(post, KickoutPath, KickoutBody),
 
     {ok, Clients2} = emqx_mgmt_api_test_util:request_api(get, ClientsPath),
     ClientsResponse2 = emqx_utils_json:decode(Clients2, [return_maps]),

--- a/changes/ce/fix-10880.en.md
+++ b/changes/ce/fix-10880.en.md
@@ -1,0 +1,1 @@
+Add a new HTTP API endpoint `/clients/kickout/bulk` for kicking out multiple clients in bulk.

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -5,6 +5,11 @@ list_clients.desc:
 list_clients.label:
 """List clients"""
 
+kickout_clients.desc:
+"""Kick out a batch of client by client IDs"""
+kickout_clients.label:
+"""Kick out a batch of client by client IDs"""
+
 clients_info_from_id.desc:
 """Get clients info by client ID"""
 clients_info_from_id.label:


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9578

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e7872c</samp>

This pull request adds a new feature to the management API that allows kicking out multiple clients by their IDs. It implements the feature in the `emqx_mgmt`, `emqx_mgmt_api_clients`, and `emqx_management_proto_v3` modules, adds a test case in the `emqx_mgmt_api_clients_SUITE` module, and updates the internationalization file `rel/i18n/emqx_mgmt_api_clients.hocon`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
