### PR TITLE
fix(coap): fix crash publish/subscribe in connectionless mode

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -381,6 +381,8 @@ ensure_keepalive_timer(Fun, #channel{keepalive = KeepAlive} = Channel) ->
     Heartbeat = emqx_keepalive:info(interval, KeepAlive),
     Fun(keepalive, Heartbeat, keepalive, Channel).
 
+check_auth_state(Msg, #channel{connection_required = false} = Channel) ->
+    call_session(handle_request, Msg, Channel);
 check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
     case is_create_connection_request(Msg) of
         true ->


### PR DESCRIPTION
this bug was introduced by https://github.com/emqx/emqx/pull/10871, so it don't need to update changes

Fixes https://emqx.atlassian.net/browse/EMQX-10119

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 95f0745</samp>

This pull request implements the connectionless mode for the CoAP gateway, which enables clients to send requests without a connection. It fixes and enhances the test suite for this feature and adds a clause to handle connectionless requests in `emqx_coap_channel.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- ~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
