### PR TITLE
ci: do not set latest for elixir image

### DIFF
--- a/.github/actions/package-macos/action.yaml
+++ b/.github/actions/package-macos/action.yaml
@@ -33,7 +33,6 @@ runs:
         HOMEBREW_NO_INSTALL_UPGRADE: 1
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
       run: |
-        brew update
         brew install curl zip unzip coreutils openssl@1.1
         echo "/usr/local/opt/bison/bin" >> $GITHUB_PATH
         echo "/usr/local/bin" >> $GITHUB_PATH

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -182,6 +182,7 @@ jobs:
         images: |
           ${{ matrix.registry }}/${{ github.repository_owner }}/${{ matrix.profile }}
         flavor: |
+          latest=${{ matrix.elixir == 'no_elixir'  }}
           suffix=${{ steps.pre-meta.outputs.img_suffix }}
         tags: |
           type=semver,pattern={{major}}.{{minor}},value=${{ needs.prepare.outputs.VERSION }}

--- a/mix.exs
+++ b/mix.exs
@@ -91,8 +91,7 @@ defmodule EMQXUmbrella.MixProject do
       {:cowlib,
        github: "ninenines/cowlib", ref: "c6553f8308a2ca5dcd69d845f0a7d098c40c3363", override: true},
       # in conflict by cowboy_swagger and cowboy
-      {:ranch,
-       github: "emqx/ranch", ref: "de8ba2a00817c0a6eb1b8f20d6fb3e44e2c9a5aa", override: true},
+      {:ranch, github: "emqx/ranch", tag: "1.8.1-emqx", override: true},
       # in conflict by grpc and eetcd
       {:gpb, "4.19.7", override: true, runtime: false},
       {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true},


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f6d891e</samp>

The pull request adds a `latest` tag to the docker image without elixir, and simplifies the docker image building process. It modifies the `tags` input of the `docker/metadata-action` step in `.github/workflows/build_and_push_docker_images.yaml`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
