### PR TITLE
feat(exproto): abandon the mountpoint field in AuthenticateRequest

### DIFF
--- a/apps/emqx_gateway_exproto/priv/protos/exproto.proto
+++ b/apps/emqx_gateway_exproto/priv/protos/exproto.proto
@@ -277,6 +277,8 @@ message ClientInfo {
 
   string username = 4;
 
+  // deprecated since v5.1.0
+  // the request value of `mountpoint` will be ignored after v5.1.0
   string mountpoint = 5;
 }
 

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
@@ -21,6 +21,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -export([
     info/1,
@@ -121,11 +122,11 @@ info(ctx, #channel{ctx = Ctx}) ->
 stats(#channel{subscriptions = Subs}) ->
     [
         {subscriptions_cnt, maps:size(Subs)},
-        {subscriptions_max, 0},
+        {subscriptions_max, infinity},
         {inflight_cnt, 0},
-        {inflight_max, 0},
+        {inflight_max, infinity},
         {mqueue_len, 0},
-        {mqueue_max, 0},
+        {mqueue_max, infinity},
         {mqueue_dropped, 0},
         {next_pkt_id, 0},
         {awaiting_rel_cnt, 0},
@@ -164,7 +165,8 @@ init(
     DefaultClientInfo = default_clientinfo(NConnInfo),
     ClientInfo = DefaultClientInfo#{
         listener => ListenerId,
-        enable_authn => EnableAuthn
+        enable_authn => EnableAuthn,
+        mountpoint => maps:get(mountpoint, Options, undefined)
     },
     Channel = #channel{
         ctx = Ctx,
@@ -758,7 +760,23 @@ enrich_conninfo(InClientInfo, ConnInfo) ->
     maps:merge(ConnInfo, maps:with(Ks, InClientInfo)).
 
 enrich_clientinfo(InClientInfo = #{proto_name := ProtoName}, ClientInfo) ->
-    Ks = [clientid, username, mountpoint],
+    Ks = [clientid, username],
+    case maps:get(mountpoint, InClientInfo, <<>>) of
+        <<>> ->
+            ok;
+        Mp ->
+            ?tp(
+                warning,
+                failed_to_override_mountpoint,
+                #{
+                    reason =>
+                        "The mountpoint in AuthenticateRequest has been deprecated. "
+                        "Please use the `gateway.exproto.mountpoint` configuration.",
+                    requested_mountpoint => Mp,
+                    configured_mountpoint => maps:get(mountpoint, ClientInfo)
+                }
+            )
+    end,
     NClientInfo = maps:merge(ClientInfo, maps:with(Ks, InClientInfo)),
     NClientInfo#{protocol => proto_name_to_protocol(ProtoName)}.
 

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
@@ -21,7 +21,6 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
--include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -export([
     info/1,
@@ -765,10 +764,10 @@ enrich_clientinfo(InClientInfo = #{proto_name := ProtoName}, ClientInfo) ->
         <<>> ->
             ok;
         Mp ->
-            ?tp(
+            ?SLOG(
                 warning,
-                failed_to_override_mountpoint,
                 #{
+                    msg => "failed_to_override_mountpoint",
                     reason =>
                         "The mountpoint in AuthenticateRequest has been deprecated. "
                         "Please use the `gateway.exproto.mountpoint` configuration.",

--- a/changes/ce/fix-11033.en.md
+++ b/changes/ce/fix-11033.en.md
@@ -1,0 +1,8 @@
+Deprecates the `mountpoint` field in `AuthenticateRequest` in ExProto gateway.
+
+This field was introduced in v4.x, but in fact, in 5.0 we have provided
+`gateway.exproto.mountpoint` for configuration, so there is no need to override
+it through the Authenticate request.
+
+Additionally, updates the default value of `subscriptions_max`, `inflight_max`,
+`mqueue_max` to `infinity`


### PR DESCRIPTION
This field was introduced in v4.x, but in fact, in 5.0 we have provided `gateway.exproto.mountpoint` for configuration, so there is no need to override it through the Authenticate request.

Additionally, updates the default value of `subscriptions_max`, `inflight_max`, `mqueue_max` to `infinity`

Fixes https://emqx.atlassian.net/browse/EMQX-10266

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7684cef</samp>

This pull request enhances the exproto module by using `snabbkaffe` for tracing, setting the channel limits to infinity, passing the mountpoint to the adapter, and deprecating the `mountpoint` field in the `AuthenticateRequest` message. These changes improve the debugging, testing, and configuration of the exproto channel and protocol.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
