### PR TITLE
fix(api/clients): drop expired sessions from durable storage

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds_state.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_state.erl
@@ -37,6 +37,7 @@
 -export([get_subscriptions/1, put_subscription/4, del_subscription/3]).
 
 -export([make_session_iterator/0, session_iterator_next/2]).
+-export([is_expired/1]).
 
 -export_type([
     t/0,
@@ -382,6 +383,10 @@ session_iterator_next(Cursor0, N) ->
     ],
     {NextVals, Cursor} = session_iterator_next(mnesia:dirty_next(?session_tab, Cursor0), N - 1),
     {ThisVal ++ NextVals, Cursor}.
+
+-spec is_expired(metadata()) -> boolean().
+is_expired(#{?last_alive_at := LastAliveAt, ?expiry_interval := ExpiryInterval}) ->
+    LastAliveAt + ExpiryInterval < erlang:system_time(millisecond).
 
 %%================================================================================
 %% Internal functions

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1094,9 +1094,17 @@ do_persistent_session_count(Cursor, N) ->
     case emqx_persistent_session_ds_state:session_iterator_next(Cursor, 1) of
         {[], _} ->
             N;
-        {_, NextCursor} ->
-            do_persistent_session_count(NextCursor, N + 1)
+        {[{_Id, Meta}], NextCursor} ->
+            case is_expired(Meta) of
+                true ->
+                    do_persistent_session_count(NextCursor, N);
+                false ->
+                    do_persistent_session_count(NextCursor, N + 1)
+            end
     end.
+
+is_expired(Meta) ->
+    emqx_persistent_session_ds_state:is_expired(Meta).
 
 do_persistent_session_query(ResultAcc, QueryState) ->
     case emqx_persistent_message:is_persistence_enabled() of
@@ -1115,7 +1123,7 @@ do_persistent_session_query1(ResultAcc, QueryState, Iter0) ->
     %% through all the nodes.
     #{limit := Limit} = QueryState,
     {Rows0, Iter} = emqx_persistent_session_ds_state:session_iterator_next(Iter0, Limit),
-    Rows = remove_live_sessions(Rows0),
+    Rows = drop_live_and_expired(Rows0),
     case emqx_mgmt_api:accumulate_query_rows(undefined, Rows, QueryState, ResultAcc) of
         {enough, NResultAcc} ->
             emqx_mgmt_api:finalize_query(NResultAcc, emqx_mgmt_api:mark_complete(QueryState, true));
@@ -1125,18 +1133,26 @@ do_persistent_session_query1(ResultAcc, QueryState, Iter0) ->
             do_persistent_session_query1(NResultAcc, QueryState, Iter)
     end.
 
-remove_live_sessions(Rows) ->
+drop_live_and_expired(Rows) ->
     lists:filtermap(
-        fun({ClientId, _Session}) ->
-            case emqx_mgmt:lookup_running_client(ClientId, _FormatFn = undefined) of
-                [] ->
-                    {true, {ClientId, emqx_persistent_session_ds_state:print_session(ClientId)}};
-                [_ | _] ->
-                    false
+        fun({ClientId, Session}) ->
+            case is_expired(Session) orelse is_live_session(ClientId) of
+                true ->
+                    false;
+                false ->
+                    {true, {ClientId, emqx_persistent_session_ds_state:print_session(ClientId)}}
             end
         end,
         Rows
     ).
+
+%% Return 'true' if there is a live channel found in the global channel registry.
+%% NOTE: We cannot afford to query all running nodes to find out if a session is live.
+%% i.e. assuming the global session registry is always enabled.
+%% Otherwise this function may return `false` for `true` causing the session to appear
+%% twice in the query result.
+is_live_session(ClientId) ->
+    [] =/= emqx_cm_registry:lookup_channels(ClientId).
 
 list_client_msgs(MsgType, ClientID, QString) ->
     case emqx_mgmt_api:parse_cont_pager_params(QString, cont_encoding(MsgType)) of


### PR DESCRIPTION
Fixes 1/2 of [EMQX-11956](https://emqx.atlassian.net/browse/EMQX-11956)

Release version: v/e5.6.0

## Summary

Drop expired sessions in /clients api query results from durable storage.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
