### PR TITLE
ci(dev): fix `--ekka-epmd` flag for elixir

### DIFF
--- a/dev
+++ b/dev
@@ -373,15 +373,15 @@ boot() {
           {:ok, _} = Application.ensure_all_started(:emqx_machine)
         '
         if [ -n "${EPMD_ARGS:-}" ]; then
-            EPMD_ARGS_ELIXIR="--erl $EPMD_ARGS"
+            EPMD_ARGS_ELIXIR="$EPMD_ARGS"
         else
-            EPMD_ARGS_ELIXIR=""
+            EPMD_ARGS_ELIXIR="-no_op true"
         fi
 
         # shellcheck disable=SC2086
         env APPS="$APPS" iex \
           --name "$EMQX_NODE_NAME" \
-          $EPMD_ARGS_ELIXIR \
+          --erl "$EPMD_ARGS_ELIXIR" \
           --erl '-user Elixir.IEx.CLI' \
           --erl '-proto_dist ekka' \
           --vm-args "$ARGS_FILE" \


### PR DESCRIPTION

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3fa8853</samp>

Fix `iex` and `epmd` issues for emqx development. This pull request avoids conflicting `--erl` flags and disables `epmd` for emqx nodes in the `dev` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
