### PR TITLE
chore: improve emqx boot script's compatibility check

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -337,6 +337,9 @@ compatiblity_info() {
   # set crash-dump bytes to zero to ensure no crash dump is generated when erl crashes
   env ERL_CRASH_DUMP_BYTES=0 "$BINDIR/$PROGNAME" \
     -noshell \
+    +S 2 \
+    +P 65536 \
+    +Q 65536 \
     -boot "$REL_DIR/start_clean" \
     -boot_var RELEASE_LIB "$ERTS_LIB_DIR/lib" \
     -eval "$COMPATIBILITY_CHECK"
@@ -408,6 +411,7 @@ remsh() {
             -setcookie "$COOKIE" \
             -hidden \
             -kernel net_ticktime "$TICKTIME" \
+            +P 65536 \
             +Q 65536 \
             +S 2 \
             $EPMD_ARGS
@@ -420,6 +424,7 @@ remsh() {
             --erl "-kernel net_ticktime $TICKTIME" \
             --erl "$EPMD_ARGS" \
             --erl "$NAME_TYPE $id" \
+            --erl "+P 65536" \
             --erl "+Q 65536" \
             --erl "+S 2" \
             --boot "$REL_DIR/start_clean"
@@ -1307,7 +1312,11 @@ case "${COMMAND}" in
               --boot "$REL_DIR/start_clean" \
               --boot-var RELEASE_LIB "$ERTS_LIB_DIR" \
               --vm-args "$REL_DIR/remote.vm.args" \
-              --erl "-start_epmd false -epmd_module ekka_epmd" \
+              --erl "-start_epmd false" \
+              --erl "-epmd_module ekka_epmd" \
+              --erl "+P 65536" \
+              --erl "+Q 65536" \
+              --erl "+S 2" \
               --rpc-eval "$NAME" "$@"
         else
             echo "EMQX node is not an Elixir node"

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -1,6 +1,6 @@
 #!/usr/bin/env escript
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
-%%! +Q 65536 +S 1
+%%! +P 65536 +Q 65536 +S 1
 %% ex: ft=erlang ts=4 sw=4 et
 %% -------------------------------------------------------------------
 %%


### PR DESCRIPTION
Release version: v/e5.8.0

## Summary

Prior to this change, the command used to check installation and os compatibility is done by starting a 'erl' process using default flags. it might be unnecessarily expensive in large VM instances.
In this change, we have added small enough `+S`, `+P` and `+Q` number to lower the cost.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
