### PR TITLE
chore: refactor azure blob connector to use new `erlazure` without `gen_server`

### DIFF
--- a/apps/emqx_bridge_azure_blob_storage/rebar.config
+++ b/apps/emqx_bridge_azure_blob_storage/rebar.config
@@ -12,5 +12,5 @@
 {deps, [
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_connector_aggregator, {path, "../../apps/emqx_connector_aggregator"}},
-    {erlazure, {git, "https://github.com/emqx/erlazure.git", {tag, "0.3.0.2"}}}
+    {erlazure, {git, "https://github.com/emqx/erlazure.git", {tag, "0.4.0.0"}}}
 ]}.


### PR DESCRIPTION
Depends on https://github.com/dkataskin/erlazure/pull/43 being merged and then synced to
our fork.

Release version: e5.8

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
