### PR TITLE
fix(gcpdev): restore original shard in mnesia tab definition

### DIFF
--- a/apps/emqx_gcp_device/src/emqx_gcp_device.erl
+++ b/apps/emqx_gcp_device/src/emqx_gcp_device.erl
@@ -8,7 +8,10 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
--define(AUTHN_SHARD, ?MODULE).
+%% NOTE
+%% We share the shard with `emqx_auth_mnesia` to ensure backward compatibility
+%% with EMQX 5.2.x and earlier.
+-define(AUTHN_SHARD, emqx_authn_shard).
 
 %% Management
 -export([put_device/1, get_device/1, remove_device/1]).


### PR DESCRIPTION
Changing the shard is not backward compatible, and leads to a crash when upgrading from 5.2.x / 5.3.0.

Fixes [EMQX-11131](https://emqx.atlassian.net/browse/EMQX-11131).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 6413afd</samp>

Changed `AUTHN_SHARD` macro to use `emqx_authn_shard` for compatibility. Updated comment in `emqx_gcp_device.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [ ] Schema changes are backward compatible
