### PR TITLE
feat: enable setting ssl common name

### DIFF
--- a/deploy/charts/emqx-enterprise/README.md
+++ b/deploy/charts/emqx-enterprise/README.md
@@ -100,6 +100,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `ssl.useExisting` | Use existing certificate or let cert-manager generate one | false |
 | `ssl.existingName` | Name of existing certificate | emqx-tls |
 | `ssl.dnsnames` | DNS name(s) for certificate to be generated | {} |
+| `ssl.commonName` | Common name for or certificate to be generated | |
 | `ssl.issuer.name` | Issuer name for certificate generation | letsencrypt-dns |
 | `ssl.issuer.kind` | Issuer kind for certificate generation | ClusterIssuer |
 

--- a/deploy/charts/emqx-enterprise/templates/certificate.yaml
+++ b/deploy/charts/emqx-enterprise/templates/certificate.yaml
@@ -9,6 +9,9 @@ spec:
   issuerRef:
     name: {{ default "letsencrypt-staging" .Values.ssl.issuer.name }}
     kind: {{ default "ClusterIssuer" .Values.ssl.issuer.kind }}
+  {{- if .Values.ssl.commonName }}
+  commonName: {{ .Values.ssl.commonName }}
+  {{- end }}
   dnsNames:
     {{- range .Values.ssl.dnsnames }}
     - {{ . }}

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -237,6 +237,7 @@ ssl:
   useExisting: false
   existingName: emqx-tls
   dnsnames: []
+  commonName: 
   issuer:
     name: letsencrypt-dns
     kind: ClusterIssuer

--- a/deploy/charts/emqx/README.md
+++ b/deploy/charts/emqx/README.md
@@ -99,6 +99,7 @@ The following table lists the configurable parameters of the emqx chart and thei
 | `ssl.enabled` | Enable SSL support | false |
 | `ssl.useExisting` | Use existing certificate or let cert-manager generate one | false |
 | `ssl.existingName` | Name of existing certificate | emqx-tls |
+| `ssl.commonName` | Common name for or certificate to be generated | |
 | `ssl.dnsnames` | DNS name(s) for certificate to be generated | {} |
 | `ssl.issuer.name` | Issuer name for certificate generation | letsencrypt-dns |
 | `ssl.issuer.kind` | Issuer kind for certificate generation | ClusterIssuer |

--- a/deploy/charts/emqx/templates/certificate.yaml
+++ b/deploy/charts/emqx/templates/certificate.yaml
@@ -9,6 +9,9 @@ spec:
   issuerRef:
     name: {{ default "letsencrypt-staging" .Values.ssl.issuer.name }}
     kind: {{ default "ClusterIssuer" .Values.ssl.issuer.kind }}
+  {{- if .Values.ssl.commonName }}
+  commonName: {{ .Values.ssl.commonName }}
+  {{- end }}
   dnsNames:
     {{- range .Values.ssl.dnsnames }}
     - {{ . }}

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -240,6 +240,7 @@ ssl:
   useExisting: false
   existingName: emqx-tls
   dnsnames: []
+  commonName: 
   issuer:
     name: letsencrypt-dns
     kind: ClusterIssuer


### PR DESCRIPTION
template, documentation, default values.yaml for value ssl.Commonname to support vault-issuer
vault-issuer (k8s clusterIssuer) requires CN to be set by default

closes: emqx#11199

