### PR TITLE
fix(retain): add `hasnext` into the meta data for the `GET /retain/messages`

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -78,7 +78,7 @@
 -callback store_retained(context(), message()) -> ok.
 -callback read_message(context(), topic()) -> {ok, list()}.
 -callback page_read(context(), topic(), non_neg_integer(), non_neg_integer()) ->
-    {ok, list()}.
+    {ok, HasNext :: boolean(), list()}.
 -callback match_messages(context(), topic(), cursor()) -> {ok, list(), cursor()}.
 -callback clear_expired(context()) -> ok.
 -callback clean(context()) -> ok.

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -231,20 +231,18 @@ page_read(_, Topic, Page, Limit) ->
             false ->
                 more
         end,
-    PageRows =
-        case SkipResult of
-            closed ->
-                [];
-            more ->
-                case qlc_next_answers(Cursor, Limit) of
-                    {closed, Rows} ->
-                        Rows;
-                    {more, Rows} ->
-                        qlc:delete_cursor(Cursor),
-                        Rows
-                end
-        end,
-    {ok, PageRows}.
+    case SkipResult of
+        closed ->
+            {ok, false, []};
+        more ->
+            case qlc_next_answers(Cursor, Limit) of
+                {closed, Rows} ->
+                    {ok, false, Rows};
+                {more, Rows} ->
+                    qlc:delete_cursor(Cursor),
+                    {ok, true, Rows}
+            end
+    end.
 
 clean(_) ->
     _ = mria:clear_table(?TAB_MESSAGE),

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -133,7 +133,7 @@ t_store_and_clean(_) ->
     ),
     timer:sleep(100),
 
-    {ok, List} = emqx_retainer:page_read(<<"retained">>, 1, 10),
+    {ok, _, List} = emqx_retainer:page_read(<<"retained">>, 1, 10),
     ?assertEqual(1, length(List)),
     ?assertMatch(
         {ok, [#message{payload = <<"this is a retained message">>}]},
@@ -159,7 +159,7 @@ t_store_and_clean(_) ->
     ),
 
     ok = emqx_retainer:clean(),
-    {ok, List2} = emqx_retainer:page_read(<<"retained">>, 1, 10),
+    {ok, _, List2} = emqx_retainer:page_read(<<"retained">>, 1, 10),
     ?assertEqual(0, length(List2)),
     ?assertMatch(
         {ok, []},
@@ -486,12 +486,12 @@ t_clear_expired(_) ->
         ),
         timer:sleep(1000),
 
-        {ok, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
+        {ok, _, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
         ?assertEqual(5, erlang:length(List)),
 
         timer:sleep(4500),
 
-        {ok, List2} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
+        {ok, _, List2} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
         ?assertEqual(0, erlang:length(List2)),
 
         ok = emqtt:disconnect(C1)
@@ -522,7 +522,7 @@ t_max_payload_size(_) ->
         ),
 
         timer:sleep(500),
-        {ok, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
+        {ok, _, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
         ?assertEqual(1, erlang:length(List)),
 
         ok = emqtt:disconnect(C1)
@@ -546,10 +546,10 @@ t_page_read(_) ->
     lists:foreach(Fun, lists:seq(1, 9)),
     timer:sleep(200),
 
-    {ok, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 5),
+    {ok, _, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 5),
     ?assertEqual(5, length(List)),
 
-    {ok, List2} = emqx_retainer:page_read(<<"retained/+">>, 2, 5),
+    {ok, _, List2} = emqx_retainer:page_read(<<"retained/+">>, 2, 5),
     ?assertEqual(4, length(List2)),
 
     ok = emqtt:disconnect(C1).


### PR DESCRIPTION
[EMQX-11709](https://emqx.atlassian.net/browse/EMQX-11709)

Release version: `v/e5.5.0`

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
