### PR TITLE
feat(ds): list disconnected persistent sessions in clients API

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -39,7 +39,13 @@
     parse_pager_params/1,
     parse_qstring/2,
     init_query_result/0,
-    accumulate_query_rows/4
+    init_query_state/5,
+    reset_query_state/1,
+    accumulate_query_rows/4,
+    finalize_query/2,
+    mark_complete/2,
+    format_query_result/3,
+    maybe_collect_total_from_tail_nodes/2
 ]).
 
 -ifdef(TEST).

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -50,6 +50,21 @@ set_special_configs(emqx_dashboard) ->
 set_special_configs(_App) ->
     ok.
 
+-spec emqx_dashboard() -> emqx_cth_suite:appspec().
+emqx_dashboard() ->
+    emqx_dashboard("dashboard.listeners.http { enable = true, bind = 18083 }").
+
+emqx_dashboard(Config) ->
+    {emqx_dashboard, #{
+        config => Config,
+        before_start => fun() ->
+            {ok, _} = emqx_common_test_http:create_default_app()
+        end,
+        after_start => fun() ->
+            true = emqx_dashboard_listener:is_ready(infinity)
+        end
+    }}.
+
 %% there is no difference between the 'request' and 'request_api'
 %% the 'request' is only to be compatible with the 'emqx_dashboard_api_test_helpers:request'
 request(Method, Url) ->

--- a/changes/ce/fix-12500.en.md
+++ b/changes/ce/fix-12500.en.md
@@ -1,0 +1,3 @@
+Now disconnected persistent sessions are returned in the `GET /clients` and `GET /client/:clientid` HTTP APIs.
+
+Known issue: the total count returned by this API may overestimate the total number of clients.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11540

Note that not all information provided by disconnected in-memory sessions is available to
disconnected persistent sessions, nor does all of them make sense.

Release version: v/e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
