### PR TITLE
build: fix the EXTRA_DEPS not working in workflows

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -168,7 +168,7 @@ jobs:
           extra_labels="org.opencontainers.image.elixir.version=${{ matrix.elixir }}"
         fi
         extra_deps=
-        if [[ "$PROFILE" = *enterprise* ]]; then
+        if [[ "${{ matrix.profile }}" = *enterprise* ]]; then
           extra_deps='libsasl2-2'
         fi
 

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -167,9 +167,14 @@ jobs:
           img_suffix="-elixir"
           extra_labels="org.opencontainers.image.elixir.version=${{ matrix.elixir }}"
         fi
+        extra_deps=
+        if [[ "$PROFILE" = *enterprise* ]]; then
+          extra_deps='libsasl2-2'
+        fi
 
         echo "img_suffix=$img_suffix" >> $GITHUB_OUTPUT
         echo "extra_labels=$extra_labels" >> $GITHUB_OUTPUT
+        echo "extra_deps=$extra_deps" >> $GITHUB_OUTPUT
 
     - uses: docker/metadata-action@v4
       id: meta
@@ -196,5 +201,6 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         build-args: |
           EMQX_NAME=${{ matrix.profile }}${{ steps.pre-meta.outputs.img_suffix }}
+          EXTRA_DEPS=${{ steps.pre-meta.outputs.extra_deps }}
         file: source/${{ matrix.os[2] }}
         context: source


### PR DESCRIPTION
Fixes  https://emqx.atlassian.net/browse/EMQX-10296

The previous fix https://github.com/emqx/emqx/pull/10629 only worked for the `make docker` command, but it didn't work in `build_and_push_docker_images.yaml`. In this one, I also set the `EXTRA_DEPS` environment variable in it.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e38236e</samp>

This pull request adds a workflow to build the enterprise profile of the `emqx` docker image. It installs the `libsasl2-2` package in the image to enable SASL authentication.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- ~Changed lines covered in coverage report~
- ~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
