### PR TITLE
fix(kafka): avoid producer name collision between Kafka and AEH bridges

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -175,14 +175,15 @@ create(BridgeId, Conf) ->
 create(Type, Name, Conf) ->
     create(Type, Name, Conf, #{}).
 
-create(Type, Name, Conf, Opts) ->
+create(Type, Name, Conf0, Opts) ->
     ?SLOG(info, #{
         msg => "create bridge",
         type => Type,
         name => Name,
-        config => emqx_utils:redact(Conf)
+        config => emqx_utils:redact(Conf0)
     }),
     TypeBin = bin(Type),
+    Conf = Conf0#{bridge_type => TypeBin, bridge_name => Name},
     {ok, _Data} = emqx_resource:create_local(
         resource_id(Type, Name),
         <<"emqx_bridge">>,
@@ -249,8 +250,9 @@ recreate(Type, Name) ->
 recreate(Type, Name, Conf) ->
     recreate(Type, Name, Conf, #{}).
 
-recreate(Type, Name, Conf, Opts) ->
+recreate(Type, Name, Conf0, Opts) ->
     TypeBin = bin(Type),
+    Conf = Conf0#{bridge_type => TypeBin, bridge_name => Name},
     emqx_resource:recreate_local(
         resource_id(Type, Name),
         bridge_to_resource_type(Type),
@@ -267,17 +269,18 @@ create_dry_run(Type, Conf0) ->
     Conf1 = maps:without([<<"name">>], Conf0),
     RawConf = #{<<"bridges">> => #{TypeBin => #{<<"temp_name">> => Conf1}}},
     try
-        #{bridges := #{TypeAtom := #{temp_name := Conf}}} =
+        #{bridges := #{TypeAtom := #{temp_name := Conf2}}} =
             hocon_tconf:check_plain(
                 emqx_bridge_schema,
                 RawConf,
                 #{atom_key => true, required => false}
             ),
+        Conf = Conf2#{bridge_type => TypeBin, bridge_name => TmpName},
         case emqx_connector_ssl:convert_certs(TmpPath, Conf) of
             {error, Reason} ->
                 {error, Reason};
             {ok, ConfNew} ->
-                ParseConf = parse_confs(bin(Type), TmpName, ConfNew),
+                ParseConf = parse_confs(TypeBin, TmpName, ConfNew),
                 emqx_resource:create_dry_run_local(bridge_to_resource_type(Type), ParseConf)
         end
     catch
@@ -387,15 +390,7 @@ parse_confs(Type, Name, Conf) when ?IS_INGRESS_BRIDGE(Type) ->
     %% receives a message from the external database.
     BId = bridge_id(Type, Name),
     BridgeHookpoint = bridge_hookpoint(BId),
-    Conf#{hookpoint => BridgeHookpoint, bridge_name => Name};
-%% TODO: rename this to `kafka_producer' after alias support is added
-%% to hocon; keeping this as just `kafka' for backwards compatibility.
-parse_confs(<<"kafka">> = _Type, Name, Conf) ->
-    Conf#{bridge_name => Name};
-parse_confs(<<"pulsar_producer">> = _Type, Name, Conf) ->
-    Conf#{bridge_name => Name};
-parse_confs(<<"kinesis_producer">> = _Type, Name, Conf) ->
-    Conf#{bridge_name => Name};
+    Conf#{hookpoint => BridgeHookpoint};
 parse_confs(BridgeType, BridgeName, Config) ->
     connector_config(BridgeType, BridgeName, Config).
 

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -166,14 +166,14 @@ values(producer) ->
 %% `emqx_bridge_resource' API
 %%-------------------------------------------------------------------------------------------------
 
-connector_config(Config, BridgeName) ->
+connector_config(Config, _BridgeName) ->
     %% Default port for AEH is 9093
     BootstrapHosts0 = maps:get(bootstrap_hosts, Config),
     BootstrapHosts = emqx_schema:parse_servers(
         BootstrapHosts0,
         emqx_bridge_azure_event_hub:host_opts()
     ),
-    Config#{bridge_name => BridgeName, bootstrap_hosts := BootstrapHosts}.
+    Config#{bootstrap_hosts := BootstrapHosts}.
 
 %%-------------------------------------------------------------------------------------------------
 %% Internal fns

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_producer_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_producer_SUITE.erl
@@ -282,6 +282,7 @@ t_same_name_azure_kafka_bridges(AehConfig) ->
     ConfigKafka = lists:keyreplace(bridge_type, 1, AehConfig, {bridge_type, ?KAFKA_BRIDGE_TYPE}),
     BridgeName = ?config(bridge_name, AehConfig),
     AehResourceId = emqx_bridge_testlib:resource_id(AehConfig),
+    KafkaResourceId = emqx_bridge_testlib:resource_id(ConfigKafka),
     TracePoint = emqx_bridge_kafka_impl_producer_sync_query,
     %% creates the AEH bridge and check it's working
     ok = emqx_bridge_testlib:t_sync_query(
@@ -292,6 +293,9 @@ t_same_name_azure_kafka_bridges(AehConfig) ->
     ),
     %% than creates a Kafka bridge with same name and delete it after creation
     ok = emqx_bridge_testlib:t_create_via_http(ConfigKafka),
+    %% check that both bridges are healthy
+    ?assertEqual({ok, connected}, emqx_resource_manager:health_check(AehResourceId)),
+    ?assertEqual({ok, connected}, emqx_resource_manager:health_check(KafkaResourceId)),
     ?assertMatch(
         {{ok, _}, {ok, _}},
         ?wait_async_action(

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
@@ -7,7 +7,7 @@
 
 -export([
     hosts/1,
-    make_client_id/1,
+    make_client_id/2,
     sasl/1,
     socket_opts/1
 ]).
@@ -24,11 +24,10 @@ hosts(Hosts) when is_list(Hosts) ->
     kpro:parse_endpoints(Hosts).
 
 %% Client ID is better to be unique to make it easier for Kafka side trouble shooting.
-make_client_id(InstanceId) ->
-    InstanceIdBin0 = to_bin(InstanceId),
-    % Removing the <<"bridge:">> from beginning for backward compatibility
-    InstanceIdBin = binary:replace(InstanceIdBin0, <<"bridge:">>, <<>>),
-    iolist_to_binary([InstanceIdBin, ":", atom_to_list(node())]).
+make_client_id(BridgeType0, BridgeName0) ->
+    BridgeType = to_bin(BridgeType0),
+    BridgeName = to_bin(BridgeName0),
+    iolist_to_binary([BridgeType, ":", BridgeName, ":", atom_to_list(node())]).
 
 sasl(none) ->
     undefined;

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -121,6 +121,8 @@ on_start(ResourceId, Config) ->
     #{
         authentication := Auth,
         bootstrap_hosts := BootstrapHosts0,
+        bridge_type := BridgeType,
+        bridge_name := BridgeName,
         hookpoint := _,
         kafka := #{
             max_batch_bytes := _,
@@ -134,7 +136,7 @@ on_start(ResourceId, Config) ->
     } = Config,
     BootstrapHosts = emqx_bridge_kafka_impl:hosts(BootstrapHosts0),
     %% Note: this is distinct per node.
-    ClientID = make_client_id(ResourceId),
+    ClientID = make_client_id(ResourceId, BridgeType, BridgeName),
     ClientOpts0 =
         case Auth of
             none -> [];
@@ -515,11 +517,11 @@ is_dry_run(ResourceId) ->
             string:equal(TestIdStart, ResourceId)
     end.
 
--spec make_client_id(resource_id()) -> atom().
-make_client_id(InstanceId) ->
-    case is_dry_run(InstanceId) of
+-spec make_client_id(resource_id(), binary(), atom() | binary()) -> atom().
+make_client_id(ResourceId, BridgeType, BridgeName) ->
+    case is_dry_run(ResourceId) of
         false ->
-            ClientID0 = emqx_bridge_kafka_impl:make_client_id(InstanceId),
+            ClientID0 = emqx_bridge_kafka_impl:make_client_id(BridgeType, BridgeName),
             binary_to_atom(ClientID0);
         true ->
             %% It is a dry run and we don't want to leak too many

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -66,7 +66,7 @@ only_once_tests() ->
     ].
 
 init_per_suite(Config) ->
-    Config.
+    [{bridge_type, <<"kafka_consumer">>} | Config].
 
 end_per_suite(_Config) ->
     emqx_mgmt_api_test_util:end_suite(),
@@ -898,8 +898,9 @@ ensure_connected(Config) ->
     ok.
 
 consumer_clientid(Config) ->
-    ResourceId = resource_id(Config),
-    binary_to_atom(emqx_bridge_kafka_impl:make_client_id(ResourceId)).
+    BridgeType = ?config(bridge_type, Config),
+    KafkaName = ?config(kafka_name, Config),
+    binary_to_atom(emqx_bridge_kafka_impl:make_client_id(BridgeType, KafkaName)).
 
 get_client_connection(Config) ->
     KafkaHost = ?config(kafka_host, Config),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -40,6 +40,7 @@
 %% TODO: rename this to `kafka_producer' after alias support is added
 %% to hocon; keeping this as just `kafka' for backwards compatibility.
 -define(BRIDGE_TYPE, "kafka").
+-define(BRIDGE_TYPE_BIN, <<"kafka">>).
 
 -define(APPS, [emqx_resource, emqx_bridge, emqx_rule_engine, emqx_bridge_kafka]).
 
@@ -438,7 +439,7 @@ t_failed_creation_then_fix(Config) ->
     {ok, #{config := WrongConfigAtom1}} = emqx_bridge:create(
         Type, erlang:list_to_atom(Name), WrongConf
     ),
-    WrongConfigAtom = WrongConfigAtom1#{bridge_name => Name},
+    WrongConfigAtom = WrongConfigAtom1#{bridge_name => Name, bridge_type => ?BRIDGE_TYPE_BIN},
     ?assertThrow(Reason when is_list(Reason), ?PRODUCER:on_start(ResourceId, WrongConfigAtom)),
     %% before throwing, it should cleanup the client process.  we
     %% retry because the supervisor might need some time to really
@@ -448,7 +449,7 @@ t_failed_creation_then_fix(Config) ->
     {ok, #{config := ValidConfigAtom1}} = emqx_bridge:create(
         Type, erlang:list_to_atom(Name), ValidConf
     ),
-    ValidConfigAtom = ValidConfigAtom1#{bridge_name => Name},
+    ValidConfigAtom = ValidConfigAtom1#{bridge_name => Name, bridge_type => ?BRIDGE_TYPE_BIN},
     {ok, State} = ?PRODUCER:on_start(ResourceId, ValidConfigAtom),
     Time = erlang:unique_integer(),
     BinTime = integer_to_binary(Time),
@@ -540,7 +541,7 @@ t_nonexistent_topic(_Config) ->
     {ok, #{config := ValidConfigAtom1}} = emqx_bridge:create(
         Type, erlang:list_to_atom(Name), Conf
     ),
-    ValidConfigAtom = ValidConfigAtom1#{bridge_name => Name},
+    ValidConfigAtom = ValidConfigAtom1#{bridge_name => Name, bridge_type => ?BRIDGE_TYPE_BIN},
     ?assertThrow(_, ?PRODUCER:on_start(ResourceId, ValidConfigAtom)),
     ok = emqx_bridge_resource:remove(BridgeId),
     delete_all_bridges(),
@@ -585,7 +586,7 @@ t_send_message_with_headers(Config) ->
     {ok, #{config := ConfigAtom1}} = emqx_bridge:create(
         Type, erlang:list_to_atom(Name), Conf
     ),
-    ConfigAtom = ConfigAtom1#{bridge_name => Name},
+    ConfigAtom = ConfigAtom1#{bridge_name => Name, bridge_type => ?BRIDGE_TYPE_BIN},
     {ok, State} = ?PRODUCER:on_start(ResourceId, ConfigAtom),
     Time1 = erlang:unique_integer(),
     BinTime1 = integer_to_binary(Time1),
@@ -807,7 +808,7 @@ t_wrong_headers_from_message(Config) ->
     {ok, #{config := ConfigAtom1}} = emqx_bridge:create(
         Type, erlang:list_to_atom(Name), Conf
     ),
-    ConfigAtom = ConfigAtom1#{bridge_name => Name},
+    ConfigAtom = ConfigAtom1#{bridge_name => Name, bridge_type => ?BRIDGE_TYPE_BIN},
     {ok, State} = ?PRODUCER:on_start(ResourceId, ConfigAtom),
     Time1 = erlang:unique_integer(),
     Payload1 = <<"wrong_header">>,


### PR DESCRIPTION
### Targeting release-52

Add bridge_name and bridge_type information on bridge start.

Fixes https://emqx.atlassian.net/browse/EMQX-10860

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ee77976</samp>

This pull request improves the emqx_bridge app and its sub-apps by refactoring the bridge type and name handling in the config parsing, client id generation, logging, and testing modules. It also enhances the test suite for the azure_event_hub bridge by adding health status checks. The main files affected are `emqx_bridge_resource.erl`, `emqx_bridge_kafka_impl.erl`, `emqx_bridge_azure_event_hub.erl`, and their corresponding test modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
