### PR TITLE
fix:update emqx_flapping process's state when update flapping_detect

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -930,7 +930,9 @@ maybe_update_zone([RootName | T], RootValue, Value) when is_atom(RootName) ->
                 end,
                 ExistingZones
             ),
-            persistent_term:put(?PERSIS_KEY(?CONF, zones), NewZones)
+            ZonesKey = ?PERSIS_KEY(?CONF, zones),
+            persistent_term:put(ZonesKey, NewZones),
+            put_config_post_change_actions(ZonesKey, NewZones)
     end,
     NewRootValue.
 


### PR DESCRIPTION
Fixes [EMQX-10233](https://emqx.atlassian.net/browse/EMQX-10233)
Update emqx_flapping process’s state when update flapping_detect configuration.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14bfd44</samp>

This pull request fixes a bug and enhances the test cases for the flapping detect feature in EMQ X. It adds a function call to `emqx_config.erl` to update the flapping detect timer when the zone configuration changes, and modifies `emqx_flapping_SUITE.erl` to check the enable flag and test the global configuration.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
