### PR TITLE
fix: the default values of retainer schema do not take effect

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -397,8 +397,13 @@ fill_defaults_for_all_roots(SchemaMod, RawConf0) ->
 %% e.g. when testing an app, we need to load its config first
 %% then start emqx_conf application which will load the
 %% possibly empty config again (then filled with defaults).
+-ifdef(TEST).
 is_already_loaded(Name) ->
     ?MODULE:get_raw([Name], #{}) =/= #{}.
+-else.
+is_already_loaded(_) ->
+    false.
+-endif.
 
 %% if a root is not found in the raw conf, fill it with default values.
 seed_default(Schema) ->

--- a/changes/ce/fix-14116.en.md
+++ b/changes/ce/fix-14116.en.md
@@ -1,0 +1,1 @@
+Fix an issue where the default configuration of retainer is generated incorrectly after joining a cluster


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13249

Looks like it was introduced by https://github.com/zmstone/emqx/commit/a03f2dd64bd2f9115d3ef0e59d35e120d7d8bae6

Before this fix, once the emqx apps were restarted (e.g., the node joined a cluster), the generated retainer's default configuration was incorrect:
```
bin/emqx remote_console

> DefaultRetainer1 = emqx_conf:get([retainer]).
> emqx_machine_boot:stop_apps(), emqx_machine_boot:ensure_apps_started().
> DefaultRetainer1 =:= emqx_conf:get([retainer]).
false
```


Release version: v/e5.8.2

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~Added tests for the changes~
- ~Added property-based tests for code which performs user input validation~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~Change log has been added to `changes/` dir for user-facing artifacts update~