### PR TITLE
ci(run.sh): fix cookie generation

### DIFF
--- a/scripts/ct/run.sh
+++ b/scripts/ct/run.sh
@@ -264,7 +264,7 @@ fi
 # rebar, mix and hex cache directory need to be writable by $DOCKER_USER
 docker exec -i $TTY -u root:root "$ERLANG_CONTAINER" bash -c "mkdir -p /.cache /.hex /.mix && chown $DOCKER_USER /.cache /.hex /.mix"
 # need to initialize .erlang.cookie manually here because / is not writable by $DOCKER_USER
-docker exec -i $TTY -u root:root "$ERLANG_CONTAINER" bash -c "openssl rand -base64 16 > /.erlang.cookie && chown $DOCKER_USER /.erlang.cookie && chmod 0400 /.erlang.cookie"
+docker exec -i $TTY -u root:root "$ERLANG_CONTAINER" bash -c "openssl rand -base64 -hex 16 > /.erlang.cookie && chown $DOCKER_USER /.erlang.cookie && chmod 0400 /.erlang.cookie"
 # the user must exist inside the container for `whoami` to work
 docker exec -i $TTY -u root:root "$ERLANG_CONTAINER" bash -c "useradd --uid $DOCKER_USER -M -d / emqx" || true
 docker exec -i $TTY -u root:root "$ERLANG_CONTAINER" bash -c "chown -R $DOCKER_USER /var/lib/secret" || true


### PR DESCRIPTION
Sometimes, the generated cookie could be interpret by erlang as a flag (e.g.: `+8w7uIsgUeG80c/ZgUDD9g==`) if not escaped properly, causing the start up to fail.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 54985c1</samp>

Fixed a bug in `run.sh` that generated invalid Erlang cookies. Used the `-hex` option for `openssl rand` to create valid cookie values.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
