### PR TITLE
feat(rebalance): improve rebalance usability

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -43,6 +43,7 @@
 {emqx_mgmt_trace,2}.
 {emqx_node_rebalance,1}.
 {emqx_node_rebalance,2}.
+{emqx_node_rebalance,3}.
 {emqx_node_rebalance_api,1}.
 {emqx_node_rebalance_api,2}.
 {emqx_node_rebalance_evacuation,1}.

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent.app.src
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent.app.src
@@ -1,6 +1,6 @@
 {application, emqx_eviction_agent, [
     {description, "EMQX Eviction Agent"},
-    {vsn, "5.1.4"},
+    {vsn, "5.1.5"},
     {registered, [
         emqx_eviction_agent_sup,
         emqx_eviction_agent,

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_api_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_api_SUITE.erl
@@ -22,12 +22,23 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_mgmt_api_test_util:init_suite([emqx_eviction_agent]),
-    Config.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_eviction_agent,
+            emqx_management,
+            {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
+        ],
+        #{
+            work_dir => emqx_cth_suite:work_dir(Config)
+        }
+    ),
+    _ = emqx_common_test_http:create_default_app(),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
-    emqx_mgmt_api_test_util:end_suite([emqx_eviction_agent]),
-    Config.
+    emqx_common_test_http:delete_default_app(),
+    emqx_cth_suite:stop(?config(apps, Config)).
 
 %%--------------------------------------------------------------------
 %% Tests

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_channel_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_channel_SUITE.erl
@@ -22,12 +22,20 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_common_test_helpers:start_apps([emqx_conf, emqx_eviction_agent]),
-    {ok, _} = emqx:update_config([rpc, port_discovery], manual),
-    Config.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx_conf,
+            emqx,
+            emqx_eviction_agent
+        ],
+        #{
+            work_dir => emqx_cth_suite:work_dir(Config)
+        }
+    ),
+    [{apps, Apps} | Config].
 
-end_per_suite(_Config) ->
-    emqx_common_test_helpers:stop_apps([emqx_eviction_agent, emqx_conf]).
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(apps, Config)).
 
 %%--------------------------------------------------------------------
 %% Tests

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_cli_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_cli_SUITE.erl
@@ -14,13 +14,21 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    emqx_common_test_helpers:start_apps([emqx_eviction_agent]),
-    Config.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_eviction_agent
+        ],
+        #{
+            work_dir => emqx_cth_suite:work_dir(Config)
+        }
+    ),
+    [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
     _ = emqx_eviction_agent:disable(foo),
-    emqx_common_test_helpers:stop_apps([emqx_eviction_agent]),
-    Config.
+
+    emqx_cth_suite:stop(?config(apps, Config)).
 
 %%--------------------------------------------------------------------
 %% Tests

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance.app.src
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance.app.src
@@ -1,11 +1,12 @@
 {application, emqx_node_rebalance, [
     {description, "EMQX Node Rebalance"},
-    {vsn, "5.0.6"},
+    {vsn, "5.0.7"},
     {registered, [
         emqx_node_rebalance_sup,
         emqx_node_rebalance,
         emqx_node_rebalance_agent,
-        emqx_node_rebalance_evacuation
+        emqx_node_rebalance_evacuation,
+        emqx_node_rebalance_purge
     ]},
     {applications, [
         kernel,

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance_api.erl
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance_api.erl
@@ -109,7 +109,8 @@ schema("/load_rebalance/availability_check") ->
             responses => #{
                 200 => response_schema(),
                 503 => error_codes([?NODE_EVACUATING], <<"Node Evacuating">>)
-            }
+            },
+            security => []
         }
     };
 schema("/load_rebalance/:node/start") ->
@@ -248,10 +249,10 @@ schema("/load_rebalance/:node/evacuation/stop") ->
     }}.
 
 '/load_rebalance/availability_check'(get, #{}) ->
-    case emqx_node_rebalance_status:local_status() of
-        disabled ->
+    case emqx_node_rebalance_status:availability_status() of
+        available ->
             {200, #{}};
-        _ ->
+        unavailable ->
             error_response(503, ?NODE_EVACUATING, <<"Node Evacuating">>)
     end.
 

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance_purge.erl
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance_purge.erl
@@ -199,7 +199,7 @@ deinit(Data) ->
     maps:without(Keys, Data).
 
 multicall(Nodes, F, A) ->
-    case apply(emqx_node_rebalance_proto_v2, F, [Nodes | A]) of
+    case apply(emqx_node_rebalance_proto_v3, F, [Nodes | A]) of
         {Results, []} ->
             case lists:partition(fun is_ok/1, lists:zip(Nodes, Results)) of
                 {_OkResults, []} ->

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance_status.erl
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance_status.erl
@@ -5,6 +5,7 @@
 -module(emqx_node_rebalance_status).
 
 -export([
+    availability_status/0,
     local_status/0,
     local_status/1,
     global_status/0,
@@ -22,6 +23,13 @@
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
+
+-spec availability_status() -> available | unavailable.
+availability_status() ->
+    case emqx_eviction_agent:enable_status() of
+        {enabled, _Kind, _ServerReference, _Options} -> unavailable;
+        disabled -> available
+    end.
 
 -spec local_status() -> disabled | {evacuation, map()} | {purge, map()} | {rebalance, map()}.
 local_status() ->

--- a/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_proto_v3.erl
+++ b/apps/emqx_node_rebalance/src/proto/emqx_node_rebalance_proto_v3.erl
@@ -1,0 +1,96 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_node_rebalance_proto_v3).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    available_nodes/1,
+    evict_connections/2,
+    evict_sessions/4,
+    connection_counts/1,
+    session_counts/1,
+    enable_rebalance_agent/2,
+    disable_rebalance_agent/2,
+    disconnected_session_counts/1,
+
+    %% Introduced in v2:
+    enable_rebalance_agent/3,
+    disable_rebalance_agent/3,
+    purge_sessions/2,
+
+    %% Introduced in v3:
+    enable_rebalance_agent/4
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+-include_lib("emqx/include/types.hrl").
+
+introduced_in() ->
+    "5.4.0".
+
+-spec available_nodes([node()]) -> emqx_rpc:multicall_result(node()).
+available_nodes(Nodes) ->
+    rpc:multicall(Nodes, emqx_node_rebalance, is_node_available, []).
+
+-spec evict_connections([node()], non_neg_integer()) ->
+    emqx_rpc:multicall_result(ok_or_error(disabled)).
+evict_connections(Nodes, Count) ->
+    rpc:multicall(Nodes, emqx_eviction_agent, evict_connections, [Count]).
+
+-spec evict_sessions([node()], non_neg_integer(), [node()], emqx_channel:conn_state()) ->
+    emqx_rpc:multicall_result(ok_or_error(disabled)).
+evict_sessions(Nodes, Count, RecipientNodes, ConnState) ->
+    rpc:multicall(Nodes, emqx_eviction_agent, evict_sessions, [Count, RecipientNodes, ConnState]).
+
+-spec connection_counts([node()]) -> emqx_rpc:multicall_result({ok, non_neg_integer()}).
+connection_counts(Nodes) ->
+    rpc:multicall(Nodes, emqx_node_rebalance, connection_count, []).
+
+-spec session_counts([node()]) -> emqx_rpc:multicall_result({ok, non_neg_integer()}).
+session_counts(Nodes) ->
+    rpc:multicall(Nodes, emqx_node_rebalance, session_count, []).
+
+-spec enable_rebalance_agent([node()], pid()) ->
+    emqx_rpc:multicall_result(ok_or_error(already_enabled | eviction_agent_busy)).
+enable_rebalance_agent(Nodes, OwnerPid) ->
+    rpc:multicall(Nodes, emqx_node_rebalance_agent, enable, [OwnerPid]).
+
+-spec disable_rebalance_agent([node()], pid()) ->
+    emqx_rpc:multicall_result(ok_or_error(already_disabled | invalid_coordinator)).
+disable_rebalance_agent(Nodes, OwnerPid) ->
+    rpc:multicall(Nodes, emqx_node_rebalance_agent, disable, [OwnerPid]).
+
+-spec disconnected_session_counts([node()]) -> emqx_rpc:multicall_result({ok, non_neg_integer()}).
+disconnected_session_counts(Nodes) ->
+    rpc:multicall(Nodes, emqx_node_rebalance, disconnected_session_count, []).
+
+%% Introduced in v2:
+
+-spec enable_rebalance_agent([node()], pid(), emqx_eviction_agent:kind()) ->
+    emqx_rpc:multicall_result(ok_or_error(already_enabled | eviction_agent_busy)).
+enable_rebalance_agent(Nodes, OwnerPid, Kind) ->
+    rpc:multicall(Nodes, emqx_node_rebalance_agent, enable, [OwnerPid, Kind]).
+
+-spec disable_rebalance_agent([node()], pid(), emqx_eviction_agent:kind()) ->
+    emqx_rpc:multicall_result(ok_or_error(already_disabled | invalid_coordinator)).
+disable_rebalance_agent(Nodes, OwnerPid, Kind) ->
+    rpc:multicall(Nodes, emqx_node_rebalance_agent, disable, [OwnerPid, Kind]).
+
+-spec purge_sessions([node()], non_neg_integer()) ->
+    emqx_rpc:multicall_result(ok_or_error(disabled)).
+purge_sessions(Nodes, Count) ->
+    rpc:multicall(Nodes, emqx_eviction_agent, purge_sessions, [Count]).
+
+%% Introduced in v3:
+
+-spec enable_rebalance_agent(
+    [node()], pid(), emqx_eviction_agent:kind(), emqx_eviction_agent:options()
+) ->
+    emqx_rpc:multicall_result(ok_or_error(eviction_agent_busy | invalid_coordinator)).
+enable_rebalance_agent(Nodes, OwnerPid, Kind, Options) ->
+    rpc:multicall(Nodes, emqx_node_rebalance_agent, enable, [OwnerPid, Kind, Options]).

--- a/apps/emqx_node_rebalance/test/emqx_node_rebalance_status_SUITE.erl
+++ b/apps/emqx_node_rebalance/test/emqx_node_rebalance_status_SUITE.erl
@@ -32,6 +32,7 @@ init_per_suite(Config) ->
     Apps = [
         emqx_conf,
         emqx,
+        emqx_eviction_agent,
         emqx_node_rebalance
     ],
     Cluster = [

--- a/changes/ee/feat-11971.en.md
+++ b/changes/ee/feat-11971.en.md
@@ -1,0 +1,4 @@
+Made `/api/v5/load_rebalance/availability_check` public, i.e. not requiring authentication. This simplifies load balancer setup.
+
+Made rebalance/evacuation more graceful during the wait health check phase. The connections to nodes marked for eviction are now not prohibited during this phase.
+During this phase it is unknown whether these nodes are all marked unhealthy by the load balancer, so prohibiting connections to them may cause multiple unssuccessful attempts to reconnect.


### PR DESCRIPTION
* make availability API endpoint public
* allow connections during wait_health_check interval
* make availability status calculation more consistent and lightweight
* refactor test to get rid of some mocks and to use cth

Fixes [EMQX-11417](https://emqx.atlassian.net/browse/EMQX-11417)

<!-- Make sure to target release-52 branch if this PR is intended to fix the issues for the release candidate. -->

## Summary
<!--
copilot:summary
-->
### <samp>🤖[[deprecated]](https://githubnext.com/copilot-for-prs-sunset) Generated by Copilot at 876c884</samp>

This pull request adds new features and refactors the emqx_eviction_agent and emqx_node_rebalance apps to support different options for enabling and disabling the eviction and rebalance agents, and to use the `gen_statem` behaviour and a new protocol version for the node rebalance agent. It also improves the test suites and the logging and error handling of the modules.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible
