### PR TITLE
ci: use v3 artifacts actions in build packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -95,13 +95,12 @@ jobs:
         apple_developer_identity: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
         apple_developer_id_bundle: ${{ secrets.APPLE_DEVELOPER_ID_BUNDLE }}
         apple_developer_id_bundle_password: ${{ secrets.APPLE_DEVELOPER_ID_BUNDLE_PASSWORD }}
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: success()
       with:
-        name: ${{ matrix.profile }}-${{ matrix.otp }}-${{ matrix.os }}
+        name: ${{ matrix.profile }}
         path: _packages/${{ matrix.profile }}/
         retention-days: 7
-        compression-level: 0
 
   linux:
     runs-on: [self-hosted, ephemeral, linux, "${{ matrix.arch }}"]
@@ -139,7 +138,7 @@ jobs:
         with_elixir:
           - 'no'
         include:
-          - profile: emqx
+          - profile: ${{ inputs.profile }}
             otp: ${{ inputs.otp_vsn }}
             arch: x64
             os: ubuntu22.04
@@ -195,7 +194,7 @@ jobs:
         fi
     - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       with:
-        name: ${{ matrix.profile }}-${{ matrix.otp }}-${{ matrix.arch }}-${{ matrix.os }}-${{ matrix.with_elixir == 'yes' && 'elixir' || 'erlang' }}
+        name: ${{ matrix.profile }}
         path: _packages/${{ matrix.profile }}/
         retention-days: 7
 
@@ -211,11 +210,10 @@ jobs:
         profile:
           - ${{ inputs.profile }}
     steps:
-    - uses: actions/download-artifact@6b208ae046db98c579e8a3aa621ab581ff575935 # v4.1.1
+    - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       with:
-        pattern: ${{ matrix.profile }}-*
+        name: ${{ matrix.profile }}
         path: packages/${{ matrix.profile }}
-        merge-multiple: true
     - name: install dos2unix
       run: sudo apt-get update -y && sudo apt install -y dos2unix
     - name: get packages
@@ -236,6 +234,9 @@ jobs:
     - name: upload to aws s3
       env:
         PROFILE: ${{ matrix.profile }}
+        REF_NAME: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.ref || github.ref_name }}
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+        AWS_CLOUDFRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
       run: |
         set -eu
         if [ $PROFILE = 'emqx' ]; then
@@ -246,5 +247,5 @@ jobs:
             echo "unknown profile $PROFILE"
             exit 1
         fi
-        aws s3 cp --recursive packages/$PROFILE s3://${{ secrets.AWS_S3_BUCKET }}/$s3dir/${{ github.ref_name }}
-        aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CLOUDFRONT_ID }} --paths "/$s3dir/${{ github.ref_name }}/*"
+        aws s3 cp --recursive packages/$PROFILE s3://$AWS_S3_BUCKET/$s3dir/$REF_NAME
+        aws cloudfront create-invalidation --distribution-id "$AWS_CLOUDFRONT_ID" --paths "/$s3dir/$REF_NAME/*"


### PR DESCRIPTION
We need to use v3 actions family in `build_packages` because v4 is on NodeJS 20, and NodeJS 20 is not supported on older platforms.
There was a messed up change when `actions/upload-artifacts` in `macos` job used v4 family, `linux` job v3 family, and `actions/download-artifacts` was v4 family. Since v4 and v3 are incompatible (i.e., v4 cannot download v3 artifcats, and vice versa), when we published latest release, it only got macos artifacts.