### PR TITLE
241009 lower default active_n from 100 to 10

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -139,7 +139,7 @@
 -type state() :: #state{}.
 -type pending_req() :: #pending_req{}.
 
--define(ACTIVE_N, 100).
+-define(ACTIVE_N, 10).
 
 -define(INFO_KEYS, [
     socktype,

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -117,7 +117,7 @@
 
 -type ws_cmd() :: {active, boolean()} | close.
 
--define(ACTIVE_N, 100).
+-define(ACTIVE_N, 10).
 -define(INFO_KEYS, [socktype, peername, sockname, sockstate]).
 -define(SOCK_STATS, [recv_oct, recv_cnt, send_oct, send_cnt]).
 

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -85,7 +85,7 @@
 
 -import(emqx_listeners, [esockd_access_rules/1]).
 
--define(ACTIVE_N, 100).
+-define(ACTIVE_N, 10).
 -define(DEFAULT_IDLE_TIMEOUT, 30000).
 -define(DEFAULT_GC_OPTS, #{count => 1000, bytes => 1024 * 1024}).
 -define(DEFAULT_OOM_POLICY, #{

--- a/apps/emqx_gateway_ocpp/src/emqx_gateway_ocpp.app.src
+++ b/apps/emqx_gateway_ocpp/src/emqx_gateway_ocpp.app.src
@@ -1,6 +1,6 @@
 {application, emqx_gateway_ocpp, [
     {description, "OCPP-J 1.6 Gateway for EMQX"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [kernel, stdlib, jesse, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
@@ -108,8 +108,6 @@
 
 -type ws_cmd() :: {active, boolean()} | close.
 
--define(ACTIVE_N, 100).
-
 -define(INFO_KEYS, [
     socktype,
     peername,

--- a/changes/ce/feat-14047.en.md
+++ b/changes/ce/feat-14047.en.md
@@ -1,0 +1,13 @@
+Lower default `active_n` value from `100` to `10`.
+
+This change improves the responsiveness of MQTT clients to control signals, particularly when publishing at high rates with small messages.
+
+The new `active_n` value of `10` is set deliberately lower than the default Receive-Maximum (`32`), to introduce more push-back at the TCP layer in the following scenarios:
+
+- The MQTT client process is blocked while performing external authorization checks.
+- The MQTT client process is blocked during data integration message sends.
+- EMQX is experiencing overload conditions.
+
+Performance testing showed no significant increase in latency across various scenarios (one-to-one, fan-in, and fan-out) on 8-core, 16GB memory nodes.
+However, on 2-core, 4GB memory nodes, the baseline latency (with active_n = `100`) was already in the higher 3-digit range with high CPU utilization.
+The decision to lower `active_n` optimizes for more common use cases where system stablity takes precedence over latency (in smaller instances).


### PR DESCRIPTION
Release version: v/e5.9.0

## Summary

See commit message.

Test results:
https://emqx.atlassian.net/wiki/spaces/QA/pages/1297843647/EMQX+e5.8.1+Performance+Testing#7.-Active-N

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
