### PR TITLE
fix(bridge-s3): pass SSL options through `convert_certs/2`

### DIFF
--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_s3, [
     {description, "EMQX Enterprise S3 Bridge"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.erl
@@ -22,6 +22,10 @@
     connector_examples/1
 ]).
 
+-export([
+    pre_config_update/4
+]).
+
 %%-------------------------------------------------------------------------------------------------
 %% `hocon_schema' API
 %%-------------------------------------------------------------------------------------------------
@@ -110,3 +114,15 @@ connector_example(put) ->
             enable_pipelining => 1
         }
     }.
+
+%% Config update
+
+pre_config_update(Path, _Name, Conf = #{<<"transport_options">> := TransportOpts}, _ConfOld) ->
+    case emqx_connector_ssl:convert_certs(filename:join(Path), TransportOpts) of
+        {ok, NTransportOpts} ->
+            {ok, Conf#{<<"transport_options">> := NTransportOpts}};
+        {error, {bad_ssl_config, Error}} ->
+            {error, Error#{reason => <<"bad_ssl_config">>}}
+    end;
+pre_config_update(_Path, _Name, Conf, _ConfOld) ->
+    {ok, Conf}.

--- a/changes/ee/fix-13197.en.md
+++ b/changes/ee/fix-13197.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with S3 Bridge that prevented automatic saving of TLS certificates and key files to the file system, when they are supplied through the Dashboard UI or Connector API.


### PR DESCRIPTION
Fixes [EMQX-12522](https://emqx.atlassian.net/browse/EMQX-12522).

Release version: e5.7.

## Summary

Regular mechanism has not been working because S3 Bridge schema structured differently.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-12522]: https://emqx.atlassian.net/browse/EMQX-12522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ