### PR TITLE
1215 chore fix app src for emqx app

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -66,7 +66,6 @@
     {plt_location, "."},
     {plt_prefix, "emqx_dialyzer"},
     {plt_apps, all_apps},
-    {plt_extra_apps, [hocon,mnesia,bcrypt,os_mon,pbkdf2,emqx_http_lib, recon]},
     {statistics, true}
 ]}.
 

--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -28,8 +28,7 @@ Quicer = {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.0.308"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),
-    {plt_extra_apps, OldExtra} = lists:keyfind(plt_extra_apps, 1, OldDialyzerConfig),
-    Extra = OldExtra ++ [quicer || IsQuicSupp()],
+    Extra = [quicer || IsQuicSupp()],
     NewDialyzerConfig = [{plt_extra_apps, Extra} | OldDialyzerConfig],
     lists:keystore(
         dialyzer,

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -10,6 +10,7 @@
         stdlib,
         gproc,
         gen_rpc,
+        mnesia,
         mria,
         ekka,
         esockd,
@@ -17,7 +18,12 @@
         sasl,
         lc,
         hocon,
-        emqx_durable_storage
+        emqx_durable_storage,
+        bcrypt,
+        pbkdf2,
+        emqx_http_lib,
+        recon,
+        os_mon
     ]},
     {mod, {emqx_app, []}},
     {env, []},

--- a/apps/emqx_gateway/src/emqx_gateway_conf.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_conf.erl
@@ -132,7 +132,7 @@ maps_key_take([K | Ks], M, Acc) ->
 
 validate_listener_name(Name) ->
     try
-        {match, _} = re:run(Name, "^[0-9a-zA-Z_-]+$"),
+        {match, _} = re:run(Name, "^[a-zA-Z][0-9a-zA-Z_-]*$"),
         ok
     catch
         _:_ ->
@@ -140,7 +140,7 @@ validate_listener_name(Name) ->
                 {badconf, #{
                     key => name,
                     value => Name,
-                    reason => illegal_listener_name
+                    reason => bad_listener_name
                 }}
             )
     end.

--- a/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.erl
@@ -166,7 +166,7 @@ start_grpc_server(GwName, Options = #{bind := ListenOn}) ->
                 {badconf, #{
                     key => server,
                     value => Options,
-                    reason => illegal_grpc_server_confs
+                    reason => invalid_grpc_server_confs
                 }}
             )
     end;
@@ -175,7 +175,7 @@ start_grpc_server(_GwName, Options) ->
         {badconf, #{
             key => server,
             value => Options,
-            reason => illegal_grpc_server_confs
+            reason => invalid_grpc_server_confs
         }}
     ).
 
@@ -196,7 +196,7 @@ start_grpc_client_channel(
                     {badconf, #{
                         key => address,
                         value => Address,
-                        reason => illegal_grpc_address
+                        reason => invalid_grpc_address
                     }}
                 )
         end,
@@ -222,7 +222,7 @@ start_grpc_client_channel(_GwName, Options) ->
         {badconf, #{
             key => handler,
             value => Options,
-            reason => ililegal_grpc_client_confs
+            reason => invalid_grpc_client_confs
         }}
     ).
 

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
@@ -250,7 +250,7 @@ init_state_and_channel([Req, Opts, _WsOpts], _State = undefined) ->
             cowboy_req:parse_cookies(Req)
         catch
             error:badarg ->
-                ?SLOG(error, #{msg => "illegal_cookie"}),
+                ?SLOG(error, #{msg => "bad_cookie"}),
                 undefined;
             Error:Reason ->
                 ?SLOG(error, #{

--- a/rebar.config
+++ b/rebar.config
@@ -97,6 +97,7 @@
     , {uuid, {git, "https://github.com/okeuday/uuid.git", {tag, "v2.0.6"}}}
     , {ssl_verify_fun, "1.1.7"}
     , {rfc3339, {git, "https://github.com/emqx/rfc3339.git", {tag, "0.2.3"}}}
+    , {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.1"}}}
     ]}.
 
 {xref_ignores,


### PR DESCRIPTION
A follow up fix for https://github.com/emqx/emqx/pull/12085#discussion_r1427735997
The static listing of `bcrypt` app in `emqx.app.src` also lead to a larger scope refactoring of `rebar.config.erl` and `mix.exs`