### PR TITLE
Add rule ID tracing support

### DIFF
--- a/apps/emqx/include/emqx_trace.hrl
+++ b/apps/emqx/include/emqx_trace.hrl
@@ -20,9 +20,14 @@
 
 -record(?TRACE, {
     name :: binary() | undefined | '_',
-    type :: clientid | topic | ip_address | undefined | '_',
+    type :: clientid | topic | ip_address | ruleid | undefined | '_',
     filter ::
-        emqx_types:topic() | emqx_types:clientid() | emqx_trace:ip_address() | undefined | '_',
+        emqx_types:topic()
+        | emqx_types:clientid()
+        | emqx_trace:ip_address()
+        | emqx_trace:ruleid()
+        | undefined
+        | '_',
     enable = true :: boolean() | '_',
     payload_encode = text :: hex | text | hidden | '_',
     extra = #{} :: map() | '_',

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -66,6 +66,9 @@
 -export_type([ip_address/0]).
 -type ip_address() :: string().
 
+-export_type([ruleid/0]).
+-type ruleid() :: binary().
+
 publish(#message{topic = <<"$SYS/", _/binary>>}) ->
     ignore;
 publish(#message{from = From, topic = Topic, payload = Payload}) when
@@ -517,6 +520,9 @@ to_trace(#{type := ip_address, ip_address := Filter} = Trace, Rec) ->
         Error ->
             Error
     end;
+to_trace(#{type := ruleid, ruleid := Filter} = Trace, Rec) ->
+    Trace0 = maps:without([type, ruleid], Trace),
+    to_trace(Trace0, Rec#?TRACE{type = ruleid, filter = Filter});
 to_trace(#{type := Type}, _Rec) ->
     {error, io_lib:format("required ~s field", [Type])};
 to_trace(#{payload_encode := PayloadEncode} = Trace, Rec) ->

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -135,14 +135,22 @@ running() ->
     lists:foldl(fun filter_traces/2, [], emqx_logger:get_log_handlers(started)).
 
 -spec filter_ruleid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
-filter_ruleid(#{meta := Meta = #{ruleid := RuleId}} = Log, {MatchId, _Name}) ->
-    filter_ret(RuleId =:= MatchId andalso is_trace(Meta), Log);
+filter_ruleid(#{meta := Meta = #{rule_id := RuleId}} = Log, {MatchId, _Name}) ->
+    RuleIDs = maps:get(rule_ids, Meta, #{}),
+    IsMatch = (RuleId =:= MatchId) orelse maps:get(MatchId, RuleIDs, false),
+    filter_ret(IsMatch andalso is_trace(Meta), Log);
+filter_ruleid(#{meta := Meta = #{rule_ids := RuleIDs}} = Log, {MatchId, _Name}) ->
+    filter_ret(maps:get(MatchId, RuleIDs, false) andalso is_trace(Meta), Log);
 filter_ruleid(_Log, _ExpectId) ->
     stop.
 
 -spec filter_clientid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
 filter_clientid(#{meta := Meta = #{clientid := ClientId}} = Log, {MatchId, _Name}) ->
-    filter_ret(ClientId =:= MatchId andalso is_trace(Meta), Log);
+    ClientIDs = maps:get(client_ids, Meta, #{}),
+    IsMatch = (ClientId =:= MatchId) orelse maps:get(MatchId, ClientIDs, false),
+    filter_ret(IsMatch andalso is_trace(Meta), Log);
+filter_clientid(#{meta := Meta = #{client_ids := ClientIDs}} = Log, {MatchId, _Name}) ->
+    filter_ret(maps:get(MatchId, ClientIDs, false) andalso is_trace(Meta), Log);
 filter_clientid(_Log, _ExpectId) ->
     stop.
 

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -33,6 +33,7 @@
 
 %% For logger handler filters callbacks
 -export([
+    filter_ruleid/2,
     filter_clientid/2,
     filter_topic/2,
     filter_ip_address/2
@@ -133,6 +134,12 @@ uninstall(HandlerId) ->
 running() ->
     lists:foldl(fun filter_traces/2, [], emqx_logger:get_log_handlers(started)).
 
+-spec filter_ruleid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
+filter_ruleid(#{meta := Meta = #{ruleid := RuleId}} = Log, {MatchId, _Name}) ->
+    filter_ret(RuleId =:= MatchId andalso is_trace(Meta), Log);
+filter_ruleid(_Log, _ExpectId) ->
+    stop.
+
 -spec filter_clientid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
 filter_clientid(#{meta := Meta = #{clientid := ClientId}} = Log, {MatchId, _Name}) ->
     filter_ret(ClientId =:= MatchId andalso is_trace(Meta), Log);
@@ -164,7 +171,9 @@ filters(#{type := clientid, filter := Filter, name := Name}) ->
 filters(#{type := topic, filter := Filter, name := Name}) ->
     [{topic, {fun ?MODULE:filter_topic/2, {ensure_bin(Filter), Name}}}];
 filters(#{type := ip_address, filter := Filter, name := Name}) ->
-    [{ip_address, {fun ?MODULE:filter_ip_address/2, {ensure_list(Filter), Name}}}].
+    [{ip_address, {fun ?MODULE:filter_ip_address/2, {ensure_list(Filter), Name}}}];
+filters(#{type := ruleid, filter := Filter, name := Name}) ->
+    [{ruleid, {fun ?MODULE:filter_ruleid/2, {ensure_bin(Filter), Name}}}].
 
 formatter(#{type := _Type, payload_encode := PayloadEncode}) ->
     {emqx_trace_formatter, #{
@@ -184,7 +193,8 @@ filter_traces(#{id := Id, level := Level, dst := Dst, filters := Filters}, Acc) 
         [{Type, {FilterFun, {Filter, Name}}}] when
             Type =:= topic orelse
                 Type =:= clientid orelse
-                Type =:= ip_address
+                Type =:= ip_address orelse
+                Type =:= ruleid
         ->
             [Init#{type => Type, filter => Filter, name => Name, filter_fun => FilterFun} | Acc];
         _ ->

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -661,13 +661,22 @@ process_request_and_action(Request, ActionState, Msg) ->
     ),
     BodyTemplate = maps:get(body, ActionState),
     Body = render_request_body(BodyTemplate, RenderTmplFunc, Msg),
-    #{
+    RenderResult = #{
         method => Method,
         path => Path,
         body => Body,
         headers => Headers,
         request_timeout => maps:get(request_timeout, ActionState)
-    }.
+    },
+    ?TRACE(
+        "QUERY_RENDER",
+        "http_connector_successfully_rendered_request",
+        #{
+            request => Request,
+            render_result => RenderResult
+        }
+    ),
+    RenderResult.
 
 merge_proplist(Proplist1, Proplist2) ->
     lists:foldl(

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -371,6 +371,29 @@ on_query(
         }
     ),
     NRequest = formalize_request(Method, BasePath, Request),
+    case NRequest of
+        {Path, Headers} ->
+            emqx_trace:rendered_action_template(
+                InstId,
+                #{
+                    path => Path,
+                    method => Method,
+                    headers => Headers,
+                    timeout => Timeout
+                }
+            );
+        {Path, Headers, Body} ->
+            emqx_trace:rendered_action_template(
+                InstId,
+                #{
+                    path => Path,
+                    method => Method,
+                    headers => Headers,
+                    timeout => Timeout,
+                    body => Body
+                }
+            )
+    end,
     Worker = resolve_pool_worker(State, KeyOrNum),
     Result0 = ehttpc:request(
         Worker,
@@ -480,6 +503,29 @@ on_query_async(
         }
     ),
     NRequest = formalize_request(Method, BasePath, Request),
+    case NRequest of
+        {Path, Headers} ->
+            emqx_trace:rendered_action_template(
+                InstId,
+                #{
+                    path => Path,
+                    method => Method,
+                    headers => Headers,
+                    timeout => Timeout
+                }
+            );
+        {Path, Headers, Body} ->
+            emqx_trace:rendered_action_template(
+                InstId,
+                #{
+                    path => Path,
+                    method => Method,
+                    headers => Headers,
+                    timeout => Timeout,
+                    body => Body
+                }
+            )
+    end,
     MaxAttempts = maps:get(max_attempts, State, 3),
     Context = #{
         attempt => 1,
@@ -661,22 +707,13 @@ process_request_and_action(Request, ActionState, Msg) ->
     ),
     BodyTemplate = maps:get(body, ActionState),
     Body = render_request_body(BodyTemplate, RenderTmplFunc, Msg),
-    RenderResult = #{
+    #{
         method => Method,
         path => Path,
         body => Body,
         headers => Headers,
         request_timeout => maps:get(request_timeout, ActionState)
-    },
-    ?TRACE(
-        "QUERY_RENDER",
-        "http_connector_successfully_rendered_request",
-        #{
-            request => Request,
-            render_result => RenderResult
-        }
-    ),
-    RenderResult.
+    }.
 
 merge_proplist(Proplist1, Proplist2) ->
     lists:foldl(

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -421,7 +421,7 @@ t_send_get_trace_messages(Config) ->
             ?assertNotEqual(nomatch, binary:match(Bin, [<<"SELECT_yielded_result">>])),
             ?assertNotEqual(nomatch, binary:match(Bin, [<<"bridge_action">>])),
             ?assertNotEqual(nomatch, binary:match(Bin, [<<"action_activated">>])),
-            ?assertNotEqual(nomatch, binary:match(Bin, [<<"successfully_rendered_request">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"action_template_rendered">>])),
             ?assertNotEqual(nomatch, binary:match(Bin, [<<"QUERY_ASYNC">>]))
         end
     ),

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -30,8 +30,8 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/asserts.hrl").
 
--define(BRIDGE_TYPE, <<"webhook">>).
--define(BRIDGE_NAME, atom_to_binary(?MODULE)).
+-define(BRIDGE_TYPE, emqx_bridge_http_test_lib:bridge_type()).
+-define(BRIDGE_NAME, emqx_bridge_http_test_lib:bridge_name()).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -73,21 +73,10 @@ suite() ->
 
 init_per_testcase(t_bad_bridge_config, Config) ->
     Config;
-init_per_testcase(t_send_async_connection_timeout, Config) ->
-    HTTPPath = <<"/path">>,
-    ServerSSLOpts = false,
-    {ok, {HTTPPort, _Pid}} = emqx_bridge_http_connector_test_server:start_link(
-        _Port = random, HTTPPath, ServerSSLOpts
-    ),
-    ResponseDelayMS = 500,
-    ok = emqx_bridge_http_connector_test_server:set_handler(
-        success_http_handler(#{response_delay => ResponseDelayMS})
-    ),
-    [
-        {http_server, #{port => HTTPPort, path => HTTPPath}},
-        {response_delay_ms, ResponseDelayMS}
-        | Config
-    ];
+init_per_testcase(Case, Config) when
+    Case =:= t_send_async_connection_timeout orelse Case =:= t_send_get_trace_messages
+->
+    emqx_bridge_http_test_lib:init_http_success_server(Config);
 init_per_testcase(t_path_not_found, Config) ->
     HTTPPath = <<"/nonexisting/path">>,
     ServerSSLOpts = false,
@@ -115,7 +104,9 @@ init_per_testcase(t_bridge_probes_header_atoms, Config) ->
     {ok, {HTTPPort, _Pid}} = emqx_bridge_http_connector_test_server:start_link(
         _Port = random, HTTPPath, ServerSSLOpts
     ),
-    ok = emqx_bridge_http_connector_test_server:set_handler(success_http_handler()),
+    ok = emqx_bridge_http_connector_test_server:set_handler(
+        emqx_bridge_http_test_lib:success_http_handler()
+    ),
     [{http_server, #{port => HTTPPort, path => HTTPPath}} | Config];
 init_per_testcase(_TestCase, Config) ->
     Server = start_http_server(#{response_delay_ms => 0}),
@@ -126,7 +117,8 @@ end_per_testcase(TestCase, _Config) when
     TestCase =:= t_too_many_requests;
     TestCase =:= t_rule_action_expired;
     TestCase =:= t_bridge_probes_header_atoms;
-    TestCase =:= t_send_async_connection_timeout
+    TestCase =:= t_send_async_connection_timeout;
+    TestCase =:= t_send_get_trace_messages
 ->
     ok = emqx_bridge_http_connector_test_server:stop(),
     persistent_term:erase({?MODULE, times_called}),
@@ -250,115 +242,8 @@ get_metrics(Name) ->
     Type = <<"http">>,
     emqx_bridge:get_metrics(Type, Name).
 
-bridge_async_config(#{port := Port} = Config) ->
-    Type = maps:get(type, Config, ?BRIDGE_TYPE),
-    Name = maps:get(name, Config, ?BRIDGE_NAME),
-    Host = maps:get(host, Config, "localhost"),
-    Path = maps:get(path, Config, ""),
-    PoolSize = maps:get(pool_size, Config, 1),
-    QueryMode = maps:get(query_mode, Config, "async"),
-    ConnectTimeout = maps:get(connect_timeout, Config, "1s"),
-    RequestTimeout = maps:get(request_timeout, Config, "10s"),
-    ResumeInterval = maps:get(resume_interval, Config, "1s"),
-    HealthCheckInterval = maps:get(health_check_interval, Config, "200ms"),
-    ResourceRequestTTL = maps:get(resource_request_ttl, Config, "infinity"),
-    LocalTopic =
-        case maps:find(local_topic, Config) of
-            {ok, LT} ->
-                lists:flatten(["local_topic = \"", LT, "\""]);
-            error ->
-                ""
-        end,
-    ConfigString = io_lib:format(
-        "bridges.~s.~s {\n"
-        "  url = \"http://~s:~p~s\"\n"
-        "  connect_timeout = \"~p\"\n"
-        "  enable = true\n"
-        %% local_topic
-        "  ~s\n"
-        "  enable_pipelining = 100\n"
-        "  max_retries = 2\n"
-        "  method = \"post\"\n"
-        "  pool_size = ~p\n"
-        "  pool_type = \"random\"\n"
-        "  request_timeout = \"~s\"\n"
-        "  body = \"${id}\"\n"
-        "  resource_opts {\n"
-        "    inflight_window = 100\n"
-        "    health_check_interval = \"~s\"\n"
-        "    max_buffer_bytes = \"1GB\"\n"
-        "    query_mode = \"~s\"\n"
-        "    request_ttl = \"~p\"\n"
-        "    resume_interval = \"~s\"\n"
-        "    start_after_created = \"true\"\n"
-        "    start_timeout = \"5s\"\n"
-        "    worker_pool_size = \"1\"\n"
-        "  }\n"
-        "  ssl {\n"
-        "    enable = false\n"
-        "  }\n"
-        "}\n",
-        [
-            Type,
-            Name,
-            Host,
-            Port,
-            Path,
-            ConnectTimeout,
-            LocalTopic,
-            PoolSize,
-            RequestTimeout,
-            HealthCheckInterval,
-            QueryMode,
-            ResourceRequestTTL,
-            ResumeInterval
-        ]
-    ),
-    ct:pal(ConfigString),
-    parse_and_check(ConfigString, Type, Name).
-
-parse_and_check(ConfigString, BridgeType, Name) ->
-    {ok, RawConf} = hocon:binary(ConfigString, #{format => map}),
-    hocon_tconf:check_plain(emqx_bridge_schema, RawConf, #{required => false, atom_key => false}),
-    #{<<"bridges">> := #{BridgeType := #{Name := RetConfig}}} = RawConf,
-    RetConfig.
-
 make_bridge(Config) ->
-    Type = ?BRIDGE_TYPE,
-    Name = ?BRIDGE_NAME,
-    BridgeConfig = bridge_async_config(Config#{
-        name => Name,
-        type => Type
-    }),
-    {ok, _} = emqx_bridge:create(
-        Type,
-        Name,
-        BridgeConfig
-    ),
-    emqx_bridge_resource:bridge_id(Type, Name).
-
-success_http_handler() ->
-    success_http_handler(#{response_delay => 0}).
-
-success_http_handler(Opts) ->
-    ResponseDelay = maps:get(response_delay, Opts, 0),
-    TestPid = self(),
-    fun(Req0, State) ->
-        {ok, Body, Req} = cowboy_req:read_body(Req0),
-        Headers = cowboy_req:headers(Req),
-        ct:pal("http request received: ~p", [
-            #{body => Body, headers => Headers, response_delay => ResponseDelay}
-        ]),
-        ResponseDelay > 0 andalso timer:sleep(ResponseDelay),
-        TestPid ! {http, Headers, Body},
-        Rep = cowboy_req:reply(
-            200,
-            #{<<"content-type">> => <<"text/plain">>},
-            <<"hello">>,
-            Req
-        ),
-        {ok, Rep, State}
-    end.
+    emqx_bridge_http_test_lib:make_bridge(Config).
 
 not_found_http_handler() ->
     TestPid = self(),
@@ -452,6 +337,103 @@ t_send_async_connection_timeout(Config) ->
     receive_request_notifications(MessageIDs, ResponseDelayMS, []),
     ok.
 
+t_send_get_trace_messages(Config) ->
+    ResponseDelayMS = ?config(response_delay_ms, Config),
+    #{port := Port, path := Path} = ?config(http_server, Config),
+    BridgeID = make_bridge(#{
+        port => Port,
+        path => Path,
+        pool_size => 1,
+        query_mode => "async",
+        connect_timeout => integer_to_list(ResponseDelayMS * 2) ++ "ms",
+        request_timeout => "10s",
+        resume_interval => "200ms",
+        health_check_interval => "200ms",
+        resource_request_ttl => "infinity"
+    }),
+    RuleTopic = iolist_to_binary([<<"my_rule_topic/">>, atom_to_binary(?FUNCTION_NAME)]),
+    SQL = <<"SELECT payload.id as id FROM \"", RuleTopic/binary, "\"">>,
+    {ok, #{<<"id">> := RuleId}} =
+        emqx_bridge_testlib:create_rule_and_action_http(
+            ?BRIDGE_TYPE,
+            RuleTopic,
+            Config,
+            #{sql => SQL}
+        ),
+    %% ===================================
+    %% Create trace for RuleId
+    %% ===================================
+    Now = erlang:system_time(second) - 10,
+    Start = Now,
+    End = Now + 60,
+    TraceName = atom_to_binary(?FUNCTION_NAME),
+    Trace = #{
+        name => TraceName,
+        type => ruleid,
+        ruleid => RuleId,
+        start_at => Start,
+        end_at => End
+    },
+    emqx_trace_SUITE:reload(),
+    ok = emqx_trace:clear(),
+    {ok, _} = emqx_trace:create(Trace),
+    %% ===================================
+
+    ResourceId = emqx_bridge_resource:resource_id(BridgeID),
+    ?retry(
+        _Interval0 = 200,
+        _NAttempts0 = 20,
+        ?assertMatch({ok, connected}, emqx_resource_manager:health_check(ResourceId))
+    ),
+    ?retry(
+        _Interval0 = 200,
+        _NAttempts0 = 20,
+        ?assertEqual(<<>>, read_rule_trace_file(TraceName, Now))
+    ),
+    Msg = emqx_message:make(RuleTopic, <<"{\"id\": 1}">>),
+    emqx:publish(Msg),
+    ?retry(
+        _Interval = 500,
+        _NAttempts = 20,
+        ?assertMatch(
+            #{
+                counters := #{
+                    'matched' := 1,
+                    'actions.failed' := 0,
+                    'actions.failed.unknown' := 0,
+                    'actions.success' := 1,
+                    'actions.total' := 1
+                }
+            },
+            emqx_metrics_worker:get_metrics(rule_metrics, RuleId)
+        )
+    ),
+
+    ok = emqx_trace_handler_SUITE:filesync(TraceName, ruleid),
+    {ok, Bin} = file:read_file(emqx_trace:log_file(TraceName, Now)),
+
+    ?retry(
+        _Interval0 = 200,
+        _NAttempts0 = 20,
+        begin
+            Bin = read_rule_trace_file(TraceName, Now),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"rule_activated">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"SELECT_yielded_result">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"bridge_action">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"action_activated">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"successfully_rendered_request">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"QUERY_ASYNC">>]))
+        end
+    ),
+    emqx_trace:delete(TraceName),
+    ok.
+
+read_rule_trace_file(TraceName, From) ->
+    emqx_trace:check(),
+    ok = emqx_trace_handler_SUITE:filesync(TraceName, ruleid),
+    {ok, Bin} = file:read_file(emqx_trace:log_file(TraceName, From)),
+    Bin.
+
 t_async_free_retries(Config) ->
     #{port := Port} = ?config(http_server, Config),
     _BridgeID = make_bridge(#{
@@ -518,7 +500,7 @@ t_async_common_retries(Config) ->
     ok.
 
 t_bad_bridge_config(_Config) ->
-    BridgeConfig = bridge_async_config(#{port => 12345}),
+    BridgeConfig = emqx_bridge_http_test_lib:bridge_async_config(#{port => 12345}),
     ?assertMatch(
         {ok,
             {{_, 201, _}, _Headers, #{
@@ -540,7 +522,7 @@ t_bad_bridge_config(_Config) ->
 
 t_start_stop(Config) ->
     #{port := Port} = ?config(http_server, Config),
-    BridgeConfig = bridge_async_config(#{
+    BridgeConfig = emqx_bridge_http_test_lib:bridge_async_config(#{
         type => ?BRIDGE_TYPE,
         name => ?BRIDGE_NAME,
         port => Port
@@ -554,7 +536,7 @@ t_path_not_found(Config) ->
         begin
             #{port := Port, path := Path} = ?config(http_server, Config),
             MQTTTopic = <<"t/webhook">>,
-            BridgeConfig = bridge_async_config(#{
+            BridgeConfig = emqx_bridge_http_test_lib:bridge_async_config(#{
                 type => ?BRIDGE_TYPE,
                 name => ?BRIDGE_NAME,
                 local_topic => MQTTTopic,
@@ -593,7 +575,7 @@ t_too_many_requests(Config) ->
         begin
             #{port := Port, path := Path} = ?config(http_server, Config),
             MQTTTopic = <<"t/webhook">>,
-            BridgeConfig = bridge_async_config(#{
+            BridgeConfig = emqx_bridge_http_test_lib:bridge_async_config(#{
                 type => ?BRIDGE_TYPE,
                 name => ?BRIDGE_NAME,
                 local_topic => MQTTTopic,
@@ -633,7 +615,7 @@ t_rule_action_expired(Config) ->
     ?check_trace(
         begin
             RuleTopic = <<"t/webhook/rule">>,
-            BridgeConfig = bridge_async_config(#{
+            BridgeConfig = emqx_bridge_http_test_lib:bridge_async_config(#{
                 type => ?BRIDGE_TYPE,
                 name => ?BRIDGE_NAME,
                 host => "non.existent.host",
@@ -689,7 +671,7 @@ t_bridge_probes_header_atoms(Config) ->
     ?check_trace(
         begin
             LocalTopic = <<"t/local/topic">>,
-            BridgeConfig0 = bridge_async_config(#{
+            BridgeConfig0 = emqx_bridge_http_test_lib:bridge_async_config(#{
                 type => ?BRIDGE_TYPE,
                 name => ?BRIDGE_NAME,
                 port => Port,

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_test_lib.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_test_lib.erl
@@ -1,0 +1,161 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2020-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_http_test_lib).
+
+-export([
+    bridge_type/0,
+    bridge_name/0,
+    make_bridge/1,
+    bridge_async_config/1,
+    init_http_success_server/1,
+    success_http_handler/0
+]).
+
+-define(BRIDGE_TYPE, bridge_type()).
+-define(BRIDGE_NAME, bridge_name()).
+
+bridge_type() ->
+    <<"webhook">>.
+
+bridge_name() ->
+    atom_to_binary(?MODULE).
+
+make_bridge(Config) ->
+    Type = ?BRIDGE_TYPE,
+    Name = ?BRIDGE_NAME,
+    BridgeConfig = bridge_async_config(Config#{
+        name => Name,
+        type => Type
+    }),
+    {ok, _} = emqx_bridge:create(
+        Type,
+        Name,
+        BridgeConfig
+    ),
+    emqx_bridge_resource:bridge_id(Type, Name).
+
+bridge_async_config(#{port := Port} = Config) ->
+    Type = maps:get(type, Config, ?BRIDGE_TYPE),
+    Name = maps:get(name, Config, ?BRIDGE_NAME),
+    Host = maps:get(host, Config, "localhost"),
+    Path = maps:get(path, Config, ""),
+    PoolSize = maps:get(pool_size, Config, 1),
+    QueryMode = maps:get(query_mode, Config, "async"),
+    ConnectTimeout = maps:get(connect_timeout, Config, "1s"),
+    RequestTimeout = maps:get(request_timeout, Config, "10s"),
+    ResumeInterval = maps:get(resume_interval, Config, "1s"),
+    HealthCheckInterval = maps:get(health_check_interval, Config, "200ms"),
+    ResourceRequestTTL = maps:get(resource_request_ttl, Config, "infinity"),
+    LocalTopic =
+        case maps:find(local_topic, Config) of
+            {ok, LT} ->
+                lists:flatten(["local_topic = \"", LT, "\""]);
+            error ->
+                ""
+        end,
+    ConfigString = io_lib:format(
+        "bridges.~s.~s {\n"
+        "  url = \"http://~s:~p~s\"\n"
+        "  connect_timeout = \"~p\"\n"
+        "  enable = true\n"
+        %% local_topic
+        "  ~s\n"
+        "  enable_pipelining = 100\n"
+        "  max_retries = 2\n"
+        "  method = \"post\"\n"
+        "  pool_size = ~p\n"
+        "  pool_type = \"random\"\n"
+        "  request_timeout = \"~s\"\n"
+        "  body = \"${id}\"\n"
+        "  resource_opts {\n"
+        "    inflight_window = 100\n"
+        "    health_check_interval = \"~s\"\n"
+        "    max_buffer_bytes = \"1GB\"\n"
+        "    query_mode = \"~s\"\n"
+        "    request_ttl = \"~p\"\n"
+        "    resume_interval = \"~s\"\n"
+        "    start_after_created = \"true\"\n"
+        "    start_timeout = \"5s\"\n"
+        "    worker_pool_size = \"1\"\n"
+        "  }\n"
+        "  ssl {\n"
+        "    enable = false\n"
+        "  }\n"
+        "}\n",
+        [
+            Type,
+            Name,
+            Host,
+            Port,
+            Path,
+            ConnectTimeout,
+            LocalTopic,
+            PoolSize,
+            RequestTimeout,
+            HealthCheckInterval,
+            QueryMode,
+            ResourceRequestTTL,
+            ResumeInterval
+        ]
+    ),
+    ct:pal(ConfigString),
+    parse_and_check(ConfigString, Type, Name).
+
+parse_and_check(ConfigString, BridgeType, Name) ->
+    {ok, RawConf} = hocon:binary(ConfigString, #{format => map}),
+    hocon_tconf:check_plain(emqx_bridge_schema, RawConf, #{required => false, atom_key => false}),
+    #{<<"bridges">> := #{BridgeType := #{Name := RetConfig}}} = RawConf,
+    RetConfig.
+
+success_http_handler() ->
+    success_http_handler(#{response_delay => 0}).
+
+success_http_handler(Opts) ->
+    ResponseDelay = maps:get(response_delay, Opts, 0),
+    TestPid = self(),
+    fun(Req0, State) ->
+        {ok, Body, Req} = cowboy_req:read_body(Req0),
+        Headers = cowboy_req:headers(Req),
+        ct:pal("http request received: ~p", [
+            #{body => Body, headers => Headers, response_delay => ResponseDelay}
+        ]),
+        ResponseDelay > 0 andalso timer:sleep(ResponseDelay),
+        TestPid ! {http, Headers, Body},
+        Rep = cowboy_req:reply(
+            200,
+            #{<<"content-type">> => <<"text/plain">>},
+            <<"hello">>,
+            Req
+        ),
+        {ok, Rep, State}
+    end.
+
+init_http_success_server(Config) ->
+    HTTPPath = <<"/path">>,
+    ServerSSLOpts = false,
+    {ok, {HTTPPort, _Pid}} = emqx_bridge_http_connector_test_server:start_link(
+        _Port = random, HTTPPath, ServerSSLOpts
+    ),
+    ResponseDelayMS = 500,
+    ok = emqx_bridge_http_connector_test_server:set_handler(
+        success_http_handler(#{response_delay => ResponseDelayMS})
+    ),
+    [
+        {http_server, #{port => HTTPPort, path => HTTPPath}},
+        {response_delay_ms, ResponseDelayMS},
+        {bridge_name, ?BRIDGE_NAME}
+        | Config
+    ].

--- a/apps/emqx_management/src/emqx_mgmt_api_trace.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_trace.erl
@@ -222,7 +222,7 @@ fields(trace) ->
             )},
         {type,
             hoconsc:mk(
-                hoconsc:enum([clientid, topic, ip_address]),
+                hoconsc:enum([clientid, topic, ip_address, ruleid]),
                 #{
                     description => ?DESC(filter_type),
                     required => true,
@@ -255,6 +255,15 @@ fields(trace) ->
                     description => ?DESC(client_ip_addess),
                     required => false,
                     example => <<"127.0.0.1">>
+                }
+            )},
+        {ruleid,
+            hoconsc:mk(
+                binary(),
+                #{
+                    description => ?DESC(ruleid_field),
+                    required => false,
+                    example => <<"my_rule">>
                 }
             )},
         {status,

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -64,8 +64,10 @@
 
 -define(COLLECT_REQ_LIMIT, 1000).
 -define(SEND_REQ(FROM, REQUEST), {'$send_req', FROM, REQUEST}).
--define(QUERY(FROM, REQUEST, SENT, EXPIRE_AT), {query, FROM, REQUEST, SENT, EXPIRE_AT}).
--define(SIMPLE_QUERY(FROM, REQUEST), ?QUERY(FROM, REQUEST, false, infinity)).
+-define(QUERY(FROM, REQUEST, SENT, EXPIRE_AT, TRACE_CTX),
+    {query, FROM, REQUEST, SENT, EXPIRE_AT, TRACE_CTX}
+).
+-define(SIMPLE_QUERY(FROM, REQUEST, TRACE_CTX), ?QUERY(FROM, REQUEST, false, infinity, TRACE_CTX)).
 -define(REPLY(FROM, SENT, RESULT), {reply, FROM, SENT, RESULT}).
 -define(INFLIGHT_ITEM(Ref, BatchOrQuery, IsRetriable, AsyncWorkerMRef),
     {Ref, BatchOrQuery, IsRetriable, AsyncWorkerMRef}
@@ -77,7 +79,10 @@
 -type id() :: binary().
 -type index() :: pos_integer().
 -type expire_at() :: infinity | integer().
--type queue_query() :: ?QUERY(reply_fun(), request(), HasBeenSent :: boolean(), expire_at()).
+-type trace_context() :: map() | undefined.
+-type queue_query() :: ?QUERY(
+    reply_fun(), request(), HasBeenSent :: boolean(), expire_at(), TraceCtx :: trace_context()
+).
 -type request() :: term().
 -type request_from() :: undefined | gen_statem:from().
 -type timeout_ms() :: emqx_schema:timeout_duration_ms().
@@ -154,7 +159,10 @@ simple_sync_query(Id, Request, QueryOpts0) ->
     emqx_resource_metrics:matched_inc(Id),
     Ref = make_request_ref(),
     ReplyTo = maps:get(reply_to, QueryOpts0, undefined),
-    Result = call_query(force_sync, Id, Index, Ref, ?SIMPLE_QUERY(ReplyTo, Request), QueryOpts),
+    TraceCtx = maps:get(trace_ctx, QueryOpts0, undefined),
+    Result = call_query(
+        force_sync, Id, Index, Ref, ?SIMPLE_QUERY(ReplyTo, Request, TraceCtx), QueryOpts
+    ),
     _ = handle_query_result(Id, Result, _HasBeenSent = false),
     Result.
 
@@ -167,8 +175,9 @@ simple_async_query(Id, Request, QueryOpts0) ->
     emqx_resource_metrics:matched_inc(Id),
     Ref = make_request_ref(),
     ReplyTo = maps:get(reply_to, QueryOpts0, undefined),
+    TraceCtx = maps:get(trace_ctx, QueryOpts0, undefined),
     Result = call_query(
-        async_if_possible, Id, Index, Ref, ?SIMPLE_QUERY(ReplyTo, Request), QueryOpts
+        async_if_possible, Id, Index, Ref, ?SIMPLE_QUERY(ReplyTo, Request, TraceCtx), QueryOpts
     ),
     _ = handle_query_result(Id, Result, _HasBeenSent = false),
     Result.
@@ -439,10 +448,10 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
     Result = call_query(force_sync, Id, Index, Ref, QueryOrBatch, QueryOpts),
     {ShouldAck, PostFn, DeltaCounters} =
         case QueryOrBatch of
-            ?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt) ->
+            ?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt, _TraceCtx) ->
                 Reply = ?REPLY(ReplyTo, HasBeenSent, Result),
                 reply_caller_defer_metrics(Id, Reply, QueryOpts);
-            [?QUERY(_, _, _, _) | _] = Batch ->
+            [?QUERY(_, _, _, _, _) | _] = Batch ->
                 batch_reply_caller_defer_metrics(Id, Result, Batch, QueryOpts)
         end,
     Data1 = aggregate_counters(Data0, DeltaCounters),
@@ -501,11 +510,13 @@ collect_and_enqueue_query_requests(Request0, Data0) ->
                     ReplyFun = maps:get(async_reply_fun, Opts, undefined),
                     HasBeenSent = false,
                     ExpireAt = maps:get(expire_at, Opts),
-                    ?QUERY(ReplyFun, Req, HasBeenSent, ExpireAt);
+                    TraceCtx = maps:get(trace_ctx, Opts, undefined),
+                    ?QUERY(ReplyFun, Req, HasBeenSent, ExpireAt, TraceCtx);
                 (?SEND_REQ(ReplyTo, {query, Req, Opts})) ->
                     HasBeenSent = false,
                     ExpireAt = maps:get(expire_at, Opts),
-                    ?QUERY(ReplyTo, Req, HasBeenSent, ExpireAt)
+                    TraceCtx = maps:get(trace_ctx, Opts, undefined),
+                    ?QUERY(ReplyTo, Req, HasBeenSent, ExpireAt, TraceCtx)
             end,
             Requests
         ),
@@ -515,7 +526,7 @@ collect_and_enqueue_query_requests(Request0, Data0) ->
 
 reply_overflown([]) ->
     ok;
-reply_overflown([?QUERY(ReplyTo, _Req, _HasBeenSent, _ExpireAt) | More]) ->
+reply_overflown([?QUERY(ReplyTo, _Req, _HasBeenSent, _ExpireAt, _TraceCtx) | More]) ->
     do_reply_caller(ReplyTo, {error, buffer_overflow}),
     reply_overflown(More).
 
@@ -630,7 +641,7 @@ do_flush(
         inflight_tid := InflightTID
     } = Data0,
     %% unwrap when not batching (i.e., batch size == 1)
-    [?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt) = Request] = Batch,
+    [?QUERY(ReplyTo, _, HasBeenSent, _ExpireAt, _TraceCtx) = Request] = Batch,
     QueryOpts = #{inflight_tid => InflightTID, simple_query => false},
     Result = call_query(async_if_possible, Id, Index, Ref, Request, QueryOpts),
     Reply = ?REPLY(ReplyTo, HasBeenSent, Result),
@@ -824,14 +835,14 @@ batch_reply_caller_defer_metrics(Id, BatchResult, Batch, QueryOpts) ->
 
 expand_batch_reply(BatchResults, Batch) when is_list(BatchResults) ->
     lists:map(
-        fun({?QUERY(FROM, _REQUEST, SENT, _EXPIRE_AT), Result}) ->
+        fun({?QUERY(FROM, _REQUEST, SENT, _EXPIRE_AT, _TraceCtx), Result}) ->
             ?REPLY(FROM, SENT, Result)
         end,
         lists:zip(Batch, BatchResults)
     );
 expand_batch_reply(BatchResult, Batch) ->
     lists:map(
-        fun(?QUERY(FROM, _REQUEST, SENT, _EXPIRE_AT)) ->
+        fun(?QUERY(FROM, _REQUEST, SENT, _EXPIRE_AT, _TraceCtx)) ->
             ?REPLY(FROM, SENT, BatchResult)
         end,
         Batch
@@ -880,7 +891,7 @@ reply_dropped(_ReplyTo, _Result) ->
 -spec batch_reply_dropped([queue_query()], {error, late_reply | request_expired}) -> ok.
 batch_reply_dropped(Batch, Result) ->
     lists:foreach(
-        fun(?QUERY(ReplyTo, _CoreReq, _HasBeenSent, _ExpireAt)) ->
+        fun(?QUERY(ReplyTo, _CoreReq, _HasBeenSent, _ExpireAt, _TraceCtx)) ->
             reply_dropped(ReplyTo, Result)
         end,
         Batch
@@ -1093,10 +1104,79 @@ call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
         {ok, _Group, #{status := ?status_connecting, error := unhealthy_target}} ->
             {error, {unrecoverable_error, unhealthy_target}};
         {ok, _Group, Resource} ->
-            do_call_query(QM, Id, Index, Ref, Query, QueryOpts, Resource);
+            set_rule_id_trace_meta_data(Query),
+            QueryResult = do_call_query(QM, Id, Index, Ref, Query, QueryOpts, Resource),
+            %% do_call_query does not throw an exception as the call to the
+            %% resource is wrapped in a try catch expression so we will always
+            %% unset the trace meta data
+            unset_rule_id_trace_meta_data(),
+            QueryResult;
         {error, not_found} ->
             ?RESOURCE_ERROR(not_found, "resource not found")
     end.
+
+set_rule_id_trace_meta_data(Requests) when is_list(Requests) ->
+    %% Get the rule ids from requests
+    RuleIDs = lists:foldl(fun collect_rule_id/2, #{}, Requests),
+    ClientIDs = lists:foldl(fun collect_client_id/2, #{}, Requests),
+    StopAfterRender = lists:foldl(fun collect_stop_after_render/2, no_info, Requests),
+    StopAfterRenderVal =
+        case StopAfterRender of
+            only_true ->
+                logger:update_process_metadata(#{stop_action_after_render => false}),
+                true;
+            only_false ->
+                false;
+            mixed ->
+                ?TRACE(
+                    warning,
+                    "ACTION",
+                    "mixed_stop_action_after_render_batch "
+                    "(A batch will be sent to connector where some but "
+                    "not all requests has stop_action_after_render set. "
+                    "The batch will get assigned "
+                    "stop_action_after_render = false)",
+                    #{rule_ids => RuleIDs, client_ids => ClientIDs}
+                ),
+                false
+        end,
+    logger:update_process_metadata(#{
+        rule_ids => RuleIDs, client_ids => ClientIDs, stop_action_after_render => StopAfterRenderVal
+    }),
+    ok;
+set_rule_id_trace_meta_data(Request) ->
+    set_rule_id_trace_meta_data([Request]),
+    ok.
+
+collect_rule_id(?QUERY(_, _, _, _, #{rule_id := RuleId}), Acc) ->
+    Acc#{RuleId => true};
+collect_rule_id(?QUERY(_, _, _, _, _), Acc) ->
+    Acc.
+
+collect_client_id(?QUERY(_, _, _, _, #{clientid := ClientId}), Acc) ->
+    Acc#{ClientId => true};
+collect_client_id(?QUERY(_, _, _, _, _), Acc) ->
+    Acc.
+
+collect_stop_after_render(?QUERY(_, _, _, _, #{stop_action_after_render := true}), no_info) ->
+    only_true;
+collect_stop_after_render(?QUERY(_, _, _, _, #{stop_action_after_render := true}), only_true) ->
+    only_true;
+collect_stop_after_render(?QUERY(_, _, _, _, #{stop_action_after_render := true}), only_false) ->
+    mixed;
+collect_stop_after_render(?QUERY(_, _, _, _, _), no_info) ->
+    only_false;
+collect_stop_after_render(?QUERY(_, _, _, _, _), only_true) ->
+    mixed;
+collect_stop_after_render(?QUERY(_, _, _, _, _), only_false) ->
+    only_false;
+collect_stop_after_render(?QUERY(_, _, _, _, _), mixed) ->
+    mixed.
+
+unset_rule_id_trace_meta_data() ->
+    logger:update_process_metadata(#{
+        rule_ids => #{}, client_ids => #{}, stop_action_after_render => false
+    }).
 
 %% action:kafka_producer:myproducer1:connector:kafka_producer:mykakfaclient1
 extract_connector_id(Id) when is_binary(Id) ->
@@ -1208,7 +1288,15 @@ do_call_query(_QM, _Id, _Index, _Ref, _Query, _QueryOpts, _Data) ->
 ).
 
 apply_query_fun(
-    sync, Mod, Id, _Index, _Ref, ?QUERY(_, Request, _, _) = _Query, ResSt, Channels, QueryOpts
+    sync,
+    Mod,
+    Id,
+    _Index,
+    _Ref,
+    ?QUERY(_, Request, _, _, _TraceCtx) = _Query,
+    ResSt,
+    Channels,
+    QueryOpts
 ) ->
     ?tp(call_query, #{id => Id, mod => Mod, query => _Query, res_st => ResSt, call_mode => sync}),
     maybe_reply_to(
@@ -1227,7 +1315,15 @@ apply_query_fun(
         QueryOpts
     );
 apply_query_fun(
-    async, Mod, Id, Index, Ref, ?QUERY(_, Request, _, _) = Query, ResSt, Channels, QueryOpts
+    async,
+    Mod,
+    Id,
+    Index,
+    Ref,
+    ?QUERY(_, Request, _, _, _TraceCtx) = Query,
+    ResSt,
+    Channels,
+    QueryOpts
 ) ->
     ?tp(call_query_async, #{
         id => Id, mod => Mod, query => Query, res_st => ResSt, call_mode => async
@@ -1268,7 +1364,7 @@ apply_query_fun(
     Id,
     _Index,
     _Ref,
-    [?QUERY(_, FirstRequest, _, _) | _] = Batch,
+    [?QUERY(_, FirstRequest, _, _, _) | _] = Batch,
     ResSt,
     Channels,
     QueryOpts
@@ -1276,7 +1372,9 @@ apply_query_fun(
     ?tp(call_batch_query, #{
         id => Id, mod => Mod, batch => Batch, res_st => ResSt, call_mode => sync
     }),
-    Requests = lists:map(fun(?QUERY(_ReplyTo, Request, _, _ExpireAt)) -> Request end, Batch),
+    Requests = lists:map(
+        fun(?QUERY(_ReplyTo, Request, _, _ExpireAt, _TraceCtx)) -> Request end, Batch
+    ),
     maybe_reply_to(
         ?APPLY_RESOURCE(
             call_batch_query,
@@ -1298,7 +1396,7 @@ apply_query_fun(
     Id,
     Index,
     Ref,
-    [?QUERY(_, FirstRequest, _, _) | _] = Batch,
+    [?QUERY(_, FirstRequest, _, _, _) | _] = Batch,
     ResSt,
     Channels,
     QueryOpts
@@ -1321,7 +1419,7 @@ apply_query_fun(
                 min_batch => minimize(Batch)
             },
             Requests = lists:map(
-                fun(?QUERY(_ReplyTo, Request, _, _ExpireAt)) -> Request end, Batch
+                fun(?QUERY(_ReplyTo, Request, _, _ExpireAt, _TraceCtx)) -> Request end, Batch
             ),
             IsRetriable = false,
             AsyncWorkerMRef = undefined,
@@ -1367,7 +1465,7 @@ handle_async_reply1(
         inflight_tid := InflightTID,
         resource_id := Id,
         buffer_worker := BufferWorkerPid,
-        min_query := ?QUERY(ReplyTo, _, _, ExpireAt) = _Query
+        min_query := ?QUERY(ReplyTo, _, _, ExpireAt, _TraceCtx) = _Query
     } = ReplyContext,
     Result
 ) ->
@@ -1399,7 +1497,7 @@ do_handle_async_reply(
         request_ref := Ref,
         buffer_worker := BufferWorkerPid,
         inflight_tid := InflightTID,
-        min_query := ?QUERY(ReplyTo, _, Sent, _ExpireAt) = _Query
+        min_query := ?QUERY(ReplyTo, _, Sent, _ExpireAt, _TraceCtx) = _Query
     },
     Result
 ) ->
@@ -1486,13 +1584,13 @@ handle_async_batch_reply2([Inflight], ReplyContext, Results0, Now) ->
     %% So we just take the original flag from the ReplyContext batch
     %% and put it back to the batch found in inflight table
     %% which must have already been set to `false`
-    [?QUERY(_ReplyTo, _, HasBeenSent, _ExpireAt) | _] = Batch,
+    [?QUERY(_ReplyTo, _, HasBeenSent, _ExpireAt, _TraceCtx) | _] = Batch,
     {RealNotExpired0, RealExpired, Results} =
         sieve_expired_requests_with_results(RealBatch, Now, Results0),
     RealNotExpired =
         lists:map(
-            fun(?QUERY(ReplyTo, CoreReq, _HasBeenSent, ExpireAt)) ->
-                ?QUERY(ReplyTo, CoreReq, HasBeenSent, ExpireAt)
+            fun(?QUERY(ReplyTo, CoreReq, _HasBeenSent, ExpireAt, TraceCtx)) ->
+                ?QUERY(ReplyTo, CoreReq, HasBeenSent, ExpireAt, TraceCtx)
             end,
             RealNotExpired0
         ),
@@ -1678,7 +1776,10 @@ inflight_get_first_retriable(InflightTID, Now) ->
     case ets:select(InflightTID, MatchSpec, _Limit = 1) of
         '$end_of_table' ->
             none;
-        {[{Ref, Query = ?QUERY(_ReplyTo, _CoreReq, _HasBeenSent, ExpireAt)}], _Continuation} ->
+        {
+            [{Ref, Query = ?QUERY(_ReplyTo, _CoreReq, _HasBeenSent, ExpireAt, _TraceCtx)}],
+            _Continuation
+        } ->
             case is_expired(ExpireAt, Now) of
                 true ->
                     {expired, Ref, [Query]};
@@ -1714,7 +1815,7 @@ inflight_append(undefined, _InflightItem) ->
     ok;
 inflight_append(
     InflightTID,
-    ?INFLIGHT_ITEM(Ref, [?QUERY(_, _, _, _) | _] = Batch0, IsRetriable, AsyncWorkerMRef)
+    ?INFLIGHT_ITEM(Ref, [?QUERY(_, _, _, _, _) | _] = Batch0, IsRetriable, AsyncWorkerMRef)
 ) ->
     Batch = mark_as_sent(Batch0),
     InflightItem = ?INFLIGHT_ITEM(Ref, Batch, IsRetriable, AsyncWorkerMRef),
@@ -1726,7 +1827,10 @@ inflight_append(
 inflight_append(
     InflightTID,
     ?INFLIGHT_ITEM(
-        Ref, ?QUERY(_ReplyTo, _Req, _HasBeenSent, _ExpireAt) = Query0, IsRetriable, AsyncWorkerMRef
+        Ref,
+        ?QUERY(_ReplyTo, _Req, _HasBeenSent, _ExpireAt, _TraceCtx) = Query0,
+        IsRetriable,
+        AsyncWorkerMRef
     )
 ) ->
     Query = mark_as_sent(Query0),
@@ -1790,9 +1894,13 @@ ack_inflight(undefined, _Ref, _BufferWorkerPid) ->
 ack_inflight(InflightTID, Ref, BufferWorkerPid) ->
     {Count, Removed} =
         case ets:take(InflightTID, Ref) of
-            [?INFLIGHT_ITEM(Ref, ?QUERY(_, _, _, _), _IsRetriable, _AsyncWorkerMRef)] ->
+            [?INFLIGHT_ITEM(Ref, ?QUERY(_, _, _, _, _), _IsRetriable, _AsyncWorkerMRef)] ->
                 {1, true};
-            [?INFLIGHT_ITEM(Ref, [?QUERY(_, _, _, _) | _] = Batch, _IsRetriable, _AsyncWorkerMRef)] ->
+            [
+                ?INFLIGHT_ITEM(
+                    Ref, [?QUERY(_, _, _, _, _) | _] = Batch, _IsRetriable, _AsyncWorkerMRef
+                )
+            ] ->
                 {length(Batch), true};
             [] ->
                 {0, false}
@@ -1942,9 +2050,9 @@ do_collect_requests(Acc, Count, Limit) ->
 
 mark_as_sent(Batch) when is_list(Batch) ->
     lists:map(fun mark_as_sent/1, Batch);
-mark_as_sent(?QUERY(ReplyTo, Req, _HasBeenSent, ExpireAt)) ->
+mark_as_sent(?QUERY(ReplyTo, Req, _HasBeenSent, ExpireAt, TraceCtx)) ->
     HasBeenSent = true,
-    ?QUERY(ReplyTo, Req, HasBeenSent, ExpireAt).
+    ?QUERY(ReplyTo, Req, HasBeenSent, ExpireAt, TraceCtx).
 
 is_unrecoverable_error({error, {unrecoverable_error, _}}) ->
     true;
@@ -1967,7 +2075,7 @@ is_async_return(_) ->
 
 sieve_expired_requests(Batch, Now) ->
     lists:partition(
-        fun(?QUERY(_ReplyTo, _CoreReq, _HasBeenSent, ExpireAt)) ->
+        fun(?QUERY(_ReplyTo, _CoreReq, _HasBeenSent, ExpireAt, _TraceCtx)) ->
             not is_expired(ExpireAt, Now)
         end,
         Batch
@@ -1978,7 +2086,7 @@ sieve_expired_requests_with_results(Batch, Now, Results) when is_list(Results) -
     {RevNotExpiredBatch, RevNotExpiredResults, ExpiredBatch} =
         lists:foldl(
             fun(
-                {?QUERY(_ReplyTo, _CoreReq, _HasBeenSent, ExpireAt) = Query, Result},
+                {?QUERY(_ReplyTo, _CoreReq, _HasBeenSent, ExpireAt, _TraceCtx) = Query, Result},
                 {NotExpAcc, ResAcc, ExpAcc}
             ) ->
                 case not is_expired(ExpireAt, Now) of
@@ -2026,15 +2134,16 @@ ensure_expire_at(#{timeout := TimeoutMS} = Opts) ->
     Opts#{expire_at => ExpireAt}.
 
 %% no need to keep the request for async reply handler
-minimize(?QUERY(_, _, _, _) = Q) ->
+minimize(?QUERY(_, _, _, _, _) = Q) ->
     do_minimize(Q);
 minimize(L) when is_list(L) ->
     lists:map(fun do_minimize/1, L).
 
 -ifdef(TEST).
-do_minimize(?QUERY(_ReplyTo, _Req, _Sent, _ExpireAt) = Query) -> Query.
+do_minimize(?QUERY(_ReplyTo, _Req, _Sent, _ExpireAt, _TraceCtx) = Query) -> Query.
 -else.
-do_minimize(?QUERY(ReplyTo, _Req, Sent, ExpireAt)) -> ?QUERY(ReplyTo, [], Sent, ExpireAt).
+do_minimize(?QUERY(ReplyTo, _Req, Sent, ExpireAt, TraceCtx)) ->
+    ?QUERY(ReplyTo, [], Sent, ExpireAt, TraceCtx).
 -endif.
 
 %% To avoid message loss due to misconfigurations, we adjust

--- a/apps/emqx_rule_engine/rebar.config
+++ b/apps/emqx_rule_engine/rebar.config
@@ -5,6 +5,14 @@
     {emqx_utils, {path, "../emqx_utils"}}
 ]}.
 
+{profiles, [
+    {test, [
+        {deps, [
+            {emqx_bridge_http, {path, "../emqx_bridge_http"}}
+        ]}
+    ]}
+]}.
+
 {erl_opts, [
     warn_unused_vars,
     warn_shadow_vars,

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -54,7 +54,8 @@ roots() ->
         {"rule_creation", sc(ref("rule_creation"), #{desc => ?DESC("root_rule_creation")})},
         {"rule_info", sc(ref("rule_info"), #{desc => ?DESC("root_rule_info")})},
         {"rule_events", sc(ref("rule_events"), #{desc => ?DESC("root_rule_events")})},
-        {"rule_test", sc(ref("rule_test"), #{desc => ?DESC("root_rule_test")})}
+        {"rule_test", sc(ref("rule_test"), #{desc => ?DESC("root_rule_test")})},
+        {"rule_apply_test", sc(ref("rule_apply_test"), #{desc => ?DESC("root_apply_rule_test")})}
     ].
 
 fields("rule_engine") ->
@@ -123,6 +124,48 @@ fields("rule_test") ->
                 }
             )},
         {"sql", sc(binary(), #{desc => ?DESC("test_sql"), required => true})}
+    ];
+fields("rule_apply_test") ->
+    [
+        {"context",
+            sc(
+                hoconsc:union([
+                    ref("ctx_pub"),
+                    ref("ctx_sub"),
+                    ref("ctx_unsub"),
+                    ref("ctx_delivered"),
+                    ref("ctx_acked"),
+                    ref("ctx_dropped"),
+                    ref("ctx_connected"),
+                    ref("ctx_disconnected"),
+                    ref("ctx_connack"),
+                    ref("ctx_check_authz_complete"),
+                    ref("ctx_bridge_mqtt"),
+                    ref("ctx_delivery_dropped")
+                ]),
+                #{
+                    desc => ?DESC("test_context"),
+                    default => #{}
+                }
+            )},
+        {"environment",
+            sc(
+                typerefl:map(),
+                #{
+                    desc =>
+                        ?DESC("test_rule_environment"),
+                    default => #{}
+                }
+            )},
+        {"stop_action_after_template_render",
+            sc(
+                typerefl:boolean(),
+                #{
+                    desc =>
+                        ?DESC("stop_action_after_template_render"),
+                    default => false
+                }
+            )}
     ];
 fields("metrics") ->
     [

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -102,52 +102,12 @@ fields("rule_events") ->
     ];
 fields("rule_test") ->
     [
-        {"context",
-            sc(
-                hoconsc:union([
-                    ref("ctx_pub"),
-                    ref("ctx_sub"),
-                    ref("ctx_unsub"),
-                    ref("ctx_delivered"),
-                    ref("ctx_acked"),
-                    ref("ctx_dropped"),
-                    ref("ctx_connected"),
-                    ref("ctx_disconnected"),
-                    ref("ctx_connack"),
-                    ref("ctx_check_authz_complete"),
-                    ref("ctx_bridge_mqtt"),
-                    ref("ctx_delivery_dropped")
-                ]),
-                #{
-                    desc => ?DESC("test_context"),
-                    default => #{}
-                }
-            )},
+        rule_input_message_context(),
         {"sql", sc(binary(), #{desc => ?DESC("test_sql"), required => true})}
     ];
 fields("rule_apply_test") ->
     [
-        {"context",
-            sc(
-                hoconsc:union([
-                    ref("ctx_pub"),
-                    ref("ctx_sub"),
-                    ref("ctx_unsub"),
-                    ref("ctx_delivered"),
-                    ref("ctx_acked"),
-                    ref("ctx_dropped"),
-                    ref("ctx_connected"),
-                    ref("ctx_disconnected"),
-                    ref("ctx_connack"),
-                    ref("ctx_check_authz_complete"),
-                    ref("ctx_bridge_mqtt"),
-                    ref("ctx_delivery_dropped")
-                ]),
-                #{
-                    desc => ?DESC("test_context"),
-                    default => #{}
-                }
-            )},
+        rule_input_message_context(),
         {"environment",
             sc(
                 typerefl:map(),
@@ -357,6 +317,29 @@ fields("ctx_delivery_dropped") ->
         {"from_username", sc(binary(), #{desc => ?DESC("event_from_username")})}
         | msg_event_common_fields()
     ].
+
+rule_input_message_context() ->
+    {"context",
+        sc(
+            hoconsc:union([
+                ref("ctx_pub"),
+                ref("ctx_sub"),
+                ref("ctx_unsub"),
+                ref("ctx_delivered"),
+                ref("ctx_acked"),
+                ref("ctx_dropped"),
+                ref("ctx_connected"),
+                ref("ctx_disconnected"),
+                ref("ctx_connack"),
+                ref("ctx_check_authz_complete"),
+                ref("ctx_bridge_mqtt"),
+                ref("ctx_delivery_dropped")
+            ]),
+            #{
+                desc => ?DESC("test_context"),
+                default => #{}
+            }
+        )}.
 
 qos() ->
     {"qos", sc(emqx_schema:qos(), #{desc => ?DESC("event_qos")})}.

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -117,7 +117,7 @@ fields("rule_apply_test") ->
                     default => #{}
                 }
             )},
-        {"stop_action_after_template_render",
+        {"stop_action_after_template_rendering",
             sc(
                 typerefl:boolean(),
                 #{

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -26,7 +26,7 @@
 
 -export([namespace/0, roots/0, fields/1]).
 
--type tag() :: rule_creation | rule_test | rule_engine.
+-type tag() :: rule_creation | rule_test | rule_engine | rule_apply_test.
 
 -spec check_params(map(), tag()) -> {ok, map()} | {error, term()}.
 check_params(Params, Tag) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -268,8 +268,8 @@ schema("/rules/:id/test") ->
         'operationId' => '/rules/:id/test',
         post => #{
             tags => [<<"rules">>],
-            description => ?DESC("api8"),
-            summary => <<"Apply a rule with the given message and environment">>,
+            description => ?DESC("api11"),
+            summary => <<"Apply a rule for testing">>,
             'requestBody' => rule_apply_test_schema(),
             responses => #{
                 400 => error_schema('BAD_REQUEST', "Invalid Parameters"),

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -471,7 +471,9 @@ do_handle_action(_RuleId, #{mod := Mod, func := Func} = Action, Selected, Envs) 
     Result.
 
 do_handle_action_get_trace_context(Action) ->
-    case logger:get_process_metadata() of
+    Metadata = logger:get_process_metadata(),
+    StopAfterRender = maps:get(stop_action_after_render, Metadata, false),
+    case Metadata of
         #{
             rule_id := RuleID,
             clientid := ClientID
@@ -479,14 +481,16 @@ do_handle_action_get_trace_context(Action) ->
             #{
                 rule_id => RuleID,
                 clientid => ClientID,
-                action_id => Action
+                action_id => Action,
+                stop_action_after_render => StopAfterRender
             };
         #{
             rule_id := RuleID
         } ->
             #{
                 rule_id => RuleID,
-                action_id => Action
+                action_id => Action,
+                stop_action_after_render => StopAfterRender
             }
     end.
 

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -420,7 +420,7 @@ handle_action(RuleId, ActId, Selected, Envs) ->
     end.
 
 -define(IS_RES_DOWN(R), R == stopped; R == not_connected; R == not_found; R == unhealthy_target).
-do_handle_action(RuleId, {bridge, BridgeType, BridgeName, ResId} = Action, Selected, _Envs) ->
+do_handle_action(_RuleId, {bridge, BridgeType, BridgeName, ResId} = Action, Selected, _Envs) ->
     trace_action_bridge("BRIDGE", Action, "bridge_action", #{}, debug),
     TraceCtx = do_handle_action_get_trace_context(Action),
     ReplyTo = {fun ?MODULE:inc_action_metrics/2, [TraceCtx], #{reply_dropped => true}},

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -69,6 +69,9 @@ apply_rule_discard_result(Rule, Columns, Envs) ->
     ok.
 
 apply_rule(Rule = #{id := RuleID}, Columns, Envs) ->
+    ?TRACE("APPLY_RULE", "rule_activated", #{
+        ruleid => RuleID, input => Columns, environment => Envs
+    }),
     ok = emqx_metrics_worker:inc(rule_metrics, RuleID, 'matched'),
     clear_rule_payload(),
     try

--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -67,7 +67,7 @@ do_apply_matched_rule(Rule, Context, Env, StopAfterRender) ->
     ApplyRuleRes.
 
 update_process_trace_metadata(true = _StopAfterRender) ->
-    logger:update_process_trace_metadata(#{
+    logger:update_process_metadata(#{
         stop_action_after_render => true
     });
 update_process_trace_metadata(false = _StopAfterRender) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -29,7 +29,7 @@ apply_rule(
     #{
         context := Context,
         environment := Env,
-        stop_action_after_template_render := StopAfterRender
+        stop_action_after_template_rendering := StopAfterRender
     }
 ) ->
     {ok, Rule} = emqx_rule_engine:get_rule(RuleId),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -30,9 +30,6 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(emqx_conf),
-    % ok = emqx_common_test_helpers:load_config(emqx_rule_engine_schema, ?CONF_DEFAULT),
-    % ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx, emqx_rule_engine, emqx_bridge, emqx_bridge_http]),
-
     Apps = emqx_cth_suite:start(
         [
             emqx,
@@ -125,7 +122,7 @@ basic_apply_rule_test_helper(Config, TraceType, StopAfterRender) ->
     Params = #{
         % body => #{
         <<"context">> => Context,
-        <<"stop_action_after_template_render">> => StopAfterRender
+        <<"stop_action_after_template_rendering">> => StopAfterRender
         % }
     },
     emqx_trace:check(),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -30,15 +30,20 @@ all() ->
 
 init_per_suite(Config) ->
     application:load(emqx_conf),
+    AppsToStart = [
+        emqx,
+        emqx_conf,
+        emqx_connector,
+        emqx_bridge,
+        emqx_bridge_http,
+        emqx_rule_engine
+    ],
+    %% I don't know why we need to stop the apps and then start them but if we
+    %% don't do this and other suites run before this suite the test cases will
+    %% fail as it seems like the connector silently refuses to start.
+    ok = emqx_cth_suite:stop(AppsToStart),
     Apps = emqx_cth_suite:start(
-        [
-            emqx,
-            emqx_conf,
-            emqx_connector,
-            emqx_bridge_http,
-            emqx_bridge,
-            emqx_rule_engine
-        ],
+        AppsToStart,
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     emqx_mgmt_api_test_util:init_suite(),

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -1,0 +1,451 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_rule_engine_api_rule_apply_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-define(CONF_DEFAULT, <<"rule_engine {rules {}}">>).
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    application:load(emqx_conf),
+    % ok = emqx_common_test_helpers:load_config(emqx_rule_engine_schema, ?CONF_DEFAULT),
+    % ok = emqx_common_test_helpers:start_apps([emqx_conf, emqx, emqx_rule_engine, emqx_bridge, emqx_bridge_http]),
+
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_connector,
+            emqx_bridge_http,
+            emqx_bridge,
+            emqx_rule_engine
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    emqx_mgmt_api_test_util:init_suite(),
+    [{apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    emqx_mgmt_api_test_util:end_suite(),
+    ok = emqx_cth_suite:stop(Apps),
+    ok.
+
+init_per_testcase(_Case, Config) ->
+    emqx_bridge_http_test_lib:init_http_success_server(Config).
+
+end_per_testcase(_TestCase, _Config) ->
+    ok = emqx_bridge_http_connector_test_server:stop(),
+    emqx_bridge_v2_testlib:delete_all_bridges(),
+    emqx_bridge_v2_testlib:delete_all_connectors(),
+    emqx_common_test_helpers:call_janitor(),
+    ok.
+
+t_basic_apply_rule_trace_ruleid(Config) ->
+    basic_apply_rule_test_helper(Config, ruleid).
+
+t_basic_apply_rule_trace_clientid(Config) ->
+    basic_apply_rule_test_helper(Config, clientid).
+
+basic_apply_rule_test_helper(Config, TraceType) ->
+    HTTPServerConfig = ?config(http_server, Config),
+    emqx_bridge_http_test_lib:make_bridge(HTTPServerConfig),
+    #{status := connected} = emqx_bridge_v2:health_check(
+        http, emqx_bridge_http_test_lib:bridge_name()
+    ),
+    %% Create Rule
+    RuleTopic = iolist_to_binary([<<"my_rule_topic/">>, atom_to_binary(?FUNCTION_NAME)]),
+    SQL = <<"SELECT payload.id as id FROM \"", RuleTopic/binary, "\"">>,
+    {ok, #{<<"id">> := RuleId}} =
+        emqx_bridge_testlib:create_rule_and_action_http(
+            http,
+            RuleTopic,
+            Config,
+            #{sql => SQL}
+        ),
+    ClientId = <<"c_emqx">>,
+    %% ===================================
+    %% Create trace for RuleId
+    %% ===================================
+    Now = erlang:system_time(second) - 10,
+    Start = Now,
+    End = Now + 60,
+    TraceName = atom_to_binary(?FUNCTION_NAME),
+    TraceValue =
+        case TraceType of
+            ruleid ->
+                RuleId;
+            clientid ->
+                ClientId
+        end,
+    Trace = #{
+        name => TraceName,
+        type => TraceType,
+        TraceType => TraceValue,
+        start_at => Start,
+        end_at => End
+    },
+    emqx_trace_SUITE:reload(),
+    ok = emqx_trace:clear(),
+    {ok, _} = emqx_trace:create(Trace),
+    %% ===================================
+    Context = #{
+        clientid => ClientId,
+        event_type => message_publish,
+        payload => <<"{\"msg\": \"hello\"}">>,
+        qos => 1,
+        topic => RuleTopic,
+        username => <<"u_emqx">>
+    },
+    Params = #{
+        % body => #{
+        <<"context">> => Context
+        % }
+    },
+    emqx_trace:check(),
+    ok = emqx_trace_handler_SUITE:filesync(TraceName, TraceType),
+    {ok, _} = file:read_file(emqx_trace:log_file(TraceName, Now)),
+    ?assertMatch({ok, _}, call_apply_rule_api(RuleId, Params)),
+    ?retry(
+        _Interval0 = 200,
+        _NAttempts0 = 20,
+        begin
+            Bin = read_rule_trace_file(TraceName, TraceType, Now),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"rule_activated">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"SELECT_yielded_result">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"bridge_action">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"action_activated">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"successfully_rendered_request">>])),
+            ?assertNotEqual(nomatch, binary:match(Bin, [<<"QUERY_ASYNC">>]))
+        end
+    ),
+    emqx_trace:delete(TraceName),
+    ok.
+
+%% Helper Functions
+
+% t_ctx_pub(_) ->
+%     SQL = <<"SELECT payload.msg as msg, clientid, username, payload, topic, qos FROM \"t/#\"">>,
+%     Context = #{
+%         clientid => <<"c_emqx">>,
+%         event_type => message_publish,
+%         payload => <<"{\"msg\": \"hello\"}">>,
+%         qos => 1,
+%         topic => <<"t/a">>,
+%         username => <<"u_emqx">>
+%     },
+%     Expected = Context#{msg => <<"hello">>},
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_sub(_) ->
+%     SQL = <<"SELECT clientid, username, topic, qos FROM \"$events/session_subscribed\"">>,
+%     Context = #{
+%         clientid => <<"c_emqx">>,
+%         event_type => session_subscribed,
+%         qos => 1,
+%         topic => <<"t/a">>,
+%         username => <<"u_emqx">>
+%     },
+
+%     do_test(SQL, Context, Context).
+
+% t_ctx_unsub(_) ->
+%     SQL = <<"SELECT clientid, username, topic, qos FROM \"$events/session_unsubscribed\"">>,
+%     Context = #{
+%         clientid => <<"c_emqx">>,
+%         event_type => session_unsubscribed,
+%         qos => 1,
+%         topic => <<"t/a">>,
+%         username => <<"u_emqx">>
+%     },
+%     do_test(SQL, Context, Context).
+
+% t_ctx_delivered(_) ->
+%     SQL =
+%         <<"SELECT from_clientid, from_username, topic, qos, node, timestamp FROM \"$events/message_delivered\"">>,
+%     Context = #{
+%         clientid => <<"c_emqx_2">>,
+%         event_type => message_delivered,
+%         from_clientid => <<"c_emqx_1">>,
+%         from_username => <<"u_emqx_1">>,
+%         payload => <<"{\"msg\": \"hello\"}">>,
+%         qos => 1,
+%         topic => <<"t/a">>,
+%         username => <<"u_emqx_2">>
+%     },
+%     Expected = check_result([from_clientid, from_username, topic, qos], [node, timestamp], Context),
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_acked(_) ->
+%     SQL =
+%         <<"SELECT from_clientid, from_username, topic, qos, node, timestamp FROM \"$events/message_acked\"">>,
+
+%     Context = #{
+%         clientid => <<"c_emqx_2">>,
+%         event_type => message_acked,
+%         from_clientid => <<"c_emqx_1">>,
+%         from_username => <<"u_emqx_1">>,
+%         payload => <<"{\"msg\": \"hello\"}">>,
+%         qos => 1,
+%         topic => <<"t/a">>,
+%         username => <<"u_emqx_2">>
+%     },
+
+%     Expected = with_node_timestampe([from_clientid, from_username, topic, qos], Context),
+
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_droped(_) ->
+%     SQL = <<"SELECT reason, topic, qos, node, timestamp FROM \"$events/message_dropped\"">>,
+%     Topic = <<"t/a">>,
+%     QoS = 1,
+%     Reason = <<"no_subscribers">>,
+%     Context = #{
+%         clientid => <<"c_emqx">>,
+%         event_type => message_dropped,
+%         payload => <<"{\"msg\": \"hello\"}">>,
+%         qos => QoS,
+%         reason => Reason,
+%         topic => Topic,
+%         username => <<"u_emqx">>
+%     },
+
+%     Expected = with_node_timestampe([reason, topic, qos], Context),
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_connected(_) ->
+%     SQL =
+%         <<"SELECT clientid, username, keepalive, is_bridge FROM \"$events/client_connected\"">>,
+
+%     Context =
+%         #{
+%             clean_start => true,
+%             clientid => <<"c_emqx">>,
+%             event_type => client_connected,
+%             is_bridge => false,
+%             peername => <<"127.0.0.1:52918">>,
+%             username => <<"u_emqx">>
+%         },
+%     Expected = check_result([clientid, username, keepalive, is_bridge], [], Context),
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_disconnected(_) ->
+%     SQL =
+%         <<"SELECT clientid, username, reason, disconnected_at, node FROM \"$events/client_disconnected\"">>,
+
+%     Context =
+%         #{
+%             clientid => <<"c_emqx">>,
+%             event_type => client_disconnected,
+%             reason => <<"normal">>,
+%             username => <<"u_emqx">>
+%         },
+%     Expected = check_result([clientid, username, reason], [disconnected_at, node], Context),
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_connack(_) ->
+%     SQL =
+%         <<"SELECT clientid, username, reason_code, node FROM \"$events/client_connack\"">>,
+
+%     Context =
+%         #{
+%             clean_start => true,
+%             clientid => <<"c_emqx">>,
+%             event_type => client_connack,
+%             reason_code => <<"sucess">>,
+%             username => <<"u_emqx">>
+%         },
+%     Expected = check_result([clientid, username, reason_code], [node], Context),
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_check_authz_complete(_) ->
+%     SQL =
+%         <<
+%             "SELECT clientid, username, topic, action, result,\n"
+%             "authz_source, node FROM \"$events/client_check_authz_complete\""
+%         >>,
+
+%     Context =
+%         #{
+%             action => <<"publish">>,
+%             clientid => <<"c_emqx">>,
+%             event_type => client_check_authz_complete,
+%             result => <<"allow">>,
+%             topic => <<"t/1">>,
+%             username => <<"u_emqx">>
+%         },
+%     Expected = check_result(
+%         [clientid, username, topic, action],
+%         [authz_source, node, result],
+%         Context
+%     ),
+
+%     do_test(SQL, Context, Expected).
+
+% t_ctx_delivery_dropped(_) ->
+%     SQL =
+%         <<"SELECT from_clientid, from_username, reason, topic, qos FROM \"$events/delivery_dropped\"">>,
+
+%     Context =
+%         #{
+%             clientid => <<"c_emqx_2">>,
+%             event_type => delivery_dropped,
+%             from_clientid => <<"c_emqx_1">>,
+%             from_username => <<"u_emqx_1">>,
+%             payload => <<"{\"msg\": \"hello\"}">>,
+%             qos => 1,
+%             reason => <<"queue_full">>,
+%             topic => <<"t/a">>,
+%             username => <<"u_emqx_2">>
+%         },
+%     Expected = check_result([from_clientid, from_username, reason, qos, topic], [], Context),
+%     do_test(SQL, Context, Expected).
+
+% t_mongo_date_function_should_return_string_in_test_env(_) ->
+%     SQL =
+%         <<"SELECT mongo_date() as mongo_date FROM \"$events/client_check_authz_complete\"">>,
+%     Context =
+%         #{
+%             action => <<"publish">>,
+%             clientid => <<"c_emqx">>,
+%             event_type => client_check_authz_complete,
+%             result => <<"allow">>,
+%             topic => <<"t/1">>,
+%             username => <<"u_emqx">>
+%         },
+%     CheckFunction = fun(Result) ->
+%         MongoDate = maps:get(mongo_date, Result),
+%         %% Use regex to match the expected string
+%         MatchResult = re:run(MongoDate, <<"ISODate\\([0-9]{4}-[0-9]{2}-[0-9]{2}T.*\\)">>),
+%         ?assertMatch({match, _}, MatchResult),
+%         ok
+%     end,
+%     do_test(SQL, Context, CheckFunction).
+
+% do_test(SQL, Context, Expected0) ->
+%     Res = emqx_rule_engine_api:'/rule_test'(
+%         post,
+%         test_rule_params(SQL, Context)
+%     ),
+%     ?assertMatch({200, _}, Res),
+%     {200, Result0} = Res,
+%     Result = emqx_utils_maps:unsafe_atom_key_map(Result0),
+%     case is_function(Expected0) of
+%         false ->
+%             Expected = maps:without([event_type], Expected0),
+%             ?assertMatch(Expected, Result, Expected);
+%         _ ->
+%             Expected0(Result)
+%     end,
+%     ok.
+
+% test_rule_params(Sql, Context) ->
+%     #{
+%         body => #{
+%             <<"context">> => Context,
+%             <<"sql">> => Sql
+%         }
+%     }.
+
+% with_node_timestampe(Keys, Context) ->
+%     check_result(Keys, [node, timestamp], Context).
+
+% check_result(Keys, Exists, Context) ->
+%     Log = fun(Format, Args) ->
+%         lists:flatten(io_lib:format(Format, Args))
+%     end,
+
+%     Base = maps:with(Keys, Context),
+
+%     fun(Result) ->
+%         maps:foreach(
+%             fun(Key, Value) ->
+%                 ?assertEqual(
+%                     Value,
+%                     maps:get(Key, Result, undefined),
+%                     Log("Key:~p value error~nResult:~p~n", [Key, Result])
+%                 )
+%             end,
+%             Base
+%         ),
+
+%         NotExists = fun(Key) -> Log("Key:~p not exists in result:~p~n", [Key, Result]) end,
+%         lists:foreach(
+%             fun(Key) ->
+%                 Find = maps:find(Key, Result),
+%                 Formatter = NotExists(Key),
+%                 ?assertMatch({ok, _}, Find, Formatter),
+%                 ?assertNotMatch({ok, undefined}, Find, Formatter),
+%                 ?assertNotMatch({ok, <<"undefined">>}, Find, Formatter)
+%             end,
+%             Exists
+%         ),
+
+%         ?assertEqual(erlang:length(Keys) + erlang:length(Exists), maps:size(Result), Result)
+%     end.
+
+call_apply_rule_api(RuleId, Params) ->
+    Method = post,
+    Path = emqx_mgmt_api_test_util:api_path(["rules", RuleId, "test"]),
+    ct:pal("sql test (http):\n  ~p", [Params]),
+    Res = request(Method, Path, Params),
+    ct:pal("sql test (http) result:\n  ~p", [Res]),
+    Res.
+
+request(Method, Path, Params) ->
+    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
+    Opts = #{return_all => true},
+    case emqx_mgmt_api_test_util:request_api(Method, Path, "", AuthHeader, Params, Opts) of
+        {ok, {Status, Headers, Body0}} ->
+            Body = maybe_json_decode(Body0),
+            {ok, {Status, Headers, Body}};
+        {error, {Status, Headers, Body0}} ->
+            Body =
+                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                    {ok, Decoded0 = #{<<"message">> := Msg0}} ->
+                        Msg = maybe_json_decode(Msg0),
+                        Decoded0#{<<"message">> := Msg};
+                    {ok, Decoded0} ->
+                        Decoded0;
+                    {error, _} ->
+                        Body0
+                end,
+            {error, {Status, Headers, Body}};
+        Error ->
+            Error
+    end.
+
+maybe_json_decode(X) ->
+    case emqx_utils_json:safe_decode(X, [return_maps]) of
+        {ok, Decoded} -> Decoded;
+        {error, _} -> X
+    end.
+
+read_rule_trace_file(TraceName, TraceType, From) ->
+    emqx_trace:check(),
+    ok = emqx_trace_handler_SUITE:filesync(TraceName, TraceType),
+    {ok, Bin} = file:read_file(emqx_trace:log_file(TraceName, From)),
+    io_lib:format("MYTRACE:~n~s", [Bin]),
+    Bin.

--- a/rel/i18n/emqx_mgmt_api_trace.hocon
+++ b/rel/i18n/emqx_mgmt_api_trace.hocon
@@ -80,6 +80,11 @@ client_ip_addess.desc:
 client_ip_addess.label:
 """Client IP Address"""
 
+ruleid.desc:
+"""Specify the Rule ID if the trace type is 'ruleid'."""
+ruleid.label:
+"""Rule ID"""
+
 trace_status.desc:
 """trace status"""
 trace_status.label:

--- a/rel/i18n/emqx_rule_api_schema.hocon
+++ b/rel/i18n/emqx_rule_api_schema.hocon
@@ -66,6 +66,18 @@ test_context.desc:
 test_context.label:
 """Event Conetxt"""
 
+test_rule_environment.desc:
+"""The environment that will be passed to the rule when it is applied. A default environment will be used if no environment is given."""
+
+test_rule_environment.label:
+"""Event Environment"""
+
+stop_action_after_template_render.desc:
+"""Set this to true if the action should be stopped after its template has been rendered."""
+
+stop_action_after_template_render.label:
+"""Stop Action After Template Rendering"""
+
 node_node.desc:
 """The node name"""
 

--- a/rel/i18n/emqx_rule_engine_api.hocon
+++ b/rel/i18n/emqx_rule_engine_api.hocon
@@ -90,4 +90,10 @@ api9.desc:
 api9.label:
 """Get configuration"""
 
+api11.desc:
+"""Apply a rule with the given message and environment"""
+
+api11.label:
+"""Apply Rule"""
+
 }


### PR DESCRIPTION
This PR:

* Adds ruleid as a new tracing type
* Adds test cases for the ruleid tracing type
* Adds the rule_ids key to the logger process meta data before calling the connector module so that traces in the connector instance will be associated with the appropriate rule id
* Adds rule id tracing for the HTTP connector (templets rendered successfully trace)

Fixes https://emqx.atlassian.net/browse/EMQX-12025 (partially)

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible