### PR TITLE
ci(temporary fix): pin `mimerl` to 1.2.0

### DIFF
--- a/.github/workflows/check_deps_integrity.yaml
+++ b/.github/workflows/check_deps_integrity.yaml
@@ -27,6 +27,11 @@ jobs:
           mix local.hex --force
           mix local.rebar --force
           mix deps.get
+      - name: debug mix deps tree
+        env:
+          MIX_ENV: emqx-enterprise
+          PROFILE: emqx-enterprise
+        run: mix deps.tree
       - run: ./scripts/check-elixir-deps-discrepancies.exs
         env:
           MIX_ENV: emqx-enterprise

--- a/mix.exs
+++ b/mix.exs
@@ -85,6 +85,9 @@ defmodule EMQXUmbrella.MixProject do
       {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true},
       # in conflict by erlavro and rocketmq
       {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true},
+      # defined too loosely by hackney; CI seems to be still fetching an outdated value
+      # TODO: remove after CI stabilizes
+      {:mimerl, "1.2.0", override: true},
       # dependencies of dependencies; we choose specific refs to match
       # what rebar3 chooses.
       # in conflict by gun and emqtt


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/8881977497/job/24386840191?pr=12948#step:8:832

```
* Discrepancies between Elixir and Rebar3 dependencies found!
  * mimerl
    * Rebar3 ref: 67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3
    * Mix ref: d0cd9fc04b9061f82490f6581e0128379830e78535e017f7780f37fea7545726
```

Could not reproduce this locally.  A possibility is that CI is still downloading from a stale repository/CDN, since mimerl 1.3.0 was released today.

Fixes <issue-or-jira-number>

Release version: v/e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
