### PR TITLE
fix: hide node.process_limit completely

### DIFF
--- a/apps/emqx_conf/test/emqx_conf_schema_tests.erl
+++ b/apps/emqx_conf/test/emqx_conf_schema_tests.erl
@@ -25,6 +25,8 @@
                 name = \"emqx1@127.0.0.1\"
                 cookie = \"emqxsecretcookie\"
                 data_dir = \"data\"
+                max_ports = 2048
+                process_limit = 10240
              }
              cluster {
                 name = emqxcl
@@ -42,6 +44,12 @@ array_nodes_test() ->
             ConfFile = to_bin(?BASE_CONF, [Nodes, Nodes]),
             {ok, Conf} = hocon:binary(ConfFile, #{format => richmap}),
             ConfList = hocon_tconf:generate(emqx_conf_schema, Conf),
+            VMArgs = proplists:get_value(vm_args, ConfList),
+            ProcLimit = proplists:get_value('+P', VMArgs),
+            MaxPort = proplists:get_value('+Q', VMArgs),
+            ?assertEqual(2048, MaxPort),
+            ?assertEqual(MaxPort * 2, ProcLimit),
+
             ClusterDiscovery = proplists:get_value(
                 cluster_discovery, proplists:get_value(ekka, ConfList)
             ),


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10248
In previous versions, we used node_converter to maintain `process_limit = max_ports * 2`, 
all functionality worked properly.
However, `emqx_config:get_raw/1` and `emqx_config:get/1` would both expose `process_limit`, causing all APIs using them to return this value.
Now using `translation/1` instead of `converter` to completely hide it.

Before(show process_limit):
```
./bin/emqx_ctl conf show node
node {
  cookie = emqxsecretcookie
  data_dir = data
  dist_buffer_size = 8192
  global_gc_interval = 15m
  max_ports = 10000
  name = emqx@127.0.0.1
  role = core
  process_limit = 20000
}
```
After(Hide process_limit):
```
./bin/emqx_ctl conf show node
node {
  cookie = emqxsecretcookie
  data_dir = data
  dist_buffer_size = 8192
  global_gc_interval = 15m
  max_ports = 10000
  name = emqx@127.0.0.1
  role = core
}
```
Hide `node.process_limit` and also ensure `vm_args+P  = node.max_ports * 2` 

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 131511b</samp>

Removed deprecated `process_limit` field and added `vm_args` schema for Erlang VM options. Updated tests to reflect the changes in `emqx_conf_schema.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
