### PR TITLE
fix: flatten error message on resource validator

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_validator.erl
+++ b/apps/emqx_resource/src/emqx_resource_validator.erl
@@ -28,10 +28,18 @@ max(Type, Max) ->
 min(Type, Min) ->
     limit(Type, '>=', Min).
 
-not_empty(ErrMsg) ->
+not_empty(ErrMsg0) ->
+    ErrMsg =
+        try
+            lists:flatten(ErrMsg0)
+        catch
+            _:_ ->
+                ErrMsg0
+        end,
     fun
         (undefined) -> {error, ErrMsg};
         (<<>>) -> {error, ErrMsg};
+        ("") -> {error, ErrMsg};
         (_) -> ok
     end.
 
@@ -50,7 +58,8 @@ len(string) -> fun string:length/1;
 len(_Type) -> fun(Val) -> Val end.
 
 err_limit({Type, {Op, Expected}, {got, Got}}) ->
-    io_lib:format("Expect the ~ts value ~ts ~p but got: ~p", [Type, Op, Expected, Got]).
+    Msg = io_lib:format("Expect the ~ts value ~ts ~p but got: ~p", [Type, Op, Expected, Got]),
+    lists:flatten(Msg).
 
 return(true, _) -> ok;
 return(false, Error) -> {error, Error}.

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -1121,10 +1121,58 @@ t_create_dry_run_local_failed(_) ->
     ).
 
 t_test_func(_) ->
+    IsErrorMsgPlainString = fun({error, Msg}) -> io_lib:printable_list(Msg) end,
     ?assertEqual(ok, erlang:apply(emqx_resource_validator:not_empty("not_empty"), [<<"someval">>])),
     ?assertEqual(ok, erlang:apply(emqx_resource_validator:min(int, 3), [4])),
     ?assertEqual(ok, erlang:apply(emqx_resource_validator:max(array, 10), [[a, b, c, d]])),
-    ?assertEqual(ok, erlang:apply(emqx_resource_validator:max(string, 10), ["less10"])).
+    ?assertEqual(ok, erlang:apply(emqx_resource_validator:max(string, 10), ["less10"])),
+    ?assertEqual(
+        true, IsErrorMsgPlainString(erlang:apply(emqx_resource_validator:min(int, 66), [42]))
+    ),
+    ?assertEqual(
+        true, IsErrorMsgPlainString(erlang:apply(emqx_resource_validator:max(int, 42), [66]))
+    ),
+    ?assertEqual(
+        true, IsErrorMsgPlainString(erlang:apply(emqx_resource_validator:min(array, 3), [[1, 2]]))
+    ),
+    ?assertEqual(
+        true,
+        IsErrorMsgPlainString(erlang:apply(emqx_resource_validator:max(array, 3), [[1, 2, 3, 4]]))
+    ),
+    ?assertEqual(
+        true, IsErrorMsgPlainString(erlang:apply(emqx_resource_validator:min(string, 3), ["1"]))
+    ),
+    ?assertEqual(
+        true, IsErrorMsgPlainString(erlang:apply(emqx_resource_validator:max(string, 3), ["1234"]))
+    ),
+    NestedMsg = io_lib:format("The answer: ~p", [42]),
+    ExpectedMsg = "The answer: 42",
+    BinMsg = <<"The answer: 42">>,
+    MapMsg = #{question => "The question", answer => 42},
+    ?assertEqual(
+        {error, ExpectedMsg},
+        erlang:apply(emqx_resource_validator:not_empty(NestedMsg), [""])
+    ),
+    ?assertEqual(
+        {error, ExpectedMsg},
+        erlang:apply(emqx_resource_validator:not_empty(NestedMsg), [<<>>])
+    ),
+    ?assertEqual(
+        {error, ExpectedMsg},
+        erlang:apply(emqx_resource_validator:not_empty(NestedMsg), [undefined])
+    ),
+    ?assertEqual(
+        {error, ExpectedMsg},
+        erlang:apply(emqx_resource_validator:not_empty(NestedMsg), [undefined])
+    ),
+    ?assertEqual(
+        {error, BinMsg},
+        erlang:apply(emqx_resource_validator:not_empty(BinMsg), [undefined])
+    ),
+    ?assertEqual(
+        {error, MapMsg},
+        erlang:apply(emqx_resource_validator:not_empty(MapMsg), [""])
+    ).
 
 t_reset_metrics(_) ->
     {ok, _} = emqx_resource:create(


### PR DESCRIPTION
### Targeting release-52

Flatten error message on resource validator.

Before this PR:
![image](https://github.com/emqx/emqx/assets/72890105/933b8365-7118-4f55-9f2e-f39eb48b720b)

After this PR:
![image](https://github.com/emqx/emqx/assets/72890105/1b5d4e56-c27d-4b1d-85d3-927b7eaa0498)



Fixes https://emqx.atlassian.net/browse/EMQX-10864

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 42877e2</samp>

This pull request enhances the validation and testing of resource configurations in `emqx_resource`. It improves the error handling and formatting of the validator functions in `emqx_resource_validator.erl` and adds more test cases to the `emqx_resource_SUITE.erl` test suite.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [na] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
