### PR TITLE
ci(machine_boot): add ci check for missing reboot apps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,7 @@ static_checks:
 	@$(REBAR) as check do xref, dialyzer
 	@if [ "$${PROFILE}" = 'emqx-enterprise' ]; then $(REBAR) ct --suite apps/emqx/test/emqx_static_checks --readable $(CT_READABLE); fi
 	./scripts/check-i18n-style.sh
+	./scripts/check_missing_reboot_apps.exs --profile $(PROFILE)
 
 APPS=$(shell $(SCRIPTS)/find-apps.sh)
 

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -146,7 +146,8 @@ basic_reboot_apps() ->
             emqx_slow_subs,
             emqx_auto_subscribe,
             emqx_plugins,
-            emqx_psk
+            emqx_psk,
+            emqx_durable_storage
         ] ++ basic_reboot_apps_edition(emqx_release:edition()).
 
 basic_reboot_apps_edition(ce) ->

--- a/scripts/check_missing_reboot_apps.exs
+++ b/scripts/check_missing_reboot_apps.exs
@@ -1,0 +1,62 @@
+#!/usr/bin/env elixir
+
+{parsed, _argv, _errors = []} =
+  OptionParser.parse(
+    System.argv(),
+    strict: [profile: :string]
+  )
+
+profile = Keyword.fetch!(parsed, :profile)
+
+:xref.start(:xref)
+:xref.set_default(:xref, warnings: false)
+rel_dir = '_build/#{profile}/lib/'
+:xref.add_release(:xref, rel_dir)
+
+{:ok, calls} = :xref.q(:xref, '(App) (XC || "mria":"create_table"/".*")')
+
+emqx_calls =
+  calls
+  |> Enum.map(&elem(&1, 0))
+  |> Enum.filter(&(to_string(&1) =~ "emqx_"))
+  |> MapSet.new()
+
+Path.wildcard(rel_dir ++ "*/ebin")
+|> Enum.each(fn dir ->
+  dir
+  |> to_charlist()
+  |> :code.add_pathz()
+end)
+
+Path.wildcard(rel_dir ++ "*")
+|> Enum.map(fn dir ->
+  dir
+  |> Path.basename()
+  |> String.to_atom()
+  |> Application.load()
+end)
+
+reboot_apps = :emqx_machine_boot.sorted_reboot_apps() |> MapSet.new()
+
+missing_reboot_apps = MapSet.difference(emqx_calls, reboot_apps)
+
+if MapSet.size(missing_reboot_apps) != 0 do
+  IO.puts(
+    :stderr,
+    IO.ANSI.format([
+      :red,
+      "Some applications are missing from `emqx_machine_boot:sorted_reboot_apps/0`!\n",
+      "Missing applications:\n",
+      Enum.map(missing_reboot_apps, fn app ->
+        "  * #{app}\n"
+      end),
+      "\n",
+      :green,
+      "Hint: maybe add them to `emqx_machine_boot:basic_reboot_apps_edition/1`\n",
+      "\n",
+      :yellow,
+      "Applications that call `mria:create_table` need to be added to that list;\n",
+      " otherwise, when a node joins a cluster, it might lose tables.\n"
+    ])
+  )
+end


### PR DESCRIPTION
In order to avoid forgetting to add an application to `emqx_machine_boot:sorted_reboot_apps`, this script checks for any calls to `mria:create_table` in all EMQX applications and checks it against said function in `emqx_machine_boot`.

Example run:

```
ͳ scripts/check_missing_reboot_apps.exs --profile emqx-enterprise
Some applications are missing from `emqx_machine_boot:sorted_reboot_apps/0`!
Missing applications:
  * emqx_durable_storage
  * emqx_ee_schema_registry

Hint: maybe add them to `emqx_machine_boot:basic_reboot_apps_edition/1`

Applications that call `mria:create_table` need to be added to that list;
 otherwise, when a node joins a cluster, it might lose tables.
```

![2023-07-10_14-34](https://github.com/emqx/emqx/assets/16166434/2efb9126-9dae-4572-9a9f-58c5a1188ce9)

Example problem: https://github.com/emqx/emqx/pull/11242

Fixes https://emqx.atlassian.net/browse/EMQX-10522

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 12aa788</samp>

Add a script and a Makefile command to check the reboot list of emqx_machine_boot. This helps to ensure that all applications that use mria are properly restarted when nodes join a cluster.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
