### PR TITLE
feat(kafka producer): do not consider action disconnected once created

### DIFF
--- a/changes/ee/feat-14048.en.md
+++ b/changes/ee/feat-14048.en.md
@@ -1,0 +1,1 @@
+Kafka/Confluent/Azure Event Hub Producer actions, once created successfully and healthy, no longer considered unhealthy even if they detect an unknown topic.  They will continue to queue messages even in such condition.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13338

Release version: e5.8.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
