### PR TITLE
fix(ds): reduce egress start flakiness

### DIFF
--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -23,6 +23,7 @@
 
 %% Management API:
 -export([
+    base_dir/0,
     open_db/2,
     update_db_config/2,
     add_generation/1,
@@ -70,6 +71,8 @@
 %%================================================================================
 %% Type declarations
 %%================================================================================
+
+-define(APP, emqx_durable_storage).
 
 -type db() :: atom().
 
@@ -188,6 +191,10 @@
 %%================================================================================
 %% API funcions
 %%================================================================================
+
+-spec base_dir() -> file:filename().
+base_dir() ->
+    application:get_env(?APP, db_data_dir, emqx:data_dir()).
 
 %% @doc Different DBs are completely independent from each other. They
 %% could represent something like different tenants.

--- a/apps/emqx_durable_storage/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_replication_layer_meta.erl
@@ -417,7 +417,7 @@ ensure_tables() ->
     ok = mria:wait_for_tables([?META_TAB, ?NODE_TAB, ?SHARD_TAB]).
 
 ensure_site() ->
-    Filename = filename:join(emqx:data_dir(), "emqx_ds_builtin_site.eterm"),
+    Filename = filename:join(emqx_ds:base_dir(), "emqx_ds_builtin_site.eterm"),
     case file:consult(Filename) of
         {ok, [Site]} ->
             ok;

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -52,7 +52,6 @@
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
--define(APP, emqx_durable_storage).
 -define(REF(ShardId), {via, gproc, {n, l, {?MODULE, ShardId}}}).
 
 %%================================================================================
@@ -608,11 +607,7 @@ rocksdb_open(Shard, Options) ->
 
 -spec db_dir(shard_id()) -> file:filename().
 db_dir({DB, ShardId}) ->
-    filename:join([base_dir(), atom_to_list(DB), binary_to_list(ShardId)]).
-
--spec base_dir() -> file:filename().
-base_dir() ->
-    application:get_env(?APP, db_data_dir, emqx:data_dir()).
+    filename:join([emqx_ds:base_dir(), atom_to_list(DB), binary_to_list(ShardId)]).
 
 -spec update_last_until(Schema, emqx_ds:time()) -> Schema when Schema :: shard_schema() | shard().
 update_last_until(Schema, Until) ->

--- a/apps/emqx_durable_storage/test/emqx_ds_storage_bitfield_lts_SUITE.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_storage_bitfield_lts_SUITE.erl
@@ -406,11 +406,16 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 suite() -> [{timetrap, {seconds, 20}}].
 
 init_per_suite(Config) ->
-    {ok, _} = application:ensure_all_started(emqx_durable_storage),
-    Config.
+    Apps = emqx_cth_suite:start(
+        [emqx_durable_storage],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{apps, Apps} | Config].
 
-end_per_suite(_Config) ->
-    ok = application:stop(emqx_durable_storage).
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    ok = emqx_cth_suite:stop(Apps),
+    ok.
 
 init_per_testcase(TC, Config) ->
     ok = emqx_ds:open_db(TC, ?DEFAULT_CONFIG),


### PR DESCRIPTION
Attempt to mitigate this frequent source of flakiness:

```
=CRASH REPORT==== 31-Jan-2024::17:30:15.025404 ===
  crasher:
    initial call: emqx_ds_replication_layer_egress:init/1
    pid: <0.11312.0>
    registered_name: []
    exception error: no match of right hand side value {error,
                                                        no_leader_for_shard}
      in function  emqx_ds_replication_layer_egress:init/1 (/emqx/apps/emqx_durable_storage/src/emqx_ds_replication_layer_egress.erl, line 93)
      in call from gen_server:init_it/2 (gen_server.erl, line 980)
      in call from gen_server:init_it/6 (gen_server.erl, line 935)
    ancestors: [<0.11310.0>,<0.11304.0>,emqx_ds_builtin_databases_sup,
                  emqx_ds_builtin_sup,emqx_ds_sup,<0.11236.0>]
    message_queue_len: 0
    messages: []
    links: [<0.11310.0>]
    dictionary: []
    trap_exit: true
    status: running
    heap_size: 376
    stack_size: 28
    reductions: 231
  neighbours:
```

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
