### PR TITLE
fix: make rule engine unescape convert \a to the terminal alarm char

### DIFF
--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -744,18 +744,18 @@ t_regex_replace(_) ->
     ?assertEqual(<<"a[cc]b[c]d">>, apply_func(regex_replace, [<<"accbcd">>, <<"c+">>, <<"[&]">>])).
 
 t_unescape(_) ->
-    ?assertEqual(<<"\n">>, emqx_rule_funcs:unescape(<<"\\n">>)),
-    ?assertEqual(<<"\t">>, emqx_rule_funcs:unescape(<<"\\t">>)),
-    ?assertEqual(<<"\r">>, emqx_rule_funcs:unescape(<<"\\r">>)),
-    ?assertEqual(<<"\b">>, emqx_rule_funcs:unescape(<<"\\b">>)),
-    ?assertEqual(<<"\f">>, emqx_rule_funcs:unescape(<<"\\f">>)),
-    ?assertEqual(<<"\v">>, emqx_rule_funcs:unescape(<<"\\v">>)),
-    ?assertEqual(<<"'">>, emqx_rule_funcs:unescape(<<"\\'">>)),
-    ?assertEqual(<<"\"">>, emqx_rule_funcs:unescape(<<"\\\"">>)),
-    ?assertEqual(<<"?">>, emqx_rule_funcs:unescape(<<"\\?">>)),
-    ?assertEqual(<<"\a">>, emqx_rule_funcs:unescape(<<"\\a">>)),
+    ?assertEqual(<<"\n">> = <<10>>, emqx_rule_funcs:unescape(<<"\\n">>)),
+    ?assertEqual(<<"\t">> = <<9>>, emqx_rule_funcs:unescape(<<"\\t">>)),
+    ?assertEqual(<<"\r">> = <<13>>, emqx_rule_funcs:unescape(<<"\\r">>)),
+    ?assertEqual(<<"\b">> = <<8>>, emqx_rule_funcs:unescape(<<"\\b">>)),
+    ?assertEqual(<<"\f">> = <<12>>, emqx_rule_funcs:unescape(<<"\\f">>)),
+    ?assertEqual(<<"\v">> = <<11>>, emqx_rule_funcs:unescape(<<"\\v">>)),
+    ?assertEqual(<<"'">> = <<39>>, emqx_rule_funcs:unescape(<<"\\'">>)),
+    ?assertEqual(<<"\"">> = <<34>>, emqx_rule_funcs:unescape(<<"\\\"">>)),
+    ?assertEqual(<<"?">> = <<63>>, emqx_rule_funcs:unescape(<<"\\?">>)),
+    ?assertEqual(<<7>>, emqx_rule_funcs:unescape(<<"\\a">>)),
     % Test escaping backslash itself
-    ?assertEqual(<<"\\">>, emqx_rule_funcs:unescape(<<"\\\\">>)),
+    ?assertEqual(<<"\\">> = <<92>>, emqx_rule_funcs:unescape(<<"\\\\">>)),
     % Test a string without any escape sequences
     ?assertEqual(<<"Hello, World!">>, emqx_rule_funcs:unescape(<<"Hello, World!">>)),
     % Test a string with escape sequences

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -289,7 +289,8 @@ unescape_string([$\\, $" | Rest], Acc) ->
 unescape_string([$\\, $? | Rest], Acc) ->
     unescape_string(Rest, [$\? | Acc]);
 unescape_string([$\\, $a | Rest], Acc) ->
-    unescape_string(Rest, [$\a | Acc]);
+    %% Terminal bell
+    unescape_string(Rest, [7 | Acc]);
 %% Start of HEX escape code
 unescape_string([$\\, $x | [$0 | _] = HexStringStart], Acc) ->
     unescape_handle_hex_string(HexStringStart, Acc);


### PR DESCRIPTION
The rule engine unescape function should convert the escape sequence \a to the alarm bell symbol (ASCII 7). This bug was created as it was assumed that Erlang convert $\a to 7 but Erlang does not handle the \a escape sequence and instead convert it to 97 (ASCII code for a).

I think the unescape rule engine function (introduced in this PR from mars https://github.com/emqx/emqx/pull/12671) is not released so release notes should not be needed?

Fixes:
https://emqx.atlassian.net/browse/EMQX-12313

Release version: v/e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible