### PR TITLE
fix(rule_engine): don't enable a rule that references non-existent bridge

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v1_compatibility_layer_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v1_compatibility_layer_SUITE.erl
@@ -448,6 +448,21 @@ bridge_node_operation_http_api_v2(Name, Node0, Op0) ->
     ct:pal("bridge node op ~p (http v2) result:\n  ~p", [{Node, Op}, Res]),
     Res.
 
+is_rule_enabled(RuleId) ->
+    {ok, #{enable := Enable}} = emqx_rule_engine:get_rule(RuleId),
+    Enable.
+
+update_rule_http(RuleId, Params) ->
+    Path = emqx_mgmt_api_test_util:api_path(["rules", RuleId]),
+    ct:pal("update rule ~p:\n  ~p", [RuleId, Params]),
+    Res = request(put, Path, Params),
+    ct:pal("update rule ~p result:\n  ~p", [RuleId, Res]),
+    Res.
+
+enable_rule_http(RuleId) ->
+    Params = #{<<"enable">> => true},
+    update_rule_http(RuleId, Params).
+
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
@@ -679,5 +694,93 @@ t_scenario_1(_Config) ->
     ?assertMatch({error, {{_, 404, _}, _, _}}, bridge_operation_http_api_v2(NameA, start)),
     %% TODO: currently, only `start' op is supported by the v2 API.
     %% ?assertMatch({error, {{_, 404, _}, _, _}}, bridge_operation_http_api_v2(NameA, restart)),
+
+    ok.
+
+t_scenario_2(Config) ->
+    %% ===================================================================================
+    %% Pre-conditions
+    %% ===================================================================================
+    ?assertMatch({ok, {{_, 200, _}, _, []}}, list_bridges_http_api_v1()),
+    ?assertMatch({ok, {{_, 200, _}, _, []}}, list_bridges_http_api_v2()),
+    %% created in the test case init
+    ?assertMatch({ok, {{_, 200, _}, _, [#{}]}}, list_connectors_http()),
+    {ok, {{_, 200, _}, _, [#{<<"name">> := _PreexistentConnectorName}]}} = list_connectors_http(),
+
+    %% ===================================================================================
+    %% Try to create a rule referencing a non-existent bridge.  It succeeds, but it's
+    %% implicitly disabled.  Trying to update it later without creating the bridge should
+    %% keep it disabled.
+    %% ===================================================================================
+    BridgeName = <<"scenario2">>,
+    RuleTopic = <<"t/scenario2">>,
+    {ok, #{<<"id">> := RuleId0}} =
+        emqx_bridge_v2_testlib:create_rule_and_action_http(
+            bridge_type(),
+            RuleTopic,
+            [
+                {bridge_name, BridgeName}
+                | Config
+            ],
+            #{overrides => #{enable => true}}
+        ),
+    ?assertNot(is_rule_enabled(RuleId0)),
+    ?assertMatch({ok, {{_, 200, _}, _, _}}, enable_rule_http(RuleId0)),
+    ?assertNot(is_rule_enabled(RuleId0)),
+
+    %% ===================================================================================
+    %% Now we create the bridge, and attempt to create a new enabled rule.  It should
+    %% start enabled.  Also, updating the previous rule to enable it should work now.
+    %% ===================================================================================
+    ?assertMatch(
+        {ok, {{_, 201, _}, _, #{}}},
+        create_bridge_http_api_v1(#{name => BridgeName})
+    ),
+    {ok, #{<<"id">> := RuleId1}} =
+        emqx_bridge_v2_testlib:create_rule_and_action_http(
+            bridge_type(),
+            RuleTopic,
+            [
+                {bridge_name, BridgeName}
+                | Config
+            ],
+            #{overrides => #{enable => true}}
+        ),
+    ?assertNot(is_rule_enabled(RuleId0)),
+    ?assert(is_rule_enabled(RuleId1)),
+    ?assertMatch({ok, {{_, 200, _}, _, _}}, enable_rule_http(RuleId0)),
+    ?assert(is_rule_enabled(RuleId0)),
+
+    %% ===================================================================================
+    %% Creating a rule with mixed existent/non-existent bridges should deny enabling it.
+    %% ===================================================================================
+    NonExistentBridgeName = <<"scenario2_not_created">>,
+    {ok, #{<<"id">> := RuleId2}} =
+        emqx_bridge_v2_testlib:create_rule_and_action_http(
+            bridge_type(),
+            RuleTopic,
+            [
+                {bridge_name, BridgeName}
+                | Config
+            ],
+            #{
+                overrides => #{
+                    enable => true,
+                    actions => [
+                        emqx_bridge_resource:bridge_id(
+                            bridge_type(),
+                            BridgeName
+                        ),
+                        emqx_bridge_resource:bridge_id(
+                            bridge_type(),
+                            NonExistentBridgeName
+                        )
+                    ]
+                }
+            }
+        ),
+    ?assertNot(is_rule_enabled(RuleId2)),
+    ?assertMatch({ok, {{_, 200, _}, _, _}}, enable_rule_http(RuleId2)),
+    ?assertNot(is_rule_enabled(RuleId2)),
 
     ok.

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -260,11 +260,13 @@ create_rule_and_action_http(BridgeType, RuleTopic, Config, Opts) ->
     BridgeName = ?config(bridge_name, Config),
     BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
     SQL = maps:get(sql, Opts, <<"SELECT * FROM \"", RuleTopic/binary, "\"">>),
-    Params = #{
+    Params0 = #{
         enable => true,
         sql => SQL,
         actions => [BridgeId]
     },
+    Overrides = maps:get(overrides, Opts, #{}),
+    Params = emqx_utils_maps:deep_merge(Params0, Overrides),
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     ct:pal("rule action params: ~p", [Params]),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -251,12 +251,20 @@ init_per_testcase(t_events, Config) ->
     ),
     ?assertMatch(#{id := <<"rule:t_events">>}, Rule),
     [{hook_points_rules, Rule} | Config];
+init_per_testcase(t_get_basic_usage_info_1, Config) ->
+    meck:new(emqx_bridge, [passthrough, no_link, no_history]),
+    meck:expect(emqx_bridge, lookup, fun(_Type, _Name) -> {ok, #{mocked => true}} end),
+    Config;
 init_per_testcase(_TestCase, Config) ->
     Config.
 
 end_per_testcase(t_events, Config) ->
     ets:delete(events_record_tab),
     ok = delete_rule(?config(hook_points_rules, Config)),
+    emqx_common_test_helpers:call_janitor(),
+    ok;
+end_per_testcase(t_get_basic_usage_info_1, _Config) ->
+    meck:unload(),
     emqx_common_test_helpers:call_janitor(),
     ok;
 end_per_testcase(_TestCase, _Config) ->

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -781,8 +781,8 @@ setup_fake_rule_engine_data() ->
                     [
                         #{function => <<"erlang:hibernate">>, args => #{}},
                         #{function => console},
-                        <<"webhook:my_webhook">>,
-                        <<"webhook:my_webhook">>
+                        <<"webhook:basic_usage_info_webhook">>,
+                        <<"webhook:basic_usage_info_webhook_disabled">>
                     ]
             }
         ),
@@ -793,8 +793,8 @@ setup_fake_rule_engine_data() ->
                 sql => <<"select 1 from topic">>,
                 actions =>
                     [
-                        <<"mqtt:my_mqtt_bridge">>,
-                        <<"webhook:my_webhook">>
+                        <<"mqtt:basic_usage_info_mqtt">>,
+                        <<"webhook:basic_usage_info_webhook">>
                     ]
             }
         ),
@@ -802,7 +802,7 @@ setup_fake_rule_engine_data() ->
         emqx_rule_engine:create_rule(
             #{
                 id => <<"rule:t_get_basic_usage_info:3">>,
-                sql => <<"select 1 from \"$bridges/mqtt:mqtt_in\"">>,
+                sql => <<"select 1 from \"$bridges/mqtt:basic_usage_info_mqtt\"">>,
                 actions =>
                     [
                         #{function => console}


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3da0f05</samp>

This pull request enhances the rule engine module to handle bridge-related rules more robustly and reliably. It adds a new feature to disable invalid rules that reference non-existent bridges, and improves the test coverage and flexibility of the rule engine and bridge modules. It affects the files `emqx_rule_engine.erl`, `emqx_bridge_v1_compatibility_layer_SUITE.erl`, `emqx_rule_engine_SUITE.erl`, and `emqx_bridge_v2_testlib.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
