### PR TITLE
ci: add selenium test for emqx docs link in dashboard

### DIFF
--- a/.github/workflows/run_docker_tests.yaml
+++ b/.github/workflows/run_docker_tests.yaml
@@ -47,6 +47,9 @@ jobs:
           echo "_EMQX_DOCKER_IMAGE_TAG=$_EMQX_DOCKER_IMAGE_TAG" >> $GITHUB_ENV
       - name: dashboard tests
         working-directory: ./scripts/ui-tests
+        env:
+          EMQX_VERSION: ${{ inputs.version-emqx }}
+          EMQX_ENTERPRISE_VERSION: ${{ inputs.version-emqx-enterprise }}
         run: |
           set -eu
           docker compose up --abort-on-container-exit --exit-code-from selenium

--- a/scripts/ui-tests/dashboard_test.py
+++ b/scripts/ui-tests/dashboard_test.py
@@ -1,3 +1,4 @@
+import os
 import time
 import unittest
 import pytest
@@ -73,3 +74,25 @@ def test_log(driver, login, dashboard_url):
     label = driver.find_element(By.XPATH, "//div[@id='app']//form//label[contains(., 'Time Offset')]")
     assert driver.find_elements(By.ID, label.get_attribute("for"))
 
+def test_docs_link(driver, login, dashboard_url):
+    dest_url = urljoin(dashboard_url, "/#/dashboard/overview")
+    driver.get(dest_url)
+    ensure_current_url(driver, dest_url)
+    xpath_link_help = "//div[@id='app']//div[@class='nav-header']//a[contains(@class, 'link-help')]"
+    link_help = driver.find_element(By.XPATH, xpath_link_help)
+    driver.execute_script("arguments[0].click();", link_help)
+
+    emqx_name = os.getenv("EMQX_NAME")
+    emqx_community_version = os.getenv("EMQX_COMMUNITY_VERSION")
+    emqx_enterprise_version = os.getenv("EMQX_ENTERPRISE_VERSION")
+    if emqx_name == 'emqx-enterprise':
+        emqx_version = f"v{emqx_enterprise_version}"
+        docs_base_url = "https://docs.emqx.com/en/enterprise"
+    else:
+        emqx_version = f"v{emqx_community_version}"
+        docs_base_url = "https://www.emqx.io/docs/en"
+    
+    emqx_version = ".".join(emqx_version.split(".")[:2])
+    docs_url = f"{docs_base_url}/{emqx_version}"
+    xpath = f"//div[@id='app']//div[@class='nav-header']//a[@href[starts-with(.,'{docs_url}')]]"
+    assert driver.find_element(By.XPATH, xpath)

--- a/scripts/ui-tests/docker-compose.yaml
+++ b/scripts/ui-tests/docker-compose.yaml
@@ -9,6 +9,10 @@ services:
   selenium:
     shm_size: '2gb'
     image: ghcr.io/emqx/selenium-chrome:latest
+    environment:
+      EMQX_NAME: ${EMQX_NAME}
+      EMQX_COMMUNITY_VERSION: ${EMQX_VERSION}
+      EMQX_ENTERPRISE_VERSION: ${EMQX_ENTERPRISE_VERSION}
     volumes:
       - ./:/app
     depends_on:


### PR DESCRIPTION
Fixes an issue when link to documentation in dashboard may not be up to date.

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
