### PR TITLE
fix: rule SQL mongo_date function should return a string in test mode

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.22"},
+    {vsn, "5.0.23"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl, uuid]},

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -1193,7 +1193,7 @@ mongo_date(MillisecondsTimestamp) ->
 mongo_date(Timestamp, Unit) ->
     InsertedTimeUnit = time_unit(Unit),
     ScaledEpoch = erlang:convert_time_unit(Timestamp, InsertedTimeUnit, millisecond),
-    convert_timestamp(ScaledEpoch).
+    mongo_date(ScaledEpoch).
 
 maybe_isodate_format(ErlTimestamp) ->
     case emqx_rule_sqltester:is_test_runtime_env() of

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -1185,15 +1185,30 @@ function_literal(Fun, Args) ->
     {invalid_func, {Fun, Args}}.
 
 mongo_date() ->
-    erlang:timestamp().
+    maybe_isodate_format(erlang:timestamp()).
 
 mongo_date(MillisecondsTimestamp) ->
-    convert_timestamp(MillisecondsTimestamp).
+    maybe_isodate_format(convert_timestamp(MillisecondsTimestamp)).
 
 mongo_date(Timestamp, Unit) ->
     InsertedTimeUnit = time_unit(Unit),
     ScaledEpoch = erlang:convert_time_unit(Timestamp, InsertedTimeUnit, millisecond),
     convert_timestamp(ScaledEpoch).
+
+maybe_isodate_format(ErlTimestamp) ->
+    case emqx_rule_sqltester:is_test_runtime_env() of
+        false ->
+            ErlTimestamp;
+        true ->
+            %% if this is called from sqltest, we need to convert it to the ISODate() format,
+            %% so that it can be correctly converted into a JSON string.
+            isodate_format(ErlTimestamp)
+    end.
+
+isodate_format({MegaSecs, Secs, MicroSecs}) ->
+    SystemTimeMs = (MegaSecs * 1000_000_000_000 + Secs * 1000_000 + MicroSecs) div 1000,
+    Ts3339Str = calendar:system_time_to_rfc3339(SystemTimeMs, [{unit, millisecond}, {offset, "Z"}]),
+    iolist_to_binary(["ISODate(", Ts3339Str, ")"]).
 
 convert_timestamp(MillisecondsTimestamp) ->
     MicroTimestamp = MillisecondsTimestamp * 1000,

--- a/changes/ee/fix-11401.en.md
+++ b/changes/ee/fix-11401.en.md
@@ -1,0 +1,1 @@
+When running one of the rule engine SQL `mongo_date` functions in the EMQX dashboard test interface, the resulting date is formatted as `ISODate(*)`, where * is the date in ISO date format instead of only the ISO date string. This is the format used by MongoDB to store dates.


### PR DESCRIPTION
The rule SQL mongo_date function should return a string with the format ISODate(*), where * is an ISO date string when running the rule in test mode.

This PR ports the functionality from https://github.com/emqx/emqx-enterprise/pull/1835 so that the when the user test SQL statements that call mongo_date the result will be formatet in the same way as in EMQX 4.4.

Fixes:
https://emqx.atlassian.net/browse/EMQX-10727

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ed031d</samp>

Added support for ISODate format in mongo_date function for rule engine tests. Updated emqx_rule_engine version and added a test case to verify the new feature. Modified `emqx_rule_funcs.erl`, `emqx_rule_sqltester.erl`, `emqx_rule_engine.app.src`, and `emqx_rule_engine_api_rule_test_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible