### PR TITLE
ci: allow customizing number of jobs when running locally

### DIFF
--- a/scripts/spellcheck/spellcheck.sh
+++ b/scripts/spellcheck/spellcheck.sh
@@ -6,6 +6,19 @@ set -euo pipefail
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.."
 PROJ_ROOT="$(pwd)"
 
+NUM_JOBS=10
+while getopts "j:" FLAG; do
+  case "$FLAG" in
+    j)
+      NUM_JOBS="${OPTARG}"
+      ;;
+    *)
+      echo "unknown flag: $FLAG"
+      ;;
+  esac
+done
+shift $((OPTIND-1))
+
 if [ -z "${1:-}" ]; then
     SCHEMA="${PROJ_ROOT}/_build/docgen/emqx/schema-en.json"
 else
@@ -29,7 +42,7 @@ set +e
 docker run --rm -i ${DOCKER_TERMINAL_OPT} --name spellcheck \
     -v "${PROJ_ROOT}"/scripts/spellcheck/dicts:/dicts \
     -v "$SCHEMA":/schema.json \
-    ghcr.io/emqx/emqx-schema-validate:0.5.1 -j 10 /schema.json
+    ghcr.io/emqx/emqx-schema-validate:0.5.1 -j "${NUM_JOBS}" /schema.json
 
 result="$?"
 


### PR DESCRIPTION
Example:

```sh
ͳ scripts/spellcheck/spellcheck.sh -j 20 _build/docgen/emqx-enterprise/schema-en.json
Adding /dicts/emqx.txt
Starting LanguageTool server...
+ java -Xms256m -Xmx512m -cp languagetool-server.jar org.languagetool.server.HTTPServer --port 8010 --public --allow-origin '*' --config config.properties
Checking /schema.json with 20 processes...
Spellcheck OK
```

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
