### PR TITLE
chore(hstream): add more information to the template description to reduce confusion

### DIFF
--- a/rel/i18n/emqx_bridge_hstreamdb.hocon
+++ b/rel/i18n/emqx_bridge_hstreamdb.hocon
@@ -41,7 +41,8 @@ local_topic.label:
 """Local Topic"""
 
 record_template.desc:
-"""The HStream Record template to be forwarded to the HStreamDB. Placeholders supported."""
+"""The HStream Record template to be forwarded to the HStreamDB. Placeholders supported.<br>
+NOTE: When you use `raw record` template (which means the data is not a valid JSON), you should use `read` or `subscription` in HStream to get the data."""
 
 record_template.label:
 """HStream Record"""


### PR DESCRIPTION


Fixes [EMQX-10562](https://emqx.atlassian.net/browse/EMQX-10562)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 191e2a7</samp>

Updated the `record_template.desc` field in `emqx_bridge_hstreamdb.hocon` to explain how to use `raw record` template and access the data in HStreamDB. This improves the user experience and documentation of the EMQ X Bridge to HStreamDB feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
