### PR TITLE
fix(mgmt): avoid using base64:decode/2 and encode/2

### DIFF
--- a/apps/emqx_management/include/emqx_mgmt.hrl
+++ b/apps/emqx_management/include/emqx_mgmt.hrl
@@ -15,3 +15,6 @@
 %%--------------------------------------------------------------------
 
 -define(DEFAULT_ROW_LIMIT, 100).
+
+-define(URL_PARAM_INTEGER, url_param_integer).
+-define(URL_PARAM_BINARY, url_param_binary).

--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -162,7 +162,7 @@ encode_continuation(end_of_data, _Encoding) ->
 encode_continuation(Cont, ?URL_PARAM_INTEGER) ->
     integer_to_binary(Cont);
 encode_continuation(Cont, ?URL_PARAM_BINARY) ->
-    emqx_utils:bin_to_hexstr(Cont).
+    emqx_utils:bin_to_hexstr(Cont, lower).
 
 %%--------------------------------------------------------------------
 %% Node Query

--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -17,12 +17,11 @@
 -module(emqx_mgmt_api).
 
 -include_lib("stdlib/include/qlc.hrl").
+-include("emqx_mgmt.hrl").
 
 -elvis([{elvis_style, dont_repeat_yourself, #{min_complexity => 100}}]).
 
 -define(LONG_QUERY_TIMEOUT, 50000).
-
--define(CONT_BASE64_OPTS, #{mode => urlsafe, padding => false}).
 
 -export([
     paginate/3
@@ -151,19 +150,19 @@ decode_continuation(none, _Encoding) ->
 decode_continuation(end_of_data, _Encoding) ->
     %% Clients should not send "after=end_of_data" back to the server
     error;
-decode_continuation(Cont, none) ->
-    Cont;
-decode_continuation(Cont, base64) ->
-    base64:decode(Cont, ?CONT_BASE64_OPTS).
+decode_continuation(Cont, ?URL_PARAM_INTEGER) ->
+    binary_to_integer(Cont);
+decode_continuation(Cont, ?URL_PARAM_BINARY) ->
+    emqx_utils:hexstr_to_bin(Cont).
 
 encode_continuation(none, _Encoding) ->
     none;
 encode_continuation(end_of_data, _Encoding) ->
     end_of_data;
-encode_continuation(Cont, none) ->
-    emqx_utils_conv:bin(Cont);
-encode_continuation(Cont, base64) ->
-    base64:encode(emqx_utils_conv:bin(Cont), ?CONT_BASE64_OPTS).
+encode_continuation(Cont, ?URL_PARAM_INTEGER) ->
+    integer_to_binary(Cont);
+encode_continuation(Cont, ?URL_PARAM_BINARY) ->
+    emqx_utils:bin_to_hexstr(Cont).
 
 %%--------------------------------------------------------------------
 %% Node Query
@@ -663,7 +662,7 @@ parse_pager_params(Params) ->
             false
     end.
 
--spec parse_cont_pager_params(map(), none | base64) ->
+-spec parse_cont_pager_params(map(), ?URL_PARAM_INTEGER | ?URL_PARAM_BINARY) ->
     #{limit := pos_integer(), continuation := none | end_of_table | binary()} | false.
 parse_cont_pager_params(Params, Encoding) ->
     Cont = continuation(Params, Encoding),
@@ -675,7 +674,7 @@ parse_cont_pager_params(Params, Encoding) ->
             false
     end.
 
--spec encode_cont_pager_params(map(), none | base64) -> map().
+-spec encode_cont_pager_params(map(), ?URL_PARAM_INTEGER | ?URL_PARAM_BINARY) -> map().
 encode_cont_pager_params(#{continuation := Cont} = Meta, ContEncoding) ->
     Meta1 = maps:remove(continuation, Meta),
     Meta1#{last => encode_continuation(Cont, ContEncoding)};

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1166,9 +1166,9 @@ maybe_cast_cont(_, PagerParams) ->
     PagerParams.
 
 %% integer packet id
-cont_encoding(inflight_msgs) -> none;
+cont_encoding(inflight_msgs) -> ?URL_PARAM_INTEGER;
 %% binary message id
-cont_encoding(mqueue_msgs) -> base64.
+cont_encoding(mqueue_msgs) -> ?URL_PARAM_BINARY.
 
 %%--------------------------------------------------------------------
 %% QueryString to Match Spec

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1135,7 +1135,7 @@ remove_live_sessions(Rows) ->
     ).
 
 list_client_msgs(MsgType, ClientID, QString) ->
-    case parse_cont_pager_params(QString, MsgType) of
+    case emqx_mgmt_api:parse_cont_pager_params(QString, cont_encoding(MsgType)) of
         false ->
             {400, #{code => <<"INVALID_PARAMETER">>, message => <<"after_limit_invalid">>}};
         PagerParams = #{} ->
@@ -1146,24 +1146,6 @@ list_client_msgs(MsgType, ClientID, QString) ->
                     format_msgs_resp(MsgType, Msgs, Meta, QString)
             end
     end.
-
-parse_cont_pager_params(QString, MsgType) ->
-    case emqx_mgmt_api:parse_cont_pager_params(QString, cont_encoding(MsgType)) of
-        false ->
-            false;
-        PagerParams ->
-            maybe_cast_cont(MsgType, PagerParams)
-    end.
-
-maybe_cast_cont(inflight_msgs, #{continuation := Cont} = PagerParams) when is_binary(Cont) ->
-    try
-        PagerParams#{continuation => emqx_utils_conv:int(Cont)}
-    catch
-        _:_ ->
-            false
-    end;
-maybe_cast_cont(_, PagerParams) ->
-    PagerParams.
 
 %% integer packet id
 cont_encoding(inflight_msgs) -> ?URL_PARAM_INTEGER;


### PR DESCRIPTION
The /2 APIs from `base64` module are not available in otp 25

Fixes and issue local to release-56 (not released yet)

Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
