### PR TITLE
test(mongodb authn, authz): add test cases for use_legacy_protocol

### DIFF
--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
@@ -285,11 +285,12 @@ raw_mongo_auth_config() ->
         <<"filter">> => #{<<"username">> => <<"${username}">>},
         <<"password_hash_field">> => <<"password_hash">>,
         <<"salt_field">> => <<"salt">>,
-        <<"is_superuser_field">> => <<"is_superuser">>
+        <<"is_superuser_field">> => <<"is_superuser">>,
+        <<"use_legacy_protocol">> => <<"auto">>
     }.
 
 user_seeds() ->
-    [
+    PlainSeed =
         #{
             data => #{
                 username => <<"plain">>,
@@ -304,7 +305,10 @@ user_seeds() ->
             config_params => #{},
             result => {ok, #{is_superuser => true}}
         },
-
+    [
+        PlainSeed#{config_params => #{<<"use_legacy_protocol">> => <<"auto">>}},
+        PlainSeed#{config_params => #{<<"use_legacy_protocol">> => <<"true">>}},
+        PlainSeed#{config_params => #{<<"use_legacy_protocol">> => <<"false">>}},
         #{
             data => #{
                 username => <<"md5">>,

--- a/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
@@ -79,10 +79,10 @@ t_run_case(Config) ->
     run_case(Config, false),
     run_case(Config, auto).
 
-run_case(Config, UseLegazyProtocol) ->
+run_case(Config, UseLegacyProtocol) ->
     Case = ?config(test_case, Config),
     ok = setup_source_data(Case),
-    ok = setup_authz_source(Case#{use_legacy_protocol => UseLegazyProtocol}),
+    ok = setup_authz_source(Case#{use_legacy_protocol => UseLegacyProtocol}),
     ok = emqx_authz_test_lib:run_checks(Case).
 
 %%------------------------------------------------------------------------------
@@ -379,11 +379,11 @@ setup_source_data(#{records := Records}) ->
     {{true, _}, _} = mc_worker_api:insert(?MONGO_CLIENT, <<"acl">>, Records),
     ok.
 
-setup_authz_source(#{filter := Filter, use_legacy_protocol := UseLegazyProtocol}) ->
+setup_authz_source(#{filter := Filter, use_legacy_protocol := UseLegacyProtocol}) ->
     setup_config(
         #{
             <<"filter">> => Filter,
-            <<"use_legacy_protocol">> => UseLegazyProtocol
+            <<"use_legacy_protocol">> => UseLegacyProtocol
         }
     ).
 

--- a/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authz_mongodb_SUITE.erl
@@ -75,9 +75,14 @@ end_per_testcase(_TestCase, _Config) ->
 %%------------------------------------------------------------------------------
 
 t_run_case(Config) ->
+    run_case(Config, true),
+    run_case(Config, false),
+    run_case(Config, auto).
+
+run_case(Config, UseLegazyProtocol) ->
     Case = ?config(test_case, Config),
     ok = setup_source_data(Case),
-    ok = setup_authz_source(Case),
+    ok = setup_authz_source(Case#{use_legacy_protocol => UseLegazyProtocol}),
     ok = emqx_authz_test_lib:run_checks(Case).
 
 %%------------------------------------------------------------------------------
@@ -374,10 +379,11 @@ setup_source_data(#{records := Records}) ->
     {{true, _}, _} = mc_worker_api:insert(?MONGO_CLIENT, <<"acl">>, Records),
     ok.
 
-setup_authz_source(#{filter := Filter}) ->
+setup_authz_source(#{filter := Filter, use_legacy_protocol := UseLegazyProtocol}) ->
     setup_config(
         #{
-            <<"filter">> => Filter
+            <<"filter">> => Filter,
+            <<"use_legacy_protocol">> => UseLegazyProtocol
         }
     ).
 
@@ -401,7 +407,8 @@ raw_mongo_authz_config() ->
         <<"username">> => mongo_username(),
         <<"password">> => mongo_password(),
 
-        <<"filter">> => #{<<"username">> => <<"${username}">>}
+        <<"filter">> => #{<<"username">> => <<"${username}">>},
+        <<"use_legacy_protocol">> => <<"auto">>
     }.
 
 mongo_server() ->


### PR DESCRIPTION
This PR adds test cases that check that the authn and authz modules for MongoDB support the use_legacy_protocol configuration option.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12245

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible