### PR TITLE
build: bump oldest otp vsn to OTP-25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@ _build
 .rebar3
 rebar3.crashdump
 .DS_Store
+# emqx_ds_replication_layer_meta:ensure_site/0
+data
 etc/gen.emqx.conf
 compile_commands.json
 cuttlefish
@@ -69,3 +71,5 @@ bom.json
 ct_run*/
 apps/emqx_conf/etc/emqx.conf.all.rendered*
 rebar-git-cache.tar
+# build docker image locally
+.docker_image_tag

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -15,7 +15,7 @@ do(Dir, CONFIG) ->
     end.
 
 assert_otp() ->
-    Oldest = 24,
+    Oldest = 25,
     Latest = 26,
     OtpRelease = list_to_integer(erlang:system_info(otp_release)),
     case OtpRelease < Oldest orelse OtpRelease > Latest of


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: v/e5.4.0

[emqx_persistent_session_ds_gc_worker.erl#L109-L126](https://github.com/emqx/emqx/blob/e5.4.0-alpha.1/apps/emqx/src/emqx_persistent_session_ds_gc_worker.erl#L109-L126)

See line 119:
```
 109   │ zombie_session_ms() ->
 110   │     NowMS = now_ms(),
 111   │     GCInterval = emqx_config:get([session_persistence, session_gc_interval]),
 112   │     BumpInterval = emqx_config:get([session_persistence, last_alive_update_interval]),
 113   │     TimeThreshold = max(GCInterval, BumpInterval) * 3,
 114   │     ets:fun2ms(
 115   │         fun(
 116   │             #session{
 117   │                 id = DSSessionId,
 118   │                 last_alive_at = LastAliveAt,
 119   │                 conninfo = #{expiry_interval := EI}
 120   │             }
 121   │         ) when
 122   │             LastAliveAt + EI + TimeThreshold =< NowMS
 123   │         ->
 124   │             DSSessionId
 125   │         end
 126   │     ).
```

_OTP-24_:
```bash
===> Compiling emqx
===> Compiling apps/emqx/src/emqx_persistent_session_ds_gc_worker.erl failed
emqx_persistent_session_ds_gc_worker.erl:119:46: only association operators '=>' are allowed in map construction
```


## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
