### PR TITLE
refactor: bump ekka to 0.19.0 w/o mnesia boot phase

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -28,7 +28,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.11.1"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.18.4"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.41.0"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},

--- a/apps/emqx/test/emqx_cth_peer.erl
+++ b/apps/emqx/test/emqx_cth_peer.erl
@@ -43,28 +43,17 @@ start_link(Name, Args, Envs, Timeout) when is_atom(Name) ->
 
 do_start(Name0, Args, Envs, Timeout, Func) when is_atom(Name0) ->
     {Name, Host} = parse_node_name(Name0),
-    %% Create exclusive current directory for the node.  Some configurations, like plugin
-    %% installation directory, are the same for the whole cluster, and nodes on the same
-    %% machine will step on each other's toes...
-    {ok, Cwd} = file:get_cwd(),
-    NodeCwd = filename:join([Cwd, Name]),
-    ok = filelib:ensure_dir(filename:join([NodeCwd, "dummy"])),
-    try
-        file:set_cwd(NodeCwd),
-        {ok, Pid, Node} = peer:Func(#{
-            name => Name,
-            host => Host,
-            args => Args,
-            env => Envs,
-            wait_boot => Timeout,
-            longnames => true,
-            shutdown => {halt, 1000}
-        }),
-        true = register(Node, Pid),
-        {ok, Node}
-    after
-        file:set_cwd(Cwd)
-    end.
+    {ok, Pid, Node} = peer:Func(#{
+        name => Name,
+        host => Host,
+        args => Args,
+        env => Envs,
+        wait_boot => Timeout,
+        longnames => true,
+        shutdown => {halt, 1000}
+    }),
+    true = register(Node, Pid),
+    {ok, Node}.
 
 stop(Node) when is_atom(Node) ->
     Pid = whereis(Node),

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -19,9 +19,9 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--include("emqx_conf.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+
 -define(NODE1, emqx_cluster_rpc).
 -define(NODE2, emqx_cluster_rpc2).
 -define(NODE3, emqx_cluster_rpc3).
@@ -42,20 +42,25 @@ suite() -> [{timetrap, {minutes, 5}}].
 groups() -> [].
 
 init_per_suite(Config) ->
-    ok = emqx_common_test_helpers:start_apps([]),
-    ok = mria:wait_for_tables(emqx_cluster_rpc:create_tables()),
-    ok = emqx_config:put([node, cluster_call, retry_interval], 1000),
-    meck:new(emqx_alarm, [non_strict, passthrough, no_link]),
-    meck:expect(emqx_alarm, activate, 3, ok),
-    meck:expect(emqx_alarm, deactivate, 3, ok),
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            {emqx_conf,
+                "node.cluster_call {"
+                "\n  retry_interval = 1s"
+                "\n  max_history = 100"
+                "\n  cleanup_interval = 500ms"
+                "\n}"}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
     meck:new(mria, [non_strict, passthrough, no_link]),
     meck:expect(mria, running_nodes, 0, [?NODE1, {node(), ?NODE2}, {node(), ?NODE3}]),
-    Config.
+    [{suite_apps, Apps} | Config].
 
-end_per_suite(_Config) ->
-    ok = emqx_common_test_helpers:stop_apps([]),
-    meck:unload(emqx_alarm),
-    ok.
+end_per_suite(Config) ->
+    ok = meck:unload(mria),
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
 init_per_testcase(_TestCase, Config) ->
     stop(),
@@ -67,7 +72,6 @@ end_per_testcase(_Config) ->
     ok.
 
 t_base_test(_Config) ->
-    emqx_cluster_rpc:reset(),
     ?assertEqual(emqx_cluster_rpc:status(), {atomic, []}),
     Pid = self(),
     MFA = {M, F, A} = {?MODULE, echo, [Pid, test]},
@@ -94,7 +98,6 @@ t_base_test(_Config) ->
     ok.
 
 t_commit_fail_test(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     {M, F, A} = {?MODULE, failed_on_node, [erlang:whereis(?NODE2)]},
     {init_failure, "MFA return not ok"} = multicall(M, F, A),
@@ -102,7 +105,6 @@ t_commit_fail_test(_Config) ->
     ok.
 
 t_commit_crash_test(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     {M, F, A} = {?MODULE, no_exist_function, []},
     {init_failure, {error, Meta}} = multicall(M, F, A),
@@ -150,7 +152,6 @@ t_commit_ok_but_apply_fail_on_other_node(_Config) ->
     ok.
 
 t_commit_concurrency(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     Pid = self(),
     {BaseM, BaseF, BaseA} = {?MODULE, echo, [Pid, test]},
@@ -211,7 +212,6 @@ receive_seq_msg(Acc) ->
     end.
 
 t_catch_up_status_handle_next_commit(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     {M, F, A} = {?MODULE, failed_on_node_by_odd, [erlang:whereis(?NODE1)]},
     {ok, 1, ok} = multicall(M, F, A, 1, 1000),
@@ -220,7 +220,6 @@ t_catch_up_status_handle_next_commit(_Config) ->
     ok.
 
 t_commit_ok_apply_fail_on_other_node_then_recover(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     ets:new(test, [named_table, public]),
     ets:insert(test, {other_mfa_result, failed}),
@@ -247,7 +246,6 @@ t_commit_ok_apply_fail_on_other_node_then_recover(_Config) ->
     ok.
 
 t_del_stale_mfa(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     MFA = {M, F, A} = {io, format, ["test"]},
     Keys = lists:seq(1, 50),
@@ -289,7 +287,6 @@ t_del_stale_mfa(_Config) ->
     ok.
 
 t_skip_failed_commit(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     {ok, 1, ok} = multicall(io, format, ["test~n"], all, 1000),
     ct:sleep(180),
@@ -310,7 +307,6 @@ t_skip_failed_commit(_Config) ->
     ok.
 
 t_fast_forward_commit(_Config) ->
-    emqx_cluster_rpc:reset(),
     {atomic, []} = emqx_cluster_rpc:status(),
     {ok, 1, ok} = multicall(io, format, ["test~n"], all, 1000),
     ct:sleep(180),
@@ -358,12 +354,10 @@ tnx_ids(Status) ->
     ).
 
 start() ->
-    {ok, Pid1} = emqx_cluster_rpc:start_link(),
-    {ok, Pid2} = emqx_cluster_rpc:start_link({node(), ?NODE2}, ?NODE2, 500),
-    {ok, Pid3} = emqx_cluster_rpc:start_link({node(), ?NODE3}, ?NODE3, 500),
-    {ok, Pid4} = emqx_cluster_rpc_cleaner:start_link(100, 500),
-    true = erlang:register(emqx_cluster_rpc_cleaner, Pid4),
-    {ok, [Pid1, Pid2, Pid3, Pid4]}.
+    {ok, _Pid2} = emqx_cluster_rpc:start_link({node(), ?NODE2}, ?NODE2, 500),
+    {ok, _Pid3} = emqx_cluster_rpc:start_link({node(), ?NODE3}, ?NODE3, 500),
+    ok = emqx_cluster_rpc:reset(),
+    ok.
 
 stop() ->
     [
@@ -376,7 +370,7 @@ stop() ->
                     erlang:exit(P, kill)
             end
         end
-     || N <- [?NODE1, ?NODE2, ?NODE3, emqx_cluster_rpc_cleaner]
+     || N <- [?NODE2, ?NODE3]
     ].
 
 receive_msg(0, _Msg) ->

--- a/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_cluster_rpc_SUITE.erl
@@ -59,7 +59,7 @@ init_per_suite(Config) ->
     [{suite_apps, Apps} | Config].
 
 end_per_suite(Config) ->
-    ok = meck:unload(mria),
+    _ = meck:unload(),
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
 init_per_testcase(_TestCase, Config) ->

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -74,10 +74,7 @@ t_copy_new_data_dir(Config) ->
         {[ok, ok, ok], []} = rpc:multicall(Nodes, ?MODULE, set_data_dir_env, []),
         ok = rpc:call(First, application, start, [emqx_conf]),
         {[ok, ok], []} = rpc:multicall(Rest, application, start, [emqx_conf]),
-
-        assert_data_copy_done(Nodes, File),
-        stop_cluster(Nodes),
-        ok
+        ok = assert_data_copy_done(Nodes, File)
     after
         stop_cluster(Nodes)
     end.
@@ -101,10 +98,7 @@ t_copy_deprecated_data_dir(Config) ->
         {[ok, ok, ok], []} = rpc:multicall(Nodes, ?MODULE, set_data_dir_env, []),
         ok = rpc:call(First, application, start, [emqx_conf]),
         {[ok, ok], []} = rpc:multicall(Rest, application, start, [emqx_conf]),
-
-        assert_data_copy_done(Nodes, File),
-        stop_cluster(Nodes),
-        ok
+        ok = assert_data_copy_done(Nodes, File)
     after
         stop_cluster(Nodes)
     end.
@@ -133,9 +127,7 @@ t_no_copy_from_newer_version_node(Config) ->
         ]),
         ok = rpc:call(First, application, start, [emqx_conf]),
         {[ok, ok], []} = rpc:multicall(Rest, application, start, [emqx_conf]),
-        ok = assert_no_cluster_conf_copied(Rest, File),
-        stop_cluster(Nodes),
-        ok
+        ok = assert_no_cluster_conf_copied(Rest, File)
     after
         stop_cluster(Nodes)
     end.
@@ -155,25 +147,29 @@ create_data_dir(File) ->
 
 set_data_dir_env() ->
     NodeDataDir = emqx:data_dir(),
-    NodeStr = atom_to_list(node()),
+    NodeConfigDir = filename:join(NodeDataDir, "configs"),
     %% will create certs and authz dir
-    ok = filelib:ensure_dir(NodeDataDir ++ "/configs/"),
-    {ok, [ConfigFile]} = application:get_env(emqx, config_files),
-    NewConfigFile = ConfigFile ++ "." ++ NodeStr,
-    ok = filelib:ensure_dir(NewConfigFile),
-    {ok, _} = file:copy(ConfigFile, NewConfigFile),
-    Bin = iolist_to_binary(io_lib:format("node.config_files = [~p]~n", [NewConfigFile])),
-    ok = file:write_file(NewConfigFile, Bin, [append]),
-    DataDir = iolist_to_binary(io_lib:format("node.data_dir = ~p~n", [NodeDataDir])),
-    ok = file:write_file(NewConfigFile, DataDir, [append]),
-    application:set_env(emqx, config_files, [NewConfigFile]),
+    ok = filelib:ensure_path(NodeConfigDir),
+    ConfigFile = filename:join(NodeConfigDir, "emqx.conf"),
+    ok = append_format(ConfigFile, "node.config_files = [~p]~n", [ConfigFile]),
+    ok = append_format(ConfigFile, "node.data_dir = ~p~n", [NodeDataDir]),
+    application:set_env(emqx, config_files, [ConfigFile]),
     %% application:set_env(emqx, data_dir, Node),
     %% We set env both cluster.hocon and cluster-override.conf, but only one will be used
-    application:set_env(emqx, cluster_hocon_file, NodeDataDir ++ "/configs/cluster.hocon"),
     application:set_env(
-        emqx, cluster_override_conf_file, NodeDataDir ++ "/configs/cluster-override.conf"
+        emqx,
+        cluster_hocon_file,
+        filename:join([NodeDataDir, "configs", "cluster.hocon"])
+    ),
+    application:set_env(
+        emqx,
+        cluster_override_conf_file,
+        filename:join([NodeDataDir, "configs", "cluster-override.conf"])
     ),
     ok.
+
+append_format(Filename, Fmt, Args) ->
+    ok = file:write_file(Filename, io_lib:format(Fmt, Args), [append]).
 
 assert_data_copy_done([_First | Rest], File) ->
     FirstDataDir = filename:dirname(filename:dirname(File)),

--- a/apps/emqx_utils/test/emqx_utils_fs_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_utils_fs_SUITE.erl
@@ -143,6 +143,44 @@ t_canonicalize_non_utf8(_) ->
         emqx_utils_fs:canonicalize(<<128, 128, 128>>)
     ).
 
+%%
+
+t_find_relpath(_) ->
+    ?assertEqual(
+        "d1/1",
+        emqx_utils_fs:find_relpath("/usr/local/nonempty/d1/1", "/usr/local/nonempty")
+    ).
+
+t_find_relpath_same(_) ->
+    ?assertEqual(
+        ".",
+        emqx_utils_fs:find_relpath("/usr/local/bin", "/usr/local/bin/")
+    ),
+    ?assertEqual(
+        ".",
+        emqx_utils_fs:find_relpath("/usr/local/bin/.", "/usr/local/bin")
+    ).
+
+t_find_relpath_no_prefix(_) ->
+    ?assertEqual(
+        "/usr/lib/erlang/lib",
+        emqx_utils_fs:find_relpath("/usr/lib/erlang/lib", "/usr/local/bin")
+    ).
+
+t_find_relpath_both_relative(_) ->
+    ?assertEqual(
+        "1/2/3",
+        emqx_utils_fs:find_relpath("local/nonempty/1/2/3", "local/nonempty")
+    ).
+
+t_find_relpath_different_types(_) ->
+    ?assertEqual(
+        "local/nonempty/1/2/3",
+        emqx_utils_fs:find_relpath("local/nonempty/1/2/3", "/usr/local/nonempty")
+    ).
+
+%%
+
 chmod_file(File, Mode) ->
     {ok, FileInfo} = file:read_file_info(File),
     ok = file:write_file_info(File, FileInfo#file_info{mode = Mode}).

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule EMQXUmbrella.MixProject do
       {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true},
       {:esockd, github: "emqx/esockd", tag: "5.11.1", override: true},
       {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-2", override: true},
-      {:ekka, github: "emqx/ekka", tag: "0.18.4", override: true},
+      {:ekka, github: "emqx/ekka", tag: "0.19.0", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "3.3.1", override: true},
       {:grpc, github: "emqx/grpc-erl", tag: "0.6.12", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.3.15", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -83,7 +83,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.11.1"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-2"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.18.4"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.3.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.3.15"}}},


### PR DESCRIPTION
## Summary

Running initial mnesia boot phase as part of ekka startup should not be required anymore since #12508 was merged. However, it's important to have in mind that the order of table management operations is now wildly different from what it was before, and that could in theory break some well-hidden implicit assumptions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] Added property-based tests for code which performs user input validation
- [ ] ~~Changed lines covered in coverage report~~
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
