### PR TITLE
fix(cluster link): trigger agent disconnection on exceptions and resource fixes

### DIFF
--- a/apps/emqx_cluster_link/src/emqx_cluster_link_extrouter_gc.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_extrouter_gc.erl
@@ -9,7 +9,7 @@
 
 -export([start_link/0]).
 
--export([run/0]).
+-export([run/0, force/1]).
 
 -behaviour(gen_server).
 -export([
@@ -34,6 +34,14 @@ start_link() ->
 
 run() ->
     gen_server:call(?SERVER, run).
+
+force(Timestamp) ->
+    case emqx_cluster_link_extrouter:actor_gc(#{timestamp => Timestamp}) of
+        1 ->
+            force(Timestamp);
+        0 ->
+            ok
+    end.
 
 %%
 

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -211,7 +211,7 @@ on_query_async(
     Callback = {fun on_async_result/2, [CallbackIn]},
     #message{topic = Topic, qos = QoS} = FwdMsg,
     %% TODO check message ordering, pick by topic,client pair?
-    ecpool:pick_and_do(
+    Result = ecpool:pick_and_do(
         {PoolName, Topic},
         fun(ConnPid) ->
             %% #delivery{} record has no valuable data for a remote link...
@@ -226,7 +226,10 @@ on_query_async(
             PubResult
         end,
         no_handover
-    ).
+    ),
+    %% This result could be `{error, ecpool_empty}', for example, which should be
+    %% recoverable.  If we didn't handle it here, it would be considered unrecoverable.
+    handle_send_result(Result).
 
 %% copied from emqx_bridge_mqtt_connector
 

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -93,6 +93,8 @@
 
 -define(PUB_TIMEOUT, 10_000).
 
+-define(AUTO_RECONNECT_INTERVAL_S, 2).
+
 -type cluster_name() :: binary().
 
 -spec resource_id(cluster_name()) -> resource_id().
@@ -173,6 +175,7 @@ on_start(ResourceId, #{pool_size := PoolSize} = ClusterConf) ->
         {name, PoolName},
         {pool_size, PoolSize},
         {pool_type, hash},
+        {auto_reconnect, ?AUTO_RECONNECT_INTERVAL_S},
         {client_opts, emqtt_client_opts(?MSG_CLIENTID_SUFFIX, ClusterConf)}
     ],
     ok = emqx_resource:allocate_resource(ResourceId, pool_name, PoolName),

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_router_syncer.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_router_syncer.erl
@@ -494,8 +494,7 @@ handle_connect_error(Reason, St) ->
     ensure_reconnect_timer(St#st{error = Reason, status = disconnected}).
 
 handle_client_down(Reason, St = #st{target = TargetCluster, actor = Actor}) ->
-    ?SLOG(error, #{
-        msg => "cluster_link_connection_failed",
+    ?tp(error, "cluster_link_connection_failed", #{
         reason => Reason,
         target_cluster => St#st.target,
         actor => St#st.actor

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_SUITE.erl
@@ -214,9 +214,8 @@ t_target_extrouting_gc(Config) ->
     Pubs1 = [M || {publish, M} <- ?drainMailbox(1_000)],
     %% We switch off `TargetNode2' first.  Since `TargetNode1' is the sole endpoint
     %% configured in Target Cluster, the link will keep working (i.e., CL MQTT ecpool
-    %% workers will stay connected).  If we turned `TargetNode1' first, then all ecpool
-    %% workers would die and stay dead (since currently we don't set `auto_reconnect' for
-    %% the pool).
+    %% workers will stay connected).  If we turned `TargetNode1' first, then the link
+    %% would stay down and stop replicating messages.
     {ok, _} = ?wait_async_action(
         emqx_cth_cluster:stop_node(TargetNode2),
         #{?snk_kind := clink_extrouter_actor_cleaned, cluster := <<"cl.target">>}

--- a/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
+++ b/apps/emqx_cluster_link/test/emqx_cluster_link_api_SUITE.erl
@@ -234,12 +234,7 @@ disable_and_force_gc(TargetOrSource, Name, Params, TCConfig, Opts) ->
 
 do_actor_gc(Node, Timestamp) ->
     %% 2 Actors: one for normal routes, one for PS routes
-    case ?ON(Node, emqx_cluster_link_extrouter:actor_gc(#{timestamp => Timestamp})) of
-        1 ->
-            do_actor_gc(Node, Timestamp);
-        0 ->
-            ok
-    end.
+    ?ON(Node, emqx_cluster_link_extrouter_gc:force(Timestamp)).
 
 wait_for_routes([Node | Nodes], ExpectedTopics) ->
     Topics = ?ON(Node, emqx_cluster_link_extrouter:topics()),

--- a/changes/ee/fix-13929.en.md
+++ b/changes/ee/fix-13929.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a cluster link could in some occasions become stuck and stop working until a manual restart on the upstream cluster was performed.


### PR DESCRIPTION
Release version: e5.8.2

## Summary

See https://github.com/emqx/emqx/pull/13928

- Previously, even if an exception occurred (such as `assert_current_incarnation` failing, for example), the agent would stay connected instead of letting it crash and recover.
- `auto_reconnect` was not set for the `ecpool` used for the forwarding resource.  So, if connection was lost and workers died, they would stay dead.
- Publish result was not handled for async queries.  So, if `{error, ecpool_empty}` was returned while the pool was empty, the message would not be retried and lost.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
