### PR TITLE
fix: bpapi undef on old node

### DIFF
--- a/apps/emqx/src/bpapi/emqx_bpapi.erl
+++ b/apps/emqx/src/bpapi/emqx_bpapi.erl
@@ -89,7 +89,8 @@ announce(Node, App) ->
     %% replicant(5.6.0) will call old core(<5.6.0) announce_fun/2 is undef on old core
     %% so we just use anonymous function to update.
     try
-        {atomic, ok} = mria:transaction(?COMMON_SHARD, fun ?MODULE:announce_fun/2, [Node, Data])
+        {atomic, ok} = mria:transaction(?COMMON_SHARD, fun ?MODULE:announce_fun/2, [Node, Data]),
+        ok
     catch
         error:undef ->
             {atomic, ok} = mria:transaction(
@@ -112,9 +113,9 @@ announce(Node, App) ->
                     _ = [update_minimum(API) || {API, _} <- Data],
                     ok
                 end
-            )
-    end,
-    ok.
+            ),
+            ok
+    end.
 
 -spec versions_file(atom()) -> file:filename_all().
 versions_file(App) ->


### PR DESCRIPTION
Fixes <issue-or-jira-number>
```
2024-03-22T05:58:01.793548+00:00 [notice] Application: emqx. Exited: {bad_return,{{emqx_app,start,[normal,[]]},{'EXIT',{{badmatch,{aborted,{undef,[{emqx_bpapi,announce_fun,['emqx@10.42.0.53',[{emqx,1},{emqx,2},{emqx_authn,1},{emqx_authz,1},{emqx_bridge,1},{emqx_bridge,2},{emqx_bridge,3},{emqx_bridge,4},{emqx_bridge,5},{emqx_bridge,6},{emqx_broker,1},{emqx_cm,1},{emqx_cm,2},{emqx_conf,1},{emqx_conf,2},{emqx_conf,3},{emqx_connector,1},{emqx_dashboard,1},{emqx_delayed,1},{emqx_delayed,2},{emqx_delayed,3},{emqx_ds,1},{emqx_ds,2},{emqx_ds,3},{emqx_ds,4},{emqx_eviction_agent,1},{emqx_eviction_agent,2},{emqx_exhook,1},{emqx_ft_storage_exporter_fs,1},{emqx_ft_storage_fs,1},{emqx_ft_storage_fs_reader,1},{emqx_gateway_api_listeners,1},{emqx_gateway_cm,1},{emqx_gateway_http,1},{emqx_license,1},{emqx_license,2},{emqx_management,1},{emqx_management,2},{emqx_management,3},{emqx_management,4},{emqx_management,5},{emqx_metrics,1},{emqx_mgmt_api_plugins,1},{emqx_mgmt_api_plugins,2},{emqx_mgmt_cluster,1},{emqx_mgmt_cluster,2},{emqx_mgmt_cluster,3},{emqx_mgmt_data_backup,1},{emqx_mgmt_trace,1},{emqx_mgmt_trace,2},{emqx_node_rebalance,1},{emqx_node_rebalance,2},{emqx_node_rebalance,3},{emqx_node_rebalance_api,1},{emqx_node_rebalance_api,2},{emqx_node_rebalance_evacuation,1},{emqx_node_rebalance_purge,1},{emqx_node_rebalance_status,1},{emqx_node_rebalance_status,2},{emqx_persistent_session_ds,1},{emqx_plugins,1},{emqx_prometheus,1},{emqx_prometheus,2},{emqx_resource,1},{emqx_resource,2},{emqx_retainer,1},{emqx_retainer,2},{emqx_rule_engine,1},{emqx_shared_sub,1},{emqx_slow_subs,1},{emqx_telemetry,1},{emqx_topic_metrics,1}]],[]},{mria_upstream,'-transactional_wrapper/3-fun-0-',4,[{file,"mria_upstream.erl"},{line,52}]},{mnesia_tm,apply_fun,3,[{file,"mnesia_tm.erl"},{line,884}]},{mnesia_tm,execute_transaction,5,[{file,"mnesia_tm.erl"},{line,860}]},{erpc,execute_call,4,[{file,"erpc.erl"},{line,589}]}]}}},[{emqx_bpapi,announce,2,[{file,"emqx_bpapi.erl"},{line,89}]},{emqx_app,start,2,[{file,"emqx_app.erl"},{line,43}]},{application_master,start_it_old,4,[{file,"application_master.erl"},{line,293}]}]}}}}. Type: permanent.
```

Release version: v/e5.6.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
