### PR TITLE
fix(authn): fix the hardcode method in trace logs

### DIFF
--- a/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_http.erl
@@ -435,19 +435,19 @@ parse_body(ContentType, _) ->
 uri_encode(T) ->
     emqx_http_lib:uri_encode(to_list(T)).
 
-request_for_log(Credential, #{url := Url} = State) ->
+request_for_log(Credential, #{url := Url, method := Method} = State) ->
     SafeCredential = emqx_authn_utils:without_password(Credential),
     case generate_request(SafeCredential, State) of
         {PathQuery, Headers} ->
             #{
-                method => post,
+                method => Method,
                 base_url => Url,
                 path_query => PathQuery,
                 headers => Headers
             };
         {PathQuery, Headers, Body} ->
             #{
-                method => post,
+                method => Method,
                 base_url => Url,
                 path_query => PathQuery,
                 headers => Headers,

--- a/changes/ce/fix-11005.en.md
+++ b/changes/ce/fix-11005.en.md
@@ -1,0 +1,1 @@
+Fix the issue where the `method` field cannot be correctly printed in the trace logs of AuthN HTTP.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10142

Before the fix, no matter what the AuthN-HTTP method configuration was set to, the following line would be printed as `method => post`.
```
2023-06-10T13:07:37.086815+08:00 [debug] msg: http_response, 
mfa: emqx_authn_http:authenticate/2, line: 214, 
peername: 127.0.0.1:42848, 
clientid: mqttx_57c315a9, 
provider: emqx_authn_http, 
request: #{base_url => <<"http://127.0.0.1:8080/webhook">>,headers => [{<<"accept">>,<<"application/json">>},{<<"cache-control">>,<<"no-cache">>},{<<"connection">>,<<"keep-alive">>},{<<"keep-alive">>,<<"timeout=30, max=1000">>}],
method => post,path_query => "/webhook?clientid=mqttx_57c315a9"},
resource: <<"emqx_authn_http:1">>, response: #{error => #{headers => [{<<"content-length">>,<<"0">>},{<<"date">>,<<"Sat, 10 Jun 2023 05:07:37 GMT">>}],status_code => 404}}, tag: AUTHN
```

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fdaac98</samp>

Add more flexibility to HTTP authentication by allowing different methods. Improve logging of HTTP requests in `emqx_authn_http`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
