### PR TITLE
fix(utils): handle proplists in deobfuscate

### DIFF
--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -157,7 +157,7 @@ deobfuscate(NewConf, OldConf) ->
 deobfuscate(NewConf, OldConf, IsSensitiveFun) ->
     maps:fold(
         fun(K, V, Acc) ->
-            case maps:find(K, OldConf) of
+            case find(K, OldConf) of
                 error ->
                     case is_redacted(K, V, IsSensitiveFun) of
                         %% don't put redacted value into new config
@@ -180,6 +180,14 @@ deobfuscate(NewConf, OldConf, IsSensitiveFun) ->
         #{},
         NewConf
     ).
+
+find(K, M) when is_map(M) ->
+    maps:find(K, M);
+find(K, PL) when is_list(PL) ->
+    case lists:keyfind(K, 1, PL) of
+        false -> error;
+        {_, V} -> {ok, V}
+    end.
 
 is_redacted(K, V) ->
     do_is_redacted(K, V, fun is_sensitive_key/1).


### PR DESCRIPTION
Fixes [EMQX-12913](https://emqx.atlassian.net/browse/EMQX-12913)

The `emqx_utils_redact:deobfuscate/3` function was not handling proplists correctly when deobfuscating the values. Proplists may come from, for example, HTTP headers.

Release version: v/e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12913]: https://emqx.atlassian.net/browse/EMQX-12913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ