### PR TITLE
fix(audit): make emqx eval command auditable

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -142,9 +142,9 @@ do(Args) ->
         ["eval" | ListOfArgs] ->
             Parsed = parse_eval_args(ListOfArgs),
             % and evaluate it on the remote node
-            case rpc:call(TargetNode, erl_eval, exprs, [Parsed, [] ]) of
-                {value, Value, _} ->
-                    io:format ("~p~n",[Value]);
+            case rpc:call(TargetNode, emqx_ctl, eval_erl, [Parsed]) of
+                {ok, Value} ->
+                    io:format("~p~n",[Value]);
                 {badrpc, Reason} ->
                     io:format("RPC to ~p failed: ~p~n", [TargetNode, Reason]),
                     halt(1)

--- a/dev
+++ b/dev
@@ -37,6 +37,7 @@ COMMANDS:
   ctl:    Equivalent to 'emqx ctl'.
           ctl command arguments should be passed after '--'
           e.g. $0 ctl -- help
+  eval:   Evaluate an Erlang expression
 
 OPTIONS:
   -p|--profile:      emqx | emqx-enterprise, defaults to 'PROFILE' env.
@@ -81,6 +82,10 @@ case "${1:-novalue}" in
         ;;
     ctl)
         COMMAND='ctl'
+        shift
+        ;;
+    eval)
+        COMMAND='eval'
         shift
         ;;
     help)
@@ -425,14 +430,22 @@ remsh() {
         $EPMD_ARGS
 }
 
+# evaluate erlang expression in remsh node
+eval_remsh_erl() {
+    local tmpnode erl_code
+    tmpnode="$(gen_tmp_node_name)"
+    erl_code="$1"
+    # shellcheck disable=SC2086 # need to expand EMQD_ARGS
+    erl -name "$tmpnode" -setcookie "$COOKIE" -hidden -noshell $EPMD_ARGS -eval "$erl_code" 2>&1
+}
+
 ctl() {
     if [ -z "${PASSTHROUGH_ARGS:-}" ]; then
         logerr "Need at least one argument for ctl command"
         logerr "e.g. $0 ctl -- help"
         exit 1
     fi
-    local tmpnode args rpc_code output result
-    tmpnode="$(gen_tmp_node_name)"
+    local args rpc_code output result
     args="$(make_erlang_args "${PASSTHROUGH_ARGS[@]}")"
     rpc_code="
         case rpc:call('$EMQX_NODE_NAME', emqx_ctl, run_command, [[$args]]) of
@@ -443,8 +456,7 @@ ctl() {
             init:stop(1)
         end"
     set +e
-    # shellcheck disable=SC2086
-    output="$(erl -name "$tmpnode" -setcookie "$COOKIE" -hidden -noshell $EPMD_ARGS -eval "$rpc_code" 2>&1)"
+    output="$(eval_remsh_erl "$rpc_code")"
     result=$?
     if [ $result -eq 0 ]; then
         echo -e "$output"
@@ -462,6 +474,10 @@ case "$COMMAND" in
         remsh
         ;;
     ctl)
+        ctl
+        ;;
+    eval)
+        PASSTHROUGH_ARGS=('eval_erl' "${PASSTHROUGH_ARGS[@]}")
         ctl
         ;;
 esac


### PR DESCRIPTION
a follow up fix for https://github.com/emqx/emqx/pull/11599

e.g.
```
2023-09-22T12:06:31.853870+02:00 [info] eval_erl {"result":"ok","node":"emqx@127.0.0.1","msg":"from_cli","duration_ms":3,"cmd":"eval_erl","args":["1+1"]}

```