### PR TITLE
refactor: change schema registry SERD_TAB to ets

### DIFF
--- a/apps/emqx_schema_registry/include/emqx_schema_registry.hrl
+++ b/apps/emqx_schema_registry/include/emqx_schema_registry.hrl
@@ -10,8 +10,10 @@
 
 %% Note: this has the `_ee_' segment for backwards compatibility.
 -define(SCHEMA_REGISTRY_SHARD, emqx_ee_schema_registry_shard).
--define(SERDE_TAB, emqx_ee_schema_registry_serde_tab).
 -define(PROTOBUF_CACHE_TAB, emqx_ee_schema_registry_protobuf_cache_tab).
+
+%% ETS table for serde build results.
+-define(SERDE_TAB, emqx_schema_registry_serde_tab).
 
 -define(EMQX_SCHEMA_REGISTRY_SPARKPLUGB_SCHEMA_NAME,
     <<"__CiYAWBja87PleCyKZ58h__SparkPlug_B_BUILT-IN">>
@@ -19,23 +21,18 @@
 -type schema_name() :: binary().
 -type schema_source() :: binary().
 
+-type serde_args() :: list().
+
 -type encoded_data() :: iodata().
 -type decoded_data() :: map().
--type serializer() ::
-    fun((decoded_data()) -> encoded_data())
-    | fun((decoded_data(), term()) -> encoded_data()).
--type deserializer() ::
-    fun((encoded_data()) -> decoded_data())
-    | fun((encoded_data(), term()) -> decoded_data()).
--type destructor() :: fun(() -> ok).
--type serde_type() :: avro.
+
+-type serde_type() :: avro | protobuf.
 -type serde_opts() :: map().
 
 -record(serde, {
     name :: schema_name(),
-    serializer :: serializer(),
-    deserializer :: deserializer(),
-    destructor :: destructor()
+    type :: serde_type(),
+    eval_context :: term()
 }).
 -type serde() :: #serde{}.
 
@@ -48,13 +45,6 @@
     fingerprint :: binary(),
     module :: module(),
     module_binary :: binary()
-}.
-
--type serde_map() :: #{
-    name := schema_name(),
-    serializer := serializer(),
-    deserializer := deserializer(),
-    destructor := destructor()
 }.
 
 -endif.

--- a/apps/emqx_schema_registry/rebar.config
+++ b/apps/emqx_schema_registry/rebar.config
@@ -5,7 +5,7 @@
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
     {emqx_rule_engine, {path, "../emqx_rule_engine"}},
-    {erlavro, {git, "https://github.com/klarna/erlavro.git", {tag, "2.9.8"}}},
+    {erlavro, {git, "https://github.com/emqx/erlavro.git", {tag, "2.10.0"}}},
     {gpb, "4.19.9"}
 ]}.
 

--- a/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_schema_registry, [
     {description, "EMQX Schema Registry"},
-    {vsn, "0.1.8"},
+    {vsn, "0.2.0"},
     {registered, [emqx_schema_registry_sup]},
     {mod, {emqx_schema_registry_app, []}},
     {included_applications, [

--- a/apps/emqx_schema_registry/src/emqx_schema_registry.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.erl
@@ -14,7 +14,6 @@
 %% API
 -export([
     start_link/0,
-    get_serde/1,
     add_schema/2,
     get_schema/1,
     delete_schema/1,
@@ -38,6 +37,11 @@
     import_config/1
 ]).
 
+%% for testing
+-export([
+    get_serde/1
+]).
+
 -type schema() :: #{
     type := serde_type(),
     source := binary(),
@@ -51,13 +55,13 @@
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec get_serde(schema_name()) -> {ok, serde_map()} | {error, not_found}.
+-spec get_serde(schema_name()) -> {ok, serde()} | {error, not_found}.
 get_serde(SchemaName) ->
     case ets:lookup(?SERDE_TAB, to_bin(SchemaName)) of
         [] ->
             {error, not_found};
         [Serde] ->
-            {ok, serde_to_map(Serde)}
+            {ok, Serde}
     end.
 
 -spec get_schema(schema_name()) -> {ok, map()} | {error, not_found}.
@@ -214,13 +218,7 @@ terminate(_Reason, _State) ->
 %%-------------------------------------------------------------------------------------------------
 
 create_tables() ->
-    ok = mria:create_table(?SERDE_TAB, [
-        {type, ordered_set},
-        {rlog_shard, ?SCHEMA_REGISTRY_SHARD},
-        {storage, ram_copies},
-        {record_name, serde},
-        {attributes, record_info(fields, serde)}
-    ]),
+    ok = emqx_utils_ets:new(?SERDE_TAB, [public, {keypos, #serde.name}]),
     ok = mria:create_table(?PROTOBUF_CACHE_TAB, [
         {type, set},
         {rlog_shard, ?SCHEMA_REGISTRY_SHARD},
@@ -228,7 +226,7 @@ create_tables() ->
         {record_name, protobuf_cache},
         {attributes, record_info(fields, protobuf_cache)}
     ]),
-    ok = mria:wait_for_tables([?SERDE_TAB, ?PROTOBUF_CACHE_TAB]),
+    ok = mria:wait_for_tables([?PROTOBUF_CACHE_TAB]),
     ok.
 
 do_build_serdes(Schemas) ->
@@ -290,15 +288,8 @@ do_build_serde(Name, Serde) when not is_binary(Name) ->
     do_build_serde(to_bin(Name), Serde);
 do_build_serde(Name, #{type := Type, source := Source}) ->
     try
-        {Serializer, Deserializer, Destructor} =
-            emqx_schema_registry_serde:make_serde(Type, Name, Source),
-        Serde = #serde{
-            name = Name,
-            serializer = Serializer,
-            deserializer = Deserializer,
-            destructor = Destructor
-        },
-        ok = mria:dirty_write(?SERDE_TAB, Serde),
+        Serde = emqx_schema_registry_serde:make_serde(Type, Name, Source),
+        true = ets:insert(?SERDE_TAB, Serde),
         ok
     catch
         Kind:Error:Stacktrace ->
@@ -320,9 +311,9 @@ ensure_serde_absent(Name) when not is_binary(Name) ->
     ensure_serde_absent(to_bin(Name));
 ensure_serde_absent(Name) ->
     case get_serde(Name) of
-        {ok, #{destructor := Destructor}} ->
-            Destructor(),
-            ok = mria:dirty_delete(?SERDE_TAB, Name);
+        {ok, Serde} ->
+            _ = ets:delete(?SERDE_TAB, Name),
+            ok = emqx_schema_registry_serde:destroy(Serde);
         {error, not_found} ->
             ok
     end.
@@ -346,12 +337,3 @@ schema_name_bin_to_atom(Bin) when size(Bin) > 255 ->
     );
 schema_name_bin_to_atom(Bin) ->
     binary_to_atom(Bin, utf8).
-
--spec serde_to_map(serde()) -> serde_map().
-serde_to_map(#serde{} = Serde) ->
-    #{
-        name => Serde#serde.name,
-        serializer => Serde#serde.serializer,
-        deserializer => Serde#serde.deserializer,
-        destructor => Serde#serde.destructor
-    }.

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -45,6 +45,7 @@ end_per_suite(_Config) ->
 init_per_group(avro, Config) ->
     Source = #{
         type => record,
+        name => <<"apitest">>,
         fields => [
             #{name => <<"i">>, type => <<"int">>},
             #{name => <<"s">>, type => <<"string">>}

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_serde_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_serde_SUITE.erl
@@ -54,6 +54,7 @@ clear_schemas() ->
 schema_params(avro) ->
     Source = #{
         type => record,
+        name => <<"n1">>,
         fields => [
             #{name => <<"i">>, type => <<"int">>},
             #{name => <<"s">>, type => <<"string">>}


### PR DESCRIPTION

Fixes 1/2 of https://emqx.atlassian.net/browse/EMQX-11881

Release version: v/e5.6.0

## Summary

* Prior to this change, it's a mria/mnesia table which may cause nodes to overwrite each other.
* Upgraded to erlavro 2.10.0 which allows assigned name to reference named type (struct)

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
