### PR TITLE
feat: attempt to automatically decode `payload` similar to key and message templates

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -469,7 +469,7 @@ render_topic({fixed, KafkaTopic}, _Message) ->
     KafkaTopic;
 render_topic({dynamic, Template}, Message) ->
     try
-        iolist_to_binary(emqx_template:render_strict(Template, Message))
+        iolist_to_binary(emqx_template:render_strict(Template, {emqx_jsonish, Message}))
     catch
         error:_Errors ->
             throw(bad_topic)

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -967,12 +967,7 @@ t_dynamic_topics(Config) ->
                 RuleTopic,
                 [
                     {bridge_name, ActionName}
-                ],
-                #{
-                    sql =>
-                        <<"select *, json_decode(payload) as payload from \"", RuleTopic/binary,
-                            "\" ">>
-                }
+                ]
             ),
             ?assertStatusAPI(Type, ActionName, <<"connected">>),
 


### PR DESCRIPTION
Should have gone into https://github.com/emqx/emqx/pull/13518, which was merged too soon.

Fixes https://emqx.atlassian.net/browse/EMQX-12656

Release version: e5.7.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
