### PR TITLE
fix: influxdb float serialization error

### DIFF
--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -638,8 +638,10 @@ value_type([UInt, <<"u">>]) when
     is_integer(UInt)
 ->
     {uint, UInt};
-value_type([Float]) when is_float(Float) ->
-    Float;
+%% write `1`, `1.0`, `-1.0` all as float
+%% see also: https://docs.influxdata.com/influxdb/v2.7/reference/syntax/line-protocol/#float
+value_type([Number]) when is_number(Number) ->
+    Number;
 value_type([<<"t">>]) ->
     't';
 value_type([<<"T">>]) ->

--- a/changes/ee/fix-11223.en.md
+++ b/changes/ee/fix-11223.en.md
@@ -1,0 +1,5 @@
+In InfluxDB bridging, if intend to write using the float data type but the placeholder represents the original value
+as an integer without a decimal point during serialization, it will result in the failure of Influx Line Protocol serialization
+and the inability to write to the InfluxDB bridge.
+
+See also: [InfluxDB v2.7 Line-Protocol](https://docs.influxdata.com/influxdb/v2.7/reference/syntax/line-protocol/#float)


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4a7ba95</samp>

Fix a bug in `emqx_bridge_influxdb_connector` that caused serialization errors when writing integers as floats to the InfluxDB bridge. Add a changelog file `fix-11223.en.md` to document the bug fix.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
