### PR TITLE
API for durable subscriptions

### DIFF
--- a/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
@@ -252,7 +252,6 @@ t_session_subscription_idempotency(Config) ->
             ok
         end,
         fun(Trace) ->
-            ct:pal("trace:\n  ~p", [Trace]),
             Session = session_open(Node1, ClientId),
             ?assertMatch(
                 #{SubTopicFilter := #{}},
@@ -326,7 +325,6 @@ t_session_unsubscription_idempotency(Config) ->
             ok
         end,
         fun(Trace) ->
-            ct:pal("trace:\n  ~p", [Trace]),
             Session = session_open(Node1, ClientId),
             ?assertEqual(
                 #{},
@@ -415,10 +413,7 @@ do_t_session_discard(Params) ->
 
             ok
         end,
-        fun(Trace) ->
-            ct:pal("trace:\n  ~p", [Trace]),
-            ok
-        end
+        []
     ),
     ok.
 

--- a/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
@@ -184,7 +184,7 @@ list_all_pubranges(Node) ->
 
 session_open(Node, ClientId) ->
     ClientInfo = #{},
-    ConnInfo = #{peername => {undefined, undefined}},
+    ConnInfo = #{peername => {undefined, undefined}, proto_name => <<"MQTT">>, proto_ver => 5},
     WillMsg = undefined,
     erpc:call(
         Node,

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -75,7 +75,8 @@
 
 %% Managment APIs:
 -export([
-    list_client_subscriptions/1
+    list_client_subscriptions/1,
+    get_client_subscription/2
 ]).
 
 %% session table operations
@@ -735,6 +736,11 @@ list_client_subscriptions(ClientId) ->
         false ->
             {error, not_found}
     end.
+
+-spec get_client_subscription(emqx_types:clientid(), emqx_types:topic()) ->
+    subscription() | undefined.
+get_client_subscription(ClientId, Topic) ->
+    emqx_persistent_session_ds_subs:cold_get_subscription(ClientId, Topic).
 
 %%--------------------------------------------------------------------
 %% Session tables operations

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -367,10 +367,10 @@ subscribe(
 subscribe(
     TopicFilter,
     SubOpts,
-    Session = #{id := ID, s := S0, props := #{upgrade_qos := UpgradeQoS}}
+    Session = #{id := ID}
 ) ->
     {UpdateRouter, S1} = emqx_persistent_session_ds_subs:on_subscribe(
-        TopicFilter, UpgradeQoS, SubOpts, S0
+        TopicFilter, SubOpts, Session
     ),
     case UpdateRouter of
         true ->
@@ -379,9 +379,8 @@ subscribe(
             ok
     end,
     S = emqx_persistent_session_ds_state:commit(S1),
-    ?tp(persistent_session_ds_subscription_added, #{
-        topic_filter => TopicFilter, is_new => UpdateRouter
-    }),
+    UpdateRouter andalso
+        ?tp(persistent_session_ds_subscription_added, #{topic_filter => TopicFilter, session => ID}),
     {ok, Session#{s => S}}.
 
 -spec unsubscribe(topic_filter(), session()) ->

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -394,7 +394,8 @@ unsubscribe(
         undefined ->
             {error, ?RC_NO_SUBSCRIPTION_EXISTED};
         Subscription = #{subopts := SubOpts} ->
-            S = do_unsubscribe(ID, TopicFilter, Subscription, S0),
+            S1 = do_unsubscribe(ID, TopicFilter, Subscription, S0),
+            S = emqx_persistent_session_ds_state:commit(S1),
             {ok, Session#{s => S}, SubOpts}
     end.
 

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -786,7 +786,7 @@ session_open(SessionId, ClientInfo, NewConnInfo, MaybeWillMsg) ->
                         maps:get(peername, NewConnInfo), S2
                     ),
                     S4 = emqx_persistent_session_ds_state:set_will_message(MaybeWillMsg, S3),
-                    S5 = emqx_persistent_session_ds_state:set_clientinfo(ClientInfo, S4),
+                    S5 = set_clientinfo(ClientInfo, S4),
                     S = emqx_persistent_session_ds_state:commit(S5),
                     Inflight = emqx_persistent_session_ds_inflight:new(
                         receive_maximum(NewConnInfo)
@@ -833,7 +833,7 @@ session_ensure_new(Id, ClientInfo, ConnInfo, MaybeWillMsg, Conf) ->
         ]
     ),
     S5 = emqx_persistent_session_ds_state:set_will_message(MaybeWillMsg, S4),
-    S6 = emqx_persistent_session_ds_state:set_clientinfo(ClientInfo, S5),
+    S6 = set_clientinfo(ClientInfo, S5),
     S = emqx_persistent_session_ds_state:commit(S6),
     #{
         id => Id,
@@ -863,6 +863,11 @@ session_drop(ID, Reason) ->
 
 now_ms() ->
     erlang:system_time(millisecond).
+
+set_clientinfo(ClientInfo0, S) ->
+    %% Remove unnecessary fields from the clientinfo:
+    ClientInfo = maps:without([cn, dn, auth_result], ClientInfo0),
+    emqx_persistent_session_ds_state:set_clientinfo(ClientInfo, S).
 
 %%--------------------------------------------------------------------
 %% RPC targets (v1)

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -338,6 +338,13 @@ print_session(ClientId) ->
 -spec subscribe(topic_filter(), emqx_types:subopts(), session()) ->
     {ok, session()} | {error, emqx_types:reason_code()}.
 subscribe(
+    #share{},
+    _SubOpts,
+    _Session
+) ->
+    %% TODO: Shared subscriptions are not supported yet:
+    {error, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED};
+subscribe(
     TopicFilter,
     SubOpts,
     Session = #{id := ID, s := S0}
@@ -421,6 +428,9 @@ do_unsubscribe(SessionId, TopicFilter, Subscription = #{id := SubId}, S0) ->
 
 -spec get_subscription(topic_filter(), session()) ->
     emqx_types:subopts() | undefined.
+get_subscription(#share{}, _) ->
+    %% TODO: shared subscriptions are not supported yet:
+    undefined;
 get_subscription(TopicFilter, #{s := S}) ->
     case emqx_persistent_session_ds_subs:lookup(TopicFilter, S) of
         _Subscription = #{props := SubOpts} ->

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -74,10 +74,12 @@
 -define(created_at, created_at).
 -define(last_alive_at, last_alive_at).
 -define(expiry_interval, expiry_interval).
-%% Unique integer used to create unique identities
+%% Unique integer used to create unique identities:
 -define(last_id, last_id).
+%% Connection info (relevent for the dashboard):
 -define(peername, peername).
 -define(will_message, will_message).
 -define(clientinfo, clientinfo).
+-define(protocol, protocol).
 
 -endif.

--- a/apps/emqx/src/emqx_persistent_session_ds.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds.hrl
@@ -65,7 +65,9 @@
     last_seqno_qos2 = 0 :: emqx_persistent_session_ds:seqno(),
     %% This stream belongs to an unsubscribed topic-filter, and is
     %% marked for deletion:
-    unsubscribed = false :: boolean()
+    unsubscribed = false :: boolean(),
+    %% Reference to the subscription state:
+    sub_state_id :: emqx_persistent_session_ds_subs:subscription_state_id()
 }).
 
 %% Session metadata keys:

--- a/apps/emqx/src/emqx_persistent_session_ds_state.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_state.erl
@@ -33,6 +33,7 @@
 -export([get_clientinfo/1, set_clientinfo/2]).
 -export([get_will_message/1, set_will_message/2, clear_will_message/1, clear_will_message_now/1]).
 -export([get_peername/1, set_peername/2]).
+-export([get_protocol/1, set_protocol/2]).
 -export([new_id/1]).
 -export([get_stream/2, put_stream/3, del_stream/2, fold_streams/3, n_streams/1]).
 -export([get_seqno/2, put_seqno/3]).
@@ -66,7 +67,8 @@
     seqno_type/0,
     stream_key/0,
     rank_key/0,
-    session_iterator/0
+    session_iterator/0,
+    protocol/0
 ]).
 
 -include("emqx_mqtt.hrl").
@@ -108,13 +110,16 @@
         dirty :: #{K => dirty | del}
     }.
 
+-type protocol() :: {binary(), emqx_types:proto_ver()}.
+
 -type metadata() ::
     #{
         ?created_at => emqx_persistent_session_ds:timestamp(),
         ?last_alive_at => emqx_persistent_session_ds:timestamp(),
         ?expiry_interval => non_neg_integer(),
         ?last_id => integer(),
-        ?peername => emqx_types:peername()
+        ?peername => emqx_types:peername(),
+        ?protocol => protocol()
     }.
 
 -type seqno_type() ::
@@ -320,6 +325,14 @@ get_peername(Rec) ->
 -spec set_peername(emqx_types:peername(), t()) -> t().
 set_peername(Val, Rec) ->
     set_meta(?peername, Val, Rec).
+
+-spec get_protocol(t()) -> protocol() | undefined.
+get_protocol(Rec) ->
+    get_meta(?protocol, Rec).
+
+-spec set_protocol(protocol(), t()) -> t().
+set_protocol(Val, Rec) ->
+    set_meta(?protocol, Val, Rec).
 
 -spec get_clientinfo(t()) -> emqx_maybe:t(emqx_types:clientinfo()).
 get_clientinfo(Rec) ->

--- a/apps/emqx/src/emqx_persistent_session_ds_state.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_state.erl
@@ -126,21 +126,31 @@
     | ?rec
     | ?committed(?QOS_2).
 
+-define(id, id).
+-define(dirty, dirty).
+-define(metadata, metadata).
+-define(subscriptions, subscriptions).
+-define(subscription_states, subscription_states).
+-define(seqnos, seqnos).
+-define(streams, streams).
+-define(ranks, ranks).
+-define(awaiting_rel, awaiting_rel).
+
 -opaque t() :: #{
-    id := emqx_persistent_session_ds:id(),
-    dirty := boolean(),
-    metadata := metadata(),
-    subscriptions := pmap(
+    ?id := emqx_persistent_session_ds:id(),
+    ?dirty := boolean(),
+    ?metadata := metadata(),
+    ?subscriptions := pmap(
         emqx_persistent_session_ds:topic_filter(), emqx_persistent_session_ds_subs:subscription()
     ),
-    subscription_states := pmap(
+    ?subscription_states := pmap(
         emqx_persistent_session_ds_subs:subscription_state_id(),
         emqx_persistent_session_ds_subs:subscription_state()
     ),
-    seqnos := pmap(seqno_type(), emqx_persistent_session_ds:seqno()),
-    streams := pmap(emqx_ds:stream(), emqx_persistent_session_ds:stream_state()),
-    ranks := pmap(term(), integer()),
-    awaiting_rel := pmap(emqx_types:packet_id(), _Timestamp :: integer())
+    ?seqnos := pmap(seqno_type(), emqx_persistent_session_ds:seqno()),
+    ?streams := pmap(emqx_ds:stream(), emqx_persistent_session_ds:stream_state()),
+    ?ranks := pmap(term(), integer()),
+    ?awaiting_rel := pmap(emqx_types:packet_id(), _Timestamp :: integer())
 }.
 
 -define(session_tab, emqx_ds_session_tab).
@@ -152,12 +162,12 @@
 -define(awaiting_rel_tab, emqx_ds_session_awaiting_rel).
 
 -define(pmaps, [
-    {subscriptions, ?subscription_tab},
-    {subscription_states, ?subscription_states_tab},
-    {streams, ?stream_tab},
-    {seqnos, ?seqno_tab},
-    {ranks, ?rank_tab},
-    {awaiting_rel, ?awaiting_rel_tab}
+    {?subscriptions, ?subscription_tab},
+    {?subscription_states, ?subscription_states_tab},
+    {?streams, ?stream_tab},
+    {?seqnos, ?seqno_tab},
+    {?ranks, ?rank_tab},
+    {?awaiting_rel, ?awaiting_rel_tab}
 ]).
 
 %% Enable this flag if you suspect some code breaks the sequence:
@@ -358,15 +368,15 @@ new_id(Rec) ->
 -spec get_subscription(emqx_persistent_session_ds:topic_filter(), t()) ->
     emqx_persistent_session_ds_subs:subscription() | undefined.
 get_subscription(TopicFilter, Rec) ->
-    gen_get(subscriptions, TopicFilter, Rec).
+    gen_get(?subscriptions, TopicFilter, Rec).
 
 -spec fold_subscriptions(fun(), Acc, t()) -> Acc.
 fold_subscriptions(Fun, Acc, Rec) ->
-    gen_fold(subscriptions, Fun, Acc, Rec).
+    gen_fold(?subscriptions, Fun, Acc, Rec).
 
 -spec n_subscriptions(t()) -> non_neg_integer().
 n_subscriptions(Rec) ->
-    gen_size(subscriptions, Rec).
+    gen_size(?subscriptions, Rec).
 
 -spec put_subscription(
     emqx_persistent_session_ds:topic_filter(),
@@ -374,22 +384,22 @@ n_subscriptions(Rec) ->
     t()
 ) -> t().
 put_subscription(TopicFilter, Subscription, Rec) ->
-    gen_put(subscriptions, TopicFilter, Subscription, Rec).
+    gen_put(?subscriptions, TopicFilter, Subscription, Rec).
 
 -spec del_subscription(emqx_persistent_session_ds:topic_filter(), t()) -> t().
 del_subscription(TopicFilter, Rec) ->
-    gen_del(subscriptions, TopicFilter, Rec).
+    gen_del(?subscriptions, TopicFilter, Rec).
 
 %%
 
 -spec get_subscription_state(emqx_persistent_session_ds_subs:subscription_state_id(), t()) ->
     emqx_persistent_session_ds_subs:subscription_state() | undefined.
 get_subscription_state(SStateId, Rec) ->
-    gen_get(subscription_states, SStateId, Rec).
+    gen_get(?subscription_states, SStateId, Rec).
 
 -spec fold_subscription_states(fun(), Acc, t()) -> Acc.
 fold_subscription_states(Fun, Acc, Rec) ->
-    gen_fold(subscription_states, Fun, Acc, Rec).
+    gen_fold(?subscription_states, Fun, Acc, Rec).
 
 -spec put_subscription_state(
     emqx_persistent_session_ds_subs:subscription_state_id(),
@@ -397,11 +407,11 @@ fold_subscription_states(Fun, Acc, Rec) ->
     t()
 ) -> t().
 put_subscription_state(SStateId, SState, Rec) ->
-    gen_put(subscription_states, SStateId, SState, Rec).
+    gen_put(?subscription_states, SStateId, SState, Rec).
 
 -spec del_subscription_state(emqx_persistent_session_ds_subs:subscription_state_id(), t()) -> t().
 del_subscription_state(SStateId, Rec) ->
-    gen_del(subscription_states, SStateId, Rec).
+    gen_del(?subscription_states, SStateId, Rec).
 
 %%
 
@@ -410,33 +420,33 @@ del_subscription_state(SStateId, Rec) ->
 -spec get_stream(stream_key(), t()) ->
     emqx_persistent_session_ds:stream_state() | undefined.
 get_stream(Key, Rec) ->
-    gen_get(streams, Key, Rec).
+    gen_get(?streams, Key, Rec).
 
 -spec put_stream(stream_key(), emqx_persistent_session_ds:stream_state(), t()) -> t().
 put_stream(Key, Val, Rec) ->
-    gen_put(streams, Key, Val, Rec).
+    gen_put(?streams, Key, Val, Rec).
 
 -spec del_stream(stream_key(), t()) -> t().
 del_stream(Key, Rec) ->
-    gen_del(streams, Key, Rec).
+    gen_del(?streams, Key, Rec).
 
 -spec fold_streams(fun(), Acc, t()) -> Acc.
 fold_streams(Fun, Acc, Rec) ->
-    gen_fold(streams, Fun, Acc, Rec).
+    gen_fold(?streams, Fun, Acc, Rec).
 
 -spec n_streams(t()) -> non_neg_integer().
 n_streams(Rec) ->
-    gen_size(streams, Rec).
+    gen_size(?streams, Rec).
 
 %%
 
 -spec get_seqno(seqno_type(), t()) -> emqx_persistent_session_ds:seqno() | undefined.
 get_seqno(Key, Rec) ->
-    gen_get(seqnos, Key, Rec).
+    gen_get(?seqnos, Key, Rec).
 
 -spec put_seqno(seqno_type(), emqx_persistent_session_ds:seqno(), t()) -> t().
 put_seqno(Key, Val, Rec) ->
-    gen_put(seqnos, Key, Val, Rec).
+    gen_put(?seqnos, Key, Val, Rec).
 
 %%
 
@@ -444,41 +454,41 @@ put_seqno(Key, Val, Rec) ->
 
 -spec get_rank(rank_key(), t()) -> integer() | undefined.
 get_rank(Key, Rec) ->
-    gen_get(ranks, Key, Rec).
+    gen_get(?ranks, Key, Rec).
 
 -spec put_rank(rank_key(), integer(), t()) -> t().
 put_rank(Key, Val, Rec) ->
-    gen_put(ranks, Key, Val, Rec).
+    gen_put(?ranks, Key, Val, Rec).
 
 -spec del_rank(rank_key(), t()) -> t().
 del_rank(Key, Rec) ->
-    gen_del(ranks, Key, Rec).
+    gen_del(?ranks, Key, Rec).
 
 -spec fold_ranks(fun(), Acc, t()) -> Acc.
 fold_ranks(Fun, Acc, Rec) ->
-    gen_fold(ranks, Fun, Acc, Rec).
+    gen_fold(?ranks, Fun, Acc, Rec).
 
 %%
 
 -spec get_awaiting_rel(emqx_types:packet_id(), t()) -> integer() | undefined.
 get_awaiting_rel(Key, Rec) ->
-    gen_get(awaiting_rel, Key, Rec).
+    gen_get(?awaiting_rel, Key, Rec).
 
 -spec put_awaiting_rel(emqx_types:packet_id(), _Timestamp :: integer(), t()) -> t().
 put_awaiting_rel(Key, Val, Rec) ->
-    gen_put(awaiting_rel, Key, Val, Rec).
+    gen_put(?awaiting_rel, Key, Val, Rec).
 
 -spec del_awaiting_rel(emqx_types:packet_id(), t()) -> t().
 del_awaiting_rel(Key, Rec) ->
-    gen_del(awaiting_rel, Key, Rec).
+    gen_del(?awaiting_rel, Key, Rec).
 
 -spec fold_awaiting_rel(fun(), Acc, t()) -> Acc.
 fold_awaiting_rel(Fun, Acc, Rec) ->
-    gen_fold(awaiting_rel, Fun, Acc, Rec).
+    gen_fold(?awaiting_rel, Fun, Acc, Rec).
 
 -spec n_awaiting_rel(t()) -> non_neg_integer().
 n_awaiting_rel(Rec) ->
-    gen_size(awaiting_rel, Rec).
+    gen_size(?awaiting_rel, Rec).
 
 %%
 

--- a/apps/emqx/src/emqx_persistent_session_ds_stream_scheduler.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_stream_scheduler.erl
@@ -126,9 +126,10 @@ find_new_streams(S) ->
 renew_streams(S0) ->
     S1 = remove_unsubscribed_streams(S0),
     S2 = remove_fully_replayed_streams(S1),
+    S3 = update_stream_subscription_state_ids(S2),
     emqx_persistent_session_ds_subs:fold(
         fun
-            (Key, #{start_time := StartTime, id := SubId, deleted := false}, Acc) ->
+            (Key, #{start_time := StartTime, id := SubId, current_state := SStateId}, Acc) ->
                 TopicFilter = emqx_topic:words(Key),
                 Streams = select_streams(
                     SubId,
@@ -137,7 +138,7 @@ renew_streams(S0) ->
                 ),
                 lists:foldl(
                     fun(I, Acc1) ->
-                        ensure_iterator(TopicFilter, StartTime, SubId, I, Acc1)
+                        ensure_iterator(TopicFilter, StartTime, SubId, SStateId, I, Acc1)
                     end,
                     Acc,
                     Streams
@@ -145,8 +146,8 @@ renew_streams(S0) ->
             (_Key, _DeletedSubscription, Acc) ->
                 Acc
         end,
-        S2,
-        S2
+        S3,
+        S3
     ).
 
 -spec on_unsubscribe(
@@ -201,7 +202,7 @@ is_fully_acked(Srs, S) ->
 %% Internal functions
 %%================================================================================
 
-ensure_iterator(TopicFilter, StartTime, SubId, {{RankX, RankY}, Stream}, S) ->
+ensure_iterator(TopicFilter, StartTime, SubId, SStateId, {{RankX, RankY}, Stream}, S) ->
     Key = {SubId, Stream},
     case emqx_persistent_session_ds_state:get_stream(Key, S) of
         undefined ->
@@ -214,7 +215,8 @@ ensure_iterator(TopicFilter, StartTime, SubId, {{RankX, RankY}, Stream}, S) ->
                         rank_x = RankX,
                         rank_y = RankY,
                         it_begin = Iterator,
-                        it_end = Iterator
+                        it_end = Iterator,
+                        sub_state_id = SStateId
                     },
                     emqx_persistent_session_ds_state:put_stream(Key, NewStreamState, S);
                 {error, recoverable, Reason} ->
@@ -348,6 +350,38 @@ remove_fully_replayed_streams(S0) ->
         end,
         S1,
         S1
+    ).
+
+%% @doc Update subscription state IDs for all streams that don't have unacked messages
+-spec update_stream_subscription_state_ids(emqx_persistent_session_ds_state:t()) ->
+    emqx_persistent_session_ds_state:t().
+update_stream_subscription_state_ids(S0) ->
+    CommQos1 = emqx_persistent_session_ds_state:get_seqno(?committed(?QOS_1), S0),
+    CommQos2 = emqx_persistent_session_ds_state:get_seqno(?committed(?QOS_2), S0),
+    %% Find the latest state IDs for each subscription:
+    LastSStateIds = emqx_persistent_session_ds_state:fold_subscriptions(
+        fun(_, #{id := SubId, current_state := SStateId}, Acc) ->
+            Acc#{SubId => SStateId}
+        end,
+        #{},
+        S0
+    ),
+    %% Update subscription state IDs for fully acked streams:
+    emqx_persistent_session_ds_state:fold_streams(
+        fun
+            (_, #srs{unsubscribed = true}, S) ->
+                S;
+            (Key = {SubId, _Stream}, SRS0, S) ->
+                case is_fully_acked(CommQos1, CommQos2, SRS0) of
+                    true ->
+                        SRS = SRS0#srs{sub_state_id = maps:get(SubId, LastSStateIds)},
+                        emqx_persistent_session_ds_state:put_stream(Key, SRS, S);
+                    false ->
+                        S
+                end
+        end,
+        S0,
+        S0
     ).
 
 %% @doc Compare the streams by the order in which they were replayed.

--- a/apps/emqx/src/emqx_persistent_session_ds_subs.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_subs.erl
@@ -24,7 +24,15 @@
 -module(emqx_persistent_session_ds_subs).
 
 %% API:
--export([on_subscribe/3, on_unsubscribe/3, gc/1, lookup/2, to_map/1, fold/3, fold_all/3]).
+-export([
+    on_subscribe/3,
+    on_unsubscribe/3,
+    gc/1,
+    lookup/2,
+    to_map/1,
+    fold/3,
+    fold_all/3
+]).
 
 -export_type([]).
 

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -429,6 +429,11 @@ enrich_deliver(ClientInfo, {deliver, Topic, Msg}, UpgradeQoS, Session) ->
         end,
     enrich_message(ClientInfo, Msg, SubOpts, UpgradeQoS).
 
+%% Caution: updating this function _may_ break consistency of replay
+%% for persistent sessions. Persistent sessions expect it to return
+%% the same result during replay. If it changes the behavior between
+%% releases, sessions restored from the cold storage may end up
+%% replaying messages with different QoS, etc.
 enrich_message(
     ClientInfo = #{clientid := ClientId},
     Msg = #message{from = ClientId},

--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
@@ -581,7 +581,6 @@ t_write_failure(Config) ->
                 )
         end),
         fun(Trace0) ->
-            ct:pal("trace: ~p", [Trace0]),
             Trace = ?of_kind(
                 [buffer_worker_flush_nack, buffer_worker_retry_inflight_failed], Trace0
             ),

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -1929,7 +1929,6 @@ t_bad_attributes(Config) ->
             ok
         end,
         fun(Trace) ->
-            ct:pal("trace:\n  ~p", [Trace]),
             ?assertMatch(
                 [
                     #{placeholder := [<<"payload">>, <<"ok">>], value := #{}},

--- a/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
@@ -517,7 +517,6 @@ t_write_failure(Config) ->
             ok
         end,
         fun(Trace0) ->
-            ct:pal("trace: ~p", [Trace0]),
             Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,

--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -520,7 +520,6 @@ t_write_failure(Config) ->
                 )
         end),
         fun(Trace0) ->
-            ct:pal("trace: ~p", [Trace0]),
             Trace = ?of_kind(buffer_worker_flush_nack, Trace0),
             ?assertMatch([#{result := {error, _}} | _], Trace),
             [#{result := {error, Error}} | _] = Trace,

--- a/apps/emqx_durable_storage/README.md
+++ b/apps/emqx_durable_storage/README.md
@@ -13,7 +13,7 @@ This makes the storage disk requirements very predictable: only the number of _p
 
 DS _backend_ is a callback module that implements `emqx_ds` behavior.
 
-EMQX repository contains the "builtin" backend, implemented in `emqx_ds_replication_layer` module, that uses RocksDB as the main storage.
+EMQX repository contains the "builtin" backend, implemented in `emqx_ds_replication_layer` module, that uses Raft algorithm for data replication, and RocksDB as the main storage.
 
 Note that builtin backend introduces the concept of **site** to alleviate the problem of changing node names.
 Site IDs are persistent, and they are randomly generated at the first startup of the node.
@@ -95,10 +95,10 @@ Consumption of messages is done in several stages:
 
 # Limitation
 
-- Builtin backend currently doesn't replicate data across different sites
 - There is no local cache of messages, which may result in transferring the same data multiple times
 
 # Documentation links
+
 TBD
 
 # Usage

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1763,7 +1763,9 @@ format_persistent_session_info(ClientId, PSInfo0) ->
         connected_at => CreatedAt,
         ip_address => IpAddress,
         is_persistent => true,
-        port => Port
+        port => Port,
+        heap_size => 0,
+        mqueue_len => 0
     },
     PSInfo = lists:foldl(
         fun result_format_time_fun/2,

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1768,7 +1768,8 @@ format_persistent_session_info(ClientId, PSInfo0) ->
         heap_size => 0,
         mqueue_len => 0,
         proto_name => ProtoName,
-        proto_ver => ProtoVer
+        proto_ver => ProtoVer,
+        subscriptions_cnt => maps:size(maps:get(subscriptions, PSInfo0, #{}))
     },
     PSInfo = lists:foldl(
         fun result_format_time_fun/2,

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1747,6 +1747,7 @@ format_channel_info(undefined, {ClientId, PSInfo0 = #{}}, _Opts) ->
 
 format_persistent_session_info(ClientId, PSInfo0) ->
     Metadata = maps:get(metadata, PSInfo0, #{}),
+    {ProtoName, ProtoVer} = maps:get(protocol, Metadata),
     PSInfo1 = maps:with([created_at, expiry_interval], Metadata),
     CreatedAt = maps:get(created_at, PSInfo1),
     case Metadata of
@@ -1765,7 +1766,9 @@ format_persistent_session_info(ClientId, PSInfo0) ->
         is_persistent => true,
         port => Port,
         heap_size => 0,
-        mqueue_len => 0
+        mqueue_len => 0,
+        proto_name => ProtoName,
+        proto_ver => ProtoVer
     },
     PSInfo = lists:foldl(
         fun result_format_time_fun/2,

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -86,7 +86,8 @@ fields(subscription) ->
         {qos, hoconsc:mk(emqx_schema:qos(), #{desc => <<"QoS">>, example => 0})},
         {nl, hoconsc:mk(integer(), #{desc => <<"No Local">>, example => 0})},
         {rap, hoconsc:mk(integer(), #{desc => <<"Retain as Published">>, example => 0})},
-        {rh, hoconsc:mk(integer(), #{desc => <<"Retain Handling">>, example => 0})}
+        {rh, hoconsc:mk(integer(), #{desc => <<"Retain Handling">>, example => 0})},
+        {durable, hoconsc:mk(boolean(), #{desc => <<"Durable subscription">>, example => false})}
     ].
 
 parameters() ->
@@ -140,6 +141,14 @@ parameters() ->
                 in => query,
                 required => false,
                 desc => <<"Shared subscription group name">>
+            })
+        },
+        {
+            durable,
+            hoconsc:mk(boolean(), #{
+                in => query,
+                required => false,
+                desc => <<"Filter subscriptions by durability">>
             })
         }
     ].

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -3346,7 +3346,6 @@ wait_n_events(NEvents, Timeout, EventName) ->
     end.
 
 assert_sync_retry_fail_then_succeed_inflight(Trace) ->
-    ct:pal("  ~p", [Trace]),
     ?assert(
         ?strict_causality(
             #{?snk_kind := buffer_worker_flush_nack, ref := _Ref},
@@ -3366,7 +3365,6 @@ assert_sync_retry_fail_then_succeed_inflight(Trace) ->
     ok.
 
 assert_async_retry_fail_then_succeed_inflight(Trace) ->
-    ct:pal("  ~p", [Trace]),
     ?assert(
         ?strict_causality(
             #{?snk_kind := handle_async_reply, action := nack},

--- a/changes/ce/fix-12874.en.md
+++ b/changes/ce/fix-12874.en.md
@@ -1,0 +1,7 @@
+- Ensure consistency of the durable message replay when the subscriptions are modified before session reconnects
+
+- Persistent sessions save inflight packet IDs for the received QoS2 messages
+
+- Make behavior of the persistent sessions consistent with the non-persistent sessions in regard to overlapping subscriptions
+
+- List persistent subscriptions in the REST API


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12030 https://emqx.atlassian.net/browse/EMQX-12032 https://emqx.atlassian.net/browse/EMQX-12200

Release version: v/e5.?

## Summary

- Track PacketIDs of unacked QoS2 PUBLISH messages received from the client
- Add REST API for listing the durable subscriptions
- Fix inconsistent behavior in regard to overlapping subscriptions
- Separate subscription object from the immutable subscription state object
- Improve REST API response for offline durable sessions

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
