### PR TITLE
fix(gcp_consumer): handle 401 errors

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -818,6 +818,61 @@ permission_denied_response() ->
         )
     }}.
 
+unauthenticated_response() ->
+    Msg = <<
+        "Request had invalid authentication credentials. Expected OAuth 2 access token,"
+        " login cookie or other valid authentication credential. "
+        "See https://developers.google.com/identity/sign-in/web/devconsole-project."
+    >>,
+    {error, #{
+        body =>
+            #{
+                <<"error">> =>
+                    #{
+                        <<"code">> => 401,
+                        <<"details">> =>
+                            [
+                                #{
+                                    <<"@type">> =>
+                                        <<"type.googleapis.com/google.rpc.ErrorInfo">>,
+                                    <<"domain">> => <<"googleapis.com">>,
+                                    <<"metadata">> =>
+                                        #{
+                                            <<"email">> =>
+                                                <<"test-516@emqx-cloud-pubsub.iam.gserviceaccount.com">>,
+                                            <<"method">> =>
+                                                <<"google.pubsub.v1.Publisher.CreateTopic">>,
+                                            <<"service">> =>
+                                                <<"pubsub.googleapis.com">>
+                                        },
+                                    <<"reason">> => <<"ACCOUNT_STATE_INVALID">>
+                                }
+                            ],
+                        <<"message">> => Msg,
+
+                        <<"status">> => <<"UNAUTHENTICATED">>
+                    }
+            },
+        headers =>
+            [
+                {<<"www-authenticate">>, <<"Bearer realm=\"https://accounts.google.com/\"">>},
+                {<<"vary">>, <<"X-Origin">>},
+                {<<"vary">>, <<"Referer">>},
+                {<<"content-type">>, <<"application/json; charset=UTF-8">>},
+                {<<"date">>, <<"Wed, 23 Aug 2023 12:41:40 GMT">>},
+                {<<"server">>, <<"ESF">>},
+                {<<"cache-control">>, <<"private">>},
+                {<<"x-xss-protection">>, <<"0">>},
+                {<<"x-frame-options">>, <<"SAMEORIGIN">>},
+                {<<"x-content-type-options">>, <<"nosniff">>},
+                {<<"alt-svc">>, <<"h3=\":443\"; ma=2592000,h3-29=\":443\"; ma=2592000">>},
+                {<<"accept-ranges">>, <<"none">>},
+                {<<"vary">>, <<"Origin,Accept-Encoding">>},
+                {<<"transfer-encoding">>, <<"chunked">>}
+            ],
+        status_code => 401
+    }}.
+
 %%------------------------------------------------------------------------------
 %% Testcases
 %%------------------------------------------------------------------------------
@@ -2102,6 +2157,81 @@ t_permission_denied_worker(Config) ->
                     case Method =:= put of
                         true ->
                             permission_denied_response();
+                        false ->
+                            meck:passthrough([PreparedRequest, Client])
+                    end
+                end,
+                fun() ->
+                    {{ok, _}, {ok, _}} =
+                        ?wait_async_action(
+                            create_bridge(
+                                Config
+                            ),
+                            #{?snk_kind := gcp_pubsub_consumer_worker_terminate},
+                            10_000
+                        ),
+
+                    ok
+                end
+            ),
+            ok
+        end,
+        []
+    ),
+    ok.
+
+t_unauthenticated_topic_check(Config) ->
+    [#{pubsub_topic := PubSubTopic}] = ?config(topic_mapping, Config),
+    ResourceId = resource_id(Config),
+    ?check_trace(
+        begin
+            %% the emulator does not check any credentials
+            emqx_common_test_helpers:with_mock(
+                emqx_bridge_gcp_pubsub_client,
+                query_sync,
+                fun(PreparedRequest = {prepared_request, {Method, Path, _Body}}, Client) ->
+                    RE = iolist_to_binary(["/topics/", PubSubTopic, "$"]),
+                    case {Method =:= get, re:run(Path, RE)} of
+                        {true, {match, _}} ->
+                            unauthenticated_response();
+                        _ ->
+                            meck:passthrough([PreparedRequest, Client])
+                    end
+                end,
+                fun() ->
+                    {{ok, _}, {ok, _}} =
+                        ?wait_async_action(
+                            create_bridge(Config),
+                            #{?snk_kind := gcp_pubsub_stop},
+                            5_000
+                        ),
+                    ?assertMatch(
+                        {ok, disconnected},
+                        emqx_resource_manager:health_check(ResourceId)
+                    ),
+                    ?assertMatch(
+                        {ok, _Group, #{error := {unhealthy_target, "Permission denied" ++ _}}},
+                        emqx_resource_manager:lookup_cached(ResourceId)
+                    ),
+                    ok
+                end
+            ),
+            ok
+        end,
+        []
+    ),
+    ok.
+
+t_unauthenticated_worker(Config) ->
+    ?check_trace(
+        begin
+            emqx_common_test_helpers:with_mock(
+                emqx_bridge_gcp_pubsub_client,
+                query_sync,
+                fun(PreparedRequest = {prepared_request, {Method, _Path, _Body}}, Client) ->
+                    case Method =:= put of
+                        true ->
+                            unauthenticated_response();
                         false ->
                             meck:passthrough([PreparedRequest, Client])
                     end


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10852

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 795361c</samp>

This pull request improves the error handling and logging for the GCP PubSub bridge consumer when the credentials are invalid or expired. It adds a new `bad_credentials` error type and updates the resource health status accordingly. It also adds tests and mocks for this scenario in the `emqx_bridge_gcp_pubsub_consumer_SUITE.erl` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [na] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
