### PR TITLE
Fix Kafka/AEH ClientId uniqueness

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_producer_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_producer_SUITE.erl
@@ -12,6 +12,7 @@
 
 -define(BRIDGE_TYPE, azure_event_hub_producer).
 -define(BRIDGE_TYPE_BIN, <<"azure_event_hub_producer">>).
+-define(KAFKA_BRIDGE_TYPE, kafka).
 -define(APPS, [emqx_resource, emqx_bridge, emqx_rule_engine]).
 
 -import(emqx_common_test_helpers, [on_exit/1]).
@@ -279,5 +280,40 @@ t_sync_query(Config) ->
         fun make_message/0,
         fun(Res) -> ?assertEqual(ok, Res) end,
         emqx_bridge_kafka_impl_producer_sync_query
+    ),
+    ok.
+
+t_same_name_azure_kafka_bridges(AehConfig) ->
+    ConfigKafka = lists:keyreplace(bridge_type, 1, AehConfig, {bridge_type, ?KAFKA_BRIDGE_TYPE}),
+    BridgeName = ?config(bridge_name, AehConfig),
+    AehResourceId = emqx_bridge_testlib:resource_id(AehConfig),
+    TracePoint = emqx_bridge_kafka_impl_producer_sync_query,
+    %% creates the AEH bridge and check it's working
+    ok = emqx_bridge_testlib:t_sync_query(
+        AehConfig,
+        fun make_message/0,
+        fun(Res) -> ?assertEqual(ok, Res) end,
+        TracePoint
+    ),
+    %% than creates a Kafka bridge with same name and delete it after creation
+    ok = emqx_bridge_testlib:t_create_via_http(ConfigKafka),
+    ?assertMatch(
+        {{ok, _}, {ok, _}},
+        ?wait_async_action(
+            emqx_bridge:disable_enable(disable, ?KAFKA_BRIDGE_TYPE, BridgeName),
+            #{?snk_kind := kafka_producer_stopped},
+            5_000
+        )
+    ),
+    % check that AEH bridge is still working
+    ?check_trace(
+        begin
+            Message = {send_message, make_message()},
+            ?assertEqual(ok, emqx_resource:simple_sync_query(AehResourceId, Message)),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([#{instance_id := AehResourceId}], ?of_kind(TracePoint, Trace))
+        end
     ),
     ok.

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
@@ -7,7 +7,7 @@
 
 -export([
     hosts/1,
-    make_client_id/2,
+    make_client_id/1,
     sasl/1,
     socket_opts/1
 ]).
@@ -24,10 +24,11 @@ hosts(Hosts) when is_list(Hosts) ->
     kpro:parse_endpoints(Hosts).
 
 %% Client ID is better to be unique to make it easier for Kafka side trouble shooting.
-make_client_id(KafkaType0, BridgeName0) ->
-    KafkaType = to_bin(KafkaType0),
-    BridgeName = to_bin(BridgeName0),
-    iolist_to_binary([KafkaType, ":", BridgeName, ":", atom_to_list(node())]).
+make_client_id(InstanceId) ->
+    InstanceIdBin0 = to_bin(InstanceId),
+    % Removing the <<"bridge:">> from beginning for backward compatibility
+    InstanceIdBin = binary:replace(InstanceIdBin0, <<"bridge:">>, <<>>),
+    iolist_to_binary([InstanceIdBin, ":", atom_to_list(node())]).
 
 sasl(none) ->
     undefined;

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -121,7 +121,6 @@ on_start(ResourceId, Config) ->
     #{
         authentication := Auth,
         bootstrap_hosts := BootstrapHosts0,
-        bridge_name := BridgeName,
         hookpoint := _,
         kafka := #{
             max_batch_bytes := _,
@@ -134,9 +133,8 @@ on_start(ResourceId, Config) ->
         topic_mapping := _
     } = Config,
     BootstrapHosts = emqx_bridge_kafka_impl:hosts(BootstrapHosts0),
-    KafkaType = kafka_consumer,
     %% Note: this is distinct per node.
-    ClientID = make_client_id(ResourceId, KafkaType, BridgeName),
+    ClientID = make_client_id(ResourceId),
     ClientOpts0 =
         case Auth of
             none -> [];
@@ -517,11 +515,11 @@ is_dry_run(ResourceId) ->
             string:equal(TestIdStart, ResourceId)
     end.
 
--spec make_client_id(resource_id(), kafka_consumer, atom() | binary()) -> atom().
-make_client_id(ResourceId, KafkaType, KafkaName) ->
-    case is_dry_run(ResourceId) of
+-spec make_client_id(resource_id()) -> atom().
+make_client_id(InstanceId) ->
+    case is_dry_run(InstanceId) of
         false ->
-            ClientID0 = emqx_bridge_kafka_impl:make_client_id(KafkaType, KafkaName),
+            ClientID0 = emqx_bridge_kafka_impl:make_client_id(InstanceId),
             binary_to_atom(ClientID0);
         true ->
             %% It is a dry run and we don't want to leak too many

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -65,7 +65,7 @@ on_start(InstId, Config) ->
     ok = emqx_resource:allocate_resource(InstId, ?kafka_resource_id, ResourceId),
     _ = maybe_install_wolff_telemetry_handlers(ResourceId),
     Hosts = emqx_bridge_kafka_impl:hosts(Hosts0),
-    ClientId = emqx_bridge_kafka_impl:make_client_id(BridgeType, BridgeName),
+    ClientId = emqx_bridge_kafka_impl:make_client_id(InstId),
     ok = emqx_resource:allocate_resource(InstId, ?kafka_client_id, ClientId),
     ClientConfig = #{
         min_metadata_refresh_interval => MinMetaRefreshInterval,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -898,8 +898,8 @@ ensure_connected(Config) ->
     ok.
 
 consumer_clientid(Config) ->
-    KafkaName = ?config(kafka_name, Config),
-    binary_to_atom(emqx_bridge_kafka_impl:make_client_id(kafka_consumer, KafkaName)).
+    ResourceId = resource_id(Config),
+    binary_to_atom(emqx_bridge_kafka_impl:make_client_id(ResourceId)).
 
 get_client_connection(Config) ->
     KafkaHost = ?config(kafka_host, Config),


### PR DESCRIPTION
### Targeting release-52

Fixes https://emqx.atlassian.net/browse/EMQX-10860

This patch fixes a ClientId collision between Kafka and Azure bridges when these bridges have the same name.
Running the test case `t_same_name_azure_kafka_bridges` without this patch results in the following error:
```{run_stage_failed,error,
    {assertEqual,
    [{module,emqx_bridge_azure_event_hub_producer_SUITE},
    {line,313},
    {expression,
        "emqx_resource : simple_sync_query ( AehResourceId , Message )"},
    {expected,ok},
    {value,
        {error,
        {resource_error,
        #{msg =>
            #{error => {error,badarg},
            id =>
                <<"bridge:azure_event_hub_producer:t_same_name_azure_kafka_bridges-576460752303423480">>,
            name => call_query,
            request =>
                {send_message,
                #{clientid => <<"-576460752303422269">>,
                payload => <<"000603AC9FE1588DD451000023C20001">>,
                timestamp => -576460752303422269}},
            stacktrace =>
                [{ets,lookup,
                ['kafka_producer_t_same_name_azure_kafka_bridges-576460752303423480',
                1],
                [{error_info,#{cause => id,module => erl_stdlib_errors}}]},
                {wolff_producers,lookup_producer,2,
                [{file,
                    "/emqx/_build/default/lib/wolff/src/wolff_producers.erl"},
                {line,177}]},
                {wolff_producers,do_pick_producer,4,
                [{file,
                    "/emqx/_build/default/lib/wolff/src/wolff_producers.erl"},
                {line,145}]},
                {wolff,send_sync,3,
                [{file,"/emqx/_build/default/lib/wolff/src/wolff.erl"},
                {line,128}]},
                {emqx_bridge_kafka_impl_producer,on_query,3,
                [{file,
                    "/emqx/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl"},
                {line,238}]},
                {emqx_resource_buffer_worker,apply_query_fun,8,
                [{file,
                    "/emqx/apps/emqx_resource/src/emqx_resource_buffer_worker.erl"},
                {line,1097}]},
                {emqx_resource_buffer_worker,simple_sync_query,3,
                [{file,
                    "/emqx/apps/emqx_resource/src/emqx_resource_buffer_worker.erl"},
                {line,153}]}
```


<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 98acf9d</samp>

This pull request simplifies the client ID generation and configuration for the Kafka and Azure Event Hub bridges by using the unique instance ID instead of the bridge type and name. It also adds support and tests for different bridge types in the Azure Event Hub bridge. It modifies the files `emqx_bridge_kafka_impl_consumer.erl`, `emqx_bridge_kafka_impl.erl`, `emqx_bridge_kafka_impl_producer.erl`, `emqx_bridge_kafka_impl_consumer_SUITE.erl`, and `emqx_bridge_azure_event_hub_producer_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
