### PR TITLE
fix: deny subscribing to +/# by default ACL

### DIFF
--- a/apps/emqx_auth/etc/acl.conf
+++ b/apps/emqx_auth/etc/acl.conf
@@ -4,7 +4,7 @@
 
 {allow, {ipaddr, "127.0.0.1"}, all, ["$SYS/#", "#"]}.
 
-{deny, all, subscribe, ["$SYS/#", {eq, "#"}]}.
+{deny, all, subscribe, ["$SYS/#", {eq, "#"}, {eq, "+/#"}]}.
 
 {allow, all}.
 %% NOTE! when deploy in production:

--- a/changes/ce/fix-13024.en.md
+++ b/changes/ce/fix-13024.en.md
@@ -1,0 +1,3 @@
+Add a default ACL deny-rule to reject subscription to `+/#` topic.
+
+Since EMQX by default rejects subscription to `#` topic, for completeness, it should reject `+/#` as well.


### PR DESCRIPTION
Fixes: https://emqx.atlassian.net/browse/EMQX-12362
Release version: v/e5.8.0


## Summary

Prior to this change, EMQX default ACL has a deny rule to reject subscribing to `#`.
For completeness, the default ACL should also deny `+/#` because they are essentially equivalent.

The eunit tests do not seem to cover default ACL rules, automation will be covered in QA env, here is a manual test result:
```
mqttx sub -t '+/#' -h 192.168.31.216 -p 1883
[5/13/2024] [9:34:54 AM] › …  Connecting...
[5/13/2024] [9:34:54 AM] › ✔  Connected
[5/13/2024] [9:34:54 AM] › …  Subscribing to +/#...
[5/13/2024] [9:34:54 AM] › ✔  Subscribed to +/#
[5/13/2024] [9:34:54 AM] › ✖  Subscription negated to +/# with code 135
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket https://github.com/emqx/emqx-docs/pull/2449
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
