### PR TITLE
fix: otel metrics create view crash

### DIFF
--- a/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
+++ b/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_opentelemetry, [
     {description, "OpenTelemetry for EMQX Broker"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {mod, {emqx_otel_app, []}},
     {applications, [

--- a/apps/emqx_opentelemetry/src/emqx_otel_metrics.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_metrics.erl
@@ -104,7 +104,7 @@ safe_stop_default_metrics() ->
         _ = opentelemetry_experimental:stop_default_metrics(),
         ok
     catch
-        %% noramal scenario, metrics supervisor is not started
+        %% normal scenario, metrics supervisor is not started
         exit:{noproc, _} -> ok
     end.
 
@@ -254,6 +254,18 @@ create_counter(Meter, Counters, CallBack) ->
         Counters
     ).
 
+%% Note: list_to_existing_atom("cpu.use") will crash
+%% so we make sure the atom is already existing here
+normalize_name(cpu_use) ->
+    'cpu.use';
+normalize_name(cpu_idle) ->
+    'cpu.idle';
+normalize_name(run_queue) ->
+    'run.queue';
+normalize_name(total_memory) ->
+    'total.memory';
+normalize_name(used_memory) ->
+    'used.memory';
 normalize_name(Name) ->
     list_to_existing_atom(lists:flatten(string:replace(atom_to_list(Name), "_", ".", all))).
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12040
Release version: v/e5.6.0
```
2024-03-19T01:51:52.161276+00:00 [error] crasher: initial call: emqx_otel_metrics:init/1, pid: <0.4962.0>, registered_name: emqx_otel_metrics, error: {badarg,[{erlang,list_to_existing_atom,["cpu.use"],[{error_info,#{module => erl_erts_errors}}]},{emqx_otel_metrics,normalize_name,1,[{file,"emqx_otel_metrics.erl"},{line,258}]},{emqx_otel_metrics,'-create_metric_views/0-fun-0-',1,[{file,"emqx_otel_metrics.erl"},{line,115}]},{lists,map,2,[{file,"lists.erl"},{line,1315}]},{emqx_otel_metrics,create_metric_views,0,[{file,"emqx_otel_metrics.erl"},{line,115}]},{emqx_otel_metrics,handle_continue,2,[{file,"emqx_otel_metrics.erl"},{line,53}]},{gen_server,try_dispatch,4,[{file,"gen_server.erl"},{line,1123}]},{gen_server,loop,7,[{file,"gen_server.erl"},{line,865}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,240}]}]}, ancestors: [emqx_otel_sup,<0.4932.0>], message_queue_len: 0, messages: [], links: [<0.4961.0>], dictionary: [], trap_exit: false, status: running, heap_size: 10958, stack_size: 28, reductions: 19102; neighbours:
```

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
