### PR TITLE
0518 improve kafka connection error logs

### DIFF
--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -245,7 +245,7 @@ t_license_setting_bc(_Config) ->
     ?assertMatch(#{<<"max_connections">> := 25}, request_dump()),
     %% get
     GetRes = request(get, uri(["license", "setting"]), []),
-    %% aslo check that the settings return correctly
+    %% also check that the settings return correctly
     validate_setting(GetRes, <<"75%">>, <<"80%">>, 25),
     %% update
     Low = <<"50%">>,

--- a/changes/ee/fix-13070.en.md
+++ b/changes/ee/fix-13070.en.md
@@ -1,0 +1,5 @@
+Improve Kafka connector error logs.
+
+Previously, specific error details, such as unreachable advertised listeners, were not logged.
+Now, error details are captured in the logs to provide more diagnostic information.
+To manage log verbosity, only the first occurrence of an error is logged, accompanied by the total count of similar errors.

--- a/dev
+++ b/dev
@@ -506,6 +506,8 @@ ctl() {
         case rpc:call('$EMQX_NODE_NAME', emqx_ctl, run_command, [[$args]]) of
           ok ->
             init:stop(0);
+          true ->
+            init:stop(0);
           Error ->
             io:format(\"~p~n\", [Error]),
             init:stop(1)


### PR DESCRIPTION
Fixes [EMQX-12403](https://emqx.atlassian.net/browse/EMQX-12403)

Release version: v/e5.7.1

## Summary

Example log when Kafka's advertised listener is unreachable.

2024-05-18T19:13:48.412913+02:00 [warning] msg: add_channel_failed, id: <<"connector:kafka_producer:k1">>, reason: #{cause => "no_connected_partition_leader",kafka_topic => "test-topic-2",kafka_client => <<"connector:kafka_producer:k1">>,first_error => {1,{down,#{reason => unresolvable_hostname,host => <<"localhostx:9092">>}}},total_errors => 2}, channel_id: <<"action:kafka_producer:k1:connector:kafka_producer:k1">>

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12403]: https://emqx.atlassian.net/browse/EMQX-12403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ