### PR TITLE
fix(resource manager): force kill process if stuck when stopping/removing

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -879,6 +879,8 @@ handle_disable_enable(ConfRootKey, Id, Enable) ->
                 ?SERVICE_UNAVAILABLE(<<"request timeout">>);
             {error, timeout} ->
                 ?SERVICE_UNAVAILABLE(<<"request timeout">>);
+            {error, Reason} when is_binary(Reason) ->
+                ?BAD_REQUEST(Reason);
             {error, Reason} ->
                 ?INTERNAL_ERROR(Reason)
         end

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -85,6 +85,7 @@
     get_allocated_resources_list/1,
     forget_allocated_resources/1,
     deallocate_resource/2,
+    clean_allocated_resources/2,
     %% Get channel config from resource
     call_get_channel_config/3,
     % Call the format query result function

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -63,6 +63,10 @@
 %% Internal exports.
 -export([worker_resource_health_check/1, worker_channel_health_check/2]).
 
+-ifdef(TEST).
+-export([stop/2]).
+-endif.
+
 % State record
 -record(data, {
     id,
@@ -254,7 +258,17 @@ remove(ResId) when is_binary(ResId) ->
 -spec remove(resource_id(), boolean()) -> ok | {error, Reason :: term()}.
 remove(ResId, ClearMetrics) when is_binary(ResId) ->
     try
-        safe_call(ResId, {remove, ClearMetrics}, ?T_OPERATION)
+        case safe_call(ResId, {remove, ClearMetrics}, ?T_OPERATION) of
+            {error, timeout} ->
+                ?tp(error, "forcefully_stopping_resource_due_to_timeout", #{
+                    action => remove,
+                    resource_id => ResId
+                }),
+                force_kill(ResId),
+                ok;
+            Res ->
+                Res
+        end
     after
         %% Ensure the supervisor has it removed, otherwise the immediate re-add will see a stale process
         %% If the 'remove' call above had succeeded, this is mostly a no-op but still needed to avoid race condition.
@@ -287,8 +301,19 @@ start(ResId, Opts) ->
 %% @doc Stop the resource
 -spec stop(resource_id()) -> ok | {error, Reason :: term()}.
 stop(ResId) ->
-    case safe_call(ResId, stop, ?T_OPERATION) of
+    stop(ResId, ?T_OPERATION).
+
+-spec stop(resource_id(), timeout()) -> ok | {error, Reason :: term()}.
+stop(ResId, Timeout) ->
+    case safe_call(ResId, stop, Timeout) of
         ok ->
+            ok;
+        {error, timeout} ->
+            ?tp(error, "forcefully_stopping_resource_due_to_timeout", #{
+                action => stop,
+                resource_id => ResId
+            }),
+            force_kill(ResId),
             ok;
         {error, _Reason} = Error ->
             Error
@@ -405,6 +430,25 @@ get_error(ResId, #{added_channels := #{} = Channels} = ResourceData) when
     end;
 get_error(_ResId, #{error := Error}) ->
     Error.
+
+force_kill(ResId) ->
+    case gproc:whereis_name(?NAME(ResId)) of
+        undefined ->
+            ok;
+        Pid when is_pid(Pid) ->
+            exit(Pid, kill),
+            try_clean_allocated_resources(ResId),
+            ok
+    end.
+
+try_clean_allocated_resources(ResId) ->
+    case try_read_cache(ResId) of
+        #data{mod = Mod} ->
+            catch emqx_resource:clean_allocated_resources(ResId, Mod),
+            ok;
+        _ ->
+            ok
+    end.
 
 %% Server start/stop callbacks
 
@@ -737,7 +781,7 @@ maybe_stop_resource(#data{status = ?rm_status_stopped} = Data) ->
     Data.
 
 stop_resource(#data{state = ResState, id = ResId} = Data) ->
-    %% We don't care the return value of the Mod:on_stop/2.
+    %% We don't care about the return value of `Mod:on_stop/2'.
     %% The callback mod should make sure the resource is stopped after on_stop/2
     %% is returned.
     HasAllocatedResources = emqx_resource:has_allocated_resources(ResId),

--- a/apps/emqx_utils/test/emqx_utils_agent.erl
+++ b/apps/emqx_utils/test/emqx_utils_agent.erl
@@ -1,0 +1,66 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%% http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% @doc Similar to Elixir's [`Agent'](https://hexdocs.pm/elixir/Agent.html).
+
+-module(emqx_utils_agent).
+
+%% API
+-export([start_link/1, get/1, get_and_update/2]).
+
+%% `gen_server' API
+-export([init/1, handle_call/3]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-type state() :: term().
+
+-type get_and_update_fn() :: fun((state()) -> {term(), state()}).
+
+-record(get_and_update, {fn :: get_and_update_fn()}).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec start_link(state()) -> gen_server:start_ret().
+start_link(InitState) ->
+    gen_server:start_link(?MODULE, InitState, []).
+
+-spec get(gen_server:server_ref()) -> term().
+get(ServerRef) ->
+    Fn = fun(St) -> {St, St} end,
+    gen_server:call(ServerRef, #get_and_update{fn = Fn}).
+
+-spec get_and_update(gen_server:server_ref(), get_and_update_fn()) -> term().
+get_and_update(ServerRef, Fn) ->
+    gen_server:call(ServerRef, #get_and_update{fn = Fn}).
+
+%%------------------------------------------------------------------------------
+%% `gen_server' API
+%%------------------------------------------------------------------------------
+
+init(InitState) ->
+    {ok, InitState}.
+
+handle_call(#get_and_update{fn = Fn}, _From, State0) ->
+    {Reply, State} = Fn(State0),
+    {reply, Reply, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------

--- a/changes/ce/fix-13181.en.md
+++ b/changes/ce/fix-13181.en.md
@@ -1,0 +1,3 @@
+Now, when attempting to stop a connector, if such operation times out, we forcefully shut down the connector process.
+
+Error messages when attempting to disable an action/source when its underlying connector is stuck were also improved.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12357

Release version: v/e5.7.1

![image](https://github.com/emqx/emqx/assets/16166434/24f82081-7336-4828-9c09-63115ad04c77)

## Summary

The original issue originated when the connector process (`emqx_resource_manager`) was stuck trying to start, and an API call to remove the action/source would arrive, timing out in a `gen_statem:call`.  

Now, the recommended workaround in such situations is to first stop the connector before disabling/removing the action/source.  Now, when stopping a connector, if the stop call times out, we forcefully kill the process.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
