### PR TITLE
fix: ft config update api return raw config

### DIFF
--- a/apps/emqx_ft/src/emqx_ft.app.src
+++ b/apps/emqx_ft/src/emqx_ft.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ft, [
     {description, "EMQX file transfer over MQTT"},
-    {vsn, "0.1.11"},
+    {vsn, "0.1.12"},
     {registered, []},
     {mod, {emqx_ft_app, []}},
     {applications, [

--- a/apps/emqx_ft/src/emqx_ft_conf.erl
+++ b/apps/emqx_ft/src/emqx_ft_conf.erl
@@ -36,7 +36,6 @@
 -export([
     load/0,
     unload/0,
-    get/0,
     update/1,
     get_raw/0
 ]).
@@ -108,10 +107,6 @@ load() ->
 unload() ->
     ok = emqx_conf:remove_handler([file_transfer]),
     maybe_stop().
-
--spec get() -> emqx_config:config().
-get() ->
-    emqx_config:get([file_transfer]).
 
 get_raw() ->
     emqx:get_raw_config([file_transfer], #{}).


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Modified the `/file_transfer` API to return the file transfer configuration in raw format rather than converting time units like "1h" to seconds, providing callers with the original configured values for consistency with other getter APIs 

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
