### PR TITLE
fix: delete connection_table when connection closed

### DIFF
--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -198,7 +198,7 @@ connection_closed(ClientId) ->
 
 -spec connection_closed(emqx_types:clientid(), chan_pid()) -> true.
 connection_closed(ClientId, ChanPid) ->
-    ets:delete_object(?CHAN_CONN_TAB, {ClientId, ChanPid}).
+    ets:delete(?CHAN_CONN_TAB, {ClientId, ChanPid}).
 
 %% @doc Get info of a channel.
 -spec get_chan_info(emqx_types:clientid()) -> maybe(emqx_types:infos()).

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -400,7 +400,7 @@ getstats(Key) ->
         _:_ -> 0
     end.
 
-stats(connections) -> emqx_stats:getstat('connections.count');
+stats(connections) -> emqx_stats:getstat('sessions.count');
 stats(live_connections) -> emqx_stats:getstat('live_connections.count');
 stats(topics) -> emqx_stats:getstat('topics.count');
 stats(subscriptions) -> emqx_stats:getstat('subscriptions.count');

--- a/changes/ce/fix-11509.en.md
+++ b/changes/ce/fix-11509.en.md
@@ -1,0 +1,3 @@
+Clear client ID and channel process mappings when connection closed.
+this fix helps keep the connection table data synchronized with the actual active channels in EMQX.
+It resolves an issue where stale `connections.count` metrics could remain after a channel finished.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10836

Clear client ID and channel process mappings when connection closed.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0c4a00f</samp>

Fix a memory leak issue in `emqx_cm` by changing the way entries are deleted from the `?CHAN_CONN_TAB` table. This table stores the client ID and channel process mapping and should be cleared when a channel is closed.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
