### PR TITLE
feat: support reload cli

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -17,6 +17,9 @@
 -ifndef(EMQX_HRL).
 -define(EMQX_HRL, true).
 
+%% Config
+-define(READ_ONLY_KEYS, [cluster, rpc, node]).
+
 %% Shard
 %%--------------------------------------------------------------------
 -define(COMMON_SHARD, emqx_common_shard).

--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -17,9 +17,6 @@
 -ifndef(EMQX_HRL).
 -define(EMQX_HRL, true).
 
-%% Config
--define(READ_ONLY_KEYS, [cluster, rpc, node]).
-
 %% Shard
 %%--------------------------------------------------------------------
 -define(COMMON_SHARD, emqx_common_shard).

--- a/apps/emqx/include/emqx_authentication.hrl
+++ b/apps/emqx/include/emqx_authentication.hrl
@@ -47,5 +47,6 @@
 -define(CMD_MOVE_REAR, rear).
 -define(CMD_MOVE_BEFORE(Before), {before, Before}).
 -define(CMD_MOVE_AFTER(After), {'after', After}).
+-define(CMD_MERGE, merge).
 
 -endif.

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.7"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.8"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -35,7 +35,8 @@
     save_to_app_env/1,
     save_to_config_map/2,
     save_to_override_conf/3,
-    reload_etc_conf_on_local_node/0
+    config_files/0,
+    include_dirs/0
 ]).
 -export([merge_envs/2]).
 
@@ -91,6 +92,7 @@
 ]).
 
 -export([ensure_atom_conf_path/2]).
+-export([load_config_files/2]).
 
 -ifdef(TEST).
 -export([erase_all/0, backup_and_write/2]).
@@ -976,95 +978,6 @@ put_config_post_change_actions(?PERSIS_KEY(?CONF, zones), _Zones) ->
     ok;
 put_config_post_change_actions(_Key, _NewValue) ->
     ok.
-
-%% @doc Reload etc/emqx.conf to runtime config except for the readonly config
--spec reload_etc_conf_on_local_node() -> ok | {error, term()}.
-reload_etc_conf_on_local_node() ->
-    case load_etc_config_file() of
-        {ok, RawConf} ->
-            case check_readonly_config(RawConf) of
-                {ok, Reloaded} -> reload_config(Reloaded);
-                {error, Error} -> {error, Error}
-            end;
-        {error, _Error} ->
-            {error, bad_hocon_file}
-    end.
-
-reload_config(AllConf) ->
-    Func = fun(Key, Conf, Acc) ->
-        case emqx:update_config([Key], Conf, #{persistent => false}) of
-            {ok, _} ->
-                io:format("Reloaded ~ts config ok~n", [Key]),
-                Acc;
-            Error ->
-                ?ELOG("Reloaded ~ts config failed~n~p~n", [Key, Error]),
-                ?SLOG(error, #{
-                    msg => "failed_to_reload_etc_config",
-                    key => Key,
-                    value => Conf,
-                    error => Error
-                }),
-                Acc#{Key => Error}
-        end
-    end,
-    Res = maps:fold(Func, #{}, AllConf),
-    case Res =:= #{} of
-        true -> ok;
-        false -> {error, Res}
-    end.
-
-%% @doc Merge etc/emqx.conf on top of cluster.hocon.
-%% For example:
-%% `authorization.sources` will be merged into cluster.hocon when updated via dashboard,
-%% but `authorization.sources` in not in the default emqx.conf file.
-%% To make sure all root keys in emqx.conf has a fully merged value.
-load_etc_config_file() ->
-    ConfFiles = config_files(),
-    Opts = #{format => map, include_dirs => include_dirs()},
-    case hocon:files(ConfFiles, Opts) of
-        {ok, RawConf} ->
-            HasDeprecatedFile = has_deprecated_file(),
-            %% Merge etc.conf on top of cluster.hocon,
-            %% Don't use map deep_merge, use hocon files merge instead.
-            %% In order to have a chance to delete. (e.g. zones.zone1.mqtt = null)
-            Keys = maps:keys(RawConf),
-            MergedRaw = load_config_files(HasDeprecatedFile, ConfFiles),
-            {ok, maps:with(Keys, MergedRaw)};
-        {error, Error} ->
-            ?SLOG(error, #{
-                msg => "failed_to_read_etc_config",
-                files => ConfFiles,
-                error => Error
-            }),
-            {error, Error}
-    end.
-
-check_readonly_config(Raw) ->
-    SchemaMod = emqx_conf:schema_module(),
-    {_AppEnvs, CheckedConf} = check_config(SchemaMod, fill_defaults(Raw), #{}),
-    case lists:filtermap(fun(Key) -> filter_changed(Key, CheckedConf) end, ?READ_ONLY_KEYS) of
-        [] ->
-            {ok, maps:without([atom_to_binary(K) || K <- ?READ_ONLY_KEYS], Raw)};
-        Error ->
-            ?SLOG(error, #{
-                msg => "failed_to_change_read_only_key_in_etc_config",
-                read_only_keys => ?READ_ONLY_KEYS,
-                error => Error
-            }),
-            {error, Error}
-    end.
-
-filter_changed(Key, ChangedConf) ->
-    Prev = get([Key], #{}),
-    New = maps:get(Key, ChangedConf, #{}),
-    case Prev =/= New of
-        true -> {true, {Key, changed(New, Prev)}};
-        false -> false
-    end.
-
-changed(New, Prev) ->
-    Diff = emqx_utils_maps:diff_maps(New, Prev),
-    maps:filter(fun(_Key, Value) -> Value =/= #{} end, maps:remove(identical, Diff)).
 
 config_files() ->
     application:get_env(emqx, config_files, []).

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -44,6 +44,8 @@
     code_change/3
 ]).
 
+-export([schema/2]).
+
 -define(MOD, {mod}).
 -define(WKEY, '?').
 

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -46,7 +46,7 @@
 
 -export([schema/2]).
 
--define(MOD, {mod}).
+-define(MOD, module).
 -define(WKEY, '?').
 
 -type handler_name() :: module().

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -46,11 +46,10 @@
 
 -export([schema/2]).
 
--define(MOD, module).
+-define(MOD, '$mod').
 -define(WKEY, '?').
 
 -type handler_name() :: module().
--type handlers() :: #{emqx_config:config_key() => handlers(), ?MOD => handler_name()}.
 
 -optional_callbacks([
     pre_config_update/3,
@@ -69,10 +68,7 @@
 ) ->
     ok | {ok, Result :: any()} | {error, Reason :: term()}.
 
--type state() :: #{
-    handlers := handlers(),
-    atom() => term()
-}.
+-type state() :: #{handlers := any()}.
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, {}, []).

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -382,7 +382,7 @@ fields("persistent_table_mria_opts") ->
     ];
 fields("persistent_session_builtin") ->
     [
-        {"type", sc(hoconsc:enum([builtin]), #{default => builtin, desc => ""})},
+        {"type", sc(hoconsc:enum([builtin]), #{default => <<"builtin">>, desc => ""})},
         {"session",
             sc(ref("persistent_table_mria_opts"), #{
                 desc => ?DESC(persistent_session_builtin_session_table)
@@ -548,7 +548,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:union([integer(), disabled]),
                 #{
-                    default => disabled,
+                    default => <<"disabled">>,
                     desc => ?DESC(mqtt_server_keepalive)
                 }
             )},
@@ -575,7 +575,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:union([range(1, inf), infinity]),
                 #{
-                    default => infinity,
+                    default => <<"infinity">>,
                     desc => ?DESC(mqtt_max_subscriptions)
                 }
             )},
@@ -639,7 +639,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:union([disabled, map()]),
                 #{
-                    default => disabled,
+                    default => <<"disabled">>,
                     desc => ?DESC(mqtt_mqueue_priorities)
                 }
             )},
@@ -647,7 +647,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:enum([highest, lowest]),
                 #{
-                    default => lowest,
+                    default => <<"lowest">>,
                     desc => ?DESC(mqtt_mqueue_default_priority)
                 }
             )},
@@ -671,7 +671,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
                 #{
-                    default => disabled,
+                    default => <<"disabled">>,
                     desc => ?DESC(mqtt_peer_cert_as_username)
                 }
             )},
@@ -679,7 +679,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
                 #{
-                    default => disabled,
+                    default => <<"disabled">>,
                     desc => ?DESC(mqtt_peer_cert_as_clientid)
                 }
             )}
@@ -1224,7 +1224,7 @@ fields("ws_opts") ->
             sc(
                 hoconsc:enum([single, multiple]),
                 #{
-                    default => multiple,
+                    default => <<"multiple">>,
                     desc => ?DESC(fields_ws_opts_mqtt_piggyback)
                 }
             )},
@@ -1248,7 +1248,7 @@ fields("ws_opts") ->
             sc(
                 hoconsc:union([infinity, integer()]),
                 #{
-                    default => infinity,
+                    default => <<"infinity">>,
                     desc => ?DESC(fields_ws_opts_max_frame_size)
                 }
             )},
@@ -1506,7 +1506,7 @@ fields("deflate_opts") ->
             sc(
                 hoconsc:enum([default, filtered, huffman_only, rle]),
                 #{
-                    default => default,
+                    default => <<"default">>,
                     desc => ?DESC(fields_deflate_opts_strategy)
                 }
             )},
@@ -1514,7 +1514,7 @@ fields("deflate_opts") ->
             sc(
                 hoconsc:enum([takeover, no_takeover]),
                 #{
-                    default => takeover,
+                    default => <<"takeover">>,
                     desc => ?DESC(fields_deflate_opts_server_context_takeover)
                 }
             )},
@@ -1522,7 +1522,7 @@ fields("deflate_opts") ->
             sc(
                 hoconsc:enum([takeover, no_takeover]),
                 #{
-                    default => takeover,
+                    default => <<"takeover">>,
                     desc => ?DESC(fields_deflate_opts_client_context_takeover)
                 }
             )},
@@ -1557,7 +1557,7 @@ fields("broker") ->
             sc(
                 hoconsc:enum([local, leader, quorum, all]),
                 #{
-                    default => quorum,
+                    default => <<"quorum">>,
                     desc => ?DESC(broker_session_locking_strategy)
                 }
             )},
@@ -1573,7 +1573,7 @@ fields("broker") ->
                     hash_clientid
                 ]),
                 #{
-                    default => round_robin,
+                    default => <<"round_robin">>,
                     desc => ?DESC(broker_shared_subscription_strategy)
                 }
             )},
@@ -1626,7 +1626,7 @@ fields("shared_subscription_group") ->
                     hash_clientid
                 ]),
                 #{
-                    default => random,
+                    default => <<"random">>,
                     desc => ?DESC(shared_subscription_strategy_enum)
                 }
             )}
@@ -1637,7 +1637,7 @@ fields("broker_perf") ->
             sc(
                 hoconsc:enum([key, tab, global]),
                 #{
-                    default => key,
+                    default => <<"key">>,
                     desc => ?DESC(broker_perf_route_lock_type)
                 }
             )},
@@ -1759,7 +1759,7 @@ fields("sysmon_vm") ->
             sc(
                 hoconsc:union([disabled, duration()]),
                 #{
-                    default => disabled,
+                    default => <<"disabled">>,
                     desc => ?DESC(sysmon_vm_long_gc)
                 }
             )},
@@ -1959,7 +1959,7 @@ fields("trace") ->
     [
         {"payload_encode",
             sc(hoconsc:enum([hex, text, hidden]), #{
-                default => text,
+                default => <<"text">>,
                 deprecated => {since, "5.0.22"},
                 importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC(fields_trace_payload_encode)
@@ -2048,7 +2048,7 @@ base_listener(Bind) ->
                 atom(),
                 #{
                     desc => ?DESC(base_listener_zone),
-                    default => 'default'
+                    default => <<"default">>
                 }
             )},
         {"limiter",
@@ -2283,7 +2283,7 @@ common_ssl_opts_schema(Defaults, Type) ->
             sc(
                 hoconsc:enum([verify_peer, verify_none]),
                 #{
-                    default => Df("verify", verify_none),
+                    default => Df("verify", <<"verify_none">>),
                     desc => ?DESC(common_ssl_opts_schema_verify)
                 }
             )},
@@ -2351,7 +2351,7 @@ common_ssl_opts_schema(Defaults, Type) ->
                     emergency, alert, critical, error, warning, notice, info, debug, none, all
                 ]),
                 #{
-                    default => notice,
+                    default => <<"notice">>,
                     desc => ?DESC(common_ssl_opts_schema_log_level),
                     importance => ?IMPORTANCE_LOW
                 }
@@ -2611,7 +2611,7 @@ authz_fields() ->
             sc(
                 hoconsc:enum([allow, deny]),
                 #{
-                    default => allow,
+                    default => <<"allow">>,
                     required => true,
                     desc => ?DESC(fields_authorization_no_match)
                 }
@@ -2620,7 +2620,7 @@ authz_fields() ->
             sc(
                 hoconsc:enum([ignore, disconnect]),
                 #{
-                    default => ignore,
+                    default => <<"ignore">>,
                     required => true,
                     desc => ?DESC(fields_authorization_deny_action)
                 }

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -382,7 +382,7 @@ fields("persistent_table_mria_opts") ->
     ];
 fields("persistent_session_builtin") ->
     [
-        {"type", sc(hoconsc:enum([builtin]), #{default => <<"builtin">>, desc => ""})},
+        {"type", sc(hoconsc:enum([builtin]), #{default => builtin, desc => ""})},
         {"session",
             sc(ref("persistent_table_mria_opts"), #{
                 desc => ?DESC(persistent_session_builtin_session_table)
@@ -548,7 +548,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:union([integer(), disabled]),
                 #{
-                    default => <<"disabled">>,
+                    default => disabled,
                     desc => ?DESC(mqtt_server_keepalive)
                 }
             )},
@@ -575,7 +575,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:union([range(1, inf), infinity]),
                 #{
-                    default => <<"infinity">>,
+                    default => infinity,
                     desc => ?DESC(mqtt_max_subscriptions)
                 }
             )},
@@ -639,7 +639,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:union([disabled, map()]),
                 #{
-                    default => <<"disabled">>,
+                    default => disabled,
                     desc => ?DESC(mqtt_mqueue_priorities)
                 }
             )},
@@ -647,7 +647,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:enum([highest, lowest]),
                 #{
-                    default => <<"lowest">>,
+                    default => lowest,
                     desc => ?DESC(mqtt_mqueue_default_priority)
                 }
             )},
@@ -671,7 +671,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
                 #{
-                    default => <<"disabled">>,
+                    default => disabled,
                     desc => ?DESC(mqtt_peer_cert_as_username)
                 }
             )},
@@ -679,7 +679,7 @@ fields("mqtt") ->
             sc(
                 hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
                 #{
-                    default => <<"disabled">>,
+                    default => disabled,
                     desc => ?DESC(mqtt_peer_cert_as_clientid)
                 }
             )}
@@ -1224,7 +1224,7 @@ fields("ws_opts") ->
             sc(
                 hoconsc:enum([single, multiple]),
                 #{
-                    default => <<"multiple">>,
+                    default => multiple,
                     desc => ?DESC(fields_ws_opts_mqtt_piggyback)
                 }
             )},
@@ -1248,7 +1248,7 @@ fields("ws_opts") ->
             sc(
                 hoconsc:union([infinity, integer()]),
                 #{
-                    default => <<"infinity">>,
+                    default => infinity,
                     desc => ?DESC(fields_ws_opts_max_frame_size)
                 }
             )},
@@ -1506,7 +1506,7 @@ fields("deflate_opts") ->
             sc(
                 hoconsc:enum([default, filtered, huffman_only, rle]),
                 #{
-                    default => <<"default">>,
+                    default => default,
                     desc => ?DESC(fields_deflate_opts_strategy)
                 }
             )},
@@ -1514,7 +1514,7 @@ fields("deflate_opts") ->
             sc(
                 hoconsc:enum([takeover, no_takeover]),
                 #{
-                    default => <<"takeover">>,
+                    default => takeover,
                     desc => ?DESC(fields_deflate_opts_server_context_takeover)
                 }
             )},
@@ -1522,7 +1522,7 @@ fields("deflate_opts") ->
             sc(
                 hoconsc:enum([takeover, no_takeover]),
                 #{
-                    default => <<"takeover">>,
+                    default => takeover,
                     desc => ?DESC(fields_deflate_opts_client_context_takeover)
                 }
             )},
@@ -1557,7 +1557,7 @@ fields("broker") ->
             sc(
                 hoconsc:enum([local, leader, quorum, all]),
                 #{
-                    default => <<"quorum">>,
+                    default => quorum,
                     desc => ?DESC(broker_session_locking_strategy)
                 }
             )},
@@ -1573,7 +1573,7 @@ fields("broker") ->
                     hash_clientid
                 ]),
                 #{
-                    default => <<"round_robin">>,
+                    default => round_robin,
                     desc => ?DESC(broker_shared_subscription_strategy)
                 }
             )},
@@ -1626,7 +1626,7 @@ fields("shared_subscription_group") ->
                     hash_clientid
                 ]),
                 #{
-                    default => <<"random">>,
+                    default => random,
                     desc => ?DESC(shared_subscription_strategy_enum)
                 }
             )}
@@ -1637,7 +1637,7 @@ fields("broker_perf") ->
             sc(
                 hoconsc:enum([key, tab, global]),
                 #{
-                    default => <<"key">>,
+                    default => key,
                     desc => ?DESC(broker_perf_route_lock_type)
                 }
             )},
@@ -1759,7 +1759,7 @@ fields("sysmon_vm") ->
             sc(
                 hoconsc:union([disabled, duration()]),
                 #{
-                    default => <<"disabled">>,
+                    default => disabled,
                     desc => ?DESC(sysmon_vm_long_gc)
                 }
             )},
@@ -1959,7 +1959,7 @@ fields("trace") ->
     [
         {"payload_encode",
             sc(hoconsc:enum([hex, text, hidden]), #{
-                default => <<"text">>,
+                default => text,
                 deprecated => {since, "5.0.22"},
                 importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC(fields_trace_payload_encode)
@@ -2048,7 +2048,7 @@ base_listener(Bind) ->
                 atom(),
                 #{
                     desc => ?DESC(base_listener_zone),
-                    default => <<"default">>
+                    default => 'default'
                 }
             )},
         {"limiter",
@@ -2283,7 +2283,7 @@ common_ssl_opts_schema(Defaults, Type) ->
             sc(
                 hoconsc:enum([verify_peer, verify_none]),
                 #{
-                    default => Df("verify", <<"verify_none">>),
+                    default => Df("verify", verify_none),
                     desc => ?DESC(common_ssl_opts_schema_verify)
                 }
             )},
@@ -2351,7 +2351,7 @@ common_ssl_opts_schema(Defaults, Type) ->
                     emergency, alert, critical, error, warning, notice, info, debug, none, all
                 ]),
                 #{
-                    default => <<"notice">>,
+                    default => notice,
                     desc => ?DESC(common_ssl_opts_schema_log_level),
                     importance => ?IMPORTANCE_LOW
                 }
@@ -2611,7 +2611,7 @@ authz_fields() ->
             sc(
                 hoconsc:enum([allow, deny]),
                 #{
-                    default => <<"allow">>,
+                    default => allow,
                     required => true,
                     desc => ?DESC(fields_authorization_no_match)
                 }
@@ -2620,7 +2620,7 @@ authz_fields() ->
             sc(
                 hoconsc:enum([ignore, disconnect]),
                 #{
-                    default => <<"ignore">>,
+                    default => ignore,
                     required => true,
                     desc => ?DESC(fields_authorization_deny_action)
                 }

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -286,9 +286,9 @@ perform_sanity_checks(_App) ->
     ok.
 
 ensure_config_handler(Module, ConfigPath) ->
-    #{handlers := Handlers} = sys:get_state(emqx_config_handler),
+    #{handlers := Handlers} = emqx_config_handler:info(),
     case emqx_utils_maps:deep_get(ConfigPath, Handlers, not_found) of
-        #{{mod} := Module} -> ok;
+        #{'$mod' := Module} -> ok;
         NotFound -> error({config_handler_missing, ConfigPath, Module, NotFound})
     end,
     ok.

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -63,12 +63,12 @@ t_fill_default_values(C) when is_list(C) ->
                     <<"enable_session_registry">> := true,
                     <<"perf">> :=
                         #{
-                            <<"route_lock_type">> := key,
+                            <<"route_lock_type">> := <<"key">>,
                             <<"trie_compaction">> := true
                         },
                     <<"route_batch_clean">> := false,
-                    <<"session_locking_strategy">> := quorum,
-                    <<"shared_subscription_strategy">> := round_robin
+                    <<"session_locking_strategy">> := <<"quorum">>,
+                    <<"shared_subscription_strategy">> := <<"round_robin">>
                 }
         },
         WithDefaults

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -99,7 +99,7 @@ t_conflict_handler(_Config) ->
     %% override
     ok = emqx_config_handler:add_handler([sysmon], emqx_config_logger),
     ?assertMatch(
-        #{handlers := #{sysmon := #{{mod} := emqx_config_logger}}},
+        #{handlers := #{sysmon := #{?MOD := emqx_config_logger}}},
         emqx_config_handler:info()
     ),
     ok.

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -19,7 +19,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--define(MOD, {mod}).
+-define(MOD, '$mod').
 -define(WKEY, '?').
 -define(CLUSTER_CONF, "/tmp/cluster.conf").
 

--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -161,4 +161,4 @@ authn_list(Authn) when is_map(Authn) ->
     [Authn].
 
 merge_config(AuthNs) ->
-    emqx_authn_api:update_config(?CONF_NS_BINARY, {merge_authenticators, AuthNs}).
+    emqx_authn_api:update_config([?CONF_NS_ATOM], {merge_authenticators, AuthNs}).

--- a/apps/emqx_authn/src/emqx_authn.erl
+++ b/apps/emqx_authn/src/emqx_authn.erl
@@ -26,10 +26,7 @@
     get_enabled_authns/0
 ]).
 
-%% Data backup
--export([
-    import_config/1
-]).
+-export([merge_config/1, import_config/1]).
 
 -include("emqx_authn.hrl").
 
@@ -162,3 +159,6 @@ authn_list(Authn) when is_list(Authn) ->
     Authn;
 authn_list(Authn) when is_map(Authn) ->
     [Authn].
+
+merge_config(AuthNs) ->
+    emqx_authn_api:update_config(?CONF_NS_BINARY, {merge_authenticators, AuthNs}).

--- a/apps/emqx_authn/src/emqx_authn_api.erl
+++ b/apps/emqx_authn/src/emqx_authn_api.erl
@@ -89,6 +89,8 @@
     param_listener_id/0
 ]).
 
+-export([update_config/2]).
+
 -elvis([{elvis_style, god_modules, disable}]).
 
 api_spec() ->

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -451,7 +451,7 @@ request_for_log(Credential, #{url := Url, method := Method} = State) ->
                 base_url => Url,
                 path_query => PathQuery,
                 headers => Headers,
-                mody => Body
+                body => Body
             }
     end.
 

--- a/apps/emqx_authz/etc/emqx_authz.conf
+++ b/apps/emqx_authz/etc/emqx_authz.conf
@@ -1,5 +1,1 @@
-authorization {
-  deny_action = ignore
-  no_match = allow
-  cache = { enable = true }
-}
+

--- a/apps/emqx_authz/include/emqx_authz.hrl
+++ b/apps/emqx_authz/include/emqx_authz.hrl
@@ -37,6 +37,7 @@
 -define(CMD_PREPEND, prepend).
 -define(CMD_APPEND, append).
 -define(CMD_MOVE, move).
+-define(CMD_MERGE, merge).
 
 -define(CMD_MOVE_FRONT, front).
 -define(CMD_MOVE_REAR, rear).

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -166,10 +166,10 @@ do_pre_config_update(?ROOT_KEY, NewConf, OldConf) ->
 do_pre_config_replace(Conf, Conf) ->
     Conf;
 do_pre_config_replace(NewConf, OldConf) ->
-    #{<<"sources">> := NewSources} = NewConf,
-    #{<<"sources">> := OldSources} = OldConf,
+    NewSources = maps:get(<<"sources">>, NewConf, []),
+    OldSources = maps:get(<<"sources">>, OldConf, []),
     NewSources1 = do_pre_config_update({?CMD_REPLACE, NewSources}, OldSources),
-    NewConf#{<<"sources">> := NewSources1}.
+    NewConf#{<<"sources">> => NewSources1}.
 
 do_pre_config_update({?CMD_MOVE, _, _} = Cmd, Sources) ->
     do_move(Cmd, Sources);

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -41,7 +41,6 @@
 -export([post_config_update/5, pre_config_update/3]).
 
 -export([acl_conf_file/0]).
--export([merge_sources/2, search/2]).
 
 %% Data backup
 -export([

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -166,8 +166,9 @@ do_pre_config_update(?ROOT_KEY, NewConf, OldConf) ->
 do_pre_config_replace(Conf, Conf) ->
     Conf;
 do_pre_config_replace(NewConf, OldConf) ->
-    NewSources = maps:get(<<"sources">>, NewConf, []),
-    OldSources = maps:get(<<"sources">>, OldConf, []),
+    Default = [emqx_authz_schema:default_authz()],
+    NewSources = maps:get(<<"sources">>, NewConf, Default),
+    OldSources = maps:get(<<"sources">>, OldConf, Default),
     NewSources1 = do_pre_config_update({?CMD_REPLACE, NewSources}, OldSources),
     NewConf#{<<"sources">> => NewSources1}.
 

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -674,6 +674,7 @@ merge_sources_test() ->
     Mysql = #{<<"type">> => <<"mysql">>, <<"enable">> => true},
     Mongo = #{<<"type">> => <<"mongodb">>, <<"enable">> => true},
     Redis = #{<<"type">> => <<"redis">>, <<"enable">> => true},
+    Postgresql = #{<<"type">> => <<"postgresql">>, <<"enable">> => true},
     HttpDisable = Http#{<<"enable">> => false},
     MysqlDisable = Mysql#{<<"enable">> => false},
     MongoDisable = Mongo#{<<"enable">> => false},
@@ -685,10 +686,10 @@ merge_sources_test() ->
 
     %% add
     ?assertEqual(
-        [Http, Mysql, Mongo, Redis],
+        [Http, Mysql, Mongo, Redis, Postgresql],
         merge_sources(
             #{<<"sources">> => [Http, Mysql]},
-            #{<<"sources">> => [Mongo, Redis]}
+            #{<<"sources">> => [Mongo, Redis, Postgresql]}
         )
     ),
     %% replace

--- a/apps/emqx_authz/src/emqx_authz_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_schema.erl
@@ -42,7 +42,8 @@
 
 -export([
     headers_no_content_type/1,
-    headers/1
+    headers/1,
+    default_authz/0
 ]).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_conf/include/emqx_conf.hrl
+++ b/apps/emqx_conf/include/emqx_conf.hrl
@@ -34,4 +34,6 @@
     tnx_id :: pos_integer() | '$1'
 }).
 
+-define(READONLY_KEYS, [cluster, rpc, node]).
+
 -endif.

--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -19,6 +19,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/emqx_schema.hrl").
+-include("emqx_conf.hrl").
 
 -export([add_handler/2, remove_handler/1]).
 -export([get/1, get/2, get_raw/1, get_raw/2, get_all/1]).
@@ -30,6 +31,7 @@
 -export([dump_schema/2]).
 -export([schema_module/0]).
 -export([gen_example_conf/2]).
+-export([reload_etc_conf_on_local_node/0]).
 
 %% TODO: move to emqx_dashboard when we stop building api schema at build time
 -export([
@@ -213,9 +215,99 @@ schema_module() ->
         Value -> list_to_existing_atom(Value)
     end.
 
+%% @doc Reload etc/emqx.conf to runtime config except for the readonly config
+-spec reload_etc_conf_on_local_node() -> ok | {error, term()}.
+reload_etc_conf_on_local_node() ->
+    case load_etc_config_file() of
+        {ok, RawConf} ->
+            case check_readonly_config(RawConf) of
+                {ok, Reloaded} -> reload_config(Reloaded);
+                {error, Error} -> {error, Error}
+            end;
+        {error, _Error} ->
+            {error, bad_hocon_file}
+    end.
+
+reload_config(AllConf) ->
+    Func = fun(Key, Conf, Acc) ->
+        case emqx:update_config([Key], Conf, #{persistent => false}) of
+            {ok, _} ->
+                io:format("Reloaded ~ts config ok~n", [Key]),
+                Acc;
+            Error ->
+                ?ELOG("Reloaded ~ts config failed~n~p~n", [Key, Error]),
+                ?SLOG(error, #{
+                    msg => "failed_to_reload_etc_config",
+                    key => Key,
+                    value => Conf,
+                    error => Error
+                }),
+                Acc#{Key => Error}
+        end
+    end,
+    Res = maps:fold(Func, #{}, AllConf),
+    case Res =:= #{} of
+        true -> ok;
+        false -> {error, Res}
+    end.
+
+%% @doc Merge etc/emqx.conf on top of cluster.hocon.
+%% For example:
+%% `authorization.sources` will be merged into cluster.hocon when updated via dashboard,
+%% but `authorization.sources` in not in the default emqx.conf file.
+%% To make sure all root keys in emqx.conf has a fully merged value.
+load_etc_config_file() ->
+    ConfFiles = emqx_config:config_files(),
+    Opts = #{format => map, include_dirs => emqx_config:include_dirs()},
+    case hocon:files(ConfFiles, Opts) of
+        {ok, RawConf} ->
+            HasDeprecatedFile = emqx_config:has_deprecated_file(),
+            %% Merge etc.conf on top of cluster.hocon,
+            %% Don't use map deep_merge, use hocon files merge instead.
+            %% In order to have a chance to delete. (e.g. zones.zone1.mqtt = null)
+            Keys = maps:keys(RawConf),
+            MergedRaw = emqx_config:load_config_files(HasDeprecatedFile, ConfFiles),
+            {ok, maps:with(Keys, MergedRaw)};
+        {error, Error} ->
+            ?SLOG(error, #{
+                msg => "failed_to_read_etc_config",
+                files => ConfFiles,
+                error => Error
+            }),
+            {error, Error}
+    end.
+
+check_readonly_config(Raw) ->
+    SchemaMod = schema_module(),
+    RawDefault = emqx_config:fill_defaults(Raw),
+    {_AppEnvs, CheckedConf} = emqx_config:check_config(SchemaMod, RawDefault),
+    case lists:filtermap(fun(Key) -> filter_changed(Key, CheckedConf) end, ?READONLY_KEYS) of
+        [] ->
+            {ok, maps:without([atom_to_binary(K) || K <- ?READONLY_KEYS], Raw)};
+        Error ->
+            ?SLOG(error, #{
+                msg => "failed_to_change_read_only_key_in_etc_config",
+                read_only_keys => ?READONLY_KEYS,
+                error => Error
+            }),
+            {error, Error}
+    end.
+
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+
+filter_changed(Key, ChangedConf) ->
+    Prev = get([Key], #{}),
+    New = maps:get(Key, ChangedConf, #{}),
+    case Prev =/= New of
+        true -> {true, {Key, changed(New, Prev)}};
+        false -> false
+    end.
+
+changed(New, Prev) ->
+    Diff = emqx_utils_maps:diff_maps(New, Prev),
+    maps:filter(fun(_Key, Value) -> Value =/= #{} end, maps:remove(identical, Diff)).
 
 %% @doc Make a resolver function that can be used to lookup the description by hocon_schema_json dump.
 make_desc_resolver(Lang) ->

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -31,6 +31,7 @@
 %% kept cluster_call for compatibility
 -define(CLUSTER_CALL, cluster_call).
 -define(CONF, conf).
+-define(UPDATE_READONLY_KEYS_PROHIBITED, "update_readonly_keys_prohibited").
 
 load() ->
     emqx_ctl:register_command(?CLUSTER_CALL, {?MODULE, admins}, [hidden]),
@@ -55,7 +56,7 @@ conf(["load", Path]) ->
 conf(["cluster_sync" | Args]) ->
     admins(Args);
 conf(["reload"]) ->
-    emqx_conf:reload_etc_conf_on_local_node();
+    reload_etc_conf_on_local_node();
 conf(_) ->
     emqx_ctl:usage(usage_conf() ++ usage_sync()).
 
@@ -190,16 +191,25 @@ load_config(Path, AuthChain) ->
         {ok, RawConf} ->
             case check_config(RawConf) of
                 ok ->
-                    maps:foreach(fun(K, V) -> update_config(K, V, AuthChain) end, RawConf);
-                {error, Reason} when is_list(Reason) ->
+                    lists:foreach(
+                        fun({K, V}) -> update_config(K, V, AuthChain) end,
+                        to_sorted_list(RawConf)
+                    );
+                {error, ?UPDATE_READONLY_KEYS_PROHIBITED = Reason} ->
                     emqx_ctl:warning("load ~ts failed~n~ts~n", [Path, Reason]),
                     emqx_ctl:warning(
                         "Maybe try `emqx_ctl conf reload` to reload etc/emqx.conf on local node~n"
                     ),
                     {error, Reason};
-                {error, Reason} when is_map(Reason) ->
-                    emqx_ctl:warning("load ~ts schema check failed~n~p~n", [Path, Reason]),
-                    {error, Reason}
+                {error, Errors} ->
+                    emqx_ctl:warning("load ~ts schema check failed~n", [Path]),
+                    lists:foreach(
+                        fun({Key, Error}) ->
+                            emqx_ctl:warning("~ts: ~p~n", [Key, Error])
+                        end,
+                        Errors
+                    ),
+                    {error, Errors}
             end;
         {error, Reason} ->
             emqx_ctl:warning("load ~ts failed~n~p~n", [Path, Reason]),
@@ -207,14 +217,11 @@ load_config(Path, AuthChain) ->
     end.
 
 update_config(?EMQX_AUTHORIZATION_CONFIG_ROOT_NAME = Key, Conf, "merge") ->
-    Res = emqx_authz:merge(Conf),
-    check_res(Key, Res);
+    check_res(Key, emqx_authz:merge(Conf));
 update_config(?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME = Key, Conf, "merge") ->
-    Res = emqx_authn:merge_config(Conf),
-    check_res(Key, Res);
+    check_res(Key, emqx_authn:merge_config(Conf));
 update_config(Key, Value, _) ->
-    Res = emqx_conf:update([Key], Value, ?OPTIONS),
-    check_res(Key, Res).
+    check_res(Key, emqx_conf:update([Key], Value, ?OPTIONS)).
 
 check_res(Key, {ok, _}) -> emqx_ctl:print("load ~ts in cluster ok~n", [Key]);
 check_res(Key, {error, Reason}) -> emqx_ctl:warning("load ~ts failed~n~p~n", [Key, Reason]).
@@ -230,24 +237,123 @@ check_keys_is_not_readonly(Conf) ->
     ReadOnlyKeys = [atom_to_binary(K) || K <- ?READONLY_KEYS],
     case ReadOnlyKeys -- Keys of
         ReadOnlyKeys -> ok;
-        _ -> {error, "update_readonly_keys_prohibited"}
+        _ -> {error, ?UPDATE_READONLY_KEYS_PROHIBITED}
     end.
 
 check_config_schema(Conf) ->
     SchemaMod = emqx_conf:schema_module(),
-    Res =
-        maps:fold(
-            fun(Key, Value, Acc) ->
-                Schema = emqx_config_handler:schema(SchemaMod, [Key]),
-                case emqx_conf:check_config(Schema, #{Key => Value}) of
-                    {ok, _} -> Acc;
-                    {error, Reason} -> #{Key => Reason}
-                end
-            end,
-            #{},
-            Conf
-        ),
-    case Res =:= #{} of
-        true -> ok;
-        false -> {error, Res}
+    Fold = fun({Key, Value}, Acc) ->
+        Schema = emqx_config_handler:schema(SchemaMod, [Key]),
+        case emqx_conf:check_config(Schema, #{Key => Value}) of
+            {ok, _} -> Acc;
+            {error, Reason} -> [{Key, Reason} | Acc]
+        end
+    end,
+    sorted_fold(Fold, Conf).
+
+%% @doc Reload etc/emqx.conf to runtime config except for the readonly config
+-spec reload_etc_conf_on_local_node() -> ok | {error, term()}.
+reload_etc_conf_on_local_node() ->
+    case load_etc_config_file() of
+        {ok, RawConf} ->
+            case check_readonly_config(RawConf) of
+                {ok, Reloaded} -> reload_config(Reloaded);
+                {error, Error} -> {error, Error}
+            end;
+        {error, _Error} ->
+            {error, bad_hocon_file}
     end.
+
+%% @doc Merge etc/emqx.conf on top of cluster.hocon.
+%% For example:
+%% `authorization.sources` will be merged into cluster.hocon when updated via dashboard,
+%% but `authorization.sources` in not in the default emqx.conf file.
+%% To make sure all root keys in emqx.conf has a fully merged value.
+load_etc_config_file() ->
+    ConfFiles = emqx_config:config_files(),
+    Opts = #{format => map, include_dirs => emqx_config:include_dirs()},
+    case hocon:files(ConfFiles, Opts) of
+        {ok, RawConf} ->
+            HasDeprecatedFile = emqx_config:has_deprecated_file(),
+            %% Merge etc.conf on top of cluster.hocon,
+            %% Don't use map deep_merge, use hocon files merge instead.
+            %% In order to have a chance to delete. (e.g. zones.zone1.mqtt = null)
+            Keys = maps:keys(RawConf),
+            MergedRaw = emqx_config:load_config_files(HasDeprecatedFile, ConfFiles),
+            {ok, maps:with(Keys, MergedRaw)};
+        {error, Error} ->
+            ?SLOG(error, #{
+                msg => "failed_to_read_etc_config",
+                files => ConfFiles,
+                error => Error
+            }),
+            {error, Error}
+    end.
+
+check_readonly_config(Raw) ->
+    SchemaMod = emqx_conf:schema_module(),
+    RawDefault = emqx_config:fill_defaults(Raw),
+    case emqx_conf:check_config(SchemaMod, RawDefault) of
+        {ok, CheckedConf} ->
+            case filter_changed_readonly_keys(CheckedConf) of
+                [] ->
+                    ReadOnlyKeys = [atom_to_binary(K) || K <- ?READONLY_KEYS],
+                    {ok, maps:without(ReadOnlyKeys, Raw)};
+                Error ->
+                    ?SLOG(error, #{
+                        msg => ?UPDATE_READONLY_KEYS_PROHIBITED,
+                        read_only_keys => ?READONLY_KEYS,
+                        error => Error
+                    }),
+                    {error, Error}
+            end;
+        {error, Error} ->
+            ?SLOG(error, #{
+                msg => "bad_etc_config_schema_found",
+                error => Error
+            }),
+            {error, Error}
+    end.
+
+reload_config(AllConf) ->
+    Fold = fun({Key, Conf}, Acc) ->
+        case emqx:update_config([Key], Conf, #{persistent => false}) of
+            {ok, _} ->
+                emqx_ctl:print("Reloaded ~ts config ok~n", [Key]),
+                Acc;
+            Error ->
+                emqx_ctl:warning("Reloaded ~ts config failed~n~p~n", [Key, Error]),
+                ?SLOG(error, #{
+                    msg => "failed_to_reload_etc_config",
+                    key => Key,
+                    value => Conf,
+                    error => Error
+                }),
+                [{Key, Error} | Acc]
+        end
+    end,
+    sorted_fold(Fold, AllConf).
+
+filter_changed_readonly_keys(Conf) ->
+    lists:filtermap(fun(Key) -> filter_changed(Key, Conf) end, ?READONLY_KEYS).
+
+filter_changed(Key, ChangedConf) ->
+    Prev = emqx_conf:get([Key], #{}),
+    New = maps:get(Key, ChangedConf, #{}),
+    case Prev =/= New of
+        true -> {true, {Key, changed(New, Prev)}};
+        false -> false
+    end.
+
+changed(New, Prev) ->
+    Diff = emqx_utils_maps:diff_maps(New, Prev),
+    maps:filter(fun(_Key, Value) -> Value =/= #{} end, maps:remove(identical, Diff)).
+
+sorted_fold(Func, Conf) ->
+    case lists:foldl(Func, [], to_sorted_list(Conf)) of
+        [] -> ok;
+        Error -> {error, Error}
+    end.
+
+to_sorted_list(Conf) ->
+    lists:keysort(1, maps:to_list(Conf)).

--- a/apps/emqx_conf/test/emqx_conf_cli_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cli_SUITE.erl
@@ -40,18 +40,21 @@ t_load_config(Config) ->
     ConfBin0 = hocon_pp:do(#{<<"authorization">> => Conf#{<<"sources">> => []}}, #{}),
     ConfFile0 = prepare_conf_file(?FUNCTION_NAME, ConfBin0, Config),
     ok = emqx_conf_cli:conf(["load", ConfFile0]),
-    ?assertEqual(Conf#{<<"sources">> := []}, emqx_conf:get_raw([Authz])),
+    ?assertEqual(Conf#{<<"sources">> => []}, emqx_conf:get_raw([Authz])),
     %% remove sources, it will reset to default file source.
     ConfBin1 = hocon_pp:do(#{<<"authorization">> => maps:remove(<<"sources">>, Conf)}, #{}),
     ConfFile1 = prepare_conf_file(?FUNCTION_NAME, ConfBin1, Config),
     ok = emqx_conf_cli:conf(["load", ConfFile1]),
     Default = [emqx_authz_schema:default_authz()],
-    ?assertEqual(Conf#{<<"sources">> := Default}, emqx_conf:get_raw([Authz])),
+    ?assertEqual(Conf#{<<"sources">> => Default}, emqx_conf:get_raw([Authz])),
     %% reset
     ConfBin2 = hocon_pp:do(#{<<"authorization">> => Conf}, #{}),
     ConfFile2 = prepare_conf_file(?FUNCTION_NAME, ConfBin2, Config),
     ok = emqx_conf_cli:conf(["load", ConfFile2]),
-    ?assertEqual(Conf, emqx_conf:get_raw([Authz])),
+    ?assertEqual(
+        Conf#{<<"sources">> => [emqx_authz_schema:default_authz()]},
+        emqx_conf:get_raw([Authz])
+    ),
     ?assertEqual({error, empty_hocon_file}, emqx_conf_cli:conf(["load", "non-exist-file"])),
     ok.
 

--- a/apps/emqx_conf/test/emqx_conf_cli_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cli_SUITE.erl
@@ -1,0 +1,72 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_conf_cli_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include("emqx_conf.hrl").
+-import(emqx_config_SUITE, [prepare_conf_file/3]).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    emqx_mgmt_api_test_util:init_suite([emqx_conf, emqx_authz]),
+    Config.
+
+end_per_suite(_Config) ->
+    emqx_mgmt_api_test_util:end_suite([emqx_conf, emqx_authz]).
+
+t_load_config(Config) ->
+    Authz = authorization,
+    Conf = emqx_conf:get_raw([Authz]),
+    %% set sources to []
+    ConfBin0 = hocon_pp:do(#{<<"authorization">> => Conf#{<<"sources">> => []}}, #{}),
+    ConfFile0 = prepare_conf_file(?FUNCTION_NAME, ConfBin0, Config),
+    ok = emqx_conf_cli:conf(["load", ConfFile0]),
+    ?assertEqual(Conf#{<<"sources">> := []}, emqx_conf:get_raw([Authz])),
+    %% remove sources, it will reset to default file source.
+    ConfBin1 = hocon_pp:do(#{<<"authorization">> => maps:remove(<<"sources">>, Conf)}, #{}),
+    ConfFile1 = prepare_conf_file(?FUNCTION_NAME, ConfBin1, Config),
+    ok = emqx_conf_cli:conf(["load", ConfFile1]),
+    Default = [emqx_authz_schema:default_authz()],
+    ?assertEqual(Conf#{<<"sources">> := Default}, emqx_conf:get_raw([Authz])),
+    %% reset
+    ConfBin2 = hocon_pp:do(#{<<"authorization">> => Conf}, #{}),
+    ConfFile2 = prepare_conf_file(?FUNCTION_NAME, ConfBin2, Config),
+    ok = emqx_conf_cli:conf(["load", ConfFile2]),
+    ?assertEqual(Conf, emqx_conf:get_raw([Authz])),
+    ?assertEqual({error, empty_hocon_file}, emqx_conf_cli:conf(["load", "non-exist-file"])),
+    ok.
+
+t_load_readonly(Config) ->
+    Base = #{<<"mqtt">> => emqx_conf:get_raw([mqtt])},
+    lists:foreach(
+        fun(Key) ->
+            Conf = emqx_conf:get_raw([Key]),
+            ConfBin0 = hocon_pp:do(Base#{Key => Conf}, #{}),
+            ConfFile0 = prepare_conf_file(?FUNCTION_NAME, ConfBin0, Config),
+            ?assertEqual(
+                {error, "update_readonly_keys_prohibited"},
+                emqx_conf_cli:conf(["load", ConfFile0])
+            )
+        end,
+        ?READONLY_KEYS
+    ),
+    ok.

--- a/apps/emqx_conf/test/emqx_conf_logger_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_logger_SUITE.erl
@@ -62,7 +62,7 @@ end_per_suite(_Config) ->
 t_log_conf(_Conf) ->
     FileExpect = #{
         <<"enable">> => true,
-        <<"formatter">> => text,
+        <<"formatter">> => <<"text">>,
         <<"level">> => <<"info">>,
         <<"rotation_count">> => 10,
         <<"rotation_size">> => <<"50MB">>,
@@ -73,7 +73,7 @@ t_log_conf(_Conf) ->
         <<"console">> =>
             #{
                 <<"enable">> => true,
-                <<"formatter">> => text,
+                <<"formatter">> => <<"text">>,
                 <<"level">> => <<"debug">>,
                 <<"time_offset">> => <<"system">>
             },

--- a/apps/emqx_ctl/src/emqx_ctl.erl
+++ b/apps/emqx_ctl/src/emqx_ctl.erl
@@ -38,6 +38,8 @@
 -export([
     print/1,
     print/2,
+    warning/1,
+    warning/2,
     usage/1,
     usage/2
 ]).
@@ -179,6 +181,14 @@ print(Msg) ->
 -spec print(io:format(), [term()]) -> ok.
 print(Format, Args) ->
     io:format("~ts", [format(Format, Args)]).
+
+-spec warning(io:format()) -> ok.
+warning(Format) ->
+    warning(Format, []).
+
+-spec warning(io:format(), [term()]) -> ok.
+warning(Format, Args) ->
+    io:format("\e[31m~ts\e[0m", [format(Format, Args)]).
 
 -spec usage([cmd_usage()]) -> ok.
 usage(UsageList) ->

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.8", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.39.7", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.39.8", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.2", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -75,7 +75,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.8"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.7"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.8"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
Fixes [EMQX-10117](https://emqx.atlassian.net/browse/EMQX-10117).
1. Add `emqx_ctl conf reload`  to reload `etc/emqx.conf` on local node.
2. Check all configs' schema before load them.
3. Add more test for emqx_conf_cli.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4006afe</samp>

This pull request improves the config management of EMQ X by adding a `conf reload` command, fixing a bug in the authorization source update, and adding a test case for the `emqx_conf_cli` module. It also introduces some code refactoring and enhancement, such as using a `warning/1` function, a `default_authz/0` function, and a `READONLY_KEYS` macro.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
