### PR TITLE
fix(rule engine metrics): bump `failed` metric when its sub-counters are bumped

### DIFF
--- a/changes/ce/fix-13916.en.md
+++ b/changes/ce/fix-13916.en.md
@@ -1,0 +1,1 @@
+Previously, when a rule's `failed.no_result` or `failed.exception` metrics were bumped, their corresponding parent metric `failed` was not also bumped.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13107

Release version: v/e5.8.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
