### PR TITLE
test(rocketmq): add an ACL test case

### DIFF
--- a/.ci/docker-compose-file/docker-compose-rocketmq.yaml
+++ b/.ci/docker-compose-file/docker-compose-rocketmq.yaml
@@ -23,6 +23,7 @@ services:
       - ./rocketmq/logs:/opt/logs
       - ./rocketmq/store:/opt/store
       - ./rocketmq/conf/broker.conf:/etc/rocketmq/broker.conf
+      - ./rocketmq/conf/plain_acl.yml:/home/rocketmq/rocketmq-4.9.4/conf/plain_acl.yml
     environment:
         NAMESRV_ADDR: "rocketmq_namesrv:9876"
         JAVA_OPTS: " -Duser.home=/opt -Drocketmq.broker.diskSpaceWarningLevelRatio=0.99"

--- a/.ci/docker-compose-file/rocketmq/conf/broker.conf
+++ b/.ci/docker-compose-file/rocketmq/conf/broker.conf
@@ -20,3 +20,5 @@ maxMessageSize=65536
 brokerRole=ASYNC_MASTER
 
 flushDiskType=ASYNC_FLUSH
+
+aclEnable=true

--- a/.ci/docker-compose-file/rocketmq/conf/plain_acl.yml
+++ b/.ci/docker-compose-file/rocketmq/conf/plain_acl.yml
@@ -1,0 +1,11 @@
+globalWhiteRemoteAddresses:
+
+accounts:
+  - accessKey: RocketMQ
+    secretKey: 12345678
+    whiteRemoteAddress:
+    admin: false
+    defaultTopicPerm: DENY
+    defaultGroupPerm: PUB|SUB
+    topicPerms:
+      - TopicTest=PUB|SUB


### PR DESCRIPTION
Fixes [EMQX-9709](https://emqx.atlassian.net/browse/EMQX-9709)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ea9b1e1</samp>

This pull request adds a test case and the necessary configuration files to enable and test the ACL feature of the rocketmq broker. The test case verifies that the client can only access the allowed topic with a valid access key and secret key, and is denied access to other topics. The configuration files define the ACL rules and the access keys for the rocketmq broker.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
