### PR TITLE
ci: in Keep master green workflow, do not try to rerun self

### DIFF
--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -31,8 +31,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --method GET -f head_sha=$(git rev-parse HEAD) -f status=completed -f exclude_pull_requests=true /repos/emqx/emqx/actions/runs > runs.json
-          for id in $(jq -r '.workflow_runs[] | select((."conclusion" != "success") and .run_attempt < 3) | .id' runs.json); do
+          gh api --method GET -f head_branch=master -f status=completed -f exclude_pull_requests=true /repos/emqx/emqx/actions/runs > runs.json
+          for id in $(jq -r '.workflow_runs[] | select((."conclusion" == "failure") and (."name" != "Keep master green") and .run_attempt < 3) | .id' runs.json); do
             echo "rerun https://github.com/emqx/emqx/actions/runs/$id"
-            gh api --method POST /repos/emqx/emqx/actions/runs/$id/rerun-failed-jobs
+            gh api --method POST /repos/emqx/emqx/actions/runs/$id/rerun-failed-jobs || true
           done

--- a/scripts/spellcheck/spellcheck.sh
+++ b/scripts/spellcheck/spellcheck.sh
@@ -29,7 +29,7 @@ set +e
 docker run --rm -i ${DOCKER_TERMINAL_OPT} --name spellcheck \
     -v "${PROJ_ROOT}"/scripts/spellcheck/dicts:/dicts \
     -v "$SCHEMA":/schema.json \
-    ghcr.io/emqx/emqx-schema-validate:0.5.0 -j 10 /schema.json
+    ghcr.io/emqx/emqx-schema-validate:0.5.1 -j 10 /schema.json
 
 result="$?"
 


### PR DESCRIPTION
Fixes some issues with "Keep master green" workflow:
- it tries to rerun itself too, and when it fails, it tries again
- do not fail the job if `rerun` API call failed
- only rerun workflows which failed, do not rerun cancelled one

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
