### PR TITLE
chore: upgrade to jesse 1.8.0 for draft-06 as default version

### DIFF
--- a/apps/emqx_gateway_ocpp/rebar.config
+++ b/apps/emqx_gateway_ocpp/rebar.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang; -*-
 
 {deps, [
-    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.7.12"}}},
+    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.0"}}},
     {emqx, {path, "../../apps/emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
     {emqx_gateway, {path, "../../apps/emqx_gateway"}}

--- a/apps/emqx_schema_registry/rebar.config
+++ b/apps/emqx_schema_registry/rebar.config
@@ -6,7 +6,7 @@
     {emqx_utils, {path, "../emqx_utils"}},
     {emqx_rule_engine, {path, "../emqx_rule_engine"}},
     {erlavro, {git, "https://github.com/emqx/erlavro.git", {tag, "2.10.0"}}},
-    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.7.12"}}},
+    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.0"}}},
     {gpb, "4.19.9"}
 ]}.
 


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-11881

Release version: v/e5.6.0

## Summary

This is a follow up fix for the json schema feature.
jesse before 1.8 uses JSON schema draft-03 as default,
1.8.0 (newly tagged) uses draft-06 as default.
-- this default value aligns with the Javascript lib used in frontend.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
