### PR TITLE
fix(influxdb): unsupported write syntax for timestamp field

### DIFF
--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -874,7 +874,9 @@ t_bad_timestamp(Config) ->
                         [
                             #{
                                 error := [
-                                    {error, {bad_timestamp, <<"bad_timestamp">>}}
+                                    {error,
+                                        {bad_timestamp,
+                                            {non_integer_timestamp, <<"bad_timestamp">>}}}
                                 ]
                             }
                         ],
@@ -883,7 +885,7 @@ t_bad_timestamp(Config) ->
                 {sync, false} ->
                     ?assertEqual(
                         {error, [
-                            {error, {bad_timestamp, <<"bad_timestamp">>}}
+                            {error, {bad_timestamp, {non_integer_timestamp, <<"bad_timestamp">>}}}
                         ]},
                         Return
                     );

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -714,8 +714,13 @@ parse_timestamp([TsBin]) ->
         {ok, binary_to_integer(TsBin)}
     catch
         _:_ ->
-            {error, TsBin}
-    end.
+            {error, {non_integer_timestamp, TsBin}}
+    end;
+parse_timestamp(InvalidTs) ->
+    %% The timestamp field must be a single integer or a single placeholder. i.e. the
+    %%   following is not allowed:
+    %%   - weather,location=us-midwest,season=summer temperature=82 ${timestamp}00
+    {error, {unsupported_placeholder_usage_for_timestamp, InvalidTs}}.
 
 continue_lines_to_points(Data, Item, Rest, ResultPointsAcc, ErrorPointsAcc) ->
     case line_to_point(Data, Item) of

--- a/changes/ee/fix-14091.en.md
+++ b/changes/ee/fix-14091.en.md
@@ -1,0 +1,11 @@
+A simple fix that removes `function_clause` from the log message if the user has provided an unsupported write syntax:
+
+```
+weather,location=us-midwest,season=summer temperature=82 ${timestamp}u
+```
+
+The error log before this fix:
+
+```
+pid: <0.558392.0>, info: {"stacktrace":["{emqx_bridge_influxdb_connector,parse_timestamp,[[1719350482910000000,<<\"u\">>]],[{file,\"emqx_bridge_influxdb_connector.erl\"},{line,692}]}", ...], ..., "error":"{error,function_clause}"}, tag: ERROR, msg: resource_exception
+```


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13324

Release version: v/e5.8.2

## Summary

A simple fix that removes `function_clause` from the log message if the user has provided an unsupported write syntax:

```
weather,location=us-midwest,season=summer temperature=82 ${timestamp}u
```

The error log before this fix:

```
pid: <0.558392.0>, info: {"stacktrace":["{emqx_bridge_influxdb_connector,parse_timestamp,[[1719350482910000000,<<\"u\">>]],[{file,\"emqx_bridge_influxdb_connector.erl\"},{line,692}]}","{emqx_bridge_influxdb_connector,lines_to_points,4,[{file,\"emqx_bridge_influxdb_connector.erl\"},{line,678}]}","{emqx_bridge_influxdb_connector,on_query_async,4,[{file,\"emqx_bridge_influxdb_connector.erl\"},{line,173}]}","{emqx_resource_buffer_worker,apply_query_fun,9,[{file,\"emqx_resource_buffer_worker.erl\"},{line,1410}]}","{emqx_resource_buffer_worker,call_query,6,[{file,\"emqx_resource_buffer_worker.erl\"},{line,1181}]}","{emqx_resource_buffer_worker,do_flush,2,[{file,\"emqx_resource_buffer_worker.erl\"},{line,667}]}","{gen_statem,loop_state_callback,11,[{file,\"gen_statem.erl\"},{line,1395}]}","{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,241}]}"],"request":"{<<\"action:influxdb:action-5d0f059f:connector:influxdb:connector-b58f4ee0\">>,#{<<\"Analog_IN_Fault_1\">> => 0,<<\"Analog_IN_Fault_2\">> => 0,<<\"Analog_IN_Fault_3\">> => 0,<<\"Analog_IN_Fault_4\">> => 0,<<\"Analog_IN_PV_1\">> => 7.460000514984131,<<\"Analog_IN_PV_2\">> => 10.082444190979004,<<\"Analog_IN_PV_3\">> => 99.18277740478516,<<\"Analog_IN_PV_4\">> => 7.19999361038208,<<\"Timestamp\">> => 1719350482910000000,<<\"measurement\">> => <<\"Temperature\">>}}","name":"call_query_async","id":"action:influxdb:action-5d0f059f:connector:influxdb:connector-b58f4ee0","error":"{error,function_clause}"}, tag: ERROR, msg: resource_exception
```


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
