### PR TITLE
feat(gcp_pubsub_producer): migrate GCP PubSub producer to actions

### DIFF
--- a/apps/emqx_bridge/src/emqx_action_info.erl
+++ b/apps/emqx_bridge/src/emqx_action_info.erl
@@ -75,6 +75,7 @@ hard_coded_action_info_modules_ee() ->
     [
         emqx_bridge_azure_event_hub_action_info,
         emqx_bridge_confluent_producer_action_info,
+        emqx_bridge_gcp_pubsub_producer_action_info,
         emqx_bridge_kafka_action_info,
         emqx_bridge_syskeeper_action_info
     ].

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -17,7 +17,7 @@
     desc/1
 ]).
 
-%% emqx_bridge_enterprise "unofficial" API
+%% `emqx_bridge_v2_schema' "unofficial" API
 -export([
     bridge_v2_examples/1,
     conn_bridge_examples/1,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -134,7 +134,7 @@ start(
 
 -spec stop(resource_id()) -> ok | {error, term()}.
 stop(ResourceId) ->
-    ?tp(gcp_pubsub_stop, #{resource_id => ResourceId}),
+    ?tp(gcp_pubsub_stop, #{instance_id => ResourceId, resource_id => ResourceId}),
     ?SLOG(info, #{
         msg => "stopping_gcp_pubsub_bridge",
         connector => ResourceId

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -8,23 +8,30 @@
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--type config() :: #{
-    attributes_template := [#{key := binary(), value := binary()}],
+-type connector_config() :: #{
     connect_timeout := emqx_schema:duration_ms(),
     max_retries := non_neg_integer(),
-    ordering_key_template := binary(),
-    payload_template := binary(),
-    pubsub_topic := binary(),
     resource_opts := #{request_ttl := infinity | emqx_schema:duration_ms(), any() => term()},
-    service_account_json := emqx_bridge_gcp_pubsub_client:service_account_json(),
-    any() => term()
+    service_account_json := emqx_bridge_gcp_pubsub_client:service_account_json()
 }.
--type state() :: #{
-    attributes_template := #{emqx_placeholder:tmpl_token() => emqx_placeholder:tmpl_token()},
+-type action_config() :: #{
+    parameters := #{
+        attributes_template := [#{key := binary(), value := binary()}],
+        ordering_key_template := binary(),
+        payload_template := binary(),
+        pubsub_topic := binary()
+    },
+    resource_opts := #{request_ttl := infinity | emqx_schema:duration_ms(), any() => term()}
+}.
+-type connector_state() :: #{
     client := emqx_bridge_gcp_pubsub_client:state(),
+    installed_actions := #{action_resource_id() => action_state()},
+    project_id := emqx_bridge_gcp_pubsub_client:project_id()
+}.
+-type action_state() :: #{
+    attributes_template := #{emqx_placeholder:tmpl_token() => emqx_placeholder:tmpl_token()},
     ordering_key_template := emqx_placeholder:tmpl_token(),
     payload_template := emqx_placeholder:tmpl_token(),
-    project_id := emqx_bridge_gcp_pubsub_client:project_id(),
     pubsub_topic := binary()
 }.
 -type headers() :: emqx_bridge_gcp_pubsub_client:headers().
@@ -41,7 +48,11 @@
     on_query_async/4,
     on_batch_query/3,
     on_batch_query_async/4,
-    on_get_status/2
+    on_get_status/2,
+    on_add_channel/4,
+    on_remove_channel/3,
+    on_get_channels/1,
+    on_get_channel_status/3
 ]).
 
 -export([reply_delegator/2]).
@@ -54,53 +65,45 @@ callback_mode() -> async_if_possible.
 
 query_mode(_Config) -> async.
 
--spec on_start(resource_id(), config()) -> {ok, state()} | {error, term()}.
+-spec on_start(connector_resource_id(), connector_config()) ->
+    {ok, connector_state()} | {error, term()}.
 on_start(InstanceId, Config0) ->
     ?SLOG(info, #{
         msg => "starting_gcp_pubsub_bridge",
         config => Config0
     }),
     Config = maps:update_with(service_account_json, fun emqx_utils_maps:binary_key_map/1, Config0),
-    #{
-        attributes_template := AttributesTemplate,
-        ordering_key_template := OrderingKeyTemplate,
-        payload_template := PayloadTemplate,
-        pubsub_topic := PubSubTopic,
-        service_account_json := #{<<"project_id">> := ProjectId}
-    } = Config,
+    #{service_account_json := #{<<"project_id">> := ProjectId}} = Config,
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of
         {ok, Client} ->
             State = #{
                 client => Client,
-                attributes_template => preproc_attributes(AttributesTemplate),
-                ordering_key_template => emqx_placeholder:preproc_tmpl(OrderingKeyTemplate),
-                payload_template => emqx_placeholder:preproc_tmpl(PayloadTemplate),
-                project_id => ProjectId,
-                pubsub_topic => PubSubTopic
+                installed_actions => #{},
+                project_id => ProjectId
             },
             {ok, State};
         Error ->
             Error
     end.
 
--spec on_stop(resource_id(), state()) -> ok | {error, term()}.
+-spec on_stop(connector_resource_id(), connector_state()) -> ok | {error, term()}.
 on_stop(InstanceId, _State) ->
     emqx_bridge_gcp_pubsub_client:stop(InstanceId).
 
--spec on_get_status(resource_id(), state()) -> connected | disconnected.
+-spec on_get_status(connector_resource_id(), connector_state()) -> connected | disconnected.
 on_get_status(_InstanceId, #{client := Client} = _State) ->
     emqx_bridge_gcp_pubsub_client:get_status(Client).
 
 -spec on_query(
-    resource_id(),
-    {send_message, map()},
-    state()
+    connector_resource_id(),
+    {message_tag(), map()},
+    connector_state()
 ) ->
     {ok, map()}
     | {error, {recoverable_error, term()}}
     | {error, term()}.
-on_query(ResourceId, {send_message, Selected}, State) ->
-    Requests = [{send_message, Selected}],
+on_query(ResourceId, {MessageTag, Selected}, State) ->
+    Requests = [{MessageTag, Selected}],
     ?TRACE(
         "QUERY_SYNC",
         "gcp_pubsub_received",
@@ -109,24 +112,25 @@ on_query(ResourceId, {send_message, Selected}, State) ->
     do_send_requests_sync(State, Requests, ResourceId).
 
 -spec on_query_async(
-    resource_id(),
-    {send_message, map()},
+    connector_resource_id(),
+    {message_tag(), map()},
     {ReplyFun :: function(), Args :: list()},
-    state()
+    connector_state()
 ) -> {ok, pid()} | {error, no_pool_worker_available}.
-on_query_async(ResourceId, {send_message, Selected}, ReplyFunAndArgs, State) ->
-    Requests = [{send_message, Selected}],
+on_query_async(ResourceId, {MessageTag, Selected}, ReplyFunAndArgs, State) ->
+    Requests = [{MessageTag, Selected}],
     ?TRACE(
         "QUERY_ASYNC",
         "gcp_pubsub_received",
         #{requests => Requests, connector => ResourceId, state => State}
     ),
+    ?tp(gcp_pubsub_producer_async, #{instance_id => ResourceId, requests => Requests}),
     do_send_requests_async(State, Requests, ReplyFunAndArgs).
 
 -spec on_batch_query(
-    resource_id(),
-    [{send_message, map()}],
-    state()
+    connector_resource_id(),
+    [{message_tag(), map()}],
+    connector_state()
 ) ->
     {ok, map()}
     | {error, {recoverable_error, term()}}
@@ -140,10 +144,10 @@ on_batch_query(ResourceId, Requests, State) ->
     do_send_requests_sync(State, Requests, ResourceId).
 
 -spec on_batch_query_async(
-    resource_id(),
-    [{send_message, map()}],
+    connector_resource_id(),
+    [{message_tag(), map()}],
     {ReplyFun :: function(), Args :: list()},
-    state()
+    connector_state()
 ) -> {ok, pid()} | {error, no_pool_worker_available}.
 on_batch_query_async(ResourceId, Requests, ReplyFunAndArgs, State) ->
     ?TRACE(
@@ -151,32 +155,92 @@ on_batch_query_async(ResourceId, Requests, ReplyFunAndArgs, State) ->
         "gcp_pubsub_received",
         #{requests => Requests, connector => ResourceId, state => State}
     ),
+    ?tp(gcp_pubsub_producer_async, #{instance_id => ResourceId, requests => Requests}),
     do_send_requests_async(State, Requests, ReplyFunAndArgs).
+
+-spec on_add_channel(
+    connector_resource_id(),
+    connector_state(),
+    action_resource_id(),
+    action_config()
+) ->
+    {ok, connector_state()}.
+on_add_channel(_ConnectorResId, ConnectorState0, ActionId, ActionConfig) ->
+    #{installed_actions := InstalledActions0} = ConnectorState0,
+    ChannelState = install_channel(ActionConfig),
+    InstalledActions = InstalledActions0#{ActionId => ChannelState},
+    ConnectorState = ConnectorState0#{installed_actions := InstalledActions},
+    {ok, ConnectorState}.
+
+-spec on_remove_channel(
+    connector_resource_id(),
+    connector_state(),
+    action_resource_id()
+) ->
+    {ok, connector_state()}.
+on_remove_channel(_ConnectorResId, ConnectorState0, ActionId) ->
+    #{installed_actions := InstalledActions0} = ConnectorState0,
+    InstalledActions = maps:remove(ActionId, InstalledActions0),
+    ConnectorState = ConnectorState0#{installed_actions := InstalledActions},
+    {ok, ConnectorState}.
+
+-spec on_get_channels(connector_resource_id()) ->
+    [{action_resource_id(), action_config()}].
+on_get_channels(ConnectorResId) ->
+    emqx_bridge_v2:get_channels_for_connector(ConnectorResId).
+
+-spec on_get_channel_status(connector_resource_id(), action_resource_id(), connector_state()) ->
+    health_check_status().
+on_get_channel_status(_ConnectorResId, _ChannelId, _ConnectorState) ->
+    %% Should we check the underlying client?  Same as on_get_status?
+    ?status_connected.
 
 %%-------------------------------------------------------------------------------------------------
 %% Helper fns
 %%-------------------------------------------------------------------------------------------------
 
+%% TODO: check if topic exists ("unhealthy target")
+install_channel(ActionConfig) ->
+    #{
+        parameters := #{
+            attributes_template := AttributesTemplate,
+            ordering_key_template := OrderingKeyTemplate,
+            payload_template := PayloadTemplate,
+            pubsub_topic := PubSubTopic
+        }
+    } = ActionConfig,
+    #{
+        attributes_template => preproc_attributes(AttributesTemplate),
+        ordering_key_template => emqx_placeholder:preproc_tmpl(OrderingKeyTemplate),
+        payload_template => emqx_placeholder:preproc_tmpl(PayloadTemplate),
+        pubsub_topic => PubSubTopic
+    }.
+
 -spec do_send_requests_sync(
-    state(),
-    [{send_message, map()}],
+    connector_state(),
+    [{message_tag(), map()}],
     resource_id()
 ) ->
     {ok, status_code(), headers()}
     | {ok, status_code(), headers(), body()}
     | {error, {recoverable_error, term()}}
     | {error, term()}.
-do_send_requests_sync(State, Requests, InstanceId) ->
-    #{client := Client} = State,
+do_send_requests_sync(ConnectorState, Requests, InstanceId) ->
+    ?tp(gcp_pubsub_producer_sync, #{instance_id => InstanceId, requests => Requests}),
+    #{client := Client} = ConnectorState,
+    %% is it safe to assume the tag is the same???  And not empty???
+    [{MessageTag, _} | _] = Requests,
+    #{installed_actions := InstalledActions} = ConnectorState,
+    ChannelState = maps:get(MessageTag, InstalledActions),
     Payloads =
         lists:map(
-            fun({send_message, Selected}) ->
-                encode_payload(State, Selected)
+            fun({_MessageTag, Selected}) ->
+                encode_payload(ChannelState, Selected)
             end,
             Requests
         ),
     Body = to_pubsub_request(Payloads),
-    Path = publish_path(State),
+    Path = publish_path(ConnectorState, ChannelState),
     Method = post,
     Request = {prepared_request, {Method, Path, Body}},
     Result = emqx_bridge_gcp_pubsub_client:query_sync(Request, Client),
@@ -184,21 +248,25 @@ do_send_requests_sync(State, Requests, InstanceId) ->
     handle_result(Result, Request, QueryMode, InstanceId).
 
 -spec do_send_requests_async(
-    state(),
-    [{send_message, map()}],
+    connector_state(),
+    [{message_tag(), map()}],
     {ReplyFun :: function(), Args :: list()}
 ) -> {ok, pid()} | {error, no_pool_worker_available}.
-do_send_requests_async(State, Requests, ReplyFunAndArgs0) ->
-    #{client := Client} = State,
+do_send_requests_async(ConnectorState, Requests, ReplyFunAndArgs0) ->
+    #{client := Client} = ConnectorState,
+    %% is it safe to assume the tag is the same???  And not empty???
+    [{MessageTag, _} | _] = Requests,
+    #{installed_actions := InstalledActions} = ConnectorState,
+    ChannelState = maps:get(MessageTag, InstalledActions),
     Payloads =
         lists:map(
-            fun({send_message, Selected}) ->
-                encode_payload(State, Selected)
+            fun({_MessageTag, Selected}) ->
+                encode_payload(ChannelState, Selected)
             end,
             Requests
         ),
     Body = to_pubsub_request(Payloads),
-    Path = publish_path(State),
+    Path = publish_path(ConnectorState, ChannelState),
     Method = post,
     Request = {prepared_request, {Method, Path, Body}},
     ReplyFunAndArgs = {fun ?MODULE:reply_delegator/2, [ReplyFunAndArgs0]},
@@ -206,18 +274,18 @@ do_send_requests_async(State, Requests, ReplyFunAndArgs0) ->
         Request, ReplyFunAndArgs, Client
     ).
 
--spec encode_payload(state(), Selected :: map()) ->
+-spec encode_payload(action_state(), Selected :: map()) ->
     #{
         data := binary(),
         attributes => #{binary() => binary()},
         'orderingKey' => binary()
     }.
-encode_payload(State, Selected) ->
+encode_payload(ActionState, Selected) ->
     #{
         attributes_template := AttributesTemplate,
         ordering_key_template := OrderingKeyTemplate,
         payload_template := PayloadTemplate
-    } = State,
+    } = ActionState,
     Data = render_payload(PayloadTemplate, Selected),
     OrderingKey = render_key(OrderingKeyTemplate, Selected),
     Attributes = proc_attributes(AttributesTemplate, Selected),
@@ -307,13 +375,8 @@ proc_attributes(AttributesTemplate, Selected) ->
 to_pubsub_request(Payloads) ->
     emqx_utils_json:encode(#{messages => Payloads}).
 
--spec publish_path(state()) -> binary().
-publish_path(
-    _State = #{
-        project_id := ProjectId,
-        pubsub_topic := PubSubTopic
-    }
-) ->
+-spec publish_path(connector_state(), action_state()) -> binary().
+publish_path(#{project_id := ProjectId}, #{pubsub_topic := PubSubTopic}) ->
     <<"/v1/projects/", ProjectId/binary, "/topics/", PubSubTopic/binary, ":publish">>.
 
 handle_result({error, Reason}, _Request, QueryMode, ResourceId) when

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_action_info.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_action_info.erl
@@ -1,0 +1,46 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_gcp_pubsub_producer_action_info).
+
+-behaviour(emqx_action_info).
+
+-export([
+    bridge_v1_type_name/0,
+    action_type_name/0,
+    connector_type_name/0,
+    schema_module/0,
+    bridge_v1_config_to_action_config/2
+]).
+
+bridge_v1_type_name() -> gcp_pubsub.
+
+action_type_name() -> gcp_pubsub_producer.
+
+connector_type_name() -> gcp_pubsub_producer.
+
+schema_module() -> emqx_bridge_gcp_pubsub_producer_schema.
+
+bridge_v1_config_to_action_config(BridgeV1Config, ConnectorName) ->
+    CommonActionKeys = emqx_bridge_v2_schema:top_level_common_action_keys(),
+    ParamsKeys = producer_action_parameters_field_keys(),
+    Config1 = maps:with(CommonActionKeys, BridgeV1Config),
+    Params = maps:with(ParamsKeys, BridgeV1Config),
+    Config1#{
+        <<"connector">> => ConnectorName,
+        <<"parameters">> => Params
+    }.
+
+%%------------------------------------------------------------------------------------------
+%% Internal helper fns
+%%------------------------------------------------------------------------------------------
+
+producer_action_parameters_field_keys() ->
+    [
+        to_bin(K)
+     || {K, _} <- emqx_bridge_gcp_pubsub_producer_schema:fields(action_parameters)
+    ].
+
+to_bin(L) when is_list(L) -> list_to_binary(L);
+to_bin(A) when is_atom(A) -> atom_to_binary(A, utf8).

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_schema.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_schema.erl
@@ -1,0 +1,223 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_gcp_pubsub_producer_schema).
+
+-import(hoconsc, [mk/2, ref/2]).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+
+%% `hocon_schema' API
+-export([
+    namespace/0,
+    roots/0,
+    fields/1,
+    desc/1
+]).
+
+%% `emqx_bridge_v2_schema' "unofficial" API
+-export([
+    bridge_v2_examples/1,
+    conn_bridge_examples/1,
+    connector_examples/1
+]).
+
+%%-------------------------------------------------------------------------------------------------
+%% `hocon_schema' API
+%%-------------------------------------------------------------------------------------------------
+
+namespace() ->
+    "gcp_pubsub_producer".
+
+roots() ->
+    [].
+
+%%=========================================
+%% Action fields
+%%=========================================
+fields(action) ->
+    {gcp_pubsub_producer,
+        mk(
+            hoconsc:map(name, ref(?MODULE, producer_action)),
+            #{
+                desc => <<"GCP PubSub Producer Action Config">>,
+                required => false
+            }
+        )};
+fields(producer_action) ->
+    emqx_bridge_v2_schema:make_producer_action_schema(
+        mk(
+            ref(?MODULE, action_parameters),
+            #{
+                required => true,
+                desc => ?DESC(producer_action)
+            }
+        )
+    );
+fields(action_parameters) ->
+    UnsupportedFields = [local_topic],
+    lists:filter(
+        fun({Key, _Schema}) -> not lists:member(Key, UnsupportedFields) end,
+        emqx_bridge_gcp_pubsub:fields(producer)
+    );
+%%=========================================
+%% Connector fields
+%%=========================================
+fields("config_connector") ->
+    %% FIXME
+    emqx_connector_schema:common_fields() ++
+        emqx_bridge_gcp_pubsub:fields(connector_config) ++
+        emqx_resource_schema:fields("resource_opts");
+%%=========================================
+%% HTTP API fields
+%%=========================================
+fields("get_bridge_v2") ->
+    emqx_bridge_schema:status_fields() ++ fields("post_bridge_v2");
+fields("post_bridge_v2") ->
+    [type_field(), name_field() | fields("put_bridge_v2")];
+fields("put_bridge_v2") ->
+    fields(producer_action).
+
+desc("config_connector") ->
+    ?DESC("config_connector");
+desc(action_parameters) ->
+    ?DESC(action_parameters);
+desc(producer_action) ->
+    ?DESC(producer_action);
+desc(_Name) ->
+    undefined.
+
+type_field() ->
+    {type, mk(gcp_pubsub_producer, #{required => true, desc => ?DESC("desc_type")})}.
+
+name_field() ->
+    {name, mk(binary(), #{required => true, desc => ?DESC("desc_name")})}.
+
+%%-------------------------------------------------------------------------------------------------
+%% `emqx_bridge_v2_schema' "unofficial" API
+%%-------------------------------------------------------------------------------------------------
+
+bridge_v2_examples(Method) ->
+    [
+        #{
+            <<"gcp_pubsub_producer">> => #{
+                summary => <<"GCP PubSub Producer Action">>,
+                value => action_example(Method)
+            }
+        }
+    ].
+
+connector_examples(Method) ->
+    [
+        #{
+            <<"gcp_pubsub_producer">> => #{
+                summary => <<"GCP PubSub Producer Connector">>,
+                value => connector_example(Method)
+            }
+        }
+    ].
+
+conn_bridge_examples(Method) ->
+    emqx_bridge_gcp_pubsub:conn_bridge_examples(Method).
+
+action_example(post) ->
+    maps:merge(
+        action_example(put),
+        #{
+            type => <<"gcp_pubsub_producer">>,
+            name => <<"my_action">>
+        }
+    );
+action_example(get) ->
+    maps:merge(
+        action_example(put),
+        #{
+            status => <<"connected">>,
+            node_status => [
+                #{
+                    node => <<"emqx@localhost">>,
+                    status => <<"connected">>
+                }
+            ]
+        }
+    );
+action_example(put) ->
+    #{
+        enable => true,
+        connector => <<"my_connector_name">>,
+        description => <<"My action">>,
+        local_topic => <<"local/topic">>,
+        resource_opts =>
+            #{batch_size => 5},
+        parameters =>
+            #{
+                pubsub_topic => <<"mytopic">>,
+                ordering_key_template => <<"${payload.ok}">>,
+                payload_template => <<"${payload}">>,
+                attributes_template =>
+                    [
+                        #{
+                            key => <<"${payload.attrs.k}">>,
+                            value => <<"${payload.attrs.v}">>
+                        }
+                    ]
+            }
+    }.
+
+connector_example(get) ->
+    maps:merge(
+        connector_example(put),
+        #{
+            status => <<"connected">>,
+            node_status => [
+                #{
+                    node => <<"emqx@localhost">>,
+                    status => <<"connected">>
+                }
+            ]
+        }
+    );
+connector_example(post) ->
+    maps:merge(
+        connector_example(put),
+        #{
+            type => <<"gcp_pubsub_producer">>,
+            name => <<"my_connector">>
+        }
+    );
+connector_example(put) ->
+    #{
+        enable => true,
+        connect_timeout => <<"10s">>,
+        pool_size => 8,
+        pipelining => 100,
+        max_retries => 2,
+        resource_opts => #{request_ttl => <<"60s">>},
+        service_account_json =>
+            #{
+                auth_provider_x509_cert_url =>
+                    <<"https://www.googleapis.com/oauth2/v1/certs">>,
+                auth_uri =>
+                    <<"https://accounts.google.com/o/oauth2/auth">>,
+                client_email =>
+                    <<"test@myproject.iam.gserviceaccount.com">>,
+                client_id => <<"123812831923812319190">>,
+                client_x509_cert_url =>
+                    <<
+                        "https://www.googleapis.com/robot/v1/"
+                        "metadata/x509/test%40myproject.iam.gserviceaccount.com"
+                    >>,
+                private_key =>
+                    <<
+                        "-----BEGIN PRIVATE KEY-----\n"
+                        "MIIEvQI..."
+                    >>,
+                private_key_id => <<"kid">>,
+                project_id => <<"myproject">>,
+                token_uri =>
+                    <<"https://oauth2.googleapis.com/token">>,
+                type => <<"service_account">>
+            }
+    }.

--- a/apps/emqx_connector/src/schema/emqx_connector_ee_schema.erl
+++ b/apps/emqx_connector/src/schema/emqx_connector_ee_schema.erl
@@ -25,6 +25,8 @@ resource_type(azure_event_hub_producer) ->
     emqx_bridge_kafka_impl_producer;
 resource_type(confluent_producer) ->
     emqx_bridge_kafka_impl_producer;
+resource_type(gcp_pubsub_producer) ->
+    emqx_bridge_gcp_pubsub_impl_producer;
 resource_type(kafka_producer) ->
     emqx_bridge_kafka_impl_producer;
 resource_type(syskeeper_forwarder) ->
@@ -62,6 +64,14 @@ connector_structs() ->
                 hoconsc:map(name, ref(emqx_bridge_confluent_producer, "config_connector")),
                 #{
                     desc => <<"Confluent Connector Config">>,
+                    required => false
+                }
+            )},
+        {gcp_pubsub_producer,
+            mk(
+                hoconsc:map(name, ref(emqx_bridge_gcp_pubsub_producer_schema, "config_connector")),
+                #{
+                    desc => <<"GCP PubSub Producer Connector Config">>,
                     required => false
                 }
             )},

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -111,6 +111,10 @@
     | {error, {recoverable_error, term()}}
     | {error, term()}.
 
+-type action_resource_id() :: resource_id().
+-type connector_resource_id() :: resource_id().
+-type message_tag() :: action_resource_id().
+
 -define(WORKER_POOL_SIZE, 16).
 
 -define(DEFAULT_BUFFER_BYTES, 256 * 1024 * 1024).

--- a/rel/i18n/emqx_bridge_gcp_pubsub_producer_schema.hocon
+++ b/rel/i18n/emqx_bridge_gcp_pubsub_producer_schema.hocon
@@ -1,0 +1,18 @@
+emqx_bridge_gcp_pubsub_producer_schema {
+
+  action_parameters.desc:
+  """Action specific configs."""
+  action_parameters.label:
+  """Action"""
+
+  producer_action.desc:
+  """Action configs."""
+  producer_action.label:
+  """Action"""
+
+  config_connector.desc:
+  """Configuration for a GCP PubSub Producer Client."""
+  config_connector.label:
+  """GCP PubSub Producer Client Configuration"""
+
+}

--- a/rel/i18n/emqx_bridge_v2_schema.hocon
+++ b/rel/i18n/emqx_bridge_v2_schema.hocon
@@ -6,4 +6,14 @@ desc_bridges_v2.desc:
 desc_bridges_v2.label:
 """Bridge Configuration"""
 
+mqtt_topic.desc:
+"""MQTT topic or topic filter as data source (action input).  If rule action is used as data source, this config should be left empty, otherwise messages will be duplicated in the remote system."""
+mqtt_topic.label:
+"""Source MQTT Topic"""
+
+config_enable.desc:
+"""Enable (true) or disable (false) this action."""
+config_enable.label:
+"""Enable or Disable"""
+
 }

--- a/rel/i18n/emqx_connector_schema.hocon
+++ b/rel/i18n/emqx_connector_schema.hocon
@@ -2,15 +2,17 @@ emqx_connector_schema {
 
 desc_connectors.desc:
 """Connectors that are used to connect to external systems"""
-
 desc_connectors.label:
 """Connectors"""
 
-
 connector_field.desc:
 """Name of connector used to connect to the resource where the action is to be performed."""
-
 connector_field.label:
 """Connector"""
+
+config_enable.desc:
+"""Enable (true) or disable (false) this connector."""
+config_enable.label:
+"""Enable or Disable"""
 
 }


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11157

## Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 75ac6e4</samp>

This pull request adds support for a new action type `gcp_pubsub_producer` that enables publishing messages to Google Cloud Pub/Sub topics using connectors and rules. It also updates the action framework in emqx to handle different action types and fields, and improves the test suite and the documentation of the existing modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
