### PR TITLE
fix: block buffer workers so they may retry requests

### DIFF
--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
@@ -541,7 +541,9 @@ t_write_failure(Config) ->
         end),
         fun(Trace0) ->
             ct:pal("trace: ~p", [Trace0]),
-            Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
+            Trace = ?of_kind(
+                [buffer_worker_flush_nack, buffer_worker_retry_inflight_failed], Trace0
+            ),
             [#{result := Result} | _] = Trace,
             case Result of
                 {async_return, {error, {resource_error, _}}} ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -403,7 +403,8 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
                 buffer_worker_retry_inflight_failed,
                 #{
                     ref => Ref,
-                    query_or_batch => QueryOrBatch
+                    query_or_batch => QueryOrBatch,
+                    result => Result
                 }
             ),
             {keep_state, Data1, {state_timeout, ResumeT, unblock}};

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -1832,6 +1832,18 @@ t_async_pool_worker_death(_Config) ->
                 NumReqs,
                 lists:sum([N || #{num_affected := N} <- Events])
             ),
+
+            %% The `DOWN' signal must trigger the transition to the `blocked' state,
+            %% otherwise the request won't be retried until the buffer worker is `blocked'
+            %% for other reasons.
+            ?assert(
+                ?strict_causality(
+                    #{?snk_kind := buffer_worker_async_agent_down, buffer_worker := _Pid0},
+                    #{?snk_kind := buffer_worker_enter_blocked, buffer_worker := _Pid1},
+                    _Pid0 =:= _Pid1,
+                    Trace
+                )
+            ),
             ok
         end
     ),

--- a/changes/ce/fix-10887.en.md
+++ b/changes/ce/fix-10887.en.md
@@ -1,0 +1,3 @@
+Fixed a potential issue where requests to bridges might take a long time to be retried.
+
+This only affected low throughput scenarios, where the buffering layer could take a long time to detect connectivity and driver problems.


### PR DESCRIPTION
- fix(buffer_worker): make buffer worker enter `blocked` state when async worker dies

  Otherwise, requests from those async workers, now retriable, might not
  be retried until the buffer worker blocks for other reasons, which
  might take a long time.

- ~~fix(resource_manager): block buffer workers after failed health check~~

  ~~Otherwise, the buffer workers won't necessarily have the timely~~
  ~~opportunity to retry inflight requests, if they are not notified of~~
  ~~the problem.~~


Fixes https://emqx.atlassian.net/browse/EMQX-10074

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bb00c17</samp>

This pull request improves the async resource query feature of `emqx_resource` by enhancing the telemetry, state management, and robustness of the buffer worker. It also adds and updates some test cases to verify the new features and behaviors.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
