### PR TITLE
chore: bump sasl_auth to 2.3.2

### DIFF
--- a/apps/emqx_auth_kerberos/rebar.config
+++ b/apps/emqx_auth_kerberos/rebar.config
@@ -3,5 +3,5 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {sasl_auth, "2.3.1"}
+    {sasl_auth, "2.3.2"}
 ]}.

--- a/mix.exs
+++ b/mix.exs
@@ -211,7 +211,7 @@ defmodule EMQXUmbrella.MixProject do
 
   # in conflict by emqx_connector and system_monitor
   def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.2", override: true}
-  def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.1", override: true}
+  def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.2", override: true}
   def common_dep(:gen_rpc), do: {:gen_rpc, github: "emqx/gen_rpc", tag: "3.4.0", override: true}
 
   def common_dep(:system_monitor),

--- a/rebar.config
+++ b/rebar.config
@@ -99,7 +99,7 @@
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.3"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
-    {sasl_auth, "2.3.1"},
+    {sasl_auth, "2.3.2"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},
     {telemetry, "1.1.0"},
     {hackney, {git, "https://github.com/emqx/hackney.git", {tag, "1.18.1-1"}}},


### PR DESCRIPTION
remove -flat_namespace flag from linker flags on Darwin

Fixes Homebrew emqx formula.

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
