### PR TITLE
refactor: add is_exist API for resource existence check

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -40,6 +40,7 @@
     unload/0,
     lookup/1,
     lookup/2,
+    is_exist_v1/2,
     get_metrics/2,
     create/3,
     disable_enable/3,
@@ -326,6 +327,9 @@ list() ->
 lookup(Id) ->
     {Type, Name} = emqx_bridge_resource:parse_bridge_id(Id),
     lookup(Type, Name).
+
+is_exist_v1(Type, Name) ->
+    emqx_resource:is_exist(emqx_bridge_resource:resource_id(Type, Name)).
 
 lookup(Type, Name) ->
     case emqx_bridge_v2:is_bridge_v2_type(Type) of

--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -44,6 +44,8 @@
     list/1,
     lookup/2,
     lookup/3,
+    lookup_raw_conf/3,
+    is_exist/3,
     create/3,
     create/4,
     %% The remove/2 function is only for internal use as it may create
@@ -239,6 +241,17 @@ lookup_action(Type, Name) ->
 
 lookup_source(Type, Name) ->
     lookup(?ROOT_KEY_SOURCES, Type, Name).
+
+is_exist(ConfRootName, Type, Name) ->
+    {error, not_found} =/= lookup_raw_conf(ConfRootName, Type, Name).
+
+lookup_raw_conf(ConfRootName, Type, Name) ->
+    case emqx:get_raw_config([ConfRootName, Type, Name], not_found) of
+        not_found ->
+            {error, not_found};
+        #{<<"connector">> := _} = RawConf ->
+            {ok, RawConf}
+    end.
 
 -spec lookup(root_cfg_key(), bridge_v2_type(), bridge_v2_name()) ->
     {ok, bridge_v2_info()} | {error, not_found}.

--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -58,7 +58,7 @@
     check_deps_and_remove/3,
     check_deps_and_remove/4
 ]).
--export([lookup_action/2, lookup_source/2]).
+-export([is_action_exist/2, is_source_exist/2]).
 
 %% Operations
 
@@ -236,11 +236,11 @@ unload_bridges(ConfRooKey) ->
 lookup(Type, Name) ->
     lookup(?ROOT_KEY_ACTIONS, Type, Name).
 
-lookup_action(Type, Name) ->
-    lookup(?ROOT_KEY_ACTIONS, Type, Name).
+is_action_exist(Type, Name) ->
+    is_exist(?ROOT_KEY_ACTIONS, Type, Name).
 
-lookup_source(Type, Name) ->
-    lookup(?ROOT_KEY_SOURCES, Type, Name).
+is_source_exist(Type, Name) ->
+    is_exist(?ROOT_KEY_SOURCES, Type, Name).
 
 is_exist(ConfRootName, Type, Name) ->
     {error, not_found} =/= lookup_raw_conf(ConfRootName, Type, Name).

--- a/apps/emqx_connector/src/emqx_connector.erl
+++ b/apps/emqx_connector/src/emqx_connector.erl
@@ -32,6 +32,7 @@
     get_metrics/2,
     list/0,
     load/0,
+    is_exist/2,
     lookup/1,
     lookup/2,
     remove/2,
@@ -234,6 +235,9 @@ lookup(Type, Name, RawConf) ->
                 raw_config => RawConf
             }}
     end.
+
+is_exist(Type, Name) ->
+    emqx_resource:is_exist(emqx_connector_resource:resource_id(Type, Name)).
 
 get_metrics(Type, Name) ->
     emqx_resource:get_metrics(emqx_connector_resource:resource_id(Type, Name)).

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -123,6 +123,7 @@
     list_instances_verbose/0,
     %% return the data of the instance
     get_instance/1,
+    is_exist/1,
     get_metrics/1,
     fetch_creation_opts/1,
     %% return all the instances of the same resource type
@@ -456,6 +457,10 @@ set_resource_status_connecting(ResId) ->
     {ok, resource_group(), resource_data()} | {error, Reason :: term()}.
 get_instance(ResId) ->
     emqx_resource_manager:lookup_cached(ResId).
+
+-spec is_exist(resource_id()) -> boolean().
+is_exist(ResId) ->
+    emqx_resource_manager:is_exist(ResId).
 
 -spec get_metrics(resource_id()) ->
     emqx_metrics_worker:metrics().

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -47,6 +47,7 @@
     list_all/0,
     list_group/1,
     lookup_cached/1,
+    is_exist/1,
     get_metrics/1,
     reset_metrics/1,
     channel_status_is_channel_added/1,
@@ -386,6 +387,10 @@ lookup_cached(ResId) ->
         error:badarg ->
             {error, not_found}
     end.
+
+%% @doc Check if the resource is cached.
+is_exist(ResId) ->
+    {error, not_found} =/= lookup_cached(ResId).
 
 %% @doc Get the metrics for the specified resource
 get_metrics(ResId) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1251,8 +1251,7 @@ continue_resource_health_check_not_connected(NewStatus, Data0) ->
 
 handle_manual_channel_health_check(From, #data{state = undefined}, _ChannelId) ->
     {keep_state_and_data, [
-        {reply, From,
-            maps:remove(config, channel_status({error, resource_disconnected}, undefined))}
+        {reply, From, channel_error_status(resource_disconnected)}
     ]};
 handle_manual_channel_health_check(
     From,
@@ -1286,14 +1285,14 @@ handle_manual_channel_health_check(
     is_map_key(ChannelId, Channels)
 ->
     %% No ongoing health check: reply with current status.
-    {keep_state_and_data, [{reply, From, maps:remove(config, maps:get(ChannelId, Channels))}]};
+    {keep_state_and_data, [{reply, From, without_channel_config(maps:get(ChannelId, Channels))}]};
 handle_manual_channel_health_check(
     From,
     _Data,
     _ChannelId
 ) ->
     {keep_state_and_data, [
-        {reply, From, maps:remove(config, channel_status({error, channel_not_found}, undefined))}
+        {reply, From, channel_error_status(channel_not_found)}
     ]}.
 
 -spec channels_health_check(resource_status(), data()) -> data().
@@ -1600,7 +1599,7 @@ handle_channel_health_check_worker_down_new_channels_and_status(
 reply_pending_channel_health_check_callers(
     ChannelId, Status0, Data0 = #data{hc_pending_callers = Pending0}
 ) ->
-    Status = maps:remove(config, Status0),
+    Status = without_channel_config(Status0),
     #{channel := CPending0} = Pending0,
     Pending = maps:get(ChannelId, CPending0, []),
     Actions = [{reply, From, Status} || From <- Pending],
@@ -1683,7 +1682,7 @@ maybe_alarm(_Status, false, ResId, Error, _PrevError) ->
             {error, Reason} ->
                 emqx_utils:readable_error_msg(Reason);
             _ ->
-                Error1 = redact_config_from_error_status(Error),
+                Error1 = without_channel_config(Error),
                 emqx_utils:readable_error_msg(Error1)
         end,
     emqx_alarm:safe_activate(
@@ -1693,10 +1692,8 @@ maybe_alarm(_Status, false, ResId, Error, _PrevError) ->
     ),
     ?tp(resource_activate_alarm, #{resource_id => ResId}).
 
-redact_config_from_error_status(#{config := _} = ErrorStatus) ->
-    maps:remove(config, ErrorStatus);
-redact_config_from_error_status(Error) ->
-    Error.
+without_channel_config(Map) ->
+    maps:without([config], Map).
 
 -spec maybe_resume_resource_workers(resource_id(), resource_status()) -> ok.
 maybe_resume_resource_workers(ResId, ?status_connected) ->
@@ -1749,7 +1746,7 @@ maybe_reply(Actions, From, Reply) ->
 data_record_to_external_map(Data) ->
     AddedChannelsWithoutConfigs =
         maps:map(
-            fun(_ChanID, Status) -> maps:remove(config, Status) end,
+            fun(_ChanID, Status) -> without_channel_config(Status) end,
             Data#data.added_channels
         ),
     #{
@@ -1856,10 +1853,13 @@ channel_status({?status_connected, Error}, ChannelConfig) ->
         config => ChannelConfig
     };
 channel_status({error, Reason}, ChannelConfig) ->
+    S = channel_error_status(Reason),
+    S#{config => ChannelConfig}.
+
+channel_error_status(Reason) ->
     #{
         status => ?status_disconnected,
-        error => Reason,
-        config => ChannelConfig
+        error => Reason
     }.
 
 channel_status_is_channel_added(#{

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -667,17 +667,14 @@ validate_bridge_existence_in_actions(#{actions := Actions, from := Froms} = _Rul
     NonExistentBridgeIDs =
         lists:filter(
             fun({Kind, Type, Name}) ->
-                LookupFn =
+                IsExist =
                     case Kind of
-                        action -> fun emqx_bridge_v2:lookup_action/2;
-                        source -> fun emqx_bridge_v2:lookup_source/2;
-                        bridge_v1 -> fun emqx_bridge:lookup/2
+                        action -> fun emqx_bridge_v2:is_action_exist/2;
+                        source -> fun emqx_bridge_v2:is_source_exist/2;
+                        bridge_v1 -> fun emqx_bridge:is_exist_v1/2
                     end,
                 try
-                    case LookupFn(Type, Name) of
-                        {ok, _} -> false;
-                        {error, _} -> true
-                    end
+                    not IsExist(Type, Name)
                 catch
                     _:_ -> true
                 end


### PR DESCRIPTION
Only a internal refactoring, no interface changes.

This is to prepare for another refactoring which can help to reduce the number of ets copies unless absolutely necessary.