### PR TITLE
ci: restore emqx app standalone tests

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -154,6 +154,8 @@ jobs:
     with:
       runner: ${{ needs.sanity-checks.outputs.runner }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
+      before_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
+      after_ref: ${{ github.sha }}
 
   run_test_cases:
     needs:

--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -146,6 +146,15 @@ jobs:
           path: ${{ matrix.profile }}.zip
           retention-days: 1
 
+  run_emqx_app_tests:
+    needs:
+      - sanity-checks
+      - compile
+    uses: ./.github/workflows/run_emqx_app_tests.yaml
+    with:
+      runner: ${{ needs.sanity-checks.outputs.runner }}
+      builder: ${{ needs.sanity-checks.outputs.builder }}
+
   run_test_cases:
     needs:
       - sanity-checks

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -160,7 +160,7 @@ jobs:
 
   run_emqx_app_tests:
     needs:
-      - sanity-checks
+      - prepare
       - compile
     uses: ./.github/workflows/run_emqx_app_tests.yaml
     with:

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -166,6 +166,8 @@ jobs:
     with:
       runner: ${{ needs.sanity-checks.outputs.runner }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
+      before_ref: ${{ github.event.before }}
+      after_ref: ${{ github.sha }}
 
   run_test_cases:
     if: needs.prepare.outputs.release != 'true'

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -158,6 +158,15 @@ jobs:
           path: ${{ matrix.profile }}.zip
           retention-days: 1
 
+  run_emqx_app_tests:
+    needs:
+      - sanity-checks
+      - compile
+    uses: ./.github/workflows/run_emqx_app_tests.yaml
+    with:
+      runner: ${{ needs.sanity-checks.outputs.runner }}
+      builder: ${{ needs.sanity-checks.outputs.builder }}
+
   run_test_cases:
     if: needs.prepare.outputs.release != 'true'
     needs:

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -164,8 +164,8 @@ jobs:
       - compile
     uses: ./.github/workflows/run_emqx_app_tests.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
-      builder: ${{ needs.sanity-checks.outputs.builder }}
+      runner: ${{ needs.prepare.outputs.runner }}
+      builder: ${{ needs.prepare.outputs.builder }}
       before_ref: ${{ github.event.before }}
       after_ref: ${{ github.sha }}
 

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -23,7 +23,7 @@ env:
 jobs:
   run_emqx_app_tests:
     runs-on: ${{ inputs.runner }}
-    container: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir}}-${{ matrix.otp }}-ubuntu22.04"
+    container: ${{ inputs.builder }}
 
     defaults:
       run:
@@ -63,5 +63,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-${{ matrix.runs-on }}
+        name: logs-${{ inputs.runner }}
         path: apps/emqx/_build/test/logs

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -1,0 +1,67 @@
+name: Check emqx app standalone
+
+# These tests are needed because we provide the `emqx` application as a standalone
+# dependency for plugins.
+
+concurrency:
+  group: test-standalone-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      runner:
+        required: true
+        type: string
+      builder:
+        required: true
+        type: string
+
+env:
+  IS_CI: "yes"
+
+jobs:
+  run_emqx_app_tests:
+    runs-on: ${{ inputs.runner }}
+    container: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir}}-${{ matrix.otp }}-ubuntu22.04"
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: run
+      run: |
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+        echo "git diff base: $GITHUB_BASE_REF"
+        if [[ "$GITHUB_BASE_REF" =~ [0-9a-f]{8,40} ]]; then
+          # base is a commit sha1
+          compare_base="$GITHUB_BASE_REF"
+        else
+          repo="${GITHUB_REPOSITORY}"
+          git remote -v
+          remote="$(git remote -v | grep -E "github\.com(:|/)$repo((\.git)|(\s))" | grep fetch | awk '{print $1}')"
+          git fetch "$remote" "$GITHUB_BASE_REF"
+          compare_base="$remote/$GITHUB_BASE_REF"
+        fi
+        changed_files="$(git diff --name-only ${compare_base} HEAD apps/emqx)"
+        if [ "$changed_files" = '' ]; then
+          echo "nothing changed in apps/emqx, ignored."
+          exit 0
+        fi
+        make ensure-rebar3
+        cp rebar3 apps/emqx/
+        cd apps/emqx
+        ./rebar3 xref
+        ./rebar3 dialyzer
+        ./rebar3 eunit -v
+        ./rebar3 ct --name 'test@127.0.0.1' -v --readable=true
+        ./rebar3 proper -d test/props
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: logs-${{ matrix.runs-on }}
+        path: apps/emqx/_build/test/logs

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -16,6 +16,12 @@ on:
       builder:
         required: true
         type: string
+      before_ref:
+        required: true
+        type: string
+      after_ref:
+        required: true
+        type: string
 
 env:
   IS_CI: "yes"
@@ -34,20 +40,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: run
+      env:
+        BEFORE_REF: ${{ inputs.before_ref }}
+        AFTER_REF: ${{ inputs.after_ref }}
       run: |
         git config --global --add safe.directory "$GITHUB_WORKSPACE"
-        echo "git diff base: $GITHUB_BASE_REF"
-        if [[ "$GITHUB_BASE_REF" =~ [0-9a-f]{8,40} ]]; then
-          # base is a commit sha1
-          compare_base="$GITHUB_BASE_REF"
-        else
-          repo="${GITHUB_REPOSITORY}"
-          git remote -v
-          remote="$(git remote -v | grep -E "github\.com(:|/)$repo((\.git)|(\s))" | grep fetch | awk '{print $1}')"
-          git fetch "$remote" "$GITHUB_BASE_REF"
-          compare_base="$remote/$GITHUB_BASE_REF"
-        fi
-        changed_files="$(git diff --name-only ${compare_base} HEAD apps/emqx)"
+        changed_files="$(git diff --name-only ${BEFORE_REF} ${AFTER_REF} apps/emqx)"
         if [ "$changed_files" = '' ]; then
           echo "nothing changed in apps/emqx, ignored."
           exit 0


### PR DESCRIPTION
Those were accidentally removed during a refactoring.

They are needed because we provide the `emqx` application as a standalone dependency for plugins.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8a6bb6f</samp>

This pull request adds a new workflow component `run_emqx_app_tests.yaml` and integrates it into the existing workflows `_pr_entrypoint.yaml` and `_push-entrypoint.yaml`. The component runs tests on the `emqx` application as a standalone dependency for plugins, using different GitHub runners and Docker containers. The tests are triggered by both pull requests and push events.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
