### PR TITLE
fix: avoid emqx starting crash if bootstrap_file is not existed

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_app.erl
+++ b/apps/emqx_management/src/emqx_mgmt_app.erl
@@ -28,13 +28,9 @@
 -include("emqx_mgmt.hrl").
 
 start(_Type, _Args) ->
-    case emqx_mgmt_auth:init_bootstrap_file() of
-        ok ->
-            emqx_conf:add_handler([api_key], emqx_mgmt_auth),
-            emqx_mgmt_sup:start_link();
-        {error, Reason} ->
-            {error, Reason}
-    end.
+    _ = emqx_mgmt_auth:init_bootstrap_file(),
+    emqx_conf:add_handler([api_key], emqx_mgmt_auth),
+    emqx_mgmt_sup:start_link().
 
 stop(_State) ->
     emqx_conf:remove_handler([api_key]),

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -52,7 +52,12 @@ groups() ->
     [
         {parallel, [parallel], [t_create, t_update, t_delete, t_authorize, t_create_unexpired_app]},
         {parallel, [parallel], ?EE_CASES},
-        {sequence, [], [t_bootstrap_file, t_bootstrap_file_with_role, t_create_failed]}
+        {sequence, [], [
+            t_application_start_with_non_exist_file,
+            t_bootstrap_file,
+            t_bootstrap_file_with_role,
+            t_create_failed
+        ]}
     ].
 
 init_per_suite(Config) ->
@@ -61,6 +66,18 @@ init_per_suite(Config) ->
 
 end_per_suite(_) ->
     emqx_mgmt_api_test_util:end_suite([emqx_conf, emqx_management]).
+
+t_application_start_with_non_exist_file(_) ->
+    application:stop(emqx_management),
+
+    Original = emqx_config:get_raw([api_key, bootstrap_file]),
+    update_file(<<"non-exist-file">>),
+
+    %% assert: start the application succeed with a non-exist bootstrap_file
+    ok = application:start(emqx_management),
+
+    update_file(Original),
+    ok.
 
 t_bootstrap_file(_) ->
     TestPath = <<"/api/v5/status">>,

--- a/changes/ce/fix-12260.en.md
+++ b/changes/ce/fix-12260.en.md
@@ -1,0 +1,1 @@
+Fixes the issue that caused emqx to fail to start when `api_key.bootstrap_file` was configured as a non-existent file.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: v/e5.5.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- ~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- [ ] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
