### PR TITLE
fix(dashboard monitor): don't sum data for local aggregation

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -214,7 +214,7 @@ all_data() ->
 inplace_downsample() ->
     All = all_data(),
     Now = erlang:system_time(millisecond),
-    Compacted = compact(Now, All, []),
+    Compacted = compact(Now, All),
     {Deletes, Writes} = compare(All, Compacted, [], []),
     {atomic, ok} = mria:transaction(
         mria:local_content_shard(),
@@ -255,18 +255,23 @@ compare([{T0, _} | _] = All, [{T1, Data1} | Compacted], Deletes, Writes) when T0
     compare(All, Compacted, Deletes, [{T1, Data1} | Writes]).
 
 %% compact the data points to a smaller set of buckets
-compact(_Now, [], Acc) ->
+%% Pre-condition: data fed to this function must be sorted chronologically.
+compact(Now, Data) ->
+    Gauges = gauges(),
+    compact(Now, Data, Gauges, []).
+
+compact(_Now, [], _Gauges, Acc) ->
     lists:reverse(Acc);
-compact(Now, [{Time, Data} | Rest], Acc) ->
+compact(Now, [{Time, Data} | Rest], Gauges, Acc) ->
     Interval = sample_interval(Now - Time),
     Bucket = round_down(Time, Interval),
-    NewAcc = merge_to_bucket(Bucket, Data, Acc),
-    compact(Now, Rest, NewAcc).
+    NewAcc = merge_to_bucket(Bucket, Data, Gauges, Acc),
+    compact(Now, Rest, Gauges, NewAcc).
 
-merge_to_bucket(Bucket, Data, [{Bucket, Data0} | Acc]) ->
-    NewData = merge_sampler_maps(Data, Data0),
+merge_to_bucket(Bucket, Data, Gauges, [{Bucket, Data0} | Acc]) ->
+    NewData = merge_local_sampler_maps(Data0, Data, Gauges),
     [{Bucket, NewData} | Acc];
-merge_to_bucket(Bucket, Data, Acc) ->
+merge_to_bucket(Bucket, Data, _Gauges, Acc) ->
     [{Bucket, Data} | Acc].
 
 %% for testing
@@ -277,6 +282,7 @@ randomize(Count, Data) when is_map(Data) ->
 randomize(Count, Data, Age) when is_map(Data) andalso is_integer(Age) ->
     Now = erlang:system_time(millisecond) - 1,
     StartTs = Now - Age,
+    Gauges = gauges(),
     lists:foreach(
         fun(_) ->
             Ts = round_down(StartTs + rand:uniform(Age), timer:seconds(10)),
@@ -285,7 +291,7 @@ randomize(Count, Data, Age) when is_map(Data) andalso is_integer(Age) ->
                 [] ->
                     store(Record);
                 [#emqx_monit{data = D} = R] ->
-                    store(R#emqx_monit{data = merge_sampler_maps(D, Data)})
+                    store(R#emqx_monit{data = merge_local_sampler_maps(Data, D, Gauges)})
             end
         end,
         lists:seq(1, Count)
@@ -370,6 +376,7 @@ merge_sampler_maps(M1, M2) when is_map(M1) andalso is_map(M2) ->
     Fun = fun(Key, Acc) -> merge_values(Key, M1, Acc) end,
     lists:foldl(Fun, M2, ?SAMPLER_LIST).
 
+%% `M1' is assumed to be newer data compared to anything `M2' has seen.
 merge_local_sampler_maps(M1, M2, Gauges) when is_map(M1) andalso is_map(M2) ->
     Fun = fun(Key, Acc) -> merge_local_values(Key, M1, Acc, Gauges) end,
     lists:foldl(Fun, M2, ?SAMPLER_LIST).
@@ -391,7 +398,7 @@ merge_local_values(Key, M1, M2, Gauges) when
     %% First argument is assumed to be from a newer timestamp, so we keep the latest.
     M2#{Key => maps:get(Key, M1, maps:get(Key, M2, 0))};
 merge_local_values(Key, M1, M2, _Gauges) ->
-    sum_values(Key, M1, M2).
+    merge_values(Key, M1, M2).
 
 max_values(Key, M1, M2) when is_map_key(Key, M1) orelse is_map_key(Key, M2) ->
     M2#{Key => max(maps:get(Key, M1, 0), maps:get(Key, M2, 0))};
@@ -554,7 +561,7 @@ downsample_local(SinceTs, TsDataMap) when map_size(TsDataMap) >= 2 ->
     TsList = ts_list(TsDataMap),
     Latest = lists:max(TsList),
     Interval = sample_interval(Latest - SinceTs),
-    Gauges = maps:from_keys(?GAUGE_SAMPLER_LIST, true),
+    Gauges = gauges(),
     downsample_local_loop(TsList, Gauges, TsDataMap, Interval, #{});
 downsample_local(_Since, TsDataMap) ->
     TsDataMap.
@@ -582,6 +589,9 @@ downsample_local_loop([Ts | Rest], Gauges, TsDataMap, Interval, Res) ->
     Inc = maps:get(Ts, TsDataMap),
     Agg = merge_local_sampler_maps(Inc, Agg0, Gauges),
     downsample_local_loop(Rest, Gauges, TsDataMap, Interval, Res#{Bucket => Agg}).
+
+gauges() ->
+    maps:from_keys(?GAUGE_SAMPLER_LIST, true).
 
 %% -------------------------------------------------------------------------------------------------
 %% timer

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -263,9 +263,9 @@ compact(Now, [{Time, Data} | Rest], Acc) ->
     NewAcc = merge_to_bucket(Bucket, Data, Acc),
     compact(Now, Rest, NewAcc).
 
-merge_to_bucket(Bucket, Data, [{Bucket, Data0} | Acc]) ->
-    NewData = merge_sampler_maps(Data, Data0),
-    [{Bucket, NewData} | Acc];
+%% Assumes input data is sorted chronologically.
+merge_to_bucket(Bucket, Data, [{Bucket, _Data0} | Acc]) ->
+    [{Bucket, Data} | Acc];
 merge_to_bucket(Bucket, Data, Acc) ->
     [{Bucket, Data} | Acc].
 
@@ -285,7 +285,7 @@ randomize(Count, Data, Age) when is_map(Data) andalso is_integer(Age) ->
                 [] ->
                     store(Record);
                 [#emqx_monit{data = D} = R] ->
-                    store(R#emqx_monit{data = merge_sampler_maps(D, Data)})
+                    store(R#emqx_monit{data = merge_sampler_cluster_maps(D, Data)})
             end
         end,
         lists:seq(1, Count)
@@ -339,7 +339,7 @@ sample_nodes(Nodes, Time) ->
     ),
     Failed =/= [] andalso
         ?LOG(badrpc_log_level(Success), #{msg => "failed_to_sample_monitor_data", errors => Failed}),
-    lists:foldl(fun(I, B) -> merge_samplers(Time, I, B) end, #{}, Success).
+    lists:foldl(fun(I, B) -> merge_samplers_cluster(Time, I, B) end, #{}, Success).
 
 concurrently_sample_nodes(Nodes, Time) ->
     %% emqx_dashboard_proto_v1:do_sample has a timeout (5s),
@@ -347,7 +347,7 @@ concurrently_sample_nodes(Nodes, Time) ->
     %% to avoid having to introduce a new bpapi proto version
     emqx_utils:pmap(fun(Node) -> do_sample(Node, Time) end, Nodes, infinity).
 
-merge_samplers(SinceTime, Increment0, Base) ->
+merge_samplers_cluster(SinceTime, Increment0, Base) ->
     Increment =
         case map_size(Increment0) > ?MAX_POSSIBLE_SAMPLES of
             true ->
@@ -356,17 +356,17 @@ merge_samplers(SinceTime, Increment0, Base) ->
             false ->
                 Increment0
         end,
-    maps:fold(fun merge_samplers_loop/3, Base, Increment).
+    maps:fold(fun merge_samplers_cluster_loop/3, Base, Increment).
 
-merge_samplers_loop(TS, Increment, Base) when is_map(Increment) ->
+merge_samplers_cluster_loop(TS, Increment, Base) when is_map(Increment) ->
     case maps:get(TS, Base, undefined) of
         undefined ->
             Base#{TS => Increment};
         BaseSample when is_map(BaseSample) ->
-            Base#{TS => merge_sampler_maps(Increment, BaseSample)}
+            Base#{TS => merge_sampler_cluster_maps(Increment, BaseSample)}
     end.
 
-merge_sampler_maps(M1, M2) when is_map(M1) andalso is_map(M2) ->
+merge_sampler_cluster_maps(M1, M2) when is_map(M1) andalso is_map(M2) ->
     Fun = fun(Key, Acc) -> merge_values(Key, M1, Acc) end,
     lists:foldl(Fun, M2, ?SAMPLER_LIST).
 
@@ -534,7 +534,7 @@ downsample(SinceTs, TsDataMap) when map_size(TsDataMap) >= 2 ->
     Latest = lists:max(TsList),
     Interval = sample_interval(Latest - SinceTs),
     downsample_loop(TsList, TsDataMap, Interval, #{});
-downsample(_Since, TsDataMap) ->
+downsample(_SinceTs, TsDataMap) ->
     TsDataMap.
 
 ts_list(TsDataMap) ->
@@ -547,10 +547,8 @@ downsample_loop([], _TsDataMap, _Interval, Res) ->
     Res;
 downsample_loop([Ts | Rest], TsDataMap, Interval, Res) ->
     Bucket = round_down(Ts, Interval),
-    Agg0 = maps:get(Bucket, Res, #{}),
-    Inc = maps:get(Ts, TsDataMap),
-    Agg = merge_sampler_maps(Inc, Agg0),
-    downsample_loop(Rest, TsDataMap, Interval, Res#{Bucket => Agg}).
+    Latest = maps:get(Ts, TsDataMap),
+    downsample_loop(Rest, TsDataMap, Interval, Res#{Bucket => Latest}).
 
 %% -------------------------------------------------------------------------------------------------
 %% timer

--- a/changes/ce/fix-14023.en.md
+++ b/changes/ce/fix-14023.en.md
@@ -1,1 +1,10 @@
-Fixed an issue with the `GET /monitor` HTTP API where returned data could return values greater than reality depending on the requested time window.
+Fixed an issue with the `GET /monitor` HTTP API where returned data could return values greater than reality depending on the requested time window.  For data points within 1 hour window, this distortion is merely visual in the dashboard.  For data points older than 1 hour, data is permanently distorted.
+
+The impacted gauges are:
+
+- `disconnected_durable_sessions`
+- `subscriptions_durable`
+- `subscriptions`
+- `topics`
+- `connections`
+- `live_connections`

--- a/changes/ce/fix-14023.en.md
+++ b/changes/ce/fix-14023.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with the `GET /monitor` HTTP API where returned data could return values greater than reality depending on the requested time window.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13262

Release version: v/e5.8.2

## Summary

When compacting or downsampling data for local node only, since data points are repeated snapshots until a change is recorded, we need to keep the latest values instead of summing them up.

#### Without patch


https://github.com/user-attachments/assets/3e3152ed-0575-46e4-ba97-abb0b2ccec13



#### With patch


https://github.com/user-attachments/assets/f899b21d-d36b-4d0a-bbd0-86657f3af249



## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
