### PR TITLE
fix: ensure that cores are always positioned ahead of replicants

### DIFF
--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
@@ -47,8 +47,8 @@ t_fix(Config) ->
         Node1,
         ?assertMatch(
             {atomic, [
-                #{node := Node2, tnx_id := 1},
-                #{node := Node1, tnx_id := 1}
+                #{node := Node1, tnx_id := 1},
+                #{node := Node2, tnx_id := 1}
             ]},
             emqx_cluster_rpc:status()
         )
@@ -58,8 +58,8 @@ t_fix(Config) ->
         ok = emqx_conf_cli:admins(["fix"]),
         ?assertMatch(
             {atomic, [
-                #{node := Node2, tnx_id := 1},
-                #{node := Node1, tnx_id := 1}
+                #{node := Node1, tnx_id := 1},
+                #{node := Node2, tnx_id := 1}
             ]},
             emqx_cluster_rpc:status()
         )
@@ -70,8 +70,8 @@ t_fix(Config) ->
         ok = emqx_conf_cli:admins(["fix"]),
         ?assertMatch(
             {atomic, [
-                #{node := Node2, tnx_id := 1},
-                #{node := Node1, tnx_id := 1}
+                #{node := Node1, tnx_id := 1},
+                #{node := Node2, tnx_id := 1}
             ]},
             emqx_cluster_rpc:status()
         )
@@ -86,8 +86,8 @@ t_fix(Config) ->
         ok = emqx_conf_cli:admins(["fix"]),
         ?assertMatch(
             {atomic, [
-                #{node := Node2, tnx_id := 5},
-                #{node := Node1, tnx_id := 5}
+                #{node := Node1, tnx_id := 5},
+                #{node := Node2, tnx_id := 5}
             ]},
             emqx_cluster_rpc:status()
         )
@@ -104,8 +104,8 @@ t_fix(Config) ->
         ok = emqx_conf_cli:admins(["fix"]),
         ?assertMatch(
             {atomic, [
-                #{node := Node2, tnx_id := 8},
-                #{node := Node1, tnx_id := 8}
+                #{node := Node1, tnx_id := 8},
+                #{node := Node2, tnx_id := 8}
             ]},
             emqx_cluster_rpc:status()
         )
@@ -117,8 +117,8 @@ t_fix(Config) ->
         ok = emqx_conf_cli:admins(["fix"]),
         ?assertMatch(
             {atomic, [
-                #{node := Node2, tnx_id := 8},
-                #{node := Node1, tnx_id := 8}
+                #{node := Node1, tnx_id := 8},
+                #{node := Node2, tnx_id := 8}
             ]},
             emqx_cluster_rpc:status()
         )


### PR DESCRIPTION
Fixes:
1. Keep cores always ahead of replicants.
2. Keep the original node order when `tnxid` is the same（the order was reversed before fixing）.

This PR ensure that we find the right config leader.

Release version: v/e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
