### PR TITLE
fix(emqx_rule_engine): set inc_action_metrics as async_reply_fun

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -220,15 +220,14 @@ send_to_matched_egress_bridges(Topic, Msg) ->
 send_message(BridgeId, Message) ->
     {BridgeType, BridgeName} = emqx_bridge_resource:parse_bridge_id(BridgeId),
     ResId = emqx_bridge_resource:resource_id(BridgeType, BridgeName),
-    send_message(BridgeType, BridgeName, ResId, Message, undefined).
+    send_message(BridgeType, BridgeName, ResId, Message, #{}).
 
-send_message(BridgeType, BridgeName, ResId, Message, ReplyTo) ->
+send_message(BridgeType, BridgeName, ResId, Message, QueryOpts0) ->
     case emqx:get_config([?ROOT_KEY, BridgeType, BridgeName], not_found) of
         not_found ->
             {error, bridge_not_found};
         #{enable := true} = Config ->
-            QueryOpts0 = query_opts(Config),
-            QueryOpts = QueryOpts0#{reply_to => ReplyTo},
+            QueryOpts = maps:merge(query_opts(Config), QueryOpts0),
             emqx_resource:query(ResId, {send_message, Message}, QueryOpts);
         #{enable := false} ->
             {error, bridge_stopped}

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -228,7 +228,7 @@ send_message(BridgeType, BridgeName, ResId, Message, ReplyTo) ->
             {error, bridge_not_found};
         #{enable := true} = Config ->
             QueryOpts0 = query_opts(Config),
-            QueryOpts = QueryOpts0#{async_reply_fun => ReplyTo},
+            QueryOpts = QueryOpts0#{reply_to => ReplyTo},
             emqx_resource:query(ResId, {send_message, Message}, QueryOpts);
         #{enable := false} ->
             {error, bridge_stopped}

--- a/apps/emqx_bridge/test/emqx_bridge_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_testlib.erl
@@ -96,11 +96,10 @@ delete_all_bridges() ->
     ).
 
 %% test helpers
-parse_and_check(Config, ConfigString, Name) ->
-    BridgeType = ?config(bridge_type, Config),
+parse_and_check(BridgeType, BridgeName, ConfigString) ->
     {ok, RawConf} = hocon:binary(ConfigString, #{format => map}),
     hocon_tconf:check_plain(emqx_bridge_schema, RawConf, #{required => false, atom_key => false}),
-    #{<<"bridges">> := #{BridgeType := #{Name := BridgeConfig}}} = RawConf,
+    #{<<"bridges">> := #{BridgeType := #{BridgeName := BridgeConfig}}} = RawConf,
     BridgeConfig.
 
 resource_id(Config) ->

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
@@ -119,13 +119,14 @@ bridge_config(TestCase, _TestGroup, Config) ->
     Host = ?config(bridge_host, Config),
     Port = ?config(bridge_port, Config),
     Version = ?config(iotdb_version, Config),
+    Type = ?config(bridge_type, Config),
     Name = <<
         (atom_to_binary(TestCase))/binary, UniqueNum/binary
     >>,
     ServerURL = iotdb_server_url(Host, Port),
     ConfigString =
         io_lib:format(
-            "bridges.iotdb.~s {\n"
+            "bridges.~s.~s {\n"
             "  enable = true\n"
             "  base_url = \"~s\"\n"
             "  authentication = {\n"
@@ -142,12 +143,13 @@ bridge_config(TestCase, _TestGroup, Config) ->
             "  }\n"
             "}\n",
             [
+                Type,
                 Name,
                 ServerURL,
                 Version
             ]
         ),
-    {Name, ConfigString, emqx_bridge_testlib:parse_and_check(Config, ConfigString, Name)}.
+    {Name, ConfigString, emqx_bridge_testlib:parse_and_check(Type, Name, ConfigString)}.
 
 make_iotdb_payload(DeviceId, Measurement, Type, Value) ->
     #{

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -32,7 +32,8 @@
     expire_at => infinity | integer(),
     async_reply_fun => reply_fun(),
     simple_query => boolean(),
-    is_buffer_supported => boolean()
+    is_buffer_supported => boolean(),
+    reply_to => reply_fun()
 }.
 -type resource_data() :: #{
     id := resource_id(),

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -290,7 +290,7 @@ query(ResId, Request, Opts) ->
                 {simple_sync, _} ->
                     %% TODO(5.1.1): pass Resource instead of ResId to simple APIs
                     %% so the buffer worker does not need to lookup the cache again
-                    emqx_resource_buffer_worker:simple_sync_query(ResId, Request);
+                    emqx_resource_buffer_worker:simple_sync_query(ResId, Request, Opts);
                 {sync, _} ->
                     emqx_resource_buffer_worker:sync_query(ResId, Request, Opts);
                 {async, _} ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -158,7 +158,9 @@ simple_async_query(Id, Request, QueryOpts0) ->
     Ref = make_request_ref(),
     Result = call_query(async_if_possible, Id, Index, Ref, ?SIMPLE_QUERY(Request), QueryOpts),
     _ = handle_query_result(Id, Result, _HasBeenSent = false),
-    Result.
+    maybe_apply_async_reply_fun(
+        Result, QueryOpts
+    ).
 
 simple_query_opts() ->
     ensure_expire_at(#{simple_query => true, timeout => infinity}).

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -351,7 +351,9 @@ do_handle_action(RuleId, {bridge, BridgeType, BridgeName, ResId}, Selected, _Env
         #{bridge_id => emqx_bridge_resource:bridge_id(BridgeType, BridgeName)}
     ),
     ReplyTo = {fun ?MODULE:inc_action_metrics/2, [RuleId]},
-    case emqx_bridge:send_message(BridgeType, BridgeName, ResId, Selected, ReplyTo) of
+    case
+        emqx_bridge:send_message(BridgeType, BridgeName, ResId, Selected, #{reply_to => ReplyTo})
+    of
         {error, Reason} when Reason == bridge_not_found; Reason == bridge_stopped ->
             throw(out_of_service);
         Result ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -200,7 +200,11 @@ init_per_group(metrics_fail_simple, Config) ->
         (_) -> simple_async
     end),
     meck:expect(?BRIDGE_IMPL, on_query, 3, {error, {unrecoverable_error, mecked_failure}}),
-    meck:expect(?BRIDGE_IMPL, on_query_async, 4, {error, {unrecoverable_error, mecked_failure}}),
+    meck:expect(?BRIDGE_IMPL, on_query_async, fun(_, _, {ReplyFun, Args}, _) ->
+        Result = {error, {unrecoverable_error, mecked_failure}},
+        erlang:apply(ReplyFun, Args ++ [Result]),
+        Result
+    end),
     [{mecked, [?BRIDGE_IMPL]} | Config];
 init_per_group(_Groupname, Config) ->
     Config.

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -19,11 +19,10 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include_lib("emqx_rule_engine/include/rule_engine.hrl").
--include_lib("emqx/include/emqx.hrl").
-
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+
+-include_lib("emqx/include/emqx.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
@@ -38,7 +37,11 @@ all() ->
         {group, runtime},
         {group, events},
         {group, telemetry},
-        {group, bugs}
+        {group, bugs},
+        {group, metrics},
+        {group, metrics_simple},
+        {group, metrics_fail},
+        {group, metrics_fail_simple}
     ].
 
 suite() ->
@@ -116,6 +119,22 @@ groups() ->
         {bugs, [], [
             t_sqlparse_payload_as,
             t_sqlparse_nested_get
+        ]},
+        {metrics, [], [
+            t_rule_metrics_sync,
+            t_rule_metrics_async
+        ]},
+        {metrics_simple, [], [
+            t_rule_metrics_sync,
+            t_rule_metrics_async
+        ]},
+        {metrics_fail, [], [
+            t_rule_metrics_sync_fail,
+            t_rule_metrics_async_fail
+        ]},
+        {metrics_fail_simple, [], [
+            t_rule_metrics_sync_fail,
+            t_rule_metrics_async_fail
         ]}
     ].
 
@@ -128,7 +147,7 @@ init_per_suite(Config) ->
     emqx_rule_funcs_demo:module_info(),
     application:load(emqx_conf),
     ok = emqx_common_test_helpers:start_apps(
-        [emqx_conf, emqx_rule_engine, emqx_authz],
+        [emqx_conf, emqx_rule_engine, emqx_authz, emqx_bridge],
         fun set_special_configs/1
     ),
     Config.
@@ -160,14 +179,37 @@ on_get_resource_status(_id, _) -> #{}.
 group(_Groupname) ->
     [].
 
+-define(BRIDGE_IMPL, emqx_bridge_mqtt_connector).
 init_per_group(registry, Config) ->
     Config;
+init_per_group(metrics_fail, Config) ->
+    meck:expect(?BRIDGE_IMPL, on_query, 3, {error, {unrecoverable_error, mecked_failure}}),
+    meck:expect(?BRIDGE_IMPL, on_query_async, 4, {error, {unrecoverable_error, mecked_failure}}),
+    [{mecked, [?BRIDGE_IMPL]} | Config];
+init_per_group(metrics_simple, Config) ->
+    meck:new(?BRIDGE_IMPL, [non_strict, no_link, passthrough]),
+    meck:expect(?BRIDGE_IMPL, query_mode, fun
+        (#{mqtt := #{query_mode := sync}}) -> simple_sync;
+        (_) -> simple_async
+    end),
+    [{mecked, [?BRIDGE_IMPL]} | Config];
+init_per_group(metrics_fail_simple, Config) ->
+    meck:new(?BRIDGE_IMPL, [non_strict, no_link, passthrough]),
+    meck:expect(?BRIDGE_IMPL, query_mode, fun
+        (#{mqtt := #{query_mode := sync}}) -> simple_sync;
+        (_) -> simple_async
+    end),
+    meck:expect(?BRIDGE_IMPL, on_query, 3, {error, {unrecoverable_error, mecked_failure}}),
+    meck:expect(?BRIDGE_IMPL, on_query_async, 4, {error, {unrecoverable_error, mecked_failure}}),
+    [{mecked, [?BRIDGE_IMPL]} | Config];
 init_per_group(_Groupname, Config) ->
     Config.
 
-end_per_group(_Groupname, _Config) ->
-    ok.
-
+end_per_group(_Groupname, Config) ->
+    case ?config(mecked, Config) of
+        undefined -> ok;
+        Mecked -> meck:unload(Mecked)
+    end.
 %%------------------------------------------------------------------------------
 %% Testcase specific setup/teardown
 %%------------------------------------------------------------------------------
@@ -2821,6 +2863,117 @@ t_get_rule_ids_by_action_reference_ingress_bridge(_Config) ->
         emqx_rule_engine:get_rule_ids_by_action(BridgeId)
     ),
     ok.
+
+%%------------------------------------------------------------------------------
+%% Test cases for rule metrics
+%%------------------------------------------------------------------------------
+
+-define(BRIDGE_TYPE, <<"mqtt">>).
+-define(BRIDGE_NAME, <<"bridge_over_troubled_water">>).
+-define(BRIDGE_CONFIG(QMODE), #{
+    <<"server">> => <<"127.0.0.1:1883">>,
+    <<"username">> => <<"user1">>,
+    <<"password">> => <<"">>,
+    <<"proto_ver">> => <<"v4">>,
+    <<"ssl">> => #{<<"enable">> => false},
+    <<"egress">> =>
+        #{
+            <<"local">> =>
+                #{
+                    <<"topic">> => <<"foo/#">>
+                },
+            <<"remote">> =>
+                #{
+                    <<"topic">> => <<"bar/${topic}">>,
+                    <<"payload">> => <<"${payload}">>,
+                    <<"qos">> => <<"${qos}">>,
+                    <<"retain">> => <<"${retain}">>
+                }
+        },
+    <<"resource_opts">> =>
+        #{
+            <<"health_check_interval">> => <<"5s">>,
+            <<"query_mode">> => QMODE,
+            <<"request_ttl">> => <<"3s">>,
+            <<"worker_pool_size">> => 1
+        }
+}).
+
+-define(SUCCESSS_METRICS, #{
+    matched := 1,
+    'actions.total' := 1,
+    'actions.failed' := 0,
+    'actions.success' := 1
+}).
+-define(FAIL_METRICS, #{
+    matched := 1,
+    'actions.total' := 1,
+    'actions.failed' := 1,
+    'actions.success' := 0
+}).
+
+t_rule_metrics_sync(_Config) ->
+    do_test_rule_metrics_success(<<"sync">>).
+
+t_rule_metrics_async(_Config) ->
+    do_test_rule_metrics_success(<<"async">>).
+
+t_rule_metrics_sync_fail(_Config) ->
+    do_test_rule_metrics_fail(<<"sync">>).
+
+t_rule_metrics_async_fail(_Config) ->
+    do_test_rule_metrics_fail(<<"async">>).
+
+do_test_rule_metrics_success(QMode) ->
+    ?assertMatch(
+        ?SUCCESSS_METRICS,
+        do_test_rule_metrics(QMode)
+    ).
+
+do_test_rule_metrics_fail(QMode) ->
+    ?assertMatch(
+        ?FAIL_METRICS,
+        do_test_rule_metrics(QMode)
+    ).
+
+do_test_rule_metrics(QMode) ->
+    BridgeId = create_bridge(?BRIDGE_TYPE, ?BRIDGE_NAME, ?BRIDGE_CONFIG(QMode)),
+    RuleId = <<"rule:test_metrics_bridge_action">>,
+    {ok, #{id := RuleId}} =
+        emqx_rule_engine:create_rule(
+            #{
+                id => RuleId,
+                sql => <<"SELECT * FROM \"topic/#\"">>,
+                actions => [BridgeId]
+            }
+        ),
+    timer:sleep(100),
+    ?assertMatch(
+        #{
+            matched := 0,
+            'actions.total' := 0,
+            'actions.failed' := 0,
+            'actions.success' := 0
+        },
+        emqx_metrics_worker:get_counters(rule_metrics, RuleId)
+    ),
+    MsgId = emqx_guid:gen(),
+    emqx:publish(#message{id = MsgId, topic = <<"topic/test">>, payload = <<"hello">>}),
+    timer:sleep(100),
+    ct:pal("bridge metrics: ~p", [
+        emqx_resource:get_metrics(emqx_bridge_resource:resource_id(BridgeId))
+    ]),
+    on_exit(
+        fun() ->
+            emqx_rule_engine:delete_rule(RuleId),
+            emqx_bridge:remove(?BRIDGE_TYPE, ?BRIDGE_NAME)
+        end
+    ),
+    emqx_metrics_worker:get_counters(rule_metrics, RuleId).
+
+create_bridge(Type, Name, Config) ->
+    {ok, _Bridge} = emqx_bridge:create(Type, Name, Config),
+    emqx_bridge_resource:bridge_id(Type, Name).
 
 %%------------------------------------------------------------------------------
 %% Internal helpers

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -189,14 +189,14 @@ init_per_group(metrics_fail, Config) ->
 init_per_group(metrics_simple, Config) ->
     meck:new(?BRIDGE_IMPL, [non_strict, no_link, passthrough]),
     meck:expect(?BRIDGE_IMPL, query_mode, fun
-        (#{mqtt := #{query_mode := sync}}) -> simple_sync;
+        (#{resource_opts := #{query_mode := sync}}) -> simple_sync;
         (_) -> simple_async
     end),
     [{mecked, [?BRIDGE_IMPL]} | Config];
 init_per_group(metrics_fail_simple, Config) ->
     meck:new(?BRIDGE_IMPL, [non_strict, no_link, passthrough]),
     meck:expect(?BRIDGE_IMPL, query_mode, fun
-        (#{mqtt := #{query_mode := sync}}) -> simple_sync;
+        (#{resource_opts := #{query_mode := sync}}) -> simple_sync;
         (_) -> simple_async
     end),
     meck:expect(?BRIDGE_IMPL, on_query, 3, {error, {unrecoverable_error, mecked_failure}}),
@@ -2960,9 +2960,6 @@ do_test_rule_metrics(QMode) ->
     MsgId = emqx_guid:gen(),
     emqx:publish(#message{id = MsgId, topic = <<"topic/test">>, payload = <<"hello">>}),
     timer:sleep(100),
-    ct:pal("bridge metrics: ~p", [
-        emqx_resource:get_metrics(emqx_bridge_resource:resource_id(BridgeId))
-    ]),
     on_exit(
         fun() ->
             emqx_rule_engine:delete_rule(RuleId),

--- a/changes/ce/fix-11126.en.md
+++ b/changes/ce/fix-11126.en.md
@@ -1,0 +1,1 @@
+Rule metrics for async mode bridges will set failure counters correctly now.


### PR DESCRIPTION
Fixes [EMQX-8842](https://emqx.atlassian.net/browse/EMQX-8842)

Next try. This time using a callback.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c23ed7</samp>

Added support for asynchronous replies from bridge resources in rule engine and resource buffer. This allows bridge actions to update metrics and tracing data after sending or receiving messages. Modified `emqx_bridge`, `emqx_resource_buffer_worker`, and `emqx_rule_runtime` modules to implement this feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] ~Schema changes are backward compatible~

