### PR TITLE
fix(management): Don't wait for an empty shard

### DIFF
--- a/apps/emqx_management/include/emqx_mgmt.hrl
+++ b/apps/emqx_management/include/emqx_mgmt.hrl
@@ -14,6 +14,4 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--define(MANAGEMENT_SHARD, emqx_management_shard).
-
 -define(DEFAULT_ROW_LIMIT, 100).

--- a/apps/emqx_management/src/emqx_mgmt_app.erl
+++ b/apps/emqx_management/src/emqx_mgmt_app.erl
@@ -28,7 +28,6 @@
 -include("emqx_mgmt.hrl").
 
 start(_Type, _Args) ->
-    ok = mria_rlog:wait_for_shards([?MANAGEMENT_SHARD], infinity),
     case emqx_mgmt_auth:init_bootstrap_file() of
         ok ->
             emqx_conf:add_handler([api_key], emqx_mgmt_auth),

--- a/changes/ce/fix-11092.en.md
+++ b/changes/ce/fix-11092.en.md
@@ -1,0 +1,2 @@
+Fix problem when replicants were unable to connect to the core node due to timeout in `mria_lb:core_nodes()` call.
+Relevant mria pull request: https://github.com/emqx/mria/pull/143


### PR DESCRIPTION
Fixes EMQX-10342

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e5803a6</samp>

This pull request removes the hard-coded management shard name and the blocking wait for the shard from the `emqx_mgmt` application. This is part of a refactoring to use Mnesia and Mria for the management data storage.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
