### PR TITLE
fix(oracle action trace): parameters should not be rendered as IO Data

### DIFF
--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -452,19 +452,19 @@ best_effort_json_test() ->
     ),
     %% List is IO Data
     ?assertMatch(
-        #{<<"what">> => <<"hej\n">>},
+        #{<<"what">> := <<"hej\n">>},
         emqx_utils_json:decode(emqx_logger_jsonfmt:best_effort_json(#{what => [<<"hej">>, 10]}))
     ),
     %% Force list to be interpreted as an array
     ?assertMatch(
-        #{<<"what">> => [<<"hej">>, 10]},
+        #{<<"what">> := [<<"hej">>, 10]},
         emqx_utils_json:decode(
             emqx_logger_jsonfmt:best_effort_json(#{what => {'$array$', [<<"hej">>, 10]}})
         )
     ),
     %% IO Data inside an array
     ?assertMatch(
-        #{<<"what">> => [<<"hej">>, 10, <<"hej\n">>]},
+        #{<<"what">> := [<<"hej">>, 10, <<"hej\n">>]},
         emqx_utils_json:decode(
             emqx_logger_jsonfmt:best_effort_json(#{
                 what => {'$array$', [<<"hej">>, 10, [<<"hej">>, 10]]}
@@ -473,7 +473,7 @@ best_effort_json_test() ->
     ),
     %% Array inside an array
     ?assertMatch(
-        #{<<"what">> => [<<"hej">>, 10, [<<"hej">>, 10]]},
+        #{<<"what">> := [<<"hej">>, 10, [<<"hej">>, 10]]},
         emqx_utils_json:decode(
             emqx_logger_jsonfmt:best_effort_json(#{
                 what => {'$array$', [<<"hej">>, 10, {'$array$', [<<"hej">>, 10]}]}

--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -270,6 +270,8 @@ json(L, Config) when is_list(L) ->
     end;
 json(Map, Config) when is_map(Map) ->
     best_effort_json_obj(Map, Config);
+json({'$array$', List}, Config) when is_list(List) ->
+    [json(I, Config) || I <- List];
 json(Term, Config) ->
     do_format_msg("~p", [Term], Config).
 
@@ -447,6 +449,36 @@ best_effort_json_test() ->
     ?assertEqual(
         <<"[\n  {\n    \"key\" : [\n      \n    ]\n  }\n]">>,
         best_effort_json([#{key => []}])
+    ),
+    %% List is IO Data
+    ?assertMatch(
+        #{<<"what">> => <<"hej\n">>},
+        emqx_utils_json:decode(emqx_logger_jsonfmt:best_effort_json(#{what => [<<"hej">>, 10]}))
+    ),
+    %% Force list to be interpreted as an array
+    ?assertMatch(
+        #{<<"what">> => [<<"hej">>, 10]},
+        emqx_utils_json:decode(
+            emqx_logger_jsonfmt:best_effort_json(#{what => {'$array$', [<<"hej">>, 10]}})
+        )
+    ),
+    %% IO Data inside an array
+    ?assertMatch(
+        #{<<"what">> => [<<"hej">>, 10, <<"hej\n">>]},
+        emqx_utils_json:decode(
+            emqx_logger_jsonfmt:best_effort_json(#{
+                what => {'$array$', [<<"hej">>, 10, [<<"hej">>, 10]]}
+            })
+        )
+    ),
+    %% Array inside an array
+    ?assertMatch(
+        #{<<"what">> => [<<"hej">>, 10, [<<"hej">>, 10]]},
+        emqx_utils_json:decode(
+            emqx_logger_jsonfmt:best_effort_json(#{
+                what => {'$array$', [<<"hej">>, 10, {'$array$', [<<"hej">>, 10]}]}
+            })
+        )
     ),
     ok.
 

--- a/apps/emqx_oracle/src/emqx_oracle.app.src
+++ b/apps/emqx_oracle/src/emqx_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_oracle, [
     {description, "EMQX Enterprise Oracle Database Connector"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ee/fix-13136.en.md
+++ b/changes/ee/fix-13136.en.md
@@ -1,0 +1,1 @@
+The template-rendered traces for Oracle actions have been enhanced for better readability.


### PR DESCRIPTION
This forces the parameters to the database statement to be rendered as a JSON array in JSON traces instead of being rendered as a string when the parameters are interpreted as IO data.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12433

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible
