### PR TITLE
ci: trigger reruns of failed checks on release-57 branch as well as master

### DIFF
--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -7,9 +7,6 @@ on:
     # run hourly
     - cron: "0 * * * *"
   workflow_dispatch:
-    inputs:
-      ref:
-        required: false
 
 permissions:
   contents: read
@@ -17,14 +14,20 @@ permissions:
 jobs:
   rerun-failed-jobs:
     if: github.repository_owner == 'emqx'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       checks: read
       actions: write
+    strategy:
+      fail-fast: false
+      matrix:
+        ref:
+          - master
+          - release-57
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:
-          ref: ${{ github.event.inputs.ref || 'master' }}
+          ref: ${{ matrix.ref }}
 
       - name: run script
         shell: bash


### PR DESCRIPTION
In order to receive comments from coveralls on PRs, we need to keep base branch builds green.

See [coverallsapp/github-action/issues/212](https://github.com/coverallsapp/github-action/issues/212) for more details.