### PR TITLE
fix(kinesis): return error message on access denied

### DIFF
--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kinesis, [
     {description, "EMQX Enterprise Amazon Kinesis Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
@@ -111,7 +111,14 @@ init(#{
     erlcloud_config:configure(
         to_str(AwsAccessKey), to_str(AwsSecretAccessKey), Host, Port, Scheme, New
     ),
-    {ok, State}.
+    % check the connection
+    case erlcloud_kinesis:list_streams() of
+        {ok, _} ->
+            {ok, State};
+        {error, Reason} ->
+            ?tp(kinesis_init_failed, #{instance_id => InstanceId, reason => Reason}),
+            {stop, Reason}
+    end.
 
 handle_call(connection_status, _From, #{stream_name := StreamName} = State) ->
     Status =

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
@@ -114,7 +114,12 @@ on_get_status(_InstanceId, #{pool_name := Pool} = State) ->
                         false -> disconnected
                     end
             end;
-        {error, _} ->
+        {error, Reason} ->
+            ?SLOG(error, #{
+                msg => "kinesis_producer_get_status_failed",
+                state => State,
+                reason => Reason
+            }),
             disconnected
     end.
 

--- a/changes/ee/fix-11444.en.md
+++ b/changes/ee/fix-11444.en.md
@@ -1,0 +1,1 @@
+Fixed error information when Kinesis bridge fails to connect to endpoint.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10764

<!-- Make sure to target release-51 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 08a1cc3</samp>

Improved the test coverage, error handling, and logging of the `emqx_bridge_kinesis` application. Bumped the version number to 0.1.1.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~[ ] Added property-based tests for code which performs user input validation~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
