### PR TITLE
fix(mongodb_action): make `batch_size` hidden and fixed in the API

### DIFF
--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -50,8 +50,8 @@
 ]).
 
 -export([
-    make_producer_action_schema/1,
-    make_consumer_action_schema/1,
+    make_producer_action_schema/1, make_producer_action_schema/2,
+    make_consumer_action_schema/1, make_consumer_action_schema/2,
     top_level_common_action_keys/0,
     project_to_actions_resource_opts/1
 ]).
@@ -282,12 +282,19 @@ top_level_common_action_keys() ->
 %%======================================================================================
 
 make_producer_action_schema(ActionParametersRef) ->
+    make_producer_action_schema(ActionParametersRef, _Opts = #{}).
+
+make_producer_action_schema(ActionParametersRef, Opts) ->
     [
         {local_topic, mk(binary(), #{required => false, desc => ?DESC(mqtt_topic)})}
-        | make_consumer_action_schema(ActionParametersRef)
+        | make_consumer_action_schema(ActionParametersRef, Opts)
     ].
 
 make_consumer_action_schema(ActionParametersRef) ->
+    make_consumer_action_schema(ActionParametersRef, _Opts = #{}).
+
+make_consumer_action_schema(ActionParametersRef, Opts) ->
+    ResourceOptsRef = maps:get(resource_opts_ref, Opts, ref(?MODULE, resource_opts)),
     [
         {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
         {connector,
@@ -297,7 +304,7 @@ make_consumer_action_schema(ActionParametersRef) ->
         {description, emqx_schema:description_schema()},
         {parameters, ActionParametersRef},
         {resource_opts,
-            mk(ref(?MODULE, resource_opts), #{
+            mk(ResourceOptsRef, #{
                 default => #{},
                 desc => ?DESC(emqx_resource_schema, "resource_opts")
             })}

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mongodb, [
     {description, "EMQX Enterprise MongoDB Bridge"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.erl
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.erl
@@ -86,7 +86,8 @@ fields(mongodb_action) ->
     emqx_bridge_v2_schema:make_producer_action_schema(
         mk(ref(?MODULE, action_parameters), #{
             required => true, desc => ?DESC(action_parameters)
-        })
+        }),
+        #{resource_opts_ref => ref(?MODULE, action_resource_opts)}
     );
 fields(action_parameters) ->
     [
@@ -95,6 +96,14 @@ fields(action_parameters) ->
     ];
 fields(connector_resource_opts) ->
     emqx_connector_schema:resource_opts_fields();
+fields(action_resource_opts) ->
+    emqx_bridge_v2_schema:resource_opts_fields([
+        {batch_size, #{
+            importance => ?IMPORTANCE_HIDDEN,
+            converter => fun(_, _) -> 1 end,
+            desc => ?DESC("batch_size")
+        }}
+    ]);
 fields(resource_opts) ->
     fields("creation_opts");
 fields(mongodb_rs) ->
@@ -212,6 +221,8 @@ desc("config") ->
 desc("creation_opts") ->
     ?DESC(emqx_resource_schema, "creation_opts");
 desc(resource_opts) ->
+    ?DESC(emqx_resource_schema, "resource_opts");
+desc(action_resource_opts) ->
     ?DESC(emqx_resource_schema, "resource_opts");
 desc(connector_resource_opts) ->
     ?DESC(emqx_resource_schema, "resource_opts");

--- a/changes/ee/fix-12317.en.md
+++ b/changes/ee/fix-12317.en.md
@@ -1,0 +1,1 @@
+Removed the `resource_opts.batch_size` field from the MongoDB Action schema, as it's still not supported.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/ED-1171

The old bridge schema already had this override, but it had not been ported to actions.

Release version: v/e5.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
