### PR TITLE
fix(sessds): Channel must destroy sessions that are kicked

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1146,9 +1146,11 @@ handle_call(
     kick,
     Channel = #channel{
         conn_state = ConnState,
-        conninfo = #{proto_ver := ProtoVer}
+        conninfo = #{proto_ver := ProtoVer},
+        session = Session
     }
 ) ->
+    emqx_session:destroy(Session),
     Channel0 = maybe_publish_will_msg(kicked, Channel),
     Channel1 =
         case ConnState of

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -36,7 +36,8 @@
 -export([
     create/3,
     open/3,
-    destroy/1
+    destroy/1,
+    kick_offline_session/1
 ]).
 
 -export([
@@ -203,6 +204,14 @@ destroy(#{clientid := ClientID}) ->
 
 destroy_session(ClientID) ->
     session_drop(ClientID, destroy).
+
+kick_offline_session(ClientID) ->
+    emqx_cm_locker:trans(
+        ClientID,
+        fun(_Nodes) ->
+            session_drop(ClientID, kicked)
+        end
+    ).
 
 %%--------------------------------------------------------------------
 %% Info, Stats

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -351,6 +351,10 @@ kickout_client(ClientId) ->
     case lookup_client({clientid, ClientId}, undefined) of
         [] ->
             {error, not_found};
+        [{ClientId, _}] ->
+            %% Offline durable session (client ID is a plain binary
+            %% without channel pid):
+            emqx_persistent_session_ds:kick_offline_session(ClientId);
         _ ->
             Results = [kickout_client(Node, ClientId) || Node <- emqx:running_nodes()],
             check_results(Results)

--- a/changes/ce/fix-12740.en.md
+++ b/changes/ce/fix-12740.en.md
@@ -1,0 +1,1 @@
+Add support for kickout of durable sessions.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12020

Release version: v/e5.?

## Summary
Add very bare-bones support for kicking out durable sessions. 
Missing features:
- Hooks won't run
- Will message won't be dispatched (proper fix depends on moving will message handling from channel to session)

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
