### PR TITLE
fix(cm): bring back pre-v5.3.0 compat in `takeover_session_begin/1`

### DIFF
--- a/apps/emqx/src/proto/emqx_cm_proto_v2.erl
+++ b/apps/emqx/src/proto/emqx_cm_proto_v2.erl
@@ -65,8 +65,10 @@ get_chann_conn_mod(ClientId, ChanPid) ->
 
 -spec takeover_session(emqx_types:clientid(), emqx_cm:chan_pid()) ->
     none
-    | {expired | persistent, emqx_session:session()}
     | {living, _ConnMod :: atom(), emqx_cm:chan_pid(), emqx_session:session()}
+    %% NOTE: v5.3.0
+    | {living, _ConnMod :: atom(), emqx_session:session()}
+    | {expired | persistent, emqx_session:session()}
     | {badrpc, _}.
 takeover_session(ClientId, ChanPid) ->
     rpc:call(node(ChanPid), emqx_cm, takeover_session, [ClientId, ChanPid], ?T_TAKEOVER * 2).

--- a/changes/ee/fix-11733.en.md
+++ b/changes/ee/fix-11733.en.md
@@ -1,0 +1,1 @@
+Resolved an incompatibility issue that led to crashes during session takeover / channel eviction when the session was residing on a remote node running EMQX v5.2.x or earlier.


### PR DESCRIPTION
Which was accidentally broken in bf164175 as part of #11592.

Fixes [EMQX-11095](https://emqx.atlassian.net/browse/EMQX-11095).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3261e0a</samp>

Fix a bug that causes channel pid to be lost when a session is taken over by another node. Update `emqx_cm.erl` to include channel pid in session takeover and stepdown messages.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
