### PR TITLE
Fix shared sub topic or subscription searching

### DIFF
--- a/apps/emqx/src/emqx_topic.erl
+++ b/apps/emqx/src/emqx_topic.erl
@@ -83,6 +83,8 @@ match(Name, Filter) when is_binary(Name), is_binary(Filter) ->
     match(words(Name), words(Filter));
 match(#share{} = Name, Filter) ->
     match_share(Name, Filter);
+match(Name, #share{} = Filter) ->
+    match_share(Name, Filter);
 match([], []) ->
     true;
 match([H | T1], [H | T2]) ->
@@ -109,7 +111,10 @@ match_share(#share{group = Group, topic = Name}, #share{group = Group, topic = F
     match(words(Name), words(Filter));
 match_share(#share{}, _) ->
     %% Otherwise, non-matched.
-    false.
+    false;
+match_share(Name, #share{topic = Filter}) when is_binary(Name) ->
+    %% Only match real topic filter for normal topic_filter/topic_name.
+    match(Name, Filter).
 
 -spec match_any(Name, [Filter]) -> boolean() when
     Name :: topic() | words(),

--- a/apps/emqx_management/src/emqx_mgmt_api_topics.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_topics.erl
@@ -149,8 +149,15 @@ qs2ms(_Tab, {Qs, _}) ->
 
 gen_match_spec([], Res) ->
     Res;
-gen_match_spec([{topic, '=:=', T} | Qs], [{{route, _, N}, [], ['$_']}]) ->
-    gen_match_spec(Qs, [{{route, T, N}, [], ['$_']}]);
+gen_match_spec([{topic, '=:=', T0} | Qs], [{{route, _, Node}, [], ['$_']}]) when is_atom(Node) ->
+    {T, D} =
+        case emqx_topic:parse(T0) of
+            {#share{group = Group, topic = Topic}, _SubOpts} ->
+                {Topic, {Group, Node}};
+            {T1, _SubOpts} ->
+                {T1, Node}
+        end,
+    gen_match_spec(Qs, [{{route, T, D}, [], ['$_']}]);
 gen_match_spec([{node, '=:=', N} | Qs], [{{route, T, _}, [], ['$_']}]) ->
     gen_match_spec(Qs, [{{route, T, N}, [], ['$_']}]).
 


### PR DESCRIPTION
Fixes [EMQX-11261](https://emqx.atlassian.net/browse/EMQX-11261)

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e9de731</samp>

This pull request adds a feature to the management API to support matching share topics, which are topics that can be subscribed by multiple clients with a common group name. It modifies the `match/2` and `match_share/2` functions in `emqx_topic.erl` and the `gen_match_spec/2` function in `emqx_mgmt_api_topics.erl` to handle share topics. It also adds test cases in `emqx_mgmt_api_subscription_SUITE.erl` and `emqx_mgmt_api_topics_SUITE.erl` to verify the functionality and correctness of the feature.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~[ ] Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- ~[ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
