### PR TITLE
refactor(session): minimize `emqx_session` interface surface

### DIFF
--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -64,7 +64,6 @@
 -export([
     info/1,
     info/2,
-    is_session/1,
     stats/1,
     obtain_next_pkt_id/1,
     get_mqueue/1
@@ -88,7 +87,6 @@
     enqueue/3,
     dequeue/2,
     filter_queue/2,
-    ignore_local/4,
     retry/2,
     terminate/3
 ]).
@@ -251,9 +249,6 @@ unpersist(Session) ->
 %%--------------------------------------------------------------------
 %% Info, Stats
 %%--------------------------------------------------------------------
-
-is_session(#session{}) -> true;
-is_session(_) -> false.
 
 %% @doc Get infos of the session.
 -spec info(session()) -> emqx_types:infos().

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -584,7 +584,7 @@ t_handle_deliver(_) ->
 
 t_handle_deliver_nl(_) ->
     ClientInfo = clientinfo(#{clientid => <<"clientid">>}),
-    Session = session(#{subscriptions => #{<<"t1">> => #{nl => 1}}}),
+    Session = session(ClientInfo, #{subscriptions => #{<<"t1">> => #{nl => 1}}}),
     Channel = channel(#{clientinfo => ClientInfo, session => Session}),
     Msg = emqx_message:make(<<"clientid">>, ?QOS_1, <<"t1">>, <<"qos1">>),
     NMsg = emqx_message:set_flag(nl, Msg),
@@ -1071,11 +1071,14 @@ connpkt(Props) ->
         password = <<"passwd">>
     }.
 
-session() -> session(#{}).
-session(InitFields) when is_map(InitFields) ->
+session() -> session(#{zone => default, clientid => <<"fake-test">>}, #{}).
+session(InitFields) -> session(#{zone => default, clientid => <<"fake-test">>}, InitFields).
+session(ClientInfo, InitFields) when is_map(InitFields) ->
     Conf = emqx_cm:get_session_confs(
-        #{zone => default, clientid => <<"fake-test">>}, #{
-            receive_maximum => 0, expiry_interval => 0
+        ClientInfo,
+        #{
+            receive_maximum => 0,
+            expiry_interval => 0
         }
     ),
     Session = emqx_session:init(Conf),


### PR DESCRIPTION
Part of [EMQX-9593](https://emqx.atlassian.net/browse/EMQX-9593)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4c26f87</samp>

This pull request simplifies and refactors the message delivery logic and data structures in the `emqx_channel`, `emqx_session`, `emqx_eviction_agent_channel`, and `emqx_persistent_session` modules. It removes unnecessary or redundant fields and calls, and centralizes the handling of the `no_local` flag. This improves the efficiency, readability, modularity, and consistency of the code.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
