### PR TITLE
feat: try to save config when post_config_update failed 

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -492,7 +492,9 @@ pre_config_update([?ROOT_KEY], RawConf, RawConf) ->
 pre_config_update([?ROOT_KEY], NewConf, _RawConf) ->
     {ok, convert_certs(NewConf)}.
 
-post_config_update([?ROOT_KEY, Type, Name], {create, _Request}, NewConf, undefined, _AppEnvs) ->
+post_config_update([?ROOT_KEY, Type, Name], {create, _Request}, NewConf, OldConf, _AppEnvs) when
+    OldConf =:= undefined orelse OldConf =:= ?TOMBSTONE_TYPE
+->
     create_listener(Type, Name, NewConf);
 post_config_update([?ROOT_KEY, Type, Name], {update, _Request}, NewConf, OldConf, _AppEnvs) ->
     update_listener(Type, Name, {OldConf, NewConf});

--- a/changes/ce/fix-11056.en.md
+++ b/changes/ce/fix-11056.en.md
@@ -1,0 +1,3 @@
+- Fix the issue where newly created listeners do not start properly at times,
+  when you delete a system default listener and add a new one named 'default', it will not start correctly.
+- Fix the bug where configuration failure on certain nodes can cause dashboard unavailability.


### PR DESCRIPTION

Fixes <issue-or-jira-number>
https://emqx.atlassian.net/browse/EMQX-10183
https://emqx.atlassian.net/browse/EMQX-10155

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 44173b3</samp>

Refine the error handling logic for applying config changes on remote nodes and post config update handlers. Support dynamic config reloading and rollback with a new error tuple and a failure function.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
