### PR TITLE
feat(api_key): add RBAC feature for the API key

### DIFF
--- a/apps/emqx/src/bhvrs/emqx_db_backup.erl
+++ b/apps/emqx/src/bhvrs/emqx_db_backup.erl
@@ -16,4 +16,21 @@
 
 -module(emqx_db_backup).
 
+-type traverse_break_reason() :: over | migrate.
+
 -callback backup_tables() -> [mria:table()].
+
+%% validate the backup
+%% return `ok` to traverse the next item
+%% return `{ok, over}` to finish the traverse
+%% return `{ok, migrate}` to call the migration callback
+-callback validate_mnesia_backup(tuple()) ->
+    ok
+    | {ok, traverse_break_reason()}
+    | {error, term()}.
+
+-callback migrate_mnesia_backup(tuple()) -> {ok, tuple()} | {error, term()}.
+
+-optional_callbacks([validate_mnesia_backup/1, migrate_mnesia_backup/1]).
+
+-export_type([traverse_break_reason/0]).

--- a/apps/emqx/test/emqx_common_test_http.erl
+++ b/apps/emqx/test/emqx_common_test_http.erl
@@ -17,6 +17,7 @@
 -module(emqx_common_test_http).
 
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
 
 -export([
     request_api/3,
@@ -90,7 +91,12 @@ create_default_app() ->
     Now = erlang:system_time(second),
     ExpiredAt = Now + timer:minutes(10),
     emqx_mgmt_auth:create(
-        ?DEFAULT_APP_ID, ?DEFAULT_APP_SECRET, true, ExpiredAt, <<"default app key for test">>
+        ?DEFAULT_APP_ID,
+        ?DEFAULT_APP_SECRET,
+        true,
+        ExpiredAt,
+        <<"default app key for test">>,
+        ?ROLE_API_SUPERUSER
     ).
 
 delete_default_app() ->

--- a/apps/emqx/test/emqx_common_test_http.erl
+++ b/apps/emqx/test/emqx_common_test_http.erl
@@ -17,7 +17,6 @@
 -module(emqx_common_test_http).
 
 -include_lib("common_test/include/ct.hrl").
--include_lib("emqx_dashboard/include/emqx_dashboard_rbac.hrl").
 
 -export([
     request_api/3,
@@ -33,6 +32,9 @@
 
 -define(DEFAULT_APP_ID, <<"default_appid">>).
 -define(DEFAULT_APP_SECRET, <<"default_app_secret">>).
+
+%% from emqx_dashboard/include/emqx_dashboard_rbac.hrl
+-define(ROLE_API_SUPERUSER, <<"api_administrator">>).
 
 request_api(Method, Url, Auth) ->
     request_api(Method, Url, [], Auth, []).

--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -13,16 +13,9 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
--define(ADMIN, emqx_admin).
+-include("emqx_dashboard_rbac.hrl").
 
-%% TODO:
-%% The predefined roles of the preliminary RBAC implementation,
-%% these may be removed when developing the full RBAC feature.
-%% In full RBAC feature, the role may be customised created and deleted,
-%% a predefined configuration would replace these macros.
--define(ROLE_VIEWER, <<"viewer">>).
--define(ROLE_SUPERUSER, <<"administrator">>).
--define(ROLE_DEFAULT, ?ROLE_SUPERUSER).
+-define(ADMIN, emqx_admin).
 
 -define(BACKEND_LOCAL, local).
 -define(SSO_USERNAME(Backend, Name), {Backend, Name}).

--- a/apps/emqx_dashboard/include/emqx_dashboard_rbac.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard_rbac.hrl
@@ -1,0 +1,33 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-ifndef(EMQX_DASHBOARD_RBAC).
+-define(EMQX_DASHBOARD_RBAC, true).
+
+%% TODO:
+%% The predefined roles of the preliminary RBAC implementation,
+%% these may be removed when developing the full RBAC feature.
+%% In full RBAC feature, the role may be customised created and deleted,
+%% a predefined configuration would replace these macros.
+-define(ROLE_VIEWER, <<"viewer">>).
+-define(ROLE_SUPERUSER, <<"administrator">>).
+-define(ROLE_DEFAULT, ?ROLE_SUPERUSER).
+
+-define(ROLE_API_VIEWER, <<"api_viewer">>).
+-define(ROLE_API_SUPERUSER, <<"api_administrator">>).
+-define(ROLE_API_PUBLISHER, <<"api_publisher">>).
+-define(ROLE_API_DEFAULT, ?ROLE_API_SUPERUSER).
+
+-endif.

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -212,7 +212,7 @@ listener_name(Protocol) ->
 
 -if(?EMQX_RELEASE_EDITION =/= ee).
 %% dialyzer complains about the `unauthorized_role' clause...
--dialyzer({no_match, [authorize/1]}).
+-dialyzer({no_match, [authorize/1, api_key_authorize/3]}).
 -endif.
 
 authorize(Req) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -251,7 +251,7 @@ listeners() ->
 
 api_key_authorize(Req, Key, Secret) ->
     Path = cowboy_req:path(Req),
-    case emqx_mgmt_auth:authorize(Path, Key, Secret) of
+    case emqx_mgmt_auth:authorize(Path, Req, Key, Secret) of
         ok ->
             {ok, #{auth_type => api_key, api_key => Key}};
         {error, <<"not_allowed">>} ->
@@ -259,6 +259,9 @@ api_key_authorize(Req, Key, Secret) ->
                 ?BAD_API_KEY_OR_SECRET,
                 <<"Not allowed, Check api_key/api_secret">>
             );
+        {error, unauthorized_role} ->
+            {403, 'UNAUTHORIZED_ROLE',
+                <<"This API Key don't have permission to access this resource">>};
         {error, _} ->
             return_unauthorized(
                 ?BAD_API_KEY_OR_SECRET,

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -416,7 +416,7 @@ ensure_role(Role) when is_binary(Role) ->
 
 -if(?EMQX_RELEASE_EDITION == ee).
 legal_role(Role) ->
-    emqx_dashboard_rbac:valid_role(Role).
+    emqx_dashboard_rbac:valid_dashboard_role(Role).
 
 role(Data) ->
     emqx_dashboard_rbac:role(Data).
@@ -447,8 +447,10 @@ lookup_user(Backend, Username) when is_atom(Backend) ->
 
 -dialyzer({no_match, [add_user/4, update_user/3]}).
 
+legal_role(?ROLE_DEFAULT) ->
+    ok;
 legal_role(_) ->
-    ok.
+    {error, <<"Role does not exist">>}.
 
 role(_) ->
     ?ROLE_DEFAULT.

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.app.src
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard_rbac, [
     {description, "EMQX Dashboard RBAC"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -6,7 +6,12 @@
 
 -include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
 
--export([check_rbac/2, role/1, valid_role/1]).
+-export([
+    check_rbac/2,
+    role/1,
+    valid_dashboard_role/1,
+    valid_api_role/1
+]).
 
 -dialyzer({nowarn_function, role/1}).
 %%=====================================================================
@@ -31,25 +36,44 @@ role(#?ADMIN{role = Role}) ->
 role([]) ->
     ?ROLE_SUPERUSER;
 role(#{role := Role}) ->
+    Role;
+role(Role) when is_binary(Role) ->
     Role.
 
-valid_role(Role) ->
-    case lists:member(Role, role_list()) of
+valid_dashboard_role(Role) ->
+    valid_role(dashboard, Role).
+
+valid_api_role(Role) ->
+    valid_role(api, Role).
+
+%% ===================================================================
+check_rbac(?ROLE_SUPERUSER, _, _) ->
+    true;
+check_rbac(?ROLE_API_SUPERUSER, _, _) ->
+    true;
+check_rbac(?ROLE_VIEWER, <<"GET">>, _) ->
+    true;
+check_rbac(?ROLE_API_VIEWER, <<"GET">>, _) ->
+    true;
+%% this API is a special case
+check_rbac(?ROLE_VIEWER, <<"POST">>, <<"/logout">>) ->
+    true;
+check_rbac(?ROLE_API_PUBLISHER, <<"POST">>, <<"/publish">>) ->
+    true;
+check_rbac(?ROLE_API_PUBLISHER, <<"POST">>, <<"/publish/bulk">>) ->
+    true;
+check_rbac(_, _, _) ->
+    false.
+
+valid_role(Type, Role) ->
+    case lists:member(Role, role_list(Type)) of
         true ->
             ok;
         _ ->
             {error, <<"Role does not exist">>}
     end.
-%% ===================================================================
-check_rbac(?ROLE_SUPERUSER, _, _) ->
-    true;
-check_rbac(?ROLE_VIEWER, <<"GET">>, _) ->
-    true;
-%% this API is a special case
-check_rbac(?ROLE_VIEWER, <<"POST">>, <<"/logout">>) ->
-    true;
-check_rbac(_, _, _) ->
-    false.
 
-role_list() ->
-    [?ROLE_VIEWER, ?ROLE_SUPERUSER].
+role_list(dashboard) ->
+    [?ROLE_VIEWER, ?ROLE_SUPERUSER];
+role_list(api) ->
+    [?ROLE_API_VIEWER, ?ROLE_API_PUBLISHER, ?ROLE_API_SUPERUSER].

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -42,7 +42,7 @@
 
 %% Internal exports (RPC)
 -export([
-    do_update/4,
+    do_update/5,
     do_delete/1,
     do_create_app/3,
     do_force_create_app/3
@@ -149,12 +149,12 @@ read(Name) ->
 update(Name, Enable, ExpiredAt, Desc, Role) ->
     case valid_role(Role) of
         ok ->
-            trans(fun ?MODULE:do_update/4, [Name, Enable, ExpiredAt, Desc]);
+            trans(fun ?MODULE:do_update/5, [Name, Enable, ExpiredAt, Desc, Role]);
         Error ->
             Error
     end.
 
-do_update(Name, Enable, ExpiredAt, Desc) ->
+do_update(Name, Enable, ExpiredAt, Desc, Role) ->
     case mnesia:read(?APP, Name, write) of
         [] ->
             mnesia:abort(not_found);
@@ -163,7 +163,8 @@ do_update(Name, Enable, ExpiredAt, Desc) ->
                 App0#?APP{
                     expired_at = ExpiredAt,
                     enable = ensure_not_undefined(Enable, Enable0),
-                    desc = ensure_not_undefined(Desc, Desc0)
+                    desc = ensure_not_undefined(Desc, Desc0),
+                    role = Role
                 },
             ok = mnesia:write(App),
             to_map(App)

--- a/changes/ee/feat-11766.en.md
+++ b/changes/ee/feat-11766.en.md
@@ -1,0 +1,8 @@
+Implemented a preliminary Role-Based Access Control for the REST API.
+
+  In this version, there are three predefined roles:
+  - Administrator: This role could access all resources.
+
+  - Viewer: This role can only view resources and data, corresponding to all GET requests in the REST API.
+
+  - Publisher: This role is special for MQTT messages publish, it can only access publish-related endpoints.

--- a/rel/i18n/emqx_mgmt_api_api_keys.hocon
+++ b/rel/i18n/emqx_mgmt_api_api_keys.hocon
@@ -30,4 +30,7 @@ format.desc:
 format.label:
 """Unique and format by [a-zA-Z0-9-_]"""
 
+role.desc:
+"""Role for this API"""
+
 }


### PR DESCRIPTION
Targeting 5.4 release.
Fixes [EMQX-11005](https://emqx.atlassian.net/browse/EMQX-11005)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e095de7</samp>

This pull request adds RBAC (role-based access control) support for the dashboard and the API in the enterprise edition of EMQX. It introduces a new `role` field for the API keys, and validates and checks the permissions of the roles using the `emqx_dashboard_rbac` module. It also updates the tests, the i18n file, and the version number of the `emqx_dashboard_rbac` application.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
