### PR TITLE
fix: improve logs for emqx_cm:request_stepdown/3

### DIFF
--- a/changes/ce/fix-14061.en.md
+++ b/changes/ce/fix-14061.en.md
@@ -1,0 +1,3 @@
+Improved log information when `emqx_cm:request_stepdown/3` fails.
+
+When a client channel needs to kill another channel with the same ClientID, it may encounter a race condition that the target channel has already been closed or killed. In this case, error logs and stack information is useless and will no longer be printed.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13324

Release version: v/e5.8.2

## Summary

Change the following log messages to debug level:

```
action: discard, file: emqx_cm.erl, line: 367, mfa: {emqx_cm,request_stepdown,3}, msg: session_stepdown_request_exception, pid: <70941.11186.7732>, reason: {killed,{gen_server,call,[<70941.3614.1870>,discard,5000]}}, stacktrace: [{gen_server,call,3,[{file,"gen_server.erl"},{line,247}]},{emqx_cm,request_stepdown,3,[{file,"emqx_cm.erl"},{line,342}]},{erpc,execute_call,4,[{file,"erpc.erl"},{line,392}]}], stale_channel: undefined, stale_pid: <70941.3614.1870>
```

```
action: discard, file: emqx_cm.erl, line: 360, mfa: {emqx_cm,request_stepdown,3}, msg: session_stepdown_request_exception, pid: <0.20910.1677>, reason: normal, stacktrace: [{emqx_ws_connection,call,3,[{file,"emqx_ws_connection.erl"},{line,177}]},{emqx_cm,request_stepdown,3,[{file,"emqx_cm.erl"},{line,335}]},{erpc,execute_call,4,[{file,"erpc.erl"},{line,392}]}], stale_channel: undefined
```

Improve the warning log message if timeout:

```
277e80594a8524b9@103.189.61.18:44322 action: {takeover,'begin'}, file: emqx_cm.erl, line: 360, mfa: {emqx_cm,request_stepdown,3}, msg: session_stepdown_request_exception, pid: <0.32731.3389>, reason: timeout, stacktrace: [{emqx_ws_connection,call,3,[{file,"emqx_ws_connection.erl"},{line,180}]},{emqx_cm,request_stepdown,3,[{file,"emqx_cm.erl"},{line,335}]},{emqx_cm,takeover_session,2,[{file,"emqx_cm.erl"},{line,298}]},{emqx_cm,'-open_session/3-fun-2-',5,[{file,"emqx_cm.erl"},{line,251}]},{emqx_cm_locker,trans,3,[{file,"emqx_cm_locker.erl"},{line,51}]},{emqx_channel,process_connect,2,[{file,"emqx_channel.erl"},{line,533}]},{emqx_ws_connection,with_channel,3,[{file,"emqx_ws_connection.erl"},{line,585}]},{cowboy_websocket,handler_call,6,[{file,"cowboy_websocket.erl"},{line,487}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}], stale_channel: [{status,running},{message_queue_len,3},{current_stacktrace,[{emqx_cm,stale_channel_info,1,[{file,"emqx_cm.erl"},{line,380}]},{emqx_cm,request_stepdown,3,[{file,"emqx_cm.erl"},{line,365}]},{emqx_cm,takeover_session,2,[{file,"emqx_cm.erl"},{line,298}]},{emqx_cm,'-open_session/3-fun-2-',5,[{file,"emqx_cm.erl"},{line,251}]},{emqx_cm_locker,trans,3,[{file,"emqx_cm_locker.erl"},{line,51}]},{emqx_channel,process_connect,2,[{file,"emqx_channel.erl"},{line,533}]},{emqx_ws_connection,with_channel,3,[{file,"emqx_ws_connection.erl"},{line,585}]},{cowboy_websocket,handler_call,6,[{file,"cowboy_websocket.erl"},{line,487}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,236}]}]}]
```


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
