### PR TITLE
fix(emqx_utils): redact proxy-authorization headers

### DIFF
--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -579,15 +579,18 @@ try_to_existing_atom(Convert, Data, Encoding) ->
         _:Reason -> {error, Reason}
     end.
 
-is_sensitive_key(token) -> true;
-is_sensitive_key("token") -> true;
-is_sensitive_key(<<"token">>) -> true;
 is_sensitive_key(authorization) -> true;
 is_sensitive_key("authorization") -> true;
 is_sensitive_key(<<"authorization">>) -> true;
+is_sensitive_key(aws_secret_access_key) -> true;
+is_sensitive_key("aws_secret_access_key") -> true;
+is_sensitive_key(<<"aws_secret_access_key">>) -> true;
 is_sensitive_key(password) -> true;
 is_sensitive_key("password") -> true;
 is_sensitive_key(<<"password">>) -> true;
+is_sensitive_key('proxy-authorization') -> true;
+is_sensitive_key("proxy-authorization") -> true;
+is_sensitive_key(<<"proxy-authorization">>) -> true;
 is_sensitive_key(secret) -> true;
 is_sensitive_key("secret") -> true;
 is_sensitive_key(<<"secret">>) -> true;
@@ -597,9 +600,9 @@ is_sensitive_key(<<"secret_key">>) -> true;
 is_sensitive_key(security_token) -> true;
 is_sensitive_key("security_token") -> true;
 is_sensitive_key(<<"security_token">>) -> true;
-is_sensitive_key(aws_secret_access_key) -> true;
-is_sensitive_key("aws_secret_access_key") -> true;
-is_sensitive_key(<<"aws_secret_access_key">>) -> true;
+is_sensitive_key(token) -> true;
+is_sensitive_key("token") -> true;
+is_sensitive_key(<<"token">>) -> true;
 is_sensitive_key(_) -> false.
 
 redact(Term) ->
@@ -710,9 +713,14 @@ redact_test_() ->
 
     Types = [atom, string, binary],
     Keys = [
-        token,
+        authorization,
+        aws_secret_access_key,
         password,
-        secret
+        'proxy-authorization',
+        secret,
+        secret_key,
+        security_token,
+        token
     ],
     [{case_name(Type, Key), fun() -> Case(Type, Key) end} || Key <- Keys, Type <- Types].
 

--- a/changes/ce/fix-10994.en.md
+++ b/changes/ce/fix-10994.en.md
@@ -1,0 +1,1 @@
+Redact `proxy-authorization` headers as used by HTTP connector to not leak secrets into log-files.


### PR DESCRIPTION
Fixes [EMQX-10003](https://emqx.atlassian.net/browse/EMQX-10003)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a650be</samp>

Enhanced the masking of sensitive keys in `emqx_utils:is_sensitive_key/1` and added more tests for it.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~Schema changes are backward compatible~
