### PR TITLE
feat:  move shared_subscription_strategy from broker to mqtt

### DIFF
--- a/apps/emqx/include/emqx_schema.hrl
+++ b/apps/emqx/include/emqx_schema.hrl
@@ -19,5 +19,6 @@
 -define(TOMBSTONE_TYPE, marked_for_deletion).
 -define(TOMBSTONE_VALUE, <<"marked_for_deletion">>).
 -define(TOMBSTONE_CONFIG_CHANGE_REQ, mark_it_for_deletion).
+-define(CONFIG_NOT_FOUND_MAGIC, '$0tFound').
 
 -endif.

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -19,6 +19,7 @@
 -elvis([{elvis_style, god_modules, disable}]).
 -include("logger.hrl").
 -include("emqx.hrl").
+-include("emqx_schema.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -export([
@@ -108,7 +109,6 @@
 -define(ZONE_CONF_PATH(ZONE, PATH), [zones, ZONE | PATH]).
 -define(LISTENER_CONF_PATH(TYPE, LISTENER, PATH), [listeners, TYPE, LISTENER | PATH]).
 
--define(CONFIG_NOT_FOUND_MAGIC, '$0tFound').
 -define(MAX_KEEP_BACKUP_CONFIGS, 10).
 
 -export_type([

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -226,7 +226,10 @@ roots(medium) ->
         {"broker",
             sc(
                 ref("broker"),
-                #{desc => ?DESC(broker)}
+                #{
+                    desc => ?DESC(broker),
+                    importance => ?IMPORTANCE_HIDDEN
+                }
             )},
         {"sys_topics",
             sc(
@@ -439,251 +442,7 @@ fields("authz_cache") ->
             )}
     ];
 fields("mqtt") ->
-    [
-        {"idle_timeout",
-            sc(
-                hoconsc:union([infinity, duration()]),
-                #{
-                    default => <<"15s">>,
-                    desc => ?DESC(mqtt_idle_timeout)
-                }
-            )},
-        {"max_packet_size",
-            sc(
-                bytesize(),
-                #{
-                    default => <<"1MB">>,
-                    desc => ?DESC(mqtt_max_packet_size)
-                }
-            )},
-        {"max_clientid_len",
-            sc(
-                range(23, 65535),
-                #{
-                    default => 65535,
-                    desc => ?DESC(mqtt_max_clientid_len)
-                }
-            )},
-        {"max_topic_levels",
-            sc(
-                range(1, 65535),
-                #{
-                    default => 128,
-                    desc => ?DESC(mqtt_max_topic_levels)
-                }
-            )},
-        {"max_qos_allowed",
-            sc(
-                qos(),
-                #{
-                    default => 2,
-                    desc => ?DESC(mqtt_max_qos_allowed)
-                }
-            )},
-        {"max_topic_alias",
-            sc(
-                range(0, 65535),
-                #{
-                    default => 65535,
-                    desc => ?DESC(mqtt_max_topic_alias)
-                }
-            )},
-        {"retain_available",
-            sc(
-                boolean(),
-                #{
-                    default => true,
-                    desc => ?DESC(mqtt_retain_available)
-                }
-            )},
-        {"wildcard_subscription",
-            sc(
-                boolean(),
-                #{
-                    default => true,
-                    desc => ?DESC(mqtt_wildcard_subscription)
-                }
-            )},
-        {"shared_subscription",
-            sc(
-                boolean(),
-                #{
-                    default => true,
-                    desc => ?DESC(mqtt_shared_subscription)
-                }
-            )},
-        {"exclusive_subscription",
-            sc(
-                boolean(),
-                #{
-                    default => false,
-                    desc => ?DESC(mqtt_exclusive_subscription)
-                }
-            )},
-        {"ignore_loop_deliver",
-            sc(
-                boolean(),
-                #{
-                    default => false,
-                    desc => ?DESC(mqtt_ignore_loop_deliver)
-                }
-            )},
-        {"strict_mode",
-            sc(
-                boolean(),
-                #{
-                    default => false,
-                    desc => ?DESC(mqtt_strict_mode)
-                }
-            )},
-        {"response_information",
-            sc(
-                string(),
-                #{
-                    default => <<"">>,
-                    desc => ?DESC(mqtt_response_information)
-                }
-            )},
-        {"server_keepalive",
-            sc(
-                hoconsc:union([integer(), disabled]),
-                #{
-                    default => disabled,
-                    desc => ?DESC(mqtt_server_keepalive)
-                }
-            )},
-        {"keepalive_backoff",
-            sc(
-                number(),
-                #{
-                    default => ?DEFAULT_BACKOFF,
-                    %% Must add required => false, zone schema has no default.
-                    required => false,
-                    importance => ?IMPORTANCE_HIDDEN
-                }
-            )},
-        {"keepalive_multiplier",
-            sc(
-                number(),
-                #{
-                    default => ?DEFAULT_MULTIPLIER,
-                    validator => fun ?MODULE:validate_keepalive_multiplier/1,
-                    desc => ?DESC(mqtt_keepalive_multiplier)
-                }
-            )},
-        {"max_subscriptions",
-            sc(
-                hoconsc:union([range(1, inf), infinity]),
-                #{
-                    default => infinity,
-                    desc => ?DESC(mqtt_max_subscriptions)
-                }
-            )},
-        {"upgrade_qos",
-            sc(
-                boolean(),
-                #{
-                    default => false,
-                    desc => ?DESC(mqtt_upgrade_qos)
-                }
-            )},
-        {"max_inflight",
-            sc(
-                range(1, 65535),
-                #{
-                    default => 32,
-                    desc => ?DESC(mqtt_max_inflight)
-                }
-            )},
-        {"retry_interval",
-            sc(
-                duration(),
-                #{
-                    default => <<"30s">>,
-                    desc => ?DESC(mqtt_retry_interval)
-                }
-            )},
-        {"max_awaiting_rel",
-            sc(
-                hoconsc:union([integer(), infinity]),
-                #{
-                    default => 100,
-                    desc => ?DESC(mqtt_max_awaiting_rel)
-                }
-            )},
-        {"await_rel_timeout",
-            sc(
-                duration(),
-                #{
-                    default => <<"300s">>,
-                    desc => ?DESC(mqtt_await_rel_timeout)
-                }
-            )},
-        {"session_expiry_interval",
-            sc(
-                duration(),
-                #{
-                    default => <<"2h">>,
-                    desc => ?DESC(mqtt_session_expiry_interval)
-                }
-            )},
-        {"max_mqueue_len",
-            sc(
-                hoconsc:union([non_neg_integer(), infinity]),
-                #{
-                    default => 1000,
-                    desc => ?DESC(mqtt_max_mqueue_len)
-                }
-            )},
-        {"mqueue_priorities",
-            sc(
-                hoconsc:union([disabled, map()]),
-                #{
-                    default => disabled,
-                    desc => ?DESC(mqtt_mqueue_priorities)
-                }
-            )},
-        {"mqueue_default_priority",
-            sc(
-                hoconsc:enum([highest, lowest]),
-                #{
-                    default => lowest,
-                    desc => ?DESC(mqtt_mqueue_default_priority)
-                }
-            )},
-        {"mqueue_store_qos0",
-            sc(
-                boolean(),
-                #{
-                    default => true,
-                    desc => ?DESC(mqtt_mqueue_store_qos0)
-                }
-            )},
-        {"use_username_as_clientid",
-            sc(
-                boolean(),
-                #{
-                    default => false,
-                    desc => ?DESC(mqtt_use_username_as_clientid)
-                }
-            )},
-        {"peer_cert_as_username",
-            sc(
-                hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
-                #{
-                    default => disabled,
-                    desc => ?DESC(mqtt_peer_cert_as_username)
-                }
-            )},
-        {"peer_cert_as_clientid",
-            sc(
-                hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
-                #{
-                    default => disabled,
-                    desc => ?DESC(mqtt_peer_cert_as_clientid)
-                }
-            )}
-    ];
+    mqtt_general() ++ mqtt_session();
 fields("zone") ->
     emqx_zone_schema:zones_without_default();
 fields("flapping_detect") ->
@@ -1563,22 +1322,7 @@ fields("broker") ->
                     desc => ?DESC(broker_session_locking_strategy)
                 }
             )},
-        {"shared_subscription_strategy",
-            sc(
-                hoconsc:enum([
-                    random,
-                    round_robin,
-                    round_robin_per_group,
-                    sticky,
-                    local,
-                    hash_topic,
-                    hash_clientid
-                ]),
-                #{
-                    default => round_robin,
-                    desc => ?DESC(broker_shared_subscription_strategy)
-                }
-            )},
+        shared_subscription_strategy(),
         {"shared_dispatch_ack_enabled",
             sc(
                 boolean(),
@@ -3564,3 +3308,283 @@ flapping_detect_converter(Conf = #{<<"window_time">> := <<"disable">>}, _Opts) -
     Conf#{<<"window_time">> => ?DEFAULT_WINDOW_TIME, <<"enable">> => false};
 flapping_detect_converter(Conf, _Opts) ->
     Conf.
+mqtt_general() ->
+    [
+        {"idle_timeout",
+            sc(
+                hoconsc:union([infinity, duration()]),
+                #{
+                    default => <<"15s">>,
+                    desc => ?DESC(mqtt_idle_timeout)
+                }
+            )},
+        {"max_packet_size",
+            sc(
+                bytesize(),
+                #{
+                    default => <<"1MB">>,
+                    desc => ?DESC(mqtt_max_packet_size)
+                }
+            )},
+        {"max_clientid_len",
+            sc(
+                range(23, 65535),
+                #{
+                    default => 65535,
+                    desc => ?DESC(mqtt_max_clientid_len)
+                }
+            )},
+        {"max_topic_levels",
+            sc(
+                range(1, 65535),
+                #{
+                    default => 128,
+                    desc => ?DESC(mqtt_max_topic_levels)
+                }
+            )},
+        {"max_topic_alias",
+            sc(
+                range(0, 65535),
+                #{
+                    default => 65535,
+                    desc => ?DESC(mqtt_max_topic_alias)
+                }
+            )},
+        {"retain_available",
+            sc(
+                boolean(),
+                #{
+                    default => true,
+                    desc => ?DESC(mqtt_retain_available)
+                }
+            )},
+        {"wildcard_subscription",
+            sc(
+                boolean(),
+                #{
+                    default => true,
+                    desc => ?DESC(mqtt_wildcard_subscription)
+                }
+            )},
+        {"shared_subscription",
+            sc(
+                boolean(),
+                #{
+                    default => true,
+                    desc => ?DESC(mqtt_shared_subscription)
+                }
+            )},
+        shared_subscription_strategy(),
+        {"exclusive_subscription",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(mqtt_exclusive_subscription)
+                }
+            )},
+        {"ignore_loop_deliver",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(mqtt_ignore_loop_deliver)
+                }
+            )},
+        {"strict_mode",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(mqtt_strict_mode)
+                }
+            )},
+        {"response_information",
+            sc(
+                string(),
+                #{
+                    default => <<"">>,
+                    desc => ?DESC(mqtt_response_information)
+                }
+            )},
+        {"server_keepalive",
+            sc(
+                hoconsc:union([integer(), disabled]),
+                #{
+                    default => disabled,
+                    desc => ?DESC(mqtt_server_keepalive)
+                }
+            )},
+        {"keepalive_backoff",
+            sc(
+                number(),
+                #{
+                    default => ?DEFAULT_BACKOFF,
+                    %% Must add required => false, zone schema has no default.
+                    required => false,
+                    importance => ?IMPORTANCE_HIDDEN
+                }
+            )},
+        {"keepalive_multiplier",
+            sc(
+                number(),
+                #{
+                    default => ?DEFAULT_MULTIPLIER,
+                    validator => fun ?MODULE:validate_keepalive_multiplier/1,
+                    desc => ?DESC(mqtt_keepalive_multiplier)
+                }
+            )},
+        {"retry_interval",
+            sc(
+                duration(),
+                #{
+                    default => <<"30s">>,
+                    desc => ?DESC(mqtt_retry_interval)
+                }
+            )},
+        {"use_username_as_clientid",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(mqtt_use_username_as_clientid)
+                }
+            )},
+        {"peer_cert_as_username",
+            sc(
+                hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
+                #{
+                    default => disabled,
+                    desc => ?DESC(mqtt_peer_cert_as_username)
+                }
+            )},
+        {"peer_cert_as_clientid",
+            sc(
+                hoconsc:enum([disabled, cn, dn, crt, pem, md5]),
+                #{
+                    default => disabled,
+                    desc => ?DESC(mqtt_peer_cert_as_clientid)
+                }
+            )}
+    ].
+%% All session's importance should be lower than general part to organize document.
+mqtt_session() ->
+    [
+        {"session_expiry_interval",
+            sc(
+                duration(),
+                #{
+                    default => <<"2h">>,
+                    desc => ?DESC(mqtt_session_expiry_interval),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"max_awaiting_rel",
+            sc(
+                hoconsc:union([integer(), infinity]),
+                #{
+                    default => 100,
+                    desc => ?DESC(mqtt_max_awaiting_rel),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"max_qos_allowed",
+            sc(
+                qos(),
+                #{
+                    default => 2,
+                    desc => ?DESC(mqtt_max_qos_allowed),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"mqueue_priorities",
+            sc(
+                hoconsc:union([disabled, map()]),
+                #{
+                    default => disabled,
+                    desc => ?DESC(mqtt_mqueue_priorities),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"mqueue_default_priority",
+            sc(
+                hoconsc:enum([highest, lowest]),
+                #{
+                    default => lowest,
+                    desc => ?DESC(mqtt_mqueue_default_priority),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"mqueue_store_qos0",
+            sc(
+                boolean(),
+                #{
+                    default => true,
+                    desc => ?DESC(mqtt_mqueue_store_qos0),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"max_mqueue_len",
+            sc(
+                hoconsc:union([non_neg_integer(), infinity]),
+                #{
+                    default => 1000,
+                    desc => ?DESC(mqtt_max_mqueue_len),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"max_inflight",
+            sc(
+                range(1, 65535),
+                #{
+                    default => 32,
+                    desc => ?DESC(mqtt_max_inflight),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"max_subscriptions",
+            sc(
+                hoconsc:union([range(1, inf), infinity]),
+                #{
+                    default => infinity,
+                    desc => ?DESC(mqtt_max_subscriptions),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"upgrade_qos",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(mqtt_upgrade_qos),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
+        {"await_rel_timeout",
+            sc(
+                duration(),
+                #{
+                    default => <<"300s">>,
+                    desc => ?DESC(mqtt_await_rel_timeout),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )}
+    ].
+
+shared_subscription_strategy() ->
+    {"shared_subscription_strategy",
+        sc(
+            hoconsc:enum([
+                random,
+                round_robin,
+                round_robin_per_group,
+                sticky,
+                local,
+                hash_topic,
+                hash_clientid
+            ]),
+            #{
+                default => round_robin,
+                desc => ?DESC(broker_shared_subscription_strategy)
+            }
+        )}.

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -440,6 +440,7 @@ zone_global_defaults() ->
                 server_keepalive => disabled,
                 session_expiry_interval => 7200000,
                 shared_subscription => true,
+                shared_subscription_strategy => round_robin,
                 strict_mode => false,
                 upgrade_qos => false,
                 use_username_as_clientid => false,

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -769,12 +769,12 @@ t_qos1_random_dispatch_if_all_members_are_down(Config) when is_list(Config) ->
 %% Expected behaviour:
 %% the messages sent to client1's inflight and mq are re-dispatched after client1 is down
 t_dispatch_qos2({init, Config}) when is_list(Config) ->
+    ok = ensure_config(round_robin, _AckEnabled = false),
     emqx_config:put_zone_conf(default, [mqtt, max_inflight], 1),
     Config;
 t_dispatch_qos2({'end', Config}) when is_list(Config) ->
     emqx_config:put_zone_conf(default, [mqtt, max_inflight], 0);
 t_dispatch_qos2(Config) when is_list(Config) ->
-    ok = ensure_config(round_robin, _AckEnabled = false),
     Topic = <<"foo/bar/1">>,
     ClientId1 = <<"ClientId1">>,
     ClientId2 = <<"ClientId2">>,
@@ -923,12 +923,12 @@ t_session_takeover(Config) when is_list(Config) ->
     ok.
 
 t_session_kicked({init, Config}) when is_list(Config) ->
+    ok = ensure_config(round_robin, _AckEnabled = false),
     emqx_config:put_zone_conf(default, [mqtt, max_inflight], 1),
     Config;
 t_session_kicked({'end', Config}) when is_list(Config) ->
     emqx_config:put_zone_conf(default, [mqtt, max_inflight], 0);
 t_session_kicked(Config) when is_list(Config) ->
-    ok = ensure_config(round_robin, _AckEnabled = false),
     Topic = <<"foo/bar/1">>,
     ClientId1 = <<"ClientId1">>,
     ClientId2 = <<"ClientId2">>,
@@ -1019,12 +1019,12 @@ ensure_config(Strategy) ->
     ensure_config(Strategy, _AckEnabled = true).
 
 ensure_config(Strategy, AckEnabled) ->
-    emqx_config:put([broker, shared_subscription_strategy], Strategy),
+    emqx_config:put([mqtt, shared_subscription_strategy], Strategy),
     emqx_config:put([broker, shared_dispatch_ack_enabled], AckEnabled),
     ok.
 
 ensure_node_config(Node, Strategy) ->
-    rpc:call(Node, emqx_config, force_put, [[broker, shared_subscription_strategy], Strategy]).
+    rpc:call(Node, emqx_config, force_put, [[mqtt, shared_subscription_strategy], Strategy]).
 
 ensure_group_config(Group2Strategy) ->
     lists:foreach(

--- a/changes/ce/feat-11034.en.md
+++ b/changes/ce/feat-11034.en.md
@@ -1,0 +1,1 @@
+Hide the broker and move the `broker.shared_subscription_strategy` to `mqtt.shared_subscription_strategy` as it belongs to `mqtt`.


### PR DESCRIPTION
Fixes 
https://emqx.atlassian.net/browse/EMQX-10254
https://emqx.atlassian.net/browse/EMQX-10260

1. Hide the broker and move the `broker.shared_subscription_strategy` to `mqtt.shared_subscription_strategy` as it belongs to `mqtt`.
2. Split the mqtt configuration into common configuration and session configuration for ease of documentation display in the future.
<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fcf5b3b</samp>

This pull request refactors and simplifies the code related to configuration and shared subscription in emqx. It introduces a macro `CONFIG_NOT_FOUND_MAGIC` to handle configuration errors and defaults, and removes a deprecated feature of shared dispatch acknowledgement. It also fixes a typo and adapts to the new configuration schema.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
