### PR TITLE
fix: use sync_transaction when update admin/token

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -338,7 +338,7 @@ generate_unique_name(NamePrefix, ApiKey) ->
     <<NamePrefix/binary, (hash_string_from_seed(ApiKey, ?DEFAULT_HASH_LEN))/binary>>.
 
 trans(Fun, Args) ->
-    case mria:transaction(?COMMON_SHARD, Fun, Args) of
+    case mria:sync_transaction(?COMMON_SHARD, Fun, Args) of
         {atomic, Res} -> {ok, Res};
         {aborted, Error} -> {error, Error}
     end.

--- a/changes/ce/fix-12111.en.md
+++ b/changes/ce/fix-12111.en.md
@@ -1,0 +1,1 @@
+Fix an issue where API tokens were sometimes unavailable by using sync_transaction function to ensure all updates are consistently synchronized to the replica node.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10699

Use the sync_transaction to synchronize all updates to the replica node. 
btw: we use ro_transaction to read admin/token.

Release version: v/e5.4.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
