### PR TITLE
fix(resource): respect the start_timeout

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_manager.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_manager.erl
@@ -50,6 +50,10 @@
     start_after_created => false
 }).
 
+-define(DEFAULT_START_OPTS, #{
+    start_timeout => timer:seconds(30)
+}).
+
 -record(?MOD_TAB, {
     backend :: atom(),
     state :: undefined | map(),
@@ -301,7 +305,7 @@ lookup(Backend) ->
 %% to avoid resource leakage the resource start will never affect the update result,
 %% so the resource_id will always be recorded
 start_resource_if_enabled(ResourceId, {ok, _} = Result, #{enable := true, backend := Backend}) ->
-    case emqx_resource:start(ResourceId) of
+    case emqx_resource:start(ResourceId, ?DEFAULT_START_OPTS) of
         ok ->
             ok;
         {error, Reason} ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -223,9 +223,10 @@ restart(ResId, Opts) when is_binary(ResId) ->
 %% @doc Start the resource
 -spec start(resource_id(), creation_opts()) -> ok | {error, Reason :: term()}.
 start(ResId, Opts) ->
-    case safe_call(ResId, start, ?T_OPERATION) of
+    StartTimeout = maps:get(start_timeout, Opts, ?T_OPERATION),
+    case safe_call(ResId, start, StartTimeout) of
         ok ->
-            wait_for_ready(ResId, maps:get(start_timeout, Opts, 5000));
+            wait_for_ready(ResId, StartTimeout);
         {error, _Reason} = Error ->
             Error
     end.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at dca8fdb</samp>

Increase the start timeout for the SSO resource and make it configurable for other resources. Refactor the `emqx_resource_manager:start/2` function to use the timeout from the creation options.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
