### PR TITLE
fix: use mria.cluster_autoclean

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -164,7 +164,7 @@ fields("cluster") ->
             sc(
                 emqx_schema:duration(),
                 #{
-                    mapping => "ekka.cluster_autoclean",
+                    mapping => "mria.cluster_autoclean",
                     default => <<"5m">>,
                     desc => ?DESC(cluster_autoclean),
                     'readOnly' => true
@@ -174,7 +174,7 @@ fields("cluster") ->
             sc(
                 boolean(),
                 #{
-                    mapping => "ekka.cluster_autoheal",
+                    mapping => "mria.cluster_autoheal",
                     default => true,
                     desc => ?DESC(cluster_autoheal),
                     'readOnly' => true

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -118,6 +118,7 @@
 
 list_nodes() ->
     Running = emqx:cluster_nodes(running),
+    %% all stopped core nodes
     Stopped = emqx:cluster_nodes(stopped),
     DownNodes = lists:map(fun stopped_node_info/1, Stopped),
     [{Node, Info} || #{node := Node} = Info <- node_info(Running)] ++ DownNodes.
@@ -181,7 +182,7 @@ node_info(Nodes) ->
     emqx_rpc:unwrap_erpc(emqx_management_proto_v3:node_info(Nodes)).
 
 stopped_node_info(Node) ->
-    {Node, #{node => Node, node_status => 'stopped'}}.
+    {Node, #{node => Node, node_status => 'stopped', role => core}}.
 
 vm_stats() ->
     Idle =

--- a/changes/ce/fix-11070.en.md
+++ b/changes/ce/fix-11070.en.md
@@ -1,0 +1,1 @@
+Fix the problem that the cluster.autoclean configuration item does not take effect.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12f4612</samp>

Fixed a bug that prevented cluster nodes from being cleaned up automatically and improved the display of node roles in the management module. Changed the configuration mapping of `cluster.autoclean` from `ekka` to `mria` and added node role information to `emqx_mgmt.erl` and the changelog.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [~] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [~] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [~] Change log has been added to `changes/` dir for user-facing artifacts update
