### PR TITLE
build: upgrade to rebar3 3.19.0-emqx-8

### DIFF
--- a/scripts/ensure-rebar3.sh
+++ b/scripts/ensure-rebar3.sh
@@ -14,7 +14,7 @@ case ${OTP_VSN} in
         VERSION="3.18.0-emqx-1"
         ;;
     25*)
-        VERSION="3.19.0-emqx-1"
+        VERSION="3.19.0-emqx-8"
         ;;
     *)
         echo "Unsupporetd Erlang/OTP version $OTP_VSN"


### PR DESCRIPTION
This version supports REBAR3_GIT_CACHE_DIR option to make use of local repos as clone reference to reduced the number of clones