### PR TITLE
feat(session): move most of persistence concerns behind session module

### DIFF
--- a/apps/emqx/include/emqx_session.hrl
+++ b/apps/emqx/include/emqx_session.hrl
@@ -1,0 +1,56 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-ifndef(EMQX_SESSION_HRL).
+-define(EMQX_SESSION_HRL, true).
+
+-record(session, {
+    %% Client's id
+    clientid :: emqx_types:clientid(),
+    id :: emqx_session:sessionID(),
+    %% Is this session a persistent session i.e. was it started with Session-Expiry > 0
+    is_persistent :: boolean(),
+    %% Expiry interval
+    expiry_interval :: non_neg_integer(),
+    %% Client’s Subscriptions.
+    subscriptions :: map(),
+    %% Max subscriptions allowed
+    max_subscriptions :: non_neg_integer() | infinity,
+    %% Upgrade QoS?
+    upgrade_qos :: boolean(),
+    %% Client <- Broker: QoS1/2 messages sent to the client but
+    %% have not been unacked.
+    inflight :: emqx_inflight:inflight(),
+    %% All QoS1/2 messages published to when client is disconnected,
+    %% or QoS1/2 messages pending transmission to the Client.
+    %%
+    %% Optionally, QoS0 messages pending transmission to the Client.
+    mqueue :: emqx_mqueue:mqueue(),
+    %% Next packet id of the session
+    next_pkt_id = 1 :: emqx_types:packet_id(),
+    %% Retry interval for redelivering QoS1/2 messages (Unit: millisecond)
+    retry_interval :: timeout(),
+    %% Client -> Broker: QoS2 messages received from the client, but
+    %% have not been completely acknowledged
+    awaiting_rel :: map(),
+    %% Maximum number of awaiting QoS2 messages allowed
+    max_awaiting_rel :: non_neg_integer() | infinity,
+    %% Awaiting PUBREL Timeout (Unit: millisecond)
+    await_rel_timeout :: timeout(),
+    %% Created at
+    created_at :: pos_integer()
+}).
+
+-endif.

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -277,32 +277,19 @@ open_session(true, ClientInfo = #{clientid := ClientId}, ConnInfo) ->
     Self = self(),
     CleanStart = fun(_) ->
         ok = discard_session(ClientId),
-        ok = emqx_persistent_session:discard_if_present(ClientId),
-        Session = create_session(ClientInfo, ConnInfo),
-        Session1 = emqx_persistent_session:persist(ClientInfo, ConnInfo, Session),
-        register_channel(ClientId, Self, ConnInfo),
-        {ok, #{session => Session1, present => false}}
+        ok = emqx_persistent_session:discard(ClientId),
+        create_register_session(ClientInfo, ConnInfo, Self)
     end,
     emqx_cm_locker:trans(ClientId, CleanStart);
 open_session(false, ClientInfo = #{clientid := ClientId}, ConnInfo) ->
     Self = self(),
     ResumeStart = fun(_) ->
-        CreateSess =
-            fun() ->
-                Session = create_session(ClientInfo, ConnInfo),
-                Session1 = emqx_persistent_session:persist(
-                    ClientInfo, ConnInfo, Session
-                ),
-                register_channel(ClientId, Self, ConnInfo),
-                {ok, #{session => Session1, present => false}}
-            end,
         case takeover_session(ClientId) of
             {persistent, Session} ->
                 %% This is a persistent session without a managing process.
                 {Session1, Pendings} =
-                    emqx_persistent_session:resume(ClientInfo, ConnInfo, Session),
-                register_channel(ClientId, Self, ConnInfo),
-
+                    emqx_persistent_session:resume(ClientInfo, Session),
+                ok = register_channel(ClientId, Self, ConnInfo),
                 {ok, #{
                     session => clean_session(Session1),
                     present => true,
@@ -312,30 +299,23 @@ open_session(false, ClientInfo = #{clientid := ClientId}, ConnInfo) ->
                 ok = emqx_session:resume(ClientInfo, Session),
                 case wrap_rpc(emqx_cm_proto_v2:takeover_finish(ConnMod, ChanPid)) of
                     {ok, Pendings} ->
-                        Session1 = emqx_persistent_session:persist(
-                            ClientInfo, ConnInfo, Session
-                        ),
-                        register_channel(ClientId, Self, ConnInfo),
+                        % FIXME
+                        % Purpose is unclear, the only thing this (supposedly) updates is
+                        % timestamp. There seems to be no tests for that logic, sadly.
+                        % Session1 = emqx_persistent_session:persist(
+                        %     ClientInfo, ConnInfo, Session
+                        % ),
+                        ok = register_channel(ClientId, Self, ConnInfo),
                         {ok, #{
-                            session => clean_session(Session1),
+                            session => clean_session(Session),
                             present => true,
                             pendings => clean_pendings(Pendings)
                         }};
                     {error, _} ->
-                        CreateSess()
+                        create_register_session(ClientInfo, ConnInfo, Self)
                 end;
-            {expired, OldSession} ->
-                _ = emqx_persistent_session:discard(ClientId, OldSession),
-                Session = create_session(ClientInfo, ConnInfo),
-                Session1 = emqx_persistent_session:persist(
-                    ClientInfo,
-                    ConnInfo,
-                    Session
-                ),
-                register_channel(ClientId, Self, ConnInfo),
-                {ok, #{session => Session1, present => false}};
             none ->
-                CreateSess()
+                create_register_session(ClientInfo, ConnInfo, Self)
         end
     end,
     emqx_cm_locker:trans(ClientId, ResumeStart).
@@ -346,6 +326,11 @@ create_session(ClientInfo, ConnInfo) ->
     ok = emqx_metrics:inc('session.created'),
     ok = emqx_hooks:run('session.created', [ClientInfo, emqx_session:info(Session)]),
     Session.
+
+create_register_session(ClientInfo = #{clientid := ClientId}, ConnInfo, ChanPid) ->
+    Session = create_session(ClientInfo, ConnInfo),
+    ok = register_channel(ClientId, ChanPid, ConnInfo),
+    {ok, #{session => Session, present => false}}.
 
 get_session_confs(#{zone := Zone, clientid := ClientId}, #{
     receive_maximum := MaxInflight, expiry_interval := EI
@@ -362,7 +347,7 @@ get_session_confs(#{zone := Zone, clientid := ClientId}, #{
         %% TODO: Add conf for allowing/disallowing persistent sessions.
         %% Note that the connection info is already enriched to have
         %% default config values for session expiry.
-        is_persistent => EI > 0
+        expiry_interval => EI
     }.
 
 mqueue_confs(Zone) ->
@@ -385,7 +370,7 @@ get_mqtt_conf(Zone, Key) ->
 takeover_session(ClientId) ->
     case lookup_channels(ClientId) of
         [] ->
-            emqx_persistent_session:lookup(ClientId);
+            emqx_session:lookup(ClientId);
         [ChanPid] ->
             takeover_session(ClientId, ChanPid);
         ChanPids ->
@@ -417,16 +402,16 @@ takeover_session(ClientId, Pid) ->
             %% request_stepdown/3
             R == unexpected_exception
         ->
-            emqx_persistent_session:lookup(ClientId);
+            emqx_session:lookup(ClientId);
         % rpc_call/3
         _:{'EXIT', {noproc, _}} ->
-            emqx_persistent_session:lookup(ClientId)
+            emqx_session:lookup(ClientId)
     end.
 
 do_takeover_session(ClientId, ChanPid) when node(ChanPid) == node() ->
     case get_chann_conn_mod(ClientId, ChanPid) of
         undefined ->
-            emqx_persistent_session:lookup(ClientId);
+            emqx_session:lookup(ClientId);
         ConnMod when is_atom(ConnMod) ->
             case request_stepdown({takeover, 'begin'}, ConnMod, ChanPid) of
                 {ok, Session} ->

--- a/apps/emqx/src/emqx_router_utils.erl
+++ b/apps/emqx/src/emqx_router_utils.erl
@@ -25,7 +25,7 @@
     insert_direct_route/2,
     insert_trie_route/2,
     insert_session_trie_route/2,
-    maybe_trans/3
+    maybe_trans/4
 ]).
 
 insert_direct_route(Tab, Route) ->
@@ -71,8 +71,8 @@ delete_trie_route(RouteTab, Route = #route{topic = Topic}, Type) ->
     end.
 
 %% @private
--spec maybe_trans(function(), list(any()), Shard :: atom()) -> ok | {error, term()}.
-maybe_trans(Fun, Args, Shard) ->
+-spec maybe_trans(function(), list(any()), Shard :: atom(), fun(() -> _)) -> ok | {error, term()}.
+maybe_trans(Fun, Args, Shard, TabLocker) ->
     case emqx:get_config([broker, perf, route_lock_type]) of
         key ->
             trans(Fun, Args, Shard);
@@ -90,7 +90,7 @@ maybe_trans(Fun, Args, Shard) ->
         tab ->
             trans(
                 fun() ->
-                    emqx_trie:lock_tables(),
+                    TabLocker(),
                     apply(Fun, Args)
                 end,
                 [],

--- a/apps/emqx/src/persistent_session/emqx_persistent_session.hrl
+++ b/apps/emqx/src/persistent_session/emqx_persistent_session.hrl
@@ -16,7 +16,6 @@
 
 -record(session_store, {
     client_id :: binary(),
-    expiry_interval :: non_neg_integer(),
     ts :: non_neg_integer(),
     session :: emqx_session:session()
 }).

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -135,6 +135,8 @@ sessioninfo() ->
             sessionid(),
             % is_persistent
             boolean(),
+            % expiry_interval
+            non_neg_integer(),
             % subscriptions
             subscriptions(),
             % max_subscriptions

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent_channel.erl
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent_channel.erl
@@ -5,9 +5,7 @@
 %% MQTT Channel
 -module(emqx_eviction_agent_channel).
 
--include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_channel.hrl").
--include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/types.hrl").
 
@@ -167,8 +165,7 @@ handle_cast(Msg, Channel) ->
 
 terminate(Reason, #{conninfo := ConnInfo, clientinfo := ClientInfo, session := Session} = Channel) ->
     ok = cancel_expiry_timer(Channel),
-    (Reason =:= expired) andalso emqx_persistent_session:persist(ClientInfo, ConnInfo, Session),
-    emqx_session:terminate(ClientInfo, Reason, Session).
+    emqx_session:terminate(ClientInfo, ConnInfo, Reason, Session).
 
 code_change(_OldVsn, Channel, _Extra) ->
     {ok, Channel}.
@@ -205,10 +202,7 @@ handle_deliver(
     Delivers1 = emqx_channel:maybe_nack(Delivers),
     Delivers2 = emqx_session:ignore_local(ClientInfo, Delivers1, ClientId, Session),
     NSession = emqx_session:enqueue(ClientInfo, Delivers2, Session),
-    NChannel = persist(NSession, Channel),
-    %% We consider queued/dropped messages as delivered since they are now in the session state.
-    emqx_channel:maybe_mark_as_delivered(Session, Delivers),
-    NChannel.
+    Channel#{session := NSession}.
 
 cancel_expiry_timer(#{expiry_timer := TRef}) when is_reference(TRef) ->
     _ = erlang:cancel_timer(TRef),
@@ -333,10 +327,6 @@ channel(ConnInfo, ClientInfo) ->
         resuming => false,
         pendings => []
     }.
-
-persist(Session, #{clientinfo := ClientInfo, conninfo := ConnInfo} = Channel) ->
-    Session1 = emqx_persistent_session:persist(ClientInfo, ConnInfo, Session),
-    Channel#{session => Session1}.
 
 info(Channel) ->
     #{


### PR DESCRIPTION
Fixes [EMQX-9593](https://emqx.atlassian.net/browse/EMQX-9593)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 436fb10</samp>

This pull request refactors the session persistence logic across several modules in the `emqx` application. It simplifies the code, removes unused or redundant components, and delegates the persistence and delivery operations to the `emqx_session` module. It also adds a license header to the `emqx_session.hrl` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
