### PR TITLE
feat(retainer): clean expired messages in separate process

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -351,7 +351,10 @@ count(Context) ->
 
 -spec start_clear_expired(context()) -> ok.
 start_clear_expired(Context) ->
-    Opts = #{deadline => erlang:system_time(millisecond)},
+    Opts = #{
+        deadline => erlang:system_time(millisecond),
+        limit => emqx_conf:get([retainer, msg_clear_limit], all)
+    },
     _Result = emqx_retainer_sup:start_gc(Context, Opts),
     ok.
 

--- a/apps/emqx_retainer/src/emqx_retainer_gc.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_gc.erl
@@ -1,0 +1,86 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_retainer_gc).
+
+-behaviour(gen_server).
+
+-include_lib("emqx/include/logger.hrl").
+
+-export([start_link/2]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+-export_type([opts/0]).
+
+-type opts() :: #{deadline => emqx_retainer:deadline()}.
+
+-type backend_state() :: term().
+
+-callback clear_expired(backend_state(), emqx_retainer:deadline()) -> ok.
+
+%%------------------------------------------------------------------------------
+%% APIs
+%%------------------------------------------------------------------------------
+
+-spec start_link(emqx_retainer:context(), opts()) -> {ok, pid()} | ignore.
+start_link(Context, Opts) ->
+    case is_responsible() of
+        true ->
+            gen_server:start_link(?MODULE, {Context, Opts}, []);
+        false ->
+            ignore
+    end.
+
+is_responsible() ->
+    Nodes = lists:sort(mria_membership:running_core_nodelist()),
+    Nodes =/= [] andalso hd(Nodes) == node().
+
+%%------------------------------------------------------------------------------
+%% gen_server callbacks
+%%------------------------------------------------------------------------------
+
+init({Context, Opts}) ->
+    ok = gen_server:cast(self(), clear_expired),
+    {ok, {Context, Opts}}.
+
+handle_call(Req, _From, State) ->
+    ?SLOG(error, #{msg => "unexpected_call", call => Req}),
+    {reply, ignored, State}.
+
+handle_cast(clear_expired, State = {Context, Opts}) ->
+    Deadline = maps:get(deadline, Opts),
+    Result = clear_expired(Context, Deadline),
+    {stop, {shutdown, Result}, State};
+handle_cast(Msg, State) ->
+    ?SLOG(error, #{msg => "unexpected_cast", cast => Msg}),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    ?SLOG(error, #{msg => "unexpected_info", info => Info}),
+    {noreply, State}.
+
+-spec clear_expired(emqx_retainer:context(), emqx_retainer:deadline()) -> ok.
+clear_expired(Context, Deadline) ->
+    Mod = emqx_retainer:backend_module(Context),
+    BackendState = emqx_retainer:backend_state(Context),
+    ok = Mod:clear_expired(BackendState, Deadline).

--- a/apps/emqx_retainer/src/emqx_retainer_gc.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_gc.erl
@@ -36,18 +36,11 @@
 -type limit() :: all | non_neg_integer().
 -type opts() :: #{
     deadline := emqx_retainer:deadline(),
-    limit => limit()
+    limit := limit()
 }.
 
 -callback clear_expired(_BackendState, emqx_retainer:deadline(), limit()) ->
     {_Complete :: boolean(), _NCleared :: non_neg_integer()}.
-
--define(DEFAULT_CLEAR_EXPIRED_LIMIT, 50_000).
-
--ifdef(TEST).
--undef(DEFAULT_CLEAR_EXPIRED_LIMIT).
--define(DEFAULT_CLEAR_EXPIRED_LIMIT, 100).
--endif.
 
 %%------------------------------------------------------------------------------
 %% APIs
@@ -97,5 +90,5 @@ clear_expired(Context, Opts) ->
     Mod = emqx_retainer:backend_module(Context),
     BackendState = emqx_retainer:backend_state(Context),
     Deadline = maps:get(deadline, Opts),
-    Limit = maps:get(limit, Opts, ?DEFAULT_CLEAR_EXPIRED_LIMIT),
+    Limit = maps:get(limit, Opts),
     Mod:clear_expired(BackendState, Deadline, Limit).

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -33,7 +33,7 @@
     delete_message/2,
     store_retained/2,
     read_message/2,
-    page_read/4,
+    page_read/5,
     match_messages/3,
     delete_cursor/2,
     clear_expired/2,
@@ -262,15 +262,14 @@ match_messages(_State, _Topic, {S0, BatchNum}) ->
 delete_cursor(_State, _Cursor) ->
     ok.
 
-page_read(_State, Topic, Page, Limit) ->
-    Now = erlang:system_time(millisecond),
+page_read(_State, Topic, Deadline, Page, Limit) ->
     S0 =
         case Topic of
             undefined ->
-                msg_stream(search_stream(undefined, ['#'], Now));
+                msg_stream(search_stream(undefined, ['#'], Deadline));
             _ ->
                 Tokens = topic_to_tokens(Topic),
-                msg_stream(search_stream(Tokens, Now))
+                msg_stream(search_stream(Tokens, Deadline))
         end,
     %% This is very inefficient, but we are limited with inherited API
     S1 = emqx_utils_stream:list(

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -16,8 +16,6 @@
 
 -module(emqx_retainer_mnesia).
 
--behaviour(emqx_retainer).
--behaviour(emqx_retainer_gc).
 -behaviour(emqx_db_backup).
 
 -include("emqx_retainer.hrl").
@@ -25,7 +23,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
 
-%% emqx_retainer callbacks
+-behaviour(emqx_retainer).
 -export([
     create/1,
     update/2,
@@ -36,9 +34,13 @@
     page_read/5,
     match_messages/3,
     delete_cursor/2,
-    clear_expired/2,
     clean/1,
     size/1
+]).
+
+-behaviour(emqx_retainer_gc).
+-export([
+    clear_expired/3
 ]).
 
 %% Internal exports (RPC)
@@ -208,7 +210,7 @@ store_retained(State, Msg = #message{topic = Topic}) ->
             ok
     end.
 
-clear_expired(_State, Deadline) ->
+clear_expired(_State, Deadline, Limit) ->
     S0 = ets_stream(?TAB_MESSAGE),
     S1 = emqx_utils_stream:filter(
         fun(#retained_message{expiry_time = ExpiryTime}) ->
@@ -217,12 +219,22 @@ clear_expired(_State, Deadline) ->
         S0
     ),
     DirtyWriteIndices = dirty_indices(write),
-    emqx_utils_stream:foreach(
+    S2 = emqx_utils_stream:map(
         fun(RetainedMsg) ->
             delete_message_with_indices(RetainedMsg, DirtyWriteIndices)
         end,
         S1
-    ).
+    ),
+    CountF = fun(_, N) -> N + 1 end,
+    case Limit of
+        all ->
+            NCleared = emqx_utils_stream:fold(CountF, 0, S2),
+            {_Complete = true, NCleared};
+        Num ->
+            {NCleared, SRest} = emqx_utils_stream:fold(CountF, 0, Num, S2),
+            Complete = SRest == [],
+            {Complete, NCleared}
+    end.
 
 delete_message(_State, Topic) ->
     Tokens = topic_to_tokens(Topic),

--- a/apps/emqx_retainer/src/emqx_retainer_schema.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_schema.erl
@@ -57,6 +57,13 @@ fields("retainer") ->
                 msg_clear_interval,
                 <<"0s">>
             )},
+        {msg_clear_limit,
+            sc(
+                pos_integer(),
+                msg_clear_limit,
+                50_000,
+                ?IMPORTANCE_HIDDEN
+            )},
         {flow_control,
             sc(
                 ?R_REF(flow_control),

--- a/apps/emqx_retainer/src/emqx_retainer_sup.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_sup.erl
@@ -16,14 +16,28 @@
 
 -module(emqx_retainer_sup).
 
--behaviour(supervisor).
-
 -export([start_link/0]).
 
+-export([start_gc/2]).
+
+-behaviour(supervisor).
 -export([init/1]).
 
 start_link() ->
     supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+
+-spec start_gc(emqx_retainer:context(), emqx_retainer_gc:opts()) ->
+    supervisor:startchild_ret().
+start_gc(Context, Opts) ->
+    ChildSpec = #{
+        id => gc,
+        start => {emqx_retainer_gc, start_link, [Context, Opts]},
+        restart => temporary,
+        type => worker
+    },
+    supervisor:start_child(?MODULE, ChildSpec).
+
+%%
 
 init([]) ->
     PoolSpec = emqx_pool_sup:spec([

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -606,12 +606,12 @@ t_clear_expired(Config) ->
         ),
         timer:sleep(1000),
 
-        {ok, _, List} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
+        {ok, _, List} = emqx_retainer:page_read(<<"retained/+">>, _Deadline = 0, 1, 10),
         ?assertEqual(5, erlang:length(List)),
 
         timer:sleep(4500),
 
-        {ok, _, List2} = emqx_retainer:page_read(<<"retained/+">>, 1, 10),
+        {ok, _, List2} = emqx_retainer:page_read(<<"retained/+">>, _Deadline = 0, 1, 10),
         ?assertEqual(0, erlang:length(List2)),
 
         ok = emqtt:disconnect(C1)

--- a/apps/emqx_retainer/test/emqx_retainer_dummy.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_dummy.erl
@@ -20,6 +20,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 
 -behaviour(emqx_retainer).
+-behaviour(emqx_retainer_gc).
 
 -export([
     create/1,
@@ -28,10 +29,10 @@
     delete_message/2,
     store_retained/2,
     read_message/2,
-    page_read/4,
+    page_read/5,
     match_messages/3,
     delete_cursor/2,
-    clear_expired/1,
+    clear_expired/3,
     clean/1,
     size/1
 ]).
@@ -60,13 +61,13 @@ store_retained(_Context, _Message) -> ok.
 
 read_message(_Context, _Topic) -> {ok, []}.
 
-page_read(_Context, _Topic, _Offset, _Limit) -> {ok, false, []}.
+page_read(_Context, _Topic, _Deadline, _Offset, _Limit) -> {ok, false, []}.
 
 match_messages(_Context, _Topic, _Cursor) -> {ok, [], 0}.
 
 delete_cursor(_Context, _Cursor) -> ok.
 
-clear_expired(_Context) -> ok.
+clear_expired(_Context, _Deadline, _Limit) -> {true, 0}.
 
 clean(_Context) -> ok.
 

--- a/apps/emqx_retainer/test/emqx_retainer_gc_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_gc_SUITE.erl
@@ -50,6 +50,7 @@ init_cluster(ExtraConf, Config) ->
         "retainer {"
         "\n enable = true"
         "\n msg_clear_interval = 0s"
+        "\n msg_clear_limit = 100"
         "\n msg_expiry_interval = 3s"
         "\n backend {"
         "\n   type = built_in_database"
@@ -102,7 +103,7 @@ t_limited_gc_runtime(Config) ->
             ok = disable_clear_expired(Config)
         end,
         fun(Trace) ->
-            %% Only one node should have ran GC:
+            %% Since limit is 100, we should observe 3 GC events for 250 messages:
             ?assertMatch(
                 [
                     #{complete := false, n_cleared := 100, ?snk_meta := #{node := N1}},

--- a/apps/emqx_retainer/test/emqx_retainer_gc_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_gc_SUITE.erl
@@ -1,0 +1,146 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_retainer_gc_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
+all() ->
+    [
+        {group, mnesia_without_indices},
+        {group, mnesia_with_indices}
+    ].
+
+groups() ->
+    TCs = emqx_common_test_helpers:all(?MODULE),
+    [
+        {mnesia_without_indices, [], TCs},
+        {mnesia_with_indices, [], TCs}
+    ].
+
+init_per_group(mnesia_without_indices, Config) ->
+    ExtraConf = "retainer.backend.index_specs = []",
+    init_cluster(ExtraConf, Config);
+init_per_group(mnesia_with_indices, Config) ->
+    init_cluster("", Config).
+
+init_cluster(ExtraConf, Config) ->
+    Conf =
+        "retainer {"
+        "\n enable = true"
+        "\n msg_clear_interval = 0s"
+        "\n msg_expiry_interval = 3s"
+        "\n backend {"
+        "\n   type = built_in_database"
+        "\n   storage_type = disc"
+        "\n }"
+        "\n }",
+    NodeSpec = #{
+        role => core,
+        apps => [emqx, emqx_conf, {emqx_retainer, [Conf, ExtraConf]}]
+    },
+    Nodes = emqx_cth_cluster:start(
+        [{emqx_retainer_gc1, NodeSpec}, {emqx_retainer_gc2, NodeSpec}],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{cluster, Nodes} | Config].
+
+end_per_group(_Group, Config) ->
+    emqx_cth_cluster:stop(?config(cluster, Config)).
+
+%%
+
+t_exclusive_gc(Config) ->
+    [N1 | _] = ?config(cluster, Config),
+    ?check_trace(
+        begin
+            Interval = 1000,
+            ok = enable_clear_expired(Interval, Config),
+            ok = timer:sleep(round(Interval * 1.5)),
+            ok = disable_clear_expired(Config)
+        end,
+        fun(Trace) ->
+            %% Only one node should have ran GC:
+            ?assertMatch(
+                [#{?snk_meta := #{node := N1}}],
+                ?of_kind(emqx_retainer_cleared_expired, Trace)
+            )
+        end
+    ).
+
+t_limited_gc_runtime(Config) ->
+    [N1 | _] = ?config(cluster, Config),
+    ?check_trace(
+        begin
+            ok = store_retained(_NMessages = 250, Config),
+            ok = timer:sleep(1000),
+            {ok, {ok, _}} = ?wait_async_action(
+                enable_clear_expired(_Interval = 1000, Config),
+                #{?snk_kind := emqx_retainer_cleared_expired, complete := true}
+            ),
+            ok = disable_clear_expired(Config)
+        end,
+        fun(Trace) ->
+            %% Only one node should have ran GC:
+            ?assertMatch(
+                [
+                    #{complete := false, n_cleared := 100, ?snk_meta := #{node := N1}},
+                    #{complete := false, n_cleared := 100, ?snk_meta := #{node := N1}},
+                    #{complete := true, n_cleared := 50, ?snk_meta := #{node := N1}}
+                ],
+                ?of_kind(emqx_retainer_cleared_expired, Trace)
+            )
+        end
+    ).
+
+store_retained(NMessages, Config) ->
+    [N1 | _] = ?config(cluster, Config),
+    ?ON(
+        N1,
+        lists:foreach(
+            fun(N) ->
+                Num = integer_to_binary(N),
+                Msg = emqx_message:make(
+                    ?MODULE,
+                    0,
+                    <<"retained/", Num/binary>>,
+                    <<"payload">>,
+                    #{retain => true},
+                    #{properties => #{'Message-Expiry-Interval' => 1}}
+                ),
+                emqx:publish(Msg)
+            end,
+            lists:seq(1, NMessages)
+        )
+    ).
+
+enable_clear_expired(Interval, Config) ->
+    [N1 | _] = ?config(cluster, Config),
+    {ok, _} = ?ON(N1, emqx_retainer:update_config(#{<<"msg_clear_interval">> => Interval})),
+    ok.
+
+disable_clear_expired(Config) ->
+    [N1 | _] = ?config(cluster, Config),
+    {ok, _} = ?ON(N1, emqx_retainer:update_config(#{<<"msg_clear_interval">> => 0})),
+    ok.

--- a/apps/emqx_utils/test/emqx_utils_stream_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_stream_tests.erl
@@ -114,6 +114,25 @@ foreach_test() ->
         emqx_utils_stream:consume(emqx_utils_stream:mqueue(100))
     ).
 
+fold_test() ->
+    S = emqx_utils_stream:drop(2, emqx_utils_stream:list([1, 2, 3, 4, 5])),
+    ?assertEqual(
+        3 * 4 * 5,
+        emqx_utils_stream:fold(fun(X, P) -> P * X end, 1, S)
+    ).
+
+fold_n_test() ->
+    S = emqx_utils_stream:repeat(
+        emqx_utils_stream:map(
+            fun(X) -> X * 2 end,
+            emqx_utils_stream:list([1, 2, 3])
+        )
+    ),
+    ?assertMatch(
+        {2 + 4 + 6 + 2 + 4 + 6 + 2, _SRest},
+        emqx_utils_stream:fold(fun(X, Sum) -> Sum + X end, 0, _N = 7, S)
+    ).
+
 chainmap_test() ->
     S = emqx_utils_stream:chainmap(
         fun(N) ->

--- a/rel/i18n/emqx_retainer_schema.hocon
+++ b/rel/i18n/emqx_retainer_schema.hocon
@@ -43,6 +43,9 @@ msg_clear_interval.desc:
 
 If `msg_clear_interval` is set to 0, that is, expired retained messages are not actively checked regularly, EMQX will only check and delete expired retained messages when preparing for delivery."""
 
+msg_clear_limit.desc:
+"""The maximum number of expired messages cleared at once each `msg_clear_interval`. Settings reasonable limit can prevent the clearing process from running for too long and consume too much resources."""
+
 msg_expiry_interval.desc:
 """Expired retained messages will not be delivered again, and a setting of 0 means that retained messages will never expire.
 


### PR DESCRIPTION
Fixes [EMQX-13213](https://emqx.atlassian.net/browse/EMQX-13213).

Release version: v5.8.2

## Summary

See individual commits.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-13213]: https://emqx.atlassian.net/browse/EMQX-13213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ