### PR TITLE
chore: move redis_type into parameters in actions

### DIFF
--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
@@ -101,7 +101,14 @@ namespace() -> "bridge_redis".
 roots() -> [].
 
 fields(action_parameters) ->
-    [{command_template, fun command_template/1}];
+    [
+        command_template(),
+        {redis_type,
+            ?HOCON(
+                ?ENUM([single, sentinel, cluster]),
+                #{required => true, desc => ?DESC(redis_type)}
+            )}
+    ];
 fields("post_single") ->
     method_fields(post, redis_single);
 fields("post_sentinel") ->
@@ -147,8 +154,8 @@ method_fields(put, ConnectorType) ->
 redis_bridge_common_fields(Type) ->
     emqx_bridge_schema:common_bridge_fields() ++
         [
-            {local_topic, mk(binary(), #{required => false, desc => ?DESC("desc_local_topic")})}
-            | fields(action_parameters)
+            {local_topic, mk(binary(), #{required => false, desc => ?DESC("desc_local_topic")})},
+            command_template()
         ] ++
         v1_resource_fields(Type).
 
@@ -222,3 +229,6 @@ is_command_template_valid(CommandSegments) ->
                 "the value of the field 'command_template' should be a nonempty "
                 "list of strings (templates for Redis command and arguments)"}
     end.
+
+command_template() ->
+    {command_template, fun command_template/1}.

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
@@ -76,13 +76,7 @@ fields(redis_action) ->
             )
         ),
     [ResOpts] = emqx_connector_schema:resource_opts_ref(?MODULE, action_resource_opts),
-    RedisType =
-        {redis_type,
-            ?HOCON(
-                ?ENUM([single, sentinel, cluster]),
-                #{required => true, desc => ?DESC(redis_type)}
-            )},
-    [RedisType | lists:keyreplace(resource_opts, 1, Schema, ResOpts)];
+    lists:keyreplace(resource_opts, 1, Schema, ResOpts);
 fields(action_resource_opts) ->
     emqx_bridge_v2_schema:resource_opts_fields([
         {batch_size, #{desc => ?DESC(batch_size)}},
@@ -130,7 +124,7 @@ resource_opts_converter(Conf, _Opts) ->
     maps:map(
         fun(_Name, SubConf) ->
             case SubConf of
-                #{<<"redis_type">> := <<"cluster">>} ->
+                #{<<"parameters">> := #{<<"redis_type">> := <<"cluster">>}} ->
                     ResOpts = maps:get(<<"resource_opts">>, SubConf, #{}),
                     %% cluster don't support batch
                     SubConf#{
@@ -218,12 +212,12 @@ action_example(RedisType, get) ->
     );
 action_example(RedisType, put) ->
     #{
-        redis_type => RedisType,
         enable => true,
         connector => <<"my_connector_name">>,
         description => <<"My action">>,
         parameters => #{
-            command_template => [<<"LPUSH">>, <<"MSGS">>, <<"${payload}">>]
+            command_template => [<<"LPUSH">>, <<"MSGS">>, <<"${payload}">>],
+            redis_type => RedisType
         },
         resource_opts => #{batch_size => 1}
     }.

--- a/apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl
+++ b/apps/emqx_bridge_redis/test/emqx_bridge_v2_redis_SUITE.erl
@@ -229,7 +229,10 @@ action_config(Name, Path, ConnectorId) ->
             <<"enable">> => true,
             <<"connector">> => ConnectorId,
             <<"parameters">> =>
-                #{<<"command_template">> => [<<"RPUSH">>, <<"MSGS/${topic}">>, <<"${payload}">>]},
+                #{
+                    <<"command_template">> => [<<"RPUSH">>, <<"MSGS/${topic}">>, <<"${payload}">>],
+                    <<"redis_type">> => atom_to_binary(RedisType)
+                },
             <<"local_topic">> => <<"t/redis">>,
             <<"resource_opts">> => #{
                 <<"batch_size">> => 1,
@@ -246,17 +249,8 @@ action_config(Name, Path, ConnectorId) ->
                 <<"worker_pool_size">> => <<"1">>
             }
         },
-    PerTypeCfg = per_type_action_config(RedisType),
-    InnerConfigMap0 = emqx_utils_maps:deep_merge(CommonCfg, PerTypeCfg),
-    InnerConfigMap = serde_roundtrip(InnerConfigMap0),
+    InnerConfigMap = serde_roundtrip(CommonCfg),
     parse_and_check_bridge_config(InnerConfigMap, Name).
-
-per_type_action_config(single) ->
-    #{<<"redis_type">> => <<"single">>};
-per_type_action_config(sentinel) ->
-    #{<<"redis_type">> => <<"sentinel">>};
-per_type_action_config(cluster) ->
-    #{<<"redis_type">> => <<"cluster">>}.
 
 %% check it serializes correctly
 serde_roundtrip(InnerConfigMap0) ->

--- a/rel/i18n/emqx_bridge_redis.hocon
+++ b/rel/i18n/emqx_bridge_redis.hocon
@@ -1,5 +1,12 @@
 emqx_bridge_redis {
 
+redis_type.label:
+"""Redis Type"""
+redis_type.desc:
+"""Single mode. Must be set to 'single' when Redis server is running in single mode.
+Sentinel mode. Must be set to 'sentinel' when Redis server is running in sentinel mode.
+Cluster mode. Must be set to 'cluster' when Redis server is running in clustered mode."""
+
 command_template.desc:
 """Redis command template used to export messages. Each list element stands for a command name or its argument.
 For example, to push payloads in a Redis list by key `msgs`, the elements should be the following:

--- a/rel/i18n/emqx_bridge_redis_schema.hocon
+++ b/rel/i18n/emqx_bridge_redis_schema.hocon
@@ -10,13 +10,6 @@ producer_action.desc:
 producer_action.label:
 """Action Parameters"""
 
-redis_type.label:
-"""Redis Type"""
-redis_type.desc:
-"""Single mode. Must be set to 'single' when Redis server is running in single mode.
-Sentinel mode. Must be set to 'sentinel' when Redis server is running in sentinel mode.
-Cluster mode. Must be set to 'cluster' when Redis server is running in clustered mode."""
-
 batch_size.label:
 """Batch Size"""
 batch_size.desc:


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11616

Release version: v/e5.4.0

Change 
```
{
type : redis,
redis_type: single,
parameters : { command_template": ["LPUSH","MSGS","${payload}"]}
}
```
To:
```
{
type : redis
parameters : {redis_type: single, command_template": ["LPUSH","MSGS","${payload}"]}
}
```

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
