### PR TITLE
ci: trigger push entrypoint for `release-5[0-9]`

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -11,7 +11,7 @@ on:
       - 'e*'
     branches:
       - 'master'
-      - 'release-5?'
+      - 'release-5[0-9]'
       - 'ci/**'
 
 env:


### PR DESCRIPTION
Port of https://github.com/emqx/emqx/pull/11915

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 5822e55</samp>

Adjust CI workflow trigger for release branches. Narrow down the branch pattern in `.github/workflows/_push-entrypoint.yaml` to only match `release-5[0-9]` branches.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
