### PR TITLE
fix(http_bridge): don't attempt to convert headers to atoms

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.1.25"},
+    {vsn, "0.1.26"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -559,7 +559,7 @@ schema("/bridges_probe") ->
                 %% references to fields, and they don't share whole-bridge validators if
                 %% they exist.  Such validators will only be triggered by
                 %% `create_dry_run'...
-                throw:{_Schema, [#{kind := validation_error} = Reason0]} ->
+                throw:{_Schema, [#{kind := _} = Reason0 | _]} ->
                     Reason = redact(Reason0),
                     ?BAD_REQUEST('TEST_FAILED', map_to_json(Reason))
             end;

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -261,7 +261,17 @@ recreate(Type, Name, Conf, Opts) ->
 create_dry_run(Type, Conf0) ->
     TmpName = iolist_to_binary([?TEST_ID_PREFIX, emqx_utils:gen_id(8)]),
     TmpPath = emqx_utils:safe_filename(TmpName),
-    Conf = emqx_utils_maps:safe_atom_key_map(Conf0),
+    %% Already typechecked, no need to catch errors
+    TypeBin = bin(Type),
+    TypeAtom = safe_atom(Type),
+    Conf1 = maps:without([<<"name">>], Conf0),
+    RawConf = #{<<"bridges">> => #{TypeBin => #{<<"a">> => Conf1}}},
+    #{bridges := #{TypeAtom := #{a := Conf}}} =
+        hocon_tconf:check_plain(
+            emqx_bridge_schema,
+            RawConf,
+            #{atom_key => true, required => false}
+        ),
     case emqx_connector_ssl:convert_certs(TmpPath, Conf) of
         {error, Reason} ->
             {error, Reason};
@@ -414,6 +424,9 @@ parse_url(Url) ->
 bin(Bin) when is_binary(Bin) -> Bin;
 bin(Str) when is_list(Str) -> list_to_binary(Str);
 bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
+
+safe_atom(Bin) when is_binary(Bin) -> binary_to_existing_atom(Bin, utf8);
+safe_atom(Atom) when is_atom(Atom) -> Atom.
 
 parse_opts(Conf, Opts0) ->
     override_start_after_created(Conf, Opts0).

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -265,8 +265,8 @@ create_dry_run(Type, Conf0) ->
     TypeBin = bin(Type),
     TypeAtom = safe_atom(Type),
     Conf1 = maps:without([<<"name">>], Conf0),
-    RawConf = #{<<"bridges">> => #{TypeBin => #{<<"a">> => Conf1}}},
-    #{bridges := #{TypeAtom := #{a := Conf}}} =
+    RawConf = #{<<"bridges">> => #{TypeBin => #{<<"temp_name">> => Conf1}}},
+    #{bridges := #{TypeAtom := #{temp_name := Conf}}} =
         hocon_tconf:check_plain(
             emqx_bridge_schema,
             RawConf,

--- a/apps/emqx_bridge/test/emqx_bridge_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_testlib.erl
@@ -212,6 +212,19 @@ probe_bridge_api(BridgeType, BridgeName, BridgeConfig) ->
     ct:pal("bridge probe result: ~p", [Res]),
     Res.
 
+try_decode_error(Body0) ->
+    case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+        {ok, #{<<"message">> := Msg0} = Body1} ->
+            case emqx_utils_json:safe_decode(Msg0, [return_maps]) of
+                {ok, Msg1} -> Body1#{<<"message">> := Msg1};
+                {error, _} -> Body1
+            end;
+        {ok, Body1} ->
+            Body1;
+        {error, _} ->
+            Body0
+    end.
+
 create_rule_and_action_http(BridgeType, RuleTopic, Config) ->
     create_rule_and_action_http(BridgeType, RuleTopic, Config, _Opts = #{}).
 

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_gcp_pubsub, [
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -363,9 +363,9 @@ service_account_json_validator(Map) ->
         {[], <<"service_account">>} ->
             ok;
         {[], Type} ->
-            {error, {wrong_type, Type}};
+            {error, #{wrong_type => Type}};
         {_, _} ->
-            {error, {missing_keys, MissingKeys}}
+            {error, #{missing_keys => MissingKeys}}
     end.
 
 service_account_json_converter(Map) when is_map(Map) ->
@@ -382,7 +382,8 @@ service_account_json_converter(Val) ->
 
 consumer_topic_mapping_validator(_TopicMapping = []) ->
     {error, "There must be at least one GCP PubSub-MQTT topic mapping"};
-consumer_topic_mapping_validator(TopicMapping = [_ | _]) ->
+consumer_topic_mapping_validator(TopicMapping0 = [_ | _]) ->
+    TopicMapping = [emqx_utils_maps:binary_key_map(TM) || TM <- TopicMapping0],
     NumEntries = length(TopicMapping),
     PubSubTopics = [KT || #{<<"pubsub_topic">> := KT} <- TopicMapping],
     DistinctPubSubTopics = length(lists:usort(PubSubTopics)),

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -220,10 +220,10 @@ parse_jwt_config(ResourceId, #{
     service_account_json := ServiceAccountJSON
 }) ->
     #{
-        project_id := ProjectId,
-        private_key_id := KId,
-        private_key := PrivateKeyPEM,
-        client_email := ServiceAccountEmail
+        <<"project_id">> := ProjectId,
+        <<"private_key_id">> := KId,
+        <<"private_key">> := PrivateKeyPEM,
+        <<"client_email">> := ServiceAccountEmail
     } = ServiceAccountJSON,
     %% fixed for pubsub; trailing slash is important.
     Aud = <<"https://pubsub.googleapis.com/">>,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -64,7 +64,9 @@ callback_mode() -> async_if_possible.
 query_mode(_Config) -> no_queries.
 
 -spec on_start(resource_id(), config()) -> {ok, state()} | {error, term()}.
-on_start(InstanceId, Config) ->
+on_start(InstanceId, Config0) ->
+    %% ensure it's a binary key map
+    Config = maps:update_with(service_account_json, fun emqx_utils_maps:binary_key_map/1, Config0),
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of
         {ok, Client} ->
             start_consumers(InstanceId, Client, Config);
@@ -125,7 +127,7 @@ start_consumers(InstanceId, Client, Config) ->
         consumer := ConsumerConfig0,
         hookpoint := Hookpoint,
         resource_opts := #{request_ttl := RequestTTL},
-        service_account_json := #{project_id := ProjectId}
+        service_account_json := #{<<"project_id">> := ProjectId}
     } = Config,
     ConsumerConfig1 = maps:update_with(topic_mapping, fun convert_topic_mapping/1, ConsumerConfig0),
     TopicMapping = maps:get(topic_mapping, ConsumerConfig1),

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -50,15 +50,16 @@ callback_mode() -> async_if_possible.
 query_mode(_Config) -> async.
 
 -spec on_start(resource_id(), config()) -> {ok, state()} | {error, term()}.
-on_start(InstanceId, Config) ->
+on_start(InstanceId, Config0) ->
     ?SLOG(info, #{
         msg => "starting_gcp_pubsub_bridge",
-        config => Config
+        config => Config0
     }),
+    Config = maps:update_with(service_account_json, fun emqx_utils_maps:binary_key_map/1, Config0),
     #{
         payload_template := PayloadTemplate,
         pubsub_topic := PubSubTopic,
-        service_account_json := #{project_id := ProjectId}
+        service_account_json := #{<<"project_id">> := ProjectId}
     } = Config,
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of
         {ok, Client} ->

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -275,14 +275,13 @@ ensure_topic(Config, Topic) ->
 
 start_control_client() ->
     RawServiceAccount = emqx_bridge_gcp_pubsub_utils:generate_service_account_json(),
-    ServiceAccount = emqx_utils_maps:unsafe_atom_key_map(RawServiceAccount),
     ConnectorConfig =
         #{
             connect_timeout => 5_000,
             max_retries => 0,
             pool_size => 1,
             resource_opts => #{request_ttl => 5_000},
-            service_account_json => ServiceAccount
+            service_account_json => RawServiceAccount
         },
     PoolName = <<"control_connector">>,
     {ok, Client} = emqx_bridge_gcp_pubsub_client:start(PoolName, ConnectorConfig),

--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_http, [
     {description, "EMQX HTTP Bridge and Connector Application"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_connector, emqx_resource, ehttpc]},
     {env, []},

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -155,7 +155,16 @@ desc("request") ->
 desc(_) ->
     undefined.
 
-validate_method(M) when M =:= <<"post">>; M =:= <<"put">>; M =:= <<"get">>; M =:= <<"delete">> ->
+validate_method(M) when
+    M =:= <<"post">>;
+    M =:= <<"put">>;
+    M =:= <<"get">>;
+    M =:= <<"delete">>;
+    M =:= post;
+    M =:= put;
+    M =:= get;
+    M =:= delete
+->
     ok;
 validate_method(M) ->
     case string:find(M, "${") of

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_connector_tests.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_connector_tests.erl
@@ -91,3 +91,121 @@ is_unwrapped_headers(Headers) ->
 is_unwrapped_header({_, V}) when is_function(V) -> false;
 is_unwrapped_header({_, [{str, _V}]}) -> throw(unexpected_tmpl_token);
 is_unwrapped_header(_) -> true.
+
+method_validator_test() ->
+    Conf0 = parse(webhook_config_hocon()),
+    ?assertMatch(
+        #{<<"method">> := _},
+        emqx_utils_maps:deep_get([<<"bridges">>, <<"webhook">>, <<"a">>], Conf0)
+    ),
+    lists:foreach(
+        fun(Method) ->
+            Conf1 = emqx_utils_maps:deep_put(
+                [<<"bridges">>, <<"webhook">>, <<"a">>, <<"method">>],
+                Conf0,
+                Method
+            ),
+            ?assertMatch(
+                #{},
+                check(Conf1),
+                #{method => Method}
+            ),
+            ?assertMatch(
+                #{},
+                check_atom_key(Conf1),
+                #{method => Method}
+            ),
+            ok
+        end,
+        [<<"post">>, <<"put">>, <<"get">>, <<"delete">>]
+    ),
+    lists:foreach(
+        fun(Method) ->
+            Conf1 = emqx_utils_maps:deep_put(
+                [<<"bridges">>, <<"webhook">>, <<"a">>, <<"method">>],
+                Conf0,
+                Method
+            ),
+            ?assertThrow(
+                {_, [
+                    #{
+                        kind := validation_error,
+                        reason := not_a_enum_symbol
+                    }
+                ]},
+                check(Conf1),
+                #{method => Method}
+            ),
+            ?assertThrow(
+                {_, [
+                    #{
+                        kind := validation_error,
+                        reason := not_a_enum_symbol
+                    }
+                ]},
+                check_atom_key(Conf1),
+                #{method => Method}
+            ),
+            ok
+        end,
+        [<<"x">>, <<"patch">>, <<"options">>]
+    ),
+    ok.
+
+%%===========================================================================
+%% Helper functions
+%%===========================================================================
+
+parse(Hocon) ->
+    {ok, Conf} = hocon:binary(Hocon),
+    Conf.
+
+%% what bridge creation does
+check(Conf) when is_map(Conf) ->
+    hocon_tconf:check_plain(emqx_bridge_schema, Conf).
+
+%% what bridge probe does
+check_atom_key(Conf) when is_map(Conf) ->
+    hocon_tconf:check_plain(emqx_bridge_schema, Conf, #{atom_key => true, required => false}).
+
+%%===========================================================================
+%% Data section
+%%===========================================================================
+
+%% erlfmt-ignore
+webhook_config_hocon() ->
+"""
+bridges.webhook.a {
+  body = \"${.}\"
+  connect_timeout = 15s
+  enable = false
+  enable_pipelining = 100
+  headers {content-type = \"application/json\", jjjjjjjjjjjjjjjjjjj = jjjjjjj}
+  max_retries = 2
+  method = post
+  pool_size = 8
+  pool_type = random
+  resource_opts {
+    health_check_interval = 15s
+    inflight_window = 100
+    max_buffer_bytes = 1GB
+    query_mode = async
+    request_ttl = 45s
+    start_after_created = true
+    start_timeout = 5s
+    worker_pool_size = 4
+  }
+  ssl {
+    ciphers = []
+    depth = 10
+    enable = false
+    hibernate_after = 5s
+    log_level = notice
+    reuse_sessions = true
+    secure_renegotiate = true
+    verify = verify_peer
+    versions = [tlsv1.3, tlsv1.2]
+  }
+  url = \"http://some.host:4000/api/echo\"
+}
+""".

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, [emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -528,7 +528,8 @@ kafka_producer_converter(Config, _HoconOpts) ->
 
 consumer_topic_mapping_validator(_TopicMapping = []) ->
     {error, "There must be at least one Kafka-MQTT topic mapping"};
-consumer_topic_mapping_validator(TopicMapping = [_ | _]) ->
+consumer_topic_mapping_validator(TopicMapping0 = [_ | _]) ->
+    TopicMapping = [emqx_utils_maps:binary_key_map(TM) || TM <- TopicMapping0],
     NumEntries = length(TopicMapping),
     KafkaTopics = [KT || #{<<"kafka_topic">> := KT} <- TopicMapping],
     DistinctKafkaTopics = length(lists:usort(KafkaTopics)),
@@ -539,6 +540,13 @@ consumer_topic_mapping_validator(TopicMapping = [_ | _]) ->
             {error, "Kafka topics must not be repeated in a bridge"}
     end.
 
+producer_strategy_key_validator(
+    #{
+        partition_strategy := _,
+        message := #{key := _}
+    } = Conf
+) ->
+    producer_strategy_key_validator(emqx_utils_maps:binary_key_map(Conf));
 producer_strategy_key_validator(#{
     <<"partition_strategy">> := key_dispatch,
     <<"message">> := #{<<"key">> := ""}

--- a/apps/emqx_bridge_oracle/src/emqx_bridge_oracle.app.src
+++ b/apps/emqx_bridge_oracle/src/emqx_bridge_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_oracle, [
     {description, "EMQX Enterprise Oracle Database Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_oracle/src/emqx_bridge_oracle.erl
+++ b/apps/emqx_bridge_oracle/src/emqx_bridge_oracle.erl
@@ -108,6 +108,8 @@ type_field(Type) ->
 name_field() ->
     {name, hoconsc:mk(binary(), #{required => true, desc => ?DESC("desc_name")})}.
 
+config_validator(#{server := _} = Config) ->
+    config_validator(emqx_utils_maps:binary_key_map(Config));
 config_validator(#{<<"server">> := Server} = Config) when
     not is_map(Server) andalso
         not is_map_key(<<"sid">>, Config) andalso

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
@@ -1090,7 +1090,7 @@ t_strategy_key_validation(Config) ->
                         <<"kind">> := <<"validation_error">>,
                         <<"reason">> := <<"Message key cannot be empty", _/binary>>
                     } = Msg
-            }}} when not is_map_key(<<"value">>, Msg),
+            }}},
         probe_bridge_api(
             Config,
             #{<<"strategy">> => <<"key_dispatch">>, <<"message">> => #{<<"key">> => <<>>}}
@@ -1104,7 +1104,7 @@ t_strategy_key_validation(Config) ->
                         <<"kind">> := <<"validation_error">>,
                         <<"reason">> := <<"Message key cannot be empty", _/binary>>
                     } = Msg
-            }}} when not is_map_key(<<"value">>, Msg),
+            }}},
         create_bridge_api(
             Config,
             #{<<"strategy">> => <<"key_dispatch">>, <<"message">> => #{<<"key">> => <<>>}}

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
@@ -40,6 +40,7 @@ groups() ->
 only_once_tests() ->
     [
         t_create_via_http,
+        t_strategy_key_validation,
         t_start_when_down,
         t_send_when_down,
         t_send_when_timeout,
@@ -313,6 +314,8 @@ create_bridge_api(Config, Overrides) ->
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
                 {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+            {error, {Status, Headers, Body0}} ->
+                {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
             Error ->
                 Error
         end,
@@ -356,8 +359,12 @@ probe_bridge_api(Config, Overrides) ->
     ct:pal("probing bridge (via http): ~p", [Params]),
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
-            {ok, {{_, 204, _}, _Headers, _Body0} = Res0} -> {ok, Res0};
-            Error -> Error
+            {ok, {{_, 204, _}, _Headers, _Body0} = Res0} ->
+                {ok, Res0};
+            {error, {Status, Headers, Body0}} ->
+                {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
+            Error ->
+                Error
         end,
     ct:pal("bridge probe result: ~p", [Res]),
     Res.
@@ -1071,6 +1078,37 @@ t_resource_manager_crash_before_producers_started(Config) ->
             ok
         end,
         []
+    ),
+    ok.
+
+t_strategy_key_validation(Config) ->
+    ?assertMatch(
+        {error,
+            {{_, 400, _}, _, #{
+                <<"message">> :=
+                    #{
+                        <<"kind">> := <<"validation_error">>,
+                        <<"reason">> := <<"Message key cannot be empty", _/binary>>
+                    } = Msg
+            }}} when not is_map_key(<<"value">>, Msg),
+        probe_bridge_api(
+            Config,
+            #{<<"strategy">> => <<"key_dispatch">>, <<"message">> => #{<<"key">> => <<>>}}
+        )
+    ),
+    ?assertMatch(
+        {error,
+            {{_, 400, _}, _, #{
+                <<"message">> :=
+                    #{
+                        <<"kind">> := <<"validation_error">>,
+                        <<"reason">> := <<"Message key cannot be empty", _/binary>>
+                    } = Msg
+            }}} when not is_map_key(<<"value">>, Msg),
+        create_bridge_api(
+            Config,
+            #{<<"strategy">> => <<"key_dispatch">>, <<"message">> => #{<<"key">> => <<>>}}
+        )
     ),
     ok.
 

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_tests.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_tests.erl
@@ -35,6 +35,17 @@ pulsar_producer_validations_test() ->
         ]},
         check(Conf)
     ),
+    %% ensure atoms exist
+    _ = [my_producer],
+    ?assertThrow(
+        {_, [
+            #{
+                path := "bridges.pulsar_producer.my_producer",
+                reason := "Message key cannot be empty when `key_dispatch` strategy is used"
+            }
+        ]},
+        check_atom_key(Conf)
+    ),
 
     ok.
 
@@ -46,8 +57,13 @@ parse(Hocon) ->
     {ok, Conf} = hocon:binary(Hocon),
     Conf.
 
+%% what bridge creation does
 check(Conf) when is_map(Conf) ->
     hocon_tconf:check_plain(emqx_bridge_schema, Conf).
+
+%% what bridge probe does
+check_atom_key(Conf) when is_map(Conf) ->
+    hocon_tconf:check_plain(emqx_bridge_schema, Conf, #{atom_key => true, required => false}).
 
 %%===========================================================================
 %% Data section


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10653

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bfa5f5f</samp>

This pull request adds support for customizing the atom conversion of webhook bridge config keys, especially the headers key, to avoid atom exhaustion. It also updates the versions of the emqx, emqx_bridge, emqx_bridge_http, and emqx_utils applications, and adds new test cases for the new features. The main files affected are `emqx_bridge_resource.erl`, `emqx_utils_maps.erl`, `emqx_bridge_http_schema.erl`, and their corresponding test modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
