### PR TITLE
fix: fix deadlock while stopping mongodb resource

### DIFF
--- a/apps/emqx_mongodb/rebar.config
+++ b/apps/emqx_mongodb/rebar.config
@@ -3,5 +3,5 @@
 {erl_opts, [debug_info]}.
 {deps, [ {emqx_connector, {path, "../../apps/emqx_connector"}}
        , {emqx_resource, {path, "../../apps/emqx_resource"}}
-       , {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.21"}}}
+       , {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.22"}}}
        ]}.

--- a/changes/ce/fix-11955.en.md
+++ b/changes/ce/fix-11955.en.md
@@ -1,0 +1,1 @@
+Fix EMQX graceful stop when there is an unavailable MongoDB resource present.


### PR DESCRIPTION
Fixes EMQX-11350

## Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 68c19c7</samp>

Updated mongodb-erlang dependency to fix SSL/TLS connection bug in emqx_mongodb. This improves the reliability and security of the MongoDB resource and connector for `emqx`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [na] Added tests for the changes (a possible test would be quite unnatural 🤔)
- [na] Added property-based tests for code which performs user input validation
- [na] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

