### PR TITLE
fix: rule engine different behavior for div and mod

### DIFF
--- a/apps/emqx_rule_engine/include/rule_engine.hrl
+++ b/apps/emqx_rule_engine/include/rule_engine.hrl
@@ -70,7 +70,8 @@
         Op =:= '-' orelse
         Op =:= '*' orelse
         Op =:= '/' orelse
-        Op =:= 'div')
+        Op =:= 'div' orelse
+        Op =:= 'mod')
 ).
 
 %% Compare operators

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -66,6 +66,7 @@ groups() ->
             t_sqlselect_with_3rd_party_impl2,
             t_sqlselect_with_3rd_party_funcs_unknown,
             t_sqlselect_001,
+            t_sqlselect_002,
             t_sqlselect_inject_props,
             t_sqlselect_01,
             t_sqlselect_02,
@@ -1080,6 +1081,36 @@ t_sqlselect_001(_Config) ->
         emqx_rule_sqltester:test(
             #{
                 sql => Sql2,
+                context =>
+                    #{
+                        payload => #{<<"what">> => 4},
+                        topic => <<"t/a">>
+                    }
+            }
+        )
+    ).
+
+t_sqlselect_002(_Config) ->
+    %% Verify that the div and mod can be used both as infix operations and as
+    %% function calls
+    Sql =
+        ""
+        "select 2 mod 2   as mod1,\n"
+        "                  mod(3, 2) as mod2,\n"
+        "                  4 div 2   as div1,\n"
+        "                  div(7, 2) as div2\n"
+        "           from \"t/#\" "
+        "",
+    ?assertMatch(
+        {ok, #{
+            <<"mod1">> := 0,
+            <<"mod2">> := 1,
+            <<"div1">> := 2,
+            <<"div2">> := 3
+        }},
+        emqx_rule_sqltester:test(
+            #{
+                sql => Sql,
                 context =>
                     #{
                         payload => #{<<"what">> => 4},

--- a/changes/ce/fix-11026.en.md
+++ b/changes/ce/fix-11026.en.md
@@ -1,0 +1,1 @@
+Addressed an inconsistency in the usage of 'div' and 'mod' operations within the rule engine. Previously, the 'div' operation was only usable as an infix operation and 'mod' could only be applied through a function call. With this change, both 'div' and 'mod' can be used via function call syntax and infix syntax.

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule EMQXUmbrella.MixProject do
       # maybe forbid to fetch quicer
       {:emqtt,
        github: "emqx/emqtt", tag: "1.8.6", override: true, system_env: maybe_no_quic_env()},
-      {:rulesql, github: "emqx/rulesql", tag: "0.1.6"},
+      {:rulesql, github: "emqx/rulesql", tag: "0.1.7"},
       {:observer_cli, "1.7.1"},
       {:system_monitor, github: "ieQu1/system_monitor", tag: "3.0.3"},
       {:telemetry, "1.1.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -70,7 +70,7 @@
     , {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.7"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}}
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.8.6"}}}
-    , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.6"}}}
+    , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.7"}}}
     , {observer_cli, "1.7.1"} % NOTE: depends on recon 2.5.x
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}


### PR DESCRIPTION
Previously, the div operation could only be used as an infix operation while mod could only be used as a function call. After this commit, one can use both div and mod using function call syntax and infix syntax.

Fixes: https://emqx.atlassian.net/browse/EMQX-10216

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cf31b65</samp>

This pull request adds support for `div` and `mod` operators in rule engine SQL queries. It updates the `rulesql` dependency, adds a new test case, and modifies the rule engine syntax definition.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible