### PR TITLE
feat: supports user-defined EPMD_ARGS environment variable

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -596,7 +596,7 @@ get_boot_config() {
     echo -e "$EMQX_BOOT_CONFIGS" | $GREP "$path_to_value=" | sed -e "s/$path_to_value=//g" | tr -d \"
 }
 
-EPMD_ARGS="-start_epmd false -epmd_module ekka_epmd -proto_dist ekka"
+EPMD_ARGS="${EPMD_ARGS:-"-start_epmd false -epmd_module ekka_epmd -proto_dist ekka"}"
 PROTO_DIST="$(get_boot_config 'cluster.proto_dist' || true)"
 TICKTIME="$(get_boot_config 'node.dist_net_ticktime' || echo '120')"
 # this environment variable is required by ekka_dist module


### PR DESCRIPTION
Now the user is able to use epmd mode by setting the EPMD_ARGS manually:

```
EPMD_ARGS="-start_epmd=true" _build/emqx-enterprise/rel/emqx/bin/emqx console
```

This is useful when a developer wants to connect a temporary Erlang node to the EMQX node. For example, the developer may want to enable the observer tool in another Erlang shell to debug a remote EMQX node:

```
erl -name test@127.0.0.1 -setcookie emqxsecretcookie
(test@127.0.0.1)2> observer:start().
```

Release version: v/e5.8.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
