### PR TITLE
Perf: in-place downsample monitor metrics

### DIFF
--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -62,9 +62,7 @@
 
 -define(DELTA_SAMPLER_LIST, [
     received,
-    %, received_bytes
     sent,
-    %, sent_bytes
     validation_succeeded,
     validation_failed,
     transformation_succeeded,
@@ -86,9 +84,6 @@
 
 -define(DELTA_SAMPLER_RATE_MAP, #{
     received => received_msg_rate,
-    %% In 5.0.0, temporarily comment it to suppress bytes rate
-    %received_bytes  => received_bytes_rate,
-    %sent_bytes      => sent_bytes_rate,
     sent => sent_msg_rate,
     validation_succeeded => validation_succeeded_rate,
     validation_failed => validation_failed_rate,

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -237,6 +237,8 @@ inplace_downsample() ->
     ),
     ok.
 
+%% compare the original data points with the compacted data points
+%% return the timestamps to be deleted and the new data points to be written
 compare(Remain, [], Deletes, Writes) ->
     %% all compacted buckets have been processed, remaining datapoints should all be deleted
     RemainTsList = lists:map(fun({T, _Data}) -> T end, Remain),
@@ -254,6 +256,7 @@ compare([{T0, _} | _] = All, [{T1, Data1} | Compacted], Deletes, Writes) when T0
     %% compare with the next compacted bucket timestamp
     compare(All, Compacted, Deletes, [{T1, Data1} | Writes]).
 
+%% compact the data points to a smaller set of buckets
 compact(_Now, [], Acc) ->
     lists:reverse(Acc);
 compact(Now, [{Time, Data} | Rest], Acc) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -196,13 +196,22 @@ t_inplace_downsample(_Config) ->
     emqx_dashboard_monitor ! clean_expired,
     %% ensure downsample happened
     ok = gen_server:call(emqx_dashboard_monitor, dummy, infinity),
-    All = emqx_dashboard_monitor:all_data(),
+    All1 = emqx_dashboard_monitor:all_data(),
+    All = drop_dummy_data_points(All1),
     AllSent = lists:map(fun({_, #{sent := S}}) -> S end, All),
     ?assertEqual(Total, lists:sum(AllSent)),
     %% check timestamps are not random after downsample
     ExpectedIntervals = [timer:minutes(10), timer:minutes(5), timer:minutes(1), timer:seconds(10)],
     ok = check_intervals(ExpectedIntervals, All),
     ok.
+
+%% there might be some data points added while downsample is running
+%% because the sampling interval during test is 1s, so they do not perfectly
+%% match the expected intervals
+%% this function is to dorp those dummy data points
+drop_dummy_data_points(All) ->
+    IsZeroValues = fun(Map) -> lists:all(fun(Value) -> Value =:= 0 end, maps:values(Map)) end,
+    lists:filter(fun({_, Map}) -> not IsZeroValues(Map) end, All).
 
 check_intervals(_, []) ->
     ok;

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -183,6 +183,39 @@ t_pmap_nodes(_Config) ->
     ok = check_sample_intervals(Interval, hd(Data), tl(Data)),
     ?assertEqual(DataPoints * length(Nodes), sum_value(Data, sent)).
 
+t_inplace_downsample(_Config) ->
+    ok = emqx_dashboard_monitor:clean(0),
+    %% -20s to ensure the oldest data point will not expire during the test
+    SinceT = 7 * timer:hours(24) - timer:seconds(20),
+    Total = 10000,
+    emqx_dashboard_monitor:randomize(Total, #{sent => 1}, SinceT),
+    %% assert original data (before downsample)
+    All0 = emqx_dashboard_monitor:all_data(),
+    AllSent0 = lists:map(fun({_, #{sent := S}}) -> S end, All0),
+    ?assertEqual(Total, lists:sum(AllSent0)),
+    emqx_dashboard_monitor ! clean_expired,
+    %% ensure downsample happened
+    ok = gen_server:call(emqx_dashboard_monitor, dummy, infinity),
+    All = emqx_dashboard_monitor:all_data(),
+    AllSent = lists:map(fun({_, #{sent := S}}) -> S end, All),
+    ?assertEqual(Total, lists:sum(AllSent)),
+    %% check timestamps are not random after downsample
+    ExpectedIntervals = [timer:minutes(10), timer:minutes(5), timer:minutes(1), timer:seconds(10)],
+    ok = check_intervals(ExpectedIntervals, All),
+    ok.
+
+check_intervals(_, []) ->
+    ok;
+check_intervals([], All) ->
+    throw({bad_intervals, All});
+check_intervals([Interval | Rest], [{Ts, _} | RestData] = All) ->
+    case (Ts rem Interval) =:= 0 of
+        true ->
+            check_intervals([Interval | Rest], RestData);
+        false ->
+            check_intervals(Rest, All)
+    end.
+
 t_randomize(_Config) ->
     ok = emqx_dashboard_monitor:clean(0),
     emqx_dashboard_monitor:randomize(1, #{sent => 100}),


### PR DESCRIPTION
Fixes [EMQX-12962](https://emqx.atlassian.net/browse/EMQX-12962)

Release version: v/e5.8.1

## Summary

Followup PR https://github.com/emqx/emqx/pull/13873

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [~] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-12962]: https://emqx.atlassian.net/browse/EMQX-12962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ