### PR TITLE
ci: add `integration_test` dir to `emqx` application

### DIFF
--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -56,7 +56,7 @@ jobs:
         ./rebar3 xref
         ./rebar3 dialyzer
         ./rebar3 eunit -v
-        ./rebar3 ct --name 'test@127.0.0.1' -v --readable=true
+        ./rebar3 as standalone_test ct --name 'test@127.0.0.1' -v --readable=true
         ./rebar3 proper -d test/props
     - uses: actions/upload-artifact@v3
       if: failure()

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -47,6 +47,16 @@
             {bbmustache, "1.10.0"},
             {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.8.6"}}}
         ]},
+        {extra_src_dirs, [{"test", [recursive]},
+                          {"integration_test", [recursive]}]}
+    ]},
+    {standalone_test, [
+        {deps, [
+            {meck, "0.9.2"},
+            {proper, "1.4.0"},
+            {bbmustache, "1.10.0"},
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.8.6"}}}
+        ]},
         {extra_src_dirs, [{"test", [recursive]}]}
     ]}
 ]}.


### PR DESCRIPTION
This gives us a place where to put tests that exercise multiple umbrella application, which is more closely related to `emqx`, but in a way that doesn't affect the standalone app tests.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a6a023e</samp>

Added a `standalone_test` profile to the `emqx` app for integration testing. Modified the `.github/workflows/run_emqx_app_tests.yaml` file to use this profile in the `ct` command.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
