### PR TITLE
1030 downgrade bridge type for old api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ mix-deps-get: $(ELIXIR_COMMON_DEPS)
 
 .PHONY: eunit
 eunit: $(REBAR) merge-config
-	@$(REBAR) eunit --name eunit@127.0.0.1 -v -c --cover_export_name $(CT_COVER_EXPORT_PREFIX)-eunit
+	@$(REBAR) eunit --name eunit@127.0.0.1 -c -v --cover_export_name $(CT_COVER_EXPORT_PREFIX)-eunit
 
 .PHONY: proper
 proper: $(REBAR)
@@ -105,16 +105,22 @@ ifneq ($(GROUPS),)
 GROUPS_ARG := --groups $(GROUPS)
 endif
 
+ifeq ($(ENABLE_COVER_COMPILE),1)
+cover_args = --cover --cover_export_name $(CT_COVER_EXPORT_PREFIX)-$(subst /,-,$1)
+else
+cover_args =
+endif
+
 ## example:
 ## env SUITES=apps/appname/test/test_SUITE.erl CASES=t_foo make apps/appname-ct
 define gen-app-ct-target
 $1-ct: $(REBAR) merge-config clean-test-cluster-config
 	$(eval SUITES := $(shell $(SCRIPTS)/find-suites.sh $1))
 ifneq ($(SUITES),)
-	@$(REBAR) ct -c -v \
+	$(REBAR) ct -v \
 		--readable=$(CT_READABLE) \
 		--name $(CT_NODE_NAME) \
-		--cover_export_name $(CT_COVER_EXPORT_PREFIX)-$(subst /,-,$1) \
+		$(call cover_args,$1) \
 		--suite $(SUITES) \
 		$(GROUPS_ARG) \
 		$(CASES_ARG)

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -902,7 +902,7 @@ format_resource(
     redact(
         maps:merge(
             RawConfFull#{
-                type => Type,
+                type => downgrade_type(Type),
                 name => maps:get(<<"name">>, RawConf, BridgeName),
                 node => Node
             },
@@ -1156,3 +1156,6 @@ non_compat_bridge_msg() ->
 
 upgrade_type(Type) ->
     emqx_bridge_lib:upgrade_type(Type).
+
+downgrade_type(Type) ->
+    emqx_bridge_lib:downgrade_type(Type).

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -255,6 +255,18 @@ pre_create_atoms() ->
         kafka__probe_
     ].
 
+http_get_bridges(UrlPath, Name0) ->
+    Name = iolist_to_binary(Name0),
+    {ok, _Code, BridgesData} = http_get(UrlPath),
+    Bridges = json(BridgesData),
+    lists:filter(
+        fun
+            (#{<<"name">> := N}) when N =:= Name -> true;
+            (_) -> false
+        end,
+        Bridges
+    ).
+
 kafka_bridge_rest_api_helper(Config) ->
     BridgeType = ?BRIDGE_TYPE,
     BridgeName = "my_kafka_bridge",
@@ -274,27 +286,16 @@ kafka_bridge_rest_api_helper(Config) ->
     BridgesPartsOpRestart = OpUrlFun("restart"),
     BridgesPartsOpStop = OpUrlFun("stop"),
     %% List bridges
-    MyKafkaBridgeExists = fun() ->
-        {ok, _Code, BridgesData} = http_get(BridgesParts),
-        Bridges = json(BridgesData),
-        lists:any(
-            fun
-                (#{<<"name">> := <<"my_kafka_bridge">>}) -> true;
-                (_) -> false
-            end,
-            Bridges
-        )
-    end,
     %% Delete if my_kafka_bridge exists
-    case MyKafkaBridgeExists() of
-        true ->
+    case http_get_bridges(BridgesParts, BridgeName) of
+        [_] ->
             %% Delete the bridge my_kafka_bridge
             {ok, 204, <<>>} = http_delete(BridgesPartsIdDeleteAlsoActions);
-        false ->
+        [] ->
             ok
     end,
     try
-        false = MyKafkaBridgeExists(),
+        ?assertEqual([], http_get_bridges(BridgesParts, BridgeName)),
         %% Create new Kafka bridge
         KafkaTopic = test_topic_one_partition(),
         CreateBodyTmp = #{
@@ -316,7 +317,7 @@ kafka_bridge_rest_api_helper(Config) ->
         CreateBody = CreateBodyTmp#{<<"ssl">> => maps:get(<<"ssl">>, Config)},
         {ok, 201, _Data} = http_post(BridgesParts, CreateBody),
         %% Check that the new bridge is in the list of bridges
-        true = MyKafkaBridgeExists(),
+        ?assertMatch([#{<<"type">> := <<"kafka">>}], http_get_bridges(BridgesParts, BridgeName)),
         %% Probe should work
         %% no extra atoms should be created when probing
         %% See pre_create_atoms() above
@@ -416,8 +417,9 @@ kafka_bridge_rest_api_helper(Config) ->
         % this delete should not be necessary beause of the also_delete_dep_actions flag
         % {ok, 204, _} = http_delete(["rules", RuleId]),
         {ok, 204, _} = http_delete(BridgesPartsIdDeleteAlsoActions),
-        false = MyKafkaBridgeExists(),
-        delete_all_bridges()
+        Remain = http_get_bridges(BridgesParts, BridgeName),
+        delete_all_bridges(),
+        ?assertEqual([], Remain)
     end,
     ok.
 


### PR DESCRIPTION

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 9b6d3c0</samp>

This pull request improves the test cases and scripts for the `emqx_bridge_kafka` app, and fixes a bug in the bridge API. It refactors the `emqx_bridge_kafka_impl_producer_SUITE.erl` file, adds a type conversion function in `emqx_bridge_api.erl`, modifies the `Makefile` and the `find-suites.sh` script to make them more consistent and configurable.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
