### PR TITLE
perf: new ws listener option to disable UTF-8 validation

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1104,6 +1104,14 @@ fields("ws_opts") ->
             sc(
                 ref("deflate_opts"),
                 #{}
+            )},
+        {"validate_utf8",
+            sc(
+                boolean(),
+                #{
+                    default => true,
+                    desc => ?DESC(fields_ws_opts_validate_utf8)
+                }
             )}
     ];
 fields("tcp_opts") ->

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -205,7 +205,8 @@ init(Req, #{listener := {Type, Listener}} = Opts) ->
         compress => get_ws_opts(Type, Listener, compress),
         deflate_opts => get_ws_opts(Type, Listener, deflate_opts),
         max_frame_size => get_ws_opts(Type, Listener, max_frame_size),
-        idle_timeout => get_ws_opts(Type, Listener, idle_timeout)
+        idle_timeout => get_ws_opts(Type, Listener, idle_timeout),
+        validate_utf8 => get_ws_opts(Type, Listener, validate_utf8)
     },
     case check_origin_header(Req, Opts) of
         {error, Reason} ->

--- a/changes/perf-12392.en.md
+++ b/changes/perf-12392.en.md
@@ -1,0 +1,4 @@
+New WebSocket listener option: `validate_utf8` for performance tuning. 
+
+
+

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1275,6 +1275,13 @@ fields_ws_opts_allow_origin_absence.desc:
 fields_ws_opts_allow_origin_absence.label:
 """Allow origin absence"""
 
+fields_ws_opts_validate_utf8.desc:
+"""Set to <code>false</code> to disable WebSocket Frame UTF-8
+  validation for performance"""
+
+fields_ws_opts_validate_utf8.label:
+"""Enable/Disable WebSocket Frame utf8 validation"""
+
 common_ssl_opts_schema_versions.desc:
 """All TLS/DTLS versions to be supported.<br/>
 NOTE: PSK ciphers are suppressed by 'tlsv1.3' version config.<br/>


### PR DESCRIPTION
perf improvement for  #12344

Release version: v/e5.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
