### PR TITLE
fix: friendly error message when creating bridges with too long names

### DIFF
--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -473,6 +473,17 @@ bin_path(ConfKeyPath) -> [bin(Key) || Key <- ConfKeyPath].
 bin(A) when is_atom(A) -> atom_to_binary(A, utf8);
 bin(B) when is_binary(B) -> B.
 
+atom(Bin) when is_binary(Bin), size(Bin) > 255 ->
+    erlang:throw(
+        iolist_to_binary(
+            io_lib:format(
+                "Name is is too long."
+                " Please provide a shorter name (<= 255 bytes)."
+                " The name that is too long: \"~s\"",
+                [Bin]
+            )
+        )
+    );
 atom(Bin) when is_binary(Bin) ->
     binary_to_atom(Bin, utf8);
 atom(Str) when is_list(Str) ->

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -605,7 +605,7 @@ create_or_update_bridge(BridgeType, BridgeName, Conf, HttpStatusCode) ->
     case emqx_bridge:create(BridgeType, BridgeName, Conf) of
         {ok, _} ->
             lookup_from_all_nodes(BridgeType, BridgeName, HttpStatusCode);
-        {error, #{kind := validation_error} = Reason} ->
+        {error, Reason} when is_map(Reason) ->
             ?BAD_REQUEST(map_to_json(Reason))
     end.
 

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -415,6 +415,26 @@ t_http_crud_apis(Config) ->
     ),
 
     %% Test bad updates
+    %% ================
+
+    %% Add bridge with a name that is too long
+    %% We only support bridge names up to 255 characters
+    LongName = list_to_binary(lists:duplicate(256, $a)),
+    NameTooLongRequestResult = request_json(
+        post,
+        uri(["bridges"]),
+        ?HTTP_BRIDGE(URL1, LongName),
+        Config
+    ),
+    ?assertMatch(
+        {ok, 400, _},
+        NameTooLongRequestResult
+    ),
+    {ok, 400, #{<<"message">> := NameTooLongMessage}} = NameTooLongRequestResult,
+    %% Use regex to check that the message contains the name
+    Match = re:run(NameTooLongMessage, LongName),
+    ?assertMatch({match, _}, Match),
+    %% Add bridge without the URL field
     {ok, 400, PutFail1} = request_json(
         put,
         uri(["bridges", BridgeID]),

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.18"},
+    {vsn, "5.0.19"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl]},

--- a/changes/ce/fix-10911.en.md
+++ b/changes/ce/fix-10911.en.md
@@ -1,0 +1,1 @@
+The error message and log entry that appear when one tries to create a bridge with a name the exceeds 255 bytes is now easier to understand.

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_bridge, [
     {description, "EMQX Enterprise data bridges"},
-    {vsn, "0.1.14"},
+    {vsn, "0.1.15"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
This commit makes the error message and log entry that appear when one tries to create a bridge with a name the exceeds 255 bytes (the max length for atoms) more friendly and easier to understand.

An even better fix would be to not store bridge names as atoms but this probably requires a more substantial change.

Fixes:
https://emqx.atlassian.net/browse/EMQX-9609

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 75ff76a</samp>

This pull request improves the error handling, validation, and configuration logic for bridges and rules in emqx. It also updates the version numbers of the affected applications: `emqx_rule_engine`, `emqx_ee_bridge`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [] Schema changes are backward compatible