### PR TITLE
test(kafka_producer): attempt to reduce test flakiness

### DIFF
--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -811,4 +811,7 @@ delete_all_bridges() ->
     %% a bunch of orphan test bridges...
     lists:foreach(fun emqx_resource:remove/1, emqx_resource:list_instances()),
     emqx_config:put([bridges], #{}),
+    %% Attempt to avoid flakiness with kerberos, like:
+    %% Failed to store credentials: Internal credentials cache error (filename: /tmp/krb5cc_1001)
+    lists:foreach(fun(Cache) -> ok = file:delete(Cache) end, filelib:wildcard("/tmp/krb5cc_*")),
     ok.


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/5200674370/jobs/9379958927#step:7:1380
```
=ERROR REPORT==== 7-Jun-2023::14:03:27.738256 ===
client probing_brod_consumers failed to connect to kafka-1.emqx.net:9095
reason:{{sasl_auth_error,{<<"krb5_get_init_creds_keytab">>,-1765328188,
                          <<"Failed to store credentials: Internal credentials cache error (filename: /tmp/krb5cc_1001)">>}},
        [{kpro_sasl,auth,7,[{file,"kpro_sasl.erl"},{line,43}]},
         {kpro_connection,init_connection,3,
                          [{file,"kpro_connection.erl"},{line,265}]},
         {kpro_connection,init,4,[{file,"kpro_connection.erl"},{line,195}]},
         {proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}
```

Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d04ee6b</samp>

Delete kerberos cache files before running kafka bridge test suite. This prevents potential authentication issues or test failures when using kerberos with kafka in `emqx_bridge_kafka_impl_producer_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
