### PR TITLE
fix(emqx_schema): use non negative integer type for 'depth' SSL option

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2044,7 +2044,7 @@ common_ssl_opts_schema(Defaults, Type) ->
             )},
         {"depth",
             sc(
-                integer(),
+                non_neg_integer(),
                 #{
                     default => Df("depth", 10),
                     desc => ?DESC(common_ssl_opts_schema_depth)

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -106,6 +106,14 @@ ssl_opts_version_gap_test_() ->
      || S <- [Sc, RanchSc]
     ].
 
+ssl_opts_cert_depth_test() ->
+    Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
+    Reason = #{expected_type => "non_neg_integer()"},
+    ?assertThrow(
+        {_Sc, [#{kind := validation_error, reason := Reason}]},
+        validate(Sc, #{<<"depth">> => -1})
+    ).
+
 bad_cipher_test() ->
     Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
     Reason = {bad_ciphers, ["foo"]},

--- a/changes/ce/fix-11051.en.md
+++ b/changes/ce/fix-11051.en.md
@@ -1,0 +1,1 @@
+Add validation to ensure that certificate 'depth' (listener SSL option) is a non negative integer.


### PR DESCRIPTION
Fixes EMQX-10276

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfad459</samp>

Fixed a bug that prevented EMQ X broker from starting with SSL/TLS when the certificate chain depth was negative. Added a unit test for the `server_ssl_opts_schema` function to check the `depth` field validation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
