### PR TITLE
Fix(topicidx): allow to return matches unique by record id

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -226,7 +226,7 @@ get_rules_ordered_by_ts() ->
 get_rules_for_topic(Topic) ->
     [
         emqx_rule_index:get_record(M, ?RULE_TOPIC_INDEX)
-     || M <- emqx_rule_index:matches(Topic, ?RULE_TOPIC_INDEX)
+     || M <- emqx_rule_index:matches(Topic, ?RULE_TOPIC_INDEX, [unique])
     ].
 
 -spec get_rules_with_same_event(Topic :: binary()) -> [rule()].

--- a/apps/emqx_rule_engine/src/emqx_rule_index.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_index.erl
@@ -16,29 +16,29 @@
 
 %% @doc Topic index for matching topics to topic filters.
 %%
-%% Works on top of ETS ordered_set table. Keys are parsed topic filters
-%% with record ID appended to the end, wrapped in a tuple to disambiguate from
-%% topic filter words. Existing table may be used if existing keys will not
-%% collide with index keys.
+%% Works on top of ETS ordered_set table. Keys are tuples constructed from
+%% parsed topic filters and record IDs, wrapped in a tuple to order them
+%% strictly greater than unit tuple (`{}`). Existing table may be used if
+%% existing keys will not collide with index keys.
 %%
 %% Designed to effectively answer questions like:
 %% 1. Does any topic filter match given topic?
 %% 2. Which records are associated with topic filters matching given topic?
-%%
-%% Questions like these are _only slightly_ less effective:
-%% 1. Which topic filters match given topic?
-%% 2. Which record IDs are associated with topic filters matching given topic?
+%% 3. Which topic filters match given topic?
+%% 4. Which record IDs are associated with topic filters matching given topic?
 
 -module(emqx_rule_index).
 
 -export([insert/4]).
 -export([delete/3]).
 -export([match/2]).
--export([matches/2]).
+-export([matches/3]).
 
+-export([get_id/1]).
+-export([get_topic/1]).
 -export([get_record/2]).
 
--type key(ID) :: [binary() | '+' | '#' | {ID}].
+-type key(ID) :: {[binary() | '+' | '#'], {ID}}.
 -type match(ID) :: key(ID).
 
 -ifdef(TEST).
@@ -46,11 +46,10 @@
 -endif.
 
 insert(Filter, ID, Record, Tab) ->
-    %% TODO: topic compact. see also in emqx_trie.erl
-    ets:insert(Tab, {emqx_topic:words(Filter) ++ [{ID}], Record}).
+    ets:insert(Tab, {{emqx_topic:words(Filter), {ID}}, Record}).
 
 delete(Filter, ID, Tab) ->
-    ets:delete(Tab, emqx_topic:words(Filter) ++ [{ID}]).
+    ets:delete(Tab, {emqx_topic:words(Filter), {ID}}).
 
 -spec match(emqx_types:topic(), ets:table()) -> match(_ID) | false.
 match(Topic, Tab) ->
@@ -59,8 +58,8 @@ match(Topic, Tab) ->
 
 match(Words, RPrefix, Tab) ->
     Prefix = lists:reverse(RPrefix),
-    K = ets:next(Tab, Prefix),
-    case match_filter(Prefix, K, Words =/= []) of
+    K = ets:next(Tab, {Prefix, {}}),
+    case match_filter(Prefix, K, Words == []) of
         true ->
             K;
         stop ->
@@ -73,7 +72,7 @@ match_rest(false, [W | Rest], RPrefix, Tab) ->
     match(Rest, [W | RPrefix], Tab);
 match_rest(plus, [W | Rest], RPrefix, Tab) ->
     case match(Rest, ['+' | RPrefix], Tab) of
-        Match when is_list(Match) ->
+        Match = {_, _} ->
             Match;
         false ->
             match(Rest, [W | RPrefix], Tab)
@@ -81,48 +80,71 @@ match_rest(plus, [W | Rest], RPrefix, Tab) ->
 match_rest(_, [], _RPrefix, _Tab) ->
     false.
 
--spec matches(emqx_types:topic(), ets:table()) -> [match(_ID)].
-matches(Topic, Tab) ->
+-spec matches(emqx_types:topic(), ets:table(), _Opts :: [unique]) -> [match(_ID)].
+matches(Topic, Tab, Opts) ->
     {Words, RPrefix} = match_init(Topic),
-    matches(Words, RPrefix, Tab).
-
-matches(Words, RPrefix, Tab) ->
-    Prefix = lists:reverse(RPrefix),
-    matches(ets:next(Tab, Prefix), Prefix, Words, RPrefix, Tab).
-
-matches(K, Prefix, Words, RPrefix, Tab) ->
-    case match_filter(Prefix, K, Words =/= []) of
-        true ->
-            [K | matches(ets:next(Tab, K), Prefix, Words, RPrefix, Tab)];
-        stop ->
-            [];
-        Matched ->
-            matches_rest(Matched, Words, RPrefix, Tab)
+    AccIn =
+        case Opts of
+            [unique | _] -> #{};
+            [] -> []
+        end,
+    Matches = matches(Words, RPrefix, AccIn, Tab),
+    case Matches of
+        #{} -> maps:values(Matches);
+        _ -> Matches
     end.
 
-matches_rest(false, [W | Rest], RPrefix, Tab) ->
-    matches(Rest, [W | RPrefix], Tab);
-matches_rest(plus, [W | Rest], RPrefix, Tab) ->
-    matches(Rest, ['+' | RPrefix], Tab) ++ matches(Rest, [W | RPrefix], Tab);
-matches_rest(_, [], _RPrefix, _Tab) ->
-    [].
+matches(Words, RPrefix, Acc, Tab) ->
+    Prefix = lists:reverse(RPrefix),
+    matches(ets:next(Tab, {Prefix, {}}), Prefix, Words, RPrefix, Acc, Tab).
 
-match_filter([], [{_ID}], _IsPrefix = false) ->
-    % NOTE: exact match is `true` only if we match whole topic, not prefix
-    true;
-match_filter([], ['#', {_ID}], _IsPrefix) ->
+matches(K, Prefix, Words, RPrefix, Acc, Tab) ->
+    case match_filter(Prefix, K, Words == []) of
+        true ->
+            matches(ets:next(Tab, K), Prefix, Words, RPrefix, match_add(K, Acc), Tab);
+        stop ->
+            Acc;
+        Matched ->
+            matches_rest(Matched, Words, RPrefix, Acc, Tab)
+    end.
+
+matches_rest(false, [W | Rest], RPrefix, Acc, Tab) ->
+    matches(Rest, [W | RPrefix], Acc, Tab);
+matches_rest(plus, [W | Rest], RPrefix, Acc, Tab) ->
+    NAcc = matches(Rest, ['+' | RPrefix], Acc, Tab),
+    matches(Rest, [W | RPrefix], NAcc, Tab);
+matches_rest(_, [], _RPrefix, Acc, _Tab) ->
+    Acc.
+
+match_add(K = {_Filter, ID}, Acc = #{}) ->
+    Acc#{ID => K};
+match_add(K, Acc) ->
+    [K | Acc].
+
+match_filter(Prefix, {Filter, _ID}, NotPrefix) ->
+    case match_filter(Prefix, Filter) of
+        exact ->
+            % NOTE: exact match is `true` only if we match whole topic, not prefix
+            NotPrefix;
+        Match ->
+            Match
+    end;
+match_filter(_, '$end_of_table', _) ->
+    stop.
+
+match_filter([], []) ->
+    exact;
+match_filter([], ['#']) ->
     % NOTE: naturally, '#' < '+', so this is already optimal for `match/2`
     true;
-match_filter([], ['+' | _], _) ->
+match_filter([], ['+' | _]) ->
     plus;
-match_filter([], [_H | _], _) ->
+match_filter([], [_H | _]) ->
     false;
-match_filter([H | T1], [H | T2], IsPrefix) ->
-    match_filter(T1, T2, IsPrefix);
-match_filter([H1 | _], [H2 | _], _) when H2 > H1 ->
+match_filter([H | T1], [H | T2]) ->
+    match_filter(T1, T2);
+match_filter([H1 | _], [H2 | _]) when H2 > H1 ->
     % NOTE: we're strictly past the prefix, no need to continue
-    stop;
-match_filter(_, '$end_of_table', _) ->
     stop.
 
 match_init(Topic) ->
@@ -134,6 +156,14 @@ match_init(Topic) ->
         Words ->
             {Words, []}
     end.
+
+-spec get_id(match(ID)) -> ID.
+get_id({_Filter, {ID}}) ->
+    ID.
+
+-spec get_topic(match(_ID)) -> emqx_types:topic().
+get_topic({Filter, _ID}) ->
+    emqx_topic:join(Filter).
 
 -spec get_record(match(_ID), ets:table()) -> _Record.
 get_record(K, Tab) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_index.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_index.erl
@@ -114,6 +114,10 @@ matches(K, Prefix, Words, RPrefix, Acc, Tab) ->
 
 matches_rest(false, [W | Rest], RPrefix, Acc, Tab) ->
     matches(Rest, [W | RPrefix], Acc, Tab);
+matches_rest({false, exact}, [W | Rest], RPrefix, Acc, Tab) ->
+    NAcc1 = matches(Rest, ['#' | RPrefix], Acc, Tab),
+    NAcc2 = matches(Rest, ['+' | RPrefix], NAcc1, Tab),
+    matches(Rest, [W | RPrefix], NAcc2, Tab);
 matches_rest(plus, [W | Rest], RPrefix, Acc, Tab) ->
     NAcc = matches(Rest, ['+' | RPrefix], Acc, Tab),
     matches(Rest, [W | RPrefix], NAcc, Tab);
@@ -129,7 +133,12 @@ match_filter(Prefix, {Filter, _ID}, NotPrefix) ->
     case match_filter(Prefix, Filter) of
         exact ->
             % NOTE: exact match is `true` only if we match whole topic, not prefix
-            NotPrefix;
+            case NotPrefix of
+                true ->
+                    true;
+                false ->
+                    {false, exact}
+            end;
         Match ->
             Match
     end;

--- a/apps/emqx_rule_engine/src/emqx_rule_index.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_index.erl
@@ -114,8 +114,8 @@ matches(K, Prefix, Words, RPrefix, Acc, Tab) ->
 
 matches_rest(false, [W | Rest], RPrefix, Acc, Tab) ->
     matches(Rest, [W | RPrefix], Acc, Tab);
-matches_rest({false, exact}, [W | Rest], RPrefix, Acc, Tab) ->
-    NAcc1 = matches(Rest, ['#' | RPrefix], Acc, Tab),
+matches_rest(sharp, [W | Rest], RPrefix, Acc, Tab) ->
+    NAcc1 = matches([], ['#' | RPrefix], Acc, Tab),
     NAcc2 = matches(Rest, ['+' | RPrefix], NAcc1, Tab),
     matches(Rest, [W | RPrefix], NAcc2, Tab);
 matches_rest(plus, [W | Rest], RPrefix, Acc, Tab) ->
@@ -137,7 +137,7 @@ match_filter(Prefix, {Filter, _ID}, NotPrefix) ->
                 true ->
                     true;
                 false ->
-                    {false, exact}
+                    sharp
             end;
         Match ->
             Match
@@ -147,6 +147,8 @@ match_filter(_, '$end_of_table', _) ->
 
 match_filter([], []) ->
     exact;
+match_filter([], ['' | _]) ->
+    sharp;
 match_filter([], ['#']) ->
     % NOTE: naturally, '#' < '+', so this is already optimal for `match/2`
     true;

--- a/apps/emqx_rule_engine/src/emqx_rule_index.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_index.erl
@@ -89,9 +89,13 @@ matches(Topic, Tab, Opts) ->
             [] -> []
         end,
     Matches = matches(Words, RPrefix, AccIn, Tab),
+    %% return rules ordered by Rule ID
     case Matches of
-        #{} -> maps:values(Matches);
-        _ -> Matches
+        #{} ->
+            maps:values(Matches);
+        _ ->
+            F = fun({_, {ID1}}, {_, {ID2}}) -> ID1 < ID2 end,
+            lists:sort(F, Matches)
     end.
 
 matches(Words, RPrefix, Acc, Tab) ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -427,8 +427,7 @@ t_get_rules_for_topic_3(_Config) ->
         <<"rule-debug-2">>,
         <<"rule-debug-3">>,
         <<"rule-debug-4">>,
-        <<"rule-debug-5">>,
-        <<"rule-debug-6">>
+        <<"rule-debug-5">>
     ]),
     ok.
 

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -58,6 +58,7 @@ groups() ->
             t_create_existing_rule,
             t_get_rules_for_topic,
             t_get_rules_for_topic_2,
+            t_get_rules_for_topic_3,
             t_get_rules_with_same_event,
             t_get_rule_ids_by_action,
             t_ensure_action_removed
@@ -398,6 +399,45 @@ t_get_rules_for_topic_2(_Config) ->
         <<"rule-debug-6">>
     ]),
     ok.
+
+t_get_rules_for_topic_3(_Config) ->
+    ok = create_rules(
+        [
+            make_simple_rule(<<"rule-debug-5">>, <<"select * from \"simple/#\"">>),
+            make_simple_rule(<<"rule-debug-4">>, <<"select * from \"simple/+\"">>),
+            make_simple_rule(<<"rule-debug-3">>, <<"select * from \"simple/+/1\"">>),
+            make_simple_rule(<<"rule-debug-2">>, <<"select * from \"simple/1\"">>),
+            make_simple_rule(
+                <<"rule-debug-1">>,
+                <<"select * from \"simple/2\", \"simple/+\", \"simple/3\"">>
+            )
+        ]
+    ),
+    Rules1 = get_rules_for_topic_in_e510_impl(<<"simple/1">>),
+    Rules2 = emqx_rule_engine:get_rules_for_topic(<<"simple/1">>),
+    %% assert, ensure the order of rules is the same as e5.1.0
+    ?assertEqual(Rules1, Rules2),
+    ?assertEqual(
+        [<<"rule-debug-1">>, <<"rule-debug-2">>, <<"rule-debug-4">>, <<"rule-debug-5">>],
+        [Id || #{id := Id} <- Rules1]
+    ),
+
+    ok = delete_rules_by_ids([
+        <<"rule-debug-1">>,
+        <<"rule-debug-2">>,
+        <<"rule-debug-3">>,
+        <<"rule-debug-4">>,
+        <<"rule-debug-5">>,
+        <<"rule-debug-6">>
+    ]),
+    ok.
+
+get_rules_for_topic_in_e510_impl(Topic) ->
+    [
+        Rule
+     || Rule = #{from := From} <- emqx_rule_engine:get_rules(),
+        emqx_topic:match_any(Topic, From)
+    ].
 
 t_get_rules_with_same_event(_Config) ->
     PubT = <<"simple/1">>,

--- a/apps/emqx_rule_engine/test/emqx_rule_index_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_index_SUITE.erl
@@ -162,8 +162,26 @@ t_match_ordering(_) ->
     ?assertEqual(Ids1, Ids2),
     ?assertEqual([t_match_id1, t_match_id2, t_match_id3], Ids1).
 
+t_match_wildcards(_) ->
+    Tab = new(),
+    emqx_rule_index:insert(<<"a/b">>, id1, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/#">>, id2, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/#">>, id3, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/c">>, id4, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/+">>, id5, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/d">>, id6, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/+/+">>, id7, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/+/#">>, id8, <<>>, Tab),
+
+    Rules = [id(M) || M <- emqx_rule_index:matches(<<"a/b/c">>, Tab, [])],
+    ?assertEqual([id2, id3, id4, id5, id7, id8], Rules),
+
+    Rules1 = [id(M) || M <- emqx_rule_index:matches(<<"a/b">>, Tab, [])],
+    ?assertEqual([id1, id2, id3, id8], Rules1),
+    ok.
+
 new() ->
-    ets:new(?MODULE, [public, ordered_set, {write_concurrency, true}]).
+    ets:new(?MODULE, [public, ordered_set, {read_concurrency, true}]).
 
 match(T, Tab) ->
     emqx_rule_index:match(T, Tab).

--- a/apps/emqx_rule_engine/test/emqx_rule_index_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_index_SUITE.erl
@@ -152,6 +152,16 @@ t_match_unique(_) ->
         [id(M) || M <- emqx_rule_index:matches(<<"a/b/c">>, Tab, [unique])]
     ).
 
+t_match_ordering(_) ->
+    Tab = new(),
+    emqx_rule_index:insert(<<"a/b/+">>, t_match_id2, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/c">>, t_match_id1, <<>>, Tab),
+    emqx_rule_index:insert(<<"a/b/#">>, t_match_id3, <<>>, Tab),
+    Ids1 = [id(M) || M <- emqx_rule_index:matches(<<"a/b/c">>, Tab, [])],
+    Ids2 = [id(M) || M <- emqx_rule_index:matches(<<"a/b/c">>, Tab, [unique])],
+    ?assertEqual(Ids1, Ids2),
+    ?assertEqual([t_match_id1, t_match_id2, t_match_id3], Ids1).
+
 new() ->
     ets:new(?MODULE, [public, ordered_set, {write_concurrency, true}]).
 


### PR DESCRIPTION
A fixe PR for https://github.com/emqx/emqx/pull/11282 and https://emqx.atlassian.net/browse/EMQX-10006

In this PR, we add a `unique` option to the `emqx_topic_index:matches/3` func. This option aims to filter out the id of the same rule in a match query

And proper testing has been added to ensure the correct functioning of the index.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0496038</samp>

This pull request simplifies and fixes the topic filter matching logic in the rule engine. It changes the key structure of the `emqx_rule_index` module and adds a `unique` option to its `matches` function. It also updates the corresponding test cases and the `emqx_rule_engine` module to use the new features.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- ~Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- ~If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
