### PR TITLE
Support zone in authn authz templates

### DIFF
--- a/apps/emqx/include/emqx_placeholder.hrl
+++ b/apps/emqx/include/emqx_placeholder.hrl
@@ -40,6 +40,7 @@
 -define(VAR_TOPIC, "topic").
 -define(VAR_ENDPOINT_NAME, "endpoint_name").
 -define(VAR_NS_CLIENT_ATTRS, {var_namespace, "client_attrs"}).
+-define(VAR_ZONE, "zone").
 
 -define(PH_PASSWORD, ?PH(?VAR_PASSWORD)).
 -define(PH_CLIENTID, ?PH(?VAR_CLIENTID)).

--- a/apps/emqx/src/emqx_mountpoint.erl
+++ b/apps/emqx/src/emqx_mountpoint.erl
@@ -38,6 +38,7 @@
     ?VAR_CLIENTID,
     ?VAR_USERNAME,
     ?VAR_ENDPOINT_NAME,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/apps/emqx_auth/include/emqx_authn.hrl
+++ b/apps/emqx_auth/include/emqx_authn.hrl
@@ -41,6 +41,7 @@
     ?VAR_CERT_SUBJECT,
     ?VAR_CERT_CN_NAME,
     ?VAR_CERT_PEM,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_rule.erl
@@ -126,6 +126,7 @@
     ?VAR_USERNAME,
     ?VAR_CLIENTID,
     ?VAR_CERT_CN_NAME,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_file_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_file_SUITE.erl
@@ -121,6 +121,34 @@ t_cert_common_name(_Config) ->
     ),
     ok.
 
+t_zone(_Config) ->
+    ClientInfo0 = emqx_authz_test_lib:base_client_info(),
+    ClientInfo = ClientInfo0#{zone => <<"zone1">>},
+    ok = setup_config(?RAW_SOURCE#{
+        <<"rules">> => <<"{allow, all, all, [\"t/${zone}/#\"]}.">>
+    }),
+
+    ?assertEqual(
+        allow,
+        emqx_access_control:authorize(ClientInfo, ?AUTHZ_PUBLISH, <<"t/zone1/1">>)
+    ),
+
+    ?assertEqual(
+        allow,
+        emqx_access_control:authorize(ClientInfo, ?AUTHZ_SUBSCRIBE, <<"t/zone1/#">>)
+    ),
+
+    ?assertEqual(
+        deny,
+        emqx_access_control:authorize(ClientInfo#{zone => other}, ?AUTHZ_SUBSCRIBE, <<"t/zone1/1">>)
+    ),
+
+    ?assertEqual(
+        deny,
+        emqx_access_control:authorize(ClientInfo, ?AUTHZ_SUBSCRIBE, <<"t/otherzone/1">>)
+    ),
+    ok.
+
 t_rich_actions(_Config) ->
     ClientInfo = emqx_authz_test_lib:base_client_info(),
 

--- a/apps/emqx_auth_mongodb/src/emqx_auth_mongodb.app.src
+++ b/apps/emqx_auth_mongodb/src/emqx_auth_mongodb.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mongodb, [
     {description, "EMQX MongoDB Authentication and Authorization"},
-    {vsn, "0.2.2"},
+    {vsn, "0.3.0"},
     {registered, []},
     {mod, {emqx_auth_mongodb_app, []}},
     {applications, [

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -41,6 +41,7 @@
     ?VAR_PEERHOST,
     ?VAR_CERT_CN_NAME,
     ?VAR_CERT_SUBJECT,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/apps/emqx_auth_mysql/src/emqx_auth_mysql.app.src
+++ b/apps/emqx_auth_mysql/src/emqx_auth_mysql.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mysql, [
     {description, "EMQX MySQL Authentication and Authorization"},
-    {vsn, "0.2.2"},
+    {vsn, "0.3.0"},
     {registered, []},
     {mod, {emqx_auth_mysql_app, []}},
     {applications, [

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -43,6 +43,7 @@
     ?VAR_PEERHOST,
     ?VAR_CERT_CN_NAME,
     ?VAR_CERT_SUBJECT,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/apps/emqx_auth_postgresql/src/emqx_auth_postgresql.app.src
+++ b/apps/emqx_auth_postgresql/src/emqx_auth_postgresql.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_postgresql, [
     {description, "EMQX PostgreSQL Authentication and Authorization"},
-    {vsn, "0.2.2"},
+    {vsn, "0.3.0"},
     {registered, []},
     {mod, {emqx_auth_postgresql_app, []}},
     {applications, [

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -43,6 +43,7 @@
     ?VAR_PEERHOST,
     ?VAR_CERT_CN_NAME,
     ?VAR_CERT_SUBJECT,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/apps/emqx_auth_redis/src/emqx_auth_redis.app.src
+++ b/apps/emqx_auth_redis/src/emqx_auth_redis.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_redis, [
     {description, "EMQX Redis Authentication and Authorization"},
-    {vsn, "0.2.2"},
+    {vsn, "0.3.0"},
     {registered, []},
     {mod, {emqx_auth_redis_app, []}},
     {applications, [

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -41,6 +41,7 @@
     ?VAR_PEERHOST,
     ?VAR_CLIENTID,
     ?VAR_USERNAME,
+    ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
 

--- a/changes/ce/feat-13923.en.md
+++ b/changes/ce/feat-13923.en.md
@@ -1,0 +1,6 @@
+Added `zone` to authentication, authorization and mountpoint template.
+
+Prior to this change, if one wants to use `zone` name in authentication or authorization rules, they would have to use `client_attrs`.
+Now `${zone}` can be used directly in authentication and authentication.
+
+As an example, here is an ACL rule making use of `zone`: `{allow, all, all, [${zone}/${username}/#]}`.

--- a/changes/ce/feat-13923.en.md
+++ b/changes/ce/feat-13923.en.md
@@ -3,4 +3,4 @@ Added `zone` to authentication, authorization and mountpoint template.
 Prior to this change, if one wants to use `zone` name in authentication or authorization rules, they would have to use `client_attrs`.
 Now `${zone}` can be used directly in authentication and authentication.
 
-As an example, here is an ACL rule making use of `zone`: `{allow, all, all, [${zone}/${username}/#]}`.
+As an example, here is an ACL rule making use of `zone`: `{allow, all, all, ["${zone}/${username}/#"]}`.


### PR DESCRIPTION
Release version: v/e5.8.2

## Summary

Added `zone` to authentication, authorization and mountpoint template.

Prior to this change, if one wants to use `zone` name in authentication or authorization rules, they would have to use `client_attrs`.
Now `${zone}` can be used directly in authentication and authentication.

As an example, here is an ACL rule making use of `zone`: `{allow, all, all, ["${zone}/${username}/#"]}`.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
