### PR TITLE
chore: add missing TLS defaults in emqx.conf

### DIFF
--- a/etc/emqx.conf
+++ b/etc/emqx.conf
@@ -1673,6 +1673,41 @@ crl_cache_refresh_interval = 15m
 ## Value: Ciphers
 listener.ssl.external.ciphers = TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_CHACHA20_POLY1305_SHA256,TLS_AES_128_CCM_SHA256,TLS_AES_128_CCM_8_SHA256,ECDHE-ECDSA-AES256-GCM-SHA384,ECDHE-RSA-AES256-GCM-SHA384,ECDHE-ECDSA-AES256-SHA384,ECDHE-RSA-AES256-SHA384,ECDHE-ECDSA-DES-CBC3-SHA,ECDH-ECDSA-AES256-GCM-SHA384,ECDH-RSA-AES256-GCM-SHA384,ECDH-ECDSA-AES256-SHA384,ECDH-RSA-AES256-SHA384,DHE-DSS-AES256-GCM-SHA384,DHE-DSS-AES256-SHA256,AES256-GCM-SHA384,AES256-SHA256,ECDHE-ECDSA-AES128-GCM-SHA256,ECDHE-RSA-AES128-GCM-SHA256,ECDHE-ECDSA-AES128-SHA256,ECDHE-RSA-AES128-SHA256,ECDH-ECDSA-AES128-GCM-SHA256,ECDH-RSA-AES128-GCM-SHA256,ECDH-ECDSA-AES128-SHA256,ECDH-RSA-AES128-SHA256,DHE-DSS-AES128-GCM-SHA256,DHE-DSS-AES128-SHA256,AES128-GCM-SHA256,AES128-SHA256,ECDHE-ECDSA-AES256-SHA,ECDHE-RSA-AES256-SHA,DHE-DSS-AES256-SHA,ECDH-ECDSA-AES256-SHA,ECDH-RSA-AES256-SHA,AES256-SHA,ECDHE-ECDSA-AES128-SHA,ECDHE-RSA-AES128-SHA,DHE-DSS-AES128-SHA,ECDH-ECDSA-AES128-SHA,ECDH-RSA-AES128-SHA,AES128-SHA
 
+## When EMQX verifies a client certificate during the x509 path validation
+## process, it constructs a certificate chain that starts with the client
+## certificate and ends with a trust anchor.
+## By default, if the setting is set to `false`, the trust anchor is the
+## rootCA, and the certificate chain must be complete.
+## However, if the setting is set to `true` or `cacert_from_cacertfile`,
+## the last certificate in the cacertfile will be used as the trust anchor
+## certificate (such as an intermediate CA). This creates a partial chain
+## in the path validation.
+## Alternatively, if the setting is set to `two_cacerts_from_cacertfile`,
+## one of the last two certificates in the cacertfile will be used as the
+## trust anchor certificate, forming a partial chain. This option is
+## particularly useful for CA certificate rotation.
+## However, please note that it incurs some additional overhead, so it
+## should only be used for certificate rotation purposes.
+##
+## Values: false | true | cacert_from_cacertfile | two_cacerts_from_cacertfile
+## listener.ssl.external.partial_chain = false
+
+## For additional client certificate validation, the value defined here must present in the
+## 'Extended Key Usage' of client certificate defined in
+## [rfc5280](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.12).
+##
+## Allowed values are
+## - "clientAuth"
+## - "serverAuth"
+## - "codeSigning"
+## - "emailProtection"
+## - "timeStamping"
+## - "ocspSigning"
+## - raw OID, example: "OID:1.3.6.1.5.5.7.3.2"
+## Comma-separated string is also supported for validating the subset of key usages.
+## example, "serverAuth,OID:1.3.6.1.5.5.7.3.2"
+##
+## listener.ssl.external.verify_peer_ext_key_usage = "clientAuth"
 
 ## Ciphers for TLS PSK.
 ## Note that 'listener.ssl.external.ciphers' and 'listener.ssl.external.psk_ciphers' cannot


### PR DESCRIPTION
- partial chain
- verify_peer_ext_key_usage

Fixes EMQX-10186

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 007144a</samp>

Add new SSL/TLS configuration options for external listener. These options allow users to customize the certificate validation, key usage verification, and pre-shared key ciphers for the `etc/emqx.conf` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
