### PR TITLE
test: make `clear_screen` safer

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1060,14 +1060,24 @@ expand_node_specs(Specs, CommonOpts) ->
         Specs
     ).
 
-%% is useful when iterating on the tests in a loop, to get rid of all
-%% the garbaged printed before the test itself beings.
+%% Useful when iterating on the tests in a loop, to get rid of all the garbaged printed
+%% before the test itself beings.
+%% Only actually does anything if the environment variable `CLEAR_SCREEN' is set to `true'
+%% and only clears the screen the screen the first time it's encountered, so it's harmless
+%% otherwise.
 clear_screen() ->
-    io:format(standard_io, "\033[H\033[2J", []),
-    io:format(standard_error, "\033[H\033[2J", []),
-    io:format(standard_io, "\033[H\033[3J", []),
-    io:format(standard_error, "\033[H\033[3J", []),
-    ok.
+    Key = {?MODULE, clear_screen},
+    case {os:getenv("CLEAR_SCREEN"), persistent_term:get(Key, false)} of
+        {"true", false} ->
+            io:format(standard_io, "\033[H\033[2J", []),
+            io:format(standard_error, "\033[H\033[2J", []),
+            io:format(standard_io, "\033[H\033[3J", []),
+            io:format(standard_error, "\033[H\033[3J", []),
+            persistent_term:put(Key, true),
+            ok;
+        _ ->
+            ok
+    end.
 
 with_mock(Mod, FnName, MockedFn, Fun) ->
     ok = meck:new(Mod, [non_strict, no_link, no_history, passthrough]),


### PR DESCRIPTION
Useful when iterating on the tests in a loop, to get rid of all the garbaged printed before the test itself beings.

Only actually does anything if the environment variable `CLEAR_SCREEN` is set to `true` and only clears the screen the screen the first time it's encountered, so it's harmless otherwise.


## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
