### PR TITLE
feat(helm): possibility to add `priorityClassName` in helm chart for pods

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
@@ -56,6 +56,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "emqx.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       volumes:
       {{- if .Values.ssl.enabled }}
       - name: ssl-cert

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -38,6 +38,9 @@ recreatePods: false
 ## Sets the minReadySeconds parameter on the stateful set. This can be used to add delay between restart / updates between the single pods.
 minReadySeconds:
 
+## Sets the priorityClassName parameter on the pods. This can be used to run the pods with increased priority.
+priorityClassName:
+
 clusterDomain: cluster.local
 
 podAnnotations: {}

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -56,6 +56,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "emqx.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       volumes:
       {{- if .Values.ssl.enabled }}
       - name: ssl-cert

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -38,6 +38,9 @@ recreatePods: false
 ## Sets the minReadySeconds parameter on the stateful set. This can be used to add delay between restart / updates between the single pods.
 minReadySeconds:
 
+## Sets the priorityClassName parameter on the pods. This can be used to run the pods with increased priority.
+priorityClassName:
+
 clusterDomain: cluster.local
 
 podAnnotations: {}


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/12378

## Summary
An optional parameter `priorityClassName` for setting the priority of the pods would help for running the broker more stable.