### PR TITLE
chore(ci): pin pytest-retry version

### DIFF
--- a/.ci/docker-compose-file/python/pytest.sh
+++ b/.ci/docker-compose-file/python/pytest.sh
@@ -20,7 +20,7 @@ fi
 apk update && apk add git curl
 git clone -b develop-5.0 https://github.com/emqx/paho.mqtt.testing.git /paho.mqtt.testing
 
-pip install pytest==7.1.2 pytest-retry
+pip install pytest==7.1.2 pytest-retry==1.3.0
 
 pytest --retries 3 -v /paho.mqtt.testing/interoperability/test_client/V5/test_connect.py -k test_basic --host "$TARGET_HOST"
 RESULT=$?

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -121,7 +121,7 @@ jobs:
         path: paho.mqtt.testing
     - name: install pytest
       run: |
-        pip install pytest==7.1.2 pytest-retry
+        pip install pytest==7.1.2 pytest-retry==1.3.0
         echo "$HOME/.local/bin" >> $GITHUB_PATH
     - name: run paho test
       timeout-minutes: 10


### PR DESCRIPTION
Fixes [EMQX-10854](https://emqx.atlassian.net/browse/EMQX-10854)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5f03b87</samp>

Pin `pytest-retry` package to fix CI test failure. This change resolves a version conflict with `pytest` in the `.ci/docker-compose-file/python/pytest.sh` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [na] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [na] Changed lines covered in coverage report
- [na] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible
