### PR TITLE
fix: remove action failed with name_clash_action_source

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -211,13 +211,13 @@ unload() ->
     emqx_conf:remove_handler(config_key_path_leaf()),
     ok.
 
-unload_bridges(ConfRooKey) ->
-    Bridges = emqx:get_config([ConfRooKey], #{}),
+unload_bridges(ConfRootKey) ->
+    Bridges = emqx:get_config([ConfRootKey], #{}),
     _ = emqx_utils:pmap(
         fun({Type, Bridge}) ->
             emqx_utils:pmap(
                 fun({Name, BridgeConf}) ->
-                    uninstall_bridge_v2(ConfRooKey, Type, Name, BridgeConf)
+                    uninstall_bridge_v2(ConfRootKey, Type, Name, BridgeConf)
                 end,
                 maps:to_list(Bridge),
                 infinity
@@ -360,7 +360,7 @@ check_deps_and_remove(BridgeType, BridgeName, AlsoDeleteActions) ->
 
 -spec check_deps_and_remove(root_cfg_key(), bridge_v2_type(), bridge_v2_name(), boolean()) ->
     ok | {error, any()}.
-check_deps_and_remove(ConfRooKey, BridgeType, BridgeName, AlsoDeleteActions) ->
+check_deps_and_remove(ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions) ->
     AlsoDelete =
         case AlsoDeleteActions of
             true -> [rule_actions];
@@ -368,13 +368,14 @@ check_deps_and_remove(ConfRooKey, BridgeType, BridgeName, AlsoDeleteActions) ->
         end,
     case
         emqx_bridge_lib:maybe_withdraw_rule_action(
+            ConfRootKey,
             BridgeType,
             BridgeName,
             AlsoDelete
         )
     of
         ok ->
-            remove(ConfRooKey, BridgeType, BridgeName);
+            remove(ConfRootKey, BridgeType, BridgeName);
         {error, Reason} ->
             {error, Reason}
     end.

--- a/changes/ce/fix-14101.en.md
+++ b/changes/ce/fix-14101.en.md
@@ -1,0 +1,1 @@
+Fixed the issue where if a source and an action were both created with the name, deleting either the source or the action would fail.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13250

Release version: v/e5.8.2

## Summary

Delete action failed if a source exists with the same name.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
