### PR TITLE
fix(listener_mgmt_api): use union member selector fn for better error messages (r5.1)

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -1104,14 +1104,9 @@ do_t_validations(_Config) ->
         emqx_utils_json:decode(ResRaw1, [return_maps]),
     ?assertMatch(
         #{
-            <<"mismatches">> :=
-                #{
-                    <<"listeners:ssl_not_required_bind">> :=
-                        #{
-                            <<"reason">> :=
-                                <<"verify must be verify_peer when CRL check is enabled">>
-                        }
-                }
+            <<"kind">> := <<"validation_error">>,
+            <<"reason">> :=
+                <<"verify must be verify_peer when CRL check is enabled">>
         },
         emqx_utils_json:decode(MsgRaw1, [return_maps])
     ),

--- a/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
@@ -912,14 +912,9 @@ do_t_validations(_Config) ->
         emqx_utils_json:decode(ResRaw1, [return_maps]),
     ?assertMatch(
         #{
-            <<"mismatches">> :=
-                #{
-                    <<"listeners:ssl_not_required_bind">> :=
-                        #{
-                            <<"reason">> :=
-                                <<"The responder URL is required for OCSP stapling">>
-                        }
-                }
+            <<"kind">> := <<"validation_error">>,
+            <<"reason">> :=
+                <<"The responder URL is required for OCSP stapling">>
         },
         emqx_utils_json:decode(MsgRaw1, [return_maps])
     ),
@@ -942,14 +937,9 @@ do_t_validations(_Config) ->
         emqx_utils_json:decode(ResRaw2, [return_maps]),
     ?assertMatch(
         #{
-            <<"mismatches">> :=
-                #{
-                    <<"listeners:ssl_not_required_bind">> :=
-                        #{
-                            <<"reason">> :=
-                                <<"The issuer PEM path is required for OCSP stapling">>
-                        }
-                }
+            <<"kind">> := <<"validation_error">>,
+            <<"reason">> :=
+                <<"The issuer PEM path is required for OCSP stapling">>
         },
         emqx_utils_json:decode(MsgRaw2, [return_maps])
     ),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -132,7 +132,7 @@ t_query_mode(CtConfig) ->
         begin
             publish_with_config_template_parameters(CtConfig1, #{"query_mode" => "sync"})
         end,
-        fun(RunStageResult, Trace) ->
+        fun(Trace) ->
             %% We should have a sync Snabbkaffe trace
             ?assertMatch([_], ?of_kind(emqx_bridge_kafka_impl_producer_sync_query, Trace))
         end
@@ -141,7 +141,7 @@ t_query_mode(CtConfig) ->
         begin
             publish_with_config_template_parameters(CtConfig1, #{"query_mode" => "async"})
         end,
-        fun(RunStageResult, Trace) ->
+        fun(Trace) ->
             %% We should have a sync Snabbkaffe trace
             ?assertMatch([_], ?of_kind(emqx_bridge_kafka_impl_producer_async_query, Trace))
         end

--- a/changes/ce/fix-11030.en.md
+++ b/changes/ce/fix-11030.en.md
@@ -1,0 +1,1 @@
+Improved error messages when a validation error occurs while using the Listeners HTTP API.


### PR DESCRIPTION
# targeting `release-51`

Fixes https://emqx.atlassian.net/browse/EMQX-10247

Before fix (update):

![image](https://github.com/emqx/emqx/assets/16166434/48793009-4c09-4ca0-802e-15411a895f88)


After fix (update):

![image](https://github.com/emqx/emqx/assets/16166434/f5fb05ee-4590-4501-87d7-a95788112bfa)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4703e0</samp>

This pull request enhances the code quality and functionality of the Kafka bridge and the listener management modules. It simplifies some test functions, updates the listener schema to use hoconsc:union, and improves the listener update API test and error handling.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
