### PR TITLE
fix(ldap): escape the escape character (\)

### DIFF
--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
@@ -241,7 +241,12 @@ user_seeds() ->
         New(<<"mqttuser0006">>, <<"mqttuser0006">>, {error, user_disabled}),
         %% IsSuperuser
         New(<<"mqttuser0007">>, <<"mqttuser0007">>, {ok, #{is_superuser => true}}),
-        New(<<"mqttuser0008 (test)">>, <<"mqttuser0008 (test)">>, {ok, #{is_superuser => true}})
+        New(<<"mqttuser0008 (test)">>, <<"mqttuser0008 (test)">>, {ok, #{is_superuser => true}}),
+        New(
+            <<"mqttuser0009 \\\\test\\\\">>,
+            <<"mqttuser0009 \\\\test\\\\">>,
+            {ok, #{is_superuser => true}}
+        )
         | Valid
     ].
 

--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
@@ -235,7 +235,7 @@ user_seeds() ->
         lists:seq(1, 5)
     ),
 
-    Specials = [<<"mqttuser0008 (test)">>],
+    Specials = [<<"mqttuser0008 (test)">>, <<"mqttuser0009 \\\\test\\\\">>],
 
     Valid =
         lists:map(

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -319,10 +319,8 @@ do_prepare_template([], State) ->
 
 filter_escape(Binary) when is_binary(Binary) ->
     filter_escape(erlang:binary_to_list(Binary));
-filter_escape([$\\ | T]) ->
-    [$\\, $\\ | filter_escape(T)];
 filter_escape([Char | T]) ->
-    case lists:member(Char, filter_control_chars()) of
+    case lists:member(Char, filter_special_chars()) of
         true ->
             [$\\, Char | filter_escape(T)];
         _ ->
@@ -331,5 +329,5 @@ filter_escape([Char | T]) ->
 filter_escape([]) ->
     [].
 
-filter_control_chars() ->
-    [$(, $), $&, $|, $=, $!, $~, $>, $<, $:, $*, $\t, $\n, $\r].
+filter_special_chars() ->
+    [$(, $), $&, $|, $=, $!, $~, $>, $<, $:, $*, $\t, $\n, $\r, $\\].

--- a/apps/emqx_ldap/test/data/emqx.io.ldif
+++ b/apps/emqx_ldap/test/data/emqx.io.ldif
@@ -166,6 +166,15 @@ uid: mqttuser0008 (test)
 isSuperuser: TRUE
 userPassword: {SHA}FCzJLOp66OwsZ9DQzXSxdTd9c0U=
 
+objectClass: top
+dn:uid=mqttuser0009 \\test\\,ou=testdevice,dc=emqx,dc=io
+objectClass: mqttUser
+objectClass: mqttDevice
+objectClass: mqttSecurity
+uid: mqttuser0009 \\test\\
+isSuperuser: TRUE
+userPassword: {SHA}awxXARLqWYx+xy0677D/TLjlyHA=
+
 ## Try to test with base DN 'ou=dashboard,dc=emqx,dc=io'
 ## with a filter ugroup=group1
 ## this should return 2 users in the query and fail the test

--- a/apps/emqx_ldap/test/emqx_ldap_filter_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_filter_SUITE.erl
@@ -235,6 +235,10 @@ t_escape(_Config) ->
     ?assertEqual(
         'or'([equalityMatch("a", "name (1) *")]),
         parse("(|(a=name\\ \\(1\\) \\*))")
+    ),
+    ?assertEqual(
+        'and'([equalityMatch("a", "\\value\\")]),
+        parse("(&(a=\\\\value\\\\))")
     ).
 
 t_value_eql_dn(_Config) ->


### PR DESCRIPTION
Fixes [EMQX-11076](https://emqx.atlassian.net/browse/EMQX-11076)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e07937a</samp>

This pull request enhances the LDAP filter parser and the LDAP authentication module to support usernames and filter strings that contain backslashes. It also adds new test cases and test data to verify the functionality and correctness of the changes. It modifies the files `emqx_ldap_filter_lexer.xrl`, `emqx_ldap.erl`, `emqx_authn_ldap_bind_SUITE.erl`, `emqx_authn_ldap_SUITE.erl`, `emqx.io.ldif`, and `emqx_ldap_filter_SUITE.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
