### PR TITLE
fix: api_listener crash when setting max_connnections as string

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -668,13 +668,7 @@ format_status(Key, Node, Listener, Acc) ->
 
 max_conn(_Int1, <<"infinity">>) -> <<"infinity">>;
 max_conn(<<"infinity">>, _Int) -> <<"infinity">>;
-max_conn(Int1, Int2) -> int(Int1) + int(Int2).
-
-%% If we set max_connections = “123”,
-%% it will be converted to #{<<"max_connections">> => <<"123">>} in the raw_conf with no error.
-%% so we need to convert it to integer, we should fix this at hocon lib in the future.
-int(Bin) when is_binary(Bin) -> binary_to_integer(Bin);
-int(Int) when is_integer(Int) -> Int.
+max_conn(Int1, Int2) -> Int1 + Int2.
 
 listener_type_status_example() ->
     [

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -668,7 +668,13 @@ format_status(Key, Node, Listener, Acc) ->
 
 max_conn(_Int1, <<"infinity">>) -> <<"infinity">>;
 max_conn(<<"infinity">>, _Int) -> <<"infinity">>;
-max_conn(Int1, Int2) -> Int1 + Int2.
+max_conn(Int1, Int2) -> int(Int1) + int(Int2).
+
+%% If we set max_connections = “123”,
+%% it will be converted to #{<<"max_connections">> => <<"123">>} in the raw_conf with no error.
+%% so we need to convert it to integer, we should fix this at hocon lib in the future.
+int(Bin) when is_binary(Bin) -> binary_to_integer(Bin);
+int(Int) when is_integer(Int) -> Int.
 
 listener_type_status_example() ->
     [

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -140,6 +140,16 @@ t_list_listeners(Config) when is_list(Config) ->
     ?assertMatch(#{<<"max_connections">> := <<"infinity">>}, Create),
     ?assert(is_running(NewListenerId)),
 
+    Update2 = request(put, NewPath, [], Create#{<<"max_connections">> => 100}),
+    ?assertMatch(#{<<"max_connections">> := 100}, Update2),
+    Get2 = request(get, NewPath, [], []),
+    ?assertMatch(#{<<"max_connections">> := 100}, Get2),
+
+    Update3 = request(put, NewPath, [], Create#{<<"max_connections">> => <<"123">>}),
+    ?assertMatch(#{<<"max_connections">> := 123}, Update3),
+    Get3 = request(get, NewPath, [], []),
+    ?assertMatch(#{<<"max_connections">> := 123}, Get3),
+
     %% delete
     ?assertEqual([], delete(NewPath)),
     ?assertEqual({error, not_found}, is_running(NewListenerId)),

--- a/changes/ce/fix-11042.en.md
+++ b/changes/ce/fix-11042.en.md
@@ -1,0 +1,1 @@
+Fix crash on `/api/listeners` when listener's max_connections is set to a string.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10271

if we setting max_connection as string via conf file.
```
listeners.tcp.default {
     bind = "0.0.0.0:1883"
     max_connections = "1234"
}
```
we will get raw_conf as 
```
> emqx_conf:get_raw([listeners,tcp,default]).
#{<<"bind">> => <<"0.0.0.0:1883">>, <<"max_connections">> => <<"1234">>
> emqx_conf:get([listeners,tcp,default]).
#{bind => {{0,0,0,0},1883}, max_connections => 1234}

```
the raw_conf's max_connections is binary, not a integer.
ideally we should check config failed by hocon when put a string as integer.
I choose to fix this quickly in emqx lib.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 091c492</samp>

This pull request adds a feature to limit the number of concurrent connections for each listener, and improves the handling of the `max_connections` parameter in the management API and the internal configuration. It also adds some test cases to verify the functionality and consistency of the feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
