### PR TITLE
fix(pulsar_producer): do not return `disconnected` when checking status (r5.1)

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -84,6 +84,8 @@
 %% Toxiproxy API
 -export([
     with_failure/5,
+    enable_failure/4,
+    heal_failure/4,
     reset_proxy/2
 ]).
 

--- a/changes/ee/fix-11038.en.md
+++ b/changes/ee/fix-11038.en.md
@@ -1,0 +1,1 @@
+Fixed a health check issue for Pulsar Producer that could lead to loss of messages when the connection to Pulsar's brokers were down.


### PR DESCRIPTION
# targeting `release-51`

Fixes https://emqx.atlassian.net/browse/EMQX-10278

Since Pulsar client has its own replayq that lives outside the management of the buffer workers, we must not return disconnected status for such bridge: otherwise, the resource manager will eventually kill the producers and data may be lost.


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a99a4cf</samp>

This pull request enhances the emqx bridge pulsar producer module and its test suite. It improves the status reporting, health check, and reconnect logic of the producer when connecting to the pulsar broker. It also adds new test functions and cases to simulate and verify the producer's resilience under network failures.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
