### PR TITLE
fix(ldap): fix status detection and auto reconnecting errors

### DIFF
--- a/.ci/docker-compose-file/docker-compose-ldap.yaml
+++ b/.ci/docker-compose-file/docker-compose-ldap.yaml
@@ -11,6 +11,8 @@ services:
     image: openldap
     #ports:
     #  - 389:389
+    volumes:
+      - ./certs/ca.crt:/etc/certs/ca.crt
     restart: always
     networks:
       - emqx_bridge

--- a/.ci/docker-compose-file/toxiproxy.json
+++ b/.ci/docker-compose-file/toxiproxy.json
@@ -179,5 +179,17 @@
     "listen": "0.0.0.0:4566",
     "upstream": "kinesis:4566",
     "enabled": true
+  },
+  {
+    "name": "ldap_tcp",
+    "listen": "0.0.0.0:389",
+    "upstream": "ldap:389",
+    "enabled": true
+  },
+  {
+    "name": "ldap_ssl",
+    "listen": "0.0.0.0:636",
+    "upstream": "ldap:636",
+    "enabled": true
   }
 ]


### PR DESCRIPTION
Fixes [EMQX-10797](https://emqx.atlassian.net/browse/EMQX-10797)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ed93ced</samp>

This pull request enhances the `emqx_ldap` application by adding failure simulation and connection status tests using toxiproxy, and by fixing a connection status bug. It also updates the docker-compose files to support the SSL connection to the LDAP server.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
