### PR TITLE
fix(dsraft): ensure DB config compat with earlier releases

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -1035,7 +1035,7 @@ force_monotonic_timestamps(DB) ->
     case erlang:get(?pd_ra_force_monotonic) of
         undefined ->
             DBConfig = emqx_ds_replication_layer_meta:db_config(DB),
-            Flag = maps:get(force_monotonic_timestamps, DBConfig),
+            Flag = maps:get(force_monotonic_timestamps, DBConfig, _Default = true),
             erlang:put(?pd_ra_force_monotonic, Flag);
         Flag ->
             ok

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
@@ -518,6 +518,16 @@ open_db_trans(DB, CreateOpts) ->
             mnesia:write(#?META_TAB{db = DB, db_props = CreateOpts}),
             CreateOpts;
         [#?META_TAB{db_props = Opts}] ->
+            case maps:merge(CreateOpts, Opts) of
+                Opts ->
+                    ok;
+                UpdatedOpts ->
+                    %% NOTE
+                    %% Preserve any new options not yet present in the DB. This is
+                    %% most likely because `Opts` is outdated, written by earlier
+                    %% EMQX version.
+                    mnesia:write(#?META_TAB{db = DB, db_props = UpdatedOpts})
+            end,
             Opts
     end.
 

--- a/changes/ee/fix-14057.en.md
+++ b/changes/ee/fix-14057.en.md
@@ -1,0 +1,1 @@
+Fix compatibility issue that prevented Messages DS DB from starting due to slightly different DB configuration schema, if EMQX was upgraded from 5.7.x with session durability enabled.


### PR DESCRIPTION
Release version: e5.8.2

## Summary

Durable-sessions-enabled EMQX 5.7.x persists DB config that is missing `force_monotonic_timestamps` key (i.e. `append_only` DB option), but the logic incorrectly relied on it being always present, even in preexisting DBs.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible
