### PR TITLE
ci: stop building packages for macos-11

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -74,9 +74,9 @@ jobs:
         otp:
           - ${{ inputs.otp_vsn }}
         os:
-          - macos-11
           - macos-12
           - macos-12-arm64
+          - macos-13
     runs-on: ${{ matrix.os }}
     steps:
     - uses: emqx/self-hosted-cleanup-action@v1.0.3

--- a/changes/ce/breaking-11994.en.md
+++ b/changes/ce/breaking-11994.en.md
@@ -1,0 +1,1 @@
+Stop releasing packages for Windows.

--- a/changes/ce/breaking-11998.en.md
+++ b/changes/ce/breaking-11998.en.md
@@ -1,0 +1,1 @@
+Stop releasing packages for MacOS 11 (BigSur).


### PR DESCRIPTION
macOS 11 (Big Sur) is unsupported as of September 26, 2023.