### PR TITLE
fix(ldap): expose request_timeout to prevent infinite hang

### DIFF
--- a/rel/i18n/emqx_ldap.hocon
+++ b/rel/i18n/emqx_ldap.hocon
@@ -23,4 +23,10 @@ The syntax of the filter follows RFC 4515 and also supports placeholders."""
 filter.label:
 """Filter"""
 
+request_timeout.desc:
+"""Sets the maximum time in milliseconds that is used for each individual request."""
+
+request_timeout.label:
+"""Request Timeout"""
+
 }


### PR DESCRIPTION
Fixes [EMQX-10849](https://emqx.atlassian.net/browse/EMQX-10849)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 23aa2b9</samp>

This pull request adds a `request_timeout` option to the LDAP authentication plugin, which allows users to configure how long to wait for LDAP responses. It also updates the internationalization file `emqx_ldap.hocon` with the corresponding labels and descriptions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
