### PR TITLE
0412 use variform for client_attrs

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -251,7 +251,7 @@ init(
             MP -> MP
         end,
     ListenerId = emqx_listeners:listener_id(Type, Listener),
-    ClientInfo0 = set_peercert_infos(
+    ClientInfo = set_peercert_infos(
         Peercert,
         #{
             zone => Zone,
@@ -269,7 +269,6 @@ init(
         },
         Zone
     ),
-    ClientInfo = initialize_client_attrs_from_cert(ClientInfo0, Peercert),
     {NClientInfo, NConnInfo} = take_ws_cookie(ClientInfo, ConnInfo),
     #channel{
         conninfo = NConnInfo,
@@ -1586,60 +1585,6 @@ enrich_client(ConnPkt, Channel = #channel{clientinfo = ClientInfo}) ->
             {error, ReasonCode, Channel#channel{clientinfo = NClientInfo}}
     end.
 
-initialize_client_attrs_from_cert(#{zone := Zone} = ClientInfo, Peercert) ->
-    Inits = get_client_attrs_init_config(Zone),
-    lists:foldl(
-        fun(Init, Acc) ->
-            do_initialize_client_attrs_from_cert(Init, Acc, Peercert)
-        end,
-        ClientInfo,
-        Inits
-    ).
-
-do_initialize_client_attrs_from_cert(
-    #{
-        extract_from := From,
-        extract_regexp := Regexp,
-        extract_as := AttrName
-    },
-    ClientInfo,
-    Peercert
-) when From =:= cn orelse From =:= dn ->
-    Attrs0 = maps:get(client_attrs, ClientInfo, #{}),
-    Attrs =
-        case extract_client_attr_from_cert(From, Regexp, Peercert) of
-            {ok, Value} ->
-                ?SLOG(
-                    debug,
-                    #{
-                        msg => "client_attr_init_from_cert",
-                        extracted_as => AttrName,
-                        extracted_value => Value
-                    }
-                ),
-                Attrs0#{AttrName => Value};
-            _ ->
-                Attrs0
-        end,
-    ClientInfo#{client_attrs => Attrs};
-do_initialize_client_attrs_from_cert(_, ClientInfo, _Peercert) ->
-    ClientInfo.
-
-extract_client_attr_from_cert(cn, Regexp, Peercert) ->
-    CN = esockd_peercert:common_name(Peercert),
-    re_extract(CN, Regexp);
-extract_client_attr_from_cert(dn, Regexp, Peercert) ->
-    DN = esockd_peercert:subject(Peercert),
-    re_extract(DN, Regexp).
-
-re_extract(Str, Regexp) when is_binary(Str) ->
-    case re:run(Str, Regexp, [{capture, all_but_first, list}]) of
-        {match, [_ | _] = List} -> {ok, iolist_to_binary(List)};
-        _ -> nomatch
-    end;
-re_extract(_NotStr, _Regexp) ->
-    ignored.
-
 set_username(
     #mqtt_packet_connect{username = Username},
     ClientInfo = #{username := undefined}
@@ -1681,33 +1626,36 @@ maybe_assign_clientid(#mqtt_packet_connect{clientid = ClientId}, ClientInfo) ->
     {ok, ClientInfo#{clientid => ClientId}}.
 
 get_client_attrs_init_config(Zone) ->
-    case get_mqtt_conf(Zone, client_attrs_init, []) of
-        L when is_list(L) -> L;
-        M when is_map(M) -> [M]
-    end.
+    get_mqtt_conf(Zone, client_attrs_init, []).
 
-maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo0) ->
+maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
     Inits = get_client_attrs_init_config(Zone),
-    ClientInfo = initialize_client_attrs_from_user_property(Inits, ConnPkt, ClientInfo0),
-    {ok, initialize_client_attrs_from_clientinfo(Inits, ClientInfo)}.
+    UserProperty = get_user_property_as_map(ConnPkt),
+    {ok, initialize_client_attrs(Inits, ClientInfo#{user_property => UserProperty})}.
 
-initialize_client_attrs_from_clientinfo(Inits, ClientInfo) ->
+initialize_client_attrs(Inits, ClientInfo) ->
     lists:foldl(
-        fun(Init, Acc) ->
+        fun(#{expression := Variform, set_as_attr := Name}, Acc) ->
             Attrs = maps:get(client_attrs, ClientInfo, #{}),
-            case extract_attr_from_clientinfo(Init, ClientInfo) of
+            case emqx_variform:render(Variform, ClientInfo) of
                 {ok, Value} ->
-                    #{extract_as := Name} = Init,
                     ?SLOG(
                         debug,
                         #{
-                            msg => "client_attr_init_from_clientinfo",
-                            extracted_as => Name,
-                            extracted_value => Value
+                            msg => "client_attr_initialized",
+                            set_as_attr => Name,
+                            attr_value => Value
                         }
                     ),
                     Acc#{client_attrs => Attrs#{Name => Value}};
-                _ ->
+                {error, Reason} ->
+                    ?SLOG(
+                        warning,
+                        #{
+                            msg => "client_attr_initialization_failed",
+                            reason => Reason
+                        }
+                    ),
                     Acc
             end
         end,
@@ -1715,67 +1663,12 @@ initialize_client_attrs_from_clientinfo(Inits, ClientInfo) ->
         Inits
     ).
 
-initialize_client_attrs_from_user_property(Inits, ConnPkt, ClientInfo) ->
-    lists:foldl(
-        fun(Init, Acc) ->
-            do_initialize_client_attrs_from_user_property(Init, ConnPkt, Acc)
-        end,
-        ClientInfo,
-        Inits
-    ).
-
-do_initialize_client_attrs_from_user_property(
-    #{
-        extract_from := user_property,
-        extract_as := PropertyKey
-    },
-    ConnPkt,
-    ClientInfo
-) ->
-    Attrs0 = maps:get(client_attrs, ClientInfo, #{}),
-    Attrs =
-        case extract_client_attr_from_user_property(ConnPkt, PropertyKey) of
-            {ok, Value} ->
-                ?SLOG(
-                    debug,
-                    #{
-                        msg => "client_attr_init_from_user_property",
-                        extracted_as => PropertyKey,
-                        extracted_value => Value
-                    }
-                ),
-                Attrs0#{PropertyKey => Value};
-            _ ->
-                Attrs0
-        end,
-    ClientInfo#{client_attrs => Attrs};
-do_initialize_client_attrs_from_user_property(_, _ConnPkt, ClientInfo) ->
-    ClientInfo.
-
-extract_client_attr_from_user_property(
-    #mqtt_packet_connect{properties = #{'User-Property' := UserProperty}}, PropertyKey
-) ->
-    case lists:keyfind(PropertyKey, 1, UserProperty) of
-        {_, Value} ->
-            {ok, Value};
-        _ ->
-            not_found
-    end;
-extract_client_attr_from_user_property(_ConnPkt, _PropertyKey) ->
-    ignored.
-
-extract_attr_from_clientinfo(#{extract_from := clientid, extract_regexp := Regexp}, #{
-    clientid := ClientId
-}) ->
-    re_extract(ClientId, Regexp);
-extract_attr_from_clientinfo(#{extract_from := username, extract_regexp := Regexp}, #{
-    username := Username
-}) when
-    Username =/= undefined
+get_user_property_as_map(#mqtt_packet_connect{properties = #{'User-Property' := UserProperty}}) when
+    is_list(UserProperty)
 ->
-    re_extract(Username, Regexp);
-extract_attr_from_clientinfo(_Config, _CLientInfo) ->
-    ignored.
+    maps:from_list(UserProperty);
+get_user_property_as_map(_) ->
+    #{}.
 
 fix_mountpoint(#{mountpoint := undefined} = ClientInfo) ->
     ClientInfo;

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3552,9 +3552,9 @@ mqtt_general() ->
             )},
         {"client_attrs_init",
             sc(
-                hoconsc:union([disabled, ref("client_attrs_init")]),
+                hoconsc:union([hoconsc:array(ref("client_attrs_init")), ref("client_attrs_init")]),
                 #{
-                    default => disabled,
+                    default => [],
                     desc => ?DESC("client_attrs_init")
                 }
             )}

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1734,19 +1734,37 @@ fields(durable_storage) ->
     emqx_ds_schema:schema();
 fields("client_attrs_init") ->
     [
-        {extract_from,
+        {expression,
             sc(
-                hoconsc:enum([clientid, username, cn, dn, user_property]),
-                #{desc => ?DESC("client_attrs_init_extract_from")}
+                typerefl:alias("string", any()),
+                #{
+                    desc => ?DESC("client_attrs_init_expression"),
+                    converter => fun compile_variform/2
+                }
             )},
-        {extract_regexp, sc(binary(), #{desc => ?DESC("client_attrs_init_extract_regexp")})},
-        {extract_as,
+        {set_as_attr,
             sc(binary(), #{
-                default => <<"alias">>,
-                desc => ?DESC("client_attrs_init_extract_as"),
+                desc => ?DESC("client_attrs_init_set_as_attr"),
                 validator => fun restricted_string/1
             })}
     ].
+
+compile_variform(undefined, _Opts) ->
+    undefined;
+compile_variform(Expression, #{make_serializable := true}) ->
+    case is_binary(Expression) of
+        true ->
+            Expression;
+        false ->
+            emqx_variform:decompile(Expression)
+    end;
+compile_variform(Expression, _Opts) ->
+    case emqx_variform:compile(Expression) of
+        {ok, Compiled} ->
+            Compiled;
+        {error, Reason} ->
+            throw(#{expression => Expression, reason => Reason})
+    end.
 
 restricted_string(Str) ->
     case emqx_utils:is_restricted_str(Str) of
@@ -3552,7 +3570,7 @@ mqtt_general() ->
             )},
         {"client_attrs_init",
             sc(
-                hoconsc:union([hoconsc:array(ref("client_attrs_init")), ref("client_attrs_init")]),
+                hoconsc:array(ref("client_attrs_init")),
                 #{
                     default => [],
                     desc => ?DESC("client_attrs_init")

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -454,7 +454,7 @@ zone_global_defaults() ->
                 upgrade_qos => false,
                 use_username_as_clientid => false,
                 wildcard_subscription => true,
-                client_attrs_init => disabled
+                client_attrs_init => []
             },
         overload_protection =>
             #{

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -170,7 +170,7 @@ t_client_attr_as_mountpoint(_Config) ->
         ?assertMatch([_], emqx_router:match_routes(MatchTopic)),
         emqtt:stop(Client)
     end),
-    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], disabled),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], []),
     ok.
 
 t_current_conns_tcp(_Config) ->

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -150,11 +150,13 @@ t_client_attr_as_mountpoint(_Config) ->
         <<"limiter">> => #{},
         <<"mountpoint">> => <<"groups/${client_attrs.ns}/">>
     },
-    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], #{
-        extract_from => clientid,
-        extract_regexp => <<"^(.+)-.+$">>,
-        extract_as => <<"ns">>
-    }),
+    {ok, Compiled} = emqx_variform:compile("nth(1,tokens(clientid,'-'))"),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], [
+        #{
+            expression => Compiled,
+            set_as_attr => <<"ns">>
+        }
+    ]),
     emqx_logger:set_log_level(debug),
     with_listener(tcp, attr_as_moutpoint, ListenerConf, fun() ->
         {ok, Client} = emqtt:start_link(#{

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -557,12 +557,14 @@ t_publish_last_will_testament_denied_topic(_Config) ->
 
 t_alias_prefix(_Config) ->
     {ok, _} = emqx_authz:update(?CMD_REPLACE, [?SOURCE_FILE_CLIENT_ATTR]),
-    ExtractSuffix = <<"^.*-(.*)$">>,
-    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], #{
-        extract_from => clientid,
-        extract_regexp => ExtractSuffix,
-        extract_as => <<"alias">>
-    }),
+    %% '^.*-(.*)$': extract the suffix after the last '-'
+    {ok, Compiled} = emqx_variform:compile("concat(regex_extract(clientid,'^.*-(.*)$'))"),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], [
+        #{
+            expression => Compiled,
+            set_as_attr => <<"alias">>
+        }
+    ]),
     ClientId = <<"org1-name2">>,
     SubTopic = <<"name2/#">>,
     SubTopicNotAllowed = <<"name3/#">>,

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -572,7 +572,7 @@ t_alias_prefix(_Config) ->
     ?assertMatch({ok, _, [?RC_NOT_AUTHORIZED]}, emqtt:subscribe(C, SubTopicNotAllowed)),
     unlink(C),
     emqtt:stop(C),
-    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], disalbed),
+    emqx_config:put_zone_conf(default, [mqtt, client_attrs_init], []),
     ok.
 
 %% client is allowed by ACL to publish to its LWT topic, is connected,

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -661,7 +661,7 @@ trans_desc(Init, Hocon, Func, Name, Options) ->
             Spec1 = trans_label(Spec0, Hocon, Name, Options),
             case Spec1 of
                 #{description := _} -> Spec1;
-                _ -> Spec1#{description => <<Name/binary, " Description">>}
+                _ -> Spec1
             end
     end.
 

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -202,7 +202,8 @@
 -export([
     md5/1,
     sha/1,
-    sha256/1
+    sha256/1,
+    hash/2
 ]).
 
 %% zip Funcs
@@ -710,24 +711,11 @@ map(Map = #{}) ->
 map(Data) ->
     error(badarg, [Data]).
 
-bin2hexstr(Bin) when is_binary(Bin) ->
-    emqx_utils:bin_to_hexstr(Bin, upper);
-%% If Bin is a bitstring which is not divisible by 8, we pad it and then do the
-%% conversion
-bin2hexstr(Bin) when is_bitstring(Bin), (8 - (bit_size(Bin) rem 8)) >= 4 ->
-    PadSize = 8 - (bit_size(Bin) rem 8),
-    Padding = <<0:PadSize>>,
-    BinToConvert = <<Padding/bitstring, Bin/bitstring>>,
-    <<_FirstByte:8, HexStr/binary>> = emqx_utils:bin_to_hexstr(BinToConvert, upper),
-    HexStr;
-bin2hexstr(Bin) when is_bitstring(Bin) ->
-    PadSize = 8 - (bit_size(Bin) rem 8),
-    Padding = <<0:PadSize>>,
-    BinToConvert = <<Padding/bitstring, Bin/bitstring>>,
-    emqx_utils:bin_to_hexstr(BinToConvert, upper).
+bin2hexstr(Bin) ->
+    emqx_variform_bif:bin2hexstr(Bin).
 
-hexstr2bin(Str) when is_binary(Str) ->
-    emqx_utils:hexstr_to_bin(Str).
+hexstr2bin(Str) ->
+    emqx_variform_bif:hexstr2bin(Str).
 
 %%------------------------------------------------------------------------------
 %% NULL Funcs
@@ -1001,7 +989,7 @@ sha256(S) when is_binary(S) ->
     hash(sha256, S).
 
 hash(Type, Data) ->
-    emqx_utils:bin_to_hexstr(crypto:hash(Type, Data), lower).
+    emqx_variform_bif:hash(Type, Data).
 
 %%------------------------------------------------------------------------------
 %% gzip Funcs

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -771,66 +771,66 @@ is_array(_) -> false.
 %% String Funcs
 %%------------------------------------------------------------------------------
 
-coalesce(List) -> emqx_variform_str:coalesce(List).
+coalesce(List) -> emqx_variform_bif:coalesce(List).
 
-coalesce(A, B) -> emqx_variform_str:coalesce(A, B).
+coalesce(A, B) -> emqx_variform_bif:coalesce(A, B).
 
-lower(S) -> emqx_variform_str:lower(S).
+lower(S) -> emqx_variform_bif:lower(S).
 
-ltrim(S) -> emqx_variform_str:ltrim(S).
+ltrim(S) -> emqx_variform_bif:ltrim(S).
 
-reverse(S) -> emqx_variform_str:reverse(S).
+reverse(S) -> emqx_variform_bif:reverse(S).
 
-rtrim(S) -> emqx_variform_str:rtrim(S).
+rtrim(S) -> emqx_variform_bif:rtrim(S).
 
-strlen(S) -> emqx_variform_str:strlen(S).
+strlen(S) -> emqx_variform_bif:strlen(S).
 
-substr(S, Start) -> emqx_variform_str:substr(S, Start).
+substr(S, Start) -> emqx_variform_bif:substr(S, Start).
 
-substr(S, Start, Length) -> emqx_variform_str:substr(S, Start, Length).
+substr(S, Start, Length) -> emqx_variform_bif:substr(S, Start, Length).
 
-trim(S) -> emqx_variform_str:trim(S).
+trim(S) -> emqx_variform_bif:trim(S).
 
-upper(S) -> emqx_variform_str:upper(S).
+upper(S) -> emqx_variform_bif:upper(S).
 
-split(S, P) -> emqx_variform_str:split(S, P).
+split(S, P) -> emqx_variform_bif:split(S, P).
 
-split(S, P, Position) -> emqx_variform_str:split(S, P, Position).
+split(S, P, Position) -> emqx_variform_bif:split(S, P, Position).
 
-tokens(S, Separators) -> emqx_variform_str:tokens(S, Separators).
+tokens(S, Separators) -> emqx_variform_bif:tokens(S, Separators).
 
-tokens(S, Separators, NoCRLF) -> emqx_variform_str:tokens(S, Separators, NoCRLF).
+tokens(S, Separators, NoCRLF) -> emqx_variform_bif:tokens(S, Separators, NoCRLF).
 
-concat(S1, S2) -> emqx_variform_str:concat(S1, S2).
+concat(S1, S2) -> emqx_variform_bif:concat(S1, S2).
 
-concat(List) -> emqx_variform_str:concat(List).
+concat(List) -> emqx_variform_bif:concat(List).
 
-sprintf_s(Format, Args) -> emqx_variform_str:sprintf_s(Format, Args).
+sprintf_s(Format, Args) -> emqx_variform_bif:sprintf_s(Format, Args).
 
-pad(S, Len) -> emqx_variform_str:pad(S, Len).
+pad(S, Len) -> emqx_variform_bif:pad(S, Len).
 
-pad(S, Len, Position) -> emqx_variform_str:pad(S, Len, Position).
+pad(S, Len, Position) -> emqx_variform_bif:pad(S, Len, Position).
 
-pad(S, Len, Position, Char) -> emqx_variform_str:pad(S, Len, Position, Char).
+pad(S, Len, Position, Char) -> emqx_variform_bif:pad(S, Len, Position, Char).
 
-replace(SrcStr, Pattern, RepStr) -> emqx_variform_str:replace(SrcStr, Pattern, RepStr).
+replace(SrcStr, Pattern, RepStr) -> emqx_variform_bif:replace(SrcStr, Pattern, RepStr).
 
 replace(SrcStr, Pattern, RepStr, Position) ->
-    emqx_variform_str:replace(SrcStr, Pattern, RepStr, Position).
+    emqx_variform_bif:replace(SrcStr, Pattern, RepStr, Position).
 
-regex_match(Str, RE) -> emqx_variform_str:regex_match(Str, RE).
+regex_match(Str, RE) -> emqx_variform_bif:regex_match(Str, RE).
 
-regex_replace(SrcStr, RE, RepStr) -> emqx_variform_str:regex_replace(SrcStr, RE, RepStr).
+regex_replace(SrcStr, RE, RepStr) -> emqx_variform_bif:regex_replace(SrcStr, RE, RepStr).
 
-ascii(Char) -> emqx_variform_str:ascii(Char).
+ascii(Char) -> emqx_variform_bif:ascii(Char).
 
-find(S, P) -> emqx_variform_str:find(S, P).
+find(S, P) -> emqx_variform_bif:find(S, P).
 
-find(S, P, Position) -> emqx_variform_str:find(S, P, Position).
+find(S, P, Position) -> emqx_variform_bif:find(S, P, Position).
 
-join_to_string(Str) -> emqx_variform_str:join_to_string(Str).
+join_to_string(Str) -> emqx_variform_bif:join_to_string(Str).
 
-join_to_string(Sep, List) -> emqx_variform_str:join_to_string(Sep, List).
+join_to_string(Sep, List) -> emqx_variform_bif:join_to_string(Sep, List).
 
 join_to_sql_values_string(List) ->
     QuotedList =
@@ -878,7 +878,7 @@ jq(FilterProgram, JSONBin) ->
         ])
     ).
 
-unescape(Str) -> emqx_variform_str:unescape(Str).
+unescape(Str) -> emqx_variform_bif:unescape(Str).
 
 %%------------------------------------------------------------------------------
 %% Array Funcs

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -61,6 +61,21 @@
 %% Control functions
 -export([coalesce/1, coalesce/2]).
 
+%% Random functions
+-export([rand_str/1, rand_int/1]).
+
+%% Schema-less encod/decode
+-export([
+    bin2hexstr/1,
+    hexstr2bin/1,
+    int2hexstr/1,
+    base64_encode/1,
+    base64_decode/1
+]).
+
+%% Hash functions
+-export([hash/2, hash_to_range/3, map_to_range/3]).
+
 -define(IS_EMPTY(X), (X =:= <<>> orelse X =:= "" orelse X =:= undefined)).
 
 %%------------------------------------------------------------------------------
@@ -389,3 +404,122 @@ is_hex_digit(_) -> false.
 
 any_to_str(Data) ->
     emqx_utils_conv:bin(Data).
+
+%%------------------------------------------------------------------------------
+%% Random functions
+%%------------------------------------------------------------------------------
+
+%% @doc Make a random string with urlsafe-base64 charset.
+rand_str(Length) when is_integer(Length) andalso Length > 0 ->
+    RawBytes = erlang:ceil((Length * 3) / 4),
+    RandomData = rand:bytes(RawBytes),
+    urlsafe(binary:part(base64_encode(RandomData), 0, Length));
+rand_str(_) ->
+    throw(#{reason => badarg, function => ?FUNCTION_NAME}).
+
+%% @doc Make a random integer in the range `[1, N]`.
+rand_int(N) when is_integer(N) andalso N >= 1 ->
+    rand:uniform(N);
+rand_int(N) ->
+    throw(#{reason => badarg, function => ?FUNCTION_NAME, expected => "positive integer", got => N}).
+
+%% TODO: call base64:encode(Bin, #{mode => urlsafe, padding => false})
+%% when oldest OTP to support is 26 or newer.
+urlsafe(Str0) ->
+    Str = replace(Str0, <<"+">>, <<"-">>),
+    replace(Str, <<"/">>, <<"_">>).
+
+%%------------------------------------------------------------------------------
+%% Data encoding
+%%------------------------------------------------------------------------------
+
+%% @doc Encode an integer to hex string. e.g. 15 as 'f'
+int2hexstr(Int) ->
+    erlang:integer_to_binary(Int, 16).
+
+%% @doc Encode bytes in hex string format.
+bin2hexstr(Bin) when is_binary(Bin) ->
+    emqx_utils:bin_to_hexstr(Bin, upper);
+%% If Bin is a bitstring which is not divisible by 8, we pad it and then do the
+%% conversion
+bin2hexstr(Bin) when is_bitstring(Bin), (8 - (bit_size(Bin) rem 8)) >= 4 ->
+    PadSize = 8 - (bit_size(Bin) rem 8),
+    Padding = <<0:PadSize>>,
+    BinToConvert = <<Padding/bitstring, Bin/bitstring>>,
+    <<_FirstByte:8, HexStr/binary>> = emqx_utils:bin_to_hexstr(BinToConvert, upper),
+    HexStr;
+bin2hexstr(Bin) when is_bitstring(Bin) ->
+    PadSize = 8 - (bit_size(Bin) rem 8),
+    Padding = <<0:PadSize>>,
+    BinToConvert = <<Padding/bitstring, Bin/bitstring>>,
+    emqx_utils:bin_to_hexstr(BinToConvert, upper).
+
+%% @doc Decode hex string into its original bytes.
+hexstr2bin(Str) when is_binary(Str) ->
+    emqx_utils:hexstr_to_bin(Str).
+
+%% @doc Encode any bytes to base64.
+base64_encode(Bin) ->
+    base64:encode(Bin).
+
+%% @doc Decode base64 encoded string.
+base64_decode(Bin) ->
+    base64:decode(Bin).
+
+%%------------------------------------------------------------------------------
+%% Hash functions
+%%------------------------------------------------------------------------------
+
+%% @doc Hash with all available algorithm provided by crypto module.
+%% Return hex format string.
+%% - md4 | md5
+%% - sha (sha1)
+%% - sha224 | sha256 | sha384 | sha512
+%% - sha3_224 | sha3_256 | sha3_384 | sha3_512
+%% - shake128 | shake256
+%% - blake2b | blake2s
+hash(<<"sha1">>, Bin) ->
+    hash(sha, Bin);
+hash(Algorithm, Bin) when is_binary(Algorithm) ->
+    Type =
+        try
+            binary_to_existing_atom(Algorithm)
+        catch
+            _:_ ->
+                throw(#{
+                    reason => unknown_hash_algorithm,
+                    algorithm => Algorithm
+                })
+        end,
+    hash(Type, Bin);
+hash(Type, Bin) when is_atom(Type) ->
+    %% lower is for backward compatibility
+    emqx_utils:bin_to_hexstr(crypto:hash(Type, Bin), lower).
+
+%% @doc Hash binary data to an integer within a specified range [Min, Max]
+hash_to_range(Bin, Min, Max) when
+    is_binary(Bin) andalso
+        size(Bin) > 0 andalso
+        is_integer(Min) andalso
+        is_integer(Max) andalso
+        Min =< Max
+->
+    Hash = hash(sha256, Bin),
+    HashNum = binary_to_integer(Hash, 16),
+    map_to_range(HashNum, Min, Max);
+hash_to_range(_, _, _) ->
+    throw(#{reason => badarg, function => ?FUNCTION_NAME}).
+
+map_to_range(Bin, Min, Max) when is_binary(Bin) andalso size(Bin) > 0 ->
+    HashNum = binary:decode_unsigned(Bin),
+    map_to_range(HashNum, Min, Max);
+map_to_range(Int, Min, Max) when
+    is_integer(Int) andalso
+        is_integer(Min) andalso
+        is_integer(Max) andalso
+        Min =< Max
+->
+    Range = Max - Min + 1,
+    Min + (Int rem Range);
+map_to_range(_, _, _) ->
+    throw(#{reason => badarg, function => ?FUNCTION_NAME}).

--- a/apps/emqx_utils/test/emqx_variform_bif_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_bif_tests.erl
@@ -1,0 +1,59 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% Most of the functions are tested as rule-engine string funcs
+-module(emqx_variform_bif_tests).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+
+regex_extract_test_() ->
+    [
+        ?_assertEqual([<<"12345">>], regex_extract("Order number: 12345", "(\\d+)")),
+        ?_assertEqual(
+            [<<"Hello">>, <<"world">>], regex_extract("Hello, world!", "(\\w+).*\s(\\w+)")
+        ),
+        ?_assertEqual([], regex_extract("No numbers here!", "(\\d+)")),
+        ?_assertEqual(
+            [<<"2021">>, <<"05">>, <<"20">>],
+            regex_extract("Date: 2021-05-20", "(\\d{4})-(\\d{2})-(\\d{2})")
+        ),
+        ?_assertEqual([<<"Hello">>], regex_extract("Hello, world!", "(Hello)")),
+        ?_assertEqual(
+            [<<"12">>, <<"34">>], regex_extract("Items: 12, Price: 34", "(\\d+).*\s(\\d+)")
+        ),
+        ?_assertEqual(
+            [<<"john.doe@example.com">>],
+            regex_extract("Contact: john.doe@example.com", "([\\w\\.]+@[\\w\\.]+)")
+        ),
+        ?_assertEqual([], regex_extract("Just some text, nothing more.", "([A-Z]\\d{3})")),
+        ?_assertEqual(
+            [<<"admin">>, <<"1234">>],
+            regex_extract("User: admin, Pass: 1234", "User: (\\w+), Pass: (\\d+)")
+        ),
+        ?_assertEqual([], regex_extract("", "(\\d+)")),
+        ?_assertEqual([], regex_extract("$$$###!!!", "(\\d+)")),
+        ?_assertEqual([<<"23.1">>], regex_extract("Erlang 23.1 version", "(\\d+\\.\\d+)")),
+        ?_assertEqual(
+            [<<"192.168.1.1">>],
+            regex_extract("Server IP: 192.168.1.1 at port 8080", "(\\d+\\.\\d+\\.\\d+\\.\\d+)")
+        )
+    ].
+
+regex_extract(Str, RegEx) ->
+    emqx_variform_bif:regex_extract(Str, RegEx).

--- a/apps/emqx_utils/test/emqx_variform_bif_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_bif_tests.erl
@@ -57,3 +57,18 @@ regex_extract_test_() ->
 
 regex_extract(Str, RegEx) ->
     emqx_variform_bif:regex_extract(Str, RegEx).
+
+rand_str_test() ->
+    ?assertEqual(3, size(emqx_variform_bif:rand_str(3))),
+    ?assertThrow(#{reason := badarg}, size(emqx_variform_bif:rand_str(0))).
+
+rand_int_test() ->
+    N = emqx_variform_bif:rand_int(10),
+    ?assert(N =< 10 andalso N >= 1),
+    ?assertThrow(#{reason := badarg}, emqx_variform_bif:rand_int(0)),
+    ?assertThrow(#{reason := badarg}, emqx_variform_bif:rand_int(-1)).
+
+base64_encode_decode_test() ->
+    RandBytes = crypto:strong_rand_bytes(100),
+    Encoded = emqx_variform_bif:base64_encode(RandBytes),
+    ?assertEqual(RandBytes, emqx_variform_bif:base64_decode(Encoded)).

--- a/apps/emqx_utils/test/emqx_variform_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_tests.erl
@@ -182,3 +182,39 @@ syntax_error_test_() ->
 
 render(Expression, Bindings) ->
     emqx_variform:render(Expression, Bindings).
+
+hash_pick_test() ->
+    lists:foreach(
+        fun(_) ->
+            {ok, Res} = render("nth(hash_to_range(rand_str(10),1,5),[1,2,3,4,5])", #{}),
+            ?assert(Res >= <<"1">> andalso Res =< <<"5">>)
+        end,
+        lists:seq(1, 100)
+    ).
+
+map_to_range_pick_test() ->
+    lists:foreach(
+        fun(_) ->
+            {ok, Res} = render("nth(map_to_range(rand_str(10),1,5),[1,2,3,4,5])", #{}),
+            ?assert(Res >= <<"1">> andalso Res =< <<"5">>)
+        end,
+        lists:seq(1, 100)
+    ).
+
+-define(ASSERT_BADARG(FUNC, ARGS),
+    ?_assertEqual(
+        {error, #{reason => badarg, function => FUNC}},
+        render(atom_to_list(FUNC) ++ ARGS, #{})
+    )
+).
+
+to_range_badarg_test_() ->
+    [
+        ?ASSERT_BADARG(hash_to_range, "(1,1,2)"),
+        ?ASSERT_BADARG(hash_to_range, "('',1,2)"),
+        ?ASSERT_BADARG(hash_to_range, "('a','1',2)"),
+        ?ASSERT_BADARG(hash_to_range, "('a',2,1)"),
+        ?ASSERT_BADARG(map_to_range, "('',1,2)"),
+        ?ASSERT_BADARG(map_to_range, "('a','1',2)"),
+        ?ASSERT_BADARG(map_to_range, "('a',2,1)")
+    ].

--- a/changes/ce/feat-12750.en.md
+++ b/changes/ce/feat-12750.en.md
@@ -7,7 +7,7 @@ an MQTT connection.
 
 ### Initialization of `client_attrs`
 
-- The `client_attrs` field can be initially populated based on the configuration from one of the
+- The `client_attrs` fields can be initially populated based on the configuration from one of the
   following sources:
   - `cn`: The common name from the TLS client's certificate.
   - `dn`: The distinguished name from the TLS client's certificate, that is, the certificate "Subject".

--- a/changes/ce/feat-12872.en.md
+++ b/changes/ce/feat-12872.en.md
@@ -7,8 +7,8 @@ an MQTT connection.
 
 ### Initialization of `client_attrs`
 
-- The `client_attrs` fields can be initially populated based on the configuration from one of the
-  following sources:
+- The `client_attrs` fields can be initially populated from one of the
+  following `clientinfo` fields:
   - `cn`: The common name from the TLS client's certificate.
   - `dn`: The distinguished name from the TLS client's certificate, that is, the certificate "Subject".
   - `clientid`: The MQTT client ID provided by the client.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1575,48 +1575,37 @@ client_attrs_init {
   label: "Client Attributes Initialization"
   desc: """~
     Specify how to initialize client attributes.
-    This config accepts one initialization rule, or a list of rules.
-    Client attributes can be initialized as `client_attrs.NAME`,
-    where `NAME` is the name of the attribute specified in the config `extract_as`.
+    Each client attribute can be initialized as `client_attrs.{NAME}`,
+    where `{NAME}` is the name of the attribute specified in the config field `set_as_attr`.
     The initialized client attribute will be stored in the `client_attrs` property with the specified name,
     and can be used as a placeholder in a template for authentication and authorization.
-    For example, use `${client_attrs.alias}` to render an HTTP POST body when `extract_as = alias`,
+    For example, use `${client_attrs.alias}` to render an HTTP POST body when `set_as_attr = alias`,
     or render listener config `moutpoint = devices/${client_attrs.alias}/` to initialize a per-client topic namespace."""
 }
 
-client_attrs_init_extract_from {
-  label: "Client Property to Extract Attribute"
-  desc: """~
-    Specify from which client property the client attribute should be extracted.
-
-    Supported values:
-    - `clientid`: Extract from the client ID.
-    - `username`: Extract from the username.
-    - `cn`: Extract from the Common Name (CN) field of the client certificate.
-    - `dn`: Extract from the Distinguished Name (DN) field of the client certificate.
-    - `user_property`: Extract from the user property sent in the MQTT v5 `CONNECT` packet.
-      In this case, `extract_regexp` is not applicable, and `extract_as` should be the user property key.
-
-    NOTE: this extraction happens **after** `clientid` or `username` is initialized
-    from `peer_cert_as_clientid` or `peer_cert_as_username` config."""
-}
-
-client_attrs_init_extract_regexp {
+client_attrs_init_expression {
   label: "Client Attribute Extraction Regular Expression"
   desc: """~
-    The regular expression to extract a client attribute from the client property specified by `client_attrs_init.extract_from` config.
-    The expression should match the entire client property value, and capturing groups are concatenated to make the client attribute.
-    For example if the client attribute is the first part of the client ID delimited by a dash, the regular expression would be `^(.+?)-.*$`.
-    Note that failure to match the regular expression will result in the client attribute being absent but not an empty string.
-    Note also that currently only printable ASCII characters are allowed as input for the regular expression extraction."""
+    A one line expression to evaluate a set of predefined string functions (like in the rule engine SQL statements).
+    The expression accepts direct variable reference, or one function call with nested calls for its arguments,
+    but it does not provide variable binding or user-defined functions and pre-bound variables.
+    For example, to extract the prefix of client ID delimited by a dot: `nth(1, tokens(clientid, '.'))`.
+
+    The variables pre-bound variables are:
+    - `cn`: Client's TLS certificate common name.
+    - `dn`: Client's TLS certificate distinguished name (the subject).
+    - `clientid`: MQTT Client ID.
+    - `username`: MQTT Client's username.
+    - `user_property.{NAME}`: User properties in the CONNECT packet.
+
+    You can read more about variform expressions in EMQX docs."""
 }
 
-client_attrs_init_extract_as {
+client_attrs_init_set_as_attr {
   label: "Name The Extracted Attribute"
   desc: """~
-    The name of the client attribute extracted from the client property specified by `client_attrs_init.extract_from` config.
-    The extracted attribute will be stored in the `client_attrs` property with this name.
-    In case `extract_from = user_property`, this should be the key of the user property."""
+    The name of the client attribute extracted from the client data.
+    The extracted attribute will be stored in the `client_attrs` property with this name."""
 }
 
 }

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1587,9 +1587,9 @@ client_attrs_init_expression {
   label: "Client Attribute Extraction Regular Expression"
   desc: """~
     A one line expression to evaluate a set of predefined string functions (like in the rule engine SQL statements).
-    The expression accepts direct variable reference, or one function call with nested calls for its arguments,
-    but it does not provide variable binding or user-defined functions and pre-bound variables.
-    For example, to extract the prefix of client ID delimited by a dot: `nth(1, tokens(clientid, '.'))`.
+    The expression can be a function call with nested calls as its arguments, or direct variable reference.
+    So far, it does not provide user-defined variable binding (like `var a=1`) or user-defined functions.
+    As an example, to extract the prefix of client ID delimited by a dot: `nth(1, tokens(clientid, '.'))`.
 
     The variables pre-bound variables are:
     - `cn`: Client's TLS certificate common name.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1575,7 +1575,8 @@ client_attrs_init {
   label: "Client Attributes Initialization"
   desc: """~
     Specify how to initialize client attributes.
-    One initial client attribute can be initialized as `client_attrs.NAME`,
+    This config accepts one initialization rule, or a list of rules.
+    Client attributes can be initialized as `client_attrs.NAME`,
     where `NAME` is the name of the attribute specified in the config `extract_as`.
     The initialized client attribute will be stored in the `client_attrs` property with the specified name,
     and can be used as a placeholder in a template for authentication and authorization.

--- a/scripts/spellcheck/dicts/emqx.txt
+++ b/scripts/spellcheck/dicts/emqx.txt
@@ -259,6 +259,7 @@ uplink
 url
 utc
 util
+variform
 ver
 vm
 vsn


### PR DESCRIPTION
Fixes [EMQX-11882](https://emqx.atlassian.net/browse/EMQX-11882)
This PR rewrites https://github.com/emqx/emqx/pull/12750 which is not released yet.

Release version: v/e5.7.0

## Summary

- Allow multiple `client_attrs` initial extractions
- Support using variform for `client_attrs` initial extraction
- Provide regexp based extraction as a variform function (so the config schema introduced in #12750 is rewritten)

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-11882]: https://emqx.atlassian.net/browse/EMQX-11882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ