### PR TITLE
Stop using boot mnesia attributes

### DIFF
--- a/apps/emqx/src/emqx_alarm.erl
+++ b/apps/emqx/src/emqx_alarm.erl
@@ -22,9 +22,7 @@
 -include("logger.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 -export([start_link/0]).
 %% API
@@ -86,7 +84,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(
         ?ACTIVATED_ALARM,
         [

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -37,6 +37,7 @@
 %%--------------------------------------------------------------------
 
 start(_Type, _Args) ->
+    emqx_utils:ensure_mria_tables(emqx),
     ok = maybe_load_config(),
     ok = emqx_persistent_session:init_db_backend(),
     _ = emqx_persistent_session_ds:init(),

--- a/apps/emqx/src/emqx_banned.erl
+++ b/apps/emqx/src/emqx_banned.erl
@@ -25,9 +25,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 -export([start_link/0, stop/0]).
 
@@ -75,7 +73,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?BANNED_TAB, [
         {type, set},
         {rlog_shard, ?COMMON_SHARD},

--- a/apps/emqx/src/emqx_exclusive_subscription.erl
+++ b/apps/emqx/src/emqx_exclusive_subscription.erl
@@ -22,13 +22,10 @@
 -logger_header("[exclusive]").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
+-export([ensure_mria_tables/0]).
 
 %% For upgrade
 -export([on_add_module/0, on_delete_module/0]).
-
--boot_mnesia({mnesia, [boot]}).
--copy_mnesia({mnesia, [copy]}).
 
 -export([
     check_subscribe/2,
@@ -53,7 +50,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     StoreProps = [
         {ets, [
             {read_concurrency, true},
@@ -75,7 +72,7 @@ mnesia(boot) ->
 %%--------------------------------------------------------------------
 
 on_add_module() ->
-    mnesia(boot).
+    ensure_mria_tables().
 
 on_delete_module() ->
     clear().

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -25,9 +25,7 @@
 -include_lib("emqx/include/emqx_router.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 -export([start_link/2]).
 
@@ -74,7 +72,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     mria_config:set_dirty_shard(?ROUTE_SHARD, true),
     ok = mria:create_table(?ROUTE_TAB, [
         {type, bag},

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -25,9 +25,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 %% API
 -export([
@@ -63,7 +61,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?ROUTING_NODE, [
         {type, set},
         {rlog_shard, ?ROUTE_SHARD},

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -25,9 +25,7 @@
 -include("types.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 %% APIs
 -export([start_link/0]).
@@ -108,7 +106,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {type, bag},
         {rlog_shard, ?SHARED_SUB_SHARD},

--- a/apps/emqx/src/emqx_trie.erl
+++ b/apps/emqx/src/emqx_trie.erl
@@ -20,11 +20,9 @@
 
 %% Mnesia bootstrap
 -export([
-    mnesia/1,
+    ensure_mria_tables/0,
     create_session_trie/1
 ]).
-
--boot_mnesia({mnesia, [boot]}).
 
 %% Trie APIs
 -export([
@@ -64,8 +62,8 @@
 %%--------------------------------------------------------------------
 
 %% @doc Create or replicate topics table.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+-spec ensure_mria_tables() -> ok.
+ensure_mria_tables() ->
     %% Optimize storage
     StoreProps = [
         {ets, [

--- a/apps/emqx_authn/src/emqx_authn.app.src
+++ b/apps/emqx_authn/src/emqx_authn.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authn, [
     {description, "EMQX Authentication"},
-    {vsn, "0.1.22"},
+    {vsn, "0.1.23"},
     {modules, []},
     {registered, [emqx_authn_sup, emqx_authn_registry]},
     {applications, [

--- a/apps/emqx_authn/src/emqx_authn_app.erl
+++ b/apps/emqx_authn/src/emqx_authn_app.erl
@@ -35,6 +35,7 @@
 %%------------------------------------------------------------------------------
 
 start(_StartType, _StartArgs) ->
+    emqx_utils:ensure_mria_tables(emqx_authn),
     %% required by test cases, ensure the injection of
     %% EMQX_AUTHENTICATION_SCHEMA_MODULE_PT_KEY
     _ = emqx_conf_schema:roots(),

--- a/apps/emqx_authn/src/enhanced_authn/emqx_enhanced_authn_scram_mnesia.erl
+++ b/apps/emqx_authn/src/enhanced_authn/emqx_enhanced_authn_scram_mnesia.erl
@@ -74,9 +74,7 @@
 
 -type user_group() :: binary().
 
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 -record(user_info, {
     user_id,
@@ -93,8 +91,7 @@
 %%------------------------------------------------------------------------------
 
 %% @doc Create or replicate tables.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {rlog_shard, ?AUTH_SHARD},
         {type, ordered_set},

--- a/apps/emqx_authn/src/simple_authn/emqx_authn_mnesia.erl
+++ b/apps/emqx_authn/src/simple_authn/emqx_authn_mnesia.erl
@@ -67,7 +67,7 @@
     import_csv/3
 ]).
 
--export([mnesia/1]).
+-export([ensure_mria_tables/0]).
 
 -export([backup_tables/0]).
 
@@ -81,8 +81,6 @@
     is_superuser :: boolean()
 }).
 
--boot_mnesia({mnesia, [boot]}).
-
 -define(TAB, ?MODULE).
 -define(AUTHN_QSCHEMA, [
     {<<"like_user_id">>, binary},
@@ -95,8 +93,7 @@
 %%------------------------------------------------------------------------------
 
 %% @doc Create or replicate tables.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {rlog_shard, ?AUTH_SHARD},
         {type, ordered_set},

--- a/apps/emqx_authz/src/emqx_authz_app.erl
+++ b/apps/emqx_authz/src/emqx_authz_app.erl
@@ -26,7 +26,7 @@
 -export([start/2, stop/1]).
 
 start(_StartType, _StartArgs) ->
-    ok = emqx_authz_mnesia:init_tables(),
+    emqx_utils:ensure_mria_tables(emqx_authz),
     {ok, Sup} = emqx_authz_sup:start_link(),
     ok = emqx_authz:init(),
     {ok, Sup}.

--- a/apps/emqx_authz/src/emqx_authz_mnesia.erl
+++ b/apps/emqx_authz/src/emqx_authz_mnesia.erl
@@ -54,8 +54,7 @@
 
 %% Management API
 -export([
-    mnesia/1,
-    init_tables/0,
+    ensure_mria_tables/0,
     store_rules/2,
     purge_rules/0,
     get_rules/1,
@@ -72,17 +71,16 @@
 -compile(nowarn_export_all).
 -endif.
 
--boot_mnesia({mnesia, [boot]}).
-
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+-spec ensure_mria_tables() -> ok.
+ensure_mria_tables() ->
     ok = mria:create_table(?ACL_TABLE, [
         {type, ordered_set},
         {rlog_shard, ?ACL_SHARDED},
         {storage, disc_copies},
         {attributes, record_info(fields, ?ACL_TABLE)},
         {storage_properties, [{ets, [{read_concurrency, true}]}]}
-    ]).
+    ]),
+    ok = mria:wait_for_tables([?ACL_TABLE]).
 
 %%--------------------------------------------------------------------
 %% emqx_authz callbacks
@@ -130,11 +128,6 @@ backup_tables() -> [?ACL_TABLE].
 %%--------------------------------------------------------------------
 %% Management API
 %%--------------------------------------------------------------------
-
-%% Init
--spec init_tables() -> ok.
-init_tables() ->
-    ok = mria_rlog:wait_for_shards([?ACL_SHARDED], infinity).
 
 %% @doc Update authz rules
 -spec store_rules(who(), rules()) -> ok.

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -17,7 +17,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0, mnesia/1]).
+-export([start_link/0, ensure_mria_tables/0]).
 
 %% Note: multicall functions are statically checked by
 %% `emqx_bapi_trans' and `emqx_bpapi_static_checks' modules. Don't
@@ -61,8 +61,6 @@
 
 -export_type([tnx_id/0, succeed_num/0]).
 
--boot_mnesia({mnesia, [boot]}).
-
 -include_lib("emqx/include/logger.hrl").
 -include("emqx_conf.hrl").
 
@@ -94,7 +92,7 @@
 %%%===================================================================
 %%% API
 %%%===================================================================
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?CLUSTER_MFA, [
         {type, ordered_set},
         {rlog_shard, ?CLUSTER_RPC_SHARD},

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -29,6 +29,7 @@
 -define(DEFAULT_INIT_TXN_ID, -1).
 
 start(_StartType, _StartArgs) ->
+    emqx_utils:ensure_mria_tables(emqx_conf),
     try
         ok = init_conf()
     catch

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -22,12 +22,10 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
--boot_mnesia({mnesia, [boot]}).
-
 -behaviour(emqx_db_backup).
 
 %% Mnesia bootstrap
--export([mnesia/1]).
+-export([ensure_mria_tables/0]).
 
 -export([
     add_user/3,
@@ -65,7 +63,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?ADMIN, [
         {type, set},
         {rlog_shard, ?DASHBOARD_SHARD},

--- a/apps/emqx_dashboard/src/emqx_dashboard_app.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_app.erl
@@ -26,6 +26,7 @@
 -include("emqx_dashboard.hrl").
 
 start(_StartType, _StartArgs) ->
+    emqx_utils:ensure_mria_tables(emqx_dashboard),
     ok = mria_rlog:wait_for_shards([?DASHBOARD_SHARD], infinity),
     {ok, Sup} = emqx_dashboard_sup:start_link(),
     case emqx_dashboard:start_listeners() of

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -22,8 +22,6 @@
 
 -behaviour(gen_server).
 
--boot_mnesia({mnesia, [boot]}).
-
 -export([start_link/0]).
 
 -export([
@@ -35,7 +33,7 @@
     code_change/3
 ]).
 
--export([mnesia/1]).
+-export([ensure_mria_tables/0]).
 
 -export([
     samplers/0,
@@ -64,7 +62,7 @@
     data :: map()
 }).
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {type, set},
         {local_content, true},

--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -27,9 +27,7 @@
     destroy_by_username/1
 ]).
 
--boot_mnesia({mnesia, [boot]}).
-
--export([mnesia/1]).
+-export([ensure_mria_tables/0]).
 
 -ifdef(TEST).
 -export([lookup_by_username/1, clean_expired_jwt/1]).
@@ -84,7 +82,7 @@ salt() ->
     <<X:16/big-unsigned-integer>> = crypto:strong_rand_bytes(2),
     iolist_to_binary(io_lib:format("~4.16.0b", [X])).
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {type, set},
         {rlog_shard, ?DASHBOARD_SHARD},

--- a/apps/emqx_management/src/emqx_mgmt_app.erl
+++ b/apps/emqx_management/src/emqx_mgmt_app.erl
@@ -28,6 +28,7 @@
 -include("emqx_mgmt.hrl").
 
 start(_Type, _Args) ->
+    emqx_utils:ensure_mria_tables(emqx_management),
     case emqx_mgmt_auth:init_bootstrap_file() of
         ok ->
             emqx_conf:add_handler([api_key], emqx_mgmt_auth),

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -20,8 +20,8 @@
 -behaviour(emqx_db_backup).
 
 %% API
--export([mnesia/1]).
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
+
 -behaviour(emqx_config_handler).
 
 -export([
@@ -63,7 +63,7 @@
     created_at = 0 :: integer() | '_'
 }).
 
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?APP, [
         {type, set},
         {rlog_shard, ?COMMON_SHARD},

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -26,9 +26,7 @@
 -include_lib("emqx/include/emqx_hooks.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 -export([
     start_link/0,
@@ -101,7 +99,7 @@
 %%------------------------------------------------------------------------------
 %% Mnesia bootstrap
 %%------------------------------------------------------------------------------
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {type, ordered_set},
         {storage, disc_copies},

--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.17"},
+    {vsn, "5.0.18"},
     {modules, []},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},
     {mod, {emqx_modules_app, []}},

--- a/apps/emqx_modules/src/emqx_modules_app.erl
+++ b/apps/emqx_modules/src/emqx_modules_app.erl
@@ -24,6 +24,7 @@
 ]).
 
 start(_Type, _Args) ->
+    emqx_utils:ensure_mria_tables(emqx_modules),
     {ok, Sup} = emqx_modules_sup:start_link(),
     maybe_enable_modules(),
     {ok, Sup}.

--- a/apps/emqx_psk/src/emqx_psk.erl
+++ b/apps/emqx_psk/src/emqx_psk.erl
@@ -63,9 +63,7 @@
     extra :: term()
 }).
 
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_mria_tables/0]).
 
 -include("emqx_psk.hrl").
 
@@ -81,8 +79,7 @@
 %%------------------------------------------------------------------------------
 
 %% @doc Create or replicate tables.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+ensure_mria_tables() ->
     ok = mria:create_table(?TAB, [
         {rlog_shard, ?PSK_SHARD},
         {type, ordered_set},
@@ -90,7 +87,8 @@ mnesia(boot) ->
         {record_name, psk_entry},
         {attributes, record_info(fields, psk_entry)},
         {storage_properties, [{ets, [{read_concurrency, true}]}]}
-    ]).
+    ]),
+    ok = mria:wait_for_tables([?TAB]).
 
 %%------------------------------------------------------------------------------
 %% Data backup

--- a/apps/emqx_psk/src/emqx_psk_app.erl
+++ b/apps/emqx_psk/src/emqx_psk_app.erl
@@ -26,7 +26,7 @@
 -include("emqx_psk.hrl").
 
 start(_Type, _Args) ->
-    ok = mria:wait_for_tables([?TAB]),
+    emqx_utils:ensure_mria_tables(emqx_psk),
     emqx_conf:add_handler([?PSK_KEY], emqx_psk),
     {ok, Sup} = emqx_psk_sup:start_link(),
     {ok, Sup}.

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -61,7 +61,8 @@
     diff_lists/3,
     merge_lists/3,
     tcp_keepalive_opts/4,
-    format/1
+    format/1,
+    ensure_mria_tables/1
 ]).
 
 -export([
@@ -528,6 +529,20 @@ tcp_keepalive_opts(OS, _Idle, _Interval, _Probes) ->
 
 format(Term) ->
     iolist_to_binary(io_lib:format("~0p", [Term])).
+
+ensure_mria_tables(App) ->
+    {ok, Modules} = application:get_key(App, modules),
+    lists:foreach(
+        fun(Module) ->
+            case erlang:function_exported(Module, ensure_mria_tables, 0) of
+                true ->
+                    ok = apply(Module, ensure_mria_tables, []);
+                false ->
+                    ok
+            end
+        end,
+        Modules
+    ).
 
 %%------------------------------------------------------------------------------
 %% Internal Functions

--- a/changes/ce/fix-11259-en.md
+++ b/changes/ce/fix-11259-en.md
@@ -1,0 +1,1 @@
+Ensure existence of mnesia tables in the `application:start` callback.


### PR DESCRIPTION
Fixes 

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a65c461</samp>

This pull request moves creation of the mria tables from the ekka module attributes to the moment when the corresponding EMQX app starts.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
