### PR TITLE
fix(bin/emqx): check app status in bash script

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -988,6 +988,7 @@ fi
 
 diagnose_boot_failure_and_die() {
     local ps_line
+    local app_status
     ps_line="$(find_emqx_process)"
     if [ -z "$ps_line" ]; then
         echo "Find more information in the latest log file: ${EMQX_LOG_DIR}/erlang.log.*"
@@ -999,9 +1000,9 @@ diagnose_boot_failure_and_die() {
         pipe_shutdown
         exit 2
     fi
-    if ! relx_nodetool 'eval' 'true = emqx:is_running()' > /dev/null; then
+    app_status="$(relx_nodetool 'eval' 'emqx:is_running()')"
+    if [ "$app_status" != 'true' ]; then
         logerr "$NAME node is started, but failed to complete the boot sequence in time."
-        echo "Please collect the logs in ${EMQX_LOG_DIR} and report a bug to EMQX team at https://github.com/emqx/emqx/issues/new/choose"
         pipe_shutdown
         exit 3
     fi


### PR DESCRIPTION
Prior to this change, 'true=emqx:is_running().' Erlang assertion is evaluated before 'emqx start' command gives up waiting.

The Erlang assertion would result in a error level crash log which can be confusing.

This commit changes the equals to 'true' check to bash script instead.

Fixes [EMQX-11701](https://emqx.atlassian.net/browse/EMQX-11701)

Release version: v/e5.5.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
