### PR TITLE
fix(emqx_schema): don't allow enabling `fail_if_no_peer_cert` if `verify_none` is set

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -120,7 +120,10 @@ fields(ssl_listener) ->
             {ssl_options,
                 sc(
                     hoconsc:ref(emqx_schema, "listener_ssl_opts"),
-                    #{desc => ?DESC(ssl_listener_options)}
+                    #{
+                        desc => ?DESC(ssl_listener_options),
+                        validator => fun emqx_schema:validate_server_ssl_opts/1
+                    }
                 )}
         ];
 fields(udp_listener) ->
@@ -132,7 +135,13 @@ fields(udp_listener) ->
 fields(dtls_listener) ->
     [{acceptors, sc(integer(), #{default => 16, desc => ?DESC(dtls_listener_acceptors)})}] ++
         fields(udp_listener) ++
-        [{dtls_options, sc(ref(dtls_opts), #{desc => ?DESC(dtls_listener_dtls_opts)})}];
+        [
+            {dtls_options,
+                sc(ref(dtls_opts), #{
+                    desc => ?DESC(dtls_listener_dtls_opts),
+                    validator => fun emqx_schema:validate_server_ssl_opts/1
+                })}
+        ];
 fields(udp_opts) ->
     [
         {active_n,

--- a/changes/ce/fix-10952.en.md
+++ b/changes/ce/fix-10952.en.md
@@ -1,0 +1,8 @@
+Disallow enabling `fail_if_no_peer_cert` in listener SSL options if `verify_none` is set.
+
+Setting `fail_if_no_peer_cert = true` and `verify = verify_none` caused connection errors
+due to incompatible options.
+This fix validates the options when creating or updating a listener to avoid these errors.
+
+Note: any old listener configuration with `fail_if_no_peer_cert = true` and `verify = verify_none`
+that was previously allowed will fail to load after applying this fix and must be manually fixed.


### PR DESCRIPTION

Setting `fail_if_no_peer_cert = true` and `verify = verify_none` causes connection errors.

Fixes EMQX-9586

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a30f034</samp>

This pull request enhances the validation of SSL and DTLS options for different types of listeners in EMQ X, to prevent insecure or invalid configurations. It adds validator functions to the schema modules `emqx_gateway_schema` and `emqx_schema`, and a test case to `emqx_schema_tests`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
