### PR TITLE
chore: bump `ehttpc` to 0.4.14

### DIFF
--- a/changes/ce/fix-13382.en.md
+++ b/changes/ce/fix-13382.en.md
@@ -1,0 +1,1 @@
+Update `emqtt` library to version 0.4.14 that includes a fix that prevents `emqtt_pool`s from reusing existing pools in an inconsistent state.

--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule EMQXUmbrella.MixProject do
       {:redbug, github: "emqx/redbug", tag: "2.0.10"},
       {:covertool, github: "zmstone/covertool", tag: "2.0.4.1", override: true},
       {:typerefl, github: "ieQu1/typerefl", tag: "0.9.1", override: true},
-      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.13", override: true},
+      {:ehttpc, github: "emqx/ehttpc", tag: "0.4.14", override: true},
       {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true},
       {:jiffy, github: "emqx/jiffy", tag: "1.0.6", override: true},
       {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true},

--- a/rebar.config
+++ b/rebar.config
@@ -77,7 +77,7 @@
     {gpb, "4.19.9"},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}},
     {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.11"}}},
-    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.13"}}},
+    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.4.14"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},


### PR DESCRIPTION
Fixes [EMQX-12421](https://emqx.atlassian.net/browse/EMQX-12421).

Release version: v5.7.2

## Summary

Emqtt 0.4.14 includes a fix that prevents `emqtt_pool` from reusing existing pools in an inconsistent state.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered in coverage report~~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-12421]: https://emqx.atlassian.net/browse/EMQX-12421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ