### PR TITLE
fix(cluster link): don't remove message publish hook if disabling the last link

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_app.erl
@@ -8,16 +8,14 @@
 
 -export([start/2, prep_stop/1, stop/1]).
 
--define(BROKER_MOD, emqx_cluster_link).
-
 start(_StartType, _StartArgs) ->
     ok = mria:wait_for_tables(emqx_cluster_link_extrouter:create_tables()),
     emqx_cluster_link_config:add_handler(),
     LinksConf = emqx_cluster_link_config:enabled_links(),
+    ok = emqx_cluster_link:register_external_broker(),
+    ok = emqx_cluster_link:put_hook(),
     case LinksConf of
         [_ | _] ->
-            ok = emqx_cluster_link:register_external_broker(),
-            ok = emqx_cluster_link:put_hook(),
             ok = start_msg_fwd_resources(LinksConf);
         _ ->
             ok

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_config.erl
@@ -231,7 +231,6 @@ pre_config_update(?LINKS_PATH, NewRawConf, OldRawConf) ->
 post_config_update(?LINKS_PATH, _Req, Old, Old, _AppEnvs) ->
     ok;
 post_config_update(?LINKS_PATH, _Req, New, Old, _AppEnvs) ->
-    ok = toggle_hook_and_broker(enabled_links(New), enabled_links(Old)),
     #{
         removed := Removed,
         added := Added,
@@ -251,18 +250,6 @@ post_config_update(?LINKS_PATH, _Req, New, Old, _AppEnvs) ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
-
-toggle_hook_and_broker([_ | _] = _NewEnabledLinks, [] = _OldEnabledLinks) ->
-    ok = emqx_cluster_link:register_external_broker(),
-    ok = emqx_cluster_link:put_hook();
-toggle_hook_and_broker([] = _NewEnabledLinks, _OldLinks) ->
-    _ = emqx_cluster_link:unregister_external_broker(),
-    ok = emqx_cluster_link:delete_hook();
-toggle_hook_and_broker(_, _) ->
-    ok.
-
-enabled_links(LinksConf) ->
-    [L || #{enable := true} = L <- LinksConf].
 
 all_ok(Results) ->
     lists:all(

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_extrouter_gc.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_extrouter_gc.erl
@@ -5,6 +5,7 @@
 -module(emqx_cluster_link_extrouter_gc).
 
 -include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
 
 -export([start_link/0]).
 
@@ -56,6 +57,7 @@ handle_cast(Cast, State) ->
 
 handle_info({timeout, TRef, _GC}, St = #st{gc_timer = TRef}) ->
     Result = run_gc_exclusive(),
+    ?tp("clink_extrouter_gc_ran", #{result => Result}),
     Timeout = choose_timeout(Result),
     {noreply, schedule_gc(Timeout, St#st{gc_timer = undefined})};
 handle_info(Info, St) ->

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_router_syncer.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_router_syncer.erl
@@ -399,8 +399,8 @@ handle_info(
                 clink_handshake_error,
                 #{actor => {St1#st.actor, St1#st.incarnation}, reason => Reason}
             ),
-            %% TODO: retry after a timeout?
-            {noreply, St1#st{error = Reason, status = disconnected}}
+            St2 = ensure_reconnect_timer(St1#st{error = Reason, status = disconnected}),
+            {noreply, St2}
     end;
 handle_info({publish, #{}}, St) ->
     {noreply, St};
@@ -476,6 +476,13 @@ post_actor_init(
     NSt = schedule_heartbeat(St#st{client = ClientPid}),
     process_bootstrap(NSt, NeedBootstrap).
 
+ensure_reconnect_timer(#st{reconnect_timer = undefined} = St) ->
+    TRef = erlang:start_timer(?RECONNECT_TIMEOUT, self(), reconnect),
+    St#st{reconnect_timer = TRef};
+ensure_reconnect_timer(#st{reconnect_timer = TRef} = St) ->
+    _ = erlang:cancel_timer(TRef),
+    ensure_reconnect_timer(St#st{reconnect_timer = undefined}).
+
 handle_connect_error(Reason, St) ->
     ?SLOG(error, #{
         msg => "cluster_link_connection_failed",
@@ -483,9 +490,8 @@ handle_connect_error(Reason, St) ->
         target_cluster => St#st.target,
         actor => St#st.actor
     }),
-    TRef = erlang:start_timer(?RECONNECT_TIMEOUT, self(), reconnect),
     _ = maybe_alarm(Reason, St),
-    St#st{reconnect_timer = TRef, error = Reason, status = disconnected}.
+    ensure_reconnect_timer(St#st{error = Reason, status = disconnected}).
 
 handle_client_down(Reason, St = #st{target = TargetCluster, actor = Actor}) ->
     ?SLOG(error, #{

--- a/changes/ee/fix-13928.en.md
+++ b/changes/ee/fix-13928.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a bidirectional cluster link could become stuck and stop working if one of the sides disabled the link for a long period of time before re-enabling it.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13098

Release version: e5.8.2

## Summary

One of the original issues is that handling heartbeats from an upstream agent rely on the message hook from cluster link app being in place.  Before this patch, after disabling the last link in a cluster, the message hook would be removed, and thus heartbeats from upstream agents would no longer be handled.  This led to live agents being garbage collected.  After the link is re-enabled, the agent state is already lost and does not recover.

The reason for it not recovering is the second issue (not handled here): even though `assert_current_incarnation` would crash while running the re-enabled hook, this crash is caught by `emqx_hooks:run_fold`, and the connection would not be closed.  Disconnecting the agent would help make everything restart from a clean slate.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
