### PR TITLE
docs(snowflake): minor fix

### DIFF
--- a/apps/emqx_bridge_snowflake/docs/user-guide.md
+++ b/apps/emqx_bridge_snowflake/docs/user-guide.md
@@ -56,7 +56,7 @@ openssl rsa -in snowflake_rsa_key.private.pem -pubout -out snowflake_rsa_key.pub
 ```
 
 ### Snowflake SQL Worksheet (+ Create --> SQL Worksheet)
-    
+
 ```sql
 USE ROLE accountadmin;
 
@@ -70,7 +70,7 @@ CREATE OR REPLACE TABLE testdatabase.public.emqx (
 );
 
 CREATE STAGE IF NOT EXISTS testdatabase.public.emqx
-FILE_FORMAT = (TYPE = CSV PARSE_HEADER = TRUE)
+FILE_FORMAT = (TYPE = CSV PARSE_HEADER = TRUE FIELD_OPTIONALLY_ENCLOSED_BY = '"')
 COPY_OPTIONS = (ON_ERROR = CONTINUE PURGE = TRUE);
 
 CREATE PIPE IF NOT EXISTS testdatabase.public.emqx AS


### PR DESCRIPTION
Since the payload column type is `string` and snowflake doesn't handle double quote escaping correctly by default, we need to tell it to consider escaped CSV columns.

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
