### PR TITLE
fix(ft-test): use new cth tooling in emqx_ft_storage_fs_SUITE

### DIFF
--- a/apps/emqx_ft/test/emqx_ft_test_helpers.erl
+++ b/apps/emqx_ft/test/emqx_ft_test_helpers.erl
@@ -24,23 +24,6 @@
 -define(S3_HOST, <<"minio">>).
 -define(S3_PORT, 9000).
 
-start_additional_node(Config, Name) ->
-    emqx_common_test_helpers:start_slave(
-        Name,
-        [
-            {apps, [emqx_ft]},
-            {join_to, node()},
-            {configure_gen_rpc, true},
-            {env_handler, env_handler(Config)}
-        ]
-    ).
-
-stop_additional_node(Node) ->
-    _ = rpc:call(Node, ekka, leave, []),
-    ok = rpc:call(Node, emqx_common_test_helpers, stop_apps, [[emqx_ft]]),
-    ok = emqx_common_test_helpers:stop_slave(Node),
-    ok.
-
 env_handler(Config) ->
     fun
         (emqx_ft) ->


### PR DESCRIPTION
In attempt to battle test flakiness.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 13bf0f1</samp>

This pull request refactors the cluster tests for the `emqx_ft` app to use the common test helpers from the `emqx` app. It simplifies the test setup and teardown, and improves the port allocation and configuration of the `emqx` app. It also removes some unused functions from `emqx_ft_test_helpers.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
