### PR TITLE
ci: explicitly specify branch names for push entrypoint

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -11,7 +11,7 @@ on:
       - 'e*'
     branches:
       - 'master'
-      - 'release-5?'
+      - 'release-5[0-9]'
       - 'ci/**'
 
 env:


### PR DESCRIPTION
Github ignores `release-5?` branch pattern and does not trigger the workflow when changes are merged into `release-53` or `release-54`.

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at d3023bb</samp>

Updated the push event workflow to run on release branches. This enables continuous integration and testing for the `release-53` and `release-54` branches of `emqx`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
