### PR TITLE
fix: increment matched counter when bridge is unhealthy

### DIFF
--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -281,9 +281,11 @@ query(ResId, Request, Opts) ->
         {ok, _Group, #{query_mode := QM, error := Error}} ->
             case {QM, Error} of
                 {_, unhealthy_target} ->
+                    emqx_resource_metrics:matched_inc(ResId),
                     emqx_resource_metrics:dropped_resource_stopped_inc(ResId),
                     ?RESOURCE_ERROR(unhealthy_target, "unhealthy target");
                 {_, {unhealthy_target, _Message}} ->
+                    emqx_resource_metrics:matched_inc(ResId),
                     emqx_resource_metrics:dropped_resource_stopped_inc(ResId),
                     ?RESOURCE_ERROR(unhealthy_target, "unhealthy target");
                 {simple_async, _} ->


### PR DESCRIPTION
### Targeting release-52
Fixes https://emqx.atlassian.net/browse/EMQX-10767

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dfcede8</samp>

This pull request fixes a bug in the `emqx_resource` module that caused the `matched` metric to be undercounted when the resource bridge was unhealthy. It also adds a test case to check the error handling of the `emqx_resource:query/2` function.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
