### PR TITLE
fix(bridge/mqtt): ensure short clientid

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -32,10 +32,10 @@
 %% `apps/emqx/src/bpapi/README.md'
 
 %% Opensource edition
--define(EMQX_RELEASE_CE, "5.4.0").
+-define(EMQX_RELEASE_CE, "5.4.1").
 
 %% Enterprise edition
--define(EMQX_RELEASE_EE, "5.4.0").
+-define(EMQX_RELEASE_EE, "5.4.1").
 
 %% The HTTP API version
 -define(EMQX_API_VERSION, "5.0").

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.1.17"},
+    {vsn, "5.1.18"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -141,4 +141,5 @@ pbkdf2(MacFun, Password, Salt, Iterations, DKLength) ->
     pbkdf2:pbkdf2(MacFun, Password, Salt, Iterations, DKLength).
 
 hex(X) when is_binary(X) ->
-    pbkdf2:to_hex(X).
+    %% TODO: change to binary:encode_hex(X, lowercase) when OTP version is always > 25
+    string:lowercase(binary:encode_hex(X)).

--- a/apps/emqx_bridge_mqtt/rebar.config
+++ b/apps/emqx_bridge_mqtt/rebar.config
@@ -1,3 +1,4 @@
 {deps, [
-    {emqx, {path, "../../apps/emqx"}}
+    {emqx, {path, "../../apps/emqx"}},
+    {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_egress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_egress.erl
@@ -81,7 +81,7 @@ mk_client_opts(WorkerId, ClientOpts = #{clientid := ClientId}) ->
     ClientOpts#{clientid := mk_clientid(WorkerId, ClientId)}.
 
 mk_clientid(WorkerId, ClientId) ->
-    iolist_to_binary([ClientId, $: | integer_to_list(WorkerId)]).
+    emqx_bridge_mqtt_lib:bytes23(ClientId, WorkerId).
 
 connect(Pid, Name) ->
     case emqtt:connect(Pid) of

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
@@ -81,7 +81,7 @@ mk_client_opts(Name, WorkerId, Ingress, ClientOpts = #{clientid := ClientId}) ->
     }.
 
 mk_clientid(WorkerId, ClientId) ->
-    iolist_to_binary([ClientId, $: | integer_to_list(WorkerId)]).
+    emqx_bridge_mqtt_lib:bytes23(ClientId, WorkerId).
 
 mk_client_event_handler(Name, Ingress = #{}) ->
     IngressVars = maps:with([server], Ingress),

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_lib.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_lib.erl
@@ -1,0 +1,57 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_mqtt_lib).
+
+-export([clientid_base/1, bytes23/2]).
+
+%% @doc Make the base ID of client IDs.
+%% A base ID is used to concatenate with pool worker ID to build a
+%% full ID.
+%% In order to avoid client ID clashing when EMQX is clustered,
+%% the base ID is the resource name concatenated with
+%% broker node name SHA-hash and truncated to 8 hex characters.
+clientid_base(Name) ->
+    bin([Name, shortener(atom_to_list(node()), 8)]).
+
+%% @doc Limit the number of bytes for client ID under 23 bytes.
+%% If Prefix and suffix concatenated is longer than 23 bytes
+%% it hashes the concatenation and replace the non-random suffix.
+bytes23(Prefix, SeqNo) ->
+    Suffix = integer_to_binary(SeqNo),
+    Concat = bin([Prefix, $:, Suffix]),
+    case size(Concat) =< 23 of
+        true ->
+            Concat;
+        false ->
+            shortener(Concat, 23)
+    end.
+
+%% @private SHA hash a string and return the prefix of
+%% the given length as hex string in binary format.
+shortener(Str, Length) when is_list(Str) ->
+    shortener(bin(Str), Length);
+shortener(Str, Length) when is_binary(Str) ->
+    true = size(Str) > 0,
+    true = (Length > 0 andalso Length =< 40),
+    Sha = crypto:hash(sha, Str),
+    %% TODO: change to binary:encode_hex(X, lowercase) when OTP version is always > 25
+    Hex = string:lowercase(binary:encode_hex(Sha)),
+    <<UniqueEnough:Length/binary, _/binary>> = Hex,
+    UniqueEnough.
+
+bin(IoList) ->
+    iolist_to_binary(IoList).

--- a/changes/ce/fix-12236.en.md
+++ b/changes/ce/fix-12236.en.md
@@ -1,0 +1,1 @@
+Ensure short client ID for MQTT bridges.


### PR DESCRIPTION
Fixes [EMQX-11662](https://emqx.atlassian.net/browse/EMQX-11662)

Release version: `v/e5.4.1`

## Summary

According to MQTT 3.1 spec, client ID should not exceed 23 bytes length.
Although most brokers actually allow longer client IDs, some actually implements this strict limitation.

Prior to this change, EMQX MQTT bridge generates client ID from bridge name (assigned by user) concatenated with node name. This concatenation is often longer than 23 bytes.

This PR makes a best effort to keep the possibility to correlate client IDs with bridge name (assigned by user).

- ClientID is prefixed with bridge name
- Concatenated with first 8 bytes from the node name's SHA hash
- Concatenated with the pool member ID

In most cases, this is not longer than 23 bytes.
However, if it still exceeds 23 bytes, SHA hash + truncation is applied again on the concatenated ID.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
