### PR TITLE
feat(charts): extend pod topology spread constraints

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx-enterprise/templates/StatefulSet.yaml
@@ -184,5 +184,20 @@ spec:
             matchLabels:
               app.kubernetes.io/name: {{ include "emqx.name" $ }}
               app.kubernetes.io/instance: {{ $.Release.Name }}
+        {{- if .minDomains }}
+          minDomains: {{ .minDomains }}
+        {{- end }}
+        {{- if .matchLabelKeys }}
+          matchLabelKeys:
+            {{- range .matchLabelKeys }}
+            - {{ . }}
+            {{- end }}
+        {{- end }}
+        {{- if .nodeAffinityPolicy }}
+          nodeAffinityPolicy: {{ .nodeAffinityPolicy }}
+        {{- end }}
+        {{- if .nodeTaintsPolicy }}
+          nodeTaintsPolicy: {{ .nodeTaintsPolicy }}
+        {{- end }}
         {{- end }}
     {{- end }}

--- a/deploy/charts/emqx/templates/StatefulSet.yaml
+++ b/deploy/charts/emqx/templates/StatefulSet.yaml
@@ -184,5 +184,20 @@ spec:
             matchLabels:
               app.kubernetes.io/name: {{ include "emqx.name" $ }}
               app.kubernetes.io/instance: {{ $.Release.Name }}
+        {{- if .minDomains }}
+          minDomains: {{ .minDomains }}
+        {{- end }}
+        {{- if .matchLabelKeys }}
+          matchLabelKeys:
+            {{- range .matchLabelKeys }}
+            - {{ . }}
+            {{- end }}
+        {{- end }}
+        {{- if .nodeAffinityPolicy }}
+          nodeAffinityPolicy: {{ .nodeAffinityPolicy }}
+        {{- end }}
+        {{- if .nodeTaintsPolicy }}
+          nodeTaintsPolicy: {{ .nodeTaintsPolicy }}
+        {{- end }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
Fixes 

## Summary

Add the latest optional features of the [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to the Helm Charts under the `topologySpreadConstraints` key. 

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
