### PR TITLE
ci: use more strict profile name check

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -232,9 +232,9 @@ warn_profile_env() ->
 %% this function is only used for test/check profiles
 get_edition_from_profile_env() ->
     case os:getenv("PROFILE") of
-        "emqx-enterprise" ++ _ ->
+        "emqx-enterprise" ->
             #{edition => ee, reltype => standard};
-        "emqx" ++ _ ->
+        "emqx" ->
             #{edition => ce, reltype => standard};
         false ->
             #{edition => ee, reltype => standard};


### PR DESCRIPTION
Since we use exact profile names (`emqx`, `emqx-enterprise`), allowing random suffixes allow typos such as `emqx-enteprise` when developing to produce bizarre results that might take some time to notice the cause.

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
