### PR TITLE
fix(rule_engine_api): avoid crash when node is rejoining cluster

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -571,10 +571,17 @@ get_rule_metrics(Id) ->
             node => Node
         }
     end,
-    [
-        Format(Node, emqx_plugin_libs_proto_v1:get_metrics(Node, rule_metrics, Id))
+    AllMetrics = [
+        {Node, emqx_plugin_libs_proto_v1:get_metrics(Node, rule_metrics, Id)}
      || Node <- mria:running_nodes()
-    ].
+    ],
+    FilteredMetrics = lists:filtermap(
+        fun
+            ({Node, Metric}) when is_map(Metric) -> {true, Format(Node, Metric)};
+            (_) -> false
+        end,
+        AllMetrics
+    ).
 
 aggregate_metrics(AllMetrics) ->
     InitMetrics = ?METRICS(0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10017

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6ee696a</samp>

Filter out invalid metrics from node responses in `emqx_rule_engine_api.erl`. This prevents aggregation errors and improves rule engine reliability.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
