### PR TITLE
chore: comment mountpoints to support direct copy-paste used

### DIFF
--- a/rel/config/examples/listeners.quic.conf.example
+++ b/rel/config/examples/listeners.quic.conf.example
@@ -5,7 +5,7 @@ listeners.quic.my_quick_listener_name {
     bind = 14567 ## or with an IP, e.g. "127.0.0.1:14567"
 
     ## When publishing or subscribing, prefix all topics with a mountpoint string
-    mountpoint = "${clientid}/msg"
+    ## mountpoint = "${clientid}/msg"
 
     ## Client authentication
     ## Type:

--- a/rel/config/examples/listeners.tcp.conf.example
+++ b/rel/config/examples/listeners.tcp.conf.example
@@ -11,7 +11,7 @@ listeners.tcp.my_tcp_listener_name {
     proxy_protocol_timeout = 8
 
     ## When publishing or subscribing, prefix all topics with a mountpoint string
-    mountpoint = "mqtt" ## Do not set this unless you know what is it for
+    ## mountpoint = "mqtt" ## Do not set this unless you know what is it for
 
     ## Client authentication
     ## Type:


### PR DESCRIPTION
some users use the examples without having a look at the comments and then blame the examples for bad

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 254748b</samp>

Comment out the `mountpoint` option in the QUIC listener example configuration file, and copy it from the TCP listener example file. This makes the example files consistent and avoids confusion for new users.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
