### PR TITLE
fix route race condition possible in core/replicant clusters

### DIFF
--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -28,7 +28,7 @@
     register_sub/2,
     lookup_subid/1,
     lookup_subpid/1,
-    get_sub_shard/2,
+    get_sub_shard_and_seq/2,
     create_seq/1,
     reclaim_seq/1
 ]).
@@ -79,11 +79,11 @@ lookup_subid(SubPid) when is_pid(SubPid) ->
 lookup_subpid(SubId) ->
     emqx_utils_ets:lookup_value(?SUBID, SubId).
 
--spec get_sub_shard(pid(), emqx_types:topic()) -> non_neg_integer().
-get_sub_shard(SubPid, Topic) ->
+-spec get_sub_shard_and_seq(pid(), emqx_types:topic()) -> {non_neg_integer(), non_neg_integer()}.
+get_sub_shard_and_seq(SubPid, Topic) ->
     case create_seq(Topic) of
-        Seq when Seq =< ?SHARD -> 0;
-        _ -> erlang:phash2(SubPid, shards_num()) + 1
+        Seq when Seq =< ?SHARD -> {0, Seq};
+        Seq1 -> {erlang:phash2(SubPid, shards_num()) + 1, Seq1}
     end.
 
 -spec shards_num() -> pos_integer().

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -160,13 +160,8 @@ do_add_route(Topic) when is_binary(Topic) ->
 
 -spec do_add_route(emqx_types:topic(), dest()) -> ok | {error, term()}.
 do_add_route(Topic, Dest) when is_binary(Topic) ->
-    case has_route(Topic, Dest) of
-        true ->
-            ok;
-        false ->
-            ok = emqx_router_helper:monitor(Dest),
-            mria_insert_route(get_schema_vsn(), Topic, Dest)
-    end.
+    ok = emqx_router_helper:monitor(Dest),
+    mria_insert_route(get_schema_vsn(), Topic, Dest).
 
 mria_insert_route(v2, Topic, Dest) ->
     mria_insert_route_v2(Topic, Dest);

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -378,7 +378,7 @@ t_shared_subscribe_3(_) ->
 
 t_shard({init, Config}) ->
     ok = meck:new(emqx_broker_helper, [passthrough, no_history]),
-    ok = meck:expect(emqx_broker_helper, get_sub_shard, fun(_, _) -> 1 end),
+    ok = meck:expect(emqx_broker_helper, get_sub_shard_and_seq, fun(_, _) -> {1, 1} end),
     emqx_broker:subscribe(<<"topic">>, <<"clientid">>),
     Config;
 t_shard(Config) when is_list(Config) ->

--- a/apps/emqx/test/emqx_broker_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_helper_SUITE.erl
@@ -65,8 +65,8 @@ t_shard_seq(_) ->
 t_shards_num(_) ->
     ?assertEqual(emqx_vm:schedulers() * 32, emqx_broker_helper:shards_num()).
 
-t_get_sub_shard(_) ->
-    ?assertEqual(0, emqx_broker_helper:get_sub_shard(self(), <<"topic">>)).
+t_get_sub_shard_and_seq(_) ->
+    ?assertMatch({0, _}, emqx_broker_helper:get_sub_shard_and_seq(self(), <<"topic">>)).
 
 t_terminate(_) ->
     ?assertEqual(ok, gen_server:stop(emqx_broker_helper)).


### PR DESCRIPTION
The problem was that emqx_router:has_route/2 check may observe a stale route, which deletion is not yet replicated from the core node to the local replicant node.

For example:
1. The only one subscriber per a given topic A unsubscribes from a replicant node.
2. The route to A is deleted by the emqx_broker.
3. Mria makes RPC to a core node, it succeeds and returns.
4. The client resubscribes or another client subscribes to the same topic A.
5. emqx_broker tries to add a route again: emqx_router:do_add_route(Topic).
6. emqx_router checks if the route is present.
7. The stale route is present because deletion not replicated yet, so no route is being added.
8. Route deletion is replicated locally but it's too late: we already have a local subscriber without a route.


Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
