### PR TITLE
fix(shared_sub): restore support for `$queue/` shared subscription

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -33,11 +33,14 @@
 -define(ERTS_MINIMUM_REQUIRED, "10.0").
 
 %%--------------------------------------------------------------------
-%% Topics' prefix: $SYS | $share
+%% Topics' prefix: $SYS | $queue | $share
 %%--------------------------------------------------------------------
 
 %% System topic
 -define(SYSTOP, <<"$SYS/">>).
+
+%% Queue topic
+-define(QUEUE, <<"$queue/">>).
 
 %%--------------------------------------------------------------------
 %% alarms

--- a/apps/emqx/src/emqx_topic.erl
+++ b/apps/emqx/src/emqx_topic.erl
@@ -244,8 +244,12 @@ parse({TopicFilter, Options}) when is_binary(TopicFilter) ->
     parse(TopicFilter, Options).
 
 -spec parse(topic(), map()) -> {topic(), map()}.
+parse(TopicFilter = <<"$queue/", _/binary>>, #{share := _Group}) ->
+    error({invalid_topic_filter, TopicFilter});
 parse(TopicFilter = <<"$share/", _/binary>>, #{share := _Group}) ->
     error({invalid_topic_filter, TopicFilter});
+parse(<<"$queue/", TopicFilter/binary>>, Options) ->
+    parse(TopicFilter, Options#{share => <<"$queue">>});
 parse(TopicFilter = <<"$share/", Rest/binary>>, Options) ->
     case binary:split(Rest, <<"/">>) of
         [_Any] ->

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -444,7 +444,7 @@ systopic_mon() ->
 sharetopic() ->
     ?LET(
         {Type, Grp, T},
-        {oneof([<<"$share">>]), list(latin_char()), normal_topic()},
+        {oneof([<<"$queue">>, <<"$share">>]), list(latin_char()), normal_topic()},
         <<Type/binary, "/", (iolist_to_binary(Grp))/binary, "/", T/binary>>
     ).
 

--- a/apps/emqx/test/emqx_topic_SUITE.erl
+++ b/apps/emqx/test/emqx_topic_SUITE.erl
@@ -212,6 +212,10 @@ t_systop(_) ->
 
 t_feed_var(_) ->
     ?assertEqual(
+        <<"$queue/client/clientId">>,
+        feed_var(<<"$c">>, <<"clientId">>, <<"$queue/client/$c">>)
+    ),
+    ?assertEqual(
         <<"username/test/client/x">>,
         feed_var(
             ?PH_USERNAME,
@@ -233,6 +237,10 @@ long_topic() ->
 
 t_parse(_) ->
     ?assertError(
+        {invalid_topic_filter, <<"$queue/t">>},
+        parse(<<"$queue/t">>, #{share => <<"g">>})
+    ),
+    ?assertError(
         {invalid_topic_filter, <<"$share/g/t">>},
         parse(<<"$share/g/t">>, #{share => <<"g">>})
     ),
@@ -246,9 +254,11 @@ t_parse(_) ->
     ),
     ?assertEqual({<<"a/b/+/#">>, #{}}, parse(<<"a/b/+/#">>)),
     ?assertEqual({<<"a/b/+/#">>, #{qos => 1}}, parse({<<"a/b/+/#">>, #{qos => 1}})),
+    ?assertEqual({<<"topic">>, #{share => <<"$queue">>}}, parse(<<"$queue/topic">>)),
     ?assertEqual({<<"topic">>, #{share => <<"group">>}}, parse(<<"$share/group/topic">>)),
     %% The '$local' and '$fastlane' topics have been deprecated.
     ?assertEqual({<<"$local/topic">>, #{}}, parse(<<"$local/topic">>)),
+    ?assertEqual({<<"$local/$queue/topic">>, #{}}, parse(<<"$local/$queue/topic">>)),
     ?assertEqual({<<"$local/$share/group/a/b/c">>, #{}}, parse(<<"$local/$share/group/a/b/c">>)),
     ?assertEqual({<<"$fastlane/topic">>, #{}}, parse(<<"$fastlane/topic">>)).
 

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -188,9 +188,9 @@ format(WhichNode, {{Topic, _Subscriber}, Options}) ->
     ).
 
 get_topic(Topic, #{share := <<"$queue">> = Group}) ->
-    filename:join([Group, Topic]);
+    emqx_topic:join([Group, Topic]);
 get_topic(Topic, #{share := Group}) ->
-    filename:join([<<"$share">>, Group, Topic]);
+    emqx_topic:join([<<"$share">>, Group, Topic]);
 get_topic(Topic, _) ->
     Topic.
 

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -187,8 +187,10 @@ format(WhichNode, {{Topic, _Subscriber}, Options}) ->
         maps:with([qos, nl, rap, rh], Options)
     ).
 
+get_topic(Topic, #{share := <<"$queue">> = Group}) ->
+    filename:join([Group, Topic]);
 get_topic(Topic, #{share := Group}) ->
-    emqx_topic:join([<<"$share">>, Group, Topic]);
+    filename:join([<<"$share">>, Group, Topic]);
 get_topic(Topic, _) ->
     Topic.
 

--- a/changes/ce/fix-11281.en.md
+++ b/changes/ce/fix-11281.en.md
@@ -1,0 +1,1 @@
+Restored support for the special `$queue/` shared subscription.


### PR DESCRIPTION
# targeting `release-51`

Partially addresses: https://emqx.atlassian.net/browse/EMQX-4589

There's still a problem with the handling of shared groups that is _not particular to the `$queue/` syntax_ and preexistent that the same client cannot subscribe to _different groups_ that have the same _topic filter_.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e7e080</samp>

This pull request implements the queue subscription feature, which allows clients to subscribe to a topic as a queue group and receive messages in a load-balanced way. It modifies the `emqx.hrl`, `emqx_topic.erl`, and `emqx_mgmt_api_subscriptions.erl` files to handle the new `$queue` topic prefix and the related options. It also updates and adds test cases in `emqx_shared_sub_SUITE.erl`, `emqx_topic_SUITE.erl`, and `emqx_proper_types.erl` to test the new feature and ensure its correctness.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
