### PR TITLE
ci: upgrade emqx/push-helm-action to v1.1

### DIFF
--- a/.github/workflows/upload-helm-charts.yaml
+++ b/.github/workflows/upload-helm-charts.yaml
@@ -42,7 +42,7 @@ jobs:
               echo "version=$(./pkg-vsn.sh emqx-enterprise)" >> $GITHUB_OUTPUT
               ;;
           esac
-      - uses: emqx/push-helm-action@v1
+      - uses: emqx/push-helm-action@v1.1
         with:
           charts_dir: "${{ github.workspace }}/deploy/charts/${{ steps.profile.outputs.profile }}"
           version: ${{ steps.profile.outputs.version }}

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.7"},
+    {vsn, "5.1.8"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.1.5
+version: 5.1.5-build.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.1.5
+appVersion: 5.1.5-build.3

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -11,6 +11,8 @@ help() {
     echo "$0 PROFILE [options]"
     echo
     echo "-h|--help:       To display this usage information"
+    echo "--release:       Print release version from emqx_release.hrl"
+    echo
     echo "--long:          Print long vsn number. e.g. 5.0.0-ubuntu20.04-amd64"
     echo "                 Otherwise short e.g. 5.0.0"
     echo "--elixir:        Include elixir version in the long version string"
@@ -32,6 +34,10 @@ while [ "$#" -gt 0 ]; do
     -h|--help)
         help
         exit 0
+        ;;
+    --release)
+        RELEASE_VERSION='yes'
+        shift 1
         ;;
     --long)
         LONG_VERSION='yes'
@@ -87,6 +93,11 @@ esac
 
 ## emqx_release.hrl is the single source of truth for release version
 RELEASE="$(grep -E "define.+${RELEASE_EDITION}" apps/emqx/include/emqx_release.hrl | cut -d '"' -f2)"
+
+if [ "${RELEASE_VERSION:-}" = 'yes' ]; then
+    echo "$RELEASE"
+    exit 0
+fi
 
 git_exact_vsn() {
     local tag

--- a/scripts/rel/check-chart-vsn.sh
+++ b/scripts/rel/check-chart-vsn.sh
@@ -25,11 +25,11 @@ if [ "$CHART_VSN" != "$APP_VSN" ]; then
     exit 2
 fi
 
-PKG_VSN="$(./pkg-vsn.sh "$PROFILE" | cut -d '-' -f 1)"
+RELEASE_VSN="$(./pkg-vsn.sh "$PROFILE" --release)"
 
-if [ "$CHART_VSN" != "$PKG_VSN" ]; then
+if [ "$CHART_VSN" != "$RELEASE_VSN" ]; then
     echo "Chart version in $CHART_FILE is not in sync with release version."
     echo "Chart version: $CHART_VSN"
-    echo "Release version: $PKG_VSN"
+    echo "Release version: $RELEASE_VSN"
     exit 3
 fi

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -182,15 +182,13 @@ assert_tag_absent() {
 }
 assert_tag_absent "$TAG"
 
-PKG_VSN=$(./pkg-vsn.sh "$PROFILE")
+RELEASE_VSN=$(./pkg-vsn.sh "$PROFILE" --release)
 
 ## Assert package version is updated to the tag which is being created
 assert_release_version() {
     local tag="$1"
-    # shellcheck disable=SC2001
-    pkg_vsn="$(echo "$PKG_VSN" | sed 's/-g[0-9a-f]\{8\}$//g')"
-    if [ "${TAG_PREFIX}${pkg_vsn}" != "${tag}" ]; then
-        logerr "The release version ($pkg_vsn) is different from the desired git tag."
+    if [ "${TAG_PREFIX}${RELEASE_VSN}" != "${tag}" ]; then
+        logerr "The release version ($RELEASE_VSN) is different from the desired git tag."
         logerr "Update the release version in emqx_release.hrl"
         exit 1
     fi
@@ -220,7 +218,7 @@ fi
 
 ## Ensure relup paths are updated
 ## TODO: add relup path db
-#./scripts/relup-base-vsns.escript check-vsn-db "$PKG_VSN" "$RELUP_PATHS"
+#./scripts/relup-base-vsns.escript check-vsn-db "$RELEASE_VSN" "$RELUP_PATHS"
 
 ## Run some additional checks (e.g. some for enterprise edition only)
 CHECKS_DIR="./scripts/rel/checks"


### PR DESCRIPTION
Fixes:

- issue when helm charts are not uploaded if emqx release version contains modifiers like `-build.3`, for example
- `cut.sh` not enforcing strict version match in `emqx_release.hrl` and `Chart.yaml`