### PR TITLE
fix(dsapi): Check status of the node via Mria

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_ds.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_ds.erl
@@ -307,7 +307,7 @@ get_site(get, #{bindings := #{site := Site}}) ->
             ?NOT_FOUND(<<"Site not found: ", Site/binary>>);
         true ->
             Node = emqx_ds_replication_layer_meta:node(Site),
-            IsUp = lists:member(Node, [node() | nodes()]),
+            IsUp = mria:cluster_status(Node) =:= running,
             Shards = shards_of_site(Site),
             ?OK(#{
                 node => Node,


### PR DESCRIPTION
Fixes [EMQX-12356](https://emqx.atlassian.net/browse/EMQX-12356)

Release version: v/e5.7.0

## Summary

Check status of the site via Mria API instead of Erlang node API to be consistent with the output of `emqx_ctl ds info` command.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12356]: https://emqx.atlassian.net/browse/EMQX-12356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ