### PR TITLE
fix(influxdb): check authentication

### DIFF
--- a/apps/emqx_bridge_influxdb/rebar.config
+++ b/apps/emqx_bridge_influxdb/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {deps, [
-    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.9"}}},
+    {influxdb, {git, "https://github.com/emqx/influxdb-client-erl", {tag, "1.1.10"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/changes/ee/fix-11031.en.md
+++ b/changes/ee/fix-11031.en.md
@@ -1,0 +1,1 @@
+Fixed credential validation when creating bridge and checking status for InfluxDB Bridges.

--- a/mix.exs
+++ b/mix.exs
@@ -193,7 +193,7 @@ defmodule EMQXUmbrella.MixProject do
   defp enterprise_deps(_profile_info = %{edition_type: :enterprise}) do
     [
       {:hstreamdb_erl, github: "hstreamdb/hstreamdb_erl", tag: "0.2.5"},
-      {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.9", override: true},
+      {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.10", override: true},
       {:wolff, github: "kafka4beam/wolff", tag: "1.7.5"},
       {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.3", override: true},
       {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.0"},


### PR DESCRIPTION
# targeting `release-51`

Checks authentication on bridge start and get status. Also, handle authentication error when sending message.

Fixes https://emqx.atlassian.net/browse/EMQX-10213

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 410faba</samp>

This pull request enhances the security and error handling of the emqx_bridge_influxdb connector by adding authentication checks and 401 error handling. It also adds test cases to verify the functionality and the expected logs and events. It modifies the `emqx_bridge_influxdb_connector.erl` and `emqx_bridge_influxdb_SUITE.erl` files.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [ ] ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- [ ] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [ ] ~Change log has been added to `changes/` dir for user-facing artifacts update~
