### PR TITLE
fix(bridge): validate bridge name before attempting to convert certificates

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -609,6 +609,8 @@ create_or_update_bridge(BridgeType, BridgeName, Conf, HttpStatusCode) ->
     case emqx_bridge:create(BridgeType, BridgeName, Conf) of
         {ok, _} ->
             lookup_from_all_nodes(BridgeType, BridgeName, HttpStatusCode);
+        {error, {pre_config_update, _HandlerMod, Reason}} when is_map(Reason) ->
+            ?BAD_REQUEST(map_to_json(redact(Reason)));
         {error, Reason} when is_map(Reason) ->
             ?BAD_REQUEST(map_to_json(redact(Reason)))
     end.

--- a/changes/ce/fix-11540.en.md
+++ b/changes/ce/fix-11540.en.md
@@ -1,0 +1,1 @@
+Improved HTTP response when attempting to create a bridge with an invalid name.


### PR DESCRIPTION
# targeting `release-52`

Fixes https://emqx.atlassian.net/browse/EMQX-10865

Example error:

```
2023-08-29T07:09:40.982986+00:00 [error] msg: change_config_crashed, mfa: emqx_config_handler:handle_update_request/4, line: 220, exception: error, key_path: [bridges,azure_event_hub_producer,'哈哈'], module: emqx_enterprise_schema, reason: badarg, stacktrace: [{erlang,iolist_to_binary,[[[98,114,105,100,103,101,115,47,97,122,117,114,101,95,101,118,101,110,116,95,104,117,98,95,112,114,111,100,117,99,101,114,47,21704,21704],<<"key">>,<<"-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAzLiGiSwpxkENtjrzS7pNLblTnWe4HUUFwYyUX0H+3TnvA86X\nEX85yZvFjkzB6lLjUkMY+C6UTVXt+mxeSJbUtSKZhX+2yoF/KYh7SaVjug5FqEqO\nLvMpDZQEhUWF2W9DG6eUgOfDoX2milSDIe10yG2WBkryipHAfE7l1t+i6Rh3on+v\n561LmrbqyBWR/cLp23RN3sHbkf2pb5/ugtU9twdgJr6Lve73rvSeulewL5BzszKD\nBrYqr+PBT5+3ItCc55bTsO7M7CzOIL99BlqdvFH7xT0U1+2BFwLe4/8kwphSqyJE\nC5oOiQB"...>>]],[{error_info,#{module => erl_erts_errors}}]},{crypto,hash,2,[{file,"crypto.erl"},{line,639}]},{emqx_tls_lib,pem_file_name,3,[{file,"emqx_tls_lib.erl"},{line,430}]},{emqx_tls_lib,save_pem_file,4,[{file,"emqx_tls_lib.erl"},{line,401}]},{emqx_tls_lib,do_ensure_ssl_file,5,[{file,"emqx_tls_lib.erl"},{line,354}]},{emqx_tls_lib,ensure_ssl_files_per_key,4,[{file,"emqx_tls_lib.erl"},{line,325}]},{emqx_connector_ssl,new_ssl_config,3,[{file,"emqx_connector_ssl.erl"},{line,34}]},{emqx_bridge_app,pre_config_update,3,[{file,"emqx_bridge_app.erl"},{line,65}]},{emqx_config_handler,call_proper_pre_config_update,1,[{file,"emqx_config_handler.erl"},{line,436}]},{emqx_config_handler,call_pre_config_update,1,[{file,"emqx_config_handler.erl"},{line,410}]},{emqx_config_handler,do_update_config,5,[{file,"emqx_config_handler.erl"},{line,281}]},{emqx_config_handler,process_update_request,3,[{file,"emqx_config_handler.erl"},{line,250}]},{emqx_config_handler,do_handle_update_request,4,[{file,"emqx_config_handler.erl"},{line,225}]},{emqx_config_handler,handle_update_request,4,[{file,"emqx_config_handler.erl"},{line,207}]},{emqx_config_handler,handle_call,3,[{file,"emqx_config_handler.erl"},{line,136}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,1149}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1178}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}], update_req: {{update,#{<<"authentication">> => #{<<"password">> => <<"ee">>},<<"bootstrap_hosts">> => <<"127.0.0.1">>,<<"connect_timeout">> => <<"5s">>,<<"enable">> => true,<<"kafka">> => #{<<"buffer">> => #{<<"memory_overload_protection">> => false,<<"mode">> => <<"memory">>,<<"per_partition_limit">> => <<"2GB">>,<<"segment_bytes">> => <<"100MB">>},<<"kafka_ext_headers">> => [],<<"kafka_header_value_encode_mode">> => <<"none">>,<<"max_batch_bytes">> => <<"896KB">>,<<"max_inflight">> => 10,<<"message">> => #{<<"key">> => <<"${.clientid}">>,<<"value">> => <<"${.}">>},<<"partition_count_refresh_interval">> => <<"60s">>,<<"partition_strategy">> => <<"random">>,<<"query_mode">> => <<"async">>,<<"required_acks">> => <<"all_isr">>,<<"sync_query_timeout">> => <<"5s">>,<<"topic">> => <<"a">>},<<"metadata_request_timeout">> => <<"5s">>,<<"min_metadata_refresh_interval">> => <<"3s">>,<<"resource_opts">> => #{<<"health_check_interval">> => <<"15s">>},<<"socket_opts">> => #{<<"recbuf">> => <<"1MB">>,<<"sndbuf">> => <<"1MB">>,<<"tcp_keepalive">> => <<"none">>},<<"ssl">> => #{<<"cacertfile">> => <<"-----BEGIN CERTIFICATE-----\nMIIDUTCCAjmgAwIBAgIJAPPYCjTmxdt/MA0GCSqGSIb3DQEBCwUAMD8xCzAJBgNV\nBAYTAkNOMREwDwYDVQQIDAhoYW5nemhvdTEMMAoGA1UECgwDRU1RMQ8wDQYDVQQD\nDAZSb290Q0EwHhcNMjAwNTA4MDgwNjUyWhcNMzAwNTA2MDgwNjUyWjA/MQswCQYD\nVQQGEwJDTjERMA8GA1UECAwIaGFuZ3pob3UxDDAKBgNVBAoMA0VNUTEPMA0GA1UE\nAwwGUm9vdENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzcgVLex1\nEZ9ON64EX8v+wcSjzOZpiEO"...>>,<<"certfile">> => <<"-----BEGIN CERTIFICATE-----\nMIIDEzCCAfugAwIBAgIBATANBgkqhkiG9w0BAQsFADA/MQswCQYDVQQGEwJDTjER\nMA8GA1UECAwIaGFuZ3pob3UxDDAKBgNVBAoMA0VNUTEPMA0GA1UEAwwGUm9vdENB\nMB4XDTIwMDUwODA4MDY1N1oXDTMwMDUwNjA4MDY1N1owPzELMAkGA1UEBhMCQ04x\nETAPBgNVBAgMCGhhbmd6aG91MQwwCgYDVQQKDANFTVExDzANBgNVBAMMBkNsaWVu\ndDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMy4hoksKcZBDbY680u6\nTS25U51nuB1FBcGMlF9B/t0"...>>,<<"enable">> => true,<<"keyfile">> => <<"-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEAzLiGiSwpxkENtjrzS7pNLblTnWe4HUUFwYyUX0H+3TnvA86X\nEX85yZvFjkzB6lLjUkMY+C6UTVXt+mxeSJbUtSKZhX+2yoF/KYh7SaVjug5FqEqO\nLvMpDZQEhUWF2W9DG6eUgOfDoX2milSDIe10yG2WBkryipHAfE7l1t+i6Rh3on+v\n561LmrbqyBWR/cLp23RN3sHbkf2pb5/ugtU9twdgJr6Lve73rvSeulewL5BzszKD\nBrYqr+PBT5+3ItCc55bTsO7M7CzOIL99BlqdvFH7xT0U1+2BFwLe4/8kwphSqyJE\nC5oOiQBFnFVNXmFQSV+"...>>,<<"verify">> => <<"verify_none">>}}},#{override_to => cluster}}
```


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dbbed50</samp>

This pull request improves the validation of bridge names in the `emqx_bridge` application. It adds a new function and a regular expression macro to check the bridge names in the configuration files and the HTTP API. It also updates the test suites to cover the new validation logic and the HTTP response.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
