### PR TITLE
fix(rule_engine_api): don't crash when formatting empty metrics

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.18"},
+    {vsn, "5.0.19"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -529,47 +529,69 @@ printable_function_name(Mod, Func) ->
     list_to_binary(lists:concat([Mod, ":", Func])).
 
 get_rule_metrics(Id) ->
-    Format = fun(
-        Node,
-        #{
-            counters :=
-                #{
-                    'matched' := Matched,
-                    'passed' := Passed,
-                    'failed' := Failed,
-                    'failed.exception' := FailedEx,
-                    'failed.no_result' := FailedNoRes,
-                    'actions.total' := OTotal,
-                    'actions.failed' := OFailed,
-                    'actions.failed.out_of_service' := OFailedOOS,
-                    'actions.failed.unknown' := OFailedUnknown,
-                    'actions.success' := OFailedSucc
-                },
-            rate :=
-                #{
-                    'matched' :=
-                        #{current := Current, max := Max, last5m := Last5M}
-                }
-        }
-    ) ->
-        #{
-            metrics => ?METRICS(
-                Matched,
-                Passed,
-                Failed,
-                FailedEx,
-                FailedNoRes,
-                OTotal,
-                OFailed,
-                OFailedOOS,
-                OFailedUnknown,
-                OFailedSucc,
-                Current,
-                Max,
-                Last5M
-            ),
-            node => Node
-        }
+    Format = fun
+        (
+            Node,
+            #{
+                counters :=
+                    #{
+                        'matched' := Matched,
+                        'passed' := Passed,
+                        'failed' := Failed,
+                        'failed.exception' := FailedEx,
+                        'failed.no_result' := FailedNoRes,
+                        'actions.total' := OTotal,
+                        'actions.failed' := OFailed,
+                        'actions.failed.out_of_service' := OFailedOOS,
+                        'actions.failed.unknown' := OFailedUnknown,
+                        'actions.success' := OFailedSucc
+                    },
+                rate :=
+                    #{
+                        'matched' :=
+                            #{current := Current, max := Max, last5m := Last5M}
+                    }
+            }
+        ) ->
+            #{
+                metrics => ?METRICS(
+                    Matched,
+                    Passed,
+                    Failed,
+                    FailedEx,
+                    FailedNoRes,
+                    OTotal,
+                    OFailed,
+                    OFailedOOS,
+                    OFailedUnknown,
+                    OFailedSucc,
+                    Current,
+                    Max,
+                    Last5M
+                ),
+                node => Node
+            };
+        (Node, _Metrics) ->
+            %% Empty metrics: can happen when a node joins another and a bridge is not yet
+            %% replicated to it, so the counters map is empty.
+            #{
+                metrics => ?METRICS(
+                    _Matched = 0,
+                    _Passed = 0,
+                    _Failed = 0,
+                    _FailedEx = 0,
+                    _FailedNoRes = 0,
+                    _OTotal = 0,
+                    _OFailed = 0,
+                    _OFailedOOS = 0,
+                    _OFailedUnknown = 0,
+                    _OFailedSucc = 0,
+                    _Current = 0,
+                    _Max = 0,
+                    _Last5M = 0
+                ),
+                node => Node
+            }
     end,
     [
         Format(Node, emqx_plugin_libs_proto_v1:get_metrics(Node, rule_metrics, Id))

--- a/changes/ce/fix-10884.en.md
+++ b/changes/ce/fix-10884.en.md
@@ -1,0 +1,1 @@
+Fixes an issue where trying to get rule info or metrics could result in a crash when a node is joining a cluster.

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_bridge, [
     {description, "EMQX Enterprise data bridges"},
-    {vsn, "0.1.14"},
+    {vsn, "0.1.15"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10073
Fixes https://github.com/emqx/emqx/issues/10714#issuecomment-1567987664

Similar issue to https://github.com/emqx/emqx/pull/10743, but on the
rule engine API.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2cc13c8</samp>

This pull request enhances the rule engine metrics API and updates the version numbers of the emqx_rule_engine and emqx_ee_bridge applications. It fixes a bug that could cause the API to crash when a node joins a cluster with a different rule configuration. It also adds a test case to verify the API behavior in this scenario.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
