### PR TITLE
fix: clean self node's cluster commit when leave cluster

### DIFF
--- a/apps/emqx_conf/src/emqx_cluster_rpc.erl
+++ b/apps/emqx_conf/src/emqx_cluster_rpc.erl
@@ -224,6 +224,7 @@ reset() -> gen_server:call(?MODULE, reset).
 status() ->
     transaction(fun ?MODULE:trans_status/0, []).
 
+%% DO NOT delete this on_leave_clean/0, It's use when rpc before v560.
 on_leave_clean() ->
     on_leave_clean(node()).
 
@@ -367,7 +368,7 @@ handle_call({fast_forward_to_commit, ToTnxId}, _From, State) ->
     NodeId = do_fast_forward_to_commit(ToTnxId, State),
     {reply, NodeId, State, catch_up(State)};
 handle_call(on_leave, _From, State) ->
-    {atomic, ok} = transaction(fun ?MODULE:on_leave_clean/0, []),
+    {atomic, ok} = transaction(fun ?MODULE:on_leave_clean/1, [node()]),
     {reply, ok, State#{is_leaving := true}};
 handle_call(_, _From, State) ->
     {reply, ok, State, catch_up(State)}.

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.1.35"},
+    {vsn, "0.1.36"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/changes/ce/fix-12843.en.md
+++ b/changes/ce/fix-12843.en.md
@@ -1,2 +1,2 @@
-Fixed cluster_rpc_commit tnx_id was not properly cleanup after 'cluster leave' on replicant nodes,
-The tnx_id of the core node will be deleted before, resulting in the failure of the core node update configuration.
+Fixed `cluster_rpc_commit` transaction ID cleanup procedure after `cluster leave` on replicant nodes.
+Previously, the transaction id of the core node would be deleted prematurely, blocking configuration updates on the core node.

--- a/changes/ce/fix-12843.en.md
+++ b/changes/ce/fix-12843.en.md
@@ -1,0 +1,2 @@
+Fixed cluster_rpc_commit tnx_id was not properly cleanup after 'cluster leave' on replicator nodes,
+The tnx_id of the core node will be deleted before, resulting in the failure of the core node update configuration.

--- a/changes/ce/fix-12843.en.md
+++ b/changes/ce/fix-12843.en.md
@@ -1,2 +1,2 @@
-Fixed cluster_rpc_commit tnx_id was not properly cleanup after 'cluster leave' on replicator nodes,
+Fixed cluster_rpc_commit tnx_id was not properly cleanup after 'cluster leave' on replicant nodes,
 The tnx_id of the core node will be deleted before, resulting in the failure of the core node update configuration.


### PR DESCRIPTION
Fixed an issue where `cluster_rpc_commit` tnx_id was not properly cleaned up on replicator nodes after using the 'cluster leave' command.

### Reproduce the issue:
1. Deploy an EMQX core node and replication node in a cluster.
2. Use the 'emqx ctl cluster leave' command on the replicator node to remove it from the cluster.
3. Attempt to update configuration via dashboard on the core node.

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
