### PR TITLE
test(authz cache): attempt to fix flaky test

### DIFF
--- a/apps/emqx/test/emqx_authz_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_authz_cache_SUITE.erl
@@ -37,7 +37,7 @@ end_per_suite(Config) ->
 %%--------------------------------------------------------------------
 
 t_cache_exclude(_) ->
-    ClientId = <<"test-id1">>,
+    ClientId = atom_to_binary(?FUNCTION_NAME),
     {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
     {ok, _} = emqtt:connect(Client),
     {ok, _, _} = emqtt:subscribe(Client, <<"nocache/+/#">>, 0),
@@ -47,11 +47,12 @@ t_cache_exclude(_) ->
     emqtt:stop(Client).
 
 t_clean_authz_cache(_) ->
-    {ok, Client} = emqtt:start_link([{clientid, <<"emqx_c">>}]),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
     {ok, _} = emqtt:connect(Client),
     {ok, _, _} = emqtt:subscribe(Client, <<"t2">>, 0),
     emqtt:publish(Client, <<"t1">>, <<"{\"x\":1}">>, 0),
-    ClientPid = find_client_pid(<<"emqx_c">>),
+    ClientPid = find_client_pid(ClientId),
     Caches = list_cache(ClientPid),
     ct:log("authz caches: ~p", [Caches]),
     ?assert(length(Caches) > 0),
@@ -60,11 +61,12 @@ t_clean_authz_cache(_) ->
     emqtt:stop(Client).
 
 t_drain_authz_cache(_) ->
-    {ok, Client} = emqtt:start_link([{clientid, <<"emqx_c">>}]),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    {ok, Client} = emqtt:start_link([{clientid, ClientId}]),
     {ok, _} = emqtt:connect(Client),
     {ok, _, _} = emqtt:subscribe(Client, <<"t2">>, 0),
     emqtt:publish(Client, <<"t1">>, <<"{\"x\":1}">>, 0),
-    ClientPid = find_client_pid(<<"emqx_c">>),
+    ClientPid = find_client_pid(ClientId),
     Caches = list_cache(ClientPid),
     ct:log("authz caches: ~p", [Caches]),
     ?assert(length(Caches) > 0),


### PR DESCRIPTION
Hypothesis: some race condition involving the previous test case, which uses the same clientid.

```
Testing apps.emqx.emqx_authz_cache_SUITE: *** FAILED test case 3 of 3 ***
%%% emqx_authz_cache_SUITE ==> t_drain_authz_cache: FAILED
%%% emqx_authz_cache_SUITE ==>
Failure/Error: ?assertEqual([], list_cache ( ClientPid ))
  expected: []
       got: [{{#{qos => 0,action_type => publish,retain => false},<<"t1">>},
              {allow,1719599365019}}]
      line: 72
```

Release version: v/e5.7.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
