### PR TITLE
chore: upgrade ehttpc from 0.5.0 to 0.6.0

### DIFF
--- a/changes/ce/feat-13942.en.md
+++ b/changes/ce/feat-13942.en.md
@@ -1,0 +1,14 @@
+The HTTP client now automatically reconnects if no activity is detected for 10 seconds after the latest request has expired.
+Previously, it would wait indefinitely for a server response, causing timeouts if the server dropped requests.
+
+This change impacts below components.
+
+- HTTP authentication
+- HTTP authorization
+- Webhook (HTTP connector)
+- GCP PubSub connector (Enterprise edition)
+- S3 connector (Enterprise edition)
+- InfluxDB connector (Enterprise edition)
+- Couchbase connector (Enterprise edition)
+- IoTDB connector (Enterprise edition)
+- Snowflake connector (Enterprise edition)

--- a/mix.exs
+++ b/mix.exs
@@ -194,7 +194,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ranch), do: {:ranch, github: "emqx/ranch", tag: "1.8.1-emqx", override: true}
 
   def common_dep(:ehttpc),
-    do: {:ehttpc, github: "emqx/ehttpc", tag: "0.5.0", override: true}
+    do: {:ehttpc, github: "emqx/ehttpc", tag: "0.6.0", override: true}
 
   def common_dep(:jiffy), do: {:jiffy, github: "emqx/jiffy", tag: "1.0.6", override: true}
 

--- a/rebar.config
+++ b/rebar.config
@@ -77,7 +77,7 @@
     {gpb, "4.19.9"},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.1"}}},
     {gun, {git, "https://github.com/emqx/gun", {tag, "1.3.11"}}},
-    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.5.0"}}},
+    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.6.0"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},


### PR DESCRIPTION
En enhancement to auto-recover: https://github.com/emqx/emqx/issues/12974

Release version: v/e5.8.1

## Summary

ehttpc-0.6.0 introduced zombie connection detection.
see https://github.com/emqx/ehttpc/pull/57

by default, if a http connection is inactive for more than 10s after the last sent request has been expired, it will try to reconnect.

Before the connection is force restarted, an `error` level log with message `force_reconnecting_zombie_http_connection` is written.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
