### PR TITLE
fix(placeholder): add back support for nested keys inside binary encoded json

### DIFF
--- a/apps/emqx_utils/src/emqx_placeholder.erl
+++ b/apps/emqx_utils/src/emqx_placeholder.erl
@@ -257,7 +257,14 @@ quote_mysql(Str) ->
 
 lookup_var(Var, Value) when Var == ?PH_VAR_THIS orelse Var == [] ->
     Value;
-lookup_var([Prop | Rest], Data) ->
+lookup_var([Prop | Rest], Data0) ->
+    Data =
+        case emqx_utils_json:safe_decode(Data0, [return_maps]) of
+            {ok, Data1} ->
+                Data1;
+            {error, _} ->
+                Data0
+        end,
     case lookup(Prop, Data) of
         {ok, Value} ->
             lookup_var(Rest, Value);

--- a/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
@@ -39,6 +39,15 @@ t_proc_tmpl_path(_) ->
         emqx_placeholder:proc_tmpl(Tks, Selected)
     ).
 
+t_proc_tmpl_path_encoded_json(_) ->
+    %% when we receive a message from the rule engine, it is a map with an encoded payload
+    Selected = #{payload => emqx_utils_json:encode(#{d1 => #{d2 => <<"hi">>}})},
+    Tks = emqx_placeholder:preproc_tmpl(<<"payload.d1.d2:${payload.d1.d2}">>),
+    ?assertEqual(
+        <<"payload.d1.d2:hi">>,
+        emqx_placeholder:proc_tmpl(Tks, Selected)
+    ).
+
 t_proc_tmpl_custom_ph(_) ->
     Selected = #{a => <<"a">>, b => <<"b">>},
     Tks = emqx_placeholder:preproc_tmpl(<<"a:${a},b:${b}">>, #{placeholders => [<<"${a}">>]}),

--- a/changes/ce/fix-11164.en.md
+++ b/changes/ce/fix-11164.en.md
@@ -1,0 +1,1 @@
+Reintroduced support for nested (i.e.: `${payload.a.b.c}`) placeholders for extracting data from rule action messages without the need for calling `json_decode(payload)` first.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10459

Without the need to call `json_decode` in the rule engine, we support placeholders with nested paths inside encoded JSON objects.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9f929ca</samp>

This pull request adds support for nested variables in the payload templates for the emqx bridge to mysql. It modifies the `emqx_placeholder` module and its test suite, and also improves the test suite for the `emqx_bridge_mysql` module. The changes enable more flexible and dynamic data mapping between mqtt messages and mysql tables.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
