### PR TITLE
fix(ws): fix MQTT packets may be reversed in the WS

### DIFF
--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -699,7 +699,7 @@ check_oom(State = #state{channel = Channel}) ->
 %%--------------------------------------------------------------------
 
 parse_incoming(<<>>, Packets, State) ->
-    {Packets, State};
+    {lists:reverse(Packets), State};
 parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
     try emqx_frame:parse(Data, ParseState) of
         {more, NParseState} ->

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -530,6 +530,14 @@ t_parse_incoming(_) ->
     Packet = ?PUBLISH_PACKET(?QOS_0, <<"t">>, undefined, <<>>),
     ?assertMatch([{incoming, Packet}], Packets1).
 
+t_parse_incoming_order(_) ->
+    Packet1 = ?PUBLISH_PACKET(?QOS_0, <<"t1">>, undefined, <<>>),
+    Packet2 = ?PUBLISH_PACKET(?QOS_0, <<"t2">>, undefined, <<>>),
+    Bin1 = emqx_frame:serialize(Packet1),
+    Bin2 = emqx_frame:serialize(Packet2),
+    {Packets1, _} = ?ws_conn:parse_incoming(erlang:iolist_to_binary([Bin1, Bin2]), [], st()),
+    ?assertMatch([{incoming, Packet1}, {incoming, Packet2}], Packets1).
+
 t_parse_incoming_frame_error(_) ->
     {Packets, _St} = ?ws_conn:parse_incoming(<<3, 2, 1, 0>>, [], st()),
     FrameError = {frame_error, malformed_packet},


### PR DESCRIPTION
Fix when a WS packet contains many MQTT packets, the order of MQTT packets will be reversed

Fixes [EMQX-10448](https://emqx.atlassian.net/browse/EMQX-10448)
Fixes #11144 

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
