### PR TITLE
fix(exclusive): allow the same client to resubscribe to an existing exclusive topic

### DIFF
--- a/apps/emqx/src/emqx_exclusive_subscription.erl
+++ b/apps/emqx/src/emqx_exclusive_subscription.erl
@@ -117,6 +117,13 @@ try_subscribe(ClientId, Topic) ->
                 write
             ),
             allow;
+        [#exclusive_subscription{clientid = ClientId, topic = Topic}] ->
+            %% Fixed the issue-13476
+            %% In this feature, the user must manually call `unsubscribe` to release the lock,
+            %% but sometimes the node may go down for some reason,
+            %% then the client will reconnect to this node and resubscribe.
+            %% We need to allow resubscription, otherwise the lock will never be released.
+            allow;
         [_] ->
             deny
     end.

--- a/apps/emqx/test/emqx_exclusive_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_exclusive_sub_SUITE.erl
@@ -56,6 +56,8 @@ t_exclusive_sub(_) ->
     {ok, _} = emqtt:connect(C1),
     ?CHECK_SUB(C1, 0),
 
+    ?CHECK_SUB(C1, 0),
+
     {ok, C2} = emqtt:start_link([
         {clientid, <<"client2">>},
         {clean_start, false},

--- a/changes/ce/fix-13515.en.md
+++ b/changes/ce/fix-13515.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the same client could not subscribe to the same exclusive topic when the node was down for some reason.


### PR DESCRIPTION


Fixes #13476  EMQX-12707

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
