### PR TITLE
Refactor: Move TCP Keepalive config schema to schema module

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -260,7 +260,7 @@ async_set_keepalive(Idle, Interval, Probes) ->
     async_set_keepalive(os:type(), self(), Idle, Interval, Probes).
 
 async_set_keepalive(OS, Pid, Idle, Interval, Probes) ->
-    case emqx_utils:tcp_keepalive_opts(OS, Idle, Interval, Probes) of
+    case emqx_schema:tcp_keepalive_opts(OS, Idle, Interval, Probes) of
         {ok, Options} ->
             async_set_socket_options(Pid, Options);
         {error, {unsupported_os, OS}} ->

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -355,7 +355,7 @@ fields(socket_opts) ->
         {tcp_keepalive,
             mk(string(), #{
                 default => <<"none">>,
-                desc => ?DESC(socket_tcp_keepalive),
+                desc => ?DESC(emqx_schema, socket_tcp_keepalive),
                 validator => fun emqx_schema:validate_tcp_keepalive/1
             })}
     ];

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
@@ -69,20 +69,8 @@ adjust_socket_buffer(Bytes, Opts) ->
             [{buffer, max(Bytes1, Bytes)} | Acc1]
     end.
 
-tcp_keepalive(None) when None =:= "none"; None =:= <<"none">> ->
-    [];
-tcp_keepalive(KeepAlive) ->
-    {Idle, Interval, Probes} = emqx_schema:parse_tcp_keepalive(KeepAlive),
-    case emqx_utils:tcp_keepalive_opts(os:type(), Idle, Interval, Probes) of
-        {ok, Opts} ->
-            Opts;
-        {error, {unsupported_os, OS}} ->
-            ?SLOG(warning, #{
-                msg => "unsupported_operation_set_tcp_keepalive",
-                os => OS
-            }),
-            []
-    end.
+tcp_keepalive(String) ->
+    emqx_schema:tcp_keepalive_opts(String).
 
 to_bin(A) when is_atom(A) ->
     atom_to_binary(A);

--- a/apps/emqx_utils/src/emqx_utils.erl
+++ b/apps/emqx_utils/src/emqx_utils.erl
@@ -64,7 +64,6 @@
     diff_lists/3,
     merge_lists/3,
     flattermap/2,
-    tcp_keepalive_opts/4,
     format/1,
     format/2,
     format_mfal/2,
@@ -547,26 +546,6 @@ safe_to_existing_atom(Atom, _Encoding) when is_atom(Atom) ->
     {ok, Atom};
 safe_to_existing_atom(_Any, _Encoding) ->
     {error, invalid_type}.
-
--spec tcp_keepalive_opts(term(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ->
-    {ok, [{keepalive, true} | {raw, non_neg_integer(), non_neg_integer(), binary()}]}
-    | {error, {unsupported_os, term()}}.
-tcp_keepalive_opts({unix, linux}, Idle, Interval, Probes) ->
-    {ok, [
-        {keepalive, true},
-        {raw, 6, 4, <<Idle:32/native>>},
-        {raw, 6, 5, <<Interval:32/native>>},
-        {raw, 6, 6, <<Probes:32/native>>}
-    ]};
-tcp_keepalive_opts({unix, darwin}, Idle, Interval, Probes) ->
-    {ok, [
-        {keepalive, true},
-        {raw, 6, 16#10, <<Idle:32/native>>},
-        {raw, 6, 16#101, <<Interval:32/native>>},
-        {raw, 6, 16#102, <<Probes:32/native>>}
-    ]};
-tcp_keepalive_opts(OS, _Idle, _Interval, _Probes) ->
-    {error, {unsupported_os, OS}}.
 
 format(Term) ->
     unicode:characters_to_binary(io_lib:format("~0p", [Term])).

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -38,18 +38,6 @@ socket_receive_buffer.desc:
 socket_receive_buffer.label:
 """Socket Receive Buffer Size"""
 
-socket_tcp_keepalive.desc:
-"""Enable TCP keepalive.
-The value is three comma separated numbers in the format of 'Idle,Interval,Probes'
- - Idle: The number of seconds a connection needs to be idle before the server begins to send out keep-alive probes (Linux default 7200).
- - Interval: The number of seconds between TCP keep-alive probes (Linux default 75).
- - Probes: The maximum number of TCP keep-alive probes to send before giving up and killing the connection if no response is obtained from the other end (Linux default 9).
-For example "240,30,5" means: TCP keepalive probes are sent after the connection is idle for 240 seconds, and the probes are sent every 30 seconds until a response is received, if it misses 5 consecutive responses, the connection should be closed.
-Default: 'none'"""
-
-socket_tcp_keepalive.label:
-"""TCP keepalive options"""
-
 desc_name.desc:
 """Action name, used as a human-readable identifier."""
 

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1709,4 +1709,16 @@ See the documentation for details on each field.
 Each row in the rest of this file must contain the same number of columns as the header line,
 and column can be omitted then its value will be `undefined`."""
 
+socket_tcp_keepalive.desc:
+"""Enable TCP keepalive.
+The value is three comma separated numbers in the format of 'Idle,Interval,Probes'
+ - Idle: The number of seconds a connection needs to be idle before the server begins to send out keep-alive probes (Linux default 7200).
+ - Interval: The number of seconds between TCP keep-alive probes (Linux default 75).
+ - Probes: The maximum number of TCP keep-alive probes to send before giving up and killing the connection if no response is obtained from the other end (Linux default 9).
+For example "240,30,5" means: EMQX will start sending probes after the connection is idle for 240 seconds, and the probes are sent every 30 seconds until a response is received, if it misses 5 consecutive responses, the connection should be closed.
+Default: 'none'"""
+
+socket_tcp_keepalive.label:
+"""TCP keepalive options"""
+
 }


### PR DESCRIPTION
So other bridges can make use of it soon.