### PR TITLE
AEH fixes, rename type and fix legacy v1 test suite

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_enterprise.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_enterprise.erl
@@ -44,7 +44,7 @@ bridge_v2_structs() ->
                     required => false
                 }
             )},
-        {azure_event_hub,
+        {azure_event_hub_producer,
             mk(
                 hoconsc:map(name, ref(emqx_bridge_azure_event_hub, bridge_v2)),
                 #{
@@ -57,7 +57,7 @@ bridge_v2_structs() ->
 api_schemas(Method) ->
     [
         api_ref(emqx_bridge_kafka, <<"kafka_producer">>, Method ++ "_bridge_v2"),
-        api_ref(emqx_bridge_azure_event_hub, <<"azure_event_hub">>, Method ++ "_bridge_v2")
+        api_ref(emqx_bridge_azure_event_hub, <<"azure_event_hub_producer">>, Method ++ "_bridge_v2")
     ].
 
 api_ref(Module, Type, Method) ->

--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -122,6 +122,7 @@ setup_mocks() ->
     catch meck:new(emqx_bridge_v2, MeckOpts),
     meck:expect(emqx_bridge_v2, bridge_v2_type_to_connector_type, 1, con_type()),
     meck:expect(emqx_bridge_v2, bridge_v1_type_to_bridge_v2_type, 1, bridge_type()),
+    meck:expect(emqx_bridge_v2, bridge_v2_type_to_connector_type, 1, con_type()),
     IsBridgeV2TypeFun = fun(Type) ->
         BridgeV2Type = bridge_type(),
         case Type of

--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -120,17 +120,16 @@ setup_mocks() ->
     meck:expect(emqx_bridge_v2_schema, fields, 1, bridge_schema()),
 
     catch meck:new(emqx_bridge_v2, MeckOpts),
-    meck:expect(emqx_bridge_v2, bridge_v2_type_to_connector_type, 1, con_type()),
+    BridgeType = bridge_type(),
+    BridgeTypeBin = atom_to_binary(BridgeType),
+    meck:expect(
+        emqx_bridge_v2,
+        bridge_v2_type_to_connector_type,
+        fun(Type) when Type =:= BridgeType; Type =:= BridgeTypeBin -> con_type() end
+    ),
     meck:expect(emqx_bridge_v2, bridge_v1_type_to_bridge_v2_type, 1, bridge_type()),
-    meck:expect(emqx_bridge_v2, bridge_v2_type_to_connector_type, 1, con_type()),
-    IsBridgeV2TypeFun = fun(Type) ->
-        BridgeV2Type = bridge_type(),
-        case Type of
-            BridgeV2Type -> true;
-            _ -> false
-        end
-    end,
-    meck:expect(emqx_bridge_v2, is_bridge_v2_type, 1, IsBridgeV2TypeFun),
+
+    meck:expect(emqx_bridge_v2, is_bridge_v2_type, fun(Type) -> Type =:= BridgeType end),
     ok.
 
 init_per_suite(Config) ->
@@ -520,8 +519,8 @@ t_load_no_matching_connector(_Config) ->
         {error,
             {post_config_update, _HandlerMod, #{
                 bridge_name := my_test_bridge_update,
-                connector_name := unknown,
-                type := _,
+                connector_name := <<"unknown">>,
+                bridge_type := _,
                 reason := "connector_not_found_or_wrong_type"
             }}},
         update_root_config(RootConf0)
@@ -537,8 +536,8 @@ t_load_no_matching_connector(_Config) ->
         {error,
             {post_config_update, _HandlerMod, #{
                 bridge_name := my_test_bridge_new,
-                connector_name := unknown,
-                type := _,
+                connector_name := <<"unknown">>,
+                bridge_type := _,
                 reason := "connector_not_found_or_wrong_type"
             }}},
         update_root_config(RootConf1)
@@ -609,7 +608,7 @@ t_create_no_matching_connector(_Config) ->
             {post_config_update, _HandlerMod, #{
                 bridge_name := _,
                 connector_name := _,
-                type := _,
+                bridge_type := _,
                 reason := "connector_not_found_or_wrong_type"
             }}},
         emqx_bridge_v2:create(bridge_type(), my_test_bridge, Conf)
@@ -629,7 +628,7 @@ t_create_wrong_connector_type(_Config) ->
             {post_config_update, _HandlerMod, #{
                 bridge_name := _,
                 connector_name := _,
-                type := wrong_type,
+                bridge_type := wrong_type,
                 reason := "connector_not_found_or_wrong_type"
             }}},
         emqx_bridge_v2:create(wrong_type, my_test_bridge, Conf)
@@ -645,7 +644,7 @@ t_update_connector_not_found(_Config) ->
             {post_config_update, _HandlerMod, #{
                 bridge_name := _,
                 connector_name := _,
-                type := _,
+                bridge_type := _,
                 reason := "connector_not_found_or_wrong_type"
             }}},
         emqx_bridge_v2:create(bridge_type(), my_test_bridge, BadConf)

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -31,8 +31,8 @@
 
 -import(hoconsc, [mk/2, enum/1, ref/2]).
 
--define(AEH_CONNECTOR_TYPE, azure_event_hub).
--define(AEH_CONNECTOR_TYPE_BIN, <<"azure_event_hub">>).
+-define(AEH_CONNECTOR_TYPE, azure_event_hub_producer).
+-define(AEH_CONNECTOR_TYPE_BIN, <<"azure_event_hub_producer">>).
 
 %%-------------------------------------------------------------------------------------------------
 %% `hocon_schema' API

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
@@ -10,8 +10,10 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--define(BRIDGE_TYPE, azure_event_hub).
--define(BRIDGE_TYPE_BIN, <<"azure_event_hub">>).
+-define(BRIDGE_TYPE, azure_event_hub_producer).
+-define(BRIDGE_TYPE_BIN, <<"azure_event_hub_producer">>).
+-define(CONNECTOR_TYPE, azure_event_hub_producer).
+-define(CONNECTOR_TYPE_BIN, <<"azure_event_hub_producer">>).
 -define(KAFKA_BRIDGE_TYPE, kafka_producer).
 -define(APPS, [emqx_resource, emqx_connector, emqx_bridge, emqx_rule_engine]).
 
@@ -88,7 +90,7 @@ common_init_per_testcase(TestCase, Config) ->
     ok = snabbkaffe:start_trace(),
     ExtraConfig ++
         [
-            {connector_type, ?BRIDGE_TYPE},
+            {connector_type, ?CONNECTOR_TYPE},
             {connector_name, Name},
             {connector_config, ConnectorConfig},
             {bridge_type, ?BRIDGE_TYPE},
@@ -156,7 +158,7 @@ connector_config(Name, KafkaHost, KafkaPort) ->
     parse_and_check_connector_config(InnerConfigMap, Name).
 
 parse_and_check_connector_config(InnerConfigMap, Name) ->
-    TypeBin = ?BRIDGE_TYPE_BIN,
+    TypeBin = ?CONNECTOR_TYPE_BIN,
     RawConf = #{<<"connectors">> => #{TypeBin => #{Name => InnerConfigMap}}},
     #{<<"connectors">> := #{TypeBin := #{Name := Config}}} =
         hocon_tconf:check_plain(emqx_connector_schema, RawConf, #{

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
@@ -15,7 +15,6 @@
 -define(CONNECTOR_TYPE, azure_event_hub_producer).
 -define(CONNECTOR_TYPE_BIN, <<"azure_event_hub_producer">>).
 -define(KAFKA_BRIDGE_TYPE, kafka_producer).
--define(APPS, [emqx_resource, emqx_connector, emqx_bridge, emqx_rule_engine]).
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
@@ -43,6 +42,7 @@ init_per_suite(Config) ->
                     emqx_resource,
                     emqx_bridge_azure_event_hub,
                     emqx_bridge,
+                    emqx_rule_engine,
                     {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
                 ],
                 #{work_dir => ?config(priv_dir, Config)}

--- a/apps/emqx_connector/src/schema/emqx_connector_ee_schema.erl
+++ b/apps/emqx_connector/src/schema/emqx_connector_ee_schema.erl
@@ -23,7 +23,7 @@ resource_type(Type) when is_binary(Type) ->
 resource_type(kafka_producer) ->
     emqx_bridge_kafka_impl_producer;
 %% We use AEH's Kafka interface.
-resource_type(azure_event_hub) ->
+resource_type(azure_event_hub_producer) ->
     emqx_bridge_kafka_impl_producer;
 resource_type(Type) ->
     error({unknown_connector_type, Type}).
@@ -31,7 +31,7 @@ resource_type(Type) ->
 %% For connectors that need to override connector configurations.
 connector_impl_module(ConnectorType) when is_binary(ConnectorType) ->
     connector_impl_module(binary_to_atom(ConnectorType, utf8));
-connector_impl_module(azure_event_hub) ->
+connector_impl_module(azure_event_hub_producer) ->
     emqx_bridge_azure_event_hub;
 connector_impl_module(_ConnectorType) ->
     undefined.
@@ -49,7 +49,7 @@ connector_structs() ->
                     required => false
                 }
             )},
-        {azure_event_hub,
+        {azure_event_hub_producer,
             mk(
                 hoconsc:map(name, ref(emqx_bridge_azure_event_hub, "config_connector")),
                 #{
@@ -82,7 +82,7 @@ api_schemas(Method) ->
         %% We need to map the `type' field of a request (binary) to a
         %% connector schema module.
         api_ref(emqx_bridge_kafka, <<"kafka_producer">>, Method ++ "_connector"),
-        api_ref(emqx_bridge_azure_event_hub, <<"azure_event_hub">>, Method ++ "_connector")
+        api_ref(emqx_bridge_azure_event_hub, <<"azure_event_hub_producer">>, Method ++ "_connector")
     ].
 
 api_ref(Module, Type, Method) ->

--- a/apps/emqx_connector/src/schema/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/schema/emqx_connector_schema.erl
@@ -57,7 +57,7 @@ enterprise_fields_connectors() -> [].
 -endif.
 
 connector_type_to_bridge_types(kafka_producer) -> [kafka, kafka_producer];
-connector_type_to_bridge_types(azure_event_hub) -> [azure_event_hub].
+connector_type_to_bridge_types(azure_event_hub_producer) -> [azure_event_hub_producer].
 
 actions_config_name() -> <<"bridges_v2">>.
 


### PR DESCRIPTION
Fixes [no ticket]

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 282e47b</samp>

This pull request updates the bridge and connector modules and schemas to support the new `azure_event_hub_producer` type for the Azure Event Hub integration. It also fixes some bugs and typos in the bridge V2 tests and configuration validation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [-] ~Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- [-] ~Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files~
- [-] ~For internal contributor: there is a jira ticket to track this change~
- [-] ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
-[-]  ~Schema changes are backward compatible~
