### PR TITLE
fix(pgsql connector): handle prepared statement already exists

### DIFF
--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -135,6 +135,7 @@ end_per_testcase(_Testcase, Config) ->
     connect_and_clear_table(Config),
     ok = snabbkaffe:stop(),
     delete_bridge(Config),
+    emqx_common_test_helpers:call_janitor(),
     ok.
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_postgresql/src/emqx_postgresql.app.src
+++ b/apps/emqx_postgresql/src/emqx_postgresql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_postgresql, [
     {description, "EMQX PostgreSQL Database Connector"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -654,7 +654,7 @@ prepare_sql_to_conn(Conn, Prepares) ->
 
 prepare_sql_to_conn(Conn, [], Statements, _Attempts) when is_pid(Conn) ->
     {ok, Statements};
-prepare_sql_to_conn(Conn, [{Key, _} | _Rest], _Statements, _MaxAttempts = 2) when is_pid(Conn) ->
+prepare_sql_to_conn(Conn, [{_Key, _} | _Rest], _Statements, _MaxAttempts = 2) when is_pid(Conn) ->
     failed_to_remove_prev_prepared_statement_error();
 prepare_sql_to_conn(
     Conn, [{Key, {SQL, _RowTemplate}} | Rest] = ToPrepare, Statements, Attempts
@@ -711,8 +711,8 @@ prepare_sql_to_conn(
 
 failed_to_remove_prev_prepared_statement_error() ->
     Msg =
-        ("A previous prepared statement for the action already exists and "
-        "we are not able to close it. Please, try to disable and then enable "
+        ("A previous prepared statement for the action already exists "
+        "but cannot be closed. Please, try to disable and then enable "
         "the connector to resolve this issue."),
     {error, unicode:charactes_to_binary(Msg)}.
 

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -714,7 +714,7 @@ failed_to_remove_prev_prepared_statement_error() ->
         ("A previous prepared statement for the action already exists "
         "but cannot be closed. Please, try to disable and then enable "
         "the connector to resolve this issue."),
-    {error, unicode:charactes_to_binary(Msg)}.
+    {error, unicode:characters_to_binary(Msg)}.
 
 to_bin(Bin) when is_binary(Bin) ->
     Bin;


### PR DESCRIPTION
In a user's log file it was found that that the pgsql driver can end up in a situation where the prepared statement for a channel/action is not properly removed before a channel with the same name as the prepared statement is added to the connector. This commit handles this by attempting to remove the old prepared statement if one already exists when adding channel.

Related issue:
https://emqx.atlassian.net/browse/EEC-1036

Fixes <issue-or-jira-number>

Release version: v/e5.7.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
-  [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
-  [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible