### PR TITLE
fix(ldap): improve the LDAP `parse_config` function

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -86,19 +86,7 @@ destroy(#{resource_id := ResourceId}) ->
 
 parse_config(Config0) ->
     Config = ensure_bind_password(Config0),
-    State = lists:foldl(
-        fun(Key, Acc) ->
-            case maps:find(Key, Config) of
-                {ok, Value} when is_binary(Value) ->
-                    Acc#{Key := erlang:binary_to_list(Value)};
-                _ ->
-                    Acc
-            end
-        end,
-        Config,
-        [query_timeout]
-    ),
-    {Config, State}.
+    {Config, emqx_ldap:parse_config(Config, [query_timeout], [])}.
 
 %% In this feature, the `bind_password` is fixed, so it should conceal from the swagger,
 %% but the connector still needs it, hence we should add it back here

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -86,7 +86,7 @@ destroy(#{resource_id := ResourceId}) ->
 
 parse_config(Config0) ->
     Config = ensure_bind_password(Config0),
-    {Config, emqx_ldap:parse_config(Config, [query_timeout], [])}.
+    {Config, maps:with([query_timeout], Config0)}.
 
 %% In this feature, the `bind_password` is fixed, so it should conceal from the swagger,
 %% but the connector still needs it, hence we should add it back here

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -27,7 +27,7 @@
 
 -export([roots/0, fields/1, desc/1]).
 
--export([do_get_status/1, parse_config/3]).
+-export([do_get_status/1]).
 
 -define(LDAP_HOST_OPTIONS, #{
     default_port => 389
@@ -113,28 +113,6 @@ ensure_username(required) ->
     true;
 ensure_username(Field) ->
     ?ECS:username(Field).
-
-parse_config(Config, ToKeep, ToString) ->
-    Convert = fun(Value) ->
-        case lists:member(Value, ToString) of
-            true ->
-                erlang:binary_to_list(Value);
-            _ ->
-                Value
-        end
-    end,
-    lists:foldl(
-        fun(Key, Acc) ->
-            case maps:find(Key, Config) of
-                {ok, Value} ->
-                    Acc#{Key => Convert(Value)};
-                _ ->
-                    Acc
-            end
-        end,
-        #{},
-        ToKeep ++ ToString
-    ).
 
 %% ===================================================================
 callback_mode() -> always_sync.

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -27,7 +27,7 @@
 
 -export([roots/0, fields/1, desc/1]).
 
--export([do_get_status/1]).
+-export([do_get_status/1, parse_config/3]).
 
 -define(LDAP_HOST_OPTIONS, #{
     default_port => 389
@@ -113,6 +113,28 @@ ensure_username(required) ->
     true;
 ensure_username(Field) ->
     ?ECS:username(Field).
+
+parse_config(Config, ToKeep, ToString) ->
+    Convert = fun(Value) ->
+        case lists:member(Value, ToString) of
+            true ->
+                erlang:binary_to_list(Value);
+            _ ->
+                Value
+        end
+    end,
+    lists:foldl(
+        fun(Key, Acc) ->
+            case maps:find(Key, Config) of
+                {ok, Value} ->
+                    Acc#{Key => Convert(Value)};
+                _ ->
+                    Acc
+            end
+        end,
+        #{},
+        ToKeep ++ ToString
+    ).
 
 %% ===================================================================
 callback_mode() -> always_sync.

--- a/apps/emqx_ldap/src/emqx_ldap_authn.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn.erl
@@ -91,14 +91,14 @@ refs() ->
 create(_AuthenticatorID, Config) ->
     do_create(?MODULE, Config).
 
-do_create(Module, Config0) ->
+do_create(Module, Config) ->
     ResourceId = emqx_authn_utils:make_resource_id(Module),
-    {Config, State} = parse_config(Config0),
+    State = parse_config(Config),
     {ok, _Data} = emqx_authn_utils:create_resource(ResourceId, emqx_ldap, Config),
     {ok, State#{resource_id => ResourceId}}.
 
-update(Config0, #{resource_id := ResourceId} = _State) ->
-    {Config, NState} = parse_config(Config0),
+update(Config, #{resource_id := ResourceId} = _State) ->
+    NState = parse_config(Config),
     case emqx_authn_utils:update_resource(emqx_ldap, Config, ResourceId) of
         {error, Reason} ->
             error({load_config_error, Reason});
@@ -143,19 +143,7 @@ authenticate(
     end.
 
 parse_config(Config) ->
-    State = lists:foldl(
-        fun(Key, Acc) ->
-            case maps:find(Key, Config) of
-                {ok, Value} when is_binary(Value) ->
-                    Acc#{Key := erlang:binary_to_list(Value)};
-                _ ->
-                    Acc
-            end
-        end,
-        Config,
-        [password_attribute, is_superuser_attribute, query_timeout]
-    ),
-    {Config, State}.
+    emqx_ldap:parse_config(Config, [query_timeout], [password_attribute, is_superuser_attribute]).
 
 %% To compatible v4.x
 is_enabled(Password, #eldap_entry{attributes = Attributes} = Entry, State) ->

--- a/apps/emqx_ldap/src/emqx_ldap_authn.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn.erl
@@ -143,7 +143,7 @@ authenticate(
     end.
 
 parse_config(Config) ->
-    emqx_ldap:parse_config(Config, [query_timeout], [password_attribute, is_superuser_attribute]).
+    maps:with([query_timeout, password_attribute, is_superuser_attribute], Config).
 
 %% To compatible v4.x
 is_enabled(Password, #eldap_entry{attributes = Attributes} = Entry, State) ->

--- a/apps/emqx_ldap/src/emqx_ldap_authz.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authz.erl
@@ -134,9 +134,9 @@ do_authorize(_Action, _Topic, [], _Entry) ->
     nomatch.
 
 new_annotations(Init, Source) ->
-    State = emqx_ldap:parse_config(Source, [query_timeout], [
-        publish_attribute, subscribe_attribute, all_attribute
-    ]),
+    State = maps:with(
+        [query_timeout, publish_attribute, subscribe_attribute, all_attribute], Source
+    ),
     maps:merge(Init, State).
 
 select_attrs(#{action_type := publish}, #{publish_attribute := Pub, all_attribute := All}) ->

--- a/apps/emqx_ldap/src/emqx_ldap_authz.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authz.erl
@@ -134,21 +134,10 @@ do_authorize(_Action, _Topic, [], _Entry) ->
     nomatch.
 
 new_annotations(Init, Source) ->
-    lists:foldl(
-        fun(Attr, Acc) ->
-            Acc#{
-                Attr =>
-                    case maps:get(Attr, Source) of
-                        Value when is_binary(Value) ->
-                            erlang:binary_to_list(Value);
-                        Value ->
-                            Value
-                    end
-            }
-        end,
-        Init,
-        [publish_attribute, subscribe_attribute, all_attribute]
-    ).
+    State = emqx_ldap:parse_config(Source, [query_timeout], [
+        publish_attribute, subscribe_attribute, all_attribute
+    ]),
+    maps:merge(Init, State).
 
 select_attrs(#{action_type := publish}, #{publish_attribute := Pub, all_attribute := All}) ->
     [Pub, All];

--- a/changes/ce/fix-11667.en.md
+++ b/changes/ce/fix-11667.en.md
@@ -1,0 +1,1 @@
+Disable access to the `logout` endpoint by the API key, this endpoint is for the Dashboard only.


### PR DESCRIPTION
Fix a problem that was found by code review.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffd9a35</samp>

Refactor LDAP config parsing logic and disable API key access to logout endpoint. The pull request extracts a common `parse_config` function in `emqx_ldap.erl` and reuses it in other modules that need to parse LDAP config. This improves code quality and consistency. The pull request also adds a changelog entry for the fix that prevents the API key from accessing the `logout` endpoint in `emqx_dashboard_sso_ldap.erl`, which is only for the Dashboard.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
