### PR TITLE
test(oracle): add match for reason field in a test case

### DIFF
--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -525,7 +525,7 @@ t_no_sid_nor_service_name(Config0) ->
     NewOracleConfig = {oracle_config, OracleConfig},
     Config = lists:keyreplace(oracle_config, 1, Config0, NewOracleConfig),
     ?assertMatch(
-        {error, #{kind := validation_error}},
+        {error, #{kind := validation_error, reason := "neither SID nor Service Name was set"}},
         create_bridge(Config)
     ),
     ok.


### PR DESCRIPTION
Added match as commented here: https://github.com/emqx/emqx/pull/10892#discussion_r1213177849

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 92c72c6</samp>

Improve validation error message for Oracle bridge configuration in `emqx_bridge_oracle_SUITE.erl`. The change is part of adding Oracle support for EMQ X bridges.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
