### PR TITLE
fix(bridges_v1): avoid merging action examples for non-v1 bridges

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_enterprise.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_enterprise.erl
@@ -82,9 +82,7 @@ schema_modules() ->
     ].
 
 examples(Method) ->
-    ActionExamples = emqx_bridge_v2_schema:examples(Method),
-    RegisteredExamples = registered_examples(Method),
-    maps:merge(ActionExamples, RegisteredExamples).
+    registered_examples(Method).
 
 registered_examples(Method) ->
     MergeFun =


### PR DESCRIPTION
Since some new bridges might not have a V1 equivalent (i.e. they are not registered in `emqx_bridge_enterprise`), we should avoid displaying their examples in the V1 API spec.

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
