### PR TITLE
refactor: force getenv to access only OS env with prefix EMQXVAR_

### DIFF
--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -583,7 +583,7 @@ getenv(Bin) when is_binary(Bin) ->
     EnvKey = ?ENV_CACHE(Bin),
     case persistent_term:get(EnvKey, undefined) of
         undefined ->
-            Name = erlang:binary_to_list(Bin),
+            Name = "EMQXVAR_" ++ erlang:binary_to_list(Bin),
             Result =
                 case os:getenv(Name) of
                     false ->

--- a/apps/emqx_utils/test/emqx_variform_bif_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_bif_tests.erl
@@ -77,5 +77,5 @@ system_test() ->
     EnvName = erlang:atom_to_list(?MODULE),
     EnvVal = erlang:atom_to_list(?FUNCTION_NAME),
     EnvNameBin = erlang:list_to_binary(EnvName),
-    os:putenv(EnvName, EnvVal),
+    os:putenv("EMQXVAR_" ++ EnvName, EnvVal),
     ?assertEqual(erlang:list_to_binary(EnvVal), emqx_variform_bif:getenv(EnvNameBin)).

--- a/changes/ce/feat-13507.en.md
+++ b/changes/ce/feat-13507.en.md
@@ -1,2 +1,4 @@
-Added a new builtin function `getenv` in the rule engine and variform expression to access the environment variables.
-Note this value is immutable once loaded from the environment.
+Added a new builtin function `getenv` in the rule engine and variform expression to access the environment variables with below limitations.
+
+- Prefix `EMQXVAR_` is added before reading from OS environment variables. i.e. `getenv('FOO_BAR')` is to read `EMQXVAR_FOO_BAR`.
+- The values are immutable once loaded from the OS environment.


### PR DESCRIPTION
follow-up fix for PR https://github.com/emqx/emqx/pull/13507