### PR TITLE
fix(gcp pubsub): massage error reason when an invalid private key is in service account json

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_gcp_pubsub, [
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
-    {vsn, "0.3.3"},
+    {vsn, "0.3.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -247,6 +247,13 @@ parse_jwt_config(ResourceId, #{
                 ?tp(error, gcp_pubsub_connector_startup_error, #{error => Error}),
                 throw("invalid private key in service account json")
         catch
+            error:function_clause ->
+                %% Function clause error inside `jose_jwk', nothing much to do...
+                %% Possibly `base64:mime_decode_binary/5' while trying to decode an
+                %% invalid private key that would probably not appear under normal
+                %% conditions...
+                ?tp(error, gcp_pubsub_connector_startup_error, #{error => invalid_private_key}),
+                throw("invalid private key in service account json");
             Kind:Reason ->
                 Error = {Kind, Reason},
                 ?tp(error, gcp_pubsub_connector_startup_error, #{error => Error}),

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -1080,7 +1080,7 @@ t_truncated_private_key(Config) ->
         fun(Res, Trace) ->
             ?assertMatch({ok, _}, Res),
             ?assertMatch(
-                [#{error := {error, function_clause}}],
+                [#{error := invalid_private_key}],
                 ?of_kind(gcp_pubsub_connector_startup_error, Trace)
             ),
             ok


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12945

Release version: e5.8.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
