### PR TITLE
fix: stop otel deps application in terminate crashed

### DIFF
--- a/apps/emqx_opentelemetry/src/emqx_otel.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel.erl
@@ -17,7 +17,7 @@
 -module(emqx_otel).
 -include_lib("emqx/include/logger.hrl").
 
--export([start_link/1]).
+-export([start_link/1, cleanup/0]).
 -export([get_cluster_gauge/1, get_stats_gauge/1, get_vm_gauge/1, get_metric_counter/1]).
 -export([init/1, handle_continue/2, handle_call/3, handle_cast/2, handle_info/2, terminate/2]).
 
@@ -25,7 +25,6 @@ start_link(Conf) ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, Conf, []).
 
 init(Conf) ->
-    erlang:process_flag(trap_exit, true),
     {ok, #{}, {continue, {setup, Conf}}}.
 
 handle_continue({setup, Conf}, State) ->
@@ -42,7 +41,6 @@ handle_info(_Msg, State) ->
     {noreply, State}.
 
 terminate(_Reason, _State) ->
-    cleanup(),
     ok.
 
 setup(Conf = #{enable := true}) ->

--- a/apps/emqx_opentelemetry/src/emqx_otel_sup.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_sup.erl
@@ -42,6 +42,7 @@ start_otel(Conf) ->
 
 -spec stop_otel() -> ok | {error, term()}.
 stop_otel() ->
+    ok = emqx_otel:cleanup(),
     case supervisor:terminate_child(?MODULE, ?WORKER) of
         ok -> supervisor:delete_child(?MODULE, ?WORKER);
         {error, not_found} -> ok;


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10826 Don't need changlog, this feature is not release yet.

Refactored OpenTelemetry metrics and views cleanup logic to be handled by emqx_otel_sup supervisor on application stop. 

Using `application:stop/1` in process terminate will cause **deallock** when `init:stop/0`.

Fixed crash log:

```
2023-08-23T16:30:17.157687+08:00 [error] Supervisor: {local,emqx_otel_sup}. Context: shutdown_error. Reason: killed. Offender: id=emqx_otel,pid=<0.2938.0>.
```
<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58be7f7</samp>

Refactor the OpenTelemetry metrics and views cleanup logic in `emqx_otel`. Move the cleanup function from the `emqx_otel` gen_server to the `emqx_otel_sup` supervisor and call it when the application is stopped.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
