### PR TITLE
fix(plugins): start/stop plugins when loading config from CLI

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_plugins/src/emqx_plugins_app.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_app.erl
@@ -18,6 +18,8 @@
 
 -behaviour(application).
 
+-include("emqx_plugins.hrl").
+
 -export([
     start/2,
     stop/1
@@ -27,7 +29,9 @@ start(_Type, _Args) ->
     %% load all pre-configured
     ok = emqx_plugins:ensure_started(),
     {ok, Sup} = emqx_plugins_sup:start_link(),
+    ok = emqx_config_handler:add_handler([?CONF_ROOT], emqx_plugins),
     {ok, Sup}.
 
 stop(_State) ->
+    ok = emqx_config_handler:remove_handler([?CONF_ROOT]),
     ok.

--- a/changes/ce/fix-11229.en.md
+++ b/changes/ce/fix-11229.en.md
@@ -1,0 +1,1 @@
+Fixed an issue preventing plugins from starting/stopping after changing configuration via `emqx ctl conf load`.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10288

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2740bb6</samp>

Added support for dynamic plugin configuration via CLI in `emqx_plugins`. Implemented a config handler and a test case for this feature. Bumped the version of `emqx_plugins` to 0.1.5.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
