### PR TITLE
fix: cache CRL with full distribution point URL

### DIFF
--- a/apps/emqx/src/emqx_crl_cache.erl
+++ b/apps/emqx/src/emqx_crl_cache.erl
@@ -74,7 +74,7 @@
     %% for future use
     extra = #{} :: map()
 }).
--type url() :: uri_string:uri_string().
+-type url() :: string().
 -type state() :: #state{}.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_ssl_crl_cache.erl
+++ b/apps/emqx/src/emqx_ssl_crl_cache.erl
@@ -40,11 +40,24 @@
 %%----------------------------------------------------------------------
 %% Purpose: Simple default CRL cache
 %%
-%% The cache is an opaque term created by ssl_pkix_db:create/1.
-%% It is essentially an ETS table, created as ssl_otp_crl_cache
-%% not not named.
-%% The cache key is named `Path` in ssl_manager module, but we override
-%% it to the full URL binary format.
+%% The cache is a part of an opaque term named DB created by `ssl_manager'
+%% from calling `ssl_pkix_db:create/1'.
+%%
+%% Insert and delete operations are abstracted by `ssl_manager'.
+%% Read operation is done by passing-through the DB term to
+%% `ssl_pkix_db:lookup/2'.
+%%
+%% The CRL cache in the DB term is essentially an ETS table.
+%% The table is created as `ssl_otp_crl_cache', but not
+%% a named table. You can find the table reference from `ets:i()'.
+%%
+%% The cache key in the original OTP implementation was the path part of the
+%% CRL distribution point URL. e.g. if the URL is `http://foo.bar.com/crl.pem'
+%% the cache key would be `"crl.pem"'.
+%% There is however no type spec for the APIs, nor there is any check
+%% on the format, making it possible to use the full URL binary
+%% string as key instead --- which can avoid cache key clash when
+%% different DPs share the same path.
 %%----------------------------------------------------------------------
 
 -module(emqx_ssl_crl_cache).

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -464,7 +464,7 @@ t_manual_refresh(Config) ->
     ?assertEqual([], ets:tab2list(Ref)),
     emqx_config_handler:start_link(),
     {ok, _} = emqx_crl_cache:start_link(),
-    URL = "http://localhost/crl.pem",
+    URL = <<"http://localhost/crl.pem">>,
     ok = snabbkaffe:start_trace(),
     ?wait_async_action(
         ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
@@ -472,10 +472,7 @@ t_manual_refresh(Config) ->
         5_000
     ),
     ok = snabbkaffe:stop(),
-    ?assertEqual(
-        [{"crl.pem", [CRLDer]}],
-        ets:tab2list(Ref)
-    ),
+    ?assertEqual([{URL, [CRLDer]}], ets:tab2list(Ref)),
     emqx_config_handler:stop(),
     ok.
 
@@ -578,14 +575,14 @@ t_unknown_messages(_Config) ->
 t_evict(_Config) ->
     emqx_config_handler:start_link(),
     {ok, _} = emqx_crl_cache:start_link(),
-    URL = "http://localhost/crl.pem",
+    URL = <<"http://localhost/crl.pem">>,
     ?wait_async_action(
         ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
         #{?snk_kind := crl_cache_insert},
         5_000
     ),
     Ref = get_crl_cache_table(),
-    ?assertMatch([{"crl.pem", _}], ets:tab2list(Ref)),
+    ?assertMatch([{URL, _}], ets:tab2list(Ref)),
     {ok, {ok, _}} = ?wait_async_action(
         emqx_crl_cache:evict(URL),
         #{?snk_kind := crl_cache_evict}

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -464,7 +464,8 @@ t_manual_refresh(Config) ->
     ?assertEqual([], ets:tab2list(Ref)),
     emqx_config_handler:start_link(),
     {ok, _} = emqx_crl_cache:start_link(),
-    URL = <<"http://localhost/crl.pem">>,
+    URL = "http://localhost/crl.pem",
+    URLBin = iolist_to_binary(URL),
     ok = snabbkaffe:start_trace(),
     ?wait_async_action(
         ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
@@ -472,7 +473,7 @@ t_manual_refresh(Config) ->
         5_000
     ),
     ok = snabbkaffe:stop(),
-    ?assertEqual([{URL, [CRLDer]}], ets:tab2list(Ref)),
+    ?assertEqual([{URLBin, [CRLDer]}], ets:tab2list(Ref)),
     emqx_config_handler:stop(),
     ok.
 
@@ -575,14 +576,15 @@ t_unknown_messages(_Config) ->
 t_evict(_Config) ->
     emqx_config_handler:start_link(),
     {ok, _} = emqx_crl_cache:start_link(),
-    URL = <<"http://localhost/crl.pem">>,
+    URL = "http://localhost/crl.pem",
+    URLBin = iolist_to_binary(URL),
     ?wait_async_action(
         ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
         #{?snk_kind := crl_cache_insert},
         5_000
     ),
     Ref = get_crl_cache_table(),
-    ?assertMatch([{URL, _}], ets:tab2list(Ref)),
+    ?assertMatch([{URLBin, _}], ets:tab2list(Ref)),
     {ok, {ok, _}} = ?wait_async_action(
         emqx_crl_cache:evict(URL),
         #{?snk_kind := crl_cache_evict}

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -514,35 +514,38 @@ t_persistent_sessions5(Config) ->
             %% Disconnect persistent sessions
             lists:foreach(fun stop_and_commit/1, [C1, C2]),
 
+            %% the order of the durable session list is not stable
+            %% se we make sure one request is to list all in-mem,
+            %% and then the next is to list all durable.
             P3 =
                 ?retry(200, 10, begin
-                    P3_ = list_request(#{limit => 3, page => 1}, Config),
+                    P3a = list_request(#{limit => 2, page => 1}, Config),
                     ?assertMatch(
                         {ok,
                             {?HTTP200, _, #{
-                                <<"data">> := [_, _, _],
+                                <<"data">> := [_, _],
                                 <<"meta">> := #{
                                     <<"count">> := 4
                                 }
                             }}},
-                        P3_
+                        P3a
                     ),
-                    P3_
+                    P3a
                 end),
             P4 =
                 ?retry(200, 10, begin
-                    P4_ = list_request(#{limit => 3, page => 2}, Config),
+                    P4a = list_request(#{limit => 2, page => 2}, Config),
                     ?assertMatch(
                         {ok,
                             {?HTTP200, _, #{
-                                <<"data">> := [_],
+                                <<"data">> := [_, _],
                                 <<"meta">> := #{
                                     <<"count">> := 4
                                 }
                             }}},
-                        P4_
+                        P4a
                     ),
-                    P4_
+                    P4a
                 end),
             {ok, {_, _, #{<<"data">> := R3}}} = P3,
             {ok, {_, _, #{<<"data">> := R4}}} = P4,

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -515,7 +515,7 @@ t_persistent_sessions5(Config) ->
             lists:foreach(fun stop_and_commit/1, [C1, C2]),
 
             %% the order of the durable session list is not stable
-            %% se we make sure one request is to list all in-mem,
+            %% so we make sure one request is to list all in-mem,
             %% and then the next is to list all durable.
             P3 =
                 ?retry(200, 10, begin

--- a/changes/ce/fix-13922.en.md
+++ b/changes/ce/fix-13922.en.md
@@ -1,0 +1,3 @@
+Change CRL (Certificate Revocation List) cache with full DP (distribution point) URL.
+
+Prior to this fix, the cache key was the path part of the URL, which leads to clash if there happen to be more than one DP sharing the same path.


### PR DESCRIPTION

Fixes [EMQX-12996](https://emqx.atlassian.net/browse/EMQX-12996)

Release version: v/e5.8.2

## Summary

Prior to this fix, CRL is cached with the path part of a URL, it leads to clash when two DPs happen to share the same path.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12996]: https://emqx.atlassian.net/browse/EMQX-12996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ