### PR TITLE
fix: upgrade jq library

### DIFF
--- a/changes/ce/fix-11565.en.md
+++ b/changes/ce/fix-11565.en.md
@@ -1,0 +1,1 @@
+Upgraded jq library from v0.3.10 to v0.3.11. In this version, jq_port programs are initiated on-demand and will not appear in users' processes unless the jq function in EMQX is used. Additionally, idle jq_port programs will auto-terminate after a set period. Note: Most EMQX users, running jq in NIF mode, will be unaffected by this update.

--- a/mix.exs
+++ b/mix.exs
@@ -826,7 +826,7 @@ defmodule EMQXUmbrella.MixProject do
 
   defp jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.10", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.11", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -42,7 +42,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.114"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.10"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.11"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),


### PR DESCRIPTION
In this commit the jq library is upgraded from v0.3.10 to v0.3.11. The new version has the following changes:

* The jq port programs is only started on demand
  - this means that users will not see jq_port in their processes list if they have not used the jq function in EMQX
* The jq port programs are terminated automatically if they are idle for a long enough time period

The default for EMQX is to run the jq library in NIF mode so most users will not be affected by this change.

Fixes:
https://emqx.atlassian.net/browse/EMQX-10911

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at bc3f2e9</samp>

This pull request updates the `jq` dependency to the latest version in both `mix.exs` and `rebar.config.erl` files. This improves the JSON parsing and transformation capabilities of emqx.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible