### PR TITLE
fix(ocsp): URL encode request path

### DIFF
--- a/apps/emqx/src/emqx_ocsp_cache.erl
+++ b/apps/emqx/src/emqx_ocsp_cache.erl
@@ -542,7 +542,8 @@ build_ocsp_request(IssuerPem, ServerCert) ->
             }
     },
     ReqDer = public_key:der_encode('OCSPRequest', Req),
-    base64:encode_to_string(ReqDer).
+    B64Encoded = base64:encode_to_string(ReqDer),
+    uri_string:quote(B64Encoded).
 
 to_bin(Str) when is_list(Str) -> list_to_binary(Str);
 to_bin(Bin) when is_binary(Bin) -> Bin.

--- a/changes/ce/fix-11347.en.md
+++ b/changes/ce/fix-11347.en.md
@@ -1,0 +1,1 @@
+Ensure that OCSP request path is properly URL encoded.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10624

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 01fa1c4</samp>

This pull request enhances the OCSP cache feature by adding a test case and encoding the OCSP request URI. It uses the `uri_string:quote/1` function and a variable for the OCSP responder URL in `emqx_ocsp_cache.erl` and `emqx_ocsp_cache_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
