### PR TITLE
fix(gcp_pubsub_producer): mark connector resource opts fields as deprecated

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_schema.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_schema.erl
@@ -81,7 +81,20 @@ fields("config_connector") ->
     emqx_connector_schema:common_fields() ++
         connector_config_fields();
 fields(connector_resource_opts) ->
-    emqx_connector_schema:resource_opts_fields();
+    %% for backwards compatibility...
+    Fields = proplists:get_keys(emqx_connector_schema:resource_opts_fields()),
+    AllFields = proplists:get_keys(emqx_resource_schema:create_opts([])),
+    DeprecatedFields = AllFields -- Fields,
+    Overrides = lists:map(
+        fun(Field) ->
+            {Field, #{
+                importance => ?IMPORTANCE_HIDDEN,
+                deprecated => {since, "5.5.0"}
+            }}
+        end,
+        DeprecatedFields
+    ),
+    emqx_resource_schema:create_opts(Overrides);
 %%=========================================
 %% HTTP API fields: action
 %%=========================================

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -1898,3 +1898,40 @@ t_bad_attributes(Config) ->
         end
     ),
     ok.
+
+t_deprecated_connector_resource_opts(Config) ->
+    ?check_trace(
+        begin
+            ServiceAccountJSON = ?config(service_account_json, Config),
+            AllResOpts = #{
+                <<"batch_size">> => 1,
+                <<"batch_time">> => <<"0ms">>,
+                <<"buffer_mode">> => <<"memory_only">>,
+                <<"buffer_seg_bytes">> => <<"10MB">>,
+                <<"health_check_interval">> => <<"15s">>,
+                <<"inflight_window">> => 100,
+                <<"max_buffer_bytes">> => <<"256MB">>,
+                <<"metrics_flush_interval">> => <<"1s">>,
+                <<"query_mode">> => <<"sync">>,
+                <<"request_ttl">> => <<"45s">>,
+                <<"resume_interval">> => <<"15s">>,
+                <<"start_after_created">> => true,
+                <<"start_timeout">> => <<"5s">>,
+                <<"worker_pool_size">> => <<"1">>
+            },
+            RawConnectorConfig = #{
+                <<"enable">> => true,
+                <<"service_account_json">> => ServiceAccountJSON,
+                <<"resource_opts">> => AllResOpts
+            },
+            ?assertMatch(
+                {ok, _},
+                emqx:update_config([connectors, ?CONNECTOR_TYPE, c], RawConnectorConfig, #{})
+            ),
+            ok
+        end,
+        fun(_Trace) ->
+            ok
+        end
+    ),
+    ok.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11703

Release version: v/e5.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files (addendum to #12283)
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
