### PR TITLE
ci: fix matrix dimensions in build_packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -194,11 +194,13 @@ jobs:
           - 5.1-0
         elixir:
           - 1.14.5
+        with_elixir:
+          - 'no'
         exclude:
-        - arch: arm64
-          build_machine: ubuntu-22.04
-        - arch: amd64
-          build_machine: aws-arm64
+          - arch: arm64
+            build_machine: ubuntu-22.04
+          - arch: amd64
+            build_machine: aws-arm64
         include:
           - profile: emqx
             otp: 25.3.2-1
@@ -207,7 +209,7 @@ jobs:
             build_machine: ubuntu-22.04
             builder: 5.1-0
             elixir: 1.14.5
-            release_with: elixir
+            with_elixir: 'yes'
           - profile: emqx
             otp: 25.3.2-1
             arch: amd64
@@ -215,7 +217,7 @@ jobs:
             build_machine: ubuntu-22.04
             builder: 5.1-0
             elixir: 1.14.5
-            release_with: elixir
+            with_elixir: 'yes'
 
     defaults:
       run:
@@ -245,12 +247,9 @@ jobs:
         fi
         echo "pwd is $PWD"
         PKGTYPES="tgz pkg"
-        IS_ELIXIR="no"
-        WITH_ELIXIR=${{ matrix.release_with }}
-        if [ "${WITH_ELIXIR:-}" == 'elixir' ]; then
+        IS_ELIXIR=${{ matrix.with_elixir }}
+        if [ "${IS_ELIXIR:-}" == 'yes' ]; then
           PKGTYPES="tgz"
-          # set Elixir build flag
-          IS_ELIXIR="yes"
         fi
         for PKGTYPE in ${PKGTYPES};
         do


### PR DESCRIPTION
Fixes the issue when Ubuntu 22+amd64 package was only built for elixir.

Verification run: https://github.com/emqx/emqx/actions/runs/5240570132/jobs/9461586245

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7a78df1</samp>

Refactor package building workflow with Elixir option. Use a matrix variable `with_elixir` to control the Elixir build flag and the package types in `.github/workflows/build_packages.yaml`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
