### PR TITLE
fix(bridge-s3): validate aggreg key template before adding a channel

### DIFF
--- a/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.app.src
+++ b/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.app.src
@@ -1,6 +1,6 @@
 {application, emqx_connector_aggregator, [
     {description, "EMQX Enterprise Connector Data Aggregator"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_utils/test/emqx_template_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_template_SUITE.erl
@@ -128,6 +128,14 @@ t_render_custom_bindings(_) ->
         render_string(Template, {?MODULE, []})
     ).
 
+t_placeholders(_) ->
+    TString = <<"a:${a},b:${b},c:$${c},d:{${d.d1}},e:${$}{e},lit:${$}{$}">>,
+    Template = emqx_template:parse(TString),
+    ?assertEqual(
+        ["a", "b", "c", "d.d1"],
+        emqx_template:placeholders(Template)
+    ).
+
 t_unparse(_) ->
     TString = <<"a:${a},b:${b},c:$${c},d:{${d.d1}},e:${$}{e},lit:${$}{$}">>,
     Template = emqx_template:parse(TString),
@@ -336,6 +344,16 @@ t_unparse_tmpl_deep(_) ->
     Term = #{<<"${a}">> => [<<"$${b}">>, "c", 2, 3.0, '${d}', {[<<"${c}">>], <<"${$}{d}">>, 0}]},
     Template = emqx_template:parse_deep(Term),
     ?assertEqual(Term, emqx_template:unparse(Template)).
+
+t_allow_this(_) ->
+    ?assertEqual(
+        {error, [{"", disallowed}]},
+        emqx_template:validate(["d"], emqx_template:parse(<<"this:${}">>))
+    ),
+    ?assertEqual(
+        {error, [{"", disallowed}]},
+        emqx_template:validate(["d"], emqx_template:parse(<<"this:${.}">>))
+    ).
 
 t_allow_var_by_namespace(_) ->
     Context = #{d => #{d1 => <<"hi">>}},

--- a/changes/ee/fix-13227.en.md
+++ b/changes/ee/fix-13227.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with S3 Bridge when running in aggregated mode, where invalid key template in the configuration haven't been reported as an error during bridge setup, but instead caused a storm of hard to recover crashes later.


### PR DESCRIPTION
Fixes [EMQX-12533](https://emqx.atlassian.net/browse/EMQX-12533).

Release version: e5.7.1

## Summary

Otherwise, invalid template will cause a storm of crashes that will eventually lead to the `emqx_bridge_s3`'s root supervisor giving up and terminating.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-12533]: https://emqx.atlassian.net/browse/EMQX-12533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ