### PR TITLE
Adds support for unlimited max connections for gateway listeners

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -304,7 +304,6 @@ do_listeners_cluster_status(Listeners) ->
                     status => #{
                         running => Running,
                         current_connections => Curr,
-                        %% XXX: Since it is taken from raw-conf, it is possible a string
                         max_connections => int(Max)
                     }
                 }
@@ -314,10 +313,15 @@ do_listeners_cluster_status(Listeners) ->
         Listeners
     ).
 
+int(infinity) ->
+    infinity;
+int(<<"infinity">>) ->
+    infinity;
 int(B) when is_binary(B) ->
     binary_to_integer(B);
 int(I) when is_integer(I) ->
     I.
+
 aggregate_listener_status(NodeStatus) ->
     aggregate_listener_status(NodeStatus, 0, 0, undefined).
 
@@ -330,10 +334,18 @@ aggregate_listener_status(
     CurrAcc,
     RunningAcc
 ) ->
+    NMaxAcc = plus_max_connections(MaxAcc, Max),
     NRunning = aggregate_running(Running, RunningAcc),
-    aggregate_listener_status(T, MaxAcc + Max, Current + CurrAcc, NRunning);
+    aggregate_listener_status(T, NMaxAcc, Current + CurrAcc, NRunning);
 aggregate_listener_status([], MaxAcc, CurrAcc, RunningAcc) ->
     {MaxAcc, CurrAcc, RunningAcc}.
+
+plus_max_connections(_, infinity) ->
+    infinity;
+plus_max_connections(infinity, _) ->
+    infinity;
+plus_max_connections(A, B) when is_integer(A) andalso is_integer(B) ->
+    A + B.
 
 aggregate_running(R, R) -> R;
 aggregate_running(R, undefined) -> R;

--- a/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_api_listeners.erl
@@ -304,7 +304,7 @@ do_listeners_cluster_status(Listeners) ->
                     status => #{
                         running => Running,
                         current_connections => Curr,
-                        max_connections => int(Max)
+                        max_connections => ensure_integer_or_infinity(Max)
                     }
                 }
             }
@@ -313,13 +313,13 @@ do_listeners_cluster_status(Listeners) ->
         Listeners
     ).
 
-int(infinity) ->
+ensure_integer_or_infinity(infinity) ->
     infinity;
-int(<<"infinity">>) ->
+ensure_integer_or_infinity(<<"infinity">>) ->
     infinity;
-int(B) when is_binary(B) ->
+ensure_integer_or_infinity(B) when is_binary(B) ->
     binary_to_integer(B);
-int(I) when is_integer(I) ->
+ensure_integer_or_infinity(I) when is_integer(I) ->
     I.
 
 aggregate_listener_status(NodeStatus) ->

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -266,7 +266,7 @@ common_listener_opts() ->
             )},
         {max_connections,
             sc(
-                hoconsc:union([infinity, pos_integer()]),
+                hoconsc:union([pos_integer(), infinity]),
                 #{
                     default => 1024,
                     desc => ?DESC(gateway_common_listener_max_connections)

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -266,7 +266,7 @@ common_listener_opts() ->
             )},
         {max_connections,
             sc(
-                integer(),
+                hoconsc:union([infinity, pos_integer()]),
                 #{
                     default => 1024,
                     desc => ?DESC(gateway_common_listener_max_connections)

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -411,6 +411,38 @@ t_listeners_tcp(_) ->
     {404, _} = request(get, "/gateways/stomp/listeners/stomp:tcp:def"),
     ok.
 
+t_listeners_max_conns(_) ->
+    {204, _} = request(put, "/gateways/stomp", #{}),
+    {404, _} = request(get, "/gateways/stomp/listeners"),
+    LisConf = #{
+        name => <<"def">>,
+        type => <<"tcp">>,
+        bind => <<"127.0.0.1:61613">>,
+        max_connections => 1024
+    },
+    {201, _} = request(post, "/gateways/stomp/listeners", LisConf),
+    {200, ConfResp} = request(get, "/gateways/stomp/listeners"),
+    assert_confs([LisConf], ConfResp),
+    {200, ConfResp1} = request(get, "/gateways/stomp/listeners/stomp:tcp:def"),
+    assert_confs(LisConf, ConfResp1),
+
+    LisConf2 = maps:merge(LisConf, #{max_connections => <<"infinity">>}),
+    {200, _} = request(
+        put,
+        "/gateways/stomp/listeners/stomp:tcp:def",
+        LisConf2
+    ),
+
+    {200, ConfResp2} = request(get, "/gateways/stomp/listeners/stomp:tcp:def"),
+    assert_confs(LisConf2, ConfResp2),
+
+    {200, [Listeners]} = request(get, "/gateways/stomp/listeners"),
+    ?assertMatch(#{max_connections := <<"infinity">>}, Listeners),
+
+    {204, _} = request(delete, "/gateways/stomp/listeners/stomp:tcp:def"),
+    {404, _} = request(get, "/gateways/stomp/listeners/stomp:tcp:def"),
+    ok.
+
 t_listeners_authn(_) ->
     GwConf = #{
         name => <<"stomp">>,

--- a/changes/ce/feat-10961.en.md
+++ b/changes/ce/feat-10961.en.md
@@ -1,0 +1,3 @@
+Adds support for unlimited max connections for gateway listeners by allowing
+infinity as a valid value for the `max_connections` field in the configuration
+and HTTP API


### PR DESCRIPTION

Fixes https://emqx.atlassian.net/browse/EMQX-10135

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b3aaf93</samp>

This pull request adds support for unlimited max connections for gateway listeners by allowing `infinity` as a valid value for the `max_connections` field in the configuration file and the schema. It also fixes some code issues related to handling max connections values in `emqx_gateway_api_listeners.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
