### PR TITLE
0928 fix ldap sso logging level and reject muti-match results

### DIFF
--- a/.ci/docker-compose-file/docker-compose-ldap.yaml
+++ b/.ci/docker-compose-file/docker-compose-ldap.yaml
@@ -6,8 +6,6 @@ services:
     build:
       context: ../..
       dockerfile: .ci/docker-compose-file/openldap/Dockerfile
-      args:
-        LDAP_TAG: ${LDAP_TAG}
     image: openldap
     #ports:
     #  - 389:389

--- a/.ci/docker-compose-file/openldap/Dockerfile
+++ b/.ci/docker-compose-file/openldap/Dockerfile
@@ -1,16 +1,4 @@
-FROM ubuntu:20.04
-
-ARG LDAP_TAG=2.5.16
-
-ENV DEBIAN_FRONTEND noninteractive
-
-RUN apt-get update -y
-RUN apt-get install -y groff groff-base curl build-essential
-RUN curl -o openldap-${LDAP_TAG}.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${LDAP_TAG}.tgz \
-    && tar xvzf openldap-${LDAP_TAG}.tgz \
-    && cd openldap-${LDAP_TAG} \
-    && ./configure && make depend && make && make install \
-    && cd .. && rm -rf  openldap-${LDAP_TAG}
+FROM docker.io/zmstone/openldap:2.5.16
 
 COPY .ci/docker-compose-file/openldap/slapd.conf /usr/local/etc/openldap/slapd.conf
 COPY apps/emqx_ldap/test/data/emqx.io.ldif /usr/local/etc/openldap/schema/emqx.io.ldif

--- a/.ci/docker-compose-file/openldap/Dockerfile
+++ b/.ci/docker-compose-file/openldap/Dockerfile
@@ -1,9 +1,12 @@
-FROM buildpack-deps:bookworm
+FROM ubuntu:20.04
 
 ARG LDAP_TAG=2.5.16
 
-RUN apt-get update && apt-get install -y groff groff-base
-RUN wget https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${LDAP_TAG}.tgz \
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y
+RUN apt-get install -y groff groff-base curl build-essential
+RUN curl -o openldap-${LDAP_TAG}.tgz https://www.openldap.org/software/download/OpenLDAP/openldap-release/openldap-${LDAP_TAG}.tgz \
     && tar xvzf openldap-${LDAP_TAG}.tgz \
     && cd openldap-${LDAP_TAG} \
     && ./configure && make depend && make && make install \

--- a/.ci/docker-compose-file/openldap/slapd.conf
+++ b/.ci/docker-compose-file/openldap/slapd.conf
@@ -1,14 +1,13 @@
 include         /usr/local/etc/openldap/schema/core.schema
 include         /usr/local/etc/openldap/schema/cosine.schema
 include         /usr/local/etc/openldap/schema/inetorgperson.schema
-include         /usr/local/etc/openldap/schema/ppolicy.schema
 include         /usr/local/etc/openldap/schema/emqx.schema
 
 TLSCACertificateFile  /usr/local/etc/openldap/cacert.pem
 TLSCertificateFile    /usr/local/etc/openldap/cert.pem
 TLSCertificateKeyFile /usr/local/etc/openldap/key.pem
 
-database bdb
+database mdb
 suffix "dc=emqx,dc=io"
 rootdn "cn=root,dc=emqx,dc=io"
 rootpw {SSHA}eoF7NhNrejVYYyGHqnt+MdKNBh4r1w3W

--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -32,10 +32,10 @@
 %% `apps/emqx/src/bpapi/README.md'
 
 %% Opensource edition
--define(EMQX_RELEASE_CE, "5.2.1").
+-define(EMQX_RELEASE_CE, "5.3.0").
 
 %% Enterprise edition
--define(EMQX_RELEASE_EE, "5.3.0-alpha.2").
+-define(EMQX_RELEASE_EE, "5.3.0-rc.1").
 
 %% The HTTP API version
 -define(EMQX_API_VERSION, "5.0").

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -124,7 +124,7 @@ login(
     of
         {ok, []} ->
             {error, user_not_found};
-        {ok, [Entry | _]} ->
+        {ok, [Entry]} ->
             case
                 emqx_resource:simple_sync_query(
                     ResourceId,

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -131,8 +131,10 @@ login(
                     {bind, Entry#eldap_entry.object_name, Sign}
                 )
             of
-                ok ->
+                {ok, #{result := ok}} ->
                     ensure_user_exists(Username);
+                {ok, #{result := invalidCredentials} = Reason} ->
+                    {error, Reason};
                 {error, _} = Error ->
                     Error
             end;

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -133,7 +133,7 @@ login(
             of
                 {ok, #{result := ok}} ->
                     ensure_user_exists(Username);
-                {ok, #{result := invalidCredentials} = Reason} ->
+                {ok, #{result := 'invalidCredentials'} = Reason} ->
                     {error, Reason};
                 {error, _} = Error ->
                     Error

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -249,7 +249,7 @@ do_ldap_query(
     #{pool_name := PoolName} = State
 ) ->
     LogMeta = #{connector => InstId, search => SearchOptions, state => emqx_utils:redact(State)},
-    ?TRACE("QUERY", "ldap_connector_received", LogMeta),
+    ?TRACE("QUERY", "ldap_connector_received_query", LogMeta),
     case
         ecpool:pick_and_do(
             PoolName,

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -279,7 +279,7 @@ do_ldap_query(
                             count => length(L)
                         }
                     ),
-                    {error, {recoverable_error, Msg}}
+                    {error, {unrecoverable_error, Msg}}
             end;
         {error, 'noSuchObject'} ->
             {ok, []};

--- a/apps/emqx_ldap/src/emqx_ldap_authn.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn.erl
@@ -131,7 +131,7 @@ authenticate(
     of
         {ok, []} ->
             ignore;
-        {ok, [Entry | _]} ->
+        {ok, [Entry]} ->
             is_enabled(Password, Entry, State);
         {error, Reason} ->
             ?TRACE_AUTHN_PROVIDER(error, "ldap_query_failed", #{

--- a/apps/emqx_ldap/src/emqx_ldap_authn_bind.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn_bind.erl
@@ -102,8 +102,14 @@ authenticate(
                     {bind, Entry#eldap_entry.object_name, Credential}
                 )
             of
-                ok ->
+                {ok, #{result := ok}} ->
                     {ok, #{is_superuser => false}};
+                {ok, #{result := 'invalidCredentials'}} ->
+                    ?TRACE_AUTHN_PROVIDER(error, "ldap_bind_failed", #{
+                        resource => ResourceId,
+                        reason => 'invalidCredentials'
+                    }),
+                    {error, bad_username_or_password};
                 {error, Reason} ->
                     ?TRACE_AUTHN_PROVIDER(error, "ldap_bind_failed", #{
                         resource => ResourceId,

--- a/apps/emqx_ldap/src/emqx_ldap_authn_bind.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authn_bind.erl
@@ -95,7 +95,7 @@ authenticate(
     of
         {ok, []} ->
             ignore;
-        {ok, [Entry | _]} ->
+        {ok, [Entry]} ->
             case
                 emqx_resource:simple_sync_query(
                     ResourceId,

--- a/apps/emqx_ldap/src/emqx_ldap_authz.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_authz.erl
@@ -111,11 +111,11 @@ authorize(
     case emqx_resource:simple_sync_query(ResourceID, {query, Client, Attrs, QueryTimeout}) of
         {ok, []} ->
             nomatch;
-        {ok, [Entry | _]} ->
+        {ok, [Entry]} ->
             do_authorize(Action, Topic, Attrs, Entry);
         {error, Reason} ->
             ?SLOG(error, #{
-                msg => "query_ldap_error",
+                msg => "ldap_query_failed",
                 reason => emqx_utils:redact(Reason),
                 resource_id => ResourceID
             }),

--- a/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
@@ -81,8 +81,8 @@ on_query(
                 #{result => ok}
             ),
             {ok, #{result => ok}};
-        {error, invalidCredentials} ->
-            {ok, #{result => invalidCredentials}};
+        {error, 'invalidCredentials'} ->
+            {ok, #{result => 'invalidCredentials'}};
         {error, Reason} ->
             ?SLOG(
                 error,

--- a/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
@@ -80,7 +80,9 @@ on_query(
                 ldap_connector_query_return,
                 #{result => ok}
             ),
-            ok;
+            {ok, #{result => ok}};
+        {error, invalidCredentials} ->
+            {ok, #{result => invalidCredentials}};
         {error, Reason} ->
             ?SLOG(
                 error,

--- a/apps/emqx_ldap/test/data/emqx.io.ldif
+++ b/apps/emqx_ldap/test/data/emqx.io.ldif
@@ -13,6 +13,12 @@ objectClass: top
 objectclass:organizationalUnit
 ou:testdevice
 
+# create dashboard.emqx.io
+dn:ou=dashboard,dc=emqx,dc=io
+objectClass: top
+objectclass:organizationalUnit
+ou:dashboard
+
 # create user admin
 dn:uid=admin,ou=testdevice,dc=emqx,dc=io
 objectClass: top
@@ -150,3 +156,23 @@ objectClass: mqttSecurity
 uid: mqttuser0007
 isSuperuser: TRUE
 userPassword: {SHA}axpQGbl00j3jvOG058y313ocnBk=
+
+## Try to test with base DN 'ou=dashboard,dc=emqx,dc=io'
+## with a filter ugroup=group1
+## this should return 2 users in the query and fail the test
+
+## echo -n "viewer1" | sha1sum | cut -d' ' -f1 | xxd -r -p | base64
+dn:uid=viewer1,ou=dashboard,dc=emqx,dc=io
+objectClass: top
+objectClass: dashboardUser
+uid: viewer1
+ugroup: group1
+userPassword: {SHA}I/LgVpQ6joiHifK7pZEQ1+0AUlg=
+
+## echo -n "viewer2" | sha1sum | cut -d' ' -f1 | xxd -r -p | base64
+dn:uid=viewer2,ou=dashboard,dc=emqx,dc=io
+objectClass: top
+objectClass: dashboardUser
+uid: viewer2
+ugroup: group1
+userPassword: {SHA}SR0qZpf8pYKKAbn6ILFvX91JuQg=

--- a/apps/emqx_ldap/test/data/emqx.schema
+++ b/apps/emqx_ldap/test/data/emqx.schema
@@ -35,10 +35,11 @@ attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4.4 NAME ( 'mqttAccountName' 'ma
 	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
 	USAGE userApplications )
 
-
-objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4 NAME 'mqttUser'
-	AUXILIARY
-	MAY ( mqttPublishTopic $ mqttSubscriptionTopic $ mqttPubSubTopic $ mqttAccountName $ isSuperuser) )
+attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.5.1 NAME 'ugroup'
+	EQUALITY caseIgnoreMatch
+	SUBSTR caseIgnoreSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	USAGE userApplications )
 
 objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.2 NAME 'mqttDevice'
 	SUP top
@@ -50,3 +51,13 @@ objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.3 NAME 'mqttSecurity'
 	SUP top
 	AUXILIARY
 	MUST ( userPassword ) )
+
+objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4 NAME 'mqttUser'
+	AUXILIARY
+	MAY ( mqttPublishTopic $ mqttSubscriptionTopic $ mqttPubSubTopic $ mqttAccountName $ isSuperuser ) )
+
+objectclass (1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.5 NAME 'dashboardUser'
+	SUP top
+    STRUCTURAL
+	MUST ( uid $ userPassword )
+    MAY ( ugroup ))

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -119,7 +119,7 @@ do_request_api(Method, Request, Opts) ->
     ReturnAll = maps:get(return_all, Opts, false),
     CompatibleMode = maps:get(compatible_mode, Opts, false),
     HttpcReqOpts = maps:get(httpc_req_opts, Opts, []),
-    ct:pal("Method: ~p, Request: ~p, Opts: ~p", [Method, Request, Opts]),
+    ct:pal("~p: ~p~nOpts: ~p", [Method, Request, Opts]),
     case httpc:request(Method, Request, [], HttpcReqOpts) of
         {error, socket_closed_remotely} ->
             {error, socket_closed_remotely};

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.3.0-alpha.2
+version: 5.3.0-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.3.0-alpha.2
+appVersion: 5.3.0-rc.1

--- a/deploy/charts/emqx/Chart.yaml
+++ b/deploy/charts/emqx/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.2.1
+version: 5.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.2.1
+appVersion: 5.3.0


### PR DESCRIPTION
fixing issues for ldap sso, targeting `release-53`

## Summary

* Do not log error level if LDAP sso login credential is invalid
* Do not proceed with authentication when multiple matched entries are found from ldap query

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
