### PR TITLE
feat(ldap-authz): integrate the LDAP authorization

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.4"},
+    {vsn, "5.1.5"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -19,7 +19,8 @@
 -export([
     hash/2,
     hash_data/2,
-    check_pass/3
+    check_pass/3,
+    compare_secure/2
 ]).
 
 -export_type([

--- a/apps/emqx_authn/src/emqx_authn_enterprise.erl
+++ b/apps/emqx_authn/src/emqx_authn_enterprise.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
 -module(emqx_authn_enterprise).

--- a/apps/emqx_authz/src/emqx_authz.app.src
+++ b/apps/emqx_authz/src/emqx_authz.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_authz, [
     {description, "An OTP application"},
-    {vsn, "0.1.24"},
+    {vsn, "0.1.25"},
     {registered, []},
     {mod, {emqx_authz_app, []}},
     {applications, [

--- a/apps/emqx_authz/src/emqx_authz_api_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_api_schema.erl
@@ -95,7 +95,9 @@ fields(position) ->
                     in => body
                 }
             )}
-    ].
+    ];
+fields(MaybeEnterprise) ->
+    emqx_authz_enterprise:fields(MaybeEnterprise).
 
 %%------------------------------------------------------------------------------
 %% http type funcs
@@ -283,7 +285,7 @@ authz_sources_types(Type) ->
             mysql,
             postgresql,
             file
-        ].
+        ] ++ emqx_authz_enterprise:authz_sources_types().
 
 to_list(A) when is_atom(A) ->
     atom_to_list(A);

--- a/apps/emqx_authz/src/emqx_authz_enterprise.erl
+++ b/apps/emqx_authz/src/emqx_authz_enterprise.erl
@@ -1,0 +1,66 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_authz_enterprise).
+
+-export([
+    type_names/0,
+    fields/1,
+    is_enterprise_module/1,
+    authz_sources_types/0,
+    type/1,
+    desc/1
+]).
+
+-if(?EMQX_RELEASE_EDITION == ee).
+
+%% type name set
+type_names() ->
+    [ldap].
+
+%% type -> type schema
+fields(ldap) ->
+    emqx_ldap_authz:fields(config).
+
+%% type -> type module
+is_enterprise_module(ldap) ->
+    {ok, emqx_ldap_authz};
+is_enterprise_module(_) ->
+    false.
+
+%% api sources set
+authz_sources_types() ->
+    [ldap].
+
+%% atom-able name -> type
+type(<<"ldap">>) -> ldap;
+type(ldap) -> ldap;
+type(Unknown) -> throw({unknown_authz_source_type, Unknown}).
+
+desc(ldap) ->
+    emqx_ldap_authz:description();
+desc(_) ->
+    undefined.
+
+-else.
+
+-dialyzer({nowarn_function, [fields/1, type/1, desc/1]}).
+
+type_names() ->
+    [].
+
+fields(Any) ->
+    error({invalid_field, Any}).
+
+is_enterprise_module(_) ->
+    false.
+
+authz_sources_types() ->
+    [].
+
+%% should never happen if the input is type-checked by hocon schema
+type(Unknown) -> throw({unknown_authz_source_type, Unknown}).
+
+desc(_) ->
+    undefined.
+-endif.

--- a/apps/emqx_authz/src/emqx_authz_schema.erl
+++ b/apps/emqx_authz/src/emqx_authz_schema.erl
@@ -43,7 +43,8 @@
 -export([
     headers_no_content_type/1,
     headers/1,
-    default_authz/0
+    default_authz/0,
+    authz_common_fields/1
 ]).
 
 %%--------------------------------------------------------------------
@@ -64,7 +65,8 @@ type_names() ->
         redis_single,
         redis_sentinel,
         redis_cluster
-    ].
+    ] ++
+        emqx_authz_enterprise:type_names().
 
 namespace() -> authz.
 
@@ -176,7 +178,9 @@ fields("node_error") ->
     [
         node_name(),
         {"error", ?HOCON(string(), #{desc => ?DESC("node_error")})}
-    ].
+    ];
+fields(MaybeEnterprise) ->
+    emqx_authz_enterprise:fields(MaybeEnterprise).
 
 common_field() ->
     [
@@ -220,8 +224,8 @@ desc(redis_sentinel) ->
     ?DESC(redis_sentinel);
 desc(redis_cluster) ->
     ?DESC(redis_cluster);
-desc(_) ->
-    undefined.
+desc(MaybeEnterprise) ->
+    emqx_authz_enterprise:desc(MaybeEnterprise).
 
 authz_common_fields(Type) ->
     [

--- a/apps/emqx_ldap/rebar.config
+++ b/apps/emqx_ldap/rebar.config
@@ -4,5 +4,6 @@
 {deps, [
         {emqx_connector, {path, "../../apps/emqx_connector"}},
         {emqx_resource, {path, "../../apps/emqx_resource"}},
-        {emqx_authn, {path, "../../apps/emqx_authn"}}
+        {emqx_authn, {path, "../../apps/emqx_authn"}},
+        {emqx_authz, {path, "../../apps/emqx_authz"}}
 ]}.

--- a/apps/emqx_ldap/src/emqx_ldap.app.src
+++ b/apps/emqx_ldap/src/emqx_ldap.app.src
@@ -5,7 +5,8 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_authn
+        emqx_authn,
+        emqx_authz
     ]},
     {env, []},
     {modules, []},

--- a/apps/emqx_ldap/src/emqx_ldap_authz.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authz.erl
@@ -1,0 +1,164 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_ldap_authz).
+
+-include_lib("emqx_authz/include/emqx_authz.hrl").
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_placeholder.hrl").
+-include_lib("eldap/include/eldap.hrl").
+
+-behaviour(emqx_authz).
+
+-define(PREPARE_KEY, ?MODULE).
+
+%% AuthZ Callbacks
+-export([
+    description/0,
+    create/1,
+    update/1,
+    destroy/1,
+    authorize/4
+]).
+
+-export([fields/1]).
+
+-ifdef(TEST).
+-compile(export_all).
+-compile(nowarn_export_all).
+-endif.
+
+%%------------------------------------------------------------------------------
+%% Hocon Schema
+%%------------------------------------------------------------------------------
+
+fields(config) ->
+    emqx_authz_schema:authz_common_fields(ldap) ++
+        [
+            {publish_attribute, attribute_meta(publish_attribute, <<"mqttPublishTopic">>)},
+            {subscribe_attribute, attribute_meta(subscribe_attribute, <<"mqttSubscriptionTopic">>)},
+            {all_attribute, attribute_meta(all_attribute, <<"mqttPubSubTopic">>)},
+            {query_timeout,
+                ?HOCON(
+                    emqx_schema:timeout_duration_ms(),
+                    #{
+                        desc => ?DESC(query_timeout),
+                        default => <<"5s">>
+                    }
+                )}
+        ] ++
+        emqx_ldap:fields(config).
+
+attribute_meta(Name, Default) ->
+    ?HOCON(
+        string(),
+        #{
+            default => Default,
+            desc => ?DESC(Name)
+        }
+    ).
+
+%%------------------------------------------------------------------------------
+%% AuthZ Callbacks
+%%------------------------------------------------------------------------------
+
+description() ->
+    "AuthZ with LDAP".
+
+create(Source) ->
+    ResourceId = emqx_authz_utils:make_resource_id(?MODULE),
+    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_ldap, Source),
+    Annotations = new_annotations(#{id => ResourceId}, Source),
+    Source#{annotations => Annotations}.
+
+update(Source) ->
+    case emqx_authz_utils:update_resource(emqx_ldap, Source) of
+        {error, Reason} ->
+            error({load_config_error, Reason});
+        {ok, Id} ->
+            Annotations = new_annotations(#{id => Id}, Source),
+            Source#{annotations => Annotations}
+    end.
+
+destroy(#{annotations := #{id := Id}}) ->
+    ok = emqx_resource:remove_local(Id).
+
+authorize(
+    Client,
+    Action,
+    Topic,
+    #{
+        query_timeout := QueryTimeout,
+        annotations := #{id := ResourceID} = Annotations
+    }
+) ->
+    Attrs = select_attrs(Action, Annotations),
+    case emqx_resource:simple_sync_query(ResourceID, {query, Client, Attrs, QueryTimeout}) of
+        {ok, []} ->
+            nomatch;
+        {ok, [Entry | _]} ->
+            do_authorize(Action, Topic, Attrs, Entry);
+        {error, Reason} ->
+            ?SLOG(error, #{
+                msg => "query_ldap_error",
+                reason => Reason,
+                resource_id => ResourceID
+            }),
+            nomatch
+    end.
+
+do_authorize(Action, Topic, [Attr | T], Entry) ->
+    Topics = proplists:get_value(Attr, Entry#eldap_entry.attributes, []),
+    case match_topic(Topic, Topics) of
+        true ->
+            {matched, allow};
+        false ->
+            do_authorize(Action, Topic, T, Entry)
+    end;
+do_authorize(_Action, _Topic, [], _Entry) ->
+    nomatch.
+
+new_annotations(Init, Source) ->
+    lists:foldl(
+        fun(Attr, Acc) ->
+            Acc#{
+                Attr =>
+                    case maps:get(Attr, Source) of
+                        Value when is_binary(Value) ->
+                            erlang:binary_to_list(Value);
+                        Value ->
+                            Value
+                    end
+            }
+        end,
+        Init,
+        [publish_attribute, subscribe_attribute, all_attribute]
+    ).
+
+select_attrs(#{action_type := publish}, #{publish_attribute := Pub, all_attribute := All}) ->
+    [Pub, All];
+select_attrs(_, #{subscribe_attribute := Sub, all_attribute := All}) ->
+    [Sub, All].
+
+match_topic(Target, Topics) ->
+    lists:any(
+        fun(Topic) ->
+            emqx_topic:match(Target, erlang:list_to_binary(Topic))
+        end,
+        Topics
+    ).

--- a/apps/emqx_ldap/src/emqx_ldap_filter_lexer.xrl
+++ b/apps/emqx_ldap/src/emqx_ldap_filter_lexer.xrl
@@ -27,5 +27,5 @@ dn : {token, {dn, TokenLine}}.
 Erlang code.
 
 %%--------------------------------------------------------------------
-%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------

--- a/apps/emqx_ldap/src/emqx_ldap_filter_parser.yrl
+++ b/apps/emqx_ldap/src/emqx_ldap_filter_parser.yrl
@@ -1,5 +1,5 @@
 Header "%%--------------------------------------------------------------------
-%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------".
 
 Nonterminals

--- a/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
 -module(emqx_ldap_SUITE).

--- a/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
@@ -1,7 +1,6 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
-
 -module(emqx_ldap_authn_SUITE).
 
 -compile(nowarn_export_all).

--- a/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
 -module(emqx_ldap_authn_SUITE).

--- a/apps/emqx_ldap/test/emqx_ldap_authz_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_authz_SUITE.erl
@@ -1,0 +1,173 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_ldap_authz_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include("emqx_authz.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(LDAP_HOST, "ldap").
+-define(LDAP_DEFAULT_PORT, 389).
+-define(LDAP_RESOURCE, <<"emqx_ldap_authz_SUITE">>).
+
+all() ->
+    emqx_authz_test_lib:all_with_table_case(?MODULE, t_run_case, cases()).
+
+groups() ->
+    emqx_authz_test_lib:table_groups(t_run_case, cases()).
+
+init_per_suite(Config) ->
+    ok = stop_apps([emqx_resource]),
+    case emqx_common_test_helpers:is_tcp_server_available(?LDAP_HOST, ?LDAP_DEFAULT_PORT) of
+        true ->
+            ok = emqx_common_test_helpers:start_apps(
+                [emqx_conf, emqx_authz],
+                fun set_special_configs/1
+            ),
+            ok = start_apps([emqx_resource]),
+            ok = create_ldap_resource(),
+            Config;
+        false ->
+            {skip, no_ldap}
+    end.
+
+end_per_suite(_Config) ->
+    ok = emqx_authz_test_lib:restore_authorizers(),
+    ok = emqx_resource:remove_local(?LDAP_RESOURCE),
+    ok = stop_apps([emqx_resource]),
+    ok = emqx_common_test_helpers:stop_apps([emqx_conf, emqx_authz]).
+
+init_per_group(Group, Config) ->
+    [{test_case, emqx_authz_test_lib:get_case(Group, cases())} | Config].
+end_per_group(_Group, _Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    ok = emqx_authz_test_lib:reset_authorizers(),
+    Config.
+end_per_testcase(_TestCase, _Config) ->
+    _ = emqx_authz:set_feature_available(rich_actions, true),
+    ok.
+
+set_special_configs(emqx_authz) ->
+    ok = emqx_authz_test_lib:reset_authorizers();
+set_special_configs(_) ->
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Testcases
+%%------------------------------------------------------------------------------
+
+t_run_case(Config) ->
+    Case = ?config(test_case, Config),
+    ok = setup_authz_source(),
+    ok = emqx_authz_test_lib:run_checks(Case).
+
+t_create_invalid(_Config) ->
+    ok = setup_authz_source(),
+    BadConfig = maps:merge(
+        raw_ldap_authz_config(),
+        #{<<"server">> => <<"255.255.255.255:33333">>}
+    ),
+    {ok, _} = emqx_authz:update(?CMD_REPLACE, [BadConfig]),
+
+    [_] = emqx_authz:lookup().
+
+%%------------------------------------------------------------------------------
+%% Case
+%%------------------------------------------------------------------------------
+cases() ->
+    [
+        #{
+            name => simpe_publish,
+            client_info => #{username => <<"mqttuser0001">>},
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"mqttuser0001/pub/1">>},
+                {allow, ?AUTHZ_PUBLISH, <<"mqttuser0001/pub/+">>},
+                {allow, ?AUTHZ_PUBLISH, <<"mqttuser0001/pub/#">>}
+            ]
+        },
+        #{
+            name => simpe_subscribe,
+            client_info => #{username => <<"mqttuser0001">>},
+            checks => [
+                {allow, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/sub/1">>},
+                {allow, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/sub/+">>},
+                {allow, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/sub/#">>}
+            ]
+        },
+
+        #{
+            name => simpe_pubsub,
+            client_info => #{username => <<"mqttuser0001">>},
+            checks => [
+                {allow, ?AUTHZ_PUBLISH, <<"mqttuser0001/pubsub/1">>},
+                {allow, ?AUTHZ_PUBLISH, <<"mqttuser0001/pubsub/+">>},
+                {allow, ?AUTHZ_PUBLISH, <<"mqttuser0001/pubsub/#">>},
+
+                {allow, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/pubsub/1">>},
+                {allow, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/pubsub/+">>},
+                {allow, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/pubsub/#">>}
+            ]
+        },
+
+        #{
+            name => simpe_unmatched,
+            client_info => #{username => <<"mqttuser0001">>},
+            checks => [
+                {deny, ?AUTHZ_PUBLISH, <<"mqttuser0001/req/mqttuser0001/+">>},
+                {deny, ?AUTHZ_PUBLISH, <<"mqttuser0001/req/mqttuser0002/+">>},
+                {deny, ?AUTHZ_SUBSCRIBE, <<"mqttuser0001/req/+/mqttuser0002">>}
+            ]
+        }
+    ].
+
+%%------------------------------------------------------------------------------
+%% Helpers
+%%------------------------------------------------------------------------------
+
+setup_authz_source() ->
+    setup_config(#{}).
+
+raw_ldap_authz_config() ->
+    #{
+        <<"enable">> => <<"true">>,
+        <<"type">> => <<"ldap">>,
+        <<"server">> => ldap_server(),
+        <<"base_object">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
+        <<"username">> => <<"cn=root,dc=emqx,dc=io">>,
+        <<"password">> => <<"public">>,
+        <<"pool_size">> => 8
+    }.
+
+setup_config(SpecialParams) ->
+    emqx_authz_test_lib:setup_config(
+        raw_ldap_authz_config(),
+        SpecialParams
+    ).
+
+ldap_server() ->
+    iolist_to_binary(io_lib:format("~s:~B", [?LDAP_HOST, ?LDAP_DEFAULT_PORT])).
+
+ldap_config() ->
+    emqx_ldap_SUITE:ldap_config([]).
+
+start_apps(Apps) ->
+    lists:foreach(fun application:ensure_all_started/1, Apps).
+
+stop_apps(Apps) ->
+    lists:foreach(fun application:stop/1, Apps).
+
+create_ldap_resource() ->
+    {ok, _} = emqx_resource:create_local(
+        ?LDAP_RESOURCE,
+        ?RESOURCE_GROUP,
+        emqx_ldap,
+        ldap_config(),
+        #{}
+    ),
+    ok.

--- a/apps/emqx_ldap/test/emqx_ldap_filter_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_filter_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
 -module(emqx_ldap_filter_SUITE).

--- a/changes/ee/feat-11386.en.md
+++ b/changes/ee/feat-11386.en.md
@@ -1,1 +1,1 @@
-Integrated the LDAP as a new authenticator.
+Integrated LDAP as a new authenticator.

--- a/changes/ee/feat-11392.en.md
+++ b/changes/ee/feat-11392.en.md
@@ -1,0 +1,1 @@
+Integrated LDAP as a authorization source.

--- a/rel/i18n/emqx_ldap_authn.hocon
+++ b/rel/i18n/emqx_ldap_authn.hocon
@@ -10,7 +10,7 @@ password_attribute.label:
 """Password Attribute"""
 
 is_superuser_attribute.desc:
-"""Indicates which attribute is used to represent whether the user is a super user."""
+"""Indicates which attribute is used to represent whether the user is a superuser."""
 
 is_superuser_attribute.label:
 """IsSuperuser Attribute"""

--- a/rel/i18n/emqx_ldap_authz.hocon
+++ b/rel/i18n/emqx_ldap_authz.hocon
@@ -1,0 +1,27 @@
+emqx_ldap_authz {
+
+publish_attribute.desc:
+"""Indicates which attribute is used to represent the allowed topics list of the `publish`."""
+
+publish_attribute.label:
+"""Publish Attribute"""
+
+subscribe_attribute.desc:
+"""Indicates which attribute is used to represent the allowed topics list of the `subscribe`."""
+
+subscribe_attribute.label:
+"""Subscribe Attribute"""
+
+all_attribute.desc:
+"""Indicates which attribute is used to represent the both allowed topics list of  `publish` and `subscribe`."""
+
+all_attribute.label:
+"""All Attribute"""
+
+query_timeout.desc:
+"""Timeout for the LDAP query."""
+
+query_timeout.label:
+"""Query Timeout"""
+
+}


### PR DESCRIPTION
Fixes [EMQX-10698](https://emqx.atlassian.net/browse/EMQX-10698)

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e49f146</samp>

This pull request adds support for LDAP as a new authorization source for enterprise users. It modifies the `emqx_authz` and `emqx_authn` modules to integrate the enterprise-specific logic and schema. It also adds the `emqx_ldap` application that provides the LDAP authentication and authorization modules, as well as the test cases and internationalization fields. It fixes some typos and updates some license headers.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
