### PR TITLE
build: avoid warnings during docker build

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -2,17 +2,17 @@ ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.3-9:1.15.7-26.2.5-3-debian12
 ARG RUN_FROM=public.ecr.aws/debian/debian:stable-20240612-slim
 ARG SOURCE_TYPE=src # tgz
 
-FROM ${BUILD_FROM} as builder_src
+FROM ${BUILD_FROM} AS builder_src
 ONBUILD COPY . /emqx
 
-FROM ${RUN_FROM} as builder_tgz
+FROM ${RUN_FROM} AS builder_tgz
 ARG PROFILE=emqx
 ARG PKG_VSN
 ARG SUFFIX
 ARG TARGETARCH
 ONBUILD COPY ${PROFILE}-${PKG_VSN}${SUFFIX}-debian12-$TARGETARCH.tar.gz /${PROFILE}.tar.gz
 
-FROM builder_${SOURCE_TYPE} as builder
+FROM builder_${SOURCE_TYPE} AS builder
 
 ARG PROFILE=emqx
 ARG IS_ELIXIR=no


### PR DESCRIPTION
- See also: https://docs.docker.com/reference/build-checks/from-as-casing/

```log
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 5)
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 8)
 => WARN: FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 15)
```

```bash
$ docker buildx version
github.com/docker/buildx 0.15.1 1c1dbb2e4cb5363110f42102744a08d034c2300d
```
Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
