### PR TITLE
feat: don't hide enable in flapping detect conf

### DIFF
--- a/apps/emqx/src/config/emqx_config_zones.erl
+++ b/apps/emqx/src/config/emqx_config_zones.erl
@@ -1,0 +1,35 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_config_zones).
+
+-behaviour(emqx_config_handler).
+
+%% API
+-export([add_handler/0, remove_handler/0, pre_config_update/3]).
+
+-define(ZONES, [zones]).
+
+add_handler() ->
+    ok = emqx_config_handler:add_handler(?ZONES, ?MODULE),
+    ok.
+
+remove_handler() ->
+    ok = emqx_config_handler:remove_handler(?ZONES),
+    ok.
+
+%% replace the old config with the new config
+pre_config_update(?ZONES, NewRaw, _OldRaw) ->
+    {ok, NewRaw}.

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1632,10 +1632,9 @@ check_banned(_ConnPkt, #channel{clientinfo = ClientInfo}) ->
 %%--------------------------------------------------------------------
 %% Flapping
 
-count_flapping_event(_ConnPkt, Channel = #channel{clientinfo = ClientInfo = #{zone := Zone}}) ->
-    is_integer(emqx_config:get_zone_conf(Zone, [flapping_detect, window_time])) andalso
-        emqx_flapping:detect(ClientInfo),
-    {ok, Channel}.
+count_flapping_event(_ConnPkt, #channel{clientinfo = ClientInfo}) ->
+    _ = emqx_flapping:detect(ClientInfo),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Authenticate

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -637,11 +637,13 @@ save_to_override_conf(false, RawConf, _Opts) ->
 
 add_handlers() ->
     ok = emqx_config_logger:add_handler(),
+    ok = emqx_config_zones:add_handler(),
     emqx_sys_mon:add_handler(),
     ok.
 
 remove_handlers() ->
     ok = emqx_config_logger:remove_handler(),
+    ok = emqx_config_zones:remove_handler(),
     emqx_sys_mon:remove_handler(),
     ok.
 
@@ -914,7 +916,8 @@ rawconf_to_conf(SchemaModule, RawPath, RawValue) ->
     emqx_utils_maps:deep_get(AtomPath, RawUserDefinedValues).
 
 %% When the global zone change, the zones is updated with the new global zone.
-%% The zones config has no config_handler callback, so we need to update via this hook
+%% The global zone's keys is too many,
+%% so we don't choose to write a global zone change emqx_config_handler callback to hook
 post_save_config_hook(?PERSIS_KEY(?CONF, zones), _Zones) ->
     emqx_flapping:update_config(),
     ok;

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -831,13 +831,14 @@ merge_with_global_defaults(GlobalDefaults, ZoneVal) ->
     NewZoneVal :: map().
 maybe_update_zone([zones | T], ZonesValue, Value) ->
     %% note, do not write to PT, return *New value* instead
-    NewZonesValue = emqx_utils_maps:deep_put(T, ZonesValue, Value),
     GLD = zone_global_defaults(),
+    NewZonesValue0 = emqx_utils_maps:deep_put(T, ZonesValue, Value),
+    NewZonesValue1 = emqx_utils_maps:deep_merge(#{default => GLD}, NewZonesValue0),
     maps:map(
         fun(_ZoneName, ZoneValue) ->
             merge_with_global_defaults(GLD, ZoneValue)
         end,
-        NewZonesValue
+        NewZonesValue1
     );
 maybe_update_zone([RootName | T], RootValue, Value) when is_atom(RootName) ->
     NewRootValue = emqx_utils_maps:deep_put(T, RootValue, Value),

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -711,7 +711,7 @@ do_put(Type, Putter, [RootName | KeyPath], DeepValue) ->
     NewValue = do_deep_put(Type, Putter, KeyPath, OldValue, DeepValue),
     Key = ?PERSIS_KEY(Type, RootName),
     persistent_term:put(Key, NewValue),
-    post_save_config_hook(Key, NewValue),
+    put_config_post_change_actions(Key, NewValue),
     ok.
 
 do_deep_get(?CONF, AtomKeyPath, Map, Default) ->
@@ -918,8 +918,8 @@ rawconf_to_conf(SchemaModule, RawPath, RawValue) ->
 %% When the global zone change, the zones is updated with the new global zone.
 %% The global zone's keys is too many,
 %% so we don't choose to write a global zone change emqx_config_handler callback to hook
-post_save_config_hook(?PERSIS_KEY(?CONF, zones), _Zones) ->
+put_config_post_change_actions(?PERSIS_KEY(?CONF, zones), _Zones) ->
     emqx_flapping:update_config(),
     ok;
-post_save_config_hook(_Key, _NewValue) ->
+put_config_post_change_actions(_Key, _NewValue) ->
     ok.

--- a/apps/emqx/src/emqx_flapping.erl
+++ b/apps/emqx/src/emqx_flapping.erl
@@ -214,7 +214,7 @@ update_timer(Timers) ->
                     start_timer(FlappingDetect, ZoneName);
                 TRef when Enable -> TRef;
                 TRef ->
-                    erlang:cancel_timer(TRef),
+                    _ = erlang:cancel_timer(TRef),
                     undefined
             end
         end,

--- a/apps/emqx/src/emqx_flapping.erl
+++ b/apps/emqx/src/emqx_flapping.erl
@@ -22,13 +22,13 @@
 -include("types.hrl").
 -include("logger.hrl").
 
--export([start_link/0, stop/0]).
+-export([start_link/0, update_config/0, stop/0]).
 
 %% API
 -export([detect/1]).
 
 -ifdef(TEST).
--export([get_policy/2]).
+-export([get_policy/1]).
 -endif.
 
 %% gen_server callbacks
@@ -59,12 +59,17 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
+update_config() ->
+    gen_server:cast(?MODULE, update_config).
+
 stop() -> gen_server:stop(?MODULE).
 
 %% @doc Detect flapping when a MQTT client disconnected.
 -spec detect(emqx_types:clientinfo()) -> boolean().
 detect(#{clientid := ClientId, peerhost := PeerHost, zone := Zone}) ->
-    Policy = #{max_count := Threshold} = get_policy([max_count, window_time, ban_time], Zone),
+    detect(ClientId, PeerHost, get_policy(Zone)).
+
+detect(ClientId, PeerHost, #{enable := true, max_count := Threshold} = Policy) ->
     %% The initial flapping record sets the detect_cnt to 0.
     InitVal = #flapping{
         clientid = ClientId,
@@ -82,24 +87,12 @@ detect(#{clientid := ClientId, peerhost := PeerHost, zone := Zone}) ->
                 [] ->
                     false
             end
-    end.
+    end;
+detect(_ClientId, _PeerHost, #{enable := false}) ->
+    false.
 
-get_policy(Keys, Zone) when is_list(Keys) ->
-    RootKey = flapping_detect,
-    Conf = emqx_config:get_zone_conf(Zone, [RootKey]),
-    lists:foldl(
-        fun(Key, Acc) ->
-            case maps:find(Key, Conf) of
-                {ok, V} -> Acc#{Key => V};
-                error -> Acc#{Key => emqx_config:get([RootKey, Key])}
-            end
-        end,
-        #{},
-        Keys
-    );
-get_policy(Key, Zone) ->
-    #{Key := Conf} = get_policy([Key], Zone),
-    Conf.
+get_policy(Zone) ->
+    emqx_config:get_zone_conf(Zone, [flapping_detect]).
 
 now_diff(TS) -> erlang:system_time(millisecond) - TS.
 
@@ -115,8 +108,8 @@ init([]) ->
         {read_concurrency, true},
         {write_concurrency, true}
     ]),
-    start_timers(),
-    {ok, #{}, hibernate}.
+    Timers = start_timers(),
+    {ok, Timers, hibernate}.
 
 handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", call => Req}),
@@ -169,17 +162,20 @@ handle_cast(
             )
     end,
     {noreply, State};
+handle_cast(update_config, State) ->
+    NState = update_timer(State),
+    {noreply, NState};
 handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", cast => Msg}),
     {noreply, State}.
 
 handle_info({timeout, _TRef, {garbage_collect, Zone}}, State) ->
-    Timestamp =
-        erlang:system_time(millisecond) - get_policy(window_time, Zone),
+    Policy = #{window_time := WindowTime} = get_policy(Zone),
+    Timestamp = erlang:system_time(millisecond) - WindowTime,
     MatchSpec = [{{'_', '_', '_', '$1', '_'}, [{'<', '$1', Timestamp}], [true]}],
     ets:select_delete(?FLAPPING_TAB, MatchSpec),
-    _ = start_timer(Zone),
-    {noreply, State, hibernate};
+    Timer = start_timer(Policy, Zone),
+    {noreply, State#{Zone => Timer}, hibernate};
 handle_info(Info, State) ->
     ?SLOG(error, #{msg => "unexpected_info", info => Info}),
     {noreply, State}.
@@ -190,18 +186,27 @@ terminate(_Reason, _State) ->
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
 
-start_timer(Zone) ->
-    case get_policy(window_time, Zone) of
-        WindowTime when is_integer(WindowTime) ->
-            emqx_utils:start_timer(WindowTime, {garbage_collect, Zone});
-        disabled ->
-            ok
-    end.
+start_timer(#{enable := true, window_time := WindowTime}, Zone) ->
+    emqx_utils:start_timer(WindowTime, {garbage_collect, Zone});
+start_timer(_Policy, _Zone) ->
+    undefined.
 
 start_timers() ->
-    maps:foreach(
-        fun(Zone, _ZoneConf) ->
-            start_timer(Zone)
+    maps:map(
+        fun(ZoneName, #{flapping_detect := FlappingDetect}) ->
+            start_timer(FlappingDetect, ZoneName)
+        end,
+        emqx:get_config([zones], #{})
+    ).
+
+update_timer(Timers) ->
+    maps:map(
+        fun(ZoneName, #{flapping_detect := FlappingDetect}) ->
+            case maps:get(ZoneName, Timers, undefined) of
+                undefined -> start_timer(FlappingDetect, ZoneName);
+                %% Don't reset this timer, it will be updated after next timeout.
+                TRef -> TRef
+            end
         end,
         emqx:get_config([zones], #{})
     ).

--- a/apps/emqx/src/emqx_flapping.erl
+++ b/apps/emqx/src/emqx_flapping.erl
@@ -50,12 +50,6 @@
     started_at :: pos_integer(),
     detect_cnt :: integer()
 }).
--define(DEFAULT_POLICY, #{
-    enable => false,
-    max_count => 15,
-    window_time => 60000,
-    ban_time => 5 * 6000
-}).
 
 -opaque flapping() :: #flapping{}.
 

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -33,7 +33,7 @@
 -define(MAX_INT_TIMEOUT_MS, 4294967295).
 %% floor(?MAX_INT_TIMEOUT_MS / 1000).
 -define(MAX_INT_TIMEOUT_S, 4294967).
--define(DEFAULT_WINDOW_TIME, "1m").
+-define(DEFAULT_WINDOW_TIME, <<"1m">>).
 
 -type duration() :: integer().
 -type duration_s() :: integer().

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -275,7 +275,7 @@ roots(low) ->
         {"flapping_detect",
             sc(
                 ref("flapping_detect"),
-                #{importance => ?IMPORTANCE_HIDDEN}
+                #{importance => ?DEFAULT_IMPORTANCE}
             )},
         {"persistent_session_store",
             sc(
@@ -685,15 +685,14 @@ fields("flapping_detect") ->
                 boolean(),
                 #{
                     default => false,
-                    deprecated => {since, "5.0.23"},
                     desc => ?DESC(flapping_detect_enable)
                 }
             )},
         {"window_time",
             sc(
-                hoconsc:union([disabled, duration()]),
+                duration(),
                 #{
-                    default => disabled,
+                    default => "1m",
                     importance => ?IMPORTANCE_HIGH,
                     desc => ?DESC(flapping_detect_window_time)
                 }

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -277,7 +277,7 @@ roots(low) ->
             sc(
                 ref("flapping_detect"),
                 #{
-                    importance => ?DEFAULT_IMPORTANCE,
+                    importance => ?IMPORTANCE_MEDIUM,
                     converter => fun flapping_detect_converter/2
                 }
             )},

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -33,6 +33,7 @@
 -define(MAX_INT_TIMEOUT_MS, 4294967295).
 %% floor(?MAX_INT_TIMEOUT_MS / 1000).
 -define(MAX_INT_TIMEOUT_S, 4294967).
+-define(DEFAULT_WINDOW_TIME, "1m").
 
 -type duration() :: integer().
 -type duration_s() :: integer().
@@ -275,7 +276,10 @@ roots(low) ->
         {"flapping_detect",
             sc(
                 ref("flapping_detect"),
-                #{importance => ?DEFAULT_IMPORTANCE}
+                #{
+                    importance => ?DEFAULT_IMPORTANCE,
+                    converter => fun flapping_detect_converter/2
+                }
             )},
         {"persistent_session_store",
             sc(
@@ -692,7 +696,7 @@ fields("flapping_detect") ->
             sc(
                 duration(),
                 #{
-                    default => "1m",
+                    default => ?DEFAULT_WINDOW_TIME,
                     importance => ?IMPORTANCE_HIGH,
                     desc => ?DESC(flapping_detect_window_time)
                 }
@@ -3495,3 +3499,9 @@ mqtt_converter(#{<<"keepalive_backoff">> := Backoff} = Mqtt, _Opts) ->
     Mqtt#{<<"keepalive_multiplier">> => Backoff * 2};
 mqtt_converter(Mqtt, _Opts) ->
     Mqtt.
+
+%% For backward compatibility with window_time is disable
+flapping_detect_converter(Conf = #{<<"window_time">> := <<"disable">>}, _Opts) ->
+    Conf#{<<"window_time">> => ?DEFAULT_WINDOW_TIME, <<"enable">> => false};
+flapping_detect_converter(Conf, _Opts) ->
+    Conf.

--- a/apps/emqx/src/emqx_zone_schema.erl
+++ b/apps/emqx/src/emqx_zone_schema.erl
@@ -58,8 +58,7 @@ hidden() ->
     [
         "stats",
         "overload_protection",
-        "conn_congestion",
-        "flapping_detect"
+        "conn_congestion"
     ].
 
 %% zone schemas are clones from the same name from root level

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -344,7 +344,7 @@ zone_global_defaults() ->
         conn_congestion =>
             #{enable_alarm => true, min_alarm_sustain_duration => 60000},
         flapping_detect =>
-            #{ban_time => 300000, max_count => 15, window_time => disabled},
+            #{ban_time => 300000, max_count => 15, window_time => 60000, enable => false},
         force_gc =>
             #{bytes => 16777216, count => 16000, enable => true},
         force_shutdown =>

--- a/apps/emqx/test/emqx_flapping_SUITE.erl
+++ b/apps/emqx/test/emqx_flapping_SUITE.erl
@@ -161,5 +161,15 @@ validate_timer(Names) ->
     ?assertEqual(maps:keys(Zones), maps:keys(Timers)),
     ok.
 
+t_window_compatibility_check(_Conf) ->
+    Flapping = emqx:get_config([flapping_detect]),
+    ok = emqx_config:init_load(emqx_schema, <<"flapping_detect {window_time = disable}">>),
+    ?assertMatch(#{window_time := 60000, enable := false}, emqx:get_config([flapping_detect])),
+    %% reset
+    FlappingBin = iolist_to_binary(["flapping_detect {", hocon_pp:do(Flapping, #{}), "}"]),
+    ok = emqx_config:init_load(emqx_schema, FlappingBin),
+    ?assertEqual(Flapping, emqx:get_config([flapping_detect])),
+    ok.
+
 get_policy(Zone) ->
     emqx_config:get_zone_conf(Zone, [flapping_detect]).

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -209,7 +209,7 @@ t_zones(_Config) ->
     ?assertEqual(Mqtt1, NewMqtt),
     %% delete the new zones
     {ok, #{}} = update_config("zones", Zones),
-    ?assertEqual(undefined, emqx_config:get_raw([new_zone, mqtt], undefined)),
+    ?assertEqual(undefined, emqx_config:get_raw([zones, new_zone], undefined)),
     ok.
 
 t_dashboard(_Config) ->


### PR DESCRIPTION
Fixes <issue-or-jira-number>
don't hide flapping_detect on global zone.
<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 169ee4a</samp>

This pull request adds and exposes the flapping detection feature for zones, which allows users to configure different policies for detecting and handling unstable MQTT clients. It also refactors and simplifies the code related to flapping detection and configuration updates in `emqx_config.erl`, `emqx_flapping.erl`, `emqx_channel.erl`, and `emqx_schema.erl`, and updates the corresponding test suite.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
