### PR TITLE
fix(quic): environment variables as cert file prefix for quic listener

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -423,8 +423,8 @@ do_start_listener(quic, ListenerName, #{bind := Bind} = Opts) ->
             ),
             ListenOpts =
                 [
-                    {certfile, str(maps:get(certfile, SSLOpts))},
-                    {keyfile, str(maps:get(keyfile, SSLOpts))},
+                    {certfile, emqx_schema:naive_env_interpolation(maps:get(certfile, SSLOpts))},
+                    {keyfile, emqx_schema:naive_env_interpolation(maps:get(keyfile, SSLOpts))},
                     {alpn, ["mqtt"]},
                     {conn_acceptors, lists:max([DefAcceptors, maps:get(acceptors, Opts, 0)])},
                     {keep_alive_interval_ms, maps:get(keep_alive_interval, Opts, 0)},
@@ -434,8 +434,10 @@ do_start_listener(quic, ListenerName, #{bind := Bind} = Opts) ->
                     {verify, maps:get(verify, SSLOpts, verify_none)}
                 ] ++
                     case maps:get(cacertfile, SSLOpts, undefined) of
-                        undefined -> [];
-                        CaCertFile -> [{cacertfile, str(CaCertFile)}]
+                        undefined ->
+                            [];
+                        CaCertFile ->
+                            [{cacertfile, emqx_schema:naive_env_interpolation(CaCertFile)}]
                     end ++
                     case maps:get(password, SSLOpts, undefined) of
                         undefined -> [];

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1435,7 +1435,9 @@ fields("listener_quic_ssl_opts") ->
                 true ->
                     {Name, Schema};
                 false ->
-                    {Name, Schema#{deprecated => {since, "5.0.20"}}}
+                    {Name, Schema#{
+                        deprecated => {since, "5.0.20"}, importance => ?IMPORTANCE_HIDDEN
+                    }}
             end
         end,
         Schema1

--- a/changes/ee/fix-11006.en.md
+++ b/changes/ee/fix-11006.en.md
@@ -1,0 +1,3 @@
+Fix QUIC listeners's default cert file paths.
+
+Prior to this change, the default cert file paths are prefixed with environment variable `${EMQX_ETC_DIR}` which were not interpolated before used in QUIC listeners.


### PR DESCRIPTION
Fixes EMQX-10227

```
env EMQX_LISTENERS__QUIC__AA='{bind=12345,enable=true}' ./dev run -p ce
Failed to start listener quic:aa on :12345: {{{badmatch,{error,config_error,tls_error}},[{quicer_listener,init,1,[{file,"quicer_listener.erl"},{line,90}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,851}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{line,814}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]},{child,undef
ined,{quicer_listener,'quic:aa'},{quicer_listener,start_link,['quic:aa',12345,{#{alpn => ["mqtt"],cacertfile => "${EMQX_ETC_DIR}/certs/cacert.pem",certfile => "${EMQX_ETC_DIR}/certs/cert.pem",conn_acceptors => 160,handshake_idle_timeout_ms => 10000,idle_timeout_ms => 0,keep_alive_interval_ms => 0,keyfile => "${EMQX_ETC_DIR}/certs/key.pem",server_resum
ption_level => 2,verify => verify_none},#{conn_callback => emqx_quic_connection,limiter => undefined,listener => {quic,aa},peer_bidi_stream_count => 10,peer_unidi_stream_count => 1,zone => default},#{active => 1,stream_callback => emqx_quic_stream}}]},transient,false,infinity,supervisor,[quicer_listener]}}.
2023-06-10T11:39:13.609387+02:00 [error] crasher: initial call: quicer_listener:init/1, pid: <0.615.0>, registered_name: [], error: {{badmatch,{error,config_error,tls_error}},[{quicer_listener,init,1,[{file,"quicer_listener.erl"},{line,90}]},{gen_server,init_it,2,[{file,"gen_server.erl"},{line,851}]},{gen_server,init_it,6,[{file,"gen_server.erl"},{lin
e,814}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}, ancestors: [quicer_listener_sup,quicer_sup,<0.443.0>], message_queue_len: 0, messages: [], links: [<0.446.0>], dictionary: [], trap_exit: true, status: running, heap_size: 376, stack_size: 28, reductions: 167; neighbours:
2023-06-10T11:39:13.609863+02:00 [error] crasher: initial call: application_master:init/4, pid: <0.439.0>, registered_name: [], exit: {{bad_return,{{emqx_app,start,[normal,[]]},{'EXIT',{{failed_to_start,"quic:aa(:12345) : {{badmatch,{error,config_error,tls_error}},\n                   [{quicer_listener,init,1,\n                                     [{f
ile,\"quicer_listener.erl\"},{line,90}]},\n                    {gen_server,init_it,2,\n                                [{file,\"gen_server.erl\"},{line,851}]},\n                    {gen_server,init_it,6,\n                                [{file,\"gen_server.erl\"},{line,814}]},\n                    {proc_lib,init_p_do_apply,3,\n
      [{file,\"proc_lib.erl\"},{line,240}]}]}"},[{emqx_listeners,'-foreach_listeners/1-fun-0-',2,[{file,"emqx_listeners.erl"},{line,798}]},{lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},{emqx_app,maybe_start_listeners,0,[{file,"emqx_app.erl"},{line,94}]},{emqx_app,start,2,[{file,"emqx_app.erl"},{line,50}]},{application_master,start_it_old,4,[{fi
le,"application_master.erl"},{line,293}]}]}}}},[{application_master,init,4,[{file,"application_master.erl"},{line,142}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}, ancestors: [<0.438.0>], message_queue_len: 1, messages: [{'EXIT',<0.440.0>,normal}], links: [<0.438.0>,<0.44.0>], dictionary: [], trap_exit: true, status: running, h
eap_size: 2586, stack_size: 28, reductions: 279; neighbours:
{"Kernel pid terminated",application_controller,"{application_start_failure,emqx,{bad_return,{{emqx_app,start,[normal,[]]},{'EXIT',{{failed_to_start,\"quic:aa(:12345) : {{badmatch,{error,config_error,tls_error}},\n                   [{quicer_listener,init,1,\n                                     [{file,\\"quicer_listener.erl\\"},{line,90}]},\n
            {gen_server,init_it,2,\n                                [{file,\\"gen_server.erl\\"},{line,851}]},\n                    {gen_server,init_it,6,\n                                [{file,\\"gen_server.erl\\"},{line,814}]},\n                    {proc_lib,init_p_do_apply,3,\n                              [{file,\\"proc_lib.erl\\"},{line,240}]}]}
\"},[{emqx_listeners,'-foreach_listeners/1-fun-0-',2,[{file,\"emqx_listeners.erl\"},{line,798}]},{lists,foreach_1,2,[{file,\"lists.erl\"},{line,1442}]},{emqx_app,maybe_start_listeners,0,[{file,\"emqx_app.erl\"},{line,94}]},{emqx_app,start,2,[{file,\"emqx_app.erl\"},{line,50}]},{application_master,start_it_old,4,[{file,\"application_master.erl\"},{line
,293}]}]}}}}}"}
Kernel pid terminated (application_controller) ({application_start_failure,emqx,{bad_return,{{emqx_app,start,[normal,[]]},{'EXIT',{{failed_to_start,"quic:aa(:12345) : {{badmatch,{error,config_error,tls_error}},\n                   [{quicer_listener,init,1,\n                                     [{file,\"quicer_listener.erl\"},{line,90}]},\n
        {gen_server,init_it,2,\n                                [{file,\"gen_server.erl\"},{line,851}]},\n                    {gen_server,init_it,6,\n                                [{file,\"gen_server.erl\"},{line,814}]},\n                    {proc_lib,init_p_do_apply,3,\n                              [{file,\"proc_lib.erl\"},{line,240}]}]}"},[{emqx_
listeners,'-foreach_listeners/1-fun-0-',2,[{file,"emqx_listeners.erl"},{line,798}]},{lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},{emqx_app,maybe_start_listeners,0,[{file,"emqx_app.erl"},{line,94}]},{emqx_app,start,2,[{file,"emqx_app.erl"},{line,50}]},{application_master,start_it_old,4,[{file,"application_mas


```

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2f834c9</samp>

Interpolate SSL listener options with environment variables and hide deprecated options from config output and dashboard. This improves the flexibility, portability, and user experience of the configuration file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
