### PR TITLE
fix(ldap): improve configuration name and docs

### DIFF
--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -54,10 +54,11 @@ fields(config) ->
         {pool_size, fun ?ECS:pool_size/1},
         {username, fun ensure_username/1},
         {password, fun ?ECS:password/1},
-        {base_object,
+        {base_dn,
             ?HOCON(binary(), #{
-                desc => ?DESC(base_object),
+                desc => ?DESC(base_dn),
                 required => true,
+                example => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
                 validator => fun emqx_schema:non_empty_string/1
             })},
         {filter,
@@ -66,6 +67,7 @@ fields(config) ->
                 #{
                     desc => ?DESC(filter),
                     default => <<"(objectClass=mqttUser)">>,
+                    example => <<"(& (objectClass=mqttUser) (uid=${username}))">>,
                     validator => fun emqx_schema:non_empty_string/1
                 }
             )}
@@ -229,9 +231,9 @@ log(Level, Format, Args) ->
     ).
 
 prepare_template(Config, State) ->
-    do_prepare_template(maps:to_list(maps:with([base_object, filter], Config)), State).
+    do_prepare_template(maps:to_list(maps:with([base_dn, filter], Config)), State).
 
-do_prepare_template([{base_object, V} | T], State) ->
+do_prepare_template([{base_dn, V} | T], State) ->
     do_prepare_template(T, State#{base_tokens => emqx_placeholder:preproc_tmpl(V)});
 do_prepare_template([{filter, V} | T], State) ->
     do_prepare_template(T, State#{filter_tokens => emqx_placeholder:preproc_tmpl(V)});

--- a/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
@@ -154,7 +154,7 @@ ldap_config(Config) ->
             "    password = public\n"
             "    pool_size = 8\n"
             "    server = \"~s:~b\"\n"
-            "    base_object=\"uid=${username},ou=testdevice,dc=emqx,dc=io\"\n"
+            "    base_dn=\"uid=${username},ou=testdevice,dc=emqx,dc=io\"\n"
             "    filter =\"(objectClass=mqttUser)\"\n"
             "    ~ts\n"
             "",

--- a/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
@@ -167,7 +167,7 @@ t_update(_Config) ->
     CorrectConfig = raw_ldap_auth_config(),
     IncorrectConfig =
         CorrectConfig#{
-            <<"base_object">> => <<"ou=testdevice,dc=emqx,dc=io">>
+            <<"base_dn">> => <<"ou=testdevice,dc=emqx,dc=io">>
         },
 
     {ok, _} = emqx:update_config(
@@ -208,7 +208,7 @@ raw_ldap_auth_config() ->
         <<"mechanism">> => <<"password_based">>,
         <<"backend">> => <<"ldap">>,
         <<"server">> => ldap_server(),
-        <<"base_object">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
+        <<"base_dn">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
         <<"username">> => <<"cn=root,dc=emqx,dc=io">>,
         <<"password">> => <<"public">>,
         <<"pool_size">> => 8

--- a/apps/emqx_ldap/test/emqx_ldap_authz_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_authz_SUITE.erl
@@ -138,7 +138,7 @@ raw_ldap_authz_config() ->
         <<"enable">> => <<"true">>,
         <<"type">> => <<"ldap">>,
         <<"server">> => ldap_server(),
-        <<"base_object">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
+        <<"base_dn">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
         <<"username">> => <<"cn=root,dc=emqx,dc=io">>,
         <<"password">> => <<"public">>,
         <<"pool_size">> => 8

--- a/rel/i18n/emqx_ldap.hocon
+++ b/rel/i18n/emqx_ldap.hocon
@@ -8,16 +8,17 @@ The LDAP default port 389 is used if `[:Port]` is not specified."""
 server.label:
 """Server Host"""
 
-base_object.desc:
+base_dn.desc:
 """The name of the base object entry (or possibly the root) relative to
 which the Search is to be performed."""
 
-base_object.label:
-"""Base Object"""
+base_dn.label:
+"""Base DN"""
 
 filter.desc:
 """The filter that defines the conditions that must be fulfilled in order
-for the Search to match a given entry."""
+for the Search to match a given entry.<br>
+The syntax of the filter follows RFC 4515 and also supports placeholders."""
 
 filter.label:
 """Filter"""


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9da7cb5</samp>

This pull request refactors the LDAP configuration field `base_object` to `base_dn` to better align with the LDAP terminology and avoid confusion. It also updates the code, tests, and documentation to use the new field name and adds an example for the `filter` field.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
