### PR TITLE
build: refactor Makefile -ct and -prop target generation

### DIFF
--- a/scripts/find-suites.sh
+++ b/scripts/find-suites.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-## If EMQX_CT_SUITES is provided, it prints the variable.
+## If EMQX_CT_SUITES or SUITES is provided, it prints the variable.
 ## Otherwise this script tries to find all test/*_SUITE.erl files of then given app,
 ## file names are separated by comma for rebar3 ct's `--suite` option
 
@@ -12,7 +12,8 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "$0")/.."
 
-## EMQX_CT_SUITES is useful in ad-hoc runs
+## EMQX_CT_SUITES or SUITES is useful in ad-hoc runs
+EMQX_CT_SUITES="${EMQX_CT_SUITES:-${SUITES:-}}"
 if [ -n "${EMQX_CT_SUITES:-}" ]; then
     echo "${EMQX_CT_SUITES}"
     exit 0


### PR DESCRIPTION
Most of the cases, the time spent executing `find-apps.sh` and `find-suites.sh` are wasted.
The only benefit is maybe `make` command target auto-completion.
 
After this PR, we no longer pre-generate all the `-ct` and `-prop` targets, rather generate only the one that is in the specified build target.