### PR TITLE
refactor: delete UDP multicast clustering strategy

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -468,7 +468,7 @@ fill_defaults(Conf) ->
     Conf1 = emqx_config:fill_defaults(Conf),
     filter_cluster_conf(Conf1).
 
--define(ALL_STRATEGY, [<<"manual">>, <<"static">>, <<"dns">>, <<"etcd">>, <<"k8s">>, <<"mcast">>]).
+-define(ALL_STRATEGY, [<<"manual">>, <<"static">>, <<"dns">>, <<"etcd">>, <<"k8s">>]).
 
 filter_cluster_conf(#{<<"cluster">> := #{<<"discovery_strategy">> := Strategy} = Cluster} = Conf) ->
     Cluster1 = maps:without(lists:delete(Strategy, ?ALL_STRATEGY), Cluster),

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -154,7 +154,7 @@ fields("cluster") ->
             )},
         {"discovery_strategy",
             sc(
-                hoconsc:enum([manual, static, dns, etcd, k8s, mcast]),
+                hoconsc:enum([manual, static, dns, etcd, k8s]),
                 #{
                     default => manual,
                     desc => ?DESC(cluster_discovery_strategy),
@@ -208,11 +208,6 @@ fields("cluster") ->
                 ?R_REF(cluster_static),
                 #{}
             )},
-        {"mcast",
-            sc(
-                ?R_REF(cluster_mcast),
-                #{importance => ?IMPORTANCE_HIDDEN}
-            )},
         {"dns",
             sc(
                 ?R_REF(cluster_dns),
@@ -247,81 +242,6 @@ fields(cluster_static) ->
                 #{
                     default => [],
                     desc => ?DESC(cluster_static_seeds),
-                    'readOnly' => true
-                }
-            )}
-    ];
-fields(cluster_mcast) ->
-    [
-        {"addr",
-            sc(
-                string(),
-                #{
-                    default => <<"239.192.0.1">>,
-                    desc => ?DESC(cluster_mcast_addr),
-                    'readOnly' => true
-                }
-            )},
-        {"ports",
-            sc(
-                hoconsc:array(integer()),
-                #{
-                    default => [4369, 4370],
-                    'readOnly' => true,
-                    desc => ?DESC(cluster_mcast_ports)
-                }
-            )},
-        {"iface",
-            sc(
-                string(),
-                #{
-                    default => <<"0.0.0.0">>,
-                    desc => ?DESC(cluster_mcast_iface),
-                    'readOnly' => true
-                }
-            )},
-        {"ttl",
-            sc(
-                range(0, 255),
-                #{
-                    default => 255,
-                    desc => ?DESC(cluster_mcast_ttl),
-                    'readOnly' => true
-                }
-            )},
-        {"loop",
-            sc(
-                boolean(),
-                #{
-                    default => true,
-                    desc => ?DESC(cluster_mcast_loop),
-                    'readOnly' => true
-                }
-            )},
-        {"sndbuf",
-            sc(
-                emqx_schema:bytesize(),
-                #{
-                    default => <<"16KB">>,
-                    desc => ?DESC(cluster_mcast_sndbuf),
-                    'readOnly' => true
-                }
-            )},
-        {"recbuf",
-            sc(
-                emqx_schema:bytesize(),
-                #{
-                    default => <<"16KB">>,
-                    desc => ?DESC(cluster_mcast_recbuf),
-                    'readOnly' => true
-                }
-            )},
-        {"buffer",
-            sc(
-                emqx_schema:bytesize(),
-                #{
-                    default => <<"32KB">>,
-                    desc => ?DESC(cluster_mcast_buffer),
                     'readOnly' => true
                 }
             )}
@@ -1100,8 +1020,6 @@ desc("cluster") ->
     ?DESC("desc_cluster");
 desc(cluster_static) ->
     ?DESC("desc_cluster_static");
-desc(cluster_mcast) ->
-    ?DESC("desc_cluster_mcast");
 desc(cluster_dns) ->
     ?DESC("desc_cluster_dns");
 desc(cluster_etcd) ->
@@ -1423,17 +1341,6 @@ map(Name, Type) -> hoconsc:map(Name, Type).
 
 cluster_options(static, Conf) ->
     [{seeds, conf_get("cluster.static.seeds", Conf, [])}];
-cluster_options(mcast, Conf) ->
-    {ok, Addr} = inet:parse_address(conf_get("cluster.mcast.addr", Conf)),
-    {ok, Iface} = inet:parse_address(conf_get("cluster.mcast.iface", Conf)),
-    Ports = conf_get("cluster.mcast.ports", Conf),
-    [
-        {addr, Addr},
-        {ports, Ports},
-        {iface, Iface},
-        {ttl, conf_get("cluster.mcast.ttl", Conf, 1)},
-        {loop, conf_get("cluster.mcast.loop", Conf, true)}
-    ];
 cluster_options(dns, Conf) ->
     [
         {name, conf_get("cluster.dns.name", Conf)},

--- a/changes/ce/breaking-12112.en.md
+++ b/changes/ce/breaking-12112.en.md
@@ -1,0 +1,1 @@
+Stop supporting UDP multicast based clustering strategy.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -7,12 +7,6 @@ When drop mode is activated or deactivated, a message is printed in the logs."""
 common_handler_drop_mode_qlen.label:
 """Queue Length before Entering Drop Mode"""
 
-cluster_mcast_addr.desc:
-"""Multicast IPv4 address."""
-
-cluster_mcast_addr.label:
-"""Cluster Multicast Address"""
-
 desc_cluster_dns.desc:
 """Service discovery via DNS SRV records."""
 
@@ -32,12 +26,6 @@ Note: contents of this file are secret, so it's necessary to set permissions to 
 
 rpc_keyfile.label:
 """RPC Keyfile"""
-
-cluster_mcast_recbuf.desc:
-"""Size of the kernel-level buffer for incoming datagrams."""
-
-cluster_mcast_recbuf.label:
-"""Cluster Muticast Sendbuf"""
 
 cluster_autoheal.desc:
 """If <code>true</code>, the node will try to heal network partitions automatically."""
@@ -208,12 +196,6 @@ Otherwise, the client might opt for IPv4, even if the server is on IPv6."""
 rpc_ipv6_only.label:
 """Use IPv6 Only"""
 
-cluster_mcast_buffer.desc:
-"""Size of the user-level buffer."""
-
-cluster_mcast_buffer.label:
-"""Cluster Muticast Buffer"""
-
 rpc_authentication_timeout.desc:
 """Timeout for the remote node authentication."""
 
@@ -225,12 +207,6 @@ cluster_call_retry_interval.desc:
 
 cluster_call_retry_interval.label:
 """Cluster Call Retry Interval"""
-
-cluster_mcast_sndbuf.desc:
-"""Size of the kernel-level buffer for outgoing datagrams."""
-
-cluster_mcast_sndbuf.label:
-"""Cluster Muticast Sendbuf"""
 
 rpc_driver.desc:
 """Transport protocol used for inter-broker communication"""
@@ -405,12 +381,6 @@ rpc_socket_sndbuf.desc:
 rpc_socket_sndbuf.label:
 """RPC Socket Sndbuf"""
 
-cluster_mcast_ttl.desc:
-"""Time-to-live (TTL) for the outgoing UDP datagrams."""
-
-cluster_mcast_ttl.label:
-"""Cluster Multicast TTL"""
-
 log_file_handler_file.desc:
 """Name the log file."""
 
@@ -434,12 +404,6 @@ desc_cluster_k8s.desc:
 
 desc_cluster_k8s.label:
 """Cluster Kubernetes"""
-
-desc_cluster_mcast.desc:
-"""Service discovery via UDP multicast."""
-
-desc_cluster_mcast.label:
-"""Cluster Multicast"""
 
 rpc_cacertfile.desc:
 """Path to certification authority TLS certificate file used to validate <code>rpc.certfile</code>.<br/>
@@ -504,12 +468,6 @@ cluster_etcd_prefix.desc:
 
 cluster_etcd_prefix.label:
 """Cluster Etcd Prefix"""
-
-cluster_mcast_iface.desc:
-"""Local IP address the node discovery service needs to bind to."""
-
-cluster_mcast_iface.label:
-"""Cluster Multicast Interface"""
 
 log_burst_limit_window_time.desc:
 """See <code>max_count</code>."""
@@ -582,13 +540,6 @@ desc_cluster_call.desc:
 
 desc_cluster_call.label:
 """Cluster Call"""
-
-cluster_mcast_ports.desc:
-"""List of UDP ports used for service discovery.<br/>
-Note: probe messages are broadcast to all the specified ports."""
-
-cluster_mcast_ports.label:
-"""Cluster Multicast Ports"""
 
 log_overload_kill_mem_size.desc:
 """Maximum memory size that the log handler process is allowed to use."""
@@ -694,12 +645,6 @@ node_crash_dump_file.desc:
 node_crash_dump_file.label:
 """Crash Dump File"""
 
-cluster_mcast_loop.desc:
-"""If <code>true</code>, loop UDP datagrams back to the local socket."""
-
-cluster_mcast_loop.label:
-"""Cluster Multicast Loop"""
-
 rpc_socket_keepalive_interval.desc:
 """The interval between keepalive messages."""
 
@@ -803,9 +748,7 @@ cluster_discovery_strategy.desc:
 - static: Configure static nodes list by setting <code>seeds</code> in config file.<br/>
 - dns: Use DNS A record to discover peer nodes.<br/>
 - etcd: Use etcd to discover peer nodes.<br/>
-- k8s: Use Kubernetes API to discover peer pods.
-- mcast: Deprecated since 5.1, will be removed in 5.2.
-  This supports discovery via UDP multicast."""
+- k8s: Use Kubernetes API to discover peer pods."""
 
 cluster_discovery_strategy.label:
 """Cluster Discovery Strategy"""

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -174,7 +174,6 @@ libcoap
 lifecycle
 localhost
 lwm
-mcast
 mnesia
 mountpoint
 mqueue


### PR DESCRIPTION
Fixes [EMQX-11546](https://emqx.atlassian.net/browse/EMQX-11546)

Release version: v/e5.4.0

## Summary

`mcast` clustering strategy was announced deprecated since 5.1, now it's the time to finally drop the support from codebase.
 
Schema change is NOT backward compatible. 

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket  https://github.com/emqx/emqx-docs/pull/2253
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
