### PR TITLE
fix(mysql_bridge): check prepare statement error messages

### DIFF
--- a/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
+++ b/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mysql, [
     {description, "EMQX Enterprise MySQL Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mysql/src/emqx_bridge_mysql_connector.erl
+++ b/apps/emqx_bridge_mysql/src/emqx_bridge_mysql_connector.erl
@@ -39,11 +39,25 @@ on_add_channel(
         ok ->
             ChannelConfig2 = maps:merge(ChannelConfig1, QueryTemplates),
             ChannelConfig = set_prepares(ChannelConfig2, ConnectorState),
-            State = State0#{
-                channels => maps:put(ChannelId, ChannelConfig, Channels),
-                connector_state => ConnectorState
-            },
-            {ok, State};
+            case maps:get(prepares, ChannelConfig) of
+                {error, {Code, ErrState, Msg}} ->
+                    Context = #{
+                        code => Code,
+                        state => ErrState,
+                        message => Msg
+                    },
+                    {error, {prepare_statement, Context}};
+                {error, undefined_table} ->
+                    {error, {unhealthy_target, <<"Undefined table">>}};
+                {error, Reason} ->
+                    {error, {prepare_statement, Reason}};
+                _ ->
+                    State = State0#{
+                        channels => maps:put(ChannelId, ChannelConfig, Channels),
+                        connector_state => ConnectorState
+                    },
+                    {ok, State}
+            end;
         {error, Error} ->
             {error, Error}
     end.

--- a/changes/ee/fix-12281.en.md
+++ b/changes/ee/fix-12281.en.md
@@ -1,0 +1,1 @@
+Improved HTTP API error message when the creation of a MySQL bridge fails.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11648

Release version: v/e5.5

![image](https://github.com/emqx/emqx/assets/16166434/e2216aed-e5be-439a-a092-83770d75115e)


## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
