### PR TITLE
Allow the `*/*` or multiple `Accept` values in header for the `/configs`  API

### DIFF
--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.0.25"},
+    {vsn, "5.0.26"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [kernel, stdlib, emqx_plugins, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -337,15 +337,38 @@ config_reset(post, _Params, Req) ->
 
 configs(get, #{query_string := QueryStr, headers := Headers}, _Req) ->
     %% Should deprecated json v1 since 5.2.0
-    case maps:get(<<"accept">>, Headers, <<"text/plain">>) of
-        <<"application/json">> -> get_configs_v1(QueryStr);
-        <<"text/plain">> -> get_configs_v2(QueryStr)
+    case find_suitable_accept(Headers, [<<"text/plain">>, <<"application/json">>]) of
+        {ok, <<"application/json">>} -> get_configs_v1(QueryStr);
+        {ok, <<"text/plain">>} -> get_configs_v2(QueryStr);
+        {error, _} = Error -> {400, #{code => 'INVALID_ACCEPT', message => ?ERR_MSG(Error)}}
     end;
 configs(put, #{body := Conf, query_string := #{<<"mode">> := Mode}}, _Req) ->
     case emqx_conf_cli:load_config(Conf, Mode) of
         ok -> {200};
         {error, [{_, Reason}]} -> {400, #{code => 'UPDATE_FAILED', message => ?ERR_MSG(Reason)}};
         {error, Errors} -> {400, #{code => 'UPDATE_FAILED', message => ?ERR_MSG(Errors)}}
+    end.
+
+find_suitable_accept(Headers, Perferences) ->
+    AcceptVal = maps:get(<<"accept">>, Headers, <<"*/*">>),
+    %% Multiple types, weighted with the quality value syntax:
+    %% Accept: text/html, application/xhtml+xml, application/xml;q=0.9, image/webp, */*;q=0.8
+    Accepts = lists:map(
+        fun(S) ->
+            [T | _] = binary:split(string:trim(S), <<";">>),
+            T
+        end,
+        re:split(AcceptVal, ",")
+    ),
+    case lists:member(<<"*/*">>, Accepts) of
+        true ->
+            {ok, lists:first(Perferences)};
+        fales ->
+            Found = lists:filter(fun(Accept) -> lists:member(Accept, Accepts) end, Perferences),
+            case Found of
+                [] -> {error, no_suitalbe_accept};
+                _ -> lists:first(Found)
+            end
     end.
 
 get_configs_v1(QueryStr) ->


### PR DESCRIPTION
to fix the following logs
<img width="946" alt="image" src="https://github.com/emqx/emqx/assets/13825269/1fb8639e-e9c2-4c1f-a2ce-8fe9f8f6f21a">

This PR is a supplement for https://github.com/emqx/emqx/pull/11180, so it don't need to add a new change logs

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 71d1f80</samp>

Added a feature to handle different accept header values in the `emqx_mgmt_api_configs` module and updated the version number of the `emqx_management` application. Also added a test case to verify the new feature in the `emqx_mgmt_api_configs_SUITE` module.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- ~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~
- ~For internal contributor: there is a jira ticket to track this change~
- [x] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
