### PR TITLE
feat(emqx_dashboard): include edition and version in swagger.json info

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.1"},
+    {vsn, "5.1.2"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.1.22"},
+    {vsn, "0.1.23"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.24"},
+    {vsn, "5.0.25"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [kernel, stdlib, mnesia, minirest, emqx, emqx_ctl]},

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -49,7 +49,7 @@ start_listeners(Listeners) ->
     Authorization = {?MODULE, authorize},
     GlobalSpec = #{
         openapi => "3.0.0",
-        info => #{title => "EMQX API", version => ?EMQX_API_VERSION},
+        info => #{title => emqx_api_name(), version => emqx_release_version()},
         servers => [#{url => emqx_dashboard_swagger:base_path()}],
         components => #{
             schemas => #{},
@@ -271,3 +271,9 @@ dynamic_dispatch() ->
         {emqx_mgmt_api_status:path(), emqx_mgmt_api_status, []},
         {'_', emqx_dashboard_not_found, []}
     ].
+
+emqx_api_name() ->
+    emqx_release:description() ++ " API".
+
+emqx_release_version() ->
+    emqx_release:version().

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -149,6 +149,15 @@ t_swagger_json(_Config) ->
     {ok, {{"HTTP/1.1", 200, "OK"}, _Headers, Body2}} =
         httpc:request(get, {Url, []}, [], [{body_format, binary}]),
     ?assertEqual(Body1, Body2),
+    ?assertMatch(
+        #{
+            <<"info">> := #{
+                <<"title">> := _,
+                <<"version">> := _
+            }
+        },
+        emqx_utils_json:decode(Body1)
+    ),
     ok.
 
 t_cli(_Config) ->


### PR DESCRIPTION
Fixes [EMQX-9569](https://emqx.atlassian.net/browse/EMQX-9569)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d7d3164</samp>

Updated the emqx dashboard and core applications to use dynamic values for the API and release versions. Exported the `build_vsn/0` function from the `emqx_release` module and used it in the `emqx_dashboard` module to generate the API specification. Modified the test case for the `get_swagger/1` function to check the API info field.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [-] ~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- [-] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [-] ~Schema changes are backward compatible~

