### PR TITLE
feat(bin/emqx): add `-init_debug` system arg when `DEBUG=2`

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -330,7 +330,7 @@ COMPATIBILITY_CHECK='
     end,
     halt(0).
 '
-[ "$DEBUG" -eq 1 ] && set -x
+[[ "$DEBUG" -gt 0 ]] && set -x
 
 compatiblity_info() {
   # RELEASE_LIB is used by Elixir
@@ -558,7 +558,7 @@ else
     fi
 fi
 logdebug "EMQX_BOOT_CONFIGS: $EMQX_BOOT_CONFIGS"
-[ "$DEBUG" -eq 1 ] && set -x
+[[ "$DEBUG" -gt 0 ]] && set -x
 
 get_boot_config() {
     path_to_value="$1"
@@ -1239,6 +1239,12 @@ case "${COMMAND}" in
         # Build an array of arguments to pass to exec later on
         # Build it here because this command will be used for logging.
         if [ "$IS_ELIXIR" = no ] || [ "${EMQX_CONSOLE_FLAVOR:-}" = 'erl' ] ; then
+            if [[ "$DEBUG" == 2 ]]; then
+              INIT_DEBUG_ARG="-init_debug"
+            else
+              INIT_DEBUG_ARG=""
+            fi
+
             # pass down RELEASE_LIB so we can switch to IS_ELIXIR=no
             # to boot an Erlang node from the elixir release
             set -- "$BINDIR/erlexec" \
@@ -1249,8 +1255,15 @@ case "${COMMAND}" in
                 -mode "$CODE_LOADING_MODE" \
                 -config "$CONF_FILE" \
                 -args_file "$ARGS_FILE" \
+                $INIT_DEBUG_ARG \
                 $EPMD_ARGS
         else
+            if [[ "$DEBUG" == 2 ]]; then
+              INIT_DEBUG_ARG="--erl -init_debug"
+            else
+              INIT_DEBUG_ARG=""
+            fi
+
             set -- "$REL_DIR/iex" \
                 --boot "$BOOTFILE" \
                 --boot-var RELEASE_LIB "${ERTS_LIB_DIR}" \
@@ -1259,6 +1272,7 @@ case "${COMMAND}" in
                 --erl "$FOREGROUNDOPTIONS" \
                 --erl "-mode $CODE_LOADING_MODE" \
                 --erl "$EPMD_ARGS" \
+                $INIT_DEBUG_ARG \
                 --werl
         fi
 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: v/e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
