### PR TITLE
fix(autn_http): log an error when `content_type` is unsupported

### DIFF
--- a/apps/emqx_auth_http/src/emqx_auth_http.app.src
+++ b/apps/emqx_auth_http/src/emqx_auth_http.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_http, [
     {description, "EMQX External HTTP API Authentication and Authorization"},
-    {vsn, "0.4.0"},
+    {vsn, "0.4.1"},
     {registered, []},
     {mod, {emqx_auth_http_app, []}},
     {applications, [

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -306,8 +306,8 @@ parse_body(<<"application/json", _/binary>>, Body) ->
 parse_body(<<"application/x-www-form-urlencoded", _/binary>>, Body) ->
     NBody = maps:from_list(cow_qs:parse_qs(Body)),
     {ok, NBody};
-parse_body(ContentType, _) ->
-    {error, {unsupported_content_type, ContentType}}.
+parse_body(_ContentType, _) ->
+    erlang:throw(unsupported_content_type).
 
 request_for_log(Credential, #{url := Url, method := Method} = State) ->
     SafeCredential = emqx_authn_utils:without_password(Credential),


### PR DESCRIPTION
Fixes https://askemq.com/t/topic/9369/2

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- ~Added property-based tests for code which performs user input validation~
- ~Changed lines covered in coverage report~
- ~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
