### PR TITLE
fix(authn): allow deleting an authenticator which failed to initialize

### DIFF
--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -221,8 +221,7 @@ schema("/authentication/:id") ->
             description => ?DESC(authentication_id_delete),
             parameters => [param_auth_id()],
             responses => #{
-                204 => <<"Authenticator deleted">>,
-                404 => error_codes([?NOT_FOUND], <<"Not Found">>)
+                204 => <<"Authenticator deleted">>
             }
         }
     };

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_chains.erl
@@ -587,8 +587,9 @@ handle_delete_authenticator(Chain, AuthenticatorID) ->
         ID =:= AuthenticatorID
     end,
     case do_delete_authenticators(MatchFun, Chain) of
-        {[], _NewChain} ->
-            {error, {not_found, {authenticator, AuthenticatorID}}};
+        {[], NewChain} ->
+            %% Idempotence intended
+            {ok, ok, NewChain};
         {[AuthenticatorID], NewChain} ->
             {ok, ok, NewChain}
     end.

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_api_SUITE.erl
@@ -409,7 +409,8 @@ test_authenticator(PathPrefix) ->
         ValidConfig2
     ),
 
-    {ok, 404, _} = request(
+    %% allow deletion of unknown (not created) authenticator
+    {ok, 204, _} = request(
         delete,
         uri(PathPrefix ++ [?CONF_NS, "password_based:redis"])
     ),
@@ -631,6 +632,12 @@ ignore_switch_to_global_chain(_) ->
     {ok, 204, _} = request(
         delete,
         uri([listeners, "tcp:default", ?CONF_NS, "password_based:http"])
+    ),
+    %% Delete unknown should retun 204
+    %% There is not even a name validation for it.
+    {ok, 204, _} = request(
+        delete,
+        uri([listeners, "tcp:default", ?CONF_NS, "password_based:httpx"])
     ),
 
     %% Local chain is empty now and should be removed

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -191,7 +191,16 @@ t_authenticator(Config) when is_list(Config) ->
         ?AUTHN:update_authenticator(ChainName, ID1, AuthenticatorConfig1)
     ),
 
+    %% delete an unknown authenticator is allowed, do not epxect not_found
+    ?assertEqual(ok, ?AUTHN:delete_authenticator(ChainName, <<"password_based:http">>)),
+    %% the deletion of the last authenticator in the chain should result in
+    %% an implict deletion of the chain
     ?assertEqual(ok, ?AUTHN:delete_authenticator(ChainName, ID1)),
+    %% expected not_found for the chain
+    ?assertEqual(
+        {error, {not_found, {chain, test}}},
+        ?AUTHN:update_authenticator(ChainName, ID1, AuthenticatorConfig1)
+    ),
 
     ?assertEqual(
         {error, {not_found, {chain, test}}},

--- a/changes/ce/fix-13678.en.md
+++ b/changes/ce/fix-13678.en.md
@@ -1,0 +1,1 @@
+Allow deletion of non-existing authenticator.


### PR DESCRIPTION
Release version: v/e5.8.0

## Summary

Prior to this fix, if a authenticator is failed to get initialized when node boots up, it will be displayed on dashboard in "disconnected" state.
But when we try to delete it from dashboard, a "not found" error is returned.

This is because although the config exists, it was not actually added to the chain (failed to init).
After this fix, the deletion in from the chain is made idempotent, i.e. allow delete even if it's not on the chain already.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
