### PR TITLE
fix: EMQX_DATA_DIR not set

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1896,7 +1896,7 @@ fields("session_storage_backend_builtin") ->
                 string(),
                 #{
                     desc => ?DESC(session_builtin_data_dir),
-                    default => <<"${EMQX_DATA_DIR}">>,
+                    default => <<"${DATA_DIR}">>,
                     importance => ?IMPORTANCE_LOW,
                     converter => fun(Path, Opts) ->
                         naive_env_interpolation(ensure_unicode_path(Path, Opts))

--- a/bin/emqx
+++ b/bin/emqx
@@ -587,10 +587,10 @@ fi
 
 DATA_DIR="$(get_boot_config 'node.data_dir')"
 # ensure no trailing /
-DATA_DIR="${DATA_DIR%/}"
+export DATA_DIR="${DATA_DIR%/}"
 if [[ $DATA_DIR != /* ]]; then
     # relative path
-    DATA_DIR="${RUNNER_ROOT_DIR}/${DATA_DIR}"
+    export DATA_DIR="${RUNNER_ROOT_DIR}/${DATA_DIR}"
 fi
 CONFIGS_DIR="$DATA_DIR/configs"
 mkdir -p "$CONFIGS_DIR"

--- a/dev
+++ b/dev
@@ -169,13 +169,13 @@ esac
 
 BASE_DIR="_build/dev-run/$PROFILE"
 export EMQX_ETC_DIR="$BASE_DIR/etc"
-export EMQX_DATA_DIR="$BASE_DIR/data"
+export DATA_DIR="$BASE_DIR/data"
 export EMQX_LOG_DIR="$BASE_DIR/log"
 export EMQX_PLUGINS__INSTALL_DIR="${EMQX_PLUGINS__INSTALL_DIR:-$BASE_DIR/plugins}"
-CONFIGS_DIR="$EMQX_DATA_DIR/configs"
+CONFIGS_DIR="$DATA_DIR/configs"
 # Use your cookie so your IDE can connect to it.
 COOKIE="${EMQX_NODE__COOKIE:-${EMQX_NODE_COOKIE:-$(cat ~/.erlang.cookie 2>/dev/null || echo 'emqxsecretcookie')}}"
-mkdir -p "$EMQX_ETC_DIR" "$EMQX_DATA_DIR/patches" "$EMQX_DATA_DIR/plugins" "$EMQX_DATA_DIR/certs" "$EMQX_LOG_DIR" "$CONFIGS_DIR"
+mkdir -p "$EMQX_ETC_DIR" "$DATA_DIR/patches" "$DATA_DIR/plugins" "$DATA_DIR/certs" "$EMQX_LOG_DIR" "$CONFIGS_DIR"
 if [ $EKKA_EPMD -eq 1 ]; then
     EPMD_ARGS='-start_epmd false -epmd_module ekka_epmd'
 else
@@ -250,7 +250,7 @@ render_hocon_conf() {
     output="$EMQX_ETC_DIR/emqx.conf"
     cp "$input" "$output"
     mustache emqx_default_erlang_cookie "$COOKIE" "$output"
-    mustache platform_data_dir "${EMQX_DATA_DIR}" "$output"
+    mustache platform_data_dir "${DATA_DIR}" "$output"
     mustache platform_log_dir "${EMQX_LOG_DIR}" "$output"
     mustache platform_etc_dir "${EMQX_ETC_DIR}" "$output"
 }
@@ -298,7 +298,7 @@ generate_app_conf() {
     ## NOTE: the generate command merges environment variables to the base config (emqx.conf),
     ## but does not include the cluster-override.conf and local-override.conf
     ## meaning, certain overrides will not be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -d "$EMQX_DATA_DIR"/configs generate
+    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -d "$DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"
@@ -311,14 +311,14 @@ append_args_file() {
     echo '' >> "$ARGS_FILE"
     cat <<EOF >> "$ARGS_FILE"
 $ERL_NAME_ARG $EMQX_NODE_NAME
--mnesia dir '"$EMQX_DATA_DIR/mnesia/$EMQX_NODE_NAME"'
+-mnesia dir '"$DATA_DIR/mnesia/$EMQX_NODE_NAME"'
 -stdlib restricted_shell emqx_restricted_shell
 +spp true
 +A 4
 +IOt 4
 +SDio 8
 -shutdown_time 30000
--pa '$EMQX_DATA_DIR/patches'
+-pa '$DATA_DIR/patches'
 -mnesia dump_log_write_threshold 5000
 -mnesia dump_log_time_threshold 60000
 -os_mon start_disksup false


### PR DESCRIPTION
Fixes <issue-or-jira-number>
```
2024-01-24T11:22:58.000646+08:00 [warning] env: {EMQX_DATA_DIR}, msg: cannot_resolve_env_variable, original: ${EMQX_DATA_DIR}
```
introduce here: https://github.com/emqx/emqx/commit/57074015c6f1a1983193ffe382e7dff29386427b#diff-7cd7fcf74d91ac97a19ed681624f639922e0426dcbae0032d0070248d8199000

1. The `data_dir` currently comes from only one place, which is `node.data_dir`. 
If it's not configured, the EMQX won't start.
2. We don't currently need to introduce a new variable(ENV) to add more complexity.
3. `DATA_DIR` is sourced from node.data_dir and can be used.
```
%% emqx line 558
DATA_DIR="$(get_boot_config 'node.data_dir')"
```

PS: I don't want to rename `DATA_DIR` to `EMQX_DATA_DIR` either, because configuration items starting with `EMQX_ `, and we don't provide EMQX_DATA_DIR config.

Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
