### PR TITLE
chore(gen_rpc): Bump version to 3.1.1

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.7"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.15"}}},
-    {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.1.0"}}},
+    {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.1.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.39.16"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -940,7 +940,9 @@ fields("rpc") ->
                     default => true,
                     desc => ?DESC(rpc_insecure_fallback)
                 }
-            )}
+            )},
+        {"ciphers", emqx_schema:ciphers_schema(tls_all_available)},
+        {"tls_versions", emqx_schema:tls_versions_schema(tls_all_available)}
     ];
 fields("log") ->
     [
@@ -1176,7 +1178,11 @@ translation("emqx") ->
         {"cluster_hocon_file", fun tr_cluster_hocon_file/1}
     ];
 translation("gen_rpc") ->
-    [{"default_client_driver", fun tr_default_config_driver/1}];
+    [
+        {"default_client_driver", fun tr_default_config_driver/1},
+        {"ssl_client_options", fun tr_gen_rpc_ssl_options/1},
+        {"ssl_server_options", fun tr_gen_rpc_ssl_options/1}
+    ];
 translation("prometheus") ->
     [
         {"collectors", fun tr_prometheus_collectors/1}
@@ -1239,6 +1245,11 @@ collector_enabled(disabled, _) -> [].
 
 tr_default_config_driver(Conf) ->
     conf_get("rpc.driver", Conf).
+
+tr_gen_rpc_ssl_options(Conf) ->
+    Ciphers = conf_get("rpc.ciphers", Conf),
+    Versions = conf_get("rpc.tls_versions", Conf),
+    [{ciphers, Ciphers}, {versions, Versions}].
 
 tr_config_files(_Conf) ->
     case os:getenv("EMQX_ETC_DIR") of

--- a/changes/ce/fix-11697.en.md
+++ b/changes/ce/fix-11697.en.md
@@ -1,0 +1,2 @@
+Use default TLS options for the EMQX backplane communications via gen_rpc.
+The corresponding PR: https://github.com/emqx/gen_rpc/pull/36

--- a/changes/ce/fix-11697.en.md
+++ b/changes/ce/fix-11697.en.md
@@ -1,2 +1,6 @@
-Use default TLS options for the EMQX backplane communications via gen_rpc.
-The corresponding PR: https://github.com/emqx/gen_rpc/pull/36
+Disable outdated TLS versions and ciphersuites in the EMQX backplane network (`gen_rpc`).
+Allow using tlsv1.3 on the backplane.
+
+Add new configuration parameters: `EMQX_RPC__TLS_VERSIONS` and `EMQX_RPC__CIPHERS`.
+
+The corresponding `gen_rpc` PR: https://github.com/emqx/gen_rpc/pull/36

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule EMQXUmbrella.MixProject do
       {:esockd, github: "emqx/esockd", tag: "5.9.7", override: true},
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-1", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.15.15", override: true},
-      {:gen_rpc, github: "emqx/gen_rpc", tag: "3.1.0", override: true},
+      {:gen_rpc, github: "emqx/gen_rpc", tag: "3.1.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.8", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.3.13", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.4", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.7"}}}
     , {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-1"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.15.15"}}}
-    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.1.0"}}}
+    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.1.1"}}}
     , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.8"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.13"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.4"}}}


### PR DESCRIPTION
Fixes #11606

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 68b9739</samp>

Updated `gen_rpc` dependency to version 3.1.1 in both `rebar.config` and `mix.exs` files.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
