### PR TITLE
feat(license): unset to default evaluation license via api or cli

### DIFF
--- a/apps/emqx_license/src/emqx_license.erl
+++ b/apps/emqx_license/src/emqx_license.erl
@@ -22,6 +22,7 @@
     unload/0,
     read_license/0,
     read_license/1,
+    unset/0,
     update_key/1,
     update_setting/1
 ]).
@@ -54,6 +55,9 @@ unload() ->
     del_license_hook(),
     emqx_conf:remove_handler(?CONF_KEY_PATH),
     emqx_license_cli:unload().
+
+unset() ->
+    update_key(emqx_license_schema:default_license()).
 
 -spec update_key(binary() | string()) ->
     {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -4,9 +4,15 @@
 
 -module(emqx_license_cli).
 
--include("emqx_license.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--export([load/0, license/1, unload/0, print_warnings/1]).
+-export([
+    load/0,
+    license/1,
+    unload/0,
+    print_warnings/1
+]).
 
 -define(PRINT_MSG(Msg), io:format(Msg)).
 
@@ -20,13 +26,9 @@ load() ->
     ok = emqx_ctl:register_command(license, {?MODULE, license}, []).
 
 license(["update", EncodedLicense]) ->
-    case emqx_license:update_key(EncodedLicense) of
-        {ok, Warnings} ->
-            ok = print_warnings(Warnings),
-            ok = ?PRINT_MSG("ok~n");
-        {error, Reason} ->
-            ?PRINT("Error: ~p~n", [Reason])
-    end;
+    do_update_license_key(fun() ->
+        emqx_license:update_key(EncodedLicense)
+    end);
 license(["info"]) ->
     lists:foreach(
         fun
@@ -37,13 +39,29 @@ license(["info"]) ->
         end,
         emqx_license_checker:dump()
     );
+license(["unset"]) ->
+    do_update_license_key(fun() ->
+        ?tp(unset_to_default_evaluation_license_key, #{operation_method => "cli"}),
+        ?SLOG(info, #{msg => "unset_to_default_evaluation_license_key", operation_method => "cli"}),
+        emqx_license:unset()
+    end);
 license(_) ->
     emqx_ctl:usage(
         [
             {"license info", "Show license info"},
+            {"license unset", "Unset license to default evaluation license"},
             {"license update <License>", "Update license given as a string"}
         ]
     ).
+
+do_update_license_key(Fun) when is_function(Fun, 0) ->
+    case Fun() of
+        {ok, Warnings} ->
+            ok = print_warnings(Warnings),
+            ok = ?PRINT_MSG("ok~n");
+        {error, Reason} ->
+            ?PRINT("Error: ~p~n", [Reason])
+    end.
 
 unload() ->
     ok = emqx_ctl:unregister_command(license).

--- a/apps/emqx_license/src/emqx_license_parser.erl
+++ b/apps/emqx_license/src/emqx_license_parser.erl
@@ -9,15 +9,13 @@
 -include_lib("emqx/include/logger.hrl").
 -include("emqx_license.hrl").
 
--define(PUBKEY, <<
-    ""
-    "\n"
-    "-----BEGIN PUBLIC KEY-----\n"
-    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbtkdos3TZmSv+D7+X5pc0yfcjum2\n"
-    "Q1DK6PCWkiQihjvjJjKFzdYzcWOgC6f4Ou3mgGAUSjdQYYnFKZ/9f5ax4g==\n"
-    "-----END PUBLIC KEY-----\n"
-    ""
->>).
+%% erlfmt-ignore
+-define(PUBKEY, <<"
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbtkdos3TZmSv+D7+X5pc0yfcjum2
+Q1DK6PCWkiQihjvjJjKFzdYzcWOgC6f4Ou3mgGAUSjdQYYnFKZ/9f5ax4g==
+-----END PUBLIC KEY-----
+">>).
 
 -define(LICENSE_PARSE_MODULES, [
     emqx_license_parser_v20220101

--- a/apps/emqx_license/src/emqx_license_schema.erl
+++ b/apps/emqx_license/src/emqx_license_schema.erl
@@ -40,6 +40,7 @@ fields(key_license) ->
         {key, #{
             type => binary(),
             default => default_license(),
+            converter => fun converter_license/2,
             %% so it's not logged
             sensitive => true,
             required => true,
@@ -80,14 +81,18 @@ check_license_watermark(Conf) ->
     end.
 
 %% @doc The default license key.
-%% This default license has 1000 connections limit.
+%% This default license has 100 connections limit.
 %% It is issued on 2023-01-09 and valid for 5 years (1825 days)
 %% NOTE: when updating a new key, the schema doc in emqx_license_schema.hocon
 %% should be updated accordingly
+%% erlfmt-ignore
 default_license() ->
-    <<
-        "MjIwMTExCjAKMTAKRXZhbHVhdGlvbgpjb250YWN0QGVtcXguaW8KZ"
-        "GVmYXVsdAoyMDIzMDEwOQoxODI1CjEwMAo=.MEUCIG62t8W15g05f"
-        "1cKx3tA3YgJoR0dmyHOPCdbUxBGxgKKAiEAhHKh8dUwhU+OxNEaOn"
-        "8mgRDtiT3R8RZooqy6dEsOmDI="
-    >>.
+    <<"
+MjIwMTExCjAKMTAKRXZhbHVhdGlvbgpjb250YWN0QGVtcXguaW8KZ
+GVmYXVsdAoyMDIzMDEwOQoxODI1CjEwMAo=.MEUCIG62t8W15g05f
+1cKx3tA3YgJoR0dmyHOPCdbUxBGxgKKAiEAhHKh8dUwhU+OxNEaOn
+8mgRDtiT3R8RZooqy6dEsOmDI=
+">>.
+
+converter_license(License, _Conf) ->
+    iolist_to_binary(string:replace(License, "\n", "", all)).

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -21,27 +22,68 @@ init_per_suite(Config) ->
 
 end_per_suite(_) ->
     emqx_common_test_helpers:stop_apps([emqx_license]),
-    ok.
-
-init_per_testcase(_Case, Config) ->
-    ok = persistent_term:put(
-        emqx_license_test_pubkey,
-        emqx_license_test_lib:public_key_pem()
-    ),
-    {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
-    Config.
-
-end_per_testcase(_Case, _Config) ->
     persistent_term:erase(emqx_license_test_pubkey),
     ok.
 
 set_special_configs(emqx_license) ->
-    Config = #{key => emqx_license_test_lib:default_license()},
+    LicenseKey = default_license(),
+    Config = #{
+        key => LicenseKey, connection_low_watermark => 0.75, connection_high_watermark => 0.8
+    },
     emqx_config:put([license], Config),
-    RawConfig = #{<<"key">> => emqx_license_test_lib:default_license()},
-    emqx_config:put_raw([<<"license">>], RawConfig);
+
+    RawConfig = #{
+        <<"key">> => LicenseKey,
+        <<"connection_low_watermark">> => <<"75%">>,
+        <<"connection_high_watermark">> => <<"80%">>
+    },
+    emqx_config:put_raw([<<"license">>], RawConfig),
+
+    ok = persistent_term:put(
+        emqx_license_test_pubkey,
+        emqx_license_test_lib:public_key_pem()
+    );
 set_special_configs(_) ->
     ok.
+
+init_per_testcase(t_unset, Config) ->
+    {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
+    MeckLicenseValues = #{
+        license_format => "220111",
+        license_type => "0",
+        customer_type => "10",
+        name => "Default Meck License",
+        email => "contact@meck.com",
+        deployment => "meck-deployment",
+        start_date => "20220111",
+        days => "100000",
+        max_connections => "100"
+    },
+    DefaultMeckLicenseKey = emqx_license_test_lib:make_license(MeckLicenseValues),
+    ok = meck:new(emqx_license_schema, [passthrough, no_history]),
+    ok = meck:expect(emqx_license_schema, default_license, fun() -> DefaultMeckLicenseKey end),
+    [{default_license_key, DefaultMeckLicenseKey} | Config];
+init_per_testcase(_Case, Config) ->
+    {ok, _} = emqx_cluster_rpc:start_link(node(), emqx_cluster_rpc, 1000),
+    Config.
+
+end_per_testcase(t_unset, _Config) ->
+    ok = meck:unload(emqx_license_schema),
+    {ok, _} = reset_license(),
+    ok;
+end_per_testcase(_Case, _Config) ->
+    {ok, _} = reset_license(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+default_license() ->
+    emqx_license_test_lib:make_license(#{max_connections => "100"}).
+
+reset_license() ->
+    emqx_license:update_key(default_license()).
 
 %%------------------------------------------------------------------------------
 %% Tests
@@ -58,6 +100,23 @@ t_update(_Config) ->
     _ = emqx_license_cli:license(["update", LicenseValue]),
     _ = emqx_license_cli:license(["reload"]),
     _ = emqx_license_cli:license(["update", "Invalid License Value"]).
+
+t_unset(Config) ->
+    ?check_trace(
+        begin
+            _ = emqx_license_cli:license(["unset"]),
+            License = maps:get(key, emqx:get_config([license])),
+            Default = ?config(default_license_key, Config),
+            ?assertEqual(License, Default)
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [#{operation_method := "cli"}],
+                ?of_kind(unset_to_default_evaluation_license_key, Trace)
+            )
+        end
+    ),
+    ok.
 
 t_conf_update(_Config) ->
     LicenseKey = emqx_license_test_lib:make_license(#{max_connections => "123"}),

--- a/changes/feat-11962.en.md
+++ b/changes/feat-11962.en.md
@@ -1,0 +1,1 @@
+Added an endpoint `/license/unset`, which can be unset license to the default trial license.

--- a/rel/i18n/emqx_license_http_api.hocon
+++ b/rel/i18n/emqx_license_http_api.hocon
@@ -12,6 +12,12 @@ desc_license_key_api.desc:
 desc_license_key_api.label:
 """Update license"""
 
+desc_license_unset_api.label:
+"""Unset license"""
+
+desc_license_unset_api.desc:
+"""Unset license to default evaluate license key"""
+
 desc_license_setting_api.desc:
 """Update license setting"""
 


### PR DESCRIPTION
Fixes [EMQX-11397](https://emqx.atlassian.net/browse/EMQX-11397)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 8bdef49</samp>

This pull request adds a feature to unset the license key and use the evaluation license in `emqx_license`. It also improves the license key update logic and adds tracing and testing support in `emqx_license_cli` and `emqx_license_http_api`. Additionally, it makes the default license key more readable in `emqx_license_schema`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
