### PR TITLE
fix: telemetry report error on windows

### DIFF
--- a/apps/emqx_telemetry/src/emqx_telemetry.app.src
+++ b/apps/emqx_telemetry/src/emqx_telemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_telemetry, [
     {description, "Report telemetry data for EMQX Opensource edition"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, [emqx_telemetry_sup, emqx_telemetry]},
     {mod, {emqx_telemetry_app, []}},
     {applications, [

--- a/apps/emqx_telemetry/src/emqx_telemetry.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry.erl
@@ -416,10 +416,9 @@ read_raw_build_info() ->
     file:read_file(Filename).
 
 vm_specs() ->
-    SysMemData = memsup:get_system_memory_data(),
     [
         {num_cpus, erlang:system_info(logical_processors)},
-        {total_memory, proplists:get_value(total_memory, SysMemData)}
+        {total_memory, emqx_mgmt:vm_stats('total.memory')}
     ].
 
 -spec mqtt_runtime_insights(state()) -> {map(), state()}.

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -70,6 +70,9 @@ end_per_suite(_Config) ->
     meck:unload(emqx_authz),
     ok.
 
+init_per_testcase(t_get_telemetry_without_memsup, Config) ->
+    ok = application:stop(os_mon),
+    init_per_testcase(t_get_telemetry, Config);
 init_per_testcase(t_get_telemetry, Config) ->
     DataDir = ?config(data_dir, Config),
     mock_httpc(),
@@ -198,6 +201,9 @@ init_per_testcase(_Testcase, Config) ->
     mock_httpc(),
     Config.
 
+end_per_testcase(t_get_telemetry_without_memsup, Config) ->
+    application:start(os_mon),
+    end_per_testcase(t_get_telemetry, Config);
 end_per_testcase(t_get_telemetry, _Config) ->
     meck:unload([httpc, emqx_telemetry]),
     application:stop(emqx_gateway),

--- a/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_api_SUITE.erl
@@ -32,7 +32,7 @@ init_per_suite(Config) ->
     ok = emqx_common_test_helpers:load_config(emqx_modules_schema, ?BASE_CONF),
     ok = emqx_common_test_helpers:load_config(emqx_telemetry_schema, ?BASE_CONF),
     ok = emqx_mgmt_api_test_util:init_suite(
-        [emqx_conf, emqx_authn, emqx_authz, emqx_telemetry],
+        [emqx_conf, emqx_authn, emqx_management, emqx_authz, emqx_telemetry],
         fun set_special_configs/1
     ),
 

--- a/changes/ce/fix-11584.en.md
+++ b/changes/ce/fix-11584.en.md
@@ -1,0 +1,1 @@
+Fixed telemetry reporting error on Windows when os_mon module is unavailable.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10938
os_mon is not included on windows, so the `SysMemData = memsup:get_system_memory_data()` always report error:
`module  could not be loaded`.

![image](https://github.com/emqx/emqx/assets/3116225/9f4a7eaa-8dd4-4122-b04c-6ed84efec5bb)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a2b06f4</samp>

Improved the reliability and portability of the emqx_telemetry application by using `emqx_mgmt:vm_stats` instead of `memsup:get_system_memory_data` to get the system memory. Added a test case to cover the scenario where `os_mon` is not available. Bumped the version number to 0.1.2.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
