### PR TITLE
fix: don't add disable bridge to connector's channel

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -221,6 +221,32 @@ t_create_remove(_) ->
     ok = emqx_bridge_v2:remove(bridge_type(), my_test_bridge),
     ok.
 
+t_create_disabled_bridge(_) ->
+    Config = #{<<"connector">> := Connector} = bridge_config(),
+    Disable = Config#{<<"enable">> => false},
+    BridgeType = bridge_type(),
+    {ok, _} = emqx_bridge_v2:create(BridgeType, my_enable_bridge, Config),
+    {ok, _} = emqx_bridge_v2:create(BridgeType, my_disable_bridge, Disable),
+    ConnectorId = emqx_connector_resource:resource_id(con_type(), Connector),
+    ?assertMatch(
+        [
+            {_, #{
+                enable := true,
+                connector := Connector,
+                bridge_type := _
+            }},
+            {_, #{
+                enable := false,
+                connector := Connector,
+                bridge_type := _
+            }}
+        ],
+        emqx_bridge_v2:get_channels_for_connector(ConnectorId)
+    ),
+    ok = emqx_bridge_v2:remove(bridge_type(), my_enable_bridge),
+    ok = emqx_bridge_v2:remove(bridge_type(), my_disable_bridge),
+    ok.
+
 t_list(_) ->
     [] = emqx_bridge_v2:list(),
     {ok, _} = emqx_bridge_v2:create(bridge_type(), my_test_bridge, bridge_config()),

--- a/apps/emqx_connector/test/emqx_connector_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_SUITE.erl
@@ -159,7 +159,7 @@ t_remove_fail({'init', Config}) ->
     meck:new(?CONNECTOR, [non_strict]),
     meck:expect(?CONNECTOR, callback_mode, 0, async_if_possible),
     meck:expect(?CONNECTOR, on_start, 2, {ok, connector_state}),
-    meck:expect(?CONNECTOR, on_get_channels, 1, [{<<"my_channel">>, #{}}]),
+    meck:expect(?CONNECTOR, on_get_channels, 1, [{<<"my_channel">>, #{enable => true}}]),
     meck:expect(?CONNECTOR, on_add_channel, 4, {ok, connector_state}),
     meck:expect(?CONNECTOR, on_stop, 2, ok),
     meck:expect(?CONNECTOR, on_get_status, 2, connected),

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -622,13 +622,16 @@ start_resource(Data, From) ->
 
 add_channels(Data) ->
     %% Add channels to the Channels map but not to the resource state
-    %% Channels will be added to the resouce state after the initial health_check
+    %% Channels will be added to the resource state after the initial health_check
     %% if that succeeds.
     ChannelIDConfigTuples = emqx_resource:call_get_channels(Data#data.id, Data#data.mod),
     Channels = Data#data.added_channels,
     NewChannels = lists:foldl(
-        fun({ChannelID, _Conf}, Acc) ->
-            maps:put(ChannelID, channel_status(), Acc)
+        fun
+            ({ChannelID, #{enable := true}}, Acc) ->
+                maps:put(ChannelID, channel_status(), Acc);
+            ({_, #{enable := false}}, Acc) ->
+                Acc
         end,
         Channels,
         ChannelIDConfigTuples


### PR DESCRIPTION
Fixes <issue-or-jira-number>

If we change one action/source's to `enable=false`,  
then **restart emqx**
It's will auto add this disable action/source  to connector's channel.

```erlang
# action:http:dafdafd:connector:http:adfasdfd   is disabled, but in the channel.
emqx_resource_manager:list_all().
[#{error => undefined,id => <<"connector:http:adfasdfd">>,
   status => connected,
   state =>
       #{port => 28083,
         request =>
             #{path => [<<>>],
               body => undefined,
               headers => [{[<<"content-type">>],[<<"application/json">>]}],
               method => [<<"undefined">>],
               max_retries => 2,request_timeout => 30000},
         host => {127,0,0,1},
         connect_timeout => 15000,pool_type => random,
         pool_name => <<"connector:http:adfasdfd">>,base_path => "/",
         installed_actions =>
             #{<<"action:http:dafdafd:connector:http:adfasdfd">> =>
                   #{path => [<<>>],
                     body => [<<"ldkfadkfd">>],
                     headers => [{[<<"content-type">>],[<<"application/json">>]}],
                     method => [<<"post">>],
                     max_retries => 2,request_timeout => 30000,
                     render_template_func =>
                         fun emqx_bridge_http_connector:render_template/2}}},
   config =>
       #{request =>
             #{path => <<>>,body => undefined,
               headers => #{'content-type' => <<"application/json">>},
               method => undefined},
         ssl =>
             #{depth => 10,hibernate_after => 5000,verify => verify_peer,
               enable => false,ciphers => [],log_level => notice,
               versions => ['tlsv1.3','tlsv1.2'],
               secure_renegotiate => true,reuse_sessions => true,
               user_lookup_fun => {fun emqx_tls_psk:lookup/3,undefined}},
         description => "dadfasd",connect_timeout => 15000,
         pool_size => 8,enable => true,
         headers => #{'content-type' => <<"application/json">>},
         url => <<"http://127.0.0.1:28083">>,pool_type => random,
         resource_opts =>
             #{start_after_created => true,start_timeout => 5000,
               health_check_interval => 15000},
         enable_pipelining => 100,connector_name => adfasdfd,
         connector_type => <<"http">>,
         base_url =>
             #{port => 28083,scheme => http,path => "/",
               host => {127,0,0,1}}},
   mod => emqx_bridge_http_connector,
   callback_mode => async_if_possible,query_mode => sync,
   added_channels =>
       #{<<"action:http:dafdafd:connector:http:adfasdfd">> =>
             #{error => undefined,status => connected}}}
```

Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
