### PR TITLE
Perf/william/save times of maps build

### DIFF
--- a/apps/emqx/src/emqx_mqtt_caps.erl
+++ b/apps/emqx/src/emqx_mqtt_caps.erl
@@ -84,7 +84,7 @@ check_pub(Zone, Flags) when is_map(Flags) ->
             error ->
                 Flags
         end,
-        get_caps(?PUBCAP_KEYS, Zone)
+        emqx_config:get_zone_conf(Zone, [mqtt])
     ).
 
 do_check_pub(#{topic_levels := Levels}, #{max_topic_levels := Limit}) when
@@ -107,7 +107,7 @@ do_check_pub(_Flags, _Caps) ->
 ) ->
     ok_or_error(emqx_types:reason_code()).
 check_sub(ClientInfo = #{zone := Zone}, Topic, SubOpts) ->
-    Caps = get_caps(?SUBCAP_KEYS, Zone),
+    Caps = emqx_config:get_zone_conf(Zone, [mqtt]),
     Flags = #{
         topic_levels => emqx_topic:levels(Topic),
         is_wildcard => emqx_topic:wildcard(Topic),

--- a/apps/emqx/src/emqx_mqtt_caps.erl
+++ b/apps/emqx/src/emqx_mqtt_caps.erl
@@ -108,23 +108,12 @@ do_check_pub(_Flags, _Caps) ->
     ok_or_error(emqx_types:reason_code()).
 check_sub(ClientInfo = #{zone := Zone}, Topic, SubOpts) ->
     Caps = get_caps(?SUBCAP_KEYS, Zone),
-    Flags = lists:foldl(
-        fun
-            (max_topic_levels, Map) ->
-                Map#{topic_levels => emqx_topic:levels(Topic)};
-            (wildcard_subscription, Map) ->
-                Map#{is_wildcard => emqx_topic:wildcard(Topic)};
-            (shared_subscription, Map) ->
-                Map#{is_shared => maps:is_key(share, SubOpts)};
-            (exclusive_subscription, Map) ->
-                Map#{is_exclusive => maps:get(is_exclusive, SubOpts, false)};
-            %% Ignore
-            (_Key, Map) ->
-                Map
-        end,
-        #{},
-        maps:keys(Caps)
-    ),
+    Flags = #{
+        topic_levels => emqx_topic:levels(Topic),
+        is_wildcard => emqx_topic:wildcard(Topic),
+        is_shared => maps:is_key(share, SubOpts),
+        is_exclusive => maps:get(is_exclusive, SubOpts, false)
+    },
     do_check_sub(Flags, Caps, ClientInfo, Topic).
 
 do_check_sub(#{topic_levels := Levels}, #{max_topic_levels := Limit}, _, _) when


### PR DESCRIPTION
Fixes [EMQX-10164](https://emqx.atlassian.net/browse/EMQX-10164)

Filter config keys for `cap` in emqx_caps seems unnecessary, without filtering we could save some heap size bumps to avoid building new maps.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b1c188f</samp>

Refactor `emqx_mqtt_caps.erl` to use map operations for zone MQTT capabilities.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] ~~Schema changes are backward compatible~~


