### PR TITLE
fix(plugins): update plugin order on whole cluster

### DIFF
--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -20,6 +20,7 @@
 -export([stop/1]).
 
 -export([share_load_module/2]).
+-export([node_name/1]).
 
 -define(APPS_CLUSTERING, [gen_rpc, mria, ekka]).
 

--- a/apps/emqx_dashboard/test/emqx_dashboard_api_test_helpers.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_api_test_helpers.erl
@@ -28,7 +28,8 @@
     multipart_formdata_request/4,
     host/0,
     uri/0,
-    uri/1
+    uri/1,
+    uri/2
 ]).
 
 -define(HOST, "http://127.0.0.1:18083").
@@ -96,10 +97,15 @@ request(Username, Method, Url, Body) ->
 host() ->
     ?HOST.
 
-uri() -> uri([]).
+uri() ->
+    uri([]).
+
 uri(Parts) when is_list(Parts) ->
+    uri(host(), Parts).
+
+uri(Host, Parts) when is_list(Host), is_list(Parts) ->
     NParts = [E || E <- Parts],
-    host() ++ "/" ++ to_list(filename:join([?BASE_PATH, ?API_VERSION | NParts])).
+    Host ++ "/" ++ to_list(filename:join([?BASE_PATH, ?API_VERSION | NParts])).
 
 auth_header(Username) ->
     Password = <<"public">>,

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -420,7 +420,7 @@ update_boot_order(post, #{bindings := #{name := Name}, body := Body}) ->
         {error, Reason} ->
             {400, #{code => 'BAD_POSITION', message => Reason}};
         Position ->
-            case emqx_plugins:ensure_enabled(Name, Position) of
+            case emqx_plugins:ensure_enabled(Name, Position, _ConfLocation = global) of
                 ok ->
                     {200};
                 {error, Reason} ->

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -61,6 +61,9 @@ request(Method, Url, Body) ->
 uri(Parts) ->
     emqx_dashboard_api_test_helpers:uri(Parts).
 
+uri(Host, Parts) ->
+    emqx_dashboard_api_test_helpers:uri(Host, Parts).
+
 %% compatible_mode will return as same as 'emqx_dashboard_api_test_helpers:request'
 request_api_with_body(Method, Url, Body) ->
     Opts = #{compatible_mode => true, httpc_req_opts => [{body_format, binary}]},
@@ -144,8 +147,14 @@ build_http_header(X) when is_list(X) ->
 build_http_header(X) ->
     [X].
 
+default_server() ->
+    ?SERVER.
+
 api_path(Parts) ->
     join_http_path([?SERVER, ?BASE_PATH | Parts]).
+
+api_path(Host, Parts) ->
+    join_http_path([Host, ?BASE_PATH | Parts]).
 
 api_path_without_base_path(Parts) ->
     join_http_path([?SERVER | Parts]).
@@ -193,9 +202,13 @@ upload_request(URL, FilePath, Name, MimeType, RequestData, AuthorizationToken) -
     ContentLength = integer_to_list(length(binary_to_list(RequestBody))),
     Headers = [
         {"Content-Length", ContentLength},
-        case AuthorizationToken =/= undefined of
-            true -> {"Authorization", "Bearer " ++ binary_to_list(AuthorizationToken)};
-            false -> {}
+        case AuthorizationToken of
+            _ when is_tuple(AuthorizationToken) ->
+                AuthorizationToken;
+            _ when is_binary(AuthorizationToken) ->
+                {"Authorization", "Bearer " ++ binary_to_list(AuthorizationToken)};
+            _ ->
+                {}
         end
     ],
     HTTPOptions = [],

--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_plugins/src/emqx_plugins_cli.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli.erl
@@ -70,7 +70,7 @@ restart(NameVsn, LogFun) ->
     ?PRINT(emqx_plugins:restart(NameVsn), LogFun).
 
 ensure_enabled(NameVsn, Position, LogFun) ->
-    ?PRINT(emqx_plugins:ensure_enabled(NameVsn, Position), LogFun).
+    ?PRINT(emqx_plugins:ensure_enabled(NameVsn, Position, _ConfLocation = global), LogFun).
 
 ensure_disabled(NameVsn, LogFun) ->
     ?PRINT(emqx_plugins:ensure_disabled(NameVsn), LogFun).

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -216,7 +216,7 @@ t_position(Config) ->
     PosApp2 = <<"position-2">>,
     ok = write_info_file(Config, PosApp2, FakeInfo),
     %% fake a disabled plugin in config
-    ok = emqx_plugins:ensure_state(PosApp2, {before, NameVsn}, false),
+    ok = ensure_state(PosApp2, {before, NameVsn}, false),
     ListFun = fun() ->
         lists:map(
             fun(
@@ -255,14 +255,14 @@ t_start_restart_and_stop(Config) ->
     Bar2 = <<"bar-2">>,
     ok = write_info_file(Config, Bar2, FakeInfo),
     %% fake a disabled plugin in config
-    ok = emqx_plugins:ensure_state(Bar2, front, false),
+    ok = ensure_state(Bar2, front, false),
 
     assert_app_running(emqx_plugin_template, false),
     ok = emqx_plugins:ensure_started(),
     assert_app_running(emqx_plugin_template, true),
 
     %% fake enable bar-2
-    ok = emqx_plugins:ensure_state(Bar2, rear, true),
+    ok = ensure_state(Bar2, rear, true),
     %% should cause an error
     ?assertError(
         #{function := _, errors := [_ | _]},
@@ -274,7 +274,7 @@ t_start_restart_and_stop(Config) ->
     %% stop all
     ok = emqx_plugins:ensure_stopped(),
     assert_app_running(emqx_plugin_template, false),
-    ok = emqx_plugins:ensure_state(Bar2, rear, false),
+    ok = ensure_state(Bar2, rear, false),
 
     ok = emqx_plugins:restart(NameVsn),
     assert_app_running(emqx_plugin_template, true),
@@ -826,3 +826,7 @@ make_tar(Cwd, NameWithVsn, TarfileVsn) ->
     after
         file:set_cwd(OriginalCwd)
     end.
+
+ensure_state(NameVsn, Position, Enabled) ->
+    %% NOTE: this is an internal function that is (legacy) exported in test builds only...
+    emqx_plugins:ensure_state(NameVsn, Position, Enabled, _ConfLocation = local).

--- a/changes/ce/fix-11548.en.md
+++ b/changes/ce/fix-11548.en.md
@@ -1,0 +1,1 @@
+Fixed an issue that prevented the plugin order to be updated on the whole cluster.


### PR DESCRIPTION
# targeting `release-52`

Fixes https://emqx.atlassian.net/browse/EMQX-10879

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8e51162</samp>

This pull request adds a new feature of global plugin configuration to the `emqx_plugins` application and updates the test code and the command line interface to support it. It also improves the dashboard API test code by introducing a new helper function and refactoring an existing one.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
