### PR TITLE
fix(kafka trace): do not include query type in trace entry

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -320,7 +320,7 @@ on_query(
             #{headers_config => KafkaHeaders, instance_id => InstId}
         ),
         emqx_trace:rendered_action_template(MessageTag, #{
-            message => KafkaMessage, send_type => sync
+            message => KafkaMessage
         }),
         do_send_msg(sync, KafkaMessage, Producers, SyncTimeout)
     catch
@@ -380,7 +380,7 @@ on_query_async(
             #{headers_config => KafkaHeaders, instance_id => InstId}
         ),
         emqx_trace:rendered_action_template(MessageTag, #{
-            message => KafkaMessage, send_type => async
+            message => KafkaMessage
         }),
         do_send_msg(async, KafkaMessage, Producers, AsyncReplyFn)
     catch


### PR DESCRIPTION
For Kafka that has its internal buffering the on_query_async callback is used both for sync and async queries (for sync queries the caller waits for a response directly after calling on_query_async). Therefore, before this commit, the trace included incorrect query type information. This has been fixed by removing the query type information from the trace. This should be okay since the query type is not essential information and can be derived from the configuration.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12363

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible