### PR TITLE
fix: always return ok when remove local resource

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -298,11 +298,7 @@ remove(Type, Name) ->
 %% just for perform_bridge_changes/1
 remove(Type, Name, _Conf, _Opts) ->
     ?SLOG(info, #{msg => "remove_bridge", type => Type, name => Name}),
-    case emqx_resource:remove_local(resource_id(Type, Name)) of
-        ok -> ok;
-        {error, not_found} -> ok;
-        {error, Reason} -> {error, Reason}
-    end.
+    emqx_resource:remove_local(resource_id(Type, Name)).
 
 %% convert bridge configs to what the connector modules want
 parse_confs(

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -266,7 +266,7 @@ remove_local(ResId) ->
         {error, not_found} ->
             ok;
         Error ->
-            %% Only log, the ResId worker is always remove in manager's remove action.
+            %% Only log, the ResId worker is always removed in manager's remove action.
             ?SLOG(warning, #{
                 msg => "remove_local_resource_failed",
                 error => Error,

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -164,7 +164,7 @@ t_create_remove_local(_) ->
             ),
 
             ?assertEqual(ok, emqx_resource:remove_local(?ID)),
-            ?assertMatch({error, _}, emqx_resource:remove_local(?ID)),
+            ?assertMatch(ok, emqx_resource:remove_local(?ID)),
 
             ?assertMatch(
                 ?RESOURCE_ERROR(not_found),

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -110,7 +110,7 @@ t_create_remove(_) ->
             ?assert(is_process_alive(Pid)),
 
             ?assertEqual(ok, emqx_resource:remove(?ID)),
-            ?assertMatch({error, _}, emqx_resource:remove(?ID)),
+            ?assertMatch(ok, emqx_resource:remove(?ID)),
 
             ?assertNot(is_process_alive(Pid))
         end,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10994

When deleting resources, not returning ok will cause some resource's `post_config_update` functions to crash directly, this crash will cause all configurations to no longer be allowed to be updated. 
We should ensure that resources can be deleted when even errors occur, so that users can re-add the correct resources after manual deletion.

```
2023-09-18T06:16:35.563750+00:00 [debug] message=call_reply event=call_reply_sent driver=tcp socket="#Port<0.44>"
2023-09-18T06:16:36.594365+00:00 [info] msg: start_ecpool_ok, mfa: emqx_resource_pool:start/3, line: 40, pool_name: <<"emqx_authz_mongodb:8265">>
2023-09-18T06:16:41.267061+00:00 [debug] msg: emqx_connector_mongo_health_check, mfa: emqx_mongodb:on_get_status/2, line: 303, instance_id: <<"emqx_authz_mongodb:8265">>, status: ok
2023-09-18T06:16:41.305360+00:00 [info] msg: stopping_mongodb_connector, mfa: emqx_mongodb:on_stop/2, line: 229, connector: <<"emqx_authz_mongodb:8265">>
2023-09-18T06:16:41.307741+00:00 [info] msg: stop_ecpool_ok, mfa: emqx_resource_pool:stop/1, line: 58, pool_name: <<"emqx_authz_mongodb:8265">>
2023-09-18T06:16:41.323602+00:00 [error] msg: change_config_crashed, mfa: emqx_config_handler:handle_update_request/4, line: 220, exception: error, key_path: [authorization,sources], module: emqx_enterprise_schema, reason: {badmatch,{error,timeout}}, stacktrace: [{emqx_authz_mongodb,destroy,1,[{file,"emqx_authz_mongodb.erl"},{line,67}]},{emqx_authz,ensure_deleted,2,[{file,"emqx_authz.erl"},{line,292}]},{emqx_authz,do_post_config_update,3,[{file,"emqx_authz.erl"},{line,246}]},{emqx_authz,post_config_update,5,[{file,"emqx_authz.erl"},{line,224}]},{emqx_config_handler,call_proper_post_config_update,1,[{file,"emqx_config_handler.erl"},{line,564}]},{emqx_config_handler,call_post_config_update,1,[{file,"emqx_config_handler.erl"},{line,543}]},{emqx_config_handler,check_and_save_configs,7,[{file,"emqx_config_handler.erl"},{line,300}]},{emqx_config_handler,handle_update_request,4,[{file,"emqx_config_handler.erl"},{line,207}]},{emqx_config_handler,handle_call,3,[{file,"emqx_config_handler.erl"},{line,136}]},{gen_server,try_handle_call,4,[{file,"gen_server.erl"},{line,1149}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1178}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}], update_req: {{update,{{delete,mongodb},#{}}},#{override_to => cluster,rawconf_with_defaults => true}}
2023-09-18T06:16:41.324027+00:00 [error] msg: cluster_rpc_apply_failed, mfa: emqx_cluster_rpc:log_and_alarm/3, line: 571, entrypoint: <<"emqx:update_config/3">>, kind: replicate, result: {error,{config_update_crashed,{badmatch,{error,timeout}}}}, tnx_id: 11364
2023-09-18T06:16:41.324286+00:00 [warning] msg: alarm_is_activated, mfa: emqx_alarm:do_actions/3, line: 418, message: <<"cluster_rpc_apply_failed=11364">>, name: cluster_rpc_apply_failed
```

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c26a18e</samp>

Improve logging and error handling for `emqx_resource` module and update test case. This change makes the module more robust and consistent with the logging conventions and avoids unnecessary crashes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
