### PR TITLE
dont silently load insecure dynlibs

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -374,6 +374,13 @@ maybe_use_portable_dynlibs() {
     BUILD_INFO="$(cat "${REL_DIR}/BUILD_INFO")"
     COMPATIBILITY_INFO="$(compatiblity_info 2>/dev/null || true)"
     if ! (echo -e "$COMPATIBILITY_INFO" | $GREP -q 'CRYPTO_OK'); then
+        if [[ ${RUN_EMQX_UNSAFE:-} != "I_AGREE" ]] ; then
+            logerr "Please ensure libcrypto, libncurses and libatomic1 are properly installed via Opearating System package manager."
+            logerr "You may set environment variable RUN_EMQX_UNSAFE=I_AGREE to workaround this but not recommended from security perspective."
+            logerr "For more information check: https://docs.emqx.com/en/emqx/latest/faq/deployment.html#emqx-failed-to-start-with-log-message-on-load-function-failed-crypto"
+            die "Unsafe operation detected."
+        fi
+
         ## failed to start, might be due to missing libs, try to be portable
         export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-$DYNLIBS_DIR}"
         if [ "$LD_LIBRARY_PATH" != "$DYNLIBS_DIR" ]; then

--- a/changes/ce/breaking-14063.en.md
+++ b/changes/ce/breaking-14063.en.md
@@ -1,0 +1,5 @@
+For security, user now must set envvar `RUN_EMQX_UNSAFE`="I_AGREE" to load dynlibs in the tar release package.
+
+This only affects the EMQX tar release package.
+This does not affect the OS installation packages (rpm, deb).
+


### PR DESCRIPTION
User now must set envvar RUN_EMQX_UNSAFE="I_AGREE" to load dynlibs in the package.

I also suggest remove the dynlib from the package. 

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
