### PR TITLE
 fix(bridge_v2 API): optional cascading delete operation

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -38,7 +38,11 @@
     list/0,
     lookup/2,
     create/3,
-    remove/2
+    remove/2,
+    %% The following is the remove function that is called by the HTTP API
+    %% It also checks for rule action dependencies and optionally removes
+    %% them
+    check_deps_and_remove/3
 ]).
 
 %% Operations
@@ -225,6 +229,25 @@ remove(BridgeType, BridgeName) ->
     of
         {ok, _} -> ok;
         {error, Reason} -> {error, Reason}
+    end.
+
+check_deps_and_remove(BridgeType, BridgeName, AlsoDeleteActions) ->
+    AlsoDelete =
+        case AlsoDeleteActions of
+            true -> [rule_actions];
+            false -> []
+        end,
+    case
+        emqx_bridge_lib:maybe_withdraw_rule_action(
+            BridgeType,
+            BridgeName,
+            AlsoDelete
+        )
+    of
+        ok ->
+            remove(BridgeType, BridgeName);
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -70,11 +70,7 @@
 namespace() -> "bridge_v2".
 
 api_spec() ->
-    %% TODO
-    %% The check_schema option needs to be set to false so we get the
-    %% query_string to the delete operation. We can change this once
-    %% we have fixed the schmea for the delete operation.
-    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => false}).
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true}).
 
 paths() ->
     [
@@ -124,6 +120,18 @@ param_path_id() ->
                 required => true,
                 example => <<"webhook:webhook_example">>,
                 desc => ?DESC("desc_param_path_id")
+            }
+        )}.
+
+param_qs_delete_cascade() ->
+    {also_delete_dep_actions,
+        mk(
+            boolean(),
+            #{
+                in => query,
+                required => false,
+                default => false,
+                desc => ?DESC("desc_qs_also_delete_dep_actions")
             }
         )}.
 
@@ -235,7 +243,7 @@ schema("/bridges_v2/:id") ->
             tags => [<<"bridges_v2">>],
             summary => <<"Delete bridge">>,
             description => ?DESC("desc_api5"),
-            parameters => [param_path_id()],
+            parameters => [param_path_id(), param_qs_delete_cascade()],
             responses => #{
                 204 => <<"Bridge deleted">>,
                 400 => error_schema(
@@ -369,7 +377,7 @@ schema("/bridges_v2_probe") ->
                 ?BRIDGE_NOT_FOUND(BridgeType, BridgeName)
         end
     );
-'/bridges_v2/:id'(delete, #{bindings := #{id := Id}, query_string := Qs} = All) ->
+'/bridges_v2/:id'(delete, #{bindings := #{id := Id}, query_string := Qs}) ->
     ?TRY_PARSE_ID(
         Id,
         case emqx_bridge_v2:lookup(BridgeType, BridgeName) of

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -373,11 +373,6 @@ schema("/bridges_v2_probe") ->
                 case emqx_bridge_v2:remove(BridgeType, BridgeName) of
                     ok ->
                         ?NO_CONTENT;
-                    {error, {active_channels, Channels}} ->
-                        ?BAD_REQUEST(
-                            {<<"Cannot delete bridge while there are active channels defined for this bridge">>,
-                                Channels}
-                        );
                     {error, timeout} ->
                         ?SERVICE_UNAVAILABLE(<<"request timeout">>);
                     {error, Reason} ->

--- a/rel/i18n/emqx_bridge_v2_api.hocon
+++ b/rel/i18n/emqx_bridge_v2_api.hocon
@@ -79,6 +79,12 @@ desc_param_path_id.desc:
 desc_param_path_id.label:
 """Bridge ID"""
 
+desc_qs_also_delete_dep_actions.desc:
+"""Whether to cascade delete dependent actions."""
+
+desc_qs_also_delete_dep_actions.label:
+"""Cascade delete dependent actions?"""
+
 desc_param_path_node.desc:
 """The node name, e.g. 'emqx@127.0.0.1'."""
 


### PR DESCRIPTION
This PR makes the delete HTTP API operation for Bridge V2 behave in the same way as in the Bridge V1 API.

Fixes:
https://emqx.atlassian.net/browse/EMQX-11293

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 1e935e9</samp>

This pull request adds a new feature and a test case to the bridge HTTP API. It allows deleting a bridge and its dependent rule actions in one request by passing a query string parameter `also_delete_dep_actions`. It also fixes some issues with the swagger spec and the error handling for the delete operation.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible