### PR TITLE
feat: enable setting ssl common name

### DIFF
--- a/deploy/charts/emqx-enterprise/README.md
+++ b/deploy/charts/emqx-enterprise/README.md
@@ -100,7 +100,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `ssl.useExisting` | Use existing certificate or let cert-manager generate one | false |
 | `ssl.existingName` | Name of existing certificate | emqx-tls |
 | `ssl.dnsnames` | DNS name(s) for certificate to be generated | {} |
-| `ssl.commonName` | Common name for or certificate to be generated | {} |
+| `ssl.commonName` | Common name for or certificate to be generated | |
 | `ssl.issuer.name` | Issuer name for certificate generation | letsencrypt-dns |
 | `ssl.issuer.kind` | Issuer kind for certificate generation | ClusterIssuer |
 

--- a/deploy/charts/emqx-enterprise/README.md
+++ b/deploy/charts/emqx-enterprise/README.md
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `ssl.useExisting` | Use existing certificate or let cert-manager generate one | false |
 | `ssl.existingName` | Name of existing certificate | emqx-tls |
 | `ssl.dnsnames` | DNS name(s) for certificate to be generated | {} |
+| `ssl.commonName` | Common name for or certificate to be generated | {} |
 | `ssl.issuer.name` | Issuer name for certificate generation | letsencrypt-dns |
 | `ssl.issuer.kind` | Issuer kind for certificate generation | ClusterIssuer |
 

--- a/deploy/charts/emqx-enterprise/templates/certificate.yaml
+++ b/deploy/charts/emqx-enterprise/templates/certificate.yaml
@@ -9,6 +9,9 @@ spec:
   issuerRef:
     name: {{ default "letsencrypt-staging" .Values.ssl.issuer.name }}
     kind: {{ default "ClusterIssuer" .Values.ssl.issuer.kind }}
+  {{- if .Values.ssl.commonName }}
+  commonName: {{ .Values.ssl.commonName }}
+  {{- end }}
   dnsNames:
     {{- range .Values.ssl.dnsnames }}
     - {{ . }}

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -237,6 +237,7 @@ ssl:
   useExisting: false
   existingName: emqx-tls
   dnsnames: []
+  commonName:
   issuer:
     name: letsencrypt-dns
     kind: ClusterIssuer

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -99,7 +99,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `ssl.enabled` | Enable SSL support | false |
 | `ssl.useExisting` | Use existing certificate or let cert-manager generate one | false |
 | `ssl.existingName` | Name of existing certificate | emqx-tls |
-| `ssl.commonName` | Common name for or certificate to be generated | {} |
+| `ssl.commonName` | Common name for or certificate to be generated | |
 | `ssl.dnsnames` | DNS name(s) for certificate to be generated | {} |
 | `ssl.issuer.name` | Issuer name for certificate generation | letsencrypt-dns |
 | `ssl.issuer.kind` | Issuer kind for certificate generation | ClusterIssuer |

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `ssl.enabled` | Enable SSL support | false |
 | `ssl.useExisting` | Use existing certificate or let cert-manager generate one | false |
 | `ssl.existingName` | Name of existing certificate | emqx-tls |
+| `ssl.commonName` | Common name for or certificate to be generated | {} |
 | `ssl.dnsnames` | DNS name(s) for certificate to be generated | {} |
 | `ssl.issuer.name` | Issuer name for certificate generation | letsencrypt-dns |
 | `ssl.issuer.kind` | Issuer kind for certificate generation | ClusterIssuer |

--- a/deploy/charts/emqx/templates/certificate.yaml
+++ b/deploy/charts/emqx/templates/certificate.yaml
@@ -9,6 +9,9 @@ spec:
   issuerRef:
     name: {{ default "letsencrypt-staging" .Values.ssl.issuer.name }}
     kind: {{ default "ClusterIssuer" .Values.ssl.issuer.kind }}
+  {{- if .Values.ssl.commonName }}
+  commonName: {{ .Values.ssl.commonName }}
+  {{- end }}
   dnsNames:
     {{- range .Values.ssl.dnsnames }}
     - {{ . }}

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -240,6 +240,7 @@ ssl:
   useExisting: false
   existingName: emqx-tls
   dnsnames: []
+  commonName: 
   issuer:
     name: letsencrypt-dns
     kind: ClusterIssuer


### PR DESCRIPTION
template and documentation for value ssl.Commonname to support vault-issuer vault-issuer (k8s clusterIssuer) requires CN to be set by default Helm chart version not bumped(versioning vs product unclear)

closes: #11199

Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b5ef5e</samp>

This pull request adds a new configuration option `ssl.commonName` to the emqx and emqx-enterprise charts, which allows users to customize the common name for the certificates generated by cert-manager. This option improves the flexibility and usability of the charts for different domain names.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
