### PR TITLE
fix(bridge_api): return 400 for all ecpool start errors

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -983,15 +983,10 @@ call_operation(NodeOrAll, OperFunc, Args = [_Nodes, BridgeType, BridgeName]) ->
             %% still on an older bpapi version that doesn't support it.
             maybe_try_restart(NodeOrAll, OperFunc, Args);
         {error, timeout} ->
-            ?SERVICE_UNAVAILABLE(<<"Request timeout">>);
+            ?BAD_REQUEST(<<"Request timeout">>);
         {error, {start_pool_failed, Name, Reason}} ->
             Msg = bin(io_lib:format("Failed to start ~p pool for reason ~p", [Name, Reason])),
-            case Reason of
-                nxdomain ->
-                    ?BAD_REQUEST(Msg);
-                _ ->
-                    ?SERVICE_UNAVAILABLE(Msg)
-            end;
+            ?BAD_REQUEST(Msg);
         {error, not_found} ->
             BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
             ?SLOG(warning, #{

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -834,7 +834,8 @@ do_start_stop_bridges(Type, Config) ->
     ),
     BadBridgeID = emqx_bridge_resource:bridge_id(?BRIDGE_TYPE_MQTT, BadName),
     ?assertMatch(
-        {ok, SC, _} when SC == 500 orelse SC == 503,
+        %% request from product: return 400 on such errors
+        {ok, SC, _} when SC == 500 orelse SC == 400,
         request(post, {operation, Type, start, BadBridgeID}, Config)
     ),
     ok = gen_tcp:close(Sock),


### PR DESCRIPTION
# targeting `release-51`

Fixes https://emqx.atlassian.net/browse/EMQX-10460 
(https://emqx.atlassian.net/browse/EMQX-10460?focusedCommentId=30126)

After fix:
![image](https://github.com/emqx/emqx/assets/16166434/f2346989-df18-49ca-b5e4-cd23cd0d6323)

![image](https://github.com/emqx/emqx/assets/16166434/822673ef-f8de-4550-9f3e-8095a1d791ff)



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2e05e90</samp>

Simplify error handling for starting bridge pools in `emqx_bridge_api.erl`. Always return a bad request with the reason message instead of different status codes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
