### PR TITLE
fix(sessds): Fix crash resulting from subscription state update

### DIFF
--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -421,7 +421,7 @@ t_subscription_state_change(Config) ->
     Port = get_mqtt_port(Node1, tcp),
     TopicFilter = <<"t/+">>,
     ClientId = mk_clientid(?FUNCTION_NAME, sub),
-    %% Helper function that waits for the session GC:
+    %% Helper function that waits for the internal session GC:
     WaitGC = fun() ->
         ?block_until(
             #{?snk_kind := sessds_renew_streams, ?snk_meta := #{clientid := ClientId}}, 5_000, 0
@@ -466,8 +466,8 @@ t_subscription_state_change(Config) ->
             ),
             %% Now ack the packet and publish some more to trigger SRS
             %% update. This should, in effect, release the reference
-            %% to the old subscription state, and let GC will delete
-            %% old subscription state:
+            %% to the old subscription state, and let GC delete old
+            %% subscription state:
             ok = emqtt:puback(Sub, PI1),
             {ok, _} = emqtt:publish(Pub, <<"t/1">>, <<"2">>, ?QOS_2),
             %% QoS of subscription has been updated:

--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -95,7 +95,8 @@ end_per_testcase(TestCase, Config) when
     TestCase =:= t_session_subscription_idempotency;
     TestCase =:= t_session_unsubscription_idempotency;
     TestCase =:= t_subscription_state_change;
-    TestCase =:= t_session_gc
+    TestCase =:= t_session_gc;
+    TestCase =:= t_storage_generations
 ->
     Nodes = ?config(nodes, Config),
     emqx_common_test_helpers:call_janitor(60_000),

--- a/changes/ce/fix-14042.en.md
+++ b/changes/ce/fix-14042.en.md
@@ -1,0 +1,1 @@
+Fix crash in the durable session after update of the subscription parameters (such as QoS, `no_local`, `upgrade_qos`, ...)


### PR DESCRIPTION
Fixes: #14039

Release version: v/e5.8.2

## Summary
Properly handle change of the subscription parameters in the durable sessions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
