### PR TITLE
feat: remove the deprecated '/gateway/*' HTTP APIs

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_api.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api.erl
@@ -63,11 +63,11 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([
+    [
         "/gateways",
         "/gateways/:name",
         "/gateways/:name/enable/:enable"
-    ]).
+    ].
 
 %%--------------------------------------------------------------------
 %% http handlers
@@ -240,9 +240,7 @@ schema("/gateways/:name/enable/:enable") ->
                         )
                     }
             }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
 
 %%--------------------------------------------------------------------
 %% params defines

--- a/apps/emqx_gateway/src/emqx_gateway_api_authn.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_authn.erl
@@ -61,11 +61,11 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([
+    [
         "/gateways/:name/authentication",
         "/gateways/:name/authentication/users",
         "/gateways/:name/authentication/users/:uid"
-    ]).
+    ].
 
 %%--------------------------------------------------------------------
 %% http handlers
@@ -318,9 +318,8 @@ schema("/gateways/:name/authentication/users/:uid") ->
                 responses =>
                     ?STANDARD_RESP(#{204 => <<"User Deleted">>})
             }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
+
 %%--------------------------------------------------------------------
 %% params defines
 

--- a/apps/emqx_gateway/src/emqx_gateway_api_authn_user_import.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_authn_user_import.erl
@@ -55,10 +55,10 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => false}).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([
+    [
         "/gateways/:name/authentication/import_users",
         "/gateways/:name/listeners/:id/authentication/import_users"
-    ]).
+    ].
 
 %%--------------------------------------------------------------------
 %% http handlers
@@ -147,9 +147,7 @@ schema("/gateways/:name/listeners/:id/authentication/import_users") ->
                 responses =>
                     ?STANDARD_RESP(#{204 => <<"Imported">>})
             }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
 
 %%--------------------------------------------------------------------
 %% params defines

--- a/apps/emqx_gateway/src/emqx_gateway_api_clients.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_clients.erl
@@ -70,12 +70,12 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([
+    [
         "/gateways/:name/clients",
         "/gateways/:name/clients/:clientid",
         "/gateways/:name/clients/:clientid/subscriptions",
         "/gateways/:name/clients/:clientid/subscriptions/:topic"
-    ]).
+    ].
 
 -define(CLIENT_QSCHEMA, [
     {<<"node">>, atom},
@@ -541,9 +541,7 @@ schema("/gateways/:name/clients/:clientid/subscriptions/:topic") ->
                 responses =>
                     ?STANDARD_RESP(#{204 => <<"Unsubscribed">>})
             }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
 
 params_client_query() ->
     params_gateway_name_in_path() ++

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -70,13 +70,13 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([
+    [
         "/gateways/:name/listeners",
         "/gateways/:name/listeners/:id",
         "/gateways/:name/listeners/:id/authentication",
         "/gateways/:name/listeners/:id/authentication/users",
         "/gateways/:name/listeners/:id/authentication/users/:uid"
-    ]).
+    ].
 
 %%--------------------------------------------------------------------
 %% http handlers
@@ -590,9 +590,7 @@ schema("/gateways/:name/listeners/:id/authentication/users/:uid") ->
                 responses =>
                     ?STANDARD_RESP(#{204 => <<"Deleted">>})
             }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
 
 %%--------------------------------------------------------------------
 %% params defines

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -45,8 +45,6 @@
     is_running/2,
     global_chain/1,
     listener_chain/3,
-    make_deprecated_paths/1,
-    make_compatible_schema/2,
     find_gateway_definitions/0
 ]).
 
@@ -530,39 +528,6 @@ default_subopts() ->
         qos => 0,
         is_new => true
     }.
-
-%% Since 5.0.8, the API path of the gateway has been changed from "gateway" to "gateways"
-%% and we need to be compatible with the old path
-get_compatible_path("/gateway") ->
-    "/gateways";
-get_compatible_path("/gateway/" ++ Rest) ->
-    "/gateways/" ++ Rest.
-
-get_deprecated_path("/gateways") ->
-    "/gateway";
-get_deprecated_path("/gateways/" ++ Rest) ->
-    "/gateway/" ++ Rest.
-
-make_deprecated_paths(Paths) ->
-    Paths ++ [get_deprecated_path(Path) || Path <- Paths].
-
-make_compatible_schema(Path, SchemaFun) ->
-    OldPath = get_compatible_path(Path),
-    make_compatible_schema2(OldPath, SchemaFun).
-
-make_compatible_schema2(Path, SchemaFun) ->
-    Schema = SchemaFun(Path),
-    maps:map(
-        fun(Key, Value) ->
-            case lists:member(Key, [get, delete, put, post]) of
-                true ->
-                    Value#{deprecated => true};
-                _ ->
-                    Value
-            end
-        end,
-        Schema
-    ).
 
 -spec find_gateway_definitions() -> list(gateway_def()).
 find_gateway_definitions() ->

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -107,9 +107,9 @@ t_gateway(_) ->
         StompGw
     ),
     {204, _} = request(put, "/gateways/stomp", #{enable => true}),
-    {200, #{enable := true}} = request(get, "/gateway/stomp"),
+    {200, #{enable := true}} = request(get, "/gateways/stomp"),
     {204, _} = request(put, "/gateways/stomp", #{enable => false}),
-    {200, #{enable := false}} = request(get, "/gateway/stomp"),
+    {200, #{enable := false}} = request(get, "/gateways/stomp"),
     {404, _} = request(put, "/gateways/undefined", #{}),
     {400, _} = request(put, "/gateways/stomp", #{bad_key => "foo"}),
     ok.
@@ -121,27 +121,14 @@ t_gateway_fail(_) ->
     {400, _} = request(put, "/gateways/coap", #{}),
     ok.
 
-t_deprecated_gateway(_) ->
-    {200, Gateways} = request(get, "/gateway"),
-    lists:foreach(fun assert_gw_unloaded/1, Gateways),
-    {404, NotFoundReq} = request(get, "/gateway/uname_gateway"),
-    assert_not_found(NotFoundReq),
-    {204, _} = request(put, "/gateway/stomp", #{}),
-    {200, StompGw} = request(get, "/gateway/stomp"),
-    assert_fields_exist(
-        [name, status, enable, created_at, started_at],
-        StompGw
-    ),
-    ok.
-
 t_gateway_enable(_) ->
     {204, _} = request(put, "/gateways/stomp", #{}),
-    {200, #{enable := Enable}} = request(get, "/gateway/stomp"),
+    {200, #{enable := Enable}} = request(get, "/gateways/stomp"),
     NotEnable = not Enable,
     {204, _} = request(put, "/gateways/stomp/enable/" ++ atom_to_list(NotEnable), undefined),
-    {200, #{enable := NotEnable}} = request(get, "/gateway/stomp"),
+    {200, #{enable := NotEnable}} = request(get, "/gateways/stomp"),
     {204, _} = request(put, "/gateways/stomp/enable/" ++ atom_to_list(Enable), undefined),
-    {200, #{enable := Enable}} = request(get, "/gateway/stomp"),
+    {200, #{enable := Enable}} = request(get, "/gateways/stomp"),
     {404, _} = request(put, "/gateways/undefined/enable/true", undefined),
     {404, _} = request(put, "/gateways/not_a_known_atom/enable/true", undefined),
     {404, _} = request(put, "/gateways/coap/enable/true", undefined),

--- a/apps/emqx_gateway_coap/src/emqx_coap_api.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_api.erl
@@ -46,7 +46,7 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([?PREFIX ++ "/request"]).
+    [?PREFIX ++ "/request"].
 
 schema(?PREFIX ++ "/request") ->
     #{
@@ -65,9 +65,7 @@ schema(?PREFIX ++ "/request") ->
                 )
             }
         }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
 
 request(post, #{body := Body, bindings := Bindings}) ->
     ClientId = maps:get(clientid, Bindings, undefined),

--- a/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
@@ -97,8 +97,6 @@ t_send_request_api(_) ->
         ?assertEqual(Payload, RPayload)
     end,
     Test("gateways/coap/clients/client1/request"),
-    timer:sleep(100),
-    Test("gateway/coap/clients/client1/request"),
     erlang:exit(ClientId, kill),
     ok.
 

--- a/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
+++ b/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
@@ -1,6 +1,6 @@
 {application, emqx_gateway_lwm2m, [
     {description, "LwM2M Gateway"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway, emqx_gateway_coap]},
     {env, []},

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_api.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_api.erl
@@ -40,9 +40,9 @@ api_spec() ->
     emqx_dashboard_swagger:spec(?MODULE).
 
 paths() ->
-    emqx_gateway_utils:make_deprecated_paths([
+    [
         ?PATH("/lookup"), ?PATH("/observe"), ?PATH("/read"), ?PATH("/write")
-    ]).
+    ].
 
 schema(?PATH("/lookup")) ->
     #{
@@ -127,9 +127,7 @@ schema(?PATH("/write")) ->
                 404 => error_codes(['CLIENT_NOT_FOUND'], <<"Clientid not found">>)
             }
         }
-    };
-schema(Path) ->
-    emqx_gateway_utils:make_compatible_schema(Path, fun schema/1).
+    }.
 
 fields(resource) ->
     [

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_api_SUITE.erl
@@ -306,7 +306,7 @@ t_observe(Config) ->
     test_recv_mqtt_response(RespTopic),
 
     %% step2, call observe API
-    ?assertMatch({204, []}, call_deprecated_send_api(Epn, "observe", "path=/3/0/1&enable=false")),
+    ?assertMatch({204, []}, call_send_api(Epn, "observe", "path=/3/0/1&enable=false")),
     timer:sleep(100),
     #coap_message{type = Type, method = Method, options = Opts} = test_recv_coap_request(UdpSock),
     ?assertEqual(con, Type),
@@ -327,9 +327,6 @@ call_lookup_api(ClientId, Path, Action) ->
 
 call_send_api(ClientId, Cmd, Query) ->
     call_send_api(ClientId, Cmd, Query, "gateways/lwm2m/clients").
-
-call_deprecated_send_api(ClientId, Cmd, Query) ->
-    call_send_api(ClientId, Cmd, Query, "gateway/lwm2m/clients").
 
 call_send_api(ClientId, Cmd, Query, API) ->
     ApiPath = emqx_mgmt_api_test_util:api_path([API, ClientId, Cmd]),

--- a/changes/ce/feat-10909.en.md
+++ b/changes/ce/feat-10909.en.md
@@ -1,0 +1,1 @@
+Remove the deprecated HTTP APIs for gateways


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10097

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2946410</samp>

This pull request refactors and simplifies the gateway API code for different gateway types, such as CoAP and LwM2M. It removes deprecated and unnecessary code, improves readability and maintainability, and updates the version of `emqx_gateway_lwm2m`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

-  ~Added tests for the changes~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
