### PR TITLE
fix(coap): channel shall not overwrite #keepalive record

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -204,9 +204,9 @@ handle_deliver(
 
 handle_timeout(_, {keepalive, NewVal}, #channel{keepalive = KeepAlive} = Channel) ->
     case emqx_keepalive:check(NewVal, KeepAlive) of
-        {ok, NewKeepAlive} ->
+        {ok, _} ->
             Channel2 = ensure_keepalive_timer(fun make_timer/4, Channel),
-            {ok, Channel2#channel{keepalive = NewKeepAlive}};
+            {ok, Channel2};
         {error, timeout} ->
             {shutdown, timeout, ensure_disconnected(keepalive_timeout, Channel)}
     end;


### PR DESCRIPTION
I managed to reproduce the problem #11779 on latest master locally.

fixes #10093
fixes #11779
fixes #11800

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b6b2287</samp>

Refactor `emqx_coap_channel` module to simplify keepalive handling and remove unused code. Remove `keepalive` field from `channel` record in `emqx_coap_channel.erl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
