### PR TITLE
chore: check ekka proto dist module type when resolving node address

### DIFF
--- a/apps/emqx_machine/src/emqx_machine.erl
+++ b/apps/emqx_machine/src/emqx_machine.erl
@@ -195,7 +195,8 @@ do_check({Node, #{resolved_ips := [IP | _]} = Plan}) ->
 node_to_ips(Node) ->
     NodeBin0 = atom_to_binary(Node),
     HostOrIP = re:replace(NodeBin0, <<"^.+@">>, <<"">>, [{return, list}]),
-    case inet:gethostbyname(HostOrIP, inet) of
+    AddressType = resolve_dist_address_type(),
+    case inet:gethostbyname(HostOrIP, AddressType) of
         {ok, #hostent{h_addr_list = AddrList}} ->
             AddrList;
         _ ->
@@ -209,4 +210,19 @@ is_tcp_port_open(IP, Port) ->
             true;
         _ ->
             false
+    end.
+
+resolve_dist_address_type() ->
+    ProtoDistStr = os:getenv("EKKA_PROTO_DIST_MOD", "inet_tcp"),
+    case ProtoDistStr of
+        "inet_tcp" ->
+            inet;
+        "inet6_tcp" ->
+            inet6;
+        "inet_tls" ->
+            inet;
+        "inet6_tls" ->
+            inet6;
+        _ ->
+            inet
     end.

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -170,7 +170,7 @@ t_open_ports_check(Config) ->
                 }
         },
         erpc:call(Core1, emqx_machine, open_ports_check, []),
-        #{core2 => Core2}
+        #{core2 => Core2, gen_rpc_port => GenRPCPort, ekka_port => EkkaPort}
     ),
 
     ok.

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -152,6 +152,7 @@ t_open_ports_check(Config) ->
     ok = emqx_cth_cluster:stop_node(Core2),
 
     ?assertEqual(ok, erpc:call(Replicant, emqx_machine, open_ports_check, [])),
+    Results = erpc:call(Core1, emqx_machine, open_ports_check, []),
     ?assertMatch(
         #{
             msg := "some ports are unreachable",
@@ -159,18 +160,21 @@ t_open_ports_check(Config) ->
                 #{
                     Core2 :=
                         #{
-                            open_ports := #{
-                                GenRPCPort := _,
-                                EkkaPort := _
-                            },
+                            open_ports := #{},
                             ports_to_check := [_, _],
                             resolved_ips := [_],
                             status := bad_ports
                         }
                 }
         },
-        erpc:call(Core1, emqx_machine, open_ports_check, []),
+        Results,
         #{core2 => Core2, gen_rpc_port => GenRPCPort, ekka_port => EkkaPort}
     ),
-
+    %% 2 ports to check; we don't assert the exact ekka port because, when running
+    %% multiple nodes on the same machine as we do in tests, the order of returned ports
+    %% might change between invocations.
+    NumPorts = 2,
+    ?assertEqual(
+        NumPorts, map_size(emqx_utils_maps:deep_get([results, Core2, open_ports], Results))
+    ),
     ok.


### PR DESCRIPTION
Follow up to https://github.com/emqx/emqx/pull/11637#discussion_r1334462917

Fixes https://emqx.atlassian.net/browse/EMQX-10944

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 37ed0ca</samp>

Added IPv6 support for cluster nodes by resolving the address type based on the distribution protocol. Modified `emqx_machine.erl` to use the new function `resolve_dist_address_type`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
