### PR TITLE
fix(ftconf): also mark `secret_access_key` key as sensitive

### DIFF
--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -632,6 +632,9 @@ is_sensitive_key(<<"proxy-authorization">>) -> true;
 is_sensitive_key(secret) -> true;
 is_sensitive_key("secret") -> true;
 is_sensitive_key(<<"secret">>) -> true;
+is_sensitive_key(secret_access_key) -> true;
+is_sensitive_key("secret_access_key") -> true;
+is_sensitive_key(<<"secret_access_key">>) -> true;
 is_sensitive_key(secret_key) -> true;
 is_sensitive_key("secret_key") -> true;
 is_sensitive_key(<<"secret_key">>) -> true;
@@ -779,6 +782,7 @@ redact_test_() ->
         'proxy-authorization',
         secret,
         secret_key,
+        secret_access_key,
         security_token,
         token,
         bind_password

--- a/changes/ce/fix-11676.en.md
+++ b/changes/ce/fix-11676.en.md
@@ -1,0 +1,1 @@
+Hide few pieces of sensitive information from debug-level logs.


### PR DESCRIPTION
Fixes [EMQX-11026](https://emqx.atlassian.net/browse/EMQX-11026).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 81cf619</samp>

Improve masking of sensitive keys in logs and configs. Add `secret_access_key` to the list of sensitive keys and handle different key types in `emqx_utils:mask_config/1`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
