### PR TITLE
1110 delete stale type converters

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -48,7 +48,7 @@
 -type wordsize() :: bytesize().
 -type percent() :: float().
 -type file() :: string().
--type comma_separated_list() :: list().
+-type comma_separated_list() :: list(string()).
 -type comma_separated_binary() :: [binary()].
 -type comma_separated_atoms() :: [atom()].
 -type ip_port() :: tuple() | integer().

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -51,7 +51,6 @@
 -type comma_separated_list() :: list().
 -type comma_separated_binary() :: [binary()].
 -type comma_separated_atoms() :: [atom()].
--type bar_separated_list() :: list().
 -type ip_port() :: tuple() | integer().
 -type cipher() :: map().
 -type port_number() :: 1..65535.
@@ -75,7 +74,6 @@
 -typerefl_from_string({percent/0, emqx_schema, to_percent}).
 -typerefl_from_string({comma_separated_list/0, emqx_schema, to_comma_separated_list}).
 -typerefl_from_string({comma_separated_binary/0, emqx_schema, to_comma_separated_binary}).
--typerefl_from_string({bar_separated_list/0, emqx_schema, to_bar_separated_list}).
 -typerefl_from_string({ip_port/0, emqx_schema, to_ip_port}).
 -typerefl_from_string({cipher/0, emqx_schema, to_erl_cipher_suite}).
 -typerefl_from_string({comma_separated_atoms/0, emqx_schema, to_comma_separated_atoms}).
@@ -118,7 +116,6 @@
     to_percent/1,
     to_comma_separated_list/1,
     to_comma_separated_binary/1,
-    to_bar_separated_list/1,
     to_ip_port/1,
     to_erl_cipher_suite/1,
     to_comma_separated_atoms/1,
@@ -157,7 +154,6 @@
     file/0,
     comma_separated_list/0,
     comma_separated_binary/0,
-    bar_separated_list/0,
     ip_port/0,
     cipher/0,
     comma_separated_atoms/0,
@@ -2563,9 +2559,6 @@ to_json_binary(Str) ->
         Error ->
             Error
     end.
-
-to_bar_separated_list(Str) ->
-    {ok, string:tokens(Str, "| ")}.
 
 %% @doc support the following format:
 %%  - 127.0.0.1:1883

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -47,7 +47,6 @@
 -type bytesize() :: integer().
 -type wordsize() :: bytesize().
 -type percent() :: float().
--type file() :: string().
 -type comma_separated_list() :: list(string()).
 -type comma_separated_binary() :: [binary()].
 -type comma_separated_atoms() :: [atom()].
@@ -151,7 +150,6 @@
     bytesize/0,
     wordsize/0,
     percent/0,
-    file/0,
     comma_separated_list/0,
     comma_separated_binary/0,
     ip_port/0,

--- a/apps/emqx_auth_http/src/emqx_authz_http_schema.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http_schema.erl
@@ -108,7 +108,7 @@ http_common_fields() ->
         ).
 
 headers(type) ->
-    typerefl:alias("map", list({binary(), binary()}));
+    typerefl:alias("map", list({binary(), binary()}), #{}, [binary(), binary()]);
 headers(desc) ->
     ?DESC(?FUNCTION_NAME);
 headers(converter) ->
@@ -121,7 +121,7 @@ headers(_) ->
     undefined.
 
 headers_no_content_type(type) ->
-    typerefl:alias("map", list({binary(), binary()}));
+    typerefl:alias("map", list({binary(), binary()}), #{}, [binary(), binary()]);
 headers_no_content_type(desc) ->
     ?DESC(?FUNCTION_NAME);
 headers_no_content_type(converter) ->

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt_schema.erl
@@ -152,7 +152,8 @@ refresh_interval(validator) -> [fun(I) -> I > 0 end];
 refresh_interval(_) -> undefined.
 
 verify_claims(type) ->
-    list();
+    %% user input is a map, converted to a list of {binary(), binary()}
+    typerefl:alias("map", list());
 verify_claims(desc) ->
     ?DESC(?FUNCTION_NAME);
 verify_claims(default) ->

--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -355,34 +355,14 @@ typename_to_spec("comma_separated_list()", _Mod) ->
     #{type => comma_separated_string};
 typename_to_spec("comma_separated_atoms()", _Mod) ->
     #{type => comma_separated_string};
-typename_to_spec("pool_type()", _Mod) ->
-    #{type => enum, symbols => [random, hash]};
-typename_to_spec("log_level()", _Mod) ->
-    #{
-        type => enum,
-        symbols => [
-            debug,
-            info,
-            notice,
-            warning,
-            error,
-            critical,
-            alert,
-            emergency,
-            all
-        ]
-    };
-typename_to_spec("rate()", _Mod) ->
-    #{type => string};
 typename_to_spec("capacity()", _Mod) ->
-    #{type => string};
-typename_to_spec("burst_rate()", _Mod) ->
     #{type => string};
 typename_to_spec("failure_strategy()", _Mod) ->
     #{type => enum, symbols => [force, drop, throw]};
 typename_to_spec("initial()", _Mod) ->
     #{type => string};
-typename_to_spec("map()", _Mod) ->
+typename_to_spec("map(" ++ Map, _Mod) ->
+    [$) | _MapArgs] = lists:reverse(Map),
     #{type => object};
 typename_to_spec("#{" ++ _, Mod) ->
     typename_to_spec("map()", Mod);

--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -305,10 +305,6 @@ hocon_schema_to_spec(?UNION(Types, _DisplayName), LocalModule) ->
 hocon_schema_to_spec(Atom, _LocalModule) when is_atom(Atom) ->
     {#{type => enum, symbols => [Atom]}, []}.
 
-typename_to_spec("user_id_type()", _Mod) ->
-    #{type => enum, symbols => [clientid, username]};
-typename_to_spec("term()", _Mod) ->
-    #{type => string};
 typename_to_spec("boolean()", _Mod) ->
     #{type => boolean};
 typename_to_spec("binary()", _Mod) ->
@@ -317,6 +313,8 @@ typename_to_spec("float()", _Mod) ->
     #{type => number};
 typename_to_spec("integer()", _Mod) ->
     #{type => number};
+typename_to_spec("pos_integer()", _Mod) ->
+    #{type => integer};
 typename_to_spec("non_neg_integer()", _Mod) ->
     #{type => number, minimum => 0};
 typename_to_spec("number()", _Mod) ->
@@ -355,26 +353,22 @@ typename_to_spec("comma_separated_list()", _Mod) ->
     #{type => comma_separated_string};
 typename_to_spec("comma_separated_atoms()", _Mod) ->
     #{type => comma_separated_string};
-typename_to_spec("capacity()", _Mod) ->
-    #{type => string};
-typename_to_spec("failure_strategy()", _Mod) ->
-    #{type => enum, symbols => [force, drop, throw]};
-typename_to_spec("initial()", _Mod) ->
-    #{type => string};
 typename_to_spec("map(" ++ Map, _Mod) ->
     [$) | _MapArgs] = lists:reverse(Map),
     #{type => object};
-typename_to_spec("#{" ++ _, Mod) ->
-    typename_to_spec("map()", Mod);
+typename_to_spec("port_number()", _Mod) ->
+    #{type => integer};
 typename_to_spec(Name, Mod) ->
     Spec = range(Name),
     Spec1 = remote_module_type(Spec, Name, Mod),
     Spec2 = typerefl_array(Spec1, Name, Mod),
     Spec3 = integer(Spec2, Name),
-    default_type(Spec3).
+    default_type(Mod, Name, Spec3).
 
-default_type(nomatch) -> #{type => string};
-default_type(Type) -> Type.
+default_type(Mod, Name, nomatch) ->
+    error({unknown_type, Mod, Name});
+default_type(_Mod, _Name, Type) ->
+    Type.
 
 range(Name) ->
     case string:split(Name, "..") of

--- a/apps/emqx_conf/src/emqx_conf.erl
+++ b/apps/emqx_conf/src/emqx_conf.erl
@@ -337,8 +337,6 @@ typename_to_spec("timeout_duration_ms()", _Mod) ->
     #{type => duration};
 typename_to_spec("percent()", _Mod) ->
     #{type => percent};
-typename_to_spec("file()", _Mod) ->
-    #{type => string};
 typename_to_spec("ip_port()", _Mod) ->
     #{type => ip_port};
 typename_to_spec("url()", _Mod) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -799,8 +799,6 @@ hocon_schema_to_spec(?UNION(Types, _DisplayName), LocalModule) ->
 hocon_schema_to_spec(Atom, _LocalModule) when is_atom(Atom) ->
     {#{type => string, enum => [Atom]}, []}.
 
-typename_to_spec("term()", _Mod) ->
-    #{type => string, example => <<"any">>};
 typename_to_spec("boolean()", _Mod) ->
     #{type => boolean};
 typename_to_spec("binary()", _Mod) ->
@@ -884,26 +882,6 @@ typename_to_spec("comma_separated_binary()", _Mod) ->
     #{type => string, example => <<"item1,item2">>};
 typename_to_spec("comma_separated_atoms()", _Mod) ->
     #{type => string, example => <<"item1,item2">>};
-typename_to_spec("pool_type()", _Mod) ->
-    #{type => string, enum => [random, hash]};
-typename_to_spec("log_level()", _Mod) ->
-    #{
-        type => string,
-        enum => [debug, info, notice, warning, error, critical, alert, emergency, all]
-    };
-typename_to_spec("rate()", _Mod) ->
-    #{type => string, example => <<"10MB">>};
-typename_to_spec("burst()", _Mod) ->
-    #{type => string, example => <<"100MB">>};
-typename_to_spec("burst_rate()", _Mod) ->
-    %% 0/0s = no burst
-    #{type => string, example => <<"10MB">>};
-typename_to_spec("failure_strategy()", _Mod) ->
-    #{type => string, example => <<"force">>};
-typename_to_spec("initial()", _Mod) ->
-    #{type => string, example => <<"0MB">>};
-typename_to_spec("bucket_name()", _Mod) ->
-    #{type => string, example => <<"retainer">>};
 typename_to_spec("json_binary()", _Mod) ->
     #{type => string, example => <<"{\"a\": [1,true]}">>};
 typename_to_spec("port_number()", _Mod) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -865,7 +865,8 @@ typename_to_spec("bytesize()", _Mod) ->
     #{type => string, example => <<"32MB">>};
 typename_to_spec("wordsize()", _Mod) ->
     #{type => string, example => <<"1024KB">>};
-typename_to_spec("map()", _Mod) ->
+typename_to_spec("map(" ++ Map, _Mod) ->
+    [$) | _MapArgs] = lists:reverse(Map),
     #{type => object, example => #{}};
 typename_to_spec("service_account_json()", _Mod) ->
     #{type => object, example => #{}};

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -851,17 +851,8 @@ typename_to_spec("file()", _Mod) ->
     #{type => string, example => <<"/path/to/file">>};
 typename_to_spec("ip_port()", _Mod) ->
     #{type => string, example => <<"127.0.0.1:80">>};
-typename_to_spec("write_syntax()", _Mod) ->
-    #{
-        type => string,
-        example =>
-            <<"${topic},clientid=${clientid}", " ", "payload=${payload},",
-                "${clientid}_int_value=${payload.int_key}i,", "bool=${payload.bool}">>
-    };
 typename_to_spec("url()", _Mod) ->
     #{type => string, example => <<"http://127.0.0.1">>};
-typename_to_spec("connect_timeout()", Mod) ->
-    typename_to_spec("timeout()", Mod);
 typename_to_spec("timeout()", _Mod) ->
     #{
         <<"oneOf">> => [
@@ -916,8 +907,6 @@ typename_to_spec("json_binary()", _Mod) ->
     #{type => string, example => <<"{\"a\": [1,true]}">>};
 typename_to_spec("port_number()", _Mod) ->
     range("1..65535");
-typename_to_spec("secret_access_key()", _Mod) ->
-    #{type => string, example => <<"TW8dPwmjpjJJuLW....">>};
 typename_to_spec(Name, Mod) ->
     try_convert_to_spec(Name, Mod, [
         fun try_remote_module_type/2,

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -845,20 +845,10 @@ typename_to_spec("timeout_duration_ms()", _Mod) ->
     #{type => string, example => <<"32s">>};
 typename_to_spec("percent()", _Mod) ->
     #{type => number, example => <<"12%">>};
-typename_to_spec("file()", _Mod) ->
-    #{type => string, example => <<"/path/to/file">>};
 typename_to_spec("ip_port()", _Mod) ->
     #{type => string, example => <<"127.0.0.1:80">>};
 typename_to_spec("url()", _Mod) ->
     #{type => string, example => <<"http://127.0.0.1">>};
-typename_to_spec("timeout()", _Mod) ->
-    #{
-        <<"oneOf">> => [
-            #{type => string, example => infinity},
-            #{type => integer}
-        ],
-        example => infinity
-    };
 typename_to_spec("bytesize()", _Mod) ->
     #{type => string, example => <<"32MB">>};
 typename_to_spec("wordsize()", _Mod) ->
@@ -866,16 +856,8 @@ typename_to_spec("wordsize()", _Mod) ->
 typename_to_spec("map(" ++ Map, _Mod) ->
     [$) | _MapArgs] = lists:reverse(Map),
     #{type => object, example => #{}};
-typename_to_spec("service_account_json()", _Mod) ->
-    #{type => object, example => #{}};
-typename_to_spec("#{" ++ _, Mod) ->
-    typename_to_spec("map()", Mod);
 typename_to_spec("qos()", _Mod) ->
     #{type => integer, minimum => 0, maximum => 2, example => 0};
-typename_to_spec("{binary(), binary()}", _Mod) ->
-    #{type => object, example => #{}};
-typename_to_spec("{string(), string()}", _Mod) ->
-    #{type => object, example => #{}};
 typename_to_spec("comma_separated_list()", _Mod) ->
     #{type => string, example => <<"item1,item2">>};
 typename_to_spec("comma_separated_binary()", _Mod) ->

--- a/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_requestBody_SUITE.erl
@@ -816,7 +816,7 @@ to_schema(Body) ->
 fields(good_ref) ->
     [
         {'webhook-host', mk(emqx_schema:ip_port(), #{default => <<"127.0.0.1:80">>})},
-        {log_dir, mk(emqx_schema:file(), #{example => "var/log/emqx"})},
+        {log_dir, mk(string(), #{example => "var/log/emqx"})},
         {tag, mk(binary(), #{desc => <<"tag">>})}
     ];
 fields(nest_ref) ->

--- a/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_swagger_response_SUITE.erl
@@ -344,10 +344,9 @@ t_complex_type(_Config) ->
                 enum := [random, hash], type := string
             }},
             {<<"timeout">>, #{
-                example := infinity,
                 <<"oneOf">> := [
-                    #{example := infinity, type := string},
-                    #{type := integer}
+                    #{example := _, type := string},
+                    #{enum := [infinity], type := string}
                 ]
             }},
             {<<"bytesize">>, #{
@@ -653,7 +652,8 @@ schema("/ref/complex_type") ->
                     {server, hoconsc:mk(emqx_schema:ip_port(), #{})},
                     {connect_timeout, hoconsc:mk(emqx_schema:timeout_duration(), #{})},
                     {pool_type, hoconsc:mk(hoconsc:enum([random, hash]), #{})},
-                    {timeout, hoconsc:mk(timeout(), #{})},
+                    {timeout,
+                        hoconsc:mk(hoconsc:union([infinity, emqx_schema:timeout_duration()]), #{})},
                     {bytesize, hoconsc:mk(emqx_schema:bytesize(), #{})},
                     {wordsize, hoconsc:mk(emqx_schema:wordsize(), #{})},
                     {maps, hoconsc:mk(map(), #{})},
@@ -687,7 +687,7 @@ to_schema(Object) ->
 fields(good_ref) ->
     [
         {'webhook-host', mk(emqx_schema:ip_port(), #{default => <<"127.0.0.1:80">>})},
-        {log_dir, mk(emqx_schema:file(), #{example => "var/log/emqx"})},
+        {log_dir, mk(string(), #{example => "var/log/emqx"})},
         {tag, mk(binary(), #{desc => <<"tag">>})}
     ];
 fields(nest_ref) ->

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -32,19 +32,16 @@
 -type duration() :: non_neg_integer().
 -type duration_s() :: non_neg_integer().
 -type bytesize() :: pos_integer().
--type comma_separated_list() :: list().
 
 -typerefl_from_string({ip_port/0, emqx_schema, to_ip_port}).
 -typerefl_from_string({duration/0, emqx_schema, to_duration}).
 -typerefl_from_string({duration_s/0, emqx_schema, to_duration_s}).
 -typerefl_from_string({bytesize/0, emqx_schema, to_bytesize}).
--typerefl_from_string({comma_separated_list/0, emqx_schema, to_comma_separated_list}).
 
 -reflect_type([
     duration/0,
     duration_s/0,
     bytesize/0,
-    comma_separated_list/0,
     ip_port/0
 ]).
 -elvis([{elvis_style, dont_repeat_yourself, disable}]).

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -57,7 +57,7 @@ fields("prometheus") ->
             )},
         {headers,
             ?HOCON(
-                typerefl:alias("map", list({string(), string()})),
+                typerefl:alias("map", list({string(), string()}), #{}, [string(), string()]),
                 #{
                     default => #{},
                     required => false,

--- a/rel/i18n/emqx_bridge_api.hocon
+++ b/rel/i18n/emqx_bridge_api.hocon
@@ -49,7 +49,7 @@ desc_api8.label:
 """Node Bridge Operate"""
 
 desc_api9.desc:
-"""Test creating a new bridge by given ID </br>
+"""Test creating a new bridge by given ID <br/>
 The ID must be of format '{type}:{name}'"""
 
 desc_api9.label:

--- a/rel/i18n/emqx_bridge_cassandra.hocon
+++ b/rel/i18n/emqx_bridge_cassandra.hocon
@@ -32,7 +32,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to Cassandra. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_clickhouse.hocon
+++ b/rel/i18n/emqx_bridge_clickhouse.hocon
@@ -32,7 +32,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to Clickhouse. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_dynamo.hocon
+++ b/rel/i18n/emqx_bridge_dynamo.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to DynamoDB. All MQTT `PUBLISH` messages with the topic
-matching the `local_topic` will be forwarded.</br>
+matching the `local_topic` will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also `local_topic` is
 configured, then both the data got from the rule and the MQTT messages that match `local_topic`
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_gcp_pubsub.hocon
+++ b/rel/i18n/emqx_bridge_gcp_pubsub.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to GCP PubSub. All MQTT 'PUBLISH' messages with the topic
-matching `local_topic` will be forwarded.</br>
+matching `local_topic` will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_greptimedb.hocon
+++ b/rel/i18n/emqx_bridge_greptimedb.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to the GreptimeDB. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""
@@ -37,8 +37,8 @@ local_topic.label:
 write_syntax.desc:
 """Conf of GreptimeDB gRPC protocol to write data points. Write syntax is a text-based format that provides the measurement, tag set, field set, and timestamp of a data point, and placeholder supported, which is the same as InfluxDB line protocol.
 See also [InfluxDB 2.3 Line Protocol](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/line-protocol/) and
-[GreptimeDB 1.8 Line Protocol](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/) </br>
-TLDR:</br>
+[GreptimeDB 1.8 Line Protocol](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/) <br/>
+TLDR:<br/>
 ```
 <measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]
 ```

--- a/rel/i18n/emqx_bridge_greptimedb_connector.hocon
+++ b/rel/i18n/emqx_bridge_greptimedb_connector.hocon
@@ -31,8 +31,8 @@ protocol.label:
 """Protocol"""
 
 server.desc:
-"""The IPv4 or IPv6 address or the hostname to connect to.</br>
-A host entry has the following form: `Host[:Port]`.</br>
+"""The IPv4 or IPv6 address or the hostname to connect to.<br/>
+A host entry has the following form: `Host[:Port]`.<br/>
 The GreptimeDB default port 8086 is used if `[:Port]` is not specified."""
 
 server.label:

--- a/rel/i18n/emqx_bridge_hstreamdb.hocon
+++ b/rel/i18n/emqx_bridge_hstreamdb.hocon
@@ -32,7 +32,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to the HStreamDB. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_influxdb.hocon
+++ b/rel/i18n/emqx_bridge_influxdb.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to the InfluxDB. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""
@@ -37,8 +37,8 @@ local_topic.label:
 write_syntax.desc:
 """Conf of InfluxDB line protocol to write data points. It is a text-based format that provides the measurement, tag set, field set, and timestamp of a data point, and placeholder supported.
 See also [InfluxDB 2.3 Line Protocol](https://docs.influxdata.com/influxdb/v2.3/reference/syntax/line-protocol/) and
-[InfluxDB 1.8 Line Protocol](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/) </br>
-TLDR:</br>
+[InfluxDB 1.8 Line Protocol](https://docs.influxdata.com/influxdb/v1.8/write_protocols/line_protocol_tutorial/) <br/>
+TLDR:<br/>
 ```
 <measurement>[,<tag_key>=<tag_value>[,<tag_key>=<tag_value>]] <field_key>=<field_value>[,<field_key>=<field_value>] [<timestamp>]
 ```

--- a/rel/i18n/emqx_bridge_influxdb_connector.hocon
+++ b/rel/i18n/emqx_bridge_influxdb_connector.hocon
@@ -49,8 +49,8 @@ protocol.label:
 """Protocol"""
 
 server.desc:
-"""The IPv4 or IPv6 address or the hostname to connect to.</br>
-A host entry has the following form: `Host[:Port]`.</br>
+"""The IPv4 or IPv6 address or the hostname to connect to.<br/>
+A host entry has the following form: `Host[:Port]`.<br/>
 The InfluxDB default port 8086 is used if `[:Port]` is not specified."""
 
 server.label:

--- a/rel/i18n/emqx_bridge_kinesis.hocon
+++ b/rel/i18n/emqx_bridge_kinesis.hocon
@@ -32,7 +32,7 @@ pool_size.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to Amazon Kinesis. All MQTT `PUBLISH` messages with the topic
-matching the `local_topic` will be forwarded.</br>
+matching the `local_topic` will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also `local_topic` is
 configured, then both the data got from the rule and the MQTT messages that match `local_topic`
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_mysql.hocon
+++ b/rel/i18n/emqx_bridge_mysql.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to MySQL. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_oracle.hocon
+++ b/rel/i18n/emqx_bridge_oracle.hocon
@@ -2,7 +2,7 @@ emqx_bridge_oracle {
 
   local_topic {
     desc = "The MQTT topic filter to be forwarded to Oracle Database. All MQTT 'PUBLISH' messages with the topic"
-           " matching the local_topic will be forwarded.</br>"
+           " matching the local_topic will be forwarded.<br/>"
            "NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is"
            " configured, then both the data got from the rule and the MQTT messages that match local_topic"
            " will be forwarded."

--- a/rel/i18n/emqx_bridge_pgsql.hocon
+++ b/rel/i18n/emqx_bridge_pgsql.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to PostgreSQL. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_redis.hocon
+++ b/rel/i18n/emqx_bridge_redis.hocon
@@ -34,7 +34,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to Redis. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_rocketmq.hocon
+++ b/rel/i18n/emqx_bridge_rocketmq.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to RocketMQ. All MQTT `PUBLISH` messages with the topic
-matching the `local_topic` will be forwarded.</br>
+matching the `local_topic` will be forwarded.<br/>
 NOTE: if the bridge is used as a rule action, `local_topic` should be left empty otherwise the messages will be duplicated."""
 
 local_topic.label:

--- a/rel/i18n/emqx_bridge_sqlserver.hocon
+++ b/rel/i18n/emqx_bridge_sqlserver.hocon
@@ -32,7 +32,7 @@ driver.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to Microsoft SQL Server. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_bridge_tdengine.hocon
+++ b/rel/i18n/emqx_bridge_tdengine.hocon
@@ -26,7 +26,7 @@ desc_type.label:
 
 local_topic.desc:
 """The MQTT topic filter to be forwarded to TDengine. All MQTT 'PUBLISH' messages with the topic
-matching the local_topic will be forwarded.</br>
+matching the local_topic will be forwarded.<br/>
 NOTE: if this bridge is used as the action of a rule (EMQX rule engine), and also local_topic is
 configured, then both the data got from the rule and the MQTT messages that match local_topic
 will be forwarded."""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -92,7 +92,7 @@ mqtt_max_topic_alias.label:
 """Max Topic Alias"""
 
 common_ssl_opts_schema_user_lookup_fun.desc:
-"""EMQX-internal callback that is used to lookup pre-shared key (PSK) identity.</br>
+"""EMQX-internal callback that is used to lookup pre-shared key (PSK) identity.<br/>
 Has no effect when TLS version is configured (or negotiated) to 1.3"""
 
 common_ssl_opts_schema_user_lookup_fun.label:
@@ -1207,7 +1207,7 @@ The SSL application already takes measures to counter-act such attempts,
 but client-initiated renegotiation can be strictly disabled by setting this option to false.
 The default value is true. Note that disabling renegotiation can result in
 long-lived connections becoming unusable due to limits on
-the number of messages the underlying cipher suite can encipher.</br>
+the number of messages the underlying cipher suite can encipher.<br/>
 Has no effect when TLS version is configured (or negotiated) to 1.3"""
 
 server_ssl_opts_schema_client_renegotiation.label:
@@ -1294,7 +1294,7 @@ common_ssl_opts_schema_secure_renegotiate.desc:
 """SSL parameter renegotiation is a feature that allows a client and a server
 to renegotiate the parameters of the SSL connection on the fly.
 RFC 5746 defines a more secure way of doing this. By enabling secure renegotiation,
-you drop support for the insecure renegotiation, prone to MitM attacks.</br>
+you drop support for the insecure renegotiation, prone to MitM attacks.<br/>
 Has no effect when TLS version is configured (or negotiated) to 1.3"""
 
 common_ssl_opts_schema_secure_renegotiate.label:
@@ -1330,7 +1330,7 @@ mqtt_max_packet_size.label:
 """Max Packet Size"""
 
 common_ssl_opts_schema_reuse_sessions.desc:
-"""Enable TLS session reuse.</br>
+"""Enable TLS session reuse.<br/>
 Has no effect when TLS version is configured (or negotiated) to 1.3"""
 
 common_ssl_opts_schema_reuse_sessions.label:


### PR DESCRIPTION
Fixes a part of [EMQX-11340](https://emqx.atlassian.net/browse/EMQX-11340)

This is a followup fix for PR https://github.com/emqx/emqx/pull/11907


## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at eaefefb</samp>

This pull request improves the validation, documentation, and consistency of the HTTP authorization and Prometheus schemas, and fixes HTML syntax errors in various HOCON files. It also copies and updates the `typename_to_spec` function from the `emqx_conf` module to the `emqx_authz_http_schema` module, to avoid a dependency between the two modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
