### PR TITLE
feat: check cluster.static.seeds's integrity

### DIFF
--- a/changes/ce/feat-11607.en.md
+++ b/changes/ce/feat-11607.en.md
@@ -1,0 +1,1 @@
+Enhanced the 'cluster info' command to automatically validate that static seeds are correctly configured.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11206

When nodes are removed from a static cluster through the CLI, an updated message will suggest that users also update their configuration files.

1. Start a cluster with nodes A, B and C.
```
cluster {
  name = emqxcl
  discovery_strategy = static
  static { seeds = [A, B, C]
}
```
2. After two weeks of running, finding only two nodes is sufficient.
3. Remove node C through `./emqx ctl cluster leave A` and `./emqx stop` on node C.
4. It is suggested that the user remove C from Node A/B's seeds, otherwise A'B will attempt to connect to C.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1d9afd2</samp>

This pull request enhances the `emqx_mgmt_cli` module with a new function to check the cluster configuration integrity and a corresponding test case. The function `check_cluster_config_integrity/2` detects and reports any nodes that are configured as seeds but not part of the cluster. The test case `t_cluster_info/1` in `emqx_mgmt_cli_SUITE.erl` covers this scenario and asserts the expected output.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
