### PR TITLE
chore: for dashboad add a 'minimum' attribute for duration_s type

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema_types.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema_types.erl
@@ -172,7 +172,7 @@ readable("duration()") ->
 readable("duration_s()") ->
     #{
         swagger => #{type => string, example => <<"1h">>},
-        dashboard => #{type => duration},
+        dashboard => #{type => duration, minimum => <<"1s">>},
         docgen => #{type => "Duration(s)", example => <<"1h">>, desc => ?DESC(duration)}
     };
 readable("duration_ms()") ->
@@ -190,7 +190,7 @@ readable("timeout_duration()") ->
 readable("timeout_duration_s()") ->
     #{
         swagger => #{type => string, example => <<"1h">>},
-        dashboard => #{type => duration},
+        dashboard => #{type => duration, minimum => <<"1s">>},
         docgen => #{type => "Duration(s)", example => <<"1h">>, desc => ?DESC(duration)}
     };
 readable("timeout_duration_ms()") ->


### PR DESCRIPTION
Release version: v/e5.6.0

## Summary

To help dashboard render duration_s better -- so there is no need to provide "milliseconds" unit.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
