### PR TITLE
ci: update condition for downloading artifact in perf test workflow

### DIFF
--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -58,7 +58,7 @@ jobs:
         python-version: '3.11'
     - run: pip install -r requirements.txt
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      if: github.event_name == 'workflow_call'
+      if: github.event_name != 'workflow_dispatch'
       with:
         pattern: "emqx-enterprise-ubuntu22.04-amd64-*"
     - name: Download emqx package


### PR DESCRIPTION
When calling workflow, the event comes from the parent workflow.
Using negative match instead to decide if we need to download artifact.

Release version: v/e5.8.1

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
