### PR TITLE
fix(Amazon Kinesis Action): batch size restriction

### DIFF
--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
@@ -212,6 +212,8 @@ desc(action_parameters) ->
     ?DESC("action_parameters");
 desc(connector_resource_opts) ->
     ?DESC(emqx_resource_schema, "resource_opts");
+desc(action_resource_opts) ->
+    ?DESC(emqx_resource_schema, "resource_opts");
 desc(_) ->
     undefined.
 

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
@@ -62,7 +62,19 @@ fields(kinesis_action) ->
                 required => true,
                 desc => ?DESC("action_parameters")
             }
-        )
+        ),
+        #{
+            resource_opts_ref => hoconsc:ref(?MODULE, action_resource_opts)
+        }
+    );
+fields(action_resource_opts) ->
+    emqx_bridge_v2_schema:action_resource_opts_fields(
+        _Overrides = [
+            {batch_size, #{
+                type => range(1, 500),
+                validator => emqx_resource_validator:max(int, 500)
+            }}
+        ]
     );
 fields("config_producer") ->
     emqx_bridge_schema:common_bridge_fields() ++
@@ -84,6 +96,7 @@ fields("resource_opts") ->
 fields("creation_opts") ->
     emqx_resource_schema:create_opts([
         {batch_size, #{
+            type => range(1, 500),
             validator => emqx_resource_validator:max(int, 500)
         }}
     ]);


### PR DESCRIPTION
Make sure that the Amazon Kinesis action has the same batch size restriction as the Amazon Kinesis bridge.

Fixes:
https://emqx.atlassian.net/browse/EMQX-11983

I don't think a change log entry is needed because the fixed code has not been released.

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible