### PR TITLE
fix(sessds): persist $SYS messages as well

### DIFF
--- a/apps/emqx/src/emqx_persistent_message.erl
+++ b/apps/emqx/src/emqx_persistent_message.erl
@@ -110,7 +110,7 @@ persist(Msg) ->
     ).
 
 needs_persistence(Msg) ->
-    not (emqx_message:get_flag(dup, Msg) orelse emqx_message:is_sys(Msg)).
+    not emqx_message:get_flag(dup, Msg).
 
 -spec store_message(emqx_types:message()) -> emqx_ds:store_batch_result().
 store_message(Msg) ->


### PR DESCRIPTION
Fixes [EMQX-12291](https://emqx.atlassian.net/browse/EMQX-12291).

Release version: v5.7

## Summary

Otherwise, persistent sessions will not be able to receive $SYS messages whatsoever.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-12291]: https://emqx.atlassian.net/browse/EMQX-12291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ