### PR TITLE
fix: increase emqx_router_sup restart intensity

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.4"},
+    {vsn, "5.1.5"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_router_sup.erl
+++ b/apps/emqx/src/emqx_router_sup.erl
@@ -41,4 +41,9 @@ init([]) ->
         hash,
         {emqx_router, start_link, []}
     ]),
-    {ok, {{one_for_all, 0, 1}, [Helper, RouterPool]}}.
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 100
+    },
+    {ok, {SupFlags, [Helper, RouterPool]}}.

--- a/changes/ce/fix-11388.en.md
+++ b/changes/ce/fix-11388.en.md
@@ -1,0 +1,6 @@
+Increase `emqx_router_sup` restart intensity.
+
+The goal is to tolerate occasional crashes that can happen under relatively normal conditions
+and don't seem critical to shutdown the whole app (emqx).
+For example, mria write/delete call delegated from a replicant to a core node by `emqx_router_helper` may fail,
+if the core node is being stopped / restarted / not ready.


### PR DESCRIPTION
The goal is to tolerate occasional crashes that can happen under relatively normal conditions and don't seem critical to shutdown the whole app (emqx). For example, mria write/delete call delegated from a replicant to a core node may fail, if the core node is being stopped / restarted / not ready.

Fixes EMQX-10703, #11310

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2769736</samp>

The pull request updates the version number of the `emqx` application and enhances the fault tolerance of the `emqx_router` process by changing its supervisor flags.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
