### PR TITLE
fix(message validation): don't call `emqx_conf:update` during boot

### DIFF
--- a/apps/emqx_message_validation/src/emqx_message_validation.erl
+++ b/apps/emqx_message_validation/src/emqx_message_validation.erl
@@ -69,10 +69,22 @@ remove_handler() ->
     ok.
 
 load() ->
-    lists:foreach(fun insert/1, emqx:get_config(?VALIDATIONS_CONF_PATH, [])).
+    Validations = emqx:get_config(?VALIDATIONS_CONF_PATH, []),
+    lists:foreach(
+        fun({Pos, Validation}) ->
+            ok = emqx_message_validation_registry:insert(Pos, Validation)
+        end,
+        lists:enumerate(Validations)
+    ).
 
 unload() ->
-    lists:foreach(fun delete/1, emqx:get_config(?VALIDATIONS_CONF_PATH, [])).
+    Validations = emqx:get_config(?VALIDATIONS_CONF_PATH, []),
+    lists:foreach(
+        fun(Validation) ->
+            ok = emqx_message_validation_registry:delete(Validation)
+        end,
+        Validations
+    ).
 
 -spec list() -> [validation()].
 list() ->


### PR DESCRIPTION
`load/0` and `unload/0` shouldn't call cluster operations.

Release version: e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
