### PR TITLE
fix(cluster link api): clientid is not required when updating

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_schema.erl
@@ -55,7 +55,7 @@ fields("link") ->
         {name, ?HOCON(binary(), #{required => true, desc => ?DESC(link_name)})},
         {server,
             emqx_schema:servers_sc(#{required => true, desc => ?DESC(server)}, ?MQTT_HOST_OPTS)},
-        {clientid, ?HOCON(binary(), #{desc => ?DESC(clientid)})},
+        {clientid, ?HOCON(binary(), #{required => false, desc => ?DESC(clientid)})},
         {username, ?HOCON(binary(), #{required => false, desc => ?DESC(username)})},
         {password, emqx_schema_secret:mk(#{required => false, desc => ?DESC(password)})},
         {ssl, #{

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
@@ -835,3 +835,12 @@ t_duplicate_topic_filters(_Config) ->
         []
     ),
     ok.
+
+%% Verifies that some fields are not required when updating a link, such as:
+%%  - clientid
+t_optional_fields_update(_Config) ->
+    Name = <<"mylink">>,
+    Params0 = maps:without([<<"clientid">>], link_params()),
+    {201, _} = create_link(Name, Params0),
+    ?assertMatch({200, _}, update_link(Name, Params0)),
+    ok.

--- a/changes/ee/fix-13888.en.md
+++ b/changes/ee/fix-13888.en.md
@@ -1,0 +1,1 @@
+Fixed an issue that prevented updating a cluster link without clientid via its HTTP API.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13183

Release version: e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
