### PR TITLE
test(session): fix quic testgroup in persistent session suite

### DIFF
--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -102,13 +102,18 @@ init_per_group(Group, Config) when Group == quic ->
         [
             {emqx,
                 ?config(emqx_config, Config) ++
-                    "\n listeners.quic.test { enable = true }"}
+                    "\n listeners.quic.test {"
+                    "\n   enable = true"
+                    "\n   ssl_options.verify = verify_peer"
+                    "\n }"}
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     [
         {port, get_listener_port(quic, test)},
         {conn_fun, quic_connect},
+        {ssl_opts, emqx_common_test_helpers:client_ssl_twoway()},
+        {ssl, true},
         {group_apps, Apps}
         | Config
     ];


### PR DESCRIPTION
Which broker after quicer 0.0.200 upgrade.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 7c94ae6</samp>

Add and test SSL verification for quic listener in emqx_persistent_session_SUITE. Use two-way SSL authentication for quic in `emqx.conf` and `client_opts`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
