### PR TITLE
refactor(nodetool): only add libs when necessary

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -21,12 +21,13 @@ main(Args) ->
                     ok
             end
     end,
-    ok = add_libs_dir(),
     case Args of
         ["hocon" | Rest] ->
+            ok = add_libs_dir(),
             %% forward the call to hocon_cli
             hocon_cli:main(Rest);
         ["check_license_key", Key0] ->
+            ok = add_libs_dir(),
             Key = cleanup_key(Key0),
             check_license(#{key => Key});
         _ ->

--- a/changes/ce/feat-11787.en.md
+++ b/changes/ce/feat-11787.en.md
@@ -1,0 +1,3 @@
+Improve `emqx` command performance.
+
+Avoid loading EMQX application code in `nodetool` script unless necessary.


### PR DESCRIPTION
Fixes [EMQX-11191](https://emqx.atlassian.net/browse/EMQX-11191)

## Summary

The `nodetool` command is started in a temp `remsh` node which mostly issues RPC to the running EMQX node.
For example, `ctl`, `ping` and `status`
However, `hocon` and `check_license_key` commands are executed locally (meaning there is no need for a running EMQX node in order to execute the command), so it needs to load all the apps before executing the command.

Prior to this fix, the loading of the emqx apps is unconditional, the apps are loaded even if it's just a plain RPC call.
The fix is to only load apps for `hocon` and `check_license_key`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
