### PR TITLE
feat: deprecated dashboard.listeners.name.enable

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -169,7 +169,7 @@ init_node(Type) ->
             ok = emqx_dashboard_desc_cache:init(),
             ok = emqx_config:put(
                 [dashboard, listeners],
-                #{http => #{enable => true, bind => 18083, proxy_header => false}}
+                #{http => #{bind => 18083, proxy_header => false}}
             ),
             ok = emqx_dashboard:start_listeners(),
             ready = emqx_dashboard_listener:regenerate_minirest_dispatch(),

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -145,7 +145,9 @@ apps() ->
 listeners(Listeners) ->
     lists:filtermap(
         fun
-            ({Protocol, Conf = #{enable := true}}) ->
+            ({_Protocol, #{bind := 0}}) ->
+                false;
+            ({Protocol, Conf = #{}}) ->
                 {Conf1, Bind} = ip_port(Conf),
                 {true, {
                     listener_name(Protocol),
@@ -153,9 +155,7 @@ listeners(Listeners) ->
                     Bind,
                     ranch_opts(Conf1),
                     proto_opts(Conf1)
-                }};
-            ({_Protocol, #{enable := false}}) ->
-                false
+                }}
         end,
         maps:to_list(Listeners)
     ).
@@ -182,7 +182,7 @@ ranch_opts(Options) ->
     SocketOpts = maps:fold(
         fun filter_false/3,
         [],
-        maps:without([enable, inet6, ipv6_v6only, proxy_header | Keys], Options)
+        maps:without([inet6, ipv6_v6only, proxy_header | Keys], Options)
     ),
     InetOpts =
         case Options of

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener.erl
@@ -174,7 +174,9 @@ diff_listeners(Type, Stop, Start) -> {#{Type => Stop}, #{Type => Start}}.
 
 -define(DIR, <<"dashboard">>).
 
-ensure_ssl_cert(#{<<"listeners">> := #{<<"https">> := #{<<"enable">> := true}}} = Conf) ->
+ensure_ssl_cert(#{<<"listeners">> := #{<<"https">> := #{<<"bind">> := Bind}}} = Conf) when
+    Bind =/= 0
+->
     Https = emqx_utils_maps:deep_get([<<"listeners">>, <<"https">>], Conf, undefined),
     Opts = #{required_keys => [[<<"keyfile">>], [<<"certfile">>], [<<"cacertfile">>]]},
     case emqx_tls_lib:ensure_ssl_files(?DIR, Https, Opts) of

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -119,7 +119,8 @@ common_listener_fields() ->
                 integer(),
                 #{
                     default => erlang:system_info(schedulers_online),
-                    desc => ?DESC(num_acceptors)
+                    desc => ?DESC(num_acceptors),
+                    importance => ?IMPORTANCE_MEDIUM
                 }
             )},
         {"max_connections",
@@ -127,7 +128,8 @@ common_listener_fields() ->
                 integer(),
                 #{
                     default => 512,
-                    desc => ?DESC(max_connections)
+                    desc => ?DESC(max_connections),
+                    importance => ?IMPORTANCE_HIGH
                 }
             )},
         {"backlog",
@@ -135,7 +137,8 @@ common_listener_fields() ->
                 integer(),
                 #{
                     default => 1024,
-                    desc => ?DESC(backlog)
+                    desc => ?DESC(backlog),
+                    importance => ?IMPORTANCE_LOW
                 }
             )},
         {"send_timeout",
@@ -143,7 +146,8 @@ common_listener_fields() ->
                 emqx_schema:duration(),
                 #{
                     default => <<"10s">>,
-                    desc => ?DESC(send_timeout)
+                    desc => ?DESC(send_timeout),
+                    importance => ?IMPORTANCE_LOW
                 }
             )},
         {"inet6",
@@ -151,7 +155,8 @@ common_listener_fields() ->
                 boolean(),
                 #{
                     default => false,
-                    desc => ?DESC(inet6)
+                    desc => ?DESC(inet6),
+                    importance => ?IMPORTANCE_LOW
                 }
             )},
         {"ipv6_v6only",
@@ -159,7 +164,8 @@ common_listener_fields() ->
                 boolean(),
                 #{
                     default => false,
-                    desc => ?DESC(ipv6_v6only)
+                    desc => ?DESC(ipv6_v6only),
+                    importance => ?IMPORTANCE_LOW
                 }
             )},
         {"proxy_header",
@@ -167,7 +173,8 @@ common_listener_fields() ->
                 boolean(),
                 #{
                     desc => ?DESC(proxy_header),
-                    default => false
+                    default => false,
+                    importance => ?IMPORTANCE_MEDIUM
                 }
             )}
     ].
@@ -178,7 +185,9 @@ enable(Bool) ->
             boolean(),
             #{
                 default => Bool,
-                required => true,
+                required => false,
+                deprecated => {since, "5.1.0"},
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC(listener_enable)
             }
         )}.
@@ -188,9 +197,10 @@ bind(Port) ->
         ?HOCON(
             ?UNION([non_neg_integer(), emqx_schema:ip_port()]),
             #{
-                default => Port,
-                required => true,
+                default => 0,
+                required => false,
                 example => "0.0.0.0:" ++ integer_to_list(Port),
+                importance => ?IMPORTANCE_HIGH,
                 desc => ?DESC(bind)
             }
         )}.

--- a/apps/emqx_dashboard/test/emqx_dashboard_api_test_helpers.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_api_test_helpers.erl
@@ -48,7 +48,6 @@ set_default_config(DefaultUsername, HAProxyEnabled, Opts) ->
     Config = #{
         listeners => #{
             http => #{
-                enable => true,
                 bind => maps:get(bind, Opts, 18083),
                 inet6 => false,
                 ipv6_v6only => false,

--- a/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl
@@ -49,8 +49,8 @@ t_update_conf(_Config) ->
     Conf = #{
         dashboard => #{
             listeners => #{
-                https => #{bind => 18084, enable => true},
-                http => #{bind => 18083, enable => true}
+                https => #{bind => 18084},
+                http => #{bind => 18083}
             }
         }
     },
@@ -68,7 +68,7 @@ t_update_conf(_Config) ->
     ?check_trace(
         begin
             Raw1 = emqx_utils_maps:deep_put(
-                [<<"listeners">>, <<"https">>, <<"enable">>], Raw, false
+                [<<"listeners">>, <<"https">>, <<"bind">>], Raw, 0
             ),
             ?assertMatch({ok, _}, emqx:update_config([<<"dashboard">>], Raw1)),
             ?assertEqual(Raw1, emqx:get_raw_config([<<"dashboard">>])),
@@ -116,7 +116,7 @@ t_update_conf(_Config) ->
     emqx_mgmt_api_test_util:end_suite([emqx_management]).
 
 t_default_ssl_cert(_Config) ->
-    Conf = #{dashboard => #{listeners => #{https => #{bind => 18084, enable => true}}}},
+    Conf = #{dashboard => #{listeners => #{https => #{bind => 18084}}}},
     validate_https(Conf, 512, default_ssl_cert(), verify_none),
     ok.
 
@@ -127,7 +127,6 @@ t_normal_ssl_cert(_Config) ->
             listeners => #{
                 https => #{
                     bind => 18084,
-                    enable => true,
                     cacertfile => naive_env_interpolation(<<"${EMQX_ETC_DIR}/certs/cacert.pem">>),
                     certfile => naive_env_interpolation(<<"${EMQX_ETC_DIR}/certs/cert.pem">>),
                     keyfile => naive_env_interpolation(<<"${EMQX_ETC_DIR}/certs/key.pem">>),
@@ -149,7 +148,6 @@ t_verify_cacertfile(_Config) ->
             listeners => #{
                 https => #{
                     bind => 18084,
-                    enable => true,
                     cacertfile => <<"">>,
                     max_connections => MaxConnection
                 }
@@ -180,7 +178,6 @@ t_bad_certfile(_Config) ->
             listeners => #{
                 https => #{
                     bind => 18084,
-                    enable => true,
                     certfile => <<"${EMQX_ETC_DIR}/certs/not_found_cert.pem">>
                 }
             }


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10292
- Make `dashboard.listeners.http.enable` and `dashbaord.listeners.https.enable` deprecated.
- Disable listeners when ` bind = 0 `.

we have default http in etc/emqx.conf
```
dashboard.listeners.http { bind = 18083}
```
<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c9d435b</samp>

This pull request refactors the dashboard listener configuration and management to use the `bind` option instead of the `enable` option, which is deprecated and hidden from the UI. It also adds the `importance` option to some schema fields to improve the dashboard UI. It updates the relevant modules and test suites to reflect these changes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
