### PR TITLE
ci: fix RUN_FROM for the docker image

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -33,7 +33,7 @@ jobs:
       ELIXIR_VSN: ${{ steps.env.outputs.ELIXIR_VSN }}
       BUILDER: ${{ steps.env.outputs.BUILDER }}
       BUILD_FROM: ${{ steps.env.outputs.BUILD_FROM }}
-      RUN_FROM: ${{ steps.env.outputs.BUILD_FROM }}
+      RUN_FROM: ${{ steps.env.outputs.RUN_FROM }}
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
         with:


### PR DESCRIPTION
`RUN_FROM` was using builder image and the final docker image size was > 1GB.

The image has been rebuilt and updated, this is to ensure it stays this way in case we need to release another one 5.7.x.

Release version: v/e5.7.*
