### PR TITLE
fix: emqx user home folder permissions

### DIFF
--- a/deploy/packages/rpm/emqx.spec
+++ b/deploy/packages/rpm/emqx.spec
@@ -93,7 +93,7 @@ exit 0
 %defattr(-,root,root)
 %{_service_dst}
 %attr(-,%{_user},%{_group}) %{_lib_home}/*
-%attr(-,%{_user},%{_group}) %dir %{_var_home}
+%attr(750,%{_user},%{_group}) %dir %{_var_home}
 %attr(-,%{_user},%{_group}) %config(noreplace) %{_var_home}/*
 %attr(-,%{_user},%{_group}) %dir %{_log_dir}
 %attr(-,%{_user},%{_group}) %config(noreplace) %{_conf_dir}/*


### PR DESCRIPTION
changed "emqx" user home directory permissions to 750

Fixes <issue-or-jira-number>

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 442cfea</samp>

Set stricter permission for `%{_var_home}` directory in `emqx.spec`. This enhances the security of the RPM package of `emqx`, a MQTT broker.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
