### PR TITLE
chore: upgrade mysql client from 1.7.4.1 to 1.7.4.2

### DIFF
--- a/apps/emqx_mysql/mix.exs
+++ b/apps/emqx_mysql/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXMysql.MixProject do
 
   def deps() do
     [
-      {:mysql, github: "emqx/mysql-otp", tag: "1.7.4.1"},
+      {:mysql, github: "emqx/mysql-otp", tag: "1.7.4.2"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
     ]

--- a/apps/emqx_mysql/rebar.config
+++ b/apps/emqx_mysql/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.4.1"}}},
+    {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.4.2"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.


### PR DESCRIPTION
Release version: v/e5.8.2

## Summary

mysql client 1.7.4.2 added more context in the init failure error returns.
See PR: https://github.com/emqx/mysql-otp/pull/10

When there are more than one set of MySQL configs, it's quite hard to tell which one is for which.
before: `timeout`
after: `#{cause => timeout,port => 3306,user => <<"root">>,host => "1.1.1.1",database => <<"test">>}`

e.g.

2024-10-07T07:12:52.857393+00:00 [error] crasher: initial call: mysql_conn:init/1, pid: <0.6494.0>, registered_name: [], exit: {#{cause => timeout,port => 3306,user => <<"root">>,host => "1.1.1.1",database => <<"test">>},[{gen_server,init_it,6,[{file,"gen_server.erl"},{line,961}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}, ancestors: [<0.6493.0>,<0.6492.0>,<0.6490.0>,ecpool_sup,<0.4205.0>], message_queue_len: 0, messages: [], links: [<0.6493.0>], dictionary: [], trap_exit: false, status: running, heap_size: 376, stack_size: 28, reductions: 286; neighbours:

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
