### PR TITLE
fix(mongodb): hide `topology.pool_size` and fix it at 1

### DIFF
--- a/changes/ee/fix-11163.en.md
+++ b/changes/ee/fix-11163.en.md
@@ -1,0 +1,1 @@
+Fixed `topology.pool_size = 1` and hid such option from users for MondoDB bridges to avoid confusion.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10408

From an old conversation with @kjellwinblad:

> There are 3 pool_sizes
> - The buffer workers pool size, just exposed here: https://github.com/emqx/emqx/pull/9742
> - The topology.pool_size, which controls the pool size for the poolboy_pool in Kjell's
  diagram (on mongodb's side).
> - The pool_size from emqx_connector_mongo:mongo_fields that controls the ecpool pool
  size (on EMQX's side).
> So we actually want to set topology.pool_size = 1 and hide it from users.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 40aecf4</samp>

Hide `pool_size` option and set it to 1 for MongoDB plugin. This avoids confusion and improves compatibility with the MongoDB driver.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [na] Added tests for the changes
- [na] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
