### PR TITLE
fix: limit mqtt max_packet_size to 256MB

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -30,6 +30,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("logger.hrl").
 
+-define(MAX_INT_MQTT_PACKET_SIZE, 268435456).
 -define(MAX_INT_TIMEOUT_MS, 4294967295).
 %% floor(?MAX_INT_TIMEOUT_MS / 1000).
 -define(MAX_INT_TIMEOUT_S, 4294967).
@@ -45,6 +46,7 @@
 -type timeout_duration_s() :: 0..?MAX_INT_TIMEOUT_S.
 -type timeout_duration_ms() :: 0..?MAX_INT_TIMEOUT_MS.
 -type bytesize() :: integer().
+-type mqtt_max_packet_size() :: 1..?MAX_INT_MQTT_PACKET_SIZE.
 -type wordsize() :: bytesize().
 -type percent() :: float().
 -type file() :: string().
@@ -71,6 +73,7 @@
 -typerefl_from_string({timeout_duration_s/0, emqx_schema, to_timeout_duration_s}).
 -typerefl_from_string({timeout_duration_ms/0, emqx_schema, to_timeout_duration_ms}).
 -typerefl_from_string({bytesize/0, emqx_schema, to_bytesize}).
+-typerefl_from_string({mqtt_max_packet_size/0, emqx_schema, to_bytesize}).
 -typerefl_from_string({wordsize/0, emqx_schema, to_wordsize}).
 -typerefl_from_string({percent/0, emqx_schema, to_percent}).
 -typerefl_from_string({comma_separated_list/0, emqx_schema, to_comma_separated_list}).
@@ -151,6 +154,7 @@
     timeout_duration_s/0,
     timeout_duration_ms/0,
     bytesize/0,
+    mqtt_max_packet_size/0,
     wordsize/0,
     percent/0,
     file/0,
@@ -3357,7 +3361,7 @@ mqtt_general() ->
             )},
         {"max_packet_size",
             sc(
-                bytesize(),
+                mqtt_max_packet_size(),
                 #{
                     default => <<"1MB">>,
                     desc => ?DESC(mqtt_max_packet_size)

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -852,6 +852,8 @@ typename_to_spec("timeout()", _Mod) ->
     };
 typename_to_spec("bytesize()", _Mod) ->
     #{type => string, example => <<"32MB">>};
+typename_to_spec("mqtt_max_packet_size()", _Mod) ->
+    #{type => string, example => <<"32MB">>};
 typename_to_spec("wordsize()", _Mod) ->
     #{type => string, example => <<"1024KB">>};
 typename_to_spec("map()", _Mod) ->

--- a/changes/ce/fix-11184.en.md
+++ b/changes/ce/fix-11184.en.md
@@ -1,0 +1,1 @@
+Config value for `max_packet_size` has a max value of 256MB defined by protocol. This is now enforced and any configuration with a value greater than that will break.


### PR DESCRIPTION
Fixes [EMQX-10270](https://emqx.atlassian.net/browse/EMQX-10270)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6766a9f</samp>

This pull request adds a new `mqtt_packet_size` type for validating and converting MQTT packet sizes, and applies it to the `max_packet_size` configuration option. It also updates the dashboard API documentation to reflect the new type.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [-] Schema changes are backward compatible
- [x] notified dashboard team about changes
