### PR TITLE
fix(conf): bump to hocon 0.40.4

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -30,7 +30,7 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.11.1"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.17.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.1"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.40.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.40.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.1"}}},

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -428,7 +428,7 @@ test_configure(Uri, Config) ->
                     <<"exporter">> := #{
                         <<"s3">> := #{
                             <<"transport_options">> := #{
-                                <<"ssl">> := #{
+                                <<"ssl">> := SSL = #{
                                     <<"enable">> := true,
                                     <<"certfile">> := <<"/", _CertFilepath/bytes>>,
                                     <<"keyfile">> := <<"/", _KeyFilepath/bytes>>
@@ -441,7 +441,7 @@ test_configure(Uri, Config) ->
                     }
                 }
             }
-        },
+        } when not is_map_key(<<"password">>, SSL),
         GetConfigJson
     ),
     ?assertMatch(

--- a/changes/ee/fix-12291.en.md
+++ b/changes/ee/fix-12291.en.md
@@ -1,0 +1,1 @@
+Fix inconsistency in how EMQX handles configuration updates where sensitive parameters are involved, which led to occurrences of stray `"******"` strings in the cluster configuration file.

--- a/mix.exs
+++ b/mix.exs
@@ -72,7 +72,7 @@ defmodule EMQXUmbrella.MixProject do
       # in conflict by emqtt and hocon
       {:getopt, "1.0.2", override: true},
       {:snabbkaffe, github: "kafka4beam/snabbkaffe", tag: "1.0.8", override: true},
-      {:hocon, github: "emqx/hocon", tag: "0.40.3", override: true},
+      {:hocon, github: "emqx/hocon", tag: "0.40.4", override: true},
       {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.3", override: true},
       {:esasl, github: "emqx/esasl", tag: "0.2.0"},
       {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -97,7 +97,7 @@
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}},
     {getopt, "1.0.2"},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.8"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.40.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.40.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.0"}}},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},


### PR DESCRIPTION
Fixes [EMQX-11636](https://emqx.atlassian.net/browse/EMQX-11636).

Release version: `e5.5.0`

## Summary

Which includes a bugfix ensuring that undefined sensitive values does not turn into `******` after `hocon_tconf:check_plain/4`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
