### PR TITLE
feat: add license setting get/put api

### DIFF
--- a/apps/emqx_enterprise/src/emqx_enterprise.app.src
+++ b/apps/emqx_enterprise/src/emqx_enterprise.app.src
@@ -1,6 +1,6 @@
 {application, emqx_enterprise, [
     {description, "EMQX Enterprise Edition"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
+++ b/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
@@ -35,7 +35,7 @@ desc(Name) ->
     ee_delegate(desc, ?EE_SCHEMA_MODULES, Name).
 
 validations() ->
-    emqx_conf_schema:validations().
+    emqx_conf_schema:validations() ++ emqx_license_schema:validations().
 
 %%------------------------------------------------------------------------------
 %% helpers

--- a/changes/ce/feat-11249.en.md
+++ b/changes/ce/feat-11249.en.md
@@ -1,0 +1,1 @@
+Support HTTP API for setting alarm watermark of license.

--- a/lib-ee/emqx_license/src/emqx_license_http_api.erl
+++ b/lib-ee/emqx_license/src/emqx_license_http_api.erl
@@ -13,11 +13,14 @@
     namespace/0,
     api_spec/0,
     paths/0,
-    schema/1
+    schema/1,
+    fields/1
 ]).
+-define(LICENSE_TAGS, [<<"License">>]).
 
 -export([
-    '/license'/2
+    '/license'/2,
+    '/license/setting'/2
 ]).
 
 -define(BAD_REQUEST, 'BAD_REQUEST').
@@ -29,14 +32,15 @@ api_spec() ->
 
 paths() ->
     [
-        "/license"
+        "/license",
+        "/license/setting"
     ].
 
 schema("/license") ->
     #{
         'operationId' => '/license',
         get => #{
-            tags => [<<"license">>],
+            tags => ?LICENSE_TAGS,
             summary => <<"Get license info">>,
             description => ?DESC("desc_license_info_api"),
             responses => #{
@@ -51,18 +55,16 @@ schema("/license") ->
             }
         },
         post => #{
-            tags => [<<"license">>],
+            tags => ?LICENSE_TAGS,
             summary => <<"Update license key">>,
             description => ?DESC("desc_license_key_api"),
             'requestBody' => emqx_dashboard_swagger:schema_with_examples(
-                emqx_license_schema:key_license(),
+                hoconsc:ref(?MODULE, key_license),
                 #{
                     license_key => #{
                         summary => <<"License key string">>,
                         value => #{
-                            <<"key">> => <<"xxx">>,
-                            <<"connection_low_watermark">> => "75%",
-                            <<"connection_high_watermark">> => "80%"
+                            <<"key">> => <<"xxx">>
                         }
                     }
                 }
@@ -77,6 +79,28 @@ schema("/license") ->
                     }
                 ),
                 400 => emqx_dashboard_swagger:error_codes([?BAD_REQUEST], <<"Bad license key">>)
+            }
+        }
+    };
+schema("/license/setting") ->
+    #{
+        'operationId' => '/license/setting',
+        get => #{
+            tags => ?LICENSE_TAGS,
+            summary => <<"Get license setting">>,
+            description => ?DESC("desc_license_setting_api"),
+            responses => #{
+                200 => setting()
+            }
+        },
+        post => #{
+            tags => ?LICENSE_TAGS,
+            summary => <<"Update license setting">>,
+            description => ?DESC("desc_license_setting_api"),
+            'requestBody' => setting(),
+            responses => #{
+                200 => setting(),
+                400 => emqx_dashboard_swagger:error_codes([?BAD_REQUEST], <<"Bad setting value">>)
             }
         }
     }.
@@ -117,3 +141,38 @@ error_msg(Code, Msg) ->
     end;
 '/license'(post, _Params) ->
     {400, error_msg(?BAD_REQUEST, <<"Invalid request params">>)}.
+
+'/license/setting'(get, _Params) ->
+    {200, maps:remove(<<"key">>, emqx_config:get_raw([license]))};
+'/license/setting'(post, #{body := Setting}) ->
+    case emqx_license:update_setting(Setting) of
+        {error, Error} ->
+            ?SLOG(error, #{
+                msg => "bad_license_setting",
+                reason => Error
+            }),
+            {400, error_msg(?BAD_REQUEST, <<"Bad license setting">>)};
+        {ok, _} ->
+            ?SLOG(info, #{msg => "updated_license_setting"}),
+            '/license/setting'(get, undefined)
+    end.
+
+fields(key_license) ->
+    Key = lists:keyfind(key, 1, emqx_license_schema:fields(key_license)),
+    [
+        Key,
+        %% FIXME: remove when 5.2.0
+        {connection_low_watermark, #{
+            type => emqx_schema:percent(),
+            deprecated => true,
+            desc => ?DESC(connection_low_watermark_field_deprecated)
+        }},
+        {connection_high_watermark, #{
+            type => emqx_schema:percent(),
+            deprecated => true,
+            desc => ?DESC(connection_high_watermark_field_deprecated)
+        }}
+    ].
+
+setting() ->
+    lists:keydelete(key, 1, emqx_license_schema:fields(key_license)).

--- a/lib-ee/emqx_license/src/emqx_license_http_api.erl
+++ b/lib-ee/emqx_license/src/emqx_license_http_api.erl
@@ -54,7 +54,7 @@ schema("/license") ->
                 )
             }
         },
-        %% FIXME: It's a update action, should use put instead of post in 5.2.0
+        %% TODO(5.x): It's a update action, should use PUT instead
         post => #{
             tags => ?LICENSE_TAGS,
             summary => <<"Update license key">>,
@@ -159,23 +159,7 @@ error_msg(Code, Msg) ->
     end.
 
 fields(key_license) ->
-    Key = lists:keyfind(key, 1, emqx_license_schema:fields(key_license)),
-    [
-        Key,
-        %% FIXME: remove when 5.2.0
-        {connection_low_watermark, #{
-            type => emqx_schema:percent(),
-            example => <<"75%">>,
-            deprecated => true,
-            desc => ?DESC(connection_low_watermark_field_deprecated)
-        }},
-        {connection_high_watermark, #{
-            type => emqx_schema:percent(),
-            example => <<"80%">>,
-            deprecated => true,
-            desc => ?DESC(connection_high_watermark_field_deprecated)
-        }}
-    ].
+    [lists:keyfind(key, 1, emqx_license_schema:fields(key_license))].
 
 setting() ->
     lists:keydelete(key, 1, emqx_license_schema:fields(key_license)).

--- a/lib-ee/emqx_license/src/emqx_license_http_api.erl
+++ b/lib-ee/emqx_license/src/emqx_license_http_api.erl
@@ -164,11 +164,13 @@ fields(key_license) ->
         %% FIXME: remove when 5.2.0
         {connection_low_watermark, #{
             type => emqx_schema:percent(),
+            example => <<"75%">>,
             deprecated => true,
             desc => ?DESC(connection_low_watermark_field_deprecated)
         }},
         {connection_high_watermark, #{
             type => emqx_schema:percent(),
+            example => <<"80%">>,
             deprecated => true,
             desc => ?DESC(connection_high_watermark_field_deprecated)
         }}

--- a/lib-ee/emqx_license/src/emqx_license_http_api.erl
+++ b/lib-ee/emqx_license/src/emqx_license_http_api.erl
@@ -54,6 +54,7 @@ schema("/license") ->
                 )
             }
         },
+        %% FIXME: It's a update action, should use put instead of post in 5.2.0
         post => #{
             tags => ?LICENSE_TAGS,
             summary => <<"Update license key">>,
@@ -93,7 +94,7 @@ schema("/license/setting") ->
                 200 => setting()
             }
         },
-        post => #{
+        put => #{
             tags => ?LICENSE_TAGS,
             summary => <<"Update license setting">>,
             description => ?DESC("desc_license_setting_api"),
@@ -144,7 +145,7 @@ error_msg(Code, Msg) ->
 
 '/license/setting'(get, _Params) ->
     {200, maps:remove(<<"key">>, emqx_config:get_raw([license]))};
-'/license/setting'(post, #{body := Setting}) ->
+'/license/setting'(put, #{body := Setting}) ->
     case emqx_license:update_setting(Setting) of
         {error, Error} ->
             ?SLOG(error, #{

--- a/lib-ee/emqx_license/src/emqx_license_schema.erl
+++ b/lib-ee/emqx_license/src/emqx_license_schema.erl
@@ -46,11 +46,13 @@ fields(key_license) ->
         {connection_low_watermark, #{
             type => emqx_schema:percent(),
             default => <<"75%">>,
+            example => <<"75%">>,
             desc => ?DESC(connection_low_watermark_field)
         }},
         {connection_high_watermark, #{
             type => emqx_schema:percent(),
             default => <<"80%">>,
+            example => <<"80%">>,
             desc => ?DESC(connection_high_watermark_field)
         }}
     ].

--- a/lib-ee/emqx_license/src/emqx_license_schema.erl
+++ b/lib-ee/emqx_license/src/emqx_license_schema.erl
@@ -16,15 +16,14 @@
 -export([roots/0, fields/1, validations/0, desc/1, tags/0]).
 
 -export([
-    default_license/0,
-    key_license/0
+    default_license/0
 ]).
 
 roots() ->
     [
         {license,
             hoconsc:mk(
-                key_license(),
+                hoconsc:ref(?MODULE, key_license),
                 #{
                     desc => ?DESC(license_root)
                 }
@@ -63,9 +62,6 @@ desc(_) ->
 
 validations() ->
     [{check_license_watermark, fun check_license_watermark/1}].
-
-key_license() ->
-    hoconsc:ref(?MODULE, key_license).
 
 check_license_watermark(Conf) ->
     case hocon_maps:get("license.connection_low_watermark", Conf) of

--- a/lib-ee/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/lib-ee/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -186,7 +186,7 @@ t_license_setting(_Config) ->
     %% update
     Low = <<"50%">>,
     High = <<"55%">>,
-    UpdateRes = request(post, uri(["license", "setting"]), #{
+    UpdateRes = request(put, uri(["license", "setting"]), #{
         <<"connection_low_watermark">> => Low,
         <<"connection_high_watermark">> => High
     }),
@@ -197,14 +197,14 @@ t_license_setting(_Config) ->
     %% update bad setting low >= high
     ?assertMatch(
         {ok, 400, _},
-        request(post, uri(["license", "setting"]), #{
+        request(put, uri(["license", "setting"]), #{
             <<"connection_low_watermark">> => <<"50%">>,
             <<"connection_high_watermark">> => <<"50%">>
         })
     ),
     ?assertMatch(
         {ok, 400, _},
-        request(post, uri(["license", "setting"]), #{
+        request(put, uri(["license", "setting"]), #{
             <<"connection_low_watermark">> => <<"51%">>,
             <<"connection_high_watermark">> => <<"50%">>
         })

--- a/lib-ee/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/lib-ee/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -193,6 +193,22 @@ t_license_setting(_Config) ->
     validate_setting(UpdateRes, Low, High),
     ?assertEqual(0.5, emqx_config:get([license, connection_low_watermark])),
     ?assertEqual(0.55, emqx_config:get([license, connection_high_watermark])),
+
+    %% update bad setting low >= high
+    ?assertMatch(
+        {ok, 400, _},
+        request(post, uri(["license", "setting"]), #{
+            <<"connection_low_watermark">> => <<"50%">>,
+            <<"connection_high_watermark">> => <<"50%">>
+        })
+    ),
+    ?assertMatch(
+        {ok, 400, _},
+        request(post, uri(["license", "setting"]), #{
+            <<"connection_low_watermark">> => <<"51%">>,
+            <<"connection_high_watermark">> => <<"50%">>
+        })
+    ),
     ok.
 
 validate_setting(Res, ExpectLow, ExpectHigh) ->

--- a/mix.exs
+++ b/mix.exs
@@ -189,7 +189,8 @@ defmodule EMQXUmbrella.MixProject do
       :emqx_bridge_rabbitmq,
       :emqx_bridge_clickhouse,
       :emqx_ft,
-      :emqx_s3
+      :emqx_s3,
+      :emqx_enterprise
     ])
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -102,6 +102,7 @@ is_community_umbrella_app("apps/emqx_oracle") -> false;
 is_community_umbrella_app("apps/emqx_bridge_rabbitmq") -> false;
 is_community_umbrella_app("apps/emqx_ft") -> false;
 is_community_umbrella_app("apps/emqx_s3") -> false;
+is_community_umbrella_app("apps/emqx_enterprise") -> false;
 is_community_umbrella_app(_) -> true.
 
 is_jq_supported() ->

--- a/rel/i18n/emqx_license_http_api.hocon
+++ b/rel/i18n/emqx_license_http_api.hocon
@@ -12,4 +12,10 @@ desc_license_key_api.desc:
 desc_license_key_api.label:
 """Update license"""
 
+desc_license_setting_api.desc:
+"""Update license setting"""
+
+desc_license_setting_api.label:
+"""Update license setting"""
+
 }

--- a/rel/i18n/emqx_license_schema.hocon
+++ b/rel/i18n/emqx_license_schema.hocon
@@ -12,6 +12,18 @@ connection_low_watermark_field.desc:
 connection_low_watermark_field.label:
 """Connection low watermark"""
 
+connection_high_watermark_field_deprecated.desc:
+"""deprecated use /license/setting instead"""
+
+connection_high_watermark_field_deprecated.label:
+"""deprecated use /license/setting instead"""
+
+connection_low_watermark_field_deprecated.desc:
+"""deprecated use /license/setting instead"""
+
+connection_low_watermark_field_deprecated.label:
+"""deprecated use /license/setting instead"""
+
 key_field.desc:
 """License string"""
 
@@ -19,12 +31,12 @@ key_field.label:
 """License string"""
 
 license_root.desc:
-"""Defines the EMQX Enterprise license. 
+"""Defines the EMQX Enterprise license.
 
 
 The default license has 100 connections limit, it is issued on 2023-01-09 and valid for 5 years (1825 days).
 
-EMQX comes with a default trial license.  For production use, please 
+EMQX comes with a default trial license.  For production use, please
 visit https://www.emqx.com/apply-licenses/emqx to apply."""
 
 license_root.label:


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10252

Add `/license/setting` GET/PUT HTTP API for setting the alarm watermark of license.

<img width="1032" alt="image" src="https://github.com/emqx/emqx/assets/3116225/f67f514c-9d9e-4d15-9df5-150d80b822dc">




<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f03d4d0</samp>

This pull request adds a new HTTP API endpoint for getting and updating the license setting of EMQ X. It also refactors the license schema and code to use the hocon schema format and macros, and updates the HTTP API documentation accordingly. The files `emqx_license_http_api.erl`, `emqx_license_schema.erl`, `emqx_license.erl`, `emqx_license_schema.hocon`, and `emqx_license_http_api.hocon` are modified.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
