### PR TITLE
fix: default value for max_conn_rate etc should be set to infinity

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -212,16 +212,28 @@ short_paths_fields() ->
 short_paths_fields(Importance) ->
     [
         {Name,
-            ?HOCON(rate_type(), #{
-                desc => ?DESC(Name),
-                required => false,
-                default => infinity,
-                importance => Importance,
-                example => Example
-            })}
+            ?HOCON(
+                rate_type(),
+                maps:merge(
+                    #{
+                        desc => ?DESC(Name),
+                        required => false,
+                        importance => Importance,
+                        example => Example
+                    },
+                    short_paths_fields_extra(Name)
+                )
+            )}
      || {Name, Example} <-
             lists:zip(short_paths(), [<<"1000/s">>, <<"1000/s">>, <<"100MB/s">>])
     ].
+
+short_paths_fields_extra(max_conn_rate) ->
+    #{
+        default => infinity
+    };
+short_paths_fields_extra(_Name) ->
+    #{}.
 
 desc(limiter) ->
     "Settings for the rate limiter.";

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -215,6 +215,7 @@ short_paths_fields(Importance) ->
             ?HOCON(rate_type(), #{
                 desc => ?DESC(Name),
                 required => false,
+                default => infinity,
                 importance => Importance,
                 example => Example
             })}

--- a/apps/emqx/test/emqx_ratelimiter_SUITE.erl
+++ b/apps/emqx/test/emqx_ratelimiter_SUITE.erl
@@ -816,8 +816,8 @@ t_no_limiter_for_listener(_) ->
     CfgStr = <<>>,
     ok = emqx_common_test_helpers:load_config(emqx_schema, CfgStr),
     ListenerOpt = emqx:get_config([listeners, tcp, default]),
-    ?assertEqual(
-        undefined,
+    ?assertMatch(
+        #{connection := #{rate := infinity}},
         emqx_limiter_utils:get_listener_opts(ListenerOpt)
     ).
 

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -418,6 +418,35 @@ t_update_listener_zone(_Config) ->
     ?assertMatch({error, {_, 400, _}}, request(put, Path, [], AddConf1)),
     ?assertMatch(#{<<"zone">> := <<"zone1">>}, request(put, Path, [], AddConf2)).
 
+t_update_listener_max_conn_rate({init, Config}) ->
+    Config;
+t_update_listener_max_conn_rate({'end', _Config}) ->
+    ok;
+t_update_listener_max_conn_rate(_Config) ->
+    ListenerId = <<"tcp:default">>,
+    Path = emqx_mgmt_api_test_util:api_path(["listeners", ListenerId]),
+    Conf = request(get, Path, [], []),
+    %% Check that default is infinity
+    ?assertMatch(#{<<"max_conn_rate">> := <<"infinity">>}, Conf),
+    %% Update to infinity
+    UpdateConfToInfinity = Conf#{<<"max_conn_rate">> => <<"infinity">>},
+    ?assertMatch(
+        #{<<"max_conn_rate">> := <<"infinity">>},
+        request(put, Path, [], UpdateConfToInfinity)
+    ),
+    %% Update to 42/s
+    UpdateConfTo42PerSec = Conf#{<<"max_conn_rate">> => <<"42/s">>},
+    ?assertMatch(
+        #{<<"max_conn_rate">> := <<"42/s">>},
+        request(put, Path, [], UpdateConfTo42PerSec)
+    ),
+    %% Update back to infinity
+    UpdateConfToInfinity = Conf#{<<"max_conn_rate">> => <<"infinity">>},
+    ?assertMatch(
+        #{<<"max_conn_rate">> := <<"infinity">>},
+        request(put, Path, [], UpdateConfToInfinity)
+    ).
+
 t_delete_nonexistent_listener(Config) when is_list(Config) ->
     NonExist = emqx_mgmt_api_test_util:api_path(["listeners", "tcp:nonexistent"]),
     ?assertMatch(

--- a/changes/ce/fix-13375.en.md
+++ b/changes/ce/fix-13375.en.md
@@ -1,0 +1,1 @@
+The value infinity has been added as default value to the listener configuration fields max_conn_rate, messages_rate and bytes_rate.


### PR DESCRIPTION
Before this PR the default value for the fields `max_conn_rate`, `messages_rate` and `bytes_rate` were not set. This is fixed by setting the default value to infinity. This breaks the corresponding dashboard fields (they can not be edited) so the dashboard also needs to be updated.

This change is according to @zmstone's suggestion in the JIRA ticket (https://emqx.atlassian.net/browse/EMQX-12514?focusedCommentId=41414)

Fixes:
https://emqx.atlassian.net/browse/EMQX-12514

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [] Added property-based tests for code which performs user input validation
- [] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible