### PR TITLE
fix: listener crash if access_rules config option is incorrect

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1808,8 +1808,9 @@ access_rules_converter(AccessRules) ->
     DeepRules =
         lists:foldr(
             fun(Rule, Acc) ->
-                Rules = re:split(Rule, <<"\\s*,\\s*">>, [{return, binary}]),
-                [Rules | Acc]
+                Rules0 = re:split(Rule, <<"\\s*,\\s*">>, [{return, binary}]),
+                Rules1 = [string:trim(R) || R <- Rules0],
+                [Rules1 | Acc]
             end,
             [],
             AccessRules

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1781,7 +1781,9 @@ mqtt_listener(Bind) ->
                     hoconsc:array(string()),
                     #{
                         desc => ?DESC(mqtt_listener_access_rules),
-                        default => [<<"allow all">>]
+                        default => [<<"allow all">>],
+                        converter => fun access_rules_converter/1,
+                        validator => fun access_rules_validator/1
                     }
                 )},
             {"proxy_protocol",
@@ -1801,6 +1803,48 @@ mqtt_listener(Bind) ->
                     }
                 )}
         ] ++ emqx_schema_hooks:injection_point('mqtt.listener').
+
+access_rules_converter(AccessRules) ->
+    DeepRules =
+        lists:foldr(
+            fun(Rule, Acc) ->
+                Rules = re:split(Rule, <<"\\s*,\\s*">>, [{return, binary}]),
+                [Rules | Acc]
+            end,
+            [],
+            AccessRules
+        ),
+    [unicode:characters_to_list(RuleBin) || RuleBin <- lists:flatten(DeepRules)].
+
+access_rules_validator(AccessRules) ->
+    InvalidRules = [Rule || Rule <- AccessRules, is_invalid_rule(Rule)],
+    case InvalidRules of
+        [] ->
+            ok;
+        _ ->
+            MsgStr = io_lib:format("invalid_rule(s): ~ts", [string:join(InvalidRules, ", ")]),
+            MsgBin = unicode:characters_to_binary(MsgStr),
+            {error, MsgBin}
+    end.
+
+is_invalid_rule(S) ->
+    try
+        [Action, CIDR] = string:tokens(S, " "),
+        case Action of
+            "allow" -> ok;
+            "deny" -> ok
+        end,
+        case CIDR of
+            "all" ->
+                ok;
+            _ ->
+                %% should not crash
+                _ = esockd_cidr:parse(CIDR, true)
+        end,
+        false
+    catch
+        _:_ -> true
+    end.
 
 base_listener(Bind) ->
     [

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1840,7 +1840,8 @@ is_invalid_rule(S) ->
                 ok;
             _ ->
                 %% should not crash
-                _ = esockd_cidr:parse(CIDR, true)
+                _ = esockd_cidr:parse(CIDR, true),
+                ok
         end,
         false
     catch

--- a/changes/ce/fix-13012.en.md
+++ b/changes/ce/fix-13012.en.md
@@ -1,0 +1,4 @@
+The MQTT listerners config option `access_rules` has been improved in the following ways:
+
+* The listener no longer crash with an incomprehensible error message if a non-valid access rule is configured. Instead a configuration error is generated.
+* One can now add several rules in a single string by separating them by comma (for example, "allow 10.0.1.0/24, deny all").


### PR DESCRIPTION
Previously when changing the access_rules configuration option of a listener to something that was not a valid rule, the listener would crash. This has now been fixed by the addition of a configuration validator that checks the access_rules field.

Additionally, a configuration option converter has been added to the access_rules field so that one can specify several rules in a single string by using "," (comma) as separator.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12315

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible