### PR TITLE
refactor(session): allow peeking at mqueue less intrusively

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -44,6 +44,7 @@
 
 -export([
     info/1,
+    info/2,
     stats/1
 ]).
 
@@ -221,11 +222,10 @@ info(CPid) when is_pid(CPid) ->
     call(CPid, info);
 info(State = #state{channel = Channel}) ->
     ChanInfo = emqx_channel:info(Channel),
-    SockInfo = maps:from_list(
-        info(?INFO_KEYS, State)
-    ),
+    SockInfo = maps:from_list(info(?INFO_KEYS, State)),
     ChanInfo#{sockinfo => SockInfo}.
 
+-spec info([atom()] | atom() | tuple(), pid() | state()) -> term().
 info(Keys, State) when is_list(Keys) ->
     [{Key, info(Key, State)} || Key <- Keys];
 info(socktype, #state{transport = Transport, socket = Socket}) ->
@@ -241,7 +241,9 @@ info(stats_timer, #state{stats_timer = StatsTimer}) ->
 info(limiter, #state{limiter = Limiter}) ->
     Limiter;
 info(limiter_timer, #state{limiter_timer = Timer}) ->
-    Timer.
+    Timer;
+info({channel, Info}, #state{channel = Channel}) ->
+    emqx_channel:info(Info, Channel).
 
 %% @doc Get stats of the connection/channel.
 -spec stats(pid() | state()) -> emqx_types:stats().

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -65,8 +65,7 @@
     info/1,
     info/2,
     stats/1,
-    obtain_next_pkt_id/1,
-    get_mqueue/1
+    obtain_next_pkt_id/1
 ]).
 
 -export([
@@ -955,6 +954,3 @@ age(Now, Ts) -> Now - Ts.
 set_field(Name, Value, Session) ->
     Pos = emqx_utils:index_of(Name, record_info(fields, session)),
     setelement(Pos + 1, Session, Value).
-
-get_mqueue(#session{mqueue = Q}) ->
-    emqx_mqueue:to_list(Q).

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -758,12 +758,15 @@ t_qos1_random_dispatch_if_all_members_are_down(Config) when is_list(Config) ->
 
     {ok, _} = emqtt:publish(ConnPub, Topic, <<"hello11">>, 1),
     ct:sleep(100),
-    {ok, Msgs1} = gen_server:call(Pid1, get_mqueue),
-    {ok, Msgs2} = gen_server:call(Pid2, get_mqueue),
+    Msgs1 = emqx_mqueue:to_list(get_mqueue(Pid1)),
+    Msgs2 = emqx_mqueue:to_list(get_mqueue(Pid2)),
     %% assert the message is in mqueue (because socket is closed)
     ?assertMatch([#message{payload = <<"hello11">>}], Msgs1 ++ Msgs2),
     emqtt:stop(ConnPub),
     ok.
+
+get_mqueue(ConnPid) ->
+    emqx_connection:info({channel, {session, mqueue}}, sys:get_state(ConnPid)).
 
 %% No ack, QoS 2 subscriptions,
 %% client1 receives one message, send pubrec, then suspend


### PR DESCRIPTION
Part of [EMQX-9593](https://emqx.atlassian.net/browse/EMQX-9593).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e1e4c64</samp>

Enhanced the `info/2` function in `emqx_channel.erl` and `emqx_connection.erl` to support nested queries for session and mqueue information. Removed obsolete and redundant functions for getting mqueue information from `emqx_channel.erl` and `emqx_session.erl`. Updated the test case in `emqx_shared_sub_SUITE.erl` to use the new `info/2` function.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~~
- [x] Schema changes are backward compatible
