### PR TITLE
fix: return 404 if built_in_database not configured as auth source

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_api_sources.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_api_sources.erl
@@ -49,6 +49,8 @@
     aggregate_metrics/1
 ]).
 
+-export([with_source/2]).
+
 -define(TAGS, [<<"Authorization">>]).
 
 api_spec() ->

--- a/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
@@ -415,7 +415,9 @@ run_examples(Code, Examples) when is_number(Code) ->
     run_examples(
         fun
             ({ok, ResCode, _}) when Code =:= ResCode -> true;
-            (_) -> false
+            (_Res) ->
+                ct:pal("check failed: ~p", [_Res]),
+                false
         end,
         Examples
     ).
@@ -455,7 +457,9 @@ make_examples(ApiMod, Replacements) ->
                             end,
                         {replace_parts(to_parts(Path), Replacements), Op, Body}
                     end,
-                    lists:sort(fun op_sort/2, maps:to_list(maps:remove('operationId', Schema)))
+                    lists:sort(
+                        fun op_sort/2, maps:to_list(maps:with([get, put, post, delete], Schema))
+                    )
                 )
             end,
             Paths

--- a/changes/ce/fix-11797.en.md
+++ b/changes/ce/fix-11797.en.md
@@ -1,0 +1,1 @@
+Modified HTTP API behavior for APIs managing the `built_in_database` authorization source: They will now return a `404` status code if `built_in_database` is not set as the authorization source, replacing the former `20X` response.

--- a/dev
+++ b/dev
@@ -227,8 +227,6 @@ prepare_erl_libs() {
         for app in "_build/${profile}/checkouts"/*; do
             erl_libs="${erl_libs}${sep}${app}"
         done
-    else
-        echo "no checkouts"
     fi
     export ERL_LIBS="$erl_libs"
 }


### PR DESCRIPTION
Fixes [EMQX-10577](https://emqx.atlassian.net/browse/EMQX-10577)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at f86468e</samp>

This pull request improves the API handling for the built-in database source in the `emqx_authz` module. It adds a `with_source/2` function to check the source status before performing API operations, and modifies the `emqx_authz_api_mnesia` module and its test suite to use this function. It also fixes some syntax issues in the `emqx_authz_api_mnesia` module.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
-  ~Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~
