### PR TITLE
fix(emqx_bridge_hstreamdb): fix resources cleanup in on_stop/2 cb

### DIFF
--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
@@ -48,7 +48,7 @@ on_start(InstId, Config) ->
 
 on_stop(InstId, _State) ->
     case emqx_resource:get_allocated_resources(InstId) of
-        #{client := Client, producer := Producer} ->
+        #{?hstreamdb_client := #{client := Client, producer := Producer}} ->
             StopClientRes = hstreamdb:stop_client(Client),
             StopProducerRes = hstreamdb:stop_producer(Producer),
             ?SLOG(info, #{

--- a/changes/ee/fix-11627.en.md
+++ b/changes/ee/fix-11627.en.md
@@ -1,0 +1,3 @@
+Fix resources cleanup in HStreamdB bridge.
+
+Prior to this fix, HStreamDB bridge might report errors during bridge configuration updates, since hstreamdb client/producer were not stopped properly.


### PR DESCRIPTION
Fixes EMQX-10962

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at da730e8</samp>

Fix a bug in `emqx_bridge_hstreamdb_connector` that caused a bad match error when stopping the bridge. Use a macro to match the hstreamdb resource type.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
