### PR TITLE
feat: the authorization API deletion should be successful  when not found

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz.erl
@@ -256,9 +256,11 @@ do_pre_config_update({{?CMD_REPLACE, Type}, Source}, Sources) ->
     ok = check_dup_types(NSources),
     NSources;
 do_pre_config_update({{?CMD_DELETE, Type}, _Source}, Sources) ->
-    {_Old, Front, Rear} = take(Type, Sources),
-    NSources = Front ++ Rear,
-    NSources;
+    try take(Type, Sources) of
+        {_Found, Front, Rear} -> Front ++ Rear
+    catch
+        throw:{not_found_source, _} -> Sources
+    end;
 do_pre_config_update({?CMD_REPLACE, Sources}, _OldSources) ->
     %% overwrite the entire config!
     NSources = lists:map(fun maybe_write_source_files/1, Sources),
@@ -293,9 +295,14 @@ do_post_config_update(?CONF_KEY_PATH, {{?CMD_REPLACE, Type}, RawNewSource}, Sour
     Front ++ [InitedSources] ++ Rear;
 do_post_config_update(?CONF_KEY_PATH, {{?CMD_DELETE, Type}, _RawNewSource}, _Sources) ->
     OldInitedSources = lookup(),
-    {OldSource, Front, Rear} = take(Type, OldInitedSources),
-    ok = ensure_deleted(OldSource, #{clear_metric => true}),
-    Front ++ Rear;
+    try take(Type, OldInitedSources) of
+        {OldSource, Front, Rear} ->
+            ok = ensure_deleted(OldSource, #{clear_metric => true}),
+            Front ++ Rear
+    catch
+        throw:{not_found_source, _} ->
+            OldInitedSources
+    end;
 do_post_config_update(?CONF_KEY_PATH, {?CMD_REPLACE, _RawNewSources}, Sources) ->
     overwrite_entire_sources(Sources);
 do_post_config_update(?CONF_KEY_PATH, {?CMD_REORDER, NewSourcesOrder}, _Sources) ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_api_sources.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_api_sources.erl
@@ -287,20 +287,10 @@ source(put, #{bindings := #{type := Type}, body := #{<<"type">> := Type} = Body}
             update_config({?CMD_REPLACE, Type}, Conf)
         end
     );
-source(put, #{bindings := #{type := Type}, body := #{<<"type">> := _OtherType}}) ->
-    with_source(
-        Type,
-        fun(_) ->
-            {400, #{code => <<"BAD_REQUEST">>, message => <<"Type mismatch">>}}
-        end
-    );
+source(put, #{bindings := #{type := _Type}, body := #{<<"type">> := _OtherType}}) ->
+    {400, #{code => <<"BAD_REQUEST">>, message => <<"Type mismatch">>}};
 source(delete, #{bindings := #{type := Type}}) ->
-    with_source(
-        Type,
-        fun(_) ->
-            update_config({?CMD_DELETE, Type}, #{})
-        end
-    ).
+    update_config({?CMD_DELETE, Type}, #{}).
 
 source_status(get, #{bindings := #{type := Type}}) ->
     with_source(

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
@@ -390,7 +390,7 @@ t_api(_) ->
                 uri(["authorization", "sources", binary_to_list(Type)]),
                 []
             ),
-            {ok, 404, _} = request(
+            {ok, 204, _} = request(
                 delete,
                 uri(["authorization", "sources", binary_to_list(Type)]),
                 []
@@ -399,7 +399,7 @@ t_api(_) ->
         Sources
     ),
 
-    {ok, 404, _TypeMismatch2} = request(
+    {ok, 400, _TypeMismatch2} = request(
         put,
         uri(["authorization", "sources", "file"]),
         #{<<"type">> => <<"built_in_database">>, <<"enable">> => false}


### PR DESCRIPTION
Fixes <issue-or-jira-number>
close https://github.com/emqx/emqx/pull/13288
All of our APIs for deleting resources should be idempotent. 
This is especially true for deleting configurations.
Since users are free to modify emqx.conf, there is no way to avoid configuration inconsistencies in the cluster.
When a problem is found here, the problematic resource can be deleted via the dashboard and then rebuilt.

It makes no sense to be able to delete a resource on some nodes and keep retrying to delete it failed on other nodes because you can't find it.

The same situation exists with authn's delete API, if this PR is ok, I'll go ahead and change the authn delete


Release version: v/e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
