### PR TITLE
fix(ft-fs): use `emqx:running_nodes()` as default cluster view

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -652,10 +652,13 @@ ensure_quic_listener(Name, UdpPort, ExtraSettings) ->
     %% Extras app starting handler. It is the second arg passed to emqx_common_test_helpers:start_apps/2
     env_handler => fun((AppName :: atom()) -> term()),
     %% Application env preset before calling `emqx_common_test_helpers:start_apps/2`
-    env => {AppName :: atom(), Key :: atom(), Val :: term()},
+    env => [{AppName :: atom(), Key :: atom(), Val :: term()}],
     %% Whether to execute `emqx_config:init_load(SchemaMod)`
     %% default: true
     load_schema => boolean(),
+    %% Which node in the cluster to join to.
+    %% default: first core node
+    join_to => node(),
     %% If we want to exercise the scenario where a node joins an
     %% existing cluster where there has already been some
     %% configuration changes (via cluster rpc), then we need to enable
@@ -690,28 +693,38 @@ emqx_cluster(Specs0, CommonOpts) ->
     ]),
     %% Set the default node of the cluster:
     CoreNodes = [node_name(Name) || {{core, Name, _}, _} <- Specs],
-    JoinTo0 =
+    JoinTo =
         case CoreNodes of
             [First | _] -> First;
             _ -> undefined
         end,
-    JoinTo =
-        case maps:find(join_to, CommonOpts) of
-            {ok, true} -> JoinTo0;
-            {ok, JT} -> JT;
-            error -> JoinTo0
-        end,
-    [
-        {Name,
-            merge_opts(Opts, #{
-                base_port => base_port(Number),
+    NodeOpts = fun(Number) ->
+        #{
+            base_port => base_port(Number),
+            env => [
+                {mria, core_nodes, CoreNodes},
+                {gen_rpc, client_config_per_node, {internal, GenRpcPorts}}
+            ]
+        }
+    end,
+    RoleOpts = fun
+        (core) ->
+            #{
                 join_to => JoinTo,
                 env => [
-                    {mria, core_nodes, CoreNodes},
-                    {mria, node_role, Role},
-                    {gen_rpc, client_config_per_node, {internal, GenRpcPorts}}
+                    {mria, node_role, core}
                 ]
-            })}
+            };
+        (replicant) ->
+            #{
+                env => [
+                    {mria, node_role, replicant},
+                    {ekka, cluster_discovery, {static, [{seeds, CoreNodes}]}}
+                ]
+            }
+    end,
+    [
+        {Name, merge_opts(merge_opts(NodeOpts(Number), RoleOpts(Role)), Opts)}
      || {{Role, Name, Opts}, Number} <- Specs
     ].
 

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -140,7 +140,7 @@ mk_cluster_specs(Config, Opts) ->
         {core, emqx_bridge_api_SUITE1, #{}},
         {core, emqx_bridge_api_SUITE2, #{}}
     ],
-    CommonOpts = #{
+    CommonOpts = Opts#{
         env => [{emqx, boot_modules, [broker]}],
         apps => [],
         % NOTE
@@ -157,7 +157,6 @@ mk_cluster_specs(Config, Opts) ->
         load_apps => ?SUITE_APPS ++ [emqx_dashboard],
         env_handler => fun load_suite_config/1,
         load_schema => false,
-        join_to => maps:get(join_to, Opts, true),
         priv_data_dir => ?config(priv_dir, Config)
     },
     emqx_common_test_helpers:emqx_cluster(Specs, CommonOpts).

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -247,7 +247,6 @@ cluster(Specs, Config) ->
         {env, Env},
         {apps, [emqx_conf]},
         {load_schema, false},
-        {join_to, true},
         {priv_data_dir, PrivDataDir},
         {env_handler, fun
             (emqx) ->

--- a/apps/emqx_ft/src/emqx_ft_assembler.erl
+++ b/apps/emqx_ft/src/emqx_ft_assembler.erl
@@ -96,7 +96,7 @@ handle_event(
         complete ->
             {next_state, start_assembling, NSt, ?internal([])};
         {incomplete, _} ->
-            Nodes = mria_mnesia:running_nodes() -- [node()],
+            Nodes = emqx:running_nodes() -- [node()],
             {next_state, {list_remote_fragments, Nodes}, NSt, ?internal([])};
         % TODO: recovery?
         {error, _} = Error ->

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
@@ -361,7 +361,7 @@ list(_Options, Query) ->
     end.
 
 list(QueryIn) ->
-    {Nodes, NodeQuery} = decode_query(QueryIn, lists:sort(mria_mnesia:running_nodes())),
+    {Nodes, NodeQuery} = decode_query(QueryIn, lists:sort(emqx:running_nodes())),
     list_nodes(NodeQuery, Nodes, #{items => []}).
 
 list_nodes(Query, Nodes = [Node | Rest], Acc) ->

--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -36,7 +36,7 @@ start_additional_node(Config, Name) ->
     ).
 
 stop_additional_node(Node) ->
-    ok = rpc:call(Node, ekka, leave, []),
+    _ = rpc:call(Node, ekka, leave, []),
     ok = rpc:call(Node, emqx_common_test_helpers, stop_apps, [[emqx_ft]]),
     ok = emqx_common_test_helpers:stop_slave(Node),
     ok.

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -284,7 +284,6 @@ cluster(Specs) ->
         {env, Env},
         {apps, [emqx_conf]},
         {load_schema, false},
-        {join_to, true},
         {env_handler, fun
             (emqx) ->
                 application:set_env(emqx, boot_modules, []),

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -159,7 +159,6 @@ cluster(Specs) ->
         {env, Env},
         {apps, [emqx_conf, emqx_management]},
         {load_schema, false},
-        {join_to, true},
         {env_handler, fun
             (emqx) ->
                 application:set_env(emqx, boot_modules, []),

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -444,7 +444,6 @@ cluster(Config) ->
                 env => [{mria, db_backend, rlog}],
                 load_schema => true,
                 start_autocluster => true,
-                join_to => true,
                 listener_ports => [],
                 conf => [{[dashboard, listeners, http, bind], 0}],
                 env_handler =>


### PR DESCRIPTION
Fixes [EMQX-10231](https://emqx.atlassian.net/browse/EMQX-10231)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0fb5453</samp>

Refactored the test code to use the emqx API for cluster management and discovery, and to support parallel application start-up and node roles. Removed the unused `join_to` option from the `emqx_cluster` function and the test suites. Replaced the `mria_mnesia:running_nodes()` function with `emqx:running_nodes()` in the emqx_ft module. Ignored the possible error return value of `ekka:leave/0` in the emqx_ft test helpers. Added the static cluster discovery option for the replicant node in the emqx_mgmt_data_backup test suite.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
