### PR TITLE
feat: add `live_connections` field for some HTTP APIs

### DIFF
--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -61,7 +61,8 @@
 -define(GAUGE_SAMPLER_LIST, [
     subscriptions,
     topics,
-    connections
+    connections,
+    live_connections
 ]).
 
 -define(SAMPLER_LIST, ?GAUGE_SAMPLER_LIST ++ ?DELTA_SAMPLER_LIST).

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -401,6 +401,7 @@ getstats(Key) ->
     end.
 
 stats(connections) -> emqx_stats:getstat('connections.count');
+stats(live_connections) -> emqx_stats:getstat('live_connections.count');
 stats(topics) -> emqx_stats:getstat('topics.count');
 stats(subscriptions) -> emqx_stats:getstat('subscriptions.count');
 stats(received) -> emqx_metrics:val('messages.received');

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -172,6 +172,11 @@ swagger_desc(topics) ->
     >>;
 swagger_desc(connections) ->
     <<
+        "Sessions at the time of sampling."
+        " Can only represent the approximate state"
+    >>;
+swagger_desc(live_connections) ->
+    <<
         "Connections at the time of sampling."
         " Can only represent the approximate state"
     >>;

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -93,16 +93,23 @@ t_monitor_current_api(_) ->
 t_monitor_current_api_live_connections(_) ->
     process_flag(trap_exit, true),
     ClientId = <<"live_conn_tests">>,
+    ClientId1 = <<"live_conn_tests1">>,
     {ok, C} = emqtt:start_link([{clean_start, false}, {clientid, ClientId}]),
     {ok, _} = emqtt:connect(C),
     ok = emqtt:disconnect(C),
-    {ok, Rate} = request(["monitor_current"]),
-    ?assertEqual(0, maps:get(<<"live_connections">>, Rate)),
-    ?assertEqual(1, maps:get(<<"connections">>, Rate)),
-    %% clears
-    {ok, C1} = emqtt:start_link([{clean_start, true}, {clientid, ClientId}]),
+    {ok, C1} = emqtt:start_link([{clean_start, true}, {clientid, ClientId1}]),
     {ok, _} = emqtt:connect(C1),
-    ok = emqtt:disconnect(C1).
+    %% waiting for emqx_stats ticker
+    timer:sleep(1500),
+    _ = emqx_dashboard_monitor:current_rate(),
+    {ok, Rate} = request(["monitor_current"]),
+    ?assertEqual(1, maps:get(<<"live_connections">>, Rate)),
+    ?assertEqual(2, maps:get(<<"connections">>, Rate)),
+    %% clears
+    ok = emqtt:disconnect(C1),
+    {ok, C2} = emqtt:start_link([{clean_start, true}, {clientid, ClientId}]),
+    {ok, _} = emqtt:connect(C2),
+    ok = emqtt:disconnect(C2).
 
 t_monitor_reset(_) ->
     restart_monitor(),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -90,6 +90,20 @@ t_monitor_current_api(_) ->
     ],
     ok.
 
+t_monitor_current_api_live_connections(_) ->
+    process_flag(trap_exit, true),
+    ClientId = <<"live_conn_tests">>,
+    {ok, C} = emqtt:start_link([{clean_start, false}, {clientid, ClientId}]),
+    {ok, _} = emqtt:connect(C),
+    ok = emqtt:disconnect(C),
+    {ok, Rate} = request(["monitor_current"]),
+    ?assertEqual(0, maps:get(<<"live_connections">>, Rate)),
+    ?assertEqual(1, maps:get(<<"connections">>, Rate)),
+    %% clears
+    {ok, C1} = emqtt:start_link([{clean_start, true}, {clientid, ClientId}]),
+    {ok, _} = emqtt:connect(C1),
+    ok = emqtt:disconnect(C1).
+
 t_monitor_reset(_) ->
     restart_monitor(),
     {ok, Rate} = request(["monitor_current"]),

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -142,6 +142,7 @@ node_info() ->
             max_fds, lists:usort(lists:flatten(erlang:system_info(check_io)))
         ),
         connections => ets:info(?CHAN_TAB, size),
+        live_connections => ets:info(?CHAN_LIVE_TAB, size),
         node_status => 'running',
         uptime => proplists:get_value(uptime, BrokerInfo),
         version => iolist_to_binary(proplists:get_value(version, BrokerInfo)),

--- a/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_nodes.erl
@@ -153,6 +153,11 @@ fields(node_info) ->
         {connections,
             mk(
                 non_neg_integer(),
+                #{desc => <<"Number of clients session in this node">>, example => 0}
+            )},
+        {live_connections,
+            mk(
+                non_neg_integer(),
                 #{desc => <<"Number of clients currently connected to this node">>, example => 0}
             )},
         {load1,

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -60,6 +60,11 @@ t_nodes_api(_) ->
     Edition = maps:get(<<"edition">>, LocalNodeInfo),
     ?assertEqual(emqx_release:edition_longstr(), Edition),
 
+    Conns = maps:get(<<"connections">>, LocalNodeInfo),
+    ?assertEqual(0, Conns),
+    LiveConns = maps:get(<<"live_connections">>, LocalNodeInfo),
+    ?assertEqual(0, LiveConns),
+
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
     NodeNameResponse =

--- a/changes/ce/feat-10948.en.md
+++ b/changes/ce/feat-10948.en.md
@@ -1,0 +1,4 @@
+Add `live_connections` field for some HTTP APIs, i.e:
+- `/monitor_current`, `/monitor_current/nodes/{node}`
+- `/monitor/nodes/{node}`, `/monitor`
+- `/node/{node}`, `/nodes`


### PR DESCRIPTION
i.e:
- `/monitor_current`, `/monitor_current/nodes/{node}`
- `/monitor/nodes/{node}`, `/monitor`
- `/node/{node}`, `/nodes`

Fixes [EMQX-10070](https://emqx.atlassian.net/browse/EMQX-10070) [10071](https://emqx.atlassian.net/browse/EMQX-10071)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a0a029e</samp>

Add a new field `live_connections` to the node statistics record and API. This field shows the number of live client sessions in a node, which are not persisted by the broker.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [X] Added tests for the changes
- [X] Changed lines covered in coverage report
- [X] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [X] For internal contributor: there is a jira ticket to track this change
- [X] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [X] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [X] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
