### PR TITLE
docs: change password label for azure event hub bridge

### DIFF
--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -291,10 +291,10 @@ auth_username_password.label:
 """Username/password Auth"""
 
 auth_sasl_password.desc:
-"""The password for connecting to Azure Event Hub.  Should be the "connection string-primary key" of a Namespace shared access policy."""
+"""The Connection String for connecting to Azure Event Hub.  Should be the "connection string-primary key" of a Namespace shared access policy."""
 
 auth_sasl_password.label:
-"""Password"""
+"""Connection String"""
 
 producer_kafka_opts.desc:
 """Azure Event Hub producer configs."""


### PR DESCRIPTION
Changed to use more specific AEH nomenclature.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 70ebb0b</samp>

Updated the configuration option for the `emqx_bridge_azure_event_hub` plugin to use the correct term "connection string" instead of "password" in the `rel/i18n/emqx_bridge_azure_event_hub.hocon` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
