### PR TITLE
feat(bridge): accept wrapped secrets as passwords

### DIFF
--- a/.ci/docker-compose-file/credentials.env
+++ b/.ci/docker-compose-file/credentials.env
@@ -1,0 +1,7 @@
+MONGO_USERNAME=emqx
+MONGO_PASSWORD=passw0rd
+MONGO_AUTHSOURCE=admin
+
+# See "Environment Variables" @ https://hub.docker.com/_/mongo
+MONGO_INITDB_ROOT_USERNAME=${MONGO_USERNAME}
+MONGO_INITDB_ROOT_PASSWORD=${MONGO_PASSWORD}

--- a/.ci/docker-compose-file/docker-compose-mongo-single-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-single-tcp.yaml
@@ -9,6 +9,9 @@ services:
       - emqx_bridge
     ports:
       - "27017:27017"
+    env_file:
+      - .env
+      - credentials.env
     command:
       --ipv6
       --bind_ip_all

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     container_name: erlang
     image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.2-3:1.14.5-25.3.2-2-ubuntu22.04}
     env_file:
+      - credentials.env
       - conf.env
     environment:
       GITHUB_ACTIONS: ${GITHUB_ACTIONS:-}

--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
@@ -278,6 +278,10 @@ raw_mongo_auth_config() ->
         <<"server">> => mongo_server(),
         <<"w_mode">> => <<"unsafe">>,
 
+        <<"auth_source">> => mongo_authsource(),
+        <<"username">> => mongo_username(),
+        <<"password">> => mongo_password(),
+
         <<"filter">> => #{<<"username">> => <<"${username}">>},
         <<"password_hash_field">> => <<"password_hash">>,
         <<"salt_field">> => <<"salt">>,
@@ -464,8 +468,20 @@ mongo_config() ->
         {database, <<"mqtt">>},
         {host, ?MONGO_HOST},
         {port, ?MONGO_DEFAULT_PORT},
+        {auth_source, mongo_authsource()},
+        {login, mongo_username()},
+        {password, mongo_password()},
         {register, ?MONGO_CLIENT}
     ].
+
+mongo_authsource() ->
+    iolist_to_binary(os:getenv("MONGO_AUTHSOURCE", "admin")).
+
+mongo_username() ->
+    iolist_to_binary(os:getenv("MONGO_USERNAME", "")).
+
+mongo_password() ->
+    iolist_to_binary(os:getenv("MONGO_PASSWORD", "")).
 
 start_apps(Apps) ->
     lists:foreach(fun application:ensure_all_started/1, Apps).

--- a/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
@@ -397,6 +397,10 @@ raw_mongo_authz_config() ->
         <<"collection">> => <<"acl">>,
         <<"server">> => mongo_server(),
 
+        <<"auth_source">> => mongo_authsource(),
+        <<"username">> => mongo_username(),
+        <<"password">> => mongo_password(),
+
         <<"filter">> => #{<<"username">> => <<"${username}">>}
     }.
 
@@ -408,8 +412,20 @@ mongo_config() ->
         {database, <<"mqtt">>},
         {host, ?MONGO_HOST},
         {port, ?MONGO_DEFAULT_PORT},
+        {auth_source, mongo_authsource()},
+        {login, mongo_username()},
+        {password, mongo_password()},
         {register, ?MONGO_CLIENT}
     ].
+
+mongo_authsource() ->
+    iolist_to_binary(os:getenv("MONGO_AUTHSOURCE", "admin")).
+
+mongo_username() ->
+    iolist_to_binary(os:getenv("MONGO_USERNAME", "")).
+
+mongo_password() ->
+    iolist_to_binary(os:getenv("MONGO_PASSWORD", "")).
 
 start_apps(Apps) ->
     lists:foreach(fun application:ensure_all_started/1, Apps).

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -356,9 +356,10 @@ parse_confs(<<"iotdb">>, Name, Conf) ->
         authentication :=
             #{
                 username := Username,
-                password := Password
+                password := Secret
             }
     } = Conf,
+    Password = emqx_secret:unwrap(Secret),
     BasicToken = base64:encode(<<Username/binary, ":", Password/binary>>),
     %% This version atom correspond to the macro ?VSN_1_1_X in
     %% emqx_bridge_iotdb.hrl. It would be better to use the macro directly, but

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_clickhouse, [
     {description, "EMQX Enterprise ClickHouse Bridge"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -145,7 +145,7 @@ on_start(
     Options = [
         {url, URL},
         {user, maps:get(username, Config, "default")},
-        {key, emqx_secret:wrap(maps:get(password, Config, "public"))},
+        {key, maps:get(password, Config, emqx_secret:wrap("public"))},
         {database, DB},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize},
@@ -243,6 +243,7 @@ connect(Options) ->
     URL = iolist_to_binary(emqx_http_lib:normalize(proplists:get_value(url, Options))),
     User = proplists:get_value(user, Options),
     Database = proplists:get_value(database, Options),
+    %% TODO: teach `clickhouse` to accept 0-arity closures as passwords.
     Key = emqx_secret:unwrap(proplists:get_value(key, Options)),
     Pool = proplists:get_value(pool, Options),
     PoolSize = proplists:get_value(pool_size, Options),

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo.app.src
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_dynamo, [
     {description, "EMQX Enterprise Dynamo Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
@@ -45,12 +45,10 @@ fields(config) ->
                 #{required => true, desc => ?DESC("aws_access_key_id")}
             )},
         {aws_secret_access_key,
-            mk(
-                binary(),
+            emqx_schema_secret:mk(
                 #{
                     required => true,
-                    desc => ?DESC("aws_secret_access_key"),
-                    sensitive => true
+                    desc => ?DESC("aws_secret_access_key")
                 }
             )},
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
@@ -89,7 +87,7 @@ on_start(
             host => Host,
             port => Port,
             aws_access_key_id => to_str(AccessKeyID),
-            aws_secret_access_key => to_str(SecretAccessKey),
+            aws_secret_access_key => SecretAccessKey,
             schema => Schema
         }},
         {pool_size, PoolSize}
@@ -182,9 +180,8 @@ do_query(
     end.
 
 connect(Opts) ->
-    Options = proplists:get_value(config, Opts),
-    {ok, _Pid} = Result = emqx_bridge_dynamo_connector_client:start_link(Options),
-    Result.
+    Config = proplists:get_value(config, Opts),
+    {ok, _Pid} = emqx_bridge_dynamo_connector_client:start_link(Config).
 
 parse_template(Config) ->
     Templates =

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_greptimedb, [
     {description, "EMQX GreptimeDB Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -147,13 +147,7 @@ fields(greptimedb) ->
         [
             {dbname, mk(binary(), #{required => true, desc => ?DESC("dbname")})},
             {username, mk(binary(), #{desc => ?DESC("username")})},
-            {password,
-                mk(binary(), #{
-                    desc => ?DESC("password"),
-                    format => <<"password">>,
-                    sensitive => true,
-                    converter => fun emqx_schema:password_converter/2
-                })}
+            {password, emqx_schema_secret:mk(#{desc => ?DESC("password")})}
         ] ++ emqx_connector_schema_lib:ssl_fields().
 
 server() ->
@@ -302,7 +296,8 @@ ssl_config(SSL = #{enable := true}) ->
 
 auth(#{username := Username, password := Password}) ->
     [
-        {auth, {basic, #{username => str(Username), password => str(Password)}}}
+        %% TODO: teach `greptimedb` to accept 0-arity closures as passwords.
+        {auth, {basic, #{username => str(Username), password => emqx_secret:unwrap(Password)}}}
     ];
 auth(_) ->
     [].

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_influxdb, [
     {description, "EMQX Enterprise InfluxDB Bridge"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -192,20 +192,14 @@ fields(influxdb_api_v1) ->
         [
             {database, mk(binary(), #{required => true, desc => ?DESC("database")})},
             {username, mk(binary(), #{desc => ?DESC("username")})},
-            {password,
-                mk(binary(), #{
-                    desc => ?DESC("password"),
-                    format => <<"password">>,
-                    sensitive => true,
-                    converter => fun emqx_schema:password_converter/2
-                })}
+            {password, emqx_schema_secret:mk(#{desc => ?DESC("password")})}
         ] ++ emqx_connector_schema_lib:ssl_fields();
 fields(influxdb_api_v2) ->
     fields(common) ++
         [
             {bucket, mk(binary(), #{required => true, desc => ?DESC("bucket")})},
             {org, mk(binary(), #{required => true, desc => ?DESC("org")})},
-            {token, mk(binary(), #{required => true, desc => ?DESC("token")})}
+            {token, emqx_schema_secret:mk(#{required => true, desc => ?DESC("token")})}
         ] ++ emqx_connector_schema_lib:ssl_fields().
 
 server() ->
@@ -363,7 +357,8 @@ protocol_config(#{
         {version, v2},
         {bucket, str(Bucket)},
         {org, str(Org)},
-        {token, Token}
+        %% TODO: teach `influxdb` to accept 0-arity closures as passwords.
+        {token, emqx_secret:unwrap(Token)}
     ] ++ ssl_config(SSL).
 
 ssl_config(#{enable := false}) ->
@@ -383,7 +378,8 @@ username(_) ->
     [].
 
 password(#{password := Password}) ->
-    [{password, str(Password)}];
+    %% TODO: teach `influxdb` to accept 0-arity closures as passwords.
+    [{password, emqx_secret:unwrap(Password)}];
 password(_) ->
     [].
 

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -379,7 +379,7 @@ username(_) ->
 
 password(#{password := Password}) ->
     %% TODO: teach `influxdb` to accept 0-arity closures as passwords.
-    [{password, emqx_secret:unwrap(Password)}];
+    [{password, str(emqx_secret:unwrap(Password))}];
 password(_) ->
     [].
 

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_iotdb, [
     {description, "EMQX Enterprise Apache IoTDB Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {modules, [
         emqx_bridge_iotdb,
         emqx_bridge_iotdb_impl

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.erl
@@ -51,12 +51,9 @@ fields(auth_basic) ->
     [
         {username, mk(binary(), #{required => true, desc => ?DESC("config_auth_basic_username")})},
         {password,
-            mk(binary(), #{
+            emqx_schema_secret:mk(#{
                 required => true,
-                desc => ?DESC("config_auth_basic_password"),
-                format => <<"password">>,
-                sensitive => true,
-                converter => fun emqx_schema:password_converter/2
+                desc => ?DESC("config_auth_basic_password")
             })}
     ].
 

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -283,11 +283,9 @@ fields(auth_username_password) ->
             })},
         {username, mk(binary(), #{required => true, desc => ?DESC(auth_sasl_username)})},
         {password,
-            mk(binary(), #{
+            emqx_connector_schema_lib:password_field(#{
                 required => true,
-                sensitive => true,
-                desc => ?DESC(auth_sasl_password),
-                converter => fun emqx_schema:password_converter/2
+                desc => ?DESC(auth_sasl_password)
             })}
     ];
 fields(auth_gssapi_kerberos) ->

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
@@ -31,8 +31,8 @@ make_client_id(BridgeType0, BridgeName0) ->
 
 sasl(none) ->
     undefined;
-sasl(#{mechanism := Mechanism, username := Username, password := Password}) ->
-    {Mechanism, Username, emqx_secret:wrap(Password)};
+sasl(#{mechanism := Mechanism, username := Username, password := Secret}) ->
+    {Mechanism, Username, Secret};
 sasl(#{
     kerberos_principal := Principal,
     kerberos_keytab_file := KeyTabFile

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -1018,112 +1018,89 @@ hocon_config(Args, ConfigTemplateFun) ->
     ),
     Hocon.
 
-%% erlfmt-ignore
 hocon_config_template() ->
-"""
-bridges.kafka.{{ bridge_name }} {
-  bootstrap_hosts = \"{{ kafka_hosts_string }}\"
-  enable = true
-  authentication = {{{ authentication }}}
-  ssl = {{{ ssl }}}
-  local_topic = \"{{ local_topic }}\"
-  kafka = {
-    message = {
-      key = \"${clientid}\"
-      value = \"${.payload}\"
-      timestamp = \"${timestamp}\"
-    }
-    buffer = {
-      memory_overload_protection = false
-    }
-    partition_strategy = {{ partition_strategy }}
-    topic = \"{{ kafka_topic }}\"
-    query_mode = {{ query_mode }}
-  }
-  metadata_request_timeout = 5s
-  min_metadata_refresh_interval = 3s
-  socket_opts {
-    nodelay = true
-  }
-  connect_timeout = 5s
-}
-""".
+    "bridges.kafka.{{ bridge_name }} {"
+    "\n   bootstrap_hosts = \"{{ kafka_hosts_string }}\""
+    "\n   enable = true"
+    "\n   authentication = {{{ authentication }}}"
+    "\n   ssl = {{{ ssl }}}"
+    "\n   local_topic = \"{{ local_topic }}\""
+    "\n   kafka = {"
+    "\n     message = {"
+    "\n       key = \"${clientid}\""
+    "\n       value = \"${.payload}\""
+    "\n       timestamp = \"${timestamp}\""
+    "\n     }"
+    "\n     buffer = {"
+    "\n       memory_overload_protection = false"
+    "\n     }"
+    "\n     partition_strategy = {{ partition_strategy }}"
+    "\n     topic = \"{{ kafka_topic }}\""
+    "\n     query_mode = {{ query_mode }}"
+    "\n   }"
+    "\n   metadata_request_timeout = 5s"
+    "\n   min_metadata_refresh_interval = 3s"
+    "\n   socket_opts {"
+    "\n     nodelay = true"
+    "\n   }"
+    "\n   connect_timeout = 5s"
+    "\n }".
 
-%% erlfmt-ignore
 hocon_config_template_with_headers() ->
-"""
-bridges.kafka.{{ bridge_name }} {
-  bootstrap_hosts = \"{{ kafka_hosts_string }}\"
-  enable = true
-  authentication = {{{ authentication }}}
-  ssl = {{{ ssl }}}
-  local_topic = \"{{ local_topic }}\"
-  kafka = {
-    message = {
-      key = \"${clientid}\"
-      value = \"${.payload}\"
-      timestamp = \"${timestamp}\"
-    }
-    buffer = {
-      memory_overload_protection = false
-    }
-    kafka_headers = \"{{ kafka_headers }}\"
-    kafka_header_value_encode_mode: json
-    kafka_ext_headers: {{{ kafka_ext_headers }}}
-    partition_strategy = {{ partition_strategy }}
-    topic = \"{{ kafka_topic }}\"
-    query_mode = {{ query_mode }}
-  }
-  metadata_request_timeout = 5s
-  min_metadata_refresh_interval = 3s
-  socket_opts {
-    nodelay = true
-  }
-  connect_timeout = 5s
-}
-""".
+    "bridges.kafka.{{ bridge_name }} {"
+    "\n   bootstrap_hosts = \"{{ kafka_hosts_string }}\""
+    "\n   enable = true"
+    "\n   authentication = {{{ authentication }}}"
+    "\n   ssl = {{{ ssl }}}"
+    "\n   local_topic = \"{{ local_topic }}\""
+    "\n   kafka = {"
+    "\n     message = {"
+    "\n       key = \"${clientid}\""
+    "\n       value = \"${.payload}\""
+    "\n       timestamp = \"${timestamp}\""
+    "\n     }"
+    "\n     buffer = {"
+    "\n       memory_overload_protection = false"
+    "\n     }"
+    "\n     kafka_headers = \"{{ kafka_headers }}\""
+    "\n     kafka_header_value_encode_mode: json"
+    "\n     kafka_ext_headers: {{{ kafka_ext_headers }}}"
+    "\n     partition_strategy = {{ partition_strategy }}"
+    "\n     topic = \"{{ kafka_topic }}\""
+    "\n     query_mode = {{ query_mode }}"
+    "\n   }"
+    "\n   metadata_request_timeout = 5s"
+    "\n   min_metadata_refresh_interval = 3s"
+    "\n   socket_opts {"
+    "\n     nodelay = true"
+    "\n   }"
+    "\n   connect_timeout = 5s"
+    "\n }".
 
-%% erlfmt-ignore
 hocon_config_template_authentication("none") ->
     "none";
 hocon_config_template_authentication(#{"mechanism" := _}) ->
-"""
-{
-    mechanism = {{ mechanism }}
-    password = {{ password }}
-    username = {{ username }}
-}
-""";
+    "{"
+    "\n     mechanism = {{ mechanism }}"
+    "\n     password = {{ password }}"
+    "\n     username = {{ username }}"
+    "\n }";
 hocon_config_template_authentication(#{"kerberos_principal" := _}) ->
-"""
-{
-    kerberos_principal = \"{{ kerberos_principal }}\"
-    kerberos_keytab_file = \"{{ kerberos_keytab_file }}\"
-}
-""".
+    "{"
+    "\n     kerberos_principal = \"{{ kerberos_principal }}\""
+    "\n     kerberos_keytab_file = \"{{ kerberos_keytab_file }}\""
+    "\n }".
 
-%% erlfmt-ignore
 hocon_config_template_ssl(Map) when map_size(Map) =:= 0 ->
-"""
-{
-    enable = false
-}
-""";
+    "{ enable = false }";
 hocon_config_template_ssl(#{"enable" := "false"}) ->
-"""
-{
-    enable = false
-}
-""";
+    "{ enable = false }";
 hocon_config_template_ssl(#{"enable" := "true"}) ->
-"""
-{
-    enable = true
-    cacertfile = \"{{{cacertfile}}}\"
-    certfile = \"{{{certfile}}}\"
-    keyfile = \"{{{keyfile}}}\"
-}
-""".
+    "{      enable = true"
+    "\n     cacertfile = \"{{{cacertfile}}}\""
+    "\n     certfile = \"{{{certfile}}}\""
+    "\n     keyfile = \"{{{keyfile}}}\""
+    "\n }".
 
 kafka_hosts_string(tcp, none) ->
     kafka_hosts_string();

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -223,144 +223,136 @@ check_atom_key(Conf) when is_map(Conf) ->
 %% Data section
 %%===========================================================================
 
-%% erlfmt-ignore
 kafka_producer_old_hocon(_WithLocalTopic = true) ->
     kafka_producer_old_hocon("mqtt {topic = \"mqtt/local\"}\n");
 kafka_producer_old_hocon(_WithLocalTopic = false) ->
     kafka_producer_old_hocon("mqtt {}\n");
 kafka_producer_old_hocon(MQTTConfig) when is_list(MQTTConfig) ->
-"""
-bridges.kafka {
-  myproducer {
-    authentication = \"none\"
-    bootstrap_hosts = \"toxiproxy:9292\"
-    connect_timeout = \"5s\"
-    metadata_request_timeout = \"5s\"
-    min_metadata_refresh_interval = \"3s\"
-    producer {
-      kafka {
-        buffer {
-          memory_overload_protection = false
-          mode = \"memory\"
-          per_partition_limit = \"2GB\"
-          segment_bytes = \"100MB\"
-        }
-        compression = \"no_compression\"
-        max_batch_bytes = \"896KB\"
-        max_inflight = 10
-        message {
-          key = \"${.clientid}\"
-          timestamp = \"${.timestamp}\"
-          value = \"${.}\"
-        }
-        partition_count_refresh_interval = \"60s\"
-        partition_strategy = \"random\"
-        required_acks = \"all_isr\"
-        topic = \"test-topic-two-partitions\"
-      }
-""" ++ MQTTConfig ++
-"""
-    }
-    socket_opts {
-      nodelay = true
-      recbuf = \"1024KB\"
-      sndbuf = \"1024KB\"
-    }
-    ssl {enable = false, verify = \"verify_peer\"}
-  }
-}
-""".
+    [
+        "bridges.kafka {"
+        "\n  myproducer {"
+        "\n    authentication = \"none\""
+        "\n    bootstrap_hosts = \"toxiproxy:9292\""
+        "\n    connect_timeout = \"5s\""
+        "\n    metadata_request_timeout = \"5s\""
+        "\n    min_metadata_refresh_interval = \"3s\""
+        "\n    producer {"
+        "\n      kafka {"
+        "\n        buffer {"
+        "\n          memory_overload_protection = false"
+        "\n          mode = \"memory\""
+        "\n          per_partition_limit = \"2GB\""
+        "\n          segment_bytes = \"100MB\""
+        "\n        }"
+        "\n        compression = \"no_compression\""
+        "\n        max_batch_bytes = \"896KB\""
+        "\n        max_inflight = 10"
+        "\n        message {"
+        "\n          key = \"${.clientid}\""
+        "\n          timestamp = \"${.timestamp}\""
+        "\n          value = \"${.}\""
+        "\n        }"
+        "\n        partition_count_refresh_interval = \"60s\""
+        "\n        partition_strategy = \"random\""
+        "\n        required_acks = \"all_isr\""
+        "\n        topic = \"test-topic-two-partitions\""
+        "\n      }",
+        MQTTConfig,
+        "\n    }"
+        "\n    socket_opts {"
+        "\n      nodelay = true"
+        "\n      recbuf = \"1024KB\""
+        "\n      sndbuf = \"1024KB\""
+        "\n    }"
+        "\n    ssl {enable = false, verify = \"verify_peer\"}"
+        "\n  }"
+        "\n}"
+    ].
 
 kafka_producer_new_hocon() ->
-    ""
-    "\n"
-    "bridges.kafka {\n"
-    "  myproducer {\n"
-    "    authentication = \"none\"\n"
-    "    bootstrap_hosts = \"toxiproxy:9292\"\n"
-    "    connect_timeout = \"5s\"\n"
-    "    metadata_request_timeout = \"5s\"\n"
-    "    min_metadata_refresh_interval = \"3s\"\n"
-    "    kafka {\n"
-    "      buffer {\n"
-    "        memory_overload_protection = false\n"
-    "        mode = \"memory\"\n"
-    "        per_partition_limit = \"2GB\"\n"
-    "        segment_bytes = \"100MB\"\n"
-    "      }\n"
-    "      compression = \"no_compression\"\n"
-    "      max_batch_bytes = \"896KB\"\n"
-    "      max_inflight = 10\n"
-    "      message {\n"
-    "        key = \"${.clientid}\"\n"
-    "        timestamp = \"${.timestamp}\"\n"
-    "        value = \"${.}\"\n"
-    "      }\n"
-    "      partition_count_refresh_interval = \"60s\"\n"
-    "      partition_strategy = \"random\"\n"
-    "      required_acks = \"all_isr\"\n"
-    "      topic = \"test-topic-two-partitions\"\n"
-    "    }\n"
-    "    local_topic = \"mqtt/local\"\n"
-    "    socket_opts {\n"
-    "      nodelay = true\n"
-    "      recbuf = \"1024KB\"\n"
-    "      sndbuf = \"1024KB\"\n"
-    "    }\n"
-    "    ssl {enable = false, verify = \"verify_peer\"}\n"
-    "    resource_opts {\n"
-    "      health_check_interval = 10s\n"
-    "    }\n"
-    "  }\n"
-    "}\n"
-    "".
+    "bridges.kafka {"
+    "\n  myproducer {"
+    "\n    authentication = \"none\""
+    "\n    bootstrap_hosts = \"toxiproxy:9292\""
+    "\n    connect_timeout = \"5s\""
+    "\n    metadata_request_timeout = \"5s\""
+    "\n    min_metadata_refresh_interval = \"3s\""
+    "\n    kafka {"
+    "\n      buffer {"
+    "\n        memory_overload_protection = false"
+    "\n        mode = \"memory\""
+    "\n        per_partition_limit = \"2GB\""
+    "\n        segment_bytes = \"100MB\""
+    "\n      }"
+    "\n      compression = \"no_compression\""
+    "\n      max_batch_bytes = \"896KB\""
+    "\n      max_inflight = 10"
+    "\n      message {"
+    "\n        key = \"${.clientid}\""
+    "\n        timestamp = \"${.timestamp}\""
+    "\n        value = \"${.}\""
+    "\n      }"
+    "\n      partition_count_refresh_interval = \"60s\""
+    "\n      partition_strategy = \"random\""
+    "\n      required_acks = \"all_isr\""
+    "\n      topic = \"test-topic-two-partitions\""
+    "\n    }"
+    "\n    local_topic = \"mqtt/local\""
+    "\n    socket_opts {"
+    "\n      nodelay = true"
+    "\n      recbuf = \"1024KB\""
+    "\n      sndbuf = \"1024KB\""
+    "\n    }"
+    "\n    ssl {enable = false, verify = \"verify_peer\"}"
+    "\n    resource_opts {"
+    "\n      health_check_interval = 10s"
+    "\n    }"
+    "\n  }"
+    "\n}".
 
-%% erlfmt-ignore
 kafka_consumer_hocon() ->
-"""
-bridges.kafka_consumer.my_consumer {
-  enable = true
-  bootstrap_hosts = \"kafka-1.emqx.net:9292\"
-  connect_timeout = 5s
-  min_metadata_refresh_interval = 3s
-  metadata_request_timeout = 5s
-  authentication = {
-    mechanism = plain
-    username = emqxuser
-    password = password
-  }
-  kafka {
-    max_batch_bytes = 896KB
-    max_rejoin_attempts = 5
-    offset_commit_interval_seconds = 3s
-    offset_reset_policy = latest
-  }
-  topic_mapping = [
-    {
-      kafka_topic = \"kafka-topic-1\"
-      mqtt_topic = \"mqtt/topic/1\"
-      qos = 1
-      payload_template = \"${.}\"
-    },
-    {
-      kafka_topic = \"kafka-topic-2\"
-      mqtt_topic = \"mqtt/topic/2\"
-      qos = 2
-      payload_template = \"v = ${.value}\"
-    }
-  ]
-  key_encoding_mode = none
-  value_encoding_mode = none
-  ssl {
-    enable = false
-    verify = verify_none
-    server_name_indication = \"auto\"
-  }
-  resource_opts {
-    health_check_interval = 10s
-  }
-}
-""".
+    "bridges.kafka_consumer.my_consumer {"
+    "\n   enable = true"
+    "\n   bootstrap_hosts = \"kafka-1.emqx.net:9292\""
+    "\n   connect_timeout = 5s"
+    "\n   min_metadata_refresh_interval = 3s"
+    "\n   metadata_request_timeout = 5s"
+    "\n   authentication = {"
+    "\n     mechanism = plain"
+    "\n     username = emqxuser"
+    "\n     password = password"
+    "\n   }"
+    "\n   kafka {"
+    "\n     max_batch_bytes = 896KB"
+    "\n     max_rejoin_attempts = 5"
+    "\n     offset_commit_interval_seconds = 3s"
+    "\n     offset_reset_policy = latest"
+    "\n   }"
+    "\n   topic_mapping = ["
+    "\n     {"
+    "\n       kafka_topic = \"kafka-topic-1\""
+    "\n       mqtt_topic = \"mqtt/topic/1\""
+    "\n       qos = 1"
+    "\n       payload_template = \"${.}\""
+    "\n     },"
+    "\n     {"
+    "\n       kafka_topic = \"kafka-topic-2\""
+    "\n       mqtt_topic = \"mqtt/topic/2\""
+    "\n       qos = 2"
+    "\n       payload_template = \"v = ${.value}\""
+    "\n     }"
+    "\n   ]"
+    "\n   key_encoding_mode = none"
+    "\n   value_encoding_mode = none"
+    "\n   ssl {"
+    "\n     enable = false"
+    "\n     verify = verify_none"
+    "\n     server_name_indication = \"auto\""
+    "\n   }"
+    "\n   resource_opts {"
+    "\n     health_check_interval = 10s"
+    "\n   }"
+    "\n }".
 
 %% assert compatibility
 bridge_schema_json_test() ->

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kinesis, [
     {description, "EMQX Enterprise Amazon Kinesis Bridge"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
@@ -62,12 +62,10 @@ fields(connector_config) ->
                 }
             )},
         {aws_secret_access_key,
-            mk(
-                binary(),
+            emqx_schema_secret:mk(
                 #{
                     required => true,
-                    desc => ?DESC("aws_secret_access_key"),
-                    sensitive => true
+                    desc => ?DESC("aws_secret_access_key")
                 }
             )},
         {endpoint,

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
@@ -97,7 +97,13 @@ init(#{
         partition_key => PartitionKey,
         stream_name => StreamName
     },
-    New =
+    %% TODO: teach `erlcloud` to to accept 0-arity closures as passwords.
+    ok = erlcloud_config:configure(
+        to_str(AwsAccessKey),
+        to_str(emqx_secret:unwrap(AwsSecretAccessKey)),
+        Host,
+        Port,
+        Scheme,
         fun(AccessKeyID, SecretAccessKey, HostAddr, HostPort, ConnectionScheme) ->
             Config0 = erlcloud_kinesis:new(
                 AccessKeyID,
@@ -107,9 +113,7 @@ init(#{
                 ConnectionScheme ++ "://"
             ),
             Config0#aws_config{retry_num = MaxRetries}
-        end,
-    erlcloud_config:configure(
-        to_str(AwsAccessKey), to_str(AwsSecretAccessKey), Host, Port, Scheme, New
+        end
     ),
     % check the connection
     case erlcloud_kinesis:list_streams() of

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
@@ -15,7 +15,7 @@
 
 -type config() :: #{
     aws_access_key_id := binary(),
-    aws_secret_access_key := binary(),
+    aws_secret_access_key := emqx_secret:t(binary()),
     endpoint := binary(),
     stream_name := binary(),
     partition_key := binary(),

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mongodb, [
     {description, "EMQX Enterprise MongoDB Bridge"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
@@ -6,9 +6,6 @@
 
 -behaviour(emqx_resource).
 
--include_lib("emqx_connector/include/emqx_connector_tables.hrl").
--include_lib("emqx_resource/include/emqx_resource.hrl").
--include_lib("typerefl/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 

--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -16,7 +16,6 @@
 -define(APPS, [emqx_bridge, emqx_resource, emqx_rule_engine, emqx_oracle, emqx_bridge_oracle]).
 -define(SID, "XE").
 -define(RULE_TOPIC, "mqtt/rule").
-% -define(RULE_TOPIC_BIN, <<?RULE_TOPIC>>).
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -32,9 +31,6 @@ groups() ->
     [
         {plain, AllTCs}
     ].
-
-only_once_tests() ->
-    [t_create_via_http].
 
 init_per_suite(Config) ->
     Config.

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
@@ -170,21 +170,17 @@ fields(auth_basic) ->
     [
         {username, mk(binary(), #{required => true, desc => ?DESC("auth_basic_username")})},
         {password,
-            mk(binary(), #{
+            emqx_schema_secret:mk(#{
                 required => true,
-                desc => ?DESC("auth_basic_password"),
-                sensitive => true,
-                converter => fun emqx_schema:password_converter/2
+                desc => ?DESC("auth_basic_password")
             })}
     ];
 fields(auth_token) ->
     [
         {jwt,
-            mk(binary(), #{
+            emqx_schema_secret:mk(#{
                 required => true,
-                desc => ?DESC("auth_token_jwt"),
-                sensitive => true,
-                converter => fun emqx_schema:password_converter/2
+                desc => ?DESC("auth_token_jwt")
             })}
     ];
 fields("get_" ++ Type) ->

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_impl_producer.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_impl_producer.erl
@@ -78,7 +78,6 @@ query_mode(_Config) ->
 -spec on_start(resource_id(), config()) -> {ok, state()}.
 on_start(InstanceId, Config) ->
     #{
-        authentication := _Auth,
         bridge_name := BridgeName,
         servers := Servers0,
         ssl := SSL
@@ -263,12 +262,14 @@ conn_opts(#{authentication := none}) ->
     #{};
 conn_opts(#{authentication := #{username := Username, password := Password}}) ->
     #{
-        auth_data => iolist_to_binary([Username, <<":">>, Password]),
+        %% TODO: teach `pulsar` to accept 0-arity closures as passwords.
+        auth_data => iolist_to_binary([Username, <<":">>, emqx_secret:unwrap(Password)]),
         auth_method_name => <<"basic">>
     };
 conn_opts(#{authentication := #{jwt := JWT}}) ->
     #{
-        auth_data => JWT,
+        %% TODO: teach `pulsar` to accept 0-arity closures as passwords.
+        auth_data => emqx_secret:unwrap(JWT),
         auth_method_name => <<"token">>
     }.
 

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_rabbitmq, [
     {description, "EMQX Enterprise RabbitMQ Bridge"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_connector.erl
@@ -72,7 +72,7 @@ fields(config) ->
                     desc => ?DESC("username")
                 }
             )},
-        {password, fun emqx_connector_schema_lib:password_required/1},
+        {password, emqx_connector_schema_lib:password_field(#{required => true})},
         {pool_size,
             hoconsc:mk(
                 typerefl:pos_integer(),
@@ -194,7 +194,6 @@ on_start(
     #{
         pool_size := PoolSize,
         payload_template := PayloadTemplate,
-        password := Password,
         delivery_mode := InitialDeliveryMode
     } = InitialConfig
 ) ->
@@ -204,7 +203,6 @@ on_start(
             persistent -> 2
         end,
     Config = InitialConfig#{
-        password => emqx_secret:wrap(Password),
         delivery_mode => DeliveryMode
     },
     ?SLOG(info, #{
@@ -240,13 +238,11 @@ on_start(
         ok ->
             {ok, State};
         {error, Reason} ->
-            LogMessage =
-                #{
-                    msg => "rabbitmq_connector_start_failed",
-                    error_reason => Reason,
-                    config => emqx_utils:redact(Config)
-                },
-            ?SLOG(info, LogMessage),
+            ?SLOG(info, #{
+                msg => "rabbitmq_connector_start_failed",
+                error_reason => Reason,
+                config => emqx_utils:redact(Config)
+            }),
             {error, Reason}
     end.
 
@@ -319,6 +315,7 @@ create_rabbitmq_connection_and_channel(Config) ->
         heartbeat := Heartbeat,
         wait_for_publish_confirmations := WaitForPublishConfirmations
     } = Config,
+    %% TODO: teach `amqp` to accept 0-arity closures as passwords.
     Password = emqx_secret:unwrap(WrappedPassword),
     SSLOptions =
         case maps:get(ssl, Config, #{}) of

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.app.src
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_rocketmq, [
     {description, "EMQX Enterprise RocketMQ Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, rocketmq]},
     {env, []},

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_sqlserver, [
     {description, "EMQX Enterprise SQL Server Bridge"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, odbc]},
     {env, []},

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -199,7 +199,7 @@ on_start(
     Options = [
         {server, to_bin(Server)},
         {username, Username},
-        {password, emqx_secret:wrap(maps:get(password, Config, ""))},
+        {password, maps:get(password, Config, "")},
         {driver, Driver},
         {database, Database},
         {pool_size, PoolSize}

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -199,7 +199,7 @@ on_start(
     Options = [
         {server, to_bin(Server)},
         {username, Username},
-        {password, maps:get(password, Config, "")},
+        {password, maps:get(password, Config, emqx_secret:wrap(""))},
         {driver, Driver},
         {database, Database},
         {pool_size, PoolSize}

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_tdengine, [
     {description, "EMQX Enterprise TDEngine Bridge"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_connector/src/emqx_connector_schema_lib.erl
+++ b/apps/emqx_connector/src/emqx_connector_schema_lib.erl
@@ -22,15 +22,15 @@
 -export([
     relational_db_fields/0,
     ssl_fields/0,
-    prepare_statement_fields/0
+    prepare_statement_fields/0,
+    password_field/0,
+    password_field/1
 ]).
 
 -export([
     pool_size/1,
     database/1,
     username/1,
-    password/1,
-    password_required/1,
     auto_reconnect/1
 ]).
 
@@ -68,9 +68,18 @@ relational_db_fields() ->
         %% See emqx_resource.hrl
         {pool_size, fun pool_size/1},
         {username, fun username/1},
-        {password, fun password/1},
+        {password, password_field()},
         {auto_reconnect, fun auto_reconnect/1}
     ].
+
+-spec password_field() -> hocon_schema:field_schema().
+password_field() ->
+    password_field(#{}).
+
+-spec password_field(#{atom() => _}) -> hocon_schema:field_schema().
+password_field(Overrides) ->
+    Base = #{desc => ?DESC("password")},
+    emqx_schema_secret:mk(maps:merge(Base, Overrides)).
 
 prepare_statement_fields() ->
     [{prepare_statement, fun prepare_statement/1}].
@@ -96,22 +105,6 @@ username(type) -> binary();
 username(desc) -> ?DESC("username");
 username(required) -> false;
 username(_) -> undefined.
-
-password(type) -> binary();
-password(desc) -> ?DESC("password");
-password(required) -> false;
-password(format) -> <<"password">>;
-password(sensitive) -> true;
-password(converter) -> fun emqx_schema:password_converter/2;
-password(_) -> undefined.
-
-password_required(type) -> binary();
-password_required(desc) -> ?DESC("password");
-password_required(required) -> true;
-password_required(format) -> <<"password">>;
-password_required(sensitive) -> true;
-password_required(converter) -> fun emqx_schema:password_converter/2;
-password_required(_) -> undefined.
 
 auto_reconnect(type) -> boolean();
 auto_reconnect(desc) -> ?DESC("auto_reconnect");

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -53,8 +53,6 @@
         filter_tokens := params_tokens()
     }.
 
--define(ECS, emqx_connector_schema_lib).
-
 %%=====================================================================
 %% Hocon schema
 roots() ->
@@ -63,9 +61,9 @@ roots() ->
 fields(config) ->
     [
         {server, server()},
-        {pool_size, fun ?ECS:pool_size/1},
+        {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {username, fun ensure_username/1},
-        {password, fun ?ECS:password/1},
+        {password, emqx_connector_schema_lib:password_field()},
         {base_dn,
             ?HOCON(binary(), #{
                 desc => ?DESC(base_dn),
@@ -124,7 +122,7 @@ server() ->
 ensure_username(required) ->
     true;
 ensure_username(Field) ->
-    ?ECS:username(Field).
+    emqx_connector_schema_lib:username(Field).
 
 %% ===================================================================
 callback_mode() -> always_sync.
@@ -223,7 +221,8 @@ connect(Options) ->
     OpenOpts = maps:to_list(maps:with([port, sslopts], Conf)),
     case eldap:open([Host], [{log, fun log/3}, {timeout, RequestTimeout} | OpenOpts]) of
         {ok, Handle} = Ret ->
-            case eldap:simple_bind(Handle, Username, Password) of
+            %% TODO: teach `eldap` to accept 0-arity closures as passwords.
+            case eldap:simple_bind(Handle, Username, emqx_secret:unwrap(Password)) of
                 ok -> Ret;
                 Error -> Error
             end;
@@ -320,13 +319,13 @@ log(Level, Format, Args) ->
     ).
 
 prepare_template(Config, State) ->
-    do_prepare_template(maps:to_list(maps:with([base_dn, filter], Config)), State).
+    maps:fold(fun prepare_template/3, State, Config).
 
-do_prepare_template([{base_dn, V} | T], State) ->
-    do_prepare_template(T, State#{base_tokens => emqx_placeholder:preproc_tmpl(V)});
-do_prepare_template([{filter, V} | T], State) ->
-    do_prepare_template(T, State#{filter_tokens => emqx_placeholder:preproc_tmpl(V)});
-do_prepare_template([], State) ->
+prepare_template(base_dn, V, State) ->
+    State#{base_tokens => emqx_placeholder:preproc_tmpl(V)};
+prepare_template(filter, V, State) ->
+    State#{filter_tokens => emqx_placeholder:preproc_tmpl(V)};
+prepare_template(_Entry, _, State) ->
     State.
 
 filter_escape(Binary) when is_binary(Binary) ->

--- a/apps/emqx_mongodb/src/emqx_mongodb.app.src
+++ b/apps/emqx_mongodb/src/emqx_mongodb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mongodb, [
     {description, "EMQX MongoDB Connector"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_mongodb/src/emqx_mongodb.erl
+++ b/apps/emqx_mongodb/src/emqx_mongodb.erl
@@ -140,7 +140,7 @@ mongo_fields() ->
         {srv_record, fun srv_record/1},
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {username, fun emqx_connector_schema_lib:username/1},
-        {password, fun emqx_connector_schema_lib:password/1},
+        {password, emqx_connector_schema_lib:password_field()},
         {use_legacy_protocol,
             hoconsc:mk(hoconsc:enum([auto, true, false]), #{
                 default => auto,
@@ -428,8 +428,8 @@ init_worker_options([{auth_source, V} | R], Acc) ->
     init_worker_options(R, [{auth_source, V} | Acc]);
 init_worker_options([{username, V} | R], Acc) ->
     init_worker_options(R, [{login, V} | Acc]);
-init_worker_options([{password, V} | R], Acc) ->
-    init_worker_options(R, [{password, emqx_secret:wrap(V)} | Acc]);
+init_worker_options([{password, Secret} | R], Acc) ->
+    init_worker_options(R, [{password, Secret} | Acc]);
 init_worker_options([{w_mode, V} | R], Acc) ->
     init_worker_options(R, [{w_mode, V} | Acc]);
 init_worker_options([{r_mode, V} | R], Acc) ->

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -280,7 +280,10 @@ do_check_prepares(#{prepares := {error, _}} = State) ->
 %% ===================================================================
 
 connect(Options) ->
-    mysql:start_link(Options).
+    %% TODO: teach `tdengine` to accept 0-arity closures as passwords.
+    {value, {password, Secret}, Rest} = lists:keytake(password, 1, Options),
+    NOptions = [{password, emqx_secret:unwrap(Secret)} | Rest],
+    mysql:start_link(NOptions).
 
 init_prepare(State = #{query_templates := Templates}) ->
     case maps:size(Templates) of

--- a/apps/emqx_oracle/src/emqx_oracle.app.src
+++ b/apps/emqx_oracle/src/emqx_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_oracle, [
     {description, "EMQX Enterprise Oracle Database Connector"},
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_oracle/src/emqx_oracle.erl
+++ b/apps/emqx_oracle/src/emqx_oracle.erl
@@ -95,7 +95,7 @@ on_start(
         {host, Host},
         {port, Port},
         {user, emqx_utils_conv:str(User)},
-        {password, jamdb_secret:wrap(maps:get(password, Config, ""))},
+        {password, maps:get(password, Config, "")},
         {sid, emqx_utils_conv:str(Sid)},
         {service_name, ServiceName},
         {pool_size, maps:get(pool_size, Config, ?DEFAULT_POOL_SIZE)},

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -131,7 +131,7 @@ on_start(
         {host, Host},
         {port, Port},
         {username, User},
-        {password, emqx_secret:wrap(maps:get(password, Config, ""))},
+        {password, maps:get(password, Config, "")},
         {database, DB},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize}
@@ -357,6 +357,7 @@ validate_table_existence([], _SQL) ->
 connect(Opts) ->
     Host = proplists:get_value(host, Opts),
     Username = proplists:get_value(username, Opts),
+    %% TODO: teach `epgsql` to accept 0-arity closures as passwords.
     Password = emqx_secret:unwrap(proplists:get_value(password, Opts)),
     case epgsql:connect(Host, Username, Password, conn_opts(Opts)) of
         {ok, _Conn} = Ok ->

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -131,7 +131,7 @@ on_start(
         {host, Host},
         {port, Port},
         {username, User},
-        {password, maps:get(password, Config, "")},
+        {password, maps:get(password, Config, emqx_secret:wrap(""))},
         {database, DB},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
         {pool_size, PoolSize}

--- a/apps/emqx_redis/src/emqx_redis.erl
+++ b/apps/emqx_redis/src/emqx_redis.erl
@@ -147,7 +147,7 @@ on_start(
         [
             {pool_size, PoolSize},
             {username, maps:get(username, Config, undefined)},
-            {password, eredis_secret:wrap(maps:get(password, Config, ""))},
+            {password, maps:get(password, Config, "")},
             {auto_reconnect, ?AUTO_RECONNECT_INTERVAL}
         ] ++ Database ++ Servers,
     Options =
@@ -296,7 +296,7 @@ redis_fields() ->
     [
         {pool_size, fun emqx_connector_schema_lib:pool_size/1},
         {username, fun emqx_connector_schema_lib:username/1},
-        {password, fun emqx_connector_schema_lib:password/1},
+        {password, emqx_connector_schema_lib:password_field()},
         {database, #{
             type => non_neg_integer(),
             default => 0,

--- a/changes/ce/feat-11896.en.md
+++ b/changes/ce/feat-11896.en.md
@@ -1,0 +1,1 @@
+Support configuring authentication-related sensitive fields in bridges (i.e. passwords, tokens, secret keys) via secrets stored as files in the file system, through special `file://` prefix.


### PR DESCRIPTION
Fixes [EMQX-10808](https://emqx.atlassian.net/browse/EMQX-10808).

Followup to #11809.

Documentation in emqx/emqx-docs#2215.

### Progress
 1. [x] Redis
 2. [x] Postgres / Matrix
 3. [x] MySQL
 4. [x] MongoDB
 5. [x] Clickhouse
 6. [x] Oracle
 7. [x] RabbitMQ
 8. [x] Cassandra
 9. [x] Kafka
10. [x] MQTT
11. [x] LDAP
12. [x] TDEngine
13. [x] SQL Server
14. [x] GreptimeDB
14. [x] InfluxDB
16. [x] IoTDB
17. [x] Azure EventHub
18. [x] AWS Dynamo
19. [x] AWS Kinesis
20. [x] Pulsar
21. [x] RocketMQ

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at e215451</samp>

This pull request improves the password handling and authentication support for various bridge plugins, such as MongoDB, Kafka, ClickHouse, and PostgreSQL. It also enhances the test modules and docker-compose files for these plugins, and updates some version numbers and code formatting.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible
