### PR TITLE
fix(shell): do not repeat print shell warnings

### DIFF
--- a/changes/ce/fix-11861.en.md
+++ b/changes/ce/fix-11861.en.md
@@ -1,0 +1,2 @@
+Fix excessive warning message print in remote console shell.
+


### PR DESCRIPTION
[EMQX-11300](https://emqx.atlassian.net/browse/EMQX-11300)

## Summary
While testing, I found out that the shell is quite not usable when a variable in shell is a long list.
For example, if I evaluate `length/1` N times, there would be N warnings.

```
L = lists:seq(1,10000). %% exceeded size limit
lists:foreach(fun(_) -> length(L) end, lists:seq(1,10)). %% warning 10 times
```

Same applies to the heap size limit.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
