### PR TITLE
fix: calling mongdate() in sqltest failed

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -38,6 +38,7 @@ test(#{<<"rawsql">> := Sql, <<"ctx">> := Context}) ->
     end.
 
 test_rule(Sql, Select, Context, EventTopics) ->
+    emqx_rule_utils:set_runtime_env_sqltest(),
     RuleId = iolist_to_binary(["test_rule", emqx_rule_id:gen()]),
     ActInstId = iolist_to_binary(["test_action", emqx_rule_id:gen()]),
     ok = emqx_rule_metrics:create_rule_metrics(RuleId),

--- a/apps/emqx_rule_engine/src/emqx_rule_utils.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_utils.erl
@@ -67,6 +67,11 @@
         , log_action/4
         ]).
 
+-export([ set_runtime_env_sqltest/0
+        , unset_runtime_env_sqltest/0
+        , get_runtime_env_sqltest/0
+        ]).
+
 -compile({no_auto_import,
           [ float/1
           ]}).
@@ -417,3 +422,15 @@ metadata_values(Metadata) ->
     ActionName = maps:get(action_name, Metadata, undefined),
     ResourceName = maps:get(resource_id, Metadata, undefined),
     [RuleId, ActionName, ResourceName].
+
+set_runtime_env_sqltest() ->
+    erlang:put('rule_runtime_env:sqltest', true), ok.
+
+unset_runtime_env_sqltest() ->
+    erlang:erase('rule_runtime_env:sqltest'), ok.
+
+get_runtime_env_sqltest() ->
+    case erlang:get('rule_runtime_env:sqltest') of
+        true -> true;
+        _ -> false
+    end.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10226

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a777d5</samp>

Improved the `mongo_date` function for rule engine SQL tests and added test cases. The function can now handle different input types and output formats, and can format the timestamp as an ISODate string if the rule engine is running in SQL test mode. The `emqx_rule_utils` module provides functions to set and check the runtime environment variable for SQL tests. The `emqx_rule_funcs_SUITE` module tests the `mongo_date` function with various arguments and formats.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
