### PR TITLE
fix: reboot emqx_dashboard after emqx_licencse

### DIFF
--- a/changes/ee/fix-12390.en.md
+++ b/changes/ee/fix-12390.en.md
@@ -1,0 +1,1 @@
+Fixed /license API request maybe crash during cluster join processes.


### PR DESCRIPTION
Fixes <issue-or-jira-number>
```
2024-01-25T09:41:46.391446+08:00 [warning] mfa: minirest_handler:apply_callback/3(142), exception: exit, path: /license, reason: {noproc,{gen_server,call,[emqx_license_checker,dump,infinity]}}, stacktrace: [{gen_server,call,3,[{file,"gen_server.erl"},{line,385}]},{emqx_license_http_api,'/license',2,[{file,"emqx_license_http_api.erl"},{line,126}]},{minirest_handler,apply_callback,3,[{file,"minirest_handler.erl"},{line,137}]},{minirest_handler,handle,2,[{file,"minirest_handler.erl"},{line,56}]},{minirest_handler,init,2,[{file,"minirest_handler.erl"},{line,27}]},{cowboy_handler,execute,2,[{file,"cowboy_handler.erl"},{line,41}]},{cowboy_stream_h,execute,3,[{file,"cowboy_stream_h.erl"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,"cowboy_stream_h.erl"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]
```
emqx_license must reboot before emqx_dashboard.
but we can't add emqx_license to emqx_dashboard.app.src，because emqx_license is enterprise app, so we inject here.
Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
