### PR TITLE
fix(plugins): fix backward compatibility

### DIFF
--- a/changes/ce/fix-11886.en.md
+++ b/changes/ce/fix-11886.en.md
@@ -1,0 +1,3 @@
+Fixed backward plugin compatibility.
+
+Currently, EMQX validates hookpoint names, so invalid hookspoints cannot be used for registering hooks. However, older versions of plugin templates used some misspelled hookpoints, and so could the real plugins. We allow the old hookpoints to be used for registering hooks, but issue a warning that they are deprecated. As before, these hooks are never called.


### PR DESCRIPTION
Fixes [EMQX-11324](https://emqx.atlassian.net/browse/EMQX-11324)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 8438d73</samp>

This pull request improves the support and testing of legacy plugin templates that use deprecated hookpoints. It refactors the `emqx_hookpoints.erl` module to use a map and log warnings, and adds a new test case in `emqx_plugins_SUITE.erl` for the legacy templates.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [na] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible
