### PR TITLE
Improve emqx ctl conf cluster_sync CLI and help text

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -89,6 +89,10 @@ admins(["skip", Node0]) ->
     emqx_cluster_rpc:skip_failed_commit(Node),
     status();
 admins(["tnxid", TnxId0]) ->
+    %% changed to 'inspect' in 5.6
+    %% TODO: delete this clause in 5.7
+    admins(["inspect", TnxId0]);
+admins(["inspect", TnxId0]) ->
     TnxId = list_to_integer(TnxId0),
     print(emqx_cluster_rpc:query(TnxId));
 admins(["fast_forward"]) ->
@@ -145,12 +149,14 @@ usage_conf() ->
 
 usage_sync() ->
     [
-        {"conf cluster_sync status", "Show cluster config sync status summary"},
-        {"conf cluster_sync skip [node]", "Increase one commit on specific node"},
-        {"conf cluster_sync tnxid <TnxId>",
-            "Display detailed information of the config change transaction at TnxId"},
-        {"conf cluster_sync fast_forward [node] [tnx_id]",
-            "Fast-forward config change transaction to tnx_id on the given node."
+        {"conf cluster_sync status", "Show cluster config sync status summary for all nodes."},
+        {"conf cluster_sync inspect <ID>",
+            "Inspect detailed information of the config change transaction at the given commit ID"},
+        {"conf cluster_sync skip [node]",
+            "Increment the (currently failing) commit on the given node.\n"
+            "WARNING: This results in inconsistent configs among the clustered nodes."},
+        {"conf cluster_sync fast_forward [node] <ID>",
+            "Fast-forward config change to the given commit ID on the given node.\n"
             "WARNING: This results in inconsistent configs among the clustered nodes."}
     ].
 

--- a/changes/ce/feat-12483.en.md
+++ b/changes/ce/feat-12483.en.md
@@ -1,0 +1,2 @@
+Renamed `emqx ctl conf cluster_sync tnxid ID` to `emqx ctl conf cluster_sync inspect ID`.
+For backward compatibility, `tnxid` is kept, but considered deprecated and will be removed in 5.7.

--- a/rel/i18n/emqx_auto_subscribe_schema.hocon
+++ b/rel/i18n/emqx_auto_subscribe_schema.hocon
@@ -8,7 +8,7 @@ auto_subscribe.label:
 
 nl.desc:
 """Default value 0.
-MQTT v3.1.1： if you subscribe to the topic published by yourself, you will receive all messages that you published.
+MQTT v3.1.1: if you subscribe to the topic published by yourself, you will receive all messages that you published.
 MQTT v5: if you set this option as 1 when subscribing, the server will not forward the message you published to you."""
 
 nl.label:


### PR DESCRIPTION
Release version: `v/e5.6.0`

## Summary

Minor improvements following up some support quitestions.

* Change `emqx ctl conf cluster_sync tnxid <ID>` to `emqx ctl conf cluster_sync inspect<ID>`
* Refine the `help` info for `emqx ctl conf cluster_sync`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket https://github.com/emqx/emqx-docs/pull/2359
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
