### PR TITLE
feat(redis): add a rule function to help formatting redis args

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -839,7 +839,7 @@ redis_field_name(K) ->
     throw({bad_redis_field_name, K}).
 
 redis_field_value(V) when erlang:is_binary(V) ->
-    iolist_to_binary([$", V, $"]);
+    V;
 redis_field_value(V) when erlang:is_integer(V) ->
     integer_to_binary(V);
 redis_field_value(V) when erlang:is_float(V) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -160,6 +160,7 @@
     find/3,
     join_to_string/1,
     join_to_string/2,
+    map_to_redis_hset_args/1,
     join_to_sql_values_string/1,
     jq/2,
     jq/3,
@@ -813,6 +814,38 @@ find(S, P, Position) -> emqx_variform_bif:find(S, P, Position).
 join_to_string(Str) -> emqx_variform_bif:join_to_string(Str).
 
 join_to_string(Sep, List) -> emqx_variform_bif:join_to_string(Sep, List).
+
+%% @doc Format map key-value pairs as redis HSET (or HMSET) command fields.
+%% Notes:
+%% - Non-string keys in the input map are dropped
+%% - Keys are not quoted
+%% - String values are always quoted
+%% - No escape sequence for keys and values
+%% - Float point values are formatted with fixed (6) decimal point compact-formatting
+map_to_redis_hset_args(Map) when erlang:is_map(Map) ->
+    [map_to_redis_hset_args | maps:fold(fun redis_hset_acc/3, [], Map)].
+
+redis_hset_acc(K, V, IoData) ->
+    try
+        [redis_field_name(K), redis_field_value(V) | IoData]
+    catch
+        _:_ ->
+            IoData
+    end.
+
+redis_field_name(K) when erlang:is_binary(K) ->
+    K;
+redis_field_name(K) ->
+    throw({bad_redis_field_name, K}).
+
+redis_field_value(V) when erlang:is_binary(V) ->
+    iolist_to_binary([$", V, $"]);
+redis_field_value(V) when erlang:is_integer(V) ->
+    integer_to_binary(V);
+redis_field_value(V) when erlang:is_float(V) ->
+    float2str(V, 6);
+redis_field_value(V) when erlang:is_boolean(V) ->
+    atom_to_binary(V).
 
 join_to_sql_values_string(List) ->
     QuotedList =

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1384,8 +1384,8 @@ t_map_to_redis_hset_args(_Config) ->
     ?assertEqual([<<"a">>, <<"1.1">>], Do(#{<<"a">> => 1.1})),
     ?assertEqual([<<"a">>, <<"true">>], Do(#{<<"a">> => true})),
     ?assertEqual([<<"a">>, <<"false">>], Do(#{<<"a">> => false})),
-    ?assertEqual([<<"a">>, <<"\"\"">>], Do(#{<<"a">> => <<"">>})),
-    ?assertEqual([<<"a">>, <<"\"i j\"">>], Do(#{<<"a">> => <<"i j">>})),
+    ?assertEqual([<<"a">>, <<"">>], Do(#{<<"a">> => <<"">>})),
+    ?assertEqual([<<"a">>, <<"i j">>], Do(#{<<"a">> => <<"i j">>})),
     %% no determined ordering
     ?assert(
         case Do(#{<<"a">> => 1, <<"b">> => 2}) of

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1376,6 +1376,27 @@ t_parse_date_errors(_) ->
 
     ok.
 
+t_map_to_redis_hset_args(_Config) ->
+    Do = fun(Map) -> tl(emqx_rule_funcs:map_to_redis_hset_args(Map)) end,
+    ?assertEqual([], Do(#{})),
+    ?assertEqual([], Do(#{1 => 2})),
+    ?assertEqual([<<"a">>, <<"1">>], Do(#{<<"a">> => 1, 3 => 4})),
+    ?assertEqual([<<"a">>, <<"1.1">>], Do(#{<<"a">> => 1.1})),
+    ?assertEqual([<<"a">>, <<"true">>], Do(#{<<"a">> => true})),
+    ?assertEqual([<<"a">>, <<"false">>], Do(#{<<"a">> => false})),
+    ?assertEqual([<<"a">>, <<"\"\"">>], Do(#{<<"a">> => <<"">>})),
+    ?assertEqual([<<"a">>, <<"\"i j\"">>], Do(#{<<"a">> => <<"i j">>})),
+    %% no determined ordering
+    ?assert(
+        case Do(#{<<"a">> => 1, <<"b">> => 2}) of
+            [<<"a">>, <<"1">>, <<"b">>, <<"2">>] ->
+                true;
+            [<<"b">>, <<"2">>, <<"a">>, <<"1">>] ->
+                true
+        end
+    ),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Utility functions
 %%------------------------------------------------------------------------------

--- a/apps/emqx_utils/src/emqx_placeholder.erl
+++ b/apps/emqx_utils/src/emqx_placeholder.erl
@@ -37,7 +37,8 @@
     proc_tmpl_deep/3,
 
     bin/1,
-    sql_data/1
+    sql_data/1,
+    lookup_var/2
 ]).
 
 -export([

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.2.0"},
+    {vsn, "5.2.1"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/changes/ee/feat-13172.en.md
+++ b/changes/ee/feat-13172.en.md
@@ -1,0 +1,5 @@
+Added a rule function `map_to_redis_hset_args` to help preparing redis HSET (or HMSET) multi-fields values.
+
+For example, if `payload.value` is a map of multiple data fields,
+this rule `SELECT  map_to_redis_hset_args(payload.value) as hset_fields FROM  "t/#"` can prepare `hset_fields`
+for redis action to render the command template like `HMSET name1 ${hset_fields}`.


### PR DESCRIPTION
Fixes [12510](https://emqx.atlassian.net/browse/EMQX-12510)

Release version: v/e5.7.1

## Summary

When data is already structured with a trusted schema, having to enumerate all possible data fields is low efficiency for both configuring EMQX action and template rendering.
Below is a IRL case.  
```
        command_template = [
          HMSET,
          "NS:2",
          f1,  "${payload.f1}",
          f2,  "${payload.f2}",
          ...
          f50000, "${payload.f50000}"
        ]
```

This PR introduces a new function named 'map_to_redis_hset_args'
it can be used to format a map's key-value pairs into redis HSET (or HMSET) arg list.
This new function is dedicated for redis to avoid abuse for other data integrations.

With the help of this function, the rule can be written as:
```
SELECT  map_to_redis_hset_args(payload) as hset_fields FROM  "t/#"
```
Then the template can be simplified as 
```
        command_template = [
          HMSET,
          "NS:2",
          ${hset_fields}
        ]
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket https://github.com/emqx/emqx-docs/pull/2514
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
