### PR TITLE
feat: Add sticky clientid shared subscription strategies

### DIFF
--- a/apps/emqx/include/emqx_shared_sub.hrl
+++ b/apps/emqx/include/emqx_shared_sub.hrl
@@ -23,6 +23,6 @@
 %% ETS tables for Shared PubSub
 -define(SHARED_SUBSCRIBER, emqx_shared_subscriber).
 -define(ALIVE_SHARED_SUBSCRIBERS, emqx_alive_shared_subscribers).
--define(SHARED_SUBS_ROUND_ROBIN_COUNTER, emqx_shared_subscriber_round_robin_counter).
+-define(SHARED_SUBS_DISPATCH_COUNTER, emqx_shared_subscriber_dispatch_counter).
 
 -endif.

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1317,6 +1317,8 @@ fields("shared_subscription_group") ->
                     round_robin,
                     round_robin_per_group,
                     sticky,
+                    sticky_clientid,
+                    sticky_prioritize_leastload,
                     local,
                     hash_topic,
                     hash_clientid
@@ -3482,6 +3484,8 @@ mqtt_general() ->
                     round_robin,
                     round_robin_per_group,
                     sticky,
+                    sticky_clientid,
+                    sticky_prioritize_leastload,
                     local,
                     hash_topic,
                     hash_clientid

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -387,6 +387,14 @@ t_hash_clientid(Config) when is_list(Config) ->
     ok = ensure_config(hash_clientid, false),
     test_two_messages(hash_clientid).
 
+t_sticky_clientid(Config) when is_list(Config) ->
+    ok = ensure_config(sticky_clientid),
+    test_two_messages(sticky_clientid).
+
+t_sticky_prioritize_leastload(Config) when is_list(Config) ->
+    ok = ensure_config(sticky_prioritize_leastload),
+    test_two_messages(sticky_prioritize_leastload).
+
 t_hash_topic(Config) when is_list(Config) ->
     ok = ensure_config(hash_topic, false),
     ClientId1 = <<"ClientId1">>,
@@ -431,9 +439,20 @@ t_hash_topic(Config) when is_list(Config) ->
     emqtt:stop(ConnPid2),
     ok.
 
-%% if the original subscriber dies, change to another one alive
 t_not_so_sticky(Config) when is_list(Config) ->
     ok = ensure_config(sticky),
+    do_not_so_sticky().
+
+t_not_so_sticky_clientid(Config) when is_list(Config) ->
+    ok = ensure_config(sticky_clientid),
+    do_not_so_sticky().
+
+t_not_so_sticky_prioritize_leastload(Config) when is_list(Config) ->
+    ok = ensure_config(sticky_prioritize_leastload),
+    do_not_so_sticky().
+
+%% if the original subscriber dies, change to another one alive
+do_not_so_sticky() ->
     ClientId1 = <<"ClientId1">>,
     ClientId2 = <<"ClientId2">>,
     {ok, C1} = emqtt:start_link([{clientid, ClientId1}]),
@@ -486,6 +505,7 @@ test_two_messages(Strategy, Group) ->
 
     case Strategy of
         sticky -> ?assertEqual(UsedSubPid1, UsedSubPid2);
+        sticky_clientid -> ?assertEqual(UsedSubPid1, UsedSubPid2);
         round_robin -> ?assertNotEqual(UsedSubPid1, UsedSubPid2);
         round_robin_per_group -> ?assertNotEqual(UsedSubPid1, UsedSubPid2);
         hash_clientid -> ?assertEqual(UsedSubPid1, UsedSubPid2);

--- a/changes/ce/feat-12676.en.md
+++ b/changes/ce/feat-12676.en.md
@@ -1,0 +1,10 @@
+Added new shared subscription strategies
+
+- `sticky_clientid`
+
+    Behaves like the `sticky` strategy but the initial pick is made by the `hash_clientid` strategy instead of random.
+
+- `sticky_prioritize_leastload`
+
+    Behaves like the `sticky` strategy but the initial pick is weighted random with weights adjusted based on the rate of
+    new publishers. This gives priority to newly joined subscribers that are estimated to have the least amount of load.

--- a/rel/config/examples/mqtt.conf.example
+++ b/rel/config/examples/mqtt.conf.example
@@ -127,7 +127,9 @@ mqtt {
     ##   - round_robin :: select the subscribers in a round-robin manner
     ##   - round_robin_per_group :: select the subscribers in round-robin fashion within each shared subscriber group
     ##   - local :: select random local subscriber otherwise select random cluster-wide
-    ##   - sticky :: always use the last selected subscriber to dispatch, until the subscriber disconnects.
+    ##   - sticky :: always use the last selected subscriber to dispatch, until the publisher or subscriber disconnects.
+    ##   - sticky_clientid :: same as sticky but the initial pick is made by the hash_clientid strategy.
+    ##   - sticky_prioritize_leastload :: same as sticky but the initial pick is weighted random with priority given to subscriber(s) estimated to have the least load.
     ##   - hash_clientid :: select the subscribers by hashing the `clientIds`
     ##   - hash_topic :: select the subscribers by hashing the source topic"""
     shared_subscription_strategy = round_robin

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -986,7 +986,10 @@ mqtt_shared_subscription_strategy.desc:
  - `round_robin`: Messages from a single publisher are dispatched to subscribers in turn;
  - `round_robin_per_group`: All messages are dispatched to subscribers in turn;
  - `local`: Randomly select a subscriber on the current node, if there are no subscribers on the current node, then randomly select within the cluster;
- - `sticky`: Continuously dispatch messages to the initially selected subscriber until their session ends;
+ - `sticky`: Continuously dispatch messages to the initially selected subscriber until the publisher or the subscriber disconnects.
+   The initial subscriber is randomly selected;
+ - `sticky_clientid`: Same as sticky but the initial pick is made by the hash_clientid strategy;
+ - `sticky_prioritize_leastload`: Same as sticky but the initial pick is weighted random with priority given to subscriber(s) estimated to have the least load;
  - `hash_clientid`: Hash the publisher's client ID to select a subscriber;
  - `hash_topic`: Hash the publishing topic to select a subscriber."""
 


### PR DESCRIPTION
Add new sticky_clientid and sticky_clientid_leastpubs strategies for shared subscriptions.

Release version: v/e5.7.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
