### PR TITLE
fix: make protobuf schema decode error reported to user less cryptic

### DIFF
--- a/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_schema_registry, [
     {description, "EMQX Schema Registry"},
-    {vsn, "0.3.0"},
+    {vsn, "0.3.1"},
     {registered, [emqx_schema_registry_sup]},
     {mod, {emqx_schema_registry_app, []}},
     {included_applications, [

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
@@ -64,7 +64,21 @@ handle_rule_function(sparkplug_encode, [Term | MoreArgs]) ->
         [?EMQX_SCHEMA_REGISTRY_SPARKPLUGB_SCHEMA_NAME, Term | MoreArgs]
     );
 handle_rule_function(schema_decode, [SchemaId, Data | MoreArgs]) ->
-    decode(SchemaId, Data, MoreArgs);
+    try
+        decode(SchemaId, Data, MoreArgs)
+    catch
+        error:{gpb_error, {decoding_failure, {_Data, _Schema, {error, function_clause, _Stack}}}} ->
+            throw(
+                {schema_decode_error, #{
+                    error_type => decoding_failure,
+                    schema_id => SchemaId,
+                    data => Data,
+                    more_args => MoreArgs,
+                    msg =>
+                        <<"The given data could not be decoded. Please check the input data and the schema.">>
+                }}
+            )
+    end;
 handle_rule_function(schema_decode, Args) ->
     error({args_count_error, {schema_decode, Args}});
 handle_rule_function(schema_encode, [SchemaId, Term | MoreArgs]) ->

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
@@ -74,7 +74,7 @@ handle_rule_function(schema_decode, [SchemaId, Data | MoreArgs]) ->
                     schema_id => SchemaId,
                     data => Data,
                     more_args => MoreArgs,
-                    msg =>
+                    explain =>
                         <<"The given data could not be decoded. Please check the input data and the schema.">>
                 }}
             )

--- a/changes/ee/fix-13147.en.md
+++ b/changes/ee/fix-13147.en.md
@@ -1,0 +1,1 @@
+Error messages for decoding failures in the rule engine protobuf decode functions have been improved by adding a clear descriptions to indicate what went wrong when message decoding fails.


### PR DESCRIPTION
Before this commit the user would see a cryptic warning log including function_clause when decoding a message failed. This commit improves this by removing function_caluse as well as some other cryptic words from the message and adding a description describing what went wrong.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12453

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible