### PR TITLE
fix: bridge to action upgrade fixup hook should run after upgrade

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_action_info.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_action_info.erl
@@ -27,8 +27,10 @@ action_to_bridge_v1_fixup(Config) ->
     emqx_utils_maps:rename(<<"parameters">>, <<"kafka">>, Config).
 
 bridge_v1_to_action_fixup(Config0) ->
-    Config = emqx_utils_maps:rename(<<"kafka">>, <<"parameters">>, Config0),
-    maps:with(producer_action_field_keys(), Config).
+    KafkaMap = emqx_utils_maps:deep_get([<<"parameters">>, <<"kafka">>], Config0),
+    Config1 = emqx_utils_maps:deep_remove([<<"parameters">>, <<"kafka">>], Config0),
+    Config2 = maps:put(<<"parameters">>, KafkaMap, Config1),
+    maps:with(producer_action_field_keys(), Config2).
 
 %%------------------------------------------------------------------------------------------
 %% Internal helper fns


### PR DESCRIPTION
This commit changes how the `emqx_action_info` callback `bridge_v1_to_action_fixup/1` works. It is now called after the automatic upgrade instead of before. Since the full Bridge V1 config might be needed to do the fixup, it is provided in a special field `<<"__bridge_v1_conf__">>`. The `<<"__bridge_v1_conf__">>` field is removed after the callback is called and can thus be ignored if it is not needed.

Manually tested with Kafka bridge config in the cluster.hocon file.

Fixes https://emqx.atlassian.net/browse/EMQX-11428

## Summary
copilot:summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible