### PR TITLE
fix(tls): fix incompatible tls options and issue with tls version gap

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -25,7 +25,7 @@
     {emqx_utils, {path, "../emqx_utils"}},
     {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.2"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
-    {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}},
+    {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -94,6 +94,18 @@ ssl_opts_tls_psk_test() ->
     Checked = validate(Sc, #{<<"versions">> => [<<"tlsv1.2">>]}),
     ?assertMatch(#{versions := ['tlsv1.2']}, Checked).
 
+ssl_opts_version_gap_test_() ->
+    Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
+    RanchSc = emqx_schema:server_ssl_opts_schema(#{}, true),
+    Reason = "Using multiple versions that include tlsv1.3 but exclude tlsv1.2 is not allowed",
+    [
+        ?_assertThrow(
+            {_, [#{kind := validation_error, reason := Reason}]},
+            validate(S, #{<<"versions">> => [<<"tlsv1.1">>, <<"tlsv1.3">>]})
+        )
+     || S <- [Sc, RanchSc]
+    ].
+
 bad_cipher_test() ->
     Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
     Reason = {bad_ciphers, ["foo"]},

--- a/changes/ce/fix-11028.en.md
+++ b/changes/ce/fix-11028.en.md
@@ -1,0 +1,7 @@
+Disallow using multiple TLS versions in the listener config that include tlsv1.3 but exclude tlsv1.2.
+
+Using TLS configuration with such version gap caused connection errors.
+Additionally, drop and log TLS options that are incompatible with the selected TLS version(s).
+
+Note: any old listener configuration with the version gap described above will fail to load
+after applying this fix and must be manually fixed.

--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,7 @@ defmodule EMQXUmbrella.MixProject do
       {:ehttpc, github: "emqx/ehttpc", tag: "0.4.10", override: true},
       {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true},
       {:jiffy, github: "emqx/jiffy", tag: "1.0.5", override: true},
-      {:cowboy, github: "emqx/cowboy", tag: "2.9.0", override: true},
+      {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true},
       {:esockd, github: "emqx/esockd", tag: "5.9.6", override: true},
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.7.2-emqx-11", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.15.2", override: true},
@@ -92,7 +92,7 @@ defmodule EMQXUmbrella.MixProject do
        github: "ninenines/cowlib", ref: "c6553f8308a2ca5dcd69d845f0a7d098c40c3363", override: true},
       # in conflict by cowboy_swagger and cowboy
       {:ranch,
-       github: "ninenines/ranch", ref: "a692f44567034dacf5efcaa24a24183788594eb7", override: true},
+       github: "emqx/ranch", ref: "de8ba2a00817c0a6eb1b8f20d6fb3e44e2c9a5aa", override: true},
       # in conflict by grpc and eetcd
       {:gpb, "4.19.7", override: true, runtime: false},
       {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -59,7 +59,7 @@
     , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.10"}}}
     , {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
-    , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}
+    , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}}
     , {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.7.2-emqx-11"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.2"}}}


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10245.

See also https://github.com/emqx/ranch/pull/1.

Need some discussion on how to handle this best. With this patch + patched ranch it works fine, but the UI does not reflect version gap fix. I.e. if a user sets TLS versions to '1.3', '1.1', we will be using '1.3' only on backend, but the UI will still be showing '1.3', '1.1'.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 599367c</samp>

Improved TLS options validation and adjustment in `emqx_tls_lib.erl`. Renamed `filter` to `ensure_valid_options` and added warnings for possible issues.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
