### PR TITLE
fix(gcp_consumer): remove unused resource_opts fields

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -209,11 +209,8 @@ fields(consumer_topic_mapping) ->
 fields("consumer_resource_opts") ->
     ResourceFields = emqx_resource_schema:fields("creation_opts"),
     SupportedFields = [
-        auto_restart_interval,
         health_check_interval,
-        request_ttl,
-        resume_interval,
-        worker_pool_size
+        request_ttl
     ],
     lists:filter(
         fun({Field, _Sc}) -> lists:member(Field, SupportedFields) end,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10789

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ce4b15b</samp>

Refactor GCP PubSub bridge configuration to remove unused fields. Update `SupportedFields` in `emqx_bridge_gcp_pubsub.erl` accordingly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [na] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [na] Changed lines covered in coverage report
- [na] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
