### PR TITLE
fix(oracle): discard nested tokens when checking table

### DIFF
--- a/apps/emqx_oracle/src/emqx_oracle.app.src
+++ b/apps/emqx_oracle/src/emqx_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_oracle, [
     {description, "EMQX Enterprise Oracle Database Connector"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ee/fix-11307.en.md
+++ b/changes/ee/fix-11307.en.md
@@ -1,0 +1,1 @@
+Fixed check for table existence to return a more friendly message in the Oracle bridge.


### PR DESCRIPTION
### Targeting release-51

Fixes https://emqx.atlassian.net/browse/EMQX-10597

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 00e760b</samp>

Updated the version number of `emqx_oracle` and fixed a bug with nested tokens in the SQL statement. The bug caused the bridge probe to fail when checking if the table exists.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
