### PR TITLE
fix(build): add libsasl2-modules-gssapi-mit as deps

### DIFF
--- a/build
+++ b/build
@@ -380,7 +380,7 @@ make_docker() {
     ## extra_deps is a comma separated list of debian 11 package names
     local extra_deps=''
     if [[ "$PROFILE" = *enterprise* ]]; then
-        extra_deps='libsasl2-2'
+        extra_deps='libsasl2-2,libsasl2-modules-gssapi-mit'
     fi
     echo '_build' >> ./.dockerignore
     set -x


### PR DESCRIPTION
Before this fix, the kerberos authentication in kafka will report the following errors:

```
...
{{sasl_auth_error,{sass_nomech,<<"SASL(-4): no mechanism available: No worthy mechs found">>}},
```

Fixes https://emqx.atlassian.net/browse/EMQX-10296

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b84623d</samp>

Add a dependency for Kerberos authentication support. The file `build` is modified to install `libsasl2-modules-gssapi-mit` for the enterprise profile of emqx.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
