### PR TITLE
fix: call odbc:disconnect/1 when sqlserver pool worker is terminated

### DIFF
--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -44,8 +44,11 @@
     on_format_query_result/1
 ]).
 
-%% callbacks for ecpool
--export([connect/1]).
+%% `ecpool_worker' API
+-export([
+    connect/1,
+    disconnect/1
+]).
 
 %% Internal exports used to execute code with ecpool worker
 -export([do_get_status/1, worker_do_insert/3]).
@@ -213,7 +216,8 @@ on_start(
         {password, maps:get(password, Config, emqx_secret:wrap(""))},
         {driver, Driver},
         {database, Database},
-        {pool_size, PoolSize}
+        {pool_size, PoolSize},
+        {on_disconnect, {?MODULE, disconnect, []}}
     ],
 
     State = #{
@@ -349,6 +353,10 @@ connect(Options) ->
     ConnectStr = lists:concat(conn_str(Options, [])),
     Opts = proplists:get_value(options, Options, []),
     odbc:connect(ConnectStr, Opts).
+
+-spec disconnect(connection_reference()) -> ok | {error, term()}.
+disconnect(ConnectionPid) ->
+    odbc:disconnect(ConnectionPid).
 
 -spec do_get_status(connection_reference()) -> Result :: boolean().
 do_get_status(Conn) ->

--- a/changes/ee/fix-13973.en.md
+++ b/changes/ee/fix-13973.en.md
@@ -1,0 +1,1 @@
+Fix an issue with MS SQL Server integration when EMQX would print a few errors and warnings in the log each time connection to the server is stopped.


### PR DESCRIPTION
before this patch emqx would log a few errors each time connector is stopped

fixes [EMQX-13224](https://emqx.atlassian.net/browse/EMQX-13224)

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13224]: https://emqx.atlassian.net/browse/EMQX-13224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ