### PR TITLE
test: ensure prevent_overlapping_partitions from ERL_FLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ $(REL_PROFILES:%=%-compile): $(REBAR) merge-config
 
 .PHONY: ct
 ct: $(REBAR) merge-config
-	@$(REBAR) ct --name $(CT_NODE_NAME) -c -v --cover_export_name $(CT_COVER_EXPORT_PREFIX)-ct
+	@env ERL_FLAGS="-kernel prevent_overlapping_partitions false" $(REBAR) ct --name $(CT_NODE_NAME) -c -v --cover_export_name $(CT_COVER_EXPORT_PREFIX)-ct
 
 ## only check bpapi for enterprise profile because it's a super-set.
 .PHONY: static_checks
@@ -118,7 +118,7 @@ define gen-app-ct-target
 $1-ct: $(REBAR) merge-config clean-test-cluster-config
 	$(eval SUITES := $(shell $(SCRIPTS)/find-suites.sh $1))
 ifneq ($(SUITES),)
-	$(REBAR) ct -v \
+	env ERL_FLAGS="-kernel prevent_overlapping_partitions false" $(REBAR) ct -v \
 		--readable=$(CT_READABLE) \
 		--name $(CT_NODE_NAME) \
 		$(call cover_args,$1) \

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_replication_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_replication_SUITE.erl
@@ -1066,10 +1066,6 @@ groups() ->
         {skipstream_lts, TCs}
     ].
 
-init_per_suite(Config) ->
-    application:set_env(kernel, prevent_overlapping_partitions, false),
-    Config.
-
 init_per_group(Group, Config) ->
     LayoutConf =
         case Group of


### PR DESCRIPTION
The last fix did not work because the flag was read at init time when `global` starts.

This is an attempt to fix test flakiness 
```
'global' at node 'test@127.0.0.1' requested disconnect from node 't_crash_stop_recover2@127.0.0.1' in order to prevent overlapping partitions
```