### PR TITLE
fix(redis trace): add separators in redis batch action trace

### DIFF
--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_redis, [
     {description, "EMQX Enterprise Redis Bridge"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_connector.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_connector.erl
@@ -6,6 +6,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/emqx_trace.hrl").
 
 -behaviour(emqx_resource).
 
@@ -143,7 +144,13 @@ on_batch_query(
             [{ChannelID, _} | _] = BatchData,
             emqx_trace:rendered_action_template(
                 ChannelID,
-                #{commands => Cmds, batch => ture}
+                #{
+                    commands => #emqx_trace_format_func_data{
+                        function = fun trace_format_commands/1,
+                        data = Cmds
+                    },
+                    batch => true
+                }
             ),
             Result = query(InstId, {cmds, Cmds}, RedisConnSt),
             ?tp(
@@ -161,6 +168,11 @@ on_batch_query(
         Error ->
             Error
     end.
+
+trace_format_commands(Commands0) ->
+    Commands1 = [[unicode:characters_to_list(S) || S <- C] || C <- Commands0],
+    Commands2 = [lists:join(" ", C) || C <- Commands1],
+    unicode:characters_to_binary(lists:join("; ", Commands2)).
 
 on_format_query_result({ok, Msg}) ->
     #{result => ok, message => Msg};

--- a/apps/emqx_bridge_redis/src/emqx_bridge_redis_connector.erl
+++ b/apps/emqx_bridge_redis/src/emqx_bridge_redis_connector.erl
@@ -170,9 +170,8 @@ on_batch_query(
     end.
 
 trace_format_commands(Commands0) ->
-    Commands1 = [[unicode:characters_to_list(S) || S <- C] || C <- Commands0],
-    Commands2 = [lists:join(" ", C) || C <- Commands1],
-    unicode:characters_to_binary(lists:join("; ", Commands2)).
+    Commands1 = [lists:join(" ", C) || C <- Commands0],
+    unicode:characters_to_binary(lists:join("; ", Commands1)).
 
 on_format_query_result({ok, Msg}) ->
     #{result => ok, message => Msg};

--- a/changes/ee/fix-13130.en.md
+++ b/changes/ee/fix-13130.en.md
@@ -1,0 +1,1 @@
+Traces for Redis action batch requests have got improved formatting. Spaces are now added between components of commands and semicolons are added between commands to make the trace message easier to read.


### PR DESCRIPTION
Logger will transform data that looks like IO data into a string which made redis batch traces look like the spaces had been removed from the strings. To prevent this, we render the batched commands into binary string separated by spaces and semicolon. The components of a single command is separated by spaces and the commands in a batch are separated by semicolons.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12428

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
