### PR TITLE
fix(sysk): fix that the syskeeper forwarding never reconnecting

### DIFF
--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_connector.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_connector.erl
@@ -213,9 +213,9 @@ on_get_status(_InstanceId, #{pool_name := Pool, ack_timeout := AckTimeout}) ->
     ),
     status_result(Health).
 
-status_result(true) -> connected;
-status_result(false) -> connecting;
-status_result({error, _}) -> connecting.
+status_result(true) -> ?status_connected;
+status_result(false) -> ?status_disconnected;
+status_result({error, _}) -> ?status_disconnected.
 
 on_add_channel(
     _InstanceId,
@@ -251,7 +251,7 @@ on_get_channels(InstanceId) ->
 on_get_channel_status(_InstanceId, ChannelId, #{channels := Channels}) ->
     case maps:is_key(ChannelId, Channels) of
         true ->
-            connected;
+            ?status_connected;
         _ ->
             {error, not_exists}
     end.

--- a/apps/emqx_bridge_syskeeper/test/emqx_bridge_syskeeper_SUITE.erl
+++ b/apps/emqx_bridge_syskeeper/test/emqx_bridge_syskeeper_SUITE.erl
@@ -347,7 +347,7 @@ t_get_status(Config) ->
         _Sleep = 500,
         _Attempts = 10,
         ?assertMatch(
-            #{status := connecting},
+            #{status := disconnected},
             emqx_bridge_v2:health_check(syskeeper_forwarder, ?SYSKEEPER_NAME)
         )
     ).

--- a/changes/ee/fix-13001.en.md
+++ b/changes/ee/fix-13001.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the syskeeper forwarder would never reconnect when the connection was lost.


### PR DESCRIPTION
Fixes EEC-1010

Release version: v/e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
