### PR TITLE
feat(schema registry): add external schema registry support

### DIFF
--- a/.ci/docker-compose-file/confluent-schema-registry/jaas.conf
+++ b/.ci/docker-compose-file/confluent-schema-registry/jaas.conf
@@ -1,0 +1,5 @@
+SchemaRegistry-Props {
+  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+  file="/etc/schema-registry/password-file"
+  debug="true";
+};

--- a/.ci/docker-compose-file/confluent-schema-registry/password-file
+++ b/.ci/docker-compose-file/confluent-schema-registry/password-file
@@ -1,0 +1,1 @@
+cpsruser:mypass,user

--- a/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
+++ b/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
@@ -1,0 +1,32 @@
+version: '3.9'
+
+## depends on kafka; see `./docker-file-compose-kafka.yaml`.
+services:
+  confluent_schema_registry: &cpsr
+    image: public.ecr.aws/ews-network/confluentinc/cp-schema-registry:7.5.1
+    container_name: confluent_schema_registry
+    restart: always
+    depends_on:
+      zookeeper:
+        condition: service_started
+      kafka_1:
+        condition: service_started
+    networks:
+      emqx_bridge:
+    environment: &cpsr-env
+      SCHEMA_REGISTRY_DEBUG: true
+      SCHEMA_REGISTRY_HOST_NAME: confluent_schema_registry
+      SCHEMA_REGISTRY_KAFKASTORE_BOOTSTRAP_SERVERS: "kafka-1.emqx.net:9092"
+  confluent_schema_registry_basicauth:
+    <<: *cpsr
+    container_name: confluent_schema_registry_basicauth
+    environment:
+      <<: *cpsr-env
+      SCHEMA_REGISTRY_HOST_NAME: confluent_schema_registry_basicauth
+      SCHEMA_REGISTRY_AUTHENTICATION_METHOD: BASIC
+      SCHEMA_REGISTRY_AUTHENTICATION_ROLES: user
+      SCHEMA_REGISTRY_AUTHENTICATION_REALM: SchemaRegistry-Props
+      SCHEMA_REGISTRY_OPTS: -Djava.security.auth.login.config=/etc/schema-registry/jaas.conf
+    volumes:
+      - ./confluent-schema-registry/jaas.conf:/etc/schema-registry/jaas.conf
+      - ./confluent-schema-registry/password-file:/etc/schema-registry/password-file

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_action_schema.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_action_schema.erl
@@ -56,7 +56,7 @@ fields(action) ->
 fields(?ACTION_TYPE) ->
     emqx_bridge_v2_schema:make_producer_action_schema(
         mk(
-            mkunion(mode, #{
+            emqx_schema:mkunion(mode, #{
                 <<"direct">> => ref(direct_parameters),
                 <<"aggregated">> => ref(aggreg_parameters)
             }),
@@ -288,20 +288,6 @@ action_example(put, direct) ->
 
 ref(Name) -> hoconsc:ref(?MODULE, Name).
 mk(Type, Meta) -> hoconsc:mk(Type, Meta).
-
-mkunion(Field, Schemas) ->
-    hoconsc:union(fun(Arg) -> scunion(Field, Schemas, Arg) end).
-
-scunion(_Field, Schemas, all_union_members) ->
-    maps:values(Schemas);
-scunion(Field, Schemas, {value, Value}) ->
-    Selector = maps:get(emqx_utils_conv:bin(Field), Value, undefined),
-    case Selector == undefined orelse maps:find(emqx_utils_conv:bin(Selector), Schemas) of
-        {ok, Schema} ->
-            [Schema];
-        _Error ->
-            throw(#{field_name => Field, expected => maps:keys(Schemas)})
-    end.
 
 block_size_validator(SizeLimit) ->
     case SizeLimit =< 4_000 * 1024 * 1024 of

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_s3, [
     {description, "EMQX Enterprise S3 Bridge"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_upload.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_upload.erl
@@ -66,7 +66,7 @@ fields(action) ->
 fields(?ACTION) ->
     emqx_bridge_v2_schema:make_producer_action_schema(
         hoconsc:mk(
-            mkunion(
+            emqx_schema:mkunion(
                 mode,
                 #{
                     <<"direct">> => ?R_REF(s3_direct_upload_parameters),
@@ -121,7 +121,7 @@ fields(s3_aggregated_upload_parameters) ->
                 )},
             {container,
                 hoconsc:mk(
-                    mkunion(type, #{
+                    emqx_schema:mkunion(type, #{
                         <<"csv">> => ?REF(s3_aggregated_container_csv)
                     }),
                     #{
@@ -195,29 +195,6 @@ fields(s3_upload_resource_opts) ->
         {batch_size, #{default => ?DEFAULT_AGGREG_BATCH_SIZE}},
         {batch_time, #{default => ?DEFAULT_AGGREG_BATCH_TIME}}
     ]).
-
-mkunion(Field, Schemas) ->
-    mkunion(Field, Schemas, none).
-
-mkunion(Field, Schemas, Default) ->
-    hoconsc:union(fun(Arg) -> scunion(Field, Schemas, Default, Arg) end).
-
-scunion(_Field, Schemas, _Default, all_union_members) ->
-    maps:values(Schemas);
-scunion(Field, Schemas, Default, {value, Value}) ->
-    Selector =
-        case maps:get(emqx_utils_conv:bin(Field), Value, undefined) of
-            undefined ->
-                Default;
-            X ->
-                emqx_utils_conv:bin(X)
-        end,
-    case maps:find(Selector, Schemas) of
-        {ok, Schema} ->
-            [Schema];
-        _Error ->
-            throw(#{field_name => Field, expected => maps:keys(Schemas)})
-    end.
 
 desc(s3) ->
     ?DESC(s3_upload);

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.eunit.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.eunit.ex
@@ -27,6 +27,8 @@ defmodule Mix.Tasks.Emqx.Eunit do
     |> String.replace_suffix("-test", "")
     |> then(& System.put_env("PROFILE", &1))
 
+    :emqx_common_test_helpers.clear_screen()
+
     args
     |> parse_args!()
     |> discover_tests()

--- a/apps/emqx_schema_registry/docker-ct
+++ b/apps/emqx_schema_registry/docker-ct
@@ -1,0 +1,3 @@
+kdc
+kafka
+schema-registry

--- a/apps/emqx_schema_registry/mix.exs
+++ b/apps/emqx_schema_registry/mix.exs
@@ -29,6 +29,7 @@ defmodule EMQXSchemaRegistry.MixProject do
       UMP.common_dep(:erlavro),
       UMP.common_dep(:jesse),
       UMP.common_dep(:gpb, runtime: true),
+      {:avlizer, github: "emqx/avlizer", tag: "0.5.1.1"},
     ]
   end
 end

--- a/apps/emqx_schema_registry/rebar.config
+++ b/apps/emqx_schema_registry/rebar.config
@@ -7,7 +7,8 @@
     {emqx_rule_engine, {path, "../emqx_rule_engine"}},
     {erlavro, {git, "https://github.com/emqx/erlavro.git", {tag, "2.10.0"}}},
     {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.0.1"}}},
-    {gpb, "4.19.9"}
+    {gpb, "4.19.9"},
+    {avlizer, {git, "https://github.com/emqx/avlizer.git", {tag, "0.5.1.1"}}}
 ]}.
 
 {shell, [

--- a/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.app.src
@@ -12,6 +12,7 @@
         erlavro,
         gpb,
         jesse,
+        avlizer,
         emqx
     ]},
     {env, []},

--- a/apps/emqx_schema_registry/src/emqx_schema_registry.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry.erl
@@ -4,8 +4,6 @@
 -module(emqx_schema_registry).
 
 -behaviour(gen_server).
--behaviour(emqx_config_handler).
--behaviour(emqx_config_backup).
 
 -include("emqx_schema_registry.hrl").
 -include_lib("emqx/include/logger.hrl").
@@ -31,12 +29,11 @@
     terminate/2
 ]).
 
-%% `emqx_config_handler' API
--export([post_config_update/5]).
-
-%% Data backup
+%% Internal exports for `emqx_schema_registry_config'
 -export([
-    import_config/1
+    async_delete_serdes/1,
+    ensure_serde_absent/1,
+    build_serdes/1
 ]).
 
 %% for testing
@@ -130,85 +127,6 @@ delete_schema(Name) ->
 -spec list_schemas() -> #{schema_name() => schema()}.
 list_schemas() ->
     emqx_config:get([?CONF_KEY_ROOT, schemas], #{}).
-
-%%-------------------------------------------------------------------------------------------------
-%% `emqx_config_handler' API
-%%-------------------------------------------------------------------------------------------------
-%% remove
-post_config_update(
-    [?CONF_KEY_ROOT, schemas, Name],
-    '$remove',
-    _NewSchemas,
-    _OldSchemas,
-    _AppEnvs
-) ->
-    async_delete_serdes([Name]),
-    ok;
-%% add or update
-post_config_update(
-    [?CONF_KEY_ROOT, schemas, NewName],
-    _Cmd,
-    NewSchema,
-    OldSchema,
-    _AppEnvs
-) ->
-    case OldSchema of
-        undefined ->
-            ok;
-        _ ->
-            ensure_serde_absent(NewName)
-    end,
-    case build_serdes([{NewName, NewSchema}]) of
-        ok ->
-            {ok, #{NewName => NewSchema}};
-        {error, Reason, SerdesToRollback} ->
-            lists:foreach(fun ensure_serde_absent/1, SerdesToRollback),
-            {error, Reason}
-    end;
-post_config_update(?CONF_KEY_PATH, _Cmd, NewConf = #{schemas := NewSchemas}, OldConf, _AppEnvs) ->
-    OldSchemas = maps:get(schemas, OldConf, #{}),
-    #{
-        added := Added,
-        changed := Changed0,
-        removed := Removed
-    } = emqx_utils_maps:diff_maps(NewSchemas, OldSchemas),
-    Changed = maps:map(fun(_N, {_Old, New}) -> New end, Changed0),
-    RemovedNames = maps:keys(Removed),
-    case RemovedNames of
-        [] ->
-            ok;
-        _ ->
-            async_delete_serdes(RemovedNames)
-    end,
-    SchemasToBuild = maps:to_list(maps:merge(Changed, Added)),
-    ok = lists:foreach(fun ensure_serde_absent/1, [N || {N, _} <- SchemasToBuild]),
-    case build_serdes(SchemasToBuild) of
-        ok ->
-            {ok, NewConf};
-        {error, Reason, SerdesToRollback} ->
-            lists:foreach(fun ensure_serde_absent/1, SerdesToRollback),
-            {error, Reason}
-    end;
-post_config_update(_Path, _Cmd, NewConf, _OldConf, _AppEnvs) ->
-    {ok, NewConf}.
-
-%%-------------------------------------------------------------------------------------------------
-%% Data backup
-%%-------------------------------------------------------------------------------------------------
-
-import_config(#{<<"schema_registry">> := #{<<"schemas">> := Schemas} = SchemaRegConf}) ->
-    OldSchemas = emqx:get_raw_config([?CONF_KEY_ROOT, schemas], #{}),
-    SchemaRegConf1 = SchemaRegConf#{<<"schemas">> => maps:merge(OldSchemas, Schemas)},
-    case emqx_conf:update(?CONF_KEY_PATH, SchemaRegConf1, #{override_to => cluster}) of
-        {ok, #{raw_config := #{<<"schemas">> := NewRawSchemas}}} ->
-            Changed = maps:get(changed, emqx_utils_maps:diff_maps(NewRawSchemas, OldSchemas)),
-            ChangedPaths = [[?CONF_KEY_ROOT, schemas, Name] || Name <- maps:keys(Changed)],
-            {ok, #{root_key => ?CONF_KEY_ROOT, changed => ChangedPaths}};
-        Error ->
-            {error, #{root_key => ?CONF_KEY_ROOT, reason => Error}}
-    end;
-import_config(_RawConf) ->
-    {ok, #{root_key => ?CONF_KEY_ROOT, changed => []}}.
 
 %%-------------------------------------------------------------------------------------------------
 %% `gen_server' API

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_app.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_app.erl
@@ -14,13 +14,9 @@ start(_StartType, _StartArgs) ->
     %% and encode functions called from the rule engine SQL like language
     ok = emqx_rule_engine:set_extra_functions_module(emqx_schema_registry_serde),
     ok = mria_rlog:wait_for_shards([?SCHEMA_REGISTRY_SHARD], infinity),
-    %% HTTP API handler
-    emqx_conf:add_handler([?CONF_KEY_ROOT, schemas, '?'], emqx_schema_registry),
-    %% Conf load / data import handler
-    emqx_conf:add_handler(?CONF_KEY_PATH, emqx_schema_registry),
+    ok = emqx_schema_registry_config:add_handlers(),
     emqx_schema_registry_sup:start_link().
 
 stop(_State) ->
-    emqx_conf:remove_handler([?CONF_KEY_ROOT, schemas, '?']),
-    emqx_conf:remove_handler(?CONF_KEY_PATH),
+    ok = emqx_schema_registry_config:remove_handlers(),
     ok.

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_config.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_config.erl
@@ -1,0 +1,130 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_schema_registry_config).
+
+-include("emqx_schema_registry.hrl").
+
+%% API
+-export([
+    add_handlers/0,
+    remove_handlers/0
+]).
+
+%% `emqx_config_handler' API
+-export([post_config_update/5]).
+
+%% `emqx_config_backup' API
+-behaviour(emqx_config_backup).
+-export([import_config/1]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-define(SCHEMA_CONF_PATH(NAME), [?CONF_KEY_ROOT, schemas, NAME]).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+-spec add_handlers() -> ok.
+add_handlers() ->
+    %% HTTP API handler
+    ok = emqx_conf:add_handler([?CONF_KEY_ROOT, schemas, '?'], ?MODULE),
+    %% Conf load / data import handler
+    ok = emqx_conf:add_handler(?CONF_KEY_PATH, ?MODULE),
+    ok.
+
+-spec remove_handlers() -> ok.
+remove_handlers() ->
+    ok = emqx_conf:remove_handler([?CONF_KEY_ROOT, schemas, '?']),
+    ok = emqx_conf:remove_handler(?CONF_KEY_PATH),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% `emqx_config_handler' API
+%%------------------------------------------------------------------------------
+
+%% remove
+post_config_update(
+    ?SCHEMA_CONF_PATH(Name),
+    '$remove',
+    _NewSchemas,
+    _OldSchemas,
+    _AppEnvs
+) ->
+    emqx_schema_registry:async_delete_serdes([Name]),
+    ok;
+%% add or update
+post_config_update(
+    ?SCHEMA_CONF_PATH(NewName),
+    _Cmd,
+    NewSchema,
+    OldSchema,
+    _AppEnvs
+) ->
+    case OldSchema of
+        undefined ->
+            ok;
+        _ ->
+            emqx_schema_registry:ensure_serde_absent(NewName)
+    end,
+    case emqx_schema_registry:build_serdes([{NewName, NewSchema}]) of
+        ok ->
+            {ok, #{NewName => NewSchema}};
+        {error, Reason, SerdesToRollback} ->
+            lists:foreach(fun emqx_schema_registry:ensure_serde_absent/1, SerdesToRollback),
+            {error, Reason}
+    end;
+post_config_update(?CONF_KEY_PATH, _Cmd, NewConf = #{schemas := NewSchemas}, OldConf, _AppEnvs) ->
+    OldSchemas = maps:get(schemas, OldConf, #{}),
+    #{
+        added := Added,
+        changed := Changed0,
+        removed := Removed
+    } = emqx_utils_maps:diff_maps(NewSchemas, OldSchemas),
+    Changed = maps:map(fun(_N, {_Old, New}) -> New end, Changed0),
+    RemovedNames = maps:keys(Removed),
+    case RemovedNames of
+        [] ->
+            ok;
+        _ ->
+            emqx_schema_registry:async_delete_serdes(RemovedNames)
+    end,
+    SchemasToBuild = maps:to_list(maps:merge(Changed, Added)),
+    ok = lists:foreach(fun emqx_schema_registry:ensure_serde_absent/1, [
+        N
+     || {N, _} <- SchemasToBuild
+    ]),
+    case emqx_schema_registry:build_serdes(SchemasToBuild) of
+        ok ->
+            {ok, NewConf};
+        {error, Reason, SerdesToRollback} ->
+            lists:foreach(fun emqx_schema_registry:ensure_serde_absent/1, SerdesToRollback),
+            {error, Reason}
+    end;
+post_config_update(_Path, _Cmd, NewConf, _OldConf, _AppEnvs) ->
+    {ok, NewConf}.
+
+%%------------------------------------------------------------------------------
+%% `emqx_config_backup' API
+%%------------------------------------------------------------------------------
+
+import_config(#{<<"schema_registry">> := #{<<"schemas">> := Schemas} = SchemaRegConf}) ->
+    OldSchemas = emqx:get_raw_config([?CONF_KEY_ROOT, schemas], #{}),
+    SchemaRegConf1 = SchemaRegConf#{<<"schemas">> => maps:merge(OldSchemas, Schemas)},
+    case emqx_conf:update(?CONF_KEY_PATH, SchemaRegConf1, #{override_to => cluster}) of
+        {ok, #{raw_config := #{<<"schemas">> := NewRawSchemas}}} ->
+            Changed = maps:get(changed, emqx_utils_maps:diff_maps(NewRawSchemas, OldSchemas)),
+            ChangedPaths = [[?CONF_KEY_ROOT, schemas, Name] || Name <- maps:keys(Changed)],
+            {ok, #{root_key => ?CONF_KEY_ROOT, changed => ChangedPaths}};
+        Error ->
+            {error, #{root_key => ?CONF_KEY_ROOT, reason => Error}}
+    end;
+import_config(_RawConf) ->
+    {ok, #{root_key => ?CONF_KEY_ROOT, changed => []}}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_external.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_external.erl
@@ -1,0 +1,373 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_schema_registry_external).
+
+-feature(maybe_expr, enable).
+
+-behaviour(gen_server).
+
+-include("emqx_schema_registry.hrl").
+
+%% API
+-export([
+    start_link/0,
+
+    add/2,
+    remove/1,
+
+    encode/4,
+    encode_with/6,
+    decode/4
+]).
+
+%% `gen_server' API
+-export([
+    init/1,
+    terminate/2,
+    handle_call/3,
+    handle_cast/2
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-define(EXTERNAL_REGISTRY_TAB, emqx_schema_registry_external).
+
+-define(NAME(RegistryName), {n, l, {?MODULE, RegistryName}}).
+-define(REF(RegistryName), {via, gproc, ?NAME(RegistryName)}).
+
+-define(bad_registry_credentials, bad_registry_credentials).
+-define(schema_not_found, schema_not_found).
+-define(bad_input, bad_input).
+-define(bad_schema_source, bad_schema_source).
+-define(external_registry_unavailable, external_registry_unavailable).
+
+-type registry_name() :: atom() | binary().
+-type encode_opts() :: #{
+    %% Default: false
+    tag => boolean()
+}.
+-type decode_opts() :: #{}.
+-type data() :: term().
+-type encoded() :: binary().
+-type arg() :: term().
+-type schema_source_hash() :: binary().
+
+%% call/cast/info events
+-record(ensure_registered, {
+    name :: registry_name(),
+    our_schema_name :: schema_name(),
+    source :: schema_source(),
+    hash :: schema_source_hash(),
+    args :: [arg()]
+}).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+add(Name, Config) ->
+    ChildSpec = worker_child_spec(Name, Config),
+    ok = emqx_schema_registry_sup:ensure_external_registry_worker_started(ChildSpec),
+    ok = initialize_registry_context(Name, Config),
+    ok.
+
+remove(Name) ->
+    ok = emqx_schema_registry_sup:ensure_external_registry_worker_absent(Name),
+    ok = deinitialize_registry_context(Name),
+    ok.
+
+-spec encode(registry_name(), data(), [arg()], encode_opts()) ->
+    {ok, encoded()} | {error, term()}.
+encode(Name, Data, Args, Opts) ->
+    with_registry(Name, fun(Context) ->
+        do_encode(Name, Context, Data, Args, Opts)
+    end).
+
+-spec encode_with(registry_name(), schema_name(), schema_source(), data(), [arg()], encode_opts()) ->
+    {ok, encoded()} | {error, term()}.
+encode_with(Name, OurSchemaName, Source, Data, Args, Opts) ->
+    with_registry(Name, fun(Context) ->
+        maybe
+            {ok, Id} ?= ensure_registered(Name, Context, OurSchemaName, Source, Args),
+            do_encode(Name, Context, Data, [Id | Args], Opts)
+        end
+    end).
+
+-spec decode(registry_name(), encoded(), [arg()], decode_opts()) ->
+    {ok, data()} | {error, term()}.
+decode(Name, Data, Args, Opts) ->
+    with_registry(Name, fun(Context) ->
+        do_decode(Name, Context, Data, Args, Opts)
+    end).
+
+%%------------------------------------------------------------------------------
+%% `gen_server' API
+%%------------------------------------------------------------------------------
+
+init(_) ->
+    process_flag(trap_exit, true),
+    create_tables(),
+    State = #{},
+    {ok, State}.
+
+terminate(_Reason, _State) ->
+    ets:foldr(
+        fun
+            ({_Id, #{on_remove := OnRemove}}, Acc) when is_function(OnRemove, 0) ->
+                _ = OnRemove(),
+                Acc;
+            (_, Acc) ->
+                Acc
+        end,
+        ok,
+        ?EXTERNAL_REGISTRY_TAB
+    ).
+
+handle_call(#ensure_registered{} = Req, _From, State) ->
+    handle_ensure_registered(Req, State);
+handle_call(Call, _From, State) ->
+    {reply, {error, {unknown_call, Call}}, State}.
+
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns (`gen_server')
+%%------------------------------------------------------------------------------
+
+create_tables() ->
+    ok = emqx_utils_ets:new(?EXTERNAL_REGISTRY_TAB, [set, public]),
+    ok.
+
+handle_ensure_registered(Req, State) ->
+    #ensure_registered{
+        name = Name,
+        our_schema_name = OurSchemaName,
+        source = Source,
+        hash = SourceHash,
+        args = Args
+    } = Req,
+    Res = with_registry(Name, fun(Context) ->
+        %% Race: another call already registered it
+        maybe
+            {ok, _Id} ?= find_cached_schema_id(Context, OurSchemaName, SourceHash)
+        else
+            error ->
+                do_register(Name, Context, OurSchemaName, Source, SourceHash, Args)
+        end
+    end),
+    {reply, Res, State}.
+
+do_register(Name, #{type := confluent} = Context, OurSchemaName, Source, SourceHash, [Subject]) ->
+    maybe
+        {ok, Id} ?= confluent_register_schema(Name, Subject, Source),
+        NewContext = add_cached_schema_id(Context, OurSchemaName, SourceHash, Id),
+        ets:insert(?EXTERNAL_REGISTRY_TAB, {id(Name), NewContext}),
+        {ok, Id}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+%%===========================
+%% Confluent
+%%===========================
+
+avlizer_auth(#{auth := none}) ->
+    undefined;
+avlizer_auth(#{auth := #{} = Opts}) ->
+    #{
+        mechanism := Mechanism,
+        username := Username,
+        password := Password
+    } = Opts,
+    {Mechanism, emqx_utils_conv:str(Username), Password}.
+
+confluent_make_encoder(Name, CacheTable, SchemaId) ->
+    try
+        {ok, avlizer_confluent:make_encoder2(?REF(id(Name)), CacheTable, SchemaId)}
+    catch
+        error:{bad_http_code, 404} ->
+            {error, ?schema_not_found};
+        error:{bad_http_code, 401} ->
+            {error, ?bad_registry_credentials}
+    end.
+
+confluent_encode(Encoder, Data) ->
+    try
+        {ok, avlizer_confluent:encode(Encoder, Data)}
+    catch
+        _:_ ->
+            {error, ?bad_input}
+    end.
+
+confluent_untag(Data) ->
+    try
+        {ok, avlizer_confluent:untag_data(Data)}
+    catch
+        _:_ ->
+            {error, ?bad_input}
+    end.
+
+confluent_make_decoder(Name, CacheTable, SchemaId) ->
+    try
+        {ok, avlizer_confluent:make_decoder2(?REF(id(Name)), CacheTable, SchemaId)}
+    catch
+        error:{bad_http_code, 404} ->
+            {error, ?schema_not_found};
+        error:{bad_http_code, 401} ->
+            {error, ?bad_registry_credentials}
+    end.
+
+confluent_decode(Decoder, Data) ->
+    try
+        {ok, avlizer_confluent:decode(Decoder, Data)}
+    catch
+        _:_ ->
+            {error, bad_input}
+    end.
+
+confluent_register_schema(Name, Subject0, Source) ->
+    Subject = emqx_utils_conv:str(Subject0),
+    case avlizer_confluent:register_schema(?REF(id(Name)), Subject, Source) of
+        {ok, Id} ->
+            {ok, Id};
+        {error, {bad_http_code, 401}} ->
+            {error, ?bad_registry_credentials};
+        {error, {bad_http_code, 409}} ->
+            {error, ?bad_schema_source};
+        {error, {bad_http_code, 422}} ->
+            {error, ?bad_schema_source};
+        {error, {bad_http_code, 500}} ->
+            {error, ?external_registry_unavailable};
+        {error, _} = Error ->
+            Error
+    end.
+
+%%===========================
+%% Misc
+%%===========================
+
+with_registry(Name, Fn) ->
+    Id = id(Name),
+    case ets:lookup(?EXTERNAL_REGISTRY_TAB, Id) of
+        [{Id, Context}] ->
+            Fn(Context);
+        [] ->
+            {error, registry_not_found}
+    end.
+
+worker_child_spec(Name, #{type := confluent} = Config) ->
+    Id = id(Name),
+    Opts = external_registry_worker_config(Config),
+    #{
+        id => Name,
+        start => {avlizer_confluent, start_link, [?REF(Id), Opts]},
+        restart => permanent,
+        shutdown => 5_000,
+        type => worker
+    }.
+
+external_registry_worker_config(#{type := confluent} = Config) ->
+    #{url := URL} = Config,
+    MAuth = avlizer_auth(Config),
+    emqx_utils_maps:put_if(
+        #{url => emqx_utils_conv:str(URL)},
+        auth,
+        MAuth,
+        MAuth =/= undefined
+    ).
+
+id(Name) ->
+    emqx_utils_conv:bin(Name).
+
+initialize_registry_context(Name, #{type := confluent = Type}) ->
+    Id = id(Name),
+    CacheTable = avlizer_confluent:get_table(?REF(Id)),
+    Context = #{type => Type, cache_table => CacheTable},
+    Id = id(Name),
+    true = ets:insert(?EXTERNAL_REGISTRY_TAB, {Id, Context}),
+    ok.
+
+deinitialize_registry_context(Name) ->
+    Id = id(Name),
+    case ets:take(?EXTERNAL_REGISTRY_TAB, Id) of
+        [{Id, #{on_remove := OnRemove}}] when is_function(OnRemove, 0) ->
+            OnRemove(),
+            ok;
+        _ ->
+            ok
+    end.
+
+do_decode(Name, #{type := confluent} = Context, Data, [SchemaId], _Opts) ->
+    %% Tag provided
+    #{cache_table := CacheTable} = Context,
+    maybe
+        true ?= is_integer(SchemaId) orelse {error, {bad_schema_id, SchemaId}},
+        {ok, Decoder} ?= confluent_make_decoder(Name, CacheTable, SchemaId),
+        confluent_decode(Decoder, Data)
+    end;
+do_decode(Name, #{type := confluent} = Context, Data0, [], _Opts) ->
+    %% Data is tagged.
+    #{cache_table := CacheTable} = Context,
+    maybe
+        {ok, {SchemaId, Data}} ?= confluent_untag(Data0),
+        {ok, Decoder} ?= confluent_make_decoder(Name, CacheTable, SchemaId),
+        confluent_decode(Decoder, Data)
+    end.
+
+do_encode(Name, #{type := confluent} = Context, Data, [SchemaId | _MaybeSubject], Opts) ->
+    %% assert
+    true = is_integer(SchemaId),
+    #{cache_table := CacheTable} = Context,
+    ShouldTag = maps:get(tag, Opts, false),
+    maybe
+        true ?= is_integer(SchemaId) orelse {error, {bad_schema_id, SchemaId}},
+        {ok, Encoder} ?= confluent_make_encoder(Name, CacheTable, SchemaId),
+        {ok, Encoded} ?= confluent_encode(Encoder, Data),
+        case ShouldTag of
+            true ->
+                {ok, avlizer_confluent:tag_data(SchemaId, Encoded)};
+            false ->
+                {ok, Encoded}
+        end
+    end.
+
+hash_source(Source) when is_binary(Source) ->
+    erlang:md5(Source).
+
+find_cached_schema_id(Context, OurSchemaName, SourceHash) ->
+    case Context of
+        #{cache := #{OurSchemaName := #{SourceHash := Id}}} ->
+            {ok, Id};
+        _ ->
+            error
+    end.
+
+add_cached_schema_id(Context, OurSchemaName, SourceHash, Id) ->
+    %% Drops any stale source hash already in context
+    Cached = #{SourceHash => Id},
+    emqx_utils_maps:deep_put([cache, OurSchemaName], Context, Cached).
+
+ensure_registered(Name, Context, OurSchemaName, Source, Args) ->
+    SourceHash = hash_source(Source),
+    maybe
+        {ok, _Id} ?= find_cached_schema_id(Context, OurSchemaName, SourceHash)
+    else
+        error ->
+            Req = #ensure_registered{
+                name = Name,
+                our_schema_name = OurSchemaName,
+                source = Source,
+                hash = SourceHash,
+                args = Args
+            },
+            gen_server:call(?MODULE, Req, infinity)
+    end.

--- a/apps/emqx_schema_registry/src/emqx_schema_registry_sup.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_sup.erl
@@ -5,38 +5,111 @@
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+%% API
+-export([
+    start_link/0,
+    start_external_registry_sup/0,
 
+    ensure_external_registry_worker_started/1,
+    ensure_external_registry_worker_absent/1
+]).
+
+%% `supervisor' API
 -export([init/1]).
 
--define(SERVER, ?MODULE).
+%% @doc
+%%
+%% emqx_schema_registry_sup
+%% |
+%% +-- emqx_schema_registry(1)  % registry process controlling local schemas
+%% |
+%% +-- emqx_schema_registry_external_sup(1)  % supervisor for external registry workers
+%%     |
+%%     +-- emqx_schema_registry_external(1) % for managing external registry context and cache
+%%     |
+%%     +-- avlizer_confluent(0..n) % for interacting with confluent schema registry
+
+%%------------------------------------------------------------------------------
+%% Type definitions
+%%------------------------------------------------------------------------------
+
+-define(root, root).
+-define(ROOT_SUP, ?MODULE).
+
+-define(external, external).
+-define(EXTERNAL_SUP, emqx_schema_registry_external_sup).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
 
 start_link() ->
-    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+    supervisor:start_link({local, ?ROOT_SUP}, ?MODULE, ?root).
 
-%% sup_flags() = #{strategy => strategy(),         % optional
-%%                 intensity => non_neg_integer(), % optional
-%%                 period => pos_integer()}        % optional
-%% child_spec() = #{id => child_id(),       % mandatory
-%%                  start => mfargs(),      % mandatory
-%%                  restart => restart(),   % optional
-%%                  shutdown => shutdown(), % optional
-%%                  type => worker(),       % optional
-%%                  modules => modules()}   % optional
-init([]) ->
+start_external_registry_sup() ->
+    supervisor:start_link({local, ?EXTERNAL_SUP}, ?MODULE, ?external).
+
+ensure_external_registry_worker_started(ChildSpec) ->
+    case supervisor:start_child(?EXTERNAL_SUP, ChildSpec) of
+        {ok, _} ->
+            ok;
+        {error, {already_started, _}} ->
+            ok
+    end.
+
+ensure_external_registry_worker_absent(WorkerId) ->
+    case supervisor:terminate_child(?EXTERNAL_SUP, WorkerId) of
+        ok ->
+            _ = supervisor:delete_child(?EXTERNAL_SUP, WorkerId),
+            ok;
+        {error, not_found} ->
+            ok
+    end.
+
+%%------------------------------------------------------------------------------
+%% `supervisor' API
+%%------------------------------------------------------------------------------
+
+init(?root) ->
     SupFlags = #{
         strategy => one_for_one,
         intensity => 10,
         period => 100
     },
-    ChildSpecs = [child_spec(emqx_schema_registry)],
-    {ok, {SupFlags, ChildSpecs}}.
+    ChildSpecs = [
+        worker_spec(emqx_schema_registry),
+        external_sup_spec()
+    ],
+    {ok, {SupFlags, ChildSpecs}};
+init(?external) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 5
+    },
+    Children = [
+        worker_spec(emqx_schema_registry_external)
+    ],
+    {ok, {SupFlags, Children}}.
 
-child_spec(Mod) ->
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+worker_spec(Mod) ->
     #{
         id => Mod,
         start => {Mod, start_link, []},
         restart => permanent,
         shutdown => 5_000,
         type => worker
+    }.
+
+external_sup_spec() ->
+    #{
+        id => ?EXTERNAL_SUP,
+        start => {?MODULE, start_external_registry_sup, []},
+        restart => permanent,
+        shutdown => infinity,
+        type => supervisor
     }.

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
@@ -787,11 +787,11 @@ t_import_config(_Config) ->
     Path = [schema_registry, schemas, <<"my_avro_schema">>],
     ?assertEqual(
         {ok, #{root_key => schema_registry, changed => []}},
-        emqx_schema_registry:import_config(RawConf)
+        emqx_schema_registry_config:import_config(RawConf)
     ),
     ?assertEqual(
         {ok, #{root_key => schema_registry, changed => [Path]}},
-        emqx_schema_registry:import_config(RawConf1)
+        emqx_schema_registry_config:import_config(RawConf1)
     ).
 
 sparkplug_example_data_base64() ->

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
@@ -753,6 +753,11 @@ t_cluster_serde_build(Config) ->
     ),
     ok.
 
+%% Verifies that importing in both `merge' and `replace' modes work with external registries
+%% t_external_registry_import_config(_Config) ->
+%%     ct:fail(todo),
+%%     ok.
+
 t_import_config(_Config) ->
     RawConf = #{
         <<"schema_registry">> =>

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -316,7 +316,7 @@ t_crud(Config) ->
         {ok, 400, #{
             <<"code">> := <<"BAD_REQUEST">>,
             <<"message">> :=
-                <<"{post_config_update,emqx_schema_registry,", _/binary>>
+                <<"{post_config_update,emqx_schema_registry_config,", _/binary>>
         }},
         request({put, SchemaName, UpdateParams#{<<"source">> := InvalidSourceBin}})
     ),
@@ -357,7 +357,7 @@ t_crud(Config) ->
         {ok, 400, #{
             <<"code">> := <<"BAD_REQUEST">>,
             <<"message">> :=
-                <<"{post_config_update,emqx_schema_registry,", _/binary>>
+                <<"{post_config_update,emqx_schema_registry_config,", _/binary>>
         }},
         request({post, Params#{<<"source">> := InvalidSourceBin}})
     ),

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -16,6 +16,12 @@
 -include("emqx_schema_registry.hrl").
 
 %%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-define(REDACTED, <<"******">>).
+
+%%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
 
@@ -40,7 +46,9 @@ groups() ->
 
 only_once_testcases() ->
     [
-        t_empty_sparkplug
+        t_empty_sparkplug,
+        t_external_registry_crud_confluent,
+        t_smoke_test_external_registry_confluent
     ].
 
 init_per_suite(Config) ->
@@ -124,11 +132,13 @@ end_per_group(_Group, _Config) ->
 
 init_per_testcase(_TestCase, Config) ->
     clear_schemas(),
+    clear_external_registries(),
     ok = snabbkaffe:start_trace(),
     Config.
 
 end_per_testcase(_TestCase, _Config) ->
     clear_schemas(),
+    clear_external_registries(),
     ok = snabbkaffe:stop(),
     emqx_common_test_helpers:call_janitor(),
     ok.
@@ -181,6 +191,14 @@ clear_schemas() ->
         emqx_schema_registry:list_schemas()
     ).
 
+clear_external_registries() ->
+    maps:foreach(
+        fun(Name, _Schema) ->
+            ok = emqx_schema_registry_config:delete_external_registry(Name)
+        end,
+        emqx_schema_registry_config:list_external_registries()
+    ).
+
 dryrun_rule(SQL, Context) ->
     Params = #{
         context => Context,
@@ -202,6 +220,139 @@ simplify_result(Res) ->
         {ok, Status, Body} ->
             {Status, Body}
     end.
+
+simple_request(Method, Path, Params) ->
+    emqx_mgmt_api_test_util:simple_request(Method, Path, Params).
+
+confluent_schema_registry_no_auth() ->
+    confluent_schema_registry_no_auth(_Overrides = #{}).
+
+confluent_schema_registry_no_auth(#{} = Overrides) ->
+    emqx_utils_maps:deep_merge(
+        #{
+            <<"type">> => <<"confluent">>,
+            <<"url">> => confluent_url_bin(without_auth),
+            <<"auth">> => <<"none">>
+        },
+        Overrides
+    ).
+
+confluent_schema_registry_with_basic_auth() ->
+    confluent_schema_registry_with_basic_auth(_Overrides = #{}).
+
+confluent_schema_registry_with_basic_auth(#{} = Overrides) ->
+    emqx_utils_maps:deep_merge(
+        #{
+            <<"type">> => <<"confluent">>,
+            <<"url">> => confluent_url_bin(with_auth),
+            <<"auth">> => confluent_schema_registry_basic_auth()
+        },
+        Overrides
+    ).
+
+confluent_schema_registry_basic_auth() ->
+    #{
+        <<"mechanism">> => <<"basic">>,
+        <<"username">> => <<"cpsruser">>,
+        <<"password">> => <<"mypass">>
+    }.
+
+list_external_registries() ->
+    Path = uri(["schema_registry_external"]),
+    simple_request(get, Path, _Params = []).
+
+get_external_registry(Name) ->
+    Path = uri(["schema_registry_external", "registry", Name]),
+    simple_request(get, Path, _Params = []).
+
+create_external_registry(Params) ->
+    Path = uri(["schema_registry_external"]),
+    simple_request(post, Path, Params).
+
+update_external_registry(Name, Params) ->
+    Path = uri(["schema_registry_external", "registry", Name]),
+    simple_request(put, Path, Params).
+
+delete_external_registry(Name) ->
+    Path = uri(["schema_registry_external", "registry", Name]),
+    simple_request(delete, Path, _Params = []).
+
+find_external_registry_worker(Name) ->
+    [
+        Pid
+     || {N, Pid, _, _} <- supervisor:which_children(emqx_schema_registry_external_sup),
+        emqx_utils_conv:bin(N) =:= Name
+    ].
+
+confluent_url_bin(WithOrWithoutAuth) ->
+    list_to_binary(confluent_url_string(WithOrWithoutAuth)).
+
+confluent_url_string(without_auth) ->
+    "http://confluent_schema_registry:8081";
+confluent_url_string(with_auth) ->
+    "http://confluent_schema_registry_basicauth:8081".
+
+start_confluent_client(WithOrWithoutAuth) ->
+    Cfg0 = #{url => confluent_url_string(WithOrWithoutAuth)},
+    Cfg = emqx_utils_maps:put_if(
+        Cfg0,
+        auth,
+        to_avlizer_auth(confluent_schema_registry_basic_auth()),
+        WithOrWithoutAuth =:= with_auth
+    ),
+    {ok, Server} = avlizer_confluent:start_link(_ServerRef = undefined, Cfg),
+    Table = avlizer_confluent:get_table(Server),
+    #{server => Server, table => Table}.
+
+to_avlizer_auth(#{<<"mechanism">> := <<"basic">>} = Auth0) ->
+    #{<<"username">> := Username, <<"password">> := Password} = Auth0,
+    {basic, emqx_utils_conv:str(Username), emqx_utils_conv:str(Password)}.
+
+register_schema_confluent(#{server := Server}, Subject, Schema) ->
+    {ok, Id} = avlizer_confluent:register_schema(Server, Subject, Schema),
+    Id.
+
+confluent_encode(Data, SchemaId, RegistryClient) ->
+    #{server := Server, table := Table} = RegistryClient,
+    Encoder = avlizer_confluent:make_encoder2(Server, Table, SchemaId),
+    avlizer_confluent:encode(Encoder, Data).
+
+confluent_encode_and_tag(Data, SchemaId, RegistryClient) ->
+    avlizer_confluent:tag_data(SchemaId, confluent_encode(Data, SchemaId, RegistryClient)).
+
+confluent_decode_untagged(Data, SchemaId, RegistryClient) ->
+    #{server := Server, table := Table} = RegistryClient,
+    Decoder = avlizer_confluent:make_decoder2(Server, Table, SchemaId),
+    avlizer_confluent:decode(Decoder, Data).
+
+avro_schema2() ->
+    avro_record:type(
+        <<"myrecord">>,
+        [avro_record:define_field(f1, avro_map:type(avro_primitive:int_type()))],
+        [{namespace, 'com.example'}]
+    ).
+
+sql(Template, Context) ->
+    Parsed = emqx_template:parse(Template),
+    iolist_to_binary(emqx_template:render_strict(Parsed, Context)).
+
+publish_context({json, Data}) ->
+    publish_context1(emqx_utils_json:encode(Data));
+publish_context({hex, Data}) ->
+    publish_context1(bin2hex(Data)).
+
+publish_context1(Payload) ->
+    #{
+        <<"clientid">> => <<"c_emqx">>,
+        <<"event_type">> => <<"message_publish">>,
+        <<"payload">> => Payload,
+        <<"qos">> => 1,
+        <<"topic">> => <<"t">>,
+        <<"username">> => <<"u_emqx">>
+    }.
+
+bin2hex(Bin) ->
+    emqx_rule_funcs:bin2hexstr(Bin).
 
 %%------------------------------------------------------------------------------
 %% Testcases
@@ -436,4 +587,158 @@ t_name_too_long(Config) ->
         }},
         request({get, SchemaName})
     ),
+    ok.
+
+%% Checks basic CRUD operations for dealing with external confluent registry.
+t_external_registry_crud_confluent(_Config) ->
+    Name1 = <<"my_reg1">>,
+    Params1 = confluent_schema_registry_no_auth(),
+    NamedParams1 = Params1#{<<"name">> => Name1},
+
+    ?assertEqual({200, #{}}, list_external_registries()),
+    ?assertMatch({404, _}, get_external_registry(Name1)),
+    ?assertMatch({404, _}, update_external_registry(Name1, Params1)),
+    ?assertMatch({204, _}, delete_external_registry(Name1)),
+
+    ?assertMatch({201, _}, create_external_registry(NamedParams1)),
+    ?assertEqual({200, Params1}, get_external_registry(Name1)),
+    ?assertMatch({200, #{Name1 := Params1}}, list_external_registries()),
+    ?assertMatch([_], find_external_registry_worker(Name1)),
+
+    Params2 = confluent_schema_registry_with_basic_auth(),
+    Expected2 = emqx_utils_maps:deep_put([<<"auth">>, <<"password">>], Params2, ?REDACTED),
+    ?assertMatch({200, Expected2}, update_external_registry(Name1, Params2)),
+    ?assertMatch({200, Expected2}, get_external_registry(Name1)),
+    ?assertMatch({200, #{Name1 := Expected2}}, list_external_registries()),
+    ?assertMatch([_], find_external_registry_worker(Name1)),
+
+    Name2 = <<"my_reg2">>,
+    Params3 = confluent_schema_registry_no_auth(),
+    NamedParams3 = Params3#{<<"name">> => Name2},
+    ?assertMatch({404, _}, get_external_registry(Name2)),
+    ?assertMatch({404, _}, update_external_registry(Name2, Params3)),
+    ?assertMatch({204, _}, delete_external_registry(Name2)),
+    ?assertMatch([], find_external_registry_worker(Name2)),
+
+    ?assertMatch({201, _}, create_external_registry(NamedParams3)),
+    ?assertMatch({200, Params3}, get_external_registry(Name2)),
+    ?assertMatch({200, #{Name1 := Expected2, Name2 := Params3}}, list_external_registries()),
+    ?assertMatch([_], find_external_registry_worker(Name1)),
+    ?assertMatch([_], find_external_registry_worker(Name2)),
+
+    ?assertMatch({204, _}, delete_external_registry(Name1)),
+    ?assertMatch({404, _}, get_external_registry(Name1)),
+    ?assertMatch({404, _}, update_external_registry(Name1, Params1)),
+    ?assertMatch({204, _}, delete_external_registry(Name1)),
+    ?assertMatch({200, #{Name2 := Params3}}, list_external_registries()),
+    ?assertMatch([], find_external_registry_worker(Name1)),
+    ?assertMatch([_], find_external_registry_worker(Name2)),
+
+    %% Bad params
+    BadParams = #{},
+    ?assertMatch({400, _}, create_external_registry(BadParams)),
+    ?assertMatch({400, _}, update_external_registry(Name2, BadParams)),
+
+    ok.
+
+%% Happy path tests when using external registry (confluent).
+t_smoke_test_external_registry_confluent(_Config) ->
+    Name1 = <<"my_reg1">>,
+    Params1 = confluent_schema_registry_with_basic_auth(),
+    NamedParams1 = Params1#{<<"name">> => Name1},
+    {201, _} = create_external_registry(NamedParams1),
+
+    RegistryClient = start_confluent_client(with_auth),
+    Subject = atom_to_list(?FUNCTION_NAME),
+    SchemaId = register_schema_confluent(RegistryClient, Subject, avro_schema2()),
+
+    %% encode: fetch schema on the fly using id; good data
+    SQL1 = sql(
+        <<
+            "select bin2hexstr(avro_encode('${.name}', json_decode(payload), ${.schema_id})) as encoded"
+            " from \"t\" "
+        >>,
+        #{name => Name1, schema_id => SchemaId}
+    ),
+    Data1 = #{<<"f1">> => #{<<"bah">> => 123}},
+    Context1 = publish_context({json, Data1}),
+    Expected1 = bin2hex(confluent_encode(Data1, SchemaId, RegistryClient)),
+    ?assertMatch(
+        {200, #{<<"encoded">> := Expected1}},
+        dryrun_rule(SQL1, Context1),
+        #{expected => Expected1}
+    ),
+
+    %% decode: fetch schema on the fly using id; good data
+    SQL2 = sql(
+        <<
+            "select avro_decode('${.name}', hexstr2bin(payload), ${.schema_id}) as decoded"
+            " from \"t\" "
+        >>,
+        #{name => Name1, schema_id => SchemaId}
+    ),
+    Encoded2 = confluent_encode(Data1, SchemaId, RegistryClient),
+    Context2 = publish_context({hex, Encoded2}),
+    Expected2 = Data1,
+    ?assertMatch(
+        {200, #{<<"decoded">> := Expected2}},
+        dryrun_rule(SQL2, Context2),
+        #{expected => Expected2}
+    ),
+
+    %% encode and tag using a schema registered in emqx
+    SchemaName3 = <<"my_schema">>,
+    Params3 = #{
+        <<"type">> => <<"avro">>,
+        <<"source">> => emqx_utils_json:encode(#{
+            <<"type">> => <<"record">>,
+            <<"name">> => <<"apitest">>,
+            <<"fields">> => [
+                #{<<"name">> => <<"i">>, <<"type">> => <<"int">>},
+                #{<<"name">> => <<"s">>, <<"type">> => <<"string">>}
+            ]
+        }),
+        <<"name">> => SchemaName3,
+        <<"description">> => <<"My schema">>
+    },
+    {ok, 201, _} = request({post, Params3}),
+
+    Subject3 = <<"subj3">>,
+    SQL3 = sql(
+        <<
+            "select bin2hexstr(schema_encode_and_tag("
+            "    '${.schema}', '${.registry}', json_decode(payload), '${.subject}')) as encoded"
+            " from \"t\" "
+        >>,
+        #{schema => SchemaName3, registry => Name1, subject => Subject3}
+    ),
+    Data3 = #{<<"i">> => 10, <<"s">> => <<"abc">>},
+    Context3 = publish_context({json, Data3}),
+    Expected3 = bin2hex(iolist_to_binary(emqx_schema_registry_serde:encode(SchemaName3, Data3))),
+    %% 40 bits => 5 * 2 hex digits
+    MagicTagHexSize = 10,
+    ?assertMatch(
+        {200, #{<<"encoded">> := <<_Tag3:MagicTagHexSize/binary, Expected3/binary>>}},
+        dryrun_rule(SQL3, Context3),
+        #{expected => Expected3}
+    ),
+
+    %% decode tagged data on the fly
+    SQL4 = sql(
+        <<
+            "select schema_decode_tagged("
+            "    '${.registry}', hexstr2bin(payload)) as decoded"
+            " from \"t\" "
+        >>,
+        #{registry => Name1}
+    ),
+    Encoded4 = confluent_encode_and_tag(Data1, SchemaId, RegistryClient),
+    Context4 = publish_context({hex, Encoded4}),
+    Expected4 = Data1,
+    ?assertMatch(
+        {200, #{<<"decoded">> := Expected4}},
+        dryrun_rule(SQL4, Context4),
+        #{expected => Expected4}
+    ),
+
     ok.

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_serde_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_serde_SUITE.erl
@@ -42,12 +42,15 @@ end_per_suite(Config) ->
     Apps = ?config(apps, Config),
     emqx_cth_suite:stop(Apps),
     ok.
+
 init_per_testcase(_TestCase, Config) ->
     Config.
 
 end_per_testcase(_TestCase, _Config) ->
     emqx_common_test_helpers:call_janitor(),
+    snabbkaffe:start_trace(),
     clear_schemas(),
+    snabbkaffe:stop(),
     ok.
 
 %%------------------------------------------------------------------------------

--- a/changes/ee/feat-13804.en.md
+++ b/changes/ee/feat-13804.en.md
@@ -1,0 +1,1 @@
+Added support for using Confluent Schema Registry as an external provider in our Schema Registry.

--- a/mix.exs
+++ b/mix.exs
@@ -159,6 +159,8 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:ra),
       {:mimerl, "1.2.0", override: true},
       common_dep(:sasl_auth),
+      # avlizer currently uses older :erlavro version
+      common_dep(:erlavro),
       common_dep(:crc32cer)
     ]
   end
@@ -285,7 +287,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:snappyer), do: {:snappyer, "1.2.9", override: true}
   def common_dep(:crc32cer), do: {:crc32cer, "0.1.8", override: true}
   def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.0.1"}
-  def common_dep(:erlavro), do: {:erlavro, github: "emqx/erlavro", tag: "2.10.0"}
+  def common_dep(:erlavro), do: {:erlavro, github: "emqx/erlavro", tag: "2.10.0", override: true}
 
   ###############################################################################################
   # BEGIN DEPRECATED FOR MIX BLOCK

--- a/rel/i18n/emqx_schema_registry_http_api.hocon
+++ b/rel/i18n/emqx_schema_registry_http_api.hocon
@@ -6,6 +6,9 @@ desc_param_path_schema_name.desc:
 desc_param_path_schema_name.label:
 """Schema name"""
 
+param_path_external_registry_name.desc:
+"""External registry name"""
+
 desc_schema_registry_api_delete.desc:
 """Delete a schema"""
 
@@ -35,5 +38,20 @@ desc_schema_registry_api_put.desc:
 
 desc_schema_registry_api_put.label:
 """Update schema"""
+
+external_registry_list.desc:
+"""List external schema registries"""
+
+external_registry_delete.desc:
+"""Delete external schema registry"""
+
+external_registry_lookup.desc:
+"""Lookup external schema registry"""
+
+external_registry_create.desc:
+"""Create external schema registry"""
+
+external_registry_update.desc:
+"""Update external schema registry"""
 
 }

--- a/rel/i18n/emqx_schema_registry_schema.hocon
+++ b/rel/i18n/emqx_schema_registry_schema.hocon
@@ -68,4 +68,39 @@ schema_type_json.desc:
 schema_type_json.label:
 """JSON Schema"""
 
+confluent_schema_registry.label:
+"""Confluent Schema Registry"""
+confluent_schema_registry.desc:
+"""Confluent External Schema Registry configuration."""
+
+schema_registry_external_type.label:
+"""External Schema Registry Type"""
+schema_registry_external_type.desc:
+"""External Schema Registry Type"""
+
+confluent_schema_registry_url.label:
+"""Registry URL"""
+confluent_schema_registry_url.desc:
+"""URL endpoint for external registry."""
+
+confluent_schema_registry_auth.label:
+"""Authentication"""
+confluent_schema_registry_auth.desc:
+"""Authentication options for accessing external registry."""
+
+confluent_schema_registry_auth_basic.label:
+"""Basic Auth"""
+confluent_schema_registry_auth_basic.desc:
+"""Use basic authentication method for accessing external registry."""
+
+confluent_schema_registry_auth_basic_username.label:
+"""Username"""
+confluent_schema_registry_auth_basic_username.desc:
+"""Username for basic authentication method."""
+
+confluent_schema_registry_auth_basic_password.label:
+"""Password"""
+confluent_schema_registry_auth_basic_password.desc:
+"""Password for basic authentication method."""
+
 }

--- a/scripts/ct/run.sh
+++ b/scripts/ct/run.sh
@@ -272,6 +272,9 @@ for dep in ${CT_DEPS}; do
                 SNOWFLAKE_ODBC_REQUEST='yes'
             fi
             ;;
+        schema-registry)
+          FILES+=( '.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml' )
+            ;;
         *)
             echo "unknown_ct_dependency $dep"
             exit 1


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12800

Release version: e5.8.1

## To do in follow ups

- Implement config import support for `schema_registry.external`. 

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
