### PR TITLE
perf(router): switch to async node-local trie index

### DIFF
--- a/apps/emqx/include/emqx_router.hrl
+++ b/apps/emqx/include/emqx_router.hrl
@@ -20,6 +20,9 @@
 %% ETS table for message routing
 -define(ROUTE_TAB, emqx_route).
 
+%% Mnesia table for persistent session routing
+-define(SESSION_TRIE, emqx_session_trie).
+
 %% Mnesia table for message routing
 -define(ROUTING_NODE, emqx_routing_node).
 

--- a/apps/emqx/src/emqx_route_index.erl
+++ b/apps/emqx/src/emqx_route_index.erl
@@ -1,0 +1,102 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2017-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Route topic index
+%%
+%% We maintain "compacted" index here, this is why index entries has no relevant IDs
+%% associated with them. Records are mapsets of route destinations. Basically:
+%% ```
+%% {<<"t/route/topic/#">>, _ID = []} => #{'node1@emqx' => [], 'node2@emqx' => [], ...}
+%% ```
+%%
+%% This layout implies that we cannot make changes concurrently, since insert and delete
+%% are not atomic operations.
+
+-module(emqx_route_index).
+
+-include("emqx.hrl").
+-include("types.hrl").
+-include("logger.hrl").
+
+-export([match/2]).
+
+-export([
+    insert/2,
+    insert/3,
+    delete/2,
+    delete/3,
+    clean/1
+]).
+
+-spec match(emqx_types:topic(), ets:table()) -> [emqx_types:route()].
+match(Topic, Tab) ->
+    Matches = emqx_topic_index:matches(Topic, Tab, []),
+    lists:flatmap(fun(M) -> expand_match(M, Tab) end, Matches).
+
+expand_match(Match, Tab) ->
+    Topic = emqx_topic_index:get_topic(Match),
+    [
+        #route{topic = Topic, dest = Dest}
+     || Ds <- emqx_topic_index:get_record(Match, Tab),
+        Dest <- maps:keys(Ds)
+    ].
+
+-spec insert(emqx_types:route(), ets:table()) -> boolean().
+insert(#route{topic = Topic, dest = Dest}, Tab) ->
+    insert(Topic, Dest, Tab).
+
+-spec insert(emqx_types:topic(), _Dest, ets:table()) -> boolean().
+insert(Topic, Dest, Tab) ->
+    Words = emqx_topic_index:words(Topic),
+    case emqx_topic:wildcard(Words) of
+        true ->
+            case emqx_topic_index:lookup(Words, ID = [], Tab) of
+                [Ds = #{}] ->
+                    emqx_topic_index:insert(Words, ID, Ds#{Dest => []}, Tab);
+                [] ->
+                    emqx_topic_index:insert(Words, ID, #{Dest => []}, Tab)
+            end;
+        false ->
+            false
+    end.
+
+-spec delete(emqx_types:route(), ets:table()) -> boolean().
+delete(#route{topic = Topic, dest = Dest}, Tab) ->
+    delete(Topic, Dest, Tab).
+
+-spec delete(emqx_types:topic(), _Dest, ets:table()) -> boolean().
+delete(Topic, Dest, Tab) ->
+    Words = emqx_topic_index:words(Topic),
+    case emqx_topic:wildcard(Words) of
+        true ->
+            case emqx_topic_index:lookup(Words, ID = [], Tab) of
+                [Ds = #{Dest := _}] when map_size(Ds) =:= 1 ->
+                    emqx_topic_index:delete(Words, ID, Tab);
+                [Ds = #{Dest := _}] ->
+                    NDs = maps:remove(Dest, Ds),
+                    emqx_topic_index:insert(Words, ID, NDs, Tab);
+                [_] ->
+                    true;
+                [] ->
+                    true
+            end;
+        false ->
+            false
+    end.
+
+-spec clean(ets:table()) -> true.
+clean(Tab) ->
+    emqx_topic_index:clean(Tab).

--- a/apps/emqx/src/emqx_route_index.erl
+++ b/apps/emqx/src/emqx_route_index.erl
@@ -22,8 +22,8 @@
 %% {<<"t/route/topic/#">>, _ID = []} => #{'node1@emqx' => [], 'node2@emqx' => [], ...}
 %% ```
 %%
-%% This layout implies that we cannot make changes concurrently, since insert and delete
-%% are not atomic operations.
+%% This layout implies that we cannot in general make changes concurrently, so there's
+%% transactional operation mode for that, employing mria transaction mechanism.
 
 -module(emqx_route_index).
 
@@ -31,17 +31,40 @@
 -include("types.hrl").
 -include("logger.hrl").
 
+-export([init/1]).
+
 -export([match/2]).
 
 -export([
-    insert/2,
     insert/3,
-    delete/2,
+    insert/4,
     delete/3,
+    delete/4,
     clean/1
 ]).
 
 -export([all/1]).
+
+-record(routeidx, {
+    key :: emqx_topic_index:key(nil()),
+    dests :: #{emqx_router:dest() => nil()}
+}).
+
+%%
+
+-spec init(atom()) -> ok.
+init(TabName) ->
+    mria:create_table(
+        TabName,
+        [
+            {type, ordered_set},
+            {storage, ram_copies},
+            {local_content, true},
+            {record_name, routeidx},
+            {attributes, record_info(fields, routeidx)},
+            {storage_properties, [{ets, [{read_concurrency, true}]}]}
+        ]
+    ).
 
 -spec match(emqx_types:topic(), ets:table()) -> [emqx_types:route()].
 match(Topic, Tab) ->
@@ -56,58 +79,75 @@ expand_match(Match, Tab) ->
         Dest <- maps:keys(Ds)
     ].
 
--spec insert(emqx_types:route(), ets:table()) -> boolean().
-insert(#route{topic = Topic, dest = Dest}, Tab) ->
-    insert(Topic, Dest, Tab).
+-spec insert(emqx_types:route(), ets:table(), _TODO) -> boolean().
+insert(#route{topic = Topic, dest = Dest}, Tab, Mode) ->
+    insert(Topic, Dest, Tab, Mode).
 
--spec insert(emqx_types:topic(), _Dest, ets:table()) -> boolean().
-insert(Topic, Dest, Tab) ->
+-spec insert(emqx_types:topic(), _Dest, ets:table(), _TODO) -> boolean().
+insert(Topic, Dest, Tab, Mode) ->
     Words = emqx_topic_index:words(Topic),
     case emqx_topic:wildcard(Words) of
-        true ->
-            case emqx_topic_index:lookup(Words, ID = [], Tab) of
-                [Ds = #{}] ->
-                    emqx_topic_index:insert(Words, ID, Ds#{Dest => []}, Tab);
-                [] ->
-                    emqx_topic_index:insert(Words, ID, #{Dest => []}, Tab)
-            end;
+        true when Mode == unsafe ->
+            mria:async_dirty(mria:local_content_shard(), fun do_insert/3, [Words, Dest, Tab]);
+        true when Mode == transactional ->
+            mria:transaction(mria:local_content_shard(), fun do_insert/3, [Words, Dest, Tab]);
         false ->
             false
     end.
 
--spec delete(emqx_types:route(), ets:table()) -> boolean().
-delete(#route{topic = Topic, dest = Dest}, Tab) ->
-    delete(Topic, Dest, Tab).
+do_insert(Words, Dest, Tab) ->
+    K = emqx_topic_index:mk_key(Words, []),
+    case mnesia:wread({Tab, K}) of
+        [#routeidx{dests = Ds} = Entry] ->
+            NEntry = Entry#routeidx{dests = Ds#{Dest => []}},
+            ok = mnesia:write(Tab, NEntry, write),
+            true;
+        [] ->
+            Entry = #routeidx{key = K, dests = #{Dest => []}},
+            ok = mnesia:write(Tab, Entry, write),
+            true
+    end.
 
--spec delete(emqx_types:topic(), _Dest, ets:table()) -> boolean().
-delete(Topic, Dest, Tab) ->
+-spec delete(emqx_types:route(), ets:table(), _TODO) -> boolean().
+delete(#route{topic = Topic, dest = Dest}, Tab, Mode) ->
+    delete(Topic, Dest, Tab, Mode).
+
+-spec delete(emqx_types:topic(), _Dest, ets:table(), _TODO) -> boolean().
+delete(Topic, Dest, Tab, Mode) ->
     Words = emqx_topic_index:words(Topic),
     case emqx_topic:wildcard(Words) of
-        true ->
-            case emqx_topic_index:lookup(Words, ID = [], Tab) of
-                [Ds = #{Dest := _}] when map_size(Ds) =:= 1 ->
-                    emqx_topic_index:delete(Words, ID, Tab);
-                [Ds = #{Dest := _}] ->
-                    NDs = maps:remove(Dest, Ds),
-                    emqx_topic_index:insert(Words, ID, NDs, Tab);
-                [_] ->
-                    true;
-                [] ->
-                    true
-            end;
+        true when Mode == unsafe ->
+            mria:async_dirty(mria:local_content_shard(), fun do_delete/3, [Words, Dest, Tab]);
+        true when Mode == transactional ->
+            mria:transaction(mria:local_content_shard(), fun do_delete/3, [Words, Dest, Tab]);
         false ->
             false
+    end.
+
+do_delete(Words, Dest, Tab) ->
+    K = emqx_topic_index:mk_key(Words, []),
+    case mnesia:wread({Tab, K}) of
+        [#routeidx{dests = Ds = #{Dest := _}}] when map_size(Ds) =:= 1 ->
+            ok = mnesia:delete(Tab, K, write),
+            true;
+        [#routeidx{dests = Ds = #{Dest := _}} = Entry] ->
+            NEntry = Entry#routeidx{dests = maps:remove(Dest, Ds)},
+            ok = mnesia:write(Tab, NEntry, write),
+            true;
+        [_] ->
+            true;
+        [] ->
+            true
     end.
 
 -spec clean(ets:table()) -> true.
 clean(Tab) ->
-    emqx_topic_index:clean(Tab).
+    mria:clear_table(Tab).
 
 -spec all(ets:table()) -> [emqx_types:route()].
 all(Tab) ->
-    % NOTE: Useful for testing, assumes particular record layout
     [
-        #route{topic = emqx_topic_index:get_topic(M), dest = Dest}
-     || {M, Ds} <- ets:tab2list(Tab),
+        #route{topic = emqx_topic_index:get_topic(K), dest = Dest}
+     || #routeidx{key = K, dests = Ds} <- ets:tab2list(Tab),
         Dest <- maps:keys(Ds)
     ].

--- a/apps/emqx/src/emqx_route_index.erl
+++ b/apps/emqx/src/emqx_route_index.erl
@@ -41,6 +41,8 @@
     clean/1
 ]).
 
+-export([all/1]).
+
 -spec match(emqx_types:topic(), ets:table()) -> [emqx_types:route()].
 match(Topic, Tab) ->
     Matches = emqx_topic_index:matches(Topic, Tab, []),
@@ -100,3 +102,12 @@ delete(Topic, Dest, Tab) ->
 -spec clean(ets:table()) -> true.
 clean(Tab) ->
     emqx_topic_index:clean(Tab).
+
+-spec all(ets:table()) -> [emqx_types:route()].
+all(Tab) ->
+    % NOTE: Useful for testing, assumes particular record layout
+    [
+        #route{topic = emqx_topic_index:get_topic(M), dest = Dest}
+     || {M, Ds} <- ets:tab2list(Tab),
+        Dest <- maps:keys(Ds)
+    ].

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -137,19 +137,48 @@ do_add_route(Topic, Dest) when is_binary(Topic) ->
             ok;
         false ->
             ok = emqx_router_helper:monitor(Dest),
-            % TODO
-            % Actually, `dirty_write` on replicant may end with rpc error, but
-            % the spec don't mention it. Thus, make dialyzer happy with this hack.
-            apply(mria, dirty_write, [?ROUTE_TAB, Route])
+            mria_insert_route(emqx_router_index:enabled(), Route)
     end.
+
+mria_insert_route(_AsyncIndex = true, Route) ->
+    mria_insert_route(Route);
+mria_insert_route(_AsyncIndex = false, Route = #route{topic = Topic}) ->
+    case emqx_topic:wildcard(Topic) of
+        true ->
+            mria_insert_route_update_trie(Route);
+        false ->
+            mria_insert_route(Route)
+    end.
+
+mria_insert_route_update_trie(Route) ->
+    emqx_router_utils:maybe_trans(
+        ?ROUTE_TAB,
+        fun emqx_router_utils:insert_trie_route/2,
+        [?ROUTE_TAB, Route],
+        ?ROUTE_SHARD
+    ).
+
+mria_insert_route(Route) ->
+    mria:dirty_write(?ROUTE_TAB, Route).
 
 %% @doc Match routes
 -spec match_routes(emqx_types:topic()) -> [emqx_types:route()].
 match_routes(Topic) when is_binary(Topic) ->
-    lookup_routes(Topic) ++ match_index(Topic).
+    lookup_routes(Topic) ++ match_index(emqx_router_index:enabled(), Topic).
 
-match_index(Topic) ->
+match_index(true, Topic) ->
+    match_local_index(Topic);
+match_index(false, Topic) ->
+    lists:flatmap(fun lookup_routes/1, match_global_trie(Topic)).
+
+match_local_index(Topic) ->
     emqx_router_index:match(Topic).
+
+match_global_trie(Topic) ->
+    case emqx_trie:empty() of
+        true -> [];
+        false -> emqx_trie:match(Topic)
+    end.
 
 -spec lookup_routes(emqx_types:topic()) -> [emqx_types:route()].
 lookup_routes(Topic) ->
@@ -174,7 +203,28 @@ do_delete_route(Topic) when is_binary(Topic) ->
 -spec do_delete_route(emqx_types:topic(), dest()) -> ok | {error, term()}.
 do_delete_route(Topic, Dest) ->
     Route = #route{topic = Topic, dest = Dest},
+    mria_delete_route(emqx_router_index:enabled(), Route).
+
+mria_delete_route(_AsyncIndex = true, Route) ->
+    mria_delete_route(Route);
+mria_delete_route(_AsyncIndex = false, Route = #route{topic = Topic}) ->
+    case emqx_topic:wildcard(Topic) of
+        true ->
+            mria_delete_route_update_trie(Route);
+        false ->
+            mria_delete_route(Route)
+    end.
+
+mria_delete_route(Route) ->
     mria:dirty_delete_object(?ROUTE_TAB, Route).
+
+mria_delete_route_update_trie(Route) ->
+    emqx_router_utils:maybe_trans(
+        ?ROUTE_TAB,
+        fun emqx_router_utils:delete_trie_route/2,
+        [?ROUTE_TAB, Route],
+        ?ROUTE_SHARD
+    ).
 
 -spec topics() -> list(emqx_types:topic()).
 topics() ->

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -60,6 +60,8 @@
     foldr_routes/2
 ]).
 
+-export([info/1]).
+
 -export([topics/0]).
 
 %% gen_server callbacks
@@ -259,6 +261,10 @@ foldl_routes(FoldFun, AccIn) ->
 -spec foldr_routes(fun((emqx_types:route(), Acc) -> Acc), Acc) -> Acc.
 foldr_routes(FoldFun, AccIn) ->
     ets:foldr(FoldFun, AccIn, ?ROUTE_TAB).
+
+-spec info(atom()) -> _Info.
+info(What) ->
+    ets:info(?ROUTE_TAB, What).
 
 call(Router, Msg) ->
     gen_server:call(Router, Msg, infinity).

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -21,7 +21,6 @@
 -include("emqx.hrl").
 -include("logger.hrl").
 -include("types.hrl").
--include_lib("mria/include/mria.hrl").
 -include_lib("emqx/include/emqx_router.hrl").
 
 %% Mnesia bootstrap
@@ -129,8 +128,12 @@ do_add_route(Topic, Dest) when is_binary(Topic) ->
             ok = emqx_router_helper:monitor(Dest),
             case emqx_topic:wildcard(Topic) of
                 true ->
-                    Fun = fun emqx_router_utils:insert_trie_route/2,
-                    emqx_router_utils:maybe_trans(Fun, [?ROUTE_TAB, Route], ?ROUTE_SHARD);
+                    emqx_router_utils:maybe_trans(
+                        ?ROUTE_TAB,
+                        fun emqx_router_utils:insert_trie_route/2,
+                        [?ROUTE_TAB, Route],
+                        ?ROUTE_SHARD
+                    );
                 false ->
                     emqx_router_utils:insert_direct_route(?ROUTE_TAB, Route)
             end
@@ -176,8 +179,12 @@ do_delete_route(Topic, Dest) ->
     Route = #route{topic = Topic, dest = Dest},
     case emqx_topic:wildcard(Topic) of
         true ->
-            Fun = fun emqx_router_utils:delete_trie_route/2,
-            emqx_router_utils:maybe_trans(Fun, [?ROUTE_TAB, Route], ?ROUTE_SHARD);
+            emqx_router_utils:maybe_trans(
+                ?ROUTE_TAB,
+                fun emqx_router_utils:delete_trie_route/2,
+                [?ROUTE_TAB, Route],
+                ?ROUTE_SHARD
+            );
         false ->
             emqx_router_utils:delete_direct_route(?ROUTE_TAB, Route)
     end.

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -139,7 +139,7 @@ do_add_route(Topic, Dest) when is_binary(Topic) ->
             ok;
         false ->
             ok = emqx_router_helper:monitor(Dest),
-            mria_insert_route(emqx_router_index:enabled(), Route)
+            mria_insert_route(emqx_router_indexer:enabled(), Route)
     end.
 
 mria_insert_route(_AsyncIndex = true, Route) ->
@@ -166,7 +166,7 @@ mria_insert_route(Route) ->
 %% @doc Match routes
 -spec match_routes(emqx_types:topic()) -> [emqx_types:route()].
 match_routes(Topic) when is_binary(Topic) ->
-    lookup_routes(Topic) ++ match_index(emqx_router_index:enabled(), Topic).
+    lookup_routes(Topic) ++ match_index(emqx_router_indexer:enabled(), Topic).
 
 match_index(true, Topic) ->
     match_local_index(Topic);
@@ -174,7 +174,7 @@ match_index(false, Topic) ->
     lists:flatmap(fun lookup_routes/1, match_global_trie(Topic)).
 
 match_local_index(Topic) ->
-    emqx_router_index:match(Topic).
+    emqx_router_indexer:match(Topic).
 
 match_global_trie(Topic) ->
     case emqx_trie:empty() of
@@ -205,7 +205,7 @@ do_delete_route(Topic) when is_binary(Topic) ->
 -spec do_delete_route(emqx_types:topic(), dest()) -> ok | {error, term()}.
 do_delete_route(Topic, Dest) ->
     Route = #route{topic = Topic, dest = Dest},
-    mria_delete_route(emqx_router_index:enabled(), Route).
+    mria_delete_route(emqx_router_indexer:enabled(), Route).
 
 mria_delete_route(_AsyncIndex = true, Route) ->
     mria_delete_route(Route);

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -137,7 +137,10 @@ do_add_route(Topic, Dest) when is_binary(Topic) ->
             ok;
         false ->
             ok = emqx_router_helper:monitor(Dest),
-            mria:dirty_write(?ROUTE_TAB, Route)
+            % TODO
+            % Actually, `dirty_write` on replicant may end with rpc error, but
+            % the spec don't mention it. Thus, make dialyzer happy with this hack.
+            apply(mria, dirty_write, [?ROUTE_TAB, Route])
     end.
 
 %% @doc Match routes

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -197,11 +197,4 @@ stats_fun() ->
     end.
 
 cleanup_routes(Node) ->
-    Patterns = [
-        #route{_ = '_', dest = Node},
-        #route{_ = '_', dest = {'_', Node}}
-    ],
-    [
-        mnesia:delete_object(?ROUTE_TAB, Route, write)
-     || Pat <- Patterns, Route <- mnesia:match_object(?ROUTE_TAB, Pat, write)
-    ].
+    emqx_router:cleanup_routes(Node).

--- a/apps/emqx/src/emqx_router_index.erl
+++ b/apps/emqx/src/emqx_router_index.erl
@@ -1,0 +1,129 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2017-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_router_index).
+
+-behaviour(gen_server).
+
+-include("emqx.hrl").
+-include("emqx_router.hrl").
+-include("types.hrl").
+-include("logger.hrl").
+
+-define(ROUTE_INDEX_TRIE, emqx_route_index_trie).
+
+-type update() :: {write | delete, emqx_types:topic(), emqx_router:dest()}.
+-type state() :: #{last_update := maybe(update())}.
+
+-export([start_link/0]).
+
+-export([match/1]).
+
+%% test only
+-export([peek_last_update/0]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-spec start_link() -> startlink_ret().
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-spec match(emqx_types:topic()) -> [emqx_types:route()].
+match(Topic) ->
+    match_entries(Topic).
+
+-spec peek_last_update() -> maybe(update()).
+peek_last_update() ->
+    gen_server:call(?MODULE, peek_last_update).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+-spec init(_) -> {ok, state()}.
+init([]) ->
+    _ = emqx_trie:create_local(?ROUTE_INDEX_TRIE, [public, named_table]),
+    ok = mria:wait_for_tables([?ROUTE_TAB]),
+    % NOTE: it's unclear if we have guarantees that we won't miss any updates
+    {ok, _} = mnesia:subscribe({table, ?ROUTE_TAB, simple}),
+    ok = emqx_router:foldl_routes(fun(Route, _) -> insert_entry(Route) end, ok),
+    {ok, #{last_update => undefined}}.
+
+-spec handle_call(_Call, _From, state()) -> {reply, _Reply, state()}.
+handle_call(peek_last_update, _From, State) ->
+    {reply, maps:get(last_update, State, undefined), State};
+handle_call(Req, {Pid, _Ref}, State) ->
+    ?SLOG(error, #{msg => "unexpected_call", call => Req, from => Pid}),
+    {reply, ignored, State}.
+
+-spec handle_cast(_Msg, state()) -> {noreply, state()}.
+handle_cast(Msg, State) ->
+    ?SLOG(error, #{msg => "unexpected_cast", cast => Msg}),
+    {noreply, State}.
+
+-spec handle_info(_Info, state()) -> {noreply, state()}.
+handle_info({mnesia_table_event, {Op, Record, _}}, State) ->
+    {noreply, handle_table_event(Op, Record, State)};
+handle_info(Info, State) ->
+    ?SLOG(error, #{msg => "unexpected_info", info => Info}),
+    {noreply, State}.
+
+handle_table_event(write, {?ROUTE_TAB, Topic, Dest}, State) ->
+    ok = insert_entry(Topic, Dest),
+    State#{last_update => {write, Topic, Dest}};
+handle_table_event(delete_object, {?ROUTE_TAB, Topic, Dest}, State) ->
+    ok = delete_entry(Topic, Dest),
+    State#{last_update => {delete, Topic, Dest}};
+%% TODO
+%% handle_table_event(delete, {?ROUTE_TAB, Topic}, State) ->
+%%     ok = delete_topic(Topic),
+%%     State;
+handle_table_event(write, {schema, ?ROUTE_TAB, _}, State) ->
+    State;
+handle_table_event(delete, {schema, ?ROUTE_TAB}, State) ->
+    ok = clean_index(),
+    State.
+
+match_entries(Topic) ->
+    emqx_trie:match(Topic, ?ROUTE_INDEX_TRIE).
+
+insert_entry(#route{topic = Topic, dest = Dest}) ->
+    insert_entry(Topic, Dest).
+
+insert_entry(Topic, Dest) ->
+    case emqx_topic:wildcard(Topic) of
+        true ->
+            emqx_trie:insert_local(Topic, Dest, ?ROUTE_INDEX_TRIE);
+        false ->
+            ok
+    end.
+
+delete_entry(Topic, Dest) ->
+    case emqx_topic:wildcard(Topic) of
+        true ->
+            emqx_trie:delete_local(Topic, Dest, ?ROUTE_INDEX_TRIE);
+        false ->
+            ok
+    end.
+
+clean_index() ->
+    emqx_trie:clear_local(?ROUTE_INDEX_TRIE).

--- a/apps/emqx/src/emqx_router_indexer.erl
+++ b/apps/emqx/src/emqx_router_indexer.erl
@@ -74,7 +74,7 @@ peek_last_update() ->
 
 -spec init(_) -> {ok, state()}.
 init([]) ->
-    ok = emqx_route_index:init(?ROUTE_INDEX),
+    _ = ets:new(?ROUTE_INDEX, [public, named_table, ordered_set, {read_concurrency, true}]),
     ok = mria:wait_for_tables([?ROUTE_TAB]),
     % NOTE
     % Must subscribe to the events before indexing the routes to make no record is missed.
@@ -115,10 +115,10 @@ handle_info(Info, State) ->
     {noreply, State}.
 
 handle_table_event(write, {?ROUTE_TAB, Topic, Dest}, State) ->
-    _ = insert_unsafe(Topic, Dest),
+    _ = insert_entry(Topic, Dest),
     State#{last_update => {write, Topic, Dest}};
 handle_table_event(delete_object, {?ROUTE_TAB, Topic, Dest}, State) ->
-    _ = delete_unsafe(Topic, Dest),
+    _ = delete_entry(Topic, Dest),
     State#{last_update => {delete, Topic, Dest}};
 %% TODO
 %% handle_table_event(delete, {?ROUTE_TAB, Topic}, State) ->
@@ -130,45 +130,14 @@ handle_table_event(delete, {schema, ?ROUTE_TAB}, State) ->
     true = emqx_topic_index:clean(?ROUTE_INDEX),
     State.
 
--define(BATCH_SIZE, 1000).
-
 build_index() ->
-    AccIn = #{n => 1, count => 0, batch => [], refs => []},
-    AccOut = submit_batch(emqx_router:foldl_routes(fun submit_batches/2, AccIn)),
-    wait_batch_completions(maps:get(refs, AccOut)).
+    emqx_router:foldl_routes(
+        fun(Route, _) -> emqx_route_index:insert(Route, ?ROUTE_INDEX) end,
+        false
+    ).
 
-submit_batches(Route, Acc = #{count := ?BATCH_SIZE}) ->
-    submit_batches(Route, submit_batch(Acc));
-submit_batches(Route, #{count := Count, batch := Batch} = Acc) ->
-    Acc#{count => Count + 1, batch => [Route | Batch]}.
+insert_entry(Topic, Dest) ->
+    emqx_route_index:insert(Topic, Dest, ?ROUTE_INDEX).
 
-submit_batch(#{n := N, count := Count, batch := Batch, refs := Refs}) when Count > 0 ->
-    Ref = {batch, N},
-    ok = emqx_pool:async_submit(fun insert_batch/3, [Ref, Batch, self()]),
-    #{n => N + 1, count => 0, batch => [], refs => [Ref | Refs]};
-submit_batch(Acc) ->
-    Acc.
-
-insert_batch(Ref, Batch, ReplyTo) ->
-    ok = lists:foreach(fun insert_transactional/1, Batch),
-    ReplyTo ! {Ref, ok}.
-
-wait_batch_completions([Ref | Rest]) ->
-    receive
-        {Ref, ok} ->
-            wait_batch_completions(Rest);
-        {Ref, Error} ->
-            ?SLOG(error, #{msg => "batch_insert_failed", error => Error}),
-            wait_batch_completions(Rest)
-    end;
-wait_batch_completions([]) ->
-    ok.
-
-insert_transactional(Route) ->
-    emqx_route_index:insert(Route, ?ROUTE_INDEX, transactional).
-
-insert_unsafe(Topic, Dest) ->
-    emqx_route_index:insert(Topic, Dest, ?ROUTE_INDEX, unsafe).
-
-delete_unsafe(Topic, Dest) ->
-    emqx_route_index:delete(Topic, Dest, ?ROUTE_INDEX, unsafe).
+delete_entry(Topic, Dest) ->
+    emqx_route_index:delete(Topic, Dest, ?ROUTE_INDEX).

--- a/apps/emqx/src/emqx_router_indexer.erl
+++ b/apps/emqx/src/emqx_router_indexer.erl
@@ -14,7 +14,7 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
--module(emqx_router_index).
+-module(emqx_router_indexer).
 
 -behaviour(gen_server).
 

--- a/apps/emqx/src/emqx_router_sup.erl
+++ b/apps/emqx/src/emqx_router_sup.erl
@@ -38,11 +38,11 @@ init([]) ->
     %% Router index
     Index = #{
         id => index,
-        start => {emqx_router_index, start_link, []},
+        start => {emqx_router_indexer, start_link, []},
         restart => permanent,
         shutdown => 5000,
         type => worker,
-        modules => [emqx_router_index]
+        modules => [emqx_router_indexer]
     },
     %% Router pool
     RouterPool = emqx_pool_sup:spec([

--- a/apps/emqx/src/emqx_router_sup.erl
+++ b/apps/emqx/src/emqx_router_sup.erl
@@ -35,6 +35,15 @@ init([]) ->
         type => worker,
         modules => [emqx_router_helper]
     },
+    %% Router index
+    Index = #{
+        id => index,
+        start => {emqx_router_index, start_link, []},
+        restart => permanent,
+        shutdown => 5000,
+        type => worker,
+        modules => [emqx_router_index]
+    },
     %% Router pool
     RouterPool = emqx_pool_sup:spec([
         router_pool,
@@ -46,4 +55,4 @@ init([]) ->
         intensity => 10,
         period => 100
     },
-    {ok, {SupFlags, [Helper, RouterPool]}}.
+    {ok, {SupFlags, [Helper, Index, RouterPool]}}.

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1405,6 +1405,14 @@ fields("broker_perf") ->
                     default => true,
                     desc => ?DESC(broker_perf_trie_compaction)
                 }
+            )},
+        {"trie_local_async",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(broker_perf_trie_local_async)
+                }
             )}
     ];
 fields("sys_topics") ->

--- a/apps/emqx/src/emqx_topic_index.erl
+++ b/apps/emqx/src/emqx_topic_index.erl
@@ -35,6 +35,8 @@
 -export([lookup/3]).
 -export([clean/1]).
 
+-export([mk_key/2]).
+
 -export([match/2]).
 -export([matches/3]).
 
@@ -43,6 +45,8 @@
 -export([get_id/1]).
 -export([get_topic/1]).
 -export([get_record/2]).
+
+-export_type([key/1]).
 
 -type topic() :: emqx_types:topic().
 -type words() :: [word()].
@@ -77,6 +81,7 @@ lookup(Filter, ID, Tab) ->
 clean(Tab) ->
     ets:delete_all_objects(Tab).
 
+-spec mk_key(topic() | words(), ID) -> key(ID).
 mk_key(Filter, ID) ->
     {words(Filter), {ID}}.
 

--- a/apps/emqx/src/emqx_topic_index.erl
+++ b/apps/emqx/src/emqx_topic_index.erl
@@ -32,6 +32,9 @@
 -export([new/0]).
 -export([insert/4]).
 -export([delete/3]).
+-export([lookup/3]).
+-export([clean/1]).
+
 -export([match/2]).
 -export([matches/3]).
 
@@ -65,6 +68,14 @@ insert(Filter, ID, Record, Tab) ->
 -spec delete(topic() | words(), _ID, ets:table()) -> true.
 delete(Filter, ID, Tab) ->
     ets:delete(Tab, mk_key(Filter, ID)).
+
+-spec lookup(topic() | words(), _ID, ets:table()) -> [_Record].
+lookup(Filter, ID, Tab) ->
+    get_record(mk_key(Filter, ID), Tab).
+
+-spec clean(ets:table()) -> true.
+clean(Tab) ->
+    ets:delete_all_objects(Tab).
 
 mk_key(Filter, ID) ->
     {words(Filter), {ID}}.

--- a/apps/emqx/src/emqx_topic_index.erl
+++ b/apps/emqx/src/emqx_topic_index.erl
@@ -221,10 +221,16 @@ get_topic({Filter, _ID}) ->
     emqx_topic:join(Filter).
 
 %% @doc Fetch the record associated with the match.
-%% NOTE: Only really useful for ETS tables where the record ID is the first element.
--spec get_record(match(_ID), ets:table()) -> _Record.
+%% May return empty list if the index entry was deleted in the meantime.
+%% NOTE: Only really useful for ETS tables where the record data is the last element.
+-spec get_record(match(_ID), ets:table()) -> [_Record].
 get_record(K, Tab) ->
-    ets:lookup_element(Tab, K, 2).
+    case ets:lookup(Tab, K) of
+        [Entry] ->
+            [erlang:element(tuple_size(Entry), Entry)];
+        [] ->
+            []
+    end.
 
 %%
 

--- a/apps/emqx/src/emqx_topic_index.erl
+++ b/apps/emqx/src/emqx_topic_index.erl
@@ -35,8 +35,6 @@
 -export([lookup/3]).
 -export([clean/1]).
 
--export([mk_key/2]).
-
 -export([match/2]).
 -export([matches/3]).
 
@@ -45,8 +43,6 @@
 -export([get_id/1]).
 -export([get_topic/1]).
 -export([get_record/2]).
-
--export_type([key/1]).
 
 -type topic() :: emqx_types:topic().
 -type words() :: [word()].
@@ -81,7 +77,6 @@ lookup(Filter, ID, Tab) ->
 clean(Tab) ->
     ets:delete_all_objects(Tab).
 
--spec mk_key(topic() | words(), ID) -> key(ID).
 mk_key(Filter, ID) ->
     {words(Filter), {ID}}.
 

--- a/apps/emqx/src/emqx_trie.erl
+++ b/apps/emqx/src/emqx_trie.erl
@@ -41,13 +41,6 @@
     empty/1
 ]).
 
--export([
-    create_local/2,
-    clear_local/1,
-    insert_local/3,
-    delete_local/3
-]).
-
 -export([is_compact/0, set_compact/1]).
 
 -ifdef(TEST).
@@ -60,14 +53,8 @@
 
 -record(?TRIE, {
     key :: ?TOPIC(binary()) | ?PREFIX(binary()),
-    count = 0 ::
-        % in case of global mnesia table
-        non_neg_integer()
-        % in case of local ets table
-        | #{_Dest => nil()}
+    count = 0 :: non_neg_integer()
 }).
-
--define(ROUTE(Topic, Dest), #route{topic = Topic, dest = Dest}).
 
 %%--------------------------------------------------------------------
 %% Mnesia bootstrap
@@ -150,7 +137,7 @@ delete(Topic, Trie) when is_binary(Topic) ->
 match(Topic) when is_binary(Topic) ->
     match(Topic, ?TRIE).
 
--spec match(emqx_types:topic(), ets:table()) -> [emqx_types:topic()] | [emqx_types:route()].
+-spec match(emqx_types:topic(), ets:table()) -> [emqx_types:topic()].
 match(Topic, Trie) when is_binary(Topic) ->
     Words = emqx_topic:words(Topic),
     case emqx_topic:wildcard(Words) of
@@ -175,45 +162,6 @@ empty() ->
 -spec empty(ets:table()) -> boolean().
 empty(Trie) ->
     ets:first(Trie) =:= '$end_of_table'.
-
-%%--------------------------------------------------------------------
-%% Node-local APIs
-%%--------------------------------------------------------------------
-
-%% @doc Create a local ETS-based trie.
-%% Local trie is used as an async index for the global routing table.
-%% Anync means that to keep index consistent it needs to be "materialized",
-%% i.e. contain roughly the same amount of information, including route
-%% destinations.
-create_local(Name, ExtraOpts) ->
-    ets:new(
-        Name,
-        ExtraOpts ++
-            [
-                ordered_set,
-                {keypos, #?TRIE.key},
-                {read_concurrency, true}
-            ]
-    ).
-
--spec clear_local(ets:table()) -> ok.
-clear_local(Trie) ->
-    _ = ets:delete_all_objects(Trie),
-    ok.
-
-%% @doc Insert an entry into the local ETS-based trie.
-%% Important: concurrent inserts and deletes may cause inconsistency.
--spec insert_local(emqx_types:topic(), _Dest, ets:table()) -> ok.
-insert_local(Topic, Dest, Trie) when is_binary(Topic) ->
-    {TopicKey, PrefixKeys} = make_keys(Topic),
-    lists:foreach(fun(Key) -> insert_key_local(Key, Dest, Trie) end, [TopicKey | PrefixKeys]).
-
-%% @doc Delete an entry from the local ETS-based trie.
-%% Important: concurrent inserts and deletes may cause inconsistency.
--spec delete_local(emqx_types:topic(), _Dest, ets:table()) -> ok.
-delete_local(Topic, Dest, Trie) when is_binary(Topic) ->
-    {TopicKey, PrefixKeys} = make_keys(Topic),
-    lists:foreach(fun(Key) -> delete_key_local(Key, Dest, Trie) end, [TopicKey | PrefixKeys]).
 
 %%--------------------------------------------------------------------
 %% Internal functions
@@ -276,35 +224,12 @@ insert_key(Key, Trie) ->
         end,
     ok = mnesia:write(Trie, T, write).
 
-insert_key_local(Key, Dest, Trie) ->
-    T =
-        case ets:lookup(Trie, Key) of
-            [#?TRIE{count = Ds} = T1] ->
-                T1#?TRIE{count = Ds#{Dest => []}};
-            [] ->
-                #?TRIE{key = Key, count = #{Dest => []}}
-        end,
-    true = ets:insert(Trie, T),
-    ok.
-
 delete_key(Key, Trie) ->
     case mnesia:wread({Trie, Key}) of
         [#?TRIE{count = C} = T] when C > 1 ->
             ok = mnesia:write(Trie, T#?TRIE{count = C - 1}, write);
         [_] ->
             ok = mnesia:delete(Trie, Key, write);
-        [] ->
-            ok
-    end.
-
-delete_key_local(Key, Dest, Trie) ->
-    case ets:lookup(Trie, Key) of
-        [#?TRIE{count = Ds = #{Dest := []}}] when map_size(Ds) =:= 1 ->
-            true = ets:delete(Trie, Key);
-        [#?TRIE{count = Ds = #{Dest := []}} = T] ->
-            true = ets:insert(Trie, T#?TRIE{count = maps:remove(Dest, Ds)});
-        [#?TRIE{}] ->
-            ok;
         [] ->
             ok
     end.
@@ -316,13 +241,8 @@ lookup_topic(Topic, Trie, true) -> lookup_topic(Topic, Trie).
 
 lookup_topic(Topic, Trie) when is_binary(Topic) ->
     case ets:lookup(Trie, ?TOPIC(Topic)) of
-        [#?TRIE{count = Ds = #{}}] ->
-            % NOTE: returning whole routes from "materialized" local trie index
-            maps:fold(fun(Dest, _, L) -> [?ROUTE(Topic, Dest) | L] end, [], Ds);
-        [#?TRIE{count = C}] ->
-            [Topic || C > 0];
-        [] ->
-            []
+        [#?TRIE{count = C}] -> [Topic || C > 0];
+        [] -> []
     end.
 
 %% this is the virtual tree root
@@ -330,7 +250,6 @@ has_prefix(empty, _Trie) ->
     true;
 has_prefix(Prefix, Trie) ->
     case ets:lookup(Trie, ?PREFIX(Prefix)) of
-        % NOTE: compatible with local trie, since non-empty mapset is always > 0
         [#?TRIE{count = C}] -> C > 0;
         [] -> false
     end.

--- a/apps/emqx/src/persistent_session/emqx_persistent_session.erl
+++ b/apps/emqx/src/persistent_session/emqx_persistent_session.erl
@@ -62,6 +62,7 @@
 -include("emqx.hrl").
 -include("emqx_channel.hrl").
 -include("emqx_persistent_session.hrl").
+-include("emqx_router.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -compile({inline, [is_store_enabled/0]}).
@@ -91,7 +92,7 @@ init_db_backend() ->
     case is_store_enabled() of
         true ->
             StorageType = storage_type(),
-            ok = emqx_trie:create_session_trie(StorageType),
+            ok = emqx_trie:create_trie(StorageType, ?SESSION_TRIE),
             ok = emqx_session_router:create_router_tab(StorageType),
             case storage_backend() of
                 builtin ->

--- a/apps/emqx/test/emqx_SUITE.erl
+++ b/apps/emqx/test/emqx_SUITE.erl
@@ -47,7 +47,7 @@ t_emqx_pubsub_api(_) ->
     emqx:subscribe(Topic1, ClientId, #{qos => 1}),
     emqx:subscribe(Topic2, ClientId, #{qos => 2}),
     ct:sleep(100),
-    ?assertEqual([Topic2, Topic1, Topic], emqx:topics()),
+    ?assertEqual([Topic, Topic1, Topic2], lists:sort(emqx:topics())),
     ?assertEqual([self()], emqx:subscribers(Topic)),
     ?assertEqual([self()], emqx:subscribers(Topic1)),
     ?assertEqual([self()], emqx:subscribers(Topic2)),

--- a/apps/emqx/test/emqx_router_SUITE.erl
+++ b/apps/emqx/test/emqx_router_SUITE.erl
@@ -102,6 +102,55 @@ t_add_delete(_) ->
     delete_route(<<"a/+/b">>, node()),
     ?assertEqual([], ?R:topics()).
 
+t_add_delete_incremental(_) ->
+    add_route(<<"a/b/c">>),
+    add_route(<<"a/+/c">>, node()),
+    add_route(<<"a/+/+">>, node()),
+    add_route(<<"a/b/#">>, node()),
+    add_route(<<"#">>, node()),
+    ?assertEqual(
+        [
+            #route{topic = <<"#">>, dest = node()},
+            #route{topic = <<"a/+/+">>, dest = node()},
+            #route{topic = <<"a/+/c">>, dest = node()},
+            #route{topic = <<"a/b/#">>, dest = node()},
+            #route{topic = <<"a/b/c">>, dest = node()}
+        ],
+        lists:sort(?R:match_routes(<<"a/b/c">>))
+    ),
+    delete_route(<<"a/+/c">>, node()),
+    ?assertEqual(
+        [
+            #route{topic = <<"#">>, dest = node()},
+            #route{topic = <<"a/+/+">>, dest = node()},
+            #route{topic = <<"a/b/#">>, dest = node()},
+            #route{topic = <<"a/b/c">>, dest = node()}
+        ],
+        lists:sort(?R:match_routes(<<"a/b/c">>))
+    ),
+    delete_route(<<"a/+/+">>, node()),
+    ?assertEqual(
+        [
+            #route{topic = <<"#">>, dest = node()},
+            #route{topic = <<"a/b/#">>, dest = node()},
+            #route{topic = <<"a/b/c">>, dest = node()}
+        ],
+        lists:sort(?R:match_routes(<<"a/b/c">>))
+    ),
+    delete_route(<<"a/b/#">>, node()),
+    ?assertEqual(
+        [
+            #route{topic = <<"#">>, dest = node()},
+            #route{topic = <<"a/b/c">>, dest = node()}
+        ],
+        lists:sort(?R:match_routes(<<"a/b/c">>))
+    ),
+    delete_route(<<"a/b/c">>, node()),
+    ?assertEqual(
+        [#route{topic = <<"#">>, dest = node()}],
+        lists:sort(?R:match_routes(<<"a/b/c">>))
+    ).
+
 t_do_add_delete(_) ->
     ?R:do_add_route(<<"a/b/c">>),
     ?R:do_add_route(<<"a/b/c">>, node()),

--- a/apps/emqx/test/emqx_router_SUITE.erl
+++ b/apps/emqx/test/emqx_router_SUITE.erl
@@ -27,9 +27,9 @@
 -define(R, emqx_router).
 
 -define(WAIT_INDEX_SYNC(UPDATE),
-    emqx_router_index:enabled() andalso
+    emqx_router_indexer:enabled() andalso
         snabbkaffe:retry(100, 10, fun() ->
-            case emqx_router_index:peek_last_update() of
+            case emqx_router_indexer:peek_last_update() of
                 UPDATE = __U -> __U;
                 _ -> throw(missing_update)
             end

--- a/apps/emqx/test/emqx_topic_index_SUITE.erl
+++ b/apps/emqx/test/emqx_topic_index_SUITE.erl
@@ -35,6 +35,20 @@ t_insert(_) ->
     ?assertEqual(<<"sensor/#">>, topic(match(<<"sensor">>, Tab))),
     ?assertEqual(t_insert_3, id(match(<<"sensor">>, Tab))).
 
+t_words(_) ->
+    Tab = emqx_topic_index:new(),
+    Topic = <<"sensor/+/metric//#">>,
+    ?assertEqual(
+        [<<"sensor">>, '+', <<"metric">>, <<>>, '#'],
+        emqx_topic_index:words(Topic)
+    ),
+    true = emqx_topic_index:insert(Topic, 1, <<>>, Tab),
+    true = emqx_topic_index:insert(emqx_topic_index:words(Topic), 2, <<>>, Tab),
+    ?assertEqual(
+        [Topic, Topic],
+        [topic(M) || M <- matches(<<"sensor/1/metric//2">>, Tab)]
+    ).
+
 t_match(_) ->
     Tab = emqx_topic_index:new(),
     true = emqx_topic_index:insert(<<"sensor/1/metric/2">>, t_match_1, <<>>, Tab),

--- a/apps/emqx/test/props/prop_emqx_route_index.erl
+++ b/apps/emqx/test/props/prop_emqx_route_index.erl
@@ -1,0 +1,254 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(prop_emqx_route_index).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("proper/include/proper.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx.hrl").
+
+-define(TOPIC, <<"t/#">>).
+
+-if(false).
+-define(TRACE(FMT, ARGS),
+    io:format("~s [~p] ~p/~p:~p " FMT "~n", [
+        calendar:system_time_to_rfc3339(erlang:system_time(millisecond), [{unit, millisecond}]),
+        self(),
+        ?FUNCTION_NAME,
+        ?FUNCTION_ARITY,
+        ?LINE
+        | ARGS
+    ])
+).
+-else.
+-define(TRACE(FMT, ARGS), []).
+-endif.
+
+-import(emqx_proper_types, [scaled/2]).
+
+prop_concurrent_route_consistency() ->
+    % Verify that the index built from an inconsistent view of the route table
+    % (due to concurrent updates) eventually converges with the route table,
+    % after concurrent updates stream ends.
+    %
+    % Essentially we want to verify that what happens in `emqx_route_indexer` does
+    % not break consistency in the presence of concurrent table updates. Particularly:
+    % 1. Subscribe to table updates.
+    % 2. Run fold over route table to build index.
+    % 3. Apply accumulated table updates to the index.
+    ?FORALL(
+        Stream,
+        scaled(10, stream_t()),
+        verify_consistency(run_stream(Stream))
+    ).
+
+verify_consistency(Ctx = #{route_tab := RouteTab, index_tab := IndexTab}) ->
+    ?assertEqual(
+        lists:sort(ets:tab2list(RouteTab)),
+        lists:sort(emqx_route_index:all(IndexTab))
+    ),
+    _ = cleanup(Ctx),
+    true.
+
+run_stream(Stream) ->
+    % Stream usually looks like this:
+    % ```
+    % [{insert,#route{topic = <<"t/#">>,dest = 1}},
+    %  {insert,#route{topic = <<"t/#">>,dest = 5}},
+    %  {insert,#route{topic = <<"t/#">>,dest = 8}},
+    %  {indexer,start},
+    %  {insert,#route{topic = <<"t/#">>,dest = 1}},
+    %  {insert,#route{topic = <<"t/#">>,dest = 4}},
+    %  {insert,#route{topic = <<"t/#">>,dest = 9}},
+    %  {fold,1},
+    %  {delete,#route{topic = <<"t/#">>,dest = 2}},
+    %  {fold,finish},
+    %  {delete,#route{topic = <<"t/#">>,dest = 4}},
+    %  {delete,#route{topic = <<"t/#">>,dest = 1}},
+    %  eos]
+    % ```
+    RouteTab = mk_route_tab(),
+    IndexTab = emqx_topic_index:new(),
+    run_stream(Stream, #{route_tab => RouteTab, index_tab => IndexTab}).
+
+run_stream(Stream, CtxIn) ->
+    lists:foldl(fun run_command/2, CtxIn, Stream).
+
+run_command({insert, Route} = Update, Ctx = #{route_tab := Tab}) ->
+    % 1. Insert route in the route table.
+    % 2. Send update to the indexer process, if it's already online.
+    ?TRACE("-- ~0p", [Update]),
+    true = ets:insert(Tab, Route),
+    _ = send_update(Update, Ctx),
+    Ctx;
+run_command({delete, Route} = Update, Ctx = #{route_tab := Tab}) ->
+    % 1. Delete route from the route table.
+    % 2. Send update to the indexer process, if it's already online.
+    ?TRACE("-- ~0p", [Update]),
+    true = ets:delete_object(Tab, Route),
+    _ = send_update(Update, Ctx),
+    Ctx;
+run_command({indexer, start}, Ctx = #{route_tab := Tab, index_tab := Idx}) ->
+    % 1. Start the indexer process.
+    %    It will wait for a `{fold, ...}` message before starting `ets:foldl` over the
+    %    route table, but will still accumulate updates in the mailbox, to process them
+    %    after the fold ends.
+    Pid = erlang:spawn_link(fun() -> run_indexer(Tab, Idx) end),
+    Ctx#{indexer => Pid};
+run_command({fold, _} = Cmd, Ctx = #{indexer := Pid}) ->
+    % 1. Send `{fold, Next}` command to the indexer process.
+    %    First such message will start `ets:foldl` over the route table. `Next` may be
+    %    either number, which tells indexer how many table entries to fold before
+    %    suspending, or atom `finish`, which tell indexer to run fold to completion.
+    % 2. Sleep for a bit, to force a kind of concurrency.
+    _ = Pid ! Cmd,
+    _ = timer:sleep(1),
+    Ctx;
+run_command(eos, Ctx = #{indexer := Pid}) ->
+    % 1. Notify indexer that we're done
+    % 2. Wait until it empties the queue and exits.
+    _ = Pid ! {eos, self()},
+    _ = ?assertReceive(done),
+    Ctx#{indexer := done}.
+
+send_update(Update, #{indexer := Pid}) ->
+    Pid ! Update;
+send_update(_Update, #{}) ->
+    ok.
+
+run_indexer(Tab, Idx) ->
+    _ = run_fold(Tab, Idx),
+    run_updater(Idx).
+
+run_fold(Tab, Idx) ->
+    ?TRACE("-- fold wait", []),
+    receive
+        {fold, Next} ->
+            ets:foldl(fun(Route, N) -> run_fold_iter(N, Route, Idx) end, Next, Tab)
+    end.
+
+run_fold_iter(0, Route, Idx) ->
+    ?TRACE("-- fold wait", []),
+    receive
+        {fold, Next} -> run_fold_iter(Next, Route, Idx)
+    end;
+run_fold_iter(Next, Route, Idx) ->
+    ?TRACE("-- ~p | Route = ~0p", [Next, Route]),
+    true = emqx_route_index:insert(Route, Idx),
+    case Next of
+        finish -> finish;
+        N -> N - 1
+    end.
+
+run_updater(Idx) ->
+    ?TRACE("-- start", []),
+    receive
+        {insert, Route} ->
+            ?TRACE("-- {insert, ~0p}", [Route]),
+            true = emqx_route_index:insert(Route, Idx),
+            run_updater(Idx);
+        {delete, Route} ->
+            ?TRACE("-- {delete, ~0p}", [Route]),
+            true = emqx_route_index:delete(Route, Idx),
+            run_updater(Idx);
+        {eos, Caller} ->
+            ?TRACE("-- eos", []),
+            Caller ! done
+    end.
+
+stream_t() ->
+    ?LET(
+        {Updates, Fold, Iters},
+        {non_empty(list(update_t())), fold_t(), list(fold_iter_t())},
+        sanitize_stream(
+            [{Op, Arg} || {_, Op, Arg} <- lists:sort(lists:flatten(Updates ++ Fold ++ Iters))],
+            #{}
+        )
+    ).
+
+sanitize_stream([Command | Rest], St) ->
+    case sanitize_command(Command, St) of
+        StNext = #{} ->
+            [Command | sanitize_stream(Rest, StNext)];
+        false ->
+            sanitize_stream(Rest, St)
+    end;
+sanitize_stream([], _) ->
+    [eos].
+
+sanitize_command({insert, Route}, St) ->
+    St#{Route => inserted};
+sanitize_command({delete, Route}, St) when map_get(Route, St) == inserted ->
+    St#{Route => deleted};
+sanitize_command({delete, _Route}, _St) ->
+    false;
+sanitize_command({indexer, start}, St) ->
+    St#{indexer => fold};
+sanitize_command({fold, finish}, St) ->
+    St#{indexer => update};
+sanitize_command({fold, _N}, St = #{indexer := fold}) ->
+    St;
+sanitize_command({fold, _N}, _St) ->
+    false.
+
+update_t() ->
+    ?LET(
+        {I, D, Route},
+        {order_t(), delay_t(), route_t()},
+        oneof([
+            [{I, insert, Route}],
+            [{I, insert, Route}, {I + D, delete, Route}]
+        ])
+    ).
+
+fold_t() ->
+    ?LET(
+        {I, D},
+        {order_t(), delay_t()},
+        [{I, indexer, start}, {I + D, fold, finish}]
+    ).
+
+fold_iter_t() ->
+    ?LET(I, order_t(), [{I, fold, range(1, 3)}]).
+
+order_t() ->
+    pos_integer().
+
+delay_t() ->
+    pos_integer().
+
+route_t() ->
+    ?LET(Dest, dest_t(), #route{topic = ?TOPIC, dest = Dest}).
+
+dest_t() ->
+    oneof(lists:seq(1, 9)).
+
+%%
+
+mk_route_tab() ->
+    % TODO: should be identical to `emqx_router` backing table.
+    ets:new(emqx_route, [
+        bag,
+        {keypos, #route.topic},
+        {read_concurrency, true},
+        {write_concurrency, true}
+    ]).
+
+cleanup(#{route_tab := RouteTab, index_tab := IndexTab}) ->
+    _ = ets:delete(RouteTab),
+    _ = ets:delete(IndexTab),
+    ok.

--- a/apps/emqx/test/props/prop_emqx_route_index.erl
+++ b/apps/emqx/test/props/prop_emqx_route_index.erl
@@ -16,6 +16,8 @@
 
 -module(prop_emqx_route_index).
 
+-compile(export_all).
+
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("proper/include/proper.hrl").
 -include_lib("emqx/include/asserts.hrl").
@@ -81,9 +83,10 @@ run_stream(Stream) ->
     %  {delete,#route{topic = <<"t/#">>,dest = 1}},
     %  eos]
     % ```
+    ok = mria:start(),
     RouteTab = mk_route_tab(),
-    IndexTab = emqx_topic_index:new(),
-    run_stream(Stream, #{route_tab => RouteTab, index_tab => IndexTab}).
+    ok = emqx_route_index:init(?MODULE),
+    run_stream(Stream, #{route_tab => RouteTab, index_tab => ?MODULE}).
 
 run_stream(Stream, CtxIn) ->
     lists:foldl(fun run_command/2, CtxIn, Stream).
@@ -148,7 +151,7 @@ run_fold_iter(0, Route, Idx) ->
     end;
 run_fold_iter(Next, Route, Idx) ->
     ?TRACE("-- ~p | Route = ~0p", [Next, Route]),
-    true = emqx_route_index:insert(Route, Idx),
+    true = emqx_route_index:insert(Route, Idx, unsafe),
     case Next of
         finish -> finish;
         N -> N - 1
@@ -159,11 +162,11 @@ run_updater(Idx) ->
     receive
         {insert, Route} ->
             ?TRACE("-- {insert, ~0p}", [Route]),
-            true = emqx_route_index:insert(Route, Idx),
+            true = emqx_route_index:insert(Route, Idx, unsafe),
             run_updater(Idx);
         {delete, Route} ->
             ?TRACE("-- {delete, ~0p}", [Route]),
-            true = emqx_route_index:delete(Route, Idx),
+            true = emqx_route_index:delete(Route, Idx, unsafe),
             run_updater(Idx);
         {eos, Caller} ->
             ?TRACE("-- eos", []),
@@ -250,5 +253,5 @@ mk_route_tab() ->
 
 cleanup(#{route_tab := RouteTab, index_tab := IndexTab}) ->
     _ = ets:delete(RouteTab),
-    _ = ets:delete(IndexTab),
+    _ = mnesia:delete_table(IndexTab),
     ok.

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_test_helpers.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_test_helpers.erl
@@ -81,7 +81,7 @@ start_cluster(NamesWithPorts, Apps, Env) ->
         NamesWithPorts
     ),
     Opts0 = [
-        {env, [{emqx, boot_modules, [broker, listeners]}] ++ Env},
+        {env, Env},
         {apps, Apps},
         {conf,
             [{[listeners, Proto, default, enable], false} || Proto <- [ssl, ws, wss]] ++

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -225,8 +225,9 @@ get_rules_ordered_by_ts() ->
 -spec get_rules_for_topic(Topic :: binary()) -> [rule()].
 get_rules_for_topic(Topic) ->
     [
-        emqx_topic_index:get_record(M, ?RULE_TOPIC_INDEX)
-     || M <- emqx_topic_index:matches(Topic, ?RULE_TOPIC_INDEX, [unique])
+        Rule
+     || M <- emqx_topic_index:matches(Topic, ?RULE_TOPIC_INDEX, [unique]),
+        Rule <- emqx_topic_index:get_record(M, ?RULE_TOPIC_INDEX)
     ].
 
 -spec get_rules_with_same_event(Topic :: binary()) -> [rule()].

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1554,7 +1554,12 @@ broker_perf_trie_compaction.desc:
 Enabling it significantly improves wildcard topic subscribe rate, if wildcard topics have unique prefixes like: 'sensor/{{id}}/+/', where ID is unique per subscriber.
 Topic match performance (when publishing) may degrade if messages are mostly published to topics with large number of levels.
 
-NOTE: This is a cluster-wide configuration. It requires all nodes to be stopped before changing it."""
+Unless <code>trie_local_async = true</code>, this is a cluster-wide configuration. It requires all nodes to be stopped before changing it."""
+
+broker_perf_trie_local_async.desc:
+"""Enable node-local async trie index, instead of a global one.
+Enabling node-local index should noticeably improve wildcard topic subscription throughput and latency,
+at the cost of slightly less clear consistency guarantees carried by a successful subscription acknowledgement."""
 
 sysmon_vm_large_heap.desc:
 """When an Erlang process consumed a large amount of memory for its heap space,


### PR DESCRIPTION
Fixes [EMQX-10728](https://emqx.atlassian.net/browse/EMQX-10728)

The router index is still basically a trie, but now it's node-local ETS table managed by the `emqx_router_index` process, updated asynchronously.

This has few drawbacks / consequences:
* Index is eventually-consistent, and to guarantee that we need materialized index, holding not just refcounts but routes themselves. Memory consumption will slightly increase per each route.
* Index may be different on different nodes at the same moment of time.
* `SUBACK` does not mean anymore that (at least) core nodes cluster knows the new route.
* There is only a single process handling mnesia table event stream, which might get overwhelmed and lag significantly behind. Though this seems highly unlikely.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 152d9dc</samp>

This pull request introduces a new route table implementation that uses a local trie index to improve the performance and consistency of the routing system. It also refactors and cleans up the code of the modules that interact with the route table, such as `emqx_router`, `emqx_router_utils`, `emqx_session_router`, and `emqx_trie`. It updates the test cases and the configuration schema to reflect the changes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
