### PR TITLE
fix(kafka_producer): handle ancient v1 config when migrating to actions

### DIFF
--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -6,7 +6,8 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
--export([atoms/0]).
+-export([atoms/0, kafka_producer_old_hocon/1]).
+
 %% ensure atoms exist
 atoms() -> [myproducer, my_consumer].
 

--- a/changes/ee/fix-12767.en.md
+++ b/changes/ee/fix-12767.en.md
@@ -1,0 +1,1 @@
+Correctly migrate older Kafka Producer configurations (pre 5.0.2) to action and connector configurations.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12064

Release version: e5.6

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
