### PR TITLE
fix: use microsecond precision as the primary key for audit logs 

### DIFF
--- a/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
@@ -516,7 +516,7 @@ do_t_session_expiration(_Config, Opts) ->
 
 t_session_gc(Config) ->
     GCInterval = ?config(gc_interval, Config),
-    [Node1, Node2, Node3] = Nodes = ?config(nodes, Config),
+    [Node1, Node2, _Node3] = Nodes = ?config(nodes, Config),
     CoreNodes = [Node1, Node2],
     [
         Port1,

--- a/apps/emqx_audit/src/emqx_audit.erl
+++ b/apps/emqx_audit/src/emqx_audit.erl
@@ -119,7 +119,7 @@ log_to_db(Log) ->
     Audit0 = to_audit(Log),
     Audit = Audit0#?AUDIT{
         node = node(),
-        created_at = erlang:system_time(millisecond)
+        created_at = erlang:system_time(microsecond)
     },
     mria:dirty_write(?AUDIT, Audit).
 

--- a/apps/emqx_audit/src/emqx_audit_api.erl
+++ b/apps/emqx_audit/src/emqx_audit_api.erl
@@ -32,7 +32,7 @@
     {<<"http_method">>, atom},
     {<<"gte_created_at">>, timestamp},
     {<<"lte_created_at">>, timestamp},
-    {<<"gte_duration_ms">>, timestamp},
+    {<<"gte_duration_ms">>, integer},
     {<<"lte_duration_ms">>, integer}
 ]).
 -define(DISABLE_MSG, <<"Audit is disabled">>).
@@ -130,14 +130,14 @@ schema("/audit") ->
                         desc => ?DESC(filter_lte_duration_ms)
                     })},
                 {gte_created_at,
-                    ?HOCON(emqx_utils_calendar:epoch_millisecond(), #{
+                    ?HOCON(emqx_utils_calendar:epoch_microsecond(), #{
                         in => query,
                         required => false,
                         example => <<"2023-10-15T00:00:00.820384+08:00">>,
                         desc => ?DESC(filter_gte_created_at)
                     })},
                 {lte_created_at,
-                    ?HOCON(emqx_utils_calendar:epoch_millisecond(), #{
+                    ?HOCON(emqx_utils_calendar:epoch_microsecond(), #{
                         in => query,
                         example => <<"2023-10-16T00:00:00.820384+08:00">>,
                         required => false,
@@ -170,7 +170,7 @@ fields(audit) ->
     [
         {created_at,
             ?HOCON(
-                emqx_utils_calendar:epoch_millisecond(),
+                emqx_utils_calendar:epoch_microsecond(),
                 #{
                     desc => "The time when the log is created"
                 }

--- a/apps/emqx_conf/src/emqx_conf_schema_types.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema_types.erl
@@ -143,6 +143,24 @@ readable("epoch_millisecond()") ->
             ]
         }
     };
+readable("epoch_microsecond()") ->
+    %% only for swagger
+    #{
+        swagger => #{
+            <<"oneOf">> => [
+                #{
+                    type => integer,
+                    example => 1640995200000000,
+                    description => <<"epoch-microsecond">>
+                },
+                #{
+                    type => string,
+                    example => <<"2022-01-01T00:00:00.000000Z">>,
+                    format => <<"date-time">>
+                }
+            ]
+        }
+    };
 readable("duration()") ->
     #{
         swagger => #{type => string, example => <<"12m">>},


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11543

In the previous PR(https://github.com/emqx/emqx/pull/12150/files#diff-c584e250931fb265270c35f788dc5ccd73d34e45fa173cc1dec8bac697db616bL122), I changed the primary key of the audit log from millisecond to microsecond. However, this led to log overwrites when inserting logs in batches simultaneously. Therefore, I have reverted the precision back to **microsecond** here.

For HTTP API queries, microsecond precision is not required. When providing milliseconds, we automatically convert them to microseconds for compatibility and ease of use.

The precision change also addressed the frequent failures in the **t_max_size** CI, as it was a root cause of those issues.


Release version: v/e5.4.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
