### PR TITLE
fix(cass): avoid using aggregates in healthcheck query

### DIFF
--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra.app.src
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_cassandra, [
     {description, "EMQX Enterprise Cassandra Bridge"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
@@ -332,7 +332,7 @@ on_get_status(_InstId, #{pool_name := PoolName} = State) ->
     end.
 
 do_get_status(Conn) ->
-    ok == element(1, ecql:query(Conn, "SELECT count(1) AS T FROM system.local")).
+    ok == element(1, ecql:query(Conn, "SELECT cluster_name FROM system.local")).
 
 do_check_prepares(#{prepare_cql := Prepares}) when is_map(Prepares) ->
     ok;

--- a/changes/ee/fix-11760.en.md
+++ b/changes/ee/fix-11760.en.md
@@ -1,0 +1,1 @@
+Simplified the CQL query employed for Cassandra bridge health check that was apparently the source of warnings in Cassandra server logs.


### PR DESCRIPTION
Fixes [EMQX-11149](https://emqx.atlassian.net/browse/EMQX-11149).

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 51c57a5</samp>

Improved the Cassandra connection check query and updated the application version. The new query uses the cluster name instead of the row count to verify the connection to the Cassandra cluster. The application version was incremented to 0.1.5 to reflect the changes.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
