### PR TITLE
fix: avoid logging unnecessary errors in async cleanup functions

### DIFF
--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -153,13 +153,17 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 clean_down(SubPid) ->
-    case ets:lookup(?SUBMON, SubPid) of
-        [{_, SubId}] ->
-            true = ets:delete(?SUBMON, SubPid),
-            true =
-                (SubId =:= undefined) orelse
-                    ets:delete_object(?SUBID, {SubId, SubPid}),
-            emqx_broker:subscriber_down(SubPid);
-        [] ->
-            ok
+    try
+        case ets:lookup(?SUBMON, SubPid) of
+            [{_, SubId}] ->
+                true = ets:delete(?SUBMON, SubPid),
+                true =
+                    (SubId =:= undefined) orelse
+                        ets:delete_object(?SUBID, {SubId, SubPid}),
+                emqx_broker:subscriber_down(SubPid);
+            [] ->
+                ok
+        end
+    catch
+        error:badarg -> ok
     end.

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -734,7 +734,11 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 clean_down({ChanPid, ClientId}) ->
-    do_unregister_channel({ClientId, ChanPid}),
+    try
+        do_unregister_channel({ClientId, ChanPid})
+    catch
+        error:badarg -> ok
+    end,
     ok = ?tp(debug, emqx_cm_clean_down, #{client_id => ClientId}).
 
 stats_fun() ->

--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -823,7 +823,11 @@ code_change(_OldVsn, State, _Extra) ->
 do_unregister_channel_task(Items, GwName, CmTabs) ->
     lists:foreach(
         fun({ChanPid, ClientId}) ->
-            do_unregister_channel(GwName, {ClientId, ChanPid}, CmTabs)
+            try
+                do_unregister_channel(GwName, {ClientId, ChanPid}, CmTabs)
+            catch
+                error:badarg -> ok
+            end
         end,
         Items
     ).

--- a/changes/ce/fix-11065.en.md
+++ b/changes/ce/fix-11065.en.md
@@ -1,0 +1,1 @@
+Avoid logging irrelevant error messages during EMQX shutdown.


### PR DESCRIPTION
Cleanup functions that access ETS tables may fail with `badarg` error during EMQX shutdown. 
They are called asynchronously by `emqx_pool` workers and accessed ETS tables may be already destroyed as their owners are shut down. This fix catches ETS `badarg` errors silently and individually, before they can be caught and logged by `emqx_pool`.

Fixes EMQX-9992

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 86e3cdb</samp>

This pull request refactors the code that uses ets tables in various modules to improve error handling and readability. It introduces a new module `emqx_utils_ets` that provides wrapper functions and a macro for ets operations. It also moves some broker-related functions to the `emqx_broker` module.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
