### PR TITLE
fix: do not crash when showing rule unsing the cmd interface

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine_cli.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_cli.erl
@@ -95,6 +95,12 @@ format_action(BridgeChannelId) when is_binary(BridgeChannelId) ->
     io_lib:format("- Name:  ~s\n"
                   "  Type:  data-bridge\n"
                  ,[BridgeChannelId]
+                 );
+format_action({bridge_v2, ActionType, ActionName}) ->
+    io_lib:format("- Name:         ~p\n"
+                  "  Action Type:  ~p\n"
+                  "  Type:         data-bridge\n"
+                 ,[ActionName, ActionType]
                  ).
 
 left_pad(Str) ->


### PR DESCRIPTION
Before the change the command line command

    $ bin/emqx ctl rules show rule_0hyd

would crash if the rule had bridge actions. This has now been fixed by adding a handler for printing  bridge actions.

Fixes:
https://emqx.atlassian.net/browse/EMQX-12548

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [] Schema changes are backward compatible