### PR TITLE
feat: port emqx/emqx-enterprise#1892, add some SQL functions

### DIFF
--- a/changes/ee/feat-12381.en.md
+++ b/changes/ee/feat-12381.en.md
@@ -1,0 +1,3 @@
+Added new SQL functions: map_keys(), map_values(), map_to_entries(), join_to_string(), join_to_string(), join_to_sql_values_string(), is_null_var(), is_not_null_var().
+
+For more information on the functions and their usage, refer to the documentation.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-10970

Release version: v/e5.6.0

port https://github.com/emqx/emqx-enterprise/pull/1892

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
