### PR TITLE
fix: suppress tls_alert warning logs

### DIFF
--- a/src/emqx_connection.erl
+++ b/src/emqx_connection.erl
@@ -767,9 +767,11 @@ handle_info(activate_socket, State = #state{sockstate = OldSst}) ->
     end;
 
 handle_info({sock_error, Reason}, State) ->
-    case Reason =/= closed andalso Reason =/= einval of
-        true -> ?LOG(warning, "socket_error: ~p", [Reason]);
-        false -> ok
+    case Reason of
+        closed -> ok;
+        einval -> ok;
+        {tls_alert, _} -> ok;
+        _ -> ?LOG(warning, #{msg => "socket_error", reason => Reason})
     end,
     handle_info({sock_closed, Reason}, close_socket(State));
 


### PR DESCRIPTION
For TLS client abnorml disconnect, EMQX prints logs as following,

"""
2024-10-21T12:11:59.498627+00:00 [warning] AAA_bench_pub_1@172.17.0.1:37746 [MQTT] socket_error: {tls_alert,{internal_error,"TLS server: In state connection received CLIENT ALERT: Fatal - Internal Error\n"}} """

Fixes <issue-or-jira-number>

Release version: v/e4.4.x

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
