### PR TITLE
fix: stop otel deps appication before reboot

### DIFF
--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -62,6 +62,8 @@ stop_apps() ->
     ?SLOG(notice, #{msg => "stopping_emqx_apps"}),
     _ = emqx_alarm_handler:unload(),
     ok = emqx_conf_app:unset_config_loaded(),
+    %% Mute otel deps application.
+    _ = emqx_otel:stop_otel(),
     lists:foreach(fun stop_one_app/1, lists:reverse(sorted_reboot_apps())).
 
 %% Those port apps are terminated after the main apps

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -42,7 +42,7 @@ init_per_suite(Config) ->
     %%   Unload emqx_authz to avoid reboot this application
     %%
     application:unload(emqx_authz),
-    emqx_common_test_helpers:start_apps([emqx_conf]),
+    emqx_common_test_helpers:start_apps([emqx_conf, emqx_opentelemetry]),
     application:set_env(emqx_machine, applications, [
         emqx_prometheus,
         emqx_modules,
@@ -56,12 +56,13 @@ init_per_suite(Config) ->
         emqx_exhook,
         emqx_authn,
         emqx_authz,
-        emqx_plugin
+        emqx_plugin,
+        emqx_opentelemetry
     ]),
     Config.
 
 end_per_suite(_Config) ->
-    emqx_common_test_helpers:stop_apps([]).
+    emqx_common_test_helpers:stop_apps([emqx_opentelemetry, emqx_conf]).
 
 init_per_testcase(t_custom_shard_transports, Config) ->
     OldConfig = application:get_env(emqx_machine, custom_shard_transports),

--- a/apps/emqx_opentelemetry/src/emqx_otel.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel.erl
@@ -30,10 +30,15 @@ start_otel(Conf) ->
 
 stop_otel() ->
     ok = cleanup(),
-    case supervisor:terminate_child(?SUPERVISOR, ?MODULE) of
-        ok -> supervisor:delete_child(?SUPERVISOR, ?MODULE);
-        {error, not_found} -> ok;
-        Error -> Error
+    case erlang:whereis(?SUPERVISOR) of
+        undefined ->
+            ok;
+        Pid ->
+            case supervisor:terminate_child(Pid, ?MODULE) of
+                ok -> supervisor:delete_child(Pid, ?MODULE);
+                {error, not_found} -> ok;
+                Error -> Error
+            end
     end.
 
 start_link(Conf) ->

--- a/apps/emqx_opentelemetry/src/emqx_otel_config.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_config.erl
@@ -52,7 +52,7 @@ post_config_update(_ConfPath, _Req, _NewConf, _OldConf, _AppEnvs) ->
     ok.
 
 ensure_otel(#{enable := true} = Conf) ->
-    _ = emqx_otel_sup:stop_otel(),
-    emqx_otel_sup:start_otel(Conf);
+    _ = emqx_otel:stop_otel(),
+    emqx_otel:start_otel(Conf);
 ensure_otel(#{enable := false}) ->
-    emqx_otel_sup:stop_otel().
+    emqx_otel:stop_otel().


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10839
Run “emqx ctl cluster leave“ on a core node in an emqx cluster. It hang. And a few errors were found in emqx.log.

```
2023-08-22T10:23:40.174746+00:00 [error] Generic server <0.3959.0> terminating. Reason: {badarg,[{ets,lookup,[emqx_mgmt_cache,sys_memory],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},{emqx_mgmt_cache,get_memory_from_cache,0,[{file,"emqx_mgmt_cache.erl"},{line,97}]},{emqx_mgmt_cache,get_sys_memory,0,[{file,"emqx_mgmt_cache.erl"},{line,30}]},{emqx_mgmt,vm_stats,1,[{file,"emqx_mgmt.erl"},{line,222}]},{emqx_otel,get_vm_gauge,1,[{file,"emqx_otel.erl"},{line,150}]},{otel_observables,'-run_callbacks/4-fun-0-',4,[{file,"otel_observables.erl"},{line,41}]},{lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},{otel_metric_reader,collect_,4,[{file,"otel_metric_reader.erl"},{line,173}]},{otel_metric_reader,handle_info,2,[{file,"otel_metric_reader.erl"},{line,156}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1200}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}. Last message: collect. State: {state,{opentelemetry_exporter,{state,<0.3959.0>,undefined,grpc,<0.3960.0>,[],undefined,#{},[#{host => "10.4.0.39",path => "/v1/traces",port => 4317,scheme => "http",ssl_options => [{verify,verify_peer},{depth,100},{cacerts,[<<48,130,4,42,48,...
|...]},{verify_fun,{fun ssl_verify_hostname:verify_fun/3,[{check_hostname,"10.4.0.39"}]}},{partial_chain,fun tls_certificate_check_shared_state:find_trusted_authority/1},{customize_hostname_check,[{match_fun,#Fun<public_key.6.29392970>}]}]}]}},<0.3956.0>,#Ref<0.2304180414.772538371.153375>,#{counter => otel_aggregation_sum,histogram => otel_aggregation_histogram_explicit,observable_counter => otel_aggregation_sum,observable_gauge => otel_aggregation_last_value,observable_updowncounter => otel_aggregation_sum,updown_counter => otel_aggregation_sum},#{},1000,#Ref<0.2304180414.772538370.177837>,callbacks_otel_meter_provider_global,view_aggregations_otel_meter_provider_global,metrics_otel_meter_provider_global,#{export_interval_ms => 1000,exporter => {opentelemetry_exporter,#{}}},{resource,undefined,{attributes,128,255,0,#{'process.executable.name' => <<"/opt/emqx/bin/emqx">>,'process.runtime.description' => <<"Erlang/OTP 25 erts-13.2.2">>,'process.runtime.name' => <<"BEAM">>,'process.runtime.version' => <<"13.2.2">>,'service.instance.id' => <<"emqx@emqx-1.emqxhs.dev-le-520-al3-2.svc.cluster.local">>,'service.name' => <<"emqx">>,'service.version' => <<"5.2.0-alpha.3-gffece91b">>,'telemetry.sdk.language' => <<"erlang">>,'telemetry.sdk.name' => <<"opentelemetry">>,'telemetry.sdk.version' => <<"0.0.0+build.1.refc51b84f">>}}}}.
2023-08-22T10:23:40.176721+00:00 [error] crasher: initial call: otel_metric_reader:init/1, pid: <0.3959.0>, registered_name: [], error: {badarg,[{ets,lookup,[emqx_mgmt_cache,sys_memory],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},{emqx_mgmt_cache,get_memory_from_cache,0,[{file,"emqx_mgmt_cache.erl"},{line,97}]},{emqx_mgmt_cache,get_sys_memory,0,[{file,"emqx_mgmt_cache.erl"},{line,30}]},{emqx_mgmt,vm_stats,1,[{file,"emqx_mgmt.erl"},{line,222}]},{emqx_otel,get_vm_gauge,1,[{file,"emqx_otel.erl"},{line,150}]},{otel_observables,'-run_callbacks/4-fun-0-',4,[{file,"otel_observables.erl"},{line,41}]},{lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},{otel_metric_reader,collect_,4,[{file,"otel_metric_reader.erl"},{line,173}]},{otel_metric_reader,handle_info,2,[{file,"otel_metric_reader.erl"},{line,156}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1200}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}, ancestors: [<0.3958.0>,<0.3956.0>,otel_meter_provider_sup,otel_metrics_sup,opentelemetry_experimental_sup,<0.3951.0>], message_queue_len: 1, messages: [{cancel_timer,#Ref<0.2304180414.772538370.177837>,false}], links: [<0.3958.0>,<0.3960.0>], dictionary: [], trap_exit: false, status: running, heap_size: 75113, stack_size: 28, reductions: 3361567; neighbours:
2023-08-22T10:23:40.177132+00:00 [error] Supervisor: {<0.3958.0>,otel_metric_reader_sup}. Context: child_terminated. Reason: {badarg,[{ets,lookup,[emqx_mgmt_cache,sys_memory],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},{emqx_mgmt_cache,get_memory_from_cache,0,[{file,"emqx_mgmt_cache.erl"},{line,97}]},{emqx_mgmt_cache,get_sys_memory,0,[{file,"emqx_mgmt_cache.erl"},{line,30}]},{emqx_mgmt,vm_stats,1,[{file,"emqx_mgmt.erl"},{line,222}]},{emqx_otel,get_vm_gauge,1,[{file,"emqx_otel.erl"},{line,150}]},{otel_observables,'-run_callbacks/4-fun-0-',4,[{file,"otel_observables.erl"},{line,41}]},{lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},{otel_metric_reader,collect_,4,[{file,"otel_metric_reader.erl"},{line,173}]},{otel_metric_reader,handle_info,2,[{file,"otel_metric_reader.erl"},{line,156}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1200}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}. Offender: id=#Ref<0.2304180414.772538371.153375>,pid=<0.3959.0>.
2023-08-22T10:23:40.177489+00:00 [error] State machine {n,l,{grpcbox_channel,<0.3959.0>}} terminating. Reason: {badarg,[{ets,lookup,[emqx_mgmt_cache,sys_memory],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},{emqx_mgmt_cache,get_memory_from_cache,0,[{file,"emqx_mgmt_cache.erl"},{line,97}]},{emqx_mgmt_cache,get_sys_memory,0,[{file,"emqx_mgmt_cache.erl"},{line,30}]},{emqx_mgmt,vm_stats,1,[{file,"emqx_mgmt.erl"},{line,222}]},{emqx_otel,get_vm_gauge,1,[{file,"emqx_otel.erl"},{line,150}]},{otel_observables,'-run_callbacks/4-fun-0-',4,[{file,"otel_observables.erl"},{line,41}]},{lists,foreach_1,2,[{file,"l...
...
2023-08-22T10:23:40.180160+00:00 [error] crasher: initial call: grpcbox_channel:init/1, pid: <0.3960.0>, registered_name: [], exit: {{badarg,[{ets,lookup,[emqx_mgmt_cache,sys_memory],[{error_info,#{cause => id,module => erl_stdlib_errors}}]},{emqx_mgmt_cache,get_memory_from_cache,0,[{file,"emqx_mgmt_cache.erl"},{line,97}]},{emqx_mgmt_cache,get_sys_memory,0,[{file,"emqx_mgmt_cache.erl"},{line,30}]},{emqx_mgmt,vm_stats,1,[{file,"emqx_mgmt.erl"},{line,222}]},{emqx_otel,get_vm_gauge,1,[{file,"emqx_otel.erl"},{line,150}]},{otel_observables,'-run_callbacks/4-fun-0-',4,[{file,"otel_observables.erl"},{line,41}]},{lists,foreach_1,2,[{file,"lists.erl"},{line,1442}]},{otel_metric_reader,collect_,4,[{file,"otel_metric_reader.erl"},{line,173}]},{otel_metric_reader,handle_info,2,[{file,"otel_metric_reader.erl"},{line,156}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1200}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]},[{gen_statem,loop_receive,3,[{file,"gen_statem.erl"},{line,1316}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}, ancestors: [<0.3959.0>,<0.3958.0>,<0.3956.0>,otel_meter_provider_sup,otel_metrics_sup,opentelemetry_experimental_sup,<0.3951.0>], message_queue_len: 1, messages: [{'EXIT',<0.3961.0>,killed}], links: [], dictionary: [], trap_exit: true, status: running, heap_size: 121536, stack_size: 28, reductions: 60774; neighbours:
2023-08-22T10:23:40.568419+00:00 [warning] msg: Dashboard monitor error, mfa: emqx_dashboard_monitor:current_rate/1, line: 144, reason: {noproc,{gen_server,call,[emqx_dashboard_monitor,current_rate,5000]}}
2023-08-22T10:23:42.601141+00:00 [warning] msg: Dashboard monitor error, mfa: emqx_dashboard_monitor:current_rate/1, line: 144, reason: {noproc,{gen_server,call,[emqx_dashboard_monitor,current_rate,5000]}}
```

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c215fe3</samp>

This pull request simplifies and improves the integration of OpenTelemetry with emqx. It refactors the `emqx_otel_sup` and `emqx_otel` modules to use a common worker specification and error handling. It also avoids potential conflicts with the `emqx_machine` application by stopping the OpenTelemetry dependencies before starting it.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
