### PR TITLE
test(cth_peer): use an exclusive current dir for each peer

### DIFF
--- a/apps/emqx/test/emqx_cth_peer.erl
+++ b/apps/emqx/test/emqx_cth_peer.erl
@@ -43,17 +43,28 @@ start_link(Name, Args, Envs, Timeout) when is_atom(Name) ->
 
 do_start(Name0, Args, Envs, Timeout, Func) when is_atom(Name0) ->
     {Name, Host} = parse_node_name(Name0),
-    {ok, Pid, Node} = peer:Func(#{
-        name => Name,
-        host => Host,
-        args => Args,
-        env => Envs,
-        wait_boot => Timeout,
-        longnames => true,
-        shutdown => {halt, 1000}
-    }),
-    true = register(Node, Pid),
-    {ok, Node}.
+    %% Create exclusive current directory for the node.  Some configurations, like plugin
+    %% installation directory, are the same for the whole cluster, and nodes on the same
+    %% machine will step on each other's toes...
+    {ok, Cwd} = file:get_cwd(),
+    NodeCwd = filename:join([Cwd, Name]),
+    ok = filelib:ensure_dir(filename:join([NodeCwd, "dummy"])),
+    try
+        file:set_cwd(NodeCwd),
+        {ok, Pid, Node} = peer:Func(#{
+            name => Name,
+            host => Host,
+            args => Args,
+            env => Envs,
+            wait_boot => Timeout,
+            longnames => true,
+            shutdown => {halt, 1000}
+        }),
+        true = register(Node, Pid),
+        {ok, Node}
+    after
+        file:set_cwd(Cwd)
+    end.
 
 stop(Node) when is_atom(Node) ->
     Pid = whereis(Node),


### PR DESCRIPTION
Attempt to fix flaky `t_cluster_update_order` test from plugin management api.

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
