### PR TITLE
fix(s3-bridge): restore backward config compatibility

### DIFF
--- a/scripts/conf-test/old-confs/e5.6.1.conf
+++ b/scripts/conf-test/old-confs/e5.6.1.conf
@@ -1,0 +1,49 @@
+node {
+  name = "emqx@127.0.0.1"
+  cookie = "emqxsecretcookie"
+  data_dir = "data"
+}
+
+actions {
+  s3 {
+    s3direct {
+      connector = s3local
+      enable = true
+      parameters {
+        acl = private
+        bucket = direct
+        content = "${.}"
+        headers {}
+        key = "${clientid}/${id}"
+      }
+      resource_opts {
+        health_check_interval = 15s
+        inflight_window = 100
+        max_buffer_bytes = 256MB
+        query_mode = async
+        request_ttl = 45s
+        worker_pool_size = 16
+      }
+    }
+  }
+}
+connectors {
+  s3 {
+    s3local {
+      access_key_id = ACCESS
+      host = localhost
+      port = 9000
+      resource_opts {health_check_interval = 15s, start_timeout = 5s}
+      secret_access_key = SECRET
+      transport_options {
+        connect_timeout = 15s
+        enable_pipelining = 100
+        headers {}
+        ipv6_probe = false
+        pool_size = 8
+        pool_type = random
+        ssl {enable = false, verify = verify_peer}
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes [EMQX-12437](https://emqx.atlassian.net/browse/EMQX-12437).

Release version: e5.7

## Summary

Recently introduced `mode` required field broke older configurations, this PR brings back backward compatibility.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-12437]: https://emqx.atlassian.net/browse/EMQX-12437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ