### PR TITLE
fix(bridge): make dryrun health check timeout more malleable

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_gcp_pubsub, [
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -191,7 +191,10 @@ fields(consumer_topic_mapping) ->
             )}
     ];
 fields("consumer_resource_opts") ->
-    ResourceFields = emqx_resource_schema:fields("creation_opts"),
+    ResourceFields =
+        emqx_resource_schema:create_opts(
+            [{health_check_interval, #{default => <<"30s">>}}]
+        ),
     SupportedFields = [
         auto_restart_interval,
         health_check_interval,

--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.1.21"},
+    {vsn, "0.1.22"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -179,7 +179,9 @@ create_dry_run(ResourceType, Config) ->
             false -> #{}
         end,
     ok = emqx_resource_manager_sup:ensure_child(ResId, <<"dry_run">>, ResourceType, Config, Opts),
-    case wait_for_ready(ResId, 5000) of
+    HealthCheckInterval = maps:get(health_check_interval, Opts, ?HEALTHCHECK_INTERVAL),
+    Timeout = emqx_utils:clamp(HealthCheckInterval, 5_000, 60_000),
+    case wait_for_ready(ResId, Timeout) of
         ok ->
             remove(ResId);
         {error, Reason} ->

--- a/apps/emqx_resource/src/schema/emqx_resource_schema.erl
+++ b/apps/emqx_resource/src/schema/emqx_resource_schema.erl
@@ -47,6 +47,7 @@ fields("resource_opts") ->
 fields("creation_opts") ->
     create_opts([]).
 
+-spec create_opts([{atom(), hocon_schema:field_schema_map()}]) -> [{atom(), hocon_schema:field()}].
 create_opts(Overrides) ->
     override(
         [

--- a/changes/ee/fix-11461.en.md
+++ b/changes/ee/fix-11461.en.md
@@ -1,0 +1,1 @@
+Made the timeout for testing bridges connectivity follow more closely the configured health check timeout.


### PR DESCRIPTION
# targeting `release-52`

Fixes https://emqx.atlassian.net/browse/EMQX-10773

- Makes the timeout for probing a bridge more malleable to account for differences between each database.
- Increases GCP PubSub Consumer default health check timeout to account for GCP slowness/throttling.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9614f60</samp>

This pull request updates the version numbers of the `emqx_bridge_gcp_pubsub` and `emqx_resource` applications and adds a new option for configuring the health check interval of GCP Pub/Sub resources. It also improves the resource readiness check and the resource schema creation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
