### PR TITLE
chore: start deprecating mcast cluster discovery

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -143,7 +143,7 @@ fields("cluster") ->
             )},
         {"discovery_strategy",
             sc(
-                hoconsc:enum([manual, static, mcast, dns, etcd, k8s]),
+                hoconsc:enum([manual, static, dns, etcd, k8s, mcast]),
                 #{
                     default => manual,
                     desc => ?DESC(cluster_discovery_strategy),
@@ -198,7 +198,7 @@ fields("cluster") ->
         {"mcast",
             sc(
                 ?R_REF(cluster_mcast),
-                #{}
+                #{importance => ?IMPORTANCE_HIDDEN}
             )},
         {"dns",
             sc(

--- a/changes/ce/fix-10943.en.md
+++ b/changes/ce/fix-10943.en.md
@@ -1,0 +1,5 @@
+Deprecated UDP mcast mechanism for cluster discovery.
+
+This feature has been planed for deprecation since 5.0 mainly due to the lack of
+actual production use.
+This feature code is not yet removed in 5.1, but the document interface is demoted.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -755,7 +755,9 @@ cluster_discovery_strategy.desc:
 - static: Configure static nodes list by setting <code>seeds</code> in config file.<br/>
 - dns: Use DNS A record to discover peer nodes.<br/>
 - etcd: Use etcd to discover peer nodes.<br/>
-- k8s: Use Kubernetes API to discover peer pods."""
+- k8s: Use Kubernetes API to discover peer pods.
+- mcast: Deprecated since 5.1, will be removed in 5.2.
+  This supports discovery via UDP multicast."""
 
 cluster_discovery_strategy.label:
 """Cluster Discovery Strategy"""


### PR DESCRIPTION
Fixes [EMQX-9563](https://emqx.atlassian.net/browse/EMQX-9563)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bdcc069</samp>

The pull request removes the `mcast` cluster discovery strategy from the configuration schema and the user interface, and warns the users about its deprecation. This change is part of the effort to simplify and improve the cluster management features.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
