### PR TITLE
fix(resource): check status when (re)starting a resource

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -223,8 +223,7 @@ restart(ResId, Opts) when is_binary(ResId) ->
 start(ResId, Opts) ->
     case safe_call(ResId, start, ?T_OPERATION) of
         ok ->
-            _ = wait_for_ready(ResId, maps:get(start_timeout, Opts, 5000)),
-            ok;
+            wait_for_ready(ResId, maps:get(start_timeout, Opts, 5000));
         {error, _Reason} = Error ->
             Error
     end.

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -246,6 +246,9 @@ batch_big_payload({async, ReplyFunAndArgs}, InstId, Batch, State = #{pid := Pid}
 on_get_status(_InstId, #{health_check_error := true}) ->
     ?tp(connector_demo_health_check_error, #{}),
     disconnected;
+on_get_status(_InstId, State = #{health_check_error := {msg, Message}}) ->
+    ?tp(connector_demo_health_check_error, #{}),
+    {disconnected, State, Message};
 on_get_status(_InstId, #{pid := Pid}) ->
     timer:sleep(300),
     case is_process_alive(Pid) of

--- a/changes/ce/fix-11094.en.md
+++ b/changes/ce/fix-11094.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where connection errors in Kafka Producer would not be reported when reconnecting the bridge.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10290

After fix:


https://github.com/emqx/emqx/assets/16166434/717ecbcb-977b-4609-9660-5df893af83b0



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6dc649</samp>

This pull request improves the testing and tracing of the resource manager and its resources. It adds a new test case for asynchronous start errors, enhances the existing test suite with tracing and health check options, and simplifies some code in `emqx_resource_manager.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
