### PR TITLE
fix(machine_boot): use shared list of reboot apps and add bridges to reboot list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ $(foreach tt,$(ALL_ELIXIR_TGZS),$(eval $(call gen-elixir-tgz-target,$(tt))))
 
 .PHONY: fmt
 fmt: $(REBAR)
-	@$(SCRIPTS)/erlfmt -w '{apps,lib-ee}/*/{src,include,test}/**/*.{erl,hrl,app.src}'
+	@$(SCRIPTS)/erlfmt -w '{apps,lib-ee}/*/{src,include,priv,test}/**/*.{erl,hrl,app.src,eterm}'
 	@$(SCRIPTS)/erlfmt -w 'rebar.config.erl'
 	@mix format
 

--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra.app.src
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         ecql
     ]},
     {env, []},

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         clickhouse
     ]},
     {env, []},

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo.app.src
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         erlcloud
     ]},
     {env, []},

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge_http,
         ehttpc
     ]},
     {env, []},

--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb.app.src
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         hstreamdb_erl
     ]},
     {env, []},

--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -2,7 +2,7 @@
     {description, "EMQX HTTP Bridge and Connector Application"},
     {vsn, "0.1.1"},
     {registered, []},
-    {applications, [kernel, stdlib, emqx_connector, emqx_resource, emqx_bridge, ehttpc]},
+    {applications, [kernel, stdlib, emqx_connector, emqx_resource, ehttpc]},
     {env, []},
     {modules, []},
     {links, []}

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         influxdb
     ]},
     {env, []},

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
@@ -11,7 +11,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge_http,
         %% for module emqx_connector_http
         emqx_connector
     ]},

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -7,7 +7,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         telemetry,
         wolff,
         brod,

--- a/apps/emqx_bridge_matrix/src/emqx_bridge_matrix.app.src
+++ b/apps/emqx_bridge_matrix/src/emqx_bridge_matrix.app.src
@@ -5,8 +5,7 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_resource,
-        emqx_bridge
+        emqx_resource
     ]},
     {env, []},
     {modules, []},

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
@@ -7,7 +7,6 @@
         stdlib,
         emqx_connector,
         emqx_resource,
-        emqx_bridge,
         emqx_mongodb
     ]},
     {env, []},

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,14 +1,13 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {applications, [
         kernel,
         stdlib,
         emqx,
         emqx_resource,
-        emqx_bridge,
         emqtt
     ]},
     {env, []},

--- a/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
+++ b/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
@@ -7,7 +7,6 @@
         stdlib,
         emqx_connector,
         emqx_resource,
-        emqx_bridge,
         emqx_mysql
     ]},
     {env, []},

--- a/apps/emqx_bridge_opents/src/emqx_bridge_opents.app.src
+++ b/apps/emqx_bridge_opents/src/emqx_bridge_opents.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         opentsdb
     ]},
     {env, []},

--- a/apps/emqx_bridge_oracle/src/emqx_bridge_oracle.app.src
+++ b/apps/emqx_bridge_oracle/src/emqx_bridge_oracle.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         emqx_oracle
     ]},
     {env, []},

--- a/apps/emqx_bridge_pgsql/src/emqx_bridge_pgsql.app.src
+++ b/apps/emqx_bridge_pgsql/src/emqx_bridge_pgsql.app.src
@@ -5,8 +5,7 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_resource,
-        emqx_bridge
+        emqx_resource
     ]},
     {env, []},
     {modules, []},

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         pulsar
     ]},
     {env, []},

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
@@ -547,6 +547,7 @@ start_cluster(Cluster) ->
             emqx_common_test_helpers:start_slave(Name, Opts)
          || {Name, Opts} <- Cluster
         ],
+    NumNodes = length(Nodes),
     on_exit(fun() ->
         emqx_utils:pmap(
             fun(N) ->
@@ -556,6 +557,11 @@ start_cluster(Cluster) ->
             Nodes
         )
     end),
+    {ok, _} = snabbkaffe:block_until(
+        %% -1 because only those that join the first node will emit the event.
+        ?match_n_events(NumNodes - 1, #{?snk_kind := emqx_machine_boot_apps_started}),
+        30_000
+    ),
     Nodes.
 
 kill_resource_managers() ->

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
@@ -6,8 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
-        ecql,
         rabbit_common,
         amqp_client
     ]},

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
@@ -7,7 +7,6 @@
         stdlib,
         emqx_connector,
         emqx_resource,
-        emqx_bridge,
         emqx_redis
     ]},
     {env, []},

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.app.src
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.app.src
@@ -2,7 +2,7 @@
     {description, "EMQX Enterprise RocketMQ Bridge"},
     {vsn, "0.1.3"},
     {registered, []},
-    {applications, [kernel, stdlib, emqx_resource, emqx_bridge, rocketmq]},
+    {applications, [kernel, stdlib, emqx_resource, rocketmq]},
     {env, []},
     {modules, []},
     {links, []}

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
@@ -2,7 +2,7 @@
     {description, "EMQX Enterprise SQL Server Bridge"},
     {vsn, "0.1.2"},
     {registered, []},
-    {applications, [kernel, stdlib, emqx_resource, emqx_bridge, odbc]},
+    {applications, [kernel, stdlib, emqx_resource, odbc]},
     {env, []},
     {modules, []},
     {links, []}

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
@@ -6,7 +6,6 @@
         kernel,
         stdlib,
         emqx_resource,
-        emqx_bridge,
         tdengine
     ]},
     {env, []},

--- a/apps/emqx_bridge_timescale/src/emqx_bridge_timescale.app.src
+++ b/apps/emqx_bridge_timescale/src/emqx_bridge_timescale.app.src
@@ -2,7 +2,7 @@
     {description, "EMQX Enterprise TimescaleDB Bridge"},
     {vsn, "0.1.2"},
     {registered, []},
-    {applications, [kernel, stdlib, emqx_resource, emqx_bridge]},
+    {applications, [kernel, stdlib, emqx_resource]},
     {env, []},
     {modules, []},
     {links, []}

--- a/apps/emqx_machine/priv/reboot_lists.eterm
+++ b/apps/emqx_machine/priv/reboot_lists.eterm
@@ -1,0 +1,110 @@
+%% -*- mode: erlang; -*-
+#{
+    %% must always be of type `load'
+    db_apps =>
+        [
+            mnesia_rocksdb,
+            mnesia,
+            mria,
+            ekka
+        ],
+    system_apps =>
+        [
+            kernel,
+            sasl,
+            crypto,
+            public_key,
+            asn1,
+            syntax_tools,
+            ssl,
+            os_mon,
+            inets,
+            compiler,
+            runtime_tools,
+            redbug,
+            xmerl,
+            {hocon, load},
+            telemetry
+        ],
+    %% must always be of type `load'
+    common_business_apps =>
+        [
+            emqx,
+            emqx_conf,
+
+            esasl,
+            observer_cli,
+            tools,
+            covertool,
+            %% started by emqx_machine
+            system_monitor,
+            emqx_utils,
+            emqx_http_lib,
+            emqx_resource,
+            emqx_connector,
+            emqx_authn,
+            emqx_authz,
+            emqx_auto_subscribe,
+            emqx_gateway,
+            emqx_gateway_stomp,
+            emqx_gateway_mqttsn,
+            emqx_gateway_coap,
+            emqx_gateway_lwm2m,
+            emqx_gateway_exproto,
+            emqx_exhook,
+            emqx_bridge,
+            emqx_bridge_mqtt,
+            emqx_bridge_http,
+            emqx_rule_engine,
+            emqx_modules,
+            emqx_management,
+            emqx_dashboard,
+            emqx_retainer,
+            emqx_prometheus,
+            emqx_psk,
+            emqx_slow_subs,
+            emqx_mongodb,
+            emqx_redis,
+            emqx_mysql,
+            emqx_plugins,
+            quicer,
+            bcrypt,
+            jq,
+            observer
+        ],
+    %% must always be of type `load'
+    ee_business_apps =>
+        [
+            emqx_license,
+            emqx_enterprise,
+            emqx_bridge_kafka,
+            emqx_bridge_pulsar,
+            emqx_bridge_gcp_pubsub,
+            emqx_bridge_cassandra,
+            emqx_bridge_opents,
+            emqx_bridge_clickhouse,
+            emqx_bridge_dynamo,
+            emqx_bridge_hstreamdb,
+            emqx_bridge_influxdb,
+            emqx_bridge_iotdb,
+            emqx_bridge_matrix,
+            emqx_bridge_mongodb,
+            emqx_bridge_mysql,
+            emqx_bridge_pgsql,
+            emqx_bridge_redis,
+            emqx_bridge_rocketmq,
+            emqx_bridge_tdengine,
+            emqx_bridge_timescale,
+            emqx_bridge_sqlserver,
+            emqx_oracle,
+            emqx_bridge_oracle,
+            emqx_bridge_rabbitmq,
+            emqx_schema_registry,
+            emqx_eviction_agent,
+            emqx_node_rebalance,
+            emqx_ft
+        ],
+    %% must always be of type `load'
+    ce_business_apps =>
+        [emqx_telemetry]
+}.

--- a/apps/emqx_machine/priv/reboot_lists.eterm
+++ b/apps/emqx_machine/priv/reboot_lists.eterm
@@ -39,6 +39,7 @@
             %% started by emqx_machine
             system_monitor,
             emqx_utils,
+            emqx_durable_storage,
             emqx_http_lib,
             emqx_resource,
             emqx_connector,

--- a/mix.exs
+++ b/mix.exs
@@ -297,6 +297,7 @@ defmodule EMQXUmbrella.MixProject do
         [
           applications: applications(edition_type),
           skip_mode_validation_for: [
+            :emqx_mix,
             :emqx_gateway,
             :emqx_gateway_stomp,
             :emqx_gateway_mqttsn,
@@ -316,7 +317,10 @@ defmodule EMQXUmbrella.MixProject do
             :emqx_auto_subscribe,
             :emqx_slow_subs,
             :emqx_plugins,
-            :emqx_ft
+            :emqx_ft,
+            :emqx_s3,
+            :emqx_durable_storage,
+            :rabbit_common
           ],
           steps: steps,
           strip_beams: false
@@ -326,137 +330,57 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def applications(edition_type) do
-    system_apps = [
-      crypto: :permanent,
-      public_key: :permanent,
-      asn1: :permanent,
-      syntax_tools: :permanent,
-      ssl: :permanent,
-      os_mon: :permanent,
-      inets: :permanent,
-      compiler: :permanent,
-      runtime_tools: :permanent,
-      redbug: :permanent,
-      xmerl: :permanent,
-      hocon: :load,
-      telemetry: :permanent
-    ]
+    {:ok,
+     [
+       %{
+         db_apps: db_apps,
+         system_apps: system_apps,
+         common_business_apps: common_business_apps,
+         ee_business_apps: ee_business_apps,
+         ce_business_apps: ce_business_apps
+       }
+     ]} = :file.consult("apps/emqx_machine/priv/reboot_lists.eterm")
 
-    db_apps =
-      if enable_rocksdb?() do
-        [:mnesia_rocksdb]
+    db_apps = filter(db_apps, %{mnesia_rocksdb: enable_rocksdb?()})
+
+    common_business_apps =
+      filter(common_business_apps, %{
+        quicer: enable_quicer?(),
+        bcrypt: enable_bcrypt?(),
+        jq: enable_jq?(),
+        observer: is_app?(:observer)
+      })
+
+    edition_specific_apps =
+      if edition_type == :enterprise do
+        ee_business_apps
       else
-        []
-      end ++
-        [
-          :mnesia,
-          :mria,
-          :ekka
-        ]
+        ce_business_apps
+      end
 
-    business_apps =
-      [
-        :emqx,
-        :emqx_conf,
-        :esasl,
-        :observer_cli,
-        :tools,
-        :covertool,
-        :system_monitor,
-        :emqx_utils,
-        :emqx_http_lib,
-        :emqx_resource,
-        :emqx_connector,
-        :emqx_authn,
-        :emqx_authz,
-        :emqx_auto_subscribe,
-        :emqx_gateway,
-        :emqx_gateway_stomp,
-        :emqx_gateway_mqttsn,
-        :emqx_gateway_coap,
-        :emqx_gateway_lwm2m,
-        :emqx_gateway_exproto,
-        :emqx_exhook,
-        :emqx_bridge,
-        :emqx_bridge_mqtt,
-        :emqx_bridge_http,
-        :emqx_rule_engine,
-        :emqx_modules,
-        :emqx_management,
-        :emqx_dashboard,
-        :emqx_retainer,
-        :emqx_prometheus,
-        :emqx_psk,
-        :emqx_slow_subs,
-        :emqx_mongodb,
-        :emqx_redis,
-        :emqx_mysql,
-        :emqx_plugins,
-        :emqx_mix
-      ] ++
-        if enable_quicer?() do
-          [:quicer]
-        else
-          []
-        end ++
-        if enable_bcrypt?() do
-          [:bcrypt]
-        else
-          []
-        end ++
-        if enable_jq?() do
-          [:jq]
-        else
-          []
-        end ++
-        if(is_app(:observer),
-          do: [:observer],
-          else: []
-        ) ++
-        case edition_type do
-          :enterprise ->
-            [
-              :emqx_license,
-              :emqx_enterprise,
-              :emqx_bridge_kafka,
-              :emqx_bridge_pulsar,
-              :emqx_bridge_gcp_pubsub,
-              :emqx_bridge_cassandra,
-              :emqx_bridge_opents,
-              :emqx_bridge_clickhouse,
-              :emqx_bridge_dynamo,
-              :emqx_bridge_hstreamdb,
-              :emqx_bridge_influxdb,
-              :emqx_bridge_iotdb,
-              :emqx_bridge_matrix,
-              :emqx_bridge_mongodb,
-              :emqx_bridge_mysql,
-              :emqx_bridge_pgsql,
-              :emqx_bridge_redis,
-              :emqx_bridge_rocketmq,
-              :emqx_bridge_tdengine,
-              :emqx_bridge_timescale,
-              :emqx_bridge_sqlserver,
-              :emqx_oracle,
-              :emqx_bridge_oracle,
-              :emqx_bridge_rabbitmq,
-              :emqx_schema_registry,
-              :emqx_eviction_agent,
-              :emqx_node_rebalance,
-              :emqx_ft
-            ]
+    business_apps = common_business_apps ++ edition_specific_apps
 
-          _ ->
-            [:emqx_telemetry]
-        end
-
-    system_apps ++
+    Enum.map(system_apps, fn app ->
+      if is_atom(app), do: {app, :permanent}, else: app
+    end) ++
       Enum.map(db_apps, &{&1, :load}) ++
       [emqx_machine: :permanent] ++
       Enum.map(business_apps, &{&1, :load})
   end
 
-  defp is_app(name) do
+  defp filter(apps, filters) do
+    Enum.filter(apps, fn app ->
+      app_name =
+        case app do
+          {app_name, _type} -> app_name
+          app_name when is_atom(app_name) -> app_name
+        end
+
+      Map.get(filters, app_name, true)
+    end)
+  end
+
+  defp is_app?(name) do
     case Application.load(name) do
       :ok ->
         true


### PR DESCRIPTION
Ensures all business applications are restarted when the node joins a cluster.

Also, unifies the apps lists in a single place to avoid repetition in `mix.exs` and `rebar.config.erl`.

```elixir
iex(emqx@127.0.0.1)1> :emqx_machine_boot.sorted_reboot_apps
[:emqx_conf, :esockd, :gproc, :emqx_redis, :ranch, :cowboy, :emqx,
 :emqx_resource, :emqx_retainer, :emqx_slow_subs, :emqx_plugins, :emqx_modules,
 :emqx_ft, :emqx_exhook, :emqx_connector, :emqx_bridge, :emqx_bridge_mqtt,
 :emqx_bridge_kafka, :emqx_bridge_pulsar, :emqx_bridge_cassandra,
 :emqx_bridge_opents, :emqx_bridge_clickhouse, :emqx_bridge_dynamo,
 :emqx_bridge_hstreamdb, :emqx_bridge_influxdb, :emqx_bridge_matrix,
 :emqx_bridge_pgsql, :emqx_bridge_rocketmq, :emqx_bridge_tdengine,
 :emqx_bridge_timescale, :emqx_bridge_sqlserver, :emqx_bridge_rabbitmq,
 :emqx_bridge_http, :emqx_management, :emqx_bridge_gcp_pubsub,
 :emqx_bridge_redis, :emqx_mongodb, :emqx_bridge_mongodb, :emqx_dashboard,
 :emqx_oracle, :emqx_bridge_oracle, :emqx_auto_subscribe, :emqx_bridge_iotdb,
 :emqx_prometheus, :emqx_mysql, :emqx_authn, :emqx_gateway, :emqx_gateway_stomp,
 :emqx_gateway_coap, :emqx_gateway_lwm2m, ...]
```

```erlang
e5.1.1-alpha.2-g3c679880(emqx@127.0.0.1)1> emqx_machine_boot:sorted_reboot_apps().
[emqx_conf,esockd,gproc,emqx_redis,ranch,cowboy,emqx,
 emqx_resource,emqx_retainer,emqx_slow_subs,emqx_plugins,
 emqx_modules,emqx_ft,emqx_exhook,emqx_connector,emqx_bridge,
 emqx_bridge_mqtt,emqx_bridge_kafka,emqx_bridge_pulsar,
 emqx_bridge_cassandra,emqx_bridge_opents,
 emqx_bridge_clickhouse,emqx_bridge_dynamo,
 emqx_bridge_hstreamdb,emqx_bridge_influxdb,
 emqx_bridge_matrix,emqx_bridge_pgsql,emqx_bridge_rocketmq,
 emqx_bridge_tdengine|...]
```

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3191dd0</samp>

This pull request improves the application rebooting mechanism of the `emqx_machine` project by using a configurable `eterm` file instead of a fixed list. It also updates the `mix.exs`, `rebar.config.erl` and `Makefile` files to support the new mechanism and enhance the project compatibility and flexibility.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
