### PR TITLE
fix(kafka_producer): do not return `disconnected` when checking status (r5.1)

### DIFF
--- a/changes/ee/fix-11040.en.md
+++ b/changes/ee/fix-11040.en.md
@@ -1,0 +1,1 @@
+Fixed a health check issue for Kafka Producer that could lead to loss of messages when the connection to Kafka's brokers were down.


### PR DESCRIPTION
# targeting `release-51`

Fixes https://emqx.atlassian.net/browse/EMQX-10279

Related: https://github.com/emqx/emqx/pull/11038

Since wolff client has its own replayq that lives outside the management of the buffer workers, we must not return disconnected status for such bridge: otherwise, the resource manager will eventually kill the producers and data may be lost.


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a03d13</samp>

Improve error handling and status reporting for `emqx_bridge_kafka_impl_producer`. Prevent wolff producers from crashing due to transient errors.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
