### PR TITLE
fix: link different document between community and enterprise

### DIFF
--- a/apps/emqx_conf/etc/emqx_conf.conf
+++ b/apps/emqx_conf/etc/emqx_conf.conf
@@ -6,7 +6,7 @@
 ## are stored in data/configs/cluster.hocon.
 ## To avoid confusion, please do not store the same configs in both files.
 ##
-## See https://docs.emqx.com/en/enterprise/v5.0/configuration/configuration.html
+## See {{ emqx_configuration_doc }} for more details.
 ## Configuration full example can be found in emqx.conf.example
 
 node {

--- a/mix.exs
+++ b/mix.exs
@@ -736,6 +736,7 @@ defmodule EMQXUmbrella.MixProject do
   defp template_vars(release, release_type, :bin = _package_type, edition_type) do
     [
       emqx_default_erlang_cookie: default_cookie(),
+      emqx_configuration_doc: emqx_configuration_doc(edition_type),
       platform_data_dir: "data",
       platform_etc_dir: "etc",
       platform_plugins_dir: "plugins",
@@ -790,6 +791,12 @@ defmodule EMQXUmbrella.MixProject do
         "EMQX"
     end
   end
+
+  defp emqx_configuration_doc(:enterprise),
+    do: "https://docs.emqx.com/en/enterprise/v5.0/configuration/configuration.html"
+
+  defp emqx_configuration_doc(:community),
+    do: "https://www.emqx.io/docs/en/v5.0/configuration/configuration.html"
 
   defp emqx_schema_mod(:enterprise), do: :emqx_enterprise_schema
   defp emqx_schema_mod(:community), do: :emqx_conf_schema

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -345,11 +345,15 @@ overlay_vars(cloud, PkgType, Edition) ->
 overlay_vars_edition(ce) ->
     [
         {emqx_schema_mod, emqx_conf_schema},
+        {emqx_configuration_doc,
+            "https://www.emqx.io/docs/en/v5.0/configuration/configuration.html"},
         {is_enterprise, "no"}
     ];
 overlay_vars_edition(ee) ->
     [
         {emqx_schema_mod, emqx_enterprise_schema},
+        {emqx_configuration_doc,
+            "https://docs.emqx.com/en/enterprise/v5.0/configuration/configuration.html"},
         {is_enterprise, "yes"}
     ].
 


### PR DESCRIPTION
Fixes [EMQX-10173](https://emqx.atlassian.net/browse/EMQX-10173)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3da07d5</samp>

Added a variable for configuration documentation URL in `rebar.config.erl` and `emqx_conf.conf`. This enables the URL to be customized for different product editions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
