### PR TITLE
docs: fix examples for PUT operations on bridge_v2 and connectors

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -241,14 +241,6 @@ values({put, bridge_v2}) ->
     );
 values({put, producer}) ->
     values({post, producer});
-values(connector) ->
-    maps:merge(
-        values(common_config),
-        #{
-            name => <<"my_azure_event_hub_producer_connector">>,
-            type => ?AEH_CONNECTOR_TYPE_BIN
-        }
-    );
 values(common_config) ->
     #{
         authentication => #{

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -205,20 +205,47 @@ values({post, bridge_v2}) ->
         values(producer),
         #{
             enable => true,
-            connector => <<"my_azure_event_hub_connector">>,
-            name => <<"my_azure_event_hub_bridge">>,
+            connector => <<"my_azure_event_hub_producer_connector">>,
+            name => <<"my_azure_event_hub_producer_bridge">>,
             type => ?AEH_CONNECTOR_TYPE_BIN
         }
     );
-values({post, AEHType}) ->
-    maps:merge(values(common_config), values(AEHType));
-values({put, AEHType}) ->
-    values({post, AEHType});
+values({post, connector}) ->
+    maps:merge(
+        values(common_config),
+        #{
+            name => <<"my_azure_event_hub_producer_connector">>,
+            type => ?AEH_CONNECTOR_TYPE_BIN
+        }
+    );
+values({post, producer}) ->
+    maps:merge(
+        #{
+            name => <<"my_azure_event_hub_producer">>,
+            type => <<"azure_event_hub_producer">>
+        },
+        maps:merge(
+            values(common_config),
+            values(producer)
+        )
+    );
+values({put, connector}) ->
+    values(common_config);
+values({put, bridge_v2}) ->
+    maps:merge(
+        values(producer),
+        #{
+            enable => true,
+            connector => <<"my_azure_event_hub_producer_connector">>
+        }
+    );
+values({put, producer}) ->
+    values({post, producer});
 values(connector) ->
     maps:merge(
         values(common_config),
         #{
-            name => <<"my_azure_event_hub_connector">>,
+            name => <<"my_azure_event_hub_producer_connector">>,
             type => ?AEH_CONNECTOR_TYPE_BIN
         }
     );
@@ -232,14 +259,12 @@ values(common_config) ->
         enable => true,
         metadata_request_timeout => <<"4s">>,
         min_metadata_refresh_interval => <<"3s">>,
-        name => <<"my_azure_event_hub_bridge">>,
         socket_opts => #{
             sndbuf => <<"1024KB">>,
             recbuf => <<"1024KB">>,
             nodelay => true,
             tcp_keepalive => <<"none">>
-        },
-        type => <<"azure_event_hub_producer">>
+        }
     };
 values(producer) ->
     #{

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -36,15 +36,12 @@
 %% -------------------------------------------------------------------------------------------------
 %% api
 
-connector_examples(_Method) ->
+connector_examples(Method) ->
     [
         #{
             <<"kafka_producer">> => #{
-                summary => <<"Kafka Connector">>,
-                value => maps:merge(
-                    #{name => <<"my_connector">>, type => <<"kafka_producer">>},
-                    values(common_config)
-                )
+                summary => <<"Kafka Producer Connector">>,
+                value => values({Method, connector})
             }
         }
     ].
@@ -53,7 +50,7 @@ bridge_v2_examples(Method) ->
     [
         #{
             <<"kafka_producer">> => #{
-                summary => <<"Kafka Bridge v2">>,
+                summary => <<"Kafka Producer Bridge v2">>,
                 value => values({Method, bridge_v2_producer})
             }
         }
@@ -88,23 +85,33 @@ values({get, KafkaType}) ->
         },
         values({post, KafkaType})
     );
+values({post, connector}) ->
+    maps:merge(
+        #{
+            name => <<"my_kafka_producer_connector">>,
+            type => <<"kafka_producer">>
+        },
+        values(common_config)
+    );
 values({post, KafkaType}) ->
     maps:merge(
         #{
-            name => <<"my_kafka_bridge">>,
+            name => <<"my_kafka_producer_bridge">>,
             type => <<"kafka_producer">>
         },
         values({put, KafkaType})
     );
-values({put, KafkaType}) when KafkaType =:= bridge_v2_producer ->
-    values(KafkaType);
+values({put, bridge_v2_producer}) ->
+    values(bridge_v2_producer);
+values({put, connector}) ->
+    values(common_config);
 values({put, KafkaType}) ->
     maps:merge(values(common_config), values(KafkaType));
 values(bridge_v2_producer) ->
     maps:merge(
         #{
             enable => true,
-            connector => <<"my_kafka_connector">>,
+            connector => <<"my_kafka_producer_connector">>,
             resource_opts => #{
                 health_check_interval => "32s"
             }


### PR DESCRIPTION
Examples would show `type` and `name` properties in the request body, which is not accepted by the schema.

Also fixes some minor inconsistencies in the example names of connectors and bridges.

Fixes [EMQX-11283](https://emqx.atlassian.net/browse/EMQX-11283)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 2a4eaf4</samp>

This pull request updates the bridge v2 configuration and API for the Azure Event Hub and Kafka connectors. It simplifies and removes redundant fields from the `emqx_bridge_azure_event_hub` module and improves the examples and values for both connectors.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] For internal contributor: there is a jira ticket to track this change
