### PR TITLE
fix: reflect bridge V1 upgreade in cluster.hocon

### DIFF
--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -662,14 +662,16 @@ remove_from_override_config(_BinKeyPath, #{persistent := false}) ->
     undefined;
 remove_from_override_config(BinKeyPath, Opts) ->
     OldConf = emqx_config:read_override_conf(Opts),
-    emqx_utils_maps:deep_remove(BinKeyPath, OldConf).
+    UpgradedOldConf = emqx_conf_schema:upgrade_raw_conf(OldConf),
+    emqx_utils_maps:deep_remove(BinKeyPath, UpgradedOldConf).
 
 %% apply new config on top of override config
 merge_to_override_config(_RawConf, #{persistent := false}) ->
     undefined;
 merge_to_override_config(RawConf, Opts) ->
     OldConf = emqx_config:read_override_conf(Opts),
-    maps:merge(OldConf, RawConf).
+    UpgradedOldConf = emqx_conf_schema:upgrade_raw_conf(OldConf),
+    maps:merge(UpgradedOldConf, RawConf).
 
 up_req({remove, _Opts}) -> '$remove';
 up_req({{update, Req}, _Opts}) -> Req.

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -662,7 +662,7 @@ remove_from_override_config(_BinKeyPath, #{persistent := false}) ->
     undefined;
 remove_from_override_config(BinKeyPath, Opts) ->
     OldConf = emqx_config:read_override_conf(Opts),
-    UpgradedOldConf = emqx_conf_schema:upgrade_raw_conf(OldConf),
+    UpgradedOldConf = upgrade_conf(OldConf),
     emqx_utils_maps:deep_remove(BinKeyPath, UpgradedOldConf).
 
 %% apply new config on top of override config
@@ -670,8 +670,24 @@ merge_to_override_config(_RawConf, #{persistent := false}) ->
     undefined;
 merge_to_override_config(RawConf, Opts) ->
     OldConf = emqx_config:read_override_conf(Opts),
-    UpgradedOldConf = emqx_conf_schema:upgrade_raw_conf(OldConf),
+    UpgradedOldConf = upgrade_conf(OldConf),
     maps:merge(UpgradedOldConf, RawConf).
+
+upgrade_conf(Conf) ->
+    try
+        ConfLoader = emqx_app:get_config_loader(),
+        SchemaModule = apply(ConfLoader, schema_module, []),
+        apply(SchemaModule, upgrade_raw_conf, [Conf])
+    catch
+        ErrorType:Reason:Stack ->
+            ?SLOG(warning, #{
+                msg => "Failed to upgrade override config",
+                error_type => ErrorType,
+                reason => Reason,
+                stacktrace => Stack
+            }),
+            Conf
+    end.
 
 up_req({remove, _Opts}) -> '$remove';
 up_req({{update, Req}, _Opts}) -> Req.

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -681,7 +681,7 @@ upgrade_conf(Conf) ->
     catch
         ErrorType:Reason:Stack ->
             ?SLOG(warning, #{
-                msg => "Failed to upgrade override config",
+                msg => "failed_to_upgrade_config",
                 error_type => ErrorType,
                 reason => Reason,
                 stacktrace => Stack


### PR DESCRIPTION
Manually tested.

Fixes:
https://emqx.atlassian.net/browse/EMQX-11353

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at ffb42d8</samp>

Fixed a bug in `emqx_config_handler` that ignored some config changes. Used `get_raw` instead of `read_override_conf` to access the override config.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
