### PR TITLE
test(kafka): attempt to reduce inter-run flakiness

### DIFF
--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -14,6 +14,8 @@ services:
       GITHUB_RUN_NUMBER: ${GITHUB_RUN_NUMBER}
       GITHUB_EVENT_NAME: ${GITHUB_EVENT_NAME}
       GITHUB_REF: ${GITHUB_REF}
+      ## to avoid dirty kerberos credentials cache between CI runs
+      KRB5CCNAME: "${KRB5CCNAME:-/tmp/krb5cc_${GITHUB_RUN_ID:-${DOCKER_USER}}}"
     networks:
       - emqx_bridge
     ports:


### PR DESCRIPTION
Another attempt to fix flaky test, follow up to https://github.com/emqx/emqx/pull/10968

Since the default path to the kerberos credential cache is `/tmp/krb5cc_$UID` (typically `/tmp/krb5cc_1001` in CI), this file might survive between workflow runs and, at some point, make a later run break when the cache becomes invalid (just a hypothesis).

This PR uses a unique file per run in an attempt to reduce inter-run interference.

Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1edb733</samp>

Set `KRB5CCNAME` environment variable for `emqx` service in `.ci/docker-compose-file/docker-compose.yaml` to use a unique Kerberos cache file for each CI run. This improves the authentication with Kafka and the stability of the CI tests.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
