### PR TITLE
chore: bump hocon to 0.39.10

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.9"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.10"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -108,7 +108,7 @@ ssl_opts_version_gap_test_() ->
 
 ssl_opts_cert_depth_test() ->
     Sc = emqx_schema:server_ssl_opts_schema(#{}, false),
-    Reason = #{expected_type => "non_neg_integer()"},
+    Reason = #{expected => "non_neg_integer()"},
     ?assertThrow(
         {_Sc, [#{kind := validation_error, reason := Reason}]},
         validate(Sc, #{<<"depth">> => -1})

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -236,7 +236,7 @@ log_rotation_count_limit_test() ->
             mismatches := #{"handler_name" :=
             #{kind := validation_error,
                 path := "log.file.default.rotation_count",
-                reason := #{expected_type := "1..128"},
+                reason := #{expected := "1..128"},
                 value := Count}
             }}]},
             hocon_tconf:generate(emqx_conf_schema, ConfMap0))

--- a/apps/emqx_resource/test/emqx_resource_schema_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_schema_tests.erl
@@ -97,7 +97,7 @@ worker_pool_size_test_() ->
             {_, [
                 #{
                     kind := validation_error,
-                    reason := #{expected_type := _},
+                    reason := #{expected := _},
                     value := WorkerPoolSize
                 }
             ]},

--- a/changes/ce/fix-11118.en.md
+++ b/changes/ce/fix-11118.en.md
@@ -1,0 +1,1 @@
+Ensure that validation errors in REST API responses are slightly less confusing. Now, if there are out-of-range errors, they will be presented as `{"value": 42, "reason": {"expected": "1..10"}, ...}`, replacing the previous usage of `expected_type` with `expected`.

--- a/lib-ee/emqx_ee_schema_registry/test/emqx_ee_schema_registry_serde_SUITE.erl
+++ b/lib-ee/emqx_ee_schema_registry/test/emqx_ee_schema_registry_serde_SUITE.erl
@@ -109,7 +109,7 @@ t_avro_invalid_json_schema(_Config) ->
     Params = schema_params(avro),
     WrongParams = Params#{source := <<"{">>},
     ?assertMatch(
-        {error, #{reason := #{expected_type := _}}},
+        {error, #{reason := #{expected := _}}},
         emqx_ee_schema_registry:add_schema(SerdeName, WrongParams)
     ),
     ok.

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.8", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.39.9", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.39.10", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.2", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -75,7 +75,7 @@
     , {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}}
     , {getopt, "1.0.2"}
     , {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.8"}}}
-    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.9"}}}
+    , {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.10"}}}
     , {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}}
     , {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}}
     , {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}}


### PR DESCRIPTION
Which comes with a fix for slightly more user-friendly validation error messages.

Fixes [EMQX-9964](https://emqx.atlassian.net/browse/EMQX-9964)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8dc1eef</samp>

Updated the dependency version of `hocon` to 0.39.10 and adjusted the validation error reasons in the schema tests to match the new error format. These changes were made to use the latest features and bug fixes of `hocon` and to improve the clarity and consistency of the configuration validation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
