### PR TITLE
fix: action config update would sometimes not be reflected in connector

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1499,14 +1499,11 @@ maybe_reply(Actions, From, Reply) ->
 
 -spec data_record_to_external_map(data()) -> resource_data().
 data_record_to_external_map(Data) ->
-    AddedChannelsList = maps:to_list(Data#data.added_channels),
-    AddedChannelsListWithoutConfigs =
-        [
-            {ChanID, maps:remove(config, Status)}
-         || {ChanID, Status} <- AddedChannelsList
-        ],
     AddedChannelsWithoutConfigs =
-        maps:from_list(AddedChannelsListWithoutConfigs),
+        maps:map(
+            fun(_ChanID, Status) -> maps:remove(config, Status) end,
+            Data#data.added_channels
+        ),
     #{
         id => Data#data.id,
         error => external_error(Data#data.error),

--- a/changes/ce/fix-13077.en.md
+++ b/changes/ce/fix-13077.en.md
@@ -1,0 +1,1 @@
+Updates to action configurations would sometimes not take effect without disabling and enabling the action. This means that an action could sometimes run with the old (previous) configuration even though it would look like the action configuration has been updated successfully.


### PR DESCRIPTION
Before this commit the following happened sometimes:

1. action status is connected
2. action config is updated to something that should change the status to disconnected
3. action status is still connected and the old config is being used by the connector even though the config has been correctly updated.

The reason for this bug is that the post_config_hook runs before the global EMQX config is updated. The post config hook is adding the new config to the connector. Since the new config causes the action to get status disconnected, the adding of the action to the connector is retried when the health check runs but this time the config will be loaded from the global config which could cause the old config to be loaded (this happens when the global config has not had time to get updated).

The above problem has been fixed in this commit by only reading action configs from the global config when the connector starts/restarts and instead store the latest configs for the actions in the connector.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12376

Release version: v/e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
