### PR TITLE
fix(kafka): fix timeout field for some kafka fields

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -276,7 +276,7 @@ fields(producer_kafka_opts) ->
             )},
         {partition_count_refresh_interval,
             mk(
-                emqx_schema:duration_s(),
+                emqx_schema:timeout_duration_s(),
                 #{
                     default => <<"60s">>,
                     desc => ?DESC(partition_count_refresh_interval)
@@ -380,8 +380,8 @@ fields(consumer_kafka_opts) ->
             )},
         {offset_commit_interval_seconds,
             mk(
-                pos_integer(),
-                #{default => 5, desc => ?DESC(consumer_offset_commit_interval_seconds)}
+                emqx_schema:timeout_duration_s(),
+                #{default => <<"5s">>, desc => ?DESC(consumer_offset_commit_interval_seconds)}
             )}
     ].
 

--- a/changes/ee/fix-10999.en.md
+++ b/changes/ee/fix-10999.en.md
@@ -1,0 +1,1 @@
+Changed schema validation for Kafka fields 'Partition Count Refresh Interval' and 'Offset Commit Interval' to avoid accepting values larger then maximum allowed.


### PR DESCRIPTION
Change type of fields 'Partition Count Refresh Interval' and 'Offset Commit Interval' to avoid accepting values larger than allowed.

Fixes https://emqx.atlassian.net/browse/EMQX-10196
Fixes https://emqx.atlassian.net/browse/EMQX-10199

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5e34d95</samp>

Refactored Kafka bridge timeout configuration to support `infinity`. Updated the types of some parameters in `emqx_bridge_kafka.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~Added tests for the changes~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [ ] ~Change log has been added to `changes/` dir for user-facing artifacts update~
