### PR TITLE
refactor: remove BridgeName from connector_config callback

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -49,11 +49,8 @@
     update/4
 ]).
 
--callback connector_config(ParsedConfig, BridgeName :: atom() | binary()) ->
-    ParsedConfig
-when
-    ParsedConfig :: #{atom() => any()}.
--optional_callbacks([connector_config/2]).
+-callback connector_config(ParsedConfig) -> ParsedConfig when ParsedConfig :: #{atom() => any()}.
+-optional_callbacks([connector_config/1]).
 
 %% bi-directional bridge with producer/consumer or ingress/egress configs
 -define(IS_BI_DIR_BRIDGE(TYPE),
@@ -391,14 +388,14 @@ parse_confs(Type, Name, Conf) when ?IS_INGRESS_BRIDGE(Type) ->
     BId = bridge_id(Type, Name),
     BridgeHookpoint = bridge_hookpoint(BId),
     Conf#{hookpoint => BridgeHookpoint};
-parse_confs(BridgeType, BridgeName, Config) ->
-    connector_config(BridgeType, BridgeName, Config).
+parse_confs(BridgeType, _BridgeName, Config) ->
+    connector_config(BridgeType, Config).
 
-connector_config(BridgeType, BridgeName, Config) ->
+connector_config(BridgeType, Config) ->
     Mod = bridge_impl_module(BridgeType),
-    case erlang:function_exported(Mod, connector_config, 2) of
+    case erlang:function_exported(Mod, connector_config, 1) of
         true ->
-            Mod:connector_config(Config, BridgeName);
+            Mod:connector_config(Config);
         false ->
             Config
     end.

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -20,7 +20,7 @@
 %% emqx_bridge_enterprise "unofficial" API
 -export([conn_bridge_examples/1]).
 
--export([connector_config/2]).
+-export([connector_config/1]).
 
 -export([producer_converter/2, host_opts/0]).
 
@@ -166,7 +166,7 @@ values(producer) ->
 %% `emqx_bridge_resource' API
 %%-------------------------------------------------------------------------------------------------
 
-connector_config(Config, _BridgeName) ->
+connector_config(Config) ->
     %% Default port for AEH is 9093
     BootstrapHosts0 = maps:get(bootstrap_hosts, Config),
     BootstrapHosts = emqx_schema:parse_servers(


### PR DESCRIPTION
As `bridge_name` is already in the Config parameter, this callback doesn't need to have it on API anymore.

Fixes https://github.com/emqx/emqx/pull/11546/files#r1310778734

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7b607c3</samp>

Simplify the `connector_config` callback and function for bridge connectors. This change affects the `emqx_bridge_azure_event_hub` module and the `emqx_bridge_resource` module.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
