### PR TITLE
fix(ft-api): make schema tags look nicer in the docs

### DIFF
--- a/apps/emqx_ft/src/emqx_ft_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_api.erl
@@ -19,6 +19,7 @@
 
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
+-include("emqx_ft_api.hrl").
 
 %% Swagger specs from hocon schema
 -export([
@@ -61,7 +62,7 @@ schema("/file_transfer/files") ->
     #{
         'operationId' => '/file_transfer/files',
         get => #{
-            tags => [<<"file_transfer">>],
+            tags => ?TAGS,
             summary => <<"List all uploaded files">>,
             description => ?DESC("file_list"),
             parameters => [
@@ -83,7 +84,7 @@ schema("/file_transfer/files/:clientid/:fileid") ->
     #{
         'operationId' => '/file_transfer/files/:clientid/:fileid',
         get => #{
-            tags => [<<"file_transfer">>],
+            tags => ?TAGS,
             summary => <<"List files uploaded in a specific transfer">>,
             description => ?DESC("file_list_transfer"),
             parameters => [

--- a/apps/emqx_ft/src/emqx_ft_api.hrl
+++ b/apps/emqx_ft/src/emqx_ft_api.hrl
@@ -1,0 +1,10 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-ifndef(__EMQX_FT_API__).
+-define(__EMQX_FT_API__, 42).
+
+-define(TAGS, [<<"File Transfer">>]).
+
+-endif.

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs_api.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs_api.erl
@@ -21,6 +21,7 @@
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include("emqx_ft_api.hrl").
 
 %% Swagger specs from hocon schema
 -export([
@@ -60,7 +61,7 @@ schema("/file_transfer/file") ->
     #{
         'operationId' => '/file_transfer/file',
         get => #{
-            tags => [<<"file_transfer">>],
+            tags => ?TAGS,
             summary => <<"Download a particular file">>,
             description => ?DESC("file_get"),
             parameters => [


### PR DESCRIPTION
Fixes <issue-or-jira-number>

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b5fcde7</samp>

This pull request improves the code quality of the file transfer API and storage exporter modules by using a common header file `emqx_ft_api.hrl` for shared definitions and macros. This reduces code duplication and enhances readability.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
