### PR TITLE
fix(datetime): make sure the epoch is not larger than the maximum supported value

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.7"},
+    {vsn, "5.1.8"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/changes/ce/fix-11424.en.md
+++ b/changes/ce/fix-11424.en.md
@@ -1,0 +1,1 @@
+Add a check for the maximum value of the timestamp in the API to ensure it is a valid Unix timestamp.


### PR DESCRIPTION
A user sets a large timestamp by API to the banned feature, the value of this timestamp is out of the supported range and will crash the list API of the banned feature, and meanwhile, there is no `clean_all` API in this feature, thus the user can't delete the bad date. 

There will be a series PRs to unify the `emqx_datetime` and `emqx_calender`

Fixes <issue-or-jira-number>

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 526c61c</samp>

Export and implement `epoch_to_rfc3339` functions in `emqx_calendar` module and improve `emqx_datetime` module to handle maximum epoch timestamp. These changes are for better compatibility and validation of date and time formats.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
