### PR TITLE
fix(ruleeng): parse bridge id on create / update

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -42,7 +42,10 @@
     list/0
 ]).
 
--export([send_message/2]).
+-export([
+    send_message/2,
+    send_message/4
+]).
 
 -export([config_key_path/0]).
 
@@ -199,14 +202,17 @@ send_to_matched_egress_bridges(Topic, Msg) ->
 send_message(BridgeId, Message) ->
     {BridgeType, BridgeName} = emqx_bridge_resource:parse_bridge_id(BridgeId),
     ResId = emqx_bridge_resource:resource_id(BridgeType, BridgeName),
+    send_message(BridgeType, BridgeName, ResId, Message).
+
+send_message(BridgeType, BridgeName, ResId, Message) ->
     case emqx:get_config([bridges, BridgeType, BridgeName], not_found) of
         not_found ->
-            {error, {bridge_not_found, BridgeId}};
+            {error, bridge_not_found};
         #{enable := true} = Config ->
             QueryOpts = query_opts(Config),
             emqx_resource:query(ResId, {send_message, Message}, QueryOpts);
         #{enable := false} ->
-            {error, {bridge_stopped, BridgeId}}
+            {error, bridge_stopped}
     end.
 
 query_opts(Config) ->

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -112,7 +112,10 @@ validate_name(Name0, Opts) ->
             case lists:all(fun is_id_char/1, Name) of
                 true ->
                     case maps:get(atom_name, Opts, true) of
-                        true -> list_to_existing_atom(Name);
+                        % NOTE
+                        % Rule may be created before bridge, thus not `list_to_existing_atom/1`,
+                        % also it is infrequent user input anyway.
+                        true -> list_to_atom(Name);
                         false -> Name0
                     end;
                 false ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -515,13 +515,13 @@ format_datetime(Timestamp, Unit) ->
 format_action(Actions) ->
     [do_format_action(Act) || Act <- Actions].
 
+do_format_action({bridge, BridgeType, BridgeName, _ResId}) ->
+    emqx_bridge_resource:bridge_id(BridgeType, BridgeName);
 do_format_action(#{mod := Mod, func := Func, args := Args}) ->
     #{
         function => printable_function_name(Mod, Func),
         args => maps:remove(preprocessed_tmpl, Args)
-    };
-do_format_action(BridgeChannelId) when is_binary(BridgeChannelId) ->
-    BridgeChannelId.
+    }.
 
 printable_function_name(emqx_rule_actions, Func) ->
     Func;


### PR DESCRIPTION
Instead of parsing it every time in the `send_message/2` hot path.

Part of [EEC-856](https://emqx.atlassian.net/browse/EEC-856).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 29fe201</samp>

This pull request introduces a new bridge action format and resource abstraction for the rule engine, and updates the relevant modules and test cases to support it. It also improves the error handling and code quality of the rule engine and the bridge modules. The main affected files are `emqx_rule_engine.erl`, `emqx_rule_actions.erl`, `emqx_rule_runtime.erl`, `emqx_bridge.erl`, and `emqx_rule_engine_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
