### PR TITLE
ci: fix sha256 task in build packages

### DIFF
--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -196,9 +196,9 @@ jobs:
         set -eu
         cd packages/${{ matrix.profile }}
         # fix the .sha256 file format
-        for var in $(ls | grep emqx | grep -v sha256); do
-          dos2unix $var.sha256
-          echo "$(cat $var.sha256) $var" | sha256sum -c || exit 1
+        for f in *.sha256; do
+          dos2unix $f
+          echo "$(cat $f) ${f%.*}" | sha256sum -c || exit 1
         done
         cd -
     - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2


### PR DESCRIPTION
Fixes an issue introduced when we moved to new major version of upload/download artifact actions.

- failing build: https://github.com/emqx/emqx/actions/runs/8144379104/job/22260407298
- successful build: https://github.com/emqx/emqx/actions/runs/8145249625/job/22262287678

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
