### PR TITLE
fix(emqx_opentelemetry): use converter to convert legacy metrics config

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.32"},
+    {vsn, "0.1.33"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib, emqx_ctl]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -77,8 +77,7 @@
 
 %% Callback to upgrade config after loaded from config file but before validation.
 upgrade_raw_conf(RawConf) ->
-    RawConf1 = emqx_connector_schema:transform_bridges_v1_to_connectors_and_bridges_v2(RawConf),
-    emqx_otel_schema:upgrade_legacy_metrics(RawConf1).
+    emqx_connector_schema:transform_bridges_v1_to_connectors_and_bridges_v2(RawConf).
 
 namespace() -> emqx.
 

--- a/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
+++ b/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_opentelemetry, [
     {description, "OpenTelemetry for EMQX Broker"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {mod, {emqx_otel_app, []}},
     {applications, [

--- a/apps/emqx_opentelemetry/test/emqx_otel_schema_SUITE.erl
+++ b/apps/emqx_opentelemetry/test/emqx_otel_schema_SUITE.erl
@@ -22,8 +22,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
-%% Backward compatibility suite for `upgrade_raw_conf/1`,
-%% expected callback is `emqx_otel_schema:upgrade_legacy_metrics/1`
+%% Backward compatibility suite for legacy metrics converter
 
 -define(OLD_CONF_ENABLED, <<
     "\n"

--- a/changes/ce/fix-12234.en.md
+++ b/changes/ce/fix-12234.en.md
@@ -1,0 +1,1 @@
+Fix old (prior to EMQX 5.4.0) Open Telemetry configuration incompatibility when the config is defined in emqx.conf.


### PR DESCRIPTION
HOCON converter is cleaner and safer option,
that will also work for configurations defined in emqx.conf. Previously used `upgrade_raw_conf/1` is currently not supported in hocon_cli (used in bin/emqx).

Fixes EMQX-11643
Release version: v/e5.4.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
