### PR TITLE
fix(nodetool): add patches directory to head of path

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -357,6 +357,14 @@ add_libs_dir() ->
         {error, Reason} ->
             %% rel file was been deleted by release handler
             error({failed_to_read_RELEASES_file, RelFile, Reason})
+    end,
+    PatchesDir = filename:join([RootDir, "data", "patches"]),
+    case filelib:is_dir(PatchesDir) of
+        true ->
+            true = code:add_patha(PatchesDir),
+            ok;
+        false ->
+            ok
     end.
 
 add_lib_dir(RootDir, Name, Vsn) ->

--- a/deploy/packages/deb/debian/rules
+++ b/deploy/packages/deb/debian/rules
@@ -36,6 +36,8 @@ install: build
 	mkdir -p debian/emqx/usr/lib/emqx/bin
 	mkdir -p debian/emqx/usr/lib/emqx/plugins
 	touch debian/emqx/usr/lib/emqx/plugins/.keep
+	mkdir -p debian/emqx/usr/lib/emqx/data/patches
+	touch debian/emqx/usr/lib/emqx/data/patches/.keep
 	mkdir -p debian/emqx/etc/emqx
 	cp bin/* debian/emqx/usr/lib/emqx/bin
 	cp -R lib debian/emqx/usr/lib/emqx

--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -40,6 +40,7 @@ EMQX, a distributed, massively scalable, highly extensible MQTT message broker.
 %install
 mkdir -p %{buildroot}%{_lib_home}
 mkdir -p %{buildroot}%{_lib_home}/plugins
+mkdir -p %{buildroot}%{_lib_home}/data/patches
 mkdir -p %{buildroot}%{_log_dir}
 mkdir -p %{buildroot}%{_unitdir}
 mkdir -p %{buildroot}%{_conf_dir}
@@ -48,6 +49,7 @@ mkdir -p %{buildroot}%{_var_home}
 
 cp -R %{_reldir}/lib %{buildroot}%{_lib_home}/
 touch %{buildroot}%{_lib_home}/plugins/.keep
+touch %{buildroot}%{_lib_home}/data/patches/.keep
 cp -R %{_reldir}/erts-* %{buildroot}%{_lib_home}/
 cp -R %{_reldir}/releases %{buildroot}%{_lib_home}/
 cp -R %{_reldir}/bin %{buildroot}%{_lib_home}/


### PR DESCRIPTION
# targeting `release-52`

This enables us to provide patches that affect `call_hocon` from `bin/emqx`.


Fixes <issue-or-jira-number>

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0f2767a</samp>

This pull request enables the hot patch feature of EMQ X for RPM and Debian packages. It creates a `patches` directory under the installation path where users can place patch files that will be applied to the running broker.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
