### PR TITLE
ci(router): fix flaky testcase

### DIFF
--- a/apps/emqx/test/emqx_routing_SUITE.erl
+++ b/apps/emqx/test/emqx_routing_SUITE.erl
@@ -100,7 +100,7 @@ mk_config_listeners(N) ->
 
 t_cluster_routing(Config) ->
     Cluster = ?config(cluster, Config),
-    Clients = [C1, C2, C3] = [start_client(N) || N <- Cluster],
+    Clients = [C1, C2, C3] = lists:sort([start_client(N) || N <- Cluster]),
     Commands = [
         {fun publish/3, [C1, <<"a/b/c">>, <<"wontsee">>]},
         {fun publish/3, [C2, <<"a/b/d">>, <<"wontsee">>]},


### PR DESCRIPTION
## Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 656d575</samp>

Sort `Clients` list in `emqx_routing_SUITE.erl` to avoid flaky tests. This change improves the test suite stability by ensuring a consistent node order.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
