### PR TITLE
feat(sessds): preserve acks / replays in session state

### DIFF
--- a/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
@@ -357,18 +357,12 @@ do_t_session_discard(Params) ->
                 _Attempts0 = 50,
                 true = map_size(emqx_persistent_session_ds:list_all_streams()) > 0
             ),
-            ?retry(
-                _Sleep0 = 100,
-                _Attempts0 = 50,
-                true = map_size(emqx_persistent_session_ds:list_all_iterators()) > 0
-            ),
             ok = emqtt:stop(Client0),
             ?tp(notice, "disconnected", #{}),
 
             ?tp(notice, "reconnecting", #{}),
-            %% we still have iterators and streams
+            %% we still have streams
             ?assert(map_size(emqx_persistent_session_ds:list_all_streams()) > 0),
-            ?assert(map_size(emqx_persistent_session_ds:list_all_iterators()) > 0),
             Client1 = start_client(ReconnectOpts),
             {ok, _} = emqtt:connect(Client1),
             ?assertEqual([], emqtt:subscriptions(Client1)),
@@ -381,7 +375,7 @@ do_t_session_discard(Params) ->
             ?assertEqual(#{}, emqx_persistent_session_ds:list_all_subscriptions()),
             ?assertEqual([], emqx_persistent_session_ds_router:topics()),
             ?assertEqual(#{}, emqx_persistent_session_ds:list_all_streams()),
-            ?assertEqual(#{}, emqx_persistent_session_ds:list_all_iterators()),
+            ?assertEqual(#{}, emqx_persistent_session_ds:list_all_pubranges()),
             ok = emqtt:stop(Client1),
             ?tp(notice, "disconnected", #{}),
 

--- a/apps/emqx/src/emqx_persistent_message_ds_replayer.erl
+++ b/apps/emqx/src/emqx_persistent_message_ds_replayer.erl
@@ -19,12 +19,12 @@
 -module(emqx_persistent_message_ds_replayer).
 
 %% API:
--export([new/0, next_packet_id/1, replay/2, commit_offset/3, poll/3, n_inflight/1]).
+-export([new/0, open/1, next_packet_id/1, replay/1, commit_offset/3, poll/3, n_inflight/1]).
 
 %% internal exports:
 -export([]).
 
--export_type([inflight/0]).
+-export_type([inflight/0, seqno/0]).
 
 -include_lib("emqx/include/logger.hrl").
 -include("emqx_persistent_session_ds.hrl").
@@ -42,17 +42,28 @@
 -type seqno() :: non_neg_integer().
 
 -record(range, {
-    stream :: emqx_ds:stream(),
+    stream :: _StreamRef,
     first :: seqno(),
-    last :: seqno(),
-    iterator_next :: emqx_ds:iterator() | undefined
+    until :: seqno(),
+    %% Type of a range:
+    %% * Inflight range is a range of yet unacked messages from this stream.
+    %% * Checkpoint range was already acked, its purpose is to keep track of the
+    %%   very last iterator for this stream.
+    type :: inflight | checkpoint,
+    %% Meaning of this depends on the type of the range:
+    %% * For inflight range, this is the iterator pointing to the first message in
+    %%   the range.
+    %% * For checkpoint range, this is the iterator pointing right past the last
+    %%   message in the range.
+    iterator :: emqx_ds:iterator()
 }).
 
 -type range() :: #range{}.
 
 -record(inflight, {
-    next_seqno = 0 :: seqno(),
-    acked_seqno = 0 :: seqno(),
+    next_seqno = 1 :: seqno(),
+    acked_until = 1 :: seqno(),
+    %% Ranges are sorted in ascending order of their sequence numbers.
     offset_ranges = [] :: [range()]
 }).
 
@@ -66,34 +77,37 @@
 new() ->
     #inflight{}.
 
+-spec open(emqx_persistent_session_ds:id()) -> inflight().
+open(SessionId) ->
+    Ranges = ro_transaction(fun() -> get_ranges(SessionId) end),
+    {AckedUntil, NextSeqno} = compute_inflight_range(Ranges),
+    #inflight{
+        acked_until = AckedUntil,
+        next_seqno = NextSeqno,
+        offset_ranges = Ranges
+    }.
+
 -spec next_packet_id(inflight()) -> {emqx_types:packet_id(), inflight()}.
-next_packet_id(Inflight0 = #inflight{next_seqno = LastSeqNo}) ->
-    Inflight = Inflight0#inflight{next_seqno = LastSeqNo + 1},
-    case LastSeqNo rem 16#10000 of
-        0 ->
-            %% We skip sequence numbers that lead to PacketId = 0 to
-            %% simplify math. Note: it leads to occasional gaps in the
-            %% sequence numbers.
-            next_packet_id(Inflight);
-        PacketId ->
-            {PacketId, Inflight}
-    end.
+next_packet_id(Inflight0 = #inflight{next_seqno = LastSeqno}) ->
+    Inflight = Inflight0#inflight{next_seqno = next_seqno(LastSeqno)},
+    {seqno_to_packet_id(LastSeqno), Inflight}.
 
 -spec n_inflight(inflight()) -> non_neg_integer().
-n_inflight(#inflight{next_seqno = NextSeqNo, acked_seqno = AckedSeqno}) ->
-    %% NOTE: this function assumes that gaps in the sequence ID occur
-    %% _only_ when the packet ID wraps:
-    case AckedSeqno >= ((NextSeqNo bsr 16) bsl 16) of
-        true ->
-            NextSeqNo - AckedSeqno;
-        false ->
-            NextSeqNo - AckedSeqno - 1
-    end.
+n_inflight(#inflight{next_seqno = NextSeqno, acked_until = AckedUntil}) ->
+    range_size(AckedUntil, NextSeqno).
 
--spec replay(emqx_persistent_session_ds:id(), inflight()) ->
-    emqx_session:replies().
-replay(_SessionId, _Inflight = #inflight{offset_ranges = _Ranges}) ->
-    [].
+-spec replay(inflight()) ->
+    {emqx_session:replies(), inflight()}.
+replay(Inflight0 = #inflight{acked_until = AckedUntil, offset_ranges = Ranges0}) ->
+    {Ranges, Replies} = lists:mapfoldr(
+        fun(Range, Acc) ->
+            replay_range(Range, AckedUntil, Acc)
+        end,
+        [],
+        Ranges0
+    ),
+    Inflight = Inflight0#inflight{offset_ranges = Ranges},
+    {Replies, Inflight}.
 
 -spec commit_offset(emqx_persistent_session_ds:id(), emqx_types:packet_id(), inflight()) ->
     {_IsValidOffset :: boolean(), inflight()}.
@@ -101,47 +115,34 @@ commit_offset(
     SessionId,
     PacketId,
     Inflight0 = #inflight{
-        acked_seqno = AckedSeqno0, next_seqno = NextSeqNo, offset_ranges = Ranges0
+        acked_until = AckedUntil, next_seqno = NextSeqno
     }
 ) ->
-    AckedSeqno =
-        case packet_id_to_seqno(NextSeqNo, PacketId) of
-            N when N > AckedSeqno0; AckedSeqno0 =:= 0 ->
-                N;
-            OutOfRange ->
-                ?SLOG(warning, #{
-                    msg => "out-of-order_ack",
-                    prev_seqno => AckedSeqno0,
-                    acked_seqno => OutOfRange,
-                    next_seqno => NextSeqNo,
-                    packet_id => PacketId
-                }),
-                AckedSeqno0
-        end,
-    Ranges = lists:filter(
-        fun(#range{stream = Stream, last = LastSeqno, iterator_next = ItNext}) ->
-            case LastSeqno =< AckedSeqno of
-                true ->
-                    %% This range has been fully
-                    %% acked. Remove it and replace saved
-                    %% iterator with the trailing iterator.
-                    update_iterator(SessionId, Stream, ItNext),
-                    false;
-                false ->
-                    %% This range still has unacked
-                    %% messages:
-                    true
-            end
-        end,
-        Ranges0
-    ),
-    Inflight = Inflight0#inflight{acked_seqno = AckedSeqno, offset_ranges = Ranges},
-    {true, Inflight}.
+    case packet_id_to_seqno(NextSeqno, PacketId) of
+        Seqno when Seqno >= AckedUntil andalso Seqno < NextSeqno ->
+            %% TODO
+            %% We do not preserve `acked_until` in the database. Instead, we discard
+            %% fully acked ranges from the database. In effect, this means that the
+            %% most recent `acked_until` the client has sent may be lost in case of a
+            %% crash or client loss.
+            Inflight1 = Inflight0#inflight{acked_until = next_seqno(Seqno)},
+            Inflight = discard_acked(SessionId, Inflight1),
+            {true, Inflight};
+        OutOfRange ->
+            ?SLOG(warning, #{
+                msg => "out-of-order_ack",
+                acked_until => AckedUntil,
+                acked_seqno => OutOfRange,
+                next_seqno => NextSeqno,
+                packet_id => PacketId
+            }),
+            {false, Inflight0}
+    end.
 
 -spec poll(emqx_persistent_session_ds:id(), inflight(), pos_integer()) ->
     {emqx_session:replies(), inflight()}.
 poll(SessionId, Inflight0, WindowSize) when WindowSize > 0, WindowSize < 16#7fff ->
-    #inflight{next_seqno = NextSeqNo0, acked_seqno = AckedSeqno} =
+    #inflight{next_seqno = NextSeqNo0, acked_until = AckedSeqno} =
         Inflight0,
     FetchThreshold = max(1, WindowSize div 2),
     FreeSpace = AckedSeqno + WindowSize - NextSeqNo0,
@@ -153,6 +154,7 @@ poll(SessionId, Inflight0, WindowSize) when WindowSize > 0, WindowSize < 16#7fff
             %% client get stuck even?
             {[], Inflight0};
         true ->
+            %% TODO: Wrap this in `mria:async_dirty/2`?
             Streams = shuffle(get_streams(SessionId)),
             fetch(SessionId, Inflight0, Streams, FreeSpace, [])
     end.
@@ -165,75 +167,206 @@ poll(SessionId, Inflight0, WindowSize) when WindowSize > 0, WindowSize < 16#7fff
 %% Internal functions
 %%================================================================================
 
-fetch(_SessionId, Inflight, _Streams = [], _N, Acc) ->
-    {lists:reverse(Acc), Inflight};
-fetch(_SessionId, Inflight, _Streams, 0, Acc) ->
-    {lists:reverse(Acc), Inflight};
-fetch(SessionId, Inflight0, [Stream | Streams], N, Publishes0) ->
-    #inflight{next_seqno = FirstSeqNo, offset_ranges = Ranges0} = Inflight0,
-    ItBegin = get_last_iterator(SessionId, Stream, Ranges0),
+compute_inflight_range([]) ->
+    {1, 1};
+compute_inflight_range(Ranges) ->
+    _RangeLast = #range{until = LastSeqno} = lists:last(Ranges),
+    RangesUnacked = lists:dropwhile(fun(#range{type = T}) -> T == checkpoint end, Ranges),
+    case RangesUnacked of
+        [#range{first = AckedUntil} | _] ->
+            {AckedUntil, LastSeqno};
+        [] ->
+            {LastSeqno, LastSeqno}
+    end.
+
+get_ranges(SessionId) ->
+    DSRanges = mnesia:match_object(
+        ?SESSION_PUBRANGE_TAB,
+        #ds_pubrange{id = {SessionId, '_'}, _ = '_'},
+        read
+    ),
+    lists:map(fun export_range/1, DSRanges).
+
+export_range(#ds_pubrange{
+    type = Type, id = {_, First}, until = Until, stream = StreamRef, iterator = It
+}) ->
+    #range{type = Type, stream = StreamRef, first = First, until = Until, iterator = It}.
+
+fetch(SessionId, Inflight0, [DSStream | Streams], N, Acc) when N > 0 ->
+    #inflight{next_seqno = FirstSeqno, offset_ranges = Ranges0} = Inflight0,
+    ItBegin = get_last_iterator(DSStream, Ranges0),
     {ok, ItEnd, Messages} = emqx_ds:next(?PERSISTENT_MESSAGE_DB, ItBegin, N),
-    {NMessages, Publishes, Inflight1} =
-        lists:foldl(
-            fun(Msg, {N0, PubAcc0, InflightAcc0}) ->
-                {PacketId, InflightAcc} = next_packet_id(InflightAcc0),
-                PubAcc = [{PacketId, Msg} | PubAcc0],
-                {N0 + 1, PubAcc, InflightAcc}
-            end,
-            {0, Publishes0, Inflight0},
-            Messages
-        ),
-    #inflight{next_seqno = LastSeqNo} = Inflight1,
-    case NMessages > 0 of
-        true ->
-            Range = #range{
-                first = FirstSeqNo,
-                last = LastSeqNo - 1,
-                stream = Stream,
-                iterator_next = ItEnd
+    {Publishes, UntilSeqno} = publish(FirstSeqno, Messages),
+    case range_size(FirstSeqno, UntilSeqno) of
+        Size when Size > 0 ->
+            Range0 = #range{
+                type = inflight,
+                first = FirstSeqno,
+                until = UntilSeqno,
+                stream = DSStream#ds_stream.ref,
+                iterator = ItBegin
             },
-            Inflight = Inflight1#inflight{offset_ranges = Ranges0 ++ [Range]},
-            fetch(SessionId, Inflight, Streams, N - NMessages, Publishes);
-        false ->
-            fetch(SessionId, Inflight1, Streams, N, Publishes)
-    end.
+            %% We need to preserve the iterator pointing to the beginning of the
+            %% range, so that we can replay it if needed.
+            ok = preserve_range(SessionId, Range0),
+            %% ...Yet we need to keep the iterator pointing past the end of the
+            %% range, so that we can pick up where we left off: it will become
+            %% `ItBegin` of the next range for this stream.
+            Range = Range0#range{iterator = ItEnd},
+            Ranges = Ranges0 ++ [Range#range{iterator = ItEnd}],
+            Inflight = Inflight0#inflight{
+                next_seqno = UntilSeqno,
+                offset_ranges = Ranges
+            },
+            fetch(SessionId, Inflight, Streams, N - Size, [Publishes | Acc]);
+        0 ->
+            fetch(SessionId, Inflight0, Streams, N, Acc)
+    end;
+fetch(_SessionId, Inflight, _Streams, _N, Acc) ->
+    Publishes = lists:append(lists:reverse(Acc)),
+    {Publishes, Inflight}.
 
--spec update_iterator(emqx_persistent_session_ds:id(), emqx_ds:stream(), emqx_ds:iterator()) -> ok.
-update_iterator(DSSessionId, Stream, Iterator) ->
-    %% Workaround: we convert `Stream' to a binary before attempting to store it in
-    %% mnesia(rocksdb) because of a bug in `mnesia_rocksdb' when trying to do
-    %% `mnesia:dirty_all_keys' later.
-    StreamBin = term_to_binary(Stream),
-    mria:dirty_write(?SESSION_ITER_TAB, #ds_iter{id = {DSSessionId, StreamBin}, iter = Iterator}).
+discard_acked(
+    SessionId,
+    Inflight0 = #inflight{acked_until = AckedUntil, offset_ranges = Ranges0}
+) ->
+    %% TODO: This could be kept and incrementally updated in the inflight state.
+    Checkpoints = find_checkpoints(Ranges0),
+    %% TODO: Wrap this in `mria:async_dirty/2`?
+    Ranges = discard_acked_ranges(SessionId, AckedUntil, Checkpoints, Ranges0),
+    Inflight0#inflight{offset_ranges = Ranges}.
 
-get_last_iterator(SessionId, Stream, Ranges) ->
-    case lists:keyfind(Stream, #range.stream, lists:reverse(Ranges)) of
-        false ->
-            get_iterator(SessionId, Stream);
-        #range{iterator_next = Next} ->
-            Next
-    end.
-
--spec get_iterator(emqx_persistent_session_ds:id(), emqx_ds:stream()) -> emqx_ds:iterator().
-get_iterator(DSSessionId, Stream) ->
-    %% See comment in `update_iterator'.
-    StreamBin = term_to_binary(Stream),
-    Id = {DSSessionId, StreamBin},
-    [#ds_iter{iter = It}] = mnesia:dirty_read(?SESSION_ITER_TAB, Id),
-    It.
-
--spec get_streams(emqx_persistent_session_ds:id()) -> [emqx_ds:stream()].
-get_streams(SessionId) ->
-    lists:map(
-        fun(#ds_stream{stream = Stream}) ->
-            Stream
+find_checkpoints(Ranges) ->
+    lists:foldl(
+        fun(#range{stream = StreamRef, until = Until}, Acc) ->
+            %% For each stream, remember the last range over this stream.
+            Acc#{StreamRef => Until}
         end,
-        mnesia:dirty_read(?SESSION_STREAM_TAB, SessionId)
+        #{},
+        Ranges
     ).
+
+discard_acked_ranges(
+    SessionId,
+    AckedUntil,
+    Checkpoints,
+    [Range = #range{until = Until, stream = StreamRef} | Rest]
+) when Until =< AckedUntil ->
+    %% This range has been fully acked.
+    %% Either discard it completely, or preserve the iterator for the next range
+    %% over this stream (i.e. a checkpoint).
+    RangeKept =
+        case maps:get(StreamRef, Checkpoints) of
+            CP when CP > Until ->
+                discard_range(SessionId, Range),
+                [];
+            Until ->
+                checkpoint_range(SessionId, Range),
+                [Range#range{type = checkpoint}]
+        end,
+    %% Since we're (intentionally) not using transactions here, it's important to
+    %% issue database writes in the same order in which ranges are stored: from
+    %% the oldest to the newest. This is also why we need to compute which ranges
+    %% should become checkpoints before we start writing anything.
+    RangeKept ++ discard_acked_ranges(SessionId, AckedUntil, Checkpoints, Rest);
+discard_acked_ranges(_SessionId, _AckedUntil, _Checkpoints, Ranges) ->
+    %% The rest of ranges (if any) still have unacked messages.
+    Ranges.
+
+replay_range(
+    Range0 = #range{type = inflight, first = First, until = Until, iterator = It},
+    AckedUntil,
+    Acc
+) ->
+    Size = range_size(First, Until),
+    FirstUnacked = max(First, AckedUntil),
+    {ok, ItNext, Messages} = emqx_ds:next(?PERSISTENT_MESSAGE_DB, It, Size),
+    MessagesUnacked =
+        case FirstUnacked of
+            First ->
+                Messages;
+            _ ->
+                lists:nthtail(range_size(First, FirstUnacked), Messages)
+        end,
+    %% Asserting that range is consistent with the message storage state.
+    {Replies, Until} = publish(FirstUnacked, MessagesUnacked),
+    Range = Range0#range{iterator = ItNext},
+    {Range, Replies ++ Acc};
+replay_range(Range0 = #range{type = checkpoint}, _AckedUntil, Acc) ->
+    {Range0, Acc}.
+
+publish(FirstSeqno, Messages) ->
+    lists:mapfoldl(
+        fun(Message, Seqno) ->
+            PacketId = seqno_to_packet_id(Seqno),
+            {{PacketId, Message}, next_seqno(Seqno)}
+        end,
+        FirstSeqno,
+        Messages
+    ).
+
+-spec preserve_range(emqx_persistent_session_ds:id(), range()) -> ok.
+preserve_range(
+    SessionId,
+    #range{first = First, until = Until, stream = StreamRef, iterator = It}
+) ->
+    DSRange = #ds_pubrange{
+        id = {SessionId, First},
+        until = Until,
+        stream = StreamRef,
+        type = inflight,
+        iterator = It
+    },
+    mria:dirty_write(?SESSION_PUBRANGE_TAB, DSRange).
+
+-spec discard_range(emqx_persistent_session_ds:id(), range()) -> ok.
+discard_range(SessionId, #range{first = First}) ->
+    mria:dirty_delete(?SESSION_PUBRANGE_TAB, {SessionId, First}).
+
+-spec checkpoint_range(emqx_persistent_session_ds:id(), range()) -> ok.
+checkpoint_range(
+    SessionId,
+    #range{type = inflight, first = First, until = Until, stream = StreamRef, iterator = ItNext}
+) ->
+    DSRange = #ds_pubrange{
+        id = {SessionId, First},
+        until = Until,
+        stream = StreamRef,
+        type = checkpoint,
+        iterator = ItNext
+    },
+    mria:dirty_write(?SESSION_PUBRANGE_TAB, DSRange);
+checkpoint_range(_SessionId, #range{type = checkpoint}) ->
+    %% This range should have been checkpointed already.
+    ok.
+
+get_last_iterator(DSStream = #ds_stream{ref = StreamRef}, Ranges) ->
+    case lists:keyfind(StreamRef, #range.stream, lists:reverse(Ranges)) of
+        false ->
+            DSStream#ds_stream.beginning;
+        #range{iterator = ItNext} ->
+            ItNext
+    end.
+
+-spec get_streams(emqx_persistent_session_ds:id()) -> [ds_stream()].
+get_streams(SessionId) ->
+    mnesia:dirty_read(?SESSION_STREAM_TAB, SessionId).
+
+next_seqno(Seqno) ->
+    NextSeqno = Seqno + 1,
+    case seqno_to_packet_id(NextSeqno) of
+        0 ->
+            %% We skip sequence numbers that lead to PacketId = 0 to
+            %% simplify math. Note: it leads to occasional gaps in the
+            %% sequence numbers.
+            NextSeqno + 1;
+        _ ->
+            NextSeqno
+    end.
 
 %% Reconstruct session counter by adding most significant bits from
 %% the current counter to the packet id.
--spec packet_id_to_seqno(non_neg_integer(), emqx_types:packet_id()) -> non_neg_integer().
+-spec packet_id_to_seqno(_Next :: seqno(), emqx_types:packet_id()) -> seqno().
 packet_id_to_seqno(NextSeqNo, PacketId) ->
     Epoch = NextSeqNo bsr 16,
     case packet_id_to_seqno_(Epoch, PacketId) of
@@ -243,9 +376,19 @@ packet_id_to_seqno(NextSeqNo, PacketId) ->
             packet_id_to_seqno_(Epoch - 1, PacketId)
     end.
 
--spec packet_id_to_seqno_(non_neg_integer(), emqx_types:packet_id()) -> non_neg_integer().
+-spec packet_id_to_seqno_(non_neg_integer(), emqx_types:packet_id()) -> seqno().
 packet_id_to_seqno_(Epoch, PacketId) ->
     (Epoch bsl 16) + PacketId.
+
+-spec seqno_to_packet_id(seqno()) -> emqx_types:packet_id().
+seqno_to_packet_id(Seqno) ->
+    Seqno rem 16#10000.
+
+range_size(FirstSeqno, UntilSeqno) ->
+    %% This function assumes that gaps in the sequence ID occur _only_ when the
+    %% packet ID wraps.
+    Size = UntilSeqno - FirstSeqno,
+    Size + (FirstSeqno bsr 16) - (UntilSeqno bsr 16).
 
 -spec shuffle([A]) -> [A].
 shuffle(L0) ->
@@ -258,6 +401,10 @@ shuffle(L0) ->
     L2 = lists:sort(L1),
     {_, L} = lists:unzip(L2),
     L.
+
+ro_transaction(Fun) ->
+    {atomic, Res} = mria:ro_transaction(?DS_MRIA_SHARD, Fun),
+    Res.
 
 -ifdef(TEST).
 
@@ -310,5 +457,41 @@ seqno_gen(NextSeqNo) ->
     Min = max(0, NextSeqNo - WindowSize),
     Max = max(0, NextSeqNo - 1),
     range(Min, Max).
+
+range_size_test_() ->
+    [
+        ?_assertEqual(0, range_size(42, 42)),
+        ?_assertEqual(1, range_size(42, 43)),
+        ?_assertEqual(1, range_size(16#ffff, 16#10001)),
+        ?_assertEqual(16#ffff - 456 + 123, range_size(16#1f0000 + 456, 16#200000 + 123))
+    ].
+
+compute_inflight_range_test_() ->
+    [
+        ?_assertEqual(
+            {1, 1},
+            compute_inflight_range([])
+        ),
+        ?_assertEqual(
+            {12, 42},
+            compute_inflight_range([
+                #range{first = 1, until = 2, type = checkpoint},
+                #range{first = 4, until = 8, type = checkpoint},
+                #range{first = 11, until = 12, type = checkpoint},
+                #range{first = 12, until = 13, type = inflight},
+                #range{first = 13, until = 20, type = inflight},
+                #range{first = 20, until = 42, type = inflight}
+            ])
+        ),
+        ?_assertEqual(
+            {13, 13},
+            compute_inflight_range([
+                #range{first = 1, until = 2, type = checkpoint},
+                #range{first = 4, until = 8, type = checkpoint},
+                #range{first = 11, until = 12, type = checkpoint},
+                #range{first = 12, until = 13, type = checkpoint}
+            ])
+        )
+    ].
 
 -endif.

--- a/apps/emqx/src/emqx_persistent_message_ds_replayer.erl
+++ b/apps/emqx/src/emqx_persistent_message_ds_replayer.erl
@@ -266,8 +266,9 @@ replay_range(
             _ ->
                 lists:nthtail(range_size(First, FirstUnacked), Messages)
         end,
+    MessagesReplay = [emqx_message:set_flag(dup, true, Msg) || Msg <- MessagesUnacked],
     %% Asserting that range is consistent with the message storage state.
-    {Replies, Until} = publish(FirstUnacked, MessagesUnacked),
+    {Replies, Until} = publish(FirstUnacked, MessagesReplay),
     %% Again, we need to keep the iterator pointing past the end of the
     %% range, so that we can pick up where we left off.
     Range = Range0#ds_pubrange{iterator = ItNext},

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -43,12 +43,25 @@
 
 -record(ds_pubrange, {
     id :: {
+        %% What session this range belongs to.
         _Session :: emqx_persistent_session_ds:id(),
+        %% Where this range starts.
         _First :: emqx_persistent_message_ds_replayer:seqno()
     },
+    %% Where this range ends: the first seqno that is not included in the range.
     until :: emqx_persistent_message_ds_replayer:seqno(),
+    %% Which stream this range is over.
     stream :: _StreamRef,
+    %% Type of a range:
+    %% * Inflight range is a range of yet unacked messages from this stream.
+    %% * Checkpoint range was already acked, its purpose is to keep track of the
+    %%   very last iterator for this stream.
     type :: inflight | checkpoint,
+    %% Meaning of this depends on the type of the range:
+    %% * For inflight range, this is the iterator pointing to the first message in
+    %%   the range.
+    %% * For checkpoint range, this is the iterator pointing right past the last
+    %%   message in the range.
     iterator :: emqx_ds:iterator()
 }).
 -type ds_pubrange() :: #ds_pubrange{}.

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -21,7 +21,7 @@
 -define(SESSION_TAB, emqx_ds_session).
 -define(SESSION_SUBSCRIPTIONS_TAB, emqx_ds_session_subscriptions).
 -define(SESSION_STREAM_TAB, emqx_ds_stream_tab).
--define(SESSION_ITER_TAB, emqx_ds_iter_tab).
+-define(SESSION_PUBRANGE_TAB, emqx_ds_pubrange_tab).
 -define(DS_MRIA_SHARD, emqx_ds_session_shard).
 
 -record(ds_sub, {
@@ -34,17 +34,24 @@
 
 -record(ds_stream, {
     session :: emqx_persistent_session_ds:id(),
-    topic_filter :: emqx_ds:topic_filter(),
+    ref :: _StreamRef,
     stream :: emqx_ds:stream(),
-    rank :: emqx_ds:stream_rank()
+    rank :: emqx_ds:stream_rank(),
+    beginning :: emqx_ds:iterator()
 }).
 -type ds_stream() :: #ds_stream{}.
--type ds_stream_bin() :: binary().
 
--record(ds_iter, {
-    id :: {emqx_persistent_session_ds:id(), ds_stream_bin()},
-    iter :: emqx_ds:iterator()
+-record(ds_pubrange, {
+    id :: {
+        _Session :: emqx_persistent_session_ds:id(),
+        _First :: emqx_persistent_message_ds_replayer:seqno()
+    },
+    until :: emqx_persistent_message_ds_replayer:seqno(),
+    stream :: _StreamRef,
+    type :: inflight | checkpoint,
+    iterator :: emqx_ds:iterator()
 }).
+-type ds_pubrange() :: #ds_pubrange{}.
 
 -record(session, {
     %% same as clientid
@@ -52,7 +59,7 @@
     %% creation time
     created_at :: _Millisecond :: non_neg_integer(),
     expires_at = never :: _Millisecond :: non_neg_integer() | never,
-    inflight :: emqx_persistent_message_ds_replayer:inflight(),
+    % last_ack = 0 :: emqx_persistent_message_ds_replayer:seqno(),
     %% for future usage
     props = #{} :: map()
 }).

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -62,7 +62,9 @@
     %%   the range.
     %% * For checkpoint range, this is the iterator pointing right past the last
     %%   message in the range.
-    iterator :: emqx_ds:iterator()
+    iterator :: emqx_ds:iterator(),
+    %% Reserved for future use.
+    misc = #{} :: map()
 }).
 -type ds_pubrange() :: #ds_pubrange{}.
 
@@ -72,7 +74,6 @@
     %% creation time
     created_at :: _Millisecond :: non_neg_integer(),
     expires_at = never :: _Millisecond :: non_neg_integer() | never,
-    % last_ack = 0 :: emqx_persistent_message_ds_replayer:seqno(),
     %% for future usage
     props = #{} :: map()
 }).

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -181,18 +181,23 @@ client_info(Key, Client) ->
     maps:get(Key, maps:from_list(emqtt:info(Client)), undefined).
 
 receive_messages(Count) ->
-    receive_messages(Count, []).
+    receive_messages(Count, 15000).
 
-receive_messages(0, Msgs) ->
-    Msgs;
-receive_messages(Count, Msgs) ->
+receive_messages(Count, Timeout) ->
+    Deadline = erlang:monotonic_time(millisecond) + Timeout,
+    receive_message_loop(Count, Deadline).
+
+receive_message_loop(0, _Deadline) ->
+    [];
+receive_message_loop(Count, Deadline) ->
+    Timeout = max(0, Deadline - erlang:monotonic_time(millisecond)),
     receive
         {publish, Msg} ->
-            receive_messages(Count - 1, [Msg | Msgs]);
+            [Msg | receive_message_loop(Count - 1, Deadline)];
         _Other ->
-            receive_messages(Count, Msgs)
-    after 15000 ->
-        Msgs
+            receive_message_loop(Count, Deadline)
+    after Timeout ->
+        []
     end.
 
 maybe_kill_connection_process(ClientId, Config) ->
@@ -229,16 +234,28 @@ wait_for_cm_unregister(ClientId, N) ->
             wait_for_cm_unregister(ClientId, N - 1)
     end.
 
-publish(Topic, Payloads) ->
-    publish(Topic, Payloads, false, 2).
+messages(Topic, Payloads) ->
+    messages(Topic, Payloads, ?QOS_2).
 
-publish(Topic, Payloads, WaitForUnregister, QoS) ->
-    Fun = fun(Client, Payload) ->
-        {ok, _} = emqtt:publish(Client, Topic, Payload, QoS)
+messages(Topic, Payloads, QoS) ->
+    [#mqtt_msg{topic = Topic, payload = P, qos = QoS} || P <- Payloads].
+
+publish(Topic, Payload) ->
+    publish(Topic, Payload, ?QOS_2).
+
+publish(Topic, Payload, QoS) ->
+    publish_many(messages(Topic, [Payload], QoS)).
+
+publish_many(Messages) ->
+    publish_many(Messages, false).
+
+publish_many(Messages, WaitForUnregister) ->
+    Fun = fun(Client, Message) ->
+        {ok, _} = emqtt:publish(Client, Message)
     end,
-    do_publish(Payloads, Fun, WaitForUnregister).
+    do_publish(Messages, Fun, WaitForUnregister).
 
-do_publish(Payloads = [_ | _], PublishFun, WaitForUnregister) ->
+do_publish(Messages = [_ | _], PublishFun, WaitForUnregister) ->
     %% Publish from another process to avoid connection confusion.
     {Pid, Ref} =
         spawn_monitor(
@@ -252,7 +269,7 @@ do_publish(Payloads = [_ | _], PublishFun, WaitForUnregister) ->
                     {port, 1883}
                 ]),
                 {ok, _} = emqtt:connect(Client),
-                lists:foreach(fun(Payload) -> PublishFun(Client, Payload) end, Payloads),
+                lists:foreach(fun(Message) -> PublishFun(Client, Message) end, Messages),
                 ok = emqtt:disconnect(Client),
                 %% Snabbkaffe sometimes fails unless all processes are gone.
                 case WaitForUnregister of
@@ -277,9 +294,7 @@ do_publish(Payloads = [_ | _], PublishFun, WaitForUnregister) ->
     receive
         {'DOWN', Ref, process, Pid, normal} -> ok;
         {'DOWN', Ref, process, Pid, What} -> error({failed_publish, What})
-    end;
-do_publish(Payload, PublishFun, WaitForUnregister) ->
-    do_publish([Payload], PublishFun, WaitForUnregister).
+    end.
 
 %%--------------------------------------------------------------------
 %% Test Cases
@@ -494,7 +509,7 @@ t_process_dies_session_expires(Config) ->
 
     maybe_kill_connection_process(ClientId, Config),
 
-    ok = publish(Topic, [Payload]),
+    ok = publish(Topic, Payload),
 
     timer:sleep(1100),
 
@@ -535,7 +550,7 @@ t_publish_while_client_is_gone_qos1(Config) ->
     ok = emqtt:disconnect(Client1),
     maybe_kill_connection_process(ClientId, Config),
 
-    ok = publish(Topic, [Payload1, Payload2], false, 1),
+    ok = publish_many(messages(Topic, [Payload1, Payload2], ?QOS_1)),
 
     {ok, Client2} = emqtt:start_link([
         {proto_ver, v5},
@@ -547,13 +562,138 @@ t_publish_while_client_is_gone_qos1(Config) ->
     {ok, _} = emqtt:ConnFun(Client2),
     Msgs = receive_messages(2),
     ?assertMatch([_, _], Msgs),
-    [Msg2, Msg1] = Msgs,
+    [Msg1, Msg2] = Msgs,
     ?assertEqual({ok, iolist_to_binary(Payload1)}, maps:find(payload, Msg1)),
     ?assertEqual({ok, 1}, maps:find(qos, Msg1)),
     ?assertEqual({ok, iolist_to_binary(Payload2)}, maps:find(payload, Msg2)),
     ?assertEqual({ok, 1}, maps:find(qos, Msg2)),
 
     ok = emqtt:disconnect(Client2).
+
+t_publish_many_while_client_is_gone_qos1(Config) ->
+    %% A persistent session should receive all of the still unacked messages
+    %% for its subscriptions after the client dies or reconnects, in addition
+    %% to new messages that were published while the client was gone. The order
+    %% of the messages should be consistent across reconnects.
+    ClientId = ?config(client_id, Config),
+    ConnFun = ?config(conn_fun, Config),
+    {ok, Client1} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {properties, #{'Session-Expiry-Interval' => 30}},
+        {clean_start, true},
+        {auto_ack, false}
+        | Config
+    ]),
+    {ok, _} = emqtt:ConnFun(Client1),
+
+    STopics = [
+        <<"t/+/foo">>,
+        <<"msg/feed/#">>,
+        <<"loc/+/+/+">>
+    ],
+    [{ok, _, [?QOS_1]} = emqtt:subscribe(Client1, ST, ?QOS_1) || ST <- STopics],
+
+    Pubs1 = [
+        #mqtt_msg{topic = <<"t/42/foo">>, payload = <<"M1">>, qos = 1},
+        #mqtt_msg{topic = <<"t/42/foo">>, payload = <<"M2">>, qos = 1},
+        #mqtt_msg{topic = <<"msg/feed/me">>, payload = <<"M3">>, qos = 1},
+        #mqtt_msg{topic = <<"loc/1/2/42">>, payload = <<"M4">>, qos = 1},
+        #mqtt_msg{topic = <<"t/42/foo">>, payload = <<"M5">>, qos = 1},
+        #mqtt_msg{topic = <<"loc/3/4/5">>, payload = <<"M6">>, qos = 1},
+        #mqtt_msg{topic = <<"msg/feed/me">>, payload = <<"M7">>, qos = 1}
+    ],
+    ok = publish_many(Pubs1),
+    NPubs1 = length(Pubs1),
+
+    Msgs1 = receive_messages(NPubs1),
+    NMsgs1 = length(Msgs1),
+    ?assertEqual(NPubs1, NMsgs1),
+
+    ct:pal("Msgs1 = ~p", [Msgs1]),
+
+    %% TODO
+    %% This assertion doesn't currently hold because `emqx_ds` doesn't enforce
+    %% strict ordering reflecting client publishing order. Instead, per-topic
+    %% ordering is guaranteed per each client. In fact, this violates the MQTT
+    %% specification, but we deemed it acceptable for now.
+    %% ?assertMatch([
+    %%     #{payload := <<"M1">>},
+    %%     #{payload := <<"M2">>},
+    %%     #{payload := <<"M3">>},
+    %%     #{payload := <<"M4">>},
+    %%     #{payload := <<"M5">>},
+    %%     #{payload := <<"M6">>},
+    %%     #{payload := <<"M7">>}
+    %% ], Msgs1),
+
+    ?assertEqual(
+        get_topicwise_order(Pubs1),
+        get_topicwise_order(Msgs1),
+        Msgs1
+    ),
+
+    NAcked = 4,
+    [ok = emqtt:puback(Client1, PktId) || #{packet_id := PktId} <- lists:sublist(Msgs1, NAcked)],
+
+    %% Ensure that PUBACKs are propagated to the channel.
+    pong = emqtt:ping(Client1),
+
+    ok = emqtt:disconnect(Client1),
+    maybe_kill_connection_process(ClientId, Config),
+
+    Pubs2 = [
+        #mqtt_msg{topic = <<"loc/3/4/5">>, payload = <<"M8">>, qos = 1},
+        #mqtt_msg{topic = <<"t/100/foo">>, payload = <<"M9">>, qos = 1},
+        #mqtt_msg{topic = <<"t/100/foo">>, payload = <<"M10">>, qos = 1},
+        #mqtt_msg{topic = <<"msg/feed/friend">>, payload = <<"M11">>, qos = 1},
+        #mqtt_msg{topic = <<"msg/feed/me">>, payload = <<"M12">>, qos = 1}
+    ],
+    ok = publish_many(Pubs2),
+    NPubs2 = length(Pubs2),
+
+    {ok, Client2} = emqtt:start_link([
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {properties, #{'Session-Expiry-Interval' => 30}},
+        {clean_start, false},
+        {auto_ack, false}
+        | Config
+    ]),
+    {ok, _} = emqtt:ConnFun(Client2),
+
+    %% Try to receive _at most_ `NPubs` messages.
+    %% There shouldn't be that much unacked messages in the replay anyway,
+    %% but it's an easy number to pick.
+    NPubs = NPubs1 + NPubs2,
+    Msgs2 = receive_messages(NPubs, _Timeout = 2000),
+    NMsgs2 = length(Msgs2),
+
+    ct:pal("Msgs2 = ~p", [Msgs2]),
+
+    ?assert(NMsgs2 < NPubs, Msgs2),
+    ?assert(NMsgs2 > NPubs2, Msgs2),
+    ?assert(NMsgs2 >= NPubs - NAcked, Msgs2),
+    NSame = NMsgs2 - NPubs2,
+    ?assertEqual(
+        [maps:with([packet_id, topic, payload], M) || M <- lists:nthtail(NMsgs1 - NSame, Msgs1)],
+        [maps:with([packet_id, topic, payload], M) || M <- lists:sublist(Msgs2, NSame)]
+    ),
+
+    ok = emqtt:disconnect(Client2).
+
+get_topicwise_order(Msgs) ->
+    maps:groups_from_list(fun get_msgpub_topic/1, fun get_msgpub_payload/1, Msgs).
+
+get_msgpub_topic(#mqtt_msg{topic = Topic}) ->
+    Topic;
+get_msgpub_topic(#{topic := Topic}) ->
+    Topic.
+
+get_msgpub_payload(#mqtt_msg{payload = Payload}) ->
+    Payload;
+get_msgpub_payload(#{payload := Payload}) ->
+    Payload.
 
 t_publish_while_client_is_gone(init, Config) -> skip_ds_tc(Config);
 t_publish_while_client_is_gone('end', _Config) -> ok.
@@ -579,7 +719,7 @@ t_publish_while_client_is_gone(Config) ->
     ok = emqtt:disconnect(Client1),
     maybe_kill_connection_process(ClientId, Config),
 
-    ok = publish(Topic, [Payload1, Payload2]),
+    ok = publish_many(messages(Topic, [Payload1, Payload2])),
 
     {ok, Client2} = emqtt:start_link([
         {proto_ver, v5},
@@ -591,7 +731,7 @@ t_publish_while_client_is_gone(Config) ->
     {ok, _} = emqtt:ConnFun(Client2),
     Msgs = receive_messages(2),
     ?assertMatch([_, _], Msgs),
-    [Msg2, Msg1] = Msgs,
+    [Msg1, Msg2] = Msgs,
     ?assertEqual({ok, iolist_to_binary(Payload1)}, maps:find(payload, Msg1)),
     ?assertEqual({ok, 2}, maps:find(qos, Msg1)),
     ?assertEqual({ok, iolist_to_binary(Payload2)}, maps:find(payload, Msg2)),

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -675,6 +675,12 @@ t_publish_many_while_client_is_gone_qos1(Config) ->
     ?assert(NMsgs2 > NPubs2, Msgs2),
     ?assert(NMsgs2 >= NPubs - NAcked, Msgs2),
     NSame = NMsgs2 - NPubs2,
+    ?assert(
+        lists:all(fun(#{dup := Dup}) -> Dup end, lists:sublist(Msgs2, NSame))
+    ),
+    ?assertNot(
+        lists:all(fun(#{dup := Dup}) -> Dup end, lists:nthtail(NSame, Msgs2))
+    ),
     ?assertEqual(
         [maps:with([packet_id, topic, payload], M) || M <- lists:nthtail(NMsgs1 - NSame, Msgs1)],
         [maps:with([packet_id, topic, payload], M) || M <- lists:sublist(Msgs2, NSame)]


### PR DESCRIPTION
Fixes [EMQX-9745](https://emqx.atlassian.net/browse/EMQX-9745).

## Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at f30b04f</samp>

This pull request enhances the persistent message and session features of emqx, by introducing a new API and data structure for replaying inflight messages, refactoring the session data structure and functions to use topic filters and subscriptions, and improving the performance and correctness of offset and range management. It also cleans up some unused or obsolete code in `emqx_persistent_session_ds.hrl`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
