### PR TITLE
test(ft): set safer suite-wide timetraps in cluster-related suites

### DIFF
--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -61,6 +61,9 @@ groups() ->
         ]}
     ].
 
+suite() ->
+    [{timetrap, {seconds, 90}}].
+
 init_per_suite(Config) ->
     ok = emqx_common_test_helpers:start_apps([emqx_ft], set_special_configs(Config)),
     Config.

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -38,6 +38,9 @@ groups() ->
         {cluster, [], emqx_common_test_helpers:all(?MODULE)}
     ].
 
+suite() ->
+    [{timetrap, {seconds, 90}}].
+
 init_per_suite(Config) ->
     ok = emqx_mgmt_api_test_util:init_suite(
         [emqx_conf, emqx_ft], emqx_ft_test_helpers:env_handler(Config)


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dc63113</samp>

Add timetrap options to two test suites for emqx_ft feature. The timetrap options set a timeout for each test case to avoid hanging or slow tests.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [ ] ~~Schema changes are backward compatible~~
