### PR TITLE
Support asynchronous mode of receiving responses to FT operations

### DIFF
--- a/apps/emqx_ft/src/emqx_ft_error.erl
+++ b/apps/emqx_ft/src/emqx_ft_error.erl
@@ -1,0 +1,39 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% @doc File Transfer error description module
+
+-module(emqx_ft_error).
+
+-export([format/1]).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+format(ok) -> <<"success">>;
+format({error, Reason}) -> format_error_reson(Reason).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+format_error_reson(Reason) when is_atom(Reason) ->
+    atom_to_binary(Reason, utf8);
+format_error_reson({ErrorKind, _}) when is_atom(ErrorKind) ->
+    atom_to_binary(ErrorKind, utf8);
+format_error_reson(_Reason) ->
+    <<"internal_error">>.

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter.erl
@@ -195,7 +195,7 @@ verify_checksum(Ctx, {Algo, Digest} = Checksum) ->
         Digest ->
             {ok, Checksum};
         Mismatch ->
-            {error, {checksum, Algo, binary:encode_hex(Mismatch)}}
+            {error, {checksum_mismatch, Algo, binary:encode_hex(Mismatch)}}
     end;
 verify_checksum(Ctx, undefined) ->
     Digest = crypto:hash_final(Ctx),

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -145,7 +145,7 @@ store_filemeta(Storage, Transfer, Meta) ->
             % We won't see conflicts in case of concurrent `store_filemeta`
             % requests. It's rather odd scenario so it's fine not to worry
             % about it too much now.
-            {error, conflict};
+            {error, filemeta_conflict};
         {error, Reason} when Reason =:= notfound; Reason =:= corrupted; Reason =:= enoent ->
             write_file_atomic(Storage, Transfer, Filepath, encode_filemeta(Meta));
         {error, _} = Error ->

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -85,7 +85,7 @@ t_list_files(Config) ->
     FileId = <<"f1">>,
 
     Node = lists:last(test_nodes(Config)),
-    ok = emqx_ft_test_helpers:upload_file(ClientId, FileId, "f1", <<"data">>, Node),
+    ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, "f1", <<"data">>, Node),
 
     {ok, 200, #{<<"files">> := Files}} =
         request_json(get, uri(["file_transfer", "files"]), Config),
@@ -114,7 +114,7 @@ t_download_transfer(Config) ->
 
     Nodes = [Node | _] = test_nodes(Config),
     NodeUpload = lists:last(Nodes),
-    ok = emqx_ft_test_helpers:upload_file(ClientId, FileId, "f1", <<"data">>, NodeUpload),
+    ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, "f1", <<"data">>, NodeUpload),
 
     ?assertMatch(
         {ok, 400, #{<<"code">> := <<"BAD_REQUEST">>}},
@@ -185,7 +185,7 @@ t_list_files_paging(Config) ->
     ],
     ok = lists:foreach(
         fun({FileId, Name, Node}) ->
-            ok = emqx_ft_test_helpers:upload_file(ClientId, FileId, Name, <<"data">>, Node)
+            ok = emqx_ft_test_helpers:upload_file(sync, ClientId, FileId, Name, <<"data">>, Node)
         end,
         Uploads
     ),

--- a/apps/emqx_ft/test/emqx_ft_async_reply_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_async_reply_SUITE.erl
@@ -55,7 +55,7 @@ t_register(_Config) ->
     PacketId = 1,
     MRef = make_ref(),
     TRef = make_ref(),
-    ok = emqx_ft_async_reply:register(PacketId, MRef, TRef),
+    ok = emqx_ft_async_reply:register(PacketId, MRef, TRef, somedata),
 
     ?assertEqual(
         undefined,
@@ -68,7 +68,7 @@ t_register(_Config) ->
     ),
 
     ?assertEqual(
-        {ok, PacketId, TRef},
+        {ok, PacketId, TRef, somedata},
         emqx_ft_async_reply:take_by_mref(MRef)
     ).
 
@@ -76,7 +76,7 @@ t_process_independence(_Config) ->
     PacketId = 1,
     MRef = make_ref(),
     TRef = make_ref(),
-    ok = emqx_ft_async_reply:register(PacketId, MRef, TRef),
+    ok = emqx_ft_async_reply:register(PacketId, MRef, TRef, somedata),
 
     Self = self(),
 
@@ -112,10 +112,10 @@ t_take(_Config) ->
     PacketId = 1,
     MRef = make_ref(),
     TRef = make_ref(),
-    ok = emqx_ft_async_reply:register(PacketId, MRef, TRef),
+    ok = emqx_ft_async_reply:register(PacketId, MRef, TRef, somedata),
 
     ?assertEqual(
-        {ok, PacketId, TRef},
+        {ok, PacketId, TRef, somedata},
         emqx_ft_async_reply:take_by_mref(MRef)
     ),
 
@@ -135,12 +135,12 @@ t_cleanup(_Config) ->
     TRef0 = make_ref(),
     MRef1 = make_ref(),
     TRef1 = make_ref(),
-    ok = emqx_ft_async_reply:register(PacketId, MRef0, TRef0),
+    ok = emqx_ft_async_reply:register(PacketId, MRef0, TRef0, somedata0),
 
     Self = self(),
 
     Pid = spawn_link(fun() ->
-        ok = emqx_ft_async_reply:register(PacketId, MRef1, TRef1),
+        ok = emqx_ft_async_reply:register(PacketId, MRef1, TRef1, somedata1),
         receive
             kickoff ->
                 ?assertEqual(
@@ -149,7 +149,7 @@ t_cleanup(_Config) ->
                 ),
 
                 ?assertEqual(
-                    {ok, PacketId, TRef1},
+                    {ok, PacketId, TRef1, somedata1},
                     emqx_ft_async_reply:take_by_mref(MRef1)
                 ),
 

--- a/apps/emqx_ft/test/emqx_ft_conf_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_conf_SUITE.erl
@@ -39,10 +39,10 @@ init_per_testcase(Case, Config) ->
         ],
         #{work_dir => emqx_cth_suite:work_dir(Case, Config)}
     ),
-    [{suite_apps, Apps} | Config].
+    [{apps, Apps} | Config].
 
 end_per_testcase(_Case, Config) ->
-    ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
+    ok = emqx_cth_suite:stop(?config(apps, Config)),
     ok.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_ft/test/emqx_ft_request_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_request_SUITE.erl
@@ -1,0 +1,113 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_ft_request_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("common_test/include/ct.hrl").
+-include_lib("stdlib/include/assert.hrl").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx_ft, "file_transfer { enable = true, assemble_timeout = 1s}"}
+        ],
+        #{work_dir => ?config(priv_dir, Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    ok.
+
+%%-------------------------------------------------------------------
+%% Tests
+%%-------------------------------------------------------------------
+
+t_upload_via_requests(_Config) ->
+    C = emqx_ft_test_helpers:start_client(<<"client">>),
+
+    FileId = <<"f1">>,
+    Data = <<"hello world">>,
+    Size = byte_size(Data),
+    Meta = #{
+        name => "test.txt",
+        expire_at => erlang:system_time(_Unit = second) + 3600,
+        size => Size
+    },
+    MetaPayload = emqx_utils_json:encode(emqx_ft:encode_filemeta(Meta)),
+    MetaTopic = <<"$file/", FileId/binary, "/init">>,
+
+    ?assertMatch(
+        {ok, #{<<"reason_code">> := 0, <<"topic">> := MetaTopic}},
+        request(C, MetaTopic, MetaPayload)
+    ),
+
+    SegmentTopic = <<"$file/", FileId/binary, "/0">>,
+
+    ?assertMatch(
+        {ok, #{<<"reason_code">> := 0, <<"topic">> := SegmentTopic}},
+        request(C, SegmentTopic, Data)
+    ),
+
+    FinTopic = <<"$file/", FileId/binary, "/fin/", (integer_to_binary(Size))/binary>>,
+
+    ?assertMatch(
+        {ok, #{<<"reason_code">> := 0, <<"topic">> := FinTopic}},
+        request(C, FinTopic, <<>>)
+    ).
+
+%%--------------------------------------------------------------------
+%% Helper functions
+%%--------------------------------------------------------------------
+
+request(C, Topic, Request) ->
+    CorrelaionData = emqx_ft_test_helpers:unique_binary_string(),
+    ResponseTopic = emqx_ft_test_helpers:unique_binary_string(),
+
+    Properties = #{
+        'Correlation-Data' => CorrelaionData,
+        'Response-Topic' => ResponseTopic
+    },
+    Opts = [{qos, 1}],
+
+    {ok, _, _} = emqtt:subscribe(C, ResponseTopic, 1),
+    {ok, _} = emqtt:publish(C, Topic, Properties, Request, Opts),
+
+    try
+        receive
+            {publish, #{
+                topic := ResponseTopic,
+                payload := Payload,
+                properties := #{'Correlation-Data' := CorrelaionData}
+            }} ->
+                {ok, emqx_utils_json:decode(Payload)}
+        after 1000 ->
+            {error, timeout}
+        end
+    after
+        emqtt:unsubscribe(C, ResponseTopic)
+    end.

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_SUITE.erl
@@ -81,8 +81,8 @@ end_per_group(_Group, _Config) ->
 
 t_multinode_exports(Config) ->
     [Node1, Node2 | _] = ?config(cluster, Config),
-    ok = emqx_ft_test_helpers:upload_file(<<"c/1">>, <<"f:1">>, "fn1", <<"data">>, Node1),
-    ok = emqx_ft_test_helpers:upload_file(<<"c/2">>, <<"f:2">>, "fn2", <<"data">>, Node2),
+    ok = emqx_ft_test_helpers:upload_file(sync, <<"c/1">>, <<"f:1">>, "fn1", <<"data">>, Node1),
+    ok = emqx_ft_test_helpers:upload_file(sync, <<"c/2">>, <<"f:2">>, "fn2", <<"data">>, Node2),
     ?assertMatch(
         [
             #{transfer := {<<"c/1">>, <<"f:1">>}, name := "fn1"},

--- a/apps/emqx_ft/test/emqx_ft_storage_fs_reader_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_fs_reader_SUITE.erl
@@ -25,11 +25,18 @@
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    ok = emqx_common_test_helpers:start_apps([emqx_ft], emqx_ft_test_helpers:env_handler(Config)),
-    Config.
+    WorkDir = ?config(priv_dir, Config),
+    Storage = emqx_ft_test_helpers:local_storage(Config),
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx_ft, #{config => emqx_ft_test_helpers:config(Storage)}}
+        ],
+        #{work_dir => WorkDir}
+    ),
+    [{suite_apps, Apps} | Config].
 
-end_per_suite(_Config) ->
-    ok = emqx_common_test_helpers:stop_apps([emqx_ft]),
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
     ok.
 
 init_per_testcase(_Case, Config) ->

--- a/changes/ee/feat-11541.en.md
+++ b/changes/ee/feat-11541.en.md
@@ -1,0 +1,3 @@
+Introduced additional way of file transfer interactions. Now client may send file transfer commands to `$file-async/...` topic instead of `$file/...` and receive command execution results as messages to `$file-response/{clientId}` topic.
+This simplifies file transfer feature usage in certain cases, for example, when a client uses MQTTv3 or when the broker is behind an MQTT bridge.
+See the [EIP-0021](https://github.com/emqx/eip) for more details.


### PR DESCRIPTION
Fixes [EEC-907](https://emqx.atlassian.net/browse/EEC-907)
EIP: https://github.com/emqx/eip/pull/80

* We add an option to send FT commands to `$file-async/...` topics. Then, success RC is returned on all kicked-off async operations (currently, only fin).
* We duplicate _final_ RC statuses to `$file-response/{ClientId}` topic in the form
```json
{
  "vsn": "0.1",
  "topic": "$file/[COMMAND]",
  "packet_id": 1,
  "reason_code": 0,
  "reason_description": "success"
}
```
* We also support [MQTT v5 request-response pattern](https://www.emqx.com/en/blog/mqtt5-request-response), that is, overriding topic for statuses with `Response-Topic` prop and sending `Correlation-Data` prop back.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 14bfa13</samp>

This pull request implements and tests a new feature for file transfer in the emqx_ft module, using a response topic and the emqx_ft_async_reply module to handle asynchronous replies from the storage workers. It also refactors the emqx_channel and emqx_cm modules to use macros and hooks, and fixes some syntax and naming issues. It adds, modifies, or deletes several files in the apps/emqx_ft and apps/emqx directories.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created a follow-up jira ticket for docs [EMQX-10888](https://emqx.atlassian.net/browse/EMQX-10888), [EMQX-10889](https://emqx.atlassian.net/browse/EMQX-10889)
- [x] Schema changes are backward compatible

