### PR TITLE
ci: always run compile job in push entrypoint

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -125,7 +125,6 @@ jobs:
     uses: ./.github/workflows/build_slim_packages.yaml
 
   compile:
-    if: needs.prepare.outputs.release != 'true'
     runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
     container: ${{ needs.init.outputs.BUILDER }}
     needs:


### PR DESCRIPTION
other jobs which depend on it only run on releases