### PR TITLE
fix(schema_registry): added OTP version into the cache key for a mixed cluster

### DIFF
--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_http, [
     {description, "EMQX HTTP Bridge and Connector Application"},
-    {vsn, "0.3.4"},
+    {vsn, "0.3.5"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, ehttpc]},
     {env, [

--- a/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_schema_registry, [
     {description, "EMQX Schema Registry"},
-    {vsn, "0.3.3"},
+    {vsn, "0.3.4"},
     {registered, [emqx_schema_registry_sup]},
     {mod, {emqx_schema_registry_app, []}},
     {included_applications, [

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
@@ -50,7 +50,9 @@
 
 -type fingerprint() :: binary().
 
--type protobuf_cache_key() :: {schema_name(), fingerprint()}.
+-type otp_release() :: string().
+
+-type protobuf_cache_key() :: {schema_name(), otp_release(), fingerprint()}.
 
 -export_type([serde_type/0]).
 
@@ -322,7 +324,7 @@ protobuf_serde_mod_name(Name) ->
 %% binaries...
 %% -spec protobuf_cache_key(schema_name(), schema_source()) -> {schema_name(), fingerprint()}.
 protobuf_cache_key(Name, Source) ->
-    {Name, erlang:md5(Source)}.
+    {Name, erlang:system_info(otp_release), erlang:md5(Source)}.
 
 -spec lazy_generate_protobuf_code(schema_name(), module(), schema_source()) ->
     {ok, module(), binary()} | {error, #{error := term(), warnings := [term()]}}.


### PR DESCRIPTION
Fixes EMQX-12556

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
