### PR TITLE
fix(mqttconn): no warn if ingress poolsize is same as config

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -99,7 +99,7 @@ choose_ingress_pool_size(
         {_Filter, #{share := _Name}} ->
             % NOTE: this is shared subscription, many workers may subscribe
             PoolSize;
-        {_Filter, #{}} ->
+        {_Filter, #{}} when PoolSize > 1 ->
             % NOTE: this is regular subscription, only one worker should subscribe
             ?SLOG(warning, #{
                 msg => "mqtt_bridge_ingress_pool_size_ignored",
@@ -110,6 +110,8 @@ choose_ingress_pool_size(
                 config_pool_size => PoolSize,
                 pool_size => 1
             }),
+            1;
+        {_Filter, #{}} when PoolSize == 1 ->
             1
     end.
 


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f7a6648</samp>

Improve regular subscription handling in `emqx_bridge_mqtt_connector`. Warn about possible errors with multiple workers and fix subscriber count.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
