### PR TITLE
0817 add coalesce function to rule sql

### DIFF
--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -392,7 +392,7 @@ subscribers(Group, Topic, FailedSubs) ->
 
 %% Select ETS table to get all subscriber pids.
 subscribers(Group, Topic) ->
-    ets:select(?SHARED_SUBSCRIPTION, [{{emqx_shared_subscription, Group, Topic, '$1'}, [], ['$1']}]).
+    ets:select(?SHARED_SUBSCRIPTION, [{{?SHARED_SUBSCRIPTION, Group, Topic, '$1'}, [], ['$1']}]).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -39,7 +39,11 @@
     contains_topic/3,
     contains_topic_match/2,
     contains_topic_match/3,
-    null/0
+    null/0,
+    coalesce/1,
+    coalesce/2,
+    coalesce_ne/1,
+    coalesce_ne/2
 ]).
 
 %% Arithmetic Funcs
@@ -430,6 +434,27 @@ null() ->
 
 bytesize(IoList) ->
     erlang:iolist_size(IoList).
+
+%% @doc coalesce returns the first non-null value
+coalesce([]) -> null();
+coalesce([undefined | T]) -> coalesce(T);
+coalesce([H | _T]) -> H.
+
+%% @doc This is a short-cut of SQL `CASE WHEN is_null(A) THEN A ELSE B END'
+coalesce(A, B) ->
+    coalesce([A, B]).
+
+%% @doc coalesce_ne returns the first non-empty value.
+%% `undefined', `""', and `<<>>' are considered 'empty'.
+coalesce_ne([]) -> null();
+coalesce_ne([undefined | T]) -> coalesce_ne(T);
+coalesce_ne(["" | T]) -> coalesce_ne(T);
+coalesce_ne([<<>> | T]) -> coalesce_ne(T);
+coalesce_ne([H | _T]) -> H.
+
+%% @doc Same as coalesce/2, but considers a value null when it's empty string.
+coalesce_ne(A, B) ->
+    coalesce_ne([A, B]).
 
 %%------------------------------------------------------------------------------
 %% Arithmetic Funcs

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -333,6 +333,26 @@ t_is_array(_) ->
      || T <- [<<>>, a]
     ].
 
+t_coalesce(_) ->
+    ?assertEqual(undefined, emqx_rule_funcs:coalesce([])),
+    ?assertEqual(undefined, emqx_rule_funcs:coalesce([undefined, undefined, undefined])),
+    ?assertEqual(42, emqx_rule_funcs:coalesce([undefined, 42, undefined])),
+    ?assertEqual(hello, emqx_rule_funcs:coalesce([hello, undefined])),
+    ?assertEqual(world, emqx_rule_funcs:coalesce([world])),
+    ?assertEqual(hello, emqx_rule_funcs:coalesce(hello, world)),
+    ?assertEqual(world, emqx_rule_funcs:coalesce(undefined, world)),
+    ok.
+
+t_coalesce_ne(_) ->
+    ?assertEqual(undefined, emqx_rule_funcs:coalesce_ne([])),
+    ?assertEqual(undefined, emqx_rule_funcs:coalesce_ne([<<>>, undefined, ""])),
+    ?assertEqual(42, emqx_rule_funcs:coalesce_ne(["", 42, undefined])),
+    ?assertEqual(hello, emqx_rule_funcs:coalesce_ne([hello, <<>>])),
+    ?assertEqual(world, emqx_rule_funcs:coalesce_ne([world])),
+    ?assertEqual(hello, emqx_rule_funcs:coalesce_ne(hello, world)),
+    ?assertEqual(world, emqx_rule_funcs:coalesce_ne("", world)),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Test cases for arith op
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
Release version: v/e5.8.0

## Summary

Add a `coalesce` function to make null checks in rule SQL simpler.
`CASE WHEN is_null(payload.foo.bar.x.y) THEN 0 ELSE payload.foo.bar.x.y END`
can be replaced with
`coalesce(payload.foo.bar.x.y, 0)`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
