### PR TITLE
fix: hstreamdb connector use unified schema

### DIFF
--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
@@ -119,10 +119,13 @@ roots() ->
 
 fields(config) ->
     [
-        {url, mk(binary(), #{required => true, desc => ?DESC("url")})},
+        {url,
+            mk(binary(), #{
+                required => true, desc => ?DESC("url"), default => <<"http://127.0.0.1:6570">>
+            })},
         {stream, mk(binary(), #{required => true, desc => ?DESC("stream_name")})},
         {partition_key, mk(binary(), #{required => false, desc => ?DESC("partition_key")})},
-        {pool_size, mk(pos_integer(), #{required => true, desc => ?DESC("pool_size")})},
+        {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {grpc_timeout, fun grpc_timeout/1}
     ] ++ emqx_connector_schema_lib:ssl_fields().
 

--- a/rel/i18n/emqx_bridge_hstreamdb_connector.hocon
+++ b/rel/i18n/emqx_bridge_hstreamdb_connector.hocon
@@ -19,31 +19,31 @@ name.label:
 """Connector Name"""
 
 url.desc:
-"""HStreamDB Server URL"""
+"""HStreamDB Server URL. Using gRPC http server address."""
 
 url.label:
 """HStreamDB Server URL"""
 
 stream_name.desc:
-"""HStreamDB Stream Name"""
+"""HStreamDB Stream Name."""
 
 stream_name.label:
 """HStreamDB Stream Name"""
 
 partition_key.desc:
-"""HStreamDB Ordering Key"""
+"""HStreamDB Partition Key. Placeholders supported."""
 
 partition_key.label:
-"""HStreamDB Ordering Key"""
+"""HStreamDB Partition Key"""
 
 pool_size.desc:
-"""HStreamDB Pool Size"""
+"""HStreamDB Pool Size."""
 
 pool_size.label:
 """HStreamDB Pool Size"""
 
 grpc_timeout.desc:
-"""HStreamDB gRPC Timeout"""
+"""HStreamDB gRPC Timeout."""
 
 grpc_timeout.label:
 """HStreamDB gRPC Timeout"""


### PR DESCRIPTION
Fixes [EMQX-10525](https://emqx.atlassian.net/browse/EMQX-10525) and [EMQX-10532](https://emqx.atlassian.net/browse/EMQX-10532)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c23c3a1</samp>

Improved the configuration and documentation of the EMQX bridge HStreamDB connector. Added a default value for the `url` field and used a common validation function for the `pool_size` field in the `emqx_bridge_hstreamdb_connector.erl` file. Updated the internationalization file `rel/i18n/emqx_bridge_hstreamdb_connector.hocon` to clarify and standardize the configuration options.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~Added tests for the changes~
- [ ] ~Changed lines covered in coverage report~
- [ ] ~Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
