### PR TITLE
chore(ci): limit token scope in workflows

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -75,6 +75,9 @@ on:
         type: string
         default: '["self-hosted","ephemeral", "linux"]'
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/build_docker_for_test.yaml
+++ b/.github/workflows/build_docker_for_test.yaml
@@ -23,6 +23,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   docker:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   check_deps_integrity:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -8,6 +8,9 @@ on:
       ref:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze
@@ -15,7 +18,6 @@ jobs:
     timeout-minutes: 360
     permissions:
       actions: read
-      contents: read
       security-events: write
     container:
       image: ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04

--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -8,6 +8,9 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   rerun-failed-jobs:
     if: github.repository_owner == 'emqx'

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -19,6 +19,9 @@ env:
   TF_VAR_prometheus_remote_write_url: ${{ secrets.TF_EMQX_PERF_TEST_PROMETHEUS_REMOTE_WRITE_URL }}
   SLACK_WEBHOOK_URL: ${{ secrets.TF_EMQX_PERF_TEST_SLACK_URL }}
 
+permissions:
+  contents: read
+
 jobs:
   prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,9 +13,14 @@ on:
         required: true
         default: false
 
+permissions:
+  contents: read
+
 jobs:
   upload:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/run_conf_tests.yaml
+++ b/.github/workflows/run_conf_tests.yaml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   run_conf_tests:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -17,6 +17,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   basic-tests:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -26,6 +26,9 @@ on:
 env:
   IS_CI: "yes"
 
+permissions:
+  contents: read
+
 jobs:
   run_emqx_app_tests:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -17,6 +17,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   helm_test:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -14,6 +14,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   relup_test_plan:
     runs-on: ["${{ inputs.runner }}", 'linux', 'x64', 'ephemeral']

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     strategy:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,6 +8,9 @@ on:
     - cron: "0 * * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     if: github.repository_owner == 'emqx'

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -20,6 +20,9 @@ on:
 env:
   IS_CI: "yes"
 
+permissions:
+  contents: read
+
 jobs:
   static_checks:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}


### PR DESCRIPTION
Fixes [EMQX-8910](https://emqx.atlassian.net/browse/EMQX-8910)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at fd15939</samp>

This pull request updates the permissions of the GitHub Actions tokens used by various workflow files in the `.github/workflows` directory. It sets the `contents` scope to `read` for most workflows, and adds the `packages` scope to `write` for the `release.yaml` workflow. This is done to improve the security of the repository by following the principle of least privilege.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
