### PR TITLE
fix(bridge-s3): expose connector-level `resource_opts` properly

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -313,10 +313,9 @@ create_action_api(Config, Overrides) ->
     ActionConfig0 = ?config(action_config, Config),
     ActionConfig = emqx_utils_maps:deep_merge(ActionConfig0, Overrides),
     Params = ActionConfig#{<<"type">> => ActionType, <<"name">> => ActionName},
-    Method = post,
     Path = emqx_mgmt_api_test_util:api_path(["actions"]),
     ct:pal("creating action (http):\n  ~p", [Params]),
-    Res = request(Method, Path, Params),
+    Res = request(post, Path, Params),
     ct:pal("action create (http) result:\n  ~p", [Res]),
     Res.
 
@@ -324,11 +323,9 @@ get_action_api(Config) ->
     ActionName = ?config(action_name, Config),
     ActionType = ?config(action_type, Config),
     ActionId = emqx_bridge_resource:bridge_id(ActionType, ActionName),
-    Params = [],
-    Method = get,
     Path = emqx_mgmt_api_test_util:api_path(["actions", ActionId]),
     ct:pal("getting action (http)"),
-    Res = request(Method, Path, Params),
+    Res = request(get, Path, []),
     ct:pal("get action (http) result:\n  ~p", [Res]),
     Res.
 
@@ -346,8 +343,7 @@ update_bridge_api(Config, Overrides) ->
     PathRoot = api_path_root(Kind),
     Path = emqx_mgmt_api_test_util:api_path([PathRoot, BridgeId]),
     ct:pal("updating bridge (~s, http):\n  ~p", [Kind, Params]),
-    Method = put,
-    Res = request(Method, Path, Params),
+    Res = request(put, Path, Params),
     ct:pal("update bridge (~s, http) result:\n  ~p", [Kind, Res]),
     Res.
 

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.erl
@@ -53,11 +53,7 @@ fields(action) ->
             }
         )};
 fields("config_connector") ->
-    lists:append([
-        emqx_connector_schema:common_fields(),
-        fields(s3_connector_config),
-        emqx_connector_schema:resource_opts_ref(?MODULE, s3_connector_resource_opts)
-    ]);
+    emqx_connector_schema:common_fields() ++ fields(s3_connector_config);
 fields(?ACTION) ->
     emqx_bridge_v2_schema:make_producer_action_schema(
         hoconsc:mk(
@@ -72,7 +68,8 @@ fields(?ACTION) ->
         }
     );
 fields(s3_connector_config) ->
-    emqx_s3_schema:fields(s3_client);
+    emqx_s3_schema:fields(s3_client) ++
+        emqx_connector_schema:resource_opts_ref(?MODULE, s3_connector_resource_opts);
 fields(s3_upload_parameters) ->
     emqx_s3_schema:fields(s3_upload) ++
         [

--- a/apps/emqx_bridge_s3/test/emqx_bridge_s3_SUITE.erl
+++ b/apps/emqx_bridge_s3/test/emqx_bridge_s3_SUITE.erl
@@ -95,6 +95,10 @@ connector_config(Name, _Config) ->
             <<"pool_size">> => 4,
             <<"max_retries">> => 0,
             <<"enable_pipelining">> => 1
+        },
+        <<"resource_opts">> => #{
+            <<"health_check_interval">> => <<"5s">>,
+            <<"start_timeout">> => <<"5s">>
         }
     }).
 


### PR DESCRIPTION
Fixes [EMQX-11877](https://emqx.atlassian.net/browse/EMQX-11877).
Fixes [EMQX-11880](https://emqx.atlassian.net/browse/EMQX-11880).

Release version: e5.6

## Summary

Attach common minimal `resource_opts` to the correct field in the S3 Bridge schema, thus exposing it to the Bridge Management APIs.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [ ] Schema changes are backward compatible (this is primary focus of the PR)
