### PR TITLE
fix: update cluster.conf's k8s default api_server value

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -375,7 +375,7 @@ fields(cluster_k8s) ->
             sc(
                 string(),
                 #{
-                    default => <<"http://10.110.111.204:8080">>,
+                    default => <<"https://kubernetes.default.svc:443">>,
                     desc => ?DESC(cluster_k8s_apiserver),
                     'readOnly' => true
                 }

--- a/changes/ce/feat-11138.en.md
+++ b/changes/ce/feat-11138.en.md
@@ -1,0 +1,4 @@
+- Change k8s `api_server` default value from `http://127.0.0.1:9091` to `https://kubernetes.default.svc:443`
+- `emqx_ctl conf show cluster` no longer displays irrelevant configuration items, such as when `discovery_strategy=static`,
+it will not display configuration information related to `etcd/k8s/dns`.
+- Remove `zones`(deprecated config key) from `emqx_ctl conf show_keys`


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10249

1. Change  k8s default api_server from `http://127.0.0.1:9091` to `https://kubernetes.default.svc:443`;
2. `emqx_ctl conf show cluster` no longer displays irrelevant configuration items, such as when `discovery_strategy=static`, it will not display configuration information related to `etcd/k8s/dns`.
3. Hide zones(deprecated config key) from `emqx_ctl conf show_keys`

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 15c4fc6</samp>

Fixed a bug and improved performance of the `conf show` CLI command in `emqx_conf_cli.erl`. Changed the default value of the `cluster.k8s.apiserver` option in `emqx_conf_schema.erl` to match the standard Kubernetes service address.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
