### PR TITLE
test(greptime): attempt to fix flaky tests

### DIFF
--- a/apps/emqx_bridge_greptimedb/rebar.config
+++ b/apps/emqx_bridge_greptimedb/rebar.config
@@ -6,7 +6,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {greptimedb, {git, "https://github.com/GreptimeTeam/greptimedb-ingester-erl", {tag, "v0.1.8"}}}
+    {greptimedb, {git, "https://github.com/thalesmg/greptimedb-ingester-erl", {tag, "v0.1.8.1"}}}
 ]}.
 {plugins, [rebar3_path_deps]}.
 {project_plugins, [erlfmt]}.

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_greptimedb, [
     {description, "EMQX GreptimeDB Bridge"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -107,6 +107,10 @@ on_start(InstId, Config) ->
     %% See: greptimedb:start_client/1
     start_client(InstId, Config).
 
+on_stop(InstId, #{client := Client}) ->
+    Res = greptimedb:stop_client(Client),
+    ?tp(greptimedb_client_stopped, #{instance_id => InstId}),
+    Res;
 on_stop(InstId, _State) ->
     case emqx_resource:get_allocated_resources(InstId) of
         #{?greptime_client := Client} ->

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
@@ -99,6 +99,8 @@ init_per_group(GreptimedbType, Config0) when
                 #{work_dir => emqx_cth_suite:work_dir(Config0)}
             ),
             {ok, _Api} = emqx_common_test_http:create_default_app(),
+            %% fixme: debugging
+            emqx_logger:set_log_level(debug),
             Config = [{use_tls, UseTLS} | Config0],
             {Name, ConfigString, GreptimedbConfig} = greptimedb_config(
                 grpcv1, GreptimedbHost, GreptimedbPort, Config

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -809,17 +809,18 @@ maybe_stop_resource(#data{status = Status} = Data) when Status =/= ?rm_status_st
 maybe_stop_resource(#data{status = ?rm_status_stopped} = Data) ->
     Data.
 
-stop_resource(#data{state = ResState, id = ResId} = Data) ->
+stop_resource(#data{id = ResId} = Data) ->
     %% We don't care about the return value of `Mod:on_stop/2'.
     %% The callback mod should make sure the resource is stopped after on_stop/2
     %% is returned.
     HasAllocatedResources = emqx_resource:has_allocated_resources(ResId),
     %% Before stop is called we remove all the channels from the resource
     NewData = remove_channels(Data),
-    case ResState =/= undefined orelse HasAllocatedResources of
+    NewResState = NewData#data.state,
+    case NewResState =/= undefined orelse HasAllocatedResources of
         true ->
             %% we clear the allocated resources after stop is successful
-            emqx_resource:call_stop(NewData#data.id, NewData#data.mod, ResState);
+            emqx_resource:call_stop(NewData#data.id, NewData#data.mod, NewResState);
         false ->
             ok
     end,

--- a/mix.exs
+++ b/mix.exs
@@ -218,8 +218,7 @@ defmodule EMQXUmbrella.MixProject do
       {:snappyer, "1.2.9", override: true},
       {:crc32cer, "0.1.8", override: true},
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1", override: true},
-      {:greptimedb,
-       github: "GreptimeTeam/greptimedb-ingester-erl", tag: "v0.1.8", override: true},
+      {:greptimedb, github: "thalesmg/greptimedb-ingester-erl", tag: "v0.1.8.1", override: true},
       # The following two are dependencies of rabbit_common. They are needed here to
       # make mix not complain about conflicting versions
       {:thoas, github: "emqx/thoas", tag: "v1.0.0", override: true},


### PR DESCRIPTION
```
=WARNING REPORT==== 18-Jun-2024::12:42:04.739109 ===
    reason: no_endpoints
    msg: failed_to_start_greptimedb_connector
    client: #{protocol => http,
              pool => <<"connector:greptimedb:emqx_bridge_greptimedb_SUITE">>,
              cli_opts =>
                  [{endpoints,[{http,"toxiproxy",4001}]},
                   {pool_size,2},
                   {pool_type,random},
                   {auto_reconnect,1},
                   {gprc_options,#{sync_start => true,
                                   connect_timeout => 5000}},
                   {dbname,"public"},
                   {auth,{basic,#{password => <<"******">>,
                                  username => "greptime_user"}}},
                   {https_enabled,false}]}
    connector: <<"connector:greptimedb:emqx_bridge_greptimedb_SUITE">>
```

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
