### PR TITLE
chore: hide `enable` flags from schema and config examples

### DIFF
--- a/apps/emqx/src/emqx_persistent_message.erl
+++ b/apps/emqx/src/emqx_persistent_message.erl
@@ -58,7 +58,7 @@ is_persistence_enabled() ->
 
 -spec is_persistence_enabled(emqx_types:zone()) -> boolean().
 is_persistence_enabled(Zone) ->
-    emqx_config:get_zone_conf(Zone, [durable_sessions, enable]).
+    emqx_config:get_zone_conf(Zone, [durable_sessions, enable], false).
 
 -spec storage_backend() -> emqx_ds:create_db_opts().
 storage_backend() ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -351,6 +351,7 @@ fields("authz_cache") ->
                 #{
                     default => true,
                     required => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(fields_cache_enable)
                 }
             )},
@@ -387,6 +388,7 @@ fields("flapping_detect") ->
                 boolean(),
                 #{
                     default => false,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(flapping_detect_enable)
                 }
             )},
@@ -423,6 +425,7 @@ fields("force_shutdown") ->
                 boolean(),
                 #{
                     default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(force_shutdown_enable)
                 }
             )},
@@ -452,6 +455,7 @@ fields("overload_protection") ->
                 boolean(),
                 #{
                     desc => ?DESC(overload_protection_enable),
+                    importance => ?IMPORTANCE_HIDDEN,
                     default => false
                 }
             )},
@@ -512,7 +516,11 @@ fields("force_gc") ->
         {"enable",
             sc(
                 boolean(),
-                #{default => true, desc => ?DESC(force_gc_enable)}
+                #{
+                    default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
+                    desc => ?DESC(force_gc_enable)
+                }
             )},
         {"count",
             sc(
@@ -1665,6 +1673,7 @@ fields("durable_sessions") ->
             sc(
                 boolean(), #{
                     desc => ?DESC(durable_sessions_enable),
+                    importance => ?IMPORTANCE_HIDDEN,
                     default => false
                 }
             )},
@@ -1888,6 +1897,7 @@ base_listener(Bind) ->
                 #{
                     default => true,
                     aliases => [enabled],
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(fields_listener_enabled)
                 }
             )},
@@ -2416,6 +2426,7 @@ client_ssl_opts_schema(Defaults) ->
                     boolean(),
                     #{
                         default => false,
+                        importance => ?IMPORTANCE_HIDDEN,
                         desc => ?DESC(client_ssl_opts_schema_enable)
                     }
                 )},

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -307,8 +307,9 @@ roots(low) ->
             )},
         {durable_sessions,
             sc(
-                ref("durable_sessions"),
+                hoconsc:union([disabled, ref("durable_sessions")]),
                 #{
+                    default => disabled,
                     importance => ?IMPORTANCE_HIDDEN
                 }
             )},

--- a/apps/emqx/src/emqx_zone_schema.erl
+++ b/apps/emqx/src/emqx_zone_schema.erl
@@ -55,7 +55,14 @@ zones_without_default() ->
 
 global_zone_with_default() ->
     lists:map(
-        fun(F) -> {F, ?HOCON(?R_REF(emqx_schema, atom_to_list(F)), #{})} end, roots() -- hidden()
+        fun
+            (durable_sessions = F) ->
+                Sc = ?HOCON(hoconsc:union([disabled, ?R_REF(emqx_schema, atom_to_list(F))]), #{}),
+                {F, Sc};
+            (F) ->
+                {F, ?HOCON(?R_REF(emqx_schema, atom_to_list(F)), #{})}
+        end,
+        roots() -- hidden()
     ).
 
 hidden() ->

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -466,18 +466,5 @@ zone_global_defaults() ->
                 enable => false
             },
         stats => #{enable => true},
-        durable_sessions =>
-            #{
-                enable => false,
-                batch_size => 100,
-                force_persistence => false,
-                idle_poll_interval => 100,
-                heartbeat_interval => 5000,
-                message_retention_period => 86400000,
-                renew_streams_interval => 1000,
-                session_gc_batch_size => 100,
-                session_gc_interval => 600000,
-                subscription_count_refresh_interval => 5000,
-                disconnected_session_count_refresh_interval => 5000
-            }
+        durable_sessions => disabled
     }.

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_schema.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_schema.erl
@@ -203,6 +203,7 @@ common_fields() ->
 
 enable(type) -> boolean();
 enable(default) -> true;
+enable(importance) -> ?IMPORTANCE_HIDDEN;
 enable(desc) -> ?DESC(?FUNCTION_NAME);
 enable(_) -> undefined.
 

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -170,7 +170,12 @@ api_authz_refs() ->
 authz_common_fields(Type) ->
     [
         {type, ?HOCON(Type, #{required => true, desc => ?DESC(type)})},
-        {enable, ?HOCON(boolean(), #{default => true, desc => ?DESC(enable)})}
+        {enable,
+            ?HOCON(boolean(), #{
+                default => true,
+                importance => ?IMPORTANCE_HIDDEN,
+                desc => ?DESC(enable)
+            })}
     ].
 
 source_types() ->

--- a/apps/emqx_auth_mnesia/src/emqx_authz_api_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authz_api_mnesia.erl
@@ -627,6 +627,13 @@ rules(delete, _) ->
                 message =>
                     <<"'built_in_database' type source must be disabled before purge.">>
             }};
+        [#{}] ->
+            %% Default is enabled
+            {400, #{
+                code => <<"BAD_REQUEST">>,
+                message =>
+                    <<"'built_in_database' type source must be disabled before purge.">>
+            }};
         [] ->
             {404, #{
                 code => <<"BAD_REQUEST">>,

--- a/apps/emqx_bridge/src/schema/emqx_bridge_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_schema.erl
@@ -123,6 +123,7 @@ common_bridge_fields() ->
                 boolean(),
                 #{
                     desc => ?DESC("desc_enable"),
+                    importance => ?IMPORTANCE_HIDDEN,
                     default => true
                 }
             )},

--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -65,6 +65,7 @@
 -export([
     make_producer_action_schema/1, make_producer_action_schema/2,
     make_consumer_action_schema/1, make_consumer_action_schema/2,
+    common_fields/0,
     top_level_common_action_keys/0,
     top_level_common_source_keys/0,
     project_to_actions_resource_opts/1,
@@ -507,16 +508,26 @@ make_consumer_action_schema(ParametersRef, Opts) ->
                 })}
         ].
 
-common_schema(ParametersRef, _Opts) ->
+common_fields() ->
     [
-        {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
+        {enable,
+            mk(boolean(), #{
+                desc => ?DESC("config_enable"),
+                importance => ?IMPORTANCE_HIDDEN,
+                default => true
+            })},
         {connector,
             mk(binary(), #{
                 desc => ?DESC(emqx_connector_schema, "connector_field"), required => true
             })},
         {tags, emqx_schema:tags_schema()},
-        {description, emqx_schema:description_schema()},
+        {description, emqx_schema:description_schema()}
+    ].
+
+common_schema(ParametersRef, _Opts) ->
+    [
         {parameters, ParametersRef}
+        | common_fields()
     ].
 
 project_to_actions_resource_opts(OldResourceOpts) ->

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.app.src
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_event_hub, [
     {description, "EMQX Enterprise Azure Event Hub Bridge"},
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -129,16 +129,7 @@ fields(actions) ->
         override(
             emqx_bridge_kafka:producer_opts(action),
             bridge_v2_overrides()
-        ) ++
-            [
-                {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
-                {connector,
-                    mk(binary(), #{
-                        desc => ?DESC(emqx_connector_schema, "connector_field"), required => true
-                    })},
-                {tags, emqx_schema:tags_schema()},
-                {description, emqx_schema:description_schema()}
-            ],
+        ) ++ emqx_bridge_v2_schema:common_fields(),
     override_documentations(Fields);
 fields(Method) ->
     Fields = emqx_bridge_kafka:fields(Method),

--- a/apps/emqx_bridge_confluent/src/emqx_bridge_confluent.app.src
+++ b/apps/emqx_bridge_confluent/src/emqx_bridge_confluent.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_confluent, [
     {description, "EMQX Enterprise Confluent Connector and Action"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_confluent/src/emqx_bridge_confluent_producer.erl
+++ b/apps/emqx_bridge_confluent/src/emqx_bridge_confluent_producer.erl
@@ -116,16 +116,7 @@ fields(actions) ->
         override(
             emqx_bridge_kafka:producer_opts(action),
             bridge_v2_overrides()
-        ) ++
-            [
-                {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
-                {connector,
-                    mk(binary(), #{
-                        desc => ?DESC(emqx_connector_schema, "connector_field"), required => true
-                    })},
-                {tags, emqx_schema:tags_schema()},
-                {description, emqx_schema:description_schema()}
-            ],
+        ) ++ emqx_bridge_v2_schema:common_fields(),
     override_documentations(Fields);
 fields(Method) ->
     Fields = emqx_bridge_kafka:fields(Method),

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_schema.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_schema.erl
@@ -72,35 +72,29 @@ fields(action) ->
             }
         )};
 fields("http_action") ->
-    [
-        {enable, mk(boolean(), #{desc => ?DESC("config_enable_bridge"), default => true})},
-        {connector,
-            mk(binary(), #{
-                desc => ?DESC(emqx_connector_schema, "connector_field"), required => true
-            })},
-        {tags, emqx_schema:tags_schema()},
-        {description, emqx_schema:description_schema()},
-        %% Note: there's an implicit convention in `emqx_bridge' that,
-        %% for egress bridges with this config, the published messages
-        %% will be forwarded to such bridges.
-        {local_topic,
-            mk(
-                binary(),
-                #{
-                    required => false,
-                    desc => ?DESC("config_local_topic"),
-                    importance => ?IMPORTANCE_HIDDEN
-                }
-            )},
-        %% Since e5.3.2, we split the http bridge to two parts: a) connector. b) actions.
-        %% some fields are moved to connector, some fields are moved to actions and composed into the
-        %% `parameters` field.
-        {parameters,
-            mk(ref("parameters_opts"), #{
-                required => true,
-                desc => ?DESC("config_parameters_opts")
-            })}
-    ] ++
+    emqx_bridge_v2_schema:common_fields() ++
+        [
+            %% Note: there's an implicit convention in `emqx_bridge' that,
+            %% for egress bridges with this config, the published messages
+            %% will be forwarded to such bridges.
+            {local_topic,
+                mk(
+                    binary(),
+                    #{
+                        required => false,
+                        desc => ?DESC("config_local_topic"),
+                        importance => ?IMPORTANCE_HIDDEN
+                    }
+                )},
+            %% Since e5.3.2, we split the http bridge to two parts: a) connector. b) actions.
+            %% some fields are moved to connector, some fields are moved to actions and composed into the
+            %% `parameters` field.
+            {parameters,
+                mk(ref("parameters_opts"), #{
+                    required => true,
+                    desc => ?DESC("config_parameters_opts")
+                })}
+        ] ++
         emqx_connector_schema:resource_opts_ref(
             ?MODULE, action_resource_opts, fun legacy_action_resource_opts_converter/2
         );

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -297,15 +297,7 @@ fields("config_consumer") ->
 fields(kafka_producer) ->
     connector_config_fields() ++ producer_opts(v1);
 fields(kafka_producer_action) ->
-    [
-        {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
-        {connector,
-            mk(binary(), #{
-                desc => ?DESC(emqx_connector_schema, "connector_field"), required => true
-            })},
-        {tags, emqx_schema:tags_schema()},
-        {description, emqx_schema:description_schema()}
-    ] ++ producer_opts(action);
+    emqx_bridge_v2_schema:common_fields() ++ producer_opts(action);
 fields(kafka_consumer) ->
     connector_config_fields() ++ fields(consumer_opts);
 fields(ssl_client_opts) ->

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.app.src
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_syskeeper, [
     {description, "EMQX Enterprise Data bridge for Syskeeper"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.erl
@@ -84,30 +84,16 @@ fields(action) ->
             }
         )};
 fields(config) ->
-    [
-        {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
-        {tags, emqx_schema:tags_schema()},
-        {description, emqx_schema:description_schema()},
-        {connector,
-            mk(binary(), #{
-                desc => ?DESC(emqx_connector_schema, "connector_field"), required => true
-            })},
-        {parameters,
-            mk(
-                ref(?MODULE, "parameters"),
-                #{required => true, desc => ?DESC("parameters")}
-            )},
-        {local_topic, mk(binary(), #{required => false, desc => ?DESC(mqtt_topic)})},
-        {resource_opts,
-            mk(
-                ref(?MODULE, "creation_opts"),
-                #{
-                    required => false,
-                    default => #{},
-                    desc => ?DESC(emqx_resource_schema, <<"resource_opts">>)
-                }
-            )}
-    ];
+    emqx_bridge_v2_schema:make_producer_action_schema(
+        mk(
+            ref(?MODULE, "parameters"),
+            #{
+                required => true,
+                desc => ?DESC("parameters")
+            }
+        ),
+        #{resource_opts_ref => ref(?MODULE, "creation_opts")}
+    );
 fields("parameters") ->
     [
         {target_topic,

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
@@ -39,7 +39,12 @@ links_schema(Meta) ->
 
 fields("link") ->
     [
-        {enable, ?HOCON(boolean(), #{default => true, desc => ?DESC(enable)})},
+        {enable,
+            ?HOCON(boolean(), #{
+                default => true,
+                importance => ?IMPORTANCE_HIDDEN,
+                desc => ?DESC(enable)
+            })},
         {name, ?HOCON(binary(), #{required => true, desc => ?DESC(link_name)})},
         {server,
             emqx_schema:servers_sc(#{required => true, desc => ?DESC(server)}, ?MQTT_HOST_OPTS)},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -997,6 +997,7 @@ fields("log_overload_kill") ->
                 boolean(),
                 #{
                     default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC("log_overload_kill_enable")
                 }
             )},
@@ -1032,6 +1033,7 @@ fields("log_burst_limit") ->
                 boolean(),
                 #{
                     default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC("log_burst_limit_enable")
                 }
             )},
@@ -1285,7 +1287,7 @@ log_handler_common_confs(Handler, Default) ->
                 #{
                     default => Enable,
                     desc => ?DESC("common_handler_enable"),
-                    importance => ?IMPORTANCE_MEDIUM
+                    importance => ?IMPORTANCE_HIDDEN
                 }
             )},
         {"formatter",

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -146,9 +146,11 @@ validations() ->
         lists:flatmap(fun hocon_schema:validations/1, common_apps()).
 
 validate_durable_sessions_strategy(Conf) ->
-    DSEnabled = hocon_maps:get("durable_sessions.enable", Conf),
+    DS = hocon_maps:get("durable_sessions", Conf),
+    DSDefined = is_map(DS),
+    DSEnabled = DSDefined andalso hocon_maps:get("durable_sessions.enable", Conf),
     DiscoveryStrategy = hocon_maps:get("cluster.discovery_strategy", Conf),
-    DSBackend = hocon_maps:get("durable_storage.messages.backend", Conf),
+    DSBackend = DSDefined andalso hocon_maps:get("durable_storage.messages.backend", Conf),
     case {DSEnabled, DSBackend} of
         {true, builtin_local} when DiscoveryStrategy =/= singleton ->
             {error, <<

--- a/apps/emqx_connector/src/schema/emqx_connector_schema.erl
+++ b/apps/emqx_connector/src/schema/emqx_connector_schema.erl
@@ -489,7 +489,12 @@ api_fields("put_connector", _Type, Fields) ->
 
 common_fields() ->
     [
-        {enable, mk(boolean(), #{desc => ?DESC("config_enable"), default => true})},
+        {enable,
+            mk(boolean(), #{
+                desc => ?DESC("config_enable"),
+                importance => ?IMPORTANCE_HIDDEN,
+                default => true
+            })},
         {tags, emqx_schema:tags_schema()},
         {description, emqx_schema:description_schema()}
     ].

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -914,7 +914,7 @@ t_list_disabled_channels(Config) ->
 t_raw_config_response_defaults(Config) ->
     Params = maps:without([<<"enable">>, <<"resource_opts">>], ?KAFKA_CONNECTOR(?CONNECTOR_NAME)),
     ?assertMatch(
-        {ok, 201, #{<<"enable">> := true, <<"resource_opts">> := #{}}},
+        {ok, 201, #{<<"resource_opts">> := #{}}},
         request_json(
             post,
             uri(["connectors"]),

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_schema.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_schema.erl
@@ -47,6 +47,7 @@ common_backend_schema(Backend) ->
             mk(
                 boolean(), #{
                     desc => ?DESC(backend_enable),
+                    importance => ?IMPORTANCE_HIDDEN,
                     required => false,
                     default => false
                 }

--- a/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
+++ b/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
@@ -53,7 +53,6 @@ fields("log_audit_handler") ->
                     importance => ?IMPORTANCE_HIDDEN
                 }
             )},
-
         {"path",
             hoconsc:mk(
                 string(),

--- a/apps/emqx_enterprise/test/emqx_enterprise_schema_SUITE.erl
+++ b/apps/emqx_enterprise/test/emqx_enterprise_schema_SUITE.erl
@@ -72,7 +72,6 @@ t_translations(_Config) ->
 
 t_audit_log_conf(_Config) ->
     FileExpect = #{
-        <<"enable">> => true,
         <<"formatter">> => <<"text">>,
         <<"level">> => <<"warning">>,
         <<"rotation_count">> => 10,
@@ -84,7 +83,6 @@ t_audit_log_conf(_Config) ->
     ExpectLog1 = #{
         <<"console">> =>
             #{
-                <<"enable">> => false,
                 <<"formatter">> => <<"text">>,
                 <<"level">> => <<"warning">>,
                 <<"time_offset">> => <<"system">>,

--- a/apps/emqx_exhook/src/emqx_exhook.app.src
+++ b/apps/emqx_exhook/src/emqx_exhook.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_exhook, [
     {description, "EMQX Extension for Hook"},
-    {vsn, "5.0.17"},
+    {vsn, "5.0.18"},
     {modules, []},
     {registered, []},
     {mod, {emqx_exhook_app, []}},

--- a/apps/emqx_exhook/src/emqx_exhook_schema.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_schema.erl
@@ -54,6 +54,7 @@ fields(server) ->
         {enable,
             ?HOCON(boolean(), #{
                 default => true,
+                importance => ?IMPORTANCE_HIDDEN,
                 desc => ?DESC(enable)
             })},
         {url,

--- a/apps/emqx_ft/src/emqx_ft_schema.erl
+++ b/apps/emqx_ft/src/emqx_ft_schema.erl
@@ -66,6 +66,7 @@ fields(file_transfer) ->
                 boolean(),
                 #{
                     desc => ?DESC("enable"),
+                    importance => ?IMPORTANCE_HIDDEN,
                     required => false,
                     default => false
                 }
@@ -242,6 +243,7 @@ common_backend_fields() ->
             mk(
                 boolean(), #{
                     desc => ?DESC("backend_enable"),
+                    importance => ?IMPORTANCE_HIDDEN,
                     required => false,
                     default => true
                 }

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -293,7 +293,6 @@ test_configure(Uri, Config) ->
                 #{
                     <<"local">> :=
                         #{
-                            <<"enable">> := true,
                             <<"segments">> :=
                                 #{
                                     <<"gc">> :=
@@ -498,12 +497,10 @@ test_configure(Uri, Config) ->
                 #{
                     <<"local">> :=
                         #{
-                            <<"enable">> := true,
                             <<"exporter">> :=
                                 #{
                                     <<"s3">> :=
                                         #{
-                                            <<"enable">> := true,
                                             <<"secret_access_key">> := ?SECRET_ACCESS_KEY
                                         }
                                 }

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -240,6 +240,7 @@ gateway_common_options() ->
                 boolean(),
                 #{
                     default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(gateway_common_enable)
                 }
             )},
@@ -413,6 +414,7 @@ common_listener_opts() ->
                 boolean(),
                 #{
                     default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(gateway_common_listener_enable)
                 }
             )},

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -107,7 +107,7 @@ t_gateway(_) ->
     {204, _} = request(put, "/gateways/stomp", #{}),
     {200, StompGw} = request(get, "/gateways/stomp"),
     assert_fields_exist(
-        [name, status, enable, created_at, started_at],
+        [name, status, created_at, started_at],
         StompGw
     ),
     {204, _} = request(put, "/gateways/stomp", #{enable => true}),
@@ -127,12 +127,12 @@ t_gateway_fail(_) ->
 
 t_gateway_enable(_) ->
     {204, _} = request(put, "/gateways/stomp", #{}),
-    {200, #{enable := Enable}} = request(get, "/gateways/stomp"),
+    Enable = emqx_config:get([gateway, stomp, enable]),
     NotEnable = not Enable,
     {204, _} = request(put, "/gateways/stomp/enable/" ++ atom_to_list(NotEnable), undefined),
-    {200, #{enable := NotEnable}} = request(get, "/gateways/stomp"),
+    NotEnable = emqx_config:get([gateway, stomp, enable]),
     {204, _} = request(put, "/gateways/stomp/enable/" ++ atom_to_list(Enable), undefined),
-    {200, #{enable := Enable}} = request(get, "/gateways/stomp"),
+    Enable = emqx_config:get([gateway, stomp, enable]),
     ?assertMatch(
         {400, #{code := <<"BAD_REQUEST">>}},
         request(put, "/gateways/undefined/enable/true", undefined)

--- a/apps/emqx_gateway_ocpp/test/emqx_ocpp_SUITE.erl
+++ b/apps/emqx_gateway_ocpp/test/emqx_ocpp_SUITE.erl
@@ -104,7 +104,6 @@ t_update_listeners(_Config) ->
             id,
             type,
             name,
-            enable,
             enable_authn,
             bind,
             acceptors,
@@ -123,7 +122,6 @@ t_update_listeners(_Config) ->
             id := <<"ocpp:ws:default">>,
             type := <<"ws">>,
             name := <<"default">>,
-            enable := true,
             enable_authn := true,
             bind := <<"0.0.0.0:33033">>,
             websocket := #{path := <<"/ocpp">>}

--- a/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_listeners.erl
@@ -595,13 +595,13 @@ format_status(Key, Node, Listener, Acc) ->
     #{
         <<"id">> := Id,
         <<"type">> := Type,
-        <<"enable">> := Enable,
         <<"running">> := Running,
         <<"max_connections">> := MaxConnections,
         <<"current_connections">> := CurrentConnections,
         <<"acceptors">> := Acceptors,
         <<"bind">> := Bind
     } = Listener,
+    Enable = maps:get(<<"enable">>, Listener, true),
     {ok, #{name := Name}} = emqx_listeners:parse_listener_id(Id),
     GroupKey = maps:get(Key, Listener),
     case maps:find(GroupKey, Acc) of

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -272,7 +272,6 @@ t_configs_key(_Config) ->
         #{
             <<"log">> := #{
                 <<"console">> := #{
-                    <<"enable">> := _,
                     <<"formatter">> := <<"text">>,
                     <<"level">> := <<"warning">>,
                     <<"time_offset">> := <<"system">>

--- a/apps/emqx_modules/src/emqx_modules_schema.erl
+++ b/apps/emqx_modules/src/emqx_modules_schema.erl
@@ -79,7 +79,12 @@ rewrite_validator(Rules) ->
 
 fields("delayed") ->
     [
-        {enable, ?HOCON(boolean(), #{default => true, desc => ?DESC(enable)})},
+        {enable,
+            ?HOCON(boolean(), #{
+                default => true,
+                importance => ?IMPORTANCE_HIDDEN,
+                desc => ?DESC(enable)
+            })},
         {max_delayed_messages,
             ?HOCON(integer(), #{desc => ?DESC(max_delayed_messages), default => 0})}
     ];

--- a/apps/emqx_modules/test/emqx_delayed_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_SUITE.erl
@@ -296,10 +296,10 @@ subscribe_proc() ->
 t_delayed_load_unload(_Config) ->
     Conf = emqx:get_raw_config([delayed]),
     Conf1 = Conf#{<<"max_delayed_messages">> => 1234},
-    ?assertMatch({ok, _}, emqx:update_config([delayed], Conf1#{<<"enable">> := true})),
+    ?assertMatch({ok, _}, emqx:update_config([delayed], Conf1#{<<"enable">> => true})),
     ?assert(is_hooks_exist()),
     ?assertEqual(1234, emqx:get_config([delayed, max_delayed_messages])),
-    ?assertMatch({ok, _}, emqx:update_config([delayed], Conf1#{<<"enable">> := false})),
+    ?assertMatch({ok, _}, emqx:update_config([delayed], Conf1#{<<"enable">> => false})),
     ?assertNot(is_hooks_exist()),
     ?assertMatch({ok, _}, emqx:update_config([delayed], Conf)),
     ok.

--- a/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
+++ b/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_opentelemetry, [
     {description, "OpenTelemetry for EMQX Broker"},
-    {vsn, "0.2.6"},
+    {vsn, "0.2.7"},
     {registered, []},
     {mod, {emqx_otel_app, []}},
     {applications, [

--- a/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_schema.erl
@@ -72,6 +72,7 @@ fields("otel_metrics") ->
                 boolean(),
                 #{
                     default => false,
+                    importance => ?IMPORTANCE_HIDDEN,
                     required => true,
                     desc => ?DESC(enable)
                 }
@@ -104,7 +105,7 @@ fields("otel_logs") ->
                 #{
                     default => false,
                     desc => ?DESC(enable),
-                    importance => ?IMPORTANCE_HIGH
+                    importance => ?IMPORTANCE_HIDDEN
                 }
             )},
         {max_queue_size,
@@ -143,7 +144,7 @@ fields("otel_traces") ->
                 #{
                     default => false,
                     desc => ?DESC(enable),
-                    importance => ?IMPORTANCE_HIGH
+                    importance => ?IMPORTANCE_HIDDEN
                 }
             )},
         {max_queue_size,

--- a/apps/emqx_plugins/src/emqx_plugins_schema.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_schema.erl
@@ -56,6 +56,8 @@ state_fields() ->
             ?HOCON(
                 boolean(),
                 #{
+                    default => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(enable),
                     required => true
                 }

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -78,6 +78,7 @@ fields(push_gateway) ->
                 #{
                     default => false,
                     required => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(push_gateway_enable)
                 }
             )},
@@ -229,6 +230,7 @@ fields(legacy_deprecated_setting) ->
                 #{
                     default => false,
                     required => true,
+                    importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(legacy_enable)
                 }
             )},

--- a/apps/emqx_psk/src/emqx_psk.app.src
+++ b/apps/emqx_psk/src/emqx_psk.app.src
@@ -2,7 +2,7 @@
 {application, emqx_psk, [
     {description, "EMQX PSK"},
     % strict semver, bump manually!
-    {vsn, "5.0.6"},
+    {vsn, "5.0.7"},
     {modules, []},
     {registered, [emqx_psk_sup]},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_psk/src/emqx_psk_schema.erl
+++ b/apps/emqx_psk/src/emqx_psk_schema.erl
@@ -42,6 +42,7 @@ fields() ->
     [
         {enable,
             ?HOCON(boolean(), #{
+                importance => ?IMPORTANCE_HIDDEN,
                 default => false,
                 require => true,
                 desc => ?DESC(enable)

--- a/apps/emqx_retainer/src/emqx_retainer_schema.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_schema.erl
@@ -43,7 +43,7 @@ roots() ->
 
 fields("retainer") ->
     [
-        {enable, sc(boolean(), enable, true)},
+        {enable, sc(boolean(), enable, true, ?IMPORTANCE_HIDDEN)},
         {msg_expiry_interval,
             sc(
                 %% not used in a `receive ... after' block, just timestamp comparison
@@ -126,6 +126,7 @@ fields(mnesia_config) ->
         {enable,
             ?HOCON(boolean(), #{
                 desc => ?DESC(mnesia_enable),
+                importance => ?IMPORTANCE_HIDDEN,
                 required => false,
                 default => true
             })}

--- a/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
@@ -76,7 +76,6 @@ t_config(_Config) ->
     ?assertMatch(
         #{
             backend := _,
-            enable := _,
             max_payload_size := _,
             msg_clear_interval := _,
             msg_expiry_interval := _
@@ -321,8 +320,7 @@ t_change_storage_type(_Config) ->
             <<"backend">> := #{
                 <<"type">> := <<"built_in_database">>,
                 <<"storage_type">> := <<"ram">>
-            },
-            <<"enable">> := true
+            }
         },
         RawConf
     ),

--- a/apps/emqx_slow_subs/src/emqx_slow_subs.app.src
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs.app.src
@@ -1,7 +1,7 @@
 {application, emqx_slow_subs, [
     {description, "EMQX Slow Subscribers Statistics"},
     % strict semver, bump manually!
-    {vsn, "1.0.7"},
+    {vsn, "1.0.8"},
     {modules, []},
     {registered, [emqx_slow_subs_sup]},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_slow_subs/src/emqx_slow_subs_schema.erl
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs_schema.erl
@@ -27,7 +27,7 @@ roots() ->
 
 fields("slow_subs") ->
     [
-        {enable, sc(boolean(), false, enable)},
+        {enable, sc(boolean(), false, enable, ?IMPORTANCE_HIDDEN)},
         {threshold,
             sc(
                 %% not used in a `receive ... after' block, just timestamp comparison
@@ -66,3 +66,6 @@ desc(_) ->
 %%--------------------------------------------------------------------
 sc(Type, Default, Desc) ->
     ?HOCON(Type, #{default => Default, desc => ?DESC(Desc)}).
+
+sc(Type, Default, Desc, Importance) ->
+    ?HOCON(Type, #{default => Default, desc => ?DESC(Desc), importance => Importance}).

--- a/rel/config/ee-examples/file_transfer-with-local-exporter.conf.example
+++ b/rel/config/ee-examples/file_transfer-with-local-exporter.conf.example
@@ -3,9 +3,6 @@
 ## NOTE: This configuration is only applicable in EMQX Enterprise edition 5.1 or later.
 
 file_transfer {
-    ## Enable the File Transfer feature
-    enable = true
-
     ## Storage backend settings
     storage {
         ## Local file system backend setting

--- a/rel/config/ee-examples/file_transfer-with-s3-exporter.conf.example
+++ b/rel/config/ee-examples/file_transfer-with-s3-exporter.conf.example
@@ -4,9 +4,6 @@
 ## Note: This configuration is only applicable for EMQX Enterprise edition 5.1 or later.
 
 file_transfer {
-    ## Enable the File Transfer feature
-    enable = true
-
     ## Storage backend settings
     storage {
         ## Local file system backend setting
@@ -51,8 +48,6 @@ file_transfer {
 
                 ## Enable the HTTPS
                 transport_options {
-                    ssl.enable = true
-
                     ## Timeout for connection attempts
                     connect_timeout = 15s
                }

--- a/rel/config/examples/delayed.conf.example
+++ b/rel/config/examples/delayed.conf.example
@@ -7,8 +7,6 @@
 ##       you should copy and paste the below data into the emqx.conf for working
 
 delayed {
-    enable = true ## false for disabled
-
     ## Maximum number of delayed messages
     ## Default: 0 (0 is no limit)
     max_delayed_messages = 0

--- a/rel/config/examples/exhook.conf.example
+++ b/rel/config/examples/exhook.conf.example
@@ -7,9 +7,6 @@ exhook.servers = [
         ## Name of the exhook server
         name = "server_1"
 
-        ## Feature switch
-        enable = false
-
         ## URL of gRPC server
         url = "http://127.0.0.1:9090"
 

--- a/rel/config/examples/flapping_detect.conf.example
+++ b/rel/config/examples/flapping_detect.conf.example
@@ -3,9 +3,6 @@
 ## Ban the client when the times of connections exceed the limit in the configured time window
 
 flapping_detect {
-    ## use 'true' to enable this feature
-    enable = false
-
     ## Time window for flapping detection
     window_time = 1m
 

--- a/rel/config/examples/force_gc.conf.example
+++ b/rel/config/examples/force_gc.conf.example
@@ -1,9 +1,6 @@
 ## Force Elrang VM garbage collection
 
 force_gc {
-    ## set 'false' to disable this feature
-    enable = true
-
     ## GC the process after this many received messages
     count = 16000
 

--- a/rel/config/examples/force_shutdown.conf.example
+++ b/rel/config/examples/force_shutdown.conf.example
@@ -3,9 +3,6 @@
 ## Forced shutdown MQTT clients for overload protection
 
 force_shutdown {
-    ## set 'false' to disable force shutdown feature
-    enable = true
-
     ## Maximum mailbox size for each Erlang process
     ## Note: Do not modify this unless you know what this is for
     max_mailbox_size = 1000

--- a/rel/config/examples/gateway.exproto.conf.example
+++ b/rel/config/examples/gateway.exproto.conf.example
@@ -16,7 +16,6 @@ gateway.exproto {
     ## Configurations for request to ConnectionHandler service
     handler {
         address = "http://127.0.0.1:9001"
-        ssl_options {enable = false}
     }
 
     listeners.tcp.default {

--- a/rel/config/examples/listeners.ssl.conf.example
+++ b/rel/config/examples/listeners.ssl.conf.example
@@ -3,7 +3,6 @@
 listeners.ssl.my_ssl_listener_name {
     ## Port or Address to listen on, 0 means disable
     bind = 8883 ## or with an IP e.g. "127.0.0.1:8883"
-    enabled = true
     acceptors = 16
     enable_authn = true
     max_connections = infinity

--- a/rel/config/examples/listeners.ws.conf.example
+++ b/rel/config/examples/listeners.ws.conf.example
@@ -3,7 +3,6 @@
 listeners.ws.my_ws_listener_name {
     ## Port or Address to listen on, 0 means disable
     bind = "0.0.0.0:8083" # or just a port number, e.g. 8083
-    enabled = true
     enable_authn = true
     max_connections = infinity
     proxy_protocol = false

--- a/rel/config/examples/listeners.wss.conf.example
+++ b/rel/config/examples/listeners.wss.conf.example
@@ -3,7 +3,6 @@
 listeners.wss.my_wss_listener_name = {
     ## Port or Address to listen on, 0 means disable
     bind = 8084 ## or with an IP, e.g. "127.0.0.1:8084"
-    enabled = true
     enable_authn = true
     max_connections = infinity
     proxy_protocol = false

--- a/rel/config/examples/log.console.conf.example
+++ b/rel/config/examples/log.console.conf.example
@@ -1,9 +1,6 @@
 ## Log to console
 
 log.console {
-    ## set true to enable this
-    enable = false
-
     ## Log level
     ## Type: debug | info | notice | warning | error | critical | alert | emergency
     level = warning

--- a/rel/config/examples/log.file.conf.example
+++ b/rel/config/examples/log.file.conf.example
@@ -1,9 +1,6 @@
 ## Log to file
 
 log.file {
-    ## Enable file log handler
-    enable = true
-
     ## Log level
     ## Type: debug | info | notice | warning | error | critical | alert | emergency
     level = warning

--- a/rel/config/examples/plugins.conf.example
+++ b/rel/config/examples/plugins.conf.example
@@ -9,10 +9,8 @@ plugins {
             ##     Format: {name}-{version}
             ##     Note: name and version should be what it is in the plugin application
             name_vsn = "my_acl-0.1.0",
-
-            enable = true ## enable this plugin
         },
-        {name_vsn = "my_rule-0.1.1", enable = false}
+        {name_vsn = "my_rule-0.1.1"}
     ]
 
     ## The installation directory for the external plugins

--- a/rel/config/examples/prometheus-pushgateway.conf.example
+++ b/rel/config/examples/prometheus-pushgateway.conf.example
@@ -5,9 +5,6 @@
 ## If you want to use push-gateway
 
 prometheus {
-    ## Set to true to make EMQX send metrics to push-gateway
-    enable = false
-
     ## URL of push-gateway server
     push_gateway_server = "http://127.0.0.1:9091"
 

--- a/rel/config/examples/prometheus.conf.example
+++ b/rel/config/examples/prometheus.conf.example
@@ -7,7 +7,6 @@
 prometheus {
   enable_basic_auth = false
   push_gateway {
-    enable = false
     url = "http://127.0.0.1:9091"
     headers {Authorization = "Basic YWRtaW46Y2JraG55eWd5QDE="}
     interval = 15s

--- a/rel/config/examples/psk_authentication.conf.example
+++ b/rel/config/examples/psk_authentication.conf.example
@@ -1,9 +1,6 @@
 ## Pre-Shared Keys authentication
 
 psk_authentication {
-    ## Set to false to disable
-    enable = true
-
     ## If init_file is specified, EMQX will import PSKs from the file into the built-in database at startup for use by the runtime
     init_file = "psk"
 

--- a/rel/config/examples/retainer.conf.example
+++ b/rel/config/examples/retainer.conf.example
@@ -5,9 +5,6 @@
 ##--------------------------------------------------------------------
 
 retainer {
-    ## set to false to disable retainer
-    enable = true
-
     ## Message retention time, default is 0 means the message will never expire
     msg_expiry_interval = 5s
 


### PR DESCRIPTION
https://emqx.atlassian.net/browse/EMQX-12730

Release version: v/e5.8

```sh
ͳ jq 'path(.. | select(.text? == "enable")) as $path | getpath($path | . += ["hash"])' < _build/docgen/emqx-enterprise/schema-v2-en.json
```

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
