### PR TITLE
fix(resource): take error from action/connector before attempting query

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -535,11 +535,13 @@ do_send_msg_with_enabled_config(
     BridgeType, BridgeName, Message, QueryOpts0, Config
 ) ->
     QueryMode = get_query_mode(BridgeType, Config),
+    ConnectorName = maps:get(connector, Config),
+    ConnectorResId = emqx_connector_resource:resource_id(BridgeType, ConnectorName),
     QueryOpts = maps:merge(
         emqx_bridge:query_opts(Config),
         QueryOpts0#{
-            query_mode => QueryMode,
-            query_mode_cache_override => false
+            connector_resource_id => ConnectorResId,
+            query_mode => QueryMode
         }
     ),
     BridgeV2Id = id(BridgeType, BridgeName),

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -557,11 +557,8 @@ check_topic_status(ClientId, WolffClientPid, KafkaTopic) ->
         ok ->
             ok;
         {error, unknown_topic_or_partition} ->
-            throw(#{
-                error => unknown_kafka_topic,
-                kafka_client_id => ClientId,
-                kafka_topic => KafkaTopic
-            });
+            Msg = iolist_to_binary([<<"Unknown topic or partition: ">>, KafkaTopic]),
+            throw({unhealthy_target, Msg});
         {error, Reason} ->
             throw(#{
                 error => failed_to_check_topic_status,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -574,8 +574,14 @@ t_nonexistent_topic(_Config) ->
         erlang:list_to_atom(Type), erlang:list_to_atom(Name), Conf
     ),
     % TODO: make sure the user facing APIs for Bridge V1 also get this error
-    #{status := disconnected, error := #{error := unknown_kafka_topic}} = emqx_bridge_v2:health_check(
-        ?BRIDGE_TYPE_V2, list_to_atom(Name)
+    ?assertMatch(
+        #{
+            status := disconnected,
+            error := {unhealthy_target, <<"Unknown topic or partition: undefined-test-topic">>}
+        },
+        emqx_bridge_v2:health_check(
+            ?BRIDGE_TYPE_V2, list_to_atom(Name)
+        )
     ),
     ok = emqx_bridge:remove(list_to_atom(Type), list_to_atom(Name)),
     delete_all_bridges(),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -140,6 +140,33 @@ t_local_topic(_) ->
     ok = emqx_connector:remove(?TYPE, test_connector),
     ok.
 
+t_unknown_topic(_Config) ->
+    ConnectorName = <<"test_connector">>,
+    BridgeName = <<"test_bridge">>,
+    BridgeV2Config0 = bridge_v2_config(ConnectorName),
+    BridgeV2Config = emqx_utils_maps:deep_put(
+        [<<"kafka">>, <<"topic">>],
+        BridgeV2Config0,
+        <<"nonexistent">>
+    ),
+    ConnectorConfig = connector_config(),
+    {ok, _} = emqx_connector:create(?TYPE, ConnectorName, ConnectorConfig),
+    {ok, _} = emqx_bridge_v2:create(?TYPE, BridgeName, BridgeV2Config),
+    Payload = <<"will be dropped">>,
+    emqx:publish(emqx_message:make(<<"kafka_t/local">>, Payload)),
+    BridgeV2Id = emqx_bridge_v2:id(?TYPE, BridgeName),
+    ?retry(
+        _Sleep0 = 50,
+        _Attempts0 = 100,
+        begin
+            ?assertEqual(1, emqx_resource_metrics:matched_get(BridgeV2Id)),
+            ?assertEqual(1, emqx_resource_metrics:dropped_get(BridgeV2Id)),
+            ?assertEqual(1, emqx_resource_metrics:dropped_resource_stopped_get(BridgeV2Id)),
+            ok
+        end
+    ),
+    ok.
+
 check_send_message_with_bridge(BridgeName) ->
     %% ######################################
     %% Create Kafka message

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -22,7 +22,7 @@
 -type resource_spec() :: map().
 -type resource_state() :: term().
 -type resource_status() :: connected | disconnected | connecting | stopped.
--type channel_status() :: connected | connecting.
+-type channel_status() :: connected | connecting | disconnected.
 -type callback_mode() :: always_sync | async_if_possible.
 -type query_mode() ::
     simple_sync
@@ -47,7 +47,7 @@
     simple_query => boolean(),
     reply_to => reply_fun(),
     query_mode => query_mode(),
-    query_mode_cache_override => boolean()
+    connector_resource_id => resource_id()
 }.
 -type resource_data() :: #{
     id := resource_id(),


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11284 
Fixes https://emqx.atlassian.net/browse/EMQX-11298

![image](https://github.com/emqx/emqx/assets/16166434/b5713eff-2883-4d2a-b93b-f01af2e16f82)


![image](https://github.com/emqx/emqx/assets/16166434/4c6e9168-7e32-4074-84e0-db1def087777)



## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 16f3671</samp>

Refactor the error handling and query mode logic for emqx_resource, emqx_bridge, and emqx_bridge_kafka to support different connectors and bridge types. Add and update test cases for the unknown topic scenario for the Kafka producer. Add the connector resource id to the query options for the bridge v2.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
