### PR TITLE
chore: remove deprecated QUIC listener config

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -417,10 +417,7 @@ do_start_listener(quic, ListenerName, #{bind := Bind} = Opts) ->
     case [A || {quicer, _, _} = A <- application:which_applications()] of
         [_] ->
             DefAcceptors = erlang:system_info(schedulers_online) * 8,
-            SSLOpts = maps:merge(
-                maps:with([certfile, keyfile], Opts),
-                maps:get(ssl_options, Opts, #{})
-            ),
+            SSLOpts = maps:get(ssl_options, Opts, #{}),
             ListenOpts =
                 [
                     {certfile, emqx_schema:naive_env_interpolation(maps:get(certfile, SSLOpts))},

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -980,7 +980,7 @@ fields("mqtt_quic_listener") ->
             sc(
                 string(),
                 #{
-                    %% TODO: deprecated => {since, "5.1.0"}
+                    deprecated => {since, "5.1.0"},
                     desc => ?DESC(fields_mqtt_quic_listener_certfile),
                     importance => ?IMPORTANCE_HIDDEN
                 }
@@ -989,7 +989,7 @@ fields("mqtt_quic_listener") ->
             sc(
                 string(),
                 #{
-                    %% TODO: deprecated => {since, "5.1.0"}
+                    deprecated => {since, "5.1.0"},
                     desc => ?DESC(fields_mqtt_quic_listener_keyfile),
                     importance => ?IMPORTANCE_HIDDEN
                 }
@@ -1068,7 +1068,7 @@ fields("mqtt_quic_listener") ->
                 #{
                     default => 0,
                     desc => ?DESC(fields_mqtt_quic_listener_idle_timeout),
-                    %% TODO: deprecated => {since, "5.1.0"}
+                    deprecated => {since, "5.1.0"},
                     %% deprecated, use idle_timeout_ms instead
                     importance => ?IMPORTANCE_HIDDEN
                 }
@@ -1085,7 +1085,7 @@ fields("mqtt_quic_listener") ->
                 #{
                     default => <<"10s">>,
                     desc => ?DESC(fields_mqtt_quic_listener_handshake_idle_timeout),
-                    %% TODO: deprecated => {since, "5.1.0"}
+                    deprecated => {since, "5.1.0"},
                     %% use handshake_idle_timeout_ms
                     importance => ?IMPORTANCE_HIDDEN
                 }


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Recent refactoring of SSL Options schema in listener breaks QUIC listener if the listener is configured with deprecated keys.

This PR remove the deprecated confs.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cc3daa7</samp>

Refactor QUIC listener configuration to remove deprecated options and use milliseconds for timeouts. This affects the `emqx_schema.erl` and `emqx_listeners.erl` files.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
