### PR TITLE
Fix(s3): change the batch_size to 1 for direct mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ endif
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= v1.9.0-beta.1
-export EMQX_EE_DASHBOARD_VERSION ?= e1.7.0-beta.11
+export EMQX_EE_DASHBOARD_VERSION ?= e1.7.0-beta.12
 
 -include default-profile.mk
 PROFILE ?= emqx

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_upload.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_upload.erl
@@ -238,12 +238,12 @@ convert_actions(undefined, _) ->
 
 convert_action(Conf = #{<<"parameters">> := Params, <<"resource_opts">> := ResourceOpts}, _) ->
     case Params of
-        #{<<"mode">> := <<"direct">>} ->
+        #{<<"mode">> := <<"aggregated">>} ->
+            Conf;
+        #{} ->
             %% NOTE: Disable batching for direct uploads.
             NResourceOpts = ResourceOpts#{<<"batch_size">> => 1, <<"batch_time">> => 0},
-            Conf#{<<"resource_opts">> := NResourceOpts};
-        #{} ->
-            Conf
+            Conf#{<<"resource_opts">> := NResourceOpts}
     end.
 
 %% Interpreting options


### PR DESCRIPTION
~It's just a temporary workaround fixing to avoid the following crash log:~

```
2024-05-24T02:41:46.285172+00:00 [error] tag: ERROR, msg: resource_exception, info: #{error => {error,{case_clause,#{mode => direct,key => [<<"test">>],content => [{var,[],[]}],bucket => [<<"emqx-file-transfer">>],upload_options => #{acl => private}}}},id => <<"action:s3:bad48af88a52468888782920b5c6206c:connector:s3:71ef671d06da4d0fa5bcc19305a29a14">>,name => call_batch_query,request => [{query,{fun emqx_rule_runtime:inc_action_metrics/2,[#{clientid => <<"c_emqx">>,rule_id => <<"72f87f5ba3b440b08af93b9c1e09fade">>,action_id => {bridge_v2,s3,bad48af88a52468888782920b5c6206c},rule_trigger_ts => [1716518499603]}],#{reply_dropped => true}},{<<"action:s3:bad48af88a52468888782920b5c6206c:connector:s3:71ef671d06da4d0fa5bcc19305a29a14">>,#{flags => #{},id => <<"0006192A1B6B546C29B200008F640000">>,node => 'emqx@10.42.3.120',timestamp => 1716518499603,metadata => #{rule_id => <<"72f87f5ba3b440b08af93b9c1e09fade">>},event => 'message.publish',username => <<"u_emqx">>,event_type => message_publish,payload => <<"{\"msg\": \"hello\"}">>,clientid => <<"c_emqx">>,topic => <<"s3:bad48af88a52468888782920b5c6206c">>,qos => 1,peerhost => <<"192.168.0.10">>,pub_props => #{'User-Property' => #{foo => <<"bar">>},'User-Property-Pairs' => [#{key => <<"foo">>},#{value => <<"bar">>}],'Message-Expiry-Interval' => 30,'Payload-Format-Indicator' => 0},publish_received_at => 1716518499603}},true,-576457358828454991,#{clientid => <<"c_emqx">>,rule_id => <<"72f87f5ba3b440b08af93b9c1e09fade">>,rule_trigger_ts => [1716518499603]}}],stacktrace => [{emqx_bridge_s3_connector,on_batch_query,3,[{file,"emqx_bridge_s3_connector.erl"},{line,321}]},{emqx_resource_buffer_worker,apply_query_fun,9,[{file,"emqx_resource_buffer_worker.erl"},{line,1443}]},{emqx_resource_buffer_worker,call_query,6,[{file,"emqx_resource_buffer_worker.erl"},{line,1181}]},{emqx_resource_buffer_worker,retry_inflight_sync,3,[{file,"emqx_resource_buffer_worker.erl"},{line,448}]},{gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1395}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}, rule_id: <<"72f87f5ba3b440b08af93b9c1e09fade">>, rule_trigger_ts: [1716518499603]
```

~In the previous implementation, it may cause `batch_size` might be set to the default value (100) in `driect` mode, i.e:~
- ~The user upgrades from the old version of EMQX, and the old configuration does not provide `batch_size` configuration.~
- ~The user creates mode=direct without providing batch_size configuration via the HTTP API.~

~The better way is to provide a configuration verification, but this is not my area of expertise, and it's hard to finish it before the 5.7.0 release. So I'm submitting this as a temporary solution.~

Meanwhile, in 5.7.0, the EMQX Dashboard will temporarily hide the two configuration items, batch_size and batch_time. （ see: https://github.com/emqx/emqx-dashboard5/releases/tag/e1.7.0-beta.12)

Other discussions before: https://emqxio.slack.com/archives/C05RY19UVDH/p1715859999352599

----
updates: improve the judgement to handle the `mode=direct` missed situation

Release version: v/e5.7

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
