### PR TITLE
fix(bridge): do not allow dot in bridge name

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
@@ -258,7 +258,7 @@ end_per_testcase(_TestCase, Config) ->
     ok = emqx_common_test_helpers:call_janitor(),
     ok.
 
--define(CONNECTOR_IMPL, dummy_connector_impl).
+-define(CONNECTOR_IMPL, emqx_bridge_v2_dummy_connector).
 init_mocks() ->
     meck:new(emqx_connector_ee_schema, [passthrough, no_link]),
     meck:expect(emqx_connector_ee_schema, resource_type, 1, ?CONNECTOR_IMPL),
@@ -534,6 +534,7 @@ t_bridges_lifecycle(Config) ->
 
     %% Try create bridge with bad characters as name
     {ok, 400, _} = request(post, uri([?ROOT]), ?KAFKA_BRIDGE(<<"隋达"/utf8>>), Config),
+    {ok, 400, _} = request(post, uri([?ROOT]), ?KAFKA_BRIDGE(<<"a.b">>), Config),
     ok.
 
 t_start_bridge_unknown_node(Config) ->

--- a/apps/emqx_bridge/test/emqx_bridge_v2_dummy_connector.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_dummy_connector.erl
@@ -1,0 +1,31 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% this module is only intended to be mocked
+-module(emqx_bridge_v2_dummy_connector).
+
+-export([
+    callback_mode/0,
+    on_start/2,
+    on_stop/2,
+    on_add_channel/4,
+    on_get_channel_status/3
+]).
+
+callback_mode() -> error(unexpected).
+on_start(_, _) -> error(unexpected).
+on_stop(_, _) -> error(unexpected).
+on_add_channel(_, _, _, _) -> error(unexpected).
+on_get_channel_status(_, _, _) -> error(unexpected).

--- a/apps/emqx_connector/test/emqx_connector_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_SUITE.erl
@@ -22,7 +22,7 @@
 -include_lib("common_test/include/ct.hrl").
 
 -define(START_APPS, [emqx, emqx_conf, emqx_connector]).
--define(CONNECTOR, dummy_connector_impl).
+-define(CONNECTOR, emqx_connector_dummy_impl).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).

--- a/apps/emqx_connector/test/emqx_connector_dummy_impl.erl
+++ b/apps/emqx_connector/test/emqx_connector_dummy_impl.erl
@@ -1,0 +1,31 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% this module is only intended to be mocked
+-module(emqx_connector_dummy_impl).
+
+-export([
+    callback_mode/0,
+    on_start/2,
+    on_stop/2,
+    on_add_channel/4,
+    on_get_channel_status/3
+]).
+
+callback_mode() -> error(unexpected).
+on_start(_, _) -> error(unexpected).
+on_stop(_, _) -> error(unexpected).
+on_add_channel(_, _, _, _) -> error(unexpected).
+on_get_channel_status(_, _, _) -> error(unexpected).


### PR DESCRIPTION
Do not allow dot in bridge name or connector name.

bridge and connector names are used as config keys in cluster.hocon.
dots which will turn the key into path.

this is a follow up fix of bridge-v2 feature which is not released yet.
so there is no compatibility issue.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 039976f</samp>

This pull request refactors and improves the validation of resource IDs, types, and names for bridges and connectors, using common functions from the `emqx_resource` module. It also adds and renames dummy connector modules for testing purposes.

