### PR TITLE
fix: change default hearbeat interval to 160s for mqtt connector

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.2.4"},
+    {vsn, "0.2.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector_schema.erl
@@ -127,7 +127,7 @@ fields("server_configs") ->
                     desc => ?DESC("clean_start")
                 }
             )},
-        {keepalive, mk_duration("MQTT Keepalive.", #{default => <<"300s">>})},
+        {keepalive, mk_duration("MQTT Keepalive.", #{default => <<"160s">>})},
         {retry_interval,
             mk_duration(
                 "Message retry interval. Delay for the MQTT bridge to retry sending the QoS1/QoS2 "

--- a/changes/ce/fix-13790.en.md
+++ b/changes/ce/fix-13790.en.md
@@ -1,0 +1,5 @@
+The default heartbeat interval for the MQTT connector has been reduced from 300 seconds to 160 seconds.
+
+This change helps maintain the underlying TCP connection by preventing timeouts due to the idle limits
+imposed by load balancers or firewalls, which typically range from 3 to 5 minutes depending on the cloud provider.
+


### PR DESCRIPTION
Release version: v/e5.8.1

## Summary

Depending on different cloud vendors, the TCP idle limit can vary from 3 ~  5 minutes.
Meaning, after idling for 3 ~ 5 minutes, the TCP link is silently dropped by the gateway/firewall/load-balancer whatsoever.
Prior to this change, the default PING interval (keepalive) for MQTT connector is 300s (5m) which is doomed to fail.
This PR changes default to 160.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~[ ] Added tests for the changes~
- ~[ ] Added property-based tests for code which performs user input validation~
- ~[ ] Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- ~[ ] For internal contributor: there is a jira ticket to track this change~
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
