### PR TITLE
feat(ds): Add a CLI interface to inspect status of DS databases

### DIFF
--- a/apps/emqx_durable_storage/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_replication_layer_meta.erl
@@ -127,15 +127,24 @@ print_status() ->
         end,
         eval_qlc(mnesia:table(?NODE_TAB))
     ),
-    io:format("~nSHARDS~n", []),
+    io:format(
+        "~nSHARDS:~nId                             Leader                            Status~n", []
+    ),
     lists:foreach(
         fun(#?SHARD_TAB{shard = {DB, Shard}, leader = Leader}) ->
+            ShardStr = string:pad(io_lib:format("~p/~s", [DB, Shard]), 30),
+            LeaderStr = string:pad(atom_to_list(Leader), 33),
             Status =
                 case lists:member(Leader, Nodes) of
-                    true -> up;
-                    false -> down
+                    true ->
+                        case node() of
+                            Leader -> "up *";
+                            _ -> "up"
+                        end;
+                    false ->
+                        "down"
                 end,
-            io:format("~p/~s    ~p    ~p~n", [DB, Shard, Leader, Status])
+            io:format("~s ~s ~s~n", [ShardStr, LeaderStr, Status])
         end,
         eval_qlc(mnesia:table(?SHARD_TAB))
     ).

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2020-2023 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2020-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@
     authz/1,
     pem_cache/1,
     olp/1,
-    data/1
+    data/1,
+    ds/1
 ]).
 
 -spec load() -> ok.
@@ -794,6 +795,24 @@ data(_) ->
     emqx_ctl:usage([
         {"data import <File>", "Import data from the specified tar archive file"},
         {"data export", "Export data"}
+    ]).
+
+%%--------------------------------------------------------------------
+%% @doc Durable storage command
+
+ds(CMD) ->
+    case emqx_persistent_message:is_persistence_enabled() of
+        true ->
+            do_ds(CMD);
+        false ->
+            emqx_ctl:usage([{"ds", "Durable storage is disabled"}])
+    end.
+
+do_ds(["info"]) ->
+    emqx_ds_replication_layer_meta:print_status();
+do_ds(_) ->
+    emqx_ctl:usage([
+        {"ds info", "Show overview of the embedded durable storage state"}
     ]).
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary
Add `emqx_ctl ds info` CLI command to inspect the state of DS shards and sites.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
