### PR TITLE
fix(tls): disable partial_chain in hot config

### DIFF
--- a/apps/emqx_auth_ext/src/emqx_auth_ext_tls_const_v1.erl
+++ b/apps/emqx_auth_ext/src/emqx_auth_ext_tls_const_v1.erl
@@ -10,7 +10,12 @@
     make_tls_verify_fun/2
 ]).
 
+-export([default_root_fun/1]).
+
 -include_lib("public_key/include/public_key.hrl").
+
+-define(unknown_ca, unknown_ca).
+
 %% @doc Build a root fun for verify TLS partial_chain.
 %% The `InputChain' is composed by OTP SSL with local cert store
 %% AND the cert (chain if any) from the client.
@@ -109,3 +114,8 @@ ext_key_opts(Str) ->
         end,
         Usages
     ).
+
+%% @doc default root fun for partial_chain 'false'
+-spec default_root_fun(_) -> ?unknown_ca.
+default_root_fun(_) ->
+    ?unknown_ca.

--- a/apps/emqx_auth_ext/src/emqx_auth_ext_tls_lib.erl
+++ b/apps/emqx_auth_ext/src/emqx_auth_ext_tls_lib.erl
@@ -13,13 +13,12 @@
 -include_lib("emqx/include/logger.hrl").
 
 -define(CONST_MOD_V1, emqx_auth_ext_tls_const_v1).
--define(unknown_ca, unknown_ca).
 %% @doc enable TLS partial_chain validation
 -spec opt_partial_chain(SslOpts :: map()) -> NewSslOpts :: map().
 opt_partial_chain(#{partial_chain := false} = SslOpts) ->
     %% For config update scenario, we must set it to override
     %% the 'existing' partial_chain in the listener
-    SslOpts#{partial_chain := fun(_) -> ?unknown_ca end};
+    SslOpts#{partial_chain := fun ?CONST_MOD_V1:default_root_fun/1};
 opt_partial_chain(#{partial_chain := true} = SslOpts) ->
     SslOpts#{partial_chain := rootfun_trusted_ca_from_cacertfile(1, SslOpts)};
 opt_partial_chain(#{partial_chain := cacert_from_cacertfile} = SslOpts) ->

--- a/apps/emqx_auth_ext/src/emqx_auth_ext_tls_lib.erl
+++ b/apps/emqx_auth_ext/src/emqx_auth_ext_tls_lib.erl
@@ -13,10 +13,13 @@
 -include_lib("emqx/include/logger.hrl").
 
 -define(CONST_MOD_V1, emqx_auth_ext_tls_const_v1).
-%% @doc enable TLS partial_chain validation if set.
+-define(unknown_ca, unknown_ca).
+%% @doc enable TLS partial_chain validation
 -spec opt_partial_chain(SslOpts :: map()) -> NewSslOpts :: map().
 opt_partial_chain(#{partial_chain := false} = SslOpts) ->
-    maps:remove(partial_chain, SslOpts);
+    %% For config update scenario, we must set it to override
+    %% the 'existing' partial_chain in the listener
+    SslOpts#{partial_chain := fun(_) -> ?unknown_ca end};
 opt_partial_chain(#{partial_chain := true} = SslOpts) ->
     SslOpts#{partial_chain := rootfun_trusted_ca_from_cacertfile(1, SslOpts)};
 opt_partial_chain(#{partial_chain := cacert_from_cacertfile} = SslOpts) ->

--- a/apps/emqx_auth_ext/test/emqx_auth_ext_schema_SUITE.erl
+++ b/apps/emqx_auth_ext/test/emqx_auth_ext_schema_SUITE.erl
@@ -24,7 +24,7 @@
     "\n"
     "    listeners.ssl.auth_ext.bind = 28883\n"
     "    listeners.ssl.auth_ext.enable = true\n"
-    "    listeners.ssl.auth_ext.ssl_options.partial_chain = true\n"
+    "    listeners.ssl.auth_ext.ssl_options.partial_chain = false\n"
     "    listeners.ssl.auth_ext.ssl_options.verify = verify_peer\n"
     "    listeners.ssl.auth_ext.ssl_options.verify_peer_ext_key_usage = \"clientAuth\"\n"
     "    "
@@ -62,5 +62,6 @@ t_conf_check_default(_Config) ->
 t_conf_check_auth_ext(_Config) ->
     Opts = esockd:get_options({'ssl:auth_ext', 28883}),
     SSLOpts = proplists:get_value(ssl_options, Opts),
+    %% Even when partial_chain is set to `false`
     ?assertMatch(Fun when is_function(Fun), proplists:get_value(partial_chain, SSLOpts)),
     ?assertMatch({Fun, _} when is_function(Fun), proplists:get_value(verify_fun, SSLOpts)).


### PR DESCRIPTION
Fixes [EMQX-12566](https://emqx.atlassian.net/browse/EMQX-12566)

Release version: e5.7.1

Previously, if `partial_chain` is set to `false` we omit it in ssl_options following OTP default.

This PR force inject `partial_chain` (using default root_fun if set to false) into ssl_options so hot config won't miss it. 

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12566]: https://emqx.atlassian.net/browse/EMQX-12566?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ