### PR TITLE
feat(helm-chart): add support for topologySpreadConstraints

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
@@ -170,3 +170,15 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "emqx.name" $ }}
+              app.kubernetes.io/instance: {{ $.Release.Name }}
+        {{- end }}
+    {{- end }}

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -128,6 +128,9 @@ service:
   ## Service type
   ##
   type: ClusterIP
+  ## The cluster IP if one wants to customize it to a fixed value
+  ##
+  clusterIP: None
   ## Port for MQTT
   ##
   mqtt: 1883
@@ -186,6 +189,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+topologySpreadConstraints: []
 
 ingress:
   ## ingress for EMQX Dashboard

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `tolerations` | Toleration labels for pod assignment | `[]` |
 | `affinity` | Map of node/pod affinities | `{}` |
+| `topologySpreadConstraints` | List of topology spread constraints without labelSelector | `[]` |
 | `service.type` | Kubernetes Service type. | ClusterIP |
 | `service.mqtt` | Port for MQTT. | 1883 |
 | `service.mqttssl` | Port for MQTT(SSL). | 8883 |

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -170,3 +170,15 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- range . }}
+        - maxSkew: {{ .maxSkew }}
+          topologyKey: {{ .topologyKey }}
+          whenUnsatisfiable: {{ .whenUnsatisfiable }}
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ include "emqx.name" $ }}
+              app.kubernetes.io/instance: {{ $.Release.Name }}
+        {{- end }}
+    {{- end }}

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -190,6 +190,8 @@ tolerations: []
 
 affinity: {}
 
+topologySpreadConstraints: []
+
 ingress:
   ## ingress for EMQX Dashboard
   dashboard:


### PR DESCRIPTION
Fixes none

## Summary

Add support for field topologySpreadConstraints (https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) on the StatefulSet in the Helm chart. All non-beta fields are included and the labelSelector is overridden.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
