### PR TITLE
fix(authn/kerberos): allow keytab_file missing in create request

### DIFF
--- a/apps/emqx_auth_kerberos/src/emqx_authn_kerberos.erl
+++ b/apps/emqx_auth_kerberos/src/emqx_authn_kerberos.erl
@@ -17,13 +17,8 @@
     authenticate/2
 ]).
 
-create(
-    AuthenticatorID,
-    #{
-        principal := Principal,
-        keytab_file := KeyTabFile
-    }
-) ->
+create(AuthenticatorID, #{principal := Principal} = Conf) ->
+    KeyTabFile = maps:get(keytab_file, Conf, <<"">>),
     KeyTabPath = resolve_keytab(KeyTabFile),
     %% kinit is not necessary for server because the keytab file
     %% must be the smae as default keytab

--- a/apps/emqx_auth_kerberos/test/emqx_authn_kerberos_SUITE.erl
+++ b/apps/emqx_auth_kerberos/test/emqx_authn_kerberos_SUITE.erl
@@ -70,7 +70,8 @@ t_create(_Config) ->
         emqx_authn_chains:list_authenticators(?GLOBAL).
 
 t_create_invalid(_Config) ->
-    InvalidConfig0 = raw_config(),
+    %% cover the case when keytab_file is not provided
+    InvalidConfig0 = maps:remove(<<"keytab_file">>, raw_config()),
     InvalidConfig = InvalidConfig0#{<<"principal">> := ?INVALID_SVR_PRINCIPAL},
 
     {error, _} = emqx:update_config(


### PR DESCRIPTION
Release version: v/e5.8.0

## Summary

EMQX should allow HTTP APIs to send authenticator create request without keytab_file.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [~ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
a fixup for feature not released yet.
- [] For internal contributor: there is a jira ticket to track this change
- [~] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
  no changes
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
