### PR TITLE
fix(redis): json decode if arg for map_to_redis_hset_args is string

### DIFF
--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -1395,6 +1395,8 @@ t_map_to_redis_hset_args(_Config) ->
                 true
         end
     ),
+    ?assertEqual([], Do(<<"not json">>)),
+    ?assertEqual([], Do([<<"not map">>, <<"not json either">>])),
     ok.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12542

Release version: v/e5.7.1

## Summary

This is a follow-up fix for PR #13172 

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [~] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
