### PR TITLE
fix(rebalance): fix rebalance swagger examples

### DIFF
--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -105,6 +105,20 @@ t_deprecated(_Config) ->
         emqx_dashboard_swagger:components([{?MODULE, deprecated_ref}], #{})
     ).
 
+t_nonempty_list(_Config) ->
+    ?assertMatch(
+        [
+            #{
+                <<"emqx_swagger_requestBody_SUITE.nonempty_list_ref">> :=
+                    #{
+                        <<"properties">> :=
+                            [{<<"list">>, #{items := #{type := string}, type := array}}]
+                    }
+            }
+        ],
+        emqx_dashboard_swagger:components([{?MODULE, nonempty_list_ref}], #{})
+    ).
+
 t_nest_object(_Config) ->
     GoodRef = <<"#/components/schemas/emqx_swagger_requestBody_SUITE.good_ref">>,
     Spec = #{
@@ -829,6 +843,10 @@ fields(deprecated_ref) ->
         {tag1, mk(binary(), #{desc => <<"tag1">>, deprecated => {since, "4.3.0"}})},
         {tag2, mk(binary(), #{desc => <<"tag2">>, deprecated => true})},
         {tag3, mk(binary(), #{desc => <<"tag3">>, deprecated => false})}
+    ];
+fields(nonempty_list_ref) ->
+    [
+        {list, mk(nonempty_list(binary()), #{})}
     ].
 
 enable(type) -> boolean();

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance_api.erl
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance_api.erl
@@ -709,25 +709,30 @@ fields(global_status) ->
 
 rebalance_example() ->
     #{
-        wait_health_check => <<"10s">>,
-        conn_evict_rate => 10,
-        sess_evict_rate => 20,
-        abs_conn_threshold => 10,
-        rel_conn_threshold => 1.5,
-        abs_sess_threshold => 10,
-        rel_sess_threshold => 1.5,
-        wait_takeover => <<"10s">>,
-        nodes => [<<"othernode@127.0.0.1">>]
+        rebalance =>
+            #{
+                wait_health_check => <<"10s">>,
+                conn_evict_rate => 10,
+                sess_evict_rate => 20,
+                abs_conn_threshold => 10,
+                rel_conn_threshold => 1.5,
+                abs_sess_threshold => 10,
+                rel_sess_threshold => 1.5,
+                wait_takeover => <<"10s">>,
+                nodes => [<<"othernode@127.0.0.1">>]
+            }
     }.
 
 rebalance_evacuation_example() ->
     #{
-        wait_health_check => <<"10s">>,
-        conn_evict_rate => 100,
-        sess_evict_rate => 100,
-        redirect_to => <<"othernode:1883">>,
-        wait_takeover => <<"10s">>,
-        migrate_to => [<<"othernode@127.0.0.1">>]
+        evacuation => #{
+            wait_health_check => <<"10s">>,
+            conn_evict_rate => 100,
+            sess_evict_rate => 100,
+            redirect_to => <<"othernode:1883">>,
+            wait_takeover => <<"10s">>,
+            migrate_to => [<<"othernode@127.0.0.1">>]
+        }
     }.
 
 local_status_response_schema() ->

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance_status.erl
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance_status.erl
@@ -51,7 +51,7 @@ format_local_status(Status) ->
 
 -spec global_status() -> #{rebalances := [{node(), map()}], evacuations := [{node(), map()}]}.
 global_status() ->
-    Nodes = mria_mnesia:running_nodes(),
+    Nodes = emqx:running_nodes(),
     {RebalanceResults, _} = emqx_node_rebalance_status_proto_v1:rebalance_status(Nodes),
     Rebalances = [
         {Node, coordinator_rebalance(Status)}

--- a/apps/emqx_node_rebalance/test/emqx_node_rebalance_status_SUITE.erl
+++ b/apps/emqx_node_rebalance/test/emqx_node_rebalance_status_SUITE.erl
@@ -1,0 +1,65 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_node_rebalance_status_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+suite() ->
+    [{timetrap, {seconds, 90}}].
+
+init_per_suite(Config) ->
+    WorkDir = ?config(priv_dir, Config),
+    Apps = [
+        emqx_conf,
+        emqx,
+        emqx_node_rebalance
+    ],
+    Cluster = [
+        {emqx_node_rebalance_status_SUITE1, #{
+            role => core,
+            apps => Apps
+        }},
+        {emqx_node_rebalance_status_SUITE2, #{
+            role => replicant,
+            apps => Apps
+        }}
+    ],
+    Nodes = emqx_cth_cluster:start(Cluster, #{work_dir => WorkDir}),
+    [{cluster_nodes, Nodes} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_cluster:stop(?config(cluster_nodes, Config)),
+    ok.
+
+%%--------------------------------------------------------------------
+%% Tests
+%%--------------------------------------------------------------------
+
+t_cluster_status(Config) ->
+    [CoreNode, ReplicantNode] = ?config(cluster_nodes, Config),
+    ok = emqx_node_rebalance_api_proto_v1:node_rebalance_evacuation_start(CoreNode, #{}),
+
+    ?assertMatch(
+        #{evacuations := [_], rebalances := []},
+        rpc:call(ReplicantNode, emqx_node_rebalance_status, global_status, [])
+    ).


### PR DESCRIPTION
Fixes [EMQX-10489](https://emqx.atlassian.net/browse/EMQX-10489)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f174cb6</samp>

This pull request enhances the swagger schema generation and validation for the dashboard API, and improves the node rebalance status and examples. It refactors the `emqx_dashboard_swagger` module, adds support for `nonempty_list` type, moves the rebalance examples to the same module, and replaces a direct mria call with an emqx wrapper. It also adds a new test module `emqx_node_rebalance_status_SUITE` to verify the cluster status after evacuation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report

~~- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~

- [x] For internal contributor: there is a jira ticket to track this change

~~- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~

- [x] Schema changes are backward compatible
