### PR TITLE
Return 404 for everything we don't know

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -72,8 +72,7 @@ start_listeners(Listeners) ->
         {"/", cowboy_static, {priv_file, emqx_dashboard, "www/index.html"}},
         {"/static/[...]", cowboy_static, {priv_dir, emqx_dashboard, "www/static"}},
         {emqx_mgmt_api_status:path(), emqx_mgmt_api_status, []},
-        {emqx_dashboard_swagger:relative_uri("/[...]"), emqx_dashboard_bad_api, []},
-        {'_', cowboy_static, {priv_file, emqx_dashboard, "www/index.html"}}
+        {'_', emqx_dashboard_not_found, []}
     ],
     BaseMinirest = #{
         base_path => emqx_dashboard_swagger:base_path(),

--- a/apps/emqx_dashboard/src/emqx_dashboard_not_found.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_not_found.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_dashboard_bad_api).
+-module(emqx_dashboard_not_found).
 
 -include_lib("emqx/include/logger.hrl").
 
@@ -23,10 +23,22 @@
 init(Req0, State) ->
     RedactedReq = emqx_utils:redact(Req0),
     ?SLOG(warning, #{msg => "unexpected_api_access", request => RedactedReq}),
+    CT = ct(cowboy_req:header(<<"accept">>, Req0, <<"text/html">>)),
     Req = cowboy_req:reply(
         404,
-        #{<<"content-type">> => <<"application/json">>},
-        <<"{\"code\": \"API_NOT_EXIST\", \"message\": \"Request Path Not Found\"}">>,
+        #{<<"content-type">> => CT},
+        ct_body(CT),
         RedactedReq
     ),
     {ok, Req, State}.
+
+ct(<<"text/plain", _/binary>>) -> <<"text/plain">>;
+ct(<<"application/json", _/binary>>) -> <<"application/json">>;
+ct(_AnyOther) -> <<"text/html">>.
+
+ct_body(<<"text/html">>) ->
+    <<"<html><head><title>404 - NOT FOUND</title></head><body><h1>404 - NOT FOUND</h1></body></html>">>;
+ct_body(<<"text/plain">>) ->
+    <<"404 - NOT FOUND">>;
+ct_body(<<"application/json">>) ->
+    <<"{\"code\": \"NOT_FOUND\", \"message\": \"Request Path Not Found\"}">>.

--- a/apps/emqx_dashboard/test/emqx_dashboard_not_found_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_not_found_SUITE.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_dashboard_bad_api_SUITE).
+-module(emqx_dashboard_not_found_SUITE).
 
 -compile(nowarn_export_all).
 -compile(export_all).
@@ -23,7 +23,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--define(SERVER, "http://127.0.0.1:18083/api/v5").
+-define(SERVER, "http://127.0.0.1:18083/").
 
 -import(emqx_mgmt_api_test_util, [request/2]).
 

--- a/changes/ce/fix-10996.en.md
+++ b/changes/ce/fix-10996.en.md
@@ -1,0 +1,1 @@
+Default to 404 for any HTTP/API request, we don't know, rather than the dashboard's index.html.


### PR DESCRIPTION
Fixes [EMQX-9435](https://emqx.atlassian.net/browse/EMQX-9435)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b561dc6</samp>

Removed the `emqx_dashboard_swagger` handler and improved the `emqx_dashboard_404` handler and its test module. This change enhances the security and usability of the dashboard by hiding the swagger API documentation and providing different 404 responses based on the request content type.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~Schema changes are backward compatible~
