### PR TITLE
Fix mqtt payload formatter error

### DIFF
--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -643,14 +643,21 @@ format_payload_limit(Type, Payload, _Limit) ->
     do_format_payload(Type, Payload).
 
 do_format_payload(text, Bytes) ->
-    try
-        [_ | _] = unicode:characters_to_list(Bytes)
-    catch
-        _:_ ->
+    case is_utf8(Bytes) of
+        true ->
+            Bytes;
+        false ->
             do_format_payload(hex, Bytes)
     end;
 do_format_payload(hex, Bytes) ->
     ["hex:", binary:encode_hex(Bytes)].
+
+is_utf8(<<>>) ->
+    true;
+is_utf8(<<_/utf8, Rest/binary>>) ->
+    is_utf8(Rest);
+is_utf8(_) ->
+    false.
 
 truncate_payload(hex, Limit, Payload) ->
     <<Part:Limit/binary, Rest/binary>> = Payload,

--- a/apps/emqx/src/emqx_trace/emqx_trace_formatter.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_formatter.erl
@@ -98,16 +98,9 @@ format_packet(Packet, Encode) ->
 
 format_payload(undefined, _) ->
     "";
-format_payload(_, hidden) ->
-    "******";
-format_payload(Payload, text) when ?MAX_PAYLOAD_FORMAT_LIMIT(Payload) ->
-    unicode:characters_to_list(Payload);
-format_payload(Payload, hex) when ?MAX_PAYLOAD_FORMAT_LIMIT(Payload) -> binary:encode_hex(Payload);
-format_payload(<<Part:?TRUNCATED_PAYLOAD_SIZE/binary, _/binary>> = Payload, Type) ->
-    emqx_packet:format_truncated_payload(Part, byte_size(Payload), Type);
+format_payload(Payload, Type) when is_binary(Payload) ->
+    emqx_packet:format_payload(Payload, Type);
 format_payload(Payload, _) ->
-    %% We don't want to crash if there is a field named payload with some other
-    %% type of value
     Payload.
 
 to_iolist(Atom) when is_atom(Atom) -> atom_to_list(Atom);

--- a/apps/emqx/src/emqx_trace/emqx_trace_json_formatter.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_json_formatter.erl
@@ -185,13 +185,10 @@ format_packet(Packet, Encode) -> emqx_packet:format(Packet, Encode).
 
 format_payload(undefined, _) ->
     "";
-format_payload(_, hidden) ->
-    "******";
-format_payload(Payload, text) when ?MAX_PAYLOAD_FORMAT_LIMIT(Payload) ->
-    unicode:characters_to_list(Payload);
-format_payload(Payload, hex) when ?MAX_PAYLOAD_FORMAT_LIMIT(Payload) -> binary:encode_hex(Payload);
-format_payload(<<Part:?TRUNCATED_PAYLOAD_SIZE/binary, _/binary>> = Payload, Type) ->
-    emqx_packet:format_truncated_payload(Part, byte_size(Payload), Type).
+format_payload(Payload, Type) when is_binary(Payload) ->
+    emqx_packet:format_payload(Payload, Type);
+format_payload(Payload, _) ->
+    Payload.
 
 format_map_set_to_list(Map) ->
     Items = [

--- a/apps/emqx/test/emqx_packet_tests.erl
+++ b/apps/emqx/test/emqx_packet_tests.erl
@@ -1,0 +1,94 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_packet_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
+
+format_payload_test_() ->
+    Hidden = fun(Payload) -> emqx_packet:format_payload(Payload, hidden) end,
+    Hex = fun(Payload) -> bin(emqx_packet:format_payload(Payload, hex)) end,
+    [
+        {"hidden", fun() -> ?assertEqual("******", Hidden(<<>>)) end},
+        {"hex empty", fun() -> ?assertEqual(<<"">>, Hex(<<"">>)) end},
+        {"hex short", fun() -> ?assertEqual(<<"hex:303030">>, Hex(<<"000">>)) end},
+        {"hex at limit", fun() ->
+            Payload = bin(lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE, 0)),
+            Expected = bin(
+                [
+                    "hex:",
+                    binary:encode_hex(bin(lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE, 0)))
+                ]
+            ),
+            ?assertEqual(Expected, Hex(Payload))
+        end},
+        {"hex long", fun() ->
+            Payload = bin(lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE + 2, 0)),
+            Prefix = binary:encode_hex(bin(lists:duplicate(?TRUNCATED_PAYLOAD_SIZE, 0))),
+            Lost = size(Payload) - ?TRUNCATED_PAYLOAD_SIZE,
+            Expected = bin(["hex:", Prefix, "...(", integer_to_list(Lost), " bytes)"]),
+            ?assertEqual(Expected, Hex(Payload))
+        end}
+    ].
+
+format_payload_utf8_test_() ->
+    Fmt = fun(P) -> bin(emqx_packet:format_payload(P, text)) end,
+    [
+        {"empty", fun() -> ?assertEqual(<<"">>, Fmt(<<>>)) end},
+        {"short ascii", fun() -> ?assertEqual(<<"abc">>, Fmt(<<"abc">>)) end},
+        {"short unicode", fun() -> ?assertEqual(<<"日志"/utf8>>, Fmt(<<"日志"/utf8>>)) end},
+        {"unicode at limit", fun() ->
+            Payload = bin(lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE div 2, <<"¢"/utf8>>)),
+            Expected = bin(["", Payload]),
+            ?assertEqual(Expected, Fmt(Payload))
+        end}
+    ].
+
+format_payload_utf8_cutoff_test_() ->
+    Fmt = fun(P) -> bin(emqx_packet:format_payload(P, text)) end,
+    Check = fun(MultiBytesChar) ->
+        Prefix = [lists:duplicate(?TRUNCATED_PAYLOAD_SIZE - 1, $a), MultiBytesChar],
+        Payload = bin([Prefix, MultiBytesChar, lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE, $b)]),
+        Lost = size(Payload) - iolist_size(Prefix),
+        Expected = bin([Prefix, "...(", integer_to_list(Lost), " bytes)"]),
+        ?assertEqual(Expected, Fmt(Payload))
+    end,
+    [
+        {"utf8 1B", fun() -> Check(<<"x"/utf8>>) end},
+        {"utf8 2B", fun() -> Check(<<"¢"/utf8>>) end},
+        {"utf8 3B", fun() -> Check(<<"€"/utf8>>) end},
+        {"utf8 4B", fun() -> Check(<<"𐍈"/utf8>>) end}
+    ].
+
+invalid_utf8_fallback_test() ->
+    %% trucate after the first byte of a utf8 encoded unicode character
+    <<FirstByte:8, Last3Bytes/binary>> = <<"𐍈"/utf8>>,
+    Prefix = iolist_to_binary([lists:duplicate(?TRUNCATED_PAYLOAD_SIZE - 1, $a), FirstByte]),
+    %% invalidate utf8 byte sequence, so it should fallback to hex
+    InvalidUtf8 = 255,
+    Payload = iolist_to_binary([
+        Prefix, Last3Bytes, InvalidUtf8, lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE, $b)
+    ]),
+    Lost = size(Payload) - iolist_size(Prefix),
+    Expected = iolist_to_binary([
+        "hex:", binary:encode_hex(Prefix), "...(", integer_to_list(Lost), " bytes)"
+    ]),
+    ?assertEqual(Expected, bin(emqx_packet:format_payload(Payload, text))),
+    ok.
+
+bin(X) ->
+    unicode:characters_to_binary(X).

--- a/apps/emqx/test/emqx_packet_tests.erl
+++ b/apps/emqx/test/emqx_packet_tests.erl
@@ -81,7 +81,7 @@ invalid_utf8_fallback_test() ->
     %% invalidate utf8 byte sequence, so it should fallback to hex
     InvalidUtf8 = 255,
     Payload = iolist_to_binary([
-        Prefix, Last3Bytes, InvalidUtf8, lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE, $b)
+        Prefix, InvalidUtf8, lists:duplicate(?MAX_PAYLOAD_FORMAT_SIZE, $b)
     ]),
     Lost = size(Payload) - iolist_size(Prefix),
     Expected = iolist_to_binary([

--- a/changes/ce/fix-13909.en.md
+++ b/changes/ce/fix-13909.en.md
@@ -1,0 +1,1 @@
+Fix log format when cannot format payload as readable utf8 unicode characters.


### PR DESCRIPTION
Release version: v/e5.8.2

## Summary

```
2024-08-30T11:06:12.595771+02:00 [debug] msg: SEND_Data, packet: 
[[80,85,66,76,73,83,72,40,81,"0",44,32,82,"0",44,32,68,"0"],", ",
[[84,111,112,105,99,61,"$LINK/cluster/route/zmd",44,32,80,97,99,107,101,116,73,100,61,"undefined"],", ",
["Payload=",{error,[],<<131,116,0,0,0,3,97,10,109,0,0,0,14,101,109,113,120,64,49,50,55,
46,48,46,48,46,49,97,11,110,6,0,160,97,136,162,145,1,119,3,36,111,112,109,0,0,0,9,104,101,
97,114,116,98,101,97,116>>}]],")"], socket: #Port<0.87>
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
