### PR TITLE
feat(kafka_consumer): add mqtt topic placeholder support

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, [emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -125,7 +125,7 @@ values(consumer) ->
         topic_mapping => [
             #{
                 kafka_topic => <<"kafka-topic-1">>,
-                mqtt_topic => <<"mqtt/topic/1">>,
+                mqtt_topic => <<"mqtt/topic/${.offset}">>,
                 qos => 1,
                 payload_template => <<"${.}">>
             },

--- a/changes/ee/feat-11402.en.md
+++ b/changes/ee/feat-11402.en.md
@@ -1,0 +1,1 @@
+Added support for using placeholders to define MQTT Topic in Kafka Consumer bridge topic mappings.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10678

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5a540fc</samp>

Added support for dynamic mqtt topic mapping in the kafka bridge using placeholders. Changed the `kafka_topic` record type and the `mqtt_topic` configuration to use `mqtt_topic_template`. Updated the test case and the version number accordingly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
