### PR TITLE
fix: upgrade wolff from 4.0.0 to 4.0.2

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.0"},
+    {wolff, "4.0.2"},
     {kafka_protocol, "4.1.8"},
     {brod_gssapi, "0.1.3"},
     {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.18.0"}}},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.0"},
+    {wolff, "4.0.2"},
     {kafka_protocol, "4.1.8"},
     {brod_gssapi, "0.1.3"},
     {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.18.0"}}},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.0"},
+    {wolff, "4.0.2"},
     {kafka_protocol, "4.1.8"},
     {brod_gssapi, "0.1.3"},
     {brod, {git, "https://github.com/kafka4beam/brod.git", {tag, "3.18.0"}}},

--- a/changes/ee/fix-13971.en.md
+++ b/changes/ee/fix-13971.en.md
@@ -1,0 +1,3 @@
+Fix Kafka producer bug introudced in EMQX Enterprise 5.8.0.
+
+Kafka producer may crash in case it has failed to fetch metadata at initialization stage.

--- a/mix.exs
+++ b/mix.exs
@@ -278,7 +278,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.0"}
+  def common_dep(:wolff), do: {:wolff, "4.0.2"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),


### PR DESCRIPTION
Fixes [EMQX-13137](https://emqx.atlassian.net/browse/EMQX-13137)

Release version: e5.8.1

## Summary

This upgrade fixes two issues.

1. A bug in wolff-4.0.0 which is not released in EMQX Enterprise 5.8.1 yet, causing the producer process to crash when buffer overflow happens while there are inflight requests sent towards Kafka. 
  Example exception: `#{cause => unexpected_id,max => 1728471879846415,min => 1728471879846415,got => 1728471879846430}`
2. A bug since wolff-3.0.0 which was released in EMQX Enterprise 5.8.0. In some corner cases, if the producer failed to fetch metadata for an existing topic, it may crash with this exception: `{{badmap,{not_initialized,1,failed_to_fetch_metadata}},[{maps,merge,[#{},{not_initialized,1,failed_
to_fetch_metadata}],[{error_info,#{module => erl_stdlib_errors}}]},{wolff_producers,do_add_topic,2...`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13137]: https://emqx.atlassian.net/browse/EMQX-13137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ