### PR TITLE
fix(iotdb): remove root `request_timeout` option

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -88,7 +88,7 @@ jobs:
         fetch-depth: 0
 
     - uses: ilammy/msvc-dev-cmd@v1.12.0
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - name: build

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -96,7 +96,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: ilammy/msvc-dev-cmd@v1.12.0
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: ${{ matrix.otp }}
     - name: build

--- a/.github/workflows/run_fvt_tests.yaml
+++ b/.github/workflows/run_fvt_tests.yaml
@@ -58,7 +58,7 @@ jobs:
         arch:
           - amd64
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/download-artifact@v3
@@ -133,7 +133,7 @@ jobs:
       # - emqx-enterprise # TODO test enterprise
 
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/download-artifact@v3

--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -14,7 +14,7 @@ jobs:
     outputs:
       version: ${{ steps.build_docker.outputs.version}}
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - name: download jmeter
@@ -57,7 +57,7 @@ jobs:
 
     needs: build_emqx_for_jmeter_tests
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/checkout@v3
@@ -153,7 +153,7 @@ jobs:
 
     needs: build_emqx_for_jmeter_tests
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/checkout@v3
@@ -259,7 +259,7 @@ jobs:
 
     needs: build_emqx_for_jmeter_tests
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/checkout@v3
@@ -361,7 +361,7 @@ jobs:
 
     needs: build_emqx_for_jmeter_tests
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/checkout@v3
@@ -460,7 +460,7 @@ jobs:
 
     needs: build_emqx_for_jmeter_tests
     steps:
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/checkout@v3

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -71,7 +71,7 @@ jobs:
         shell: bash
     steps:
       # setup Erlang to run lux
-    - uses: erlef/setup-beam@v1.15.2
+    - uses: erlef/setup-beam@v1.15.4
       with:
         otp-version: 25.3.2
     - uses: actions/checkout@v3

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.erl
@@ -141,14 +141,6 @@ request_config() ->
                     default => 2,
                     desc => ?DESC("config_max_retries")
                 }
-            )},
-        {request_timeout,
-            mk(
-                emqx_schema:timeout_duration_ms(),
-                #{
-                    default => <<"15s">>,
-                    desc => ?DESC("config_request_timeout")
-                }
             )}
     ].
 

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
@@ -132,7 +132,7 @@ bridge_config(TestCase, _TestGroup, Config) ->
             "     username = \"root\"\n"
             "     password = \"root\"\n"
             "  }\n"
-            "iotdb_version = \"~s\"\n"
+            "  iotdb_version = \"~s\"\n"
             "  pool_size = 1\n"
             "  resource_opts = {\n"
             "     health_check_interval = 5000\n"

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -107,11 +107,13 @@ t_copy_deprecated_data_dir(Config) ->
         stop_cluster(Nodes)
     end.
 
-t_no_copy_from_newer_version_node(_Config) ->
+t_no_copy_from_newer_version_node(Config) ->
     net_kernel:start(['master2@127.0.0.1', longnames]),
     ct:timetrap({seconds, 120}),
     snabbkaffe:fix_ct_logging(),
-    Cluster = cluster([cluster_spec({core, 10}), cluster_spec({core, 11}), cluster_spec({core, 12})]),
+    Cluster = cluster(
+        [cluster_spec({core, 10}), cluster_spec({core, 11}), cluster_spec({core, 12})], Config
+    ),
     OKs = [ok, ok, ok],
     [First | Rest] = Nodes = start_cluster(Cluster),
     try

--- a/rel/i18n/emqx_bridge_iotdb.hocon
+++ b/rel/i18n/emqx_bridge_iotdb.hocon
@@ -59,12 +59,6 @@ config_max_retries.desc:
 config_max_retries.label:
 """HTTP Request Max Retries"""
 
-config_request_timeout.desc:
-"""HTTP request timeout."""
-
-config_request_timeout.label:
-"""HTTP Request Timeout"""
-
 desc_config.desc:
 """Configuration for Apache IoTDB bridge."""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10175

Since IoTDB bridge is not used as an authn/authz source and reuses the webhook connector, we should have only one request timeout field (the `resource_opts.request_ttl` one) like the webhook bridge does, to avoid confusion and potentially bad configuration combinations.

Requires frontend changes: https://github.com/emqx/emqx-dashboard5/pull/1467

With the above patch:

![image](https://github.com/emqx/emqx/assets/16166434/454b3dee-a1fe-4fa2-a2a6-223a5bf3519b)


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 18683f4</samp>

This pull request removes the unused `request_timeout` option from the `emqx_bridge_iotdb` application and its related files, and fixes a typo in the test file. The purpose is to simplify the configuration, avoid confusion, and improve the test coverage.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
