### PR TITLE
feat(pulsar): retry health check a bit before returning (r5.1)

### DIFF
--- a/changes/ee/feat-11024.en.md
+++ b/changes/ee/feat-11024.en.md
@@ -1,0 +1,1 @@
+Added a small improvement to reduce the chance of seeing the `connecting` state when creating/updating a Pulsar Producer bridge.


### PR DESCRIPTION
# targeting `release-51`

Fixes https://emqx.atlassian.net/browse/EMQX-10228

This is a cosmetic fix for the Pulsar Producer bridge health check status.

Pulsar connection process is asynchronous, therefore, when a bridge of this type is created or updated (which is the same as stopping and re-creating it), the immediate status will be connecting because it’s indeed still connecting.  The bridge will connect very soon afterwards (assuming there are no true network/config issue), but having to refresh the UI to see the new status and/or seeing the resource alarm might annoy users.

This workaround adds a few retries to account for that effect to reduce the probability of seeing the `connecting` state on such happy-paths.

After patch:


https://github.com/emqx/emqx/assets/16166434/eec3edb8-17de-40de-957d-27bb73f53782



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 39ea2c8</samp>

Improve health check for emqx bridge pulsar plugin by adding a retry timeout and using a macro. Change `emqx_bridge_pulsar_impl_producer.erl` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
