### PR TITLE
fix(ldap): use the search result as bind target

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -124,11 +124,11 @@ login(
     of
         {ok, []} ->
             {error, user_not_found};
-        {ok, [_Entry | _]} ->
+        {ok, [Entry | _]} ->
             case
                 emqx_resource:simple_sync_query(
                     ResourceId,
-                    {bind, Sign}
+                    {bind, Entry#eldap_entry.object_name, Sign}
                 )
             of
                 ok ->

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -177,7 +177,7 @@ on_query(InstId, {query, Data, Attrs}, State) ->
     on_query(InstId, {query, Data}, [{attributes, Attrs}], State);
 on_query(InstId, {query, Data, Attrs, Timeout}, State) ->
     on_query(InstId, {query, Data}, [{attributes, Attrs}, {timeout, Timeout}], State);
-on_query(InstId, {bind, _Data} = Req, State) ->
+on_query(InstId, {bind, _DN, _Data} = Req, State) ->
     emqx_ldap_bind_worker:on_query(InstId, Req, State).
 
 on_get_status(_InstId, #{pool_name := PoolName} = _State) ->

--- a/apps/emqx_ldap/src/emqx_ldap_authn_bind.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn_bind.erl
@@ -95,11 +95,11 @@ authenticate(
     of
         {ok, []} ->
             ignore;
-        {ok, [_Entry | _]} ->
+        {ok, [Entry | _]} ->
             case
                 emqx_resource:simple_sync_query(
                     ResourceId,
-                    {bind, Credential}
+                    {bind, Entry#eldap_entry.object_name, Credential}
                 )
             of
                 ok ->

--- a/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
@@ -58,14 +58,12 @@ on_stop(InstId, _State) ->
 
 on_query(
     InstId,
-    {bind, Data},
+    {bind, DN, Data},
     #{
-        base_tokens := DNTks,
         bind_password := PWTks,
         bind_pool_name := PoolName
     } = State
 ) ->
-    DN = emqx_placeholder:proc_tmpl(DNTks, Data),
     Password = emqx_placeholder:proc_tmpl(PWTks, Data),
 
     LogMeta = #{connector => InstId, state => State},


### PR DESCRIPTION
## Summary

Avoid using `base_dn` template in LDAP bind query.
Prior to this change, `base_dn` is a template which can be rendered then used in LDAP search argument, and also used to render the DN in bind query.
Such implementation forces the DN to contain values which are template-able in EMQX. e.g. `uid=${username}`
However, often there are requirements to search user in LDAP using other information such as `email` which is not a part of DN.
After this change, the filter condition will need to be specific enough to find only one user, then use the DN from the query result for binding.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
