### PR TITLE
fix: redact all headers from logs

### DIFF
--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -88,7 +88,7 @@ t_http_api(_) ->
                         <<"method">> := <<"put">>,
                         <<"body">> := #{<<"mqtt">> := #{<<"max_qos_allowed">> := 1}},
                         <<"bindings">> := _,
-                        <<"headers">> := #{<<"authorization">> := <<"******">>}
+                        <<"headers">> := "******"
                     },
                     <<"http_status_code">> := 200,
                     <<"operation_result">> := <<"success">>,

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.0.15"},
+    {vsn, "5.0.16"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -717,6 +717,9 @@ is_sensitive_key(<<"jwt">>) -> true;
 is_sensitive_key(authorization) -> true;
 is_sensitive_key("authorization") -> true;
 is_sensitive_key(<<"authorization">>) -> true;
+is_sensitive_key(headers) -> true;
+is_sensitive_key("headers") -> true;
+is_sensitive_key(<<"headers">>) -> true;
 is_sensitive_key(bind_password) -> true;
 is_sensitive_key("bind_password") -> true;
 is_sensitive_key(<<"bind_password">>) -> true;
@@ -879,6 +882,7 @@ redact_test_() ->
         secret_key,
         secret_access_key,
         security_token,
+        headers,
         token,
         bind_password
     ],


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-11904

Since headers are usually used for authentication and the headers used for that are very flexible, we redact all headers from logs to avoid leaking anything.

Release version: v/e5.5.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
