### PR TITLE
ci(dev_script): fix patches vm.args path

### DIFF
--- a/dev
+++ b/dev
@@ -290,7 +290,7 @@ append_args_file() {
 +IOt 4
 +SDio 8
 -shutdown_time 30000
--pa '"$EMQX_DATA_DIR/patches"'
+-pa '$EMQX_DATA_DIR/patches'
 -mnesia dump_log_write_threshold 5000
 -mnesia dump_log_time_threshold 60000
 -os_mon start_disksup false


### PR DESCRIPTION
Fixes the path to the patches directory so it works with `quickrun`.

Before fix:
```
iex(emqx@127.0.0.1)3> :init.get_arguments()
[
  # ...
  pa: ['"_build/dev-run/emqx/data/patches"'],
  # ...
]
```

After fix:
```
iex(emqx@127.0.0.1)1> :init.get_arguments()
[
  # ...
  pa: ['_build/dev-run/emqx/data/patches'],
  # ...
]
```

Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
