### PR TITLE
chore: bump emqx_auth_http app vsn

### DIFF
--- a/apps/emqx_auth_http/src/emqx_auth_http.app.src
+++ b/apps/emqx_auth_http/src/emqx_auth_http.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_http, [
     {description, "EMQX External HTTP API Authentication and Authorization"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {mod, {emqx_auth_http_app, []}},
     {applications, [


### PR DESCRIPTION
A release has been cut in emqx-platform.git between `e5.6.1` and current `HEAD` of release-57.