### PR TITLE
fix(authn): fix pbkdf2 option validation

### DIFF
--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -83,7 +83,7 @@ do_check_pass({_SimpleHash, _Salt, _SaltPosition} = HashParams, PasswordHash, Pa
     compare_secure(Hash, PasswordHash).
 
 -spec hash(hash_params(), password()) -> password_hash().
-hash({pbkdf2, MacFun, Salt, Iterations, DKLength}, Password) ->
+hash({pbkdf2, MacFun, Salt, Iterations, DKLength}, Password) when Iterations > 0 ->
     case pbkdf2(MacFun, Password, Salt, Iterations, DKLength) of
         {ok, HashPasswd} ->
             hex(HashPasswd);

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
@@ -92,7 +92,7 @@ fields(pbkdf2) ->
             )},
         {iterations,
             sc(
-                integer(),
+                pos_integer(),
                 #{required => true, desc => "Iteration count for PBKDF2 hashing algorithm."}
             )},
         {dk_length, fun dk_length/1}

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_password_hashing_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_password_hashing_SUITE.erl
@@ -185,3 +185,29 @@ hash_examples() ->
             }
         }
     ].
+
+t_pbkdf2_schema(_Config) ->
+    Config = fun(Iterations) ->
+        #{
+            <<"pbkdf2">> => #{
+                <<"name">> => <<"pbkdf2">>,
+                <<"mac_fun">> => <<"sha">>,
+                <<"iterations">> => Iterations
+            }
+        }
+    end,
+
+    ?assertException(
+        throw,
+        {emqx_authn_password_hashing, _},
+        hocon_tconf:check_plain(emqx_authn_password_hashing, Config(0), #{}, [pbkdf2])
+    ),
+    ?assertException(
+        throw,
+        {emqx_authn_password_hashing, _},
+        hocon_tconf:check_plain(emqx_authn_password_hashing, Config(-1), #{}, [pbkdf2])
+    ),
+    ?assertMatch(
+        #{<<"pbkdf2">> := _},
+        hocon_tconf:check_plain(emqx_authn_password_hashing, Config(1), #{}, [pbkdf2])
+    ).

--- a/changes/ce/fix-11780.en.md
+++ b/changes/ce/fix-11780.en.md
@@ -1,0 +1,1 @@
+Fixed validation of the `iterations` field of the `pbkdf2` password hashing algorithm. Now, `iterations` must be strictly positive. Previously, it could be set to 0, which led to a nonfunctional authenticator.


### PR DESCRIPTION
Fixes [EMQX-10777](https://emqx.atlassian.net/browse/EMQX-10777)

Also fixed a bug with password hashing made inside a transaction.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 364b3e2</samp>

This pull request fixes a bug and improves the validation and testing of the PBKDF2 hashing algorithm for password authentication. It changes the schema of the `iterations` parameter to `pos_integer()`, adds a guard clause to the `hash` function, and adds a test case for the schema validation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Schema changes are **NOT** backward compatible. However, configurations that are now forbidden couldn't be functional.

