### PR TITLE
ci: pull haproxy image from ghcr

### DIFF
--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -177,6 +177,7 @@ backend emqx_wss_back
     server emqx-2 $NODE2:8083 check-send-proxy send-proxy-v2-ssl-cn
 EOF
 
+HAPROXY_IMAGE='ghcr.io/haproxytech/haproxy-docker-alpine:2.4.27'
 
 haproxy_cid=$(docker run -d --name haproxy \
                      --net "$NET" \
@@ -184,8 +185,8 @@ haproxy_cid=$(docker run -d --name haproxy \
                      -v "$(pwd)/apps/emqx/etc/certs:/usr/local/etc/haproxy/certs" \
                      -w /usr/local/etc/haproxy \
                      "${HAPROXY_PORTS[@]}" \
-                     "public.ecr.aws/docker/library/haproxy:2.4" \
-                     bash -c 'set -euo pipefail;
+                     "${HAPROXY_IMAGE}" \
+                     sh -c 'set -euo pipefail;
                               cat certs/cert.pem certs/key.pem > /tmp/emqx.pem;
                               haproxy -f haproxy.cfg')
 


### PR DESCRIPTION
Unable to find image 'public.ecr.aws/docker/library/haproxy:2.4' locally
[51](https://github.com/emqx/emqx/actions/runs/9594332475/job/26457097093?pr=13304#step:6:52)
docker: Error response from daemon: toomanyrequests: Rate exceeded.