### PR TITLE
fix(emqx_mgmt): catch OOM shutdown exits properly when calling a conn procces

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -713,5 +713,17 @@ call_conn(ConnMod, Pid, Req) ->
         exit:{R, _} when R =:= shutdown; R =:= noproc ->
             {error, shutdown};
         exit:{{shutdown, _OOMInfo}, _Location} ->
-            {error, shutdown}
+            {error, shutdown};
+        exit:timeout ->
+            ?SLOG(
+                warning,
+                #{
+                    msg => "call_client_connection_process_timeout",
+                    request => Req,
+                    pid => Pid,
+                    module => ConnMod,
+                    stacktrace => erlang:process_info(Pid, current_stacktrace)
+                }
+            ),
+            {error, timeout}
     end.

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -711,5 +711,7 @@ call_conn(ConnMod, Pid, Req) ->
         exit:R when R =:= shutdown; R =:= normal ->
             {error, shutdown};
         exit:{R, _} when R =:= shutdown; R =:= noproc ->
+            {error, shutdown};
+        exit:{{shutdown, _OOMInfo}, _Location} ->
             {error, shutdown}
     end.

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1232,6 +1232,8 @@ list_client_msgs(MsgType, ClientID, QString) ->
                         code => 'NOT_IMPLEMENTED',
                         message => <<"API not implemented for persistent sessions">>
                     }};
+                {error, Reason} ->
+                    ?INTERNAL_ERROR(Reason);
                 {Msgs, Meta = #{}} when is_list(Msgs) ->
                     format_msgs_resp(MsgType, Msgs, Meta, QString)
             end

--- a/changes/ce/fix-12814.en.md
+++ b/changes/ce/fix-12814.en.md
@@ -1,0 +1,4 @@
+Handle several errors in `/clients/{clientid}/mqueue_messages` and `/clients/{clientid}/inflight_messages` APIs:
+
+- Internal timeout, which means that EMQX failed to get the list of Inflight/Mqueue messages within the default timeout of 5 s. This error may occur when the system is under a heavy load. The API will return 500 `{"code":"INTERNAL_ERROR","message":"timeout"}` response and log additional details.
+- Client shutdown. The error may occur if the client connection is shutdown during the API call. The API will return 404 `{"code": "CLIENT_SHUTDOWN", "message": "Client connection has been shutdown"}` response in this case.


### PR DESCRIPTION
1. The exit reason is expected to include gen_server `Location`:
  `{{shutdown, OOMInfo}, Location}`.
2. Handle call client timeouts

Fixes EMQX-12124

Release version: v/e5.6.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
