### PR TITLE
test(kafka_producer): minor adjustments to test suite

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1388,13 +1388,13 @@ select_free_port(GenModule, Fun) when
 %% groups() ->
 %%   emqx_common_test_helpers:groups(?MODULE, [case1, case2]).
 %%
-%% case1(matrxi) ->
+%% case1(matrix) ->
 %%   {g1, [[tcp, no_auth],
 %%         [ssl, no_auth],
 %%         [ssl, basic_auth]
 %%        ]};
 %%
-%% case2(matrxi) ->
+%% case2(matrix) ->
 %%   {g1, ...}
 %% ...
 %%


### PR DESCRIPTION
- Use `emqx_cth_suite`.
- Use `query_mode` matrix value when setting up bridge in a couple test cases.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at a60b96c</samp>

This pull request improves the test suite for the kafka producer module and fixes some typos in the comments of the routing algorithm test helpers. It refactors the `emqx_bridge_kafka_impl_producer_SUITE.erl` file to use the `emqx_cth_suite` module and simplify the producer setup. It also corrects the spelling of `case1` and `case2` in the `emqx_common_test_helpers.erl` file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
