### PR TITLE
fix(coap): increase received packet counter for keepalive

### DIFF
--- a/changes/ce/fix-11791.en.md
+++ b/changes/ce/fix-11791.en.md
@@ -1,0 +1,1 @@
+Fixed an issue that prevented heartbeats from correctly keeping the CoAP Gateway connections alive.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11193 
Fixes https://github.com/emqx/emqx/issues/11779

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e2a0a17</samp>

This pull request enhances the CoAP gateway functionality and testing. It adds a new config option for heartbeat interval, fixes a typo and a statistics issue in the channel module, and introduces a new test case for the heartbeat mechanism. It also refactors and simplifies some test code.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
