### PR TITLE
fix: crash when listing non bridge_v1 compatible bridge_v2

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -233,9 +233,13 @@ list_with_lookup_fun(LookupFun) ->
                 fun(Name, _RawConf, Acc) ->
                     [
                         begin
-                            {ok, BridgeInfo} =
-                                LookupFun(Type, Name),
-                            BridgeInfo
+                            case LookupFun(Type, Name) of
+                                {ok, BridgeInfo} ->
+                                    BridgeInfo;
+                                {error, not_bridge_v1_compatible} = Err ->
+                                    %% Filtered out by the caller
+                                    Err
+                            end
                         end
                         | Acc
                     ]


### PR DESCRIPTION
Fixes:
https://emqx.atlassian.net/browse/EMQX-11271

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8fb426e</samp>

Filter out bridges that are not compatible with v1 API in `emqx_bridge_v2`. This is part of a refactoring to support both v1 and v2 bridge APIs.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible

Test case will be added in follow up PR
