### PR TITLE
ci: fix push_entrypoint workflow

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -211,6 +211,9 @@ jobs:
       - init
       - prepare
       - compile
+    permissions:
+      contents: read
+      pull-requests: write
     uses: ./.github/workflows/run_test_cases.yaml
     with:
       builder: ${{ needs.init.outputs.BUILDER }}


### PR DESCRIPTION
Follow up patch for #13609