### PR TITLE
fix(sessds): drop streams related to deleted subscriptions

### DIFF
--- a/apps/emqx/src/emqx_persistent_sequence.erl
+++ b/apps/emqx/src/emqx_persistent_sequence.erl
@@ -1,0 +1,39 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_persistent_sequence).
+
+-include("emqx_persistent_session_ds.hrl").
+
+-export([next/1]).
+
+-type name() :: term().
+
+%% Get the next sequence number for a given name.
+%% Should be called inside a transaction.
+-spec next(name()) -> integer().
+next(Name) ->
+    case mnesia:read(?SESSION_SEQUENCE_TAB, Name, write) of
+        [#ds_sequence{next = Next}] ->
+            write(Name, Next + 1),
+            Next;
+        [] ->
+            write(Name, 1),
+            0
+    end.
+
+write(Name, Next) ->
+    mnesia:write(?SESSION_SEQUENCE_TAB, #ds_sequence{name = Name, next = Next}, write).

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -792,16 +792,21 @@ session_read_subscriptions(DSSessionId, LockKind) ->
     ),
     mnesia:select(?SESSION_SUBSCRIPTIONS_TAB, MS, LockKind).
 
-session_read_pubranges(DSSessionID) ->
-    session_read_pubranges(DSSessionID, read).
-
-session_read_pubranges(DSSessionId, LockKind) ->
+session_read_pubrange_ids(DSSessionId, LockKind) ->
     MS = ets:fun2ms(
         fun(#ds_pubrange{id = {Sess, First}}) when Sess =:= DSSessionId ->
             {DSSessionId, First}
         end
     ),
     mnesia:select(?SESSION_PUBRANGE_TAB, MS, LockKind).
+
+session_read_pubranges(DSSessionId) ->
+    MS = ets:fun2ms(
+        fun(#ds_pubrange{id = {Sess, _}} = Range) when Sess =:= DSSessionId ->
+            Range
+        end
+    ),
+    mnesia:select(?SESSION_PUBRANGE_TAB, MS, read).
 
 session_read_offsets(DSSessionID) ->
     session_read_offsets(DSSessionID, read).
@@ -929,7 +934,7 @@ session_drop_streams(DSSessionId) ->
 %% must be called inside a transaction
 -spec session_drop_pubranges(id()) -> ok.
 session_drop_pubranges(DSSessionId) ->
-    RangeIds = session_read_pubranges(DSSessionId, write),
+    RangeIds = session_read_pubrange_ids(DSSessionId, write),
     lists:foreach(
         fun(RangeId) ->
             mnesia:delete(?SESSION_PUBRANGE_TAB, RangeId, write)

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -659,7 +659,6 @@ session_open(SessionId, NewConnInfo) ->
     session().
 session_ensure_new(SessionId, ConnInfo) ->
     transaction(fun() ->
-        ok = session_drop_records(SessionId),
         Session = export_session(session_create(SessionId, ConnInfo)),
         Session#{
             subscriptions => subs_new(),

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -18,7 +18,6 @@
 
 -behaviour(emqx_session).
 
--include("emqx.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
@@ -590,12 +589,23 @@ create_tables() ->
             {attributes, record_info(fields, ds_committed_offset)}
         ]
     ),
+    ok = mria:create_table(
+        ?SESSION_SEQUENCE_TAB,
+        [
+            {rlog_shard, ?DS_MRIA_SHARD},
+            {type, set},
+            {storage, storage()},
+            {record_name, ds_sequence},
+            {attributes, record_info(fields, ds_sequence)}
+        ]
+    ),
     ok = mria:wait_for_tables([
         ?SESSION_TAB,
         ?SESSION_SUBSCRIPTIONS_TAB,
         ?SESSION_STREAM_TAB,
         ?SESSION_PUBRANGE_TAB,
-        ?SESSION_COMMITTED_OFFSET_TAB
+        ?SESSION_COMMITTED_OFFSET_TAB,
+        ?SESSION_SEQUENCE_TAB
     ]),
     ok.
 

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -27,6 +27,8 @@
 
 -define(DS_MRIA_SHARD, emqx_ds_session_shard).
 
+-define(SESSION_STREAM_SEQ, emqx_ds_stream_seq).
+
 -define(T_INFLIGHT, 1).
 -define(T_CHECKPOINT, 2).
 
@@ -43,6 +45,8 @@
     ref :: _StreamRef,
     stream :: emqx_ds:stream(),
     rank :: emqx_ds:stream_rank(),
+    topic_filter :: emqx_types:topic(),
+    start_time :: emqx_ds:time(),
     beginning :: emqx_ds:iterator()
 }).
 -type ds_stream() :: #ds_stream{}.

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -23,6 +23,8 @@
 -define(SESSION_STREAM_TAB, emqx_ds_stream_tab).
 -define(SESSION_PUBRANGE_TAB, emqx_ds_pubrange_tab).
 -define(SESSION_COMMITTED_OFFSET_TAB, emqx_ds_committed_offset_tab).
+-define(SESSION_SEQUENCE_TAB, emqx_ds_sequence).
+
 -define(DS_MRIA_SHARD, emqx_ds_session_shard).
 
 -define(T_INFLIGHT, 1).
@@ -86,6 +88,8 @@
     %% Where this marker is pointing to: the first seqno that is not marked.
     until :: emqx_persistent_message_ds_replayer:seqno()
 }).
+
+-record(ds_sequence, {name :: term(), next :: non_neg_integer()}).
 
 -record(session, {
     %% same as clientid

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -563,7 +563,7 @@ t_process_dies_session_expires(Config) ->
     ?assertEqual(0, client_info(session_present, Client2)),
 
     %% We should not receive the pending message
-    ?assertEqual([], receive_messages(1)),
+    ?assertEqual([], receive_messages(1, 5_000)),
 
     emqtt:disconnect(Client2).
 


### PR DESCRIPTION
Fixes [EMQX-11537](https://emqx.atlassian.net/browse/EMQX-11537).

## Summary

Also stop conflating same `emqx_ds:stream()` that is part of more than one subscription into a single `#ds_stream{}`. This could have been the source of subtle bugs, for instance when start times of those subscriptions differ significantly.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [ ] Schema changes are backward compatible
