### PR TITLE
0308 load cluster hocon to generate app.config

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -747,7 +747,11 @@ relx_start_command() {
 # Function to check configs without generating them
 check_config() {
     ## this command checks the configs without generating any files
-    call_hocon -v -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf check_schema
+    call_hocon -v \
+        -s "$SCHEMA_MOD" \
+        -c "$DATA_DIR"/configs/cluster.hocon \
+        -c "$EMQX_ETC_DIR"/emqx.conf \
+        check_schema
 }
 
 # Function to generate app.config and vm.args
@@ -763,11 +767,19 @@ generate_config() {
     local NOW_TIME
     NOW_TIME="$(date +'%Y.%m.%d.%H.%M.%S')"
 
-    ## this command populates two files: app.<time>.config and vm.<time>.args
-    ## NOTE: the generate command merges environment variables to the base config (emqx.conf),
-    ## but does not include the cluster-override.conf and local-override.conf
-    ## meaning, certain overrides will not be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -d "$DATA_DIR"/configs generate
+    ## This command populates two files: app.<time>.config and vm.<time>.args
+    ## It takes input sources and overlays values in below order:
+    ##   - $DATA_DIR/cluster.hocon (if exists)
+    ##   - etc/emqx.conf
+    ##   - environment variables starts with EMQX_ e.g. EMQX_NODE__ROLE
+    ##
+    ## NOTE: it's a known issue that cluster.hocon may change right after the node boots up
+    ##       because it has to sync cluster.hocon from other nodes.
+    call_hocon -v -t "$NOW_TIME" \
+        -s "$SCHEMA_MOD" \
+        -c "$DATA_DIR"/configs/cluster.hocon \
+        -c "$EMQX_ETC_DIR"/emqx.conf \
+        -d "$DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"

--- a/bin/emqx
+++ b/bin/emqx
@@ -986,7 +986,7 @@ if [[ "$IS_BOOT_COMMAND" == 'yes' && "$(get_boot_config 'node.db_backend')" == "
     if ! (echo -e "$COMPATIBILITY_INFO" | $GREP -q 'MNESIA_OK'); then
       logwarn "DB Backend is RLOG, but an incompatible OTP version has been detected. Falling back to using Mnesia DB backend."
       export EMQX_NODE__DB_BACKEND=mnesia
-      export EMQX_NODE__DB_ROLE=core
+      export EMQX_NODE__ROLE=core
     fi
 fi
 

--- a/dev
+++ b/dev
@@ -63,8 +63,23 @@ if [ -n "${DEBUG:-}" ]; then
 fi
 
 export HOCON_ENV_OVERRIDE_PREFIX='EMQX_'
-export EMQX_LOG__FILE__DEFAULT__ENABLE='false'
-export EMQX_LOG__CONSOLE__ENABLE='true'
+case "${EMQX_DEFAULT_LOG_HANDLER:-console}" in
+    console|default)
+        export EMQX_LOG__FILE__DEFAULT__ENABLE='false'
+        export EMQX_LOG__CONSOLE__ENABLE='true'
+        ;;
+    file)
+        export EMQX_LOG__FILE__DEFAULT__ENABLE='true'
+        export EMQX_LOG__CONSOLE__ENABLE='false'
+        ;;
+    both)
+        export EMQX_LOG__CONSOLE__ENABLE='true'
+        export EMQX_LOG__FILE__ENABLE='true'
+        ;;
+    *)
+        ;;
+esac
+
 SYSTEM="$(./scripts/get-distro.sh)"
 if [ -n "${EMQX_NODE_NAME:-}" ]; then
     export EMQX_NODE__NAME="${EMQX_NODE_NAME}"
@@ -284,7 +299,8 @@ call_hocon() {
           os:putenv(\"EMQX_NODE__DB_BACKEND\", \"mnesia\"),
           os:putenv(\"EMQX_NODE__DB_ROLE\", \"core\")
         end,
-        ok = hocon_cli:main([$args]),
+        {Time, ok} = timer:tc(fun() -> ok = hocon_cli:main([$args]) end),
+        io:format(user, \"Took ~pms to generate config~n\", [Time div 1000]),
         init:stop().
     "
     erl -noshell -eval "$erl_code"
@@ -297,11 +313,18 @@ generate_app_conf() {
     local NOW_TIME
     NOW_TIME="$(date +'%Y.%m.%d.%H.%M.%S')"
 
-    ## this command populates two files: app.<time>.config and vm.<time>.args
-    ## NOTE: the generate command merges environment variables to the base config (emqx.conf),
-    ## but does not include the cluster-override.conf and local-override.conf
-    ## meaning, certain overrides will not be mapped to app.<time>.config file
-    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" -c "$EMQX_ETC_DIR"/emqx.conf -d "$EMQX_DATA_DIR"/configs generate
+    ## This command populates two files: app.<time>.config and vm.<time>.args
+    ## It takes input sources and overlays values in below order:
+    ##   - $DATA_DIR/cluster.hocon (if exists)
+    ##   - etc/emqx.conf
+    ##   - environment variables starts with EMQX_ e.g. EMQX_NODE__ROLE
+    ##
+    ## NOTE: it's a known issue that cluster.hocon may change right after the node boots up
+    ##       because it has to sync cluster.hocon from other nodes.
+    call_hocon -v -t "$NOW_TIME" -s "$SCHEMA_MOD" \
+        -c "$EMQX_DATA_DIR"/configs/cluster.hocon \
+        -c "$EMQX_ETC_DIR"/emqx.conf \
+        -d "$EMQX_DATA_DIR"/configs generate
 
     ## filenames are per-hocon convention
     CONF_FILE="$CONFIGS_DIR/app.$NOW_TIME.config"


### PR DESCRIPTION
Fixes [EMQX-10893](https://emqx.atlassian.net/browse/EMQX-10893)

Release version: v/e5.6.0

## Summary

Prior to this change, cluster.hocon was not loaded to generate app.\<time>.config,
because it might change after boot.
This behavior lead to an issue for logging behaviour since logger has to be configured before the node boot.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
