### PR TITLE
fix(calendar): leap year time to unix timestamp

### DIFF
--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1062,6 +1062,18 @@ t_parse_date_errors(_) ->
     ?assertEqual(
         UnixTs,
         emqx_rule_funcs:date_to_unix_ts(second, <<"%Y-%m-%d %H:%M:%S">>, <<"2022-05-26 10-40-12">>)
+    ),
+
+    UnixTsLeap0 = 1582948800,
+    ?assertEqual(
+        UnixTsLeap0,
+        emqx_rule_funcs:date_to_unix_ts(second, <<"%Y-%m-%d %H:%M:%S">>, <<"2020-02-29 12:00:00">>)
+    ),
+
+    UnixTsLeap1 = 1709265631,
+    ?assertEqual(
+        UnixTsLeap1,
+        emqx_rule_funcs:date_to_unix_ts(second, <<"%Y-%m-%d %H:%M:%S">>, <<"2024-03-01 12:00:31">>)
     ).
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_utils/src/emqx_utils_calendar.erl
+++ b/apps/emqx_utils/src/emqx_utils_calendar.erl
@@ -478,7 +478,8 @@ do_parse(DateStr, Unit, Formatter) ->
             (year, V, Res) ->
                 Res + dy(V) * ?SECONDS_PER_DAY * Precise - (?SECONDS_FROM_0_TO_1970 * Precise);
             (month, V, Res) ->
-                Res + dm(V) * ?SECONDS_PER_DAY * Precise;
+                Dm = dym(maps:get(year, DateInfo, 0), V),
+                Res + Dm * ?SECONDS_PER_DAY * Precise;
             (day, V, Res) ->
                 Res + (V * ?SECONDS_PER_DAY * Precise);
             (hour, V, Res) ->
@@ -562,6 +563,14 @@ date_size(nanosecond) -> 9;
 date_size(timezone) -> 5;
 date_size(timezone1) -> 6;
 date_size(timezone2) -> 9.
+
+dym(Y, M) ->
+    case is_leap_year(Y) of
+        true when M > 2 ->
+            dm(M) + 1;
+        _ ->
+            dm(M)
+    end.
 
 dm(1) -> 0;
 dm(2) -> 31;

--- a/changes/ce/fix-12621.en.md
+++ b/changes/ce/fix-12621.en.md
@@ -1,0 +1,1 @@
+Fix rule SQL built-in function `date_to_unix_ts` is incorrect in March and later monthes in leap years.


### PR DESCRIPTION
Fixes [EMQX-11930](https://emqx.atlassian.net/browse/EMQX-11930)

Release version: v/e5.5.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action]~(https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
