### PR TITLE
fix(frame): improve some error reasons when parsing invalid packet

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -473,7 +473,7 @@ parse_packet(
     {Properties, <<>>} = parse_properties(Rest, ?MQTT_PROTO_V5, StrictMode),
     #mqtt_packet_auth{reason_code = ReasonCode, properties = Properties};
 parse_packet(Header, _FrameBin, _Options) ->
-    ?PARSE_ERR(#{hit => malformed_packet, header_type => Header#mqtt_packet_header.type}).
+    ?PARSE_ERR(#{hint => malformed_packet, header_type => Header#mqtt_packet_header.type}).
 
 parse_will_message(
     Packet = #mqtt_packet_connect{

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -546,7 +546,7 @@ t_parse_incoming_frame_error(_) ->
             {incoming,
                 {frame_error, #{
                     header_type := _,
-                    hit := malformed_packet
+                    hint := malformed_packet
                 }}}
         ],
         Packets

--- a/apps/emqx/test/emqx_ws_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_ws_connection_SUITE.erl
@@ -540,8 +540,17 @@ t_parse_incoming_order(_) ->
 
 t_parse_incoming_frame_error(_) ->
     {Packets, _St} = ?ws_conn:parse_incoming(<<3, 2, 1, 0>>, [], st()),
-    FrameError = {frame_error, malformed_packet},
-    [{incoming, FrameError}] = Packets.
+
+    ?assertMatch(
+        [
+            {incoming,
+                {frame_error, #{
+                    header_type := _,
+                    hit := malformed_packet
+                }}}
+        ],
+        Packets
+    ).
 
 t_handle_incomming_frame_error(_) ->
     FrameError = {frame_error, bad_qos},

--- a/changes/ce/perf-11532.en.md
+++ b/changes/ce/perf-11532.en.md
@@ -1,1 +1,1 @@
-Improve some error reasons for parsing with invalid packets.
+Improve some error reasons when parsing invalid packets.

--- a/changes/ce/perf-11532.en.md
+++ b/changes/ce/perf-11532.en.md
@@ -1,0 +1,1 @@
+Improve some error reasons for parsing with invalid packets.


### PR DESCRIPTION
Fixes [EMQX-10528](https://emqx.atlassian.net/browse/EMQX-10528)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 333528d</samp>

Improve error handling of malformed MQTT packets in `emqx_frame.erl`. Add more details to error messages and prevent badmatch exceptions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
