### PR TITLE
ci: enable coveralls parallel send

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -565,6 +565,7 @@ coveralls() ->
                 {coveralls_service_job_id, os:getenv("GITHUB_RUN_ID")},
                 {coveralls_commit_sha, os:getenv("GITHUB_SHA")},
                 {coveralls_coverdata, "_build/test/cover/*.coverdata"},
+                {coveralls_parallel, true},
                 {coveralls_service_name, "github"}
             ],
             case


### PR DESCRIPTION
Since we use coveralls' [parallel webhook API](https://docs.coveralls.io/api-parallel-build-webhook), it seems we should also set it in our [plugin config](https://github.com/emqx/coveralls-erl/blob/02daa4e5f157ff16d10b41ce00b829bc8734a9e1/src/rebar3_coveralls.erl#L132).

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
