### PR TITLE
fix: fix cacerts option type and remove default value

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.3"},
+    {vsn, "5.1.4"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2019,9 +2019,9 @@ common_ssl_opts_schema(Defaults, Type) ->
             )},
         {"cacerts",
             sc(
-                boolean(),
+                hoconsc:array(binary()),
                 #{
-                    default => false,
+                    required => false,
                     desc => ?DESC(common_ssl_opts_schema_cacerts)
                 }
             )},


### PR DESCRIPTION
Fixes #11370
See https://www.erlang.org/doc/man/ssl.html#type-client_cacerts

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b63799</samp>

This pull request allows multiple CA certificates for SSL/TLS connections and updates the emqx version number. It changes the type of the `cacerts` option in `emqx_schema.erl` and the `vsn` field in `emqx.app.src`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
