### PR TITLE
feat: rename log.file.to to log.file.path

### DIFF
--- a/apps/emqx/src/config/emqx_config_logger.erl
+++ b/apps/emqx/src/config/emqx_config_logger.erl
@@ -151,7 +151,7 @@ tr_file_handler({HandlerName, SubConf}) ->
         level => conf_get("level", SubConf),
         config => (log_handler_conf(SubConf))#{
             type => wrap,
-            file => conf_get("to", SubConf),
+            file => conf_get("path", SubConf),
             max_no_files => conf_get("rotation_count", SubConf),
             max_no_bytes => conf_get("rotation_size", SubConf)
         },

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -909,13 +909,13 @@ fields("console_handler") ->
     log_handler_common_confs(console);
 fields("log_file_handler") ->
     [
-        {"to",
+        {"path",
             sc(
                 file(),
                 #{
                     desc => ?DESC("log_file_handler_file"),
                     default => <<"${EMQX_LOG_DIR}/emqx.log">>,
-                    aliases => [file],
+                    aliases => [file, to],
                     importance => ?IMPORTANCE_HIGH,
                     converter => fun(Path, Opts) ->
                         emqx_schema:naive_env_interpolation(ensure_unicode_path(Path, Opts))

--- a/apps/emqx_conf/test/emqx_conf_logger_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_logger_SUITE.erl
@@ -43,7 +43,7 @@
                 file {
                 enable = true
                 level = info
-                to = \"log/emqx.log\"
+                path = \"log/emqx.log\"
                 }
              }
     """).
@@ -67,7 +67,7 @@ t_log_conf(_Conf) ->
         <<"rotation_count">> => 10,
         <<"rotation_size">> => <<"50MB">>,
         <<"time_offset">> => <<"system">>,
-        <<"to">> => <<"log/emqx.log">>
+        <<"path">> => <<"log/emqx.log">>
     },
     ExpectLog1 = #{
         <<"console">> =>

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -206,7 +206,7 @@ log_rotation_count_limit_test() ->
     """
     log.file {
     enable = true
-    to = \"log/emqx.log\"
+    path = \"log/emqx.log\"
     formatter = text
     level = debug
     rotation = {count = ~w}
@@ -434,7 +434,7 @@ log_path_test_() ->
         #{<<"log">> => #{<<"file_handlers">> => #{<<"name1">> => #{<<"file">> => Path}}}}
     end,
     Assert = fun(Name, Path, Conf) ->
-        ?assertMatch(#{log := #{file := #{Name := #{to := Path}}}}, Conf)
+        ?assertMatch(#{log := #{file := #{Name := #{path := Path}}}}, Conf)
     end,
 
     [
@@ -452,7 +452,7 @@ log_path_test_() ->
                                 "handler_name" :=
                                     #{
                                         kind := validation_error,
-                                        path := "log.file.name1.to",
+                                        path := "log.file.name1.path",
                                         reason := {"bad_file_path_string", _}
                                     }
                             }
@@ -471,7 +471,7 @@ log_path_test_() ->
                                 "handler_name" :=
                                     #{
                                         kind := validation_error,
-                                        path := "log.file.name1.to",
+                                        path := "log.file.name1.path",
                                         reason := {"not_string", _}
                                     }
                             }

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -100,7 +100,7 @@ t_log(_Config) ->
     File = "log/emqx-test.log",
     %% update handler
     Log1 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"enable">>], Log, true),
-    Log2 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"to">>], Log1, File),
+    Log2 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"path">>], Log1, File),
     {ok, #{}} = update_config(<<"log">>, Log2),
     {ok, Log3} = logger:get_handler_config(default),
     ?assertMatch(#{config := #{file := File}}, Log3),
@@ -116,7 +116,7 @@ t_log(_Config) ->
     Handler = emqx_utils_maps:deep_get([<<"file">>, <<"default">>], Log2),
     NewLog1 = emqx_utils_maps:deep_put([<<"file">>, <<"new">>], Log2, Handler),
     NewLog2 = emqx_utils_maps:deep_put(
-        [<<"file">>, <<"new">>, <<"to">>], NewLog1, File1
+        [<<"file">>, <<"new">>, <<"path">>], NewLog1, File1
     ),
     {ok, #{}} = update_config(<<"log">>, NewLog2),
     {ok, Log4} = logger:get_handler_config(new),

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -35,7 +35,7 @@ init_per_testcase(t_log_path, Config) ->
     Log = emqx_conf:get_raw([log], #{}),
     File = "log/emqx-test.log",
     Log1 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"enable">>], Log, true),
-    Log2 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"to">>], Log1, File),
+    Log2 = emqx_utils_maps:deep_put([<<"file">>, <<"default">>, <<"path">>], Log1, File),
     {ok, #{}} = emqx_conf:update([log], Log2, #{rawconf_with_defaults => true}),
     Config;
 init_per_testcase(_, Config) ->

--- a/changes/ce/feat-11062.en.md
+++ b/changes/ce/feat-11062.en.md
@@ -1,0 +1,1 @@
+Rename `log.file.to` to `log.file.path`.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4dfe3c5</samp>

Renamed `to` key to `path` in `log_file_handler` config and updated schema, tests, and config builder accordingly. This improves clarity and consistency of the config format and eases migration.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
