### PR TITLE
fix: tls_certfile_gc notice log don't print abspath

### DIFF
--- a/apps/emqx/src/emqx_tls_certfile_gc.erl
+++ b/apps/emqx/src/emqx_tls_certfile_gc.erl
@@ -228,7 +228,8 @@ find_managed_files(Filter, Dir) ->
                         Acc
                 end;
             (AbsPath, {error, Reason}, Acc) ->
-                ?SLOG(notice, "filesystem_object_inaccessible", #{
+                ?SLOG(notice, #{
+                    msg => "filesystem_object_inaccessible",
                     abspath => AbsPath,
                     reason => Reason
                 }),

--- a/apps/emqx/src/emqx_tls_certfile_gc.erl
+++ b/apps/emqx/src/emqx_tls_certfile_gc.erl
@@ -227,6 +227,8 @@ find_managed_files(Filter, Dir) ->
                     false ->
                         Acc
                 end;
+            (AbsPath, {error, enoent}, Acc) when AbsPath == Dir ->
+                Acc;
             (AbsPath, {error, Reason}, Acc) ->
                 ?SLOG(notice, #{
                     msg => "filesystem_object_inaccessible",

--- a/dev
+++ b/dev
@@ -158,7 +158,7 @@ export EMQX_LOG_DIR="$BASE_DIR/log"
 CONFIGS_DIR="$EMQX_DATA_DIR/configs"
 # Use your cookie so your IDE can connect to it.
 COOKIE="${EMQX_NODE__COOKIE:-${EMQX_NODE_COOKIE:-$(cat ~/.erlang.cookie || echo 'emqxsecretcookie')}}"
-mkdir -p "$EMQX_ETC_DIR" "$EMQX_DATA_DIR/patches" "$EMQX_LOG_DIR" "$CONFIGS_DIR"
+mkdir -p "$EMQX_ETC_DIR" "$EMQX_DATA_DIR/patches" "$EMQX_DATA_DIR/certs" "$EMQX_LOG_DIR" "$CONFIGS_DIR"
 if [ $EKKA_EPMD -eq 1 ]; then
     EPMD_ARGS='-start_epmd false -epmd_module ekka_epmd'
 else


### PR DESCRIPTION
Fixes <issue-or-jira-number>
`make run` keep printing tls gc error log.

_build/dev-run/emqx/data/certs" enoent

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9dbee2b</samp>

This pull request improves the logging and testing of the `emqx_tls_certfile_gc` module, which handles certificate management for TLS connections. It adds a `msg` key to the log messages and a `certs` directory to the `dev` script.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
