### PR TITLE
ci: use more sensible name for checks

### DIFF
--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -29,6 +29,7 @@ env:
 jobs:
   eunit_and_proper:
     runs-on: ${{ inputs.runner }}
+    name: "eunit_and_proper (${{ matrix.profile }})"
     strategy:
       fail-fast: false
       matrix:
@@ -69,6 +70,7 @@ jobs:
 
   ct_docker:
     runs-on: ${{ inputs.runner }}
+    name: "ct_docker (${{ matrix.app }}-${{ matrix.suitegroup }})"
     strategy:
       fail-fast: false
       matrix:
@@ -116,6 +118,7 @@ jobs:
 
   ct:
     runs-on: ${{ inputs.runner }}
+    name: "ct (${{ matrix.app }}-${{ matrix.suitegroup }})"
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +157,17 @@ jobs:
         with:
           name: logs-${{ matrix.profile }}-${{ matrix.prefix }}-${{ matrix.otp }}-sg${{ matrix.suitegroup }}
           path: _build/test/logs
+
+  tests_passed:
+    needs:
+      - eunit_and_proper
+      - ct
+      - ct_docker
+    runs-on: ${{ inputs.runner }}
+    strategy:
+      fail-fast: false
+    steps:
+      - run: echo "All tests passed"
 
   make_cover:
     needs:

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -23,6 +23,7 @@ env:
 jobs:
   static_checks:
     runs-on: ${{ inputs.runner }}
+    name: "static_checks (${{ matrix.profile }})"
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Right now check names are auto-generated by github based on all matrix dimensions. This patch overrides this for especially hairy cases in run_test_cases workflow.

Other improvements:
- override check names in static_checks workflow so that we do not have references to OTP or builder version and can use these checks consistently in required checks (otherwise we will have to update required checks each time we bump builder version)
- add a no-op "tests_passed" job for test cases to be used as required check instead of make_cover (it takes ~10 min)