### PR TITLE
ci: test emqx_rule_engine with both ce and ee profiles, use ee by default

### DIFF
--- a/scripts/ct/run.sh
+++ b/scripts/ct/run.sh
@@ -124,6 +124,9 @@ if [ -z "${PROFILE+x}" ]; then
         apps/emqx_dashboard)
             export PROFILE='emqx-enterprise'
             ;;
+        apps/emqx_rule_engine)
+            export PROFILE='emqx-enterprise'
+            ;;
         lib-ee*)
             ## ensure enterprise profile when testing lib-ee applications
             export PROFILE='emqx-enterprise'

--- a/scripts/find-apps.sh
+++ b/scripts/find-apps.sh
@@ -91,14 +91,15 @@ matrix() {
                 entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
                 ;;
-            apps/emqx_bridge_kafka)
-                entries+=("$(format_app_entry "$app" 3 emqx-enterprise "$runner")")
-                ;;
             apps/emqx_connector)
                 entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
                 ;;
             apps/emqx_dashboard)
+                entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
+                entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
+                ;;
+            apps/emqx_rule_engine)
                 entries+=("$(format_app_entry "$app" 1 emqx "$runner")")
                 entries+=("$(format_app_entry "$app" 1 emqx-enterprise "$runner")")
                 ;;


### PR DESCRIPTION
Fixes -

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at b75b8ef</samp>

This pull request updates the `find-apps.sh` and `scripts/ct/run.sh` scripts to support the emqx_rule_engine app and the differences between the emqx and emqx-enterprise editions. It ensures that the correct dependencies and features are included in each profile and that the tests run with the appropriate configuration.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
