### PR TITLE
fix(rules_api): downgrade bridge id

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -522,7 +522,7 @@ format_action(Actions) ->
 do_format_action({bridge, BridgeType, BridgeName, _ResId}) ->
     emqx_bridge_resource:bridge_id(BridgeType, BridgeName);
 do_format_action({bridge_v2, BridgeType, BridgeName}) ->
-    emqx_bridge_resource:bridge_id(BridgeType, BridgeName);
+    emqx_bridge_resource:bridge_id(emqx_bridge_lib:downgrade_type(BridgeType), BridgeName);
 do_format_action(#{mod := Mod, func := Func, args := Args}) ->
     #{
         function => printable_function_name(Mod, Func),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
@@ -310,6 +310,20 @@ t_rule_engine(_) ->
     }),
     {400, _} = emqx_rule_engine_api:'/rule_engine'(put, #{body => #{<<"something">> => <<"weird">>}}).
 
+t_downgrade_bridge_type(_) ->
+    #{id := RuleId} = create_rule((?SIMPLE_RULE(<<>>))#{<<"actions">> => [<<"kafka:name">>]}),
+    ?assertMatch(
+        %% returns a bridges_v2 ID
+        {200, #{data := [#{actions := [<<"kafka:name">>]}]}},
+        emqx_rule_engine_api:'/rules'(get, #{query_string => #{}})
+    ),
+    ?assertMatch(
+        %% returns a bridges_v2 ID
+        {200, #{actions := [<<"kafka:name">>]}},
+        emqx_rule_engine_api:'/rules/:id'(get, #{bindings => #{id => RuleId}})
+    ),
+    ok.
+
 rules_fixture(N) ->
     lists:map(
         fun(Seq0) ->


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11312

After fix:

![image](https://github.com/emqx/emqx/assets/16166434/1d77ee96-b85b-4e10-a899-7a1df1c0e390)


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 0ee74cd</samp>

Fix a bug in the `do_format_action` function for the `bridge_v2` action type and add a test case. The bug fix ensures that the bridge ID is consistent with the legacy bridge format and avoids conflicts or errors. The test case verifies the correct bridge ID for the `bridge_v2` action type using the `kafka` bridge type as an example.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
