### PR TITLE
Follow up #12299

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= v1.6.1
-export EMQX_EE_DASHBOARD_VERSION ?= e1.5.0-beta.3
+export EMQX_EE_DASHBOARD_VERSION ?= e1.5.0-beta.8
 
 PROFILE ?= emqx
 REL_PROFILES := emqx emqx-enterprise

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -1177,6 +1177,9 @@ format_resource(
         )
     ).
 
+%% FIXME:
+%% missing metrics:
+%% 'retried.success' and 'retried.failed'
 format_metrics(#{
     counters := #{
         'dropped' := Dropped,

--- a/apps/emqx_prometheus/rebar.config
+++ b/apps/emqx_prometheus/rebar.config
@@ -4,6 +4,7 @@
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
     {emqx_auth, {path, "../emqx_auth"}},
+    {emqx_resource, {path, "../emqx_resource"}},
     {prometheus, {git, "https://github.com/emqx/prometheus.erl", {tag, "v4.10.0.2"}}}
 ]}.
 

--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -5,7 +5,7 @@
     {vsn, "5.0.19"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
-    {applications, [kernel, stdlib, prometheus, emqx, emqx_auth, emqx_management]},
+    {applications, [kernel, stdlib, prometheus, emqx, emqx_auth, emqx_resource, emqx_management]},
     {mod, {emqx_prometheus_app, []}},
     {env, []},
     {licenses, ["Apache-2.0"]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -90,8 +90,6 @@
 
 -define(HTTP_OPTIONS, [{autoredirect, true}, {timeout, 60000}]).
 
--define(LOGICAL_SUM_METRIC_NAMES, []).
-
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
@@ -280,7 +278,7 @@ aggre_or_zip_init_acc() ->
     }.
 
 logic_sum_metrics() ->
-    ?LOGICAL_SUM_METRIC_NAMES.
+    [].
 
 %%--------------------------------------------------------------------
 %% Collector

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -473,37 +473,37 @@ emqx_collect(K = emqx_cert_expiry_at, D) -> gauge_metrics(?MG(K, D)).
 stats_metric_meta() ->
     [
         %% connections
-        {emqx_connections_count, counter, 'connections.count'},
-        {emqx_connections_max, counter, 'connections.max'},
-        {emqx_live_connections_count, counter, 'live_connections.count'},
-        {emqx_live_connections_max, counter, 'live_connections.max'},
+        {emqx_connections_count, gauge, 'connections.count'},
+        {emqx_connections_max, gauge, 'connections.max'},
+        {emqx_live_connections_count, gauge, 'live_connections.count'},
+        {emqx_live_connections_max, gauge, 'live_connections.max'},
         %% sessions
-        {emqx_sessions_count, counter, 'sessions.count'},
-        {emqx_sessions_max, counter, 'sessions.max'},
-        {emqx_channels_count, counter, 'channels.count'},
-        {emqx_channels_max, counter, 'channels.max'},
+        {emqx_sessions_count, gauge, 'sessions.count'},
+        {emqx_sessions_max, gauge, 'sessions.max'},
+        {emqx_channels_count, gauge, 'channels.count'},
+        {emqx_channels_max, gauge, 'channels.max'},
         %% pub/sub stats
-        {emqx_suboptions_count, counter, 'suboptions.count'},
-        {emqx_suboptions_max, counter, 'suboptions.max'},
-        {emqx_subscribers_count, counter, 'subscribers.count'},
-        {emqx_subscribers_max, counter, 'subscribers.max'},
-        {emqx_subscriptions_count, counter, 'subscriptions.count'},
-        {emqx_subscriptions_max, counter, 'subscriptions.max'},
-        {emqx_subscriptions_shared_count, counter, 'subscriptions.shared.count'},
-        {emqx_subscriptions_shared_max, counter, 'subscriptions.shared.max'},
+        {emqx_suboptions_count, gauge, 'suboptions.count'},
+        {emqx_suboptions_max, gauge, 'suboptions.max'},
+        {emqx_subscribers_count, gauge, 'subscribers.count'},
+        {emqx_subscribers_max, gauge, 'subscribers.max'},
+        {emqx_subscriptions_count, gauge, 'subscriptions.count'},
+        {emqx_subscriptions_max, gauge, 'subscriptions.max'},
+        {emqx_subscriptions_shared_count, gauge, 'subscriptions.shared.count'},
+        {emqx_subscriptions_shared_max, gauge, 'subscriptions.shared.max'},
         %% delayed
-        {emqx_delayed_count, counter, 'delayed.count'},
-        {emqx_delayed_max, counter, 'delayed.max'}
+        {emqx_delayed_count, gauge, 'delayed.count'},
+        {emqx_delayed_max, gauge, 'delayed.max'}
     ].
 
 stats_metric_cluster_consistened_meta() ->
     [
         %% topics
-        {emqx_topics_max, counter, 'topics.max'},
-        {emqx_topics_count, counter, 'topics.count'},
+        {emqx_topics_max, gauge, 'topics.max'},
+        {emqx_topics_count, gauge, 'topics.count'},
         %% retained
-        {emqx_retained_count, counter, 'retained.count'},
-        {emqx_retained_max, counter, 'retained.max'}
+        {emqx_retained_count, gauge, 'retained.count'},
+        {emqx_retained_max, gauge, 'retained.max'}
     ].
 
 stats_data(Mode) ->

--- a/apps/emqx_prometheus/src/emqx_prometheus_auth.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_auth.erl
@@ -64,8 +64,8 @@
     | emqx_authz_status
     | emqx_authz_nomatch
     | emqx_authz_total
-    | emqx_authz_success
-    | emqx_authz_failed.
+    | emqx_authz_allow
+    | emqx_authz_deny.
 
 %% Please don't remove this attribute, prometheus uses it to
 %% automatically register collectors.
@@ -186,9 +186,9 @@ collect_auth(K = emqx_authz_nomatch, Data) ->
     counter_metrics(?MG(K, Data));
 collect_auth(K = emqx_authz_total, Data) ->
     counter_metrics(?MG(K, Data));
-collect_auth(K = emqx_authz_success, Data) ->
+collect_auth(K = emqx_authz_allow, Data) ->
     counter_metrics(?MG(K, Data));
-collect_auth(K = emqx_authz_failed, Data) ->
+collect_auth(K = emqx_authz_deny, Data) ->
     counter_metrics(?MG(K, Data));
 %%====================
 %% Authz rules count
@@ -313,8 +313,8 @@ authz_metric_meta() ->
         {emqx_authz_status, gauge},
         {emqx_authz_nomatch, counter},
         {emqx_authz_total, counter},
-        {emqx_authz_success, counter},
-        {emqx_authz_failed, counter}
+        {emqx_authz_allow, counter},
+        {emqx_authz_deny, counter}
     ].
 
 authz_metric(names) ->
@@ -363,8 +363,8 @@ lookup_authz_metrics_local(Type) ->
                 emqx_authz_status => emqx_prometheus_cluster:status_to_number(Status),
                 emqx_authz_nomatch => ?MG0(nomatch, Counters),
                 emqx_authz_total => ?MG0(total, Counters),
-                emqx_authz_success => ?MG0(success, Counters),
-                emqx_authz_failed => ?MG0(failed, Counters)
+                emqx_authz_allow => ?MG0(allow, Counters),
+                emqx_authz_deny => ?MG0(deny, Counters)
             };
         {error, _Reason} ->
             maps:from_keys(authz_metric(names) -- [emqx_authz_enable], 0)

--- a/apps/emqx_prometheus/src/emqx_prometheus_auth.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_auth.erl
@@ -485,6 +485,8 @@ mnesia_size(Tab) ->
 
 do_metric(emqx_authn_enable, #{enable := B}, _) ->
     emqx_prometheus_cluster:boolean_to_number(B);
+do_metric(emqx_authz_enable, #{enable := B}, _) ->
+    emqx_prometheus_cluster:boolean_to_number(B);
 do_metric(K, _, Metrics) ->
     ?MG0(K, Metrics).
 

--- a/apps/emqx_prometheus/src/emqx_prometheus_cluster.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_cluster.erl
@@ -38,6 +38,8 @@
 
 -callback aggre_or_zip_init_acc() -> map().
 
+-callback logic_sum_metrics() -> list().
+
 -define(MG(K, MAP), maps:get(K, MAP)).
 -define(PG0(K, PROPLISTS), proplists:get_value(K, PROPLISTS, 0)).
 

--- a/apps/emqx_prometheus/src/emqx_prometheus_cluster.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_cluster.erl
@@ -16,6 +16,7 @@
 -module(emqx_prometheus_cluster).
 
 -include("emqx_prometheus.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 
 -export([
     raw_data/2,
@@ -194,11 +195,11 @@ logic_sum(_, _) ->
 boolean_to_number(true) -> 1;
 boolean_to_number(false) -> 0.
 
-status_to_number(connected) -> 1;
-%% for auth
-status_to_number(stopped) -> 0;
-%% for data_integration
-status_to_number(disconnected) -> 0.
+status_to_number(?status_connected) -> 1;
+status_to_number(?status_connecting) -> 0;
+status_to_number(?status_disconnected) -> 0;
+status_to_number(?rm_status_stopped) -> 0;
+status_to_number(_) -> 0.
 
 metric_names(MetricWithType) when is_list(MetricWithType) ->
     [Name || {Name, _Type} <- MetricWithType].


### PR DESCRIPTION
Contains some fixes for #12299
Includes
- Some metric types are incorrect.
- The problem of cluster aggregation failure and no node label.
- The problem of incorrect connector indicators.
- The problem of missing action indicator.

BUG found and marked TODO:
`emqx_bridge_v2_api:format_metrics/1` havs missing metrics: `'retried.success'` and `'retried.failed'`

See also for detials:
Fixes [EMQX-11794](https://emqx.atlassian.net/browse/EMQX-11794) [EMQX-11795](https://emqx.atlassian.net/browse/EMQX-11795) [EMQX-11789](https://emqx.atlassian.net/browse/EMQX-11789) [EMQX-11799](https://emqx.atlassian.net/browse/EMQX-11799) [EMQX-11800](https://emqx.atlassian.net/browse/EMQX-11800) [EMQX-11801](https://emqx.atlassian.net/browse/EMQX-11801) [EMQX-11802](https://emqx.atlassian.net/browse/EMQX-11802)

Release version: v/e5.5.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
