### PR TITLE
fix(tlslib): bring back deterministic filenames for managed certs

### DIFF
--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -206,6 +206,24 @@ ssl_file_replace_test() ->
     ?assert(filelib:is_regular(IssuerPem2)),
     ok.
 
+ssl_file_deterministic_names_test() ->
+    SSL0 = #{
+        <<"keyfile">> => test_key(),
+        <<"certfile">> => test_key()
+    },
+    Dir0 = filename:join(["/tmp", ?FUNCTION_NAME, "ssl0"]),
+    Dir1 = filename:join(["/tmp", ?FUNCTION_NAME, "ssl1"]),
+    {ok, SSLFiles0} = emqx_tls_lib:ensure_ssl_files(Dir0, SSL0),
+    ?assertEqual(
+        {ok, SSLFiles0},
+        emqx_tls_lib:ensure_ssl_files(Dir0, SSL0)
+    ),
+    ?assertNotEqual(
+        {ok, SSLFiles0},
+        emqx_tls_lib:ensure_ssl_files(Dir1, SSL0)
+    ),
+    _ = file:del_dir_r(filename:join(["/tmp", ?FUNCTION_NAME])).
+
 bin(X) -> iolist_to_binary(X).
 
 test_key() ->


### PR DESCRIPTION
Fixes [EMQX-10163](https://emqx.atlassian.net/browse/EMQX-10163)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c05f462</samp>

Improved file name generation for PEM files in `emqx_tls_lib.erl`. Added a test case for the new logic in `emqx_tls_lib_tests.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] ~~Schema changes are backward compatible~~
