### PR TITLE
chore: do not obfuscate vars in templates

### DIFF
--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -150,9 +150,15 @@ is_sensitive_header("proxy-authorization") ->
 is_sensitive_header(_Any) ->
     false.
 
-redact_v(V) when is_binary(V) -> <<?REDACT_VAL>>;
-%% The HOCON schema system may generate sensitive values with this format
+redact_v(V) when is_binary(V) ->
+    case emqx_placeholder:preproc_tmpl(V) of
+        [{var, _}] ->
+            V;
+        _ ->
+            <<?REDACT_VAL>>
+    end;
 redact_v([{str, Bin}]) when is_binary(Bin) ->
+    %% The HOCON schema system may generate sensitive values with this format
     [{str, <<?REDACT_VAL>>}];
 redact_v(_V) ->
     ?REDACT_VAL.

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -1,0 +1,51 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_utils_redact_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+is_redacted_test_() ->
+    [
+        ?_assertNot(is_redacted(password, <<"secretpass">>)),
+        ?_assertNot(is_redacted(password, <<>>)),
+        ?_assertNot(is_redacted(password, undefined)),
+        ?_assert(is_redacted(password, <<"******">>)),
+        ?_assertNot(is_redacted(password, fun() -> <<"secretpass">> end)),
+        ?_assertNot(is_redacted(password, emqx_secret:wrap(<<"secretpass">>))),
+        ?_assert(is_redacted(password, fun() -> <<"******">> end)),
+        ?_assert(is_redacted(password, emqx_secret:wrap(<<"******">>)))
+    ].
+
+no_redact_template_var_test() ->
+    ?assertEqual(
+        #{
+            password => <<"${var}">>,
+            account_key => <<"${path.to.var}">>,
+            <<"secret">> => <<"******">>,
+            private_key => <<"******">>
+        },
+        redact(#{
+            password => <<"${var}">>,
+            <<"secret">> => <<"abc">>,
+            account_key => <<"${path.to.var}">>,
+            private_key => <<"${var}more">>
+        })
+    ).
+
+redact(X) -> emqx_utils:redact(X).
+
+is_redacted(Key, Value) ->
+    emqx_utils:is_redacted(Key, Value).

--- a/apps/emqx_utils/test/emqx_utils_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_tests.erl
@@ -17,18 +17,6 @@
 
 -include_lib("eunit/include/eunit.hrl").
 
-is_redacted_test_() ->
-    [
-        ?_assertNot(emqx_utils:is_redacted(password, <<"secretpass">>)),
-        ?_assertNot(emqx_utils:is_redacted(password, <<>>)),
-        ?_assertNot(emqx_utils:is_redacted(password, undefined)),
-        ?_assert(emqx_utils:is_redacted(password, <<"******">>)),
-        ?_assertNot(emqx_utils:is_redacted(password, fun() -> <<"secretpass">> end)),
-        ?_assertNot(emqx_utils:is_redacted(password, emqx_secret:wrap(<<"secretpass">>))),
-        ?_assert(emqx_utils:is_redacted(password, fun() -> <<"******">> end)),
-        ?_assert(emqx_utils:is_redacted(password, emqx_secret:wrap(<<"******">>)))
-    ].
-
 foldl_while_test_() ->
     [
         ?_assertEqual(


### PR DESCRIPTION
Release version: v/e5.8.2

## Summary

It's kinda silly to render a template var ref as `******` for the dashboard.
This PR make it 'smarter' but risking at clashing an authentic sensitive string value.
e.g. if one sets password as `${looks_like_a_var_but_not_really}`, then nobody except for themselves will should sorry.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
