### PR TITLE
fix(s3-bridge): report inconsistent `min/max_part_size` option

### DIFF
--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_upload.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_upload.erl
@@ -69,7 +69,11 @@ fields(?ACTION) ->
             }),
             #{
                 required => true,
-                desc => ?DESC(s3_upload)
+                desc => ?DESC(s3_upload),
+                %% NOTE
+                %% There seems to be no way to attach validators to union types, thus we
+                %% have to attach a "common denominator" validator here.
+                validator => validators(s3_upload_parameters)
             }
         ),
         #{
@@ -210,6 +214,9 @@ desc(s3_upload_resource_opts) ->
     ?DESC(emqx_resource_schema, resource_opts);
 desc(_Name) ->
     undefined.
+
+validators(s3_upload_parameters) ->
+    emqx_s3_schema:validators(s3_uploader).
 
 convert_actions(Conf = #{}, Opts) ->
     maps:map(fun(_Name, ConfAction) -> convert_action(ConfAction, Opts) end, Conf);

--- a/apps/emqx_bridge_s3/test/emqx_bridge_s3_aggreg_upload_SUITE.erl
+++ b/apps/emqx_bridge_s3/test/emqx_bridge_s3_aggreg_upload_SUITE.erl
@@ -156,6 +156,24 @@ t_create_via_http(Config) ->
 t_on_get_status(Config) ->
     emqx_bridge_v2_testlib:t_on_get_status(Config, #{}).
 
+t_invalid_config(Config) ->
+    ?assertMatch(
+        {error,
+            {_Status, _, #{
+                <<"code">> := <<"BAD_REQUEST">>,
+                <<"message">> := #{<<"kind">> := <<"validation_error">>}
+            }}},
+        emqx_bridge_v2_testlib:create_bridge_api(
+            Config,
+            _Overrides = #{
+                <<"parameters">> => #{
+                    <<"min_part_size">> => <<"5GB">>,
+                    <<"max_part_size">> => <<"100MB">>
+                }
+            }
+        )
+    ).
+
 t_aggreg_upload(Config) ->
     Bucket = ?config(s3_bucket, Config),
     BridgeName = ?config(bridge_name, Config),

--- a/apps/emqx_s3/src/emqx_s3_schema.erl
+++ b/apps/emqx_s3/src/emqx_s3_schema.erl
@@ -10,6 +10,7 @@
 -import(hoconsc, [mk/2, ref/2]).
 
 -export([roots/0, fields/1, namespace/0, tags/0, desc/1]).
+-export([validators/1]).
 
 -export([translate/1]).
 -export([translate/2]).
@@ -176,6 +177,14 @@ desc(s3_upload) ->
     "S3 upload options";
 desc(transport_options) ->
     "Options for the HTTP transport layer used by the S3 client".
+
+validators(s3_uploader) ->
+    [fun validate_part_size/1].
+
+validate_part_size(Conf) ->
+    Min = hocon_maps:get(<<"min_part_size">>, Conf),
+    Max = hocon_maps:get(<<"max_part_size">>, Conf),
+    Min =< Max orelse {error, <<"Inconsistent 'min_part_size': cannot exceed 'max_part_size'">>}.
 
 translate(Conf) ->
     translate(Conf, #{}).


### PR DESCRIPTION
Fixes [EMQX-12422](https://emqx.atlassian.net/browse/EMQX-12422).

Release version: e5.7

## Summary

Report inconsistent `min_part_size` / `max_part_size` configuration parameters as a validation error.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [ ] **Schema changes are backward compatible**


[EMQX-12422]: https://emqx.atlassian.net/browse/EMQX-12422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ