### PR TITLE
Upgrade jesse from 1.8.0.1 to 1.8.1.1

### DIFF
--- a/apps/emqx_gateway_ocpp/rebar.config
+++ b/apps/emqx_gateway_ocpp/rebar.config
@@ -1,7 +1,7 @@
 %% -*- mode: erlang; -*-
 
 {deps, [
-    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.0.1"}}},
+    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.1.1"}}},
     {emqx, {path, "../../apps/emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
     {emqx_gateway, {path, "../../apps/emqx_gateway"}}

--- a/apps/emqx_schema_registry/rebar.config
+++ b/apps/emqx_schema_registry/rebar.config
@@ -6,7 +6,7 @@
     {emqx_utils, {path, "../emqx_utils"}},
     {emqx_rule_engine, {path, "../emqx_rule_engine"}},
     {erlavro, {git, "https://github.com/emqx/erlavro.git", {tag, "2.10.0"}}},
-    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.0.1"}}},
+    {jesse, {git, "https://github.com/emqx/jesse.git", {tag, "1.8.1.1"}}},
     {gpb, "4.19.9"},
     {avlizer, {git, "https://github.com/emqx/avlizer.git", {tag, "0.5.1.1"}}}
 ]}.

--- a/mix.exs
+++ b/mix.exs
@@ -152,7 +152,6 @@ defmodule EMQXUmbrella.MixProject do
       {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true},
       # set by hackney (dependency)
       {:ssl_verify_fun, "1.1.7", override: true},
-      common_dep(:rfc3339),
       common_dep(:bcrypt),
       common_dep(:uuid),
       {:quickrand, github: "okeuday/quickrand", tag: "v2.0.6", override: true},
@@ -238,9 +237,6 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:bcrypt),
     do: {:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.2", override: true}
 
-  # hex version 0.2.2 used by `jesse` has buggy mix.exs
-  def common_dep(:rfc3339), do: {:rfc3339, github: "emqx/rfc3339", tag: "0.2.3", override: true}
-
   def common_dep(:minirest),
     do: {:minirest, github: "emqx/minirest", tag: "1.4.3", override: true}
 
@@ -289,7 +285,7 @@ defmodule EMQXUmbrella.MixProject do
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.9", override: true}
   def common_dep(:crc32cer), do: {:crc32cer, "0.1.8", override: true}
-  def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.0.1"}
+  def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.1.1"}
   def common_dep(:erlavro), do: {:erlavro, github: "emqx/erlavro", tag: "2.10.0", override: true}
 
   ###############################################################################################

--- a/rebar.config
+++ b/rebar.config
@@ -109,7 +109,6 @@
     {jsone, {git, "https://github.com/emqx/jsone.git", {tag, "1.7.1"}}},
     {uuid, {git, "https://github.com/okeuday/uuid.git", {tag, "v2.0.6"}}},
     {ssl_verify_fun, "1.1.7"},
-    {rfc3339, {git, "https://github.com/emqx/rfc3339.git", {tag, "0.2.3"}}},
     {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.2"}}},
     {ra, {git, "https://github.com/emqx/ra.git", {tag, "v2.14.0-emqx-1"}}}
 ]}.


### PR DESCRIPTION

Fixes [EMQX-13219](https://emqx.atlassian.net/browse/EMQX-13219)

Release version: v/e5.8.2

## Summary

Also got rid of indirect dependency rfc3339

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [~] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [~] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [~] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13219]: https://emqx.atlassian.net/browse/EMQX-13219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ