### PR TITLE
Remove the use of -boot_mnesia attributes through out the codebase

### DIFF
--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -37,6 +37,7 @@
 %%--------------------------------------------------------------------
 
 start(_Type, _Args) ->
+    ensure_tables(),
     ok = maybe_load_config(),
     _ = emqx_persistent_message:init(),
     ok = maybe_start_quicer(),
@@ -122,3 +123,12 @@ get_description() -> emqx_release:description().
 
 get_release() ->
     emqx_release:version().
+
+ensure_tables() ->
+    ok = emqx_router:ensure_tables(),
+    ok = emqx_router_helper:ensure_tables(),
+    ok = emqx_trie:ensure_tables(),
+    ok = emqx_delayed:ensure_tables(),
+    ok = emqx_exclusive_subscription:ensure_tables(),
+    ok = emqx_shared_sub:ensure_tables(),
+    ok.

--- a/apps/emqx/src/emqx_banned.erl
+++ b/apps/emqx/src/emqx_banned.erl
@@ -24,11 +24,6 @@
 -include("types.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
-%% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
-
 -export([start_link/0, stop/0]).
 
 -export([
@@ -71,20 +66,6 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 -endif.
-
-%%--------------------------------------------------------------------
-%% Mnesia bootstrap
-%%--------------------------------------------------------------------
-
-mnesia(boot) ->
-    ok = mria:create_table(?BANNED_TAB, [
-        {type, set},
-        {rlog_shard, ?COMMON_SHARD},
-        {storage, disc_copies},
-        {record_name, banned},
-        {attributes, record_info(fields, banned)},
-        {storage_properties, [{ets, [{read_concurrency, true}]}]}
-    ]).
 
 %%--------------------------------------------------------------------
 %% Data backup
@@ -236,6 +217,7 @@ clear() ->
 %%--------------------------------------------------------------------
 
 init([]) ->
+    ensure_tables(),
     {ok, ensure_expiry_timer(#{expiry_timer => undefined})}.
 
 handle_call(Req, _From, State) ->
@@ -302,3 +284,17 @@ on_banned(#banned{who = {clientid, ClientId}}) ->
     ok;
 on_banned(_) ->
     ok.
+
+%%--------------------------------------------------------------------
+%% Mnesia bootstrap
+%%--------------------------------------------------------------------
+
+ensure_tables() ->
+    ok = mria:create_table(?BANNED_TAB, [
+        {type, set},
+        {rlog_shard, ?COMMON_SHARD},
+        {storage, disc_copies},
+        {record_name, banned},
+        {attributes, record_info(fields, banned)},
+        {storage_properties, [{ets, [{read_concurrency, true}]}]}
+    ]).

--- a/apps/emqx/src/emqx_exclusive_subscription.erl
+++ b/apps/emqx/src/emqx_exclusive_subscription.erl
@@ -22,13 +22,10 @@
 -logger_header("[exclusive]").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
+-export([ensure_tables/0]).
 
 %% For upgrade
 -export([on_add_module/0, on_delete_module/0]).
-
--boot_mnesia({mnesia, [boot]}).
--copy_mnesia({mnesia, [copy]}).
 
 -export([
     check_subscribe/2,
@@ -53,7 +50,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_tables() ->
     StoreProps = [
         {ets, [
             {read_concurrency, true},
@@ -75,7 +72,7 @@ mnesia(boot) ->
 %%--------------------------------------------------------------------
 
 on_add_module() ->
-    mnesia(boot).
+    ensure_tables().
 
 on_delete_module() ->
     clear().

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -24,9 +24,7 @@
 -include_lib("emqx/include/emqx_router.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_tables/0]).
 
 -export([start_link/2]).
 
@@ -93,7 +91,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_tables() ->
     mria_config:set_dirty_shard(?ROUTE_SHARD, true),
     ok = mria:create_table(?ROUTE_TAB, [
         {type, bag},

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -25,9 +25,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_tables/0]).
 
 %% API
 -export([
@@ -63,7 +61,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?ROUTING_NODE, [
         {type, set},
         {rlog_shard, ?ROUTE_SHARD},

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -25,9 +25,7 @@
 -include("types.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_tables/0]).
 
 %% APIs
 -export([start_link/0]).
@@ -108,7 +106,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?TAB, [
         {type, bag},
         {rlog_shard, ?SHARED_SUB_SHARD},

--- a/apps/emqx/src/emqx_trie.erl
+++ b/apps/emqx/src/emqx_trie.erl
@@ -20,12 +20,10 @@
 
 %% Mnesia bootstrap
 -export([
-    mnesia/1,
+    ensure_tables/0,
     wait_for_tables/0,
     create_session_trie/1
 ]).
-
--boot_mnesia({mnesia, [boot]}).
 
 %% Trie APIs
 -export([
@@ -65,8 +63,8 @@
 %%--------------------------------------------------------------------
 
 %% @doc Create or replicate topics table.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+-spec ensure_tables() -> ok.
+ensure_tables() ->
     %% Optimize storage
     StoreProps = [
         {ets, [

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_app.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia_app.erl
@@ -25,6 +25,7 @@
 start(_StartType, _StartArgs) ->
     ok = emqx_authz_mnesia:init_tables(),
     ok = emqx_authn_mnesia:init_tables(),
+    ok = emqx_authn_scram_mnesia:init_tables(),
     ok = emqx_authz:register_source(?AUTHZ_TYPE, emqx_authz_mnesia),
     ok = emqx_authn:register_provider(?AUTHN_TYPE_SIMPLE, emqx_authn_mnesia),
     ok = emqx_authn:register_provider(?AUTHN_TYPE_SCRAM, emqx_authn_scram_mnesia),

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -57,7 +57,7 @@
     import_csv/3
 ]).
 
--export([mnesia/1, init_tables/0]).
+-export([init_tables/0]).
 
 -export([backup_tables/0]).
 
@@ -71,8 +71,6 @@
     is_superuser :: boolean()
 }).
 
--boot_mnesia({mnesia, [boot]}).
-
 -define(TAB, ?MODULE).
 -define(AUTHN_QSCHEMA, [
     {<<"like_user_id">>, binary},
@@ -84,9 +82,9 @@
 %% Mnesia bootstrap
 %%------------------------------------------------------------------------------
 
-%% @doc Create or replicate tables.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+%% Init
+-spec init_tables() -> ok.
+init_tables() ->
     ok = mria:create_table(?TAB, [
         {rlog_shard, ?AUTHN_SHARD},
         {type, ordered_set},
@@ -94,12 +92,8 @@ mnesia(boot) ->
         {record_name, user_info},
         {attributes, record_info(fields, user_info)},
         {storage_properties, [{ets, [{read_concurrency, true}]}]}
-    ]).
-
-%% Init
--spec init_tables() -> ok.
-init_tables() ->
-    ok = mria_rlog:wait_for_shards([?AUTHN_SHARD], infinity).
+    ]),
+    ok = mria:wait_for_tables([?TAB]).
 
 %%------------------------------------------------------------------------------
 %% Data backup

--- a/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
@@ -65,9 +65,7 @@
 
 -type user_group() :: binary().
 
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([init_tables/0]).
 
 -record(user_info, {
     user_id,
@@ -84,8 +82,8 @@
 %%------------------------------------------------------------------------------
 
 %% @doc Create or replicate tables.
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
+-spec init_tables() -> ok.
+init_tables() ->
     ok = mria:create_table(?TAB, [
         {rlog_shard, ?AUTHN_SHARD},
         {type, ordered_set},

--- a/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
@@ -54,7 +54,6 @@
 
 %% Management API
 -export([
-    mnesia/1,
     init_tables/0,
     store_rules/2,
     purge_rules/0,
@@ -71,18 +70,6 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 -endif.
-
--boot_mnesia({mnesia, [boot]}).
-
--spec mnesia(boot | copy) -> ok.
-mnesia(boot) ->
-    ok = mria:create_table(?ACL_TABLE, [
-        {type, ordered_set},
-        {rlog_shard, ?ACL_SHARDED},
-        {storage, disc_copies},
-        {attributes, record_info(fields, ?ACL_TABLE)},
-        {storage_properties, [{ets, [{read_concurrency, true}]}]}
-    ]).
 
 %%--------------------------------------------------------------------
 %% emqx_authz callbacks
@@ -136,7 +123,14 @@ backup_tables() -> [?ACL_TABLE].
 %% Init
 -spec init_tables() -> ok.
 init_tables() ->
-    ok = mria_rlog:wait_for_shards([?ACL_SHARDED], infinity).
+    ok = mria:create_table(?ACL_TABLE, [
+        {type, ordered_set},
+        {rlog_shard, ?ACL_SHARDED},
+        {storage, disc_copies},
+        {attributes, record_info(fields, ?ACL_TABLE)},
+        {storage_properties, [{ets, [{read_concurrency, true}]}]}
+    ]),
+    ok = mria:wait_for_tables([?ACL_TABLE]).
 
 %% @doc Update authz rules
 -spec store_rules(who(), rules()) -> ok.

--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -17,7 +17,7 @@
 -behaviour(gen_server).
 
 %% API
--export([start_link/0, mnesia/1]).
+-export([start_link/0, ensure_tables/0]).
 
 %% Note: multicall functions are statically checked by
 %% `emqx_bapi_trans' and `emqx_bpapi_static_checks' modules. Don't
@@ -63,8 +63,6 @@
 
 -export_type([tnx_id/0, succeed_num/0]).
 
--boot_mnesia({mnesia, [boot]}).
-
 -include_lib("emqx/include/logger.hrl").
 -include("emqx_conf.hrl").
 
@@ -96,7 +94,8 @@
 %%%===================================================================
 %%% API
 %%%===================================================================
-mnesia(boot) ->
+
+ensure_tables() ->
     ok = mria:create_table(?CLUSTER_MFA, [
         {type, ordered_set},
         {rlog_shard, ?CLUSTER_RPC_SHARD},

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -27,6 +27,7 @@
 -include("emqx_conf.hrl").
 
 start(_StartType, _StartArgs) ->
+    ok = emqx_cluster_rpc:ensure_tables(),
     try
         ok = init_conf()
     catch

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -22,12 +22,10 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
--boot_mnesia({mnesia, [boot]}).
-
 -behaviour(emqx_db_backup).
 
 %% Mnesia bootstrap
--export([mnesia/1]).
+-export([ensure_tables/0]).
 
 -export([
     add_user/4,
@@ -70,7 +68,7 @@
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------
 
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?ADMIN, [
         {type, set},
         {rlog_shard, ?DASHBOARD_SHARD},

--- a/apps/emqx_dashboard/src/emqx_dashboard_app.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_app.erl
@@ -26,6 +26,9 @@
 -include("emqx_dashboard.hrl").
 
 start(_StartType, _StartArgs) ->
+    emqx_dashboard_admin:ensure_tables(),
+    emqx_dashboard_monitor:ensure_tables(),
+    emqx_dashboard_token:ensure_tables(),
     ok = mria_rlog:wait_for_shards([?DASHBOARD_SHARD], infinity),
     {ok, Sup} = emqx_dashboard_sup:start_link(),
     case emqx_dashboard:start_listeners() of

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -22,8 +22,6 @@
 
 -behaviour(gen_server).
 
--boot_mnesia({mnesia, [boot]}).
-
 -export([start_link/0]).
 
 -export([
@@ -35,7 +33,7 @@
     code_change/3
 ]).
 
--export([mnesia/1]).
+-export([ensure_tables/0]).
 
 -export([
     samplers/0,
@@ -64,7 +62,7 @@
     data :: map()
 }).
 
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?TAB, [
         {type, set},
         {local_content, true},

--- a/apps/emqx_dashboard/src/emqx_dashboard_token.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_token.erl
@@ -27,9 +27,7 @@
     destroy_by_username/1
 ]).
 
--boot_mnesia({mnesia, [boot]}).
-
--export([mnesia/1]).
+-export([ensure_tables/0]).
 
 -ifdef(TEST).
 -export([lookup_by_username/1, clean_expired_jwt/1]).
@@ -87,7 +85,7 @@ salt() ->
     <<X:16/big-unsigned-integer>> = crypto:strong_rand_bytes(2),
     iolist_to_binary(io_lib:format("~4.16.0b", [X])).
 
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?TAB, [
         {type, set},
         {rlog_shard, ?DASHBOARD_SHARD},

--- a/apps/emqx_management/src/emqx_mgmt_app.erl
+++ b/apps/emqx_management/src/emqx_mgmt_app.erl
@@ -28,6 +28,7 @@
 -include("emqx_mgmt.hrl").
 
 start(_Type, _Args) ->
+    emqx_mgmt_auth:ensure_tables(),
     case emqx_mgmt_auth:init_bootstrap_file() of
         ok ->
             emqx_conf:add_handler([api_key], emqx_mgmt_auth),

--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -14,16 +14,16 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 -module(emqx_mgmt_auth).
+
+-behaviour(emqx_config_handler).
+-behaviour(emqx_db_backup).
+
 -include_lib("emqx_mgmt.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--behaviour(emqx_db_backup).
-
 %% API
--export([mnesia/1]).
--boot_mnesia({mnesia, [boot]}).
--behaviour(emqx_config_handler).
+-export([ensure_tables/0]).
 
 -export([
     create/4,
@@ -67,7 +67,7 @@
 
 -define(DEFAULT_HASH_LEN, 16).
 
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?APP, [
         {type, set},
         {rlog_shard, ?COMMON_SHARD},

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -26,9 +26,7 @@
 -include_lib("emqx/include/emqx_hooks.hrl").
 
 %% Mnesia bootstrap
--export([mnesia/1]).
-
--boot_mnesia({mnesia, [boot]}).
+-export([ensure_tables/0]).
 
 -export([
     start_link/0,
@@ -105,7 +103,7 @@
 %%------------------------------------------------------------------------------
 %% Mnesia bootstrap
 %%------------------------------------------------------------------------------
-mnesia(boot) ->
+ensure_tables() ->
     ok = mria:create_table(?TAB, [
         {type, ordered_set},
         {storage, disc_copies},

--- a/apps/emqx_psk/src/emqx_psk.app.src
+++ b/apps/emqx_psk/src/emqx_psk.app.src
@@ -2,7 +2,7 @@
 {application, emqx_psk, [
     {description, "EMQX PSK"},
     % strict semver, bump manually!
-    {vsn, "5.0.4"},
+    {vsn, "5.0.5"},
     {modules, []},
     {registered, [emqx_psk_sup]},
     {applications, [kernel, stdlib]},


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖 Generated by Copilot at 41a31bd</samp>

This pull request refactors the mnesia table management for various emqx modules and features, using the new `mria` library. It removes the old `mnesia/1` function and replaces it with the `ensure_tables/0` or `init_tables/0` functions, depending on the module. It also updates the `init/1` functions of the application modules to call the appropriate table management functions. This simplifies the code, improves the consistency, and avoids unnecessary bootstrapping.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
