### PR TITLE
fix: bpapi announce's bad node name

### DIFF
--- a/apps/emqx/test/emqx_bpapi_SUITE.erl
+++ b/apps/emqx/test/emqx_bpapi_SUITE.erl
@@ -44,10 +44,11 @@ t_announce(Config) ->
     meck:new(emqx_bpapi, [passthrough, no_history]),
     Filename = filename:join(?config(data_dir, Config), "test.versions"),
     meck:expect(emqx_bpapi, versions_file, fun(_) -> Filename end),
-    ?assertMatch(ok, emqx_bpapi:announce(emqx)),
+    FakeNode = 'fake-node@127.0.0.1',
+    ?assertMatch(ok, emqx_bpapi:announce(FakeNode, emqx)),
     timer:sleep(100),
-    ?assertMatch(4, emqx_bpapi:supported_version(node(), api2)),
-    ?assertMatch(2, emqx_bpapi:supported_version(node(), api1)),
+    ?assertMatch(4, emqx_bpapi:supported_version(FakeNode, api2)),
+    ?assertMatch(2, emqx_bpapi:supported_version(FakeNode, api1)),
     ?assertMatch(2, emqx_bpapi:supported_version(api2)),
     ?assertMatch(2, emqx_bpapi:supported_version(api1)).
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11886

Mira‘s transaction only run on core node. we can't run node() on transaction. otherwise The replicant node never write bpapi version.

https://github.com/emqx/emqx/commit/76d242df9bb034ab1401b3e45652c2b577125908#diff-cca246fd249ba536867e4912365801199feab54d2fd5c3d2ba56473002c1c16fR1061-R1070
the front of 550 was fixed call as `running_node`, and this commit tried to ignore the nodes that couldn't be upgraded.However, the replicant nodes have never updated their status correctly and have always been in the nodes that cannot be upgraded.
Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
