### PR TITLE
test(sessds): wait client disconnect propagates to broker

### DIFF
--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -91,6 +91,7 @@
     clean_down/1,
     mark_channel_connected/1,
     mark_channel_disconnected/1,
+    is_channel_connected/1,
     get_connected_client_count/0
 ]).
 


### PR DESCRIPTION
## Summary

Make sure to wait until client disconnect propagates to the channel state on the broker side in `emqx_persistent_session_SUITE` test suite.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
