### PR TITLE
fix(hstream): handle the `unavailable` error code

### DIFF
--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
@@ -309,6 +309,13 @@ do_append_records(false, Producer, Record) ->
                 msg => "HStreamDB producer sync append success",
                 record => Record
             });
+        %% the HStream is warming up or buzy, something are not ready yet, retry after a while
+        {error, {unavailable, _} = Reason} ->
+            {error,
+                {recoverable_error, #{
+                    msg => "HStreamDB is warming up or buzy, will retry after a moment",
+                    reason => Reason
+                }}};
         {error, Reason} = Err ->
             ?tp(
                 hstreamdb_connector_query_return,


### PR DESCRIPTION
The "unavailable" error code just means that the HStream is warming up or busy, HStream guarantees that a retry will work well.

Fixes [EMQX-10563](https://emqx.atlassian.net/browse/EMQX-10563)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7ac8715</samp>

Add error handling for HStreamDB server unavailability in `emqx_bridge_hstreamdb_connector`. This change improves the connector's resilience and retry logic.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
