### PR TITLE
fix(postgres_schema): fix usages of `resource_opts` in connector and action schemas

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -177,7 +177,7 @@ roots() ->
 fields(actions) ->
     registered_schema_fields();
 fields(resource_opts) ->
-    emqx_resource_schema:create_opts(_Overrides = []).
+    resource_opts_fields(_Overrides = []).
 
 registered_schema_fields() ->
     [

--- a/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
+++ b/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
@@ -85,7 +85,10 @@ fields({Field, Type}) when
     Field == "put_connector";
     Field == "post_connector"
 ->
-    emqx_connector_schema:api_fields(Field, Type, fields("connection_fields")).
+    Fields =
+        fields("connection_fields") ++
+            emqx_connector_schema:resource_opts_ref(?MODULE, resource_opts),
+    emqx_connector_schema:api_fields(Field, Type, Fields).
 
 server() ->
     Meta = #{desc => ?DESC("server")},


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11569

Release version: v/e5.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
