### PR TITLE
fix(broker): Fix ownership of subopt table

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -25,7 +25,7 @@
 -include("types.hrl").
 -include("emqx_mqtt.hrl").
 
--export([start_link/2]).
+-export([start_link/2, create_tabs/0]).
 
 %% PubSub
 -export([
@@ -104,7 +104,6 @@
 
 -spec start_link(atom(), pos_integer()) -> startlink_ret().
 start_link(Pool, Id) ->
-    ok = create_tabs(),
     gen_server:start_link(
         {local, emqx_utils:proc_name(?BROKER, Id)},
         ?MODULE,

--- a/apps/emqx/src/emqx_broker_sup.erl
+++ b/apps/emqx/src/emqx_broker_sup.erl
@@ -32,8 +32,9 @@ start_link() ->
 
 init([]) ->
     %% Broker pool
+    ok = emqx_broker:create_tabs(),
     PoolSize = emqx:get_config([node, broker_pool_size], emqx_vm:schedulers() * 2),
-    BrokerPool = emqx_pool_sup:spec(broker_pool_sup, [
+    BrokerPool = emqx_pool_sup:spec(broker_pool_sup, permanent, [
         broker_pool,
         hash,
         PoolSize,

--- a/apps/emqx/src/emqx_pool_sup.erl
+++ b/apps/emqx/src/emqx_pool_sup.erl
@@ -20,7 +20,7 @@
 
 -include("types.hrl").
 
--export([spec/1, spec/2]).
+-export([spec/1, spec/2, spec/3]).
 
 -export([
     start_link/0,
@@ -39,10 +39,14 @@ spec(Args) ->
 
 -spec spec(any(), list()) -> supervisor:child_spec().
 spec(ChildId, Args) ->
+    spec(ChildId, transient, Args).
+
+-spec spec(any(), transient | permanent | temporary, list()) -> supervisor:child_spec().
+spec(ChildId, Restart, Args) ->
     #{
         id => ChildId,
         start => {?MODULE, start_link, Args},
-        restart => transient,
+        restart => Restart,
         shutdown => infinity,
         type => supervisor,
         modules => [?MODULE]


### PR DESCRIPTION
Fixes [EMQX-13127](https://emqx.atlassian.net/browse/EMQX-13127)

Release version: v/e5.8.1

## Summary

Fix ownership of the emqx_broker's runtime tables. Fix restart strategy for `emqx_broker`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13127]: https://emqx.atlassian.net/browse/EMQX-13127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ