### PR TITLE
0118 fix authz cache excludes type

### DIFF
--- a/apps/emqx/src/emqx_access_control.erl
+++ b/apps/emqx/src/emqx_access_control.erl
@@ -135,6 +135,7 @@ is_username_defined(_) -> false.
 check_authorization_cache(ClientInfo, Action, Topic) ->
     case emqx_authz_cache:get_authz_cache(Action, Topic) of
         not_found ->
+            inc_authz_metrics(cache_miss),
             AuthzResult = do_authorize(ClientInfo, Action, Topic),
             emqx_authz_cache:put_authz_cache(Action, Topic, AuthzResult),
             AuthzResult;
@@ -219,7 +220,9 @@ inc_authz_metrics(allow) ->
 inc_authz_metrics(deny) ->
     emqx_metrics:inc('authorization.deny');
 inc_authz_metrics(cache_hit) ->
-    emqx_metrics:inc('authorization.cache_hit').
+    emqx_metrics:inc('authorization.cache_hit');
+inc_authz_metrics(cache_miss) ->
+    emqx_metrics:inc('authorization.cache_miss').
 
 inc_authn_metrics(error) ->
     emqx_metrics:inc('authentication.failure');

--- a/apps/emqx/src/emqx_authz_cache.erl
+++ b/apps/emqx/src/emqx_authz_cache.erl
@@ -56,7 +56,7 @@ drain_k() -> {?MODULE, drain_timestamp}.
 -spec is_enabled(emqx_types:topic()) -> boolean().
 is_enabled(Topic) ->
     case emqx:get_config([authorization, cache]) of
-        #{enable := true, excludes := Filters} ->
+        #{enable := true, excludes := Filters} when Filters =/= [] ->
             not is_excluded(Topic, Filters);
         #{enable := IsEnabled} ->
             IsEnabled

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -258,7 +258,8 @@
 -define(STASTS_ACL_METRICS, [
     {counter, 'authorization.allow'},
     {counter, 'authorization.deny'},
-    {counter, 'authorization.cache_hit'}
+    {counter, 'authorization.cache_hit'},
+    {counter, 'authorization.cache_miss'}
 ]).
 
 %% Statistic metrics for auth checking
@@ -702,6 +703,7 @@ reserved_idx('session.terminated') -> 224;
 reserved_idx('authorization.allow') -> 300;
 reserved_idx('authorization.deny') -> 301;
 reserved_idx('authorization.cache_hit') -> 302;
+reserved_idx('authorization.cache_miss') -> 303;
 reserved_idx('authentication.success') -> 310;
 reserved_idx('authentication.success.anonymous') -> 311;
 reserved_idx('authentication.failure') -> 312;

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -468,7 +468,7 @@ fields(authz_cache) ->
                 }
             )},
         {excludes,
-            sc(hoconsc:array(string()), #{
+            sc(hoconsc:array(binary()), #{
                 default => [],
                 desc => ?DESC(fields_authz_cache_excludes)
             })}

--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.0.18"},
+    {vsn, "5.0.19"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx, emqx_management]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -486,6 +486,8 @@ emqx_collect(emqx_authorization_deny, Stats) ->
     counter_metric(?C('authorization.deny', Stats));
 emqx_collect(emqx_authorization_cache_hit, Stats) ->
     counter_metric(?C('authorization.cache_hit', Stats));
+emqx_collect(emqx_authorization_cache_miss, Stats) ->
+    counter_metric(?C('authorization.cache_miss', Stats));
 emqx_collect(emqx_authorization_superuser, Stats) ->
     counter_metric(?C('authorization.superuser', Stats));
 emqx_collect(emqx_authorization_nomatch, Stats) ->
@@ -591,6 +593,7 @@ emqx_metrics_acl() ->
         emqx_authorization_allow,
         emqx_authorization_deny,
         emqx_authorization_cache_hit,
+        emqx_authorization_cache_miss,
         emqx_authorization_superuser,
         emqx_authorization_nomatch,
         emqx_authorization_matched_allow,


### PR DESCRIPTION
Fixes [EMQX-11734](https://emqx.atlassian.net/browse/EMQX-11734)

Release version: `v/e5.5.0`

## Summary

This is s a follow-up fix for https://github.com/emqx/emqx/pull/12289 (not released yet)

Also added a `cache_miss` counter (exported to prometheus)