### PR TITLE
refactor: remove esasl from deps, use sasl_auth 2.3.0

### DIFF
--- a/apps/emqx_auth_http/test/emqx_authn_scram_restapi_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_scram_restapi_SUITE.erl
@@ -157,7 +157,7 @@ t_authenticate_bad_username(_Config) ->
 
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(<<"badusername">>),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(<<"badusername">>),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -182,7 +182,7 @@ t_authenticate_bad_password(_Config) ->
 
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -202,7 +202,7 @@ t_authenticate_bad_password(_Config) ->
     ) = receive_packet(),
 
     {continue, ClientFinalMessage, _ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -321,7 +321,7 @@ test_is_superuser(State, ExpectedIsSuperuser) ->
 
     set_user_handler(Username, Password, #{is_superuser => ExpectedIsSuperuser}),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     {continue, ServerFirstMessage, ServerCache} =
         emqx_authn_scram_restapi:authenticate(
@@ -334,7 +334,7 @@ test_is_superuser(State, ExpectedIsSuperuser) ->
         ),
 
     {continue, ClientFinalMessage, ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -353,7 +353,7 @@ test_is_superuser(State, ExpectedIsSuperuser) ->
             State
         ),
 
-    ok = esasl_scram:check_server_final_message(
+    ok = sasl_auth_scram:check_server_final_message(
         ServerFinalMessage, ClientCache#{algorithm => ?ALGORITHM}
     ),
 
@@ -410,7 +410,7 @@ init_auth(Config) ->
     State.
 
 make_user_info(Password, Algorithm, IterationCount) ->
-    {StoredKey, ServerKey, Salt} = esasl_scram:generate_authentication_info(
+    {StoredKey, ServerKey, Salt} = sasl_auth_scram:generate_authentication_info(
         Password,
         #{
             algorithm => Algorithm,
@@ -435,7 +435,7 @@ receive_packet() ->
 create_connection(Username, Password) ->
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -458,7 +458,7 @@ create_connection(Username, Password) ->
     ) = receive_packet(),
 
     {continue, ClientFinalMessage, ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -483,7 +483,7 @@ create_connection(Username, Password) ->
         #{'Authentication-Data' := ServerFinalMessage}
     ) = receive_packet(),
 
-    ok = esasl_scram:check_server_final_message(
+    ok = sasl_auth_scram:check_server_final_message(
         ServerFinalMessage, ClientCache#{algorithm => ?ALGORITHM}
     ),
     {ok, Pid}.

--- a/apps/emqx_auth_kerberos/rebar.config
+++ b/apps/emqx_auth_kerberos/rebar.config
@@ -3,5 +3,5 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {sasl_auth, {git, "https://github.com/kafka4beam/sasl_auth.git", {tag, "v2.2.0"}}}
+    {sasl_auth, "2.3.0"}
 ]}.

--- a/apps/emqx_auth_mnesia/mix.exs
+++ b/apps/emqx_auth_mnesia/mix.exs
@@ -27,7 +27,7 @@ defmodule EMQXAuthMnesia.MixProject do
     [
       {:emqx, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
-      UMP.common_dep(:esasl),
+      UMP.common_dep(:sasl_auth),
     ]
   end
 end

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
@@ -9,7 +9,7 @@
         stdlib,
         emqx,
         emqx_auth,
-        esasl
+        sasl_auth
     ]},
     {env, []},
     {modules, []},

--- a/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
@@ -268,7 +268,7 @@ user_info_record(
     user_info_record(UserGroup, UserID, Password, IsSuperuser, State).
 
 user_info_record(UserGroup, UserID, Password, IsSuperuser, State) ->
-    {StoredKey, ServerKey, Salt} = esasl_scram:generate_authentication_info(Password, State),
+    {StoredKey, ServerKey, Salt} = sasl_auth_scram:generate_authentication_info(Password, State),
     #user_info{
         user_id = {UserGroup, UserID},
         stored_key = StoredKey,
@@ -282,7 +282,7 @@ fields_to_update(
     [keys_and_salt | Rest],
     State
 ) ->
-    {StoredKey, ServerKey, Salt} = esasl_scram:generate_authentication_info(Password, State),
+    {StoredKey, ServerKey, Salt} = sasl_auth_scram:generate_authentication_info(Password, State),
     [
         {keys_and_salt, {StoredKey, ServerKey, Salt}}
         | fields_to_update(UserInfo, Rest, State)

--- a/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
@@ -107,7 +107,7 @@ t_authenticate(_Config) ->
 
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -130,7 +130,7 @@ t_authenticate(_Config) ->
     ) = receive_packet(),
 
     {continue, ClientFinalMessage, ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -155,7 +155,7 @@ t_authenticate(_Config) ->
         #{'Authentication-Data' := ServerFinalMessage}
     ) = receive_packet(),
 
-    ok = esasl_scram:check_server_final_message(
+    ok = sasl_auth_scram:check_server_final_message(
         ServerFinalMessage, ClientCache#{algorithm => Algorithm}
     ).
 
@@ -190,7 +190,7 @@ t_authenticate_bad_username(_Config) ->
 
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(<<"badusername">>),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(<<"badusername">>),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -215,7 +215,7 @@ t_authenticate_bad_password(_Config) ->
 
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -235,7 +235,7 @@ t_authenticate_bad_password(_Config) ->
     ) = receive_packet(),
 
     {continue, ClientFinalMessage, _ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -333,7 +333,7 @@ t_update_user_keys(_Config) ->
 
     {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -353,7 +353,7 @@ t_update_user_keys(_Config) ->
     ) = receive_packet(),
 
     {continue, ClientFinalMessage, ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -378,7 +378,7 @@ t_update_user_keys(_Config) ->
         #{'Authentication-Data' := ServerFinalMessage}
     ) = receive_packet(),
 
-    ok = esasl_scram:check_server_final_message(
+    ok = sasl_auth_scram:check_server_final_message(
         ServerFinalMessage, ClientCache#{algorithm => Algorithm}
     ).
 
@@ -447,7 +447,7 @@ test_is_superuser(UserInfo, ExpectedIsSuperuser) ->
 
     {ok, _} = emqx_authn_scram_mnesia:add_user(UserInfo0, State),
 
-    ClientFirstMessage = esasl_scram:client_first_message(Username),
+    ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
     {continue, ServerFirstMessage, ServerCache} =
         emqx_authn_scram_mnesia:authenticate(
@@ -460,7 +460,7 @@ test_is_superuser(UserInfo, ExpectedIsSuperuser) ->
         ),
 
     {continue, ClientFinalMessage, ClientCache} =
-        esasl_scram:check_server_first_message(
+        sasl_auth_scram:check_server_first_message(
             ServerFirstMessage,
             #{
                 client_first_message => ClientFirstMessage,
@@ -479,7 +479,7 @@ test_is_superuser(UserInfo, ExpectedIsSuperuser) ->
             State
         ),
 
-    ok = esasl_scram:check_server_final_message(
+    ok = sasl_auth_scram:check_server_final_message(
         ServerFinalMessage, ClientCache#{algorithm => sha512}
     ),
 

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -10,7 +10,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {sasl_auth, {git, "https://github.com/kafka4beam/sasl_auth.git", {tag, "v2.2.0"}}}
+    {sasl_auth, "2.3.0"}
 ]}.
 
 {shell, [

--- a/apps/emqx_machine/priv/reboot_lists.eterm
+++ b/apps/emqx_machine/priv/reboot_lists.eterm
@@ -39,7 +39,6 @@
         [
             emqx,
             emqx_conf,
-            esasl,
             emqx_utils,
             emqx_durable_storage,
             emqx_ds_backends,

--- a/apps/emqx_utils/src/emqx_utils_scram.erl
+++ b/apps/emqx_utils/src/emqx_utils_scram.erl
@@ -47,7 +47,7 @@ check_client_first_message(
     Bin, _Cache, #{iteration_count := IterationCount}, RetrieveFun, OnErrFun
 ) ->
     case
-        esasl_scram:check_client_first_message(
+        sasl_auth_scram:check_client_first_message(
             Bin,
             #{
                 iteration_count => IterationCount,
@@ -66,7 +66,7 @@ check_client_first_message(
 
 check_client_final_message(Bin, Cache, #{algorithm := Alg}, OnErrFun, ResultKeys) ->
     case
-        esasl_scram:check_client_final_message(
+        sasl_auth_scram:check_client_final_message(
             Bin,
             Cache#{algorithm => Alg}
         )

--- a/mix.exs
+++ b/mix.exs
@@ -132,7 +132,6 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:snabbkaffe),
       common_dep(:hocon),
       common_dep(:emqx_http_lib),
-      common_dep(:esasl),
       common_dep(:jose),
       # in conflict by ehttpc and emqtt
       common_dep(:gun),
@@ -216,7 +215,7 @@ defmodule EMQXUmbrella.MixProject do
 
   # in conflict by emqx_connector and system_monitor
   def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.2", override: true}
-  def common_dep(:esasl), do: {:esasl, github: "emqx/esasl", tag: "0.2.1"}
+  def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.0", override: true}
   def common_dep(:gen_rpc), do: {:gen_rpc, github: "emqx/gen_rpc", tag: "3.4.0", override: true}
 
   def common_dep(:system_monitor),
@@ -273,9 +272,6 @@ defmodule EMQXUmbrella.MixProject do
       override: true,
       system_env: emqx_app_system_env()
     }
-
-  def common_dep(:sasl_auth),
-    do: {:sasl_auth, github: "kafka4beam/sasl_auth", tag: "v2.2.0", override: true}
 
   ###############################################################################################
   # BEGIN DEPRECATED FOR MIX BLOCK

--- a/rebar.config
+++ b/rebar.config
@@ -100,7 +100,7 @@
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.3"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
-    {esasl, {git, "https://github.com/emqx/esasl", {tag, "0.2.1"}}},
+    {sasl_auth, "2.3.0"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},
     {telemetry, "1.1.0"},
     {hackney, {git, "https://github.com/emqx/hackney.git", {tag, "1.18.1-1"}}},


### PR DESCRIPTION
Release version: v/e5.8.0

## Summary

`sasl_auth-2.3.0` added the scram implementation so there is no need for the `esasl` lib any more.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [n/a] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [n/a] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
