### PR TITLE
fix(HStreamDB bridge/action): restrict configuration parameters

### DIFF
--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb.erl
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb.erl
@@ -173,14 +173,16 @@ fields(action_parameters) ->
         {record_template,
             mk(binary(), #{default => <<"${payload}">>, desc => ?DESC("record_template")})},
         {aggregation_pool_size,
-            mk(integer(), #{
+            mk(pos_integer(), #{
                 default => ?DEFAULT_AGG_POOL_SIZE, desc => ?DESC("aggregation_pool_size")
             })},
         {max_batches,
-            mk(integer(), #{default => ?DEFAULT_MAX_BATCHES, desc => ?DESC("max_batches")})},
+            mk(pos_integer(), #{default => ?DEFAULT_MAX_BATCHES, desc => ?DESC("max_batches")})},
         {writer_pool_size,
-            mk(integer(), #{default => ?DEFAULT_WRITER_POOL_SIZE, desc => ?DESC("writer_pool_size")})},
-        {batch_size, mk(integer(), #{default => 100, desc => ?DESC("batch_size")})},
+            mk(pos_integer(), #{
+                default => ?DEFAULT_WRITER_POOL_SIZE, desc => ?DESC("writer_pool_size")
+            })},
+        {batch_size, mk(pos_integer(), #{default => 100, desc => ?DESC("batch_size")})},
         {batch_interval,
             mk(emqx_schema:timeout_duration_ms(), #{
                 default => ?DEFAULT_BATCH_INTERVAL_RAW, desc => ?DESC("batch_interval")


### PR DESCRIPTION
This PR restricts a few HStreamDB bridge/action parameters from being any integer to being integers greater than 0. Lower values than 1 for these parameters resulted in runtime errors.

I don't think a change log entry is necessary for this PR as the changed config parameters did not exist in the previous release.

Fixes:
https://emqx.atlassian.net/browse/EMQX-11939

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
