### PR TITLE
fix(bridge): ensure the username of pgsql must exists

### DIFF
--- a/apps/emqx_connector/src/emqx_connector.app.src
+++ b/apps/emqx_connector/src/emqx_connector.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_connector, [
     {description, "EMQX Data Integration Connectors"},
-    {vsn, "0.1.26"},
+    {vsn, "0.1.27"},
     {registered, []},
     {mod, {emqx_connector_app, []}},
     {applications, [

--- a/changes/ee/fix-11225.en.md
+++ b/changes/ee/fix-11225.en.md
@@ -1,0 +1,1 @@
+Fix the `username` of PostgreSQL/Timescale/MatrixDB bridges could be empty


### PR DESCRIPTION
Fixes [EMQX-10382](https://emqx.atlassian.net/browse/EMQX-10382)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8cee751</samp>

Fixed a PostgreSQL connector bug and added a helper function. The bug prevented connecting to PostgreSQL with empty `username` fields, and the helper function `adjust_fields` in `emqx_connector_pgsql.erl` handles this case.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
