### PR TITLE
fix(nodetool): increase graceful stop timeout

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -831,7 +831,7 @@ wait_for() {
     shift
     CMD="$*"
     while true; do
-        if $CMD >/dev/null 2>&1; then
+        if $CMD; then
             return 0
         fi
         if [ "$WAIT_TIME" -le 0 ]; then

--- a/bin/emqx
+++ b/bin/emqx
@@ -812,7 +812,7 @@ is_down() {
     if ps -p "$PID" >/dev/null; then
         # still around
         # shellcheck disable=SC2009 # this grep pattern is not a part of the program names
-        if ps -efp "$PID" | $GREP -q 'defunct'; then
+        if ps -fp "$PID" | $GREP -q 'defunct'; then
             # zombie state, print parent pid
             parent="$(ps -o ppid= -p "$PID" | tr -d ' ')"
             logwarn "$PID is marked <defunct>, parent: $(ps -p "$parent")"

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -8,6 +8,8 @@
 %% -------------------------------------------------------------------
 -mode(compile).
 
+-define(SHUTDOWN_TIMEOUT_MS, 120_000).
+
 main(Args) ->
     case os:type() of
         {win32, nt} -> ok;
@@ -85,9 +87,14 @@ do(Args) ->
             %% a "pong"
             io:format("pong\n");
         ["stop"] ->
-            case rpc:call(TargetNode, emqx_machine, graceful_shutdown, [], 60000) of
+            case rpc:call(TargetNode, emqx_machine, graceful_shutdown, [], ?SHUTDOWN_TIMEOUT_MS) of
                 ok ->
                     ok;
+                {badrpc, timeout} ->
+                    io:format("EMQX is still shutting down, it failed to stop gracefully "
+                              "within the configured timeout of: ~ps\n",
+                              [erlang:convert_time_unit(?SHUTDOWN_TIMEOUT_MS, millisecond, second)]),
+                    halt(1);
                 {badrpc, nodedown} ->
                     %% nodetool commands are always executed after a ping
                     %% which if the code gets here, it's because the target node

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -87,7 +87,10 @@ do(Args) ->
             %% a "pong"
             io:format("pong\n");
         ["stop"] ->
-            case rpc:call(TargetNode, emqx_machine, graceful_shutdown, [], ?SHUTDOWN_TIMEOUT_MS) of
+            Pid = start_shutdown_status(),
+            Res = rpc:call(TargetNode, emqx_machine, graceful_shutdown, [], ?SHUTDOWN_TIMEOUT_MS),
+            true = stop_shutdown_status(Pid),
+            case Res of
                 ok ->
                     ok;
                 {badrpc, timeout} ->
@@ -151,6 +154,18 @@ do(Args) ->
             io:format("Usage: nodetool chkconfig|getpid|ping|stop|rpc|rpc_infinity|rpcterms|eval|cold_eval [Terms] [RPC]\n")
     end,
     net_kernel:stop().
+
+start_shutdown_status() ->
+    spawn_link(fun shutdown_status_loop/0).
+
+stop_shutdown_status(Pid) ->
+    true = unlink(Pid),
+    true = exit(Pid, stop).
+
+shutdown_status_loop() ->
+    timer:sleep(10_000),
+    io:format("EMQX is shutting down, please wait...\n", []),
+    shutdown_status_loop().
 
 parse_eval_args(Args) ->
     % shells may process args into more than one, and end up stripping

--- a/changes/ce/fix-11567.en.md
+++ b/changes/ce/fix-11567.en.md
@@ -1,0 +1,3 @@
+Improve EMQX graceful shutdown (`emqx stop` command):
+- increase timeout from 1 to 2 minutes
+- print an error message if EMQX can't stop gracefully within the configured timeout

--- a/changes/ce/fix-11567.en.md
+++ b/changes/ce/fix-11567.en.md
@@ -1,3 +1,4 @@
 Improve EMQX graceful shutdown (`emqx stop` command):
 - increase timeout from 1 to 2 minutes
 - print an error message if EMQX can't stop gracefully within the configured timeout
+- print periodic status messages while EMQX is shutting down


### PR DESCRIPTION
Fixes [EMQX-10835](https://emqx.atlassian.net/browse/EMQX-10835)


1 core, 1 replicant  cluster on a local machine test (i5-7200U 2 physical cores, 16GB RAM).
before this fix:
200K clients, ~1.2M topics/subscriptions:
```
root@serge-Latitude-5480:/home/serge/work/emqx/tmp/emqx1# date; bin/emqx stop; date
16:32:25 +0300
escript: exception error: no case clause matching {badrpc,timeout}
  in function  nodetool__escript__1693__920746__671869__2:do/1 (/home/serge/work/emqx/tmp/emqx1/bin/nodetool, line 88)
  in call from escript:run/2 (escript.erl, line 750)
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 
  in call from init:do_boot/3 
ERROR: Graceful shutdown failed PID=[80468]
16:33:27 +0300
```

Replicant config was tuned for high-latency network:
```
node {
  name = "emqx1@127.0.0.1"
  cookie = "emqxsecretcookie"
  data_dir = "data"
  db_role = replicant
  broker_pool_size = 4000
  generic_pool_size = 2000
  channel_cleanup_batch_size = 10
  rpc_module = rpc
}
```
Increased pool sizes may contribute to the longer graceful shutdown time. 
I haven't noticed any issues, it simply looks like 1 minute rpc timeout is too low to gracefully shutdown a highly loaded node. 
As expected, `emqx` app shutdown time is the longest:
```
2023-09-05T17:20:48.763183+03:00 [debug] msg: stopping_app, mfa: emqx_machine_boot:stop_one_app/1, line: 89, app: emqx
2023-09-05T17:20:48.770902+03:00 [notice] ssl:default stopped on 0.0.0.0:8884
2023-09-05T17:20:48.779091+03:00 [notice] tcp:default stopped on 0.0.0.0:1884
2023-09-05T17:22:27.532862+03:00 [notice] Application: emqx. Exited: stopped. Type: permanent.
```
 
## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a8d6bd</samp>

This change improves the documentation of a pull request that enhances the graceful shutdown feature of EMQX. It adds a file `fix-11567.en.md` that explains the increased timeout and the error message for the shutdown process.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
