### PR TITLE
fix: authz clean-cache clientid always return not_found

### DIFF
--- a/apps/emqx_ctl/src/emqx_ctl.app.src
+++ b/apps/emqx_ctl/src/emqx_ctl.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ctl, [
     {description, "Backend for emqx_ctl script"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {mod, {emqx_ctl_app, []}},
     {applications, [

--- a/apps/emqx_ctl/src/emqx_ctl.erl
+++ b/apps/emqx_ctl/src/emqx_ctl.erl
@@ -119,8 +119,7 @@ run_command(Cmd, Args) when is_atom(Cmd) ->
     case lookup_command(Cmd) of
         [{Mod, Fun}] ->
             try
-                _ = apply(Mod, Fun, [Args]),
-                ok
+                apply(Mod, Fun, [Args])
             catch
                 _:Reason:Stacktrace ->
                     ?LOG_ERROR(#{

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -707,7 +707,7 @@ authz(["cache-clean", "all"]) ->
     with_log(fun emqx_mgmt:clean_authz_cache_all/0, Msg);
 authz(["cache-clean", ClientId]) ->
     Msg = io_lib:format("Drain ~ts authz cache", [ClientId]),
-    with_log(fun() -> emqx_mgmt:clean_authz_cache(list_to_binary(ClientId)) end, Msg);
+    with_log(fun() -> emqx_mgmt:clean_authz_cache(iolist_to_binary(ClientId)) end, Msg);
 authz(_) ->
     emqx_ctl:usage(
         [

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -707,7 +707,7 @@ authz(["cache-clean", "all"]) ->
     with_log(fun emqx_mgmt:clean_authz_cache_all/0, Msg);
 authz(["cache-clean", ClientId]) ->
     Msg = io_lib:format("Drain ~ts authz cache", [ClientId]),
-    with_log(fun() -> emqx_mgmt:clean_authz_cache(ClientId) end, Msg);
+    with_log(fun() -> emqx_mgmt:clean_authz_cache(list_to_binary(ClientId)) end, Msg);
 authz(_) ->
     emqx_ctl:usage(
         [
@@ -921,12 +921,14 @@ for_node(Fun, Node) ->
     end.
 
 with_log(Fun, Msg) ->
-    case Fun() of
+    Res = Fun(),
+    case Res of
         ok ->
             emqx_ctl:print("~s OK~n", [Msg]);
         {error, Reason} ->
             emqx_ctl:print("~s FAILED~n~p~n", [Msg, Reason])
-    end.
+    end,
+    Res.
 
 cluster_info() ->
     RunningNodes = safe_call_mria(running_nodes, [], []),

--- a/changes/ce/fix-11531.en.md
+++ b/changes/ce/fix-11531.en.md
@@ -1,0 +1,1 @@
+Fixed issue where authorization cache cleaning cli was not working properly for specific client ID.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10872
Fixed issue where authorization cache cleaning was not working properly for specific client ID.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3088efd</samp>

This pull request enhances the emqx_ctl and emqx_mgmt_cli modules with bug fixes, improved error handling, and new test cases. It also updates the version number of the emqx_ctl application and removes some redundant code.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
