### PR TITLE
feat: hide node.process_limit

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -65,6 +65,8 @@
     emqx_slow_subs_schema,
     emqx_mgmt_api_key_schema
 ]).
+%% 1 million default ports counter
+-define(DEFAULT_MAX_PORTS, 1024 * 1024).
 
 %% root config should not have a namespace
 namespace() -> undefined.
@@ -83,7 +85,10 @@ roots() ->
             {"node",
                 sc(
                     ?R_REF("node"),
-                    #{translate_to => ["emqx"]}
+                    #{
+                        translate_to => ["emqx"],
+                        converter => fun node_converter/2
+                    }
                 )},
             {"cluster",
                 sc(
@@ -441,8 +446,8 @@ fields("node") ->
                 #{
                     mapping => "vm_args.+P",
                     desc => ?DESC(process_limit),
-                    default => 2097152,
-                    importance => ?IMPORTANCE_MEDIUM,
+                    default => ?DEFAULT_MAX_PORTS * 2,
+                    importance => ?IMPORTANCE_HIDDEN,
                     'readOnly' => true
                 }
             )},
@@ -452,7 +457,7 @@ fields("node") ->
                 #{
                     mapping => "vm_args.+Q",
                     desc => ?DESC(max_ports),
-                    default => 1048576,
+                    default => ?DEFAULT_MAX_PORTS,
                     importance => ?IMPORTANCE_HIGH,
                     'readOnly' => true
                 }
@@ -1388,3 +1393,10 @@ ensure_unicode_path(Path, _) when is_list(Path) ->
     Path;
 ensure_unicode_path(Path, _) ->
     throw({"not_string", Path}).
+
+node_converter(#{<<"process_limit">> := _} = Conf, _Opts) ->
+    Conf;
+node_converter(#{<<"max_ports">> := MaxPorts} = Conf, _Opts) ->
+    Conf#{<<"process_limit">> => MaxPorts * 2};
+node_converter(Conf, _Opts) ->
+    Conf.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10248

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b4ae426</samp>

This pull request enhances the `node` configuration schema with a macro and a converter function to dynamically set and tune the `max_ports` and `process_limit` options for the Erlang VM. These options affect the performance and stability of the EMQ X broker.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
