### PR TITLE
fix(tdengine): update the default template and fix a typo in the changes

### DIFF
--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.erl
@@ -23,7 +23,7 @@
 
 -define(DEFAULT_SQL, <<
     "insert into t_mqtt_msg(ts, msgid, mqtt_topic, qos, payload, arrived) "
-    "values (${ts}, ${id}, ${topic}, ${qos}, ${payload}, ${timestamp})"
+    "values (${ts}, '${id}', '${topic}', ${qos}, '${payload}', ${timestamp})"
 >>).
 
 %% -------------------------------------------------------------------------------------------------

--- a/changes/ee/fix-11266.en.md
+++ b/changes/ee/fix-11266.en.md
@@ -13,7 +13,7 @@ Fix and improve support for TDEngine `insert` syntax.
 
    `insert into table_${topic} values (${ts}, '${id}', '${topic}')`
 
-Note: This is a breaking change, at the former, the string-type values are automatically quoted, bu now, you should manually quote them.
+Note: This is a breaking change. Previously the values of string type were quoted automatically, but now they must be quoted explicitly.
 
 For example:
 


### PR DESCRIPTION
Fixes [EMQX-10588](https://emqx.atlassian.net/browse/EMQX-10588)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0b28356</samp>

This pull request fixes a bug in the `emqx_bridge_tdengine` module that caused SQL errors when inserting MQTT messages with special characters or reserved keywords in the payload. It also corrects a typo in the documentation file `changes/ee/fix-11266.en.md`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
