### PR TITLE
fix: cli list return nothing when list is empty

### DIFF
--- a/apps/emqx_modules/src/emqx_modules.app.src
+++ b/apps/emqx_modules/src/emqx_modules.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_modules, [
     {description, "EMQX Modules"},
-    {vsn, "5.0.22"},
+    {vsn, "5.0.23"},
     {modules, []},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},
     {mod, {emqx_modules_app, []}},

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.17"},
+    {vsn, "5.0.18"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia_cli.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia_cli.erl
@@ -32,10 +32,11 @@ load() ->
     ok = emqx_ctl:register_command(retainer, {?MODULE, retainer}, []).
 
 retainer(["info"]) ->
-    ?PRINT("Number of retained messages: ~p~n", [emqx_retainer:retained_count()]);
+    count();
 retainer(["topics"]) ->
-    [?PRINT("~ts~n", [I]) || I <- emqx_retainer_mnesia:topics()],
-    ok;
+    topic(1, 1000);
+retainer(["topics", Start, Len]) ->
+    topic(list_to_integer(Start), list_to_integer(Len));
 retainer(["clean", Topic]) ->
     emqx_retainer:delete(list_to_binary(Topic));
 retainer(["clean"]) ->
@@ -65,7 +66,9 @@ retainer(_) ->
     emqx_ctl:usage(
         [
             {"retainer info", "Show the count of retained messages"},
-            {"retainer topics", "Show all topics of retained messages"},
+            {"retainer topics", "Same as retainer topic 1 1000"},
+            {"retainer topics <Start> <Length>",
+                "Show topics of retained messages by the specified range"},
             {"retainer clean", "Clean all retained messages"},
             {"retainer clean <Topic>", "Clean retained messages by the specified topic filter"},
             {"retainer reindex status", "Show reindex status"},
@@ -98,3 +101,12 @@ do_reindex(Force) ->
         end
     ),
     ?PRINT_MSG("Reindexing finished~n").
+
+count() ->
+    ?PRINT("Number of retained messages: ~p~n", [emqx_retainer:retained_count()]).
+
+topic(Start, Len) ->
+    count(),
+    Topics = lists:sublist(emqx_retainer_mnesia:topics(), Start, Len),
+    [?PRINT("~ts~n", [I]) || I <- Topics],
+    ok.

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia_cli.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia_cli.erl
@@ -67,7 +67,7 @@ retainer(_) ->
         [
             {"retainer info", "Show the count of retained messages"},
             {"retainer topics", "Same as retainer topic 1 1000"},
-            {"retainer topics <Start> <Length>",
+            {"retainer topics <Start> <Limit>",
                 "Show topics of retained messages by the specified range"},
             {"retainer clean", "Clean all retained messages"},
             {"retainer clean <Topic>", "Clean retained messages by the specified topic filter"},

--- a/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
@@ -44,6 +44,9 @@ t_info(_Config) ->
 t_topics(_Config) ->
     ok = emqx_retainer_mnesia_cli:retainer(["topics"]).
 
+t_topics_with_len(_Config) ->
+    ok = emqx_retainer_mnesia_cli:retainer(["topics", "100", "200"]).
+
 t_clean(_Config) ->
     ok = emqx_retainer_mnesia_cli:retainer(["clean"]).
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10950 and https://emqx.atlassian.net/browse/EMQX-11004
Also add new command:
```
./bin/emqx ctl retainer topics <Start> <Length>
```


<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f4a88f7</samp>

This pull request improves the CLI commands for emqx management, observer, and retainer modules, by adding features, handling edge cases, and fixing bugs. It also updates the version numbers of the emqx_modules and emqx_retainer applications, and adds a test case for the retainer command.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
