### PR TITLE
fix: add handling of message_validation_failed ctx for rule testing

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -307,6 +307,13 @@ fields("ctx_delivery_dropped") ->
         {"from_clientid", sc(binary(), #{desc => ?DESC("event_from_clientid")})},
         {"from_username", sc(binary(), #{desc => ?DESC("event_from_username")})}
         | msg_event_common_fields()
+    ];
+fields("ctx_schema_validation_failed") ->
+    Event = 'schema.validation_failed',
+    [
+        {"event_type", event_type_sc(Event)},
+        {"validation", sc(binary(), #{desc => ?DESC("event_validation")})}
+        | msg_event_common_fields()
     ].
 
 rule_input_message_context() ->
@@ -324,7 +331,8 @@ rule_input_message_context() ->
                 ref("ctx_connack"),
                 ref("ctx_check_authz_complete"),
                 ref("ctx_bridge_mqtt"),
-                ref("ctx_delivery_dropped")
+                ref("ctx_delivery_dropped"),
+                ref("ctx_schema_validation_failed")
             ]),
             #{
                 desc => ?DESC("test_context"),

--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -197,6 +197,8 @@ is_test_runtime_env() ->
 
 %% Most events have the original `topic' input, but their own topic (i.e.: `$events/...')
 %% is different from `topic'.
+get_in_topic(#{event_type := schema_validation_failed}) ->
+    <<"$events/schema_validation_failed">>;
 get_in_topic(Context) ->
     case maps:find(event_topic, Context) of
         {ok, EventTopic} ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_test_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_test_SUITE.erl
@@ -214,6 +214,21 @@ t_ctx_delivery_dropped(_) ->
     Expected = check_result([from_clientid, from_username, reason, qos, topic], [], Context),
     do_test(SQL, Context, Expected).
 
+t_ctx_schema_validation_failed(_) ->
+    SQL =
+        <<"SELECT validation FROM \"$events/schema_validation_failed\"">>,
+    Context = #{
+        <<"clientid">> => <<"c_emqx">>,
+        <<"event_type">> => <<"schema_validation_failed">>,
+        <<"payload">> => <<"{\"msg\": \"hello\"}">>,
+        <<"qos">> => 1,
+        <<"topic">> => <<"t/a">>,
+        <<"username">> => <<"u_emqx">>,
+        <<"validation">> => <<"m">>
+    },
+    Expected = check_result([validation], [], Context),
+    do_test(SQL, Context, Expected).
+
 t_mongo_date_function_should_return_string_in_test_env(_) ->
     SQL =
         <<"SELECT mongo_date() as mongo_date FROM \"$events/client_check_authz_complete\"">>,

--- a/rel/i18n/emqx_rule_api_schema.hocon
+++ b/rel/i18n/emqx_rule_api_schema.hocon
@@ -360,6 +360,12 @@ event_username.desc:
 event_username.label:
 """Username"""
 
+event_validation.desc:
+"""Validation"""
+
+event_validation.label:
+"""Validation"""
+
 root_rule_info.desc:
 """Schema for rule info"""
 


### PR DESCRIPTION
Before this commit, the backend could not handle the test context for message_validation_failed events that could be sent from the dashboard since no handling code for this contexts existed in the backend. This has now been fixed by adding such handling code.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12354

Release version: e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible