### PR TITLE
fix: 500 error response when downloading non-existent trace files

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -552,6 +552,8 @@ group_trace_files(TraceLog, TraceFiles) ->
                 empty;
             ({ok, _Node, _Bin}) ->
                 nonempty;
+            ({error, _Node, enoent}) ->
+                empty;
             ({error, Node, Reason}) ->
                 ?SLOG(error, #{
                     msg => "download_trace_log_error",

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -389,7 +389,16 @@ t_download_empty_trace(_Config) ->
     ),
     {error, {{_, 404, _}, _Headers, Body}} =
         request_api(get, api_path(<<"trace/", Name/binary, "/download">>), [], #{return_all => true}),
-    ?assertMatch(#{<<"message">> := <<"Trace is empty">>}, emqx_utils_json:decode(Body)).
+    ?assertMatch(#{<<"message">> := <<"Trace is empty">>}, emqx_utils_json:decode(Body)),
+    File = emqx_trace:log_file(Name, Now),
+    ct:pal("FileName: ~p", [File]),
+    ?assertEqual({ok, <<>>}, file:read_file(File)),
+    ?assertEqual(ok, file:delete(File)),
+    %% return 404 if trace file is not found
+    {error, {{_, 404, _}, _Headers, Body}} =
+        request_api(get, api_path(<<"trace/", Name/binary, "/download">>), [], #{return_all => true}),
+    ?assertMatch(#{<<"message">> := <<"Trace is empty">>}, emqx_utils_json:decode(Body)),
+    ok.
 
 to_rfc3339(Second) ->
     list_to_binary(calendar:system_time_to_rfc3339(Second)).

--- a/changes/ce/fix-11757.en.md
+++ b/changes/ce/fix-11757.en.md
@@ -1,0 +1,1 @@
+Fixed 500 error response when downloading non-existent trace files, now returns 404.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11070
When a new node joins, traces that are in the stopped status will not generate trace files on the new node, leading to 500 errors when downloading traces.

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1021088</samp>

Add a clause to handle missing trace files in `emqx_mgmt_api_trace.erl` and update the corresponding test case in `emqx_mgmt_api_trace_SUITE.erl`. This improves the robustness and correctness of the trace file download API.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
