### PR TITLE
fix(channel): expect there's no session yet on disconnect

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1211,7 +1211,7 @@ handle_info(
 ) when
     ConnState =:= connected orelse ConnState =:= reauthenticating
 ->
-    {Intent, Session1} = emqx_session:disconnect(ClientInfo, ConnInfo, Session),
+    {Intent, Session1} = session_disconnect(ClientInfo, ConnInfo, Session),
     Channel1 = ensure_disconnected(Reason, maybe_publish_will_msg(Channel)),
     Channel2 = Channel1#channel{session = Session1},
     case maybe_shutdown(Reason, Intent, Channel2) of
@@ -2190,6 +2190,11 @@ ensure_disconnected(
     ChanPid = self(),
     emqx_cm:mark_channel_disconnected(ChanPid),
     Channel#channel{conninfo = NConnInfo, conn_state = disconnected}.
+
+session_disconnect(ClientInfo, ConnInfo, Session) when Session /= undefined ->
+    emqx_session:disconnect(ClientInfo, ConnInfo, Session);
+session_disconnect(_ClientInfo, _ConnInfo, undefined) ->
+    {shutdown, undefined}.
 
 %%--------------------------------------------------------------------
 %% Maybe Publish will msg

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -611,8 +611,8 @@ maybe_mock_impl_mod({Mock, _State}) when is_atom(Mock) ->
     Mock.
 -else.
 -spec maybe_mock_impl_mod(_Session) -> no_return().
-maybe_mock_impl_mod(_) ->
-    error(noimpl).
+maybe_mock_impl_mod(Session) ->
+    error(noimpl, [Session]).
 -endif.
 
 -spec choose_impl_mod(conninfo()) -> module().


### PR DESCRIPTION
## Summary

In rare situations, it's possible to arrive at `handle_info({sock_closed, ...` clause in `emqx_channel` with no session. This PR fixes connection crashes in such cases.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
