### PR TITLE
fix(gateway): avoid scanning modules of known gateway apps

### DIFF
--- a/apps/emqx_gateway/test/emqx_gateway_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_SUITE.erl
@@ -74,7 +74,10 @@ end_per_testcase(_TestCase, _Config) ->
 %%--------------------------------------------------------------------
 
 t_registered_gateway(_) ->
-    [{coap, #{cbkmod := emqx_gateway_coap}} | _] = emqx_gateway:registered_gateway().
+    ?assertMatch(
+        [{coap, #{cbkmod := emqx_gateway_coap}} | _],
+        lists:sort(emqx_gateway:registered_gateway())
+    ).
 
 t_load_unload_list_lookup(_) ->
     {ok, _} = emqx_gateway:load(?GWNAME, #{idle_timeout => 1000}),

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
@@ -8,9 +8,12 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("typerefl/include/types.hrl").
 
--export([fields/1, desc/1]).
+-behaviour(hocon_schema).
+-export([namespace/0, fields/1, desc/1]).
 
 -define(NOT_EMPTY(MSG), emqx_resource_validator:not_empty(MSG)).
+
+namespace() -> gateway.
 
 fields(jt808) ->
     [

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
@@ -54,9 +54,8 @@ fields(jt808_proto) ->
     [
         {auth,
             sc(
-                hoconsc:union([
-                    ref(anonymous_true), ref(anonymous_false)
-                ])
+                hoconsc:union([ref(anonymous_true), ref(anonymous_false)]),
+                #{desc => ?DESC(jt808_auth)}
             )},
         {up_topic, fun up_topic/1},
         {dn_topic, fun dn_topic/1}
@@ -64,12 +63,18 @@ fields(jt808_proto) ->
 fields(anonymous_true) ->
     [
         {allow_anonymous,
-            sc(hoconsc:union([true]), #{desc => ?DESC(allow_anonymous), required => true})}
+            sc(
+                hoconsc:union([true]),
+                #{desc => ?DESC(jt808_allow_anonymous), required => true}
+            )}
     ] ++ fields_reg_auth_required(false);
 fields(anonymous_false) ->
     [
         {allow_anonymous,
-            sc(hoconsc:union([false]), #{desc => ?DESC(allow_anonymous), required => true})}
+            sc(
+                hoconsc:union([false]),
+                #{desc => ?DESC(jt808_allow_anonymous), required => true}
+            )}
     ] ++ fields_reg_auth_required(true).
 
 fields_reg_auth_required(Required) ->
@@ -105,14 +110,14 @@ jt808_frame_max_length(_) ->
     undefined.
 
 up_topic(type) -> binary();
-up_topic(desc) -> ?DESC(?FUNCTION_NAME);
+up_topic(desc) -> ?DESC(jt808_up_topic);
 up_topic(default) -> ?DEFAULT_UP_TOPIC;
 up_topic(validator) -> [?NOT_EMPTY("the value of the field 'up_topic' cannot be empty")];
 up_topic(required) -> true;
 up_topic(_) -> undefined.
 
 dn_topic(type) -> binary();
-dn_topic(desc) -> ?DESC(?FUNCTION_NAME);
+dn_topic(desc) -> ?DESC(jt808_dn_topic);
 dn_topic(default) -> ?DEFAULT_DN_TOPIC;
 dn_topic(validator) -> [?NOT_EMPTY("the value of the field 'dn_topic' cannot be empty")];
 dn_topic(required) -> true;
@@ -124,6 +129,10 @@ desc(jt808_frame) ->
     "Limits for the JT/T 808 frames.";
 desc(jt808_proto) ->
     "The JT/T 808 protocol options.";
+desc(anonymous_false) ->
+    ?DESC(jt808_allow_anonymous);
+desc(anonymous_true) ->
+    ?DESC(jt808_allow_anonymous);
 desc(_) ->
     undefined.
 

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -101,10 +101,9 @@ end_per_testcase(_Case, Config) ->
     ok.
 
 boot_apps(Case, JT808Conf, Config) ->
-    application:load(emqx_gateway_jt808),
     Apps = emqx_cth_suite:start(
         [
-            cowboy,
+            emqx,
             {emqx_conf, JT808Conf},
             emqx_gateway
         ],

--- a/rel/i18n/emqx_jt808_schema.hocon
+++ b/rel/i18n/emqx_jt808_schema.hocon
@@ -3,19 +3,22 @@ emqx_jt808_schema {
 jt808_frame_max_length.desc:
 """The maximum length of the JT/T 808 frame."""
 
+jt808_auth.desc:
+"""Authentication settings of the JT/T 808 Gateway."""
+
 jt808_allow_anonymous.desc:
 """Allow anonymous access to the JT/T 808 Gateway."""
 
-registry_url.desc
+registry_url.desc:
 """The JT/T 808 device registry central URL."""
 
-authentication_url.desc
+authentication_url.desc:
 """The JT/T 808 device authentication central URL."""
 
-jt808_up_topic.desc
+jt808_up_topic.desc:
 """The topic of the JT/T 808 protocol upstream message."""
 
-jt808_dn_topic.desc
+jt808_dn_topic.desc:
 """The topic of the JT/T 808 protocol downstream message."""
 
 retry_interval.desc:


### PR DESCRIPTION
## Summary

Since the set of known gateways is already predefined in `emqx_gateway_utils` it makes no sense to scan over all modules just to find out the same set of modules. Cutting out this scanning saves few seconds per each `emqx_conf` application startup, which is especially noticeable when running tests.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
