### PR TITLE
fix(mnesia authz): destroy authz records on mnesia authz destroy

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
@@ -95,7 +95,9 @@ create(Source) -> Source.
 
 update(Source) -> Source.
 
-destroy(_Source) -> ok.
+destroy(_Source) ->
+    {atomic, ok} = mria:clear_table(?ACL_TABLE),
+    ok.
 
 authorize(
     #{

--- a/apps/emqx_auth_mnesia/test/emqx_authz_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_mnesia_SUITE.erl
@@ -221,6 +221,35 @@ t_normalize_rules(_Config) ->
         )
     ).
 
+t_destroy(_Config) ->
+    ClientInfo = emqx_authz_test_lib:base_client_info(),
+
+    ok = emqx_authz_mnesia:store_rules(
+        {username, <<"username">>},
+        [#{<<"permission">> => <<"allow">>, <<"action">> => <<"publish">>, <<"topic">> => <<"t">>}]
+    ),
+
+    ?assertEqual(
+        allow,
+        emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>)
+    ),
+
+    ok = emqx_authz_test_lib:reset_authorizers(),
+
+    ?assertEqual(
+        deny,
+        emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>)
+    ),
+
+    ok = setup_config(),
+
+    %% After destroy, the rules should be empty
+
+    ?assertEqual(
+        deny,
+        emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t">>)
+    ).
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/changes/ce/fix-11762.en.md
+++ b/changes/ce/fix-11762.en.md
@@ -1,0 +1,1 @@
+Fixed destruction of built_in_database authorization source. Now all the ACL records are removed when the authorization source is destroyed. Previosly, old records were left in the database, which could cause problems when creating authorization source back.


### PR DESCRIPTION
Fixes [EMQX-11002](https://emqx.atlassian.net/browse/EMQX-11002)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5573f9d</samp>

Fix a bug in `emqx_authz_mnesia` that left stale rules in the database after destroying the source. Add a test case to verify the fix.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible
