### PR TITLE
fix(emqx_psk): wait for Mria table on app start

### DIFF
--- a/apps/emqx_machine/src/emqx_machine.app.src
+++ b/apps/emqx_machine/src/emqx_machine.app.src
@@ -3,7 +3,7 @@
     {id, "emqx_machine"},
     {description, "The EMQX Machine"},
     % strict semver, bump manually!
-    {vsn, "0.2.6"},
+    {vsn, "0.2.7"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -144,7 +144,8 @@ basic_reboot_apps() ->
             emqx_authz,
             emqx_slow_subs,
             emqx_auto_subscribe,
-            emqx_plugins
+            emqx_plugins,
+            emqx_psk
         ] ++ basic_reboot_apps_edition(emqx_release:edition()).
 
 basic_reboot_apps_edition(ce) ->

--- a/apps/emqx_psk/include/emqx_psk.hrl
+++ b/apps/emqx_psk/include/emqx_psk.hrl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -14,21 +14,6 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_psk_app).
+-define(TAB, emqx_psk).
 
--behaviour(application).
-
--export([
-    start/2,
-    stop/1
-]).
-
--include("emqx_psk.hrl").
-
-start(_Type, _Args) ->
-    ok = mria:wait_for_tables([?TAB]),
-    {ok, Sup} = emqx_psk_sup:start_link(),
-    {ok, Sup}.
-
-stop(_State) ->
-    ok.
+-define(PSK_SHARD, emqx_psk_shard).

--- a/apps/emqx_psk/src/emqx_psk.app.src
+++ b/apps/emqx_psk/src/emqx_psk.app.src
@@ -2,7 +2,7 @@
 {application, emqx_psk, [
     {description, "EMQX PSK"},
     % strict semver, bump manually!
-    {vsn, "5.0.2"},
+    {vsn, "5.0.3"},
     {modules, []},
     {registered, [emqx_psk_sup]},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_psk/src/emqx_psk.erl
+++ b/apps/emqx_psk/src/emqx_psk.erl
@@ -66,8 +66,7 @@
 
 -boot_mnesia({mnesia, [boot]}).
 
--define(TAB, ?MODULE).
--define(PSK_SHARD, emqx_psk_shard).
+-include("emqx_psk.hrl").
 
 -define(DEFAULT_DELIMITER, <<":">>).
 

--- a/changes/ce/fix-11150.en.md
+++ b/changes/ce/fix-11150.en.md
@@ -1,0 +1,2 @@
+Wait for Mria table when emqx_psk app is being started to ensure that
+PSK data is synced to replicant nodes even if they don't have init PSK file.


### PR DESCRIPTION
This ensures emqx_psk table is synced to a replicant even if it doesn't have init psk file.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3eca80e</samp>

This pull request adds the emqx_psk application as a dependency of the emqx_machine application, and updates the versions and code of both applications. The emqx_psk application provides the functionality of pre-shared keys (PSK) for MQTT connections.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
