### PR TITLE
chore: bump observer_cli from 1.7.1 to 1.7.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -223,7 +223,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:uuid), do: {:uuid, github: "okeuday/uuid", tag: "v2.0.6", override: true}
   def common_dep(:redbug), do: {:redbug, github: "emqx/redbug", tag: "2.0.10"}
-  def common_dep(:observer_cli), do: {:observer_cli, "1.7.1"}
+  def common_dep(:observer_cli), do: {:observer_cli, "1.7.5"}
 
   def common_dep(:jose),
     do: {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -94,7 +94,7 @@
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.0"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x
-    {observer_cli, "1.7.1"},
+    {observer_cli, "1.7.5"},
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.5"}}},
     {getopt, "1.0.2"},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},


### PR DESCRIPTION
Fixes <issue-or-jira-number>

```
1.7.5

Fix crash when mnesia table with external copies. Which mnesia:table_info(TabName, storage_type) returns tuple {ext, _, _}

Correct the order of the application information; the items Memory and Reductions have been switched.
1.7.4

fix crash when ets:info/1 return undefined.
1.7.3

fix system pane exception by ps command.
1.7.2

Fix error when inspecting process that monitors via {RegName, Node}.
```

Release version: v/e5.8.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
