### PR TITLE
fix(dynamo): escape JSON string in the Dynamo template to avoid inserting error

### DIFF
--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector_client.erl
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector_client.erl
@@ -144,7 +144,7 @@ apply_template({Key, Msg} = Req, Templates) ->
         undefined ->
             Req;
         Template ->
-            {Key, emqx_placeholder:proc_tmpl(Template, Msg)}
+            {Key, emqx_placeholder:proc_json(Template, Msg)}
     end;
 %% now there is no batch delete, so
 %% 1. we can simply replace the `send_message` to `put`

--- a/apps/emqx_utils/src/emqx_utils_json.erl
+++ b/apps/emqx_utils/src/emqx_utils_json.erl
@@ -46,7 +46,7 @@
     ]}
 ).
 
--export([is_json/1]).
+-export([is_json/1, escape_string/1]).
 
 -compile({inline, [is_json/1]}).
 
@@ -108,6 +108,10 @@ safe_decode(Json, Opts) ->
 is_json(Json) ->
     element(1, safe_decode(Json)) =:= ok.
 
+-spec escape_string(binary()) -> binary().
+escape_string(Bin) ->
+    escape_string(Bin, <<>>).
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------
@@ -142,3 +146,24 @@ from_ejson(T) ->
 to_binary(B) when is_binary(B) -> B;
 to_binary(L) when is_list(L) ->
     iolist_to_binary(L).
+
+escape_string(<<$", Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $">>);
+escape_string(<<$\\, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $\\>>);
+escape_string(<<$\/, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $\/>>);
+escape_string(<<$\b, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $b>>);
+escape_string(<<$\f, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $f>>);
+escape_string(<<$\n, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $n>>);
+escape_string(<<$\r, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $r>>);
+escape_string(<<$\t, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, $\\, $t>>);
+escape_string(<<C/utf8, Bin/binary>>, Acc) ->
+    escape_string(Bin, <<Acc/binary, C/utf8>>);
+escape_string(<<"">>, Acc) ->
+    Acc.


### PR DESCRIPTION
Fixes [EMQX-10617](https://emqx.atlassian.net/browse/EMQX-10617)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 920e9fb</samp>

Add JSON template support for DynamoDB bridge. Export and implement new functions in `emqx_placeholder` and `emqx_utils_json` modules to handle JSON encoding and placeholders. Update the template example in `rel/i18n/emqx_bridge_dynamo.hocon` file to use JSON format.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
