### PR TITLE
feat: implement OpenTelemetry tracing

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -75,8 +75,8 @@
     payload :: emqx_types:payload(),
     %% Timestamp (Unit: millisecond)
     timestamp :: integer(),
-    %% not used so far, for future extension
-    extra = [] :: term()
+    %% Miscellaneous extensions, currently used for OpenTelemetry context propagation
+    extra = #{} :: term()
 }).
 
 -record(delivery, {

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -854,10 +854,14 @@ with_channel(Fun, Args, State = #state{channel = Channel}) ->
 
 %%--------------------------------------------------------------------
 %% Handle outgoing packets
+handle_outgoing(Packets, State) ->
+    Res = do_handle_outgoing(Packets, State),
+    emqx_external_trace:end_trace_send(Packets),
+    Res.
 
-handle_outgoing(Packets, State) when is_list(Packets) ->
+do_handle_outgoing(Packets, State) when is_list(Packets) ->
     send(lists:map(serialize_and_inc_stats_fun(State), Packets), State);
-handle_outgoing(Packet, State) ->
+do_handle_outgoing(Packet, State) ->
     send((serialize_and_inc_stats_fun(State))(Packet), State).
 
 serialize_and_inc_stats_fun(#state{serialize = Serialize}) ->

--- a/apps/emqx/src/emqx_external_trace.erl
+++ b/apps/emqx/src/emqx_external_trace.erl
@@ -1,0 +1,109 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_external_trace).
+
+-callback trace_process_publish(Packet, Channel, fun((Packet, Channel) -> Res)) -> Res when
+    Packet :: emqx_types:packet(),
+    Channel :: emqx_channel:channel(),
+    Res :: term().
+
+-callback start_trace_send(list(emqx_types:deliver()), emqx_channel:channel()) ->
+    list(emqx_types:deliver()).
+
+-callback end_trace_send(emqx_types:packet() | [emqx_types:packet()]) -> ok.
+
+-callback event(EventName :: term(), Attributes :: term()) -> ok.
+
+-export([
+    register_provider/1,
+    unregister_provider/1,
+    trace_process_publish/3,
+    start_trace_send/2,
+    end_trace_send/1,
+    event/1,
+    event/2
+]).
+
+-define(PROVIDER, {?MODULE, trace_provider}).
+
+-define(with_provider(IfRegisitered, IfNotRegisired),
+    case persistent_term:get(?PROVIDER, undefined) of
+        undefined ->
+            IfNotRegisired;
+        Provider ->
+            Provider:IfRegisitered
+    end
+).
+
+%%--------------------------------------------------------------------
+%% provider API
+%%--------------------------------------------------------------------
+
+-spec register_provider(module()) -> ok | {error, term()}.
+register_provider(Module) when is_atom(Module) ->
+    case is_valid_provider(Module) of
+        true ->
+            persistent_term:put(?PROVIDER, Module);
+        false ->
+            {error, invalid_provider}
+    end.
+
+-spec unregister_provider(module()) -> ok | {error, term()}.
+unregister_provider(Module) ->
+    case persistent_term:get(?PROVIDER, undefined) of
+        Module ->
+            persistent_term:erase(?PROVIDER),
+            ok;
+        _ ->
+            {error, not_registered}
+    end.
+
+%%--------------------------------------------------------------------
+%% trace API
+%%--------------------------------------------------------------------
+
+-spec trace_process_publish(Packet, Channel, fun((Packet, Channel) -> Res)) -> Res when
+    Packet :: emqx_types:packet(),
+    Channel :: emqx_channel:channel(),
+    Res :: term().
+trace_process_publish(Packet, Channel, ProcessFun) ->
+    ?with_provider(?FUNCTION_NAME(Packet, Channel, ProcessFun), ProcessFun(Packet, Channel)).
+
+-spec start_trace_send(list(emqx_types:deliver()), emqx_channel:channel()) ->
+    list(emqx_types:deliver()).
+start_trace_send(Delivers, Channel) ->
+    ?with_provider(?FUNCTION_NAME(Delivers, Channel), Delivers).
+
+-spec end_trace_send(emqx_types:packet() | [emqx_types:packet()]) -> ok.
+end_trace_send(Packets) ->
+    ?with_provider(?FUNCTION_NAME(Packets), ok).
+
+event(Name) ->
+    event(Name, #{}).
+
+-spec event(term(), term()) -> ok.
+event(Name, Attributes) ->
+    ?with_provider(?FUNCTION_NAME(Name, Attributes), ok).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+is_valid_provider(Module) ->
+    lists:all(
+        fun({F, A}) -> erlang:function_exported(Module, F, A) end,
+        ?MODULE:behaviour_info(callbacks)
+    ).

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -960,6 +960,8 @@ serialize_properties(Props) when is_map(Props) ->
 
 serialize_property(_, Disabled) when Disabled =:= disabled; Disabled =:= undefined ->
     <<>>;
+serialize_property(internal_extra, _) ->
+    <<>>;
 serialize_property('Payload-Format-Indicator', Val) ->
     <<16#01, Val>>;
 serialize_property('Message-Expiry-Interval', Val) ->

--- a/apps/emqx/src/emqx_message.erl
+++ b/apps/emqx/src/emqx_message.erl
@@ -311,7 +311,8 @@ to_packet(
         qos = QoS,
         headers = Headers,
         topic = Topic,
-        payload = Payload
+        payload = Payload,
+        extra = Extra
     }
 ) ->
     #mqtt_packet{
@@ -324,8 +325,8 @@ to_packet(
         variable = #mqtt_packet_publish{
             topic_name = Topic,
             packet_id = PacketId,
-            properties = filter_pub_props(
-                maps:get(properties, Headers, #{})
+            properties = maybe_put_extra(
+                Extra, filter_pub_props(maps:get(properties, Headers, #{}))
             )
         },
         payload = Payload
@@ -344,6 +345,11 @@ filter_pub_props(Props) ->
         ],
         Props
     ).
+
+maybe_put_extra(Extra, Props) when map_size(Extra) > 0 ->
+    Props#{internal_extra => Extra};
+maybe_put_extra(_Extra, Props) ->
+    Props.
 
 %% @doc Message to map
 -spec to_map(emqx_types:message()) -> message_map().

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -452,9 +452,15 @@ to_message(
     Headers
 ) ->
     Msg = emqx_message:make(ClientId, QoS, Topic, Payload),
+    {Extra, Props1} =
+        case maps:take(internal_extra, Props) of
+            error -> {#{}, Props};
+            ExtraProps -> ExtraProps
+        end,
     Msg#message{
         flags = #{dup => Dup, retain => Retain},
-        headers = Headers#{properties => Props}
+        headers = Headers#{properties => Props1},
+        extra = Extra
     }.
 
 -spec will_msg(#mqtt_packet_connect{}) -> emqx_types:message().

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -207,7 +207,7 @@ t_to_map(_) ->
         {topic, <<"topic">>},
         {payload, <<"payload">>},
         {timestamp, emqx_message:timestamp(Msg)},
-        {extra, []}
+        {extra, #{}}
     ],
     ?assertEqual(List, emqx_message:to_list(Msg)),
     ?assertEqual(maps:from_list(List), emqx_message:to_map(Msg)).
@@ -223,7 +223,7 @@ t_from_map(_) ->
         topic => <<"topic">>,
         payload => <<"payload">>,
         timestamp => emqx_message:timestamp(Msg),
-        extra => []
+        extra => #{}
     },
     ?assertEqual(Map, emqx_message:to_map(Msg)),
     ?assertEqual(Msg, emqx_message:from_map(emqx_message:to_map(Msg))).

--- a/apps/emqx_opentelemetry/rebar.config
+++ b/apps/emqx_opentelemetry/rebar.config
@@ -1,7 +1,15 @@
 %% -*- mode: erlang -*-
 
-{deps, [
-    {emqx, {path, "../emqx"}}
+{deps,
+    [ {emqx, {path, "../emqx"}}
+    %% trace
+    , {opentelemetry_api, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_api"}}
+    , {opentelemetry, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry"}}
+    %% log metrics
+    , {opentelemetry_experimental, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_experimental"}}
+    , {opentelemetry_api_experimental, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_api_experimental"}}
+    %% export
+    , {opentelemetry_exporter, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_exporter"}}
 ]}.
 
 {edoc_opts, [{preprocess, true}]}.

--- a/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
+++ b/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
@@ -1,9 +1,16 @@
 {application, emqx_opentelemetry, [
     {description, "OpenTelemetry for EMQX Broker"},
-    {vsn, "0.1.2"},
+    {vsn, "0.2.0"},
     {registered, []},
     {mod, {emqx_otel_app, []}},
     {applications, [kernel, stdlib, emqx]},
+    {included_applications, [
+        opentelemetry,
+        opentelemetry_api,
+        opentelemetry_api_experimental,
+        opentelemetry_experimental,
+        opentelemetry_exporter
+    ]},
     {env, []},
     {modules, []},
     {licenses, ["Apache 2.0"]},

--- a/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
@@ -42,6 +42,11 @@ fields("opentelemetry") ->
                     required => true,
                     desc => ?DESC(enable)
                 }
+            )},
+        {trace,
+            ?HOCON(
+                ?R_REF("trace"),
+                #{desc => ?DESC(trace)}
             )}
     ];
 fields("exporter") ->
@@ -75,8 +80,28 @@ fields("exporter") ->
                     desc => ?DESC(interval)
                 }
             )}
+    ];
+fields("trace") ->
+    [
+        {enable,
+            ?HOCON(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(trace_enable)
+                }
+            )},
+        {trace_all,
+            ?HOCON(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(trace_all)
+                }
+            )}
     ].
 
 desc("opentelemetry") -> ?DESC(opentelemetry);
 desc("exporter") -> ?DESC(exporter);
+desc("trace") -> ?DESC(trace);
 desc(_) -> undefined.

--- a/apps/emqx_opentelemetry/src/emqx_otel_sup.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_sup.erl
@@ -42,7 +42,7 @@ init([]) ->
     },
     Children =
         case emqx_conf:get([opentelemetry]) of
-            #{enable := false} -> [];
-            #{enable := true} = Conf -> [worker_spec(emqx_otel, Conf)]
+            #{enable := false, trace := #{enable := false}} -> [];
+            Conf -> [worker_spec(emqx_otel, Conf)]
         end,
     {ok, {SupFlags, Children}}.

--- a/apps/emqx_opentelemetry/src/emqx_otel_trace.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_trace.erl
@@ -1,0 +1,219 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_otel_trace).
+
+-behaviour(emqx_external_trace).
+
+-export([toggle_registered/1]).
+
+-export([
+    trace_process_publish/3,
+    start_trace_send/2,
+    end_trace_send/1,
+    event/2
+]).
+
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("opentelemetry_api/include/otel_tracer.hrl").
+
+-define(EMQX_OTEL_CTX, otel_ctx).
+%% NOTE: it's possible to use trace_flags to set is_sampled flag
+-define(IS_ENABLED, emqx_enable).
+-define(USER_PROPERTY, 'User-Property').
+
+-define(TRACE_ALL, emqx:get_config([opentelemetry, trace, trace_all], false)).
+%%--------------------------------------------------------------------
+%% config
+%%--------------------------------------------------------------------
+
+-spec toggle_registered(boolean()) -> ok | {error, term()}.
+toggle_registered(true = _Enable) ->
+    emqx_external_trace:register_provider(?MODULE);
+toggle_registered(false = _Enable) ->
+    _ = emqx_external_trace:unregister_provider(?MODULE),
+    ok.
+
+%%--------------------------------------------------------------------
+%% trace API
+%%--------------------------------------------------------------------
+
+-spec trace_process_publish(Packet, Channel, fun((Packet, Channel) -> Res)) -> Res when
+    Packet :: emqx_types:packet(),
+    Channel :: emqx_channel:channel(),
+    Res :: term().
+trace_process_publish(Packet, Channel, ProcessFun) ->
+    case maybe_init_ctx(Packet) of
+        false ->
+            ProcessFun(Packet, Channel);
+        RootCtx ->
+            RootCtx1 = otel_ctx:set_value(RootCtx, ?IS_ENABLED, true),
+            Attrs = maps:merge(packet_attributes(Packet), channel_attributes(Channel)),
+            SpanCtx = otel_tracer:start_span(RootCtx1, ?current_tracer, process_message, #{
+                attributes => Attrs
+            }),
+            Ctx = otel_tracer:set_current_span(RootCtx1, SpanCtx),
+            %% put ctx to packet, so it can be further propagated
+            Packet1 = put_ctx_to_packet(Ctx, Packet),
+            %% TODO: consider getting rid of propagating Ctx through process dict as it's anyway seems to have
+            %% very limited usage
+            otel_ctx:attach(Ctx),
+            try
+                ProcessFun(Packet1, Channel)
+            after
+                ?end_span(),
+                clear()
+            end
+    end.
+
+-spec start_trace_send(list(emqx_types:deliver()), emqx_channel:channel()) ->
+    list(emqx_types:deliver()).
+start_trace_send(Delivers, Channel) ->
+    lists:map(
+        fun({deliver, Topic, Msg} = Deliver) ->
+            case get_ctx_from_msg(Msg) of
+                Ctx when is_map(Ctx) ->
+                    Attrs = maps:merge(
+                        msg_attributes(Msg), sub_channel_attributes(Channel)
+                    ),
+                    StartOpts = #{attributes => Attrs},
+                    SpanCtx = otel_tracer:start_span(
+                        Ctx, ?current_tracer, send_published_message, StartOpts
+                    ),
+                    Msg1 = put_ctx_to_msg(
+                        otel_tracer:set_current_span(Ctx, SpanCtx), Msg
+                    ),
+                    {deliver, Topic, Msg1};
+                _ ->
+                    Deliver
+            end
+        end,
+        Delivers
+    ).
+
+-spec end_trace_send(emqx_types:packet() | [emqx_types:packet()]) -> ok.
+end_trace_send(Packets) ->
+    lists:foreach(
+        fun(Packet) ->
+            case get_ctx_from_packet(Packet) of
+                Ctx when is_map(Ctx) ->
+                    otel_span:end_span(otel_tracer:current_span_ctx(Ctx));
+                _ ->
+                    ok
+            end
+        end,
+        packets_list(Packets)
+    ).
+
+%% NOTE: adds an event only within an active span (Otel Ctx must be set in the calling process dict)
+-spec event(opentelemetry:event_name(), opentelemetry:attributes_map()) -> ok.
+event(Name, Attributes) ->
+    case otel_ctx:get_value(?IS_ENABLED, false) of
+        true ->
+            ?add_event(Name, Attributes),
+            ok;
+        false ->
+            ok
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+packets_list(Packets) when is_list(Packets) ->
+    Packets;
+packets_list(Packet) ->
+    [Packet].
+
+maybe_init_ctx(#mqtt_packet{variable = Packet}) ->
+    case should_trace_packet(Packet) of
+        true ->
+            Ctx = extract_traceparent_from_packet(Packet),
+            should_trace_context(Ctx) andalso Ctx;
+        false ->
+            false
+    end.
+
+extract_traceparent_from_packet(Packet) ->
+    Ctx = otel_ctx:new(),
+    case emqx_packet:info(properties, Packet) of
+        #{?USER_PROPERTY := UserProps} ->
+            otel_propagator_text_map:extract_to(Ctx, UserProps);
+        _ ->
+            Ctx
+    end.
+
+should_trace_context(RootCtx) ->
+    map_size(RootCtx) > 0 orelse ?TRACE_ALL.
+
+should_trace_packet(Packet) ->
+    not is_sys(emqx_packet:info(topic_name, Packet)).
+
+%% TODO: move to emqx_topic module?
+is_sys(<<"$SYS/", _/binary>> = _Topic) -> true;
+is_sys(_Topic) -> false.
+
+msg_attributes(Msg) ->
+    #{
+        'mqtt.topic' => emqx_message:topic(Msg),
+        'mqtt.from.clientid' => emqx_message:from(Msg)
+    }.
+
+packet_attributes(#mqtt_packet{variable = Packet}) ->
+    #{'mqtt.topic' => emqx_packet:info(topic_name, Packet)}.
+
+channel_attributes(Channel) ->
+    #{'mqtt.subscriber.clientid' => emqx_channel:info(clientid, Channel)}.
+
+sub_channel_attributes(Channel) ->
+    Attrs = channel_attributes(Channel),
+    case emqx_channel:info({session, subscriptions}, Channel) of
+        Subs when is_map(Subs) ->
+            Attrs#{'mqtt.subscriber.subscriptions' => maps:keys(Subs)};
+        _ ->
+            Attrs
+    end.
+
+put_ctx_to_msg(OtelCtx, Msg = #message{extra = Extra}) when is_map(Extra) ->
+    Msg#message{extra = Extra#{?EMQX_OTEL_CTX => OtelCtx}};
+%% extra field has not being used previously and defaulted to an empty list, it's safe to overwrite it
+put_ctx_to_msg(OtelCtx, Msg) when is_record(Msg, message) ->
+    Msg#message{extra = #{?EMQX_OTEL_CTX => OtelCtx}}.
+
+put_ctx_to_packet(
+    OtelCtx, #mqtt_packet{variable = #mqtt_packet_publish{properties = Props} = PubPacket} = Packet
+) ->
+    Extra = maps:get(internal_extra, Props, #{}),
+    Props1 = Props#{internal_extra => Extra#{?EMQX_OTEL_CTX => OtelCtx}},
+    Packet#mqtt_packet{variable = PubPacket#mqtt_packet_publish{properties = Props1}}.
+
+get_ctx_from_msg(#message{extra = Extra}) ->
+    from_extra(Extra).
+
+get_ctx_from_packet(#mqtt_packet{
+    variable = #mqtt_packet_publish{properties = #{internal_extra := Extra}}
+}) ->
+    from_extra(Extra);
+get_ctx_from_packet(_) ->
+    undefined.
+
+from_extra(#{?EMQX_OTEL_CTX := OtelCtx}) ->
+    OtelCtx;
+from_extra(_) ->
+    undefined.
+
+clear() ->
+    otel_ctx:clear().

--- a/dev
+++ b/dev
@@ -40,6 +40,7 @@ COMMANDS:
   eval:   Evaluate an Erlang expression
 
 OPTIONS:
+  -h|--help:         Print this usage info.
   -p|--profile:      emqx | emqx-enterprise, defaults to 'PROFILE' env.
   -c|--compile:      Force recompile, otherwise starts with the already built libs
                      in '_build/\$PROFILE/lib/'.
@@ -98,6 +99,10 @@ esac
 
 while [ "$#" -gt 0 ]; do
     case $1 in
+        -h|--help)
+            usage
+            exit 0
+            ;;
         -n|--name)
             EMQX_NODE_NAME="$2"
             shift 1
@@ -119,6 +124,7 @@ while [ "$#" -gt 0 ]; do
             ;;
         *)
             logerr "Unknown argument $1"
+            usage
             exit 1
             ;;
     esac

--- a/dev
+++ b/dev
@@ -206,6 +206,13 @@ prepare_erl_libs() {
             fi
         done
     fi
+    if [ -e "_build/${profile}/checkouts" ]; then
+        for app in "_build/${profile}/checkouts"/*; do
+            erl_libs="${erl_libs}${sep}${app}"
+        done
+    else
+        echo "no checkouts"
+    fi
     export ERL_LIBS="$erl_libs"
 }
 

--- a/dev
+++ b/dev
@@ -46,6 +46,7 @@ OPTIONS:
                      in '_build/\$PROFILE/lib/'.
   -e|--ekka-epmd:    Force to use ekka_epmd.
   -n|--name:         Node name, defaults to \$EMQX_NODE__NAME or the \$EMQX_NODE_NAME env.
+  -s|--shortnames:   Use shortnames for erlang node name (ie. use -sname parameter).
 
 ENVIRONMENT VARIABLES:
 
@@ -70,6 +71,7 @@ PROFILE="${PROFILE:-emqx}"
 FORCE_COMPILE=0
 # Do not start using ekka epmd by default, so your IDE can connect to it
 EKKA_EPMD=0
+SHORTNAMES=0
 COMMAND='run'
 case "${1:-novalue}" in
     novalue)
@@ -116,6 +118,9 @@ while [ "$#" -gt 0 ]; do
             ;;
         -e|--ekka-epmd)
             EKKA_EPMD=1
+            ;;
+        -s|--shortnames)
+            SHORTNAMES=1
             ;;
         --)
             shift
@@ -175,6 +180,12 @@ if [ $EKKA_EPMD -eq 1 ]; then
     EPMD_ARGS='-start_epmd false -epmd_module ekka_epmd'
 else
     EPMD_ARGS=''
+fi
+
+if [ $SHORTNAMES -eq 1 ]; then
+    ERL_NAME_ARG='-sname'
+else
+    ERL_NAME_ARG='-name'
 fi
 
 
@@ -301,7 +312,7 @@ append_args_file() {
     ## ensure a new line at the end
     echo '' >> "$ARGS_FILE"
     cat <<EOF >> "$ARGS_FILE"
--name $EMQX_NODE_NAME
+$ERL_NAME_ARG $EMQX_NODE_NAME
 -mnesia dir '"$EMQX_DATA_DIR/mnesia/$EMQX_NODE_NAME"'
 -stdlib restricted_shell emqx_restricted_shell
 +spp true
@@ -399,7 +410,7 @@ boot() {
 
         # shellcheck disable=SC2086
         env APPS="$APPS" iex \
-          --name "$EMQX_NODE_NAME" \
+          -$ERL_NAME_ARG "$EMQX_NODE_NAME" \
           --erl "$EPMD_ARGS_ELIXIR" \
           --erl '-user Elixir.IEx.CLI' \
           --erl '-proto_dist ekka' \
@@ -415,7 +426,7 @@ boot() {
         "
 
         # shellcheck disable=SC2086
-        erl -name "$EMQX_NODE_NAME" \
+        erl $ERL_NAME_ARG "$EMQX_NODE_NAME" \
             $EPMD_ARGS \
             -proto_dist ekka \
             -args_file "$ARGS_FILE" \
@@ -429,14 +440,18 @@ boot() {
 gen_tmp_node_name() {
     local rnd
     rnd="$(od -t u -N 4 /dev/urandom | head -n1 | awk '{print $2 % 1000}')"
-    echo "remsh${rnd}-${EMQX_NODE_NAME}"
+    if [ $SHORTNAMES -eq  1 ]; then
+        echo "remsh${rnd}"
+    else
+        echo "remsh${rnd}-${EMQX_NODE_NAME}"
+    fi
 }
 
 remsh() {
     local tmpnode
     tmpnode="$(gen_tmp_node_name)"
     # shellcheck disable=SC2086
-    erl -name "$tmpnode" \
+    erl $ERL_NAME_ARG "$tmpnode" \
         -hidden \
         -setcookie "$COOKIE" \
         -remsh "$EMQX_NODE_NAME" \
@@ -449,7 +464,7 @@ eval_remsh_erl() {
     tmpnode="$(gen_tmp_node_name)"
     erl_code="$1"
     # shellcheck disable=SC2086 # need to expand EMQD_ARGS
-    erl -name "$tmpnode" -setcookie "$COOKIE" -hidden -noshell $EPMD_ARGS -eval "$erl_code" 2>&1
+    erl $ERL_NAME_ARG "$tmpnode" -setcookie "$COOKIE" -hidden -noshell $EPMD_ARGS -eval "$erl_code" 2>&1
 }
 
 ctl() {

--- a/mix.exs
+++ b/mix.exs
@@ -98,37 +98,7 @@ defmodule EMQXUmbrella.MixProject do
       # set by hackney (dependency)
       {:ssl_verify_fun, "1.1.6", override: true},
       {:uuid, github: "okeuday/uuid", tag: "v2.0.6", override: true},
-      {:quickrand, github: "okeuday/quickrand", tag: "v2.0.6", override: true},
-      {:opentelemetry_api,
-       github: "emqx/opentelemetry-erlang",
-       sparse: "apps/opentelemetry_api",
-       tag: "v1.3.0-emqx",
-       override: true,
-       runtime: false},
-      {:opentelemetry,
-       github: "emqx/opentelemetry-erlang",
-       sparse: "apps/opentelemetry",
-       tag: "v1.3.0-emqx",
-       override: true,
-       runtime: false},
-      {:opentelemetry_api_experimental,
-       github: "emqx/opentelemetry-erlang",
-       sparse: "apps/opentelemetry_api_experimental",
-       tag: "v1.3.0-emqx",
-       override: true,
-       runtime: false},
-      {:opentelemetry_experimental,
-       github: "emqx/opentelemetry-erlang",
-       sparse: "apps/opentelemetry_experimental",
-       tag: "v1.3.0-emqx",
-       override: true,
-       runtime: false},
-      {:opentelemetry_exporter,
-       github: "emqx/opentelemetry-erlang",
-       sparse: "apps/opentelemetry_exporter",
-       tag: "v1.3.0-emqx",
-       override: true,
-       runtime: false}
+      {:quickrand, github: "okeuday/quickrand", tag: "v2.0.6", override: true}
     ] ++
       emqx_apps(profile_info, version) ++
       enterprise_deps(profile_info) ++ bcrypt_dep() ++ jq_dep() ++ quicer_dep()

--- a/rebar.config
+++ b/rebar.config
@@ -84,14 +84,6 @@
     %% in conflict by erlavro and rocketmq
     , {jsone, {git, "https://github.com/emqx/jsone.git", {tag, "1.7.1"}}}
     , {uuid, {git, "https://github.com/okeuday/uuid.git", {tag, "v2.0.6"}}}
-    %% trace
-    , {opentelemetry_api, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_api"}}
-    , {opentelemetry, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry"}}
-    %% log metrics
-    , {opentelemetry_experimental, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_experimental"}}
-    , {opentelemetry_api_experimental, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_api_experimental"}}
-    %% export
-    , {opentelemetry_exporter, {git_subdir, "https://github.com/emqx/opentelemetry-erlang", {tag, "v1.3.0-emqx"}, "apps/opentelemetry_exporter"}}
     ]}.
 
 {xref_ignores,

--- a/rel/i18n/emqx_otel_schema.hocon
+++ b/rel/i18n/emqx_otel_schema.hocon
@@ -4,12 +4,20 @@ opentelemetry.desc: "Open Telemetry Toolkit configuration"
 
 exporter.desc: "Open Telemetry Exporter"
 
-enable.desc: "Enable or disable open telemetry metrics"
+enable.desc: "Enable or disable Open Telemetry metrics"
 
 protocol.desc: "Open Telemetry Exporter Protocol"
 
 endpoint.desc: "Open Telemetry Exporter Endpoint"
 
 interval.desc: "The interval of sending metrics to Open Telemetry Endpoint"
+
+trace.desc: "Open Telemetry trace configuration"
+
+trace_enable.desc: "Enable or disable Open Telemetry trace"
+
+trace_all.desc:
+"""If enabled, all published messages are traced, a new trace ID is generated if it can't be extracted from the message.
+Otherwise, only messages published with trace context are traced. Disabled by default."""
 
 }


### PR DESCRIPTION
Closes EMQX-10535
<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e36685c</samp>

This pull request adds Opentelemetry tracing to the MQTT message lifecycle in the `emqx` application. It modifies the `emqx_broker`, `emqx_channel`, and `emqx_connection` modules to create and propagate trace spans and events for each message processing and delivery step. It also adds a new module `emqx_otel_trace` to implement the tracing logic and a new field `extra` to the `message` and `mqtt_packet` records to store the trace context. The purpose of this change is to enable observability and performance analysis of the MQTT broker using Opentelemetry.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
