### PR TITLE
chore: wait_for cowboy listener release sock when stop_listener

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -368,7 +368,8 @@ wait_listener_stopped(ListenOn) ->
 
 wait_listener_stopped(ListenOn, 3) ->
     Log = #{
-        msg => "cowboy_listener_not_closed_when_stopping_listener",
+        msg => "port_not_released_after_listener_stopped",
+        explain => "Expecting the operating system to release the port soon.",
         listener => ListenOn,
         wait_seconds => 9
     },


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11829
Log a warning msg when wait time > 9s.

Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
