### PR TITLE
fix: plugin config sync from new-joined node when try starting it

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -734,6 +734,7 @@ do_ensure_started(NameVsn) ->
         fun() ->
             case ensure_exists_and_installed(NameVsn) of
                 ok ->
+                    _ = maybe_load_config_schema(NameVsn, ?normal),
                     Plugin = do_read_plugin(NameVsn),
                     ok = load_code_start_apps(NameVsn, Plugin);
                 {error, #{reason := Reason} = ReasonMap} ->

--- a/changes/ce/fix-13721.en.md
+++ b/changes/ce/fix-13721.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the plugin configuration file could not be retrieved from other nodes in the cluster when trying to start the plugin and the plugin configuration file did not exist.


### PR DESCRIPTION
Fixes [EMQX-10080](https://emqx.atlassian.net/browse/EMQX-10080)

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] TODO: Added tests for the changes
 - Need a release with plugin's config from repo: https://github.com/emqx/emqx-plugin-template
- ~[ ] Added property-based tests for code which performs user input validation~
- ~[ ] Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~


[EMQX-10080]: https://emqx.atlassian.net/browse/EMQX-10080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ