### PR TITLE
fix(audit): make 'emqx eval' command auditable

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -140,11 +140,12 @@ do(Args) ->
                     io:format("~p\n", [Other])
             end;
         ["eval" | ListOfArgs] ->
+            % parse args locally in the remsh node
             Parsed = parse_eval_args(ListOfArgs),
             % and evaluate it on the remote node
-            case rpc:call(TargetNode, emqx_ctl, eval_erl, [Parsed]) of
+            case rpc:call(TargetNode, emqx_ctl, run_command, [eval_erl, Parsed], infinity) of
                 {ok, Value} ->
-                    io:format("~p~n",[Value]);
+                    io:format("~p~n", [Value]);
                 {badrpc, Reason} ->
                     io:format("RPC to ~p failed: ~p~n", [TargetNode, Reason]),
                     halt(1)

--- a/scripts/test/emqx-boot.bats
+++ b/scripts/test/emqx-boot.bats
@@ -12,8 +12,16 @@
     [[ "$output" =~ "ERROR: Invalid node name,".+ ]]
 }
 
-@test "corrupted cluster config file" {
+@test "corrupted cluster-override.conf" {
     conffile="./_build/$PROFILE/rel/emqx/data/configs/cluster-override.conf"
+    echo "{" > $conffile
+    run ./_build/$PROFILE/rel/emqx/bin/emqx console
+    [[ $status -ne 0 ]]
+    rm -f $conffile
+}
+
+@test "corrupted cluster.hocon" {
+    conffile="./_build/$PROFILE/rel/emqx/data/configs/cluster.hocon"
     echo "{" > $conffile
     run ./_build/$PROFILE/rel/emqx/bin/emqx console
     [[ $status -ne 0 ]]


### PR DESCRIPTION
follow up fix for https://github.com/emqx/emqx/pull/11660

only made `dev eval` command working in #11660 missed `emqx eval`