### PR TITLE
refactor(message validation): rename `message_name` to `message_type`

### DIFF
--- a/apps/emqx_message_validation/src/emqx_message_validation.erl
+++ b/apps/emqx_message_validation/src/emqx_message_validation.erl
@@ -247,8 +247,8 @@ evaluate_schema_check(Check, Validation, #message{payload = Data}) ->
     #{name := Name} = Validation,
     ExtraArgs =
         case Check of
-            #{type := protobuf, message_name := MessageName} ->
-                [MessageName];
+            #{type := protobuf, message_type := MessageType} ->
+                [MessageType];
             _ ->
                 []
         end,

--- a/apps/emqx_message_validation/src/emqx_message_validation_schema.erl
+++ b/apps/emqx_message_validation/src/emqx_message_validation_schema.erl
@@ -121,8 +121,8 @@ fields(check_protobuf) ->
     [
         {type, mk(protobuf, #{default => protobuf, desc => ?DESC("check_protobuf_type")})},
         {schema, mk(binary(), #{required => true, desc => ?DESC("check_protobuf_schema")})},
-        {message_name,
-            mk(binary(), #{required => true, desc => ?DESC("check_protobuf_message_name")})}
+        {message_type,
+            mk(binary(), #{required => true, desc => ?DESC("check_protobuf_message_type")})}
     ];
 fields(check_avro) ->
     [

--- a/apps/emqx_message_validation/test/emqx_message_validation_tests.erl
+++ b/apps/emqx_message_validation/test/emqx_message_validation_tests.erl
@@ -309,7 +309,7 @@ duplicated_check_test_() ->
                         schema_check(
                             protobuf,
                             <<"a">>,
-                            #{<<"message_name">> => <<"a">>}
+                            #{<<"message_type">> => <<"a">>}
                         )
                     ])
                 ])

--- a/rel/i18n/emqx_message_validation_schema.hocon
+++ b/rel/i18n/emqx_message_validation_schema.hocon
@@ -30,9 +30,9 @@ emqx_message_validation_schema {
   check_protobuf_schema.label:
   """Schema name"""
 
-  check_protobuf_message_name.desc:
+  check_protobuf_message_type.desc:
   """Message name to use during check."""
-  check_protobuf_message_name.label:
+  check_protobuf_message_type.label:
   """Message name"""
 
   check_sql_type.desc:


### PR DESCRIPTION
On Product's behest, to make naming consistent with protobuf nomenclature.

https://protobuf.dev/programming-guides/proto3/#adding-types

Release version: e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
