### PR TITLE
ci: explicitly specify architecture in runner labels

### DIFF
--- a/.ci/docker-compose-file/docker-compose-pgsql-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-pgsql-tls.yaml
@@ -8,7 +8,7 @@ services:
       dockerfile: ./pgsql/Dockerfile
       args:
         POSTGRES_USER: postgres
-        BUILD_FROM: postgres:${PGSQL_TAG}
+        BUILD_FROM: public.ecr.aws/docker/library/postgres:${PGSQL_TAG}
     image: emqx_pgsql:${PGSQL_TAG}
     restart: always
     environment:

--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   sanity-checks:
-    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted","ephemeral"]' || '["ubuntu-22.04"]') }}
+    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]') }}
     container: "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04"
     outputs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
@@ -24,7 +24,7 @@ jobs:
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
       version-emqx: ${{ steps.matrix.outputs.version-emqx }}
       version-emqx-enterprise: ${{ steps.matrix.outputs.version-emqx-enterprise }}
-      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted", "ephemeral"]' || '["ubuntu-22.04"]' }}
+      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]' }}
       builder: "ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04"
       builder_vsn: "5.1-4"
       otp_vsn: "25.3.2-2"
@@ -57,8 +57,8 @@ jobs:
         env:
           ACTIONLINT_VSN: 1.6.25
         run: |
-          wget https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VSN}/actionlint_${ACTIONLINT_VSN}_linux_amd64.tar.gz
-          tar zxf actionlint_${ACTIONLINT_VSN}_linux_amd64.tar.gz actionlint
+          wget -q https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VSN}/actionlint_${ACTIONLINT_VSN}_linux_$(dpkg --print-architecture).tar.gz -O actionlint.tar.gz
+          tar zxf actionlint.tar.gz actionlint
           # TODO: enable shellcheck when all the current issues are fixed
           ./actionlint -color \
             -shellcheck= \

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted", "ephemeral"]' || '["ubuntu-22.04"]') }}
+    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]') }}
     container: 'ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04'
     outputs:
       profile: ${{ steps.parse-git-ref.outputs.profile }}
@@ -29,7 +29,7 @@ jobs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
       ct-host: ${{ steps.matrix.outputs.ct-host }}
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
-      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted", "ephemeral"]' || '["ubuntu-22.04"]' }}
+      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]' }}
       builder: 'ghcr.io/emqx/emqx-builder/5.1-4:1.14.5-25.3.2-2-ubuntu22.04'
       builder_vsn: '5.1-4'
       otp_vsn: '25.3.2-2'

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -73,7 +73,7 @@ on:
       runner_labels:
         required: false
         type: string
-        default: '["self-hosted","ephemeral", "linux"]'
+        default: '["self-hosted","ephemeral","linux","x64"]'
 
 jobs:
   docker:

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -151,7 +151,7 @@ jobs:
         path: _packages/${{ matrix.profile }}/
 
   linux:
-    runs-on: ['self-hosted', 'linux', "${{ matrix.arch }}"]
+    runs-on: ['self-hosted', 'ephemeral', 'linux', "${{ matrix.arch }}"]
     # always run in builder container because the host might have the wrong OTP version etc.
     # otherwise buildx.sh does not run docker if arch and os matches the target arch and os.
     container:

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   linux:
     if: github.repository_owner == 'emqx'
-    runs-on: ['self-hosted', 'linux', "${{ matrix.arch }}", 'ephemeral']
+    runs-on: ['self-hosted', 'ephemeral', 'linux', "${{ matrix.arch }}"]
     container:
       image: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}"
 

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -30,7 +30,7 @@ on:
       runner_labels:
         required: false
         type: string
-        default: '["self-hosted","ephemeral"]'
+        default: '["self-hosted","ephemeral", "linux", "x64"]'
       builder:
         required: false
         type: string

--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -118,7 +118,6 @@ jobs:
       env:
         PGSQL_TAG: ${{ matrix.pgsql_tag }}
       run: |
-        docker pull postgres:${PGSQL_TAG}
         docker compose \
           -f .ci/docker-compose-file/docker-compose-emqx-cluster.yaml \
           -f .ci/docker-compose-file/docker-compose-pgsql-tls.yaml \
@@ -245,7 +244,7 @@ jobs:
         cd scripts/jwks-server
         mvn package
         cd target
-        docker run --name jwks_server --network emqx_bridge --ip 172.100.239.88 -d -v $(pwd)/jwkserver-0.0.1.jar:/jwks_server/jwkserver-0.0.1.jar --workdir /jwks_server openjdk:8-jdk bash \
+        docker run --name jwks_server --network emqx_bridge --ip 172.100.239.88 -d -v $(pwd)/jwkserver-0.0.1.jar:/jwks_server/jwkserver-0.0.1.jar --workdir /jwks_server public.ecr.aws/amazoncorretto/amazoncorretto:8 bash \
         -c "java -jar jwkserver-0.0.1.jar"
     - name: run jmeter
       run: |

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -184,7 +184,7 @@ haproxy_cid=$(docker run -d --name haproxy \
                      -v "$(pwd)/apps/emqx/etc/certs:/usr/local/etc/haproxy/certs" \
                      -w /usr/local/etc/haproxy \
                      "${HAPROXY_PORTS[@]}" \
-                     "haproxy:2.4" \
+                     "public.ecr.aws/docker/library/haproxy:2.4" \
                      bash -c 'set -euo pipefail;
                               cat certs/cert.pem certs/key.pem > /tmp/emqx.pem;
                               haproxy -f haproxy.cfg')


### PR DESCRIPTION
Both amd64 and arm64 runners have "self-hosted", "ephemeral" and "linux" labels. Not all of our workflows can run seamlessly on both architectures. 