### PR TITLE
feat: make republish action possible run without dead-loop

### DIFF
--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
@@ -173,7 +173,8 @@ t_source(Config) ->
                         payload => <<"${payload}">>,
                         qos => 0,
                         retain => false,
-                        user_properties => []
+                        user_properties => [],
+                        direct_dispatch => false
                     },
                     function => republish
                 }

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -144,7 +144,7 @@ fields("republish_args") ->
     [
         {topic,
             ?HOCON(
-                binary(),
+                emqx_schema:template(),
                 #{
                     desc => ?DESC("republish_args_topic"),
                     required => true,
@@ -162,7 +162,7 @@ fields("republish_args") ->
             )},
         {retain,
             ?HOCON(
-                hoconsc:union([boolean(), binary()]),
+                hoconsc:union([boolean(), emqx_schema:template()]),
                 #{
                     desc => ?DESC("republish_args_retain"),
                     default => <<"${retain}">>,
@@ -171,7 +171,7 @@ fields("republish_args") ->
             )},
         {payload,
             ?HOCON(
-                binary(),
+                emqx_schema:template(),
                 #{
                     desc => ?DESC("republish_args_payload"),
                     default => <<"${payload}">>,
@@ -188,11 +188,19 @@ fields("republish_args") ->
             )},
         {user_properties,
             ?HOCON(
-                binary(),
+                emqx_schema:template(),
                 #{
                     desc => ?DESC("republish_args_user_properties"),
                     default => <<"${user_properties}">>,
                     example => <<"${pub_props.'User-Property'}">>
+                }
+            )},
+        {direct_dispatch,
+            ?HOCON(
+                hoconsc:union([boolean(), emqx_schema:template()]),
+                #{
+                    desc => ?DESC("republish_args_direct_dispatch"),
+                    default => false
                 }
             )}
     ];
@@ -263,7 +271,7 @@ actions() ->
     end.
 
 qos() ->
-    hoconsc:union([emqx_schema:qos(), binary()]).
+    hoconsc:union([emqx_schema:qos(), emqx_schema:template()]).
 
 rule_engine_settings() ->
     [

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -136,6 +136,8 @@
     ltrim/1,
     reverse/1,
     rtrim/1,
+    rtrim/2,
+    rm_prefix/2,
     strlen/1,
     substr/2,
     substr/3,
@@ -769,6 +771,10 @@ ltrim(S) -> emqx_variform_bif:ltrim(S).
 reverse(S) -> emqx_variform_bif:reverse(S).
 
 rtrim(S) -> emqx_variform_bif:rtrim(S).
+
+rtrim(S, Chars) -> emqx_variform_bif:rtrim(S, Chars).
+
+rm_prefix(S, Prefix) -> emqx_variform_bif:rm_prefix(S, Prefix).
 
 strlen(S) -> emqx_variform_bif:strlen(S).
 

--- a/apps/emqx_schema_validation/test/emqx_schema_validation_http_api_SUITE.erl
+++ b/apps/emqx_schema_validation/test/emqx_schema_validation_http_api_SUITE.erl
@@ -1499,7 +1499,8 @@ t_republish_action_failure(_Config) ->
                                 <<"qos">> => 0,
                                 <<"retain">> => false,
                                 <<"topic">> => <<"t/republished">>,
-                                <<"user_properties">> => <<>>
+                                <<"user_properties">> => <<>>,
+                                <<"direct_dispatch">> => false
                             }
                     }
                 ]

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -25,6 +25,7 @@
     reverse/1,
     rtrim/1,
     rtrim/2,
+    rm_prefix/2,
     strlen/1,
     substr/2,
     substr/3,
@@ -106,6 +107,17 @@ rtrim(S) when is_binary(S) ->
 
 rtrim(S, Chars) when is_binary(S) ->
     string:trim(S, trailing, Chars).
+
+%% @doc Remove the prefix of a string if there is a match.
+%% The original stirng is returned if there is no match.
+rm_prefix(S, Prefix) ->
+    Size = size(Prefix),
+    case S of
+        <<P:Size/binary, Rem/binary>> when P =:= Prefix ->
+            Rem;
+        _ ->
+            S
+    end.
 
 strlen(S) when is_binary(S) ->
     string:length(S).

--- a/changes/ce/feat-13516.en.md
+++ b/changes/ce/feat-13516.en.md
@@ -1,0 +1,4 @@
+Add a `direct_dispatch` argument for `republish` action.
+
+When `direct_dispatch` is set to `true` (or rendered as `true` from template) the message will be directly dispatched to subscribers.
+This can be used to avoid to triggering other rules or recursively trigger the self-rule.

--- a/rel/i18n/emqx_rule_engine_schema.hocon
+++ b/rel/i18n/emqx_rule_engine_schema.hocon
@@ -113,6 +113,23 @@ Placeholders like <code>${.payload.content_type}</code> may be used."""
 republish_args_mqtt_properties.label:
 """MQTT Properties"""
 
+republish_args_direct_dispatch.desc:
+"""Enable direct dispatch to subscribers without initiating a new message publish event.
+When set to `true`, this prevents the recursive processing of a message by the same action
+and is used when the output message does not require further processing.
+
+However, enabling this feature has several limitations:
+
+- The output message from this action is not retained.
+- It does not trigger other rules that operate based on the output topic of this action.
+- It does not activate rules that select from the `$events/message_publish`.
+- It does not trigger plugins that use the `'message.publish'` hook.
+- Topic metrics are not collected for the output message of this action.
+- Message schema validation is not applied (feature of EMQX Enterprise).
+- Message transformation processes are not applied (feature of EMQX Enterprise)."""
+
+republish_args_direct_dispatch.label: "Direct Dispatch"
+
 republish_function.desc:
 """Republish the message as a new MQTT message"""
 


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/13511
Release version: v/e5.8.0

## Summary

The republish action triggers `message.publish` hook which then triggers the republish action itself again. i.e. dead-loop
This PR adds a new option named `direct_dispatch` to the republish action so it can skip running the `message.pubhsh` hook again.

This should allow forwarding messages mutually (without topic name-space) between two clusters without looping.
Example config:
```
rule_engine {
  ignore_sys_message = true
  jq_function_default_timeout = "10s"
  rules {
    brdige-unmount {
      actions = [
        {
          args {
            direct_dispatch = true
            mqtt_properties {}
            payload = "${payload}"
            qos = 0
            retain = false
            topic = "${newtopic}"
            user_properties = ""
          }
          function = republish
        }
      ]
      description = ""
      enable = true
      metadata {created_at = 1721825550385}
      name = ""
      sql = """~
        SELECT
          *,
          regex_replace(topic, 'forward/', '') as newtopic
        FROM
          "forward/#"~"""
    }
    bridge-forward {
      actions = [
        "mqtt:forward"
      ]
      description = ""
      enable = true
      metadata {created_at = 1721825179642}
      name = ""
      sql = """~
        SELECT
          *
        FROM
          "#"
        WHERE
          not topic =~ 'forward/#'~"""
    }
  }
}
actions {
  mqtt {
    forward {
      connector = bridge
      enable = true
      parameters {
        payload = "${payload}"
        qos = 1
        retain = false
        topic = "forward/${topic}"
      }
      resource_opts {
        health_check_interval = "15s"
        inflight_window = 100
        max_buffer_bytes = "256MB"
        query_mode = async
        request_ttl = "45s"
        worker_pool_size = 16
      }
    }
  }
}
connectors {
  mqtt {
    bridge {
      bridge_mode = false
      clean_start = true
      description = ""
      enable = true
      keepalive = "300s"
      max_inflight = 32
      pool_size = 8
      proto_ver = v4
      resource_opts {
        health_check_interval = "15s"
        start_after_created = true
        start_timeout = "5s"
      }
      retry_interval = "15s"
      #server = "172.17.0.4:1883"  ############ <------------------------ the peer node
      server = "172.17.0.3:1883"
      ssl {
        ciphers = []
        depth = 10
        enable = false
        hibernate_after = "5s"
        log_level = notice
        reuse_sessions = true
        secure_renegotiate = true
        verify = verify_peer
        versions = [
          "tlsv1.3",
          "tlsv1.2"
        ]
      }
    }
  }
}
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
