### PR TITLE
fix: don't crash when debug huge payload

### DIFF
--- a/apps/emqx/include/emqx_mqtt.hrl
+++ b/apps/emqx/include/emqx_mqtt.hrl
@@ -680,6 +680,7 @@ end).
 -define(THROW_SERIALIZE_ERROR(Reason), erlang:throw({?FRAME_SERIALIZE_ERROR, Reason})).
 
 -define(MAX_PAYLOAD_FORMAT_SIZE, 1024).
+-define(TRUNCATED_PAYLOAD_SIZE, 100).
 -define(MAX_PAYLOAD_FORMAT_LIMIT(Bin), (byte_size(Bin) =< ?MAX_PAYLOAD_FORMAT_SIZE)).
 
 -endif.

--- a/apps/emqx/src/emqx_trace/emqx_trace_formatter.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_formatter.erl
@@ -76,13 +76,8 @@ format_payload(_, hidden) ->
 format_payload(Payload, text) when ?MAX_PAYLOAD_FORMAT_LIMIT(Payload) ->
     unicode:characters_to_list(Payload);
 format_payload(Payload, hex) when ?MAX_PAYLOAD_FORMAT_LIMIT(Payload) -> binary:encode_hex(Payload);
-format_payload(<<Part:100, _/binary>> = Payload, _) ->
-    [
-        Part,
-        "... The ",
-        integer_to_list(byte_size(Payload) - 100),
-        " bytes of this log are truncated"
-    ].
+format_payload(<<Part:?TRUNCATED_PAYLOAD_SIZE/binary, _/binary>> = Payload, Type) ->
+    emqx_packet:format_truncated_payload(Part, byte_size(Payload), Type).
 
 to_iolist(Atom) when is_atom(Atom) -> atom_to_list(Atom);
 to_iolist(Int) when is_integer(Int) -> integer_to_list(Int);

--- a/changes/ce/fix-11454.en.md
+++ b/changes/ce/fix-11454.en.md
@@ -1,0 +1,1 @@
+Fixed crashing when debugging/tracing with large payloads(introduce when [#11279](https://github.com/emqx/emqx/pull/11279))


### PR DESCRIPTION
Fixes crash introduce by https://github.com/emqx/emqx/pull/11279
Trace:
```
2023-08-16T15:33:52.095565+08:00 [MQTT] client-truncated1@127.0.0.1:65125 msg: mqtt_packet_received, packet: PUBLISH(Q0, R0, D0, Topic=/test, PacketId=undefined, Payload=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy... The 925 bytes of this log are truncated)
2023-08-16T15:33:52.096069+08:00 [PUBLISH] client-truncated1@127.0.0.1:65125 msg: publish_to, topic: /test, payload: yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy... The 925 bytes of this log are truncated
```

Debug log
```
2023-08-16T15:33:52.095743+08:00 [debug] msg: mqtt_packet_received, mfa: emqx_connection:handle_msg/2, line: 575, peername: 127.0.0.1:65125, clientid: client-truncated1, packet: PUBLISH(Q0, R0, D0, Topic=/test, PacketId=undefined, Payload=yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy... The 925 bytes of this log are truncated), tag: MQTT
2023-08-16T15:33:52.096110+08:00 [debug] msg: publish_to, mfa: emqx_trace:publish/1, line: 73, peername: 127.0.0.1:65125, clientid: client-truncated1, topic: /test, payload: yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy... The 925 bytes of this log are truncated, tag: PUBLISH
```
<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1af0407</samp>

This pull request adds a feature to truncate and format large payloads in the trace log. It defines a macro `TRUNCATED_PAYLOAD_SIZE` to set the limit, exports and uses a function `format_truncated_payload/3` in `emqx_packet.erl`, and updates the `emqx_trace_formatter.erl` and `emqx_trace_SUITE.erl` modules accordingly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
