### PR TITLE
test: replace 'slave' and 'ct_slave' with 'peer'

### DIFF
--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -91,11 +91,7 @@
     %% Working directory
     %% If this directory is not empty, starting up the node applications will fail
     %% Default: "${ClusterOpts.work_dir}/${nodename}"
-    work_dir => file:name(),
-
-    % Tooling to manage nodes
-    % Default: `ct_slave`.
-    driver => ct_slave | slave
+    work_dir => file:name()
 }}.
 
 -spec start([nodespec()], ClusterOpts) ->
@@ -162,8 +158,7 @@ mk_init_nodespec(N, Name, NodeOpts, ClusterOpts) ->
         role => core,
         apps => [],
         base_port => BasePort,
-        work_dir => filename:join([WorkDir, Node]),
-        driver => ct_slave
+        work_dir => filename:join([WorkDir, Node])
     },
     maps:merge(Defaults, NodeOpts).
 

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -575,7 +575,7 @@ t_local(Config) when is_list(Config) ->
         <<"sticky_group">> => sticky
     },
 
-    Node = start_slave('local_shared_sub_local_1', 21999),
+    Node = start_peer('local_shared_sub_local_1', 21999),
     ok = ensure_group_config(GroupConfig),
     ok = ensure_group_config(Node, GroupConfig),
 
@@ -606,7 +606,7 @@ t_local(Config) when is_list(Config) ->
 
     emqtt:stop(ConnPid1),
     emqtt:stop(ConnPid2),
-    stop_slave(Node),
+    stop_peer(Node),
 
     ?assertEqual(local, emqx_shared_sub:strategy(<<"local_group">>)),
     ?assertEqual(local, RemoteLocalGroupStrategy),
@@ -628,7 +628,7 @@ t_remote(Config) when is_list(Config) ->
         <<"sticky_group">> => sticky
     },
 
-    Node = start_slave('remote_shared_sub_remote_1', 21999),
+    Node = start_peer('remote_shared_sub_remote_1', 21999),
     ok = ensure_group_config(GroupConfig),
     ok = ensure_group_config(Node, GroupConfig),
 
@@ -664,7 +664,7 @@ t_remote(Config) when is_list(Config) ->
     after
         emqtt:stop(ConnPidLocal),
         emqtt:stop(ConnPidRemote),
-        stop_slave(Node)
+        stop_peer(Node)
     end.
 
 t_local_fallback(Config) when is_list(Config) ->
@@ -677,7 +677,7 @@ t_local_fallback(Config) when is_list(Config) ->
     Topic = <<"local_foo/bar">>,
     ClientId1 = <<"ClientId1">>,
     ClientId2 = <<"ClientId2">>,
-    Node = start_slave('local_fallback_shared_sub_1', 11888),
+    Node = start_peer('local_fallback_shared_sub_1', 11888),
 
     {ok, ConnPid1} = emqtt:start_link([{clientid, ClientId1}]),
     {ok, _} = emqtt:connect(ConnPid1),
@@ -693,7 +693,7 @@ t_local_fallback(Config) when is_list(Config) ->
     {true, UsedSubPid2} = last_message(<<"hello2">>, [ConnPid1], 2_000),
 
     emqtt:stop(ConnPid1),
-    stop_slave(Node),
+    stop_peer(Node),
 
     ?assertEqual(UsedSubPid1, UsedSubPid2),
     ok.
@@ -1253,7 +1253,7 @@ recv_msgs(Count, Msgs) ->
         Msgs
     end.
 
-start_slave(Name, Port) ->
+start_peer(Name, Port) ->
     {ok, Node} = emqx_cth_peer:start_link(
         Name,
         ebin_path()
@@ -1262,7 +1262,7 @@ start_slave(Name, Port) ->
     setup_node(Node, Port),
     Node.
 
-stop_slave(Node) ->
+stop_peer(Node) ->
     rpc:call(Node, mria, leave, []),
     emqx_cth_peer:stop(Node).
 

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -63,7 +63,6 @@ init_per_suite(Config) ->
         end,
     emqx_common_test_helpers:boot_modules(all),
     emqx_common_test_helpers:start_apps([]),
-    emqx_logger:set_log_level(debug),
     [{dist_pid, DistPid} | Config].
 
 end_per_suite(Config) ->

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -588,7 +588,6 @@ cluster(Config) ->
         [
             {apps, [emqx_conf, emqx_rule_engine, emqx_bridge]},
             {listener_ports, []},
-            {peer_mod, slave},
             {priv_data_dir, PrivDataDir},
             {load_schema, true},
             {start_autocluster, true},
@@ -611,7 +610,7 @@ start_cluster(Cluster) ->
     Nodes = lists:map(
         fun({Name, Opts}) ->
             ct:pal("starting ~p", [Name]),
-            emqx_common_test_helpers:start_slave(Name, Opts)
+            emqx_common_test_helpers:start_peer(Name, Opts)
         end,
         Cluster
     ),
@@ -620,7 +619,7 @@ start_cluster(Cluster) ->
         emqx_utils:pmap(
             fun(N) ->
                 ct:pal("stopping ~p", [N]),
-                emqx_common_test_helpers:stop_slave(N)
+                emqx_common_test_helpers:stop_peer(N)
             end,
             Nodes
         )

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_impl_producer_SUITE.erl
@@ -517,19 +517,11 @@ try_decode_json(Payload) ->
 
 cluster(Config) ->
     PrivDataDir = ?config(priv_dir, Config),
-    PeerModule =
-        case os:getenv("IS_CI") of
-            false ->
-                slave;
-            _ ->
-                ct_slave
-        end,
     Cluster = emqx_common_test_helpers:emqx_cluster(
         [core, core],
         [
             {apps, [emqx_conf] ++ ?APPS ++ [pulsar]},
             {listener_ports, []},
-            {peer_mod, PeerModule},
             {priv_data_dir, PrivDataDir},
             {load_schema, true},
             {start_autocluster, true},
@@ -551,7 +543,7 @@ cluster(Config) ->
 start_cluster(Cluster) ->
     Nodes =
         [
-            emqx_common_test_helpers:start_slave(Name, Opts)
+            emqx_common_test_helpers:start_peer(Name, Opts)
          || {Name, Opts} <- Cluster
         ],
     NumNodes = length(Nodes),
@@ -559,7 +551,7 @@ start_cluster(Cluster) ->
         emqx_utils:pmap(
             fun(N) ->
                 ct:pal("stopping ~p", [N]),
-                ok = emqx_common_test_helpers:stop_slave(N)
+                ok = emqx_common_test_helpers:stop_peer(N)
             end,
             Nodes
         )

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -222,16 +222,16 @@ assert_config_load_done(Nodes) ->
     ).
 
 stop_cluster(Nodes) ->
-    emqx_utils:pmap(fun emqx_common_test_helpers:stop_slave/1, Nodes).
+    emqx_utils:pmap(fun emqx_common_test_helpers:stop_peer/1, Nodes).
 
 start_cluster(Specs) ->
-    [emqx_common_test_helpers:start_slave(Name, Opts) || {Name, Opts} <- Specs].
+    [emqx_common_test_helpers:start_peer(Name, Opts) || {Name, Opts} <- Specs].
 
 start_cluster_async(Specs) ->
     [
         begin
             Opts1 = maps:remove(join_to, Opts),
-            spawn_link(fun() -> emqx_common_test_helpers:start_slave(Name, Opts1) end),
+            spawn_link(fun() -> emqx_common_test_helpers:start_peer(Name, Opts1) end),
             timer:sleep(7_000)
         end
      || {Name, Opts} <- Specs

--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_SUITE.erl
@@ -50,9 +50,9 @@ end_per_suite(Config) ->
 init_per_testcase(Case, Config) ->
     _ = emqx_eviction_agent:disable(test_eviction),
     ok = snabbkaffe:start_trace(),
-    start_slave(Case, Config).
+    start_peer(Case, Config).
 
-start_slave(t_explicit_session_takeover, Config) ->
+start_peer(t_explicit_session_takeover, Config) ->
     NodeNames =
         [
             t_explicit_session_takeover_donor,
@@ -65,19 +65,19 @@ start_slave(t_explicit_session_takeover, Config) ->
     ),
     ok = snabbkaffe:start_trace(),
     [{evacuate_nodes, ClusterNodes} | Config];
-start_slave(_Case, Config) ->
+start_peer(_Case, Config) ->
     Config.
 
 end_per_testcase(TestCase, Config) ->
     emqx_eviction_agent:disable(test_eviction),
     ok = snabbkaffe:stop(),
-    stop_slave(TestCase, Config).
+    stop_peer(TestCase, Config).
 
-stop_slave(t_explicit_session_takeover, Config) ->
+stop_peer(t_explicit_session_takeover, Config) ->
     emqx_eviction_agent_test_helpers:stop_cluster(
         ?config(evacuate_nodes, Config)
     );
-stop_slave(_Case, _Config) ->
+stop_peer(_Case, _Config) ->
     ok.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_license/test/emqx_license_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_SUITE.erl
@@ -112,7 +112,7 @@ setup_test(TestCase, Config) when
             end}
         ]
     ),
-    Nodes = [emqx_common_test_helpers:start_slave(Name, Opts) || {Name, Opts} <- Cluster],
+    Nodes = [emqx_common_test_helpers:start_peer(Name, Opts) || {Name, Opts} <- Cluster],
     [{nodes, Nodes}, {cluster, Cluster}, {old_license, LicenseKey}];
 setup_test(_TestCase, _Config) ->
     [].

--- a/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_SUITE.erl
@@ -42,8 +42,8 @@ t_cluster_query(_Config) ->
     ct:timetrap({seconds, 120}),
     snabbkaffe:fix_ct_logging(),
     [{Name, Opts}, {Name1, Opts1}] = cluster_specs(),
-    Node1 = emqx_common_test_helpers:start_slave(Name, Opts),
-    Node2 = emqx_common_test_helpers:start_slave(Name1, Opts1),
+    Node1 = emqx_common_test_helpers:start_peer(Name, Opts),
+    Node2 = emqx_common_test_helpers:start_peer(Name1, Opts1),
     try
         process_flag(trap_exit, true),
         ClientLs1 = [start_emqtt_client(Node1, I, 2883) || I <- lists:seq(1, 10)],
@@ -168,8 +168,8 @@ t_cluster_query(_Config) ->
         _ = lists:foreach(fun(C) -> emqtt:disconnect(C) end, ClientLs1),
         _ = lists:foreach(fun(C) -> emqtt:disconnect(C) end, ClientLs2)
     after
-        emqx_common_test_helpers:stop_slave(Node1),
-        emqx_common_test_helpers:stop_slave(Node2)
+        emqx_common_test_helpers:stop_peer(Node1),
+        emqx_common_test_helpers:stop_peer(Node2)
     end,
     ok.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_cluster_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_cluster_SUITE.erl
@@ -54,8 +54,6 @@ t_cluster_topology_api_empty_resp(_) ->
     ).
 
 t_cluster_topology_api_replicants(Config) ->
-    %% some time to stabilize
-    timer:sleep(3000),
     [Core1, Core2, Replicant] = _NodesList = ?config(cluster, Config),
     {200, Core1Resp} = rpc:call(Core1, emqx_mgmt_api_cluster, cluster_topology, [get, #{}]),
     {200, Core2Resp} = rpc:call(Core2, emqx_mgmt_api_cluster, cluster_topology, [get, #{}]),

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -194,8 +194,8 @@ t_api_listeners_list_not_ready(Config) when is_list(Config) ->
     snabbkaffe:fix_ct_logging(),
     Cluster = [{Name, Opts}, {Name1, Opts1}] = cluster([core, core]),
     ct:pal("Starting ~p", [Cluster]),
-    Node1 = emqx_common_test_helpers:start_slave(Name, Opts),
-    Node2 = emqx_common_test_helpers:start_slave(Name1, Opts1),
+    Node1 = emqx_common_test_helpers:start_peer(Name, Opts),
+    Node2 = emqx_common_test_helpers:start_peer(Name1, Opts1),
     try
         L1 = get_tcp_listeners(Node1),
 
@@ -214,8 +214,8 @@ t_api_listeners_list_not_ready(Config) when is_list(Config) ->
         ?assert(length(L1) > length(L2), Comment),
         ?assertEqual(length(L2), length(L3), Comment)
     after
-        emqx_common_test_helpers:stop_slave(Node1),
-        emqx_common_test_helpers:stop_slave(Node2)
+        emqx_common_test_helpers:stop_peer(Node1),
+        emqx_common_test_helpers:stop_peer(Node2)
     end.
 
 t_clear_certs(Config) when is_list(Config) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -129,8 +129,8 @@ t_multiple_nodes_api(_) ->
     Seq2 = list_to_atom(atom_to_list(?MODULE) ++ "2"),
     Cluster = [{Name, Opts}, {Name1, Opts1}] = cluster([{core, Seq1}, {core, Seq2}]),
     ct:pal("Starting ~p", [Cluster]),
-    Node1 = emqx_common_test_helpers:start_slave(Name, Opts),
-    Node2 = emqx_common_test_helpers:start_slave(Name1, Opts1),
+    Node1 = emqx_common_test_helpers:start_peer(Name, Opts),
+    Node2 = emqx_common_test_helpers:start_peer(Name1, Opts1),
     try
         {200, NodesList} = rpc:call(Node1, emqx_mgmt_api_nodes, nodes, [get, #{}]),
         All = [Node1, Node2],
@@ -148,8 +148,8 @@ t_multiple_nodes_api(_) ->
         ]),
         ?assertMatch(#{node := Node1}, Node11)
     after
-        emqx_common_test_helpers:stop_slave(Node1),
-        emqx_common_test_helpers:stop_slave(Node2)
+        emqx_common_test_helpers:stop_peer(Node1),
+        emqx_common_test_helpers:stop_peer(Node2)
     end,
     ok.
 

--- a/apps/emqx_node_rebalance/test/emqx_node_rebalance_SUITE.erl
+++ b/apps/emqx_node_rebalance/test/emqx_node_rebalance_SUITE.erl
@@ -136,7 +136,7 @@ t_rebalance_node_crash(Config) ->
     ?assertWaitEvent(
         begin
             ok = rpc:call(DonorNode, emqx_node_rebalance, start, [Opts]),
-            emqx_common_test_helpers:stop_slave(RecipientNode)
+            emqx_common_test_helpers:stop_peer(RecipientNode)
         end,
         #{?snk_kind := emqx_node_rebalance_started},
         1000

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
@@ -348,19 +348,11 @@ receive_published(Line) ->
 
 cluster(Config) ->
     PrivDataDir = ?config(priv_dir, Config),
-    PeerModule =
-        case os:getenv("IS_CI") of
-            false ->
-                slave;
-            _ ->
-                ct_slave
-        end,
     Cluster = emqx_common_test_helpers:emqx_cluster(
         [core, core],
         [
             {apps, ?APPS},
             {listener_ports, []},
-            {peer_mod, PeerModule},
             {priv_data_dir, PrivDataDir},
             {load_schema, true},
             {start_autocluster, true},
@@ -382,7 +374,7 @@ cluster(Config) ->
 
 start_cluster(Cluster) ->
     Nodes = [
-        emqx_common_test_helpers:start_slave(Name, Opts)
+        emqx_common_test_helpers:start_peer(Name, Opts)
      || {Name, Opts} <- Cluster
     ],
     NumNodes = length(Nodes),
@@ -390,7 +382,7 @@ start_cluster(Cluster) ->
         emqx_utils:pmap(
             fun(N) ->
                 ct:pal("stopping ~p", [N]),
-                ok = emqx_common_test_helpers:stop_slave(N)
+                ok = emqx_common_test_helpers:stop_peer(N)
             end,
             Nodes
         )

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1386,7 +1386,7 @@ However it's no longer useful because the shared-subscrption messages in a expir
 base_listener_enable_authn.desc:
 """Set <code>true</code> (default) to enable client authentication on this listener, the authentication
 process goes through the configured authentication chain.
-When set to <code>false</code> to allow any clients with or without authentication information such as username or password to log in.
+When set to <code>false</code>, any client (with or without username/password) is allowed to connect.
 When set to <code>quick_deny_anonymous</code>, it behaves like when set to <code>true</code>, but clients will be
 denied immediately without going through any authenticators if <code>username</code> is not provided. This is useful to fence off
 anonymous clients early."""


### PR DESCRIPTION
Release version: `v/e5.4.0`

## Summary

Use only `peer` module for all cluster tests.
i.e. no more `slave` and `ct_slave` in the codebase.