### PR TITLE
fix: alias listeners.Type.Name.enabled as listeners.Type.Name.enable

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -368,7 +368,7 @@ console_print(_Fmt, _Args) -> ok.
 %% Start MQTT/TCP listener
 -spec do_start_listener(atom(), atom(), map()) ->
     {ok, pid() | {skipped, atom()}} | {error, term()}.
-do_start_listener(_Type, _ListenerName, #{enabled := false}) ->
+do_start_listener(_Type, _ListenerName, #{enable := false}) ->
     {ok, {skipped, listener_disabled}};
 do_start_listener(Type, ListenerName, #{bind := ListenOn} = Opts) when
     Type == tcp; Type == ssl
@@ -499,8 +499,8 @@ post_config_update([?ROOT_KEY, Type, Name], {update, _Request}, NewConf, OldConf
 post_config_update([?ROOT_KEY, Type, Name], ?MARK_DEL, _, OldConf = #{}, _AppEnvs) ->
     remove_listener(Type, Name, OldConf);
 post_config_update([?ROOT_KEY, Type, Name], {action, _Action, _}, NewConf, OldConf, _AppEnvs) ->
-    #{enabled := NewEnabled} = NewConf,
-    #{enabled := OldEnabled} = OldConf,
+    #{enable := NewEnabled} = NewConf,
+    #{enable := OldEnabled} = OldConf,
     case {NewEnabled, OldEnabled} of
         {true, true} ->
             ok = maybe_unregister_ocsp_stapling_refresh(Type, Name, NewConf),
@@ -810,7 +810,7 @@ has_enabled_listener_conf_by_type(Type) ->
     lists:any(
         fun({Id, LConf}) when is_map(LConf) ->
             {ok, #{type := Type0}} = parse_listener_id(Id),
-            Type =:= Type0 andalso maps:get(enabled, LConf, true)
+            Type =:= Type0 andalso maps:get(enable, LConf, true)
         end,
         list()
     ).

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1750,13 +1750,12 @@ mqtt_listener(Bind) ->
 
 base_listener(Bind) ->
     [
-        {"enabled",
+        {"enable",
             sc(
                 boolean(),
                 #{
                     default => true,
-                    %% TODO(5.2): change field name to 'enable' and keep 'enabled' as an alias
-                    aliases => [enable],
+                    aliases => [enabled],
                     desc => ?DESC(fields_listener_enabled)
                 }
             )},

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -618,7 +618,7 @@ ensure_quic_listener(Name, UdpPort, ExtraSettings) ->
                 "TLS_AES_128_GCM_SHA256",
                 "TLS_CHACHA20_POLY1305_SHA256"
             ],
-        enabled => true,
+        enable => true,
         idle_timeout => 15000,
         ssl_options => #{
             certfile => filename:join(code:lib_dir(emqx), "etc/certs/cert.pem"),

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -229,7 +229,7 @@ t_ssl_password_cert(Config) ->
         keyfile => filename:join(DataDir, "server-password.key")
     },
     LConf = #{
-        enabled => true,
+        enable => true,
         bind => {{127, 0, 0, 1}, Port},
         mountpoint => <<>>,
         zone => default,

--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -363,14 +363,14 @@ listeners_test() ->
     ?assertMatch(
         #{
             <<"bind">> := {{0, 0, 0, 0}, 1883},
-            <<"enabled">> := true
+            <<"enable">> := true
         },
         Tcp
     ),
     ?assertMatch(
         #{
             <<"bind">> := {{0, 0, 0, 0}, 8083},
-            <<"enabled">> := true,
+            <<"enable">> := true,
             <<"websocket">> := #{<<"mqtt_path">> := "/mqtt"}
         },
         Ws

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_test_helpers.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_test_helpers.erl
@@ -84,7 +84,7 @@ start_cluster(NamesWithPorts, Apps, Env) ->
         {env, [{emqx, boot_modules, [broker, listeners]}] ++ Env},
         {apps, Apps},
         {conf,
-            [{[listeners, Proto, default, enabled], false} || Proto <- [ssl, ws, wss]] ++
+            [{[listeners, Proto, default, enable], false} || Proto <- [ssl, ws, wss]] ++
                 [{[rpc, mode], async}]}
     ],
     Cluster = emqx_common_test_helpers:emqx_cluster(

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -510,9 +510,9 @@ action_listeners_by_id(post, #{bindings := #{id := Id, action := Action}}) ->
 
 %%%==============================================================================================
 
-enabled(start) -> #{<<"enabled">> => true};
-enabled(stop) -> #{<<"enabled">> => false};
-enabled(restart) -> #{<<"enabled">> => true}.
+enabled(start) -> #{<<"enable">> => true};
+enabled(stop) -> #{<<"enable">> => false};
+enabled(restart) -> #{<<"enable">> => true}.
 
 err_msg(Atom) when is_atom(Atom) -> atom_to_binary(Atom);
 err_msg(Reason) -> list_to_binary(err_msg_str(Reason)).
@@ -594,7 +594,7 @@ format_status(Key, Node, Listener, Acc) ->
     #{
         <<"id">> := Id,
         <<"type">> := Type,
-        <<"enabled">> := Enabled,
+        <<"enable">> := Enable,
         <<"running">> := Running,
         <<"max_connections">> := MaxConnections,
         <<"current_connections">> := CurrentConnections,
@@ -609,7 +609,7 @@ format_status(Key, Node, Listener, Acc) ->
                 GroupKey => #{
                     name => Name,
                     type => Type,
-                    enable => Enabled,
+                    enable => Enable,
                     ids => [Id],
                     acceptors => Acceptors,
                     bind => iolist_to_binary(emqx_listeners:format_bind(Bind)),

--- a/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
@@ -206,9 +206,9 @@ cluster_specs() ->
             {env, [{emqx, boot_modules, all}]},
             {apps, []},
             {conf, [
-                {[listeners, ssl, default, enabled], false},
-                {[listeners, ws, default, enabled], false},
-                {[listeners, wss, default, enabled], false}
+                {[listeners, ssl, default, enable], false},
+                {[listeners, ws, default, enable], false},
+                {[listeners, wss, default, enable], false}
             ]}
         ],
     emqx_common_test_helpers:emqx_cluster(

--- a/changes/ce/feat-11226.en.md
+++ b/changes/ce/feat-11226.en.md
@@ -1,0 +1,1 @@
+Unify the listener switch to `enable`, while being compatible with the previous `enabled`.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10501

- Most listeners use "enable" for configuration and HTTP API
- Only `listeners.tcp.x` uses "enabled" as primary key(enable as alias) for backwards compatibility
- The Listeners HTTP API still uses "enable"
- We want to standardize on "enable" going forward, but remain compatible with existing "enabled" configurations 

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5c07980</samp>

This pull request standardizes the `enable` key name in the listener configuration map across different API endpoints and files. It also fixes some typos and renames the schema file to match the module name.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/{ce,ee}/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
