### PR TITLE
fix: bridge_v1 http api crash when create rabbitmq source

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -1221,6 +1221,10 @@ unpack_bridge_conf(Type, PackedConf, TopLevelConf) ->
 bridge_v1_is_valid(BridgeV1Type, BridgeName) ->
     bridge_v1_is_valid(?ROOT_KEY_ACTIONS, BridgeV1Type, BridgeName).
 
+%% rabbitmq's source don't have v1 version. but action has v1 version...
+%% There's no good way to distinguish it, so it has to be hardcoded here.
+bridge_v1_is_valid(?ROOT_KEY_SOURCES, rabbitmq, _BridgeName) ->
+    false;
 bridge_v1_is_valid(ConfRootKey, BridgeV1Type, BridgeName) ->
     BridgeV2Type = ?MODULE:bridge_v1_type_to_bridge_v2_type(BridgeV1Type),
     case lookup_conf(ConfRootKey, BridgeV2Type, BridgeName) of

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
@@ -144,6 +144,8 @@ t_source(Config) ->
     Name = atom_to_binary(?FUNCTION_NAME),
     create_source(Name),
     Sources = emqx_bridge_v2:list(sources),
+    %% Don't show rabbitmq source in bridge_v1_list
+    ?assertEqual([], emqx_bridge_v2:bridge_v1_list_and_transform()),
     Any = fun(#{name := BName}) -> BName =:= Name end,
     ?assert(lists:any(Any, Sources), Sources),
     Topic = <<"tesldkafd">>,


### PR DESCRIPTION
Fixes <issue-or-jira-number>

RabbitMQ's source only have v2 version. It's should not show in bridge_v1_list. otherwise it's will crash.

Release version: v/e5.6.0
```
{
    "code": "INTERNAL_ERROR",
    "message": "throw, {emqx_bridge_schema,[#{kind => validation_error,path => \"bridges.rabbitmq.foo\",reason => unknown_fields,unknown => \"no_ack,queue\",unmatched => \"delivery_mode,exchange,...\"}]}, [{hocon_tconf,assert,2,[{file,\"hocon_tconf.erl\"},{line,1230}]},{hocon_tconf,map,4,[{file,\"hocon_tconf.erl\"},{line,303}]},{hocon_tconf,do_check,4,[{file,\"hocon_tconf.erl\"},{line,267}]},{emqx_bridge_api,fill_defaults,2,[{file,\"emqx_bridge_api.erl\"},{line,1013}]},{emqx_bridge_api,format_resource,2,[{file,\"emqx_bridge_api.erl\"},{line,924}]},{emqx_bridge_api,'-/bridges/2-lc$^1/1-1-',2,[{file,\"emqx_bridge_api.erl\"},{line,493}]},{emqx_bridge_api,'-/bridges/2-lc$^0/1-0-',1,[{file,\"emqx_bridge_api.erl\"},{line,493}]},{emqx_bridge_api,'/bridges',2,[{file,\"emqx_bridge_api.erl\"},{line,494}]},{minirest_handler,apply_callback,3,[{file,\"minirest_handler.erl\"},{line,137}]},{minirest_handler,handle,2,[{file,\"minirest_handler.erl\"},{line,56}]},{minirest_handler,init,2,[{file,\"minirest_handler.erl\"},{line,27}]},{cowboy_handler,execute,2,[{file,\"cowboy_handler.erl\"},{line,41}]},{cowboy_stream_h,execute,3,[{file,\"cowboy_stream_h.erl\"},{line,318}]},{cowboy_stream_h,request_process,3,[{file,\"cowboy_stream_h.erl\"},{line,302}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,240}]}]"
}
```

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
