### PR TITLE
fix(routing): add heuristic for routing schema in empty cluster

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -66,6 +66,7 @@
 {emqx_resource,2}.
 {emqx_retainer,1}.
 {emqx_retainer,2}.
+{emqx_router,1}.
 {emqx_rule_engine,1}.
 {emqx_shared_sub,1}.
 {emqx_slow_subs,1}.

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -92,9 +92,11 @@
 ]).
 
 -export_type([dest/0]).
+-export_type([schemavsn/0]).
 
 -type group() :: binary().
 -type dest() :: node() | {group(), node()}.
+-type schemavsn() :: v1 | v2.
 
 %% Operation :: {add, ...} | {delete, ...}.
 -type batch() :: #{batch_route() => _Operation :: tuple()}.
@@ -642,8 +644,6 @@ match_to_route(M) ->
 %% --------------------------------------------------------------------
 
 -define(PT_SCHEMA_VSN, {?MODULE, schemavsn}).
-
--type schemavsn() :: v1 | v2.
 
 %% @doc Get the schema version in use.
 %% BPAPI RPC Target @ emqx_router_proto

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -804,8 +804,7 @@ mk_conflict_resolution_action(State) ->
         "\n      Below conditions should be true for each of the nodes in order to proceed:"
         "\n     a) Command 'ets:info(emqx_subscriber, size)' prints `0`."
         "\n     b) Command 'emqx ctl topics list' prints No topics.`"
-        "\n   3. Upgrade the nodes to 5.6.0 or newer"
-        "\n   4. Restart the node",
+        "\n   3. Upgrade the nodes to 5.6.0 or newer.",
     FormatUnkown =
         "Additionally, the following nodes were unreachable during startup: ~0p."
         "It is strongly advised to include them in the manual resolution procedure as well.",

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -645,6 +645,8 @@ match_to_route(M) ->
 
 -type schemavsn() :: v1 | v2.
 
+%% @doc Get the schema version in use.
+%% BPAPI RPC Target @ emqx_router_proto
 -spec get_schema_vsn() -> schemavsn().
 get_schema_vsn() ->
     persistent_term:get(?PT_SCHEMA_VSN).

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -747,14 +747,14 @@ choose_schema_vsn(ConfSchema, ClusterSchema, State) ->
         [Schema] when ClusterSchema =:= undefined ->
             %% There are existing records following some schema, we have to use it.
             Schema;
-        [v1, v2] when ClusterSchema =/= undefined ->
+        _Conflicting when ClusterSchema =/= undefined ->
             %% There are existing records in both v1 and v2 schema,
             %% we have to use what the peer nodes agreed on.
             %% because it could be HTIS node which caused cnoflict.
             %%
             %% The stale records will be left-over, but harmless
             ClusterSchema;
-        [v1, v2] ->
+        _Conflicting ->
             Desc = schema_conflict_reason(records, State),
             io:format(standard_error, "Error: ~ts~n", [Desc]),
             ?SLOG(critical, #{

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -686,9 +686,11 @@ deinit_schema() ->
 discover_cluster_schema_vsn() ->
     discover_cluster_schema_vsn(emqx:running_nodes() -- [node()]).
 
+-spec discover_cluster_schema_vsn([node()]) ->
+    {schemavsn() | undefined, _State :: [{node(), schemavsn() | undefined, _Details}]}.
 discover_cluster_schema_vsn([]) ->
     %% single node
-    undefined;
+    {undefined, []};
 discover_cluster_schema_vsn(Nodes) ->
     Responses = lists:zipwith(
         fun

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -750,9 +750,19 @@ choose_schema_vsn(ConfSchema, ClusterSchema, State) ->
         _Conflicting when ClusterSchema =/= undefined ->
             %% There are existing records in both v1 and v2 schema,
             %% we have to use what the peer nodes agreed on.
-            %% because it could be HTIS node which caused cnoflict.
+            %% because it could be THIS node which caused the cnoflict.
             %%
             %% The stale records will be left-over, but harmless
+            Desc =
+                "Conflicting schema version detected for routing records, but "
+                "all the peer nodes are running the same version, so this node "
+                "will use the same schema but discard the harmless stale records. "
+                "This warning will go away after the next full cluster (non-rolling) restart.",
+            ?SLOG(warning, #{
+                msg => "conflicting_routing_storage_detected",
+                resolved => ClusterSchema,
+                description => Desc
+            }),
             ClusterSchema;
         _Conflicting ->
             Desc = schema_conflict_reason(records, State),

--- a/apps/emqx/src/proto/emqx_router_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_router_proto_v1.erl
@@ -1,0 +1,37 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_router_proto_v1).
+
+-behaviour(emqx_bpapi).
+
+-export([introduced_in/0]).
+
+-export([
+    get_routing_schema_vsn/1
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-define(TIMEOUT, 3_000).
+
+introduced_in() ->
+    "5.6.0".
+
+-spec get_routing_schema_vsn([node()]) ->
+    [emqx_rpc:erpc(emqx_router:schema_vsn())].
+get_routing_schema_vsn(Nodes) ->
+    erpc:multicall(Nodes, emqx_router, get_schema_vsn, [], ?TIMEOUT).

--- a/apps/emqx/src/proto/emqx_router_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_router_proto_v1.erl
@@ -32,6 +32,6 @@ introduced_in() ->
     "5.6.0".
 
 -spec get_routing_schema_vsn([node()]) ->
-    [emqx_rpc:erpc(emqx_router:schema_vsn())].
+    [emqx_rpc:erpc(emqx_router:schemavsn())].
 get_routing_schema_vsn(Nodes) ->
     erpc:multicall(Nodes, emqx_router, get_schema_vsn, [], ?TIMEOUT).

--- a/changes/ce/fix-12768.en.md
+++ b/changes/ce/fix-12768.en.md
@@ -1,0 +1,1 @@
+When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.

--- a/changes/ce/fix-12768.en.md
+++ b/changes/ce/fix-12768.en.md
@@ -1,13 +1,3 @@
 Fixed an issue which may occur when performing rolling upgrade, especially when upgrading from a version earlier than 5.4.0.
 
 When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.
-
-In case you get the following message about broken routing during rolling upgrade: "There are records in the routing tables either related to both v1 and v2 storage schemas, or conflicting with storage schema assumed by the cluster. This probably means that some nodes in the cluster use v1 schema and some use v2, independently of each other. The routing is likely broken. Manual intervention and full cluster restart is required. This node will shut down.", please follow the steps below to resolve the issue.
-1. Stop listeners on legacy nodes: `$ emqx eval 'emqx_listener:stop()'`
-2. Wait until they are safe to restart.
-   This could take some time, depending on the number of clients and their subscriptions.
-   Those conditions should be true for both nodes in order to proceed:
-    * `$ emqx eval 'ets:info(emqx_subscriber, size)'` prints `0`.
-    * `$ emqx ctl topics list` prints `No topics.`
-3. Upgrade the nodes to the latest version.
-4. Restart the nodes.

--- a/changes/ce/fix-12768.en.md
+++ b/changes/ce/fix-12768.en.md
@@ -1,3 +1,3 @@
-Fixed an issue which may occur when upgrading from versions prior to 5.4 to 5.4 or later.
+Fixed an issue which may occur when performing rolling upgrade, especially when upgrading from a version earlier than 5.4.0.
 
 When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.

--- a/changes/ce/fix-12768.en.md
+++ b/changes/ce/fix-12768.en.md
@@ -1,3 +1,6 @@
 Fixed an issue which may occur when performing rolling upgrade, especially when upgrading from a version earlier than 5.4.0.
 
 When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.
+
+The version also logs instructions for how to manually resolve if conflict is detected in a running cluster.
+

--- a/changes/ce/fix-12768.en.md
+++ b/changes/ce/fix-12768.en.md
@@ -1,1 +1,3 @@
+Fixed an issue which may occur when upgrading from versions prior to 5.4 to 5.4 or later.
+
 When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.

--- a/changes/ce/fix-12768.en.md
+++ b/changes/ce/fix-12768.en.md
@@ -1,3 +1,13 @@
 Fixed an issue which may occur when performing rolling upgrade, especially when upgrading from a version earlier than 5.4.0.
 
 When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.
+
+In case you get the following message about broken routing during rolling upgrade: "There are records in the routing tables either related to both v1 and v2 storage schemas, or conflicting with storage schema assumed by the cluster. This probably means that some nodes in the cluster use v1 schema and some use v2, independently of each other. The routing is likely broken. Manual intervention and full cluster restart is required. This node will shut down.", please follow the steps below to resolve the issue.
+1. Stop listeners on legacy nodes: `$ emqx eval 'emqx_listener:stop()'`
+2. Wait until they are safe to restart.
+   This could take some time, depending on the number of clients and their subscriptions.
+   Those conditions should be true for both nodes in order to proceed:
+    * `$ emqx eval 'ets:info(emqx_subscriber, size)'` prints `0`.
+    * `$ emqx ctl topics list` prints `No topics.`
+3. Upgrade the nodes to the latest version.
+4. Restart the nodes.


### PR DESCRIPTION
Fixes [EMQX-12068](https://emqx.atlassian.net/browse/EMQX-12068).

Release version: v5.6

## Summary

When the cluster is empty (more precisely, routing tables are empty), try to additionally ask the cluster nodes for the routing schema in use, to make more informed decision about routing storage schema upon startup. This should make routing storage schema less likely to diverge across cluster nodes, especially when the cluster is composed of different versions of EMQX.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible