### PR TITLE
chore: delete stale macro

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -36,6 +36,3 @@
 
 %% Enterprise edition
 -define(EMQX_RELEASE_EE, "5.5.0").
-
-%% The HTTP API version
--define(EMQX_API_VERSION, "5.0").


### PR DESCRIPTION
EMQX_API_VERSION is no longer in use since 5.2.0

