### PR TITLE
fix(kafka): fix template processing for header

### DIFF
--- a/changes/ee/fix-11527.en.md
+++ b/changes/ee/fix-11527.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with Kafka header handling when placeholders resolve to an array of key-value pairs (e.g.: `[{"key": "foo", "value": "bar"}]`).


### PR DESCRIPTION
### Targeting release-52

Fixes https://emqx.atlassian.net/browse/EMQX-10846

Fixes the header template handling when it translates to an array of key/value elements.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c63bfc9</samp>

This pull request improves the Kafka bridge functionality and testing by enabling more flexible and robust header handling. It allows JSON lists and objects as header values, and updates the `emqx_bridge_kafka_impl_producer` module and its test suite accordingly. It also fixes some inconsistencies and errors in the header templates and their usage.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
