### PR TITLE
fix: release el7 packages again

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/5.3-11:1.15.7-26.2.5.2-1-ubuntu22.04
+    image:  ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.3-11:1.15.7-26.2.5.2-1-ubuntu22.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -63,7 +63,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '5.3-11'
+        default: '5.3-13'
 
 permissions:
   contents: read
@@ -118,6 +118,7 @@ jobs:
           - debian10
           - el9
           - el8
+          - el7
           - amzn2
           - amzn2023
         arch:

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -26,7 +26,7 @@ jobs:
   prepare:
     runs-on: ubuntu-latest
     if: github.repository_owner == 'emqx'
-    container: ghcr.io/emqx/emqx-builder/5.3-11:1.15.7-26.2.5-1-ubuntu20.04
+    container: ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5-1-ubuntu20.04
     outputs:
       BENCH_ID: ${{ steps.prepare.outputs.BENCH_ID }}
       PACKAGE_FILE: ${{ steps.package_file.outputs.PACKAGE_FILE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -112,6 +112,8 @@ jobs:
           push "ubuntu/jammy" "packages/$PROFILE-$VERSION-ubuntu22.04-arm64.deb"
           push "ubuntu/noble" "packages/$PROFILE-$VERSION-ubuntu24.04-amd64.deb"
           push "ubuntu/noble" "packages/$PROFILE-$VERSION-ubuntu24.04-arm64.deb"
+          push "el/7" "packages/$PROFILE-$VERSION-el7-amd64.rpm"
+          push "el/7" "packages/$PROFILE-$VERSION-el7-arm64.rpm"
           push "el/8" "packages/$PROFILE-$VERSION-el8-amd64.rpm"
           push "el/8" "packages/$PROFILE-$VERSION-el8-arm64.rpm"
           push "el/9" "packages/$PROFILE-$VERSION-el9-amd64.rpm"

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,5 +1,5 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.3-11:1.15.7-26.2.5.2-1-debian12
-ARG RUN_FROM=public.ecr.aws/debian/debian:stable-20240612-slim
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-debian12
+ARG RUN_FROM=debian:12-slim
 ARG SOURCE_TYPE=src # tgz
 
 FROM ${BUILD_FROM} AS builder_src

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=5.3-11
+export EMQX_BUILDER_VSN=5.3-13
 export OTP_VSN=26.2.5.2-1
 export ELIXIR_VSN=1.15.7
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu22.04

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -36,7 +36,7 @@ help() {
     echo ""
     echo "--builder <BUILDER>:"
     echo "    Docker image to use for building"
-    echo "    E.g. ghcr.io/emqx/emqx-builder/5.3-11:1.15.7-26.2.5.2-1-debian12"
+    echo "    E.g. ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-debian12"
     echo "    For hot upgrading tar.gz, specify a builder image with the same OS distribution as the running one."
     echo "    Specifically, for EMQX's docker containers hot upgrading, please use the debian12-based builder. "
 }


### PR DESCRIPTION
CS says we need to keep el7 for now.

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
