### PR TITLE
fix(sso): add an API with authorization-free to list running backends

### DIFF
--- a/rel/i18n/emqx_dashboard_sso_api.hocon
+++ b/rel/i18n/emqx_dashboard_sso_api.hocon
@@ -1,5 +1,10 @@
 emqx_dashboard_api {
 
+list_running.desc:
+"""List all running SSO backends"""
+list_running.label:
+"""Running Backends"""
+
 get_sso.desc:
 """List all SSO backends"""
 get_sso.label:


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2283db6</samp>

This pull request adds two new SSO API endpoints to the `emqx_dashboard_sso` app: `/sso/running` to check the running status of SSO backends, and `/sso/login/:backend` to initiate the SSO login process for a specific backend. It also modifies the `emqx_dashboard` app to allow some SSO requests without authorization, and adds internationalization support and tests for the new APIs.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
