### PR TITLE
chore(bridge): drop deprecated `mode` setting from examples / tests

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -233,7 +233,6 @@ info_example_basic(mqtt) ->
 mqtt_main_example() ->
     #{
         enable => true,
-        mode => cluster_shareload,
         server => <<"127.0.0.1:1883">>,
         proto_ver => <<"v4">>,
         username => <<"foo">>,

--- a/apps/emqx_bridge/src/schema/emqx_bridge_compatible_config.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_compatible_config.erl
@@ -68,7 +68,6 @@ up(#{<<"connector">> := Connector} = Config) ->
         Cn(password, <<>>),
         Cn(clean_start, true),
         Cn(keepalive, <<"60s">>),
-        Cn(mode, <<"cluster_shareload">>),
         Cn(proto_ver, <<"v4">>),
         Cn(server, undefined),
         Cn(retry_interval, <<"15s">>),

--- a/apps/emqx_bridge/test/emqx_bridge_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_SUITE.erl
@@ -160,7 +160,6 @@ t_update_ssl_conf(Config) ->
         <<"bridge_mode">> => false,
         <<"clean_start">> => true,
         <<"keepalive">> => <<"60s">>,
-        <<"mode">> => <<"cluster_shareload">>,
         <<"proto_ver">> => <<"v4">>,
         <<"server">> => <<"127.0.0.1:1883">>,
         <<"ssl">> =>


### PR DESCRIPTION
It makes little sense to show it in examples / use it in test fixtures.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 09290f8</samp>

Remove the `mode` option from the bridge configuration and related files. This option was redundant and only supported one value, `cluster_shareload`, which is now the default and implicit behavior.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
