### PR TITLE
chore: rename `message_queue_too_long` error reason to `mailbox_overflow` (5.6.1 port)

### DIFF
--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.1.0"},
+    {vsn, "5.1.1"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -261,7 +261,7 @@ check_oom(Pid, #{
             ok;
         [{message_queue_len, QLen}, {total_heap_size, HeapSize}] ->
             do_check_oom([
-                {QLen, MaxQLen, message_queue_too_long},
+                {QLen, MaxQLen, mailbox_overflow},
                 {HeapSize, MaxHeapSize, proc_heap_too_large}
             ])
     end.

--- a/apps/emqx_utils/test/emqx_utils_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_utils_SUITE.erl
@@ -150,7 +150,7 @@ t_check(_) ->
     ?assertEqual(ok, emqx_utils:check_oom(Policy)),
     [self() ! {msg, I} || I <- lists:seq(1, 6)],
     ?assertEqual(
-        {shutdown, #{reason => message_queue_too_long, value => 11, max => 10}},
+        {shutdown, #{reason => mailbox_overflow, value => 11, max => 10}},
         emqx_utils:check_oom(Policy)
     ).
 

--- a/changes/ce/fix-12766.en.md
+++ b/changes/ce/fix-12766.en.md
@@ -1,0 +1,3 @@
+Rename `message_queue_too_long` error reason to `mailbox_overflow`
+
+`mailbox_overflow` is consistent with the corresponding config parameter: `force_shutdown.max_mailbox_size`.


### PR DESCRIPTION
5.6.1 port of: https://github.com/emqx/emqx/pull/12766  
`mailbox_overflow` is consistent with the corresponding config parameter:
 'force_shutdown.max_mailbox_size'

Fixes EMQX-12058
Release version: v/e5.6.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
