### PR TITLE
fix(auhtn/kerberos): method name follow spec non-normaltive example

### DIFF
--- a/apps/emqx_auth_kerberos/include/emqx_auth_kerberos.hrl
+++ b/apps/emqx_auth_kerberos/include/emqx_auth_kerberos.hrl
@@ -13,7 +13,9 @@
 
 -define(AUTHN_TYPE_KERBEROS, {?AUTHN_MECHANISM_GSSAPI, ?AUTHN_BACKEND}).
 
--define(AUTHN_METHOD, <<"GSSAPI-KERBEROS">>).
+%% Following non-normative example provided in spec
+%% https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901256
+-define(AUTHN_METHOD, <<"GS2-KRB5">>).
 
 -define(SERVICE, <<"mqtt">>).
 

--- a/apps/emqx_auth_kerberos/test/emqx_authn_kerberos_SUITE.erl
+++ b/apps/emqx_auth_kerberos/test/emqx_authn_kerberos_SUITE.erl
@@ -103,7 +103,7 @@ t_authenticate(_Config) ->
 
 t_authenticate_bad_method(_Config) ->
     _ = init_auth(),
-    %% The method is GSSAPI-KERBEROS, sending just "GSSAPI" will fail
+    %% The method is GS2-KRB5, sending just "GSSAPI" will fail
     Method = <<"GSSAPI">>,
     Args = emqx_authn_kerberos_client:auth_args(?CLI_KEYTAB_FILE, ?CLI_PRINCIPAL, Method),
     {ok, C} = emqtt:start_link(

--- a/apps/emqx_auth_kerberos/test/emqx_authn_kerberos_client.erl
+++ b/apps/emqx_auth_kerberos/test/emqx_authn_kerberos_client.erl
@@ -24,7 +24,7 @@ server_principal() ->
     bin(["mqtt/", server_fqdn(), "@", realm()]).
 
 auth_args(ClientKeytab, CLientPrincipal) ->
-    auth_args(ClientKeytab, CLientPrincipal, <<"GSSAPI-KERBEROS">>).
+    auth_args(ClientKeytab, CLientPrincipal, <<"GS2-KRB5">>).
 
 auth_args(ClientKeytab, CLientPrincipal, Method) ->
     auth_args(ClientKeytab, CLientPrincipal, Method, undefined).
@@ -101,7 +101,7 @@ auth_handle(
     end.
 
 props(Data) ->
-    props(Data, <<"GSSAPI-KERBEROS">>).
+    props(Data, <<"GS2-KRB5">>).
 
 props(Data, Method) ->
     #{


### PR DESCRIPTION
Release version: v/e5.8.0

## Summary

Just found out that the is a non-normative example provided in the spec for kerberos authentication.
https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901256

> Non-normative example showing a Kerberos challenge
> - Client to Server CONNECT Authentication Method="GS2-KRB5"
> - Server to Client AUTH rc=0x18 Authentication Method="GS2-KRB5"
> - Client to Server AUTH rc=0x18 Authentication Method="GS2-KRB5" Authentication Data=initial context token
> - Server to Client AUTH rc=0x18 Authentication Method="GS2-KRB5" Authentication Data=reply context token
> - Client to Server AUTH rc=0x18 Authentication Method="GS2-KRB5"
> - Server to Client CONNACK rc=0 Authentication Method="GS2-KRB5" Authentication Data=outcome of authentication

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
