### PR TITLE
feat(gcp_pubsub_bridges): make service account json a binary

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -25,7 +25,7 @@
 
 -export([get_jwt_authorization_header/1]).
 
--type service_account_json() :: emqx_bridge_gcp_pubsub:service_account_json().
+-type service_account_json() :: map().
 -type project_id() :: binary().
 -type duration() :: non_neg_integer().
 -type config() :: #{

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -94,8 +94,9 @@ query_mode(_Config) -> no_queries.
 -spec on_start(connector_resource_id(), connector_config()) ->
     {ok, connector_state()} | {error, term()}.
 on_start(ConnectorResId, Config0) ->
-    %% ensure it's a binary key map
-    Config = maps:update_with(service_account_json, fun emqx_utils_maps:binary_key_map/1, Config0),
+    Config = maps:update_with(
+        service_account_json, fun(X) -> emqx_utils_json:decode(X, [return_maps]) end, Config0
+    ),
     #{service_account_json := #{<<"project_id">> := ProjectId}} = Config,
     case emqx_bridge_gcp_pubsub_client:start(ConnectorResId, Config) of
         {ok, Client} ->

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -73,7 +73,9 @@ on_start(InstanceId, Config0) ->
         msg => "starting_gcp_pubsub_bridge",
         instance_id => InstanceId
     }),
-    Config = maps:update_with(service_account_json, fun emqx_utils_maps:binary_key_map/1, Config0),
+    Config = maps:update_with(
+        service_account_json, fun(X) -> emqx_utils_json:decode(X, [return_maps]) end, Config0
+    ),
     #{service_account_json := #{<<"project_id">> := ProjectId}} = Config,
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of
         {ok, Client} ->

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -909,7 +909,7 @@ t_not_a_json(Config) ->
     ?assertMatch(
         {error, #{
             kind := validation_error,
-            reason := #{exception := {error, {badmap, "not a json"}}},
+            reason := "not a json",
             %% should be censored as it contains secrets
             value := <<"******">>
         }},

--- a/apps/emqx_conf/src/emqx_conf_schema_types.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema_types.erl
@@ -261,20 +261,6 @@ readable("comma_separated_atoms()") ->
         dashboard => #{type => comma_separated_string},
         docgen => #{type => "String", example => <<"item1,item2">>}
     };
-readable("service_account_json()") ->
-    %% This is a bit special,
-    %% service_account_josn in swagger spec is an object
-    %% the same in documenation.
-    %% However, dashboard wish it to be a string
-    %% TODO:
-    %%   - Change type definition to stirng().
-    %%   - Convert the embedded object to a escaped JSON string.
-    %%   - Delete this function clause once the above is done.
-    #{
-        swagger => #{type => object},
-        dashboard => #{type => string},
-        docgen => #{type => "Map"}
-    };
 readable("json_binary()") ->
     #{
         swagger => #{type => string, example => <<"{\"a\": [1,true]}">>},

--- a/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
+++ b/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
@@ -19,7 +19,8 @@
 ]).
 
 %% Callback to upgrade config after loaded from config file but before validation.
-upgrade_raw_conf(RawConf) ->
+upgrade_raw_conf(RawConf0) ->
+    RawConf = emqx_bridge_gcp_pubsub:upgrade_raw_conf(RawConf0),
     emqx_conf_schema:upgrade_raw_conf(RawConf).
 
 namespace() ->

--- a/changes/ee/feat-12577.en.md
+++ b/changes/ee/feat-12577.en.md
@@ -1,0 +1,1 @@
+Changed the type of `service_account_json` of both GCP PubSub Producer and Consumer connectors to a string.  Now, it's possible to set this field to a JSON-encoded string.  Using the previous format (a HOCON map) is still supported but not encouraged.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11384

Today, service_account_json config field is an embedded object (map()).

This requires user to embed a JSON object into the config file instead of embedding it as a string.

We should support binary() type as input, but keep supporting map() for backward compatibility.

Release version: v/e5.6

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
