### PR TITLE
fix(bridge_redis): fix `on_stop` `function_clause` error when there's no state

### DIFF
--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ee_connector, [
     {description, "EMQX Enterprise connectors"},
-    {vsn, "0.1.13"},
+    {vsn, "0.1.14"},
     {registered, []},
     {applications, [
         kernel,

--- a/lib-ee/emqx_ee_connector/src/emqx_ee_connector_redis.erl
+++ b/lib-ee/emqx_ee_connector/src/emqx_ee_connector_redis.erl
@@ -44,7 +44,9 @@ on_start(InstId, #{command_template := CommandTemplate} = Config) ->
     end.
 
 on_stop(InstId, #{conn_st := RedisConnSt}) ->
-    emqx_connector_redis:on_stop(InstId, RedisConnSt).
+    emqx_connector_redis:on_stop(InstId, RedisConnSt);
+on_stop(InstId, undefined = _State) ->
+    emqx_connector_redis:on_stop(InstId, undefined).
 
 on_get_status(InstId, #{conn_st := RedisConnSt}) ->
     emqx_connector_redis:on_get_status(InstId, RedisConnSt).


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10215

Before fix:


https://github.com/emqx/emqx/assets/16166434/0894dece-fd4c-4151-ae06-b5f5ddc59ba4



After fix:


https://github.com/emqx/emqx/assets/16166434/fa353f51-ae57-4809-a950-9686aca62b12



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8dbce76</samp>

Fixed a bug in `emqx_ee_connector_redis` module that caused an error when stopping a Redis connector with no connection. Bumped the version of `emqx_ee_connector` application to 0.1.14.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
