### PR TITLE
fix(rule_maps): avoid losing data when using `emqx_rule_maps:nested_put`

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_maps.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_maps.erl
@@ -129,15 +129,6 @@ general_find({index, _}, List, _OrgData, Handler) when not is_list(List) ->
 
 do_put({key, Key}, Val, Map, _OrgData) when is_map(Map) ->
     maps:put(Key, Val, Map);
-do_put({key, Key}, Val, Data, _OrgData) when is_binary(Data) ->
-    case emqx_utils_json:safe_decode(Data, [return_maps]) of
-        {ok, Map = #{}} ->
-            %% Avoid losing other keys when the data is an encoded map...
-            Map#{Key => Val};
-        _ ->
-            %% Fallback to the general case otherwise.
-            #{Key => Val}
-    end;
 do_put({key, Key}, Val, Data, _OrgData) when not is_map(Data) ->
     #{Key => Val};
 do_put({index, {const, Index}}, Val, List, _OrgData) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_maps.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_maps.erl
@@ -129,6 +129,15 @@ general_find({index, _}, List, _OrgData, Handler) when not is_list(List) ->
 
 do_put({key, Key}, Val, Map, _OrgData) when is_map(Map) ->
     maps:put(Key, Val, Map);
+do_put({key, Key}, Val, Data, _OrgData) when is_binary(Data) ->
+    case emqx_utils_json:safe_decode(Data, [return_maps]) of
+        {ok, Map = #{}} ->
+            %% Avoid losing other keys when the data is an encoded map...
+            Map#{Key => Val};
+        _ ->
+            %% Fallback to the general case otherwise.
+            #{Key => Val}
+    end;
 do_put({key, Key}, Val, Data, _OrgData) when not is_map(Data) ->
     #{Key => Val};
 do_put({index, {const, Index}}, Val, List, _OrgData) ->

--- a/apps/emqx_rule_engine/test/emqx_rule_maps_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_maps_SUITE.erl
@@ -71,7 +71,25 @@ t_nested_put_map(_) ->
     ?assertEqual(
         #{k => #{<<"t">> => #{<<"a">> => v1}}},
         nested_put(?path([k, t, <<"a">>]), v1, #{k => #{<<"t">> => v0}})
-    ).
+    ),
+    %% since we currently support passing a binary-encoded json as input...
+    ?assertEqual(
+        #{payload => #{<<"a">> => v1, <<"b">> => <<"v2">>}},
+        nested_put(
+            ?path([payload, <<"a">>]),
+            v1,
+            #{payload => emqx_utils_json:encode(#{b => <<"v2">>})}
+        )
+    ),
+    ?assertEqual(
+        #{payload => #{<<"a">> => #{<<"old">> => <<"v2">>, <<"new">> => v1}}},
+        nested_put(
+            ?path([payload, <<"a">>, <<"new">>]),
+            v1,
+            #{payload => emqx_utils_json:encode(#{a => #{old => <<"v2">>}})}
+        )
+    ),
+    ok.
 
 t_nested_put_index(_) ->
     ?assertEqual([1, a, 3], nested_put(?path([{ic, 2}]), a, [1, 2, 3])),


### PR DESCRIPTION
# targeting `release-51`

Fixes https://emqx.atlassian.net/browse/EMQX-10541

The cause was that a binary JSON payload was losing its keys when being handled by rule engine, leading to a message like `#{measurement => <<"temp">>, <<"value">> => undefined, ...}`

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bffef38</samp>

This pull request enhances the test utilities and functionality for the HTTP and IoTDB bridges. It improves the `emqx_bridge_testlib` module to allow custom SQL statements for rules and actions. It adds a new test case to `emqx_bridge_iotdb_impl_SUITE` to verify the device ID extraction from the rule engine message payload. It also modifies the `emqx_rule_maps` module and its test suite to support updating binary-encoded JSON objects in nested maps.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
