### PR TITLE
fix(topics-api): respond with correct totals to paged queries

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds_router.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_router.erl
@@ -33,7 +33,10 @@
 ]).
 
 %% Topics API
--export([stream/1]).
+-export([
+    stream/1,
+    stats/1
+]).
 
 -export([cleanup_routes/1]).
 -export([print_routes/1]).
@@ -210,6 +213,14 @@ foldr_routes(FoldFun, AccIn) ->
     emqx_utils_stream:stream(emqx_types:route()).
 stream(MTopic) ->
     emqx_utils_stream:chain(stream(?PS_ROUTER_TAB, MTopic), stream(?PS_FILTERS_TAB, MTopic)).
+
+%% @doc Retrieve router stats.
+%% n_routes: total number of routes, should be equal to the length of `stream('_')`.
+-spec stats(n_routes) -> non_neg_integer().
+stats(n_routes) ->
+    NTopics = ets:info(?PS_ROUTER_TAB, size),
+    NFilters = ets:info(?PS_FILTERS_TAB, size),
+    emqx_maybe:define(NTopics, 0) + emqx_maybe:define(NFilters, 0).
 
 %%--------------------------------------------------------------------
 %% Internal fns

--- a/apps/emqx_management/test/emqx_mgmt_api_topics_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_topics_SUITE.erl
@@ -246,12 +246,20 @@ t_persistent_topics(_Config) ->
         lists:sort(maps:get(<<"data">>, Matched))
     ),
     %% Are results the same when paginating?
-    #{<<"data">> := Page1} = request_json(get, ["topics"], [{"page", "1"}, {"limit", "3"}]),
+    #{<<"data">> := Page1} = R1 = request_json(get, ["topics"], [{"page", "1"}, {"limit", "3"}]),
     #{<<"data">> := Page2} = request_json(get, ["topics"], [{"page", "2"}, {"limit", "3"}]),
     #{<<"data">> := Page3} = request_json(get, ["topics"], [{"page", "3"}, {"limit", "3"}]),
     ?assertEqual(
         lists:sort(Expected),
         lists:sort(Page1 ++ Page2 ++ Page3)
+    ),
+    %% Count respects persistent sessions.
+    ?assertMatch(
+        #{
+            <<"meta">> := #{<<"page">> := 1, <<"limit">> := 3, <<"count">> := 8},
+            <<"data">> := [_, _, _]
+        },
+        R1
     ),
     %% Filtering by node makes no sense for persistent sessions.
     ?assertMatch(


### PR DESCRIPTION
Fixes [EMQX-12050](https://emqx.atlassian.net/browse/EMQX-12050)

Release version: v5.6

## Summary

Before this PR, total count of topics was not estimated properly when a query produced partial results. This is fixed by including the number of persistent router topics in `count` when session persistence is enabled.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible