### PR TITLE
fix(emqx_machine): add emqx_ee_schema_registry to the reboot apps list

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -157,7 +157,8 @@ basic_reboot_apps_edition(ee) ->
         emqx_s3,
         emqx_ft,
         emqx_eviction_agent,
-        emqx_node_rebalance
+        emqx_node_rebalance,
+        emqx_ee_schema_registry
     ];
 %% unexcepted edition, should not happen
 basic_reboot_apps_edition(_) ->

--- a/changes/ee/fix-11242.en.md
+++ b/changes/ee/fix-11242.en.md
@@ -1,0 +1,5 @@
+Restart emqx_ee_schema_registry when a node joins a cluster.
+
+As emqx_ee_schema_registry uses Mria tables, a node joining a cluster needs to restart this application in order to
+start relevant Mria shard processes.
+This is needed to ensure a correct behaviour in Core/Replicant mode.


### PR DESCRIPTION
As emqx_ee_schema_registry uses Mria tables (schema_registry_shard), a node joining a cluster needs to restart this application in order to restart relevant Mria shard processes.

The scenario addressed by this fix:
1. start one core node (A)
2. start another core node (B)
3. join B to A (mria is restarted but emqx_ee_schema_registry is not, it means that there is no emqx_ee_schema_registry shard on this node anymore):
Node A:
```
e5.1.0-g58a83739(emqx@127.0.0.1)20> 
(search)`sup': supervisor:which_children(mria_shards_sup).
[{emqx_ee_schema_registry_shard,<0.3537.0>,supervisor,
                                [mria_core_shard_sup]},
 {emqx_psk_shard,<0.3371.0>,supervisor,[mria_core_shard_sup]},
...
```
Node B:
```
e5.1.0-g58a83739(emqx1@127.0.0.1)15> supervisor:which_children(mria_shards_sup).
[{emqx_psk_shard,<0.4285.0>,supervisor,
                 [mria_core_shard_sup]},
 {emqx_dashboard_shard,<0.4145.0>,supervisor,
                       [mria_core_shard_sup]},
...
```
4. start replicant node C and join A, B cluster
5.  If node C chooses node B for emqx_ee_schema_registry_shard, it will wait forever for the upstream shard

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 57208a2</samp>

This pull request fixes a bug with Mria tables in cluster mode by adding `emqx_ee_schema_registry` to the boot sequence of `emqx_machine`. It also updates the changelog for the Enterprise Edition with a file `changes/ee/fix-11209.en.md`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
