### PR TITLE
chore: ciphers should allow empty space(comma_separated_binary)

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1216,9 +1216,9 @@ inc_counter(Key, Inc) ->
 set_tcp_keepalive({quic, _Listener}) ->
     ok;
 set_tcp_keepalive({Type, Id}) ->
-    Conf = emqx_config:get_listener_conf(Type, Id, [tcp_options, keepalive], <<"none">>),
-    case iolist_to_binary(Conf) of
-        <<"none">> ->
+    Conf = emqx_config:get_listener_conf(Type, Id, [tcp_options, keepalive], "none"),
+    case Conf of
+        "none" ->
             ok;
         Value ->
             %% the value is already validated by schema, so we do not validate it again.

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2331,7 +2331,8 @@ converter_ciphers(<<>>, _Opts) ->
     [];
 converter_ciphers(Ciphers, _Opts) when is_list(Ciphers) -> Ciphers;
 converter_ciphers(Ciphers, _Opts) when is_binary(Ciphers) ->
-    binary:split(Ciphers, <<",">>, [global]).
+    {ok, List} = to_comma_separated_binary(binary_to_list(Ciphers)),
+    List.
 
 default_ciphers(Which) ->
     lists:map(
@@ -2649,7 +2650,7 @@ validate_tcp_keepalive(Value) ->
 %% @doc This function is used as value validator and also run-time parser.
 parse_tcp_keepalive(Str) ->
     try
-        [Idle, Interval, Probes] = binary:split(iolist_to_binary(Str), <<",">>, [global]),
+        {ok, [Idle, Interval, Probes]} = to_comma_separated_binary(Str),
         %% use 10 times the Linux defaults as range limit
         IdleInt = parse_ka_int(Idle, "Idle", 1, 7200_0),
         IntervalInt = parse_ka_int(Interval, "Interval", 1, 75_0),


### PR DESCRIPTION
It's part of https://github.com/emqx/emqx/pull/11466/
don't need changelog.
Now we support: 
```
ciphers = "x,y,z" 
ciphers = " x, y, z " 
```
Ignore the empty space.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4b5553</samp>

This pull request fixes some bugs and adds some tests related to the configuration of listeners in EMQX. It introduces a new function `to_comma_separated_binary` to handle comma-separated lists of ciphers and TCP keepalive options. It also enhances the test suite `emqx_listeners_update_SUITE.erl` to cover the dynamic and validation aspects of these options.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
