### PR TITLE
Make retainer pluggable

### DIFF
--- a/apps/emqx_retainer/include/emqx_retainer.hrl
+++ b/apps/emqx_retainer/include/emqx_retainer.hrl
@@ -13,6 +13,8 @@
 %% See the License for the specific language governing permissions and
 %% limitations under the License.
 %%--------------------------------------------------------------------
+-ifndef(EMQX_RETAINER_HRL).
+-define(EMQX_RETAINER_HRL, true).
 
 -include_lib("emqx/include/emqx.hrl").
 
@@ -22,22 +24,4 @@
 -define(TAB_INDEX_META, emqx_retainer_index_meta).
 -define(RETAINER_SHARD, emqx_retainer_shard).
 
--type topic() :: binary().
--type payload() :: binary().
--type message() :: #message{}.
-
--type context() :: #{
-    context_id := pos_integer(),
-    atom() => term()
-}.
-
--define(DELIVER_SEMAPHORE, deliver_remained_quota).
--type semaphore() :: ?DELIVER_SEMAPHORE.
--type cursor() :: undefined | term().
--type result() :: term().
-
--define(SHARED_CONTEXT_TAB, emqx_retainer_ctx).
--record(shared_context, {key :: atom(), value :: term()}).
--type shared_context_key() :: ?DELIVER_SEMAPHORE.
-
--type backend() :: emqx_retainer_storage_mnesia.
+-endif.

--- a/apps/emqx_retainer/src/emqx_retainer_app.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_app.erl
@@ -26,12 +26,12 @@
 ]).
 
 start(_Type, _Args) ->
-    ok = emqx_retainer_mnesia_cli:load(),
+    ok = emqx_retainer_cli:load(),
     init_bucket(),
     emqx_retainer_sup:start_link().
 
 stop(_State) ->
-    ok = emqx_retainer_mnesia_cli:unload(),
+    ok = emqx_retainer_cli:unload(),
     delete_bucket(),
     ok.
 

--- a/apps/emqx_retainer/src/emqx_retainer_dispatcher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_dispatcher.erl
@@ -44,6 +44,9 @@
 ]).
 
 -type limiter() :: emqx_htb_limiter:limiter().
+-type context() :: emqx_retainer:context().
+-type topic() :: emqx_types:topic().
+-type cursor() :: emqx_retainer:cursor().
 
 -define(POOL, ?MODULE).
 

--- a/apps/emqx_retainer/src/emqx_retainer_dispatcher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_dispatcher.erl
@@ -236,7 +236,7 @@ cast(Msg) ->
 
 -spec dispatch(context(), pid(), topic(), cursor(), limiter()) -> {ok, limiter()}.
 dispatch(Context, Pid, Topic, Cursor, Limiter) ->
-    Mod = emqx_retainer:get_backend_module(),
+    Mod = emqx_retainer:backend_module(Context),
     case Cursor =/= undefined orelse emqx_topic:wildcard(Topic) of
         false ->
             {ok, Result} = erlang:apply(Mod, read_message, [Context, Topic]),

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -27,6 +27,7 @@
 %% emqx_retainer callbacks
 -export([
     create/1,
+    update/2,
     close/1,
     delete_message/2,
     store_retained/2,
@@ -102,7 +103,7 @@ create(#{storage_type := StorageType}) ->
         StorageType
     ),
     %% The context is not used by this backend
-    #{}.
+    #{storage_type => StorageType}.
 
 create_table(Table, RecordName, Attributes, Type, StorageType) ->
     Copies =
@@ -137,6 +138,11 @@ create_table(Table, RecordName, Attributes, Type, StorageType) ->
             {atomic, ok} = mnesia:change_table_copy_type(Table, node(), Copies),
             ok
     end.
+
+update(#{storage_type := StorageType}, #{storage_type := StorageType}) ->
+    ok;
+update(_Context, _NewConfig) ->
+    need_recreate.
 
 close(_Context) -> ok.
 

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -644,7 +644,7 @@ t_reindex(_) ->
 
 t_get_basic_usage_info(_Config) ->
     ?assertEqual(#{retained_messages => 0}, emqx_retainer:get_basic_usage_info()),
-    Context = undefined,
+    Context = emqx_retainer:context(),
     lists:foreach(
         fun(N) ->
             Num = integer_to_binary(N),
@@ -788,8 +788,8 @@ t_compatibility_for_deliver_rate(_) ->
     ).
 
 t_update_config(_) ->
-    OldConf = emqx_config:get([retainer]),
-    NewConf = emqx_utils_maps:deep_put([backend, storage_type], OldConf, disk),
+    OldConf = emqx_config:get_raw([retainer]),
+    NewConf = emqx_utils_maps:deep_put([<<"backend">>, <<"storage_type">>], OldConf, <<"disk">>),
     emqx_retainer:update_config(NewConf).
 
 %%--------------------------------------------------------------------
@@ -836,7 +836,7 @@ with_conf(ConfMod, Case) ->
     emqx_retainer:update_config(NewConf),
     try
         Case(),
-        emqx_retainer:update_config(Conf)
+        {ok, _} = emqx_retainer:update_config(Conf)
     catch
         Type:Error:Strace ->
             emqx_retainer:update_config(Conf),

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -19,8 +19,6 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
--define(CLUSTER_RPC_SHARD, emqx_cluster_rpc_shard).
-
 -include("emqx_retainer.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
@@ -788,6 +786,11 @@ t_compatibility_for_deliver_rate(_) ->
         },
         Parser(DeliveryInf)
     ).
+
+t_update_config(_) ->
+    OldConf = emqx_config:get([retainer]),
+    NewConf = emqx_utils_maps:deep_put([backend, storage_type], OldConf, disk),
+    emqx_retainer:update_config(NewConf).
 
 %%--------------------------------------------------------------------
 %% Helper functions

--- a/apps/emqx_retainer/test/emqx_retainer_backend_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_backend_SUITE.erl
@@ -1,0 +1,104 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_retainer_backend_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+%%--------------------------------------------------------------------
+%% Setups
+%%--------------------------------------------------------------------
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+-define(BASE_CONF, #{
+    <<"retainer">> =>
+        #{
+            <<"enable">> => true,
+            <<"backend">> =>
+                #{
+                    <<"type">> => <<"built_in_database">>,
+                    <<"storage_type">> => <<"ram">>,
+                    <<"max_retained_messages">> => 0
+                }
+        }
+}).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx, #{
+                before_start => fun() ->
+                    ok = emqx_schema_hooks:inject_from_modules([emqx_retainer_dummy])
+                end
+            }},
+            emqx_conf,
+            {emqx_retainer, ?BASE_CONF}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+%%--------------------------------------------------------------------
+%% Test Cases
+%%--------------------------------------------------------------------
+
+t_external_backend(_Config) ->
+    {ok, _} = emqx_retainer:update_config(#{
+        <<"enable">> => true,
+        <<"backend">> => #{
+            <<"enable">> => false
+        },
+        <<"external_backends">> =>
+            #{
+                <<"dummy">> => #{<<"enable">> => true}
+            }
+    }),
+    ?assertMatch(
+        ok,
+        emqx_retainer:clean()
+    ),
+    ?assertMatch(
+        ok,
+        emqx_retainer:delete(<<"topic">>)
+    ),
+    ?assertMatch(
+        {ok, []},
+        emqx_retainer:read_message(<<"topic">>)
+    ),
+    ?assertMatch(
+        {ok, false, []},
+        emqx_retainer:page_read(<<"topic">>, 0, 10)
+    ),
+    ?assertEqual(
+        0,
+        emqx_retainer:retained_count()
+    ),
+    ?assertEqual(
+        emqx_retainer_dummy,
+        emqx_retainer:backend_module()
+    ),
+    ?assertEqual(
+        true,
+        emqx_retainer:enabled()
+    ).

--- a/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_cli_SUITE.erl
@@ -38,22 +38,22 @@ end_per_suite(Config) ->
     emqx_cth_suite:stop(?config(suite_apps, Config)).
 
 t_reindex_status(_Config) ->
-    ok = emqx_retainer_mnesia_cli:retainer(["reindex", "status"]).
+    ok = emqx_retainer_cli:retainer(["reindex", "status"]).
 
 t_info(_Config) ->
-    ok = emqx_retainer_mnesia_cli:retainer(["info"]).
+    ok = emqx_retainer_cli:retainer(["info"]).
 
 t_topics(_Config) ->
-    ok = emqx_retainer_mnesia_cli:retainer(["topics"]).
+    ok = emqx_retainer_cli:retainer(["topics"]).
 
 t_topics_with_len(_Config) ->
-    ok = emqx_retainer_mnesia_cli:retainer(["topics", "100", "200"]).
+    ok = emqx_retainer_cli:retainer(["topics", "100", "200"]).
 
 t_clean(_Config) ->
-    ok = emqx_retainer_mnesia_cli:retainer(["clean"]).
+    ok = emqx_retainer_cli:retainer(["clean"]).
 
 t_topic(_Config) ->
-    ok = emqx_retainer_mnesia_cli:retainer(["clean", "foo/bar"]).
+    ok = emqx_retainer_cli:retainer(["clean", "foo/bar"]).
 
 t_reindex(_Config) ->
     {ok, C} = emqtt:start_link([{clean_start, true}, {proto_ver, v5}]),
@@ -84,6 +84,6 @@ t_reindex(_Config) ->
     ),
 
     emqx_config:put([retainer, backend, index_specs], [[4, 5]]),
-    ok = emqx_retainer_mnesia_cli:retainer(["reindex", "start"]),
+    ok = emqx_retainer_cli:retainer(["reindex", "start"]),
 
     ?assertEqual(1000, mnesia:table_info(?TAB_INDEX, size)).

--- a/apps/emqx_retainer/test/emqx_retainer_dummy.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_dummy.erl
@@ -1,0 +1,98 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_retainer_dummy).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+
+-behaviour(emqx_retainer).
+
+-export([
+    create/1,
+    update/2,
+    close/1,
+    delete_message/2,
+    store_retained/2,
+    read_message/2,
+    page_read/4,
+    match_messages/3,
+    clear_expired/1,
+    clean/1,
+    size/1
+]).
+
+-behaviour(emqx_schema_hooks).
+
+-export([
+    fields/1,
+    injected_fields/0
+]).
+
+injected_fields() ->
+    #{
+        'retainer.external_backends' => external_backend_fields()
+    }.
+
+create(_Config) -> #{}.
+
+update(_Context, _Config) -> ok.
+
+close(_Context) -> ok.
+
+delete_message(_Context, _Topic) -> ok.
+
+store_retained(_Context, _Message) -> ok.
+
+read_message(_Context, _Topic) -> {ok, []}.
+
+page_read(_Context, _Topic, _Offset, _Limit) -> {ok, false, []}.
+
+match_messages(_Context, _Topic, _Cursor) -> {ok, [], 0}.
+
+clear_expired(_Context) -> ok.
+
+clean(_Context) -> ok.
+
+size(_Context) -> 0.
+
+external_backend_fields() ->
+    [
+        {dummy, hoconsc:ref(?MODULE, dummy)}
+    ].
+
+fields(dummy) ->
+    [
+        {module,
+            hoconsc:mk(
+                emqx_retainer_dummy,
+                #{
+                    desc => <<"dummy backend mod">>,
+                    required => false,
+                    default => <<"emqx_retainer_dummy">>,
+                    importance => ?IMPORTANCE_HIDDEN
+                }
+            )},
+        {enable,
+            hoconsc:mk(
+                boolean(),
+                #{
+                    desc => <<"enable dummy backend">>,
+                    required => true,
+                    default => false
+                }
+            )}
+    ].

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -621,7 +621,7 @@ mock_httpc() ->
     ).
 
 mock_advanced_mqtt_features() ->
-    Context = undefined,
+    Context = emqx_retainer:context(),
     lists:foreach(
         fun(N) ->
             Num = integer_to_binary(N),

--- a/rel/i18n/emqx_retainer_schema.hocon
+++ b/rel/i18n/emqx_retainer_schema.hocon
@@ -33,6 +33,9 @@ mnesia_config_storage_type.desc:
 mnesia_config_type.desc:
 """Backend type."""
 
+mnesia_enable.desc:
+"""Enable built-in Mnesia backend."""
+
 msg_clear_interval.desc:
 """Interval for EMQX to scan expired messages and delete them. Never scan if the value is 0."""
 


### PR DESCRIPTION
Fixes [EMQX-11837](https://emqx.atlassian.net/browse/EMQX-11837)

1. removes any direct usages of retainer backends; code is refactored a bit
2. schema is extended to support alternative backend. 

### Problem

Changing schema is the most challenging part.

For a long time, for retainer backend options, we had the following config
```
backend {
   type = built_in_database
   storage_type = ram
   ...
}
```

with the intention to change the type and the set of options for an alternative backend:

```
backend {
   type = some_new_backend
   new_option = some_value
   ...
}
```

However, we discouraged this approach many times because it led to inconsistent configurations after the change. When the bootstrap config is again merged with the cluster config, we obtain something like

```
backend {
   type = some_new_backend
   storage_type = ram
   new_option = some_value
   ...
}

```

So 
1. One one hand, the used approach is actually impossible to extend;
2. On the other hand, we need to keep backward compatibility.

### Proposed solution

This PR introduces the following structure:

```
backend { # this always configures the builtin backend
   type = built_in_database # this is deprecated & hidden
   enable = false # default is true
   storage_type = ram
   ...
}
external_backends { # these are injected additional backends
   fdb_ds => {
      enable => true
   }
}
```

The term `external` somewhat reflects that the storage and its settings are in the other apps and config sections (the ds configs introduced by Dmitrii).

### Alternative approaches

Alternative approach was to
* Introduce not `external_backends` but just `backends`;
* Make a converter placing legacy `backend` section under `backends.builtin` path.

But things seemed to be too complex, and this led to strange behavior even in tests...

@zmstone @ieQu1, what do you think?

Release version: v/e5.?

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [na] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

