### PR TITLE
fix(ldap): Return correct reason code when password is wrong

### DIFF
--- a/apps/emqx_ldap/src/emqx_ldap_authn.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn.erl
@@ -249,7 +249,7 @@ verify_password(Algorithm, LDAPPasswordType, LDAPPassword, Salt, Position, Passw
         true ->
             {ok, is_superuser(Entry, State)};
         _ ->
-            {error, invalid_password}
+            {error, bad_username_or_password}
     end.
 
 is_superuser(Entry, #{is_superuser_attribute := Attr} = _State) ->

--- a/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_authn_SUITE.erl
@@ -237,7 +237,7 @@ user_seeds() ->
         %% Not exists
         New(<<"notexists">>, <<"notexists">>, {error, not_authorized}),
         %% Wrong Password
-        New(<<"mqttuser0001">>, <<"wrongpassword">>, {error, invalid_password}),
+        New(<<"mqttuser0001">>, <<"wrongpassword">>, {error, bad_username_or_password}),
         %% Disabled
         New(<<"mqttuser0006">>, <<"mqttuser0006">>, {error, user_disabled}),
         %% IsSuperuser


### PR DESCRIPTION
Fixes [EMQX-10794](https://emqx.atlassian.net/browse/EMQX-10794)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1302953</samp>

Improve LDAP authentication security and usability by changing the error message for authentication failure to `bad_username_or_password` in `emqx_ldap_authn.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
