### PR TITLE
feat(republish): allow templating mqtt properties

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_SUITE.erl
@@ -640,7 +640,7 @@ t_ingress_mqtt_bridge_with_rules(_) ->
         #{
             <<"name">> => <<"A_rule_get_messages_from_a_source_mqtt_bridge">>,
             <<"enable">> => true,
-            <<"actions">> => [#{<<"function">> => "emqx_bridge_mqtt_SUITE:inspect"}],
+            <<"actions">> => [#{<<"function">> => <<"emqx_bridge_mqtt_SUITE:inspect">>}],
             <<"sql">> => <<"SELECT * from \"$bridges/", BridgeIDIngress/binary, "\"">>
         }
     ),

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.26"},
+    {vsn, "5.0.27"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [kernel, stdlib, mnesia, minirest, emqx, emqx_ctl, emqx_bridge_http]},

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -255,7 +255,7 @@ format_mqtt_properties(MQTTPropertiesTemplate, Selected, Env) ->
                 catch
                     Kind:Error ->
                         ?SLOG(
-                            error,
+                            debug,
                             #{
                                 msg => "bad_mqtt_property_value_ignored",
                                 rule_id => RuleId,
@@ -292,7 +292,7 @@ coerce_properties_values(MQTTProperties, #{metadata := #{rule_id := RuleId}}) ->
             catch
                 throw:bad_integer ->
                     ?SLOG(
-                        error,
+                        debug,
                         #{
                             msg => "bad_mqtt_property_value_ignored",
                             rule_id => RuleId,
@@ -304,7 +304,7 @@ coerce_properties_values(MQTTProperties, #{metadata := #{rule_id := RuleId}}) ->
                     Acc;
                 Kind:Reason:Stacktrace ->
                     ?SLOG(
-                        error,
+                        debug,
                         #{
                             msg => "bad_mqtt_property_value_ignored",
                             rule_id => RuleId,

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -327,4 +327,5 @@ coerce_properties_values(MQTTProperties, #{metadata := #{rule_id := RuleId}}) ->
 encode_mqtt_property('Payload-Format-Indicator', V) -> ensure_int(V);
 encode_mqtt_property('Message-Expiry-Interval', V) -> ensure_int(V);
 encode_mqtt_property('Subscription-Identifier', V) -> ensure_int(V);
-encode_mqtt_property(_Prop, V) -> V.
+%% note: `emqx_placeholder:proc_tmpl/2' currently always return a binary.
+encode_mqtt_property(_Prop, V) when is_binary(V) -> V.

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -257,9 +257,10 @@ format_mqtt_properties(MQTTPropertiesTemplate, Selected, Env) ->
                         ?SLOG(
                             error,
                             #{
-                                msg => "bad_mqtt_prop_value",
+                                msg => "bad_mqtt_property_value_ignored",
                                 rule_id => RuleId,
-                                reason => {Kind, Error},
+                                exception => Kind,
+                                reason => Error,
                                 property => K,
                                 selected => Selected
                             }
@@ -297,9 +298,10 @@ coerce_properties_values(MQTTProperties, #{metadata := #{rule_id := RuleId}}) ->
                     ?SLOG(
                         error,
                         #{
-                            msg => "bad_mqtt_prop_value",
+                            msg => "bad_mqtt_property_value_ignored",
                             rule_id => RuleId,
-                            reason => {Kind, Error},
+                            reason => Error,
+                            exception => Kind,
                             property => K,
                             value => V
                         }

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.23"},
+    {vsn, "5.0.24"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl, uuid]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -188,9 +188,7 @@ fields("republish_mqtt_properties") ->
         {'Content-Type', ?HOCON(binary(), #{required => false, desc => ?DESC('Content-Type')})},
         {'Response-Topic', ?HOCON(binary(), #{required => false, desc => ?DESC('Response-Topic')})},
         {'Correlation-Data',
-            ?HOCON(binary(), #{required => false, desc => ?DESC('Correlation-Data')})},
-        {'Subscription-Identifier',
-            ?HOCON(binary(), #{required => false, desc => ?DESC('Subscription-Identifier')})}
+            ?HOCON(binary(), #{required => false, desc => ?DESC('Correlation-Data')})}
     ].
 
 desc("rule_engine") ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -23,6 +23,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
+-include_lib("emqx/include/asserts.hrl").
 -include_lib("emqx/include/emqx.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
@@ -74,6 +75,7 @@ groups() ->
             t_sqlselect_inject_props,
             t_sqlselect_01,
             t_sqlselect_02,
+            t_sqlselect_03,
             t_sqlselect_1,
             t_sqlselect_2,
             t_sqlselect_3,
@@ -520,13 +522,16 @@ t_get_rule_ids_by_action(_) ->
 t_ensure_action_removed(_) ->
     Id = <<"t_ensure_action_removed">>,
     GetSelectedData = <<"emqx_rule_sqltester:get_selected_data">>,
-    emqx:update_config(
+    {ok, _} = emqx:update_config(
         [rule_engine, rules, Id],
         #{
             <<"actions">> => [
                 #{<<"function">> => GetSelectedData},
                 #{<<"function">> => <<"console">>},
-                #{<<"function">> => <<"republish">>},
+                #{
+                    <<"function">> => <<"republish">>,
+                    <<"args">> => #{<<"topic">> => <<"some/topic">>}
+                },
                 <<"mysql:foo">>,
                 <<"mqtt:bar">>
             ],
@@ -1406,6 +1411,189 @@ t_sqlselect_02(_Config) ->
 
     emqtt:stop(Client),
     delete_rule(TopicRule1).
+
+t_sqlselect_03(_Config) ->
+    init_events_counters(),
+    SQL = "SELECT * FROM \"t/r\" ",
+    Repub = republish_action(
+        <<"t/republish">>,
+        <<"${.}">>,
+        <<"${pub_props.'User-Property'}">>,
+        #{
+            <<"Payload-Format-Indicator">> => <<"${.payload.pfi}">>,
+            <<"Message-Expiry-Interval">> => <<"${.payload.mei}">>,
+            <<"Content-Type">> => <<"${.payload.ct}">>,
+            <<"Response-Topic">> => <<"${.payload.rt}">>,
+            <<"Correlation-Data">> => <<"${.payload.cd}">>,
+            <<"Subscription-Identifier">> => <<"${.payload.si}">>
+        }
+    ),
+    RepubRaw = emqx_utils_maps:binary_key_map(Repub#{function => <<"republish">>}),
+    ct:pal("republish action raw:\n  ~p", [RepubRaw]),
+    RuleRaw = #{
+        <<"sql">> => SQL,
+        <<"actions">> => [RepubRaw]
+    },
+    {ok, _} = emqx_conf:update([rule_engine, rules, ?TMP_RULEID], RuleRaw, #{}),
+    on_exit(fun() -> emqx_rule_engine:delete_rule(?TMP_RULEID) end),
+    %% to check what republish is actually producing without loss of information
+    SQL1 = "select * from \"t/republish\" ",
+    RuleId0 = ?TMP_RULEID,
+    RuleId1 = <<RuleId0/binary, "2">>,
+    {ok, _} = emqx_rule_engine:create_rule(
+        #{
+            sql => SQL1,
+            id => RuleId1,
+            actions => [
+                #{
+                    function => <<"emqx_rule_engine_SUITE:action_record_triggered_events">>,
+                    args => #{}
+                }
+            ]
+        }
+    ),
+    on_exit(fun() -> emqx_rule_engine:delete_rule(RuleId1) end),
+
+    UserProps = maps:to_list(#{<<"mykey">> => <<"myval">>}),
+    Payload =
+        emqx_utils_json:encode(
+            #{
+                pfi => 1,
+                mei => 2,
+                ct => <<"3">>,
+                rt => <<"4">>,
+                cd => <<"5">>,
+                si => 6,
+                ta => 7
+            }
+        ),
+    {ok, Client} = emqtt:start_link([
+        {username, <<"emqx">>},
+        {proto_ver, v5},
+        {properties, #{'Topic-Alias-Maximum' => 100}}
+    ]),
+    on_exit(fun() -> emqtt:stop(Client) end),
+    {ok, _} = emqtt:connect(Client),
+    {ok, _, _} = emqtt:subscribe(Client, <<"t/republish">>, 0),
+    PubProps = #{'User-Property' => UserProps},
+    ExpectedMQTTProps0 = #{
+        'Payload-Format-Indicator' => 1,
+        'Message-Expiry-Interval' => 2,
+        'Content-Type' => <<"3">>,
+        'Response-Topic' => <<"4">>,
+        'Correlation-Data' => <<"5">>,
+        'Subscription-Identifier' => 6,
+        %% currently, `Topic-Alias' is dropped `emqx_message:filter_pub_props',
+        %% so the channel controls those aliases on its own, starting from 1.
+        'Topic-Alias' => 1,
+        'User-Property' => UserProps
+    },
+    emqtt:publish(Client, <<"t/r">>, PubProps, Payload, [{qos, 0}]),
+    receive
+        {publish, #{topic := <<"t/republish">>, properties := Props1}} ->
+            ?assertEqual(ExpectedMQTTProps0, Props1),
+            ok
+    after 2000 ->
+        ct:pal("mailbox:\n  ~p", [?drainMailbox()]),
+        ct:fail("message not republished (l. ~b)", [?LINE])
+    end,
+    ExpectedMQTTProps1 = #{
+        'Payload-Format-Indicator' => 1,
+        'Message-Expiry-Interval' => 2,
+        'Content-Type' => <<"3">>,
+        'Response-Topic' => <<"4">>,
+        'Correlation-Data' => <<"5">>,
+        'Subscription-Identifier' => 6,
+        'User-Property' => maps:from_list(UserProps),
+        'User-Property-Pairs' => [
+            #{key => K, value => V}
+         || {K, V} <- UserProps
+        ]
+    },
+    ?assertMatch(
+        [
+            {'message.publish', #{
+                topic := <<"t/republish">>,
+                pub_props := ExpectedMQTTProps1
+            }}
+        ],
+        ets:lookup(events_record_tab, 'message.publish'),
+        #{expected_props => ExpectedMQTTProps1}
+    ),
+
+    ct:pal("testing payload that is not a json object"),
+    emqtt:publish(Client, <<"t/r">>, PubProps, <<"not-a-map">>, [{qos, 0}]),
+    ExpectedMQTTProps2 = #{
+        %% currently, `Topic-Alias' is dropped `emqx_message:filter_pub_props',
+        %% so the channel controls those aliases on its own, starting from 1.
+        'Topic-Alias' => 1,
+        'User-Property' => UserProps
+    },
+    receive
+        {publish, #{topic := T1, properties := Props2}} ->
+            ?assertEqual(ExpectedMQTTProps2, Props2),
+            %% empty this time, due to topic alias set before
+            ?assertEqual(<<>>, T1),
+            ok
+    after 2000 ->
+        ct:pal("mailbox:\n  ~p", [?drainMailbox()]),
+        ct:fail("message not republished (l. ~b)", [?LINE])
+    end,
+
+    ct:pal("testing payload with some uncoercible keys"),
+    ets:delete_all_objects(events_record_tab),
+    Payload1 =
+        emqx_utils_json:encode(#{
+            pfi => <<"bad_value1">>,
+            mei => <<"bad_value2">>,
+            ct => <<"some_value3">>,
+            rt => <<"some_value4">>,
+            cd => <<"some_value5">>,
+            si => <<"bad_value6">>,
+            ta => <<"bad_value7">>
+        }),
+    emqtt:publish(Client, <<"t/r">>, PubProps, Payload1, [{qos, 0}]),
+    ExpectedMQTTProps3 = #{
+        %% currently, `Topic-Alias' is dropped `emqx_message:filter_pub_props',
+        %% so the channel controls those aliases on its own, starting from 1.
+        'Topic-Alias' => 1,
+        'Content-Type' => <<"some_value3">>,
+        'Response-Topic' => <<"some_value4">>,
+        'Correlation-Data' => <<"some_value5">>,
+        'User-Property' => UserProps
+    },
+    receive
+        {publish, #{topic := T2, properties := Props3}} ->
+            ?assertEqual(ExpectedMQTTProps3, Props3),
+            %% empty this time, due to topic alias set before
+            ?assertEqual(<<>>, T2),
+            ok
+    after 2000 ->
+        ct:pal("mailbox:\n  ~p", [?drainMailbox()]),
+        ct:fail("message not republished (l. ~b)", [?LINE])
+    end,
+    ExpectedMQTTProps4 = #{
+        'Content-Type' => <<"some_value3">>,
+        'Response-Topic' => <<"some_value4">>,
+        'Correlation-Data' => <<"some_value5">>,
+        'User-Property' => maps:from_list(UserProps),
+        'User-Property-Pairs' => [
+            #{key => K, value => V}
+         || {K, V} <- UserProps
+        ]
+    },
+    ?assertMatch(
+        [
+            {'message.publish', #{
+                topic := <<"t/republish">>,
+                pub_props := ExpectedMQTTProps4
+            }}
+        ],
+        ets:lookup(events_record_tab, 'message.publish'),
+        #{expected_props => ExpectedMQTTProps4}
+    ),
+
+    ok.
 
 t_sqlselect_1(_Config) ->
     SQL =
@@ -3211,6 +3399,9 @@ republish_action(Topic, Payload) ->
     republish_action(Topic, Payload, <<"${user_properties}">>).
 
 republish_action(Topic, Payload, UserProperties) ->
+    republish_action(Topic, Payload, UserProperties, _MQTTProperties = #{}).
+
+republish_action(Topic, Payload, UserProperties, MQTTProperties) ->
     #{
         function => republish,
         args => #{
@@ -3218,6 +3409,7 @@ republish_action(Topic, Payload, UserProperties) ->
             topic => Topic,
             qos => 0,
             retain => false,
+            mqtt_properties => MQTTProperties,
             user_properties => UserProperties
         }
     }.

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -1424,8 +1424,7 @@ t_sqlselect_03(_Config) ->
             <<"Message-Expiry-Interval">> => <<"${.payload.mei}">>,
             <<"Content-Type">> => <<"${.payload.ct}">>,
             <<"Response-Topic">> => <<"${.payload.rt}">>,
-            <<"Correlation-Data">> => <<"${.payload.cd}">>,
-            <<"Subscription-Identifier">> => <<"${.payload.si}">>
+            <<"Correlation-Data">> => <<"${.payload.cd}">>
         }
     ),
     RepubRaw = emqx_utils_maps:binary_key_map(Repub#{function => <<"republish">>}),
@@ -1462,9 +1461,7 @@ t_sqlselect_03(_Config) ->
                 mei => 2,
                 ct => <<"3">>,
                 rt => <<"4">>,
-                cd => <<"5">>,
-                si => 6,
-                ta => 7
+                cd => <<"5">>
             }
         ),
     {ok, Client} = emqtt:start_link([
@@ -1482,7 +1479,6 @@ t_sqlselect_03(_Config) ->
         'Content-Type' => <<"3">>,
         'Response-Topic' => <<"4">>,
         'Correlation-Data' => <<"5">>,
-        'Subscription-Identifier' => 6,
         %% currently, `Topic-Alias' is dropped `emqx_message:filter_pub_props',
         %% so the channel controls those aliases on its own, starting from 1.
         'Topic-Alias' => 1,
@@ -1503,7 +1499,6 @@ t_sqlselect_03(_Config) ->
         'Content-Type' => <<"3">>,
         'Response-Topic' => <<"4">>,
         'Correlation-Data' => <<"5">>,
-        'Subscription-Identifier' => 6,
         'User-Property' => maps:from_list(UserProps),
         'User-Property-Pairs' => [
             #{key => K, value => V}
@@ -1524,6 +1519,9 @@ t_sqlselect_03(_Config) ->
     ct:pal("testing payload that is not a json object"),
     emqtt:publish(Client, <<"t/r">>, PubProps, <<"not-a-map">>, [{qos, 0}]),
     ExpectedMQTTProps2 = #{
+        'Content-Type' => <<"undefined">>,
+        'Correlation-Data' => <<"undefined">>,
+        'Response-Topic' => <<"undefined">>,
         %% currently, `Topic-Alias' is dropped `emqx_message:filter_pub_props',
         %% so the channel controls those aliases on its own, starting from 1.
         'Topic-Alias' => 1,
@@ -1548,9 +1546,7 @@ t_sqlselect_03(_Config) ->
             mei => <<"bad_value2">>,
             ct => <<"some_value3">>,
             rt => <<"some_value4">>,
-            cd => <<"some_value5">>,
-            si => <<"bad_value6">>,
-            ta => <<"bad_value7">>
+            cd => <<"some_value5">>
         }),
     emqtt:publish(Client, <<"t/r">>, PubProps, Payload1, [{qos, 0}]),
     ExpectedMQTTProps3 = #{

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_schema_tests.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_schema_tests.erl
@@ -43,7 +43,6 @@ rule_engine.rules.my_rule {
           \"Content-Type\" = \"${.payload.ct}\"
           \"Response-Topic\" = \"${.payload.rt}\"
           \"Correlation-Data\" = \"${.payload.cd}\"
-          \"Subscription-Identifier\" = \"${.payload.si}\"
         }
         user_properties = \"${pub_props.'User-Property'}\"
       }
@@ -113,8 +112,7 @@ republish_test_() ->
                                                 <<"Message-Expiry-Interval">> := <<_/binary>>,
                                                 <<"Content-Type">> := <<_/binary>>,
                                                 <<"Response-Topic">> := <<_/binary>>,
-                                                <<"Correlation-Data">> := <<_/binary>>,
-                                                <<"Subscription-Identifier">> := <<_/binary>>
+                                                <<"Correlation-Data">> := <<_/binary>>
                                             }
                                     }
                             },

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_schema_tests.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_schema_tests.erl
@@ -1,0 +1,134 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_rule_engine_schema_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+%%===========================================================================
+%% Data Section
+%%===========================================================================
+
+%% erlfmt-ignore
+republish_hocon0() ->
+"""
+rule_engine.rules.my_rule {
+  description = \"some desc\"
+  metadata = {created_at = 1693918992079}
+  sql = \"select * from \\\"t/topic\\\" \"
+  actions = [
+    {function = console}
+    { function = republish
+      args = {
+        payload = \"${.}\"
+        qos = 0
+        retain = false
+        topic = \"t/repu\"
+        mqtt_properties {
+          \"Payload-Format-Indicator\" = \"${.payload.pfi}\"
+          \"Message-Expiry-Interval\" = \"${.payload.mei}\"
+          \"Content-Type\" = \"${.payload.ct}\"
+          \"Response-Topic\" = \"${.payload.rt}\"
+          \"Correlation-Data\" = \"${.payload.cd}\"
+          \"Subscription-Identifier\" = \"${.payload.si}\"
+        }
+        user_properties = \"${pub_props.'User-Property'}\"
+      }
+    },
+    \"bridges:kafka:kprodu\",
+    { function = custom_fn
+      args = {
+        actually = not_republish
+      }
+    }
+  ]
+}
+""".
+
+%%===========================================================================
+%% Helper functions
+%%===========================================================================
+
+parse(Hocon) ->
+    {ok, Conf} = hocon:binary(Hocon),
+    Conf.
+
+check(Conf) when is_map(Conf) ->
+    hocon_tconf:check_plain(emqx_rule_engine_schema, Conf).
+
+-define(validation_error(Reason, Value),
+    {emqx_rule_engine_schema, [
+        #{
+            kind := validation_error,
+            reason := Reason,
+            value := Value
+        }
+    ]}
+).
+
+-define(ok_config(Cfg), #{
+    <<"rule_engine">> :=
+        #{
+            <<"rules">> :=
+                #{
+                    <<"my_rule">> :=
+                        Cfg
+                }
+        }
+}).
+
+%%===========================================================================
+%% Test cases
+%%===========================================================================
+
+republish_test_() ->
+    BaseConf = parse(republish_hocon0()),
+    [
+        {"base config",
+            ?_assertMatch(
+                ?ok_config(
+                    #{
+                        <<"actions">> := [
+                            #{<<"function">> := console},
+                            #{
+                                <<"function">> := republish,
+                                <<"args">> :=
+                                    #{
+                                        <<"mqtt_properties">> :=
+                                            #{
+                                                <<"Payload-Format-Indicator">> := <<_/binary>>,
+                                                <<"Message-Expiry-Interval">> := <<_/binary>>,
+                                                <<"Content-Type">> := <<_/binary>>,
+                                                <<"Response-Topic">> := <<_/binary>>,
+                                                <<"Correlation-Data">> := <<_/binary>>,
+                                                <<"Subscription-Identifier">> := <<_/binary>>
+                                            }
+                                    }
+                            },
+                            <<"bridges:kafka:kprodu">>,
+                            #{
+                                <<"function">> := <<"custom_fn">>,
+                                <<"args">> :=
+                                    #{
+                                        <<"actually">> := <<"not_republish">>
+                                    }
+                            }
+                        ]
+                    }
+                ),
+                check(BaseConf)
+            )}
+    ].

--- a/apps/emqx_utils/src/emqx_placeholder.erl
+++ b/apps/emqx_utils/src/emqx_placeholder.erl
@@ -277,18 +277,27 @@ lookup_var([Prop | Rest], Data0) ->
     end.
 
 lookup(Prop, Data) when is_binary(Prop) ->
-    case maps:get(Prop, Data, undefined) of
-        undefined ->
-            try
-                {ok, maps:get(binary_to_existing_atom(Prop, utf8), Data)}
+    case do_one_lookup(Prop, Data) of
+        {error, undefined} ->
+            try binary_to_existing_atom(Prop, utf8) of
+                AtomKey ->
+                    do_one_lookup(AtomKey, Data)
             catch
-                error:{badkey, _} ->
-                    {error, undefined};
                 error:badarg ->
                     {error, undefined}
             end;
-        Value ->
+        {ok, Value} ->
             {ok, Value}
+    end.
+
+do_one_lookup(Key, Data) ->
+    try
+        {ok, maps:get(Key, Data)}
+    catch
+        error:{badkey, _} ->
+            {error, undefined};
+        error:{badmap, _} ->
+            {error, undefined}
     end.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.0.7"},
+    {vsn, "5.0.8"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
@@ -256,3 +256,25 @@ t_proc_tmpl_arbitrary_var_name_double_quote(_) ->
         <<"a:1,a:1-1,b:1,b:2,c:1.0,d:oo,d1:hi}">>,
         emqx_placeholder:proc_tmpl(Tks, Selected)
     ).
+
+t_proc_tmpl_badmap(_Config) ->
+    ThisTks = emqx_placeholder:preproc_tmpl(<<"${.}">>),
+    Tks = emqx_placeholder:preproc_tmpl(<<"${.a.b.c}">>),
+    BadMap = <<"not-a-map">>,
+    ?assertEqual(
+        <<"not-a-map">>,
+        emqx_placeholder:proc_tmpl(ThisTks, BadMap)
+    ),
+    ?assertEqual(
+        <<"undefined">>,
+        emqx_placeholder:proc_tmpl(Tks, #{<<"a">> => #{<<"b">> => BadMap}})
+    ),
+    ?assertEqual(
+        <<"undefined">>,
+        emqx_placeholder:proc_tmpl(Tks, #{<<"a">> => BadMap})
+    ),
+    ?assertEqual(
+        <<"undefined">>,
+        emqx_placeholder:proc_tmpl(Tks, BadMap)
+    ),
+    ok.

--- a/changes/ce/feat-11568.en.md
+++ b/changes/ce/feat-11568.en.md
@@ -1,0 +1,1 @@
+Added support for defining templates for MQTT publish properties in Republish rule action.

--- a/changes/ce/fix-11568.en.md
+++ b/changes/ce/fix-11568.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where an ill-defined builtin rule action config could be interpreted as a custom user function.

--- a/rel/i18n/emqx_rule_engine_schema.hocon
+++ b/rel/i18n/emqx_rule_engine_schema.hocon
@@ -103,6 +103,16 @@ You may also call <code>map_put</code> function like
 to inject user properties.
 NOTE: MQTT spec allows duplicated user property names, but EMQX Rule-Engine does not."""
 
+republish_args_user_properties.label:
+"""User Properties"""
+
+republish_args_mqtt_properties.desc:
+"""From which variable should the MQTT Publish Properties of the message be taken from.
+Placeholders like <code>${.payload.content_type}</code> may be used."""
+
+republish_args_mqtt_properties.label:
+"""MQTT Properties"""
+
 republish_function.desc:
 """Republish the message as a new MQTT message"""
 

--- a/rel/i18n/emqx_rule_engine_schema.hocon
+++ b/rel/i18n/emqx_rule_engine_schema.hocon
@@ -107,7 +107,7 @@ republish_args_user_properties.label:
 """User Properties"""
 
 republish_args_mqtt_properties.desc:
-"""From which variable should the MQTT Publish Properties of the message be taken from.
+"""From which variable should the MQTT Publish Properties of the message be taken.
 Placeholders like <code>${.payload.content_type}</code> may be used."""
 
 republish_args_mqtt_properties.label:


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10912

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e442481</samp>

Added support for customizing MQTT properties and user properties of republished messages in the rule engine. The republish action now accepts maps of templates for these properties, which are processed by the `emqx_rule_actions` module. The changes also include new types, fields, and functions in the `emqx_rule_engine_schema` and `emqx_dashboard_swagger` modules, as well as new test cases and modules in the `emqx_rule_engine` app. The versions of the `emqx_dashboard` and `emqx_rule_engine` apps were also bumped.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [na] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [na] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [na] Change log has been added to `changes/` dir for user-facing artifacts update
