### PR TITLE
ci: trigger re-run of app version check after release

### DIFF
--- a/.github/workflows/apps_version_check.yaml
+++ b/.github/workflows/apps_version_check.yaml
@@ -1,6 +1,9 @@
 name: Check Apps Version
 
-on: [pull_request]
+on:
+  pull_request: {}
+  repository_dispatch:
+    types: [new_release_published]
 
 jobs:
   check_apps_version:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,3 +101,9 @@ jobs:
           push "el/8" "packages/$PROFILE-$VERSION-el8-arm64.rpm"
           push "el/9" "packages/$PROFILE-$VERSION-el9-amd64.rpm"
           push "el/9" "packages/$PROFILE-$VERSION-el9-arm64.rpm"
+      - name: trigger re-run of app versions check
+        if: startsWith(github.ref_name, 'v') && (github.event_name == 'release' || inputs.publish_release_artefacts)
+        uses: peter-evans/repository-dispatch@v2.1.1
+        with:
+          event-type: new_release_published
+          client-payload: '{"version": "${{ steps.profile.outputs.version }}"}'


### PR DESCRIPTION

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d04736a</samp>

Updated GitHub workflows to check app versions when a new release is published. Modified `.github/workflows/apps_version_check.yaml` to run on repository dispatch events and `.github/workflows/release.yaml` to trigger such events with the release version.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
