### PR TITLE
fix: lost messages when clickhouse closes while sending messages

### DIFF
--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -465,8 +465,19 @@ transform_and_log_clickhouse_result(ClickhouseErrorResult, ResourceID, SQL) ->
         reason => ClickhouseErrorResult
     }),
     case ClickhouseErrorResult of
+        %% TODO: The hackeny errors that the clickhouse library forwards are
+        %% very loosely defined. We should try to make sure that the following
+        %% handles all error cases that we need to handle as recoverable_error
         {error, ecpool_empty} ->
             {error, {recoverable_error, ecpool_empty}};
+        {error, econnrefused} ->
+            {error, {recoverable_error, econnrefused}};
+        {error, closed} ->
+            {error, {recoverable_error, closed}};
+        {error, {closed, PartialBody}} ->
+            {error, {recoverable_error, {closed_partial_body, PartialBody}}};
+        {error, disconnected} ->
+            {error, {recoverable_error, disconnected}};
         _ ->
             {error, ClickhouseErrorResult}
     end.

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -450,10 +450,14 @@ execute_sql_in_clickhouse_server_using_connection(Connection, SQL) ->
 
 %% This function transforms the result received from clickhouse to something
 %% that is a little bit more readable and creates approprieate log messages
-transform_and_log_clickhouse_result({ok, 200, <<"">>} = _ClickhouseResult, _, _) ->
+transform_and_log_clickhouse_result({ok, ResponseCode, <<"">>} = _ClickhouseResult, _, _) when
+    ResponseCode =:= 200; ResponseCode =:= 204
+->
     snabbkaffe_log_return(ok),
     ok;
-transform_and_log_clickhouse_result({ok, 200, Data}, _, _) ->
+transform_and_log_clickhouse_result({ok, ResponseCode, Data}, _, _) when
+    ResponseCode =:= 200; ResponseCode =:= 204
+->
     Result = {ok, Data},
     snabbkaffe_log_return(Result),
     Result;
@@ -464,23 +468,57 @@ transform_and_log_clickhouse_result(ClickhouseErrorResult, ResourceID, SQL) ->
         sql => SQL,
         reason => ClickhouseErrorResult
     }),
-    case ClickhouseErrorResult of
+    case is_recoverable_error(ClickhouseErrorResult) of
         %% TODO: The hackeny errors that the clickhouse library forwards are
         %% very loosely defined. We should try to make sure that the following
         %% handles all error cases that we need to handle as recoverable_error
-        {error, ecpool_empty} ->
-            {error, {recoverable_error, ecpool_empty}};
-        {error, econnrefused} ->
-            {error, {recoverable_error, econnrefused}};
-        {error, closed} ->
-            {error, {recoverable_error, closed}};
-        {error, {closed, PartialBody}} ->
-            {error, {recoverable_error, {closed_partial_body, PartialBody}}};
-        {error, disconnected} ->
-            {error, {recoverable_error, disconnected}};
-        _ ->
-            {error, ClickhouseErrorResult}
+        true ->
+            ?SLOG(warning, #{
+                msg => "clickhouse connector: sql query failed (recoverable)",
+                recoverable_error => true,
+                connector => ResourceID,
+                sql => SQL,
+                reason => ClickhouseErrorResult
+            }),
+            to_recoverable_error(ClickhouseErrorResult);
+        false ->
+            ?SLOG(error, #{
+                msg => "clickhouse connector: sql query failed (unrecoverable)",
+                recoverable_error => false,
+                connector => ResourceID,
+                sql => SQL,
+                reason => ClickhouseErrorResult
+            }),
+            to_error_tuple(ClickhouseErrorResult)
     end.
+
+to_recoverable_error({error, Reason}) ->
+    {error, {recoverable_error, Reason}};
+to_recoverable_error(Error) ->
+    {error, {recoverable_error, Error}}.
+
+to_error_tuple({error, Reason}) ->
+    {error, {unrecoverable_error, Reason}};
+to_error_tuple(Error) ->
+    {error, {unrecoverable_error, Error}}.
+
+is_recoverable_error({error, Reason}) ->
+    is_recoverable_error_reason(Reason);
+is_recoverable_error(_) ->
+    false.
+
+is_recoverable_error_reason(ecpool_empty) ->
+    true;
+is_recoverable_error_reason(econnrefused) ->
+    true;
+is_recoverable_error_reason(closed) ->
+    true;
+is_recoverable_error_reason({closed, _PartialBody}) ->
+    true;
+is_recoverable_error_reason(disconnected) ->
+    true;
+is_recoverable_error_reason(_) ->
+    false.
 
 snabbkaffe_log_return(_Result) ->
     ?tp(

--- a/changes/ee/fix-10997.en.md
+++ b/changes/ee/fix-10997.en.md
@@ -1,0 +1,1 @@
+The ClickHouse bridge had a problem that could cause messages to be dropped when the ClickHouse server is closed while sending messages even when the request_ttl is set to infinity. This has been fixed by treating errors due to a closed connection as recoverable errors.


### PR DESCRIPTION
I think this can be merged without test case so that it gets into the 5.1 release. I can create a follow up PR with a test case.

Fixes:
https://emqx.atlassian.net/browse/EMQX-10217

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 61488ec</samp>

Improve error handling in `emqx_bridge_clickhouse_connector.erl` by distinguishing recoverable and fatal errors when sending queries to clickhouse. Add a TODO comment for future improvement.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes. Will add test case in a follow up PR
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible