### PR TITLE
fix(machine_boot): inject connector/bridge apps as dependencies to `emqx_connector` app

### DIFF
--- a/apps/emqx_bridge_es/src/emqx_bridge_es.app.src
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es.app.src
@@ -10,8 +10,7 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_resource,
-        emqx_connector
+        emqx_resource
     ]},
     {env, []},
     {licenses, ["Business Source License 1.1"]},

--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -2,7 +2,7 @@
     {description, "EMQX HTTP Bridge and Connector Application"},
     {vsn, "0.2.2"},
     {registered, []},
-    {applications, [kernel, stdlib, emqx_connector, emqx_resource, ehttpc]},
+    {applications, [kernel, stdlib, emqx_resource, ehttpc]},
     {env, [{emqx_action_info_modules, [emqx_bridge_http_action_info]}]},
     {modules, []},
     {links, []}

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.app.src
@@ -10,9 +10,7 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_resource,
-        %% for module emqx_connector_http
-        emqx_connector
+        emqx_resource
     ]},
     {env, []},
     {licenses, ["Business Source License 1.1"]},

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
@@ -5,7 +5,6 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_connector,
         emqx_resource,
         emqx_mongodb
     ]},

--- a/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
+++ b/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
@@ -5,7 +5,6 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_connector,
         emqx_resource,
         emqx_mysql
     ]},

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
@@ -5,7 +5,6 @@
     {applications, [
         kernel,
         stdlib,
-        emqx_connector,
         emqx_resource,
         emqx_redis
     ]},

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -178,6 +178,11 @@ app_deps(App, RebootApps) ->
 %% `emqx_bridge' is special in that it needs all the bridges apps to
 %% be started before it, so that, when it loads the bridges from
 %% configuration, the bridge app and its dependencies need to be up.
+%%
+%% `emqx_connector' also needs to start all connector dependencies for the same reason.
+%% Since standalone apps like `emqx_mongodb' are already dependencies of `emqx_bridge_*'
+%% apps, we may apply the same tactic for `emqx_connector' and inject individual bridges
+%% as its dependencies.
 inject_bridge_deps(RebootAppDeps) ->
     BridgeApps = [
         App
@@ -188,6 +193,8 @@ inject_bridge_deps(RebootAppDeps) ->
         fun
             ({emqx_bridge, Deps0}) when is_list(Deps0) ->
                 {emqx_bridge, Deps0 ++ BridgeApps};
+            ({emqx_connector, Deps0}) when is_list(Deps0) ->
+                {emqx_connector, Deps0 ++ BridgeApps};
             (App) ->
                 App
         end,

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -392,7 +392,7 @@ t_create_webhook_v1_bridges_api({'init', Config}) ->
     lists:foreach(
         fun(App) ->
             _ = application:stop(App),
-            {ok, [App]} = application:ensure_all_started(App)
+            {ok, _} = application:ensure_all_started(App)
         end,
         [emqx_connector, emqx_bridge]
     ),

--- a/apps/emqx_mongodb/src/emqx_mongodb.app.src
+++ b/apps/emqx_mongodb/src/emqx_mongodb.app.src
@@ -1,12 +1,11 @@
 {application, emqx_mongodb, [
     {description, "EMQX MongoDB Connector"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [
         kernel,
         stdlib,
         mongodb,
-        emqx_connector,
         emqx_resource
     ]},
     {env, []},

--- a/apps/emqx_mysql/src/emqx_mysql.app.src
+++ b/apps/emqx_mysql/src/emqx_mysql.app.src
@@ -1,12 +1,11 @@
 {application, emqx_mysql, [
     {description, "EMQX MySQL Database Connector"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,
         stdlib,
         mysql,
-        emqx_connector,
         emqx_resource
     ]},
     {env, []},

--- a/apps/emqx_postgresql/src/emqx_postgresql.app.src
+++ b/apps/emqx_postgresql/src/emqx_postgresql.app.src
@@ -1,12 +1,11 @@
 {application, emqx_postgresql, [
     {description, "EMQX PostgreSQL Database Connector"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [
         kernel,
         stdlib,
         epgsql,
-        emqx_connector,
         emqx_resource
     ]},
     {env, []},

--- a/apps/emqx_redis/src/emqx_redis.app.src
+++ b/apps/emqx_redis/src/emqx_redis.app.src
@@ -1,13 +1,12 @@
 {application, emqx_redis, [
     {description, "EMQX Redis Database Connector"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [
         kernel,
         stdlib,
         eredis,
         eredis_cluster,
-        emqx_connector,
         emqx_resource
     ]},
     {env, []},

--- a/changes/ce/fix-12359.en.md
+++ b/changes/ce/fix-12359.en.md
@@ -1,0 +1,1 @@
+Fixed an issue that could lead to error logs when restarting a node configured with some types of data bridges.  Said bridges could also start in a failed state, requiring manual restart.

--- a/changes/ce/fix-12359.en.md
+++ b/changes/ce/fix-12359.en.md
@@ -1,1 +1,1 @@
-Fixed an issue that could lead to error logs when restarting a node configured with some types of data bridges.  Said bridges could also start in a failed state, requiring manual restart.
+Fixed an issue that could lead to error messages when restarting a node configured with some types of data bridges.  Said bridges could also start in a failed state, requiring manual restart.


### PR DESCRIPTION
For the same reasons as we inject `emqx_bridge_*` applications as dependencies to `emqx_bridge` when starting the node.  Already configured connectors are started when `emqx_connector` application starts, and may lead to crashes and noise in the logs.  One example is to configure a mongodb bridge and restart the node.

Thanks to @SergeTupchiy for noticing this.  :beers: 

Fixes https://emqx.atlassian.net/browse/EMQX-11771

Release version: v/e5.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
