### PR TITLE
perf(prometheus): udpate the prometheus dep vsn

### DIFF
--- a/apps/emqx_prometheus/grafana_template/ErlangVM.json
+++ b/apps/emqx_prometheus/grafana_template/ErlangVM.json
@@ -1207,7 +1207,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "erlang_vm_statistics_run_queues_length_total{job=~\"$job\", instance=\"$instance\"}",
+          "expr": "erlang_vm_statistics_run_queues_length{job=~\"$job\", instance=\"$instance\"}",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "Run queue length",

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -3,7 +3,7 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {branch, "enhance-sample-perf"}}}
+    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0-emqx-1"}}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -3,7 +3,7 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {prometheus, {git, "https://github.com/deadtrickster/prometheus.erl", {tag, "v4.8.1"}}}
+    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {branch, "enhance-sample-perf"}}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -3,7 +3,7 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0-emqx-1"}}}
+    {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.1"}}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -170,4 +170,7 @@ validate_push_gateway_server(Url) ->
 
 %% for CI test, CI don't load the whole emqx_conf_schema.
 translation(Name) ->
+    %% translate 'vm_dist_collector', 'mnesia_collector', 'vm_statistics_collector',
+    %% 'vm_system_info_collector', 'vm_memory_collector', 'vm_msacc_collector'
+    %% to prometheus envrionments
     emqx_conf_schema:translation(Name).

--- a/changes/ce/perf-10941.en.md
+++ b/changes/ce/perf-10941.en.md
@@ -1,0 +1,3 @@
+Improve the collection speed of Prometheus metrics when setting
+`prometheus.vm_dist_collector=disabled` and
+rename `erlang_vm_statistics_run_queues_length_total` to `erlang_vm_statistics_run_queues_length`

--- a/changes/ce/perf-10941.en.md
+++ b/changes/ce/perf-10941.en.md
@@ -1,3 +1,3 @@
 Improve the collection speed of Prometheus metrics when setting
 `prometheus.vm_dist_collector=disabled` and
-rename `erlang_vm_statistics_run_queues_length_total` to `erlang_vm_statistics_run_queues_length`
+metric `erlang_vm_statistics_run_queues_length_total` is renamed to `erlang_vm_statistics_run_queues_length`


### PR DESCRIPTION
it's based on v4.10.0 of upstream and patched this PR: https://github.com/emqx/prometheus.erl/pull/5.

Additionally, after updating to v4.10.0,  it renamed the `erlang_vm_statistics_run_queues_length_total` to `erlang_vm_statistics_run_queues_length` due to https://github.com/deadtrickster/prometheus.erl/commit/d0feb0df58825a277c55e79ba1b39d65499aab32 and https://github.com/rabbitmq/rabbitmq-server/issues/4380

It will affect the Grafana templates at https://grafana.com/grafana/dashboards/17446-emqx/

Fixes part of https://emqx.atlassian.net/browse/EMQX-9891

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ae63890</samp>

This pull request updates the `prometheus` dependency to use a forked repository with performance enhancements, and adds a comment to clarify a configuration translation function in `emqx_prometheus_schema.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
