### PR TITLE
fix: cli's args in audit log should be array

### DIFF
--- a/apps/emqx_ctl/src/emqx_ctl.app.src
+++ b/apps/emqx_ctl/src/emqx_ctl.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ctl, [
     {description, "Backend for emqx_ctl script"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {mod, {emqx_ctl_app, []}},
     {applications, [

--- a/apps/emqx_ctl/src/emqx_ctl.erl
+++ b/apps/emqx_ctl/src/emqx_ctl.erl
@@ -331,13 +331,14 @@ safe_to_existing_atom(Str) ->
 is_initialized() ->
     ets:info(?CMD_TAB) =/= undefined.
 
-audit_log(Level, From, Log) ->
+audit_log(Level, From, Log = #{args := Args}) ->
     case lookup_command(audit) of
         {error, _} ->
             ignore;
         {ok, {Mod, Fun}} ->
             try
-                apply(Mod, Fun, [Level, From, Log])
+                Log1 = Log#{args => [unicode:characters_to_binary(A) || A <- Args]},
+                apply(Mod, Fun, [Level, From, Log1])
             catch
                 _:Reason:Stacktrace ->
                     ?LOG_ERROR(#{

--- a/apps/emqx_dashboard/src/emqx_dashboard.app.src
+++ b/apps/emqx_dashboard/src/emqx_dashboard.app.src
@@ -2,7 +2,7 @@
 {application, emqx_dashboard, [
     {description, "EMQX Web Dashboard"},
     % strict semver, bump manually!
-    {vsn, "5.0.28"},
+    {vsn, "5.0.29"},
     {modules, []},
     {registered, [emqx_dashboard_sup]},
     {applications, [

--- a/apps/emqx_dashboard/src/emqx_dashboard_cli.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_cli.erl
@@ -70,7 +70,7 @@ admins(_) ->
 unload() ->
     emqx_ctl:unregister_command(admins).
 
-bin(S) -> iolist_to_binary(S).
+bin(S) -> unicode:characters_to_binary(S).
 
 print_error(Reason) when is_binary(Reason) ->
     emqx_ctl:print("Error: ~s~n", [Reason]).


### PR DESCRIPTION
- Fixes cli's args in audit log should be array. https://emqx.atlassian.net/browse/EMQX-11066

```
> emqx ctl conf show log
```

Before, the args is `["show","log"]` will format as `{"args":"showlog"}`
```
io:format("~ts",[emqx_logger_jsonfmt:format(#{level=>info, meta=>#{args=>["show","log"], cmd=>conf, duration_ms=>4, from=>cli, node=>'emqx@127.0.0.1', time=>1696731332367582}, msg=>undefined}, #{chars_limit=>unlimited, depth=>100, single_line=>true, time_offset=>[]})]).
{"time":1696731332367582,"level":"info","node":"emqx@127.0.0.1","from":"cli","duration_ms":4,"cmd":"conf","args":"showlog"}
```
We should format it as `{"args":["show", "log"]}`
After:
```
io:format("~ts",[emqx_logger_jsonfmt:format(#{level=>info, meta=>#{args=>[<<"show">>,<<"log">>], cmd=>conf, duration_ms=>4, from=>cli, node=>'emqx@127.0.0.1', time=>1696731332367582}, msg=>undefined}, #{chars_limit=>unlimited, depth=>100, single_line=>true, time_offset=>[]})]).
{"time":1696731332367582,"level":"info","node":"emqx@127.0.0.1","from":"cli","duration_ms":4,"cmd":"conf","args":["show","log"]}
```

- Fixes crashed when adding unicode username from cli.

After:
```
./bin/emqx ctl admins add 测试 dflfkad1
Error: Bad Username. Only upper and lower case letters, numbers and underscores are supported
```

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 482e82f</samp>

This pull request improves the command-line interface and auditing features of the `emqx_ctl` and `emqx_dashboard` applications. It also updates their version numbers in the `.app.src` files.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
