### PR TITLE
fix(autoclean): change default autoclean duration to 1 day

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -165,7 +165,7 @@ fields("cluster") ->
                 emqx_schema:duration(),
                 #{
                     mapping => "mria.cluster_autoclean",
-                    default => <<"5m">>,
+                    default => <<"1d">>,
                     desc => ?DESC(cluster_autoclean),
                     'readOnly' => true
                 }


### PR DESCRIPTION
In order to avoid issues like https://github.com/emqx/emqx/pull/11102

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8b92920</samp>

Changed the default value of `mria.cluster_autoclean` to 1 day in `emqx_conf_schema.erl` to improve Mnesia cluster performance and stability.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
