### PR TITLE
feat: support bootstrap_file on authentication for build-in-database

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mnesia, [
     {description, "EMQX Buitl-in Database Authentication and Authorization"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {mod, {emqx_auth_mnesia_app, []}},
     {applications, [

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -543,8 +543,9 @@ boostrap_user_from_file(Config, State) ->
     case maps:get(boostrap_file, Config, <<>>) of
         <<>> ->
             ok;
-        FileName ->
+        FileName0 ->
             #{boostrap_type := Type} = Config,
+            FileName = emqx_schema:naive_env_interpolation(FileName0),
             case file:read_file(FileName) of
                 {ok, FileData} ->
                     %% if there is a key conflict, override with the key which from the bootstrap file
@@ -552,10 +553,10 @@ boostrap_user_from_file(Config, State) ->
                     ok;
                 {error, Reason} ->
                     ?SLOG(warning, #{
-                        msg => "boostrap_authn(built_in_database)_failed",
+                        msg => "boostrap_authn_built_in_database_failed",
                         boostrap_file => FileName,
                         boostrap_type => Type,
-                        reason => Reason
+                        reason => emqx_utils:explain_posix(Reason)
                     })
             end
     end.

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia_schema.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia_schema.erl
@@ -46,7 +46,7 @@ select_union_member(_Kind, _Value) ->
 fields(builtin_db) ->
     [
         {password_hash_algorithm, fun emqx_authn_password_hashing:type_rw/1}
-    ] ++ common_fields();
+    ] ++ common_fields() ++ bootstrap_fields();
 fields(builtin_db_api) ->
     [
         {password_hash_algorithm, fun emqx_authn_password_hashing:type_rw_api/1}
@@ -69,3 +69,24 @@ common_fields() ->
         {backend, emqx_authn_schema:backend(?AUTHN_BACKEND)},
         {user_id_type, fun user_id_type/1}
     ] ++ emqx_authn_schema:common_fields().
+
+bootstrap_fields() ->
+    [
+        {bootstrap_file,
+            ?HOCON(
+                binary(),
+                #{
+                    desc => ?DESC(bootstrap_file),
+                    required => false,
+                    default => <<>>
+                }
+            )},
+        {bootstrap_type,
+            ?HOCON(
+                ?ENUM([hash, plain]), #{
+                    desc => ?DESC(bootstrap_type),
+                    required => false,
+                    default => <<"plain">>
+                }
+            )}
+    ].

--- a/changes/ce/feat-13336.en.md
+++ b/changes/ce/feat-13336.en.md
@@ -1,1 +1,1 @@
-Added support for configuring the bootstrap_file and bootstrap_type when using the built-in db authentication method.
+Added new configs `bootstrap_file` and `bootstrap_type` for built-in database for authentication to support bootstrapping the table with csv and json file.

--- a/changes/ce/feat-13336.en.md
+++ b/changes/ce/feat-13336.en.md
@@ -1,0 +1,1 @@
+Added support for configuring the bootstrap_file and bootstrap_type when using the built-in db authentication method.

--- a/rel/i18n/emqx_authn_mnesia_schema.hocon
+++ b/rel/i18n/emqx_authn_mnesia_schema.hocon
@@ -10,13 +10,15 @@ user_id_type.label:
 """Authentication ID Type"""
 
 bootstrap_file.desc:
-"""The bootstrap file imports users into the built-in database."""
+"""The bootstrap file imports users into the built-in database.
+the file content format is determined by `bootstrap_type`."""
 
 bootstrap_file.label:
 """Bootstrap File Path"""
 
 bootstrap_type.desc:
-"""plain: bootstrap_file.cvs should be `user_id,password,is_superuser`.
-hash: bootstrap_file.cvs should be `user_id,password_hash,salt,is_superuser`"""
+"""plain: bootstrap_file.cvs should have lines of format `{user_id},{password},{is_superuser}` where `user_id` can be either clientid or username depending on `user_id_type`.
+hash: bootstrap_file.cvs should have line of format `{user_id},{password_hash},{salt},{is_superuser}.`
+All file format support is the same as `authentication/password_based:built_in_database/import_users` API."""
 
 }

--- a/rel/i18n/emqx_authn_mnesia_schema.hocon
+++ b/rel/i18n/emqx_authn_mnesia_schema.hocon
@@ -9,4 +9,14 @@ user_id_type.desc:
 user_id_type.label:
 """Authentication ID Type"""
 
+bootstrap_file.desc:
+"""The bootstrap file imports users into the built-in database."""
+
+bootstrap_file.label:
+"""Bootstrap File Path"""
+
+bootstrap_type.desc:
+"""plain: bootstrap_file.cvs should be `user_id,password,is_superuser`.
+hash: bootstrap_file.cvs should be `user_id,password_hash,salt,is_superuser`"""
+
 }

--- a/rel/i18n/emqx_authn_mnesia_schema.hocon
+++ b/rel/i18n/emqx_authn_mnesia_schema.hocon
@@ -19,8 +19,22 @@ bootstrap_file.label:
 """Bootstrap File Path"""
 
 bootstrap_type.desc:
-"""`plain`: bootstrap_file.csv should have lines of format `{user_id},{password},{is_superuser}` where `user_id` can be either clientid or username depending on `user_id_type`.
-`hash`: bootstrap_file.csv should have line of format `{user_id},{password_hash},{salt},{is_superuser}.`
-All file format support is the same as `authentication/password_based:built_in_database/import_users` API."""
+"""- **`plain`**:
+     - Format: `{user_id},{password},{is_superuser}`
+     - `user_id`: Can be `clientid` or `username`, based on `user_id_type`.
+     - `password`: User's plaintext password.
+     - `is_superuser`: Boolean, user's administrative status.
+
+   - **`hash`**:
+     - Format: `{user_id},{password_hash},{salt},{is_superuser}`
+     - Definitions similar to `plain` type, with `password_hash` and `salt` added for security.
+
+All file format support is the same as `authentication/password_based:built_in_database/import_users` API.
+Json file plain format example:`[{"user_id": "my_user","password": "s3cr3tp@ssw0rd","is_superuser": true}]`.
+CSV file hash format example :`user_id,password_hash,salt,is_superuser\nmy_user,b6c743545a7817ae8c8f624371d5f5f0373234bb0ff36b8ffbf19bce0e06ab75,de1024f462fb83910fd13151bd4bd235,true`
+
+Formula for `password_hash`:
+If configured as `password_hash_algorithm {name = sha256, salt_position = suffix}`,
+the Python code to calculate the `password_hash` is `hashlib.sha256(password + salt).hexdigest()`."""
 
 }

--- a/rel/i18n/emqx_authn_mnesia_schema.hocon
+++ b/rel/i18n/emqx_authn_mnesia_schema.hocon
@@ -37,6 +37,6 @@ Here is a CSV example: `user_id,password_hash,salt,is_superuser\nmy_user,b6c7435
 
 And JSON content should be decoded into an array of objects, for example: `[{"user_id": "my_user","password": "s3cr3tp@ssw0rd","is_superuser": true}]`.
 
-The hash string for password_hash depends on how password_hash_algorithm is configured for the built-in database authentication mechanism. For example, if it's configured as `password_hash_algorithm {name = sha256, salt_position = suffix}`, then the salt is appended to the password before hashed. Here is the equivalent Python expression: `hashlib.sha256(password + salt).hexdigest()`."""
+The hash string for `password_hash` depends on how `password_hash_algorithm` is configured for the built-in database authentication mechanism. For example, if it's configured as `password_hash_algorithm {name = sha256, salt_position = suffix}`, then the salt is appended to the password before hashed. Here is the equivalent Python expression: `hashlib.sha256(password + salt).hexdigest()`."""
 
 }

--- a/rel/i18n/emqx_authn_mnesia_schema.hocon
+++ b/rel/i18n/emqx_authn_mnesia_schema.hocon
@@ -19,22 +19,24 @@ bootstrap_file.label:
 """Bootstrap File Path"""
 
 bootstrap_type.desc:
-"""- **`plain`**:
-     - Format: `{user_id},{password},{is_superuser}`
-     - `user_id`: Can be `clientid` or `username`, based on `user_id_type`.
-     - `password`: User's plaintext password.
-     - `is_superuser`: Boolean, user's administrative status.
+"""Specify which type of content the bootstrap file has.
 
-   - **`hash`**:
-     - Format: `{user_id},{password_hash},{salt},{is_superuser}`
-     - Definitions similar to `plain` type, with `password_hash` and `salt` added for security.
+- **`plain`**:
+  - Expected data fields: `user_id`, `password`, `is_superuser`
+  - `user_id`: Can be Client ID or username, depending on built-in database authentication's `user_id_type` config.
+  - `password`: User's plaintext password.
+  - `is_superuser`: Boolean, user's administrative status.
 
-All file format support is the same as `authentication/password_based:built_in_database/import_users` API.
-Json file plain format example:`[{"user_id": "my_user","password": "s3cr3tp@ssw0rd","is_superuser": true}]`.
-CSV file hash format example :`user_id,password_hash,salt,is_superuser\nmy_user,b6c743545a7817ae8c8f624371d5f5f0373234bb0ff36b8ffbf19bce0e06ab75,de1024f462fb83910fd13151bd4bd235,true`
+- **`hash`**:
+  - Expected data fields: `user_id`,`password_hash`,`salt`,`is_superuser`
+  - Definitions similar to `plain` type, with `password_hash` and `salt` added for security.
 
-Formula for `password_hash`:
-If configured as `password_hash_algorithm {name = sha256, salt_position = suffix}`,
-the Python code to calculate the `password_hash` is `hashlib.sha256(password + salt).hexdigest()`."""
+The content can be either in CSV, or JSON format.
+
+Here is a CSV example: `user_id,password_hash,salt,is_superuser\nmy_user,b6c743545a7817ae8c8f624371d5f5f0373234bb0ff36b8ffbf19bce0e06ab75,de1024f462fb83910fd13151bd4bd235,true`
+
+And JSON content should be decoded into an array of objects, for example: `[{"user_id": "my_user","password": "s3cr3tp@ssw0rd","is_superuser": true}]`.
+
+The hash string for password_hash depends on how password_hash_algorithm is configured for the built-in database authentication mechanism. For example, if it's configured as `password_hash_algorithm {name = sha256, salt_position = suffix}`, then the salt is appended to the password before hashed. Here is the equivalent Python expression: `hashlib.sha256(password + salt).hexdigest()`."""
 
 }

--- a/rel/i18n/emqx_authn_mnesia_schema.hocon
+++ b/rel/i18n/emqx_authn_mnesia_schema.hocon
@@ -11,14 +11,16 @@ user_id_type.label:
 
 bootstrap_file.desc:
 """The bootstrap file imports users into the built-in database.
-the file content format is determined by `bootstrap_type`."""
+The file content format is determined by `bootstrap_type`.
+Remove the item from the bootstrap file when you have made changes in other way,
+otherwise, after restarting, the bootstrap item will be overridden again."""
 
 bootstrap_file.label:
 """Bootstrap File Path"""
 
 bootstrap_type.desc:
-"""plain: bootstrap_file.cvs should have lines of format `{user_id},{password},{is_superuser}` where `user_id` can be either clientid or username depending on `user_id_type`.
-hash: bootstrap_file.cvs should have line of format `{user_id},{password_hash},{salt},{is_superuser}.`
+"""`plain`: bootstrap_file.csv should have lines of format `{user_id},{password},{is_superuser}` where `user_id` can be either clientid or username depending on `user_id_type`.
+`hash`: bootstrap_file.csv should have line of format `{user_id},{password_hash},{salt},{is_superuser}.`
 All file format support is the same as `authentication/password_based:built_in_database/import_users` API."""
 
 }


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12593

close #8714, #9148
This feature needs to be used before enabling built_in_database authn,
 so it makes sense to add configuration items to it.

Use the same template for initialization as for importing users:

Import data only on build-in-dabase create.

Support for JSON, CSV files.
```
authentication = [
  {
    backend = built_in_database
    mechanism = password_based
    password_hash_algorithm {name = sha256, salt_position = suffix}
    user_id_type = username
    
    # new items
    bootstrap_file = "/opt/init_user.json"
    bootstrap_type = hash | plain
  }
]
```

Release version: v/e5.7.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
