### PR TITLE
fix(emqx_conf): don't sync the MFA to a leaved node

### DIFF
--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -145,6 +145,8 @@ jobs:
 
   pgsql_authn_authz:
     runs-on: ubuntu-22.04
+    env:
+      _EMQX_DOCKER_IMAGE_TAG: emqx/emqx:${{ needs.build_emqx_for_jmeter_tests.outputs.version }}
 
     strategy:
       fail-fast: false
@@ -175,7 +177,6 @@ jobs:
     - name: docker compose up
       timeout-minutes: 5
       env:
-        _EMQX_DOCKER_IMAGE_TAG: emqx/emqx:${{ needs.build_emqx_for_jmeter_tests.outputs.version }}
         PGSQL_TAG: ${{ matrix.pgsql_tag }}
       run: |
         docker-compose \
@@ -246,6 +247,10 @@ jobs:
           echo "check logs failed"
           exit 1
         fi
+    - name: dump docker compose logs
+      if: failure()
+      run: |
+        docker-compose -f .ci/docker-compose-file/docker-compose-emqx-cluster.yaml logs --no-color > ./jmeter_logs/emqx.log
     - uses: actions/upload-artifact@v3
       if: always()
       with:

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -27,7 +27,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.4"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.5"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.10"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.2"}}},

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -28,7 +28,8 @@
     reset/0,
     status/0,
     skip_failed_commit/1,
-    fast_forward_to_commit/2
+    fast_forward_to_commit/2,
+    on_leave/0
 ]).
 -export([
     commit/2,
@@ -40,7 +41,8 @@
     make_initiate_call_req/3,
     read_next_mfa/1,
     trans_query/1,
-    trans_status/0
+    trans_status/0,
+    on_leave_clean/0
 ]).
 
 -export([
@@ -211,6 +213,9 @@ reset() -> gen_server:call(?MODULE, reset).
 status() ->
     transaction(fun ?MODULE:trans_status/0, []).
 
+on_leave_clean() ->
+    mnesia:delete({?CLUSTER_COMMIT, node()}).
+
 -spec latest_tnx_id() -> pos_integer().
 latest_tnx_id() ->
     {atomic, TnxId} = transaction(fun ?MODULE:get_cluster_tnx_id/0, []),
@@ -264,6 +269,10 @@ skip_failed_commit(Node) ->
 -spec fast_forward_to_commit(node(), pos_integer()) -> pos_integer().
 fast_forward_to_commit(Node, ToTnxId) ->
     gen_server:call({?MODULE, Node}, {fast_forward_to_commit, ToTnxId}).
+
+%% It is necessary to clean this node commit record in the cluster
+on_leave() ->
+    gen_server:call(?MODULE, on_leave).
 %%%===================================================================
 %%% gen_server callbacks
 %%%===================================================================
@@ -271,7 +280,7 @@ fast_forward_to_commit(Node, ToTnxId) ->
 %% @private
 init([Node, RetryMs]) ->
     {ok, _} = mnesia:subscribe({table, ?CLUSTER_MFA, simple}),
-    State = #{node => Node, retry_interval => RetryMs},
+    State = #{node => Node, retry_interval => RetryMs, is_leaving => false},
     %% The init transaction ID is set in emqx_conf_app after
     %% it has fetched the latest config from one of the core nodes
     TnxId = emqx_app:get_init_tnx_id(),
@@ -306,6 +315,9 @@ handle_call(skip_failed_commit, _From, State = #{node := Node}) ->
 handle_call({fast_forward_to_commit, ToTnxId}, _From, State) ->
     NodeId = do_fast_forward_to_commit(ToTnxId, State),
     {reply, NodeId, State, catch_up(State)};
+handle_call(on_leave, _From, State) ->
+    {atomic, ok} = transaction(fun ?MODULE:on_leave_clean/0, []),
+    {reply, ok, State#{is_leaving := true}};
 handle_call(_, _From, State) ->
     {reply, ok, State, catch_up(State)}.
 
@@ -328,7 +340,7 @@ code_change(_OldVsn, State, _Extra) ->
 %%%===================================================================
 catch_up(State) -> catch_up(State, false).
 
-catch_up(#{node := Node, retry_interval := RetryMs} = State, SkipResult) ->
+catch_up(#{node := Node, retry_interval := RetryMs, is_leaving := false} = State, SkipResult) ->
     case transaction(fun ?MODULE:read_next_mfa/1, [Node]) of
         {atomic, caught_up} ->
             ?TIMEOUT;
@@ -353,7 +365,10 @@ catch_up(#{node := Node, retry_interval := RetryMs} = State, SkipResult) ->
         {aborted, Reason} ->
             ?SLOG(error, #{msg => "read_next_mfa_transaction_failed", error => Reason}),
             RetryMs
-    end.
+    end;
+catch_up(#{is_leaving := true}, _SkipResult) ->
+    ?SLOG(info, #{msg => "ignore_mfa_transactions", reason => "Node is in leaving"}),
+    ?TIMEOUT.
 
 read_next_mfa(Node) ->
     NextId =

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -120,6 +120,7 @@ cluster(["join", SNode]) ->
             emqx_ctl:print("Failed to join the cluster: ~0p~n", [Error])
     end;
 cluster(["leave"]) ->
+    emqx_cluster_rpc:on_leave(),
     case ekka:leave() of
         ok ->
             emqx_ctl:print("Leave the cluster successfully.~n"),

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -120,7 +120,6 @@ cluster(["join", SNode]) ->
             emqx_ctl:print("Failed to join the cluster: ~0p~n", [Error])
     end;
 cluster(["leave"]) ->
-    emqx_cluster_rpc:on_leave(),
     case ekka:leave() of
         ok ->
             emqx_ctl:print("Leave the cluster successfully.~n"),

--- a/changes/ce/fix-11148.en.md
+++ b/changes/ce/fix-11148.en.md
@@ -1,0 +1,1 @@
+Fix when a node has left the cluster, other nodes still try to synchronize configuration update operations to it.

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule EMQXUmbrella.MixProject do
       {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true},
       {:esockd, github: "emqx/esockd", tag: "5.9.6", override: true},
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.7.2-emqx-11", override: true},
-      {:ekka, github: "emqx/ekka", tag: "0.15.4", override: true},
+      {:ekka, github: "emqx/ekka", tag: "0.15.5", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.8", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.3.11", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -62,7 +62,7 @@
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.6"}}}
     , {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.7.2-emqx-11"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.4"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.5"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
     , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.8"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.11"}}}


### PR DESCRIPTION
Fixes [EMQX-10113](https://emqx.atlassian.net/browse/EMQX-10113)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7de4ef6</samp>

Added a feature to clean up cluster configuration commit records when a node leaves the cluster. Invoked this feature in the `leave` CLI command.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
