### PR TITLE
fix: keep builtin_console actions not complain args

### DIFF
--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.0.29"},
+    {vsn, "5.0.30"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [kernel, stdlib, emqx_plugins, minirest, emqx, emqx_ctl, emqx_bridge_http]},

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -647,7 +647,7 @@ set_keepalive(put, #{bindings := #{clientid := ClientID}, body := Body}) ->
         error ->
             {400, 'BAD_REQUEST', "Interval Not Found"};
         {ok, Interval} ->
-            case emqx_mgmt:set_keepalive(emqx_mgmt_util:urldecode(ClientID), Interval) of
+            case emqx_mgmt:set_keepalive(ClientID, Interval) of
                 ok -> lookup(#{clientid => ClientID});
                 {error, not_found} -> {404, ?CLIENTID_NOT_FOUND};
                 {error, Reason} -> {400, #{code => 'PARAMS_ERROR', message => Reason}}

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -45,11 +45,15 @@
 %%--------------------------------------------------------------------
 parse_action(#{function := ActionFunc} = Action) ->
     {Mod, Func} = parse_action_func(ActionFunc),
-    #{
-        mod => Mod,
-        func => Func,
-        args => pre_process_args(Mod, Func, maps:get(args, Action, #{}))
-    }.
+    Res = #{mod => Mod, func => Func},
+    %% builtin_action_console don't have args field.
+    %% Attempting to save args to the console action config could cause validation issues
+    case Action of
+        #{args := Args} ->
+            Res#{args => pre_process_args(Mod, Func, Args)};
+        _ ->
+            Res
+    end.
 
 %%--------------------------------------------------------------------
 %% callbacks of emqx_rule_action

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.0.25"},
+    {vsn, "5.0.26"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [kernel, stdlib, rulesql, getopt, emqx_ctl, uuid]},

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -525,6 +525,10 @@ do_format_action(#{mod := Mod, func := Func, args := Args}) ->
     #{
         function => printable_function_name(Mod, Func),
         args => maps:remove(preprocessed_tmpl, Args)
+    };
+do_format_action(#{mod := Mod, func := Func}) ->
+    #{
+        function => printable_function_name(Mod, Func)
     }.
 
 printable_function_name(emqx_rule_actions, Func) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -114,6 +114,7 @@ fields("builtin_action_console") ->
         {args,
             ?HOCON(map(), #{
                 deprecated => true,
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => "The arguments of the built-in 'console' action",
                 default => #{}
             })}

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -98,10 +98,25 @@ fields("builtin_action_republish") ->
     ];
 fields("builtin_action_console") ->
     [
-        {function, ?HOCON(console, #{desc => ?DESC("console_function")})}
+        {function, ?HOCON(console, #{desc => ?DESC("console_function")})},
         %% we may support some args for the console action in the future
-        %, {args, sc(map(), #{desc => "The arguments of the built-in 'console' action",
-        %    default => #{}})}
+
+        %% "args" needs to be a reserved/ignored field in the schema
+        %% to maintain compatibility with rule data that may contain
+        %% it due to a validation bug in previous versions.
+
+        %% The "args" field was not validated by the HOCON schema before 5.2.0,
+        %% which allowed rules to be created with invalid "args" data.
+        %% In 5.2.1 the validation was added,
+        %% so existing rules saved with invalid "args" would now fail validation
+        %% To maintain backward compatibility for existing rule data that may contain invalid "args",
+        %% the field needs to be included in the schema even though it is not a valid field.
+        {args,
+            ?HOCON(map(), #{
+                deprecated => true,
+                desc => "The arguments of the built-in 'console' action",
+                default => #{}
+            })}
     ];
 fields("user_provided_function") ->
     [

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_schema_tests.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_schema_tests.erl
@@ -30,7 +30,7 @@ rule_engine.rules.my_rule {
   metadata = {created_at = 1693918992079}
   sql = \"select * from \\\"t/topic\\\" \"
   actions = [
-    {function = console}
+    {function = console, args = {test = 1}}
     { function = republish
       args = {
         payload = \"${.}\"


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10992
Don't need changelog, v5.2.0 is ok.

There was previously a bug allowing invalid fields:

The API for creation/update did not validate the args field, and rules were being created with default args.

The configuration file also did not validate the args field.

Now after being fixed, validation has been enabled:

This causes any rules/configurations saved earlier with invalid args to no longer work.

We fixed the validate here:
https://github.com/emqx/emqx/commit/78c5a779d7c721663470609acc80c52efd3c7886#diff-5799d1ec01ad3359596ab22f7781d2b34e8f7909194bb0785f7d1dbe677a0d88L202-L208



compatibility with `actions. args`
```
rule_engine {
  ignore_sys_message = true
  jq_function_default_timeout = 10s
  rules {
    rule_u54w {
      actions = [
        {
          args {}
          function = console
        }
      ]
      description = ""
      enable = true
      metadata {created_at = 1694748634418}
      name = ""
      sql = "SELECT\n  *\nFROM\n  \"t/#\" \n  WHERE payload.message.header.function='pmMsgReq'"
    }
  }
}
```
And 
<img width="1569" alt="image" src="https://github.com/emqx/emqx/assets/3116225/27bd2147-e5b6-41d2-b680-21c886bf3b7b">

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d72348c</samp>

Fix a validation bug for the `builtin_action_console` rule action and update the `emqx_rule_engine` version. The bug caused the console action to fail validation when saving the rule config due to an invalid `args` field. The fix removes the `args` field from the console action config and adds it to the schema as a deprecated and ignored field. The version update reflects the bug fix and other changes in the application.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
