### PR TITLE
fix({action,connector}_schema): fix `resource_opts` subfields for connectors and actions, and remove redundant subfields from actions, use query mode from actions

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -48,7 +48,8 @@
 -export([
     make_producer_action_schema/1,
     make_consumer_action_schema/1,
-    top_level_common_action_keys/0
+    top_level_common_action_keys/0,
+    project_to_actions_resource_opts/1
 ]).
 
 -export_type([action_type/0]).
@@ -203,8 +204,8 @@ types_sc() ->
 resource_opts_fields() ->
     resource_opts_fields(_Overrides = []).
 
-resource_opts_fields(Overrides) ->
-    ActionROFields = [
+common_resource_opts_subfields() ->
+    [
         batch_size,
         batch_time,
         buffer_mode,
@@ -219,7 +220,13 @@ resource_opts_fields(Overrides) ->
         start_after_created,
         start_timeout,
         worker_pool_size
-    ],
+    ].
+
+common_resource_opts_subfields_bin() ->
+    lists:map(fun atom_to_binary/1, common_resource_opts_subfields()).
+
+resource_opts_fields(Overrides) ->
+    ActionROFields = common_resource_opts_subfields(),
     lists:filter(
         fun({Key, _Sc}) -> lists:member(Key, ActionROFields) end,
         emqx_resource_schema:create_opts(Overrides)
@@ -273,6 +280,10 @@ make_consumer_action_schema(ActionParametersRef) ->
                 desc => ?DESC(emqx_resource_schema, "resource_opts")
             })}
     ].
+
+project_to_actions_resource_opts(OldResourceOpts) ->
+    Subfields = common_resource_opts_subfields_bin(),
+    maps:with(Subfields, OldResourceOpts).
 
 -ifdef(TEST).
 -include_lib("hocon/include/hocon_types.hrl").

--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -217,8 +217,6 @@ common_resource_opts_subfields() ->
         query_mode,
         request_ttl,
         resume_interval,
-        start_after_created,
-        start_timeout,
         worker_pool_size
     ].
 

--- a/apps/emqx_bridge/test/emqx_bridge_v2_tests.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_tests.erl
@@ -69,7 +69,6 @@ connector_resource_opts_test() ->
     %% These are used by `emqx_resource_manager' itself to manage the resource lifecycle.
     MinimumROFields = [
         health_check_interval,
-        query_mode,
         start_after_created,
         start_timeout
     ],

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_action_info.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_action_info.erl
@@ -69,13 +69,23 @@ connector_action_config_to_bridge_v1_config(ConnectorConfig, ActionConfig) ->
 bridge_v1_config_to_connector_config(BridgeV1Conf) ->
     %% To statisfy the emqx_bridge_api_SUITE:t_http_crud_apis/1
     ok = validate_webhook_url(maps:get(<<"url">>, BridgeV1Conf, undefined)),
-    maps:without(?REMOVED_KEYS ++ ?ACTION_KEYS ++ ?PARAMETER_KEYS, BridgeV1Conf).
+    ConnectorConfig0 = maps:without(?REMOVED_KEYS ++ ?ACTION_KEYS ++ ?PARAMETER_KEYS, BridgeV1Conf),
+    emqx_utils_maps:update_if_present(
+        <<"resource_opts">>,
+        fun emqx_connector_schema:project_to_connector_resource_opts/1,
+        ConnectorConfig0
+    ).
 
 bridge_v1_config_to_action_config(BridgeV1Conf, ConnectorName) ->
     Parameters = maps:with(?PARAMETER_KEYS, BridgeV1Conf),
     Parameters1 = Parameters#{<<"path">> => <<>>, <<"headers">> => #{}},
     CommonKeys = [<<"enable">>, <<"description">>],
-    ActionConfig = maps:with(?ACTION_KEYS ++ CommonKeys, BridgeV1Conf),
+    ActionConfig0 = maps:with(?ACTION_KEYS ++ CommonKeys, BridgeV1Conf),
+    ActionConfig = emqx_utils_maps:update_if_present(
+        <<"resource_opts">>,
+        fun emqx_bridge_v2_schema:project_to_actions_resource_opts/1,
+        ActionConfig0
+    ),
     ActionConfig#{<<"parameters">> => Parameters1, <<"connector">> => ConnectorName}.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
@@ -120,6 +120,7 @@ fields("get_sentinel") ->
     method_fields(get, redis_sentinel);
 fields("get_cluster") ->
     method_fields(get, redis_cluster);
+%% old bridge v1 schema
 fields(Type) when
     Type == redis_single orelse Type == redis_sentinel orelse Type == redis_cluster
 ->
@@ -147,7 +148,7 @@ redis_bridge_common_fields(Type) ->
             {local_topic, mk(binary(), #{required => false, desc => ?DESC("desc_local_topic")})}
             | fields(action_parameters)
         ] ++
-        resource_fields(Type).
+        v1_resource_fields(Type).
 
 connector_fields(Type) ->
     emqx_redis:fields(Type).
@@ -158,7 +159,7 @@ type_name_fields(Type) ->
         {name, mk(binary(), #{required => true, desc => ?DESC("desc_name")})}
     ].
 
-resource_fields(Type) ->
+v1_resource_fields(Type) ->
     [
         {resource_opts,
             mk(

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
@@ -51,8 +51,10 @@ fields("config_connector") ->
                 )}
         ] ++
         emqx_redis:redis_fields() ++
-        emqx_connector_schema:resource_opts_ref(?MODULE, resource_opts) ++
+        emqx_connector_schema:resource_opts_ref(?MODULE, connector_resource_opts) ++
         emqx_connector_schema_lib:ssl_fields();
+fields(connector_resource_opts) ->
+    emqx_connector_schema:resource_opts_fields();
 fields(action) ->
     {?TYPE,
         ?HOCON(
@@ -74,15 +76,7 @@ fields(redis_action) ->
                 }
             )
         ),
-    ResOpts =
-        {resource_opts,
-            ?HOCON(
-                ?R_REF(resource_opts),
-                #{
-                    required => true,
-                    desc => ?DESC(emqx_resource_schema, resource_opts)
-                }
-            )},
+    [ResOpts] = emqx_connector_schema:resource_opts_ref(?MODULE, action_resource_opts),
     RedisType =
         {redis_type,
             ?HOCON(
@@ -90,8 +84,8 @@ fields(redis_action) ->
                 #{required => true, desc => ?DESC(redis_type)}
             )},
     [RedisType | lists:keyreplace(resource_opts, 1, Schema, ResOpts)];
-fields(resource_opts) ->
-    emqx_resource_schema:create_opts([
+fields(action_resource_opts) ->
+    emqx_bridge_v2_schema:resource_opts_fields([
         {batch_size, #{desc => ?DESC(batch_size)}},
         {batch_time, #{desc => ?DESC(batch_time)}}
     ]);
@@ -124,6 +118,10 @@ desc(redis_action) ->
     ?DESC(redis_action);
 desc(resource_opts) ->
     ?DESC(emqx_resource_schema, resource_opts);
+desc(connector_resource_opts) ->
+    ?DESC(emqx_resource_schema, "resource_opts");
+desc(action_resource_opts) ->
+    ?DESC(emqx_resource_schema, "resource_opts");
 desc(_Name) ->
     undefined.
 

--- a/apps/emqx_connector/src/schema/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/schema/emqx_connector_schema.erl
@@ -533,7 +533,6 @@ resource_opts_ref(Module, RefName) ->
 common_resource_opts_subfields() ->
     [
         health_check_interval,
-        query_mode,
         start_after_created,
         start_timeout
     ].

--- a/apps/emqx_connector/src/schema/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/schema/emqx_connector_schema.erl
@@ -28,7 +28,8 @@
 -export([
     transform_bridges_v1_to_connectors_and_bridges_v2/1,
     transform_bridge_v1_config_to_action_config/4,
-    top_level_common_connector_keys/0
+    top_level_common_connector_keys/0,
+    project_to_connector_resource_opts/1
 ]).
 
 -export([roots/0, fields/1, desc/1, namespace/0, tags/0]).
@@ -195,7 +196,7 @@ split_bridge_to_connector_and_action(
                         case maps:is_key(ConnectorFieldNameBin, BridgeV1Conf) of
                             true ->
                                 PrevFieldConfig =
-                                    project_to_connector_resource_opts(
+                                    maybe_project_to_connector_resource_opts(
                                         ConnectorFieldNameBin,
                                         maps:get(ConnectorFieldNameBin, BridgeV1Conf)
                                     ),
@@ -231,11 +232,14 @@ split_bridge_to_connector_and_action(
         end,
     {BridgeType, BridgeName, ActionMap, ConnectorName, ConnectorMap}.
 
-project_to_connector_resource_opts(<<"resource_opts">>, OldResourceOpts) ->
-    Subfields = common_resource_opts_subfields_bin(),
-    maps:with(Subfields, OldResourceOpts);
-project_to_connector_resource_opts(_, OldConfig) ->
+maybe_project_to_connector_resource_opts(<<"resource_opts">>, OldResourceOpts) ->
+    project_to_connector_resource_opts(OldResourceOpts);
+maybe_project_to_connector_resource_opts(_, OldConfig) ->
     OldConfig.
+
+project_to_connector_resource_opts(OldResourceOpts) ->
+    Subfields = common_resource_opts_subfields_bin(),
+    maps:with(Subfields, OldResourceOpts).
 
 transform_bridge_v1_config_to_action_config(
     BridgeV1Conf, ConnectorName, ConnectorConfSchemaMod, ConnectorConfSchemaName


### PR DESCRIPTION
The connector query mode is inferred during its creation, and later it must be overridden by an action, anyway.

Release version: v/e5.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
