### PR TITLE
chore: deprecate user_lookup_fun for client SSL option

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2248,16 +2248,6 @@ common_ssl_opts_schema(Defaults, Type) ->
             )},
         {"versions", tls_versions_schema(Collection)},
         {"ciphers", ciphers_schema(D(ciphers))},
-        {"user_lookup_fun",
-            sc(
-                typerefl:alias("string", any()),
-                #{
-                    default => <<"emqx_tls_psk:lookup">>,
-                    converter => fun ?MODULE:user_lookup_fun_tr/2,
-                    importance => ?IMPORTANCE_HIDDEN,
-                    desc => ?DESC(common_ssl_opts_schema_user_lookup_fun)
-                }
-            )},
         {"secure_renegotiate",
             sc(
                 boolean(),
@@ -2334,6 +2324,16 @@ server_ssl_opts_schema(Defaults, IsRanchListener) ->
                     #{
                         default => Df(handshake_timeout, <<"15s">>),
                         desc => ?DESC(server_ssl_opts_schema_handshake_timeout)
+                    }
+                )},
+            {"user_lookup_fun",
+                sc(
+                    typerefl:alias("string", any()),
+                    #{
+                        default => <<"emqx_tls_psk:lookup">>,
+                        converter => fun ?MODULE:user_lookup_fun_tr/2,
+                        importance => ?IMPORTANCE_HIDDEN,
+                        desc => ?DESC(common_ssl_opts_schema_user_lookup_fun)
                     }
                 )}
         ] ++
@@ -2451,6 +2451,14 @@ client_ssl_opts_schema(Defaults) ->
                         example => disable,
                         validator => fun emqx_schema:non_empty_string/1,
                         desc => ?DESC(client_ssl_opts_schema_server_name_indication)
+                    }
+                )},
+            {"user_lookup_fun",
+                sc(
+                    string(),
+                    #{
+                        deprecated => {since, "5.8.1"},
+                        importance => ?IMPORTANCE_HIDDEN
                     }
                 )}
         ].

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -423,8 +423,6 @@ t_create_webhook_v1_bridges_api(Config) ->
                                     <<"log_level">> => <<"notice">>,
                                     <<"reuse_sessions">> => true,
                                     <<"secure_renegotiate">> => true,
-                                    <<"user_lookup_fun">> =>
-                                        <<"emqx_tls_psk:lookup">>,
                                     <<"verify">> => <<"verify_none">>,
                                     <<"versions">> =>
                                         [


### PR DESCRIPTION
Release version: v/e5.8.1

## Summary

No impact to users.
It's a server-only option, should not have been added to client opts.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
