### PR TITLE
fix(mysql_bridge): make nxdomain a 400 API error

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -985,9 +985,13 @@ call_operation(NodeOrAll, OperFunc, Args = [_Nodes, BridgeType, BridgeName]) ->
         {error, timeout} ->
             ?SERVICE_UNAVAILABLE(<<"Request timeout">>);
         {error, {start_pool_failed, Name, Reason}} ->
-            ?SERVICE_UNAVAILABLE(
-                bin(io_lib:format("Failed to start ~p pool for reason ~p", [Name, Reason]))
-            );
+            Msg = bin(io_lib:format("Failed to start ~p pool for reason ~p", [Name, Reason])),
+            case Reason of
+                nxdomain ->
+                    ?BAD_REQUEST(Msg);
+                _ ->
+                    ?SERVICE_UNAVAILABLE(Msg)
+            end;
         {error, not_found} ->
             BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
             ?SLOG(warning, #{

--- a/apps/emqx_mysql/rebar.config
+++ b/apps/emqx_mysql/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
         %% NOTE: mind ecpool version when updating eredis_cluster version
-        {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.2"}}},
+        {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.3"}}},
         {emqx_connector, {path, "../../apps/emqx_connector"}},
         {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/changes/ee/fix-11175.en.md
+++ b/changes/ee/fix-11175.en.md
@@ -1,0 +1,1 @@
+Now when using a nonexistent hostname for connecting to MySQL will result in a 400 error rather than 503 in the HTTP API.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10460

![image](https://github.com/emqx/emqx/assets/16166434/a0b4e909-b657-4936-90c9-0ab7edd6e3b7)


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 06b7d1b</samp>

This pull request improves the error handling and the SSL support of the emqx_bridge and emqx_mysql plugins. It returns a more accurate error code and message when starting a bridge with an invalid domain name, and it updates the `mysql` dependency to fix a connection bug with MySQL 8.0.26 or later.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
