### PR TITLE
fix: do not validate JWT iat

### DIFF
--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -309,7 +309,7 @@ do_verify(JWT, [JWK | More], VerifyClaims) ->
     try jose_jws:verify(JWK, JWT) of
         {true, Payload, _JWT} ->
             Claims0 = emqx_utils_json:decode(Payload, [return_maps]),
-            Claims = try_convert_to_num(Claims0, [<<"exp">>, <<"iat">>, <<"nbf">>]),
+            Claims = try_convert_to_num(Claims0, [<<"exp">>, <<"nbf">>]),
             case verify_claims(Claims, VerifyClaims) of
                 ok ->
                     {ok, Claims};
@@ -330,9 +330,6 @@ verify_claims(Claims, VerifyClaims0) ->
         [
             {<<"exp">>, fun(ExpireTime) ->
                 is_number(ExpireTime) andalso Now < ExpireTime
-            end},
-            {<<"iat">>, fun(IssueAt) ->
-                is_number(IssueAt) andalso IssueAt =< Now
             end},
             {<<"nbf">>, fun(NotBefore) ->
                 is_number(NotBefore) andalso NotBefore =< Now

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -133,7 +133,7 @@ t_hmac_based(_) ->
     Credential4 = Credential#{password => JWS4},
     ?assertMatch({ok, #{is_superuser := false}}, emqx_authn_jwt:authenticate(Credential4, State3)),
 
-    %% Issued At
+    %% Issued At (iat) should not matter
     Payload5 = #{
         <<"username">> => <<"myuser">>,
         <<"iat">> => erlang:system_time(second) - 60,
@@ -149,9 +149,7 @@ t_hmac_based(_) ->
     },
     JWS6 = generate_jws('hmac-based', Payload6, Secret),
     Credential6 = Credential#{password => JWS6},
-    ?assertEqual(
-        {error, bad_username_or_password}, emqx_authn_jwt:authenticate(Credential6, State3)
-    ),
+    ?assertMatch({ok, #{is_superuser := false}}, emqx_authn_jwt:authenticate(Credential6, State3)),
 
     %% Not Before
     Payload7 = #{


### PR DESCRIPTION
iat means "issued at", which is the unix epoch to record the time when the token was issued.
previously, iat is not allowed to be in the future. this cause some trouble for tokens issued in a host which does not have clock synchronized.

given that the most important (security wise) claims are nbf (not before) and exp (expire), iat validation has been removed.

Release version: v/e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
