### PR TITLE
fix: fix two minor issues of bulti-in authn/authz

### DIFF
--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
@@ -142,7 +142,7 @@ salt_position(desc) -> "Salt position for PLAIN, MD5, SHA, SHA256 and SHA512 alg
 salt_position(_) -> undefined.
 
 dk_length(type) ->
-    integer();
+    pos_integer();
 dk_length(required) ->
     false;
 dk_length(desc) ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_rule_raw.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_rule_raw.erl
@@ -98,7 +98,7 @@ validate_rule_topics(RuleRaw) ->
     throw({missing_topic_or_topics, RuleRaw}).
 
 validate_rule_topic(<<"eq ", TopicRaw/binary>>) ->
-    {eq, validate_rule_topic(TopicRaw)};
+    {eq, TopicRaw};
 validate_rule_topic(TopicRaw) when is_binary(TopicRaw) -> TopicRaw.
 
 validate_rule_permission(<<"allow">>) -> allow;

--- a/changes/ce/fix-13389.en.md
+++ b/changes/ce/fix-13389.en.md
@@ -1,0 +1,3 @@
+Fixed that the `Derived Key Length` for `pbkdf2` could be set to a negative integer.
+
+Fixed topics in the authorization rules might be parsed incorrectly.


### PR DESCRIPTION
1. the `Derived Key Length` for `pbkdf2` should be a positive integer.
2. fix topics in the authorization rules might be parsed incorrectly

Fixes EMQX-11414 EMQX-10583

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
