### PR TITLE
ci cost reduction

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   sanity-checks:
-    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]') }}
+    runs-on: ubuntu-22.04
     container: "ghcr.io/emqx/emqx-builder/5.2-3:1.14.5-25.3.2-2-ubuntu22.04"
     outputs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
@@ -24,8 +24,6 @@ jobs:
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
       version-emqx: ${{ steps.matrix.outputs.version-emqx }}
       version-emqx-enterprise: ${{ steps.matrix.outputs.version-emqx-enterprise }}
-      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]' }}
-      xl_runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted","ephemeral-xl","linux","x64"]' || '["ubuntu-22.04"]' }}
       builder: "ghcr.io/emqx/emqx-builder/5.2-3:1.14.5-25.3.2-2-ubuntu22.04"
       builder_vsn: "5.2-3"
       otp_vsn: "25.3.2-2"
@@ -116,7 +114,7 @@ jobs:
           echo "version-emqx-enterprise=$(./pkg-vsn.sh emqx-enterprise)" | tee -a $GITHUB_OUTPUT
 
   compile:
-    runs-on: ${{ fromJSON(needs.sanity-checks.outputs.xl_runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral-xl","linux","x64"]') }}
     container: ${{ needs.sanity-checks.outputs.builder }}
     needs:
       - sanity-checks
@@ -154,7 +152,6 @@ jobs:
       - compile
     uses: ./.github/workflows/run_emqx_app_tests.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.xl_runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       before_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       after_ref: ${{ github.sha }}
@@ -165,7 +162,6 @@ jobs:
       - compile
     uses: ./.github/workflows/run_test_cases.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       ct-matrix: ${{ needs.sanity-checks.outputs.ct-matrix }}
       ct-host: ${{ needs.sanity-checks.outputs.ct-host }}
@@ -177,7 +173,6 @@ jobs:
       - compile
     uses: ./.github/workflows/static_checks.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       ct-matrix: ${{ needs.sanity-checks.outputs.ct-matrix }}
 
@@ -186,7 +181,6 @@ jobs:
       - sanity-checks
     uses: ./.github/workflows/build_slim_packages.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
       builder_vsn: ${{ needs.sanity-checks.outputs.builder_vsn }}
       otp_vsn: ${{ needs.sanity-checks.outputs.otp_vsn }}
@@ -197,7 +191,6 @@ jobs:
       - sanity-checks
     uses: ./.github/workflows/build_docker_for_test.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       otp_vsn: ${{ needs.sanity-checks.outputs.otp_vsn }}
       elixir_vsn: ${{ needs.sanity-checks.outputs.elixir_vsn }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
@@ -208,8 +201,6 @@ jobs:
       - sanity-checks
       - build_slim_packages
     uses: ./.github/workflows/spellcheck.yaml
-    with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
 
   run_conf_tests:
     needs:
@@ -217,7 +208,6 @@ jobs:
       - compile
     uses: ./.github/workflows/run_conf_tests.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
 
   check_deps_integrity:
@@ -225,7 +215,6 @@ jobs:
       - sanity-checks
     uses: ./.github/workflows/check_deps_integrity.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       builder: ${{ needs.sanity-checks.outputs.builder }}
 
   run_jmeter_tests:
@@ -234,7 +223,6 @@ jobs:
       - build_docker_for_test
     uses: ./.github/workflows/run_jmeter_tests.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
 
   run_docker_tests:
@@ -243,7 +231,6 @@ jobs:
       - build_docker_for_test
     uses: ./.github/workflows/run_docker_tests.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
       version-emqx-enterprise: ${{ needs.sanity-checks.outputs.version-emqx-enterprise }}
 
@@ -253,6 +240,5 @@ jobs:
       - build_docker_for_test
     uses: ./.github/workflows/run_helm_tests.yaml
     with:
-      runner_labels: ${{ needs.sanity-checks.outputs.runner_labels }}
       version-emqx: ${{ needs.sanity-checks.outputs.version-emqx }}
       version-emqx-enterprise: ${{ needs.sanity-checks.outputs.version-emqx-enterprise }}

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   prepare:
-    runs-on: ${{ fromJSON(github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]') }}
+    runs-on: ubuntu-22.04
     container: 'ghcr.io/emqx/emqx-builder/5.2-3:1.14.5-25.3.2-2-ubuntu22.04'
     outputs:
       profile: ${{ steps.parse-git-ref.outputs.profile }}
@@ -29,7 +29,6 @@ jobs:
       ct-matrix: ${{ steps.matrix.outputs.ct-matrix }}
       ct-host: ${{ steps.matrix.outputs.ct-host }}
       ct-docker: ${{ steps.matrix.outputs.ct-docker }}
-      runner_labels: ${{ github.repository_owner == 'emqx' && '["self-hosted","ephemeral","linux","x64"]' || '["ubuntu-22.04"]' }}
       builder: 'ghcr.io/emqx/emqx-builder/5.2-3:1.14.5-25.3.2-2-ubuntu22.04'
       builder_vsn: '5.2-3'
       otp_vsn: '25.3.2-2'
@@ -108,7 +107,6 @@ jobs:
       otp_vsn: ${{ needs.prepare.outputs.otp_vsn }}
       elixir_vsn: ${{ needs.prepare.outputs.elixir_vsn }}
       builder_vsn: ${{ needs.prepare.outputs.builder_vsn }}
-      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
     secrets: inherit
 
   build_slim_packages:
@@ -117,7 +115,6 @@ jobs:
       - prepare
     uses: ./.github/workflows/build_slim_packages.yaml
     with:
-      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       builder_vsn: ${{ needs.prepare.outputs.builder_vsn }}
       otp_vsn: ${{ needs.prepare.outputs.otp_vsn }}
@@ -125,7 +122,7 @@ jobs:
 
   compile:
     if: needs.prepare.outputs.release != 'true'
-    runs-on: ${{ fromJSON(needs.prepare.outputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ needs.prepare.outputs.builder }}
     needs:
       - prepare
@@ -162,7 +159,6 @@ jobs:
       - compile
     uses: ./.github/workflows/run_emqx_app_tests.yaml
     with:
-      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       before_ref: ${{ github.event.before }}
       after_ref: ${{ github.sha }}
@@ -174,7 +170,6 @@ jobs:
       - compile
     uses: ./.github/workflows/run_test_cases.yaml
     with:
-      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       ct-matrix: ${{ needs.prepare.outputs.ct-matrix }}
       ct-host: ${{ needs.prepare.outputs.ct-host }}
@@ -187,7 +182,6 @@ jobs:
       - compile
     uses: ./.github/workflows/run_conf_tests.yaml
     with:
-      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
 
   static_checks:
@@ -197,6 +191,5 @@ jobs:
       - compile
     uses: ./.github/workflows/static_checks.yaml
     with:
-      runner_labels: ${{ needs.prepare.outputs.runner_labels }}
       builder: ${{ needs.prepare.outputs.builder }}
       ct-matrix: ${{ needs.prepare.outputs.ct-matrix }}

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -28,9 +28,6 @@ on:
       builder_vsn:
         required: true
         type: string
-      runner_labels:
-        required: true
-        type: string
     secrets:
       DOCKER_HUB_USER:
         required: true
@@ -70,14 +67,10 @@ on:
         required: false
         type: string
         default: '5.2-3'
-      runner_labels:
-        required: false
-        type: string
-        default: '["self-hosted","ephemeral","linux","x64"]'
 
 jobs:
   docker:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build_docker_for_test.yaml
+++ b/.github/workflows/build_docker_for_test.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       otp_vsn:
         required: true
         type: string
@@ -25,7 +22,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     env:
       EMQX_NAME: ${{ matrix.profile }}
       PKG_VSN: ${{ startsWith(matrix.profile, 'emqx-enterprise') && inputs.version-emqx-enterprise || inputs.version-emqx }}

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -115,6 +115,7 @@ jobs:
       with:
         name: ${{ matrix.profile }}
         path: _packages/${{ matrix.profile }}/
+        retention-days: 7
 
   mac:
     strategy:
@@ -149,6 +150,7 @@ jobs:
       with:
         name: ${{ matrix.profile }}
         path: _packages/${{ matrix.profile }}/
+        retention-days: 7
 
   linux:
     runs-on: ['self-hosted', 'ephemeral', 'linux', "${{ matrix.arch }}"]
@@ -246,6 +248,7 @@ jobs:
       with:
         name: ${{ matrix.profile }}
         path: _packages/${{ matrix.profile }}/
+        retention-days: 7
 
   publish_artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -153,7 +153,7 @@ jobs:
         retention-days: 7
 
   linux:
-    runs-on: ['self-hosted', 'ephemeral', 'linux', "${{ matrix.arch }}"]
+    runs-on: [self-hosted, ephemeral, linux, "${{ matrix.arch }}"]
     # always run in builder container because the host might have the wrong OTP version etc.
     # otherwise buildx.sh does not run docker if arch and os matches the target arch and os.
     container:
@@ -201,8 +201,6 @@ jobs:
         shell: bash
 
     steps:
-    - uses: AutoModality/action-clean@v1
-
     - uses: actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.ref }}

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   linux:
     if: github.repository_owner == 'emqx'
-    runs-on: ['self-hosted', 'ephemeral', 'linux', "${{ matrix.arch }}"]
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container:
       image: "ghcr.io/emqx/emqx-builder/${{ matrix.builder }}:${{ matrix.elixir }}-${{ matrix.otp }}-${{ matrix.os }}"
 
@@ -21,7 +21,6 @@ jobs:
       matrix:
         profile:
           - ['emqx', 'master']
-          - ['emqx-enterprise', 'release-52']
           - ['emqx-enterprise', 'release-53']
         otp:
           - 25.3.2-2
@@ -101,7 +100,6 @@ jobs:
         otp:
           - 25.3.2-2
         os:
-          - macos-13
           - macos-12-arm64
 
     steps:

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -77,6 +77,7 @@ jobs:
         with:
           name: ${{ matrix.profile[0] }}
           path: _packages/${{ matrix.profile[0] }}/
+          retention-days: 7
       - name: Send notification to Slack
         uses: slackapi/slack-github-action@v1.23.0
         if: failure()

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -113,7 +113,6 @@ jobs:
         otp:
         - ${{ inputs.otp_vsn }}
         os:
-        - macos-11
         - macos-12-arm64
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       builder:
         required: true
         type: string
@@ -27,10 +24,6 @@ on:
     inputs:
       ref:
         required: false
-      runner_labels:
-        required: false
-        type: string
-        default: '["self-hosted","ephemeral", "linux", "x64"]'
       builder:
         required: false
         type: string
@@ -50,7 +43,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     env:
       EMQX_NAME: ${{ matrix.profile[0] }}
 

--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -3,16 +3,13 @@ name: Check integrity of rebar and mix dependencies
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       builder:
         required: true
         type: string
 
 jobs:
   check_deps_integrity:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ inputs.builder }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 360
     permissions:
       actions: read

--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   rerun-failed-jobs:
     if: github.repository_owner == 'emqx'
-    runs-on: ['self-hosted', 'linux', 'x64', 'ephemeral']
+    runs-on: ubuntu-22.04
     permissions:
       checks: read
       actions: write

--- a/.github/workflows/run_conf_tests.yaml
+++ b/.github/workflows/run_conf_tests.yaml
@@ -45,4 +45,4 @@ jobs:
         with:
           name: logs-${{ matrix.profile }}
           path: _build/${{ matrix.profile }}/rel/emqx/logs
-
+          retention-days: 7

--- a/.github/workflows/run_conf_tests.yaml
+++ b/.github/workflows/run_conf_tests.yaml
@@ -7,16 +7,13 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       builder:
         required: true
         type: string
 
 jobs:
   run_conf_tests:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ inputs.builder }}
     env:
       PROFILE: ${{ matrix.profile }}

--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       version-emqx:
         required: true
         type: string
@@ -19,7 +16,7 @@ on:
 
 jobs:
   basic-tests:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     defaults:
       run:
         shell: bash
@@ -63,7 +60,7 @@ jobs:
           docker compose rm -fs
 
   paho-mqtt-testing:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -10,9 +10,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       builder:
         required: true
         type: string
@@ -28,7 +25,7 @@ env:
 
 jobs:
   run_emqx_app_tests:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ inputs.builder }}
 
     defaults:

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -63,3 +63,4 @@ jobs:
       with:
         name: logs-emqx-app-tests
         path: apps/emqx/_build/test/logs
+        retention-days: 7

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       version-emqx:
         required: true
         type: string
@@ -19,7 +16,7 @@ on:
 
 jobs:
   helm_test:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -3,16 +3,13 @@ name: JMeter integration tests
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       version-emqx:
         required: true
         type: string
 
 jobs:
   jmeter_artifact:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     steps:
     - name: Cache Jmeter
       id: cache-jmeter
@@ -42,7 +39,7 @@ jobs:
         retention-days: 3
 
   advanced_feat:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
 
     strategy:
       fail-fast: false
@@ -94,7 +91,7 @@ jobs:
         retention-days: 3
 
   pgsql_authn_authz:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
 
     strategy:
       fail-fast: false
@@ -161,7 +158,7 @@ jobs:
         retention-days: 3
 
   mysql_authn_authz:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
 
     strategy:
       fail-fast: false
@@ -221,7 +218,7 @@ jobs:
         retention-days: 3
 
   JWT_authn:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
 
     strategy:
       fail-fast: false
@@ -273,7 +270,7 @@ jobs:
         retention-days: 3
 
   built_in_database_authn_authz:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/run_jmeter_tests.yaml
+++ b/.github/workflows/run_jmeter_tests.yaml
@@ -39,6 +39,7 @@ jobs:
       with:
         name: apache-jmeter.tgz
         path: /tmp/apache-jmeter.tgz
+        retention-days: 3
 
   advanced_feat:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -90,6 +91,7 @@ jobs:
       with:
         name: jmeter_logs
         path: ./jmeter_logs
+        retention-days: 3
 
   pgsql_authn_authz:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -156,6 +158,7 @@ jobs:
       with:
         name: jmeter_logs
         path: ./jmeter_logs
+        retention-days: 3
 
   mysql_authn_authz:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -215,6 +218,7 @@ jobs:
       with:
         name: jmeter_logs
         path: ./jmeter_logs
+        retention-days: 3
 
   JWT_authn:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -266,6 +270,7 @@ jobs:
       with:
         name: jmeter_logs
         path: ./jmeter_logs
+        retention-days: 3
 
   built_in_database_authn_authz:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -309,3 +314,4 @@ jobs:
       with:
         name: jmeter_logs
         path: ./jmeter_logs
+        retention-days: 3

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -54,6 +54,7 @@ jobs:
           _packages
           scripts
           .ci
+        retention-days: 7
 
   relup_test_run:
     needs:
@@ -117,3 +118,4 @@ jobs:
         name: debug_data
         path: |
           lux_logs
+        retention-days: 3

--- a/.github/workflows/run_relup_tests.yaml
+++ b/.github/workflows/run_relup_tests.yaml
@@ -7,16 +7,13 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner:
-        required: true
-        type: string
       builder:
         required: true
         type: string
 
 jobs:
   relup_test_plan:
-    runs-on: ["${{ inputs.runner }}", 'linux', 'x64', 'ephemeral']
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ inputs.builder }}
     outputs:
       CUR_EE_VSN: ${{ steps.find-versions.outputs.CUR_EE_VSN }}
@@ -60,7 +57,7 @@ jobs:
     needs:
       - relup_test_plan
     if: needs.relup_test_plan.outputs.OLD_VERSIONS != '[]'
-    runs-on: ["${{ inputs.runner }}", 'linux', 'x64', 'ephemeral']
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -68,6 +68,7 @@ jobs:
         with:
           name: coverdata
           path: _build/test/cover
+          retention-days: 7
 
   ct_docker:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -111,6 +112,7 @@ jobs:
         with:
           name: coverdata
           path: _build/test/cover
+          retention-days: 7
       - name: compress logs
         if: failure()
         run: tar -czf logs.tar.gz _build/test/logs
@@ -119,6 +121,7 @@ jobs:
         with:
           name: logs-${{ matrix.profile }}-${{ matrix.prefix }}-${{ matrix.otp }}-sg${{ matrix.suitegroup }}
           path: logs.tar.gz
+          retention-days: 7
 
   ct:
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
@@ -156,6 +159,7 @@ jobs:
           name: coverdata
           path: _build/test/cover
           if-no-files-found: warn # do not fail if no coverdata found
+          retention-days: 7
       - name: compress logs
         if: failure()
         run: tar -czf logs.tar.gz _build/test/logs
@@ -164,6 +168,7 @@ jobs:
         with:
           name: logs-${{ matrix.profile }}-${{ matrix.prefix }}-${{ matrix.otp }}-sg${{ matrix.suitegroup }}
           path: logs.tar.gz
+          retention-days: 7
 
   tests_passed:
     needs:

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       builder:
         required: true
         type: string
@@ -28,7 +25,7 @@ env:
 
 jobs:
   eunit_and_proper:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
     name: "eunit_and_proper (${{ matrix.profile }})"
     strategy:
       fail-fast: false
@@ -71,7 +68,7 @@ jobs:
           retention-days: 7
 
   ct_docker:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
     name: "${{ matrix.app }}-${{ matrix.suitegroup }} (${{ matrix.profile }})"
     strategy:
       fail-fast: false
@@ -124,7 +121,7 @@ jobs:
           retention-days: 7
 
   ct:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
     name: "${{ matrix.app }}-${{ matrix.suitegroup }} (${{ matrix.profile }})"
     strategy:
       fail-fast: false
@@ -175,7 +172,7 @@ jobs:
       - eunit_and_proper
       - ct
       - ct_docker
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
     steps:
@@ -186,7 +183,7 @@ jobs:
       - eunit_and_proper
       - ct
       - ct_docker
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ inputs.builder }}
     strategy:
       fail-fast: false
@@ -226,7 +223,7 @@ jobs:
   # do this in a separate job
   upload_coverdata:
     needs: make_cover
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ubuntu-22.04
     steps:
       - name: Coveralls Finished
         env:

--- a/.github/workflows/spellcheck.yaml
+++ b/.github/workflows/spellcheck.yaml
@@ -6,10 +6,6 @@ concurrency:
 
 on:
   workflow_call:
-    inputs:
-      runner_labels:
-        required: true
-        type: string
 
 jobs:
   spellcheck:
@@ -18,7 +14,7 @@ jobs:
         profile:
         - emqx
         - emqx-enterprise
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -11,7 +11,7 @@ on:
 jobs:
   stale:
     if: github.repository_owner == 'emqx'
-    runs-on: ['self-hosted', 'linux', 'x64', 'ephemeral']
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     permissions:
       issues: write
       pull-requests: none

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -7,9 +7,6 @@ concurrency:
 on:
   workflow_call:
     inputs:
-      runner_labels:
-        required: true
-        type: string
       builder:
         required: true
         type: string
@@ -22,7 +19,7 @@ env:
 
 jobs:
   static_checks:
-    runs-on: ${{ fromJSON(inputs.runner_labels) }}
+    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON('["self-hosted","ephemeral","linux","x64"]') || 'ubuntu-22.04' }}
     name: "static_checks (${{ matrix.profile }})"
     strategy:
       fail-fast: false

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -92,7 +92,6 @@ matrix() {
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
                 ;;
             apps/emqx_bridge_kafka)
-                entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
                 entries+=("$(format_app_entry "$app" 3 emqx-enterprise "$runner")")
                 ;;
             apps/emqx_connector)

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -91,6 +91,10 @@ matrix() {
                 entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
                 ;;
+            apps/emqx_bridge_kafka)
+                entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
+                entries+=("$(format_app_entry "$app" 3 emqx-enterprise "$runner")")
+                ;;
             apps/emqx_connector)
                 entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")


### PR DESCRIPTION
Aiming to reduce github costs.

- move runner labels configuration back to individual workflows
- do not use github's macos runner in PRs
- limit retention on all artifacts
- always use github runners for lightweight jobs to reduce waiting time
- prefer self-hosted runners in private forks
- prefer self-hosted runners for workflows with large matrix to avoid being rate-limited

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at cd88bbe</samp>

This pull request adds the `retention-days` parameter to various `upload-artifact` actions in several GitHub workflows to reduce the storage usage of GitHub artifacts. It also removes the `macos-11` value from the `build_slim_packages` workflow to fix errors caused by the unavailable runner.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
