### PR TITLE
fix: allow viewers to change their own passwords

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -248,8 +248,8 @@ clean_expired_jwt(Now) ->
 
 -if(?EMQX_RELEASE_EDITION == ee).
 check_rbac(Req, JWT) ->
-    #?ADMIN_JWT{exptime = _ExpTime, extra = Extra, username = _Username} = JWT,
-    case emqx_dashboard_rbac:check_rbac(Req, Extra) of
+    #?ADMIN_JWT{exptime = _ExpTime, extra = Extra, username = Username} = JWT,
+    case emqx_dashboard_rbac:check_rbac(Req, Username, Extra) of
         true ->
             save_new_jwt(JWT);
         _ ->

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.app.src
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.app.src
@@ -1,6 +1,6 @@
 {application, emqx_dashboard_rbac, [
     {description, "EMQX Dashboard RBAC"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ce/feat-11785.en.md
+++ b/changes/ce/feat-11785.en.md
@@ -1,0 +1,1 @@
+Allow viewer to change their own passwords, viewer can't change other's password.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11190
- viewer can change own password
- viewer can't change other's password
- superuser can change everyone's password
<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2388d36</samp>

Added a feature to allow users to change their own passwords via the dashboard API. Modified the `emqx_dashboard_rbac` and `emqx_dashboard_token` modules to handle the permission logic and pass the username parameter. Added a test case to verify the feature. Bumped the `emqx_dashboard_rbac` version.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
