### PR TITLE
fix: shared-sub with nl sub-option should cause protocol error

### DIFF
--- a/changes/ce/fix-11074.en.md
+++ b/changes/ce/fix-11074.en.md
@@ -1,1 +1,1 @@
-Fix Protocol spec MQTT-5.0 [MQTT-3.8.3-4].
+Fix to adhere to Protocol spec MQTT-5.0 [MQTT-3.8.3-4].

--- a/changes/ce/fix-11074.en.md
+++ b/changes/ce/fix-11074.en.md
@@ -1,0 +1,1 @@
+Fix Protocol spec MQTT-5.0 [MQTT-3.8.3-4].


### PR DESCRIPTION
Fixes [EMQX-10238](https://emqx.atlassian.net/browse/EMQX-10238)
CI needs https://github.com/emqx/paho.mqtt.testing/pull/13 merged.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 178711f</samp>

Fix protocol error for shared subscriptions with no local flag in MQTT v5. Improve reason code handling and add test case for `emqx_packet` module.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [~] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [~] Change log has been added to `changes/` dir for user-facing artifacts update
