### PR TITLE
ci(fix): skip flow when there are no changes

### DIFF
--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -35,6 +35,7 @@ jobs:
         shell: bash
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
+      skip: ${{ steps.matrix.outputs.skip }}
     steps:
     - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       with:
@@ -49,12 +50,16 @@ jobs:
         changed_files="$(git diff --name-only ${BEFORE_REF} ${AFTER_REF} apps/emqx)"
         if [ "$changed_files" = '' ]; then
           echo "nothing changed in apps/emqx, ignored."
-          echo "matrix=[]" | tee -a $GITHUB_OUTPUT
+          echo 'matrix=[]' | tee -a $GITHUB_OUTPUT
+          echo 'skip=true' | tee -a $GITHUB_OUTPUT
           exit 0
+        else
+          echo 'skip=false' | tee -a $GITHUB_OUTPUT
+          echo 'matrix=[{"type": "eunit_proper_and_static"},{"type": "1_3"},{"type": "2_3"},{"type": "3_3"}]' | tee -a $GITHUB_OUTPUT
         fi
-        echo 'matrix=[{"type": "eunit_proper_and_static"},{"type": "1_3"},{"type": "2_3"},{"type": "3_3"}]' | tee -a $GITHUB_OUTPUT
 
   run_emqx_app_tests:
+    if: needs.prepare_matrix.outputs.skip != 'true'
     needs:
       - prepare_matrix
     runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}


### PR DESCRIPTION
```
Error when evaluating 'strategy' for job 'run_emqx_app_tests'. emqx/emqx/.github/workflows/run_emqx_app_tests.yaml@689347f60e5e2e5fc612aa0282c74c0eb26e8281 (Line: 65, Col: 9): Matrix must define at least one vector
```

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
