### PR TITLE
fix: dont log supervisor_report for malformed_utf8_string_length

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -781,6 +781,7 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             ?LOG(info, #{
+                msg => "frame_parse_error",
                 reason => Reason,
                 at_state => emqx_frame:describe_state(ParseState),
                 input_bytes => Data,
@@ -790,6 +791,7 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
             {[{frame_error, Reason} | Packets], NState};
         error:Reason:Stacktrace ->
             ?LOG(error, #{
+                msg => "frame_parse_failed",
                 at_state => emqx_frame:describe_state(ParseState),
                 input_bytes => Data,
                 parsed_packets => Packets,

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -714,18 +714,14 @@ parse_utf8_string(<<Len:16/big, Str:Len/binary, Rest/binary>>, true) ->
     {validate_utf8(Str), Rest};
 parse_utf8_string(<<Len:16/big, Str:Len/binary, Rest/binary>>, false) ->
     {Str, Rest};
-parse_utf8_string(<<Len:16/big, Rest/binary>>, _) when
-    Len > byte_size(Rest)
-->
+parse_utf8_string(<<Len:16/big, Rest/binary>>, _) when Len > byte_size(Rest) ->
     ?PARSE_ERR(#{
         cause => malformed_utf8_string,
         parsed_length => Len,
         remaining_bytes_length => byte_size(Rest)
     });
-parse_utf8_string(Bin, _) when
-    2 > byte_size(Bin)
-->
-    ?PARSE_ERR(#{reason => malformed_utf8_string_length}).
+parse_utf8_string(Bin, _) when 2 > byte_size(Bin) ->
+    ?PARSE_ERR(#{cause => malformed_utf8_string_length}).
 
 parse_will_payload(<<Len:16/big, Data:Len/binary, Rest/binary>>) ->
     {Data, Rest};

--- a/apps/emqx/src/emqx_quic_data_stream.erl
+++ b/apps/emqx/src/emqx_quic_data_stream.erl
@@ -391,12 +391,14 @@ parse_incoming(Data, PS) ->
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             ?SLOG(info, #{
+                msg => "frame_parse_error",
                 reason => Reason,
                 input_bytes => Data
             }),
             {[{frame_error, Reason}], PS};
         error:Reason:Stacktrace ->
             ?SLOG(error, #{
+                msg => "frame_parse_failed",
                 input_bytes => Data,
                 reason => Reason,
                 stacktrace => Stacktrace

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -733,6 +733,7 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
     catch
         throw:{?FRAME_PARSE_ERROR, Reason} ->
             ?LOG(info, #{
+                msg => "frame_parse_error",
                 reason => Reason,
                 at_state => emqx_frame:describe_state(ParseState),
                 input_bytes => Data
@@ -742,6 +743,7 @@ parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
             {[{incoming, FrameError} | Packets], NState};
         error:Reason:Stacktrace ->
             ?LOG(error, #{
+                msg => "frame_parse_failed",
                 at_state => emqx_frame:describe_state(ParseState),
                 input_bytes => Data,
                 exception => Reason,

--- a/changes/ce/fix-14099.en.md
+++ b/changes/ce/fix-14099.en.md
@@ -1,0 +1,5 @@
+Removed an error level log when failed to validate UTF-8 strings in MQTT messages:
+
+```
+{"time":"2024-10-11T06:05:07.610048+00:00","level":"error","msg":"supervisor: {esockd_connection_sup,0.53591191.0}, errorContext: connection_shutdown, reason: #{cause => invalid_topic,reason => malformed_utf8_string_length}, offender: [{pid,0.53591191.0},...]", ..., "error_logger":{"type":"supervisor_report","tag":"error_report"}}
+```


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13328

Release version: v/e5.8.2

## Summary

1. Fix the issue that esockd prints a supervisor report on exit:

```
{"time":"2024-10-11T06:05:07.610048+00:00","level":"error","msg":"supervisor: {esockd_connection_sup,0.53591191.0}, errorContext: connection_shutdown, reason: #{cause => invalid_topic,reason => malformed_utf8_string_length}, offender: [{pid,0.53591191.0},{name,connection},{mfargs,{emqx_connection,start_link,[#{listener => {tcp,default},limiter => #{client => #{messages => #{low_watermark => 0,initial => 0,rate => 150.0,burst => 0,max_retry_time => 3600000,failure_strategy => force,divisible => true}},connection => #{initial => 0,rate => 100.0,burst => 0}},enable_authn => true,zone => default}]}}]","domain":["supervisor_report"],"pid":"0.5121.0","error_logger":{"type":"supervisor_report","tag":"error_report"}}
```

2.  Improve the esockd log messages by add more metadata like `peername` and `sockname`, see the `reason` field in the following examples:

Before the change:
```
2024-10-29T14:29:07.817301+08:00 [notice] supervisor: {esockd_connection_sup,<0.5006.0>}, errorContext: malformed_packet, reason: #{cause => malformed_packet,header_type => 4}, offender: [{pid,<0.5006.0>},{name,connection},{mfargs,{emqx_connection,start_link,[#{listener => {tcp,default},limiter => #{connection => #{initial => 0,burst => 0,rate => infinity}},enable_authn => true,zone => default}]}}]
```

After the change:
```
2024-10-29T14:43:50.851741+08:00 [notice] supervisor: {esockd_connection_sup,<0.5918.0>}, errorContext: malformed_packet, reason: #{cause => malformed_packet,peername => {{127,0,0,1},60802},sockname => {{127,0,0,1},1883},header_type => 4}, offender: [{pid,<0.5918.0>},{name,connection},{mfargs,{emqx_connection,start_link,[#{listener => {tcp,default},limiter => #{connection => #{initial => 0,burst => 0,rate => infinity}},enable_authn => true,zone => default}]}}]
```

3. the `msg` field was missing from some of the logs:

```
2024-10-29T14:29:07.816660+08:00 [info] tag: MQTT, peername: 127.0.0.1:59024, reason: #{cause => malformed_packet,header_type => 4}, at_state: <<"clean">>, input_bytes: <<"GET / HTTP/1.1\r\nHost: 127.0.0.1:1883\r\nUser-Agent: curl/7.79.1\r\nAccept: */*\r\n\r\n">>, parsed_packets: []
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
