### PR TITLE
0829 upgrade kerberos auth libs

### DIFF
--- a/apps/emqx_auth_kerberos/rebar.config
+++ b/apps/emqx_auth_kerberos/rebar.config
@@ -3,5 +3,5 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {sasl_auth, "2.3.0"}
+    {sasl_auth, "2.3.1"}
 ]}.

--- a/apps/emqx_bridge_azure_event_hub/mix.exs
+++ b/apps/emqx_bridge_azure_event_hub/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXBridgeAzureEventHub.MixProject do
     [
       {:wolff, github: "kafka4beam/wolff", tag: "3.0.2"},
       {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.5", override: true},
-      {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.1"},
+      {:brod_gssapi, "0.1.3"},
       {:brod, github: "kafka4beam/brod", tag: "3.18.0"},
       ## TODO: remove `mix.exs` from `wolff` and remove this override
       ## TODO: remove `mix.exs` from `pulsar` and remove this override

--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
     {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "3.0.2"}}},
     {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.5"}}},
-    {brod_gssapi, {git, "https://github.com/kafka4beam/brod_gssapi.git", {tag, "v0.1.1"}}},
+    {brod_gssapi, "0.1.3"},
     {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.18.0"}}},
     {snappyer, "1.2.9"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},

--- a/apps/emqx_bridge_confluent/mix.exs
+++ b/apps/emqx_bridge_confluent/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXBridgeConfluent.MixProject do
     [
       {:wolff, github: "kafka4beam/wolff", tag: "3.0.2"},
       {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.5", override: true},
-      {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.1"},
+      {:brod_gssapi, "0.1.3"},
       {:brod, github: "kafka4beam/brod", tag: "3.18.0"},
       ## TODO: remove `mix.exs` from `wolff` and remove this override
       ## TODO: remove `mix.exs` from `pulsar` and remove this override

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
     {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "3.0.2"}}},
     {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.5"}}},
-    {brod_gssapi, {git, "https://github.com/kafka4beam/brod_gssapi.git", {tag, "v0.1.1"}}},
+    {brod_gssapi, "0.1.3"},
     {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.18.0"}}},
     {snappyer, "1.2.9"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXBridgeKafka.MixProject do
     [
       {:wolff, github: "kafka4beam/wolff", tag: "3.0.2"},
       {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.5", override: true},
-      {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.1"},
+      {:brod_gssapi, "0.1.3"},
       {:brod, github: "kafka4beam/brod", tag: "3.18.0"},
       ## TODO: remove `mix.exs` from `wolff` and remove this override
       ## TODO: remove `mix.exs` from `pulsar` and remove this override

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -4,7 +4,7 @@
 {deps, [
     {wolff, {git, "https://github.com/kafka4beam/wolff.git", {tag, "3.0.2"}}},
     {kafka_protocol, {git, "https://github.com/kafka4beam/kafka_protocol.git", {tag, "4.1.5"}}},
-    {brod_gssapi, {git, "https://github.com/kafka4beam/brod_gssapi.git", {tag, "v0.1.1"}}},
+    {brod_gssapi, "0.1.3"},
     {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.18.0"}}},
     {snappyer, "1.2.9"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -9,8 +9,7 @@
     {snappyer, "1.2.9"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
-    {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {sasl_auth, "2.3.0"}
+    {emqx_bridge, {path, "../../apps/emqx_bridge"}}
 ]}.
 
 {shell, [

--- a/mix.exs
+++ b/mix.exs
@@ -390,7 +390,7 @@ defmodule EMQXUmbrella.MixProject do
       {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true},
       {:wolff, github: "kafka4beam/wolff", tag: "3.0.2"},
       {:kafka_protocol, github: "kafka4beam/kafka_protocol", tag: "4.1.5", override: true},
-      {:brod_gssapi, github: "kafka4beam/brod_gssapi", tag: "v0.1.1"},
+      {:brod_gssapi, "0.1.3", override: true},
       {:brod, github: "kafka4beam/brod", tag: "3.18.0"},
       {:snappyer, "1.2.9", override: true},
       {:crc32cer, "0.1.8", override: true},

--- a/mix.exs
+++ b/mix.exs
@@ -211,7 +211,7 @@ defmodule EMQXUmbrella.MixProject do
 
   # in conflict by emqx_connector and system_monitor
   def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.2", override: true}
-  def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.0", override: true}
+  def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.1", override: true}
   def common_dep(:gen_rpc), do: {:gen_rpc, github: "emqx/gen_rpc", tag: "3.4.0", override: true}
 
   def common_dep(:system_monitor),

--- a/rebar.config
+++ b/rebar.config
@@ -99,7 +99,7 @@
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.3"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
-    {sasl_auth, "2.3.0"},
+    {sasl_auth, "2.3.1"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},
     {telemetry, "1.1.0"},
     {hackney, {git, "https://github.com/emqx/hackney.git", {tag, "1.18.1-1"}}},


### PR DESCRIPTION
Release version: v/e5.8.1

## Summary

Upgrade libs:

`brod_gssapi-0.1.3`: `sasl_auth:client_done` was previously missing, maybe causing mem leak, but unsure
`sasl_auth-2.3.1`: changed to use `MEMORY` (previously `FILE`) type credentials cache, should fix the flaky tests

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
