### PR TITLE
feat(dsraft): support atomic batches + preconditions

### DIFF
--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -327,9 +327,8 @@ t_11_batch_preconditions(Config) ->
             ?assertEqual(
                 ok,
                 emqx_ds:store_batch(DB, Batch1)
-            )
-        end,
-        fun(_Trace) ->
+            ),
+
             %% Wait at least until current epoch ends.
             ct:sleep(1000),
             %% There's no messages in the DB.
@@ -337,7 +336,8 @@ t_11_batch_preconditions(Config) ->
                 [],
                 emqx_ds_test_helpers:consume(DB, emqx_topic:words(<<"t/#">>))
             )
-        end
+        end,
+        []
     ).
 
 t_12_batch_precondition_conflicts(Config) ->

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -19,6 +19,7 @@
 -compile(nowarn_export_all).
 
 -include("../../emqx/include/emqx.hrl").
+-include("../../emqx_durable_storage/include/emqx_ds.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include("../../emqx/include/asserts.hrl").
@@ -145,7 +146,7 @@ t_06_smoke_add_generation(Config) ->
     ?assertMatch(ok, emqx_ds:add_generation(DB)),
     [
         {Gen1, #{created_at := Created1, since := Since1, until := Until1}},
-        {Gen2, #{created_at := Created2, since := Since2, until := undefined}}
+        {_Gen2, #{created_at := Created2, since := Since2, until := undefined}}
     ] = maps:to_list(emqx_ds:list_generations_with_lifetimes(DB)),
     %% Check units of the return values (+/- 10s from test begin time):
     ?give_or_take(BeginTime, 10_000, Created1),
@@ -234,8 +235,8 @@ t_09_atomic_store_batch(Config) ->
     DB = ?FUNCTION_NAME,
     ?check_trace(
         begin
-            application:set_env(emqx_durable_storage, egress_batch_size, 1),
-            ?assertMatch(ok, emqx_ds:open_db(DB, opts(Config))),
+            DBOpts = (opts(Config))#{atomic_batches => true},
+            ?assertMatch(ok, emqx_ds:open_db(DB, DBOpts)),
             Msgs = [
                 message(<<"1">>, <<"1">>, 0),
                 message(<<"2">>, <<"2">>, 1),
@@ -243,13 +244,8 @@ t_09_atomic_store_batch(Config) ->
             ],
             ?assertEqual(
                 ok,
-                emqx_ds:store_batch(DB, Msgs, #{
-                    atomic => true,
-                    sync => true
-                })
-            ),
-            {ok, Flush} = ?block_until(#{?snk_kind := emqx_ds_buffer_flush}),
-            ?assertMatch(#{batch := [_, _, _]}, Flush)
+                emqx_ds:store_batch(DB, Msgs, #{sync => true})
+            )
         end,
         []
     ),
@@ -288,6 +284,124 @@ t_10_non_atomic_store_batch(Config) ->
         end
     ),
     ok.
+
+t_11_batch_preconditions(Config) ->
+    DB = ?FUNCTION_NAME,
+    ?check_trace(
+        begin
+            DBOpts = (opts(Config))#{
+                atomic_batches => true,
+                force_monotonic_timestamps => false
+            },
+            ?assertMatch(ok, emqx_ds:open_db(DB, DBOpts)),
+
+            %% Conditional delete
+            TS = 42,
+            Batch1 = #dsbatch{
+                preconditions = [{if_exists, matcher(<<"c1">>, <<"t/a">>, '_', TS)}],
+                operations = [{delete, matcher(<<"c1">>, <<"t/a">>, '_', TS)}]
+            },
+            %% Conditional insert
+            M1 = message(<<"c1">>, <<"t/a">>, <<"M1">>, TS),
+            Batch2 = #dsbatch{
+                preconditions = [{unless_exists, matcher(<<"c1">>, <<"t/a">>, '_', TS)}],
+                operations = [M1]
+            },
+
+            %% No such message yet, precondition fails:
+            ?assertEqual(
+                {error, unrecoverable, {precondition_failed, not_found}},
+                emqx_ds:store_batch(DB, Batch1)
+            ),
+            %% No such message yet, `unless` precondition holds:
+            ?assertEqual(
+                ok,
+                emqx_ds:store_batch(DB, Batch2)
+            ),
+            %% Now there's such message, `unless` precondition now fails:
+            ?assertEqual(
+                {error, unrecoverable, {precondition_failed, M1}},
+                emqx_ds:store_batch(DB, Batch2)
+            ),
+            %% On the other hand, `if` precondition now holds:
+            ?assertEqual(
+                ok,
+                emqx_ds:store_batch(DB, Batch1)
+            )
+        end,
+        fun(_Trace) ->
+            %% Wait at least until current epoch ends.
+            ct:sleep(1000),
+            %% There's no messages in the DB.
+            ?assertEqual(
+                [],
+                emqx_ds_test_helpers:consume(DB, emqx_topic:words(<<"t/#">>))
+            )
+        end
+    ).
+
+t_12_batch_precondition_conflicts(Config) ->
+    DB = ?FUNCTION_NAME,
+    NBatches = 50,
+    NMessages = 10,
+    ?check_trace(
+        begin
+            DBOpts = (opts(Config))#{
+                atomic_batches => true,
+                force_monotonic_timestamps => false
+            },
+            ?assertMatch(ok, emqx_ds:open_db(DB, DBOpts)),
+
+            ConflictBatches = [
+                #dsbatch{
+                    %% If the slot is free...
+                    preconditions = [{if_exists, matcher(<<"c1">>, <<"t/slot">>, _Free = <<>>, 0)}],
+                    %% Take it and write NMessages extra messages, so that batches take longer to
+                    %% process and have higher chances to conflict with each other.
+                    operations =
+                        [
+                            message(<<"c1">>, <<"t/slot">>, integer_to_binary(I), _TS = 0)
+                            | [
+                                message(<<"c1">>, {"t/owner/~p/~p", [I, J]}, <<>>, I * 100 + J)
+                             || J <- lists:seq(1, NMessages)
+                            ]
+                        ]
+                }
+             || I <- lists:seq(1, NBatches)
+            ],
+
+            %% Run those batches concurrently.
+            ok = emqx_ds:store_batch(DB, [message(<<"c1">>, <<"t/slot">>, <<>>, 0)]),
+            Results = emqx_utils:pmap(
+                fun(B) -> emqx_ds:store_batch(DB, B) end,
+                ConflictBatches,
+                infinity
+            ),
+
+            %% Only one should have succeeded.
+            ?assertEqual([ok], [Ok || Ok = ok <- Results]),
+
+            %% While other failed with an identical `precondition_failed`.
+            Failures = lists:usort([PreconditionFailed || {error, _, PreconditionFailed} <- Results]),
+            ?assertMatch(
+                [{precondition_failed, #message{topic = <<"t/slot">>, payload = <<_/bytes>>}}],
+                Failures
+            ),
+
+            %% Wait at least until current epoch ends.
+            ct:sleep(1000),
+            %% Storage should contain single batch's messages.
+            [{precondition_failed, #message{payload = IOwner}}] = Failures,
+            WinnerBatch = lists:nth(binary_to_integer(IOwner), ConflictBatches),
+            BatchMessages = lists:sort(WinnerBatch#dsbatch.operations),
+            DBMessages = emqx_ds_test_helpers:consume(DB, emqx_topic:words(<<"t/#">>)),
+            ?assertEqual(
+                BatchMessages,
+                DBMessages
+            )
+        end,
+        []
+    ).
 
 t_smoke_delete_next(Config) ->
     DB = ?FUNCTION_NAME,
@@ -534,11 +648,24 @@ message(ClientId, Topic, Payload, PublishedAt) ->
 
 message(Topic, Payload, PublishedAt) ->
     #message{
-        topic = Topic,
-        payload = Payload,
+        topic = try_format(Topic),
+        payload = try_format(Payload),
         timestamp = PublishedAt,
         id = emqx_guid:gen()
     }.
+
+matcher(ClientID, Topic, Payload, Timestamp) ->
+    #message_matcher{
+        from = ClientID,
+        topic = try_format(Topic),
+        timestamp = Timestamp,
+        payload = Payload
+    }.
+
+try_format({Fmt, Args}) ->
+    emqx_utils:format(Fmt, Args);
+try_format(String) ->
+    String.
 
 delete(DB, It, Selector, BatchSize) ->
     delete(DB, It, Selector, BatchSize, 0).
@@ -562,9 +689,18 @@ all() ->
 
 groups() ->
     TCs = emqx_common_test_helpers:all(?MODULE),
+    %% TODO: Remove once builtin-local supports preconditions + atomic batches.
+    BuiltinLocalTCs =
+        TCs --
+            [
+                t_09_atomic_store_batch,
+                t_11_batch_preconditions,
+                t_12_batch_precondition_conflicts
+            ],
+    BuiltinRaftTCs = TCs,
     [
-        {builtin_local, TCs},
-        {builtin_raft, TCs}
+        {builtin_local, BuiltinLocalTCs},
+        {builtin_raft, BuiltinRaftTCs}
     ].
 
 init_per_group(builtin_local, Config) ->

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -304,7 +304,7 @@ get_streams(DB, TopicFilter, StartTime) ->
 -spec make_iterator(
     emqx_ds:db(), emqx_ds:ds_specific_stream(), emqx_ds:topic_filter(), emqx_ds:time()
 ) ->
-    emqx_ds:make_iterator_result(emqx_ds:ds_specific_iterator()).
+    emqx_ds:make_iterator_result(iterator()).
 make_iterator(DB, ?stream(Shard, InnerStream), TopicFilter, StartTime) ->
     ShardId = {DB, Shard},
     case
@@ -318,7 +318,7 @@ make_iterator(DB, ?stream(Shard, InnerStream), TopicFilter, StartTime) ->
             Error
     end.
 
--spec update_iterator(emqx_ds:db(), emqx_ds:ds_specific_iterator(), emqx_ds:message_key()) ->
+-spec update_iterator(emqx_ds:db(), iterator(), emqx_ds:message_key()) ->
     emqx_ds:make_iterator_result(iterator()).
 update_iterator(DB, Iter0 = #{?tag := ?IT, ?shard := Shard, ?enc := StorageIter0}, Key) ->
     case emqx_ds_storage_layer:update_iterator({DB, Shard}, StorageIter0, Key) of
@@ -396,7 +396,7 @@ do_next(DB, Iter0 = #{?tag := ?IT, ?shard := Shard, ?enc := StorageIter0}, N) ->
     end.
 
 -spec do_delete_next(emqx_ds:db(), delete_iterator(), emqx_ds:delete_selector(), pos_integer()) ->
-    emqx_ds:delete_next_result(emqx_ds:delete_iterator()).
+    emqx_ds:delete_next_result(delete_iterator()).
 do_delete_next(
     DB, Iter = #{?tag := ?DELETE_IT, ?shard := Shard, ?enc := StorageIter0}, Selector, N
 ) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -101,7 +101,10 @@
         n_shards => pos_integer(),
         n_sites => pos_integer(),
         replication_factor => pos_integer(),
-        replication_options => _TODO :: #{}
+        replication_options => _TODO :: #{},
+        %% Inherited from `emqx_ds:generic_db_opts()`.
+        force_monotonic_timestamps => boolean(),
+        atomic_batches => boolean()
     }.
 
 %% This enapsulates the stream entity from the replication level.

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -1036,9 +1036,9 @@ assign_timestamps(true, Latest0, [Message0 = #message{} | Rest], Acc, N, Sz) ->
     MSize = approx_message_size(Message0),
     assign_timestamps(true, Latest, Rest, [Message | Acc], N + 1, Sz + MSize);
 assign_timestamps(false, Latest0, [Message0 = #message{} | Rest], Acc, N, Sz) ->
-    Timestamp = emqx_message:timestamp(Message0),
-    Latest = max(Latest0, Timestamp),
-    Message = assign_timestamp(Timestamp, Message0),
+    TimestampUs = emqx_message:timestamp(Message0),
+    Latest = max(Latest0, TimestampUs),
+    Message = assign_timestamp(TimestampUs, Message0),
     MSize = approx_message_size(Message0),
     assign_timestamps(false, Latest, Rest, [Message | Acc], N + 1, Sz + MSize);
 assign_timestamps(ForceMonotonic, Latest, [Operation | Rest], Acc, N, Sz) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -140,7 +140,7 @@
     }.
 
 %% Write batch.
-%% Instances of this type currently form the mojority of the Raft log.
+%% Instances of this type currently form the majority of the Raft log.
 -type batch() :: #{
     ?tag := ?BATCH,
     ?batch_operations := [emqx_ds:operation()],
@@ -281,7 +281,7 @@ store_batch_atomic(DB, Batch, _Opts) ->
         [] ->
             ok;
         [_ | _] ->
-            {error, unrecoverable, nonatomic_batch_spans_multiple_storages}
+            {error, unrecoverable, atomic_batch_spans_multiple_shards}
     end.
 
 -spec get_streams(emqx_ds:db(), emqx_ds:topic_filter(), emqx_ds:time()) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -675,7 +675,7 @@ list_nodes() ->
 -define(SHARD_RPC(DB, SHARD, NODE, BODY),
     case
         emqx_ds_replication_layer_shard:servers(
-            DB, SHARD, application:get_env(emqx_durable_storage, reads, leader_preferred)
+            DB, SHARD, application:get_env(emqx_ds_builtin_raft, reads, leader_preferred)
         )
     of
         [{_, NODE} | _] ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -83,6 +83,7 @@
     ra_state/0
 ]).
 
+-include_lib("emqx_durable_storage/include/emqx_ds.hrl").
 -include_lib("emqx_utils/include/emqx_message.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 -include("emqx_ds_replication_layer.hrl").
@@ -135,11 +136,12 @@
         ?enc := emqx_ds_storage_layer:delete_iterator()
     }.
 
-%% TODO: this type is obsolete and is kept only for compatibility with
-%% BPAPIs. Remove it when emqx_ds_proto_v4 is gone (EMQX 5.6)
+%% Write batch.
+%% Instances of this type currently form the mojority of the Raft log.
 -type batch() :: #{
     ?tag := ?BATCH,
-    ?batch_messages := [emqx_types:message()]
+    ?batch_operations := [emqx_ds:operation()],
+    ?batch_preconditions => [emqx_ds:precondition()]
 }.
 
 -type generation_rank() :: {shard_id(), term()}.
@@ -240,14 +242,43 @@ drop_db(DB) ->
     _ = emqx_ds_proto_v4:drop_db(list_nodes(), DB),
     emqx_ds_replication_layer_meta:drop_db(DB).
 
--spec store_batch(emqx_ds:db(), [emqx_types:message(), ...], emqx_ds:message_store_opts()) ->
+-spec store_batch(emqx_ds:db(), emqx_ds:batch(), emqx_ds:message_store_opts()) ->
     emqx_ds:store_batch_result().
-store_batch(DB, Messages, Opts) ->
+store_batch(DB, Batch = #dsbatch{preconditions = [_ | _]}, Opts) ->
+    %% NOTE: Atomic batch is implied, will not check with DB config.
+    store_batch_atomic(DB, Batch, Opts);
+store_batch(DB, Batch, Opts) ->
+    case emqx_ds_replication_layer_meta:db_config(DB) of
+        #{atomic_batches := true} ->
+            store_batch_atomic(DB, Batch, Opts);
+        #{} ->
+            store_batch_buffered(DB, Batch, Opts)
+    end.
+
+store_batch_buffered(DB, #dsbatch{operations = Operations}, Opts) ->
+    store_batch_buffered(DB, Operations, Opts);
+store_batch_buffered(DB, Batch, Opts) ->
     try
-        emqx_ds_buffer:store_batch(DB, Messages, Opts)
+        emqx_ds_buffer:store_batch(DB, Batch, Opts)
     catch
         error:{Reason, _Call} when Reason == timeout; Reason == noproc ->
             {error, recoverable, Reason}
+    end.
+
+store_batch_atomic(DB, Batch, _Opts) ->
+    Shards = shards_of_batch(DB, Batch),
+    case Shards of
+        [Shard] ->
+            case ra_store_batch(DB, Shard, Batch) of
+                {timeout, ServerId} ->
+                    {error, recoverable, {timeout, ServerId}};
+                Result ->
+                    Result
+            end;
+        [] ->
+            ok;
+        [_ | _] ->
+            {error, unrecoverable, nonatomic_batch_spans_multiple_storages}
     end.
 
 -spec get_streams(emqx_ds:db(), emqx_ds:topic_filter(), emqx_ds:time()) ->
@@ -417,6 +448,23 @@ shard_of_key(DB, Key) ->
     N = emqx_ds_replication_shard_allocator:n_shards(DB),
     Hash = erlang:phash2(Key, N),
     integer_to_binary(Hash).
+
+shards_of_batch(DB, #dsbatch{operations = Operations, preconditions = Preconditions}) ->
+    shards_of_batch(DB, Preconditions, shards_of_batch(DB, Operations, []));
+shards_of_batch(DB, Operations) ->
+    shards_of_batch(DB, Operations, []).
+
+shards_of_batch(DB, [Operation | Rest], Acc) ->
+    case shard_of_operation(DB, Operation, clientid, #{}) of
+        Shard when Shard =:= hd(Acc) ->
+            shards_of_batch(DB, Rest, Acc);
+        Shard when Acc =:= [] ->
+            shards_of_batch(DB, Rest, [Shard]);
+        ShardAnother ->
+            [ShardAnother | Acc]
+    end;
+shards_of_batch(_DB, [], Acc) ->
+    Acc.
 
 %%================================================================================
 %% Internal exports (RPC targets)
@@ -639,13 +687,22 @@ list_nodes() ->
     end
 ).
 
--spec ra_store_batch(emqx_ds:db(), emqx_ds_replication_layer:shard_id(), [emqx_types:message()]) ->
-    ok | {timeout, _} | {error, recoverable | unrecoverable, _Err}.
-ra_store_batch(DB, Shard, Messages) ->
-    Command = #{
-        ?tag => ?BATCH,
-        ?batch_messages => Messages
-    },
+-spec ra_store_batch(emqx_ds:db(), emqx_ds_replication_layer:shard_id(), emqx_ds:batch()) ->
+    ok | {timeout, _} | emqx_ds:error(_).
+ra_store_batch(DB, Shard, Batch) ->
+    case Batch of
+        #dsbatch{operations = Operations, preconditions = Preconditions} ->
+            Command = #{
+                ?tag => ?BATCH,
+                ?batch_operations => Operations,
+                ?batch_preconditions => Preconditions
+            };
+        Operations ->
+            Command = #{
+                ?tag => ?BATCH,
+                ?batch_operations => Operations
+            }
+    end,
     Servers = emqx_ds_replication_layer_shard:servers(DB, Shard, leader_preferred),
     case emqx_ds_replication_layer_shard:process_command(Servers, Command, ?RA_TIMEOUT) of
         {ok, Result, _Leader} ->
@@ -782,6 +839,7 @@ ra_drop_shard(DB, Shard) ->
 
 -define(pd_ra_idx_need_release, '$emqx_ds_raft_idx_need_release').
 -define(pd_ra_bytes_need_release, '$emqx_ds_raft_bytes_need_release').
+-define(pd_ra_force_monotonic, '$emqx_ds_raft_force_monotonic').
 
 -spec init(_Args :: map()) -> ra_state().
 init(#{db := DB, shard := Shard}) ->
@@ -791,18 +849,30 @@ init(#{db := DB, shard := Shard}) ->
     {ra_state(), _Reply, _Effects}.
 apply(
     RaftMeta,
-    #{
+    Command = #{
         ?tag := ?BATCH,
-        ?batch_messages := MessagesIn
+        ?batch_operations := OperationsIn
     },
     #{db_shard := DBShard = {DB, Shard}, latest := Latest0} = State0
 ) ->
-    ?tp(ds_ra_apply_batch, #{db => DB, shard => Shard, batch => MessagesIn, latest => Latest0}),
-    {Stats, Latest, Messages} = assign_timestamps(Latest0, MessagesIn),
-    Result = emqx_ds_storage_layer:store_batch(DBShard, Messages, #{durable => false}),
-    State = State0#{latest := Latest},
-    set_ts(DBShard, Latest),
-    Effects = try_release_log(Stats, RaftMeta, State),
+    ?tp(ds_ra_apply_batch, #{db => DB, shard => Shard, batch => OperationsIn, latest => Latest0}),
+    Preconditions = maps:get(?batch_preconditions, Command, []),
+    {Stats, Latest, Operations} = assign_timestamps(DB, Latest0, OperationsIn),
+    %% FIXME
+    case emqx_ds_precondition:verify(emqx_ds_storage_layer, DBShard, Preconditions) of
+        ok ->
+            Result = emqx_ds_storage_layer:store_batch(DBShard, Operations, #{durable => false}),
+            State = State0#{latest := Latest},
+            set_ts(DBShard, Latest),
+            Effects = try_release_log(Stats, RaftMeta, State);
+        PreconditionFailed = {precondition_failed, _} ->
+            Result = {error, unrecoverable, PreconditionFailed},
+            State = State0,
+            Effects = [];
+        Result ->
+            State = State0,
+            Effects = []
+    end,
     Effects =/= [] andalso ?tp(ds_ra_effects, #{effects => Effects, meta => RaftMeta}),
     {State, Result, Effects};
 apply(
@@ -877,6 +947,21 @@ apply(
     Effects = handle_custom_event(DBShard, Latest, CustomEvent),
     {State#{latest => Latest}, ok, Effects}.
 
+assign_timestamps(DB, Latest, Messages) ->
+    ForceMonotonic = force_monotonic_timestamps(DB),
+    assign_timestamps(ForceMonotonic, Latest, Messages, [], 0, 0).
+
+force_monotonic_timestamps(DB) ->
+    case erlang:get(?pd_ra_force_monotonic) of
+        undefined ->
+            DBConfig = emqx_ds_replication_layer_meta:db_config(DB),
+            Flag = maps:get(force_monotonic_timestamps, DBConfig),
+            erlang:put(?pd_ra_force_monotonic, Flag);
+        Flag ->
+            ok
+    end,
+    Flag.
+
 try_release_log({_N, BatchSize}, RaftMeta = #{index := CurrentIdx}, State) ->
     %% NOTE
     %% Because cursor release means storage flush (see
@@ -939,10 +1024,7 @@ tick(TimeMs, #{db_shard := DBShard = {DB, Shard}, latest := Latest}) ->
     ?tp(emqx_ds_replication_layer_tick, #{db => DB, shard => Shard, timestamp => Timestamp}),
     handle_custom_event(DBShard, Timestamp, tick).
 
-assign_timestamps(Latest, Messages) ->
-    assign_timestamps(Latest, Messages, [], 0, 0).
-
-assign_timestamps(Latest0, [Message0 | Rest], Acc, N, Sz) ->
+assign_timestamps(true, Latest0, [Message0 = #message{} | Rest], Acc, N, Sz) ->
     case emqx_message:timestamp(Message0, microsecond) of
         TimestampUs when TimestampUs > Latest0 ->
             Latest = TimestampUs,
@@ -951,8 +1033,17 @@ assign_timestamps(Latest0, [Message0 | Rest], Acc, N, Sz) ->
             Latest = Latest0 + 1,
             Message = assign_timestamp(Latest, Message0)
     end,
-    assign_timestamps(Latest, Rest, [Message | Acc], N + 1, Sz + approx_message_size(Message0));
-assign_timestamps(Latest, [], Acc, N, Size) ->
+    MSize = approx_message_size(Message0),
+    assign_timestamps(true, Latest, Rest, [Message | Acc], N + 1, Sz + MSize);
+assign_timestamps(false, Latest0, [Message0 = #message{} | Rest], Acc, N, Sz) ->
+    Timestamp = emqx_message:timestamp(Message0),
+    Latest = max(Latest0, Timestamp),
+    Message = assign_timestamp(Timestamp, Message0),
+    MSize = approx_message_size(Message0),
+    assign_timestamps(false, Latest, Rest, [Message | Acc], N + 1, Sz + MSize);
+assign_timestamps(ForceMonotonic, Latest, [Operation | Rest], Acc, N, Sz) ->
+    assign_timestamps(ForceMonotonic, Latest, Rest, [Operation | Acc], N + 1, Sz);
+assign_timestamps(_ForceMonotonic, Latest, [], Acc, N, Size) ->
     {{N, Size}, Latest, lists:reverse(Acc)}.
 
 assign_timestamp(TimestampUs, Message) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.hrl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.hrl
@@ -19,7 +19,8 @@
 -define(enc, 3).
 
 %% ?BATCH
--define(batch_messages, 2).
+-define(batch_operations, 2).
+-define(batch_preconditions, 4).
 -define(timestamp, 3).
 
 %% add_generation / update_config

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -56,6 +56,7 @@
     topic/0,
     batch/0,
     operation/0,
+    deletion/0,
     precondition/0,
     stream/0,
     delete_stream/0,
@@ -110,7 +111,9 @@
     message()
     %% Delete a message.
     %% Does nothing if the message does not exist.
-    | {delete, message_matcher('_')}.
+    | deletion().
+
+-type deletion() :: {delete, message_matcher('_')}.
 
 %% Precondition.
 %% Fails whole batch if the storage already has the matching message (`if_exists'),

--- a/apps/emqx_durable_storage/src/emqx_ds_precondition.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_precondition.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 20212024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.

--- a/apps/emqx_durable_storage/src/emqx_ds_precondition.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_precondition.erl
@@ -1,0 +1,184 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 20212024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_ds_precondition).
+-include_lib("emqx_utils/include/emqx_message.hrl").
+-include_lib("emqx_durable_storage/include/emqx_ds.hrl").
+
+-export([verify/3]).
+-export([matches/2]).
+
+-export_type([matcher/0, mismatch/0]).
+
+-type matcher() :: #message_matcher{}.
+-type mismatch() :: emqx_types:message() | not_found.
+
+-callback lookup_message(_Ctx, matcher()) ->
+    emqx_types:message() | not_found | emqx_ds:error(_).
+
+%%
+
+-spec verify(module(), _Ctx, [emqx_ds:precondition()]) ->
+    ok | {precondition_failed, mismatch()} | emqx_ds:error(_).
+verify(Mod, Ctx, [_Precondition = {Cond, Msg} | Rest]) ->
+    case verify_precondition(Mod, Ctx, Cond, Msg) of
+        ok ->
+            verify(Mod, Ctx, Rest);
+        Failed ->
+            Failed
+    end;
+verify(_Mod, _Ctx, []) ->
+    ok.
+
+verify_precondition(Mod, Ctx, if_exists, Matcher) ->
+    case Mod:lookup_message(Ctx, Matcher) of
+        Msg = #message{} ->
+            verify_match(Msg, Matcher);
+        not_found ->
+            {precondition_failed, not_found};
+        Error = {error, _, _} ->
+            Error
+    end;
+verify_precondition(Mod, Ctx, unless_exists, Matcher) ->
+    case Mod:lookup_message(Ctx, Matcher) of
+        Msg = #message{} ->
+            verify_nomatch(Msg, Matcher);
+        not_found ->
+            ok;
+        Error = {error, _, _} ->
+            Error
+    end.
+
+verify_match(Msg, Matcher) ->
+    case matches(Msg, Matcher) of
+        true -> ok;
+        false -> {precondition_failed, Msg}
+    end.
+
+verify_nomatch(Msg, Matcher) ->
+    case matches(Msg, Matcher) of
+        false -> ok;
+        true -> {precondition_failed, Msg}
+    end.
+
+-spec matches(emqx_types:message(), matcher()) -> boolean().
+matches(
+    Message,
+    #message_matcher{from = From, topic = Topic, payload = Pat, headers = Headers}
+) ->
+    case Message of
+        #message{from = From, topic = Topic} when Pat =:= '_' ->
+            matches_headers(Message, Headers);
+        #message{from = From, topic = Topic, payload = Pat} ->
+            matches_headers(Message, Headers);
+        _ ->
+            false
+    end.
+
+matches_headers(_Message, MatchHeaders) when map_size(MatchHeaders) =:= 0 ->
+    true;
+matches_headers(#message{headers = Headers}, MatchHeaders) ->
+    maps:intersect(MatchHeaders, Headers) =:= MatchHeaders.
+
+%% Basic tests
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-compile(export_all).
+
+conjunction_test() ->
+    %% Contradictory preconditions, always false.
+    Preconditions = [
+        {if_exists, matcher(<<"c1">>, <<"t/1">>, 0, '_')},
+        {unless_exists, matcher(<<"c1">>, <<"t/1">>, 0, '_')}
+    ],
+    ?assertEqual(
+        {precondition_failed, not_found},
+        verify(?MODULE, [], Preconditions)
+    ),
+    %% Check that the order does not matter.
+    ?assertEqual(
+        {precondition_failed, not_found},
+        verify(?MODULE, [], lists:reverse(Preconditions))
+    ),
+    ?assertEqual(
+        {precondition_failed, message(<<"c1">>, <<"t/1">>, 0, <<>>)},
+        verify(
+            ?MODULE,
+            [message(<<"c1">>, <<"t/1">>, 0, <<>>)],
+            Preconditions
+        )
+    ).
+
+matches_test() ->
+    ?assert(
+        matches(
+            message(<<"mtest1">>, <<"t/same">>, 12345, <<?MODULE_STRING>>),
+            matcher(<<"mtest1">>, <<"t/same">>, 12345, '_')
+        )
+    ).
+
+matches_headers_test() ->
+    ?assert(
+        matches(
+            message(<<"mtest2">>, <<"t/same">>, 23456, <<?MODULE_STRING>>, #{h1 => 42, h2 => <<>>}),
+            matcher(<<"mtest2">>, <<"t/same">>, 23456, '_', #{h2 => <<>>})
+        )
+    ).
+
+mismatches_headers_test() ->
+    ?assertNot(
+        matches(
+            message(<<"mtest3">>, <<"t/same">>, 23456, <<?MODULE_STRING>>, #{h1 => 42, h2 => <<>>}),
+            matcher(<<"mtest3">>, <<"t/same">>, 23456, '_', #{h2 => <<>>, h3 => <<"required">>})
+        )
+    ).
+
+matcher(ClientID, Topic, TS, Payload) ->
+    matcher(ClientID, Topic, TS, Payload, #{}).
+
+matcher(ClientID, Topic, TS, Payload, Headers) ->
+    #message_matcher{
+        from = ClientID,
+        topic = Topic,
+        timestamp = TS,
+        payload = Payload,
+        headers = Headers
+    }.
+
+message(ClientID, Topic, TS, Payload) ->
+    message(ClientID, Topic, TS, Payload, #{}).
+
+message(ClientID, Topic, TS, Payload, Headers) ->
+    #message{
+        id = <<>>,
+        qos = 0,
+        from = ClientID,
+        topic = Topic,
+        timestamp = TS,
+        payload = Payload,
+        headers = Headers
+    }.
+
+lookup_message(Messages, Matcher) ->
+    case lists:search(fun(M) -> matches(M, Matcher) end, Messages) of
+        {value, Message} ->
+            Message;
+        false ->
+            not_found
+    end.
+
+-endif.

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -64,6 +64,7 @@
 -export_type([
     gen_id/0,
     generation/0,
+    batch/0,
     cf_refs/0,
     stream/0,
     delete_stream/0,

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -37,6 +37,9 @@
     next/4,
     delete_next/5,
 
+    %% Preconditions
+    lookup_message/2,
+
     %% Generations
     update_config/3,
     add_generation/2,
@@ -74,6 +77,7 @@
     batch_store_opts/0
 ]).
 
+-include("emqx_ds.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
 -define(REF(ShardId), {via, gproc, {n, l, {?MODULE, ShardId}}}).
@@ -114,6 +118,11 @@
 -type cf_refs() :: [cf_ref()].
 
 -type gen_id() :: 0..16#ffff.
+
+-type batch() :: [
+    {emqx_ds:time(), emqx_types:message()}
+    | emqx_ds:deletion()
+].
 
 %% Options affecting how batches should be stored.
 %% See also: `emqx_ds:message_store_opts()'.
@@ -294,6 +303,10 @@
     | {ok, end_of_stream}
     | emqx_ds:error(_).
 
+%% Lookup a single message, for preconditions to work.
+-callback lookup_message(shard_id(), generation_data(), emqx_ds_precondition:matcher()) ->
+    emqx_types:message() | not_found | emqx_ds:error(_).
+
 -callback handle_event(shard_id(), generation_data(), emqx_ds:time(), CustomEvent | tick) ->
     [CustomEvent].
 
@@ -317,14 +330,10 @@ drop_shard(Shard) ->
 
 %% @doc This is a convenicence wrapper that combines `prepare' and
 %% `commit' operations.
--spec store_batch(
-    shard_id(),
-    [{emqx_ds:time(), emqx_types:message()}],
-    batch_store_opts()
-) ->
+-spec store_batch(shard_id(), batch(), batch_store_opts()) ->
     emqx_ds:store_batch_result().
-store_batch(Shard, Messages, Options) ->
-    case prepare_batch(Shard, Messages, #{}) of
+store_batch(Shard, Batch, Options) ->
+    case prepare_batch(Shard, Batch, #{}) of
         {ok, CookedBatch} ->
             commit_batch(Shard, CookedBatch, Options);
         ignore ->
@@ -342,23 +351,21 @@ store_batch(Shard, Messages, Options) ->
 %%
 %% The underlying storage layout MAY use timestamp as a unique message
 %% ID.
--spec prepare_batch(
-    shard_id(),
-    [{emqx_ds:time(), emqx_types:message()}],
-    batch_prepare_opts()
-) -> {ok, cooked_batch()} | ignore | emqx_ds:error(_).
-prepare_batch(Shard, Messages = [{Time, _} | _], Options) ->
+-spec prepare_batch(shard_id(), batch(), batch_prepare_opts()) ->
+    {ok, cooked_batch()} | ignore | emqx_ds:error(_).
+prepare_batch(Shard, Batch, Options) ->
     %% NOTE
     %% We assume that batches do not span generations. Callers should enforce this.
     ?tp(emqx_ds_storage_layer_prepare_batch, #{
-        shard => Shard, messages => Messages, options => Options
+        shard => Shard, batch => Batch, options => Options
     }),
     %% FIXME: always store messages in the current generation
-    case generation_at(Shard, Time) of
+    Time = batch_starts_at(Batch),
+    case is_integer(Time) andalso generation_at(Shard, Time) of
         {GenId, #{module := Mod, data := GenData}} ->
             T0 = erlang:monotonic_time(microsecond),
             Result =
-                case Mod:prepare_batch(Shard, GenData, Messages, Options) of
+                case Mod:prepare_batch(Shard, GenData, Batch, Options) of
                     {ok, CookedBatch} ->
                         {ok, #{?tag => ?COOKED_BATCH, ?generation => GenId, ?enc => CookedBatch}};
                     Error = {error, _, _} ->
@@ -368,11 +375,21 @@ prepare_batch(Shard, Messages = [{Time, _} | _], Options) ->
             %% TODO store->prepare
             emqx_ds_builtin_metrics:observe_store_batch_time(Shard, T1 - T0),
             Result;
+        false ->
+            %% No write operations in this batch.
+            ignore;
         not_found ->
+            %% Generation is likely already GCed.
             ignore
-    end;
-prepare_batch(_Shard, [], _Options) ->
-    ignore.
+    end.
+
+-spec batch_starts_at(batch()) -> emqx_ds:time() | undefined.
+batch_starts_at([{Time, _Message} | _]) when is_integer(Time) ->
+    Time;
+batch_starts_at([{delete, #message_matcher{timestamp = Time}} | _]) ->
+    Time;
+batch_starts_at([]) ->
+    undefined.
 
 %% @doc Commit cooked batch to the storage.
 %%
@@ -558,6 +575,16 @@ update_config(ShardId, Since, Options) ->
     ok | {error, overlaps_existing_generations}.
 add_generation(ShardId, Since) ->
     gen_server:call(?REF(ShardId), #call_add_generation{since = Since}, infinity).
+
+-spec lookup_message(shard_id(), emqx_ds_precondition:matcher()) ->
+    emqx_types:message() | not_found | emqx_ds:error(_).
+lookup_message(ShardId, Matcher = #message_matcher{timestamp = Time}) ->
+    case generation_at(ShardId, Time) of
+        {_GenId, #{module := Mod, data := GenData}} ->
+            Mod:lookup_message(ShardId, GenData, Matcher);
+        not_found ->
+            not_found
+    end.
 
 -spec list_generations_with_lifetimes(shard_id()) ->
     #{

--- a/apps/emqx_durable_storage/test/emqx_ds_test_helpers.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_test_helpers.erl
@@ -377,7 +377,7 @@ nodes_of_clientid(DB, ClientId, Nodes = [N0 | _]) ->
 shard_of_clientid(DB, Node, ClientId) ->
     ?ON(
         Node,
-        emqx_ds_buffer:shard_of_message(DB, #message{from = ClientId}, clientid)
+        emqx_ds_buffer:shard_of_operation(DB, #message{from = ClientId}, clientid)
     ).
 
 %% Consume eagerly:


### PR DESCRIPTION
Release version: e5.8

## Summary

Support recent `emqx_ds` API changes in `emqx_ds_builtin_raft` backend, storage layer and all 3 storage layouts.

Note: preconditions support in `emqx_ds_builtin_raft` is not robust and production-grade. Due to a slight mismatch between concepts of _snapshot_ in `ra` and _snapshot_ in the storage layer, there's a small risk of diverging replicas. This will be fixed in a followup PR.

For details see individual commits.

Prerequisite for #13542.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
