### PR TITLE
fix(trace): respect trace start_at time as is

### DIFF
--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -651,8 +651,7 @@ to_trace(#{type := Type}, _Rec) ->
 to_trace(#{payload_encode := PayloadEncode} = Trace, Rec) ->
     to_trace(maps:remove(payload_encode, Trace), Rec#?TRACE{payload_encode = PayloadEncode});
 to_trace(#{start_at := StartAt} = Trace, Rec) ->
-    {ok, Sec} = to_system_second(StartAt),
-    to_trace(maps:remove(start_at, Trace), Rec#?TRACE{start_at = Sec});
+    to_trace(maps:remove(start_at, Trace), Rec#?TRACE{start_at = StartAt});
 to_trace(#{end_at := EndAt} = Trace, Rec) ->
     Now = now_second(),
     case to_system_second(EndAt) of

--- a/apps/emqx/src/emqx_trace/emqx_trace_dl.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_dl.erl
@@ -53,6 +53,7 @@ update(Name, Enable) ->
 insert_new_trace(Trace) ->
     case mnesia:read(?TRACE, Trace#?TRACE.name) of
         [] ->
+            %% allow one new trace for each filter in the same second
             #?TRACE{start_at = StartAt, type = Type, filter = Filter} = Trace,
             Match = #?TRACE{_ = '_', start_at = StartAt, type = Type, filter = Filter},
             case mnesia:match_object(?TRACE, Match, read) of

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_replication_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_replication_SUITE.erl
@@ -1066,6 +1066,10 @@ groups() ->
         {skipstream_lts, TCs}
     ].
 
+init_per_suite(Config) ->
+    application:set_env(kernel, prevent_overlapping_partitions, false),
+    Config.
+
 init_per_group(Group, Config) ->
     LayoutConf =
         case Group of


### PR DESCRIPTION
## Summary

Prior to this fix, the start_at provided when creating the trace is overriden if it's earlier than the current system time.

it's not necessary to ensure `start_at` is always the latest second because the exact start time might be delayed anyway (due to the async nature of the trace start/stop being triggered by message passing and timer events).

This is unnecessary, and leads to test cases being flaky.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
