### PR TITLE
fix(mongodb): hide batch_size for mongodb resource

### DIFF
--- a/changes/ee/fix-10998.en.md
+++ b/changes/ee/fix-10998.en.md
@@ -1,0 +1,2 @@
+Do not allow `batch_size` option for MongoDB bridge resource.
+MongoDB connector currently does not support batching, the `bath_size` config value is forced to be 1 if provided.

--- a/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mongodb.erl
+++ b/lib-ee/emqx_ee_bridge/src/emqx_ee_bridge_mongodb.erl
@@ -37,8 +37,24 @@ fields("config") ->
     [
         {enable, mk(boolean(), #{desc => ?DESC("enable"), default => true})},
         {collection, mk(binary(), #{desc => ?DESC("collection"), default => <<"mqtt">>})},
-        {payload_template, mk(binary(), #{required => false, desc => ?DESC("payload_template")})}
-    ] ++ emqx_resource_schema:fields("resource_opts");
+        {payload_template, mk(binary(), #{required => false, desc => ?DESC("payload_template")})},
+        {resource_opts,
+            mk(
+                ref(?MODULE, "creation_opts"),
+                #{required => true, desc => ?DESC(emqx_resource_schema, "creation_opts")}
+            )}
+    ];
+fields("creation_opts") ->
+    %% so far, mongodb connector does not support batching
+    %% but we cannot delete this field due to compatibility reasons
+    %% so we'll keep this field, but hide it in the docs.
+    emqx_resource_schema:create_opts([
+        {batch_size, #{
+            importance => ?IMPORTANCE_HIDDEN,
+            converter => fun(_, _) -> 1 end,
+            desc => ?DESC("batch_size")
+        }}
+    ]);
 fields(mongodb_rs) ->
     emqx_connector_mongo:fields(rs) ++ fields("config");
 fields(mongodb_sharded) ->

--- a/rel/i18n/emqx_ee_bridge_mongodb.hocon
+++ b/rel/i18n/emqx_ee_bridge_mongodb.hocon
@@ -54,4 +54,9 @@ payload_template.desc:
 payload_template.label:
 """Payload template"""
 
+batch_size.desc:
+"""There is no batching support for MongoDB at the moment, so this config field has no effect. Internally the value is overridden to 1."""
+batch_size.label:
+"""Batch Size"""
+
 }


### PR DESCRIPTION
MongoDB connector currently does not support batching so the batch_size option has no effect.
However we cannot remove the field, so we choose to hide it from schema

Fixes [EMQX-10220](https://emqx.atlassian.net/browse/EMQX-10220)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bbf2993</samp>

Added `resource_opts` field to MongoDB bridge schema and modified `create_opts` function in `emqx_resource_schema` module. These changes make the MongoDB bridge consistent with other resource schemas and disable batching for MongoDB. Updated internationalization file for the `batch_size` field.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
