### PR TITLE
fix(ssl-clients): allow wildcard certificates by default

### DIFF
--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -542,12 +542,18 @@ to_client_opts(Type, Opts) ->
                     {depth, Get(depth)},
                     {password, ensure_str(Get(password))},
                     {secure_renegotiate, Get(secure_renegotiate)}
-                ],
+                ] ++ hostname_check(Verify),
                 Versions
             );
         false ->
             []
     end.
+
+hostname_check(verify_none) ->
+    [];
+hostname_check(verify_peer) ->
+    %% allow wildcard certificates
+    [{customize_hostname_check, [{match_fun, public_key:pkix_verify_hostname_match_fun(https)}]}].
 
 resolve_cert_path_for_read_strict(Path) ->
     case resolve_cert_path_for_read(Path) of

--- a/apps/emqx/test/emqx_tls_lib_tests.erl
+++ b/apps/emqx/test/emqx_tls_lib_tests.erl
@@ -240,7 +240,7 @@ to_client_opts_test() ->
     Versions13Only = ['tlsv1.3'],
     Options = #{
         enable => true,
-        verify => "Verify",
+        verify => verify_none,
         server_name_indication => "SNI",
         ciphers => "Ciphers",
         depth => "depth",
@@ -249,9 +249,16 @@ to_client_opts_test() ->
         secure_renegotiate => "secure_renegotiate",
         reuse_sessions => "reuse_sessions"
     },
-    Expected1 = lists:usort(maps:keys(Options) -- [enable]),
+    Expected0 = lists:usort(maps:keys(Options) -- [enable]),
+    Expected1 = lists:sort(Expected0 ++ [customize_hostname_check]),
     ?assertEqual(
-        Expected1, lists:usort(proplists:get_keys(emqx_tls_lib:to_client_opts(tls, Options)))
+        Expected0, lists:usort(proplists:get_keys(emqx_tls_lib:to_client_opts(tls, Options)))
+    ),
+    ?assertEqual(
+        Expected1,
+        lists:usort(
+            proplists:get_keys(emqx_tls_lib:to_client_opts(tls, Options#{verify => verify_peer}))
+        )
     ),
     Expected2 =
         lists:usort(

--- a/changes/ce/fix-12962.en.md
+++ b/changes/ce/fix-12962.en.md
@@ -1,0 +1,4 @@
+TLS clients can now verify server hostname against wildcard certificate.
+
+For example, if a certificate is issued for host `*.example.com`,
+TLS clients is able to verify server hostnames like `srv1.example.com`.


### PR DESCRIPTION
Fixes [EMQX-12214](https://emqx.atlassian.net/browse/EMQX-12214)

Release version: v/e5.7.0

## Summary

Support wildcard certificates.
Tested manually with testing wildcard certificate issued to `*.local.net`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12214]: https://emqx.atlassian.net/browse/EMQX-12214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ