### PR TITLE
fix(sso): Disable access to `logout` endpoint by the `API key`

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -156,6 +156,8 @@ authorize(<<"/api/v5/users", _/binary>>, _ApiKey, _ApiSecret) ->
     {error, <<"not_allowed">>};
 authorize(<<"/api/v5/api_key", _/binary>>, _ApiKey, _ApiSecret) ->
     {error, <<"not_allowed">>};
+authorize(<<"/api/v5/logout", _/binary>>, _ApiKey, _ApiSecret) ->
+    {error, <<"not_allowed">>};
 authorize(_Path, ApiKey, ApiSecret) ->
     Now = erlang:system_time(second),
     case find_by_api_key(ApiKey) of

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -43,7 +43,9 @@ login_success.desc:
 """Dashboard Auth Success"""
 
 logout_api.desc:
-"""Dashboard user logout"""
+"""Dashboard user logout.
+This endpoint is only for the Dashboard, not the `API Key`.
+The token from the `/login` endpoint must be a bearer authorization in the headers."""
 logout_api.label:
 """Dashboard user logout"""
 


### PR DESCRIPTION
Fixes [EMQX-11029](https://emqx.atlassian.net/browse/EMQX-11029)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 4f4868a</samp>

Reject `API Key` requests to `/api/v5/logout` and update its description. This prevents unauthorized access to the Dashboard logout feature and improves the documentation of the Dashboard API.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
