### PR TITLE
chore(dev): support the EMQX_NODE__NAME variable

### DIFF
--- a/dev
+++ b/dev
@@ -43,7 +43,7 @@ OPTIONS:
   -c|--compile:      Force recompile, otherwise starts with the already built libs
                      in '_build/\$PROFILE/lib/'.
   -e|--ekka-epmd:    Force to use ekka_epmd.
-  -n|--name:         Node name, defaults to \$EMQX_NODE_NAME env.
+  -n|--name:         Node name, defaults to \$EMQX_NODE__NAME or the \$EMQX_NODE_NAME env.
 
 ENVIRONMENT VARIABLES:
 
@@ -63,7 +63,7 @@ export HOCON_ENV_OVERRIDE_PREFIX='EMQX_'
 export EMQX_LOG__FILE__DEFAULT__ENABLE='false'
 export EMQX_LOG__CONSOLE__ENABLE='true'
 SYSTEM="$(./scripts/get-distro.sh)"
-EMQX_NODE_NAME="${EMQX_NODE_NAME:-emqx@127.0.0.1}"
+EMQX_NODE_NAME="${EMQX_NODE__NAME:-${EMQX_NODE_NAME:-emqx@127.0.0.1}}"
 PROFILE="${PROFILE:-emqx}"
 FORCE_COMPILE=0
 # Do not start using ekka epmd by default, so your IDE can connect to it
@@ -158,7 +158,7 @@ export EMQX_LOG_DIR="$BASE_DIR/log"
 export EMQX_PLUGINS__INSTALL_DIR="${EMQX_PLUGINS__INSTALL_DIR:-$BASE_DIR/plugins}"
 CONFIGS_DIR="$EMQX_DATA_DIR/configs"
 # Use your cookie so your IDE can connect to it.
-COOKIE="${EMQX_NODE__COOKIE:-${EMQX_NODE_COOKIE:-$(cat ~/.erlang.cookie || echo 'emqxsecretcookie')}}"
+COOKIE="${EMQX_NODE__COOKIE:-${EMQX_NODE_COOKIE:-$(cat ~/.erlang.cookie 2>/dev/null || echo 'emqxsecretcookie')}}"
 mkdir -p "$EMQX_ETC_DIR" "$EMQX_DATA_DIR/patches" "$EMQX_DATA_DIR/plugins" "$EMQX_DATA_DIR/certs" "$EMQX_LOG_DIR" "$CONFIGS_DIR"
 if [ $EKKA_EPMD -eq 1 ]; then
     EPMD_ARGS='-start_epmd false -epmd_module ekka_epmd'


### PR DESCRIPTION
We use the `EMQX_NODE__NAME` to configure the node name, but it is not supported in the `dev` script

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d4aba52</samp>

Refactor emqx configuration system to simplify node name and cookie management. Use `EMQX_NODE__NAME` and `dev` file to set and store these values.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
