### PR TITLE
fix(rule SQL): allow expressions as array items

### DIFF
--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -102,6 +102,7 @@ groups() ->
             t_sqlparse_array_index_3,
             t_sqlparse_array_index_4,
             t_sqlparse_array_index_5,
+            t_sqlparse_array_with_expressions,
             t_sqlparse_select_matadata_1,
             t_sqlparse_array_range_1,
             t_sqlparse_array_range_2,
@@ -3037,6 +3038,30 @@ t_sqlparse_array_index_5(_Config) ->
                 V =:= [1, 2, 3, 4]
             end,
             maps:to_list(Res00)
+        )
+    ).
+
+t_sqlparse_array_with_expressions(_Config) ->
+    Sql =
+        "select "
+        "  [21 + 21, abs(-abs(-2)), [1 + 1], 4] "
+        "from \"t/#\" ",
+    {ok, Res} =
+        emqx_rule_sqltester:test(
+            #{
+                sql => Sql,
+                context => #{
+                    payload => <<"">>,
+                    topic => <<"t/a">>
+                }
+            }
+        ),
+    ?assert(
+        lists:any(
+            fun({_K, V}) ->
+                V =:= [42, 2, [2], 4]
+            end,
+            maps:to_list(Res)
         )
     ).
 

--- a/changes/ce/fix-12657.en.md
+++ b/changes/ce/fix-12657.en.md
@@ -1,0 +1,9 @@
+The rule engine SQL-based language previously did not allow putting any expressions as array elements in array literals (only constants and variable references where allowed). This has not been fixed so that one can use any expressions as array elements.
+
+The following is now permitted, for example:
+
+```
+select
+  [21 + 21, abs(-abs(-2)), [1 + 1], 4] as my_array
+from "t/#"
+```

--- a/changes/ce/fix-12657.en.md
+++ b/changes/ce/fix-12657.en.md
@@ -1,4 +1,4 @@
-The rule engine SQL-based language previously did not allow putting any expressions as array elements in array literals (only constants and variable references where allowed). This has not been fixed so that one can use any expressions as array elements.
+The rule engine SQL-based language previously did not allow putting any expressions as array elements in array literals (only constants and variable references were allowed). This has now been fixed so that one can use any expressions as array elements.
 
 The following is now permitted, for example:
 

--- a/mix.exs
+++ b/mix.exs
@@ -65,7 +65,7 @@ defmodule EMQXUmbrella.MixProject do
       # maybe forbid to fetch quicer
       {:emqtt,
        github: "emqx/emqtt", tag: "1.10.1", override: true, system_env: maybe_no_quic_env()},
-      {:rulesql, github: "emqx/rulesql", tag: "0.1.7"},
+      {:rulesql, github: "emqx/rulesql", tag: "0.1.8"},
       {:observer_cli, "1.7.1"},
       {:system_monitor, github: "ieQu1/system_monitor", tag: "3.0.3"},
       {:telemetry, "1.1.0"},

--- a/rebar.config
+++ b/rebar.config
@@ -91,7 +91,7 @@
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.7"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.10.1"}}},
-    {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.7"}}},
+    {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.1.8"}}},
     % NOTE: depends on recon 2.5.x
     {observer_cli, "1.7.1"},
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.3"}}},


### PR DESCRIPTION
This PR upgrades the rulesql library to allow using expressions as array literal elements in the rule engine SQL like language. 

Fixes:
https://github.com/emqx/emqx/issues/12465
https://emqx.atlassian.net/browse/EMQX-11953

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
