### PR TITLE
fix(emqx_prometheus): make json output for /stats the same data

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -24,8 +24,6 @@
 
 -include("emqx_prometheus.hrl").
 
--include_lib("prometheus/include/prometheus.hrl").
--include_lib("prometheus/include/prometheus_model.hrl").
 -include_lib("emqx/include/logger.hrl").
 
 -import(
@@ -172,31 +170,9 @@ collect_mf(_Registry, Callback) ->
 
 %% @private
 collect(<<"json">>) ->
-    Metrics = emqx_metrics:all(),
-    Stats = emqx_stats:getstats(),
-    VMData = emqx_vm_data(),
-    #{
-        stats => maps:from_list([collect_stats(Name, Stats) || Name <- emqx_stats()]),
-        metrics => maps:from_list([collect_stats(Name, VMData) || Name <- emqx_vm()]),
-        packets => maps:from_list([collect_stats(Name, Metrics) || Name <- emqx_metrics_packets()]),
-        messages => maps:from_list([collect_stats(Name, Metrics) || Name <- emqx_metrics_messages()]),
-        delivery => maps:from_list([collect_stats(Name, Metrics) || Name <- emqx_metrics_delivery()]),
-        client => maps:from_list([collect_stats(Name, Metrics) || Name <- emqx_metrics_client()]),
-        session => maps:from_list([collect_stats(Name, Metrics) || Name <- emqx_metrics_session()])
-    };
+    emqx_prometheus_json_format:format();
 collect(<<"prometheus">>) ->
     prometheus_text_format:format().
-
-%% @private
-collect_stats(Name, Stats) ->
-    R = collect_metrics(Name, Stats),
-    case R#'Metric'.gauge of
-        undefined ->
-            {_, Val} = R#'Metric'.counter,
-            {Name, Val};
-        {_, Val} ->
-            {Name, Val}
-    end.
 
 collect_metrics(Name, Metrics) ->
     emqx_collect(Name, Metrics).

--- a/apps/emqx_prometheus/src/emqx_prometheus_json_format.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_json_format.erl
@@ -1,0 +1,189 @@
+-module(emqx_prometheus_json_format).
+
+-export([
+    content_type/0,
+    format/0,
+    format/1
+]).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("prometheus/include/prometheus_model.hrl").
+
+-behaviour(prometheus_format).
+
+-define(TAB, ?MODULE).
+
+%%====================================================================
+%% Macros
+%%====================================================================
+
+%%====================================================================
+%% Format API
+%%====================================================================
+
+-spec content_type() -> binary().
+%% @doc
+%% Returns content type of custom json format.
+%% @end
+content_type() ->
+    <<"application/json">>.
+
+%% @equiv format(default)
+-spec format() -> binary().
+%% @doc
+%% Formats `default' registry using the latest text format.
+%% @end
+format() ->
+    format(default).
+
+-spec format(Registry :: prometheus_registry:registry()) -> binary().
+%% @doc
+%% Formats `Registry' using the latest text format.
+%% @end
+format(Registry) ->
+    _ =
+        case ets:whereis(?TAB) of
+            undefined ->
+                _Tab = ets:new(?TAB, [bag, named_table, public, {write_concurrency, true}]);
+            _Ref ->
+                ets:delete_all_objects(?TAB)
+        end,
+    ok = prometheus_registry:collect(
+        Registry,
+        fun(_Registry, Collector) ->
+            prometheus_collector:collect_mf(
+                Registry,
+                Collector,
+                fun store_mf_metrics/1
+            )
+        end
+    ),
+    Result = ets:foldl(fun aggregate_tab/2, #{}, ?TAB),
+    ?SLOG(
+        debug,
+        #{
+            msg => emqx_prometheus_json_format_result,
+            registry => Registry,
+            result => Result
+        }
+    ),
+    emqx_utils_json:encode(Result).
+
+%%====================================================================
+%% Private Parts
+%%====================================================================
+aggregate_tab({K, V0}, M) ->
+    V = to_map(V0),
+    case maps:get(K, M, undefined) of
+        undefined ->
+            M#{K => V};
+        OldValues when is_list(OldValues) ->
+            M#{K => [V | OldValues]};
+        OldValue ->
+            M#{K => [V, OldValue]}
+    end.
+
+to_map(V) when is_list(V) ->
+    maps:from_list(V);
+to_map(V) ->
+    V.
+
+%% @private
+store_mf_metrics(#'MetricFamily'{name = Name, metric = Metrics}) ->
+    lists:foreach(
+        fun(Metric) ->
+            store_metric(Name, Metric)
+        end,
+        Metrics
+    ).
+
+store_metric(Name, #'Metric'{
+    label = Labels,
+    counter = #'Counter'{value = Value}
+}) ->
+    store_series(Name, label_pairs_to_proplist(Labels), Value);
+store_metric(Name, #'Metric'{
+    label = Labels,
+    gauge = #'Gauge'{value = Value}
+}) ->
+    store_series(Name, label_pairs_to_proplist(Labels), Value);
+store_metric(Name, #'Metric'{
+    label = Labels,
+    untyped = #'Untyped'{value = Value}
+}) ->
+    store_series(Name, label_pairs_to_proplist(Labels), Value);
+store_metric(Name, #'Metric'{
+    label = Labels,
+    summary = #'Summary'{
+        sample_count = Count,
+        sample_sum = Sum,
+        quantile = Quantiles
+    }
+}) ->
+    LabelsList = label_pairs_to_proplist(Labels),
+    store_series([Name, "_count"], LabelsList, Count),
+    store_series([Name, "_sum"], LabelsList, Sum),
+    [
+        store_series(
+            [Name],
+            LabelsList ++
+                label_pairs_to_proplist([
+                    #'LabelPair'{name = "quantile", value = io_lib:format("~p", [QN])}
+                ]),
+
+            QV
+        )
+     || #'Quantile'{quantile = QN, value = QV} <- Quantiles
+    ];
+store_metric(Name, #'Metric'{
+    label = Labels,
+    histogram = #'Histogram'{
+        sample_count = Count,
+        sample_sum = Sum,
+        bucket = Buckets
+    }
+}) ->
+    LabelsList = label_pairs_to_proplist(Labels),
+    [store_histogram_bucket(Name, LabelsList, Bucket) || Bucket <- Buckets],
+    store_series([Name, "_count"], LabelsList, Count),
+    store_series([Name, "_sum"], LabelsList, Sum).
+
+store_histogram_bucket(Name, LabelsList, #'Bucket'{
+    cumulative_count = BCount,
+    upper_bound = BBound
+}) ->
+    BLValue = bound_to_label_value(BBound),
+    store_series(
+        [Name, "_bucket"],
+        LabelsList ++
+            label_pairs_to_proplist([#'LabelPair'{name = "le", value = BLValue}]),
+
+        BCount
+    ).
+
+label_pairs_to_proplist(Labels) ->
+    Fun = fun(#'LabelPair'{name = Name, value = Value}) ->
+        {Name, Value}
+    end,
+    lists:map(Fun, Labels).
+
+store_series(_Name, _LString, undefined) ->
+    ok;
+store_series(Name, [], Value) ->
+    ets:insert(?TAB, {to_key([Name], []), Value});
+store_series(Name, LString, Value) ->
+    ets:insert(?TAB, {to_key([Name], []), [{value, Value} | LString]}).
+
+to_key([], All) ->
+    list_to_binary(lists:flatten(lists:reverse(All)));
+to_key([H | T], All) when is_binary(H) ->
+    to_key(T, [binary_to_list(H) | All]);
+to_key([H | T], All) ->
+    to_key(T, [H | All]).
+
+bound_to_label_value(Bound) when is_integer(Bound) ->
+    integer_to_list(Bound);
+bound_to_label_value(Bound) when is_float(Bound) ->
+    float_to_list(Bound);
+bound_to_label_value(infinity) ->
+    "+Inf".

--- a/changes/ce/fix-10972.en.md
+++ b/changes/ce/fix-10972.en.md
@@ -1,0 +1,1 @@
+API endpoint `/prometheus/stats` now returns the same set of data for both, JSON and plain-text, content-types.


### PR DESCRIPTION
Fixes [EMQX-9570](https://emqx.atlassian.net/browse/EMQX-9570)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 719ee5d</samp>

Added a new module `emqx_prometheus_json_format` to handle the JSON format logic for the Prometheus metrics. Refactored and simplified the `emqx_prometheus` module to use the new module. Updated the test case for the Prometheus API to match the new JSON format.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible
