### PR TITLE
fix(redis): validate database number

### DIFF
--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -294,7 +294,7 @@ redis_fields() ->
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {password, fun emqx_connector_schema_lib:password/1},
         {database, #{
-            type => integer(),
+            type => non_neg_integer(),
             default => 0,
             desc => ?DESC("database")
         }},

--- a/changes/ce/fix-11039.en.md
+++ b/changes/ce/fix-11039.en.md
@@ -1,0 +1,1 @@
+Fixed database number validation for Redis connector. Previously negative numbers were accepted as valid database numbers.


### PR DESCRIPTION
Fixes [EMQX-10211](https://emqx.atlassian.net/browse/EMQX-10211)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1511d80</samp>

This pull request improves the test and validation of redis authentication in emqx. It refactors and fixes a test case in `emqx_authn_redis_SUITE.erl` and changes the schema of the `database` field in `emqx_connector_redis.erl` to use `non_neg_integer()`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
~~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [ ] **Schema changes are NOT backward compatible** but we probably do not want to handle configurations having `database = -123` for Redis resources.

