### PR TITLE
fix(sessds): Rename last_alive_update_interval -> heartbeat_interval

### DIFF
--- a/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/integration_test/emqx_persistent_session_ds_SUITE.erl
@@ -57,7 +57,7 @@ init_per_testcase(t_session_gc = TestCase, Config) ->
         roles => [core, core, core],
         extra_emqx_conf =>
             "\n durable_sessions {"
-            "\n   last_alive_update_interval = 500ms "
+            "\n   heartbeat_interval = 500ms "
             "\n   session_gc_interval = 1s "
             "\n   session_gc_batch_size = 2 "
             "\n }"

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -1146,11 +1146,11 @@ receive_maximum(ConnInfo) ->
 expiry_interval(ConnInfo) ->
     maps:get(expiry_interval, ConnInfo, 0).
 
-%% Note: we don't allow overriding `last_alive_update_interval' per
+%% Note: we don't allow overriding `heartbeat_interval' per
 %% zone, since the GC process is responsible for all sessions
 %% regardless of the zone.
 bump_interval() ->
-    emqx_config:get([durable_sessions, last_alive_update_interval]).
+    emqx_config:get([durable_sessions, heartbeat_interval]).
 
 get_config(#{zone := Zone}, Key) ->
     emqx_config:get_zone_conf(Zone, [durable_sessions | Key]).

--- a/apps/emqx/src/emqx_persistent_session_ds_gc_worker.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds_gc_worker.erl
@@ -134,7 +134,7 @@ start_gc() ->
 
 gc_context() ->
     GCInterval = emqx_config:get([durable_sessions, session_gc_interval]),
-    BumpInterval = emqx_config:get([durable_sessions, last_alive_update_interval]),
+    BumpInterval = emqx_config:get([durable_sessions, heartbeat_interval]),
     TimeThreshold = max(GCInterval, BumpInterval) * 3,
     NowMS = now_ms(),
     #{

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1678,12 +1678,12 @@ fields("durable_sessions") ->
                     desc => ?DESC(session_ds_idle_poll_interval)
                 }
             )},
-        {"last_alive_update_interval",
+        {"heartbeat_interval",
             sc(
                 timeout_duration(),
                 #{
                     default => <<"5000ms">>,
-                    desc => ?DESC(session_ds_last_alive_update_interval)
+                    desc => ?DESC(session_ds_heartbeat_interval)
                 }
             )},
         {"renew_streams_interval",

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -471,7 +471,7 @@ zone_global_defaults() ->
                 batch_size => 100,
                 force_persistence => false,
                 idle_poll_interval => 100,
-                last_alive_update_interval => 5000,
+                heartbeat_interval => 5000,
                 message_retention_period => 86400000,
                 renew_streams_interval => 5000,
                 session_gc_batch_size => 100,

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -78,7 +78,7 @@ init_per_group(persistence_enabled, Config) ->
             ?EMQX_CONFIG ++
                 "durable_sessions {\n"
                 "  enable = true\n"
-                "  last_alive_update_interval = 100ms\n"
+                "  heartbeat_interval = 100ms\n"
                 "  renew_streams_interval = 100ms\n"
                 "  session_gc_interval = 2s\n"
                 "}"},

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -71,7 +71,7 @@ init_per_group(persistence_enabled = Group, Config) ->
             {emqx,
                 "durable_sessions = {\n"
                 "  enable = true\n"
-                "  last_alive_update_interval = 100ms\n"
+                "  heartbeat_interval = 100ms\n"
                 "  renew_streams_interval = 100ms\n"
                 "  session_gc_interval = 2s\n"
                 "}\n"}

--- a/apps/emqx_management/test/emqx_mgmt_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_SUITE.erl
@@ -61,7 +61,7 @@ init_per_group(persistence_enabled, Config) ->
             {emqx,
                 "durable_sessions {\n"
                 "  enable = true\n"
-                "  last_alive_update_interval = 100ms\n"
+                "  heartbeat_interval = 100ms\n"
                 "  renew_streams_interval = 100ms\n"
                 "}"},
             emqx_management

--- a/changes/ce/fix-13062.en.md
+++ b/changes/ce/fix-13062.en.md
@@ -1,0 +1,1 @@
+Rename configuration parameter `durable_sessions.last_alive_update_interval` to `durable_sessions.heartbeat_interval`.


### PR DESCRIPTION
Fixes [EMQX-12398](https://emqx.atlassian.net/browse/EMQX-12398)

Release version: v/e5.?

## Summary

Rename configuration parameter `durable_sessions.last_alive_update_interval` to `durable_sessions.heartbeat_interval`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12398]: https://emqx.atlassian.net/browse/EMQX-12398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ