### PR TITLE
fix: keep percentage type's range is 0%~100%

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2496,7 +2496,11 @@ to_integer(Str) ->
     end.
 
 to_percent(Str) ->
-    {ok, hocon_postprocess:percent(Str)}.
+    Percent = hocon_postprocess:percent(Str),
+    case is_number(Percent) andalso Percent >= 0.0 andalso Percent =< 1.0 of
+        true -> {ok, Percent};
+        false -> {error, Str}
+    end.
 
 to_comma_separated_list(Str) ->
     {ok, string:tokens(Str, ", ")}.
@@ -2724,15 +2728,17 @@ check_cpu_watermark(Conf) ->
     check_watermark("sysmon.os.cpu_low_watermark", "sysmon.os.cpu_high_watermark", Conf).
 
 check_watermark(LowKey, HighKey, Conf) ->
-    case hocon_maps:get(LowKey, Conf) of
-        undefined ->
+    case to_percent(hocon_maps:get(LowKey, Conf)) of
+        {error, undefined} ->
             true;
-        Low ->
-            High = hocon_maps:get(HighKey, Conf),
-            case Low < High of
-                true -> true;
-                false -> {bad_watermark, #{LowKey => Low, HighKey => High}}
-            end
+        {ok, Low} ->
+            case to_percent(hocon_maps:get(HighKey, Conf)) of
+                {ok, High} when High > Low -> true;
+                {ok, High} -> {bad_watermark, #{LowKey => Low, HighKey => High}};
+                {error, HighVal} -> {bad_watermark, #{HighKey => HighVal}}
+            end;
+        {error, Low} ->
+            {bad_watermark, #{LowKey => Low}}
     end.
 
 str(A) when is_atom(A) ->

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -332,8 +332,8 @@ load_etc_config_file() ->
 
 filter_readonly_config(Raw) ->
     SchemaMod = emqx_conf:schema_module(),
-    RawDefault = fill_defaults(Raw),
     try
+        RawDefault = fill_defaults(Raw),
         _ = emqx_config:check_config(SchemaMod, RawDefault),
         ReadOnlyKeys = [atom_to_binary(K) || K <- ?READONLY_KEYS],
         {ok, maps:without(ReadOnlyKeys, Raw)}

--- a/changes/ce/fix-11271.en.md
+++ b/changes/ce/fix-11271.en.md
@@ -1,0 +1,1 @@
+Ensure that the range of percentage type is from 0% to 100%.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10551
1. Keep percentage range is 0%~100%.
2. fix fill_default raw_conf crash when check_process_watermark.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 11ee6ab</samp>

This pull request adds support for percent values in the configuration schema, and fixes a bug that caused the `filter_readonly_config` function to crash when the configuration was invalid or incomplete. It modifies the files `emqx_schema.erl` and `emqx_conf_cli.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
