### PR TITLE
fix(connector aggregator): use `{continue, _}` instead of 0 timeout

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.4.0"},
+    {vsn, "0.4.1"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.app.src
+++ b/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.app.src
@@ -1,6 +1,6 @@
 {application, emqx_connector_aggregator, [
     {description, "EMQX Enterprise Connector Data Aggregator"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [
         kernel,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13302

Release version: e5.8.2

## Problem

1) First allocated buffer gets 3 records, its delivery is started and completes just fine.
2) As the 3rd record from the first batch is pushed, it triggers the allocation of a
   second buffer.
3) After delivery is completed, 3 more records are pushed into this 2nd buffer.
4) As the 3rd record from the second batch is pushed, it triggers the allocation of a
   3rd buffer.  This time, however, no delivery process is started.
5) Seconds later, probably due to a ~tick~ timeout, delivery of this 3rd, empty buffer is
   started and completed, indeed reporting to be empty.  Delivery of the 2nd buffer is
   never started.

Albeit the causing sequence of events causing the race condition is not yet exactly determined,
this is an attempt to avoid the possibility of other events being processed before an
enqueued delivery is started.

Examples:

- https://github.com/emqx/emqx/actions/runs/11365721751/job/31614944950#step:5:510
  - [logs-emqx-enterprise-apps_emqx_bridge_snowflake-sg1_1.zip](https://github.com/user-attachments/files/17411909/logs-emqx-enterprise-apps_emqx_bridge_snowflake-sg1_1.zip)

- https://github.com/emqx/emqx/actions/runs/11367014664?pr=14008
  - [logs-emqx-enterprise-apps_emqx_bridge_snowflake-sg1_1_b.zip](https://github.com/user-attachments/files/17411914/logs-emqx-enterprise-apps_emqx_bridge_snowflake-sg1_1_b.zip)

### Hypothesis

1) 0 timeout is aborted if any request or message arrives concurrently.
2) Last pushed record triggers `cast {rotate_buffer, FD}`, which places buffer in
   `#st.queued` and allocates a fresh empty buffer and sets it as current.
3) Concurrently, some request or message arrives, cancelling the 0-timeout that would
   enqueue the delivery of the full buffer.
4) After `tick` timeouts, it triggers `cast {close_buffer, Timestamp}`, which processes
   only the current empty buffer.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
