### PR TITLE
chore: hide plugins from conf load cli

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -170,7 +170,7 @@ drop_hidden_roots(Conf) ->
     lists:foldl(fun(K, Acc) -> maps:remove(K, Acc) end, Conf, hidden_roots()).
 
 hidden_roots() ->
-    [<<"trace">>, <<"stats">>, <<"broker">>, <<"persistent_session_store">>].
+    [<<"trace">>, <<"stats">>, <<"broker">>, <<"persistent_session_store">>, <<"plugins">>].
 
 get_config(Key) ->
     case emqx:get_raw_config([Key], undefined) of


### PR DESCRIPTION
Port https://github.com/emqx/emqx/pull/11084 to release-51
<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36ee872</samp>

Hide plugins configuration from CLI output. Modify `hidden_roots` function in `emqx_conf_cli.erl` to exclude `<<"plugins">>` key from the config tree.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
