### PR TITLE
feat: update greptimedb client lib and ci version

### DIFF
--- a/.ci/docker-compose-file/docker-compose-greptimedb.yaml
+++ b/.ci/docker-compose-file/docker-compose-greptimedb.yaml
@@ -4,7 +4,7 @@ services:
   greptimedb:
     container_name: greptimedb
     hostname: greptimedb
-    image: greptime/greptimedb:v0.4.4
+    image: greptime/greptimedb:v0.7.1
     expose:
       - "4000"
       - "4001"

--- a/apps/emqx_bridge_greptimedb/rebar.config
+++ b/apps/emqx_bridge_greptimedb/rebar.config
@@ -6,7 +6,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {greptimedb, {git, "https://github.com/GreptimeTeam/greptimedb-client-erl", {tag, "v0.1.7"}}}
+    {greptimedb, {git, "https://github.com/GreptimeTeam/greptimedb-ingester-erl", {tag, "v0.1.8"}}}
 ]}.
 {plugins, [rebar3_path_deps]}.
 {project_plugins, [erlfmt]}.

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
@@ -324,7 +324,7 @@ query_by_clientid(Topic, ClientId, Config) ->
         {"Content-Type", "application/x-www-form-urlencoded"}
     ],
     Body = <<"sql=select * from \"", Topic/binary, "\" where clientid='", ClientId/binary, "'">>,
-    {ok, 200, _Headers, RawBody0} =
+    {ok, _, _Headers, RawBody0} =
         ehttpc:request(
             EHttpcPoolName,
             post,
@@ -335,7 +335,6 @@ query_by_clientid(Topic, ClientId, Config) ->
 
     case emqx_utils_json:decode(RawBody0, [return_maps]) of
         #{
-            <<"code">> := 0,
             <<"output">> := [
                 #{
                     <<"records">> := #{

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
@@ -324,7 +324,7 @@ query_by_clientid(Topic, ClientId, Config) ->
         {"Content-Type", "application/x-www-form-urlencoded"}
     ],
     Body = <<"sql=select * from \"", Topic/binary, "\" where clientid='", ClientId/binary, "'">>,
-    {ok, _, _Headers, RawBody0} =
+    {ok, StatusCode, _Headers, RawBody0} =
         ehttpc:request(
             EHttpcPoolName,
             post,
@@ -343,12 +343,12 @@ query_by_clientid(Topic, ClientId, Config) ->
                     }
                 }
             ]
-        } ->
+        } when StatusCode >= 200 andalso StatusCode =< 300 ->
             make_row(Schema, Rows);
         #{
             <<"code">> := Code,
             <<"error">> := Error
-        } ->
+        } when StatusCode > 300 ->
             GreptimedbName = ?config(greptimedb_name, Config),
             Type = greptimedb_type_bin(?config(greptimedb_type, Config)),
             BridgeId = emqx_bridge_resource:bridge_id(Type, GreptimedbName),
@@ -366,7 +366,9 @@ query_by_clientid(Topic, ClientId, Config) ->
                 _ ->
                     %% Table not found
                     #{}
-            end
+            end;
+        Error ->
+            {error, Error}
     end.
 
 make_row(null, _Rows) ->

--- a/mix.exs
+++ b/mix.exs
@@ -212,7 +212,8 @@ defmodule EMQXUmbrella.MixProject do
       {:crc32cer, "0.1.8", override: true},
       {:supervisor3, "1.1.12", override: true},
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1", override: true},
-      {:greptimedb, github: "GreptimeTeam/greptimedb-client-erl", tag: "v0.1.7", override: true},
+      {:greptimedb,
+       github: "GreptimeTeam/greptimedb-ingester-erl", tag: "v0.1.8", override: true},
       # The following two are dependencies of rabbit_common. They are needed here to
       # make mix not complain about conflicting versions
       {:thoas, github: "emqx/thoas", tag: "v1.0.0", override: true},


### PR DESCRIPTION
Release version: v/e5.7.0

## Summary

* The `greptimedb-client-erl` was renamed into `greptimedb-ingester-erl`. This PR changes nothing but uses the latest version of `greptimedb-ingester-erl` and keeps backward compatibility.
* Updated the `greptimedb` image version in CI too.



## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
