### PR TITLE
refactor: change mria default rpc module from 'gen_rpc' to 'rpc'

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -652,7 +652,7 @@ fields("node") ->
                 hoconsc:enum([gen_rpc, rpc]),
                 #{
                     mapping => "mria.rlog_rpc_module",
-                    default => gen_rpc,
+                    default => rpc,
                     'readOnly' => true,
                     importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(db_rpc_module)

--- a/changes/ce/feat-11752.en.md
+++ b/changes/ce/feat-11752.en.md
@@ -1,0 +1,3 @@
+Change default RPC driver from 'gen_rpc' to 'rpc' for core-replica database sync.
+
+This improves core-replica data replication latency.


### PR DESCRIPTION
Fixes [EMQX-10892](https://emqx.atlassian.net/browse/EMQX-10892)
Erlang distribution seems to outperform gen_rpc (unless gen_rpc clients are scaled up, but this is not easy to achive for shard transport as it may reorder events). 
More details can be found in jira.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at c687d45</samp>

Changed the default RPC module for Mnesia replication log from `gen_rpc` to `rpc` in `emqx_conf_schema.erl`. This avoids potential conflicts with other applications and improves Mnesia replication stability and performance.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
