### PR TITLE
feat(ds): move session data from `mnesia` to `emqx_ds`

### DIFF
--- a/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
@@ -25,6 +25,7 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
+    emqx_common_test_helpers:clear_screen(),
     TCApps = emqx_cth_suite:start(
         app_specs(),
         #{work_dir => emqx_cth_suite:work_dir(Config)}
@@ -198,6 +199,22 @@ force_last_alive_at(ClientId, Time) ->
     S = emqx_persistent_session_ds_state:set_last_alive_at(Time, S0),
     _ = emqx_persistent_session_ds_state:commit(S),
     ok.
+
+%% Helper for determining if rpc faults should be injected.
+%% When storing session data in DS, failing here could lead to a session being considered
+%% new and not loaded, since we read non-atomically from the DB.  If getting the streams
+%% fail due to rpc problems, it leniently returns an empty list of streams, and that
+%% results in a "new" session.
+is_restoring_session() ->
+    {current_stacktrace, Stacktrace} = process_info(self(), current_stacktrace),
+    is_restoring_session(Stacktrace).
+
+is_restoring_session([]) ->
+    false;
+is_restoring_session([{emqx_persistent_session_ds, session_open, _, _} | _Rest]) ->
+    true;
+is_restoring_session([_ | Rest]) ->
+    is_restoring_session(Rest).
 
 %%------------------------------------------------------------------------------
 %% Testcases
@@ -649,7 +666,7 @@ t_session_replay_retry(_Config) ->
         ClientsPub
     ),
 
-    Pubs0 = emqx_common_test_helpers:wait_publishes(NClients, 5_000),
+    Pubs0 = emqx_common_test_helpers:wait_publishes(NClients, 6_000),
     NPubs = length(Pubs0),
     ?assertEqual(NClients, NPubs, ?drainMailbox(1_500)),
 
@@ -658,9 +675,18 @@ t_session_replay_retry(_Config) ->
     %% Make `emqx_ds` believe that roughly half of the shards are unavailable.
     ok = emqx_ds_test_helpers:mock_rpc_result(
         fun(_Node, emqx_ds_replication_layer, _Function, [_DB, Shard | _]) ->
-            case erlang:phash2(Shard) rem 2 of
-                0 -> unavailable;
-                1 -> passthrough
+            %% When storing session data in DS, failing here could lead to a session being
+            %% considered new and not loaded, since we read non-atomically from the DB.
+            %% If getting the streams fail due to rpc problems, it leniently returns an
+            %% empty list of streams, and that results in a "new" session.
+            case is_restoring_session() of
+                true ->
+                    passthrough;
+                false ->
+                    case erlang:phash2(Shard) rem 2 of
+                        0 -> unavailable;
+                        1 -> passthrough
+                    end
             end
         end
     ),

--- a/apps/emqx/src/emqx_ds_schema.erl
+++ b/apps/emqx/src/emqx_ds_schema.erl
@@ -80,7 +80,7 @@ namespace() ->
 schema() ->
     [
         {messages,
-            ds_schema(ref(builtin), #{
+            ds_schema(ref(builtin), 'durable_storage.messages', #{
                 default =>
                     #{
                         <<"backend">> => builtin
@@ -89,7 +89,7 @@ schema() ->
                 desc => ?DESC(messages)
             })},
         {sessions,
-            ds_schema(ref(builtin_session), #{
+            ds_schema(ref(builtin_session), 'durable_storage.sessions', #{
                 default =>
                     #{
                         <<"backend">> => builtin
@@ -290,11 +290,11 @@ desc(_) ->
 %% Internal functions
 %%================================================================================
 
-ds_schema(MainRef, Options) ->
+ds_schema(MainRef, InjectionPoint, Options) ->
     sc(
         hoconsc:union([
             MainRef
-            | emqx_schema_hooks:injection_point('durable_storage.backends', [])
+            | emqx_schema_hooks:union_option_injections(InjectionPoint, [])
         ]),
         Options
     ).

--- a/apps/emqx/src/emqx_persistent_message.erl
+++ b/apps/emqx/src/emqx_persistent_message.erl
@@ -56,7 +56,7 @@ init() ->
         Backend = storage_backend(),
         ok = emqx_ds:open_db(?PERSISTENT_MESSAGE_DB, Backend),
         ok = emqx_persistent_session_ds_router:init_tables(),
-        ok = emqx_persistent_session_ds:create_tables(),
+        ok = initialize_session_ds_state(),
         ok
     end).
 
@@ -71,6 +71,15 @@ is_persistence_enabled(Zone) ->
 -spec storage_backend() -> emqx_ds:create_db_opts().
 storage_backend() ->
     storage_backend([durable_storage, messages]).
+
+-ifdef(STORE_STATE_IN_DS).
+initialize_session_ds_state() ->
+    ok = emqx_persistent_session_ds_state:open_db(storage_backend([durable_storage, sessions])).
+-else.
+initialize_session_ds_state() ->
+    ok = emqx_persistent_session_ds_state:create_tables().
+%% -ifdef(STORE_STATE_IN_DS).
+-endif.
 
 %% Dev-only option: force all messages to go through
 %% `emqx_persistent_session_ds':

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -79,7 +79,7 @@
 ]).
 
 %% session table operations
--export([create_tables/0, sync/1]).
+-export([sync/1]).
 
 %% internal export used by session GC process
 -export([destroy_session/1]).
@@ -673,9 +673,6 @@ list_client_subscriptions(ClientId) ->
 %%--------------------------------------------------------------------
 %% Session tables operations
 %%--------------------------------------------------------------------
-
-create_tables() ->
-    emqx_persistent_session_ds_state:create_tables().
 
 %% @doc Force syncing of the transient state to persistent storage
 sync(ClientId) ->

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -18,12 +18,18 @@
 
 -define(PERSISTENT_MESSAGE_DB, emqx_persistent_message).
 
+-ifdef(STORE_STATE_IN_DS).
+-define(PERSISTENT_SESSION_DB, emqx_persistent_session).
+%% ELSE ifdef(STORE_STATE_IN_DS).
+-else.
 -define(SESSION_TAB, emqx_ds_session).
 -define(SESSION_SUBSCRIPTIONS_TAB, emqx_ds_session_subscriptions).
 -define(SESSION_STREAM_TAB, emqx_ds_stream_tab).
 -define(SESSION_PUBRANGE_TAB, emqx_ds_pubrange_tab).
 -define(SESSION_COMMITTED_OFFSET_TAB, emqx_ds_committed_offset_tab).
 -define(DS_MRIA_SHARD, emqx_ds_session_shard).
+%% END ifdef(STORE_STATE_IN_DS).
+-endif.
 
 %%%%% Session sequence numbers:
 

--- a/apps/emqx/src/emqx_persistent_session_ds_state.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_state.erl
@@ -374,7 +374,8 @@ commit(
         ?unset_dirty
     }.
 
-store_batch(Batch) ->
+store_batch(Batch0) ->
+    Batch = [{emqx_message:timestamp(Msg, microsecond), Msg} || Msg <- Batch0],
     emqx_ds:store_batch(?DB, Batch, #{atomic => true, auto_assign_timestamps => false}).
 %% ELSE ifdef(STORE_STATE_IN_DS).
 -else.

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -141,6 +141,7 @@ end_per_group(_, _Config) ->
     ok.
 
 init_per_testcase(TestCase, Config) ->
+    emqx_common_test_helpers:clear_screen(),
     Config1 = preconfig_per_testcase(TestCase, Config),
     case erlang:function_exported(?MODULE, TestCase, 2) of
         true -> ?MODULE:TestCase(init, Config1);

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -50,7 +50,8 @@
     printable_utf8/0,
     printable_codepoint/0,
     raw_duration/0,
-    large_raw_duration/0
+    large_raw_duration/0,
+    clientid/0
 ]).
 
 %% Generic Types

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -163,14 +163,7 @@
         %% shard (if applicable to the backend), as the batch will be split accordingly
         %% even if this flag is `true'.
         %% Default: `false'.
-        atomic => boolean(),
-        %% Defines whether to automatically assign strictly monotonically increasing
-        %% internal timestamps when storing messages (which precludes upserting even if
-        %% crafting timestamps in the message), or allow repeated timestamps in the DB
-        %% (which allows upserting keys, depending on the properties of the layout
-        %% keymapper).
-        %% Default: `true'.
-        auto_assign_timestamps => boolean()
+        atomic => boolean()
     }.
 
 -type generic_db_opts() ::
@@ -306,11 +299,15 @@ drop_db(DB) ->
             Module:drop_db(DB)
     end.
 
--spec store_batch(db(), [emqx_types:message()], message_store_opts()) -> store_batch_result().
+-spec store_batch(
+    db(), [emqx_types:message() | {time(), emqx_types:message()}], message_store_opts()
+) ->
+    store_batch_result().
 store_batch(DB, Msgs, Opts) ->
     ?module(DB):store_batch(DB, Msgs, Opts).
 
--spec store_batch(db(), [emqx_types:message()]) -> store_batch_result().
+-spec store_batch(db(), [emqx_types:message() | {time(), emqx_types:message()}]) ->
+    store_batch_result().
 store_batch(DB, Msgs) ->
     store_batch(DB, Msgs, #{}).
 

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -163,7 +163,14 @@
         %% shard (if applicable to the backend), as the batch will be split accordingly
         %% even if this flag is `true'.
         %% Default: `false'.
-        atomic => boolean()
+        atomic => boolean(),
+        %% Defines whether to automatically assign strictly monotonically increasing
+        %% internal timestamps when storing messages (which precludes upserting even if
+        %% crafting timestamps in the message), or allow repeated timestamps in the DB
+        %% (which allows upserting keys, depending on the properties of the layout
+        %% keymapper).
+        %% Default: `true'.
+        auto_assign_timestamps => boolean()
     }.
 
 -type generic_db_opts() ::

--- a/apps/emqx_durable_storage/src/emqx_ds_replication_layer.hrl
+++ b/apps/emqx_durable_storage/src/emqx_ds_replication_layer.hrl
@@ -33,7 +33,6 @@
 %% ?BATCH
 -define(batch_messages, 2).
 -define(timestamp, 3).
--define(opts, 4).
 
 %% add_generation / update_config
 -define(config, 2).

--- a/apps/emqx_durable_storage/src/emqx_ds_replication_layer.hrl
+++ b/apps/emqx_durable_storage/src/emqx_ds_replication_layer.hrl
@@ -33,6 +33,7 @@
 %% ?BATCH
 -define(batch_messages, 2).
 -define(timestamp, 3).
+-define(opts, 4).
 
 %% add_generation / update_config
 -define(config, 2).

--- a/apps/emqx_durable_storage/src/emqx_ds_replication_layer_egress.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_replication_layer_egress.erl
@@ -41,6 +41,7 @@
 -export_type([]).
 
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %%================================================================================
 %% Type declarations
@@ -52,21 +53,13 @@
 -type message() :: emqx_types:message().
 
 -record(enqueue_req, {
-    message :: message(),
-    sync :: boolean(),
-    auto_assign_timestamps :: boolean()
+    message :: message() | {emqx_ds:time(), message()},
+    sync :: boolean()
 }).
 -record(enqueue_atomic_req, {
-    batch :: [message()],
-    sync :: boolean(),
-    auto_assign_timestamps :: boolean()
+    batch :: [message() | {emqx_ds:time(), message()}],
+    sync :: boolean()
 }).
-
--type bucket() :: auto_ts | no_auto_ts.
--type store_opts() :: #{
-    auto_assign_timestamps := boolean()
-}.
--type msg_or_atomic_batch() :: {atomic, pos_integer(), [message()]} | message().
 
 %%================================================================================
 %% API functions
@@ -80,18 +73,16 @@ start_link(DB, Shard) ->
     ok.
 store_batch(DB, Messages, Opts) ->
     Sync = maps:get(sync, Opts, true),
-    AutoAssignTimestamps = maps:get(auto_assign_timestamps, Opts, true),
     case maps:get(atomic, Opts, false) of
         false ->
             lists:foreach(
                 fun(Message) ->
-                    Shard = emqx_ds_replication_layer:shard_of_message(DB, Message, clientid),
+                    Shard = shard_of_message(DB, Message),
                     gen_server:call(
                         ?via(DB, Shard),
                         #enqueue_req{
                             message = Message,
-                            sync = Sync,
-                            auto_assign_timestamps = AutoAssignTimestamps
+                            sync = Sync
                         },
                         infinity
                     )
@@ -105,15 +96,14 @@ store_batch(DB, Messages, Opts) ->
                         ?via(DB, Shard),
                         #enqueue_atomic_req{
                             batch = Batch,
-                            sync = Sync,
-                            auto_assign_timestamps = AutoAssignTimestamps
+                            sync = Sync
                         },
                         infinity
                     )
                 end,
                 maps:groups_from_list(
                     fun(Message) ->
-                        emqx_ds_replication_layer:shard_of_message(DB, Message, clientid)
+                        shard_of_message(DB, Message)
                     end,
                     Messages
                 )
@@ -129,17 +119,9 @@ store_batch(DB, Messages, Opts) ->
     shard :: emqx_ds_replication_layer:shard_id(),
     n = 0 :: non_neg_integer(),
     tref :: reference(),
-    buckets = #{} :: #{
-        _Bucket ::
-            term() =>
-                #{
-                    msgs := [emqx_types:message()],
-                    pending_replies := [gen_server:from()],
-                    n := non_neg_integer()
-                }
-    }
+    batch = [] :: [emqx_types:message() | {emqx_ds:time(), emqx_types:message()}],
+    pending_replies = [] :: [gen_server:from()]
 }).
--type s() :: #s{}.
 
 init([DB, Shard]) ->
     process_flag(trap_exit, true),
@@ -151,13 +133,13 @@ init([DB, Shard]) ->
     },
     {ok, S}.
 
-handle_call(#enqueue_req{message = Msg, sync = Sync, auto_assign_timestamps = AutoTS}, From, S) ->
-    do_enqueue(From, Sync, AutoTS, Msg, S);
+handle_call(#enqueue_req{message = Msg, sync = Sync}, From, S) ->
+    do_enqueue(From, Sync, Msg, S);
 handle_call(
-    #enqueue_atomic_req{batch = Batch, sync = Sync, auto_assign_timestamps = AutoTS}, From, S
+    #enqueue_atomic_req{batch = Batch, sync = Sync}, From, S
 ) ->
     Len = length(Batch),
-    do_enqueue(From, Sync, AutoTS, {atomic, Len, Batch}, S);
+    do_enqueue(From, Sync, {atomic, Len, Batch}, S);
 handle_call(_Call, _From, S) ->
     {reply, {error, unknown_call}, S}.
 
@@ -183,23 +165,12 @@ terminate(_Reason, _S) ->
 -define(COOLDOWN_MIN, 1000).
 -define(COOLDOWN_MAX, 5000).
 
-do_flush(S = #s{n = 0}) ->
+do_flush(S = #s{batch = []}) ->
     S#s{tref = start_timer()};
-do_flush(S = #s{buckets = Buckets}) ->
-    do_flush1(maps:to_list(Buckets), S).
-
-do_flush1([] = _Buckets, S) ->
-    S#s{
-        n = 0,
-        buckets = #{},
-        tref = start_timer()
-    };
-do_flush1(
-    [{Bucket, #{msgs := Messages, pending_replies := Replies}} | Rest],
-    S = #s{db = DB, shard = Shard}
+do_flush(
+    S = #s{batch = Messages, pending_replies = Replies, db = DB, shard = Shard}
 ) ->
-    StoreOpts = bucket_to_store_opts(Bucket),
-    case emqx_ds_replication_layer:ra_store_batch(DB, Shard, lists:reverse(Messages), StoreOpts) of
+    case emqx_ds_replication_layer:ra_store_batch(DB, Shard, lists:reverse(Messages)) of
         ok ->
             ?tp(
                 emqx_ds_replication_layer_egress_flush,
@@ -222,12 +193,22 @@ do_flush1(
             %% `infinity' timeout.
             lists:foreach(fun(From) -> gen_server:reply(From, {error, Error}) end, Replies)
     end,
-    do_flush1(Rest, S).
+    S#s{
+        n = 0,
+        batch = [],
+        pending_replies = [],
+        tref = start_timer()
+    }.
 
-do_enqueue(From, Sync, AutoTS, MsgOrBatch, S0 = #s{n = N}) ->
+do_enqueue(From, Sync, MsgOrBatch, S0 = #s{n = N, batch = Batch, pending_replies = Replies}) ->
     NMax = application:get_env(emqx_durable_storage, egress_batch_size, 1000),
-    Bucket = bucket(AutoTS),
-    S1 = add_to_bucket(Bucket, MsgOrBatch, S0),
+    S1 =
+        case MsgOrBatch of
+            {atomic, NumMsgs, Msgs} ->
+                S0#s{n = N + NumMsgs, batch = Msgs ++ Batch};
+            Msg ->
+                S0#s{n = N + 1, batch = [Msg | Batch]}
+        end,
     %% TODO: later we may want to delay the reply until the message is
     %% replicated, but it requies changes to the PUBACK/PUBREC flow to
     %% allow for async replies. For now, we ack when the message is
@@ -235,7 +216,14 @@ do_enqueue(From, Sync, AutoTS, MsgOrBatch, S0 = #s{n = N}) ->
     %%
     %% Otherwise, the client would freeze for at least flush interval,
     %% or until the buffer is filled.
-    S2 = add_pending_or_reply(Bucket, Sync, From, S1),
+    S2 =
+        case Sync of
+            true ->
+                S1#s{pending_replies = [From | Replies]};
+            false ->
+                gen_server:reply(From, ok),
+                S1
+        end,
     S =
         case N >= NMax of
             true ->
@@ -252,61 +240,7 @@ start_timer() ->
     Interval = application:get_env(emqx_durable_storage, egress_flush_interval, 100),
     erlang:send_after(Interval, self(), ?flush).
 
--spec bucket(boolean()) -> bucket().
-bucket(AutoTS) ->
-    case AutoTS of
-        true -> auto_ts;
-        false -> no_auto_ts
-    end.
-
--spec bucket_to_store_opts(bucket()) -> store_opts().
-bucket_to_store_opts(auto_ts) ->
-    #{auto_assign_timestamps => true};
-bucket_to_store_opts(no_auto_ts) ->
-    #{auto_assign_timestamps => false}.
-
--spec add_to_bucket(bucket(), msg_or_atomic_batch(), s()) -> s().
-add_to_bucket(Bucket, {atomic, NumMsgs, Msgs}, S0 = #s{n = N0, buckets = Buckets0}) ->
-    Buckets =
-        maps:update_with(
-            Bucket,
-            fun(#{msgs := Msgs0, n := M0} = Previous) ->
-                Previous#{
-                    msgs := Msgs ++ Msgs0,
-                    n := M0 + NumMsgs
-                }
-            end,
-            #{msgs => Msgs, n => NumMsgs, pending_replies => []},
-            Buckets0
-        ),
-    S0#s{n = N0 + NumMsgs, buckets = Buckets};
-add_to_bucket(Bucket, Msg, S0 = #s{n = N0, buckets = Buckets0}) ->
-    Buckets =
-        maps:update_with(
-            Bucket,
-            fun(#{msgs := Msgs0, n := M0} = Previous) ->
-                Previous#{
-                    msgs := [Msg | Msgs0],
-                    n := M0 + 1
-                }
-            end,
-            #{msgs => [Msg], n => 1, pending_replies => []},
-            Buckets0
-        ),
-    S0#s{n = N0 + 1, buckets = Buckets}.
-
--spec add_pending_or_reply(bucket(), boolean(), gen_server:from(), s()) -> s().
-add_pending_or_reply(_Bucket, _Sync = false, From, S) ->
-    gen_server:reply(From, ok),
-    S;
-add_pending_or_reply(Bucket, _Sync = true, From, S0) ->
-    #s{buckets = Buckets0} = S0,
-    Buckets =
-        maps:update_with(
-            Bucket,
-            fun(Previous = #{pending_replies := Replies}) ->
-                Previous#{pending_replies := [From | Replies]}
-            end,
-            Buckets0
-        ),
-    S0#s{buckets = Buckets}.
+shard_of_message(DB, #message{} = Message) ->
+    emqx_ds_replication_layer:shard_of_message(DB, Message, clientid);
+shard_of_message(DB, {_Ts, #message{} = Message}) ->
+    shard_of_message(DB, Message).

--- a/apps/emqx_durable_storage/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_replication_layer_meta.erl
@@ -405,8 +405,8 @@ filter_shards(DB) ->
 
 -spec filter_shards(emqx_ds:db(), fun((_) -> boolean())) ->
     [emqx_ds_replication_layer:shard_id()].
-filter_shards(DB, Predicte) ->
-    filter_shards(DB, Predicte, fun(#?SHARD_TAB{shard = {_, ShardId}}) ->
+filter_shards(DB, Predicate) ->
+    filter_shards(DB, Predicate, fun(#?SHARD_TAB{shard = {_, ShardId}}) ->
         ShardId
     end).
 

--- a/apps/emqx_durable_storage/test/emqx_ds_storage_bitfield_lts_SUITE.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_storage_bitfield_lts_SUITE.erl
@@ -278,6 +278,7 @@ t_atomic_store_batch(_Config) ->
 t_non_atomic_store_batch(_Config) ->
     DB = ?FUNCTION_NAME,
     ?check_trace(
+        #{timetrap => 10_000},
         begin
             application:set_env(emqx_durable_storage, egress_batch_size, 1),
             Msgs = [
@@ -292,6 +293,10 @@ t_non_atomic_store_batch(_Config) ->
                     atomic => false,
                     sync => true
                 })
+            ),
+            snabbkaffe:block_until(
+                ?match_n_events(3, #{?snk_kind := emqx_ds_replication_layer_egress_flush}),
+                infinity
             ),
 
             ok

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1112,7 +1112,6 @@ do_list_clients_cluster_query(
         {Rows, QueryState1 = #{complete := Complete0}} ->
             case emqx_mgmt_api:accumulate_query_rows(Node, Rows, QueryState1, ResultAcc) of
                 {enough, NResultAcc} ->
-                    %% TODO: add persistent session count?
                     %% TODO: this may return `{error, _, _}'...
                     QueryState2 = emqx_mgmt_api:maybe_collect_total_from_tail_nodes(
                         Tail, QueryState1

--- a/mix.exs
+++ b/mix.exs
@@ -264,8 +264,23 @@ defmodule EMQXUmbrella.MixProject do
       :debug_info,
       {:compile_info, [{:emqx_vsn, String.to_charlist(version)}]},
       {:d, :EMQX_RELEASE_EDITION, erlang_edition(edition_type)},
+      ## Uncomment to force enable the experimental feature of storing session data in
+      ## durable storage.
+      # {:d, :STORE_STATE_IN_DS, true},
       {:d, :snk_kind, :msg}
-    ]
+    ] ++ store_state_in_ds_flag()
+  end
+
+  defp store_state_in_ds_flag() do
+    if store_state_in_ds?() do
+      [{:d, :STORE_STATE_IN_DS, true}]
+    else
+      []
+    end
+  end
+
+  defp store_state_in_ds?() do
+    "1" == System.get_env("STORE_STATE_IN_DS")
   end
 
   def maybe_no_quic_env() do

--- a/rebar.config
+++ b/rebar.config
@@ -15,6 +15,9 @@
     warn_obsolete_guard,
     compressed,
     nowarn_unused_import,
+    %% Uncomment to force enable the experimental feature of storing session data in
+    %% durable storage.
+    %% {d, 'STORE_STATE_IN_DS', true},
     {d, snk_kind, msg}
 ]}.
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -204,6 +204,7 @@ common_compile_opts(Edition, Vsn) ->
         {d, 'EMQX_RELEASE_EDITION', Edition}
     ] ++
         [{d, 'EMQX_BENCHMARK'} || os:getenv("EMQX_BENCHMARK") =:= "1"] ++
+        [{d, 'STORE_STATE_IN_DS'} || os:getenv("STORE_STATE_IN_DS") =:= "1"] ++
         [{d, 'BUILD_WITHOUT_QUIC'} || not is_quicer_supported()].
 
 warn_profile_env() ->

--- a/rel/i18n/emqx_ds_schema.hocon
+++ b/rel/i18n/emqx_ds_schema.hocon
@@ -5,6 +5,11 @@ messages.desc:
   """~
   Configuration related to the durable storage of MQTT messages.~"""
 
+sessions.label: "MQTT session storage"
+sessions.desc:
+  """~
+  Configuration related to the durable storage of MQTT sessions.~"""
+
 builtin.label: "Builtin backend"
 builtin.desc:
   """~


### PR DESCRIPTION
Partially fixes https://emqx.atlassian.net/browse/EMQX-11841

Release version: v/e5.7

## Summary

This implements storing session data into DS itself, instead of relying on mnesia.

By default, things will stay as before, using mnesia to store session data.

To enable this new feature, one must compile the project setting the environment variable `STORE_STATE_IN_DS=1`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
