### PR TITLE
fix(tls): remove `cacerts` config for now

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2017,14 +2017,6 @@ common_ssl_opts_schema(Defaults, Type) ->
                     desc => ?DESC(common_ssl_opts_schema_cacertfile)
                 }
             )},
-        {"cacerts",
-            sc(
-                boolean(),
-                #{
-                    default => false,
-                    desc => ?DESC(common_ssl_opts_schema_cacerts)
-                }
-            )},
         {"certfile",
             sc(
                 binary(),

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -478,13 +478,11 @@ to_server_opts(Type, Opts) ->
     Versions = integral_versions(Type, maps:get(versions, Opts, undefined)),
     Ciphers = integral_ciphers(Versions, maps:get(ciphers, Opts, undefined)),
     Path = fun(Key) -> resolve_cert_path_for_read_strict(maps:get(Key, Opts, undefined)) end,
-    CACerts = get_cacerts(maps:get(cacerts, Opts, false)),
     ensure_valid_options(
         maps:to_list(Opts#{
             keyfile => Path(keyfile),
             certfile => Path(certfile),
             cacertfile => Path(cacertfile),
-            cacerts => CACerts,
             ciphers => Ciphers,
             versions => Versions
         }),
@@ -513,13 +511,11 @@ to_client_opts(Type, Opts) ->
             SNI = ensure_sni(Get(server_name_indication)),
             Versions = integral_versions(Type, Get(versions)),
             Ciphers = integral_ciphers(Versions, Get(ciphers)),
-            CACerts = get_cacerts(GetD(cacerts, false)),
             ensure_valid_options(
                 [
                     {keyfile, KeyFile},
                     {certfile, CertFile},
                     {cacertfile, CAFile},
-                    {cacerts, CACerts},
                     {verify, Verify},
                     {server_name_indication, SNI},
                     {versions, Versions},
@@ -665,13 +661,3 @@ ensure_ssl_file_key(SSL, RequiredKeyPaths) ->
         [] -> ok;
         Miss -> {error, #{reason => ssl_file_option_not_found, which_options => Miss}}
     end.
-
-get_cacerts(true = _UseSystemCACerts) ->
-    try
-        public_key:cacerts_get()
-    catch
-        _:_ ->
-            undefined
-    end;
-get_cacerts(false = _UseSystemCACerts) ->
-    undefined.

--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -229,7 +229,6 @@ to_client_opts_test() ->
     Versions13Only = ['tlsv1.3'],
     Options = #{
         enable => true,
-        cacerts => true,
         verify => "Verify",
         server_name_indication => "SNI",
         ciphers => "Ciphers",
@@ -265,28 +264,7 @@ to_client_opts_test() ->
             )
         )
     ),
-    Expected4 = lists:usort(maps:keys(Options) -- [enable, cacerts]),
-    ?assertEqual(
-        Expected4,
-        lists:usort(
-            proplists:get_keys(
-                emqx_tls_lib:to_client_opts(tls, Options#{cacerts := false})
-            )
-        )
-    ),
-    emqx_common_test_helpers:with_mock(
-        public_key,
-        cacerts_get,
-        fun() -> ok = {error, enoent} end,
-        fun() ->
-            ?assertNot(
-                lists:member(
-                    cacerts,
-                    proplists:get_keys(emqx_tls_lib:to_client_opts(tls, Options))
-                )
-            )
-        end
-    ).
+    ok.
 
 to_server_opts_test() ->
     VersionsAll = [tlsv1, 'tlsv1.1', 'tlsv1.2', 'tlsv1.3'],

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.app.src
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_event_hub, [
     {description, "EMQX Enterprise Azure Event Hub Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -200,7 +200,8 @@ auth_overrides() ->
 
 ssl_overrides() ->
     #{
-        "cacerts" => mk(boolean(), #{default => true}),
+        %% FIXME: change this once the config option is defined
+        %% "cacerts" => mk(boolean(), #{default => true}),
         "enable" => mk(true, #{default => true}),
         "server_name_indication" =>
             mk(

--- a/changes/ce/fix-11372.en.md
+++ b/changes/ce/fix-11372.en.md
@@ -1,0 +1,1 @@
+Removed the recently introduced `cacerts` option from TLS client schema due to incompatibilities with some cluster discovery mechanisms.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/11370

Related: https://github.com/emqx/emqx/pull/11371

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6b38f8c</samp>

This pull request removes the `cacerts` option from the SSL/TLS configuration for the EMQX bridges and the core `emqx_tls_lib.erl` module. This is to avoid errors or warnings when connecting to or accepting connections from some cloud services that do not require or expect this option. It also updates the version number and the test case for the affected modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] If there should be document changes, a PR to emqx-docs.git is sent, or a jira ticket is created to follow up
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
