### PR TITLE
perf: optimize resource status/state/error cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -332,6 +332,10 @@ fmt: $(REBAR)
 	@$(SCRIPTS)/erlfmt -w 'bin/nodetool'
 	@mix format
 
+.PHONY: fmt-diff
+fmt-diff:
+	@env ERLFMT_WRITE=true ./scripts/git-hook-pre-commit.sh
+
 .PHONY: clean-test-cluster-config
 clean-test-cluster-config:
 	@rm -f apps/emqx_conf/data/configs/cluster.hocon || true

--- a/apps/emqx_bridge/src/emqx_bridge_resource.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_resource.erl
@@ -282,7 +282,7 @@ create_dry_run(Type0, Conf0) ->
     end.
 
 create_dry_run_bridge_v1(Type, Conf0) ->
-    TmpName = iolist_to_binary([?TEST_ID_PREFIX, emqx_utils:gen_id(8)]),
+    TmpName = ?PROBE_ID_NEW(),
     TmpPath = emqx_utils:safe_filename(TmpName),
     %% Already type checked, no need to catch errors
     TypeBin = bin(Type),

--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -781,7 +781,7 @@ create_dry_run(ConfRootKey, Type, Conf0) ->
     end.
 
 create_dry_run_helper(ConfRootKey, BridgeV2Type, ConnectorRawConf, BridgeV2RawConf) ->
-    BridgeName = iolist_to_binary([?TEST_ID_PREFIX, emqx_utils:gen_id(8)]),
+    BridgeName = ?PROBE_ID_NEW(),
     ConnectorType = connector_type(BridgeV2Type),
     OnReadyCallback =
         fun(ConnectorId) ->
@@ -1708,7 +1708,7 @@ get_conf_root_key(_NoMatch) ->
 
 bridge_v1_create_dry_run(BridgeType, RawConfig0) ->
     RawConf = maps:without([<<"name">>], RawConfig0),
-    TmpName = iolist_to_binary([?TEST_ID_PREFIX, emqx_utils:gen_id(8)]),
+    TmpName = ?PROBE_ID_NEW(),
     PreviousRawConf = undefined,
     try
         #{

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -532,11 +532,11 @@ do_send_msg(sync, KafkaTopic, KafkaMessage, Producers, SyncTimeout) ->
             {error, timeout}
     end;
 do_send_msg(async, KafkaTopic, KafkaMessage, Producers, AsyncReplyFn) ->
-    %% * Must be a batch because wolff:cast2 are batch APIs
+    %% * Must be a batch because wolff send and cast are batch APIs
     %% * Must be a single element batch because wolff books calls, but not batch sizes
     %%   for counters and gauges.
     Batch = [KafkaMessage],
-    {_Partition, Pid} = wolff:cast2(
+    {_Partition, Pid} = wolff:send2(
         Producers, KafkaTopic, Batch, {fun ?MODULE:on_kafka_ack/3, [AsyncReplyFn]}
     ),
     %% This Pid is returned, but not monitored by caller

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -234,14 +234,6 @@ t_rest_api(Config) ->
     },
     ok = kafka_bridge_rest_api_helper(Cfg).
 
-%% So that we can check if new atoms are created when they are not supposed to be created
-pre_create_atoms() ->
-    [
-        kafka_producer__probe_,
-        probedryrun,
-        kafka__probe_
-    ].
-
 http_get_bridges(UrlPath, Name0) ->
     Name = iolist_to_binary(Name0),
     {ok, _Code, BridgesData} = http_get(UrlPath),
@@ -307,7 +299,6 @@ kafka_bridge_rest_api_helper(Config) ->
         ?assertMatch([#{<<"type">> := <<"kafka">>}], http_get_bridges(BridgesParts, BridgeName)),
         %% Probe should work
         %% no extra atoms should be created when probing
-        %% See pre_create_atoms() above
         AtomsBefore = erlang:system_info(atom_count),
         {ok, 204, _} = http_post(BridgesProbeParts, CreateBody),
         AtomsAfter = erlang:system_info(atom_count),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -859,7 +859,7 @@ t_invalid_partition_count_metrics(Config) ->
             %% Simulate `invalid_partition_count'
             emqx_common_test_helpers:with_mock(
                 wolff,
-                cast2,
+                send2,
                 fun(_Producers, _Topic, _Msgs, _AckCallback) ->
                     throw(#{
                         cause => invalid_partition_count,

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -14,6 +14,8 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
+-ifndef(EMQX_RESOURCE_HRL).
+-define(EMQX_RESOURCE_HRL, true).
 %% bridge/connector/action status
 -define(status_connected, connected).
 -define(status_connecting, connecting).
@@ -71,9 +73,9 @@
     query_mode := query_mode(),
     config := resource_config(),
     error := term(),
-    state := resource_state(),
     status := resource_status(),
-    added_channels := term()
+    added_channels := term(),
+    state := resource_state()
 }.
 -type resource_group() :: binary().
 -type creation_opts() :: #{
@@ -168,3 +170,6 @@
 -define(TAG, "RESOURCE").
 
 -define(RESOURCE_ALLOCATION_TAB, emqx_resource_allocations).
+-define(RESOURCE_STATE_CACHE, emqx_resource_cache).
+
+-endif.

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -28,7 +28,7 @@
 -type resource_type() :: atom().
 -type resource_module() :: module().
 -type resource_id() :: binary().
--type channel_id() :: binary().
+-type channel_id() :: action_resource_id() | source_resource_id().
 -type raw_resource_config() :: binary() | raw_term_resource_config().
 -type raw_term_resource_config() :: #{binary() => term()} | [raw_term_resource_config()].
 -type resource_config() :: term().

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -175,6 +175,6 @@
 -define(TAG, "RESOURCE").
 
 -define(RESOURCE_ALLOCATION_TAB, emqx_resource_allocations).
--define(RESOURCE_STATE_CACHE, emqx_resource_cache).
+-define(RESOURCE_CACHE, emqx_resource_cache).
 
 -endif.

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -159,7 +159,12 @@
 
 %% Keep this test_id_prefix is match "^[A-Za-z0-9]+[A-Za-z0-9-_]*$".
 %% See `hocon_tconf`
--define(TEST_ID_PREFIX, "t_probe_").
+-define(PROBE_ID_PREFIX, "PROBE_").
+-define(PROBE_ID_RAND_BYTES, 8).
+-define(PROBE_ID_NEW(),
+    iolist_to_binary([?PROBE_ID_PREFIX, emqx_utils:rand_id(?PROBE_ID_RAND_BYTES)])
+).
+-define(PROBE_ID_MATCH(Suffix), <<?PROBE_ID_PREFIX, _:?PROBE_ID_RAND_BYTES/binary, Suffix/binary>>).
 -define(RES_METRICS, resource_metrics).
 -define(LOG_LEVEL(_L_),
     case _L_ of

--- a/apps/emqx_resource/include/emqx_resource_runtime.hrl
+++ b/apps/emqx_resource/include/emqx_resource_runtime.hrl
@@ -1,0 +1,47 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-ifndef(EMQX_RESOURCE_RUNTIME_HRL).
+-define(EMQX_RESOURCE_RUNTIME_HRL, true).
+
+-include("emqx_resource.hrl").
+
+-define(NO_CHANNEL, no_channel).
+
+%% status and error, cached in ets for each connector
+-type st_err() :: #{
+    status := resource_status(),
+    error := term()
+}.
+
+%% the relatively stable part to be cached in persistent_term for each connector
+-type stable() :: #{
+    mod := module(),
+    callback_mode := callback_mode(),
+    query_mode := query_mode(),
+    state := term()
+}.
+
+%% the rutime context to be used for each channel
+-record(rt, {
+    st_err :: st_err(),
+    stable :: stable(),
+    channel_status :: ?NO_CHANNEL | channel_status()
+}).
+
+-type runtime() :: #rt{}.
+
+-endif.

--- a/apps/emqx_resource/include/emqx_resource_runtime.hrl
+++ b/apps/emqx_resource/include/emqx_resource_runtime.hrl
@@ -28,7 +28,7 @@
 }.
 
 %% the relatively stable part to be cached in persistent_term for each connector
--type stable() :: #{
+-type cb() :: #{
     mod := module(),
     callback_mode := callback_mode(),
     query_mode := query_mode(),
@@ -38,7 +38,7 @@
 %% the rutime context to be used for each channel
 -record(rt, {
     st_err :: st_err(),
-    stable :: stable(),
+    cb :: cb(),
     channel_status :: ?NO_CHANNEL | channel_status()
 }).
 

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -799,11 +799,13 @@ validate_name(Name) ->
     ok.
 
 -spec is_dry_run(resource_id()) -> boolean().
-is_dry_run(ResId) ->
-    case string:find(ResId, ?TEST_ID_PREFIX) of
-        nomatch -> false;
-        TestIdStart -> string:equal(TestIdStart, ResId)
-    end.
+is_dry_run(?PROBE_ID_MATCH(_)) ->
+    %% A probe connector
+    true;
+is_dry_run(ID) ->
+    %% A probe action/source
+    RE = ":" ++ ?PROBE_ID_PREFIX ++ "[a-zA-Z0-9]{8}:",
+    match =:= re:run(ID, RE, [{capture, none}]).
 
 validate_name(<<>>, _Opts) ->
     invalid_data("Name cannot be empty string");

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -473,14 +473,16 @@ fetch_creation_opts(Opts) ->
 
 -spec list_instances() -> [resource_id()].
 list_instances() ->
-    [Id || #{id := Id} <- list_instances_verbose()].
+    emqx_resource_cache:all_ids().
 
 -spec list_instances_verbose() -> [_ResourceDataWithMetrics :: map()].
 list_instances_verbose() ->
-    [
-        Res#{metrics => get_metrics(ResId)}
-     || #{id := ResId} = Res <- emqx_resource_manager:list_all()
-    ].
+    lists:map(
+        fun(#{id := ResId} = Res) ->
+            Res#{metrics => get_metrics(ResId)}
+        end,
+        emqx_resource_manager:list_all()
+    ).
 
 -spec list_instances_by_type(module()) -> [resource_id()].
 list_instances_by_type(ResourceType) ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1212,7 +1212,7 @@ call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
             ?RESOURCE_ERROR(stopped, "resource stopped or disabled");
         {ok, #rt{st_err = #{status := ?status_connecting, error := unhealthy_target}}} ->
             {error, {unrecoverable_error, unhealthy_target}};
-        {ok, #rt{st_err = #{status := Status}, stable = Resource, channel_status = ChanSt}} ->
+        {ok, #rt{st_err = #{status := Status}, cb = Resource, channel_status = ChanSt}} ->
             IsAlwaysSend = is_always_send(QueryOpts, Resource),
             case Status =:= ?status_connected orelse IsAlwaysSend of
                 true ->

--- a/apps/emqx_resource/src/emqx_resource_cache.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache.erl
@@ -40,7 +40,7 @@
     extra = []
 }).
 
--type chan_key() :: {ConnectorId :: binary(), ChannelID :: binary()}.
+-type chan_key() :: {connector_resource_id(), channel_id()}.
 
 -record(channel, {
     id :: chan_key(),

--- a/apps/emqx_resource/src/emqx_resource_cache.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache.erl
@@ -1,0 +1,306 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_resource_cache).
+
+%% CRUD APIs
+-export([new/0, write/3, is_exist/1, read/1, safe_read/1, erase/1]).
+%% For Config management
+-export([all_ids/0, list_all/0, group_ids/1]).
+%% For health checks etc.
+-export([read_status/1, read_mod/1, read_manager_pid/1]).
+%% Hot-path
+-export([get_runtime/1]).
+
+-include("emqx_resource_runtime.hrl").
+-include_lib("stdlib/include/ms_transform.hrl").
+
+-record(connector, {
+    id :: binary(),
+    group :: binary(),
+    manager_pid :: pid(),
+    st_err :: st_err(),
+    config :: term(),
+    extra = []
+}).
+
+-type chan_key() :: {ConnectorId :: binary(), ChannelID :: binary()}.
+
+-record(channel, {
+    id :: chan_key(),
+    error :: term(),
+    status :: channel_status(),
+    extra = []
+}).
+
+-define(STATE_PT_KEY(ID), {?MODULE, ID}).
+
+new() ->
+    emqx_utils_ets:new(?RESOURCE_STATE_CACHE, [
+        ordered_set,
+        public,
+        {read_concurrency, true},
+        {keypos, 2}
+    ]).
+
+-spec write(pid(), binary(), resource_data()) -> ok.
+write(ManagerPid, Group, Data) ->
+    #{
+        id := ID,
+        mod := Mod,
+        callback_mode := CallbackMode,
+        query_mode := QueryMode,
+        config := Config,
+        error := Error,
+        state := State,
+        status := Status,
+        added_channels := AddedChannels
+    } = Data,
+    Connector = #connector{
+        id = ID,
+        group = Group,
+        manager_pid = ManagerPid,
+        st_err = #{
+            status => Status,
+            error => external_error(Error)
+        },
+        config = Config,
+        extra = []
+    },
+    Channels = lists:map(fun to_channel_record/1, maps:to_list(AddedChannels)),
+    Stable = #{
+        mod => Mod,
+        callback_mode => CallbackMode,
+        query_mode => QueryMode,
+        state => State
+    },
+    %% erase old channels (if any)
+    ok = erase_old_channels(ID, maps:keys(AddedChannels)),
+    %% put stable state in persistent_term
+    ok = put_state_pt(ID, Stable),
+    %% insert connector and channel states
+    true = ets:insert(?RESOURCE_STATE_CACHE, [Connector | Channels]),
+    ok.
+
+%% @doc Read cached pieces and return a externalized map.
+%% NOTE: Do not call this in hot-path.
+%% TODO: move `group' into `resource_data()'.
+-spec read(resource_id()) -> {resource_group(), resource_data()}.
+read(ID) ->
+    case safe_read(ID) of
+        [] ->
+            error({not_found, ID});
+        [{G, D}] ->
+            {G, D}
+    end.
+
+-spec safe_read(resource_id()) -> [{resource_group(), resource_data()}].
+safe_read(ID) ->
+    case ets:lookup(?RESOURCE_STATE_CACHE, ID) of
+        [] ->
+            [];
+        [#connector{group = G} = C] ->
+            Channels = find_channels(ID),
+            [{G, make_resource_data(ID, C, Channels)}]
+    end.
+
+-spec read_status(resource_id()) -> not_found | st_err().
+read_status(ID) ->
+    ets:lookup_element(?RESOURCE_STATE_CACHE, ID, #connector.st_err, not_found).
+
+-spec read_manager_pid(resource_id()) -> not_found | pid().
+read_manager_pid(ID) ->
+    ets:lookup_element(?RESOURCE_STATE_CACHE, ID, #connector.manager_pid, not_found).
+
+-spec read_mod(resource_id()) -> not_found | {ok, module()}.
+read_mod(ID) ->
+    case get_state_pt(ID) of
+        undefined ->
+            not_found;
+        #{mod := Mod} ->
+            {ok, Mod}
+    end.
+
+-spec erase(resource_id()) -> ok.
+erase(ID) ->
+    MS = ets:fun2ms(fun(#channel{id = {C, _}}) when C =:= ID -> true end),
+    _ = ets:select_delete(?RESOURCE_STATE_CACHE, MS),
+    _ = ets:delete(?RESOURCE_STATE_CACHE, ID),
+    _ = del_state_pt(?STATE_PT_KEY(ID)),
+    ok.
+
+erase_old_channels(ID, NewChanIds) ->
+    OldChanIds = maps:keys(find_channels(ID)),
+    DelChanIds = OldChanIds -- NewChanIds,
+    lists:foreach(fun erase_channel/1, DelChanIds).
+
+erase_channel(ChanId) ->
+    Key = split_channel_id(ChanId),
+    ets:delete(?RESOURCE_STATE_CACHE, Key).
+
+-spec list_all() -> [resource_data()].
+list_all() ->
+    IDs = all_ids(),
+    lists:foldr(
+        fun(ID, Acc) ->
+            case safe_read(ID) of
+                [] ->
+                    Acc;
+                [{_G, Data}] ->
+                    [Data | Acc]
+            end
+        end,
+        [],
+        IDs
+    ).
+
+group_ids(Group) ->
+    MS = ets:fun2ms(fun(#connector{id = ID, group = G}) when G =:= Group -> ID end),
+    ets:select(?RESOURCE_STATE_CACHE, MS).
+
+all_ids() ->
+    MS = ets:fun2ms(fun(#connector{id = ID}) -> ID end),
+    ets:select(?RESOURCE_STATE_CACHE, MS).
+
+%% @doc The most performance-critical call.
+%% NOTE: ID is the action ID, but not connector ID.
+-spec get_runtime(resource_id()) -> {ok, runtime()} | {error, not_found}.
+get_runtime(ID) ->
+    ChanKey = {ConnectorId, _ChanID} = split_channel_id(ID),
+    try
+        Stable = get_state_pt(ConnectorId),
+        ChannelStatus = get_channel_status(ChanKey),
+        StErr = ets:lookup_element(?RESOURCE_STATE_CACHE, ConnectorId, #connector.st_err),
+        {ok, #rt{
+            st_err = StErr,
+            stable = Stable,
+            channel_status = ChannelStatus
+        }}
+    catch
+        error:badarg ->
+            {error, not_found}
+    end.
+
+get_channel_status({_, ?NO_CHANNEL}) ->
+    ?NO_CHANNEL;
+get_channel_status(ChanKey) ->
+    ets:lookup_element(?RESOURCE_STATE_CACHE, ChanKey, #channel.status, ?NO_CHANNEL).
+
+get_state_pt(ID) ->
+    try
+        persistent_term:get(?STATE_PT_KEY(ID))
+    catch
+        error:badarg ->
+            undefined
+    end.
+
+to_channel_record({ID0, #{status := Status, error := Error}}) ->
+    ID = split_channel_id(ID0),
+    #channel{
+        id = ID,
+        status = Status,
+        error = Error,
+        extra = []
+    }.
+
+split_channel_id(Id) when is_binary(Id) ->
+    case binary:split(Id, <<":">>, [global]) of
+        [
+            ChannelGlobalType,
+            ChannelSubType,
+            ChannelName,
+            <<"connector">>,
+            ConnectorType,
+            ConnectorName
+        ] ->
+            ConnectorId = <<"connector:", ConnectorType/binary, ":", ConnectorName/binary>>,
+            ChannelId =
+                <<ChannelGlobalType/binary, ":", ChannelSubType/binary, ":", ChannelName/binary>>,
+            {ConnectorId, ChannelId};
+        _ ->
+            %% this is not a per-channel query, e.g. for authn/authz
+            {Id, ?NO_CHANNEL}
+    end.
+
+%% State can be quite bloated, caching it in ets means excessive large term copies,
+%% for each and every query so we keep it in persistent_term instead.
+%% Connector state is relatively static, so persistent_term update triggered GC is less of a concern
+%% comparing to other fields such as `status' and `error', which may change very often.
+put_state_pt(ID, State) ->
+    case get_state_pt(ID) of
+        S when S =:= State ->
+            %% identical
+            ok;
+        _ ->
+            _ = persistent_term:put(?STATE_PT_KEY(ID), State),
+            ok
+    end.
+
+del_state_pt(ID) ->
+    _ = persistent_term:erase(?STATE_PT_KEY(ID)),
+    ok.
+
+is_exist(ID) ->
+    ets:member(?RESOURCE_STATE_CACHE, ID).
+
+make_resource_data(ID, Connector, Channels) ->
+    #connector{
+        st_err = #{
+            error := Error,
+            status := Status
+        },
+        config = Config
+    } = Connector,
+    #{
+        mod := Mod,
+        callback_mode := CallbackMode,
+        query_mode := QueryMode,
+        state := State
+    } = get_state_pt(ID),
+
+    #{
+        id => ID,
+        mod => Mod,
+        callback_mode => CallbackMode,
+        query_mode => QueryMode,
+        error => Error,
+        status => Status,
+        config => Config,
+        added_channels => Channels,
+        state => State
+    }.
+
+find_channels(ConnectorID) ->
+    MS = ets:fun2ms(fun(#channel{id = {Cid, _}} = C) when Cid =:= ConnectorID -> C end),
+    List = ets:select(?RESOURCE_STATE_CACHE, MS),
+    lists:foldl(
+        fun(
+            #channel{
+                id = {ConnectorId, ChannelId},
+                status = Status,
+                error = Error
+            },
+            Acc
+        ) ->
+            Key = iolist_to_binary([ChannelId, ":", ConnectorId]),
+            Acc#{Key => #{status => Status, error => Error}}
+        end,
+        #{},
+        List
+    ).
+
+external_error({error, Reason}) -> Reason;
+external_error(Other) -> Other.

--- a/apps/emqx_resource/src/emqx_resource_cache_cleaner.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache_cleaner.erl
@@ -22,7 +22,6 @@
     handle_call/3,
     handle_cast/2,
     handle_info/2,
-    code_change/3,
     terminate/2
 ]).
 -export([add/2]).
@@ -63,9 +62,6 @@ handle_info(_Info, State) ->
 
 terminate(_Reason, _State) ->
     ok.
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 maybe_erase_cache(DownManager, ID) ->
     case emqx_resource_cache:read_manager_pid(ID) =:= DownManager of

--- a/apps/emqx_resource/src/emqx_resource_cache_cleaner.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache_cleaner.erl
@@ -1,0 +1,78 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_resource_cache_cleaner).
+
+-export([start_link/0]).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    code_change/3,
+    terminate/2
+]).
+-export([add/2]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+add(ID, Pid) ->
+    gen_server:call(?SERVER, {add, ID, Pid}, infinity).
+
+init(_) ->
+    process_flag(trap_exit, true),
+    {ok, #{pmon => emqx_pmon:new()}}.
+
+handle_call({add, ID, Pid}, _From, #{pmon := Pmon} = State) ->
+    NewPmon = emqx_pmon:monitor(Pid, ID, Pmon),
+    {reply, ok, State#{pmon => NewPmon}};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info({'DOWN', _MRef, process, Pid, _Reason}, #{pmon := Pmon} = State) ->
+    NewPmon =
+        case emqx_pmon:find(Pid, Pmon) of
+            {ok, ID} ->
+                maybe_erase_cache(Pid, ID),
+                emqx_pmon:erase(Pid, Pmon);
+            error ->
+                Pmon
+        end,
+    {noreply, State#{pmon => NewPmon}};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+maybe_erase_cache(DownManager, ID) ->
+    case emqx_resource_cache:read_manager_pid(ID) =:= DownManager of
+        true ->
+            emqx_resource_cache:erase(ID);
+        false ->
+            %% already erased, or already replaced by another manager due to quick
+            %% retart by supervisor
+            ok
+    end.

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -55,8 +55,7 @@
 ]).
 
 -export([
-    set_resource_status_connecting/1,
-    make_test_id/0
+    set_resource_status_connecting/1
 ]).
 
 % Server
@@ -231,7 +230,7 @@ create(ResId, Group, ResourceType, Config, Opts) ->
 -spec create_dry_run(resource_module(), resource_config()) ->
     ok | {error, Reason :: term()}.
 create_dry_run(ResourceType, Config) ->
-    ResId = make_test_id(),
+    ResId = ?PROBE_ID_NEW(),
     create_dry_run(ResId, ResourceType, Config).
 
 create_dry_run(ResId, ResourceType, Config) ->
@@ -1006,10 +1005,6 @@ terminate_health_check_workers(Data) ->
         end,
         Pending
     ).
-
-make_test_id() ->
-    RandId = iolist_to_binary(emqx_utils:gen_id(16)),
-    <<?TEST_ID_PREFIX, RandId/binary>>.
 
 handle_add_channel(From, Data, ChannelId, Config) ->
     Channels = Data#data.added_channels,

--- a/apps/emqx_resource/src/emqx_resource_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_sup.erl
@@ -34,7 +34,7 @@ init([]) ->
         id => emqx_resource_cache_cleaner,
         start => {emqx_resource_cache_cleaner, start_link, []},
         restart => permanent,
-        shutdown => infinity,
+        shutdown => 5_000,
         type => worker,
         modules => [emqx_resource_cache_cleaner]
     },

--- a/apps/emqx_resource/src/emqx_resource_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_sup.erl
@@ -27,8 +27,17 @@ start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
 
 init([]) ->
+    ok = emqx_resource_cache:new(),
     SupFlags = #{strategy => one_for_one, intensity => 10, period => 10},
     Metrics = emqx_metrics_worker:child_spec(?RES_METRICS),
+    CacheCleaner = #{
+        id => emqx_resource_cache_cleaner,
+        start => {emqx_resource_cache_cleaner, start_link, []},
+        restart => permanent,
+        shutdown => infinity,
+        type => worker,
+        modules => [emqx_resource_cache_cleaner]
+    },
     ResourceManager =
         #{
             id => emqx_resource_manager_sup,
@@ -45,4 +54,4 @@ init([]) ->
         shutdown => infinity,
         type => supervisor
     },
-    {ok, {SupFlags, [Metrics, ResourceManager, WorkerSup]}}.
+    {ok, {SupFlags, [Metrics, CacheCleaner, ResourceManager, WorkerSup]}}.

--- a/apps/emqx_resource/test/emqx_resource_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_tests.erl
@@ -26,12 +26,12 @@ is_dry_run_test_() ->
         ?_assert(emqx_resource:is_dry_run(bin([?PROBE_ID_NEW(), "_abc"]))),
         ?_assert(
             emqx_resource:is_dry_run(
-                bin(["acton:typeA:", ?PROBE_ID_NEW(), ":connector:typeB:dryrun"])
+                bin(["action:typeA:", ?PROBE_ID_NEW(), ":connector:typeB:dryrun"])
             )
         ),
         ?_assertNot(
             emqx_resource:is_dry_run(
-                bin(["acton:type1:dryrun:connector:typeb:dryrun"])
+                bin(["action:type1:dryrun:connector:typeb:dryrun"])
             )
         )
     ].

--- a/apps/emqx_resource/test/emqx_resource_tests.erl
+++ b/apps/emqx_resource/test/emqx_resource_tests.erl
@@ -1,0 +1,39 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_resource_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("emqx_resource.hrl").
+
+is_dry_run_test_() ->
+    [
+        ?_assert(emqx_resource:is_dry_run(?PROBE_ID_NEW())),
+        ?_assertNot(emqx_resource:is_dry_run("foobar")),
+        ?_assert(emqx_resource:is_dry_run(bin([?PROBE_ID_NEW(), "_abc"]))),
+        ?_assert(
+            emqx_resource:is_dry_run(
+                bin(["acton:typeA:", ?PROBE_ID_NEW(), ":connector:typeB:dryrun"])
+            )
+        ),
+        ?_assertNot(
+            emqx_resource:is_dry_run(
+                bin(["acton:type1:dryrun:connector:typeb:dryrun"])
+            )
+        )
+    ].
+
+bin(X) -> iolist_to_binary(X).

--- a/scripts/git-hook-pre-commit.sh
+++ b/scripts/git-hook-pre-commit.sh
@@ -12,12 +12,14 @@ if [[ "${files_dirty}" == '' ]] && [[ "${files_cached}" == '' ]]; then
     exit 0
 fi
 files="$(echo -e "${files_dirty} \n ${files_cached}" | xargs)"
+
+# mix format check is quite fast
+which mix && mix format --check-formatted
+
 if [ "${ERLFMT_WRITE:-false}" = 'true' ]; then
     # shellcheck disable=SC2086
     ./scripts/erlfmt -w $files
 else
-    # mix format check is quite fast
-    which mix && mix format --check-formatted
     # shellcheck disable=SC2086
     if ! (./scripts/erlfmt -c $files); then
         echo "EXECUTE 'make fmt-diff' to fix" >&2

--- a/scripts/git-hook-pre-commit.sh
+++ b/scripts/git-hook-pre-commit.sh
@@ -6,20 +6,22 @@ if [ -n "${FORCE:-}" ]; then
     exit 0
 fi
 
-OPT="${1:--c}"
-
-# mix format check is quite fast
-which mix && mix format --check-formatted
-
 files_dirty="$(git diff --name-only | grep -E '.*\.erl' || true)"
 files_cached="$(git diff --cached --name-only | grep -E '.*\.erl' || true)"
 if [[ "${files_dirty}" == '' ]] && [[ "${files_cached}" == '' ]]; then
     exit 0
 fi
 files="$(echo -e "${files_dirty} \n ${files_cached}" | xargs)"
-# shellcheck disable=SC2086
-if ! (./scripts/erlfmt $OPT $files); then
-    echo "EXECUTE 'make fmt' to fix" >&2
-    exit 1
+if [ "${ERLFMT_WRITE:-false}" = 'true' ]; then
+    # shellcheck disable=SC2086
+    ./scripts/erlfmt -w $files
+else
+    # mix format check is quite fast
+    which mix && mix format --check-formatted
+    # shellcheck disable=SC2086
+    if ! (./scripts/erlfmt -c $files); then
+        echo "EXECUTE 'make fmt-diff' to fix" >&2
+        exit 1
+    fi
+    ./scripts/apps-version-check.sh
 fi
-./scripts/apps-version-check.sh


### PR DESCRIPTION
Fixes: https://emqx.atlassian.net/browse/EMQX-11308
Release version: v/e5.8.1

## Summary

Prior to this fix, resource manager state data is cached in ets table (via grpoc).
It's quite a bloated map to copy for each and every message to send,
it's especially expensive when there are multiple channels added to one connector.

This PR breaks up the cache into 3 parts.

- Connector `status`, `error` and `config` are cached in ets table `emqx_resource_cache`,
  since `status` and `error` tend to change often, it makes less sense to cache in persistent-term. 
  Also,`status` and `error` are grouped into the same record field of the cached tuple, so it can be looked-up with `ets:lookup_element` to avoid copying the full record (`config` can be large).
- Connector's channels (actions) are cached in the same ets table, but using a per-channel key.
  This allows us to call `ets:lookup_element` to directly get channel status/error instead of copying all the channels in a map then lookup inside the map.
- The relatively stable parts, such as callback module, query mode, and callback state are cached in persistent-term.
  This can avoid copying the terms when processing the queries.

## Test results
```
emqtt_bench pub -s -I 100 -L 0 -h localhost -p 1883 -t p/1 -c 1000 -s 100
```
Same test scenario, comparing to 5.8.0
- Total RAM 500MB -> 300MB.
- Connection process RAM 310KB -> 106KB.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [~] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
