### PR TITLE
perf(broker): avoid usorting aggregated routes in a loop

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -285,16 +285,16 @@ aggre([#route{topic = To, dest = Node}]) when is_atom(Node) ->
 aggre([#route{topic = To, dest = {Group, _Node}}]) ->
     [{To, Group}];
 aggre(Routes) ->
-    lists:foldl(
-        fun
-            (#route{topic = To, dest = Node}, Acc) when is_atom(Node) ->
-                [{To, Node} | Acc];
-            (#route{topic = To, dest = {Group, _Node}}, Acc) ->
-                lists:usort([{To, Group} | Acc])
-        end,
-        [],
-        Routes
-    ).
+    aggre(Routes, false, []).
+
+aggre([#route{topic = To, dest = Node} | Rest], Dedup, Acc) when is_atom(Node) ->
+    aggre(Rest, Dedup, [{To, Node} | Acc]);
+aggre([#route{topic = To, dest = {Group, _Node}} | Rest], _Dedup, Acc) ->
+    aggre(Rest, true, [{To, Group} | Acc]);
+aggre([], false, Acc) ->
+    Acc;
+aggre([], true, Acc) ->
+    lists:usort(Acc).
 
 %% @doc Forward message to another node.
 -spec forward(node(), emqx_types:topic(), emqx_types:delivery(), RpcMode :: sync | async) ->

--- a/apps/emqx/src/emqx_session_router.erl
+++ b/apps/emqx/src/emqx_session_router.erl
@@ -243,8 +243,8 @@ handle_call(Req, _From, State) ->
 
 handle_cast({delete_routes, SessionID, Subscriptions}, State) ->
     %% TODO: Make a batch for deleting all routes.
-    Fun = fun({Topic, _}) -> do_delete_route(Topic, SessionID) end,
-    ok = lists:foreach(Fun, maps:to_list(Subscriptions)),
+    Fun = fun(Topic, _) -> do_delete_route(Topic, SessionID) end,
+    ok = maps:foreach(Fun, Subscriptions),
     {noreply, State};
 handle_cast({resume_end, SessionID, Pid}, State) ->
     case emqx_utils_ets:lookup_value(?SESSION_INIT_TAB, SessionID) of


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f25df3</samp>

Refactor `aggre/1` function in `emqx_broker.erl` to use tail recursion and avoid repeated deduplication. Simplify `handle_cast/2` clause for deleting routes in `emqx_session_router.erl` by using `maps:foreach/2`. The purpose is to improve performance and memory efficiency.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
