### PR TITLE
feat: reduce bcrypt rounds to a usable value

### DIFF
--- a/changes/ce/feat-11487.en.md
+++ b/changes/ce/feat-11487.en.md
@@ -1,0 +1,2 @@
+The bcrypt work factor is limited to the range 5-10, because higher values consume too much CPU resources.
+Bcrypt library is updated to allow parallel hash evaluation.

--- a/mix.exs
+++ b/mix.exs
@@ -815,7 +815,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp bcrypt_dep() do
     if enable_bcrypt?(),
-      do: [{:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.0", override: true}],
+      do: [{:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.1", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 bcrypt() ->
-    {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.0"}}}.
+    {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.1"}}}.
 
 quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.114"}}}.


### PR DESCRIPTION
Fixes [EMQX-10399](https://emqx.atlassian.net/browse/EMQX-10399)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e371b88</samp>

This pull request updates the `bcrypt` dependency to the latest version and lowers the default salt rounds for BCRYPT password hashing in the `emqx_authn` application. These changes aim to improve the performance and compatibility of password hashing for authentication.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [na] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible.

