### PR TITLE
test(ft): make proptest scaling less aggressive

### DIFF
--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -57,6 +57,7 @@
 %% Generic Types
 -export([
     scaled/2,
+    logscaled/2,
     fixedmap/1
 ]).
 
@@ -690,6 +691,10 @@ limited_list(N, T) ->
 -spec scaled(number(), proptype()) -> proptype().
 scaled(F, T) when F > 0 ->
     ?SIZED(S, resize(round(S * F), T)).
+
+-spec logscaled(number(), proptype()) -> proptype().
+logscaled(F, T) when F > 0 ->
+    ?SIZED(S, resize(round(math:log(S + 1) * F), T)).
 
 -spec fixedmap(#{_Key => proptype()}) -> proptype().
 fixedmap(M) ->

--- a/apps/emqx_ft/test/props/prop_emqx_ft_assembly.erl
+++ b/apps/emqx_ft/test/props/prop_emqx_ft_assembly.erl
@@ -18,7 +18,7 @@
 
 -include_lib("proper/include/proper.hrl").
 
--import(emqx_proper_types, [scaled/2, fixedmap/1, typegen/0, generate/2]).
+-import(emqx_proper_types, [scaled/2, logscaled/2, fixedmap/1, typegen/0, generate/2]).
 
 -define(COVERAGE_TIMEOUT, 10000).
 
@@ -177,10 +177,10 @@ nsegs(Filesize, [BaseSegsize | _]) ->
     Filesize div max(1, BaseSegsize) + 1.
 
 segments_t(Filesize, Segsizes) ->
-    scaled(nsegs(Filesize, Segsizes), list({node_t(), segment_t(Filesize, Segsizes)})).
+    logscaled(nsegs(Filesize, Segsizes), list({node_t(), segment_t(Filesize, Segsizes)})).
 
 segments_t(Filesize, Segsizes, Hole) ->
-    scaled(nsegs(Filesize, Segsizes), list({node_t(), segment_t(Filesize, Segsizes, Hole)})).
+    logscaled(nsegs(Filesize, Segsizes), list({node_t(), segment_t(Filesize, Segsizes, Hole)})).
 
 segment_t(Filesize, Segsizes, Hole) ->
     ?SUCHTHATMAYBE(


### PR DESCRIPTION
## Summary

This should likely help to avoid proptest instances where seconds need to be spent on `emqx_proper_types:generate/2` of segments list.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] ~~Added tests for the changes~~
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered in coverage report~~
- [ ] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
