### PR TITLE
fix: rule engine different behavior for div and mod

### DIFF
--- a/apps/emqx_rule_engine/include/rule_engine.hrl
+++ b/apps/emqx_rule_engine/include/rule_engine.hrl
@@ -149,7 +149,8 @@
                        Op =:= '-' orelse
                        Op =:= '*' orelse
                        Op =:= '/' orelse
-                       Op =:= 'div')).
+                       Op =:= 'div' orelse
+                       Op =:= 'mod')).
 
 %% Compare operators
 -define(is_comp(Op), (Op =:= '=' orelse

--- a/changes/v4.4.19-en.md
+++ b/changes/v4.4.19-en.md
@@ -46,3 +46,5 @@
 - Fixed an issue where the WebHook plugin failed to execute the `on_client_connack` hook [#10710](https://github.com/emqx/emqx/pull/10710).
 
   See https://github.com/emqx/emqx/issues/10628 for more details.
+
+- Addressed an inconsistency in the usage of 'div' and 'mod' operations within the rule engine. Previously, the 'div' operation was only usable as an infix operation and 'mod' could only be applied through a function call. With this change, both 'div' and 'mod' can be used via function call syntax and infix syntax.

--- a/rebar.config
+++ b/rebar.config
@@ -57,7 +57,7 @@
     , {replayq, {git, "https://github.com/emqx/replayq", {tag, "0.3.5"}}}
     , {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {branch, "2.0.4"}}}
     , {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.2.3.2"}}}
-    , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.5"}}}
+    , {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.7"}}}
     , {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}}
     , {observer_cli, "1.6.1"} % NOTE: depends on recon 2.5.1
     , {getopt, "1.0.1"}


### PR DESCRIPTION
Previously, the div operation could only be used as an infix operation while mod could only be used as a function call. After this commit, one can use both div and mod using function call syntax and infix syntax.

Fixes: https://emqx.atlassian.net/browse/EMQX-10216

Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0903c2f</samp>

Fixed a bug in the rule engine's SQL syntax that caused incorrect results for 'div' and 'mod' operations. Added tests and documentation for these operations.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible
