### PR TITLE
fix(schema): ensure enterprise module is correctly loaded

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.3"},
+    {vsn, "5.1.4"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.1.24"},
+    {vsn, "0.1.25"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/src/schema/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_schema.erl
@@ -87,12 +87,18 @@ bridge_api_union(Refs) ->
 
 -if(?EMQX_RELEASE_EDITION == ee).
 enterprise_api_schemas(Method) ->
+    %% We *must* do this to ensure the module is really loaded, especially when we use
+    %% `call_hocon' from `nodetool' to generate initial configurations.
+    _ = emqx_bridge_enterprise:module_info(),
     case erlang:function_exported(emqx_bridge_enterprise, api_schemas, 1) of
         true -> emqx_bridge_enterprise:api_schemas(Method);
         false -> []
     end.
 
 enterprise_fields_bridges() ->
+    %% We *must* do this to ensure the module is really loaded, especially when we use
+    %% `call_hocon' from `nodetool' to generate initial configurations.
+    _ = emqx_bridge_enterprise:module_info(),
     case erlang:function_exported(emqx_bridge_enterprise, fields, 1) of
         true -> emqx_bridge_enterprise:fields(bridges);
         false -> []

--- a/changes/ee/fix-11366.en.md
+++ b/changes/ee/fix-11366.en.md
@@ -1,0 +1,1 @@
+Fixed an issue that could prevent a pod from starting if some bridge configuration were specified in `bootstrapConfig` using EMQX Operator.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10654

Despite loading the application in `nodetool`, we need to invoke `:module_info()` to force the module to be actually loaded, especially when it's called in `call_hocon` to generate the initial configurations.  Otherwise, it'll fail to list all the bridge schemas.

Note: this only happens when bridge configuration is added to `etc/emqx.conf`.  Setting it via `data/configs/cluster.hocon` works without this patch. 

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 055229f</samp>

Fixed bugs and updated versions for emqx bridge plugin and emqx broker. Added code to load `emqx_bridge_enterprise` module in `emqx_bridge_schema.erl` and updated version numbers in `emqx_bridge.app.src` and `emqx.app.src`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [na] Added tests for the changes
- [na] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
