### PR TITLE
build: pin base docker image to stable-20240612-slim

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -164,8 +164,9 @@ jobs:
           DOCKER_LATEST: ${{ inputs.latest }}
           DOCKER_PUSH: false
           DOCKER_BUILD_NOCACHE: true
+          DOCKER_PLATFORMS: linux/amd64
           DOCKER_LOAD: true
-          EMQX_RUNNER: 'public.ecr.aws/debian/debian:12-slim'
+          EMQX_RUNNER: 'public.ecr.aws/debian/debian:stable-20240612-slim'
           EMQX_DOCKERFILE: 'deploy/docker/Dockerfile'
           PKG_VSN: ${{ needs.build.outputs.PKG_VSN }}
           EMQX_BUILDER_VERSION: ${{ inputs.builder_vsn }}
@@ -184,7 +185,7 @@ jobs:
         timeout-minutes: 1
         run: |
           for tag in $(cat .emqx_docker_image_tags); do
-            CID=$(docker run -d -P $tag)
+            CID=$(docker run -d -p 18083:18083 $tag)
             HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' $CID)
             ./scripts/test/emqx-smoke-test.sh localhost $HTTP_PORT
             docker rm -f $CID
@@ -214,7 +215,7 @@ jobs:
           DOCKER_BUILD_NOCACHE: false
           DOCKER_PLATFORMS: linux/amd64,linux/arm64
           DOCKER_LOAD: false
-          EMQX_RUNNER: 'public.ecr.aws/debian/debian:12-slim'
+          EMQX_RUNNER: 'public.ecr.aws/debian/debian:stable-20240612-slim'
           EMQX_DOCKERFILE: 'deploy/docker/Dockerfile'
           PKG_VSN: ${{ needs.build.outputs.PKG_VSN }}
           EMQX_BUILDER_VERSION: ${{ inputs.builder_vsn }}

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ BUILD = $(CURDIR)/build
 SCRIPTS = $(CURDIR)/scripts
 export EMQX_RELUP ?= true
 export EMQX_DEFAULT_BUILDER = ghcr.io/emqx/emqx-builder/5.3-8:1.15.7-26.2.5-2-debian12
-export EMQX_DEFAULT_RUNNER = public.ecr.aws/debian/debian:12-slim
+export EMQX_DEFAULT_RUNNER = public.ecr.aws/debian/debian:stable-20240612-slim
 export EMQX_REL_FORM ?= tgz
 export QUICER_DOWNLOAD_FROM_RELEASE = 1
 ifeq ($(OS),Windows_NT)

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.3-8:1.15.7-26.2.5-2-debian12
-ARG RUN_FROM=public.ecr.aws/debian/debian:12-slim
+ARG RUN_FROM=public.ecr.aws/debian/debian:stable-20240612-slim
 ARG SOURCE_TYPE=src # tgz
 
 FROM ${BUILD_FROM} as builder_src


### PR DESCRIPTION
latest version of 12-slim as of today is configured to fetch i386 packages

```
docker run -it --rm --platform linux/amd64 public.ecr.aws/debian/debian:12-slim
Unable to find image 'public.ecr.aws/debian/debian:12-slim' locally
12-slim: Pulling from debian/debian
0e7ee8520e07: Pull complete
Digest: sha256:465c9569a7fd7f28a7f263a6407307c0294e9f037b65035d3cbeacb737288215
Status: Downloaded newer image for public.ecr.aws/debian/debian:12-slim
root@7277eab43d64:/# apt-get update
Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
Get:2 http://deb.debian.org/debian bookworm-updates InRelease [55.4 kB]
Get:3 http://deb.debian.org/debian-security bookworm-security InRelease [48.0 kB]
Get:4 http://deb.debian.org/debian bookworm/main i386 Packages [8679 kB]
Get:5 http://deb.debian.org/debian bookworm-updates/main i386 Packages [13.8 kB]
Get:6 http://deb.debian.org/debian-security bookworm-security/main i386 Packages [160 kB]
Fetched 9107 kB in 5s (1722 kB/s)
Reading package lists... Done
```