### PR TITLE
fix(ds): avoid crashes when starting on Windows

### DIFF
--- a/apps/emqx_durable_storage/src/emqx_ds_app.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_app.erl
@@ -13,12 +13,20 @@ start(_Type, _Args) ->
     emqx_ds_sup:start_link().
 
 init_mnesia() ->
+    %% FIXME: This is a temporary workaround to avoid crashes when starting on Windows
+    Storage =
+        case mria:rocksdb_backend_available() of
+            true ->
+                rocksdb_copies;
+            _ ->
+                disc_copies
+        end,
     ok = mria:create_table(
         ?SESSION_TAB,
         [
             {rlog_shard, ?DS_SHARD},
             {type, set},
-            {storage, rocksdb_copies},
+            {storage, Storage},
             {record_name, session},
             {attributes, record_info(fields, session)}
         ]

--- a/apps/emqx_durable_storage/src/emqx_durable_storage.app.src
+++ b/apps/emqx_durable_storage/src/emqx_durable_storage.app.src
@@ -2,7 +2,7 @@
 {application, emqx_durable_storage, [
     {description, "Message persistence and subscription replays for EMQX"},
     % strict semver, bump manually!
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, rocksdb, gproc, mria]},

--- a/changes/ce/fix-11352.en.md
+++ b/changes/ce/fix-11352.en.md
@@ -1,0 +1,1 @@
+Fixed this [#11345](https://github.com/emqx/emqx/issues/11345) crash issue when starting on Windows or any other platform without RocksDB support.


### PR DESCRIPTION
Fixes #11345 

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14b7691</samp>

This pull request fixes a crash issue and adds a workaround for using `emqx_durable_storage` on Windows. It changes the storage option for mria to `disc_copies` and updates the version number to `0.1.2`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
