### PR TITLE
fix(http): avoid crash if the old sample data dont contain `live_conn…

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -249,7 +249,7 @@ merge_cluster_sampler_map(M1, M2) ->
             (topics, Map) ->
                 Map#{topics => maps:get(topics, M1)};
             (Key, Map) ->
-                Map#{Key => maps:get(Key, M1) + maps:get(Key, M2)}
+                Map#{Key => maps:get(Key, M1, 0) + maps:get(Key, M2, 0)}
         end,
     lists:foldl(Fun, #{}, ?SAMPLER_LIST).
 


### PR DESCRIPTION
…ections`

In version 5.1.0, a new metric called "live_connections" was added. However, we try to merge some data from the Mria disk table, which may include old data formats.

Therefore, maps:get/3 is needed to avoid crashes.

logs:
```
2023-06-14T06:53:24.629890+00:00 [warning] mfa: minirest_handler:apply_callback/3, line: 116, exception: error, path: /monitor, reason: {badkey,live_connections}, stacktrace: [{erlang,map_get,[live_connections,#{connections => 0,dropped => 0,received => 0,sent => 0,subscriptions => 0,topics => 0}],[{error_info,#{module => erl_erts_errors}}]},{emqx_dashboard_monitor,'-merge_cluster_sampler_map/2-fun-0-',4,[{file,"emqx_dashboard_monitor.erl"},{line,252}]},{lists,foldl_1,3,[{file,"lists.erl"},{line,1355}]},{emqx_dashboard_monitor,merge_cluster_samplers,3,[{file,"emqx_dashboard_monitor.erl"},{line,243}]},{maps,fold_1,3,[{file,"maps.erl"},{line,411}]},{emqx_dashboard_monitor,do_sample,3,[{file,"emqx_dashboard_monitor.erl"},{line,227}]},{emqx_dashboard_monitor,samplers,2,[{file,"emqx_dashboard_monitor.erl"},{line,84}]},{emqx_dashboard_monitor_api,'-dashboard_samplers_fun/1-fun-0-',2,[{file,"emqx_dashboard_monitor_api.erl"},{line,130}]},{emqx_utils_api,with_node_or_cluster,2,[{file,"emqx_utils_api.erl"},{line,44}]},{minirest_handler,apply_callback,3,[{file,"minirest_handler.erl"},{line,111}]},{minirest_handler,handle,2,[{file,"minirest_handler.erl"},{line,44}]},{minirest_handler,init,2,[{file,"minirest_handler.erl"},{line,27}]},{cowboy_handler,execute,2,[{file,"cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]
```

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 80e2c2c</samp>

Fix potential badkey errors and improve dashboard monitor performance. Add default values for missing keys in `M1` and `M2` maps in `emqx_dashboard_monitor.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
