### PR TITLE
feat(authz): use extensible map format for actions in authz rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,14 +130,14 @@ $(foreach app,$(APPS),$(eval $(call gen-app-prop-target,$(app))))
 ct-suite: $(REBAR) merge-config clean-test-cluster-config
 ifneq ($(TESTCASE),)
 ifneq ($(GROUP),)
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE) --group $(GROUP)
+	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE) --group $(GROUP)
 else
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
+	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
 endif
 else ifneq ($(GROUP),)
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --group $(GROUP)
+	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --group $(GROUP)
 else
-	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)
+	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)
 endif
 
 .PHONY: cover

--- a/Makefile
+++ b/Makefile
@@ -130,14 +130,14 @@ $(foreach app,$(APPS),$(eval $(call gen-app-prop-target,$(app))))
 ct-suite: $(REBAR) merge-config clean-test-cluster-config
 ifneq ($(TESTCASE),)
 ifneq ($(GROUP),)
-	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE) --group $(GROUP)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE) --group $(GROUP)
 else
-	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --case $(TESTCASE)
 endif
 else ifneq ($(GROUP),)
-	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --group $(GROUP)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)  --group $(GROUP)
 else
-	$(REBAR) ct -c -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)
+	$(REBAR) ct -v --readable=$(CT_READABLE) --name $(CT_NODE_NAME) --suite $(SUITE)
 endif
 
 .PHONY: cover

--- a/apps/emqx/include/emqx_access_control.hrl
+++ b/apps/emqx/include/emqx_access_control.hrl
@@ -18,3 +18,17 @@
 -define(EMQX_AUTHORIZATION_CONFIG_ROOT_NAME, "authorization").
 -define(EMQX_AUTHORIZATION_CONFIG_ROOT_NAME_ATOM, authorization).
 -define(EMQX_AUTHORIZATION_CONFIG_ROOT_NAME_BINARY, <<"authorization">>).
+
+-define(DEFAULT_ACTION_QOS, 0).
+-define(DEFAULT_ACTION_RETAIN, false).
+
+-define(AUTHZ_SUBSCRIBE(QOS), #{action_type => subscribe, qos => QOS}).
+-define(AUTHZ_SUBSCRIBE, ?AUTHZ_SUBSCRIBE(?DEFAULT_ACTION_QOS)).
+
+-define(AUTHZ_PUBLISH(QOS, RETAIN), #{action_type => publish, qos => QOS, retain => RETAIN}).
+-define(AUTHZ_PUBLISH(QOS), ?AUTHZ_PUBLISH(QOS, ?DEFAULT_ACTION_RETAIN)).
+-define(AUTHZ_PUBLISH, ?AUTHZ_PUBLISH(?DEFAULT_ACTION_QOS)).
+
+-define(authz_action(PUBSUB, QOS), #{action_type := PUBSUB, qos := QOS}).
+-define(authz_action(PUBSUB), ?authz_action(PUBSUB, _)).
+-define(authz_action, ?authz_action(_)).

--- a/apps/emqx/include/emqx_placeholder.hrl
+++ b/apps/emqx/include/emqx_placeholder.hrl
@@ -21,7 +21,7 @@
 
 -define(PH(Type), <<"${", Type/binary, "}">>).
 
-%% action: publish/subscribe/all
+%% action: publish/subscribe
 -define(PH_ACTION, <<"${action}">>).
 
 %% cert
@@ -79,6 +79,7 @@
 -define(PH_REASON, <<"${reason}">>).
 
 -define(PH_ENDPOINT_NAME, <<"${endpoint_name}">>).
+-define(PH_RETAIN, <<"${retain}">>).
 
 %% sync change these place holder with binary def.
 -define(PH_S_ACTION, "${action}").
@@ -113,5 +114,6 @@
 -define(PH_S_NODE, "${node}").
 -define(PH_S_REASON, "${reason}").
 -define(PH_S_ENDPOINT_NAME, "${endpoint_name}").
+-define(PH_S_RETAIN, "${retain}").
 
 -endif.

--- a/apps/emqx/src/emqx_authz_cache.erl
+++ b/apps/emqx/src/emqx_authz_cache.erl
@@ -16,7 +16,7 @@
 
 -module(emqx_authz_cache).
 
--include("emqx.hrl").
+-include("emqx_access_control.hrl").
 
 -export([
     list_authz_cache/0,
@@ -159,8 +159,7 @@ dump_authz_cache() ->
 map_authz_cache(Fun) ->
     [
         Fun(R)
-     || R = {{SubPub, _T}, _Authz} <- erlang:get(),
-        SubPub =:= publish orelse SubPub =:= subscribe
+     || R = {{?authz_action, _T}, _Authz} <- erlang:get()
     ].
 foreach_authz_cache(Fun) ->
     _ = map_authz_cache(Fun),

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1840,7 +1840,7 @@ check_pub_alias(_Packet, _Channel) ->
     ok.
 
 %%--------------------------------------------------------------------
-%% Athorization action
+%% Authorization action
 
 authz_action(#mqtt_packet{
     header = #mqtt_packet_header{qos = QoS, retain = Retain}, variable = #mqtt_packet_publish{}

--- a/apps/emqx/src/emqx_types.erl
+++ b/apps/emqx/src/emqx_types.erl
@@ -29,6 +29,7 @@
 -export_type([
     zone/0,
     pubsub/0,
+    pubsub_action/0,
     subid/0
 ]).
 
@@ -127,7 +128,12 @@
     | exactly_once.
 
 -type zone() :: atom().
--type pubsub() :: publish | subscribe.
+-type pubsub_action() :: publish | subscribe.
+
+-type pubsub() ::
+    #{action_type := subscribe, qos := qos()}
+    | #{action_type := publish, qos := qos(), retain := boolean()}.
+
 -type subid() :: binary() | atom().
 
 -type group() :: binary() | undefined.

--- a/apps/emqx/test/emqx_authz_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_authz_cache_SUITE.erl
@@ -43,8 +43,6 @@ t_clean_authz_cache(_) ->
     ct:sleep(100),
     ClientPid =
         case emqx_cm:lookup_channels(<<"emqx_c">>) of
-            [Pid] when is_pid(Pid) ->
-                Pid;
             Pids when is_list(Pids) ->
                 lists:last(Pids);
             _ ->

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -908,7 +908,8 @@ t_check_pub_alias(_) ->
 t_check_sub_authzs(_) ->
     emqx_config:put_zone_conf(default, [authorization, enable], true),
     TopicFilter = {<<"t">>, ?DEFAULT_SUBOPTS},
-    [{TopicFilter, 0}] = emqx_channel:check_sub_authzs([TopicFilter], channel()).
+    Subscribe = ?SUBSCRIBE_PACKET(1, [TopicFilter]),
+    [{TopicFilter, 0}] = emqx_channel:check_sub_authzs(Subscribe, [TopicFilter], channel()).
 
 t_enrich_connack_caps(_) ->
     ok = meck:new(emqx_mqtt_caps, [passthrough, no_history]),

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -20,6 +20,7 @@
 
 -include_lib("proper/include/proper.hrl").
 -include("emqx.hrl").
+-include("emqx_access_control.hrl").
 
 %% High level Types
 -export([
@@ -34,7 +35,8 @@
     subopts/0,
     nodename/0,
     normal_topic/0,
-    normal_topic_filter/0
+    normal_topic_filter/0,
+    pubsub/0
 ]).
 
 %% Basic Types
@@ -481,6 +483,23 @@ normal_topic_filter() ->
             end
         end
     ).
+
+subscribe_action() ->
+    ?LET(
+        Qos,
+        qos(),
+        ?AUTHZ_SUBSCRIBE(Qos)
+    ).
+
+publish_action() ->
+    ?LET(
+        {Qos, Retain},
+        {qos(), boolean()},
+        ?AUTHZ_PUBLISH(Qos, Retain)
+    ).
+
+pubsub() ->
+    oneof([publish_action(), subscribe_action()]).
 
 %%--------------------------------------------------------------------
 %% Basic Types

--- a/apps/emqx_authz/include/emqx_authz.hrl
+++ b/apps/emqx_authz/include/emqx_authz.hrl
@@ -18,16 +18,6 @@
 
 -define(APP, emqx_authz).
 
--define(ALLOW_DENY(A),
-    ((A =:= allow) orelse (A =:= <<"allow">>) orelse
-        (A =:= deny) orelse (A =:= <<"deny">>))
-).
--define(PUBSUB(A),
-    ((A =:= subscribe) orelse (A =:= <<"subscribe">>) orelse
-        (A =:= publish) orelse (A =:= <<"publish">>) orelse
-        (A =:= all) orelse (A =:= <<"all">>))
-).
-
 %% authz_mnesia
 -define(ACL_TABLE, emqx_acl).
 
@@ -72,6 +62,20 @@
             topic => <<"eq test/#">>,
             permission => <<"deny">>,
             action => <<"all">>
+        },
+        #{
+            topic => <<"test/toopic/3">>,
+            permission => <<"allow">>,
+            action => <<"publish">>,
+            qos => [<<"1">>],
+            retain => <<"true">>
+        },
+        #{
+            topic => <<"test/toopic/4">>,
+            permission => <<"allow">>,
+            action => <<"publish">>,
+            qos => [<<"0">>, <<"1">>, <<"2">>],
+            retain => <<"all">>
         }
     ]
 }).
@@ -92,6 +96,20 @@
             topic => <<"eq test/#">>,
             permission => <<"deny">>,
             action => <<"all">>
+        },
+        #{
+            topic => <<"test/toopic/3">>,
+            permission => <<"allow">>,
+            action => <<"publish">>,
+            qos => [<<"1">>],
+            retain => <<"true">>
+        },
+        #{
+            topic => <<"test/toopic/4">>,
+            permission => <<"allow">>,
+            action => <<"publish">>,
+            qos => [<<"0">>, <<"1">>, <<"2">>],
+            retain => <<"all">>
         }
     ]
 }).
@@ -111,9 +129,28 @@
             topic => <<"eq test/#">>,
             permission => <<"deny">>,
             action => <<"all">>
+        },
+        #{
+            topic => <<"test/toopic/3">>,
+            permission => <<"allow">>,
+            action => <<"publish">>,
+            qos => [<<"1">>],
+            retain => <<"true">>
+        },
+        #{
+            topic => <<"test/toopic/4">>,
+            permission => <<"allow">>,
+            action => <<"publish">>,
+            qos => [<<"0">>, <<"1">>, <<"2">>],
+            retain => <<"all">>
         }
     ]
 }).
+
+-define(USERNAME_RULES_EXAMPLE_COUNT, length(maps:get(rules, ?USERNAME_RULES_EXAMPLE))).
+-define(CLIENTID_RULES_EXAMPLE_COUNT, length(maps:get(rules, ?CLIENTID_RULES_EXAMPLE))).
+-define(ALL_RULES_EXAMPLE_COUNT, length(maps:get(rules, ?ALL_RULES_EXAMPLE))).
+
 -define(META_EXAMPLE, #{
     page => 1,
     limit => 100,
@@ -121,3 +158,8 @@
 }).
 
 -define(RESOURCE_GROUP, <<"emqx_authz">>).
+
+-define(AUTHZ_FEATURES, [rich_actions]).
+
+-define(DEFAULT_RULE_QOS, [0, 1, 2]).
+-define(DEFAULT_RULE_RETAIN, all).

--- a/apps/emqx_authz/include/emqx_authz.hrl
+++ b/apps/emqx_authz/include/emqx_authz.hrl
@@ -49,12 +49,12 @@
     username => user1,
     rules => [
         #{
-            topic => <<"test/toopic/1">>,
+            topic => <<"test/topic/1">>,
             permission => <<"allow">>,
             action => <<"publish">>
         },
         #{
-            topic => <<"test/toopic/2">>,
+            topic => <<"test/topic/2">>,
             permission => <<"allow">>,
             action => <<"subscribe">>
         },
@@ -64,14 +64,14 @@
             action => <<"all">>
         },
         #{
-            topic => <<"test/toopic/3">>,
+            topic => <<"test/topic/3">>,
             permission => <<"allow">>,
             action => <<"publish">>,
             qos => [<<"1">>],
             retain => <<"true">>
         },
         #{
-            topic => <<"test/toopic/4">>,
+            topic => <<"test/topic/4">>,
             permission => <<"allow">>,
             action => <<"publish">>,
             qos => [<<"0">>, <<"1">>, <<"2">>],
@@ -83,12 +83,12 @@
     clientid => client1,
     rules => [
         #{
-            topic => <<"test/toopic/1">>,
+            topic => <<"test/topic/1">>,
             permission => <<"allow">>,
             action => <<"publish">>
         },
         #{
-            topic => <<"test/toopic/2">>,
+            topic => <<"test/topic/2">>,
             permission => <<"allow">>,
             action => <<"subscribe">>
         },
@@ -98,14 +98,14 @@
             action => <<"all">>
         },
         #{
-            topic => <<"test/toopic/3">>,
+            topic => <<"test/topic/3">>,
             permission => <<"allow">>,
             action => <<"publish">>,
             qos => [<<"1">>],
             retain => <<"true">>
         },
         #{
-            topic => <<"test/toopic/4">>,
+            topic => <<"test/topic/4">>,
             permission => <<"allow">>,
             action => <<"publish">>,
             qos => [<<"0">>, <<"1">>, <<"2">>],
@@ -116,12 +116,12 @@
 -define(ALL_RULES_EXAMPLE, #{
     rules => [
         #{
-            topic => <<"test/toopic/1">>,
+            topic => <<"test/topic/1">>,
             permission => <<"allow">>,
             action => <<"publish">>
         },
         #{
-            topic => <<"test/toopic/2">>,
+            topic => <<"test/topic/2">>,
             permission => <<"allow">>,
             action => <<"subscribe">>
         },
@@ -131,14 +131,14 @@
             action => <<"all">>
         },
         #{
-            topic => <<"test/toopic/3">>,
+            topic => <<"test/topic/3">>,
             permission => <<"allow">>,
             action => <<"publish">>,
             qos => [<<"1">>],
             retain => <<"true">>
         },
         #{
-            topic => <<"test/toopic/4">>,
+            topic => <<"test/topic/4">>,
             permission => <<"allow">>,
             action => <<"publish">>,
             qos => [<<"0">>, <<"1">>, <<"2">>],

--- a/apps/emqx_authz/src/emqx_authz.app.src
+++ b/apps/emqx_authz/src/emqx_authz.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authz, [
     {description, "An OTP application"},
-    {vsn, "0.1.23"},
+    {vsn, "0.1.24"},
     {registered, []},
     {mod, {emqx_authz_app, []}},
     {applications, [

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -39,6 +39,11 @@
     get_enabled_authzs/0
 ]).
 
+-export([
+    feature_available/1,
+    set_feature_available/2
+]).
+
 -export([post_config_update/5, pre_config_update/3]).
 
 -export([acl_conf_file/0]).
@@ -518,6 +523,28 @@ maybe_convert_acl_file(RawConf, _Fun) ->
 read_acl_file(#{<<"path">> := Path} = Source) ->
     {ok, Rules} = emqx_authz_file:read_file(Path),
     maps:remove(<<"path">>, Source#{<<"rules">> => Rules}).
+
+%%------------------------------------------------------------------------------
+%% Extednded Features
+%%------------------------------------------------------------------------------
+
+-if(?EMQX_RELEASE_EDITION == ee).
+
+-define(DEFAULT_RICH_ACTIONS, true).
+
+-else.
+
+-define(DEFAULT_RICH_ACTIONS, false).
+
+-endif.
+
+-define(FEATURE_KEY(_NAME_), {?MODULE, _NAME_}).
+
+feature_available(rich_actions) ->
+    persistent_term:get(?FEATURE_KEY(rich_actions), ?DEFAULT_RICH_ACTIONS).
+
+set_feature_available(Feature, Enable) when is_boolean(Enable) ->
+    persistent_term:put(?FEATURE_KEY(Feature), Enable).
 
 %%------------------------------------------------------------------------------
 %% Internal function

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -525,7 +525,7 @@ read_acl_file(#{<<"path">> := Path} = Source) ->
     maps:remove(<<"path">>, Source#{<<"rules">> => Rules}).
 
 %%------------------------------------------------------------------------------
-%% Extednded Features
+%% Extended Features
 %%------------------------------------------------------------------------------
 
 -define(DEFAULT_RICH_ACTIONS, true).

--- a/apps/emqx_authz/src/emqx_authz.erl
+++ b/apps/emqx_authz/src/emqx_authz.erl
@@ -528,15 +528,7 @@ read_acl_file(#{<<"path">> := Path} = Source) ->
 %% Extednded Features
 %%------------------------------------------------------------------------------
 
--if(?EMQX_RELEASE_EDITION == ee).
-
 -define(DEFAULT_RICH_ACTIONS, true).
-
--else.
-
--define(DEFAULT_RICH_ACTIONS, false).
-
--endif.
 
 -define(FEATURE_KEY(_NAME_), {?MODULE, _NAME_}).
 

--- a/apps/emqx_authz/src/emqx_authz_file.erl
+++ b/apps/emqx_authz/src/emqx_authz_file.erl
@@ -16,7 +16,6 @@
 
 -module(emqx_authz_file).
 
--include("emqx_authz.hrl").
 -include_lib("emqx/include/logger.hrl").
 
 -behaviour(emqx_authz).

--- a/apps/emqx_authz/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_authz/src/emqx_authz_mongodb.erl
@@ -77,14 +77,7 @@ authorize(
     }
 ) ->
     RenderedFilter = emqx_authz_utils:render_deep(FilterTemplate, Client),
-    Result =
-        try
-            emqx_resource:simple_sync_query(ResourceID, {find, Collection, RenderedFilter, #{}})
-        catch
-            error:Error -> {error, Error}
-        end,
-
-    case Result of
+    case emqx_resource:simple_sync_query(ResourceID, {find, Collection, RenderedFilter, #{}}) of
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "query_mongo_error",
@@ -93,8 +86,6 @@ authorize(
                 filter => RenderedFilter,
                 resource_id => ResourceID
             }),
-            nomatch;
-        {ok, []} ->
             nomatch;
         {ok, Rows} ->
             Rules = lists:flatmap(fun parse_rule/1, Rows),

--- a/apps/emqx_authz/src/emqx_authz_mysql.erl
+++ b/apps/emqx_authz/src/emqx_authz_mysql.erl
@@ -86,8 +86,6 @@ authorize(
     case
         emqx_resource:simple_sync_query(ResourceID, {prepared_query, ?PREPARE_KEY, RenderParams})
     of
-        {ok, _ColumnNames, []} ->
-            nomatch;
         {ok, ColumnNames, Rows} ->
             do_authorize(Client, Action, Topic, ColumnNames, Rows);
         {error, Reason} ->

--- a/apps/emqx_authz/src/emqx_authz_mysql.erl
+++ b/apps/emqx_authz/src/emqx_authz_mysql.erl
@@ -55,7 +55,7 @@ create(#{query := SQL} = Source0) ->
     ResourceId = emqx_authz_utils:make_resource_id(?MODULE),
     Source = Source0#{prepare_statement => #{?PREPARE_KEY => PrepareSQL}},
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mysql, Source),
-    Source#{annotations => #{id => ResourceId, tmpl_oken => TmplToken}}.
+    Source#{annotations => #{id => ResourceId, tmpl_token => TmplToken}}.
 
 update(#{query := SQL} = Source0) ->
     {PrepareSQL, TmplToken} = emqx_authz_utils:parse_sql(SQL, '?', ?PLACEHOLDERS),
@@ -64,7 +64,7 @@ update(#{query := SQL} = Source0) ->
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, Id} ->
-            Source#{annotations => #{id => Id, tmpl_oken => TmplToken}}
+            Source#{annotations => #{id => Id, tmpl_token => TmplToken}}
     end.
 
 destroy(#{annotations := #{id := Id}}) ->
@@ -72,57 +72,51 @@ destroy(#{annotations := #{id := Id}}) ->
 
 authorize(
     Client,
-    PubSub,
+    Action,
     Topic,
     #{
         annotations := #{
             id := ResourceID,
-            tmpl_oken := TmplToken
+            tmpl_token := TmplToken
         }
     }
 ) ->
-    RenderParams = emqx_authz_utils:render_sql_params(TmplToken, Client),
+    Vars = emqx_authz_utils:vars_for_rule_query(Client, Action),
+    RenderParams = emqx_authz_utils:render_sql_params(TmplToken, Vars),
     case
         emqx_resource:simple_sync_query(ResourceID, {prepared_query, ?PREPARE_KEY, RenderParams})
     of
-        {ok, _Columns, []} ->
+        {ok, _ColumnNames, []} ->
             nomatch;
-        {ok, Columns, Rows} ->
-            do_authorize(Client, PubSub, Topic, Columns, Rows);
+        {ok, ColumnNames, Rows} ->
+            do_authorize(Client, Action, Topic, ColumnNames, Rows);
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "query_mysql_error",
                 reason => Reason,
-                tmpl_oken => TmplToken,
+                tmpl_token => TmplToken,
                 params => RenderParams,
                 resource_id => ResourceID
             }),
             nomatch
     end.
 
-do_authorize(_Client, _PubSub, _Topic, _Columns, []) ->
+do_authorize(_Client, _Action, _Topic, _ColumnNames, []) ->
     nomatch;
-do_authorize(Client, PubSub, Topic, Columns, [Row | Tail]) ->
-    case
+do_authorize(Client, Action, Topic, ColumnNames, [Row | Tail]) ->
+    try
         emqx_authz_rule:match(
-            Client,
-            PubSub,
-            Topic,
-            emqx_authz_rule:compile(format_result(Columns, Row))
+            Client, Action, Topic, emqx_authz_utils:parse_rule_from_row(ColumnNames, Row)
         )
     of
         {matched, Permission} -> {matched, Permission};
-        nomatch -> do_authorize(Client, PubSub, Topic, Columns, Tail)
+        nomatch -> do_authorize(Client, Action, Topic, ColumnNames, Tail)
+    catch
+        error:Reason ->
+            ?SLOG(error, #{
+                msg => "match_rule_error",
+                reason => Reason,
+                rule => Row
+            }),
+            do_authorize(Client, Action, Topic, ColumnNames, Tail)
     end.
-
-format_result(Columns, Row) ->
-    Permission = lists:nth(index(<<"permission">>, Columns), Row),
-    Action = lists:nth(index(<<"action">>, Columns), Row),
-    Topic = lists:nth(index(<<"topic">>, Columns), Row),
-    {Permission, all, Action, [Topic]}.
-
-index(Elem, List) ->
-    index(Elem, List, 1).
-index(_Elem, [], _Index) -> {error, not_found};
-index(Elem, [Elem | _List], Index) -> Index;
-index(Elem, [_ | List], Index) -> index(Elem, List, Index + 1).

--- a/apps/emqx_authz/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_authz/src/emqx_authz_postgresql.erl
@@ -93,8 +93,6 @@ authorize(
     case
         emqx_resource:simple_sync_query(ResourceID, {prepared_query, ResourceID, RenderedParams})
     of
-        {ok, _Columns, []} ->
-            nomatch;
         {ok, Columns, Rows} ->
             do_authorize(Client, Action, Topic, column_names(Columns), Rows);
         {error, Reason} ->

--- a/apps/emqx_authz/src/emqx_authz_redis.erl
+++ b/apps/emqx_authz/src/emqx_authz_redis.erl
@@ -70,19 +70,20 @@ destroy(#{annotations := #{id := Id}}) ->
 
 authorize(
     Client,
-    PubSub,
+    Action,
     Topic,
     #{
         cmd_template := CmdTemplate,
         annotations := #{id := ResourceID}
     }
 ) ->
-    Cmd = emqx_authz_utils:render_deep(CmdTemplate, Client),
+    Vars = emqx_authz_utils:vars_for_rule_query(Client, Action),
+    Cmd = emqx_authz_utils:render_deep(CmdTemplate, Vars),
     case emqx_resource:simple_sync_query(ResourceID, {cmd, Cmd}) of
         {ok, []} ->
             nomatch;
         {ok, Rows} ->
-            do_authorize(Client, PubSub, Topic, Rows);
+            do_authorize(Client, Action, Topic, Rows);
         {error, Reason} ->
             ?SLOG(error, #{
                 msg => "query_redis_error",
@@ -93,21 +94,60 @@ authorize(
             nomatch
     end.
 
-do_authorize(_Client, _PubSub, _Topic, []) ->
+do_authorize(_Client, _Action, _Topic, []) ->
     nomatch;
-do_authorize(Client, PubSub, Topic, [TopicFilter, Action | Tail]) ->
-    case
+do_authorize(Client, Action, Topic, [TopicFilterRaw, RuleEncoded | Tail]) ->
+    try
         emqx_authz_rule:match(
             Client,
-            PubSub,
+            Action,
             Topic,
-            emqx_authz_rule:compile({allow, all, Action, [TopicFilter]})
+            compile_rule(RuleEncoded, TopicFilterRaw)
         )
     of
         {matched, Permission} -> {matched, Permission};
-        nomatch -> do_authorize(Client, PubSub, Topic, Tail)
+        nomatch -> do_authorize(Client, Action, Topic, Tail)
+    catch
+        error:Reason ->
+            ?SLOG(error, #{
+                msg => "match_rule_error",
+                reason => Reason,
+                rule_encoded => RuleEncoded,
+                topic_filter_raw => TopicFilterRaw
+            }),
+            do_authorize(Client, Action, Topic, Tail)
+    end.
+
+compile_rule(RuleBin, TopicFilterRaw) ->
+    RuleRaw =
+        maps:merge(
+            #{
+                <<"permission">> => <<"allow">>,
+                <<"topic">> => TopicFilterRaw
+            },
+            parse_rule(RuleBin)
+        ),
+    case emqx_authz_rule_raw:parse_rule(RuleRaw) of
+        {ok, {Permission, Action, Topics}} ->
+            emqx_authz_rule:compile({Permission, all, Action, Topics});
+        {error, Reason} ->
+            error(Reason)
     end.
 
 tokens(Query) ->
     Tokens = binary:split(Query, <<" ">>, [global]),
     [Token || Token <- Tokens, size(Token) > 0].
+
+parse_rule(<<"publish">>) ->
+    #{<<"action">> => <<"publish">>};
+parse_rule(<<"subscribe">>) ->
+    #{<<"action">> => <<"subscribe">>};
+parse_rule(<<"all">>) ->
+    #{<<"action">> => <<"all">>};
+parse_rule(Bin) when is_binary(Bin) ->
+    case emqx_utils_json:safe_decode(Bin, [return_maps]) of
+        {ok, Map} when is_map(Map) ->
+            maps:with([<<"qos">>, <<"action">>, <<"retain">>], Map);
+        {error, Error} ->
+            error({invalid_topic_rule, Bin, Error})
+    end.

--- a/apps/emqx_authz/src/emqx_authz_rule.erl
+++ b/apps/emqx_authz/src/emqx_authz_rule.erl
@@ -16,9 +16,9 @@
 
 -module(emqx_authz_rule).
 
--include("emqx_authz.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_placeholder.hrl").
+-include("emqx_authz.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -32,49 +32,122 @@
     compile/1
 ]).
 
--type ipaddress() ::
-    {ipaddr, esockd_cidr:cidr_string()}
-    | {ipaddrs, list(esockd_cidr:cidr_string())}.
+-type permission() :: allow | deny.
 
--type username() :: {username, binary()}.
-
--type clientid() :: {clientid, binary()}.
-
--type who() ::
+-type who_condition() ::
     ipaddress()
     | username()
     | clientid()
     | {'and', [ipaddress() | username() | clientid()]}
     | {'or', [ipaddress() | username() | clientid()]}
     | all.
+-type ipaddress() ::
+    {ipaddr, esockd_cidr:cidr_string()}
+    | {ipaddrs, list(esockd_cidr:cidr_string())}.
+-type username() :: {username, binary()}.
+-type clientid() :: {clientid, binary()}.
 
--type action() :: subscribe | publish | all.
--type permission() :: allow | deny.
+-type action_condition() ::
+    subscribe
+    | publish
+    | #{action_type := subscribe, qos := qos_condition()}
+    | #{action_type := publish | all, qos := qos_condition(), retain := retain_condition()}
+    | all.
+-type qos_condition() :: [qos()].
+-type retain_condition() :: retain() | all.
 
--type rule() :: {permission(), who(), action(), list(emqx_types:topic())}.
+-type topic_condition() :: list(emqx_types:topic() | {eq, emqx_types:topic()}).
+
+-type rule() :: {permission(), who_condition(), action_condition(), topic_condition()}.
+
+-type qos() :: 0..2.
+-type retain() :: boolean().
+-type action() ::
+    #{action_type := subscribe, qos := qos()}
+    | #{action_type := publish, qos := qos(), retain := retain()}.
 
 -export_type([
-    action/0,
-    permission/0
+    permission/0,
+    who_condition/0,
+    action_condition/0,
+    topic_condition/0
 ]).
 
+-define(IS_PERMISSION(Permission), (Permission =:= allow orelse Permission =:= deny)).
+
 compile({Permission, all}) when
-    ?ALLOW_DENY(Permission)
+    ?IS_PERMISSION(Permission)
 ->
     {Permission, all, all, [compile_topic(<<"#">>)]};
 compile({Permission, Who, Action, TopicFilters}) when
-    ?ALLOW_DENY(Permission), ?PUBSUB(Action), is_list(TopicFilters)
+    ?IS_PERMISSION(Permission) andalso is_list(TopicFilters)
 ->
-    {atom(Permission), compile_who(Who), atom(Action), [
+    {Permission, compile_who(Who), compile_action(Action), [
         compile_topic(Topic)
      || Topic <- TopicFilters
     ]};
-compile({Permission, _Who, _Action, _TopicFilter}) when not ?ALLOW_DENY(Permission) ->
+compile({Permission, _Who, _Action, _TopicFilter}) when not ?IS_PERMISSION(Permission) ->
     throw({invalid_authorization_permission, Permission});
-compile({_Permission, _Who, Action, _TopicFilter}) when not ?PUBSUB(Action) ->
-    throw({invalid_authorization_action, Action});
 compile(BadRule) ->
     throw({invalid_authorization_rule, BadRule}).
+
+compile_action(Action) ->
+    compile_action(emqx_authz:feature_available(rich_actions), Action).
+
+-define(IS_ACTION_WITH_RETAIN(Action), (Action =:= publish orelse Action =:= all)).
+
+compile_action(_RichActionsOn, subscribe) ->
+    subscribe;
+compile_action(_RichActionsOn, Action) when ?IS_ACTION_WITH_RETAIN(Action) ->
+    Action;
+compile_action(true = _RichActionsOn, {subscribe, Opts}) when is_list(Opts) ->
+    #{
+        action_type => subscribe,
+        qos => qos_from_opts(Opts)
+    };
+compile_action(true = _RichActionsOn, {Action, Opts}) when
+    ?IS_ACTION_WITH_RETAIN(Action) andalso is_list(Opts)
+->
+    #{
+        action_type => Action,
+        qos => qos_from_opts(Opts),
+        retain => retain_from_opts(Opts)
+    };
+compile_action(_RichActionsOn, Action) ->
+    throw({invalid_authorization_action, Action}).
+
+qos_from_opts(Opts) ->
+    try
+        case proplists:get_all_values(qos, Opts) of
+            [] ->
+                ?DEFAULT_RULE_QOS;
+            QoSs ->
+                lists:flatmap(
+                    fun
+                        (QoS) when is_integer(QoS) ->
+                            [validate_qos(QoS)];
+                        (QoS) when is_list(QoS) ->
+                            lists:map(fun validate_qos/1, QoS)
+                    end,
+                    QoSs
+                )
+        end
+    catch
+        bad_qos ->
+            throw({invalid_authorization_qos, Opts})
+    end.
+
+validate_qos(QoS) when is_integer(QoS), QoS >= 0, QoS =< 2 ->
+    QoS;
+validate_qos(_) ->
+    throw(bad_qos).
+
+retain_from_opts(Opts) ->
+    case proplists:get_value(retain, Opts, ?DEFAULT_RULE_RETAIN) of
+        all -> all;
+        Retain when is_boolean(Retain) -> Retain;
+        _ -> throw({invalid_authorization_retain, Opts})
+    end.
 
 compile_who(all) ->
     all;
@@ -99,8 +172,12 @@ compile_who({ipaddrs, CIDRs}) ->
 compile_who({'and', L}) when is_list(L) ->
     {'and', [compile_who(Who) || Who <- L]};
 compile_who({'or', L}) when is_list(L) ->
-    {'or', [compile_who(Who) || Who <- L]}.
+    {'or', [compile_who(Who) || Who <- L]};
+compile_who(Who) ->
+    throw({invalid_who, Who}).
 
+compile_topic("eq " ++ Topic) ->
+    {eq, emqx_topic:words(bin(Topic))};
 compile_topic(<<"eq ", Topic/binary>>) ->
     {eq, emqx_topic:words(Topic)};
 compile_topic({eq, Topic}) ->
@@ -117,45 +194,65 @@ compile_topic(Topic) ->
         Tokens -> {pattern, Tokens}
     end.
 
-atom(B) when is_binary(B) ->
-    try
-        binary_to_existing_atom(B, utf8)
-    catch
-        _E:_S -> binary_to_atom(B)
-    end;
-atom(A) when is_atom(A) -> A.
-
 bin(L) when is_list(L) ->
     list_to_binary(L);
 bin(B) when is_binary(B) ->
     B.
 
--spec matches(emqx_types:clientinfo(), emqx_types:pubsub(), emqx_types:topic(), [rule()]) ->
+-spec matches(emqx_types:clientinfo(), action(), emqx_types:topic(), [rule()]) ->
     {matched, allow} | {matched, deny} | nomatch.
-matches(_Client, _PubSub, _Topic, []) ->
+matches(_Client, _Action, _Topic, []) ->
     nomatch;
-matches(Client, PubSub, Topic, [{Permission, Who, Action, TopicFilters} | Tail]) ->
-    case match(Client, PubSub, Topic, {Permission, Who, Action, TopicFilters}) of
-        nomatch -> matches(Client, PubSub, Topic, Tail);
+matches(Client, Action, Topic, [{Permission, WhoCond, ActionCond, TopicCond} | Tail]) ->
+    case match(Client, Action, Topic, {Permission, WhoCond, ActionCond, TopicCond}) of
+        nomatch -> matches(Client, Action, Topic, Tail);
         Matched -> Matched
     end.
 
--spec match(emqx_types:clientinfo(), emqx_types:pubsub(), emqx_types:topic(), rule()) ->
+-spec match(emqx_types:clientinfo(), action(), emqx_types:topic(), rule()) ->
     {matched, allow} | {matched, deny} | nomatch.
-match(Client, PubSub, Topic, {Permission, Who, Action, TopicFilters}) ->
+match(Client, Action, Topic, {Permission, WhoCond, ActionCond, TopicCond}) ->
     case
-        match_action(PubSub, Action) andalso
-            match_who(Client, Who) andalso
-            match_topics(Client, Topic, TopicFilters)
+        match_action(Action, ActionCond) andalso
+            match_who(Client, WhoCond) andalso
+            match_topics(Client, Topic, TopicCond)
     of
         true -> {matched, Permission};
         _ -> nomatch
     end.
 
-match_action(publish, publish) -> true;
-match_action(subscribe, subscribe) -> true;
-match_action(_, all) -> true;
-match_action(_, _) -> false.
+-spec match_action(action(), action_condition()) -> boolean().
+match_action(#{action_type := publish}, PubSubCond) when is_atom(PubSubCond) ->
+    match_pubsub(publish, PubSubCond);
+match_action(
+    #{action_type := publish, qos := QoS, retain := Retain}, #{
+        action_type := publish, qos := QoSCond, retain := RetainCond
+    }
+) ->
+    match_qos(QoS, QoSCond) andalso match_retain(Retain, RetainCond);
+match_action(#{action_type := publish, qos := QoS, retain := Retain}, #{
+    action_type := all, qos := QoSCond, retain := RetainCond
+}) ->
+    match_qos(QoS, QoSCond) andalso match_retain(Retain, RetainCond);
+match_action(#{action_type := subscribe}, PubSubCond) when is_atom(PubSubCond) ->
+    match_pubsub(subscribe, PubSubCond);
+match_action(#{action_type := subscribe, qos := QoS}, #{action_type := subscribe, qos := QoSCond}) ->
+    match_qos(QoS, QoSCond);
+match_action(#{action_type := subscribe, qos := QoS}, #{action_type := all, qos := QoSCond}) ->
+    match_qos(QoS, QoSCond);
+match_action(_, _) ->
+    false.
+
+match_pubsub(publish, publish) -> true;
+match_pubsub(subscribe, subscribe) -> true;
+match_pubsub(_, all) -> true;
+match_pubsub(_, _) -> false.
+
+match_qos(QoS, QoSs) -> lists:member(QoS, QoSs).
+
+match_retain(_, all) -> true;
+match_retain(Retain, Retain) when is_boolean(Retain) -> true;
+match_retain(_, _) -> false.
 
 match_who(_, all) ->
     true;

--- a/apps/emqx_authz/src/emqx_authz_rule.erl
+++ b/apps/emqx_authz/src/emqx_authz_rule.erl
@@ -60,7 +60,7 @@
 
 -type rule() :: {permission(), who_condition(), action_condition(), topic_condition()}.
 
--type qos() :: 0..2.
+-type qos() :: emqx_types:qos().
 -type retain() :: boolean().
 -type action() ::
     #{action_type := subscribe, qos := qos()}

--- a/apps/emqx_authz/src/emqx_authz_rule_raw.erl
+++ b/apps/emqx_authz/src/emqx_authz_rule_raw.erl
@@ -1,0 +1,197 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2021-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%
+%% @doc
+%% This module converts authz rule fields obtained from
+%% external sources like database or API to the format
+%% accepted by emqx_authz_rule module.
+%%--------------------------------------------------------------------
+
+-module(emqx_authz_rule_raw).
+
+-export([parse_rule/1, format_rule/1]).
+
+-include("emqx_authz.hrl").
+
+-type rule_raw() :: #{binary() => binary() | [binary()]}.
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec parse_rule(rule_raw()) ->
+    {ok, {
+        emqx_authz_rule:permission(),
+        emqx_authz_rule:action_condition(),
+        emqx_authz_rule:topic_condition()
+    }}
+    | {error, term()}.
+parse_rule(
+    #{
+        <<"permission">> := PermissionRaw,
+        <<"action">> := ActionTypeRaw
+    } = RuleRaw
+) ->
+    try
+        Topics = validate_rule_topics(RuleRaw),
+        Permission = validate_rule_permission(PermissionRaw),
+        ActionType = validate_rule_action_type(ActionTypeRaw),
+        Action = validate_rule_action(ActionType, RuleRaw),
+        {ok, {Permission, Action, Topics}}
+    catch
+        throw:ValidationError ->
+            {error, ValidationError}
+    end;
+parse_rule(RuleRaw) ->
+    {error, {invalid_rule, RuleRaw}}.
+
+-spec format_rule({
+    emqx_authz_rule:permission(),
+    emqx_authz_rule:action_condition(),
+    emqx_authz_rule:topic_condition()
+}) -> map().
+format_rule({Permission, Action, Topics}) when is_list(Topics) ->
+    maps:merge(
+        #{
+            topic => lists:map(fun format_topic/1, Topics),
+            permission => Permission
+        },
+        format_action(Action)
+    );
+format_rule({Permission, Action, Topic}) ->
+    maps:merge(
+        #{
+            topic => format_topic(Topic),
+            permission => Permission
+        },
+        format_action(Action)
+    ).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+validate_rule_topics(#{<<"topic">> := TopicRaw}) when is_binary(TopicRaw) ->
+    [validate_rule_topic(TopicRaw)];
+validate_rule_topics(#{<<"topics">> := TopicsRaw}) when is_list(TopicsRaw) ->
+    lists:map(fun validate_rule_topic/1, TopicsRaw);
+validate_rule_topics(RuleRaw) ->
+    throw({invalid_topics, RuleRaw}).
+
+validate_rule_topic(<<"eq ", TopicRaw/binary>>) ->
+    {eq, validate_rule_topic(TopicRaw)};
+validate_rule_topic(TopicRaw) when is_binary(TopicRaw) -> TopicRaw.
+
+validate_rule_permission(<<"allow">>) -> allow;
+validate_rule_permission(<<"deny">>) -> deny;
+validate_rule_permission(PermissionRaw) -> throw({invalid_permission, PermissionRaw}).
+
+validate_rule_action_type(<<"publish">>) -> publish;
+validate_rule_action_type(<<"subscribe">>) -> subscribe;
+validate_rule_action_type(<<"all">>) -> all;
+validate_rule_action_type(ActionRaw) -> throw({invalid_action, ActionRaw}).
+
+validate_rule_action(ActionType, RuleRaw) ->
+    validate_rule_action(emqx_authz:feature_available(rich_actions), ActionType, RuleRaw).
+
+%% rich_actions disabled
+validate_rule_action(false, ActionType, _RuleRaw) ->
+    ActionType;
+%% rich_actions enabled
+validate_rule_action(true, publish, RuleRaw) ->
+    Qos = validate_rule_qos(maps:get(<<"qos">>, RuleRaw, ?DEFAULT_RULE_QOS)),
+    Retain = validate_rule_retain(maps:get(<<"retain">>, RuleRaw, <<"all">>)),
+    {publish, [{qos, Qos}, {retain, Retain}]};
+validate_rule_action(true, subscribe, RuleRaw) ->
+    Qos = validate_rule_qos(maps:get(<<"qos">>, RuleRaw, ?DEFAULT_RULE_QOS)),
+    {subscribe, [{qos, Qos}]};
+validate_rule_action(true, all, RuleRaw) ->
+    Qos = validate_rule_qos(maps:get(<<"qos">>, RuleRaw, ?DEFAULT_RULE_QOS)),
+    Retain = validate_rule_retain(maps:get(<<"retain">>, RuleRaw, <<"all">>)),
+    {all, [{qos, Qos}, {retain, Retain}]}.
+
+validate_rule_qos(QosInt) when is_integer(QosInt) andalso QosInt >= 0 andalso QosInt =< 2 ->
+    [QosInt];
+validate_rule_qos(QosBin) when is_binary(QosBin) ->
+    try
+        QosRawList = binary:split(QosBin, <<",">>, [global]),
+        lists:map(fun validate_rule_qos_atomic/1, QosRawList)
+    catch
+        _:_ ->
+            throw({invalid_qos, QosBin})
+    end;
+validate_rule_qos(QosList) when is_list(QosList) ->
+    try
+        lists:map(fun validate_rule_qos_atomic/1, QosList)
+    catch
+        invalid_qos ->
+            throw({invalid_qos, QosList})
+    end;
+validate_rule_qos(undefined) ->
+    ?DEFAULT_RULE_QOS;
+validate_rule_qos(null) ->
+    ?DEFAULT_RULE_QOS;
+validate_rule_qos(QosRaw) ->
+    throw({invalid_qos, QosRaw}).
+
+validate_rule_qos_atomic(<<"0">>) -> 0;
+validate_rule_qos_atomic(<<"1">>) -> 1;
+validate_rule_qos_atomic(<<"2">>) -> 2;
+validate_rule_qos_atomic(0) -> 0;
+validate_rule_qos_atomic(1) -> 1;
+validate_rule_qos_atomic(2) -> 2;
+validate_rule_qos_atomic(_) -> throw(invalid_qos).
+
+validate_rule_retain(<<"0">>) -> false;
+validate_rule_retain(<<"1">>) -> true;
+validate_rule_retain(0) -> false;
+validate_rule_retain(1) -> true;
+validate_rule_retain(<<"true">>) -> true;
+validate_rule_retain(<<"false">>) -> false;
+validate_rule_retain(true) -> true;
+validate_rule_retain(false) -> false;
+validate_rule_retain(undefined) -> ?DEFAULT_RULE_RETAIN;
+validate_rule_retain(null) -> ?DEFAULT_RULE_RETAIN;
+validate_rule_retain(<<"all">>) -> ?DEFAULT_RULE_RETAIN;
+validate_rule_retain(Retain) -> throw({invalid_retain, Retain}).
+
+format_action(Action) ->
+    format_action(emqx_authz:feature_available(rich_actions), Action).
+
+%% rich_actions disabled
+format_action(false, Action) when is_atom(Action) ->
+    #{
+        action => Action
+    };
+format_action(false, {ActionType, _Opts}) ->
+    #{
+        action => ActionType
+    };
+%% rich_actions enabled
+format_action(true, Action) when is_atom(Action) ->
+    #{
+        action => Action
+    };
+format_action(true, {ActionType, Opts}) ->
+    #{
+        action => ActionType,
+        qos => proplists:get_value(qos, Opts, ?DEFAULT_RULE_QOS),
+        retain => proplists:get_value(retain, Opts, ?DEFAULT_RULE_RETAIN)
+    }.
+
+format_topic({eq, Topic}) when is_binary(Topic) ->
+    <<"eq ", Topic/binary>>;
+format_topic(Topic) when is_binary(Topic) ->
+    Topic.

--- a/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_api_mnesia_SUITE.erl
@@ -96,7 +96,7 @@ t_api(_) ->
             <<"hasnext">> := false
         }
     } = emqx_utils_json:decode(Request1),
-    ?assertEqual(3, length(Rules1)),
+    ?assertEqual(?USERNAME_RULES_EXAMPLE_COUNT, length(Rules1)),
 
     {ok, 200, Request1_1} =
         request(
@@ -204,7 +204,7 @@ t_api(_) ->
     } =
         emqx_utils_json:decode(Request4),
     #{<<"clientid">> := <<"client1">>, <<"rules">> := Rules3} = emqx_utils_json:decode(Request5),
-    ?assertEqual(3, length(Rules3)),
+    ?assertEqual(?CLIENTID_RULES_EXAMPLE_COUNT, length(Rules3)),
 
     {ok, 204, _} =
         request(
@@ -253,7 +253,7 @@ t_api(_) ->
             []
         ),
     #{<<"rules">> := Rules5} = emqx_utils_json:decode(Request7),
-    ?assertEqual(3, length(Rules5)),
+    ?assertEqual(?ALL_RULES_EXAMPLE_COUNT, length(Rules5)),
 
     {ok, 204, _} =
         request(

--- a/apps/emqx_authz/test/emqx_authz_file_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_file_SUITE.erl
@@ -38,21 +38,19 @@ all() ->
 groups() ->
     [].
 
-init_per_suite(Config) ->
-    Config.
-
-end_per_suite(_Config) ->
-    ok = emqx_authz_test_lib:restore_authorizers().
-
 init_per_testcase(TestCase, Config) ->
     Apps = emqx_cth_suite:start(
-        [{emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"}, emqx_authz],
+        [
+            {emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"},
+            emqx_authz
+        ],
         #{work_dir => filename:join(?config(priv_dir, Config), TestCase)}
     ),
     [{tc_apps, Apps} | Config].
 
 end_per_testcase(_TestCase, Config) ->
-    emqx_cth_suite:stop(?config(tc_apps, Config)).
+    emqx_cth_suite:stop(?config(tc_apps, Config)),
+    _ = emqx_authz:set_feature_available(rich_actions, true).
 
 %%------------------------------------------------------------------------------
 %% Testcases

--- a/apps/emqx_authz/test/emqx_authz_jwt_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_jwt_SUITE.erl
@@ -22,6 +22,7 @@
 -include_lib("emqx/include/emqx_placeholder.hrl").
 -include_lib("emqx_authn/include/emqx_authn.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -341,12 +342,12 @@ t_check_undefined_expire(_Config) ->
 
     ?assertMatch(
         {matched, allow},
-        emqx_authz_client_info:authorize(Client, subscribe, <<"a/b">>, undefined)
+        emqx_authz_client_info:authorize(Client, ?AUTHZ_SUBSCRIBE, <<"a/b">>, undefined)
     ),
 
     ?assertMatch(
         {matched, deny},
-        emqx_authz_client_info:authorize(Client, subscribe, <<"a/bar">>, undefined)
+        emqx_authz_client_info:authorize(Client, ?AUTHZ_SUBSCRIBE, <<"a/bar">>, undefined)
     ).
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_mysql_SUITE.erl
@@ -27,10 +27,10 @@
 -define(MYSQL_RESOURCE, <<"emqx_authz_mysql_SUITE">>).
 
 all() ->
-    emqx_common_test_helpers:all(?MODULE).
+    emqx_authz_test_lib:all_with_table_case(?MODULE, t_run_case, cases()).
 
 groups() ->
-    [].
+    emqx_authz_test_lib:table_groups(t_run_case, cases()).
 
 init_per_suite(Config) ->
     ok = stop_apps([emqx_resource]),
@@ -41,13 +41,7 @@ init_per_suite(Config) ->
                 fun set_special_configs/1
             ),
             ok = start_apps([emqx_resource]),
-            {ok, _} = emqx_resource:create_local(
-                ?MYSQL_RESOURCE,
-                ?RESOURCE_GROUP,
-                emqx_mysql,
-                mysql_config(),
-                #{}
-            ),
+            ok = create_mysql_resource(),
             Config;
         false ->
             {skip, no_mysql}
@@ -59,9 +53,18 @@ end_per_suite(_Config) ->
     ok = stop_apps([emqx_resource]),
     ok = emqx_common_test_helpers:stop_apps([emqx_conf, emqx_authz]).
 
+init_per_group(Group, Config) ->
+    [{test_case, emqx_authz_test_lib:get_case(Group, cases())} | Config].
+end_per_group(_Group, _Config) ->
+    ok.
+
 init_per_testcase(_TestCase, Config) ->
     ok = emqx_authz_test_lib:reset_authorizers(),
     Config.
+end_per_testcase(_TestCase, _Config) ->
+    _ = emqx_authz:set_feature_available(rich_actions, true),
+    ok = drop_table(),
+    ok.
 
 set_special_configs(emqx_authz) ->
     ok = emqx_authz_test_lib:reset_authorizers();
@@ -72,189 +75,11 @@ set_special_configs(_) ->
 %% Testcases
 %%------------------------------------------------------------------------------
 
-t_topic_rules(_Config) ->
-    ClientInfo = #{
-        clientid => <<"clientid">>,
-        username => <<"username">>,
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
-
-    ok = emqx_authz_test_lib:test_no_topic_rules(ClientInfo, fun setup_client_samples/2),
-
-    ok = emqx_authz_test_lib:test_allow_topic_rules(ClientInfo, fun setup_client_samples/2),
-
-    ok = emqx_authz_test_lib:test_deny_topic_rules(ClientInfo, fun setup_client_samples/2).
-
-t_lookups(_Config) ->
-    ClientInfo = #{
-        clientid => <<"clientid">>,
-        cn => <<"cn">>,
-        dn => <<"dn">>,
-        username => <<"username">>,
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
-
-    %% by clientid
-
-    ok = init_table(),
-    ok = q(
-        <<
-            "INSERT INTO acl(clientid, topic, permission, action)"
-            "VALUES(?, ?, ?, ?)"
-        >>,
-        [<<"clientid">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = ${clientid}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% by peerhost
-
-    ok = init_table(),
-    ok = q(
-        <<
-            "INSERT INTO acl(peerhost, topic, permission, action)"
-            "VALUES(?, ?, ?, ?)"
-        >>,
-        [<<"127.0.0.1">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE peerhost = ${peerhost}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% by cn
-
-    ok = init_table(),
-    ok = q(
-        <<
-            "INSERT INTO acl(cn, topic, permission, action)"
-            "VALUES(?, ?, ?, ?)"
-        >>,
-        [<<"cn">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE cn = ${cert_common_name}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% by dn
-
-    ok = init_table(),
-    ok = q(
-        <<
-            "INSERT INTO acl(dn, topic, permission, action)"
-            "VALUES(?, ?, ?, ?)"
-        >>,
-        [<<"dn">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE dn = ${cert_subject}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% strip double quote support
-
-    ok = init_table(),
-    ok = q(
-        <<
-            "INSERT INTO acl(clientid, topic, permission, action)"
-            "VALUES(?, ?, ?, ?)"
-        >>,
-        [<<"clientid">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = \"${clientid}\""
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ).
-
-t_mysql_error(_Config) ->
-    ClientInfo = #{
-        clientid => <<"clientid">>,
-        username => <<"username">>,
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
-
-    ok = setup_config(
-        #{<<"query">> => <<"SOME INVALID STATEMENT">>}
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [{deny, subscribe, <<"a">>}]
-    ).
+t_run_case(Config) ->
+    Case = ?config(test_case, Config),
+    ok = setup_source_data(Case),
+    ok = setup_authz_source(Case),
+    ok = emqx_authz_test_lib:run_checks(Case).
 
 t_create_invalid(_Config) ->
     BadConfig = maps:merge(
@@ -265,44 +90,284 @@ t_create_invalid(_Config) ->
 
     [_] = emqx_authz:lookup().
 
-t_nonbinary_values(_Config) ->
-    ClientInfo = #{
-        clientid => clientid,
-        username => "username",
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
+%%------------------------------------------------------------------------------
+%% Cases
+%%------------------------------------------------------------------------------
 
-    ok = init_table(),
-    ok = q(
-        <<
-            "INSERT INTO acl(clientid, username, topic, permission, action)"
-            "VALUES(?, ?, ?, ?, ?)"
-        >>,
-        [<<"clientid">>, <<"username">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
+cases() ->
+    [
         #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = ${clientid} AND username = ${username}"
-            >>
-        }
-    ),
+            name => base_publish,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'allow', 'publish')",
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'b', 'allow', 'subscribe')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = ${username}",
+            client_info => #{username => <<"username">>},
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"a">>},
+                {deny, ?AUTHZ_PUBLISH, <<"b">>},
+                {deny, ?AUTHZ_SUBSCRIBE, <<"a">>},
+                {allow, ?AUTHZ_SUBSCRIBE, <<"b">>}
+            ]
+        },
+        #{
+            name => rule_by_clientid_cn_dn_peerhost,
+            setup => [
+                "CREATE TABLE acl(clientid VARCHAR(255), cn VARCHAR(255), dn VARCHAR(255),"
+                " peerhost VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255), action VARCHAR(255))",
 
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ).
+                "INSERT INTO acl(clientid, cn, dn, peerhost, topic, permission, action)"
+                " VALUES('clientid', 'cn', 'dn', '127.0.0.1', 'a', 'allow', 'publish')"
+            ],
+            query =>
+                "SELECT permission, action, topic FROM acl WHERE"
+                " clientid = ${clientid} AND cn = ${cert_common_name}"
+                " AND dn = ${cert_subject} AND peerhost = ${peerhost}",
+            client_info => #{
+                clientid => <<"clientid">>,
+                cn => <<"cn">>,
+                dn => <<"dn">>,
+                peerhost => {127, 0, 0, 1}
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"a">>},
+                {deny, ?AUTHZ_PUBLISH, <<"b">>}
+            ]
+        },
+        #{
+            name => topics_literal_wildcard_variable,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't/${username}', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't/${clientid}', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 'eq t/${username}', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't/#', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't1/+', 'allow', 'publish')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"t/username">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/clientid">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/${username}">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/1/2">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t1/1">>},
+                {deny, ?AUTHZ_PUBLISH, <<"t1/1/2">>},
+                {deny, ?AUTHZ_PUBLISH, <<"abc">>},
+                {deny, ?AUTHZ_SUBSCRIBE, <<"t/username">>}
+            ]
+        },
+        #{
+            name => qos_retain_in_query_result,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255),"
+                "qos_s VARCHAR(255), retain_s VARCHAR(255))",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't1', 'allow', 'publish', '1', 'true')",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't2', 'allow', 'publish', '2', 'false')",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't3', 'allow', 'publish', '0,1,2', 'all')",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't4', 'allow', 'subscribe', '1', null)",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't5', 'allow', 'subscribe', '0,1,2', null)"
+            ],
+            query =>
+                "SELECT permission, action, topic, qos_s as qos, retain_s as retain"
+                " FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(0, true), <<"t1">>},
+
+                {allow, ?AUTHZ_PUBLISH(2, false), <<"t2">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t2">>},
+                {deny, ?AUTHZ_PUBLISH(2, true), <<"t2">>},
+
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t3">>},
+                {allow, ?AUTHZ_PUBLISH(2, false), <<"t3">>},
+                {allow, ?AUTHZ_PUBLISH(2, true), <<"t3">>},
+                {allow, ?AUTHZ_PUBLISH(0, false), <<"t3">>},
+
+                {allow, ?AUTHZ_SUBSCRIBE(1), <<"t4">>},
+                {deny, ?AUTHZ_SUBSCRIBE(2), <<"t4">>},
+
+                {allow, ?AUTHZ_SUBSCRIBE(1), <<"t5">>},
+                {allow, ?AUTHZ_SUBSCRIBE(2), <<"t5">>},
+                {allow, ?AUTHZ_SUBSCRIBE(0), <<"t5">>}
+            ]
+        },
+        #{
+            name => qos_retain_in_query_result_as_integer,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255),"
+                "qos_i VARCHAR(255), retain_i VARCHAR(255))",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_i, retain_i)"
+                " VALUES('username', 't1', 'allow', 'publish', 1, 1)"
+            ],
+            query =>
+                "SELECT permission, action, topic, qos_i as qos, retain_i as retain"
+                " FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(0, true), <<"t1">>}
+            ]
+        },
+        #{
+            name => retain_in_query_result_as_boolean,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255),"
+                " action VARCHAR(255), retain_b BOOLEAN)",
+
+                "INSERT INTO acl(username, topic, permission, action, retain_b)"
+                " VALUES('username', 't1', 'allow', 'publish', true)",
+
+                "INSERT INTO acl(username, topic, permission, action, retain_b)"
+                " VALUES('username', 't2', 'allow', 'publish', false)"
+            ],
+            query =>
+                "SELECT permission, action, topic, retain_b as retain"
+                " FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t1">>},
+                {allow, ?AUTHZ_PUBLISH(1, false), <<"t2">>},
+                {deny, ?AUTHZ_PUBLISH(1, true), <<"t2">>}
+            ]
+        },
+        #{
+            name => nonbin_values_in_client_info,
+            setup => [
+                "CREATE TABLE acl(who VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255),"
+                " action VARCHAR(255))",
+
+                "INSERT INTO acl(who, topic, permission, action)"
+                " VALUES('username', 't/${username}', 'allow', 'publish')",
+
+                "INSERT INTO acl(who, topic, permission, action)"
+                " VALUES('clientid', 't/${clientid}', 'allow', 'publish')"
+            ],
+            query =>
+                "SELECT permission, action, topic"
+                " FROM acl WHERE who = ${username} OR who = ${clientid}",
+            client_info => #{
+                %% string, not a binary
+                username => "username",
+                %% atom, not a binary
+                clientid => clientid
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"t/username">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/clientid">>},
+                {deny, ?AUTHZ_PUBLISH, <<"t/foo">>}
+            ]
+        },
+        #{
+            name => null_retain_qos,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(qos VARCHAR(255), retain VARCHAR(255),"
+                " topic VARCHAR(255), permission VARCHAR(255), action VARCHAR(255))",
+
+                "INSERT INTO acl(qos, retain, topic, permission, action)"
+                " VALUES(NULL, NULL,  'tp', 'allow', 'publish')"
+            ],
+            query =>
+                "SELECT permission, action, topic, qos FROM acl",
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(0, false), <<"tp">>},
+                {allow, ?AUTHZ_PUBLISH(1, false), <<"tp">>},
+                {allow, ?AUTHZ_PUBLISH(2, true), <<"tp">>},
+
+                {deny, ?AUTHZ_PUBLISH(0, true), <<"xxx">>}
+            ]
+        },
+        #{
+            name => strip_double_quote,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'allow', 'publish')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = \"${username}\"",
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
+        },
+        #{
+            name => invalid_query,
+            setup => [],
+            query => "SELECT permission, action, topic FROM acl WHER",
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
+        },
+        #{
+            name => pgsql_error,
+            setup => [],
+            query =>
+                "SELECT permission, action, topic FROM table_not_exists WHERE username = ${username}",
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"t">>}
+            ]
+        }
+    ].
 
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------
+
+setup_source_data(#{setup := Queries}) ->
+    lists:foreach(
+        fun(Query) ->
+            _ = q(Query)
+        end,
+        Queries
+    ).
+
+setup_authz_source(#{query := Query}) ->
+    setup_config(
+        #{
+            <<"query">> => Query
+        }
+    ).
 
 raw_mysql_authz_config() ->
     #{
@@ -332,51 +397,8 @@ q(Sql, Params) ->
         {sql, Sql, Params}
     ).
 
-init_table() ->
-    ok = drop_table(),
-    ok = q(
-        "CREATE TABLE acl(\n"
-        "                       username VARCHAR(255),\n"
-        "                       clientid VARCHAR(255),\n"
-        "                       peerhost VARCHAR(255),\n"
-        "                       cn VARCHAR(255),\n"
-        "                       dn VARCHAR(255),\n"
-        "                       topic VARCHAR(255),\n"
-        "                       permission VARCHAR(255),\n"
-        "                       action VARCHAR(255))"
-    ).
-
 drop_table() ->
     ok = q("DROP TABLE IF EXISTS acl").
-
-setup_client_samples(ClientInfo, Samples) ->
-    #{username := Username} = ClientInfo,
-    ok = init_table(),
-    ok = lists:foreach(
-        fun(#{topics := Topics, permission := Permission, action := Action}) ->
-            lists:foreach(
-                fun(Topic) ->
-                    q(
-                        <<
-                            "INSERT INTO acl(username, topic, permission, action)"
-                            "VALUES(?, ?, ?, ?)"
-                        >>,
-                        [Username, Topic, Permission, Action]
-                    )
-                end,
-                Topics
-            )
-        end,
-        Samples
-    ),
-    setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE username = ${username}"
-            >>
-        }
-    ).
 
 setup_config(SpecialParams) ->
     emqx_authz_test_lib:setup_config(
@@ -400,3 +422,13 @@ start_apps(Apps) ->
 
 stop_apps(Apps) ->
     lists:foreach(fun application:stop/1, Apps).
+
+create_mysql_resource() ->
+    {ok, _} = emqx_resource:create_local(
+        ?MYSQL_RESOURCE,
+        ?RESOURCE_GROUP,
+        emqx_mysql,
+        mysql_config(),
+        #{}
+    ),
+    ok.

--- a/apps/emqx_authz/test/emqx_authz_postgresql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_postgresql_SUITE.erl
@@ -352,6 +352,19 @@ cases() ->
             checks => [
                 {deny, ?AUTHZ_PUBLISH, <<"t">>}
             ]
+        },
+        #{
+            name => invalid_rule,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                %% 'permit' is invalid value for action
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'permit', 'publish')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = ${username}",
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
         }
         %% TODO: add case for unknown variables after fixing EMQX-10400
     ].

--- a/apps/emqx_authz/test/emqx_authz_postgresql_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_postgresql_SUITE.erl
@@ -27,10 +27,10 @@
 -define(PGSQL_RESOURCE, <<"emqx_authz_pgsql_SUITE">>).
 
 all() ->
-    emqx_common_test_helpers:all(?MODULE).
+    emqx_authz_test_lib:all_with_table_case(?MODULE, t_run_case, cases()).
 
 groups() ->
-    [].
+    emqx_authz_test_lib:table_groups(t_run_case, cases()).
 
 init_per_suite(Config) ->
     ok = stop_apps([emqx_resource]),
@@ -41,13 +41,7 @@ init_per_suite(Config) ->
                 fun set_special_configs/1
             ),
             ok = start_apps([emqx_resource]),
-            {ok, _} = emqx_resource:create_local(
-                ?PGSQL_RESOURCE,
-                ?RESOURCE_GROUP,
-                emqx_connector_pgsql,
-                pgsql_config(),
-                #{}
-            ),
+            {ok, _} = create_pgsql_resource(),
             Config;
         false ->
             {skip, no_pgsql}
@@ -59,9 +53,18 @@ end_per_suite(_Config) ->
     ok = stop_apps([emqx_resource]),
     ok = emqx_common_test_helpers:stop_apps([emqx_conf, emqx_authz]).
 
+init_per_group(Group, Config) ->
+    [{test_case, emqx_authz_test_lib:get_case(Group, cases())} | Config].
+end_per_group(_Group, _Config) ->
+    ok.
+
 init_per_testcase(_TestCase, Config) ->
     ok = emqx_authz_test_lib:reset_authorizers(),
     Config.
+end_per_testcase(_TestCase, _Config) ->
+    _ = emqx_authz:set_feature_available(rich_actions, true),
+    ok = drop_table(),
+    ok.
 
 set_special_configs(emqx_authz) ->
     ok = emqx_authz_test_lib:reset_authorizers();
@@ -72,194 +75,11 @@ set_special_configs(_) ->
 %% Testcases
 %%------------------------------------------------------------------------------
 
-t_topic_rules(_Config) ->
-    ClientInfo = #{
-        clientid => <<"clientid">>,
-        username => <<"username">>,
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
-
-    ok = emqx_authz_test_lib:test_no_topic_rules(ClientInfo, fun setup_client_samples/2),
-
-    ok = emqx_authz_test_lib:test_allow_topic_rules(ClientInfo, fun setup_client_samples/2),
-
-    ok = emqx_authz_test_lib:test_deny_topic_rules(ClientInfo, fun setup_client_samples/2).
-
-t_lookups(_Config) ->
-    ClientInfo = #{
-        clientid => <<"clientid">>,
-        cn => <<"cn">>,
-        dn => <<"dn">>,
-        username => <<"username">>,
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
-
-    %% by clientid
-
-    ok = init_table(),
-    ok = insert(
-        <<
-            "INSERT INTO acl(clientid, topic, permission, action)"
-            "VALUES($1, $2, $3, $4)"
-        >>,
-        [<<"clientid">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = ${clientid}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% by peerhost
-
-    ok = init_table(),
-    ok = insert(
-        <<
-            "INSERT INTO acl(peerhost, topic, permission, action)"
-            "VALUES($1, $2, $3, $4)"
-        >>,
-        [<<"127.0.0.1">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE peerhost = ${peerhost}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% by cn
-
-    ok = init_table(),
-    ok = insert(
-        <<
-            "INSERT INTO acl(cn, topic, permission, action)"
-            "VALUES($1, $2, $3, $4)"
-        >>,
-        [<<"cn">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE cn = ${cert_common_name}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% by dn
-
-    ok = init_table(),
-    ok = insert(
-        <<
-            "INSERT INTO acl(dn, topic, permission, action)"
-            "VALUES($1, $2, $3, $4)"
-        >>,
-        [<<"dn">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE dn = ${cert_subject}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ),
-
-    %% strip double quote support
-
-    ok = init_table(),
-    ok = insert(
-        <<
-            "INSERT INTO acl(clientid, topic, permission, action)"
-            "VALUES($1, $2, $3, $4)"
-        >>,
-        [<<"clientid">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = \"${clientid}\""
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ).
-
-t_pgsql_error(_Config) ->
-    ClientInfo = #{
-        clientid => <<"clientid">>,
-        username => <<"username">>,
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
-
-    ok = setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = ${username}"
-            >>
-        }
-    ),
-
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [{deny, subscribe, <<"a">>}]
-    ).
+t_run_case(Config) ->
+    Case = ?config(test_case, Config),
+    ok = setup_source_data(Case),
+    ok = setup_authz_source(Case),
+    ok = emqx_authz_test_lib:run_checks(Case).
 
 t_create_invalid(_Config) ->
     BadConfig = maps:merge(
@@ -270,44 +90,290 @@ t_create_invalid(_Config) ->
 
     [_] = emqx_authz:lookup().
 
-t_nonbinary_values(_Config) ->
-    ClientInfo = #{
-        clientid => clientid,
-        username => "username",
-        peerhost => {127, 0, 0, 1},
-        zone => default,
-        listener => {tcp, default}
-    },
+%%------------------------------------------------------------------------------
+%% Cases
+%%------------------------------------------------------------------------------
 
-    ok = init_table(),
-    ok = insert(
-        <<
-            "INSERT INTO acl(clientid, username, topic, permission, action)"
-            "VALUES($1, $2, $3, $4, $5)"
-        >>,
-        [<<"clientid">>, <<"username">>, <<"a">>, <<"allow">>, <<"subscribe">>]
-    ),
-
-    ok = setup_config(
+cases() ->
+    [
         #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE clientid = ${clientid} AND username = ${username}"
-            >>
-        }
-    ),
+            name => base_publish,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'allow', 'publish')",
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'b', 'allow', 'subscribe')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = ${username}",
+            client_info => #{username => <<"username">>},
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"a">>},
+                {deny, ?AUTHZ_PUBLISH, <<"b">>},
+                {deny, ?AUTHZ_SUBSCRIBE, <<"a">>},
+                {allow, ?AUTHZ_SUBSCRIBE, <<"b">>}
+            ]
+        },
+        #{
+            name => rule_by_clientid_cn_dn_peerhost,
+            setup => [
+                "CREATE TABLE acl(clientid VARCHAR(255), cn VARCHAR(255), dn VARCHAR(255),"
+                " peerhost VARCHAR(255), topic VARCHAR(255),"
+                " permission VARCHAR(255), action VARCHAR(255))",
 
-    ok = emqx_authz_test_lib:test_samples(
-        ClientInfo,
-        [
-            {allow, subscribe, <<"a">>},
-            {deny, subscribe, <<"b">>}
-        ]
-    ).
+                "INSERT INTO acl(clientid, cn, dn, peerhost, topic, permission, action)"
+                " VALUES('clientid', 'cn', 'dn', '127.0.0.1', 'a', 'allow', 'publish')"
+            ],
+            query =>
+                "SELECT permission, action, topic FROM acl WHERE"
+                " clientid = ${clientid} AND cn = ${cert_common_name}"
+                " AND dn = ${cert_subject} AND peerhost = ${peerhost}",
+            client_info => #{
+                clientid => <<"clientid">>,
+                cn => <<"cn">>,
+                dn => <<"dn">>,
+                peerhost => {127, 0, 0, 1}
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"a">>},
+                {deny, ?AUTHZ_PUBLISH, <<"b">>}
+            ]
+        },
+        #{
+            name => topics_literal_wildcard_variable,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't/${username}', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't/${clientid}', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 'eq t/${username}', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't/#', 'allow', 'publish')",
+
+                "INSERT INTO acl(username, topic, permission, action) "
+                "VALUES('username', 't1/+', 'allow', 'publish')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"t/username">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/clientid">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/${username}">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/1/2">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t1/1">>},
+                {deny, ?AUTHZ_PUBLISH, <<"t1/1/2">>},
+                {deny, ?AUTHZ_PUBLISH, <<"abc">>},
+                {deny, ?AUTHZ_SUBSCRIBE, <<"t/username">>}
+            ]
+        },
+        #{
+            name => qos_retain_in_query_result,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255),"
+                "qos_s VARCHAR(255), retain_s VARCHAR(255))",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't1', 'allow', 'publish', '1', 'true')",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't2', 'allow', 'publish', '2', 'false')",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't3', 'allow', 'publish', '0,1,2', 'all')",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't4', 'allow', 'subscribe', '1', null)",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_s, retain_s)"
+                " VALUES('username', 't5', 'allow', 'subscribe', '0,1,2', null)"
+            ],
+            query =>
+                "SELECT permission, action, topic, qos_s as qos, retain_s as retain"
+                " FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(0, true), <<"t1">>},
+
+                {allow, ?AUTHZ_PUBLISH(2, false), <<"t2">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t2">>},
+                {deny, ?AUTHZ_PUBLISH(2, true), <<"t2">>},
+
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t3">>},
+                {allow, ?AUTHZ_PUBLISH(2, false), <<"t3">>},
+                {allow, ?AUTHZ_PUBLISH(2, true), <<"t3">>},
+                {allow, ?AUTHZ_PUBLISH(0, false), <<"t3">>},
+
+                {allow, ?AUTHZ_SUBSCRIBE(1), <<"t4">>},
+                {deny, ?AUTHZ_SUBSCRIBE(2), <<"t4">>},
+
+                {allow, ?AUTHZ_SUBSCRIBE(1), <<"t5">>},
+                {allow, ?AUTHZ_SUBSCRIBE(2), <<"t5">>},
+                {allow, ?AUTHZ_SUBSCRIBE(0), <<"t5">>}
+            ]
+        },
+        #{
+            name => qos_retain_in_query_result_as_integer,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255),"
+                "qos_i VARCHAR(255), retain_i VARCHAR(255))",
+
+                "INSERT INTO acl(username, topic, permission, action, qos_i, retain_i)"
+                " VALUES('username', 't1', 'allow', 'publish', 1, 1)"
+            ],
+            query =>
+                "SELECT permission, action, topic, qos_i as qos, retain_i as retain"
+                " FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(0, true), <<"t1">>}
+            ]
+        },
+        #{
+            name => retain_in_query_result_as_boolean,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255),"
+                " action VARCHAR(255), retain_b BOOLEAN)",
+
+                "INSERT INTO acl(username, topic, permission, action, retain_b)"
+                " VALUES('username', 't1', 'allow', 'publish', true)",
+
+                "INSERT INTO acl(username, topic, permission, action, retain_b)"
+                " VALUES('username', 't2', 'allow', 'publish', false)"
+            ],
+            query =>
+                "SELECT permission, action, topic, retain_b as retain"
+                " FROM acl WHERE username = ${username}",
+            client_info => #{
+                username => <<"username">>
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, true), <<"t1">>},
+                {deny, ?AUTHZ_PUBLISH(1, false), <<"t1">>},
+                {allow, ?AUTHZ_PUBLISH(1, false), <<"t2">>},
+                {deny, ?AUTHZ_PUBLISH(1, true), <<"t2">>}
+            ]
+        },
+        #{
+            name => nonbin_values_in_client_info,
+            setup => [
+                "CREATE TABLE acl(who VARCHAR(255), topic VARCHAR(255), permission VARCHAR(255),"
+                " action VARCHAR(255))",
+
+                "INSERT INTO acl(who, topic, permission, action)"
+                " VALUES('username', 't/${username}', 'allow', 'publish')",
+
+                "INSERT INTO acl(who, topic, permission, action)"
+                " VALUES('clientid', 't/${clientid}', 'allow', 'publish')"
+            ],
+            query =>
+                "SELECT permission, action, topic"
+                " FROM acl WHERE who = ${username} OR who = ${clientid}",
+            client_info => #{
+                %% string, not a binary
+                username => "username",
+                %% atom, not a binary
+                clientid => clientid
+            },
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"t/username">>},
+                {allow, ?AUTHZ_PUBLISH, <<"t/clientid">>},
+                {deny, ?AUTHZ_PUBLISH, <<"t/foo">>}
+            ]
+        },
+        #{
+            name => array_null_qos,
+            features => [rich_actions],
+            setup => [
+                "CREATE TABLE acl(qos INTEGER[], "
+                " topic VARCHAR(255), permission VARCHAR(255), action VARCHAR(255))",
+
+                "INSERT INTO acl(qos, topic, permission, action)"
+                " VALUES('{1,2}', 'tp', 'allow', 'publish')",
+
+                "INSERT INTO acl(qos, topic, permission, action)"
+                " VALUES(NULL, 'ts', 'allow', 'subscribe')"
+            ],
+            query =>
+                "SELECT permission, action, topic, qos FROM acl",
+            checks => [
+                {allow, ?AUTHZ_PUBLISH(1, false), <<"tp">>},
+                {allow, ?AUTHZ_PUBLISH(2, false), <<"tp">>},
+                {deny, ?AUTHZ_PUBLISH(3, false), <<"tp">>},
+
+                {allow, ?AUTHZ_SUBSCRIBE(1), <<"ts">>},
+                {allow, ?AUTHZ_SUBSCRIBE(2), <<"ts">>}
+            ]
+        },
+        #{
+            name => strip_double_quote,
+            setup => [
+                "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
+                "permission VARCHAR(255), action VARCHAR(255))",
+                "INSERT INTO acl(username, topic, permission, action) VALUES('username', 'a', 'allow', 'publish')"
+            ],
+            query => "SELECT permission, action, topic FROM acl WHERE username = \"${username}\"",
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
+        },
+        #{
+            name => invalid_query,
+            setup => [],
+            query => "SELECT permission, action, topic FROM acl WHER",
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"a">>}
+            ]
+        },
+        #{
+            name => pgsql_error,
+            setup => [],
+            query =>
+                "SELECT permission, action, topic FROM table_not_exists WHERE username = ${username}",
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"t">>}
+            ]
+        }
+        %% TODO: add case for unknown variables after fixing EMQX-10400
+    ].
 
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------
+
+setup_source_data(#{setup := Queries}) ->
+    lists:foreach(
+        fun(Query) ->
+            _ = q(Query)
+        end,
+        Queries
+    ).
+
+setup_authz_source(#{query := Query}) ->
+    setup_config(
+        #{
+            <<"query">> => Query
+        }
+    ).
 
 raw_pgsql_authz_config() ->
     #{
@@ -331,60 +397,9 @@ q(Sql) ->
         {query, Sql}
     ).
 
-insert(Sql, Params) ->
-    {ok, _} = emqx_resource:simple_sync_query(
-        ?PGSQL_RESOURCE,
-        {query, Sql, Params}
-    ),
-    ok.
-
-init_table() ->
-    ok = drop_table(),
-    {ok, _, _} = q(
-        "CREATE TABLE acl(\n"
-        "                       username VARCHAR(255),\n"
-        "                       clientid VARCHAR(255),\n"
-        "                       peerhost VARCHAR(255),\n"
-        "                       cn VARCHAR(255),\n"
-        "                       dn VARCHAR(255),\n"
-        "                       topic VARCHAR(255),\n"
-        "                       permission VARCHAR(255),\n"
-        "                       action VARCHAR(255))"
-    ),
-    ok.
-
 drop_table() ->
     {ok, _, _} = q("DROP TABLE IF EXISTS acl"),
     ok.
-
-setup_client_samples(ClientInfo, Samples) ->
-    #{username := Username} = ClientInfo,
-    ok = init_table(),
-    ok = lists:foreach(
-        fun(#{topics := Topics, permission := Permission, action := Action}) ->
-            lists:foreach(
-                fun(Topic) ->
-                    insert(
-                        <<
-                            "INSERT INTO acl(username, topic, permission, action)"
-                            "VALUES($1, $2, $3, $4)"
-                        >>,
-                        [Username, Topic, Permission, Action]
-                    )
-                end,
-                Topics
-            )
-        end,
-        Samples
-    ),
-    setup_config(
-        #{
-            <<"query">> => <<
-                "SELECT permission, action, topic "
-                "FROM acl WHERE username = ${username}"
-            >>
-        }
-    ).
 
 setup_config(SpecialParams) ->
     emqx_authz_test_lib:setup_config(
@@ -402,6 +417,15 @@ pgsql_config() ->
         server => <<?PGSQL_HOST>>,
         ssl => #{enable => false}
     }.
+
+create_pgsql_resource() ->
+    emqx_resource:create_local(
+        ?PGSQL_RESOURCE,
+        ?RESOURCE_GROUP,
+        emqx_connector_pgsql,
+        pgsql_config(),
+        #{}
+    ).
 
 start_apps(Apps) ->
     lists:foreach(fun application:ensure_all_started/1, Apps).

--- a/apps/emqx_authz/test/emqx_authz_rule_raw_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_rule_raw_SUITE.erl
@@ -1,0 +1,274 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_authz_rule_raw_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+end_per_testcase(_TestCase, _Config) ->
+    _ = emqx_authz:set_feature_available(rich_actions, true),
+    ok.
+
+t_parse_ok(_Config) ->
+    lists:foreach(
+        fun({Expected, RuleRaw}) ->
+            _ = emqx_authz:set_feature_available(rich_actions, true),
+            ?assertEqual({ok, Expected}, emqx_authz_rule_raw:parse_rule(RuleRaw)),
+            _ = emqx_authz:set_feature_available(rich_actions, false),
+            ?assertEqual({ok, simple_rule(Expected)}, emqx_authz_rule_raw:parse_rule(RuleRaw))
+        end,
+        ok_cases()
+    ).
+
+t_parse_error(_Config) ->
+    emqx_authz:set_feature_available(rich_actions, true),
+    lists:foreach(
+        fun(RuleRaw) ->
+            ?assertMatch(
+                {error, _},
+                emqx_authz_rule_raw:parse_rule(RuleRaw)
+            )
+        end,
+        error_cases() ++ error_rich_action_cases()
+    ),
+
+    %% without rich actions some fields are not parsed, so they are not errors when invalid
+    _ = emqx_authz:set_feature_available(rich_actions, false),
+    lists:foreach(
+        fun(RuleRaw) ->
+            ?assertMatch(
+                {error, _},
+                emqx_authz_rule_raw:parse_rule(RuleRaw)
+            )
+        end,
+        error_cases()
+    ),
+    lists:foreach(
+        fun(RuleRaw) ->
+            ?assertMatch(
+                {ok, _},
+                emqx_authz_rule_raw:parse_rule(RuleRaw)
+            )
+        end,
+        error_rich_action_cases()
+    ).
+
+t_format(_Config) ->
+    ?assertEqual(
+        #{
+            action => subscribe,
+            permission => allow,
+            qos => [1, 2],
+            retain => true,
+            topic => [<<"a/b/c">>]
+        },
+        emqx_authz_rule_raw:format_rule(
+            {allow, {subscribe, [{qos, [1, 2]}, {retain, true}]}, [<<"a/b/c">>]}
+        )
+    ),
+    ?assertEqual(
+        #{
+            action => publish,
+            permission => allow,
+            topic => [<<"a/b/c">>]
+        },
+        emqx_authz_rule_raw:format_rule(
+            {allow, publish, [<<"a/b/c">>]}
+        )
+    ).
+
+t_format_no_rich_action(_Config) ->
+    _ = emqx_authz:set_feature_available(rich_actions, false),
+
+    Rule = {allow, {subscribe, [{qos, [1, 2]}, {retain, true}]}, [<<"a/b/c">>]},
+
+    ?assertEqual(
+        #{action => subscribe, permission => allow, topic => [<<"a/b/c">>]},
+        emqx_authz_rule_raw:format_rule(Rule)
+    ).
+
+%%--------------------------------------------------------------------
+%% Cases
+%%--------------------------------------------------------------------
+
+ok_cases() ->
+    [
+        {
+            {allow, {publish, [{qos, [0, 1, 2]}, {retain, all}]}, [<<"a/b/c">>]},
+            #{
+                <<"permission">> => <<"allow">>,
+                <<"topic">> => <<"a/b/c">>,
+                <<"action">> => <<"publish">>
+            }
+        },
+        {
+            {deny, {subscribe, [{qos, [1, 2]}]}, [{eq, <<"a/b/c">>}]},
+            #{
+                <<"permission">> => <<"deny">>,
+                <<"topic">> => <<"eq a/b/c">>,
+                <<"action">> => <<"subscribe">>,
+                <<"retain">> => <<"true">>,
+                <<"qos">> => <<"1,2">>
+            }
+        },
+        {
+            {allow, {publish, [{qos, [0, 1, 2]}, {retain, all}]}, [<<"a">>, <<"b">>]},
+            #{
+                <<"permission">> => <<"allow">>,
+                <<"topics">> => [<<"a">>, <<"b">>],
+                <<"action">> => <<"publish">>
+            }
+        },
+        {
+            {allow, {all, [{qos, [0, 1, 2]}, {retain, all}]}, []},
+            #{
+                <<"permission">> => <<"allow">>,
+                <<"topics">> => [],
+                <<"action">> => <<"all">>
+            }
+        },
+        %% Retain
+        {
+            expected_rule_with_qos_retain([0, 1, 2], true),
+            rule_with_raw_qos_retain(#{<<"retain">> => <<"true">>})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], true),
+            rule_with_raw_qos_retain(#{<<"retain">> => true})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], false),
+            rule_with_raw_qos_retain(#{<<"retain">> => false})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], false),
+            rule_with_raw_qos_retain(#{<<"retain">> => <<"false">>})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], all),
+            rule_with_raw_qos_retain(#{<<"retain">> => <<"all">>})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], all),
+            rule_with_raw_qos_retain(#{<<"retain">> => undefined})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], all),
+            rule_with_raw_qos_retain(#{<<"retain">> => null})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], all),
+            rule_with_raw_qos_retain(#{})
+        },
+        %% Qos
+        {
+            expected_rule_with_qos_retain([2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => <<"2">>})
+        },
+        {
+            expected_rule_with_qos_retain([2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => [<<"2">>]})
+        },
+        {
+            expected_rule_with_qos_retain([1, 2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => <<"1,2">>})
+        },
+        {
+            expected_rule_with_qos_retain([1, 2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => [<<"1">>, <<"2">>]})
+        },
+        {
+            expected_rule_with_qos_retain([1, 2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => [1, 2]})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => undefined})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], all),
+            rule_with_raw_qos_retain(#{<<"qos">> => null})
+        }
+    ].
+
+error_cases() ->
+    [
+        #{
+            <<"permission">> => <<"allo">>,
+            <<"topic">> => <<"a/b/c">>,
+            <<"action">> => <<"publish">>
+        },
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"topic">> => <<"a/b/c">>,
+            <<"action">> => <<"publis">>
+        },
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"topic">> => #{},
+            <<"action">> => <<"publish">>
+        },
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"action">> => <<"publish">>
+        }
+    ].
+
+error_rich_action_cases() ->
+    [
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"topics">> => [],
+            <<"action">> => <<"publish">>,
+            <<"qos">> => 3
+        },
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"topics">> => [],
+            <<"action">> => <<"publish">>,
+            <<"qos">> => <<"three">>
+        },
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"topics">> => [],
+            <<"action">> => <<"publish">>,
+            <<"retain">> => 3
+        }
+    ].
+
+expected_rule_with_qos_retain(QoS, Retain) ->
+    {allow, {publish, [{qos, QoS}, {retain, Retain}]}, []}.
+
+rule_with_raw_qos_retain(Overrides) ->
+    maps:merge(base_raw_rule(), Overrides).
+
+base_raw_rule() ->
+    #{
+        <<"permission">> => <<"allow">>,
+        <<"topics">> => [],
+        <<"action">> => <<"publish">>
+    }.
+
+simple_rule({Pemission, {Action, _Opts}, Topics}) ->
+    {Pemission, Action, Topics}.

--- a/apps/emqx_authz/test/emqx_authz_rule_raw_SUITE.erl
+++ b/apps/emqx_authz/test/emqx_authz_rule_raw_SUITE.erl
@@ -181,6 +181,14 @@ ok_cases() ->
             expected_rule_with_qos_retain([0, 1, 2], all),
             rule_with_raw_qos_retain(#{})
         },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], true),
+            rule_with_raw_qos_retain(#{<<"retain">> => <<"1">>})
+        },
+        {
+            expected_rule_with_qos_retain([0, 1, 2], false),
+            rule_with_raw_qos_retain(#{<<"retain">> => <<"0">>})
+        },
         %% Qos
         {
             expected_rule_with_qos_retain([2], all),
@@ -254,6 +262,12 @@ error_rich_action_cases() ->
             <<"topics">> => [],
             <<"action">> => <<"publish">>,
             <<"retain">> => 3
+        },
+        #{
+            <<"permission">> => <<"allow">>,
+            <<"topics">> => [],
+            <<"action">> => <<"publish">>,
+            <<"qos">> => [<<"3">>]
         }
     ].
 

--- a/apps/emqx_authz/test/emqx_authz_test_lib.erl
+++ b/apps/emqx_authz/test/emqx_authz_test_lib.erl
@@ -107,6 +107,8 @@ run_checks(#{checks := Checks} = Case) ->
         Checks
     ).
 
+run_check(ClientInfo, Fun) when is_function(Fun, 0) ->
+    run_check(ClientInfo, Fun());
 run_check(ClientInfo, {ExpectedPermission, Action, Topic}) ->
     ?assertEqual(
         ExpectedPermission,

--- a/apps/emqx_authz/test/emqx_authz_test_lib.erl
+++ b/apps/emqx_authz/test/emqx_authz_test_lib.erl
@@ -22,8 +22,6 @@
 -compile(nowarn_export_all).
 -compile(export_all).
 
--define(DEFAULT_CHECK_AVAIL_TIMEOUT, 1000).
-
 reset_authorizers() ->
     reset_authorizers(deny, false, []).
 
@@ -53,216 +51,68 @@ setup_config(BaseConfig, SpecialParams) ->
         {error, Reason} -> {error, Reason}
     end.
 
-test_samples(ClientInfo, Samples) ->
+%%--------------------------------------------------------------------
+%% Table-based test helpers
+%%--------------------------------------------------------------------
+
+all_with_table_case(Mod, TableCase, Cases) ->
+    (emqx_common_test_helpers:all(Mod) -- [TableCase]) ++
+        [{group, Name} || Name <- case_names(Cases)].
+
+table_groups(TableCase, Cases) ->
+    [{Name, [], [TableCase]} || Name <- case_names(Cases)].
+
+case_names(Cases) ->
+    lists:map(fun(Case) -> maps:get(name, Case) end, Cases).
+
+get_case(Name, Cases) ->
+    [Case] = [C || C <- Cases, maps:get(name, C) =:= Name],
+    Case.
+
+setup_default_permission(Case) ->
+    DefaultPermission = maps:get(default_permission, Case, deny),
+    emqx_authz_test_lib:reset_authorizers(DefaultPermission, false).
+
+base_client_info() ->
+    #{
+        clientid => <<"clientid">>,
+        username => <<"username">>,
+        peerhost => {127, 0, 0, 1},
+        zone => default,
+        listener => {tcp, default}
+    }.
+
+client_info(Overrides) ->
+    maps:merge(base_client_info(), Overrides).
+
+enable_features(Case) ->
+    Features = maps:get(features, Case, []),
     lists:foreach(
-        fun({Expected, Action, Topic}) ->
-            ct:pal(
-                "client_info: ~p, action: ~p, topic: ~p, expected: ~p",
-                [ClientInfo, Action, Topic, Expected]
-            ),
-            ?assertEqual(
-                Expected,
-                emqx_access_control:authorize(
-                    ClientInfo,
-                    Action,
-                    Topic
-                )
-            )
+        fun(Feature) ->
+            Enable = lists:member(Feature, Features),
+            emqx_authz:set_feature_available(Feature, Enable)
         end,
-        Samples
+        ?AUTHZ_FEATURES
     ).
 
-test_no_topic_rules(ClientInfo, SetupSamples) ->
-    %% No rules
-
-    ok = reset_authorizers(deny, false),
-    ok = SetupSamples(ClientInfo, []),
-
-    ok = test_samples(
-        ClientInfo,
-        [
-            {deny, subscribe, <<"#">>},
-            {deny, subscribe, <<"subs">>},
-            {deny, publish, <<"pub">>}
-        ]
+run_checks(#{checks := Checks} = Case) ->
+    _ = setup_default_permission(Case),
+    _ = enable_features(Case),
+    ClientInfoOverrides = maps:get(client_info, Case, #{}),
+    ClientInfo = client_info(ClientInfoOverrides),
+    lists:foreach(
+        fun(Check) ->
+            run_check(ClientInfo, Check)
+        end,
+        Checks
     ).
 
-test_allow_topic_rules(ClientInfo, SetupSamples) ->
-    Samples = [
-        #{
-            topics => [
-                <<"eq testpub1/${username}">>,
-                <<"testpub2/${clientid}">>,
-                <<"testpub3/#">>
-            ],
-            permission => <<"allow">>,
-            action => <<"publish">>
-        },
-        #{
-            topics => [
-                <<"eq testsub1/${username}">>,
-                <<"testsub2/${clientid}">>,
-                <<"testsub3/#">>
-            ],
-            permission => <<"allow">>,
-            action => <<"subscribe">>
-        },
-
-        #{
-            topics => [
-                <<"eq testall1/${username}">>,
-                <<"testall2/${clientid}">>,
-                <<"testall3/#">>
-            ],
-            permission => <<"allow">>,
-            action => <<"all">>
-        }
-    ],
-
-    ok = reset_authorizers(deny, false),
-    ok = SetupSamples(ClientInfo, Samples),
-
-    ok = test_samples(
-        ClientInfo,
-        [
-            %% Publish rules
-
-            {deny, publish, <<"testpub1/username">>},
-            {allow, publish, <<"testpub1/${username}">>},
-            {allow, publish, <<"testpub2/clientid">>},
-            {allow, publish, <<"testpub3/foobar">>},
-
-            {deny, publish, <<"testpub2/username">>},
-            {deny, publish, <<"testpub1/clientid">>},
-
-            {deny, subscribe, <<"testpub1/username">>},
-            {deny, subscribe, <<"testpub2/clientid">>},
-            {deny, subscribe, <<"testpub3/foobar">>},
-
-            %% Subscribe rules
-
-            {deny, subscribe, <<"testsub1/username">>},
-            {allow, subscribe, <<"testsub1/${username}">>},
-            {allow, subscribe, <<"testsub2/clientid">>},
-            {allow, subscribe, <<"testsub3/foobar">>},
-            {allow, subscribe, <<"testsub3/+/foobar">>},
-            {allow, subscribe, <<"testsub3/#">>},
-
-            {deny, subscribe, <<"testsub2/username">>},
-            {deny, subscribe, <<"testsub1/clientid">>},
-            {deny, subscribe, <<"testsub4/foobar">>},
-            {deny, publish, <<"testsub1/username">>},
-            {deny, publish, <<"testsub2/clientid">>},
-            {deny, publish, <<"testsub3/foobar">>},
-
-            %% All rules
-
-            {deny, subscribe, <<"testall1/username">>},
-            {allow, subscribe, <<"testall1/${username}">>},
-            {allow, subscribe, <<"testall2/clientid">>},
-            {allow, subscribe, <<"testall3/foobar">>},
-            {allow, subscribe, <<"testall3/+/foobar">>},
-            {allow, subscribe, <<"testall3/#">>},
-            {deny, publish, <<"testall1/username">>},
-            {allow, publish, <<"testall1/${username}">>},
-            {allow, publish, <<"testall2/clientid">>},
-            {allow, publish, <<"testall3/foobar">>},
-
-            {deny, subscribe, <<"testall2/username">>},
-            {deny, subscribe, <<"testall1/clientid">>},
-            {deny, subscribe, <<"testall4/foobar">>},
-            {deny, publish, <<"testall2/username">>},
-            {deny, publish, <<"testall1/clientid">>},
-            {deny, publish, <<"testall4/foobar">>}
-        ]
-    ).
-
-test_deny_topic_rules(ClientInfo, SetupSamples) ->
-    Samples = [
-        #{
-            topics => [
-                <<"eq testpub1/${username}">>,
-                <<"testpub2/${clientid}">>,
-                <<"testpub3/#">>
-            ],
-            permission => <<"deny">>,
-            action => <<"publish">>
-        },
-        #{
-            topics => [
-                <<"eq testsub1/${username}">>,
-                <<"testsub2/${clientid}">>,
-                <<"testsub3/#">>
-            ],
-            permission => <<"deny">>,
-            action => <<"subscribe">>
-        },
-
-        #{
-            topics => [
-                <<"eq testall1/${username}">>,
-                <<"testall2/${clientid}">>,
-                <<"testall3/#">>
-            ],
-            permission => <<"deny">>,
-            action => <<"all">>
-        }
-    ],
-
-    ok = reset_authorizers(allow, false),
-    ok = SetupSamples(ClientInfo, Samples),
-
-    ok = test_samples(
-        ClientInfo,
-        [
-            %% Publish rules
-
-            {allow, publish, <<"testpub1/username">>},
-            {deny, publish, <<"testpub1/${username}">>},
-            {deny, publish, <<"testpub2/clientid">>},
-            {deny, publish, <<"testpub3/foobar">>},
-
-            {allow, publish, <<"testpub2/username">>},
-            {allow, publish, <<"testpub1/clientid">>},
-
-            {allow, subscribe, <<"testpub1/username">>},
-            {allow, subscribe, <<"testpub2/clientid">>},
-            {allow, subscribe, <<"testpub3/foobar">>},
-
-            %% Subscribe rules
-
-            {allow, subscribe, <<"testsub1/username">>},
-            {deny, subscribe, <<"testsub1/${username}">>},
-            {deny, subscribe, <<"testsub2/clientid">>},
-            {deny, subscribe, <<"testsub3/foobar">>},
-            {deny, subscribe, <<"testsub3/+/foobar">>},
-            {deny, subscribe, <<"testsub3/#">>},
-
-            {allow, subscribe, <<"testsub2/username">>},
-            {allow, subscribe, <<"testsub1/clientid">>},
-            {allow, subscribe, <<"testsub4/foobar">>},
-            {allow, publish, <<"testsub1/username">>},
-            {allow, publish, <<"testsub2/clientid">>},
-            {allow, publish, <<"testsub3/foobar">>},
-
-            %% All rules
-
-            {allow, subscribe, <<"testall1/username">>},
-            {deny, subscribe, <<"testall1/${username}">>},
-            {deny, subscribe, <<"testall2/clientid">>},
-            {deny, subscribe, <<"testall3/foobar">>},
-            {deny, subscribe, <<"testall3/+/foobar">>},
-            {deny, subscribe, <<"testall3/#">>},
-            {allow, publish, <<"testall1/username">>},
-            {deny, publish, <<"testall1/${username}">>},
-            {deny, publish, <<"testall2/clientid">>},
-            {deny, publish, <<"testall3/foobar">>},
-
-            {allow, subscribe, <<"testall2/username">>},
-            {allow, subscribe, <<"testall1/clientid">>},
-            {allow, subscribe, <<"testall4/foobar">>},
-            {allow, publish, <<"testall2/username">>},
-            {allow, publish, <<"testall1/clientid">>},
-            {allow, publish, <<"testall4/foobar">>}
-        ]
+run_check(ClientInfo, {ExpectedPermission, Action, Topic}) ->
+    ?assertEqual(
+        ExpectedPermission,
+        emqx_access_control:authorize(
+            ClientInfo,
+            Action,
+            Topic
+        )
     ).

--- a/apps/emqx_exhook/src/emqx_exhook.app.src
+++ b/apps/emqx_exhook/src/emqx_exhook.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_exhook, [
     {description, "EMQX Extension for Hook"},
-    {vsn, "5.0.13"},
+    {vsn, "5.0.14"},
     {modules, []},
     {registered, []},
     {mod, {emqx_exhook_app, []}},

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -16,9 +16,9 @@
 
 -module(emqx_exhook_handler).
 
--include("emqx_exhook.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 
 -export([
     on_client_connect/2,
@@ -132,12 +132,13 @@ on_client_authenticate(ClientInfo, AuthResult) ->
             {ok, AuthResult}
     end.
 
-on_client_authorize(ClientInfo, PubSub, Topic, Result) ->
+on_client_authorize(ClientInfo, Action, Topic, Result) ->
     Bool = maps:get(result, Result, deny) == allow,
+    %% TODO: Support full action in major release
     Type =
-        case PubSub of
-            publish -> 'PUBLISH';
-            subscribe -> 'SUBSCRIBE'
+        case Action of
+            ?authz_action(publish) -> 'PUBLISH';
+            ?authz_action(subscribe) -> 'SUBSCRIBE'
         end,
     Req = #{
         clientinfo => clientinfo(ClientInfo),

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -19,7 +19,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include("emqx_exhook.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
@@ -126,7 +126,7 @@ t_access_failed_if_no_server_running(Config) ->
         allow,
         emqx_access_control:authorize(
             ClientInfo#{username => <<"gooduser">>},
-            publish,
+            ?AUTHZ_PUBLISH,
             <<"acl/1">>
         )
     ),
@@ -135,7 +135,7 @@ t_access_failed_if_no_server_running(Config) ->
         deny,
         emqx_access_control:authorize(
             ClientInfo#{username => <<"baduser">>},
-            publish,
+            ?AUTHZ_PUBLISH,
             <<"acl/2">>
         )
     ),
@@ -148,7 +148,7 @@ t_access_failed_if_no_server_running(Config) ->
 
     ?assertMatch(
         {stop, #{result := deny, from := exhook}},
-        emqx_exhook_handler:on_client_authorize(ClientInfo, publish, <<"t/1">>, #{
+        emqx_exhook_handler:on_client_authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t/1">>, #{
             result => allow, from => exhook
         })
     ),

--- a/apps/emqx_exhook/test/props/prop_exhook_hooks.erl
+++ b/apps/emqx_exhook/test/props/prop_exhook_hooks.erl
@@ -18,6 +18,7 @@
 
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 
 -import(
     emqx_proper_types,
@@ -29,7 +30,8 @@
         connack_return_code/0,
         topictab/0,
         topic/0,
-        subopts/0
+        subopts/0,
+        pubsub/0
     ]
 ).
 
@@ -138,7 +140,7 @@ prop_client_authorize() ->
         {ClientInfo0, PubSub, Topic, Result, Meta},
         {
             clientinfo(),
-            oneof([publish, subscribe]),
+            pubsub(),
             topic(),
             oneof([MkResult(allow), MkResult(deny)]),
             request_meta()
@@ -554,8 +556,8 @@ authresult_to_bool(AuthResult) ->
 aclresult_to_bool(#{result := Result}) ->
     Result == allow.
 
-pubsub_to_enum(publish) -> 'PUBLISH';
-pubsub_to_enum(subscribe) -> 'SUBSCRIBE'.
+pubsub_to_enum(?authz_action(publish)) -> 'PUBLISH';
+pubsub_to_enum(?authz_action(subscribe)) -> 'SUBSCRIBE'.
 
 from_conninfo(ConnInfo) ->
     #{

--- a/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
+++ b/apps/emqx_gateway/src/bhvrs/emqx_gateway_conn.erl
@@ -715,13 +715,13 @@ parse_incoming(
             NState = State#state{parse_state = NParseState},
             parse_incoming(Rest, [Packet | Packets], NState)
     catch
-        error:Reason:Stk ->
+        error:Reason:Stack ->
             ?SLOG(error, #{
                 msg => "parse_frame_failed",
                 at_state => ParseState,
                 input_bytes => Data,
                 reason => Reason,
-                stacktrace => Stk
+                stacktrace => Stack
             }),
             {[{frame_error, Reason} | Packets], State}
     end.

--- a/apps/emqx_gateway/src/emqx_gateway_ctx.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_ctx.erl
@@ -162,8 +162,8 @@ connection_closed(_Ctx = #{gwname := GwName}, ClientId) ->
     emqx_types:topic()
 ) ->
     allow | deny.
-authorize(_Ctx, ClientInfo, PubSub, Topic) ->
-    emqx_access_control:authorize(ClientInfo, PubSub, Topic).
+authorize(_Ctx, ClientInfo, Action, Topic) ->
+    emqx_access_control:authorize(ClientInfo, Action, Topic).
 
 metrics_inc(_Ctx = #{gwname := GwName}, Name) ->
     emqx_gateway_metrics:inc(GwName, Name).

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -47,9 +47,6 @@
 
 -include("emqx_coap.hrl").
 -include_lib("emqx/include/logger.hrl").
--include_lib("emqx/include/emqx_authentication.hrl").
-
--define(AUTHN, ?EMQX_AUTHENTICATION_CONFIG_ROOT_NAME_ATOM).
 
 -record(channel, {
     %% Context
@@ -166,8 +163,8 @@ init(
         conn_state = idle
     }.
 
-validator(Type, Topic, Ctx, ClientInfo) ->
-    emqx_gateway_ctx:authorize(Ctx, ClientInfo, Type, Topic).
+validator(Action, Topic, Ctx, ClientInfo) ->
+    emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic).
 
 -spec send_request(pid(), coap_message()) -> any().
 send_request(Channel, Request) ->

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -59,15 +59,14 @@ init_per_suite(Config) ->
     application:load(emqx_gateway_coap),
     ok = emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
     emqx_mgmt_api_test_util:init_suite([emqx_conf, emqx_authn, emqx_gateway]),
-    ok = meck:new(emqx_access_control, [passthrough, no_history, no_link]),
     Config.
 
 end_per_suite(_) ->
-    meck:unload(emqx_access_control),
     {ok, _} = emqx:remove_config([<<"gateway">>, <<"coap">>]),
     emqx_mgmt_api_test_util:end_suite([emqx_gateway, emqx_authn, emqx_conf]).
 
 init_per_testcase(t_connection_with_authn_failed, Config) ->
+    ok = meck:new(emqx_access_control, [passthrough]),
     ok = meck:expect(
         emqx_access_control,
         authenticate,
@@ -75,12 +74,11 @@ init_per_testcase(t_connection_with_authn_failed, Config) ->
     ),
     Config;
 init_per_testcase(_, Config) ->
+    ok = meck:new(emqx_access_control, [passthrough]),
     Config.
 
-end_per_testcase(t_connection_with_authn_failed, Config) ->
-    ok = meck:delete(emqx_access_control, authenticate, 1),
-    Config;
 end_per_testcase(_, Config) ->
+    ok = meck:unload(emqx_access_control),
     Config.
 
 default_config() ->
@@ -212,6 +210,38 @@ t_publish(_) ->
         end
     end,
     with_connection(Topics, Action).
+
+t_publish_with_retain_qos_expiry(_) ->
+    _ = meck:expect(
+        emqx_access_control,
+        authorize,
+        fun(_, #{action_type := publish, qos := 1, retain := true}, _) ->
+            allow
+        end
+    ),
+
+    Topics = [<<"abc">>],
+    Action = fun(Topic, Channel, Token) ->
+        Payload = <<"123">>,
+        URI = pubsub_uri(binary_to_list(Topic), Token) ++ "&retain=true&qos=1&expiry=60",
+
+        %% Sub topic first
+        emqx:subscribe(Topic),
+
+        Req = make_req(post, Payload),
+        {ok, changed, _} = do_request(Channel, URI, Req),
+
+        receive
+            {deliver, Topic, Msg} ->
+                ?assertEqual(Topic, Msg#message.topic),
+                ?assertEqual(Payload, Msg#message.payload)
+        after 500 ->
+            ?assert(false)
+        end
+    end,
+    with_connection(Topics, Action),
+
+    _ = meck:validate(emqx_access_control).
 
 t_subscribe(_) ->
     %% can subscribe to a normal topic

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_channel.erl
@@ -19,6 +19,7 @@
 -include("emqx_exproto.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 
@@ -428,7 +429,8 @@ handle_call(
         clientinfo = ClientInfo
     }
 ) ->
-    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, subscribe, TopicFilter) of
+    Action = ?AUTHZ_SUBSCRIBE(Qos),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, TopicFilter) of
         deny ->
             {reply, {error, ?RESP_PERMISSION_DENY, <<"Authorization deny">>}, Channel};
         _ ->
@@ -464,7 +466,8 @@ handle_call(
                 }
     }
 ) ->
-    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, publish, Topic) of
+    Action = ?AUTHZ_PUBLISH(Qos),
+    case emqx_gateway_ctx:authorize(Ctx, ClientInfo, Action, Topic) of
         deny ->
             {reply, {error, ?RESP_PERMISSION_DENY, <<"Authorization deny">>}, Channel};
         _ ->

--- a/apps/emqx_gateway_mqttsn/src/emqx_gateway_mqttsn.app.src
+++ b/apps/emqx_gateway_mqttsn/src/emqx_gateway_mqttsn.app.src
@@ -1,6 +1,6 @@
 {application, emqx_gateway_mqttsn, [
     {description, "MQTT-SN Gateway"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_mysql/src/emqx_mysql.app.src
+++ b/apps/emqx_mysql/src/emqx_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mysql, [
     {description, "EMQX MySQL Database Connector"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -361,7 +361,7 @@ prepare_sql_to_conn(Conn, [{Key, SQL} | PrepareList]) when is_pid(Conn) ->
             ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
             {error, undefined_table};
         {error, Reason} ->
-            % FIXME: we should try to differ on transient failers and
+            % FIXME: we should try to differ on transient failures and
             % syntax failures. Retrying syntax failures is not very productive.
             ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
             {error, Reason}

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.20"},
+    {vsn, "5.0.21"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl, uuid]},

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -20,6 +20,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx_bridge/include/emqx_bridge_resource.hrl").
 
 -export([
@@ -160,7 +161,10 @@ on_client_connack(ConnInfo, Reason, _, Conf) ->
         Conf
     ).
 
-on_client_check_authz_complete(ClientInfo, PubSub, Topic, Result, AuthzSource, Conf) ->
+%% TODO: support full action in major release
+on_client_check_authz_complete(
+    ClientInfo, ?authz_action(PubSub), Topic, Result, AuthzSource, Conf
+) ->
     apply_event(
         'client.check_authz_complete',
         fun() ->

--- a/changes/ee/feat-11132.en.md
+++ b/changes/ee/feat-11132.en.md
@@ -1,0 +1,2 @@
+Add support for MQTT action authorization based on QoS level and Retain flag values.
+Now, EMQX can check by ACL whether a client has permission to publish/subscribe using a specified QoS level and to use retained messages.

--- a/rel/i18n/emqx_authz_api_mnesia.hocon
+++ b/rel/i18n/emqx_authz_api_mnesia.hocon
@@ -1,9 +1,19 @@
 emqx_authz_api_mnesia {
 
 action.desc:
-"""Authorized action (pub/sub/all)"""
+"""Authorized action (publish/subscribe/all)"""
 action.label:
 """action"""
+
+qos.desc:
+"""QoS of authorized action"""
+qos.label:
+"""QoS"""
+
+retain.desc:
+"""Retain flag of authorized action"""
+retain.label:
+"""retain"""
 
 clientid.desc:
 """ClientID"""


### PR DESCRIPTION
Fixes [EMQX-9766](https://emqx.atlassian.net/browse/EMQX-9766)

## Problem

We have to control whether a client can write retain messages or subscribe/publish using certain QoS levels.

## Current model

In authz, we have
* *subjects* — "who" makes a request/action
* *permissions* — resolution whether to allow an action or not, `allow` and `deny`
* *resources* — "what" is allowed. We have resources split into `topic` and `action` (publish, subscribe, all)

## New model

The current model is not very extensible. We have hotwired primitive types for all resources. We need to extend the model to support more complex resources.

Since the topic is considered to be more or less "constant" data-like structure (e.g. different clients may subscribe the same topic in a different manner), we choose to extend the `action` part of the resource.
This also more or less reflects the MQTT protocol itself, where the QoS/Retain are a part of the PUBLISH/SUBSCRIBE packet: different clients subscribe differently to the same topic.

### Internal model

Internally we extend the signature of the `emqx_access_control:authorize/3` callback.
From
```erlang
-type pubsub() :: publish | subscribe.
...
-spec authorize(emqx_types:clientinfo(), emqx_types:pubsub(), emqx_types:topic()) ->
    allow | deny.
```

To
```erlang
-type pubsub() ::
    #{action_type := subscribe, qos := qos()}
    | #{action_type := publish, qos := qos(), retain := boolean()}.
...
-spec authorize(emqx_types:clientinfo(), emqx_types:pubsub(), emqx_types:topic()) ->
    allow | deny.
```

Thus, we make `emqx_types:pubsub()` extensible if needed.

We update all the entry points (including gateways) to pass the new extended action to the `authorize/3` function.

### External model

That is, how the user will configure the authorization rules.

We now explicitly differentiate between three types of rules:
* `raw` rules: rules obtained as plain data structures from a database or API, having the format like:
```erlang
#{
    <<"permission">> => <<"allow">>,
    <<"topic">> => <<"a/b/c">>,
    <<"action">> => <<"subscribe">>,
    <<"retain">> => <<"true">>,
    <<"qos">> => <<"1,2">>
}
%% or
#{
    <<"permission">> => <<"allow">>,
    <<"topic">> => [<<"a/b/c">>, <<"d">>],
    <<"action">> => <<"subscribe">>,
    <<"retain">> => <<"true">>,
    <<"qos">> => [1, 2]
}
...
```
We have a module `emqx_authz_rule_raw` to convert between `raw` and `dsl` rules.
* `dsl` rules: rules described with Erlang data structures. They are used by `mnesia` and `file` backends.
We use `emqx_authz_rule` to convert from `dsl` to `compiled` rules.
* `compiled` rules: slightly converter `dsl` rules, used for final matching.

We refactor the backends to utilize the common parser and validator of `raw` rules.

## Test refactoring

Previous test implementation was not very flexible and was not able to test the new model.
The problem was that the test both "inserted" the test data into a database and then also "queried" the database to check the results. However, many bugs may come from how the data is inserted into the database in the wild, because this is the part that is more likely to be customized by the user.

So we refactor the tests to be more like authn tests, where for each test we have its own storage schema and inserted data.
Example:
```erlang
...
#{
    name => qos_retain_in_query_result_as_integer,
    setup => [
        "CREATE TABLE acl(username VARCHAR(255), topic VARCHAR(255), "
        "permission VARCHAR(255), action VARCHAR(255),"
        "qos_i VARCHAR(255), retain_i VARCHAR(255))",

        "INSERT INTO acl(username, topic, permission, action, qos_i, retain_i)"
        " VALUES('username', 't1', 'allow', 'publish', 1, 1)"
    ],
    query =>
        "SELECT permission, action, topic, qos_i as qos, retain_i as retain"
        " FROM acl WHERE username = ${username}",
    client_info => #{
        username => <<"username">>
    },
    checks => [
        {allow, ?PUBLISH_ACTION(1, true), <<"t1">>},
        {deny, ?PUBLISH_ACTION(1, false), <<"t1">>},
        {deny, ?PUBLISH_ACTION(0, true), <<"t1">>}
    ]
},
...
```
Here we explicitly check that `retain` flag stored as an integer is handled correctly.


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d49e101</samp>

This pull request enhances the authorization logic and features of the EMQ X broker by adding support for QoS and retain properties in the publish action, and by refactoring and improving the code quality and compatibility of the authorization modules and test suites. It also introduces a new placeholder for the retain flag, a new module for parsing and formatting raw rules, and some new macros and types for the action conditions. The pull request affects several files in the `apps/emqx_authz` and `apps/emqx` directories.

## PR Checklist

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up: [EMQX-10404](https://emqx.atlassian.net/browse/EMQX-10404) 
- [x] Schema changes are backward compatible

