### PR TITLE
chore: correct persistent_session_store's default value type to boolean

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -335,11 +335,11 @@ fields("persistent_session_store") ->
                     default => #{
                         <<"type">> => <<"builtin">>,
                         <<"session">> =>
-                            #{<<"ram_cache">> => <<"true">>},
+                            #{<<"ram_cache">> => true},
                         <<"session_messages">> =>
-                            #{<<"ram_cache">> => <<"true">>},
+                            #{<<"ram_cache">> => true},
                         <<"messages">> =>
-                            #{<<"ram_cache">> => <<"false">>}
+                            #{<<"ram_cache">> => false}
                     },
                     desc => ?DESC(persistent_session_store_backend)
                 }


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 599eb9f</samp>

Fixed a bug in `persistent_session_store_backend` schema that ignored `ram_cache` option when set to `"false"`. Changed `ram_cache` option values from strings to booleans for consistency.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
