### PR TITLE
fix(mysql_bridge): allow deleting bridge when sql contains undefined fields

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_testlib.erl
@@ -184,6 +184,15 @@ update_bridge_api(Config, Overrides) ->
     ct:pal("bridge update result: ~p", [Res]),
     Res.
 
+delete_bridge_http_api_v1(Opts) ->
+    #{type := Type, name := Name} = Opts,
+    BridgeId = emqx_bridge_resource:bridge_id(Type, Name),
+    Path = emqx_mgmt_api_test_util:api_path(["bridges", BridgeId]),
+    ct:pal("deleting bridge (http v1)"),
+    Res = emqx_bridge_v2_testlib:request(delete, Path, _Params = []),
+    ct:pal("bridge delete (http v1) result:\n  ~p", [Res]),
+    Res.
+
 op_bridge_api(Op, BridgeType, BridgeName) ->
     BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
     Path = emqx_mgmt_api_test_util:api_path(["bridges", BridgeId, Op]),

--- a/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
+++ b/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mysql, [
     {description, "EMQX Enterprise MySQL Bridge"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ee/fix-12281.en.md
+++ b/changes/ee/fix-12281.en.md
@@ -1,0 +1,1 @@
+Improved HTTP API error message when the creation of a MySQL bridge fails.

--- a/changes/ee/fix-12281.en.md
+++ b/changes/ee/fix-12281.en.md
@@ -1,1 +1,0 @@
-Improved HTTP API error message when the creation of a MySQL bridge fails.

--- a/changes/ee/fix-12282.en.md
+++ b/changes/ee/fix-12282.en.md
@@ -1,0 +1,3 @@
+Improved HTTP API error message when the creation of a MySQL bridge fails.
+
+Fixed an issue that prevented removing a MySQL bridge when its SQL contained undefined columns.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11655

Fixes https://emqx.atlassian.net/browse/EMQX-11648

Release version: v/e5.5

![image](https://github.com/emqx/emqx/assets/16166434/e2216aed-e5be-439a-a092-83770d75115e)


## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
