### PR TITLE
feat(rocketmq): refactored bridge to avoid leaking resources during crashes at creation

### DIFF
--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
@@ -145,7 +145,7 @@ on_stop(InstanceId, _State) ->
             ({_, _Topic, Producer}) ->
                 _ = rocketmq:stop_and_delete_supervised_producers(Producer)
         end,
-        emqx_resource:lookup_allocated_resources(InstanceId)
+        emqx_resource:get_allocated_resources_list(InstanceId)
     ).
 
 on_query(InstanceId, Query, State) ->

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -85,7 +85,7 @@
     allocate_resource/3,
     has_allocated_resources/1,
     get_allocated_resources/1,
-    lookup_allocated_resources/1,
+    get_allocated_resources_list/1,
     forget_allocated_resources/1
 ]).
 
@@ -520,8 +520,8 @@ get_allocated_resources(InstanceId) ->
     Objects = ets:lookup(?RESOURCE_ALLOCATION_TAB, InstanceId),
     maps:from_list([{K, V} || {_InstanceId, K, V} <- Objects]).
 
--spec lookup_allocated_resources(resource_id()) -> list(tuple()).
-lookup_allocated_resources(InstanceId) ->
+-spec get_allocated_resources_list(resource_id()) -> list(tuple()).
+get_allocated_resources_list(InstanceId) ->
     ets:lookup(?RESOURCE_ALLOCATION_TAB, InstanceId).
 
 -spec forget_allocated_resources(resource_id()) -> ok.

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -85,6 +85,7 @@
     allocate_resource/3,
     has_allocated_resources/1,
     get_allocated_resources/1,
+    lookup_allocated_resources/1,
     forget_allocated_resources/1
 ]).
 
@@ -518,6 +519,10 @@ has_allocated_resources(InstanceId) ->
 get_allocated_resources(InstanceId) ->
     Objects = ets:lookup(?RESOURCE_ALLOCATION_TAB, InstanceId),
     maps:from_list([{K, V} || {_InstanceId, K, V} <- Objects]).
+
+-spec lookup_allocated_resources(resource_id()) -> list(tuple()).
+lookup_allocated_resources(InstanceId) ->
+    ets:lookup(?RESOURCE_ALLOCATION_TAB, InstanceId).
 
 -spec forget_allocated_resources(resource_id()) -> ok.
 forget_allocated_resources(InstanceId) ->

--- a/changes/ee/feat-10908.en.md
+++ b/changes/ee/feat-10908.en.md
@@ -1,0 +1,1 @@
+Refactored the RocketMQ bridge to avoid leaking resources during crashes at creation.


### PR DESCRIPTION

Fixes [EMQX-9938](https://emqx.atlassian.net/browse/EMQX-9938)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1939668</samp>

This pull request improves the integration of `emqx_bridge_rocketmq` with the `emqx_resource` module, by refactoring the connector code and adding a new query function. This enhances the resource management and the code quality of the bridge.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
