### PR TITLE
chore(gcp_pubsub_consumer): unhide GCP PubSub Consumer bridge for e5.2.0

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_enterprise.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_enterprise.erl
@@ -20,8 +20,7 @@ api_schemas(Method) ->
         %% We need to map the `type' field of a request (binary) to a
         %% bridge schema module.
         api_ref(emqx_bridge_gcp_pubsub, <<"gcp_pubsub">>, Method ++ "_producer"),
-        %% TODO: un-hide for e5.2.0...
-        %% api_ref(emqx_bridge_gcp_pubsub, <<"gcp_pubsub_consumer">>, Method ++ "_consumer"),
+        api_ref(emqx_bridge_gcp_pubsub, <<"gcp_pubsub_consumer">>, Method ++ "_consumer"),
         api_ref(emqx_bridge_kafka, <<"kafka_consumer">>, Method ++ "_consumer"),
         %% TODO: rename this to `kafka_producer' after alias support is added
         %% to hocon; keeping this as just `kafka' for backwards compatibility.
@@ -263,7 +262,6 @@ gcp_pubsub_structs() ->
                 hoconsc:map(name, ref(emqx_bridge_gcp_pubsub, "config_consumer")),
                 #{
                     desc => <<"EMQX Enterprise Config">>,
-                    importance => ?IMPORTANCE_HIDDEN,
                     required => false
                 }
             )}

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -902,16 +902,15 @@ t_consume_ok(Config) ->
                 ?assertEqual(3, emqx_resource_metrics:received_get(ResourceId))
             ),
 
-            %% FIXME: uncomment after API spec is un-hidden...
-            %% %% Check that the bridge probe API doesn't leak atoms.
-            %% ProbeRes0 = probe_bridge_api(Config),
-            %% ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0),
-            %% AtomsBefore = erlang:system_info(atom_count),
-            %% %% Probe again; shouldn't have created more atoms.
-            %% ProbeRes1 = probe_bridge_api(Config),
-            %% ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes1),
-            %% AtomsAfter = erlang:system_info(atom_count),
-            %% ?assertEqual(AtomsBefore, AtomsAfter),
+            %% Check that the bridge probe API doesn't leak atoms.
+            ProbeRes0 = probe_bridge_api(Config),
+            ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0),
+            AtomsBefore = erlang:system_info(atom_count),
+            %% Probe again; shouldn't have created more atoms.
+            ProbeRes1 = probe_bridge_api(Config),
+            ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes1),
+            AtomsAfter = erlang:system_info(atom_count),
+            ?assertEqual(AtomsBefore, AtomsAfter),
 
             assert_non_received_metrics(BridgeName),
             ?block_until(
@@ -1027,8 +1026,8 @@ t_on_get_status(Config) ->
     ?assertMatch({ok, connecting}, emqx_resource_manager:health_check(ResourceId)),
     ok.
 
-t_create_via_http_api(_Config) ->
-    ct:comment("FIXME: implement after API specs are un-hidden in e5.2.0..."),
+t_create_update_via_http_api(Config) ->
+    emqx_bridge_testlib:t_create_via_http(Config),
     ok.
 
 t_multiple_topic_mappings(Config) ->


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10506

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 05c3e02</samp>

This pull request adds support for Google Cloud Pub/Sub bridges to the emqx_bridge module and its test suite. It enables users to create, configure, and monitor `gcp_pubsub_consumer` bridges via the HTTP API, dashboard, and CLI.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [na] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files (already registered in the original PR)
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
