### PR TITLE
fix(actions): increment rule statistics even if channel is not installed

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -21,6 +21,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
@@ -343,7 +344,7 @@ t_send_message_through_rule(_) ->
     BridgeName = my_test_bridge,
     {ok, _} = emqx_bridge_v2:create(bridge_type(), BridgeName, bridge_config()),
     %% Create a rule to send message to the bridge
-    {ok, _} = emqx_rule_engine:create_rule(
+    {ok, #{id := RuleId}} = emqx_rule_engine:create_rule(
         #{
             sql => <<"select * from \"t/a\"">>,
             id => atom_to_binary(?FUNCTION_NAME),
@@ -357,6 +358,7 @@ t_send_message_through_rule(_) ->
             description => <<"bridge_v2 test rule">>
         }
     ),
+    on_exit(fun() -> emqx_rule_engine:delete_rule(RuleId) end),
     %% Register name for this process
     register(registered_process_name(), self()),
     %% Send message to the topic
@@ -371,7 +373,6 @@ t_send_message_through_rule(_) ->
         ct:fail("Failed to receive message")
     end,
     unregister(registered_process_name()),
-    ok = emqx_rule_engine:delete_rule(atom_to_binary(?FUNCTION_NAME)),
     ok = emqx_bridge_v2:remove(bridge_type(), BridgeName),
     ok.
 
@@ -892,6 +893,95 @@ t_lookup_status_when_connecting(_Config) ->
     #{resource_data := #{added_channels := Channels}} = Res,
     [{_Id, ChannelData}] = maps:to_list(Channels),
     ?assertMatch(#{status := ?status_disconnected}, ChannelData),
+    ok.
+
+t_rule_pointing_to_non_operational_channel(_Config) ->
+    %% Check that, if a rule sends a message to an action that is not yet installed and
+    %% uses `simple_async_internal_buffer', then it eventually increments the rule's
+    %% failed counter.
+    ResponseETS = ets:new(response_ets, [public]),
+    ets:insert(ResponseETS, {on_get_status_value, ?status_connecting}),
+    OnGetStatusFun = wrap_fun(fun() ->
+        ets:lookup_element(ResponseETS, on_get_status_value, 2)
+    end),
+
+    ConnectorConfig = emqx_utils_maps:deep_merge(con_config(), #{
+        <<"on_get_status_fun">> => OnGetStatusFun,
+        <<"resource_opts">> => #{<<"start_timeout">> => 100}
+    }),
+    ConnectorName = ?FUNCTION_NAME,
+    ct:pal("connector config:\n  ~p", [ConnectorConfig]),
+    ?check_trace(
+        begin
+            %% FIXME: this should only matter for the action.  yet, currently the query
+            %% mode from the connector is stored once by the resource manager and later
+            %% used to decide how to call the resource...
+            meck:new(con_mod(), [passthrough, no_history, non_strict]),
+            on_exit(fun() -> catch meck:unload([con_mod()]) end),
+            meck:expect(con_mod(), query_mode, 1, simple_async_internal_buffer),
+            meck:expect(con_mod(), callback_mode, 0, async_if_possible),
+
+            {ok, _} = emqx_connector:create(con_type(), ConnectorName, ConnectorConfig),
+
+            ActionName = my_test_action,
+            ChanStatusFun = wrap_fun(fun() -> ?status_disconnected end),
+            ActionConfig = (bridge_config())#{
+                <<"on_get_channel_status_fun">> => ChanStatusFun,
+                <<"connector">> => atom_to_binary(ConnectorName)
+            },
+            ct:pal("action config:\n  ~p", [ActionConfig]),
+            {ok, _} = emqx_bridge_v2:create(bridge_type(), ActionName, ActionConfig),
+
+            ?assertMatch(
+                {ok, #{
+                    error := <<"Not installed">>,
+                    status := ?status_connecting,
+                    resource_data := #{status := ?status_connecting}
+                }},
+                emqx_bridge_v2:lookup(bridge_type(), ActionName)
+            ),
+
+            {ok, #{id := RuleId}} = emqx_rule_engine:create_rule(
+                #{
+                    sql => <<"select * from \"t/a\"">>,
+                    id => atom_to_binary(?FUNCTION_NAME),
+                    actions => [
+                        <<
+                            (atom_to_binary(bridge_type()))/binary,
+                            ":",
+                            (atom_to_binary(ActionName))/binary
+                        >>
+                    ]
+                }
+            ),
+            on_exit(fun() -> emqx_rule_engine:delete_rule(RuleId) end),
+
+            Msg = emqx_message:make(<<"t/a">>, <<"payload">>),
+            emqx:publish(Msg),
+
+            ActionId = emqx_bridge_v2:id(bridge_type(), ActionName, ConnectorName),
+            ?assertEqual(1, emqx_resource_metrics:matched_get(ActionId)),
+            ?assertEqual(1, emqx_resource_metrics:failed_get(ActionId)),
+            ?retry(
+                _Sleep0 = 100,
+                _Attempts = 20,
+                ?assertMatch(
+                    #{
+                        counters :=
+                            #{
+                                matched := 1,
+                                'actions.failed' := 1
+                            }
+                    },
+                    emqx_metrics_worker:get_metrics(rule_metrics, RuleId)
+                )
+            ),
+
+            ok
+        end,
+        []
+    ),
+
     ok.
 
 %% Helper Functions

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1148,6 +1148,14 @@ error_if_channel_is_not_installed(Id, QueryOpts) ->
             ok
     end.
 
+do_call_query(QM, Id, Index, Ref, Query, #{query_mode := ReqQM} = QueryOpts, Resource) when
+    ReqQM =:= simple_sync_internal_buffer; ReqQM =:= simple_async_internal_buffer
+->
+    %% The query overrides the query mode of the resource, send even in disconnected state
+    ?tp(simple_query_override, #{query_mode => ReqQM}),
+    #{mod := Mod, state := ResSt, callback_mode := CBM, added_channels := Channels} = Resource,
+    CallMode = call_mode(QM, CBM),
+    apply_query_fun(CallMode, Mod, Id, Index, Ref, Query, ResSt, Channels, QueryOpts);
 do_call_query(QM, Id, Index, Ref, Query, QueryOpts, #{query_mode := ResQM} = Resource) when
     ResQM =:= simple_sync_internal_buffer; ResQM =:= simple_async_internal_buffer
 ->


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11494 

Release version: e5.4

### Note

Even after this fix, the frontend seems to need some adjustment.  Apparently, it's reading from `failed` when rendering the failed metrics for the action, but it should consider `actions.failed`.

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
