### PR TITLE
fix(kafka): do not hide nodelay field

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -358,7 +358,7 @@ fields(socket_opts) ->
                 boolean(),
                 #{
                     default => true,
-                    importance => ?IMPORTANCE_HIDDEN,
+                    importance => ?IMPORTANCE_LOW,
                     desc => ?DESC(socket_nodelay)
                 }
             )},


### PR DESCRIPTION
otherwise:
it's returned in the GET response,
but it's not allowed in the POST request

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 282867a</samp>

Expose the `socket_nodelay` option for the Kafka bridge. This option allows users to enable or disable the TCP_NODELAY flag for the TCP socket that connects to the Kafka broker.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
