### PR TITLE
fix: remove redis_type from redis action

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -56,6 +56,8 @@
     project_to_actions_resource_opts/1
 ]).
 
+-export([actions_convert_from_connectors/1]).
+
 -export_type([action_type/0]).
 
 %% Should we explicitly list them here so dialyzer may be more helpful?
@@ -304,6 +306,23 @@ make_consumer_action_schema(ActionParametersRef) ->
 project_to_actions_resource_opts(OldResourceOpts) ->
     Subfields = common_resource_opts_subfields_bin(),
     maps:with(Subfields, OldResourceOpts).
+
+actions_convert_from_connectors(RawConf = #{<<"actions">> := Actions}) ->
+    Actions1 =
+        maps:map(fun(ActionType, ActionMap) ->
+            maps:map(fun(_ActionName, Action) ->
+            #{<<"connector">> := ConnName} = Action,
+            ConnType = atom_to_binary(emqx_bridge_v2:connector_type(ActionType)),
+            ConnPath = [<<"connectors">>, ConnType, ConnName],
+            case emqx_utils_maps:deep_find(ConnPath, RawConf) of
+                {ok, ConnConf} ->
+                    emqx_action_info:action_convert_from_connector(ActionType, ConnConf, Action);
+                {not_found, _KeyPath, _Data} -> Action
+            end
+                 end, ActionMap)
+             end, Actions),
+    maps:put(<<"actions">>, Actions1, RawConf);
+actions_convert_from_connectors(RawConf) -> RawConf.
 
 -ifdef(TEST).
 -include_lib("hocon/include/hocon_types.hrl").

--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -309,20 +309,30 @@ project_to_actions_resource_opts(OldResourceOpts) ->
 
 actions_convert_from_connectors(RawConf = #{<<"actions">> := Actions}) ->
     Actions1 =
-        maps:map(fun(ActionType, ActionMap) ->
-            maps:map(fun(_ActionName, Action) ->
-            #{<<"connector">> := ConnName} = Action,
-            ConnType = atom_to_binary(emqx_bridge_v2:connector_type(ActionType)),
-            ConnPath = [<<"connectors">>, ConnType, ConnName],
-            case emqx_utils_maps:deep_find(ConnPath, RawConf) of
-                {ok, ConnConf} ->
-                    emqx_action_info:action_convert_from_connector(ActionType, ConnConf, Action);
-                {not_found, _KeyPath, _Data} -> Action
-            end
-                 end, ActionMap)
-             end, Actions),
+        maps:map(
+            fun(ActionType, ActionMap) ->
+                maps:map(
+                    fun(_ActionName, Action) ->
+                        #{<<"connector">> := ConnName} = Action,
+                        ConnType = atom_to_binary(emqx_bridge_v2:connector_type(ActionType)),
+                        ConnPath = [<<"connectors">>, ConnType, ConnName],
+                        case emqx_utils_maps:deep_find(ConnPath, RawConf) of
+                            {ok, ConnConf} ->
+                                emqx_action_info:action_convert_from_connector(
+                                    ActionType, ConnConf, Action
+                                );
+                            {not_found, _KeyPath, _Data} ->
+                                Action
+                        end
+                    end,
+                    ActionMap
+                )
+            end,
+            Actions
+        ),
     maps:put(<<"actions">>, Actions1, RawConf);
-actions_convert_from_connectors(RawConf) -> RawConf.
+actions_convert_from_connectors(RawConf) ->
+    RawConf.
 
 -ifdef(TEST).
 -include_lib("hocon/include/hocon_types.hrl").

--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -610,7 +610,7 @@ t_load_no_matching_connector(_Config) ->
                 bridge_name := my_test_bridge_update,
                 connector_name := <<"unknown">>,
                 bridge_type := _,
-                reason := "connector_not_found_or_wrong_type"
+                reason := <<"connector_not_found_or_wrong_type">>
             }}},
         update_root_config(RootConf0)
     ),
@@ -627,7 +627,7 @@ t_load_no_matching_connector(_Config) ->
                 bridge_name := my_test_bridge_new,
                 connector_name := <<"unknown">>,
                 bridge_type := _,
-                reason := "connector_not_found_or_wrong_type"
+                reason := <<"connector_not_found_or_wrong_type">>
             }}},
         update_root_config(RootConf1)
     ),
@@ -696,11 +696,11 @@ t_create_no_matching_connector(_Config) ->
     Conf = (bridge_config())#{<<"connector">> => <<"wrong_connector_name">>},
     ?assertMatch(
         {error,
-            {post_config_update, _HandlerMod, #{
+            {pre_config_update, _HandlerMod, #{
                 bridge_name := _,
                 connector_name := _,
                 bridge_type := _,
-                reason := "connector_not_found_or_wrong_type"
+                reason := <<"connector_not_found_or_wrong_type">>
             }}},
         emqx_bridge_v2:create(bridge_type(), my_test_bridge, Conf)
     ),
@@ -716,11 +716,11 @@ t_create_wrong_connector_type(_Config) ->
     Conf = bridge_config(),
     ?assertMatch(
         {error,
-            {post_config_update, _HandlerMod, #{
+            {pre_config_update, _HandlerMod, #{
                 bridge_name := _,
                 connector_name := _,
                 bridge_type := wrong_type,
-                reason := "connector_not_found_or_wrong_type"
+                reason := <<"connector_not_found_or_wrong_type">>
             }}},
         emqx_bridge_v2:create(wrong_type, my_test_bridge, Conf)
     ),
@@ -732,11 +732,11 @@ t_update_connector_not_found(_Config) ->
     BadConf = Conf#{<<"connector">> => <<"wrong_connector_name">>},
     ?assertMatch(
         {error,
-            {post_config_update, _HandlerMod, #{
+            {pre_config_update, _HandlerMod, #{
                 bridge_name := _,
                 connector_name := _,
                 bridge_type := _,
-                reason := "connector_not_found_or_wrong_type"
+                reason := <<"connector_not_found_or_wrong_type">>
             }}},
         emqx_bridge_v2:create(bridge_type(), my_test_bridge, BadConf)
     ),

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_redis, [
     {description, "EMQX Enterprise Redis Bridge"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.erl
@@ -105,8 +105,12 @@ fields(action_parameters) ->
         command_template(),
         {redis_type,
             ?HOCON(
-                ?ENUM([single, sentinel, cluster]),
-                #{required => true, desc => ?DESC(redis_type)}
+                ?ENUM([single, sentinel, cluster]), #{
+                    required => false,
+                    desc => ?DESC(redis_type),
+                    hidden => true,
+                    importance => ?IMPORTANCE_HIDDEN
+                }
             )}
     ];
 fields("post_single") ->

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_schema.erl
@@ -145,21 +145,9 @@ resource_opts_converter(Conf, _Opts) ->
 bridge_v2_examples(Method) ->
     [
         #{
-            <<"redis_single_producer">> => #{
-                summary => <<"Redis Single Producer Action">>,
+            <<"redis">> => #{
+                summary => <<"Redis Action">>,
                 value => action_example(single, Method)
-            }
-        },
-        #{
-            <<"redis_sentinel_producer">> => #{
-                summary => <<"Redis Sentinel Producer Action">>,
-                value => action_example(sentinel, Method)
-            }
-        },
-        #{
-            <<"redis_cluster_producer">> => #{
-                summary => <<"Redis Cluster Producer Action">>,
-                value => action_example(cluster, Method)
             }
         }
     ].

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -80,7 +80,6 @@ upgrade_raw_conf(Raw0) ->
     Raw1 = emqx_connector_schema:transform_bridges_v1_to_connectors_and_bridges_v2(Raw0),
     emqx_bridge_v2_schema:actions_convert_from_connectors(Raw1).
 
-
 namespace() -> emqx.
 
 tags() ->

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -76,8 +76,10 @@
 -define(DEFAULT_MAX_PORTS, 1024 * 1024).
 
 %% Callback to upgrade config after loaded from config file but before validation.
-upgrade_raw_conf(RawConf) ->
-    emqx_connector_schema:transform_bridges_v1_to_connectors_and_bridges_v2(RawConf).
+upgrade_raw_conf(Raw0) ->
+    Raw1 = emqx_connector_schema:transform_bridges_v1_to_connectors_and_bridges_v2(Raw0),
+    emqx_bridge_v2_schema:actions_convert_from_connectors(Raw1).
+
 
 namespace() -> emqx.
 

--- a/apps/emqx_connector/src/emqx_connector.erl
+++ b/apps/emqx_connector/src/emqx_connector.erl
@@ -113,15 +113,13 @@ pre_config_update([?ROOT_KEY], NewConf, _RawConf) ->
         ok -> {ok, convert_certs(NewConf)};
         Error -> Error
     end;
-pre_config_update([?ROOT_KEY, Type, Name], Oper, undefined)
-    when ?ENABLE_OR_DISABLE(Oper) ->
-    {error,  #{
-        reason => <<"connector_not_found">>,
-        connector_name => Name,
-        connector_type => Type
-    }};
-pre_config_update([?ROOT_KEY, _Type, _Name], Oper, OldConfig)
-    when ?ENABLE_OR_DISABLE(Oper) ->
+pre_config_update([?ROOT_KEY, _Type, _Name], Oper, undefined) when
+    ?ENABLE_OR_DISABLE(Oper)
+->
+    {error, connector_not_found};
+pre_config_update([?ROOT_KEY, _Type, _Name], Oper, OldConfig) when
+    ?ENABLE_OR_DISABLE(Oper)
+->
     %% to save the 'enable' to the config files
     {ok, OldConfig#{<<"enable">> => operation_to_enable(Oper)}};
 pre_config_update([?ROOT_KEY, _Type, Name] = Path, Conf = #{}, _OldConfig) ->

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -136,14 +136,16 @@ create(Type, Name, Conf0, Opts) ->
         config => emqx_utils:redact(Conf0)
     }),
     TypeBin = bin(Type),
+    ResourceId = resource_id(Type, Name),
     Conf = Conf0#{connector_type => TypeBin, connector_name => Name},
     {ok, _Data} = emqx_resource:create_local(
-        resource_id(Type, Name),
+        ResourceId,
         <<"emqx_connector">>,
         ?MODULE:connector_to_resource_type(Type),
         parse_confs(TypeBin, Name, Conf),
         parse_opts(Conf, Opts)
     ),
+    _ = emqx_alarm:ensure_deactivated(ResourceId),
     ok.
 
 update(ConnectorId, {OldConf, Conf}) ->


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11695

Two major changes have been made:

1. Redis actions no longer require the `redis_type` parameter. It can be inferred by the connector being used.
This parameter has caused some confusion in the prev version. When users configure the `redis_type` of actions as "sentinel," the corresponding connector should ideally be set as "sentinel" as well. However, it was observed that the actions could still run even if the connector was set as "single."

2. We will make the following improvements to the code for bulk importing connectors and actions:
If a connector is referenced by an action, it cannot be deleted successfully. Therefore, we will prioritize deleting actions before updating connectors.
While creating an action, if the corresponding connector does not exist, an error will be thrown. Hence, it is necessary to create the connector first.
By implementing these changes, we ensure a proper sequence for importing connectors and actions, avoiding potential errors and ensuring successful operations.


Release version: v/e5.5.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
