### PR TITLE
feat(banned): add a new API used to clear all banned data

### DIFF
--- a/apps/emqx/src/emqx_banned.erl
+++ b/apps/emqx/src/emqx_banned.erl
@@ -38,7 +38,8 @@
     delete/1,
     info/1,
     format/1,
-    parse/1
+    parse/1,
+    clear/0
 ]).
 
 %% gen_server callbacks
@@ -225,6 +226,10 @@ delete(Who) ->
 
 info(InfoKey) ->
     mnesia:table_info(?BANNED_TAB, InfoKey).
+
+clear() ->
+    _ = mria:clear_table(?BANNED_TAB),
+    ok.
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/apps/emqx_management/src/emqx_mgmt_api_banned.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_banned.erl
@@ -79,6 +79,13 @@ schema("/banned") ->
                     ?DESC(create_banned_api_response400)
                 )
             }
+        },
+        delete => #{
+            description => ?DESC(clear_banned_api),
+            tags => ?TAGS,
+            parameters => [],
+            'requestBody' => [],
+            responses => #{204 => <<"No Content">>}
         }
     };
 schema("/banned/:as/:who") ->
@@ -168,7 +175,10 @@ banned(post, #{body := Body}) ->
                     OldBannedFormat = emqx_utils_json:encode(format(Old)),
                     {400, 'ALREADY_EXISTS', OldBannedFormat}
             end
-    end.
+    end;
+banned(delete, _) ->
+    emqx_banned:clear(),
+    {204}.
 
 delete_banned(delete, #{bindings := Params}) ->
     case emqx_banned:look_up(Params) of

--- a/changes/ce/feat-11436.en.md
+++ b/changes/ce/feat-11436.en.md
@@ -1,0 +1,1 @@
+Add a new API endpoint `DELETE  /banned` to clear all `banned` data.

--- a/rel/i18n/emqx_mgmt_api_banned.hocon
+++ b/rel/i18n/emqx_mgmt_api_banned.hocon
@@ -57,4 +57,9 @@ who.desc:
 who.label:
 """Ban Object"""
 
+clear_banned_api.desc:
+"""Clear all banned data."""
+clear_banned_api.label:
+"""Clear"""
+
 }


### PR DESCRIPTION
A follow-up PR of this #11424.

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2fc0468</samp>

Added a new API endpoint and a database function for clearing all banned data in `emqx`. The `clear` endpoint in `emqx_mgmt_api_banned` calls the `clear/0` function in `emqx_banned` to delete all records of banned clients and topics. The endpoint also has a description and a label in different languages in `rel/i18n/emqx_mgmt_api_banned.hocon`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
