### PR TITLE
1109 dump json file for i18n

### DIFF
--- a/build
+++ b/build
@@ -12,6 +12,12 @@ if [ "${DEBUG:-0}" -eq 1 ]; then
     export DIAGNOSTIC=1
 fi
 
+log_red() {
+  local RED='\033[0;31m' # Red
+  local NC='\033[0m' # No Color
+  echo -e "${RED}${1}${NC}"
+}
+
 PROFILE_ARG="$1"
 ARTIFACT="$2"
 
@@ -34,7 +40,7 @@ case "$(is_enterprise "$PROFILE_ARG"),$(is_enterprise "$PROFILE_ENV")" in
         true
         ;;
     *)
-        echo "PROFILE env var is set to '$PROFILE_ENV', but '$0' arg1 is '$PROFILE_ARG'"
+        log_red "PROFILE env var is set to '$PROFILE_ENV', but '$0' arg1 is '$PROFILE_ARG'"
         exit 1
         ;;
 esac
@@ -134,8 +140,13 @@ make_docs() {
         "ok = emqx_conf:dump_schema('$docdir', $SCHEMA_MODULE), \
          halt(0)."
     local desc="$docdir/desc.en.hocon"
-    log "Generating $desc"
-    scripts/merge-i18n.escript | jq --sort-keys . > "$desc"
+    if command -v jq &> /dev/null; then
+        log "Generating $desc"
+        scripts/merge-i18n.escript | jq --sort-keys . > "$desc"
+    else
+        # it is not a big deal if we cannot generate the desc
+        log_red "NOT Generated: $desc"
+    fi
 }
 
 ## arg1 is the profile for which the following args (as app names) should be excluded
@@ -152,8 +163,8 @@ assert_no_excluded_deps() {
     for app in "${excluded_apps[@]}"; do
         found="$($FIND "$rel_dir" -maxdepth 1 -type d -name "$app-*")"
         if [ -n "${found}" ]; then
-            echo "ERROR: ${app} should not be included in ${PROFILE}"
-            echo "ERROR: found ${app} in ${rel_dir}"
+            log_red "ERROR: ${app} should not be included in ${PROFILE}"
+            log_red "ERROR: found ${app} in ${rel_dir}"
             exit 1
         fi
     done
@@ -294,7 +305,7 @@ make_tgz() {
     mkdir -p "${tard}/emqx"
     mkdir -p "${pkgpath}"
     if [ ! -f "$src_tarball" ]; then
-        log "ERROR: $src_tarball is not found"
+        log_red "ERROR: $src_tarball is not found"
     fi
     $TAR zxf "${src_tarball}" -C "${tard}/emqx"
     if [ -f "${tard}/emqx/releases/${PKG_VSN}/relup" ]; then

--- a/build
+++ b/build
@@ -133,6 +133,9 @@ make_docs() {
     erl -noshell -eval \
         "ok = emqx_conf:dump_schema('$docdir', $SCHEMA_MODULE), \
          halt(0)."
+    local desc="$docdir/desc.en.hocon"
+    log "Generating $desc"
+    scripts/merge-i18n.escript | jq --sort-keys . > "$desc"
 }
 
 ## arg1 is the profile for which the following args (as app names) should be excluded

--- a/scripts/merge-i18n.escript
+++ b/scripts/merge-i18n.escript
@@ -1,0 +1,41 @@
+#!/usr/bin/env escript
+
+%% This script is only used at build time to generate the merged desc.en.hocon in JSON format
+%% but NOT the file generated to _build/$PROFILE/lib/emqx_dashboard/priv (which is HOCON format).
+%%
+%% The generated JSON file is used as the source of truth when translating to other languages.
+
+-mode(compile).
+
+-define(RED, "\e[31m").
+-define(RESET, "\e[39m").
+
+main(_) ->
+    try
+        _ = hocon:module_info()
+    catch
+        _:_ ->
+            fail("hocon module not found, please make sure the project is compiled")
+    end,
+    %% wildcard all .hocon files in rel/i18n
+    Files = filelib:wildcard("rel/i18n/*.hocon"),
+    case Files of
+        [_ | _] ->
+            ok;
+        [] ->
+            fail("No .hocon files found in rel/i18n")
+    end,
+    case hocon:files(Files) of
+        {ok, Map} ->
+            JSON = jiffy:encode(Map),
+            io:format("~s~n", [JSON]);
+        {error, Reason} ->
+            fail("~p~n", [Reason])
+    end.
+
+fail(Str) ->
+    fail(Str, []).
+
+fail(Str, Args) ->
+    io:format(standard_error, ?RED ++ "ERROR: " ++ Str ++ ?RESET ++ "~n", Args),
+    halt(1).

--- a/scripts/pre-compile.sh
+++ b/scripts/pre-compile.sh
@@ -25,10 +25,12 @@ cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
 # generate merged config files and English translation of the desc (desc.en.hocon)
 ./scripts/merge-config.escript
 
+I18N_REPO_BRANCH="v$(./pkg-vsn.sh "${PROFILE_STR}" | tr -d '.' | cut -c 1-2)"
+
 # download desc (i18n) translations
 curl -L --silent --show-error \
      --output "apps/emqx_dashboard/priv/desc.zh.hocon" \
-    'https://raw.githubusercontent.com/emqx/emqx-i18n/main/desc.zh.hocon'
+     "https://raw.githubusercontent.com/emqx/emqx-i18n/${I18N_REPO_BRANCH}/desc.zh.hocon"
 
 # TODO
 # make sbom a build artifcat


### PR DESCRIPTION
Fixes a part of [EMQX-11340](https://emqx.atlassian.net/browse/EMQX-11340)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 3f4aff8</samp>

This pull request adds a new step in the build process to generate a JSON file with the English dashboard descriptions from the HOCON files, and modifies the existing step to download the matching Chinese translations from the `emqx-i18n` repository. The JSON file is used as the source of truth for translating to other languages.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
