### PR TITLE
fix(cluster-link): provide `emqx_broker` API to fold over topics

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_router_bootstrap.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_router_bootstrap.erl
@@ -100,10 +100,9 @@ select_routes_by_topics(Topics) ->
     [encode_route(Topic, Topic) || Topic <- Topics, emqx_broker:subscribers(Topic) =/= []].
 
 select_routes_by_wildcards(Wildcards) ->
-    emqx_utils_ets:keyfoldl(
+    emqx_broker:foldl_topics(
         fun(Topic, Acc) -> intersecting_route(Topic, Wildcards) ++ Acc end,
-        [],
-        ?SUBSCRIBER
+        []
     ).
 
 select_shared_sub_routes_by_topics([T | Topics]) ->

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_router_syncer.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_router_syncer.erl
@@ -373,9 +373,7 @@ handle_info(
         #{
             result := Res,
             need_bootstrap := NeedBootstrap
-        } = AckInfoMap} = emqx_cluster_link_mqtt:decode_resp(
-        Payload
-    ),
+        } = AckInfoMap} = emqx_cluster_link_mqtt:decode_resp(Payload),
     St1 = St#st{
         actor_init_req_id = undefined, actor_init_timer = undefined, remote_actor_info = AckInfoMap
     },
@@ -402,8 +400,6 @@ handle_info(
             %% TODO: retry after a timeout?
             {noreply, St1#st{error = Reason, status = disconnected}}
     end;
-handle_info({publish, #{}}, St) ->
-    {noreply, St};
 handle_info({timeout, TRef, reconnect}, St = #st{reconnect_timer = TRef}) ->
     {noreply, process_connect(St#st{reconnect_timer = undefined})};
 handle_info({timeout, TRef, actor_reinit}, St = #st{actor_init_timer = TRef}) ->

--- a/changes/ee/fix-13927.en.md
+++ b/changes/ee/fix-13927.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where Cluster Link bootstrap process could have crashed if the source cluster had one or more very crowded topics.


### PR DESCRIPTION
Release version: e5.8.1

## Summary

Provide dedicated `emqx_broker` API to "fold" over unique topics. Without it, cluster link bootstrap process relied on scanning `?SUBSCRIBER` table, and was likely to crash on internal "shard" records in this table. This slipped through tests because a cluster needs A LOT of subscribers for a single topic for those records to appear in the table.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
