### PR TITLE
fix(gw): close the stomp connections once an error frame occured

### DIFF
--- a/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_channel.erl
@@ -448,7 +448,9 @@ handle_in(
     Topic = header(<<"destination">>, Headers),
     case emqx_gateway_ctx:authorize(Ctx, ClientInfo, publish, Topic) of
         deny ->
-            handle_out(error, {receipt_id(Headers), "Authorization Deny"}, Channel);
+            ErrMsg = io_lib:format("Insufficient permissions for ~s", [Topic]),
+            ErrorFrame = error_frame(receipt_id(Headers), ErrMsg),
+            shutdown(acl_denied, ErrorFrame, Channel);
         allow ->
             case header(<<"transaction">>, Headers) of
                 undefined ->
@@ -494,20 +496,25 @@ handle_in(
             ),
             case do_subscribe(NTopicFilters, NChannel) of
                 [] ->
-                    ErrMsg = "Permission denied",
-                    handle_out(error, {receipt_id(Headers), ErrMsg}, Channel);
+                    ErrMsg = io_lib:format(
+                        "The client.subscribe hook blocked the ~s subscription request",
+                        [TopicFilter]
+                    ),
+                    ErrorFrame = error_frame(receipt_id(Headers), ErrMsg),
+                    shutdown(normal, ErrorFrame, Channel);
                 [{MountedTopic, SubOpts} | _] ->
                     NSubs = [{SubId, MountedTopic, Ack, SubOpts} | Subs],
                     NChannel1 = NChannel#channel{subscriptions = NSubs},
                     handle_out_and_update(receipt, receipt_id(Headers), NChannel1)
             end;
-        {error, ErrMsg, NChannel} ->
-            ?SLOG(error, #{
-                msg => "failed_top_subscribe_topic",
-                topic => Topic,
-                reason => ErrMsg
-            }),
-            handle_out(error, {receipt_id(Headers), ErrMsg}, NChannel)
+        {error, subscription_id_inused, NChannel} ->
+            ErrMsg = io_lib:format("Subscription id ~w is in used", [SubId]),
+            ErrorFrame = error_frame(receipt_id(Headers), ErrMsg),
+            shutdown(subscription_id_inused, ErrorFrame, NChannel);
+        {error, acl_denied, NChannel} ->
+            ErrMsg = io_lib:format("Insufficient permissions for ~s", [Topic]),
+            ErrorFrame = error_frame(receipt_id(Headers), ErrMsg),
+            shutdown(acl_denied, ErrorFrame, NChannel)
     end;
 handle_in(
     ?PACKET(?CMD_UNSUBSCRIBE, Headers),
@@ -691,7 +698,7 @@ check_subscribed_status(
         {SubId, MountedTopic, _Ack, _} ->
             ok;
         {SubId, _OtherTopic, _Ack, _} ->
-            {error, "Conflict subscribe id"};
+            {error, subscription_id_inused};
         false ->
             ok
     end.
@@ -704,7 +711,7 @@ check_sub_acl(
     }
 ) ->
     case emqx_gateway_ctx:authorize(Ctx, ClientInfo, subscribe, ParsedTopic) of
-        deny -> {error, "ACL Deny"};
+        deny -> {error, acl_denied};
         allow -> ok
     end.
 

--- a/apps/emqx_gateway_stomp/src/emqx_stomp_frame.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_frame.erl
@@ -185,6 +185,8 @@ parse(headers, Bin, State) ->
     parse(hdname, Bin, State);
 parse(hdname, <<?LF, _Rest/binary>>, _State) ->
     error(unexpected_linefeed);
+parse(hdname, <<?COLON, $\s, Rest/binary>>, State = #parser_state{acc = Acc}) ->
+    parse(hdvalue, Rest, State#parser_state{hdname = Acc, acc = <<>>});
 parse(hdname, <<?COLON, Rest/binary>>, State = #parser_state{acc = Acc}) ->
     parse(hdvalue, Rest, State#parser_state{hdname = Acc, acc = <<>>});
 parse(hdname, <<Ch:8, Rest/binary>>, State) ->

--- a/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
+++ b/apps/emqx_gateway_stomp/test/emqx_stomp_SUITE.erl
@@ -1088,6 +1088,11 @@ parse(Data) ->
     Parser = emqx_stomp_frame:initial_parse_state(ProtoEnv),
     emqx_stomp_frame:parse(Data, Parser).
 
+get_field(command, #stomp_frame{command = Command}) ->
+    Command;
+get_field(body, #stomp_frame{body = Body}) ->
+    Body.
+
 send_connection_frame(Sock, Username, Password) ->
     send_connection_frame(Sock, Username, Password, <<"0,0">>).
 

--- a/changes/ce/fix-11018.en.md
+++ b/changes/ce/fix-11018.en.md
@@ -1,0 +1,5 @@
+Fixed multiple issues with the Stomp gateway, including:
+- Fixed an issue where `is_superuser` was not working correctly.
+- Fixed an issue where the mountpoint was not being removed in message delivery.
+- After a message or subscription request fails, the Stomp client should be disconnected
+  immediately after replying with an ERROR message.


### PR DESCRIPTION
According to the Stomp v1.2 specification:

> The server MAY send ERROR frames if something goes wrong. In this case,
> it MUST then close the connection just after sending the ERROR frame

Additional, fixes the `is_superuser` is not working for all gateways

Fixes https://emqx.atlassian.net/browse/EMQX-10235 https://emqx.atlassian.net/browse/EMQX-10240 https://emqx.atlassian.net/browse/EMQX-10239

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 394f5d6</samp>

This pull request improves the STOMP gateway functionality and testing in the `emqx_gateway` and `emqx_gateway_stomp` applications. It fixes a bug in the STOMP frame parser, enhances the error handling and messaging for STOMP commands, refactors the test modules to use helper functions and increase coverage, and merges the authentication result with the client information for better authorization.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
