### PR TITLE
Make formatting of action result trace entries better

### DIFF
--- a/apps/emqx/src/emqx_trace/emqx_trace_json_formatter.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_json_formatter.erl
@@ -88,6 +88,21 @@ prepare_key_value(packet = K, V, PEncode) ->
                 V
         end,
     {K, NewV};
+prepare_key_value(K, {recoverable_error, Msg} = OrgV, PEncode) ->
+    try
+        prepare_key_value(
+            K,
+            #{
+                error_type => recoverable_error,
+                msg => Msg,
+                additional_info => <<"The operation may be retried.">>
+            },
+            PEncode
+        )
+    catch
+        _:_ ->
+            {K, OrgV}
+    end;
 prepare_key_value(rule_ids = K, V, _PEncode) ->
     NewV =
         try

--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
@@ -29,7 +29,8 @@
     on_query_async/4,
     on_batch_query/3,
     on_batch_query_async/4,
-    on_get_status/2
+    on_get_status/2,
+    on_format_query_result/1
 ]).
 
 %% callbacks of ecpool
@@ -458,6 +459,11 @@ handle_result({error, Error}) ->
     {error, {unrecoverable_error, Error}};
 handle_result(Res) ->
     Res.
+
+on_format_query_result({ok, Result}) ->
+    #{result => ok, info => Result};
+on_format_query_result(Result) ->
+    Result.
 
 %%--------------------------------------------------------------------
 %% utils

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -38,7 +38,8 @@
     on_get_channels/1,
     on_query/3,
     on_batch_query/3,
-    on_get_status/2
+    on_get_status/2,
+    on_format_query_result/1
 ]).
 
 %% callbacks for ecpool
@@ -518,6 +519,13 @@ transform_and_log_clickhouse_result(ClickhouseErrorResult, ResourceID, SQL) ->
             }),
             to_error_tuple(ClickhouseErrorResult)
     end.
+
+on_format_query_result(ok) ->
+    #{result => ok, message => <<"">>};
+on_format_query_result({ok, Message}) ->
+    #{result => ok, message => Message};
+on_format_query_result(Result) ->
+    Result.
 
 to_recoverable_error({error, Reason}) ->
     {error, {recoverable_error, Reason}};

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
@@ -26,7 +26,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([
@@ -183,6 +184,11 @@ on_batch_query(InstanceId, [{_ChannelId, _} | _] = Query, State) ->
     do_query(InstanceId, Query, State);
 on_batch_query(_InstanceId, Query, _State) ->
     {error, {unrecoverable_error, {invalid_request, Query}}}.
+
+on_format_query_result({ok, Result}) ->
+    #{result => ok, info => Result};
+on_format_query_result(Result) ->
+    Result.
 
 health_check_timeout() ->
     2500.

--- a/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
@@ -23,7 +23,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([
@@ -287,6 +288,9 @@ on_query_async(
     emqx_bridge_http_connector:on_query_async(
         InstanceId, {ChannelId, Msg}, ReplyFunAndArgs, State
     ).
+
+on_format_query_result(Result) ->
+    emqx_bridge_http_connector:on_format_query_result(Result).
 
 on_add_channel(
     InstanceId,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -53,7 +53,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([reply_delegator/2]).
@@ -487,6 +488,11 @@ handle_result({error, Reason} = Result, _Request, QueryMode, ResourceId) ->
     ),
     Result;
 handle_result({ok, _} = Result, _Request, _QueryMode, _ResourceId) ->
+    Result.
+
+on_format_query_result({ok, Info}) ->
+    #{result => ok, info => Info};
+on_format_query_result(Result) ->
     Result.
 
 reply_delegator(ReplyFunAndArgs, Response) ->

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -27,7 +27,8 @@
     on_batch_query/3,
     on_query_async/4,
     on_batch_query_async/4,
-    on_get_status/2
+    on_get_status/2,
+    on_format_query_result/1
 ]).
 -export([reply_callback/2]).
 
@@ -452,6 +453,11 @@ do_query(InstId, Channel, Client, Points) ->
                     {error, {recoverable_error, Reason}}
             end
     end.
+
+on_format_query_result({ok, {affected_rows, Rows}}) ->
+    #{result => ok, affected_rows => Rows};
+on_format_query_result(Result) ->
+    Result.
 
 do_async_query(InstId, Channel, Client, Points, ReplyFunAndArgs) ->
     ?SLOG(info, #{

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -27,7 +27,8 @@
     on_batch_query/3,
     on_query_async/4,
     on_batch_query_async/4,
-    on_get_status/2
+    on_get_status/2,
+    on_format_query_result/1
 ]).
 -export([reply_callback/2]).
 
@@ -208,6 +209,9 @@ on_batch_query_async(
             ),
             {error, {unrecoverable_error, Reason}}
     end.
+
+on_format_query_result(Result) ->
+    emqx_bridge_http_connector:on_format_query_result(Result).
 
 on_get_status(_InstId, #{client := Client}) ->
     case influxdb:is_alive(Client) andalso ok =:= influxdb:check_auth(Client) of

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
@@ -26,7 +26,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([
@@ -389,6 +390,9 @@ on_batch_query(
         Error ->
             Error
     end.
+
+on_format_query_result(Result) ->
+    emqx_bridge_http_connector:on_format_query_result(Result).
 
 on_add_channel(
     InstanceId,

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
@@ -39,7 +39,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([
@@ -317,6 +318,11 @@ handle_result({error, Reason} = Error, Requests, InstanceId) ->
         reason => Reason
     }),
     Error.
+
+on_format_query_result({ok, Result}) ->
+    #{result => ok, info => Result};
+on_format_query_result(Result) ->
+    Result.
 
 parse_template(Config) ->
     #{payload_template := PayloadTemplate, partition_key := PartitionKeyTemplate} = Config,

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
@@ -18,7 +18,8 @@
     on_get_status/2,
     on_query/3,
     on_start/2,
-    on_stop/2
+    on_stop/2,
+    on_format_query_result/1
 ]).
 
 %%========================================================================================
@@ -84,6 +85,11 @@ on_query(InstanceId, {Channel, Message0}, #{channels := Channels, connector_stat
     Res;
 on_query(InstanceId, Request, _State = #{connector_state := ConnectorState}) ->
     emqx_mongodb:on_query(InstanceId, Request, ConnectorState).
+
+on_format_query_result({{Result, Info}, Documents}) ->
+    #{result => Result, info => Info, documents => Documents};
+on_format_query_result(Result) ->
+    Result.
 
 on_remove_channel(_InstanceId, #{channels := Channels} = State, ChannelId) ->
     NewState = State#{channels => maps:remove(ChannelId, Channels)},

--- a/apps/emqx_bridge_opents/src/emqx_bridge_opents_connector.erl
+++ b/apps/emqx_bridge_opents/src/emqx_bridge_opents_connector.erl
@@ -27,7 +27,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([connector_examples/1]).
@@ -174,6 +175,11 @@ on_batch_query(
         Error ->
             Error
     end.
+
+on_format_query_result({ok, StatusCode, BodyMap}) ->
+    #{result => ok, status_code => StatusCode, body => BodyMap};
+on_format_query_result(Result) ->
+    Result.
 
 on_get_status(_InstanceId, #{server := Server}) ->
     Result =

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -20,7 +20,8 @@
     on_get_status/2,
     on_get_channel_status/3,
     on_query/3,
-    on_query_async/4
+    on_query_async/4,
+    on_format_query_result/1
 ]).
 
 -type pulsar_client_id() :: atom().
@@ -233,6 +234,11 @@ on_query_async2(ChannelId, Producers, Message, MessageTmpl, AsyncReplyFn) ->
         is_async => true
     }),
     pulsar:send(Producers, [PulsarMessage], #{callback_fn => AsyncReplyFn}).
+
+on_format_query_result({ok, Info}) ->
+    #{result => ok, info => Info};
+on_format_query_result(Result) ->
+    Result.
 
 %%-------------------------------------------------------------------------------------
 %% Internal fns

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -39,7 +39,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 %% callbacks for ecpool
@@ -319,6 +320,11 @@ on_batch_query(ResourceId, BatchRequests, State) ->
         #{requests => BatchRequests, connector => ResourceId, state => State}
     ),
     do_query(ResourceId, BatchRequests, ?SYNC_QUERY_MODE, State).
+
+on_format_query_result({ok, Rows}) ->
+    #{result => ok, rows => Rows};
+on_format_query_result(Result) ->
+    Result.
 
 on_get_status(_InstanceId, #{pool_name := PoolName} = _State) ->
     Health = emqx_resource_pool:health_check_workers(

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
@@ -28,7 +28,8 @@
     on_add_channel/4,
     on_remove_channel/3,
     on_get_channels/1,
-    on_get_channel_status/3
+    on_get_channel_status/3,
+    on_format_query_result/1
 ]).
 
 -export([connector_examples/1]).
@@ -214,6 +215,11 @@ on_batch_query(InstanceId, BatchReq, State) ->
     LogMeta = #{connector => InstanceId, request => BatchReq, state => State},
     ?SLOG(error, LogMeta#{msg => "invalid_request"}),
     {error, {unrecoverable_error, invalid_request}}.
+
+on_format_query_result({ok, ResultMap}) ->
+    #{result => ok, info => ResultMap};
+on_format_query_result(Result) ->
+    Result.
 
 on_get_status(_InstanceId, #{pool_name := PoolName} = State) ->
     case

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -30,7 +30,8 @@
     on_stop/2,
     on_query/3,
     on_batch_query/3,
-    on_get_status/2
+    on_get_status/2,
+    on_format_query_result/1
 ]).
 
 %% ecpool connect & reconnect
@@ -213,6 +214,13 @@ on_batch_query(
         state => State
     }),
     {error, {unrecoverable_error, invalid_request}}.
+
+on_format_query_result({ok, ColumnNames, Rows}) ->
+    #{result => ok, column_names => ColumnNames, rows => Rows};
+on_format_query_result({ok, DataList}) ->
+    #{result => ok, column_names_rows_list => DataList};
+on_format_query_result(Result) ->
+    Result.
 
 mysql_function(sql) ->
     query;

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_test_connector.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_test_connector.erl
@@ -29,7 +29,9 @@
     on_start/2,
     on_stop/2,
     on_query/3,
+    on_query_async/4,
     on_batch_query/3,
+    on_batch_query_async/4,
     on_get_status/2,
     on_add_channel/4,
     on_remove_channel/3,
@@ -85,6 +87,14 @@ on_query(
 ) ->
     ok.
 
+on_query_async(
+    _InstId,
+    _Query,
+    _State,
+    _Callback
+) ->
+    ok.
+
 on_batch_query(
     _InstId,
     [{ChannelId, _Req} | _] = Msg,
@@ -94,6 +104,14 @@ on_batch_query(
     Pid = binary_to_term(emqx_utils:hexstr_to_bin(PidBin)),
     Pid ! Msg,
     emqx_trace:rendered_action_template(ChannelId, #{nothing_to_render => ok}),
+    ok.
+
+on_batch_query_async(
+    _InstId,
+    _Batch,
+    _State,
+    _Callback
+) ->
     ok.
 
 on_get_status(_InstId, _State) ->


### PR DESCRIPTION
This PR contains three fixes:

* [fix(rule tracing): format result traces in a more structured way](https://github.com/emqx/emqx/commit/ca88f5731ba2c4b1b3bbe6edc65ed852eae209fd)
* [fix(rule tracing): clean up error tuple in the action_failed trace](https://github.com/emqx/emqx/commit/feecc36607e8b215188898d72de9e2b621e215ac)
* [fix(rule tracing): make sure that recoverable errors are traced](https://github.com/emqx/emqx/pull/12981/commits/09ee7ec0e22341ebfdc83c89f87e37c2b3e51d49)

Fixes:
https://emqx.atlassian.net/wiki/spaces/MP/pages/980516948/Acceptance+report#%E2%9D%8C-InfluxDB

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
