### PR TITLE
refactor: introduce extra macro to be overridden in different repos

### DIFF
--- a/apps/emqx_enterprise/src/emqx_enterprise.app.src
+++ b/apps/emqx_enterprise/src/emqx_enterprise.app.src
@@ -1,6 +1,6 @@
 {application, emqx_enterprise, [
     {description, "EMQX Enterprise Edition"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
+++ b/apps/emqx_enterprise/src/emqx_enterprise_schema.erl
@@ -13,6 +13,8 @@
 -export([upgrade_raw_conf/1]).
 -export([injected_fields/0]).
 
+%% DO NOT REMOVE.  This is used in other repositories.
+-define(EXTRA_SCHEMA_MODULES, []).
 -define(EE_SCHEMA_MODULES, [
     emqx_license_schema,
     emqx_schema_registry_schema,
@@ -108,7 +110,7 @@ fields("log_audit_handler") ->
             )}
     ] ++ CommonConfs1;
 fields(Name) ->
-    ee_delegate(fields, ?EE_SCHEMA_MODULES, Name).
+    ee_delegate(fields, ?EXTRA_SCHEMA_MODULES ++ ?EE_SCHEMA_MODULES, Name).
 
 translations() ->
     emqx_conf_schema:translations().
@@ -123,7 +125,7 @@ translation(Name) ->
 desc("log_audit_handler") ->
     ?DESC(emqx_conf_schema, "desc_audit_log_handler");
 desc(Name) ->
-    ee_delegate(desc, ?EE_SCHEMA_MODULES, Name).
+    ee_delegate(desc, ?EXTRA_SCHEMA_MODULES ++ ?EE_SCHEMA_MODULES, Name).
 
 validations() ->
     emqx_conf_schema:validations() ++ emqx_license_schema:validations().

--- a/apps/emqx_oracle/src/emqx_oracle.app.src
+++ b/apps/emqx_oracle/src/emqx_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_oracle, [
     {description, "EMQX Enterprise Oracle Database Connector"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_oracle/src/emqx_oracle_schema.erl
+++ b/apps/emqx_oracle/src/emqx_oracle_schema.erl
@@ -19,7 +19,7 @@
 namespace() -> oracle.
 
 roots() ->
-    [{config, #{type => hoconsc:ref(?REF_MODULE, config)}}].
+    [].
 
 fields(config) ->
     Fields =


### PR DESCRIPTION
The idea is to only use this new macro for introducing extra schema modules that are idiosyncratic to the repo itself, thus avoiding missing some schema modules when overridding `?EE_SCHEMA_MODULES` as is done today.

Release version: e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
