### PR TITLE
fix(plugins): do not stop Elixir protected apps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -270,6 +270,7 @@ defmodule EMQXUmbrella.MixProject do
       :debug_info,
       {:compile_info, [{:emqx_vsn, String.to_charlist(version)}]},
       {:d, :EMQX_RELEASE_EDITION, erlang_edition(edition_type)},
+      {:d, :EMQX_ELIXIR},
       {:d, :snk_kind, :msg}
     ]
   end


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: v/e5.7.1

## Summary

On one hand, Elixir plugins might include Elixir itself, when targetting a non-Elixir EMQX release.  If, on the other hand, the EMQX release already includes Elixir, we shouldn't stop Elixir nor IEx, or the running IEx shell will break.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

~- [ ] Added tests for the changes~ Tested manually
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
