### PR TITLE
fix: don't crash retainer api when retainer is disabled

### DIFF
--- a/changes/ce/fix-14090.en.md
+++ b/changes/ce/fix-14090.en.md
@@ -1,0 +1,1 @@
+Don't crash retainer api when retainer is disabled


### PR DESCRIPTION
fix: https://askemq.com/t/topic/9875

Release version: v/e5.8.2

<img width="1131" alt="image" src="https://github.com/user-attachments/assets/8ee51a49-68fb-41df-9da4-f102b633a03f">



## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
