### PR TITLE
fix: update gpb library to fix type error

### DIFF
--- a/apps/emqx_schema_registry/rebar.config
+++ b/apps/emqx_schema_registry/rebar.config
@@ -6,7 +6,7 @@
   {emqx_utils, {path, "../emqx_utils"}},
   {emqx_rule_engine, {path, "../emqx_rule_engine"}},
   {erlavro, {git, "https://github.com/klarna/erlavro.git", {tag, "2.9.8"}}},
-  {gpb, "4.19.7"}
+  {gpb, "4.19.9"}
 ]}.
 
 {shell, [

--- a/changes/ee/fix-11542.en.md
+++ b/changes/ee/fix-11542.en.md
@@ -1,0 +1,1 @@
+Enhanced Google ProtoBuf schema registry support: Now, when assigning a float to an integer using the rule engine functions `schema_encode` or `sparkplug_encode`, a `gpb_type_error` will be raised instead of the previous `badarith` error.

--- a/mix.exs
+++ b/mix.exs
@@ -93,7 +93,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by cowboy_swagger and cowboy
       {:ranch, github: "emqx/ranch", tag: "1.8.1-emqx", override: true},
       # in conflict by grpc and eetcd
-      {:gpb, "4.19.7", override: true, runtime: false},
+      {:gpb, "4.19.9", override: true, runtime: false},
       {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true},
       # set by hackney (dependency)
       {:ssl_verify_fun, "1.1.6", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
     [ {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.2"}}}
     , {redbug, "2.0.8"}
     , {covertool, {git, "https://github.com/zmstone/covertool", {tag, "2.0.4.1"}}}
-    , {gpb, "4.19.7"}
+    , {gpb, "4.19.9"}
     , {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}}
     , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.9"}}}
     , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.11"}}}


### PR DESCRIPTION
This fixes a bug in the protobuf schema registry functionality. Before this fix one would get a badarith error if one tried to assign a float value to an uint64 field. However, this commit fixes this by upgrading gpb so we instead will get a gpb_type_error which is what we want.

Fixes:
https://emqx.atlassian.net/browse/EMQX-10775

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 36d44ca</samp>

Updated `gpb` dependency to fix a bug with float encoding and decoding in Google ProtoBuf schemas. Added a test case and a changelog entry for the bug fix.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible