### PR TITLE
fix(emqx_trace): don't download empty trace log file

### DIFF
--- a/changes/ce/fix-11506.en.md
+++ b/changes/ce/fix-11506.en.md
@@ -1,0 +1,4 @@
+Don't download a trace log file if it is empty.
+
+After this fix, GET `/api/v5/trace/clientempty/download` returns 404 `{"code":"NOT_FOUND","message":"Trace is empty"}`
+If no events matching the trace condition occurred.


### PR DESCRIPTION
Fixes EMQX-10274
<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 871eaa0</samp>

This pull request enhances the trace API and log features of emqx. It uses common definitions and error handling for the API functions, adds a destination field to the trace record, and ensures the trace log is consistent and non-empty before sending or deleting it.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
