### PR TITLE
fix: upgrade to gen_rpc 3.3.1 which does not log cast args only arity

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.9"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.17.0"}}},
-    {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.0"}}},
+    {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.40.3"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},

--- a/changes/ce/fix-12081.en.md
+++ b/changes/ce/fix-12081.en.md
@@ -1,7 +1,9 @@
-Updated `gen_rpc` library to version 3.3.0. The new version includes
+Updated `gen_rpc` library to version 3.3.1. The new version includes
 several performance improvements:
 
 - Avoid allocating extra memory for the packets before they are sent
   to the wire in some cases
 
 - Bypass network for the local calls
+
+- Avoid senstive data leaking in debug logs [#12202](https://github.com/emqx/emqx/pull/12202)

--- a/mix.exs
+++ b/mix.exs
@@ -56,7 +56,7 @@ defmodule EMQXUmbrella.MixProject do
       {:esockd, github: "emqx/esockd", tag: "5.9.9", override: true},
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-2", override: true},
       {:ekka, github: "emqx/ekka", tag: "0.17.0", override: true},
-      {:gen_rpc, github: "emqx/gen_rpc", tag: "3.3.0", override: true},
+      {:gen_rpc, github: "emqx/gen_rpc", tag: "3.3.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.12", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.3.15", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.7", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -72,7 +72,7 @@
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.9"}}}
     , {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-2"}}}
     , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.17.0"}}}
-    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.0"}}}
+    , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.1"}}}
     , {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.15"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.7"}}}


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11595

Release version: `v/e5.4.0`

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
