### PR TITLE
feat(retain): add two new endpoints for retain API

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.19"},
+    {vsn, "5.0.20"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer_api.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_api.erl
@@ -181,7 +181,6 @@ lookup_retained(get, #{query_string := Qs}) ->
     Page = maps:get(<<"page">>, Qs, 1),
     Limit = maps:get(<<"limit">>, Qs, emqx_mgmt:default_row_limit()),
     Topic = maps:get(<<"topic">>, Qs, undefined),
-    ct:print("Qs:~p~n", [Qs]),
     {ok, Msgs} = emqx_retainer_mnesia:page_read(undefined, Topic, Page, Limit),
     {200, #{
         data => [format_message(Msg) || Msg <- Msgs],

--- a/changes/ce/feat-12272.en.md
+++ b/changes/ce/feat-12272.en.md
@@ -1,0 +1,3 @@
+Added a new endpoint `DELETE /retainer/messages` to `retain` API to clean all retained messages
+
+Also added an optional topic filter in the query string for the endpoint "GET /retainer/messages", e.g. "topic=t/1".

--- a/rel/i18n/emqx_retainer_api.hocon
+++ b/rel/i18n/emqx_retainer_api.hocon
@@ -27,8 +27,13 @@ list_retained_api.desc:
 list_retained_api.label:
 """List retained messages."""
 
+delete_messages.desc:
+"""Delete all retained messages"""
+delete_messages.label:
+"""Delete Retained Messages"""
+
 lookup_api.desc:
-"""Lookup a message by a topic without wildcards."""
+"""Lookup a message by a topic without wildcards, ."""
 lookup_api.label:
 """Lookup a message"""
 
@@ -55,6 +60,9 @@ retained_list.desc:
 
 topic.desc:
 """Topic."""
+
+query_match_topic.desc:
+"""Topic filter, supports wildcards, omit this to match all messages."""
 
 unsupported_backend.desc:
 """Unsupported backend."""

--- a/rel/i18n/emqx_retainer_api.hocon
+++ b/rel/i18n/emqx_retainer_api.hocon
@@ -33,7 +33,7 @@ delete_messages.label:
 """Delete Retained Messages"""
 
 lookup_api.desc:
-"""Lookup a message by a topic without wildcards, ."""
+"""Lookup a message by a topic without wildcards."""
 lookup_api.label:
 """Lookup a message"""
 


### PR DESCRIPTION
Fixes [EMQX-11668](https://emqx.atlassian.net/browse/EMQX-11668)

Release version: v/e5.5.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
