### PR TITLE
fix: trace formatter should not crash when given a non-binary payload

### DIFF
--- a/changes/ce/fix-13140.en.md
+++ b/changes/ce/fix-13140.en.md
@@ -1,0 +1,1 @@
+The issue causing text traces for the republish action to crash and not display correctly has been resolved.


### PR DESCRIPTION
Fixes:
https://emqx.atlassian.net/browse/EMQX-12474

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible