### PR TITLE
chore: upgrade gun and ehttpc

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -428,7 +428,8 @@ do_get_status(ResourceId, Timeout) ->
                         msg => "ehttpc_health_check_failed",
                         connector => ResourceId,
                         reason => Reason,
-                        worker => Worker
+                        worker => Worker,
+                        wait_time => Timeout
                     }),
                     false
             end

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule EMQXUmbrella.MixProject do
       {:redbug, github: "emqx/redbug", tag: "2.0.10"},
       {:covertool, github: "zmstone/covertool", tag: "2.0.4.1", override: true},
       {:typerefl, github: "ieQu1/typerefl", tag: "0.9.1", override: true},
-      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.11", override: true},
+      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.12", override: true},
       {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true},
       {:jiffy, github: "emqx/jiffy", tag: "1.0.6", override: true},
       {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true},
@@ -77,7 +77,7 @@ defmodule EMQXUmbrella.MixProject do
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},
       # in conflict by ehttpc and emqtt
-      {:gun, github: "emqx/gun", tag: "1.3.9", override: true},
+      {:gun, github: "emqx/gun", tag: "1.3.10", override: true},
       # in conflict by emqx_connector and system_monitor
       {:epgsql, github: "emqx/epgsql", tag: "4.7.1.1", override: true},
       # in conflict by emqx and observer_cli

--- a/rebar.config
+++ b/rebar.config
@@ -64,8 +64,8 @@
     , {covertool, {git, "https://github.com/zmstone/covertool", {tag, "2.0.4.1"}}}
     , {gpb, "4.19.9"}
     , {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}}
-    , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.9"}}}
-    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.11"}}}
+    , {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.10"}}}
+    , {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.12"}}}
     , {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}}
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}}


### PR DESCRIPTION
- gun from 1.3.9 to 1.3.10 for otp 26 type spec fix
- ehttpc from 0.4.11 to 0.4.12 for error handling improvements

Fixes <issue-or-jira-number>

Release version: `v/e5.5.0`

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
