### PR TITLE
fix: shared-sub with nl sub-option should cause protocol error

### DIFF
--- a/changes/ce/fix-11074.en.md
+++ b/changes/ce/fix-11074.en.md
@@ -1,0 +1,1 @@
+Fix to adhere to Protocol spec MQTT-5.0 [MQTT-3.8.3-4].


### PR DESCRIPTION
~Fixes <issue-or-jira-number>~
cherry pick from #11074

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at adc3ba1</samp>

Fix the error handling and compliance of shared subscriptions with the no local flag in MQTT 5.0. Add a test case and a changelog entry for this fix.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
