### PR TITLE
fix: mask the value of the authorization header whatever its case

### DIFF
--- a/changes/ce/fix-11134.en.md
+++ b/changes/ce/fix-11134.en.md
@@ -1,0 +1,1 @@
+Fix the value of the uppercase `authorization` header is not obfuscated.


### PR DESCRIPTION
Fixes [EMQX-10629](https://emqx.atlassian.net/browse/EMQX-10269) 

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d485f8f</samp>

Enhance `is_sensitive_key` function to filter out authorization header. Add test case for `emqx_utils.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
