### PR TITLE
fix: handle case that zombie process terminated

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -805,6 +805,12 @@ generate_config() {
     mv -f "$TMP_ARG_FILE" "$ARGS_FILE"
 }
 
+# check if a PID is defunct
+is_defunct() {
+    local PID="$1"
+    ps -fp "$PID" | $GREP -q 'defunct'
+}
+
 # check if a PID is down
 # shellcheck disable=SC2317 # call in func `nodetool_shutdown()`
 is_down() {
@@ -812,9 +818,13 @@ is_down() {
     if ps -p "$PID" >/dev/null; then
         # still around
         # shellcheck disable=SC2009 # this grep pattern is not a part of the program names
-        if ps -fp "$PID" | $GREP -q 'defunct'; then
+        if is_defunct "$PID"; then
             # zombie state, print parent pid
             parent="$(ps -o ppid= -p "$PID" | tr -d ' ')"
+            if [ -z "$parent" ] && ! is_defunct "$PID"; then
+                # process terminated in the meanwhile
+                return 0;
+            fi
             logwarn "$PID is marked <defunct>, parent: $(ps -p "$parent")"
             return 0
         fi


### PR DESCRIPTION
When emqx is stopped, sometimes it found out that the process is at zombie state and tries to get the parent PID but the process has already finished in the meanwhile, printing an error message like this:

```
error: process ID list syntax error

Usage:
 ps [options]

 Try 'ps --help <simple|list|output|threads|misc|all>'
  or 'ps --help <s|l|o|t|m|a>'
 for additional help text.

For more details see ps(1).
WARNING: 281777 is marked <defunct>, parent:
ok
```



<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
