### PR TITLE
fix: got incorrect target version when relup

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_relup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_relup.erl
@@ -20,7 +20,7 @@
 -include_lib("typerefl/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 
--export([get_upgrade_status/0, emqx_relup_upgrade/1]).
+-export([get_upgrade_status/0, emqx_relup_upgrade/0]).
 
 -export([
     api_spec/0,
@@ -474,24 +474,18 @@ validate_name(Name) ->
 
 '/relup/upgrade'(post, _) ->
     ?ASSERT_PKG_READY(
-        upgrade_with_targe_vsn(fun(TargetVsn) ->
-            run_upgrade_on_nodes(emqx:running_nodes(), TargetVsn)
-        end)
+        run_upgrade_on_nodes(emqx:running_nodes())
     ).
 
 '/relup/upgrade/:node'(post, #{bindings := #{node := NodeNameStr}}) ->
     ?ASSERT_PKG_READY(
-        upgrade_with_targe_vsn(
-            fun(TargetVsn) ->
-                emqx_utils_api:with_node(
-                    NodeNameStr,
-                    fun
-                        (Node) when node() =:= Node ->
-                            run_upgrade(TargetVsn);
-                        (Node) when is_atom(Node) ->
-                            run_upgrade_on_nodes([Node], TargetVsn)
-                    end
-                )
+        emqx_utils_api:with_node(
+            NodeNameStr,
+            fun
+                (Node) when node() =:= Node ->
+                    run_upgrade();
+                (Node) when is_atom(Node) ->
+                    run_upgrade_on_nodes([Node])
             end
         )
     ).
@@ -541,18 +535,8 @@ call_emqx_relup_main(Fun, Args, Default) ->
             Default
     end.
 
-upgrade_with_targe_vsn(Fun) ->
-    case get_target_vsn() of
-        {ok, TargetVsn} ->
-            Fun(TargetVsn);
-        {error, no_relup_package_installed} ->
-            return_package_not_installed();
-        {error, multiple_relup_packages_installed} ->
-            return_internal_error(<<"Multiple relup package installed">>)
-    end.
-
-run_upgrade_on_nodes(Nodes, TargetVsn) ->
-    {[_ | _] = Res, []} = emqx_mgmt_api_relup_proto_v1:run_upgrade(Nodes, TargetVsn),
+run_upgrade_on_nodes(Nodes) ->
+    {[_ | _] = Res, []} = emqx_mgmt_api_relup_proto_v1:run_upgrade(Nodes),
     case lists:filter(fun(R) -> R =/= ok end, Res) of
         [] ->
             {204};
@@ -565,22 +549,15 @@ run_upgrade_on_nodes(Nodes, TargetVsn) ->
             end
     end.
 
-run_upgrade(TargetVsn) ->
-    case emqx_relup_upgrade(TargetVsn) of
+run_upgrade() ->
+    case emqx_relup_upgrade() of
         no_pkg_installed -> return_package_not_installed();
         ok -> {204};
         {error, Reason} -> upgrade_return(Reason)
     end.
 
-emqx_relup_upgrade(TargetVsn) ->
-    call_emqx_relup_main(upgrade, [TargetVsn], no_pkg_installed).
-
-get_target_vsn() ->
-    case get_installed_packages() of
-        [PackageInfo] -> {ok, target_vsn_from_rel_vsn(maps_get(rel_vsn, PackageInfo))};
-        [] -> {error, no_relup_package_installed};
-        _ -> {error, multiple_relup_packages_installed}
-    end.
+emqx_relup_upgrade() ->
+    call_emqx_relup_main(upgrade, [], no_pkg_installed).
 
 get_installed_packages() ->
     lists:filtermap(
@@ -592,12 +569,6 @@ get_installed_packages() ->
         end,
         emqx_plugins:list(hidden)
     ).
-
-target_vsn_from_rel_vsn(Vsn) ->
-    case string:split(binary_to_list(Vsn), "-") of
-        [_] -> throw({invalid_vsn, Vsn});
-        [VsnStr | _] -> VsnStr
-    end.
 
 delete_installed_packages() ->
     lists:foreach(
@@ -611,8 +582,7 @@ delete_installed_packages() ->
 
 format_package_info(PluginInfo) when is_map(PluginInfo) ->
     Vsn = maps_get(rel_vsn, PluginInfo),
-    TargetVsn = target_vsn_from_rel_vsn(Vsn),
-    case call_emqx_relup_main(get_package_info, [TargetVsn], no_pkg_installed) of
+    case call_emqx_relup_main(get_package_info, [], no_pkg_installed) of
         no_pkg_installed ->
             throw({get_pkg_info_failed, <<"No relup package is installed">>});
         {error, Reason} ->

--- a/apps/emqx_management/src/proto/emqx_mgmt_api_relup_proto_v1.erl
+++ b/apps/emqx_management/src/proto/emqx_mgmt_api_relup_proto_v1.erl
@@ -21,7 +21,7 @@
 
 -export([
     introduced_in/0,
-    run_upgrade/2,
+    run_upgrade/1,
     get_upgrade_status_from_all_nodes/0,
     get_upgrade_status/1
 ]).
@@ -32,9 +32,9 @@
 introduced_in() ->
     "5.8.0".
 
--spec run_upgrade([node()], string()) -> emqx_rpc:multicall_result().
-run_upgrade(Nodes, TargetVsn) ->
-    rpc:multicall(Nodes, emqx_mgmt_api_relup, emqx_relup_upgrade, [TargetVsn], ?RPC_TIMEOUT_OP).
+-spec run_upgrade([node()]) -> emqx_rpc:multicall_result().
+run_upgrade(Nodes) ->
+    rpc:multicall(Nodes, emqx_mgmt_api_relup, emqx_relup_upgrade, [], ?RPC_TIMEOUT_OP).
 
 -spec get_upgrade_status_from_all_nodes() -> emqx_rpc:multicall_result().
 get_upgrade_status_from_all_nodes() ->

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -185,7 +185,7 @@ project_app_excluded("apps/" ++ AppStr, ExcludedApps) ->
 
 plugins() ->
     [
-        {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.1.1"}}},
+        {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.2.1"}}},
         %% emqx main project does not require port-compiler
         %% pin at root level for deterministic
         {pc, "v1.14.0"}


### PR DESCRIPTION
- Relup failed due to get incorrect target vsn. We don't need target vsn anymore because we have only one tarball in the relup-plugin.
- Speed up package info reading by appending hash str to the unpacked dir name.

https://emqx.atlassian.net/browse/EMQX-12897

Release version: e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
