### PR TITLE
chore(ds): simplify return type of `storage_layer:next/{1,2}`

### DIFF
--- a/apps/emqx/test/emqx_persistent_messages_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_messages_SUITE.erl
@@ -272,9 +272,9 @@ consume(Shard, IteratorId) when is_binary(IteratorId) ->
 
 consume(It) ->
     case emqx_ds_storage_layer:next(It) of
-        {value, Msg, NIt} ->
+        {ok, NIt, [Msg]} ->
             [emqx_persistent_message:deserialize(Msg) | consume(NIt)];
-        none ->
+        end_of_stream ->
             []
     end.
 

--- a/apps/emqx_durable_storage/test/props/prop_replay_message_storage.erl
+++ b/apps/emqx_durable_storage/test/props/prop_replay_message_storage.erl
@@ -225,12 +225,9 @@ run_iterator_commands([iterate | Rest], It, Ctx) ->
             []
     end;
 run_iterator_commands([{preserve, restore} | Rest], It, Ctx) ->
-    #{
-        db := DB,
-        replay := Replay
-    } = Ctx,
+    #{db := DB} = Ctx,
     Serial = emqx_ds_message_storage_bitmask:preserve_iterator(It),
-    {ok, ItNext} = emqx_ds_message_storage_bitmask:restore_iterator(DB, Replay, Serial),
+    {ok, ItNext} = emqx_ds_message_storage_bitmask:restore_iterator(DB, Serial),
     run_iterator_commands(Rest, ItNext, Ctx);
 run_iterator_commands([], It, _Ctx) ->
     iterate_db(It).


### PR DESCRIPTION
Part of https://emqx.atlassian.net/browse/EMQX-10942

The goal is to help make it clear to the caller of `next` what to do next: if the iterator should still be used or if no new messages will ever come out of it.

From:

```erlang
-spec next(iterator()) -> {value, binary(), iterator()} | none | {error, closed}.
```

To:

```erlang
-spec next(iterator()) -> {ok, iterator(), [binary()]} | end_of_stream.

-spec next(iterator(), pos_integer()) -> {ok, iterator(), [binary()]} | end_of_stream.
```

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3b78729</samp>

This pull request refactors the storage layer API and the modules that use it to support batch fetching of messages, error handling, and version compatibility. It also simplifies the code and improves the test coverage and quality. The main changes are in the `emqx_ds_message_storage_bitmask`, `emqx_ds_storage_layer`, and `emqx_persistent_messages_SUITE` modules, and their corresponding test modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
