### PR TITLE
fix(emqx_mgmt_data_backup): remove an uploaded backup file if it's not valid (5.6.1 port)

### DIFF
--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.1.0"},
+    {vsn, "5.1.1"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [

--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -315,8 +315,10 @@ do_upload(BackupFileNameStr, BackupFileContent) ->
     catch
         error:{badmatch, {error, Reason}}:Stack ->
             ?SLOG(error, #{msg => "emqx_data_upload_failed", reason => Reason, stacktrace => Stack}),
+            _ = file:delete(FilePath),
             {error, Reason};
         Class:Reason:Stack ->
+            _ = file:delete(FilePath),
             ?SLOG(error, #{
                 msg => "emqx_data_upload_failed",
                 exception => Class,

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -199,7 +199,11 @@ upload_backup_test(Config, BackupName) ->
     ?assertEqual(ok, upload_backup(?NODE3_PORT, Auth, UploadFile)),
     %% This file was specially forged to pass upload validation bat fail on import
     ?assertEqual(ok, upload_backup(?NODE2_PORT, Auth, BadImportFile)),
-    ?assertEqual({error, bad_request}, upload_backup(?NODE1_PORT, Auth, BadUploadFile)).
+    ?assertEqual({error, bad_request}, upload_backup(?NODE1_PORT, Auth, BadUploadFile)),
+    %% Invalid file must not be kept
+    ?assertMatch(
+        {error, {_, 404, _}}, backup_file_op(get, ?NODE1_PORT, Auth, ?BAD_UPLOAD_BACKUP, [])
+    ).
 
 import_backup_test(Config, BackupName) ->
     Auth = ?config(auth, Config),

--- a/changes/ce/fix-12759.en.md
+++ b/changes/ce/fix-12759.en.md
@@ -1,0 +1,1 @@
+Do not save invalid uploaded backup files.


### PR DESCRIPTION
Port of https://github.com/emqx/emqx/pull/12759/files

Fixes EMQX-11808

Release version: v/e5.6.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
