### PR TITLE
fix(s3): handle extra configured headers correctly

### DIFF
--- a/apps/emqx_s3/src/emqx_s3.app.src
+++ b/apps/emqx_s3/src/emqx_s3.app.src
@@ -1,6 +1,6 @@
 {application, emqx_s3, [
     {description, "EMQX S3"},
-    {vsn, "5.0.12"},
+    {vsn, "5.0.13"},
     {modules, []},
     {registered, [emqx_s3_sup]},
     {applications, [

--- a/apps/emqx_s3/src/emqx_s3.app.src
+++ b/apps/emqx_s3/src/emqx_s3.app.src
@@ -8,8 +8,7 @@
         stdlib,
         gproc,
         erlcloud,
-        ehttpc,
-        emqx_bridge_http
+        ehttpc
     ]},
     {mod, {emqx_s3_app, []}}
 ]}.

--- a/apps/emqx_s3/src/emqx_s3_client.erl
+++ b/apps/emqx_s3/src/emqx_s3_client.erl
@@ -388,7 +388,7 @@ with_path_and_query_only(Url, Fun) ->
 
 %% Users provide headers as a map, but erlcloud expects a list of tuples with string keys and values.
 headers_user_to_erlcloud_request(UserHeaders) ->
-    [{to_list_string(K), V} || {K, V} <- maps:to_list(UserHeaders)].
+    [{string:to_lower(to_list_string(K)), V} || {K, V} <- maps:to_list(UserHeaders)].
 
 %% Ehttpc returns operates on headers as a list of tuples with binary keys.
 %% Erlcloud expects a list of tuples with string values and lowcase string keys
@@ -409,6 +409,8 @@ to_binary(Val) when is_binary(Val) -> Val.
 
 to_list_string(Val) when is_binary(Val) ->
     binary_to_list(Val);
+to_list_string(Val) when is_atom(Val) ->
+    atom_to_list(Val);
 to_list_string(Val) when is_list(Val) ->
     Val.
 

--- a/changes/ee/fix-12241.en.md
+++ b/changes/ee/fix-12241.en.md
@@ -1,0 +1,1 @@
+Fix an issue where setting up extra HTTP headers for communication with S3 API would break File Transfers using S3 storage backend.


### PR DESCRIPTION
Fixes [EMQX-11665](https://emqx.atlassian.net/browse/EMQX-11665)

Release version: e5.4

## Summary

* Header names in config become atoms.

    Probably because of blanket `unsafe_atom_key_map/1` in `emqx_config`.

* Header names should be normalized to lowercase.

    Otherwise signature will be incorrect.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
