### PR TITLE
fix: set `info` level for potentially flooding log events

### DIFF
--- a/apps/emqx/src/emqx_access_control.erl
+++ b/apps/emqx/src/emqx_access_control.erl
@@ -184,7 +184,7 @@ log_result(#{username := Username}, Topic, Action, From, Result) ->
     end,
     case Result of
         allow -> ?SLOG(info, (LogMeta())#{msg => "authorization_permission_allowed"});
-        deny -> ?SLOG(warning, (LogMeta())#{msg => "authorization_permission_denied"})
+        deny -> ?SLOG(info, (LogMeta())#{msg => "authorization_permission_denied"})
     end.
 
 %% @private Format authorization rules source.

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -613,7 +613,7 @@ process_publish(Packet = ?PUBLISH_PACKET(QoS, Topic, PacketId), Channel) ->
             do_publish(PacketId, Msg, NChannel);
         {error, Rc = ?RC_NOT_AUTHORIZED, NChannel} ->
             ?SLOG(
-                warning,
+                info,
                 #{
                     msg => "cannot_publish_to_topic",
                     reason => emqx_reason_codes:name(Rc)
@@ -632,7 +632,7 @@ process_publish(Packet = ?PUBLISH_PACKET(QoS, Topic, PacketId), Channel) ->
             end;
         {error, Rc = ?RC_QUOTA_EXCEEDED, NChannel} ->
             ?SLOG(
-                warning,
+                info,
                 #{
                     msg => "cannot_publish_to_topic",
                     reason => emqx_reason_codes:name(Rc)

--- a/apps/emqx/src/emqx_session_events.erl
+++ b/apps/emqx/src/emqx_session_events.erl
@@ -63,7 +63,7 @@ handle_event(ClientInfo, {dropped, Msg, #{reason := queue_full, logctx := Ctx}})
     ok = inc_pd('send_msg.dropped', 1),
     ok = inc_pd('send_msg.dropped.queue_full', 1),
     ?SLOG(
-        warning,
+        info,
         Ctx#{
             msg => "dropped_msg_due_to_mqueue_is_full",
             payload => Msg#message.payload

--- a/apps/emqx_license/src/emqx_license.erl
+++ b/apps/emqx_license/src/emqx_license.erl
@@ -85,7 +85,7 @@ check(_ConnInfo, AckProps) ->
         {ok, #{max_connections := MaxClients}} ->
             case check_max_clients_exceeded(MaxClients) of
                 true ->
-                    ?SLOG(error, #{msg => "connection_rejected_due_to_license_limit_reached"}),
+                    ?SLOG(info, #{msg => "connection_rejected_due_to_license_limit_reached"}),
                     {stop, {error, ?RC_QUOTA_EXCEEDED}};
                 false ->
                     {ok, AckProps}

--- a/changes/ce/fix-12513.en.md
+++ b/changes/ce/fix-12513.en.md
@@ -1,0 +1,1 @@
+Change level of several flooding log events from warning to info.


### PR DESCRIPTION
Temporary fix for EMQX-11530, while I'm working on a log throttling feature

Release version: v/e5.

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
