### PR TITLE
ci: update perf test workflow

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -105,6 +105,15 @@ jobs:
       builder_vsn: ${{ needs.init.outputs.BUILDER_VSN }}
     secrets: inherit
 
+  performance_test:
+    if: needs.prepare.outputs.release == 'true'
+    needs:
+      - init
+      - prepare
+      - build_packages
+    uses: ./.github/workflows/performance_test.yaml
+    secrets: inherit
+
   build_and_push_docker_images:
     if: needs.prepare.outputs.release == 'true'
     needs:

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -77,32 +77,14 @@ jobs:
 
         set -euo pipefail
 
-        MESSAGE_TS=\${MESSAGE_TS:-''}
-
-        if [ -z "\${MESSAGE_TS}" ]; then
-          method='chat.postMessage'
-          jq -n --argjson attachments "\$(<attachments.json)" \
-            '{"channel": "$SLACK_CHANNEL_ID", "attachments": \$attachments}' > /tmp/slack-payload.json
-        else
-          method='chat.update'
-          jq -n --argjson attachments "\$(<attachments.json)" \
-                --arg ts "\$MESSAGE_TS" \
-            '{"channel": "$SLACK_CHANNEL_ID", "attachments": \$attachments, "ts": \$ts}' > /tmp/slack-payload.json
-        fi
-
+        jq -n --argjson attachments "\$(<attachments.json)" \
+          '{"channel": "$SLACK_CHANNEL_ID", "text": "EMQX performance test `\($scenario)` (<\($url)|Workflow Run>)", "attachments": \$attachments}' > /tmp/slack-payload.json
         curl -s -X POST \
           -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
           -H "Content-type: application/json; charset=UTF-8" \
-          --data @/tmp/slack-payload.json "https://slack.com/api/\$method" > /tmp/slack-response.json
+          --data @/tmp/slack-payload.json "https://slack.com/api/chat.postMessage"
         EOF
         chmod +x slack.sh
-
-        job_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs/$GITHUB_JOB"
-        jq -n --arg url "$job_url" --arg scenario "${{ matrix.scenario }}" \
-          '[{"color": "#dbab09", "pretext": "Starting EMQX performance test \($scenario) (<\($url)|Workflow Run>)", "fields": [{"title": "Creating infrastructure", "short": false}]}]' > attachments.json
-
-        ./slack.sh
-        echo "MESSAGE_TS=$(jq -r '.ts' /tmp/slack-response.json)" >> "$GITHUB_ENV"
 
     - name: Create infrastructure
       id: infra
@@ -147,10 +129,6 @@ jobs:
       run: |
         success=0
 
-        jq '. += [{"color": "36a64f", "fields": [{"title": "Infrastructure created OK", "short": false}]}]' \
-          attachments.json 1<> attachments.json
-        ./slack.sh
-
         export TMPDIR=$(mktemp -d)
         echo "TMPDIR=$TMPDIR" >> $GITHUB_ENV
 
@@ -164,25 +142,12 @@ jobs:
           success=1
           jq --arg mem1 "$MEM_CORE_1" --arg mem2 "$MEM_CORE_2" '. += [{"color": "#ff0000", "fields": [{"title": "Initial RAM usage is too high", "short": false, "value": "Core 1: \($mem1)%\nCore 2: \($mem2)%"}]}]' \
             attachments.json 1<> attachments.json
-        else
-          jq '. += [{"color": "#36a64f", "fields": [{"title": "Initial RAM usage is OK", "short": false}]}]' \
-            attachments.json 1<> attachments.json
         fi
-
-        ./slack.sh
 
         ansible loadgen -m command -a 'systemctl start loadgen' --become
 
-        jq '. += [{"color": "#dbab09", "fields": [{"title": "Started load generators", "short": false}]}]' \
-          attachments.json 1<> attachments.json
-        ./slack.sh
-
         sleep $DURATION
         PERIOD="${DURATION}s" scripts/summary.sh >> $GITHUB_STEP_SUMMARY
-
-        jq '. += [{"color": "#dbab09", "fields": [{"title": "Test completed, cleaning up", "short": false}]}]' \
-          attachments.json 1<> attachments.json
-        ./slack.sh
 
         echo "success=$success" >> $GITHUB_OUTPUT
 
@@ -196,16 +161,12 @@ jobs:
       run: |
         success=${{ steps.benchmark.outputs.success }}
 
-        jq '. += [{"color": "#dbab09", "fields": [{"title": "Analyzing results", "short": false}]}]' \
-          attachments.json 1<> attachments.json
-        ./slack.sh
-
-        CPU_CORE_1=$(jq -r '.[] | select(.host == "emqx-core-1") | .mem' $TMPDIR/cpu.json)
-        CPU_CORE_2=$(jq -r '.[] | select(.host == "emqx-core-2") | .mem' $TMPDIR/cpu.json)
+        CPU_CORE_1=$(jq -r '.[] | select(.host == "emqx-core-1") | .cpu' $TMPDIR/cpu.json)
+        CPU_CORE_2=$(jq -r '.[] | select(.host == "emqx-core-2") | .cpu' $TMPDIR/cpu.json)
 
         if [ $(echo "$CPU_CORE_1 > $CPU_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ] \
         || [ $(echo "$CPU_CORE_2 > $CPU_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ]; then
-          success=2
+          success=1
           jq --arg cpu1 "$CPU_CORE_1" --arg cpu2 "$CPU_CORE_2" '. += [{"color": "#ff0000", "fields": [{"title": "CPU utilization was too high", "short": false, "value": "Core 1: \($cpu1)%\nCore 2: \($cpu2)%"}]}]' \
             attachments.json 1<> attachments.json
         fi
@@ -215,42 +176,33 @@ jobs:
 
         if [ $(echo "$MEM_CORE_1 > $RAM_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ] \
         || [ $(echo "$MEM_CORE_2 > $RAM_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ]; then
-          success=3
+          success=1
           jq --arg mem1 "$MEM_CORE_1" --arg mem2 "$MEM_CORE_2" '. += [{"color": "#ff0000", "fields": [{"title": "RAM usage was too high", "short": false, "value": "Core 1: \($mem1)%\nCore 2: \($mem2)%"}]}]' \
             attachments.json 1<> attachments.json
         fi
 
-        MESSAGES_RECEIVED=$(jq -r '.messages_received' $TMPDIR/emqx_exporter_metrics.json)
-        MESSAGES_SENT=$(jq -r '.messages_sent' $TMPDIR/emqx_exporter_metrics.json)
-        MESSAGES_ACKED=$(jq -r '.messages_acked' $TMPDIR/emqx_exporter_metrics.json)
-        MESSAGES_PUBLISH=$(jq -r '.messages_publish' $TMPDIR/emqx_exporter_metrics.json)
-        MESSAGES_DELIVERED=$(jq -r '.messages_delivered' $TMPDIR/emqx_exporter_metrics.json)
-        MESSAGES_DROPPED=$(jq -r '.messages_dropped' $TMPDIR/emqx_exporter_metrics.json)
+        RECEIVED_MSG_RATE=$(jq -r '.received_msg_rate' $TMPDIR/monitor_current.json)
+        SENT_MSG_RATE=$(jq -r '.sent_msg_rate' $TMPDIR/monitor_current.json)
 
-        if [ $(echo "$MESSAGES_RECEIVED < $MESSAGES_RECEIVED_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
-        || [ $(echo "$MESSAGES_SENT < $MESSAGES_SENT_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
-        || [ $(echo "$MESSAGES_ACKED < $MESSAGES_ACKED_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
-        || [ $(echo "$MESSAGES_PUBLISH < $MESSAGES_PUBLISH_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
-        || [ $(echo "$MESSAGES_DELIVERED < $MESSAGES_DELIVERED_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
-        || [ $(echo "$MESSAGES_DROPPED > $MESSAGES_DROPPED_BASELINE * (1 + $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ]; then
-          success=4
-          jq --arg received "$MESSAGES_RECEIVED" --arg sent "$MESSAGES_SENT" --arg acked "$MESSAGES_ACKED" \
-            --arg publish "$MESSAGES_PUBLISH" --arg delivered "$MESSAGES_DELIVERED" --arg dropped "$MESSAGES_DROPPED" \
-            '. += [{"color": "#ff0000", "fields": [{"title": "Messages were not processed correctly", "short": false, "value": "Received: \($received)\nSent: \($sent)\nAcked: \($acked)\nPublish: \($publish)\nDelivered: \($delivered)\nDropped: \($dropped)"}]}]' \
+        if [ $(echo "$RECEIVED_MSG_RATE < $RECEIVED_MSG_RATE_BASELINE * (1 - $ALLOWED_DEVIATION_MSG_RATE)" | bc -l) -eq 1 ] \
+        || [ $(echo "$SENT_MSG_RATE < $SENT_MSG_RATE_BASELINE * (1 - $ALLOWED_DEVIATION_MSG_RATE)" | bc -l) -eq 1 ]; then
+          success=1
+          jq --arg received_msg_rate "$RECEIVED_MSG_RATE" --arg sent_msg_rate "$SENT_MSG_RATE" \
+            '. += [{"color": "#ff0000", "fields": [{"title": "Message rate was too low", "short": false, "value": "Received message rate: \($received_msg_rate)\nSent message rate: \($sent_msg_rate)}]}]' \
             attachments.json 1<> attachments.json
         fi
 
-        ./slack.sh
+        MESSAGES_DROPPED=$(jq -r '.messages_dropped' $TMPDIR/emqx_exporter_metrics.json)
+        if [ $(echo "$MESSAGES_DROPPED > 100" | bc) -eq 1 ]; then
+          success=1
+          jq --arg dropped "$MESSAGES_DROPPED" '. += [{"color": "#ff0000", "fields": [{"title": "Too many dropped messages", "short": false, "value": "Dropped: \($dropped)"}]}]' \
+            attachments.json 1<> attachments.json
+        fi
 
         if [ $success != 0 ]; then
-          jq '. += [{"color": "#ff0000", "fields": [{"title": "Test failed", "short": false}]}]' \
-            attachments.json 1<> attachments.json
           ./slack.sh
           exit 1
         fi
-        jq '. += [{"color": "36a64f", "fields": [{"title": "Test OK", "short": false}]}]' \
-          attachments.json 1<> attachments.json
-        ./slack.sh
 
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: failure()

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -128,7 +128,7 @@ jobs:
 
         EMQX_API_URL=$(terraform output -raw emqx_dashboard_url)
         ansible loadgen -m command -a 'systemctl start loadgen' --become --limit 'loadgen-emqtt_bench-1.*'
-        # wait until all subscribers are connected
+        echo "Waiting for subscribers to connect"
         subs=0
         while [ $subs -lt 10000 ]; do
           curl -s -u perftest:perftest "$EMQX_API_URL/api/v5/monitor_current" > "$TMPDIR/monitor_current.json"
@@ -136,14 +136,14 @@ jobs:
           sleep 1
         done
         ansible loadgen -m command -a 'systemctl start loadgen' --become --limit 'loadgen-emqtt_bench-2.*'
-        # wait until all publishers are up
+        echo "Waiting for publishers to connect"
         conns=$(jq -r '.live_connections "$TMPDIR/monitor_current.json")
         while [ $conns -lt 20000 ]; do
           curl -s -u perftest:perftest "$EMQX_API_URL/api/v5/monitor_current" > "$TMPDIR/monitor_current.json"
-          conns=$(jq -r '.live_connections "$TMPDIR/monitor_current.json")
+          conns=$(jq -r '.live_connections' "$TMPDIR/monitor_current.json")
           sleep 1
         done
-
+        echo "All clients connected, sleep for $DURATION seconds"
         sleep $DURATION
         PERIOD="${DURATION}s" scripts/summary.sh | tee -a $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -99,8 +99,8 @@ jobs:
     - name: Report failure
       if: failure()
       run: |
-        jq '. += [{"color": "#ff0000", "fields": [{"title": "Infrastructure creation failed", "short": false}]}]' \
-          attachments.json 1<> attachments.json
+        jq -n '[{"color": "#ff0000", "fields": [{"title": "Infrastructure creation failed", "short": false}]}]' > attachments.json
+        jq -n --argjson attachments "$(<attachments.json)" '{"attachments": $attachments}' > slack-payload.json
 
     - name: Run benchmark
       if: success()
@@ -111,6 +111,7 @@ jobs:
 
         export TMPDIR=$(mktemp -d)
         echo "TMPDIR=$TMPDIR" >> $GITHUB_ENV
+        echo '[]' > attachments.json
 
         PERIOD=1m scripts/summary.sh
 
@@ -178,7 +179,8 @@ jobs:
           jq --arg dropped "$MESSAGES_DROPPED" '. += [{"color": "#ff0000", "fields": [{"title": "Too many dropped messages", "short": false, "value": "Dropped: \($dropped)"}]}]' \
             attachments.json 1<> attachments.json
         fi
-        jq -n --argjson attachments "\$(<attachments.json)" '{"attachments": \$attachments}' > slack-payload.json
+
+        jq -n --argjson attachments "$(<attachments.json)" '{"attachments": $attachments}' > slack-payload.json
 
         exit $success
 

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -35,9 +35,6 @@ jobs:
     defaults:
       run:
         shell: bash
-    env:
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-      SLACK_CHANNEL_ID: ${{ secrets.SLACK_PERFTEST_CHANNEL_ID }}
 
     steps:
     - name: Configure AWS Credentials
@@ -69,22 +66,6 @@ jobs:
       run: |
         version=${{ github.event.inputs.emqx_version }}
         wget https://www.emqx.com/en/downloads/enterprise/${version}/emqx-enterprise-${version}-ubuntu22.04-amd64.deb
-
-    - name: Create helper script to send messages to Slack
-      run: |
-        cat <<EOF > slack.sh
-        #!/bin/bash
-
-        set -euo pipefail
-
-        jq -n --argjson attachments "\$(<attachments.json)" \
-          '{"channel": "$SLACK_CHANNEL_ID", "text": "EMQX performance test `\($scenario)` (<\($url)|Workflow Run>)", "attachments": \$attachments}' > /tmp/slack-payload.json
-        curl -s -X POST \
-          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
-          -H "Content-type: application/json; charset=UTF-8" \
-          --data @/tmp/slack-payload.json "https://slack.com/api/chat.postMessage"
-        EOF
-        chmod +x slack.sh
 
     - name: Create infrastructure
       id: infra
@@ -120,7 +101,6 @@ jobs:
       run: |
         jq '. += [{"color": "#ff0000", "fields": [{"title": "Infrastructure creation failed", "short": false}]}]' \
           attachments.json 1<> attachments.json
-        ./slack.sh
 
     - name: Run benchmark
       if: success()
@@ -188,7 +168,7 @@ jobs:
         || [ $(echo "$SENT_MSG_RATE < $SENT_MSG_RATE_BASELINE * (1 - $ALLOWED_DEVIATION_MSG_RATE)" | bc -l) -eq 1 ]; then
           success=1
           jq --arg received_msg_rate "$RECEIVED_MSG_RATE" --arg sent_msg_rate "$SENT_MSG_RATE" \
-            '. += [{"color": "#ff0000", "fields": [{"title": "Message rate was too low", "short": false, "value": "Received message rate: \($received_msg_rate)\nSent message rate: \($sent_msg_rate)}]}]' \
+            '. += [{"color": "#ff0000", "fields": [{"title": "Message rate was too low", "short": false, "value": "Received message rate: \($received_msg_rate)\nSent message rate: \($sent_msg_rate)"}]}]' \
             attachments.json 1<> attachments.json
         fi
 
@@ -198,12 +178,21 @@ jobs:
           jq --arg dropped "$MESSAGES_DROPPED" '. += [{"color": "#ff0000", "fields": [{"title": "Too many dropped messages", "short": false, "value": "Dropped: \($dropped)"}]}]' \
             attachments.json 1<> attachments.json
         fi
+        jq -n --argjson attachments "\$(<attachments.json)" '{"attachments": \$attachments}' > slack-payload.json
 
-        if [ $success != 0 ]; then
-          ./slack.sh
-          exit 1
-        fi
+        exit $success
 
+    - name: Post to Slack
+      if: failure()
+      uses: slackapi/slack-github-action@v1.27.0
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      with:
+        channel-id: ${{ secrets.SLACK_PERFTEST_CHANNEL_ID }}
+        slack-message: "EMQX performance test ${{ matrix.scenario }} failed. <${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}|Workflow Run>"
+        payload-file-path: slack-payload.json
+        payload-file-path-parsed: false
+    
     - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: failure()
       with:

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -76,6 +76,7 @@ jobs:
 
         echo "${{ secrets.EMQX_ENTERPRISE_LICENSE }}" > emqx5.lic
         cat ${{ matrix.scenario }}.env >> "$GITHUB_ENV"
+        echo '{}' > slack-payload.json
 
         terraform init
         set +e

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -50,7 +50,7 @@ jobs:
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: emqx/tf-emqx-performance-test
-        ref: 20241004-prep-for-ci
+        ref: 20241007-update-ci-test
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
       with:

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -137,7 +137,7 @@ jobs:
         done
         ansible loadgen -m command -a 'systemctl start loadgen' --become --limit 'loadgen-emqtt_bench-2.*'
         echo "Waiting for publishers to connect"
-        conns=$(jq -r '.live_connections "$TMPDIR/monitor_current.json")
+        conns=$(jq -r '.live_connections' "$TMPDIR/monitor_current.json")
         while [ $conns -lt 20000 ]; do
           curl -s -u perftest:perftest "$EMQX_API_URL/api/v5/monitor_current" > "$TMPDIR/monitor_current.json"
           conns=$(jq -r '.live_connections' "$TMPDIR/monitor_current.json")

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -126,7 +126,7 @@ jobs:
         fi
 
         EMQX_API_URL=$(terraform output -raw emqx_dashboard_url)
-        ansible loadgen -m command -a 'systemctl start loadgen' --limit 'loadgen-emqtt_bench-1.*'
+        ansible loadgen -m command -a 'systemctl start loadgen' --become --limit 'loadgen-emqtt_bench-1.*'
         # wait until all subscribers are connected
         subs=0
         while [ $subs -lt 10000 ]; do
@@ -134,7 +134,7 @@ jobs:
           subs=$(jq -r '.subscriptions "$TMPDIR/monitor_current.json")
           sleep 1
         done
-        ansible loadgen -m command -a 'systemctl start loadgen' --limit 'loadgen-emqtt_bench-2.*'
+        ansible loadgen -m command -a 'systemctl start loadgen' --become --limit 'loadgen-emqtt_bench-2.*'
         # wait until all publishers are up
         conns=$(jq -r '.live_connections "$TMPDIR/monitor_current.json")
         while [ $conns -lt 20000 ]; do

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -125,10 +125,26 @@ jobs:
             attachments.json 1<> attachments.json
         fi
 
-        ansible loadgen -m command -a 'systemctl start loadgen' --become
+        EMQX_API_URL=$(terraform output -raw emqx_dashboard_url)
+        ansible loadgen -m command -a 'systemctl start loadgen' --limit 'loadgen-emqtt_bench-1.*'
+        # wait until all subscribers are connected
+        subs=0
+        while [ $subs -lt 10000 ]; do
+          curl -s -u perftest:perftest "$EMQX_API_URL/api/v5/monitor_current" > "$TMPDIR/monitor_current.json"
+          subs=$(jq -r '.subscriptions "$TMPDIR/monitor_current.json")
+          sleep 1
+        done
+        ansible loadgen -m command -a 'systemctl start loadgen' --limit 'loadgen-emqtt_bench-2.*'
+        # wait until all publishers are up
+        conns=$(jq -r '.live_connections "$TMPDIR/monitor_current.json")
+        while [ $conns -lt 20000 ]; do
+          curl -s -u perftest:perftest "$EMQX_API_URL/api/v5/monitor_current" > "$TMPDIR/monitor_current.json"
+          conns=$(jq -r '.live_connections "$TMPDIR/monitor_current.json")
+          sleep 1
+        done
 
         sleep $DURATION
-        PERIOD="${DURATION}s" scripts/summary.sh >> $GITHUB_STEP_SUMMARY
+        PERIOD="${DURATION}s" scripts/summary.sh | tee -a $GITHUB_STEP_SUMMARY
 
         echo "success=$success" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -1,68 +1,43 @@
-name: Performance Test Suite
+name: Performance Test
 
 on:
-  push:
-    branches:
-      - 'perf/**'
-  schedule:
-    - cron:  '0 1 * * MON-FRI'
+  workflow_call:
+    secrets:
+      AWS_ACCESS_KEY_PERF_TEST:
+        required: true
+      AWS_SECRET_ACCESS_KEY_PERF_TEST:
+        required: true
+      AWS_DEFAULT_REGION_PERF_TEST:
+        required: true
+      SLACK_BOT_TOKEN:
+        required: true
+      SLACK_PERFTEST_CHANNEL_ID:
+        required: true
+      EMQX_ENTERPRISE_LICENSE:
+        required: true
   workflow_dispatch:
     inputs:
-      ref:
+      emqx_version:
         required: false
-
-env:
-  TF_AWS_REGION: eu-west-1
-  TF_VAR_s3_bucket_name: tf-emqx-performance-test2
-  TF_VAR_test_duration: 1800
-  TF_VAR_prometheus_remote_write_region: eu-west-1
-  TF_VAR_prometheus_remote_write_url: ${{ secrets.TF_EMQX_PERF_TEST_PROMETHEUS_REMOTE_WRITE_URL }}
-  SLACK_WEBHOOK_URL: ${{ secrets.TF_EMQX_PERF_TEST_SLACK_URL }}
+        default: '5.8.0'
 
 permissions:
   contents: read
 
 jobs:
-  prepare:
+  perftest:
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'emqx'
-    container: ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5-1-ubuntu20.04
-    outputs:
-      BENCH_ID: ${{ steps.prepare.outputs.BENCH_ID }}
-      PACKAGE_FILE: ${{ steps.package_file.outputs.PACKAGE_FILE }}
-
-    steps:
-    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        fetch-depth: 0
-        ref: ${{ github.event.inputs.ref }}
-    - name: Work around https://github.com/actions/checkout/issues/766
-      run: |
-        git config --global --add safe.directory "$GITHUB_WORKSPACE"
-    - id: prepare
-      run: |
-        echo "EMQX_NAME=emqx" >> $GITHUB_ENV
-        echo "CODE_PATH=$GITHUB_WORKSPACE" >> $GITHUB_ENV
-        echo "BENCH_ID=$(date --utc +%F)/emqx-$(./pkg-vsn.sh emqx)" >> $GITHUB_OUTPUT
-    - name: Build deb package
-      run: |
-        make ${EMQX_NAME}-pkg
-        ./scripts/pkg-tests.sh ${EMQX_NAME}-pkg
-    - name: Get package file name
-      id: package_file
-      run: |
-        echo "PACKAGE_FILE=$(find _packages/emqx -name 'emqx-*.deb' | head -n 1 | xargs basename)" >> $GITHUB_OUTPUT
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      with:
-        name: emqx-ubuntu20.04
-        path: _packages/emqx/${{ steps.package_file.outputs.PACKAGE_FILE }}
-
-  scenario_1on1:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
+    strategy:
+      max-parallel: 1
+      matrix:
+        scenario:
+          - tests/ci/pubsub-2x2c4g-10k-20k-tps
+    defaults:
+      run:
+        shell: bash
     env:
-      TF_VAR_package_file: ${{ needs.prepare.outputs.PACKAGE_FILE }}
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_CHANNEL_ID: ${{ secrets.SLACK_PERFTEST_CHANNEL_ID }}
 
     steps:
     - name: Configure AWS Credentials
@@ -70,276 +45,217 @@ jobs:
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PERF_TEST }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PERF_TEST }}
-        aws-region: eu-west-1
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION_PERF_TEST }}
     - name: Checkout tf-emqx-performance-test
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       with:
         repository: emqx/tf-emqx-performance-test
-        path: tf-emqx-performance-test
-        ref: v0.2.3
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      with:
-        name: emqx-ubuntu20.04
-        path: tf-emqx-performance-test/
+        ref: 20241004-prep-for-ci
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
       with:
+        terraform_version: 1.6.4
         terraform_wrapper: false
-    - name: run scenario
-      working-directory: ./tf-emqx-performance-test
-      timeout-minutes: 60
-      env:
-        TF_VAR_bench_id: "${{ needs.prepare.outputs.BENCH_ID }}/1on1"
-        TF_VAR_use_emqttb: 1
-        TF_VAR_use_emqtt_bench: 0
-        TF_VAR_emqttb_instance_count: 1
-        TF_VAR_emqttb_instance_type: c5.2xlarge
-        TF_VAR_emqttb_scenario: '@pubsub_fwd -n 50_000 --pub-qos 1 --sub-qos 1'
-        TF_VAR_emqx_instance_type: c5.2xlarge
-        TF_VAR_emqx_instance_count: 3
-      run: |
-        terraform init
-        terraform apply -auto-approve
-        ./wait-emqttb.sh
-        ./fetch-metrics.sh
-        terraform destroy -auto-approve
-        aws s3 sync --exclude '*' --include '*.tar.gz' s3://$TF_VAR_s3_bucket_name/$TF_VAR_bench_id .
-    - name: Send notification to Slack
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+    - uses: actions/setup-python@v5
       with:
-        payload-file-path: "./tf-emqx-performance-test/slack-payload.json"
-    - name: terraform destroy
-      if: always()
-      working-directory: ./tf-emqx-performance-test
+        python-version: '3.11'
+    - run: pip install -r requirements.txt
+    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      if: github.event_name == 'workflow_call'
+      with:
+        pattern: "emqx-enterprise-ubuntu22.04-amd64-*"
+    - name: Download emqx package
+      if: github.event_name == 'workflow_dispatch'
       run: |
-        terraform destroy -auto-approve
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+        version=${{ github.event.inputs.emqx_version }}
+        wget https://www.emqx.com/en/downloads/enterprise/${version}/emqx-enterprise-${version}-ubuntu22.04-amd64.deb
+
+    - name: Create helper script to send messages to Slack
+      run: |
+        cat <<EOF > slack.sh
+        #!/bin/bash
+
+        set -euo pipefail
+
+        MESSAGE_TS=\${MESSAGE_TS:-''}
+
+        if [ -z "\${MESSAGE_TS}" ]; then
+          method='chat.postMessage'
+          jq -n --argjson attachments "\$(<attachments.json)" \
+            '{"channel": "$SLACK_CHANNEL_ID", "attachments": \$attachments}' > /tmp/slack-payload.json
+        else
+          method='chat.update'
+          jq -n --argjson attachments "\$(<attachments.json)" \
+                --arg ts "\$MESSAGE_TS" \
+            '{"channel": "$SLACK_CHANNEL_ID", "attachments": \$attachments, "ts": \$ts}' > /tmp/slack-payload.json
+        fi
+
+        curl -s -X POST \
+          -H "Authorization: Bearer $SLACK_BOT_TOKEN" \
+          -H "Content-type: application/json; charset=UTF-8" \
+          --data @/tmp/slack-payload.json "https://slack.com/api/\$method" > /tmp/slack-response.json
+        EOF
+        chmod +x slack.sh
+
+        job_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs/$GITHUB_JOB"
+        jq -n --arg url "$job_url" --arg scenario "${{ matrix.scenario }}" \
+          '[{"color": "#dbab09", "pretext": "Starting EMQX performance test \($scenario) (<\($url)|Workflow Run>)", "fields": [{"title": "Creating infrastructure", "short": false}]}]' > attachments.json
+
+        ./slack.sh
+        echo "MESSAGE_TS=$(jq -r '.ts' /tmp/slack-response.json)" >> "$GITHUB_ENV"
+
+    - name: Create infrastructure
+      id: infra
+      timeout-minutes: 30
+      run: |
+        mv emqx-enterprise-*.deb emqx-enterprise-ubuntu22.04-amd64.deb
+        ls -lh *.deb
+
+        echo "${{ secrets.EMQX_ENTERPRISE_LICENSE }}" > emqx5.lic
+        cat ${{ matrix.scenario }}.env >> "$GITHUB_ENV"
+
+        terraform init
+        set +e
+        terraform apply -var spec_file=${{ matrix.scenario }}.yaml -auto-approve -lock=false
+        # retry once
+        if [ $? != 0 ]; then
+          echo "Retrying once"
+          set -e
+          terraform apply -var spec_file=${{ matrix.scenario }}.yaml -auto-approve -lock=false
+        fi
+        set -e
+        echo "ssh_key_path=$(terraform output -raw ssh_key_path)" >> $GITHUB_OUTPUT
+
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: success()
       with:
-        name: metrics
+        name: ssh_private_key
         path: |
-          "./tf-emqx-performance-test/*.tar.gz"
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
+          ${{ steps.infra.outputs.ssh_key_path }}
+
+    - name: Report failure
+      if: failure()
+      run: |
+        jq '. += [{"color": "#ff0000", "fields": [{"title": "Infrastructure creation failed", "short": false}]}]' \
+          attachments.json 1<> attachments.json
+        ./slack.sh
+
+    - name: Run benchmark
+      if: success()
+      id: benchmark
+      timeout-minutes: 60
+      run: |
+        success=0
+
+        jq '. += [{"color": "36a64f", "fields": [{"title": "Infrastructure created OK", "short": false}]}]' \
+          attachments.json 1<> attachments.json
+        ./slack.sh
+
+        export TMPDIR=$(mktemp -d)
+        echo "TMPDIR=$TMPDIR" >> $GITHUB_ENV
+
+        PERIOD=1m scripts/summary.sh
+
+        MEM_CORE_1=$(jq -r '.[] | select(.host == "emqx-core-1") | .mem' $TMPDIR/mem.json)
+        MEM_CORE_2=$(jq -r '.[] | select(.host == "emqx-core-2") | .mem' $TMPDIR/mem.json)
+
+        if [ $(echo "$MEM_CORE_1 > $INITIAL_RAM_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MEM_CORE_2 > $INITIAL_RAM_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ]; then
+          success=1
+          jq --arg mem1 "$MEM_CORE_1" --arg mem2 "$MEM_CORE_2" '. += [{"color": "#ff0000", "fields": [{"title": "Initial RAM usage is too high", "short": false, "value": "Core 1: \($mem1)%\nCore 2: \($mem2)%"}]}]' \
+            attachments.json 1<> attachments.json
+        else
+          jq '. += [{"color": "#36a64f", "fields": [{"title": "Initial RAM usage is OK", "short": false}]}]' \
+            attachments.json 1<> attachments.json
+        fi
+
+        ./slack.sh
+
+        ansible loadgen -m command -a 'systemctl start loadgen' --become
+
+        jq '. += [{"color": "#dbab09", "fields": [{"title": "Started load generators", "short": false}]}]' \
+          attachments.json 1<> attachments.json
+        ./slack.sh
+
+        sleep $DURATION
+        PERIOD="${DURATION}s" scripts/summary.sh >> $GITHUB_STEP_SUMMARY
+
+        jq '. += [{"color": "#dbab09", "fields": [{"title": "Test completed, cleaning up", "short": false}]}]' \
+          attachments.json 1<> attachments.json
+        ./slack.sh
+
+        echo "success=$success" >> $GITHUB_OUTPUT
+
+    - name: Cleanup infrastructure
+      if: always()
+      run: |
+        terraform destroy -var spec_file=${{ matrix.scenario }}.yaml -auto-approve
+
+    - name: Analyze results
+      if: success()
+      run: |
+        success=${{ steps.benchmark.outputs.success }}
+
+        jq '. += [{"color": "#dbab09", "fields": [{"title": "Analyzing results", "short": false}]}]' \
+          attachments.json 1<> attachments.json
+        ./slack.sh
+
+        CPU_CORE_1=$(jq -r '.[] | select(.host == "emqx-core-1") | .mem' $TMPDIR/cpu.json)
+        CPU_CORE_2=$(jq -r '.[] | select(.host == "emqx-core-2") | .mem' $TMPDIR/cpu.json)
+
+        if [ $(echo "$CPU_CORE_1 > $CPU_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ] \
+        || [ $(echo "$CPU_CORE_2 > $CPU_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ]; then
+          success=2
+          jq --arg cpu1 "$CPU_CORE_1" --arg cpu2 "$CPU_CORE_2" '. += [{"color": "#ff0000", "fields": [{"title": "CPU utilization was too high", "short": false, "value": "Core 1: \($cpu1)%\nCore 2: \($cpu2)%"}]}]' \
+            attachments.json 1<> attachments.json
+        fi
+
+        MEM_CORE_1=$(jq -r '.[] | select(.host == "emqx-core-1") | .mem' $TMPDIR/mem.json)
+        MEM_CORE_2=$(jq -r '.[] | select(.host == "emqx-core-2") | .mem' $TMPDIR/mem.json)
+
+        if [ $(echo "$MEM_CORE_1 > $RAM_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MEM_CORE_2 > $RAM_BASELINE * (1 + $ALLOWED_DEVIATION_CPU_RAM)" | bc -l) -eq 1 ]; then
+          success=3
+          jq --arg mem1 "$MEM_CORE_1" --arg mem2 "$MEM_CORE_2" '. += [{"color": "#ff0000", "fields": [{"title": "RAM usage was too high", "short": false, "value": "Core 1: \($mem1)%\nCore 2: \($mem2)%"}]}]' \
+            attachments.json 1<> attachments.json
+        fi
+
+        MESSAGES_RECEIVED=$(jq -r '.messages_received' $TMPDIR/emqx_exporter_metrics.json)
+        MESSAGES_SENT=$(jq -r '.messages_sent' $TMPDIR/emqx_exporter_metrics.json)
+        MESSAGES_ACKED=$(jq -r '.messages_acked' $TMPDIR/emqx_exporter_metrics.json)
+        MESSAGES_PUBLISH=$(jq -r '.messages_publish' $TMPDIR/emqx_exporter_metrics.json)
+        MESSAGES_DELIVERED=$(jq -r '.messages_delivered' $TMPDIR/emqx_exporter_metrics.json)
+        MESSAGES_DROPPED=$(jq -r '.messages_dropped' $TMPDIR/emqx_exporter_metrics.json)
+
+        if [ $(echo "$MESSAGES_RECEIVED < $MESSAGES_RECEIVED_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MESSAGES_SENT < $MESSAGES_SENT_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MESSAGES_ACKED < $MESSAGES_ACKED_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MESSAGES_PUBLISH < $MESSAGES_PUBLISH_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MESSAGES_DELIVERED < $MESSAGES_DELIVERED_BASELINE * (1 - $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ] \
+        || [ $(echo "$MESSAGES_DROPPED > $MESSAGES_DROPPED_BASELINE * (1 + $ALLOWED_DEVIATION_MESSAGES)" | bc -l) -eq 1 ]; then
+          success=4
+          jq --arg received "$MESSAGES_RECEIVED" --arg sent "$MESSAGES_SENT" --arg acked "$MESSAGES_ACKED" \
+            --arg publish "$MESSAGES_PUBLISH" --arg delivered "$MESSAGES_DELIVERED" --arg dropped "$MESSAGES_DROPPED" \
+            '. += [{"color": "#ff0000", "fields": [{"title": "Messages were not processed correctly", "short": false, "value": "Received: \($received)\nSent: \($sent)\nAcked: \($acked)\nPublish: \($publish)\nDelivered: \($delivered)\nDropped: \($dropped)"}]}]' \
+            attachments.json 1<> attachments.json
+        fi
+
+        ./slack.sh
+
+        if [ $success != 0 ]; then
+          jq '. += [{"color": "#ff0000", "fields": [{"title": "Test failed", "short": false}]}]' \
+            attachments.json 1<> attachments.json
+          ./slack.sh
+          exit 1
+        fi
+        jq '. += [{"color": "36a64f", "fields": [{"title": "Test OK", "short": false}]}]' \
+          attachments.json 1<> attachments.json
+        ./slack.sh
+
+    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
       if: failure()
       with:
         name: terraform
         path: |
-          ./tf-emqx-performance-test/.terraform
-          ./tf-emqx-performance-test/*.tfstate
-
-  scenario_fanout:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
-      - scenario_1on1
-    env:
-      TF_VAR_package_file: ${{ needs.prepare.outputs.PACKAGE_FILE }}
-
-    steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PERF_TEST }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PERF_TEST }}
-        aws-region: eu-west-1
-    - name: Checkout tf-emqx-performance-test
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        repository: emqx/tf-emqx-performance-test
-        path: tf-emqx-performance-test
-        ref: v0.2.3
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      with:
-        name: emqx-ubuntu20.04
-        path: tf-emqx-performance-test/
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
-      with:
-        terraform_wrapper: false
-    - name: run scenario
-      working-directory: ./tf-emqx-performance-test
-      timeout-minutes: 60
-      env:
-        TF_VAR_bench_id: "${{ needs.prepare.outputs.BENCH_ID }}/fan-out"
-        TF_VAR_use_emqttb: 1
-        TF_VAR_use_emqtt_bench: 0
-        TF_VAR_emqttb_instance_count: 1
-        TF_VAR_emqttb_instance_type: c5.2xlarge
-        TF_VAR_emqttb_scenario: '@pub --topic "t/%n" --conninterval 10ms --pubinterval 20ms --num-clients 5 --size 16 @sub --topic "t/#" --conninterval 10ms --num-clients 1000'
-        TF_VAR_emqx_instance_type: c5.large
-        TF_VAR_emqx_instance_count: 3
-      run: |
-        terraform init
-        terraform apply -auto-approve
-        ./wait-emqttb.sh
-        ./fetch-metrics.sh
-        terraform destroy -auto-approve
-        aws s3 sync --exclude '*' --include '*.tar.gz' s3://$TF_VAR_s3_bucket_name/$TF_VAR_bench_id .
-    - name: Send notification to Slack
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-      with:
-        payload-file-path: "./tf-emqx-performance-test/slack-payload.json"
-    - name: terraform destroy
-      if: always()
-      working-directory: ./tf-emqx-performance-test
-      run: |
-        terraform destroy -auto-approve
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      if: success()
-      with:
-        name: metrics
-        path: |
-          "./tf-emqx-performance-test/*.tar.gz"
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      if: failure()
-      with:
-        name: terraform
-        path: |
-          ./tf-emqx-performance-test/.terraform
-          ./tf-emqx-performance-test/*.tfstate
-
-  scenario_fanin:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
-      - scenario_1on1
-      - scenario_fanout
-    env:
-      TF_VAR_package_file: ${{ needs.prepare.outputs.PACKAGE_FILE }}
-
-    steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PERF_TEST }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PERF_TEST }}
-        aws-region: eu-west-1
-    - name: Checkout tf-emqx-performance-test
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        repository: emqx/tf-emqx-performance-test
-        path: tf-emqx-performance-test
-        ref: v0.2.3
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      with:
-        name: emqx-ubuntu20.04
-        path: tf-emqx-performance-test/
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
-      with:
-        terraform_wrapper: false
-    - name: run scenario
-      working-directory: ./tf-emqx-performance-test
-      timeout-minutes: 60
-      env:
-        TF_VAR_bench_id: "${{ needs.prepare.outputs.BENCH_ID }}/fan-in"
-        TF_VAR_use_emqttb: 1
-        TF_VAR_use_emqtt_bench: 0
-        TF_VAR_emqttb_instance_count: 2
-        TF_VAR_emqttb_start_n_multiplier: 25000
-        TF_VAR_emqttb_instance_type: c5.xlarge
-        TF_VAR_emqttb_scenario: '@pub --topic t/%n --conninterval 10ms --pubinterval 1s --num-clients 25_000 --start-n $START_N --size 16 @sub --topic \$share/perf/t/# --conninterval 10ms --num-clients 250'
-        TF_VAR_emqx_instance_type: c5.2xlarge
-        TF_VAR_emqx_instance_count: 3
-      run: |
-        terraform init
-        terraform apply -auto-approve
-        ./wait-emqttb.sh
-        ./fetch-metrics.sh
-        terraform destroy -auto-approve
-        aws s3 sync --exclude '*' --include '*.tar.gz' s3://$TF_VAR_s3_bucket_name/$TF_VAR_bench_id .
-    - name: Send notification to Slack
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-      with:
-        payload-file-path: "./tf-emqx-performance-test/slack-payload.json"
-    - name: terraform destroy
-      if: always()
-      working-directory: ./tf-emqx-performance-test
-      run: |
-        terraform destroy -auto-approve
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      if: success()
-      with:
-        name: metrics
-        path: |
-          "./tf-emqx-performance-test/*.tar.gz"
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      if: failure()
-      with:
-        name: terraform
-        path: |
-          ./tf-emqx-performance-test/.terraform
-          ./tf-emqx-performance-test/*.tfstate
-
-  scenario_1m_conns:
-    runs-on: ubuntu-latest
-    needs:
-      - prepare
-      - scenario_fanin
-      - scenario_fanout
-      - scenario_1on1
-    env:
-      TF_VAR_package_file: ${{ needs.prepare.outputs.PACKAGE_FILE }}
-
-    steps:
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-      with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PERF_TEST }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PERF_TEST }}
-        aws-region: eu-west-1
-    - name: Checkout tf-emqx-performance-test
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        repository: emqx/tf-emqx-performance-test
-        path: tf-emqx-performance-test
-        ref: v0.2.3
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      with:
-        name: emqx-ubuntu20.04
-        path: tf-emqx-performance-test/
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # v3.1.1
-      with:
-        terraform_wrapper: false
-    - name: run scenario
-      working-directory: ./tf-emqx-performance-test
-      timeout-minutes: 60
-      env:
-        TF_VAR_bench_id: "${{ needs.prepare.outputs.BENCH_ID }}/1m-connections"
-        TF_VAR_use_emqttb: 1
-        TF_VAR_use_emqtt_bench: 0
-        TF_VAR_emqttb_instance_count: 5
-        TF_VAR_emqttb_instance_type: c5.2xlarge
-        TF_VAR_emqttb_scenario: '@conn -N 200_000 --conninterval 1ms'
-        TF_VAR_emqx_instance_type: c5.2xlarge
-        TF_VAR_emqx_instance_count: 3
-      run: |
-        terraform init
-        terraform apply -auto-approve
-        ./wait-emqttb.sh
-        ./fetch-metrics.sh
-        terraform destroy -auto-approve
-        aws s3 sync --exclude '*' --include '*.tar.gz' s3://$TF_VAR_s3_bucket_name/$TF_VAR_bench_id .
-    - name: Send notification to Slack
-      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
-      with:
-        payload-file-path: "./tf-emqx-performance-test/slack-payload.json"
-    - name: terraform destroy
-      if: always()
-      working-directory: ./tf-emqx-performance-test
-      run: |
-        terraform destroy -auto-approve
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      if: success()
-      with:
-        name: metrics
-        path: |
-          "./tf-emqx-performance-test/*.tar.gz"
-    - uses: actions/upload-artifact@89ef406dd8d7e03cfd12d9e0a4a378f454709029 # v4.3.5
-      if: failure()
-      with:
-        name: terraform
-        path: |
-          ./tf-emqx-performance-test/.terraform
-          ./tf-emqx-performance-test/*.tfstate
+          .terraform
+          *.tfstate


### PR DESCRIPTION
Fixes [EMQX-13182](https://emqx.atlassian.net/browse/EMQX-13182)

Release version: v/e5.8.1

## Summary

Rewrote `performance_test` workflow.
Now it will be called when a release tag is pushed (incl. alpha, beta and rc), and will run a set of predefined performance tests (for now it's just `tests/ci/pubsub-2x2c4g-10k-20k-tps`, see emqx/tf-emqx-performance-test#31).
The job will be considered successful if all of the conditions below are met:
- initial RAM usage on EMQX nodes are within the predefined boundaries
- CPU and RAM usage on EMQX nodes during load test are within the predefined boundaries
- total number of messages processed is within the predefined boundaries

The job can be triggered manually for specified EMQX version.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13182]: https://emqx.atlassian.net/browse/EMQX-13182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ