### PR TITLE
fix: redact secrets from RocketMQ debug log

### DIFF
--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq_connector.erl
@@ -244,7 +244,7 @@ do_query(
     ?TRACE(
         "QUERY",
         "rocketmq_connector_received",
-        #{connector => InstanceId, query => Query, state => State}
+        #{connector => InstanceId, query => Query, state => redact(State)}
     ),
     ChannelId = get_channel_id(Query),
     #{

--- a/changes/ee/fix-12681.en.md
+++ b/changes/ee/fix-12681.en.md
@@ -1,0 +1,1 @@
+When sending messages to a RocketMQ bridge/action while debug level logging was activated, secrets could be emitted in debug level log messages. This has now been fixed.


### PR DESCRIPTION
Fixes:
https://emqx.atlassian.net/browse/EMQX-11987
Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
