### PR TITLE
0602 add enable as an alias for enabled

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -301,6 +301,8 @@ fields("persistent_session_store") ->
                 boolean(),
                 #{
                     default => false,
+                    %% TODO(5.2): change field name to 'enable' and keep 'enabled' as an alias
+                    aliases => [enable],
                     desc => ?DESC(persistent_session_store_enabled)
                 }
             )},
@@ -1989,6 +1991,8 @@ base_listener(Bind) ->
                 boolean(),
                 #{
                     default => true,
+                    %% TODO(5.2): change field name to 'enable' and keep 'enabled' as an alias
+                    aliases => [enable],
                     desc => ?DESC(fields_listener_enabled)
                 }
             )},

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -210,9 +210,13 @@ sync_data_from_node(Node) ->
         {ok, DataBin} ->
             case zip:unzip(DataBin, [{cwd, emqx:data_dir()}]) of
                 {ok, []} ->
-                    ?SLOG(debug, #{node => Node, msg => "sync_data_from_node_ignore"});
+                    ?SLOG(debug, #{node => Node, msg => "sync_data_from_node_empty_response"});
                 {ok, Files} ->
-                    ?SLOG(debug, #{node => Node, msg => "sync_data_from_node_ok", files => Files})
+                    ?SLOG(debug, #{
+                        node => Node,
+                        msg => "sync_data_from_node_non_empty_response",
+                        files => Files
+                    })
             end,
             ok;
         Error ->

--- a/changes/ce/feat-10926.en.md
+++ b/changes/ce/feat-10926.en.md
@@ -1,0 +1,5 @@
+Allow 'enable' as well as 'enabled' as the state flag for listeners.
+
+Prior to this change, listener can be enable/disabled by setting the 'true' or 'false' on the 'enabled' config.
+This is slightly different naming comparing to other state flags in the system.
+No the 'enable' flag is added as an aliase on listeners.


### PR DESCRIPTION
Fixes [EMQX-1026](https://emqx.atlassian.net/browse/EMQX-10126)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 04a4ad7</samp>

This pull request improves the listener schema and the configuration synchronization logic. It adds an alias for the `enabled` field in listener schemas, and enhances the log messages and the module organization in the `sync_data_from_node` function.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
