### PR TITLE
fix: HTTP API /api/v5/publish schema

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_publish.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_publish.erl
@@ -57,7 +57,7 @@ schema("/publish") ->
             responses => #{
                 ?ALL_IS_WELL => hoconsc:mk(hoconsc:ref(?MODULE, publish_ok)),
                 ?PARTIALLY_OK => hoconsc:mk(hoconsc:ref(?MODULE, publish_error)),
-                ?BAD_REQUEST => bad_request_schema(),
+                ?BAD_REQUEST => hoconsc:mk(hoconsc:ref(?MODULE, bad_request)),
                 ?DISPATCH_ERROR => hoconsc:mk(hoconsc:ref(?MODULE, publish_error))
             }
         }
@@ -196,11 +196,13 @@ fields(bad_request) ->
     [
         {code,
             hoconsc:mk(string(), #{
-                desc => <<"BAD_REQUEST">>
+                desc => <<"BAD_REQUEST">>,
+                example => ?RC_TOPIC_NAME_INVALID
             })},
         {message,
             hoconsc:mk(binary(), #{
-                desc => ?DESC(error_message)
+                desc => ?DESC(error_message),
+                example => to_binary(emqx_reason_codes:name(?RC_TOPIC_NAME_INVALID))
             })}
     ].
 

--- a/changes/ce/fix-11493.en.md
+++ b/changes/ce/fix-11493.en.md
@@ -1,0 +1,1 @@
+Example for and documentation for /api/v5/publish bad request response has been fixed. Previously the documentation example said that the bad request response could return a list in the body which was not actually the case.

--- a/changes/ce/fix-11493.en.md
+++ b/changes/ce/fix-11493.en.md
@@ -1,1 +1,1 @@
-Example for and documentation for /api/v5/publish bad request response has been fixed. Previously the documentation example said that the bad request response could return a list in the body which was not actually the case.
+Examples and documentation for /api/v5/publish bad request response have been fixed. Previously the documentation example said that the bad request response could return a list in the body which was not actually the case.


### PR DESCRIPTION
The schema for the /api/v5/publish HTTP API endpoint was incorrect. For 400 (Bad Request) error it cannot return a list but the incorrect schema declared that the response could include a list.

Fixes:
https://emqx.atlassian.net/browse/EMQX-10837
https://github.com/emqx/emqx/issues/11488

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3ffbb7d</samp>

Simplify and improve schema validation for publish API in `emqx_mgmt_api_publish.erl`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible