### PR TITLE
ci: fix build package script

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -123,7 +123,8 @@ jobs:
       publish: ${{ needs.prepare.outputs.release }}
       otp_vsn: ${{ needs.prepare.outputs.otp_vsn }}
       elixir_vsn: ${{ needs.prepare.outputs.elixir_vsn }}
-      runner: ${{ needs.prepare.outputs.runner }}
+      # workaround: self-hosted runners do not have access to org-level secrets?
+      runner: ubuntu-22.04
       builder_vsn: ${{ needs.prepare.outputs.builder_vsn }}
 
   compile:
@@ -188,4 +189,3 @@ jobs:
       runner: ${{ needs.prepare.outputs.runner }}
       builder: ${{ needs.prepare.outputs.builder }}
       ct-matrix: ${{ needs.prepare.outputs.ct-matrix }}
-

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -170,4 +170,3 @@ jobs:
           EMQX_NAME=${{ matrix.profile }}${{ steps.pre-meta.outputs.img_suffix }}
           EXTRA_DEPS=${{ steps.pre-meta.outputs.extra_deps }}
         file: source/${{ matrix.os[2] }}
-

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -261,7 +261,7 @@ jobs:
         name: ${{ matrix.profile }}
         path: packages/${{ matrix.profile }}
     - name: install dos2unix
-      run: sudo apt-get update && sudo apt install -y dos2unix
+      run: apt-get update && apt install -y dos2unix
     - name: get packages
       run: |
         set -eu


### PR DESCRIPTION
Since the runner changed from `ubuntu-22.04` to self hosted runner, `sudo` is no longer passwordless.


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4217dc</samp>

This pull request updates two GitHub workflows to improve consistency and efficiency. It renames the Docker Hub secrets in `build_and_push_docker_images.yaml` and removes the sudo command from `build_packages.yaml`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
