### PR TITLE
fix: ensure config update error text is readable

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -354,8 +354,12 @@ configs(get, #{query_string := QueryStr, headers := Headers}, _Req) ->
     end;
 configs(put, #{body := Conf, query_string := #{<<"mode">> := Mode}}, _Req) ->
     case emqx_conf_cli:load_config(Conf, #{mode => Mode, log => none}) of
-        ok -> {200};
-        {error, Msg} -> {400, #{<<"content-type">> => <<"text/plain">>}, Msg}
+        ok ->
+            {200};
+        {error, MsgList} ->
+            JsonFun = fun(K, V) -> {K, emqx_utils_maps:binary_string(V)} end,
+            JsonMap = emqx_utils_maps:jsonable_map(maps:from_list(MsgList), JsonFun),
+            {400, #{<<"content-type">> => <<"text/plain">>}, JsonMap}
     end.
 
 find_suitable_accept(Headers, Preferences) when is_list(Preferences), length(Preferences) > 0 ->


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10733

Make sure  put `/configs`  return readable msg.
```
curl -X 'PUT' \
  'http://127.0.0.1:28083/api/v5/configs?mode=merge' \
  -H 'accept: */*' \
  -H 'Content-Type: text/plain' \
  -d 'log.console.level=badwarning'
```
before:
```
": {\"log\":{\"kind\":\"validation_error\",\"matched_type\":[98,114,111,107,101,114,58,109,113,116,116,95,119,115,115,95,108,105,115,116,101,110,101,114],\"path\":[108,105,115,116,101,110,101,114,115,46,119,115,115,46,100,101,102,97,117,108,116,46,115,115,108,95,111,112,116,105,111,110,115],\"reason\":\"unknown_fields\",\"unknown\":[103,99,95,97,102,116,101,114,95,104,97,110,100,115,104,97,107,101],\"unmatched\":[99,105,112,104,101,114,115,44,99,108,105,101,110,116,95,114,101,110,101,103,111,116,105,97,116,105,111,110,44,46,46,46]}}"
```
after :
```
{"log":{"reason":"unable_to_convert_to_enum_symbol","value":"badwarning",
"path":"log.console.level","kind":"validation_error"}}
```

Release version: v/e5.4.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
