### PR TITLE
fix(prom): api crash when tls cert file non existed

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.app.src
+++ b/apps/emqx_prometheus/src/emqx_prometheus.app.src
@@ -2,7 +2,7 @@
 {application, emqx_prometheus, [
     {description, "Prometheus for EMQX"},
     % strict semver, bump manually!
-    {vsn, "5.0.19"},
+    {vsn, "5.0.20"},
     {modules, []},
     {registered, [emqx_prometheus_sup]},
     {applications, [kernel, stdlib, prometheus, emqx, emqx_auth, emqx_resource, emqx_management]},

--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -883,13 +883,17 @@ gen_point(Type, Name, Path) ->
 %% TODO: cert manager for more generic utils functions
 cert_expiry_at_from_path(Path0) ->
     Path = emqx_schema:naive_env_interpolation(Path0),
-    {ok, PemBin} = file:read_file(Path),
-    [CertEntry | _] = public_key:pem_decode(PemBin),
-    Cert = public_key:pem_entry_decode(CertEntry),
-    %% TODO: Not fully tested for all certs type
-    {'utcTime', NotAfterUtc} =
-        Cert#'Certificate'.'tbsCertificate'#'TBSCertificate'.validity#'Validity'.'notAfter',
-    utc_time_to_epoch(NotAfterUtc).
+    case file:read_file(Path) of
+        {ok, PemBin} ->
+            [CertEntry | _] = public_key:pem_decode(PemBin),
+            Cert = public_key:pem_entry_decode(CertEntry),
+            %% TODO: Not fully tested for all certs type
+            {'utcTime', NotAfterUtc} =
+                Cert#'Certificate'.'tbsCertificate'#'TBSCertificate'.validity#'Validity'.'notAfter',
+            utc_time_to_epoch(NotAfterUtc);
+        {error, _} ->
+            0
+    end.
 
 utc_time_to_epoch(UtcTime) ->
     date_to_expiry_epoch(utc_time_to_datetime(UtcTime)).
@@ -898,7 +902,7 @@ utc_time_to_datetime(Str) ->
     {ok, [Year, Month, Day, Hour, Minute, Second], _} = io_lib:fread(
         "~2d~2d~2d~2d~2d~2dZ", Str
     ),
-    %% Alwoys Assuming YY is in 2000
+    %% Always Assuming YY is in 2000
     {{2000 + Year, Month, Day}, {Hour, Minute, Second}}.
 
 %% 62167219200 =:= calendar:datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}}).

--- a/changes/ce/fix-12606.en.md
+++ b/changes/ce/fix-12606.en.md
@@ -1,0 +1,1 @@
+Fix the issue of the endpoint `/prometheus/stats` crashing when the listener's cert file is unreadable.


### PR DESCRIPTION
Fixes [EMQX-11914](https://emqx.atlassian.net/browse/EMQX-11914)
Fixes #12603 

The prom data of `emqx_cert_expiry_at` will be `0` for non-existed cert.

Release version: v/e5.5.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
