### PR TITLE
perf: dashboard monitor downsample algorithm

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -96,8 +96,7 @@ latest2time(infinity) -> infinity;
 latest2time(Latest) -> erlang:system_time(millisecond) - (Latest * 1000).
 
 %% When the number of samples exceeds 1000, it affects the rendering speed of dashboard UI.
-%% granularity_adapter is an oversampling of the samples.
-%% Use more granular data and reduce data density.
+%% granularity_adapter does the downsampling of the data points
 %%
 %% [
 %%   Data1 = #{time => T1, k1 => 1, k2 => 2},
@@ -111,10 +110,14 @@ latest2time(Latest) -> erlang:system_time(millisecond) - (Latest * 1000).
 %%   ...
 %% ]
 %%
-granularity_adapter(List) when length(List) > 1000 ->
-    granularity_adapter(List, []);
 granularity_adapter(List) ->
-    List.
+    case length(List) > 1000 of
+        true ->
+            NewList = granularity_adapter(List, []),
+            granularity_adapter(NewList);
+        false ->
+            List
+    end.
 
 current_rate(all) ->
     current_rate_cluster();

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -47,7 +47,9 @@
 -export([do_sample/2]).
 
 %% For tests
--export([current_rate_cluster/0, sample_interval/1, store/1, format/1, clean/1, lookup/1]).
+-export([
+    current_rate_cluster/0, sample_interval/1, store/1, format/1, clean/1, lookup/1, sample_nodes/3
+]).
 
 -define(TAB, ?MODULE).
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -323,13 +323,10 @@ adjust_synthetic_cluster_metrics(Metrics0) ->
 
 format({badrpc, Reason}) ->
     {badrpc, Reason};
-format(Data) ->
-    All = maps:fold(fun format/3, [], Data),
-    Compare = fun(#{time_stamp := T1}, #{time_stamp := T2}) -> T1 =< T2 end,
-    lists:sort(Compare, All).
-
-format(TimeStamp, Data, All) ->
-    [Data#{time_stamp => TimeStamp} | All].
+format(Data0) ->
+    Data1 = maps:to_list(Data0),
+    Data = lists:keysort(1, Data1),
+    lists:map(fun({TimeStamp, V}) -> V#{time_stamp => TimeStamp} end, Data).
 
 cal_rate(_Now, undefined) ->
     AllSamples = ?GAUGE_SAMPLER_LIST ++ maps:values(?DELTA_SAMPLER_RATE_MAP),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -177,7 +177,7 @@ t_pmap_nodes(_Config) ->
     ok = insert_data_points(DataPoints, StartTs, Now),
     Nodes = [node(), node(), node()],
     %% this function calls emqx_utils:pmap to do the job
-    Data0 = emqx_dashboard_monitor:sample_nodes(Nodes, StartTs, #{}),
+    Data0 = emqx_dashboard_monitor:sample_nodes(Nodes, StartTs),
     Data1 = emqx_dashboard_monitor:fill_gaps(Data0, StartTs),
     Data = emqx_dashboard_monitor:format(Data1),
     ok = check_sample_intervals(Interval, hd(Data), tl(Data)),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -182,6 +182,14 @@ t_pmap_nodes(_Config) ->
     TotalSent = check_sample_intervals(Interval, hd(Data), tl(Data), _Index = 1, Total0),
     ?assertEqual(DataPoints * length(Nodes), TotalSent).
 
+t_randomize(_Config) ->
+    ok = emqx_dashboard_monitor:clean(0),
+    emqx_dashboard_monitor:randomize(1, #{sent => 100}),
+    Since = integer_to_list(7 * timer:hours(24)),
+    {ok, Samplers} = request(["monitor"], "latest=" ++ Since),
+    Count = lists:sum(lists:map(fun(#{<<"sent">> := S}) -> S end, Samplers)),
+    ?assertEqual(100, Count).
+
 t_downsample_7d(_Config) ->
     MaxAge = 7 * timer:hours(24),
     test_downsample(MaxAge, 10).

--- a/changes/ce/feat-13873.en.md
+++ b/changes/ce/feat-13873.en.md
@@ -1,0 +1,13 @@
+Improve `/api/v5/monitor` endpoint performance.
+
+Prior to this enhancement, the dashboard monitor page often timeout when there are many nodes in the cluster.
+Below are detailed changes:
+
+- Make concurrent RPC calls towards nodes in the cluster to retrieve metrics.
+- Data points are downsampled to reduce dencity.
+  Dencity is adjusted according to the requested time span in the query:
+  - `10s` when query the last `1h`
+  - `1m` when query the last `1d`
+  - `5m` when query the last `3d`
+  - `10m` when query the last `7d`
+- Insert dummy data points for gaps in the timeline (if EMQX has stopped for a while), so the gap will be visible in the dashboard.


### PR DESCRIPTION
Partially fixes [EMQX-12962](https://emqx.atlassian.net/browse/EMQX-12962)

Release version: v/e5.8.1

## Summary

The old downsample implementation was not recursive.
So it only does reduce once, from maximum 60480 -> 30240, then that's it.

### Test result:

When the table is full (`60480` records), the latency of `/api/v5/monitor?latest=604800` call is:

- Baseline: `2.5s` (single node)
- After downsample algorithm fix: `500ms` (single node)
- Wall-clock aligned timestamps: `260ms` (single node)
- No sorting: `230ms` (single node, and the same for two-node cluster).

### Test helper:

Evaluate below expression in `remote_console` to generate random data points.

```
D = #{dropped => 0,sent => 1,connections => 1000,topics => 0,
  persisted => 0,received => 0,live_connections => 1000,
  disconnected_durable_sessions => 0,
  subscriptions_durable => 0,transformation_succeeded => 0,
  validation_failed => 0,validation_succeeded => 0}.

emqx_dashboard_monitor:randomize(60480, D, 7*timer:hours(24)).
```

To clean data:
```
emqx_dashboard_monitor:clean(0).
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12962]: https://emqx.atlassian.net/browse/EMQX-12962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ