### PR TITLE
Add kafka bridge tcp keepalive option

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -74,7 +74,8 @@ values(common_config) ->
         socket_opts => #{
             sndbuf => <<"1024KB">>,
             recbuf => <<"1024KB">>,
-            nodelay => true
+            nodelay => true,
+            tcp_keepalive => <<"none">>
         }
     };
 values(producer) ->
@@ -236,7 +237,13 @@ fields(socket_opts) ->
                     importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(socket_nodelay)
                 }
-            )}
+            )},
+        {tcp_keepalive,
+            mk(string(), #{
+                default => <<"none">>,
+                desc => ?DESC(socket_tcp_keepalive),
+                validator => fun emqx_schema:validate_tcp_keepalive/1
+            })}
     ];
 fields(producer_opts) ->
     [

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -131,6 +131,7 @@ on_start(ResourceId, Config) ->
             offset_commit_interval_seconds := _,
             offset_reset_policy := _
         },
+        socket_opts := SocketOpts0,
         ssl := SSL,
         topic_mapping := _
     } = Config,
@@ -144,8 +145,10 @@ on_start(ResourceId, Config) ->
             Auth -> [{sasl, emqx_bridge_kafka_impl:sasl(Auth)}]
         end,
     ClientOpts = add_ssl_opts(ClientOpts0, SSL),
+    SocketOpts = emqx_bridge_kafka_impl:socket_opts(SocketOpts0),
+    ClientOpts1 = [{extra_sock_opts, SocketOpts} | ClientOpts],
     ok = emqx_resource:allocate_resource(ResourceId, ?kafka_client_id, ClientID),
-    case brod:start_client(BootstrapHosts, ClientID, ClientOpts) of
+    case brod:start_client(BootstrapHosts, ClientID, ClientOpts1) of
         ok ->
             ?tp(
                 kafka_consumer_client_started,

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -57,7 +57,8 @@
     pub_props_to_packet/1,
     safe_filename/1,
     diff_lists/3,
-    merge_lists/3
+    merge_lists/3,
+    tcp_keepalive_opts/4
 ]).
 
 -export([
@@ -487,6 +488,26 @@ safe_to_existing_atom(Atom, _Encoding) when is_atom(Atom) ->
     {ok, Atom};
 safe_to_existing_atom(_Any, _Encoding) ->
     {error, invalid_type}.
+
+-spec tcp_keepalive_opts(term(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
+    {ok, [{keepalive, true} | {raw, non_neg_integer(), non_neg_integer(), binary()}]}
+    | {error, {unsupported_os, term()}}.
+tcp_keepalive_opts({unix, linux}, Idle, Interval, Probes) ->
+    {ok, [
+        {keepalive, true},
+        {raw, 6, 4, <<Idle:32/native>>},
+        {raw, 6, 5, <<Interval:32/native>>},
+        {raw, 6, 6, <<Probes:32/native>>}
+    ]};
+tcp_keepalive_opts({unix, darwin}, Idle, Interval, Probes) ->
+    {ok, [
+        {keepalive, true},
+        {raw, 6, 16#10, <<Idle:32/native>>},
+        {raw, 6, 16#101, <<Interval:32/native>>},
+        {raw, 6, 16#102, <<Probes:32/native>>}
+    ]};
+tcp_keepalive_opts(OS, _Idle, _Interval, _Probes) ->
+    {error, {unsupported_os, OS}}.
 
 %%------------------------------------------------------------------------------
 %% Internal Functions

--- a/changes/ee/feat-11003.en.md
+++ b/changes/ee/feat-11003.en.md
@@ -1,0 +1,1 @@
+Add an option to configure TCP keepalive in Kafka bridge.

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -38,6 +38,24 @@ socket_send_buffer.desc:
 socket_send_buffer.label:
 """Socket Send Buffer Size"""
 
+socket_receive_buffer.desc:
+"""Fine tune the socket receive buffer. The default value is tuned for high throughput."""
+
+socket_receive_buffer.label:
+"""Socket Receive Buffer Size"""
+
+socket_tcp_keepalive.desc:
+"""Enable TCP keepalive for Kafka bridge connections.
+The value is three comma separated numbers in the format of 'Idle,Interval,Probes'
+ - Idle: The number of seconds a connection needs to be idle before the server begins to send out keep-alive probes (Linux default 7200).
+ - Interval: The number of seconds between TCP keep-alive probes (Linux default 75).
+ - Probes: The maximum number of TCP keep-alive probes to send before giving up and killing the connection if no response is obtained from the other end (Linux default 9).
+For example "240,30,5" means: TCP keepalive probes are sent after the connection is idle for 240 seconds, and the probes are sent every 30 seconds until a response is received, if it misses 5 consecutive responses, the connection should be closed.
+Default: 'none'"""
+
+socket_tcp_keepalive.label:
+"""TCP keepalive options"""
+
 desc_name.desc:
 """Bridge name, used as a human-readable description of the bridge."""
 
@@ -55,12 +73,6 @@ consumer_max_batch_bytes.desc:
 
 consumer_max_batch_bytes.label:
 """Fetch Bytes"""
-
-socket_receive_buffer.desc:
-"""Fine tune the socket receive buffer. The default value is tuned for high throughput."""
-
-socket_receive_buffer.label:
-"""Socket Receive Buffer Size"""
 
 consumer_topic_mapping.desc:
 """Defines the mapping between Kafka topics and MQTT topics. Must contain at least one item."""


### PR DESCRIPTION
Fixes EMQX-8725

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 273abcb</samp>

This pull request adds support for TCP keepalive for Kafka bridge connections and refactors the socket options handling for the Kafka bridge producer and consumer. It introduces a new `tcp_keepalive` option in the `socket_opts` map and a new `emqx_utils:tcp_keepalive_opts` function that returns the socket options for different operating systems. It also adds a test case to validate the `tcp_keepalive` option.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
