### PR TITLE
Do not publish pre-release artifacts

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -63,7 +63,8 @@ jobs:
           ./actionlint -color \
             -shellcheck= \
             -ignore 'label ".+" is unknown' \
-            -ignore 'value "emqx-enterprise" in "exclude"'
+            -ignore 'value "emqx-enterprise" in "exclude"' \
+            -ignore 'value "emqx-enterprise-elixir" in "exclude"'
       - name: Check line-break at EOF
         run: |
           ./scripts/check-nl-at-eof.sh

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -88,6 +88,11 @@ jobs:
         registry:
           - 'docker.io'
           - 'public.ecr.aws'
+        exclude:
+          - profile: emqx-enterprise
+            registry: 'public.ecr.aws'
+          - profile: emqx-enterprise-elixir
+            registry: 'public.ecr.aws'
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,7 +59,7 @@ jobs:
         with:
           asset_paths: '["packages/*"]'
       - name: update to emqx.io
-        if: startsWith(github.ref_name, 'v') && (github.event_name == 'release' || inputs.publish_release_artefacts)
+        if: startsWith(github.ref_name, 'v') && ((github.event_name == 'release' && !github.event.prerelease) || inputs.publish_release_artefacts)
         run: |
           set -eux
           curl -w %{http_code} \
@@ -70,6 +70,7 @@ jobs:
                -d "{\"repo\":\"emqx/emqx\", \"tag\": \"${{ github.ref_name }}\" }" \
                ${{ secrets.EMQX_IO_RELEASE_API }}
       - name: Push to packagecloud.io
+        if: (github.event_name == 'release' && !github.event.prerelease) || inputs.publish_release_artefacts
         env:
           PROFILE: ${{ steps.profile.outputs.profile }}
           VERSION: ${{ steps.profile.outputs.version }}

--- a/.github/workflows/upload-helm-charts.yaml
+++ b/.github/workflows/upload-helm-charts.yaml
@@ -43,6 +43,7 @@ jobs:
               ;;
           esac
       - uses: emqx/push-helm-action@v1.1
+        if: github.event_name == 'release' && !github.event.prerelease
         with:
           charts_dir: "${{ github.workspace }}/deploy/charts/${{ steps.profile.outputs.profile }}"
           version: ${{ steps.profile.outputs.version }}


### PR DESCRIPTION
Fixes the following:
- failure to push emqx-enterprise docker images to our AWS ECR (the repo does not exist there)
- publishing `alpha`, `beta` and `rc` packages to packagecloud.io
- publishing `alpha`, `beta` and `rc` versions of helm charts

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2b8b7a</samp>

This pull request updates some GitHub workflows to add or modify conditions for certain steps related to publishing and uploading artifacts. The main goal is to avoid running these steps for prereleases or unintended images.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
