### PR TITLE
0816 no unknown dialyzer option otp 26 or later

### DIFF
--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -64,6 +64,7 @@
 
 -export_type([listener_id/0]).
 
+-if(OTP_RELEASE >= 26).
 -dialyzer(
     {no_unknown, [
         is_running/3,
@@ -74,6 +75,7 @@
         quic_listener_conf_rollback/3
     ]}
 ).
+-endif.
 
 -type listener_id() :: atom() | binary().
 -type listener_type() :: tcp | ssl | ws | wss | quic | dtls.

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -405,14 +405,9 @@ do_safe_relative_path(Path) ->
         OK -> OK
     end.
 
--if(?OTP_RELEASE < 23).
-safe_relative_path_2(Path) ->
-    filename:safe_relative_path(Path).
--else.
 safe_relative_path_2(Path) ->
     {ok, Cwd} = file:get_cwd(),
     filelib:safe_relative_path(Path, Cwd).
--endif.
 
 -spec reload(App :: atom(), SpecAppConfig :: special_config_handler()) -> ok.
 reload(App, SpecAppConfigHandler) ->

--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -942,11 +942,8 @@ root_backup_dir() ->
     ok = ensure_path(Dir),
     Dir.
 
--if(?OTP_RELEASE < 25).
-ensure_path(Path) -> filelib:ensure_dir(filename:join([Path, "dummy"])).
--else.
-ensure_path(Path) -> filelib:ensure_path(Path).
--endif.
+ensure_path(Path) ->
+    filelib:ensure_path(Path).
 
 local_datetime(MillisecondTs) ->
     calendar:system_time_to_local_time(MillisecondTs, millisecond).


### PR DESCRIPTION
`emqx.git` as dependency for `emqtt` fails on OTP 25.
Not dialyzer check fail, but compile failure.
```
_build/test/lib/emqx/apps/emqx/src/emqx_listeners.erl:67:2: unknown dialyzer warning option: no_unknown
```