### PR TITLE
fix(kinesis): set validators for static constraints

### DIFF
--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
@@ -30,8 +30,27 @@ roots() ->
 
 fields("config_producer") ->
     emqx_bridge_schema:common_bridge_fields() ++
-        emqx_resource_schema:fields("resource_opts") ++
-        fields(connector_config) ++ fields(producer);
+        fields("resource_opts") ++
+        fields(connector_config) ++
+        fields(producer);
+fields("resource_opts") ->
+    [
+        {resource_opts,
+            mk(
+                ref(?MODULE, "creation_opts"),
+                #{
+                    required => false,
+                    default => #{},
+                    desc => ?DESC(emqx_resource_schema, "creation_opts")
+                }
+            )}
+    ];
+fields("creation_opts") ->
+    emqx_resource_schema:create_opts([
+        {batch_size, #{
+            validator => emqx_resource_validator:max(int, 500)
+        }}
+    ]);
 fields(connector_config) ->
     [
         {aws_access_key_id,
@@ -121,6 +140,8 @@ fields("put_producer") ->
 
 desc("config_producer") ->
     ?DESC("desc_config");
+desc("creation_opts") ->
+    ?DESC(emqx_resource_schema, "creation_opts");
 desc(_) ->
     undefined.
 
@@ -160,6 +181,8 @@ sc(Type, Meta) -> hoconsc:mk(Type, Meta).
 mk(Type, Meta) -> hoconsc:mk(Type, Meta).
 
 enum(OfSymbols) -> hoconsc:enum(OfSymbols).
+
+ref(Module, Name) -> hoconsc:ref(Module, Name).
 
 type_field_producer() ->
     {type, mk(enum([kinesis_producer]), #{required => true, desc => ?DESC("desc_type")})}.

--- a/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_impl_producer_SUITE.erl
@@ -902,3 +902,17 @@ t_empty_payload_template(Config) ->
         emqx_utils_json:decode(Data, [return_maps])
     ),
     ok.
+
+t_validate_static_constraints(Config) ->
+    % From <https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html>:
+    % "Each PutRecords request can support up to 500 records.
+    %  Each record in the request can be as large as 1 MiB,
+    %  up to a limit of 5 MiB for the entire request, including partition keys."
+    %
+    % Message size and request size shall be controlled by user, so there is no validators
+    % for them - if exceeded, it will fail like on `t_publish_big_msg` test.
+    ?assertThrow(
+        {emqx_bridge_schema, [#{kind := validation_error, value := 501}]},
+        generate_config([{batch_size, 501} | Config])
+    ),
+    ok.

--- a/changes/ee/fix-11494.en.md
+++ b/changes/ee/fix-11494.en.md
@@ -1,0 +1,1 @@
+Added schema validator to reflect Amazon Kinesis' static constraint: batch request can support up to 500 records (max batch size);


### PR DESCRIPTION
### Targeting release-52

Fixes https://emqx.atlassian.net/browse/EMQX-10833

Add scheme validators for Kinesis static contraints:
> Each PutRecords request can support up to 500 records. Each record in the request can be as large as 1 MiB, up to a limit of 5 MiB for the entire request, including partition keys.
https://docs.aws.amazon.com/kinesis/latest/APIReference/API_PutRecords.html

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 60b37ab</samp>

This pull request enhances the Kinesis bridge configuration and testing. It uses hocon schema references to avoid duplication and a macro to define the maximum buffer size. It also adds and tests the `max_batch_bytes` option to control the size of Kinesis records.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
