### PR TITLE
feat(resource): allow `on_batch_query{,_async}` to return a list of individual results

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds_inflight.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_inflight.erl
@@ -337,7 +337,7 @@ process_test_cmds([{push, N} | Tl], Cnt0) ->
     Cnt = Cnt0 + N,
     [{push, Cnt} | process_test_cmds(Tl, Cnt)].
 
-iqueue_print(I = #iqueue{head = Hd, head_end = HdEnd, queue = Q, tail = Tl, tail_end = TlEnd}) ->
+iqueue_print(#iqueue{head = Hd, head_end = HdEnd, queue = Q, tail = Tl, tail_end = TlEnd}) ->
     #{
         hd => {Hd, HdEnd},
         tl => {Tl, TlEnd},

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -114,6 +114,8 @@
     | {error, {recoverable_error, term()}}
     | {error, term()}.
 
+-type batch_query_result() :: query_result() | [query_result()].
+
 -type action_resource_id() :: resource_id().
 -type source_resource_id() :: resource_id().
 -type connector_resource_id() :: resource_id().

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -170,7 +170,8 @@
 -callback on_query(resource_id(), Request :: term(), resource_state()) -> query_result().
 
 %% when calling emqx_resource:on_batch_query/3
--callback on_batch_query(resource_id(), Request :: term(), resource_state()) -> query_result().
+-callback on_batch_query(resource_id(), Request :: term(), resource_state()) ->
+    batch_query_result().
 
 %% when calling emqx_resource:on_query_async/4
 -callback on_query_async(

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -135,6 +135,15 @@ on_query(_InstId, get_counter, #{pid := Pid}) ->
     after 1000 ->
         {error, timeout}
     end;
+on_query(_InstId, {individual_reply, IsSuccess}, #{pid := Pid}) ->
+    ReqRef = make_ref(),
+    From = {self(), ReqRef},
+    Pid ! {From, {individual_reply, IsSuccess}},
+    receive
+        {ReqRef, Res} -> Res
+    after 1000 ->
+        {error, timeout}
+    end;
 on_query(_InstId, {sleep_before_reply, For}, #{pid := Pid}) ->
     ?tp(connector_demo_sleep, #{mode => sync, for => For}),
     ReqRef = make_ref(),
@@ -169,6 +178,9 @@ on_query_async(_InstId, block_now, ReplyFun, #{pid := Pid}) ->
 on_query_async(_InstId, {big_payload, Payload}, ReplyFun, #{pid := Pid}) ->
     Pid ! {big_payload, Payload, ReplyFun},
     {ok, Pid};
+on_query_async(_InstId, {individual_reply, IsSuccess}, ReplyFun, #{pid := Pid}) ->
+    Pid ! {individual_reply, IsSuccess, ReplyFun},
+    {ok, Pid};
 on_query_async(_InstId, {sleep_before_reply, For}, ReplyFun, #{pid := Pid}) ->
     ?tp(connector_demo_sleep, #{mode => async, for => For}),
     Pid ! {{sleep_before_reply, For}, ReplyFun},
@@ -184,6 +196,8 @@ on_batch_query(InstId, BatchReq, State) ->
             batch_get_counter(sync, InstId, State);
         {big_payload, _Payload} ->
             batch_big_payload(sync, InstId, BatchReq, State);
+        {individual_reply, _IsSuccess} ->
+            batch_individual_reply(sync, InstId, BatchReq, State);
         {random_reply, Num} ->
             %% async batch retried
             make_random_reply(Num)
@@ -200,6 +214,8 @@ on_batch_query_async(InstId, BatchReq, ReplyFunAndArgs, #{pid := Pid} = State) -
             on_query_async(InstId, block_now, ReplyFunAndArgs, State);
         {big_payload, _Payload} ->
             batch_big_payload({async, ReplyFunAndArgs}, InstId, BatchReq, State);
+        {individual_reply, _IsSuccess} ->
+            batch_individual_reply({async, ReplyFunAndArgs}, InstId, BatchReq, State);
         {random_reply, Num} ->
             %% only take the first Num in the batch should be random enough
             Pid ! {{random_reply, Num}, ReplyFunAndArgs},
@@ -241,6 +257,21 @@ batch_big_payload({async, ReplyFunAndArgs}, InstId, Batch, State = #{pid := Pid}
         fun(Req = {big_payload, _}) -> on_query_async(InstId, Req, ReplyFunAndArgs, State) end,
         Batch
     ),
+    {ok, Pid}.
+
+batch_individual_reply(sync, InstId, Batch, State) ->
+    lists:map(
+        fun(Req = {individual_reply, _}) -> on_query(InstId, Req, State) end,
+        Batch
+    );
+batch_individual_reply({async, ReplyFunAndArgs}, InstId, Batch, State) ->
+    Pid = spawn(fun() ->
+        Results = lists:map(
+            fun(Req = {individual_reply, _}) -> on_query(InstId, Req, State) end,
+            Batch
+        ),
+        apply_reply(ReplyFunAndArgs, Results)
+    end),
     {ok, Pid}.
 
 on_get_status(_InstId, #{health_check_error := true}) ->
@@ -337,6 +368,22 @@ counter_loop(
                 State;
             {{FromPid, ReqRef}, get} ->
                 FromPid ! {ReqRef, Num},
+                State;
+            {{FromPid, ReqRef}, {individual_reply, IsSuccess}} ->
+                Res =
+                    case IsSuccess of
+                        true -> ok;
+                        false -> {error, {unrecoverable_error, bad_request}}
+                    end,
+                FromPid ! {ReqRef, Res},
+                State;
+            {individual_reply, IsSuccess, ReplyFun} ->
+                Res =
+                    case IsSuccess of
+                        true -> ok;
+                        false -> {error, {unrecoverable_error, bad_request}}
+                    end,
+                apply_reply(ReplyFun, Res),
                 State;
             {{random_reply, RandNum}, ReplyFun} ->
                 %% usually a behaving  connector should reply once and only once for


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11892

## Summary

This allows callers of batching resources to receive results specific to their requests,
rather than a broad success or failure for the whole batch.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
