### PR TITLE
fix: bad error message when rule engine schema name is too long

### DIFF
--- a/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_schema_registry, [
     {description, "EMQX Schema Registry"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, [emqx_schema_registry_sup]},
     {mod, {emqx_schema_registry_app, []}},
     {included_applications, [

--- a/apps/emqx_schema_registry/src/emqx_schema_registry.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.erl
@@ -64,7 +64,7 @@ get_serde(SchemaName) ->
 get_schema(SchemaName) ->
     case
         emqx_config:get(
-            [?CONF_KEY_ROOT, schemas, binary_to_atom(SchemaName)], undefined
+            [?CONF_KEY_ROOT, schemas, schema_name_bin_to_atom(SchemaName)], undefined
         )
     of
         undefined ->
@@ -332,6 +332,20 @@ async_delete_serdes(Names) ->
 
 to_bin(A) when is_atom(A) -> atom_to_binary(A);
 to_bin(B) when is_binary(B) -> B.
+
+schema_name_bin_to_atom(Bin) when size(Bin) > 255 ->
+    erlang:throw(
+        iolist_to_binary(
+            io_lib:format(
+                "Name is is too long."
+                " Please provide a shorter name (<= 255 bytes)."
+                " The name that is too long: \"~s\"",
+                [Bin]
+            )
+        )
+    );
+schema_name_bin_to_atom(Bin) ->
+    binary_to_atom(Bin, utf8).
 
 -spec serde_to_map(serde()) -> serde_map().
 serde_to_map(#serde{} = Serde) ->

--- a/changes/ce/fix-11522.en.md
+++ b/changes/ce/fix-11522.en.md
@@ -1,0 +1,1 @@
+Improved error message for rule engine schema registry when schema name exceeds permissible length.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10778

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c65db82</samp>

Improved schema name validation and bumped up the application version. The changes prevent potential atom exhaustion and reflect the code updates in `emqx_schema_registry`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [  Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible