### PR TITLE
feat(emqx_conf): support AAAA cluster dns record type

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -259,7 +259,7 @@ fields(cluster_dns) ->
             )},
         {"record_type",
             sc(
-                hoconsc:enum([a, srv]),
+                hoconsc:enum([a, aaaa, srv]),
                 #{
                     default => a,
                     desc => ?DESC(cluster_dns_record_type),

--- a/changes/ce/feat-12467.en.md
+++ b/changes/ce/feat-12467.en.md
@@ -1,0 +1,1 @@
+Support cluster discovery using AAAA DNS record type.


### PR DESCRIPTION
Ekka autocluster DNS already supports AAAA records, so it's only needed to update enum in schema.

Fixes #12448 

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
