### PR TITLE
0620 autoclean default value to 24h

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ endif
 
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
-export EMQX_DASHBOARD_VERSION ?= v1.3.0
+export EMQX_DASHBOARD_VERSION ?= v1.3.0-1
 export EMQX_EE_DASHBOARD_VERSION ?= e1.1.0
 
 # `:=` should be used here, otherwise the `$(shell ...)` will be executed every time when the variable is used

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -165,7 +165,7 @@ fields("cluster") ->
                 emqx_schema:duration(),
                 #{
                     mapping => "mria.cluster_autoclean",
-                    default => <<"5m">>,
+                    default => <<"24h">>,
                     desc => ?DESC(cluster_autoclean),
                     'readOnly' => true
                 }

--- a/examples/cluster-with-dns.conf.example
+++ b/examples/cluster-with-dns.conf.example
@@ -16,9 +16,6 @@ cluster {
     ## List of core nodes that the replicant will connect to
     core_nodes = ["emqx1@192.168.0.1", "emqx2@192.168.0.2"]
 
-    ## Remove disconnected nodes from the cluster after this interval
-    autoclean = 5m
-
     ## If true, the node will try to heal network partitions automatically
     autoheal = true
 

--- a/examples/cluster-with-etcd-ssl.conf.example
+++ b/examples/cluster-with-etcd-ssl.conf.example
@@ -16,9 +16,6 @@ cluster {
     ## List of core nodes that the replicant will connect to
     core_nodes = ["emqx1@192.168.0.1", "emqx2@192.168.0.2"]
 
-    ## Remove disconnected nodes from the cluster after this interval
-    autoclean = 5m
-
     ## If true, the node will try to heal network partitions automatically
     autoheal = true
 

--- a/examples/cluster-with-etcd.conf.example
+++ b/examples/cluster-with-etcd.conf.example
@@ -16,9 +16,6 @@ cluster {
     ## List of core nodes that the replicant will connect to
     core_nodes = ["emqx1@192.168.0.1", "emqx2@192.168.0.2"]
 
-    ## Remove disconnected nodes from the cluster after this interval
-    autoclean = 5m
-
     ## If true, the node will try to heal network partitions automatically
     autoheal = true
 

--- a/examples/cluster-with-k8s.conf.example
+++ b/examples/cluster-with-k8s.conf.example
@@ -16,9 +16,6 @@ cluster {
     ## List of core nodes that the replicant will connect to
     core_nodes = ["emqx1@192.168.0.1", "emqx2@192.168.0.2"]
 
-    ## Remove disconnected nodes from the cluster after this interval
-    autoclean = 5m
-
     ## If true, the node will try to heal network partitions automatically
     autoheal = true
 

--- a/examples/cluster-with-manual.conf.example
+++ b/examples/cluster-with-manual.conf.example
@@ -16,9 +16,6 @@ cluster {
     ## List of core nodes that the replicant will connect to
     core_nodes = ["emqx1@192.168.0.1", "emqx2@192.168.0.2"]
 
-    ## Remove disconnected nodes from the cluster after this interval
-    autoclean = 5m
-
     ## If true, the node will try to heal network partitions automatically
     autoheal = true
  }

--- a/examples/cluster-with-static.conf.example
+++ b/examples/cluster-with-static.conf.example
@@ -16,9 +16,6 @@ cluster {
     ## List of core nodes that the replicant will connect to
     core_nodes = ["emqx1@192.168.0.1", "emqx2@192.168.0.2"]
 
-    ## Remove disconnected nodes from the cluster after this interval
-    autoclean = 5m
-
     ## If true, the node will try to heal network partitions automatically
     autoheal = true
 


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-10295
No changelog update as the autoclean was not functioning prior to 5.1.0

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [~] Added tests for the changes
- [~] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
