### PR TITLE
fix(emqx_conf_app): fix release version detect during cluster conf sync

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -134,12 +134,20 @@ sync_cluster_conf2(Nodes) ->
                 msg => "ignored_nodes_when_sync_cluster_conf"
             },
             ?SLOG(warning, Warning);
-        true ->
+        true when Failed =/= [] ->
             %% There are core nodes running but no one was able to reply.
             ?SLOG(error, #{
                 msg => "failed_to_sync_cluster_conf",
                 nodes => Nodes,
                 failed => Failed,
+                not_ready => NotReady
+            });
+        true ->
+            %% There are core nodes booting up
+            ?SLOG(info, #{
+                msg => "peer_not_ready_for_config_sync",
+                reason => "The 'not_ready' peer node(s) are loading configs",
+                nodes => Nodes,
                 not_ready => NotReady
             });
         false ->

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -180,17 +180,7 @@ sync_cluster_conf2(Nodes) ->
 
 %% @private Filter out the nodes which are running a newer version than this node.
 sync_cluster_conf3(Ready) ->
-    NotNewer = fun({ok, #{release := RemoteRelease}}) ->
-        try
-            emqx_release:vsn_compare(RemoteRelease) =/= newer
-        catch
-            _:_ ->
-                %% If the version is not valid (without v or e prefix),
-                %% we know it's older than v5.1.0/e5.1.0
-                true
-        end
-    end,
-    case lists:filter(NotNewer, Ready) of
+    case lists:filter(fun is_older_or_same_version/1, Ready) of
         [] ->
             %% All available core nodes are running a newer version than this node.
             %% Start this node without syncing cluster config from them.
@@ -212,6 +202,19 @@ sync_cluster_conf3(Ready) ->
         Ready2 ->
             sync_cluster_conf4(Ready2)
     end.
+
+is_older_or_same_version({ok, #{release := RemoteRelease}}) ->
+    try
+        emqx_release:vsn_compare(RemoteRelease) =/= newer
+    catch
+        _:_ ->
+            %% If the version is not valid (without v or e prefix),
+            %% we know it's older than v5.1.0/e5.1.0
+            true
+    end;
+is_older_or_same_version(_) ->
+    %% older version has no 'release' field
+    true.
 
 %% @private Some core nodes are running and replied with their configs successfully.
 %% Try to sort the results and save the first one for local use.


### PR DESCRIPTION
Fixes EMQX-10384

## Summary

Issue was introduced in https://github.com/emqx/emqx/pull/10902
versions earlier than e5.0.3 does not have `release` field in the rpc return value.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [~] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
