### PR TITLE
refactor: delete non-prod code

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -425,17 +425,7 @@ get_backend_module() ->
 
 create_resource(Context, #{type := built_in_database} = Cfg) ->
     emqx_retainer_mnesia:create_resource(Cfg),
-    Context;
-create_resource(Context, #{type := DB} = Config) ->
-    ResourceID = erlang:iolist_to_binary([io_lib:format("~ts_~ts", [?APP, DB])]),
-    _ = emqx_resource:create(
-        ResourceID,
-        <<"emqx_retainer">>,
-        list_to_existing_atom(io_lib:format("~ts_~ts", [emqx_connector, DB])),
-        Config,
-        #{}
-    ),
-    Context#{resource_id => ResourceID}.
+    Context.
 
 -spec close_resource(context()) -> ok | {error, term()}.
 close_resource(#{resource_id := ResourceId}) ->


### PR DESCRIPTION
So far the retainer backend type is always `built_in_database`. The slightly over-engineered pre-implementation to support another backend is likely not going to fly as the EMQX resource framework is mostly for auth and data integration. i.e. not generic enough for retained messages.

Release version: `v/e5.6.0`

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
