### PR TITLE
feat(quic): conn scope keepalive

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2411,9 +2411,7 @@ ensure_keepalive_timer(
     Val =
         case maps:get(conn_shared_state, ConnInfo, undefined) of
             #{cnts_ref := CntRef} ->
-                fun() ->
-                    emqx_quic_connection:read_cnt(CntRef, control_packet)
-                end;
+                _MFA = {emqx_quic_connection, read_cnt, [CntRef, control_packet]};
             undefined ->
                 emqx_pd:get_counter(recv_pkt)
         end,

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -276,7 +276,8 @@ init(
         },
         Zone
     ),
-    {NClientInfo, NConnInfo} = take_conn_info_fields([ws_cookie, peersni], ClientInfo, ConnInfo),
+    {NClientInfo, NConnInfo0} = take_conn_info_fields([ws_cookie, peersni], ClientInfo, ConnInfo),
+    NConnInfo = maybe_quic_shared_state(NConnInfo0, Opts),
     #channel{
         conninfo = NConnInfo,
         clientinfo = NClientInfo,
@@ -294,6 +295,11 @@ init(
         resuming = false,
         pendings = []
     }.
+
+maybe_quic_shared_state(ConnInfo, #{conn_shared_state := QSS}) ->
+    ConnInfo#{conn_shared_state => QSS};
+maybe_quic_shared_state(ConnInfo, _) ->
+    ConnInfo.
 
 set_peercert_infos(NoSSL, ClientInfo, _) when
     NoSSL =:= nossl;
@@ -2374,17 +2380,44 @@ init_alias_maximum(_ConnPkt, _ClientInfo) ->
 
 %% MQTT 5
 ensure_keepalive(#{'Server-Keep-Alive' := Interval}, Channel = #channel{conninfo = ConnInfo}) ->
+    ensure_quic_conn_idle_timeout(Interval, Channel),
     ensure_keepalive_timer(Interval, Channel#channel{conninfo = ConnInfo#{keepalive => Interval}});
 %% MQTT 3,4
 ensure_keepalive(_AckProps, Channel = #channel{conninfo = ConnInfo}) ->
+    ensure_quic_conn_idle_timeout(maps:get(keepalive, ConnInfo), Channel),
     ensure_keepalive_timer(maps:get(keepalive, ConnInfo), Channel).
+
+ensure_quic_conn_idle_timeout(Timeout, #channel{
+    clientinfo = #{zone := Zone},
+    conninfo = #{socktype := quic, sock := Sock}
+}) ->
+    Conn = element(2, Sock),
+    #{keepalive_multiplier := Mul} =
+        emqx_config:get_zone_conf(Zone, [mqtt]),
+    %%% The original idle_timeout is from the listener, now we update it per connection
+    %%% Conn could be closed so we don't check the ret val
+    _ = quicer:setopt(Conn, settings, #{idle_timeout_ms => timer:seconds(Timeout * Mul)}, false),
+    ok;
+ensure_quic_conn_idle_timeout(_, _) ->
+    ok.
 
 ensure_keepalive_timer(0, Channel) ->
     Channel;
 ensure_keepalive_timer(disabled, Channel) ->
     Channel;
-ensure_keepalive_timer(Interval, Channel = #channel{clientinfo = #{zone := Zone}}) ->
-    Keepalive = emqx_keepalive:init(Zone, Interval),
+ensure_keepalive_timer(
+    Interval, Channel = #channel{clientinfo = #{zone := Zone}, conninfo = ConnInfo}
+) ->
+    Val =
+        case maps:get(conn_shared_state, ConnInfo, undefined) of
+            #{cnts_ref := CntRef} ->
+                fun() ->
+                    emqx_quic_connection:read_cnt(CntRef, control_packet)
+                end;
+            undefined ->
+                emqx_pd:get_counter(recv_pkt)
+        end,
+    Keepalive = emqx_keepalive:init(Zone, Val, Interval),
     ensure_timer(keepalive, Channel#channel{keepalive = Keepalive}).
 
 clear_keepalive(Channel = #channel{timers = Timers}) ->

--- a/apps/emqx/src/emqx_keepalive.erl
+++ b/apps/emqx/src/emqx_keepalive.erl
@@ -16,6 +16,8 @@
 
 -module(emqx_keepalive).
 
+-include("types.hrl").
+
 -export([
     init/1,
     init/2,
@@ -36,7 +38,7 @@
     %% the received packets since last keepalive check
     statval :: non_neg_integer(),
     %% stat reader func
-    stat_reader :: mfa() | undefined,
+    stat_reader :: mfargs() | undefined,
     %% The number of idle intervals allowed before disconnecting the client.
     idle_milliseconds = 0 :: non_neg_integer(),
     max_idle_millisecond :: pos_integer()

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1768,12 +1768,13 @@ format_channel_info(WhichNode, {_, ClientInfo0, ClientStats}, Opts) ->
     Node = maps:get(node, ClientInfo0, WhichNode),
     ClientInfo1 = emqx_utils_maps:deep_remove([conninfo, clientid], ClientInfo0),
     ClientInfo2 = emqx_utils_maps:deep_remove([conninfo, username], ClientInfo1),
+    ClientInfo3 = emqx_utils_maps:deep_remove([conninfo, sock], ClientInfo2),
     StatsMap = maps:without(
         [memory, next_pkt_id, total_heap_size],
         maps:from_list(ClientStats)
     ),
-    ClientInfo3 = maps:remove(will_msg, ClientInfo2),
-    ClientInfoMap0 = maps:fold(fun take_maps_from_inner/3, #{}, ClientInfo3),
+    ClientInfo4 = maps:remove(will_msg, ClientInfo3),
+    ClientInfoMap0 = maps:fold(fun take_maps_from_inner/3, #{}, ClientInfo4),
     {IpAddress, Port} = peername_dispart(maps:get(peername, ClientInfoMap0)),
     Connected = maps:get(conn_state, ClientInfoMap0) =:= connected,
     ClientInfoMap1 = maps:merge(StatsMap, ClientInfoMap0),

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1102,7 +1102,7 @@ t_keepalive(Config) ->
     [Pid] = emqx_cm:lookup_channels(list_to_binary(ClientId)),
     %% will reset to max keepalive if keepalive > max keepalive
     #{conninfo := #{keepalive := InitKeepalive}} = emqx_connection:info(Pid),
-    ?assertMatch({keepalive, _, _, _, 65536500}, element(5, element(9, sys:get_state(Pid)))),
+    ?assertMatch({keepalive, _, _, _, _, 65536500}, element(5, element(9, sys:get_state(Pid)))),
 
     ?assertMatch(
         {ok, {?HTTP200, _, #{<<"keepalive">> := 11}}},

--- a/changes/ce/feat-13814.en.md
+++ b/changes/ce/feat-13814.en.md
@@ -1,0 +1,6 @@
+Connection Scope Keepalive for MQTT over QUIC Multi-Stream:
+
+Introduced a new feature to keep MQTT connections alive when data streams are active but contrl stream is quiet.
+Previously, clients were required to send MQTT.PINGREQ on idle control streams to keep the connection alive.
+A shared state is now maintained for each connection, tracking activity from all streams.
+This shared state is used to determine if the connection is still alive, reducing the risk of keepalive timeouts due to Head-of-Line (HOL) blocking.


### PR DESCRIPTION
Fixes [EMQX-13134](https://emqx.atlassian.net/browse/EMQX-13134)
Intro a new feature for MQTT over QUIC multi-stream, called connection scope keepalive
We used to require the client to send MQTT.PINGREQ on idle control stream to keep the connection alive even when the data stream is active, this PR intro a conn shared state which has counters could be bumped by all the streams in the same connection, so the keepalive  could read this shared counters to judge if conn is still alive. 
This hopefully could further mitigate the keepalive timeout due to HOL blocking.

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13134]: https://emqx.atlassian.net/browse/EMQX-13134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ