### PR TITLE
ci: use ephemeral self hosted runners

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   sanity-checks:
-    runs-on: ${{ github.repository_owner == 'emqx' && 'aws-amd64' || 'ubuntu-22.04' }}
+    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted","ephemeral"]' || '["ubuntu-22.04"]') }}
     container: "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04"
     outputs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
@@ -24,7 +24,7 @@ jobs:
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
       version-emqx: ${{ steps.matrix.outputs.version-emqx }}
       version-emqx-enterprise: ${{ steps.matrix.outputs.version-emqx-enterprise }}
-      runner: ${{ github.repository_owner == 'emqx' && 'aws-amd64' || 'ubuntu-22.04' }}
+      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted", "ephemeral"]' || '["ubuntu-22.04"]' }}
       builder: "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04"
       builder_vsn: "5.1-4"
       otp_vsn: "25.3.2-2"
@@ -115,7 +115,7 @@ jobs:
           echo "version-emqx-enterprise=$(./pkg-vsn.sh emqx-enterprise)" | tee -a $GITHUB_OUTPUT
 
   compile:
-    runs-on: ${{ needs.sanity-checks.outputs.runner }}
+    runs-on: ${{ fromJSON(needs.sanity-checks.outputs.runner_labels) }}
     container: ${{ needs.sanity-checks.outputs.builder }}
     needs:
       - sanity-checks
@@ -153,7 +153,7 @@ jobs:
       - compile
     uses: ./.github/workflows/run_emqx_app_tests.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       before_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       after_ref: ${{ github.sha }}
@@ -164,7 +164,7 @@ jobs:
       - compile
     uses: ./.github/workflows/run_test_cases.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       ct-matrix: ${{ needs.sanity-checks.outputs.ct-matrix }}
       ct-host: ${{ needs.sanity-checks.outputs.ct-host }}
@@ -176,7 +176,7 @@ jobs:
       - compile
     uses: ./.github/workflows/static_checks.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       ct-matrix: ${{ needs.sanity-checks.outputs.ct-matrix }}
 
@@ -185,7 +185,7 @@ jobs:
       - sanity-checks
     uses: ./.github/workflows/build_slim_packages.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       builder_vsn: ${{ needs.sanity-checks.outputs.builder_vsn }}
       otp_vsn: ${{ needs.sanity-checks.outputs.otp_vsn }}
@@ -196,6 +196,7 @@ jobs:
       - sanity-checks
     uses: ./.github/workflows/build_docker_for_test.yaml
     with:
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       otp_vsn: ${{ needs.sanity-checks.outputs.otp_vsn }}
       elixir_vsn: ${{ needs.sanity-checks.outputs.elixir_vsn }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
@@ -207,7 +208,7 @@ jobs:
       - build_slim_packages
     uses: ./.github/workflows/spellcheck.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
 
   run_conf_tests:
     needs:
@@ -215,7 +216,7 @@ jobs:
       - compile
     uses: ./.github/workflows/run_conf_tests.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
 
   check_deps_integrity:
@@ -223,7 +224,7 @@ jobs:
       - sanity-checks
     uses: ./.github/workflows/check_deps_integrity.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
 
   run_jmeter_tests:
@@ -232,6 +233,7 @@ jobs:
       - build_docker_for_test
     uses: ./.github/workflows/run_jmeter_tests.yaml
     with:
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
 
   run_docker_tests:
@@ -240,7 +242,7 @@ jobs:
       - build_docker_for_test
     uses: ./.github/workflows/run_docker_tests.yaml
     with:
-      runner: ${{ needs.sanity-checks.outputs.runner }}
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
       version-emqx-enterprise: ${{ needs.sanity-checks.outputs.version-emqx-enterprise }}
 
@@ -250,5 +252,6 @@ jobs:
       - build_docker_for_test
     uses: ./.github/workflows/run_helm_tests.yaml
     with:
+      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
       version-emqx-enterprise: ${{ needs.sanity-checks.outputs.version-emqx-enterprise }}

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -11,9 +11,7 @@ on:
       - 'e*'
     branches:
       - 'master'
-      - 'release-51'
-      - 'release-52'
-      - 'release-53'
+      - 'release-5?'
       - 'ci/**'
 
 env:
@@ -21,7 +19,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ${{ github.repository_owner == 'emqx' && 'aws-amd64' || 'ubuntu-22.04' }}
+    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted", "ephemeral"]' || '["ubuntu-22.04"]') }}
     container: 'ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04'
     outputs:
       profile: ${{ steps.parse-git-ref.outputs.profile }}
@@ -31,7 +29,7 @@ jobs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
       ct-host: ${{ steps.matrix.outputs.ct-host }}
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
-      runner: ${{ github.repository_owner == 'emqx' && 'aws-amd64' || 'ubuntu-22.04' }}
+      runner_labels: ${{ github.repository_owner == 'emqx' && '["aws-amd64"]' || '["ubuntu-22.04"]' }}
       builder: 'ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04'
       builder_vsn: '5.1-4'
       otp_vsn: '25.3.2-2'
@@ -95,7 +93,6 @@ jobs:
       otp_vsn: ${{ needs.prepare.outputs.otp_vsn }}
       elixir_vsn: ${{ needs.prepare.outputs.elixir_vsn }}
       builder_vsn: ${{ needs.prepare.outputs.builder_vsn }}
-      runner: ${{ needs.prepare.outputs.runner }}
     secrets: inherit
 
   build_and_push_docker_images:
@@ -111,7 +108,7 @@ jobs:
       otp_vsn: ${{ needs.prepare.outputs.otp_vsn }}
       elixir_vsn: ${{ needs.prepare.outputs.elixir_vsn }}
       builder_vsn: ${{ needs.prepare.outputs.builder_vsn }}
-      runner: ${{ needs.prepare.outputs.runner }}
+      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
     secrets: inherit
 
   build_slim_packages:
@@ -120,7 +117,7 @@ jobs:
       - prepare
     uses: ./.github/workflows/build_slim_packages.yaml
     with:
-      runner: ${{ needs.prepare.outputs.runner }}
+      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       builder_vsn: ${{ needs.prepare.outputs.builder_vsn }}
       otp_vsn: ${{ needs.prepare.outputs.otp_vsn }}
@@ -128,7 +125,7 @@ jobs:
 
   compile:
     if: needs.prepare.outputs.release != 'true'
-    runs-on: ${{ needs.prepare.outputs.runner }}
+    runs-on: ${{ fromJSON(needs.prepare.outputs.runner_labels) }}
     container: ${{ needs.prepare.outputs.builder }}
     needs:
       - prepare
@@ -165,7 +162,7 @@ jobs:
       - compile
     uses: ./.github/workflows/run_emqx_app_tests.yaml
     with:
-      runner: ${{ needs.prepare.outputs.runner }}
+      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       before_ref: ${{ github.event.before }}
       after_ref: ${{ github.sha }}
@@ -177,7 +174,7 @@ jobs:
       - compile
     uses: ./.github/workflows/run_test_cases.yaml
     with:
-      runner: ${{ needs.prepare.outputs.runner }}
+      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       ct-matrix: ${{ needs.prepare.outputs.ct-matrix }}
       ct-host: ${{ needs.prepare.outputs.ct-host }}
@@ -190,7 +187,7 @@ jobs:
       - compile
     uses: ./.github/workflows/run_conf_tests.yaml
     with:
-      runner: ${{ needs.prepare.outputs.runner }}
+      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
 
   static_checks:
@@ -200,6 +197,6 @@ jobs:
       - compile
     uses: ./.github/workflows/static_checks.yaml
     with:
-      runner: ${{ needs.prepare.outputs.runner }}
+      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       ct-matrix: ${{ needs.prepare.outputs.ct-matrix }}

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -29,7 +29,7 @@ jobs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
       ct-host: ${{ steps.matrix.outputs.ct-host }}
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
-      runner_labels: ${{ github.repository_owner == 'emqx' && '["aws-amd64"]' || '["ubuntu-22.04"]' }}
+      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted", "ephemeral"]' || '["ubuntu-22.04"]' }}
       builder: 'ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04'
       builder_vsn: '5.1-4'
       otp_vsn: '25.3.2-2'

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -28,7 +28,7 @@ on:
       builder_vsn:
         required: true
         type: string
-      runner:
+      runner_labels:
         required: true
         type: string
     secrets:
@@ -70,14 +70,14 @@ on:
         required: false
         type: string
         default: '5.1-4'
-      runner:
+      runner_labels:
         required: false
         type: string
-        default: 'ubuntu-22.04'
+        default: '["self-hosted","ephemeral"]'
 
 jobs:
   docker:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -73,7 +73,7 @@ on:
       runner_labels:
         required: false
         type: string
-        default: '["self-hosted","ephemeral"]'
+        default: '["self-hosted","ephemeral", "linux"]'
 
 jobs:
   docker:

--- a/.github/workflows/build_docker_for_test.yaml
+++ b/.github/workflows/build_docker_for_test.yaml
@@ -7,6 +7,9 @@ concurrency:
 on:
   workflow_call:
     inputs:
+      runner_labels:
+        required: true
+        type: string
       otp_vsn:
         required: true
         type: string
@@ -22,7 +25,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     env:
       EMQX_NAME: ${{ matrix.profile }}
       PKG_VSN: ${{ startsWith(matrix.profile, 'emqx-enterprise') && inputs.version-emqx-enterprise || inputs.version-emqx }}

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -19,9 +19,6 @@ on:
       elixir_vsn:
         required: true
         type: string
-      runner:
-        required: true
-        type: string
       builder_vsn:
         required: true
         type: string
@@ -62,10 +59,6 @@ on:
         required: false
         type: string
         default: '1.14.5'
-      runner:
-        required: false
-        type: string
-        default: 'ubuntu-22.04'
       builder_vsn:
         required: false
         type: string
@@ -158,7 +151,7 @@ jobs:
         path: _packages/${{ matrix.profile }}/
 
   linux:
-    runs-on: ${{ matrix.build_machine }}
+    runs-on: ['self-hosted', 'linux', "${{ matrix.arch }}"]
     # always run in builder container because the host might have the wrong OTP version etc.
     # otherwise buildx.sh does not run docker if arch and os matches the target arch and os.
     container:
@@ -172,7 +165,7 @@ jobs:
         otp:
           - ${{ inputs.otp_vsn }}
         arch:
-          - amd64
+          - x64
           - arm64
         os:
           - ubuntu22.04
@@ -186,26 +179,17 @@ jobs:
           - el7
           - amzn2
           - amzn2023
-        build_machine:
-          - aws-arm64
-          - aws-amd64
         builder:
           - ${{ inputs.builder_vsn }}
         elixir:
           - ${{ inputs.elixir_vsn }}
         with_elixir:
           - 'no'
-        exclude:
-          - arch: arm64
-            build_machine: aws-amd64
-          - arch: amd64
-            build_machine: aws-arm64
         include:
           - profile: emqx
             otp: ${{ inputs.otp_vsn }}
-            arch: amd64
+            arch: x64
             os: ubuntu22.04
-            build_machine: aws-amd64
             builder: ${{ inputs.builder_vsn }}
             elixir: ${{ inputs.elixir_vsn }}
             with_elixir: 'yes'

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   linux:
     if: github.repository_owner == 'emqx'
-    runs-on: aws-${{ matrix.arch }}
+    runs-on: ['self-hosted', 'linux', "${{ matrix.arch }}", 'ephemeral']
     container:
       image: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}"
 
@@ -26,7 +26,7 @@ jobs:
         otp:
           - 25.3.2-2
         arch:
-          - amd64
+          - x64
         os:
           - debian10
           - ubuntu22.04
@@ -41,7 +41,6 @@ jobs:
         shell: bash
 
     steps:
-      - uses: emqx/self-hosted-cleanup-action@v1.0.3
       - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.profile[1] }}
@@ -105,7 +104,6 @@ jobs:
           - macos-12-arm64
 
     steps:
-      - uses: emqx/self-hosted-cleanup-action@v1.0.3
       - uses: actions/checkout@v3
         with:
           ref: ${{ matrix.branch }}

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       builder:
@@ -27,10 +27,10 @@ on:
     inputs:
       ref:
         required: false
-      runner:
+      runner_labels:
         required: false
         type: string
-        default: 'ubuntu-22.04'
+        default: '["self-hosted","ephemeral"]'
       builder:
         required: false
         type: string
@@ -50,7 +50,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     env:
       EMQX_NAME: ${{ matrix.profile[0] }}
 
@@ -64,7 +64,6 @@ jobs:
     container: "ghcr.io/emqx/emqx-builder/${{ inputs.builder_vsn }}:${{ inputs.elixir_vsn }}-${{ matrix.profile[1] }}-${{ matrix.profile[2] }}"
 
     steps:
-    - uses: AutoModality/action-clean@v1
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -3,7 +3,7 @@ name: Check integrity of rebar and mix dependencies
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       builder:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   check_deps_integrity:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     container: ${{ inputs.builder }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   rerun-failed-jobs:
-    runs-on: ubuntu-22.04
     if: github.repository_owner == 'emqx'
+    runs-on: ['self-hosted', 'linux', 'x64', 'ephemeral']
     permissions:
       checks: read
       actions: write

--- a/.github/workflows/run_conf_tests.yaml
+++ b/.github/workflows/run_conf_tests.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       builder:
@@ -16,7 +16,7 @@ on:
 
 jobs:
   run_conf_tests:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     container: ${{ inputs.builder }}
     env:
       PROFILE: ${{ matrix.profile }}
@@ -27,7 +27,6 @@ jobs:
           - emqx
           - emqx-enterprise
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.profile }}

--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       version-emqx:
@@ -19,7 +19,7 @@ on:
 
 jobs:
   basic-tests:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     defaults:
       run:
         shell: bash
@@ -63,7 +63,7 @@ jobs:
           docker compose rm -fs
 
   paho-mqtt-testing:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     defaults:
       run:
         shell: bash
@@ -83,7 +83,6 @@ jobs:
           - mnesia
           - rlog
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/checkout@v3
       - uses: actions/download-artifact@v3
         with:
@@ -110,9 +109,8 @@ jobs:
             echo "DUMP_CONTAINER_LOGS_END"
             exit 1
           fi
-      # node_dump requires netstat, which is not available in the container
       # simple smoke test for node_dump
-      # - name: test node_dump
-      #   run: |
-      #     docker exec -u root node1.emqx.io apt update && apt install -y net-tools
-      #     docker exec node1.emqx.io node_dump
+      - name: test node_dump
+        run: |
+          docker exec -u root node1.emqx.io apt update && apt install -y net-tools
+          docker exec node1.emqx.io node_dump

--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -112,5 +112,5 @@ jobs:
       # simple smoke test for node_dump
       - name: test node_dump
         run: |
-          docker exec -u root node1.emqx.io apt update && apt install -y net-tools
+          docker exec -t -u root node1.emqx.io bash -c 'apt-get -y update && apt-get -y install net-tools'
           docker exec node1.emqx.io node_dump

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -10,7 +10,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       builder:
@@ -28,7 +28,7 @@ env:
 
 jobs:
   run_emqx_app_tests:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     container: ${{ inputs.builder }}
 
     defaults:
@@ -61,5 +61,5 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: failure()
       with:
-        name: logs-${{ inputs.runner }}
+        name: logs-emqx-app-tests
         path: apps/emqx/_build/test/logs

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -7,6 +7,9 @@ concurrency:
 on:
   workflow_call:
     inputs:
+      runner_labels:
+        required: true
+        type: string
       version-emqx:
         required: true
         type: string
@@ -16,7 +19,7 @@ on:
 
 jobs:
   helm_test:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -3,13 +3,16 @@ name: JMeter integration tests
 on:
   workflow_call:
     inputs:
+      runner_labels:
+        required: true
+        type: string
       version-emqx:
         required: true
         type: string
 
 jobs:
   jmeter_artifact:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
     - name: Cache Jmeter
       id: cache-jmeter
@@ -38,7 +41,7 @@ jobs:
         path: /tmp/apache-jmeter.tgz
 
   advanced_feat:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     strategy:
       fail-fast: false
@@ -89,7 +92,7 @@ jobs:
         path: ./jmeter_logs
 
   pgsql_authn_authz:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     strategy:
       fail-fast: false
@@ -155,7 +158,7 @@ jobs:
         path: ./jmeter_logs
 
   mysql_authn_authz:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     strategy:
       fail-fast: false
@@ -214,7 +217,7 @@ jobs:
         path: ./jmeter_logs
 
   JWT_authn:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     strategy:
       fail-fast: false
@@ -265,7 +268,7 @@ jobs:
         path: ./jmeter_logs
 
   built_in_database_authn_authz:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -118,6 +118,7 @@ jobs:
       env:
         PGSQL_TAG: ${{ matrix.pgsql_tag }}
       run: |
+        docker pull postgres:${PGSQL_TAG}
         docker compose \
           -f .ci/docker-compose-file/docker-compose-emqx-cluster.yaml \
           -f .ci/docker-compose-file/docker-compose-pgsql-tls.yaml \

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   relup_test_plan:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ["${{ inputs.runner }}", 'linux', 'x64', 'ephemeral']
     container: ${{ inputs.builder }}
     outputs:
       CUR_EE_VSN: ${{ steps.find-versions.outputs.CUR_EE_VSN }}
@@ -25,7 +25,6 @@ jobs:
       run:
         shell: bash
     steps:
-    - uses: AutoModality/action-clean@v1
     - uses: actions/download-artifact@v3
       with:
         name: emqx-enterprise
@@ -60,7 +59,7 @@ jobs:
     needs:
       - relup_test_plan
     if: needs.relup_test_plan.outputs.OLD_VERSIONS != '[]'
-    runs-on: ubuntu-22.04
+    runs-on: ["${{ inputs.runner }}", 'linux', 'x64', 'ephemeral']
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       builder:
@@ -28,7 +28,7 @@ env:
 
 jobs:
   eunit_and_proper:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     name: "eunit_and_proper (${{ matrix.profile }})"
     strategy:
       fail-fast: false
@@ -41,7 +41,6 @@ jobs:
     container: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-ubuntu22.04"
 
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.profile }}
@@ -69,7 +68,7 @@ jobs:
           path: _build/test/cover
 
   ct_docker:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     name: "ct_docker (${{ matrix.app }}-${{ matrix.suitegroup }})"
     strategy:
       fail-fast: false
@@ -81,7 +80,6 @@ jobs:
         shell: bash
 
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.profile }}
@@ -117,7 +115,7 @@ jobs:
           path: _build/test/logs
 
   ct:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     name: "ct (${{ matrix.app }}-${{ matrix.suitegroup }})"
     strategy:
       fail-fast: false
@@ -130,7 +128,6 @@ jobs:
         shell: bash
 
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.profile }}
@@ -163,7 +160,7 @@ jobs:
       - eunit_and_proper
       - ct
       - ct_docker
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     strategy:
       fail-fast: false
     steps:
@@ -174,7 +171,7 @@ jobs:
       - eunit_and_proper
       - ct
       - ct_docker
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     container: ${{ inputs.builder }}
     strategy:
       fail-fast: false
@@ -182,7 +179,6 @@ jobs:
         profile:
           - emqx-enterprise
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.profile }}
@@ -215,7 +211,7 @@ jobs:
   # do this in a separate job
   upload_coverdata:
     needs: make_cover
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - name: Coveralls Finished
         env:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -108,11 +108,14 @@ jobs:
         with:
           name: coverdata
           path: _build/test/cover
+      - name: compress logs
+        if: failure()
+        run: tar -czf logs.tar.gz _build/test/logs
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs-${{ matrix.profile }}-${{ matrix.prefix }}-${{ matrix.otp }}-sg${{ matrix.suitegroup }}
-          path: _build/test/logs
+          path: logs.tar.gz
 
   ct:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -149,11 +152,14 @@ jobs:
           name: coverdata
           path: _build/test/cover
           if-no-files-found: warn # do not fail if no coverdata found
+      - name: compress logs
+        if: failure()
+        run: tar -czf logs.tar.gz _build/test/logs
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
           name: logs-${{ matrix.profile }}-${{ matrix.prefix }}-${{ matrix.otp }}-sg${{ matrix.suitegroup }}
-          path: _build/test/logs
+          path: logs.tar.gz
 
   tests_passed:
     needs:

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
 
@@ -18,7 +18,7 @@ jobs:
         profile:
         - emqx
         - emqx-enterprise
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,8 +10,8 @@ on:
 
 jobs:
   stale:
-    runs-on: ubuntu-22.04
     if: github.repository_owner == 'emqx'
+    runs-on: ['self-hosted', 'linux', 'x64', 'ephemeral']
     permissions:
       issues: write
       pull-requests: none

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -7,7 +7,7 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
+      runner_labels:
         required: true
         type: string
       builder:
@@ -22,7 +22,7 @@ env:
 
 jobs:
   static_checks:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     name: "static_checks (${{ matrix.profile }})"
     strategy:
       fail-fast: false
@@ -30,7 +30,6 @@ jobs:
         include: ${{ fromJson(inputs.ct-matrix) }}
     container: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-ubuntu22.04"
     steps:
-      - uses: AutoModality/action-clean@v1
       - uses: actions/download-artifact@v3
         with:
           name: ${{ matrix.profile }}


### PR DESCRIPTION
Fixes [EMQX-10451](https://emqx.atlassian.net/browse/EMQX-10451)

Related:

- https://github.com/emqx/terraform-aws-github-runner/pull/1
- https://github.com/emqx/terraform-aws-github-runner/pull/2
- https://github.com/emqx/terraform-aws-github-runner/pull/3
- https://github.com/emqx/terraform-aws-github-runner/pull/4
- https://github.com/emqx/terraform-aws-github-runner/pull/5

Release run: https://github.com/emqx/terraform-aws-github-runner/actions/runs/6398139202

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ba7e4d4</samp>

Updated the `sanity-checks` job in `.github/workflows/_pr_entrypoint.yaml` to use `self-hosted` runners for the `emqx` organization and fixed the `runner` output.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
