### PR TITLE
fix: add range validation for max_clientid_len

### DIFF
--- a/priv/emqx.schema
+++ b/priv/emqx.schema
@@ -276,6 +276,9 @@ end}.
 {validator, "range:1-65535", "must be 1 to 65535",
   fun(X) -> X >= 1 andalso X =< 65535 end}.
 
+{validator, "range:23-65535", "must be 23 to 65535",
+  fun(X) -> X >= 23 andalso X =< 65535 end}.
+
 {validator, "range:1-9", "must be 1 to 9",
   fun(X) -> X >= 1 andalso X =< 9 end}.
 
@@ -955,7 +958,8 @@ end}.
 %% @doc Set the Max ClientId Length Allowed.
 {mapping, "mqtt.max_clientid_len", "emqx.max_clientid_len", [
   {default, 65535},
-  {datatype, integer}
+  {datatype, integer},
+  {validators, ["range:23-65535"]}
 ]}.
 
 %% @doc Set the Maximum topic levels.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 38d92c9</samp>

Add a new validator for MQTT client identifier lengths and use it in `emqx.schema`. This ensures that the configuration option `mqtt.max_clientid_len` is within the valid range of 23 to 65535.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
