### PR TITLE
fix(postgres): format unicode error messages from driver

### DIFF
--- a/apps/emqx_connector/src/emqx_connector.app.src
+++ b/apps/emqx_connector/src/emqx_connector.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_connector, [
     {description, "EMQX Data Integration Connectors"},
-    {vsn, "0.1.32"},
+    {vsn, "0.1.33"},
     {registered, []},
     {mod, {emqx_connector_app, []}},
     {applications, [

--- a/changes/ee/fix-11754.en.md
+++ b/changes/ee/fix-11754.en.md
@@ -1,0 +1,1 @@
+Improved log formatting for Postgres bridge when there are unicode characters in the error messages returned by the driver.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11024

Sample error:

```
{error, error, <<"42501">>, insufficient_privilege,
<<229,175,185,232,161,168,32,109,113,116,116,95,117,115,101,114,32,230,157,131,233,153,144,228,184,141,229,164,159>>,
[]}
```
Simulating the error log:
```
2023-10-11T20:28:31.666871+00:00 [error] mfa: emqx_connector_pgsql:deleteme/0(570), driver_error_code: <<"42501">>, driver_error_codename: insufficient, driver_error_message: 对表 mqtt_user 权限不够, driver_raw_reason: {error,error,<<"42501">>,insufficient,<<229,175,185,232,161,168,32,109,113,116,116,95,117,115,101,114,32,230,157,131,233,153,144,228,184,141,229,164,159>>,[]}, driver_severity: error
```

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 58c40bb</samp>

Improved error logging and updated version for `emqx_connector`. The pull request enhances the log messages for various error events in the `emqx_connector_pgsql` module and updates the version number of the `emqx_connector` application to 0.1.33.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
