### PR TITLE
fix(postgres_bridge): fix table existence check and handle sync_required

### DIFF
--- a/changes/ee/fix-11338.en.md
+++ b/changes/ee/fix-11338.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the PostgreSQL bridge connection could crash under high message rates.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10629

During health checking, we check whether tables in the SQL statement exist.  Such check was done by asking the backend to parse the statement using a named prepared statements.  Concurrent health checks could then result in the error:

```erlang
{error,{error,error,<<"42P05">>,duplicate_prepared_statement,<<"prepared statement \"get_status\" already exists">>,[{file,<<"prepare.c">>},{line,<<"451">>},{routine,<<"StorePreparedStatement">>},{severity,<<"ERROR">>}]}}
```

This could lead to an inconsistent state in the driver process, which would crash later when a message from the backend (`READY_FOR_QUERY`, "idle"):

```
  2023-07-24T13:05:58.892043+00:00 [error] Generic server <0.2134.0> terminating. Reason: {'module could not be loaded',[{undefined,handle_message,[90,<<"I">>,...
```

Added calls to `epgsql:sync/1` for functions that could return `{error, sync_required}`.

Also, redundant calls to `parse2` were removed to reduce the number of requests.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 55e95ea</samp>

This pull request enhances the PostgreSQL bridge feature of EMQ X by improving the error handling and robustness of the `emqx_connector_pgsql` module and adding a new test case to the `emqx_bridge_pgsql_SUITE` module. The changes aim to prevent connection failures and bad parse errors when using the bridge to sync MQTT messages with PostgreSQL tables.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
