### PR TITLE
feat: support on duplicate clause in mysql

### DIFF
--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -220,7 +220,7 @@ prepare_sql_bulk_extend_template(Template, Separator) ->
     ExtendParamTemplate = iolist_to_binary([Separator, ValuesTemplate]),
     emqx_placeholder:preproc_tmpl(ExtendParamTemplate).
 
-%% This function is similar to emqx_utils_sql:parse_insert/1 but can
+%% This function is similar to emqx_utils_sql:split_insert/1 but can
 %% also handle Clickhouse's SQL extension for INSERT statments that allows the
 %% user to specify different formats:
 %%

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -237,43 +237,29 @@ on_start(
             {error, Reason}
     end.
 
-on_add_channel(
-    _InstId,
-    #{
-        installed_channels := InstalledChannels
-    } = OldState,
-    ChannelId,
-    ChannelConfig
-) ->
-    {ok, ChannelState} = create_channel_state(ChannelConfig),
-    NewInstalledChannels = maps:put(ChannelId, ChannelState, InstalledChannels),
-    %% Update state
-    NewState = OldState#{installed_channels => NewInstalledChannels},
-    {ok, NewState}.
+on_add_channel(_InstId, OldState, ChannelId, #{parameters := Params}) ->
+    #{installed_channels := InstalledChannels} = OldState,
+    case parse_sql_template(Params) of
+        {ok, Templs} ->
+            ChannelState = #{
+                sql_templates => Templs,
+                channel_conf => Params
+            },
+            NewInstalledChannels = maps:put(ChannelId, ChannelState, InstalledChannels),
+            %% Update state
+            NewState = OldState#{installed_channels => NewInstalledChannels},
+            {ok, NewState};
+        {error, Reason} ->
+            {error, Reason}
+    end.
 
-create_channel_state(
-    #{parameters := ChannelConf}
-) ->
-    State = #{sql_templates => parse_sql_template(ChannelConf), channel_conf => ChannelConf},
-    {ok, State}.
-
-on_remove_channel(
-    _InstId,
-    #{
-        installed_channels := InstalledChannels
-    } = OldState,
-    ChannelId
-) ->
+on_remove_channel(_InstId, #{installed_channels := InstalledChannels} = OldState, ChannelId) ->
     NewInstalledChannels = maps:remove(ChannelId, InstalledChannels),
     %% Update state
     NewState = OldState#{installed_channels => NewInstalledChannels},
     {ok, NewState}.
 
-on_get_channel_status(
-    InstanceId,
-    ChannelId,
-    #{installed_channels := Channels} = State
-) ->
+on_get_channel_status(InstanceId, ChannelId, #{installed_channels := Channels} = State) ->
     case maps:find(ChannelId, Channels) of
         {ok, _} -> on_get_status(InstanceId, State);
         error -> ?status_disconnected
@@ -405,70 +391,53 @@ conn_str([{_, _} | Opts], Acc) ->
     | {error, {recoverable_error, term()}}
     | {error, {unrecoverable_error, term()}}
     | {error, term()}.
-do_query(
-    ResourceId,
-    Query,
-    ApplyMode,
-    #{
-        pool_name := PoolName,
-        installed_channels := Channels
-    } = State
-) ->
+do_query(ResourceId, Query, ApplyMode, State) ->
+    #{pool_name := PoolName, installed_channels := Channels} = State,
     ?TRACE(
         "SINGLE_QUERY_SYNC",
         "sqlserver_connector_received",
         #{query => Query, connector => ResourceId, state => State}
     ),
-
     ChannelId = get_channel_id(Query),
     QueryTuple = get_query_tuple(Query),
     #{sql_templates := Templates} = ChannelState = maps:get(ChannelId, Channels),
     ChannelConf = maps:get(channel_conf, ChannelState, #{}),
     %% only insert sql statement for single query and batch query
-    case apply_template(QueryTuple, Templates, ChannelConf) of
-        {?ACTION_SEND_MESSAGE, SQL} ->
-            emqx_trace:rendered_action_template(ChannelId, #{
-                sql => SQL
-            }),
-            Result = ecpool:pick_and_do(
-                PoolName,
-                {?MODULE, worker_do_insert, [SQL, State]},
-                ApplyMode
-            );
-        QueryTuple ->
-            Result = {error, {unrecoverable_error, invalid_query}};
-        _ ->
-            Result = {error, {unrecoverable_error, failed_to_apply_sql_template}}
-    end,
-    case Result of
-        {error, Reason} ->
-            ?tp(
-                sqlserver_connector_query_return,
-                #{error => Reason}
-            ),
-            ?SLOG(error, #{
-                msg => "sqlserver_connector_do_query_failed",
-                connector => ResourceId,
-                query => Query,
-                reason => Reason
-            }),
-            case Reason of
-                ecpool_empty ->
-                    {error, {recoverable_error, Reason}};
-                _ ->
-                    Result
-            end;
-        _ ->
-            ?tp(
-                sqlserver_connector_query_return,
-                #{result => Result}
-            ),
-            Result
-    end.
+    Result =
+        case apply_template(QueryTuple, Templates, ChannelConf) of
+            {?ACTION_SEND_MESSAGE, SQL} ->
+                emqx_trace:rendered_action_template(ChannelId, #{
+                    sql => SQL
+                }),
+                ecpool:pick_and_do(
+                    PoolName,
+                    {?MODULE, worker_do_insert, [SQL, State]},
+                    ApplyMode
+                );
+            QueryTuple ->
+                {error, {unrecoverable_error, invalid_query}};
+            _ ->
+                {error, {unrecoverable_error, failed_to_apply_sql_template}}
+        end,
+    handle_result(Result, ResourceId, Query).
 
-worker_do_insert(
-    Conn, SQL, #{resource_opts := ResourceOpts, pool_name := ResourceId}
-) ->
+handle_result({error, Reason}, ResourceId, Query) ->
+    ?tp(sqlserver_connector_query_return, #{error => Reason}),
+    ?SLOG(error, #{
+        msg => "sqlserver_connector_do_query_failed",
+        connector => ResourceId,
+        query => Query,
+        reason => Reason
+    }),
+    case Reason of
+        ecpool_empty -> {error, {recoverable_error, ecpool_empty}};
+        _ -> {error, Reason}
+    end;
+handle_result(Result, _, _) ->
+    ?tp(sqlserver_connector_query_return, #{result => Result}),
+    Result.
+
+worker_do_insert(Conn, SQL, #{resource_opts := ResourceOpts, pool_name := ResourceId}) ->
     LogMeta = #{connector => ResourceId},
     try
         case execute(Conn, SQL, ?REQUEST_TTL(ResourceOpts)) of
@@ -529,9 +498,12 @@ parse_sql_template(Config) ->
             <<>> -> #{};
             SQLTemplate -> #{?ACTION_SEND_MESSAGE => SQLTemplate}
         end,
-
-    BatchInsertTks = #{},
-    parse_sql_template(maps:to_list(RawSQLTemplates), BatchInsertTks).
+    try
+        {ok, parse_sql_template(maps:to_list(RawSQLTemplates), #{})}
+    catch
+        throw:Reason ->
+            {error, Reason}
+    end.
 
 parse_sql_template([{Key, H} | T], BatchInsertTks) ->
     case emqx_utils_sql:get_statement_type(H) of
@@ -539,17 +511,14 @@ parse_sql_template([{Key, H} | T], BatchInsertTks) ->
             parse_sql_template(T, BatchInsertTks);
         insert ->
             case emqx_utils_sql:split_insert(H) of
-                {ok, {InsertSQL, Params}} ->
-                    parse_sql_template(
-                        T,
-                        BatchInsertTks#{
-                            Key =>
-                                #{
-                                    ?BATCH_INSERT_PART => InsertSQL,
-                                    ?BATCH_PARAMS_TOKENS => emqx_placeholder:preproc_tmpl(Params)
-                                }
-                        }
-                    );
+                {ok, {InsertPart, Values}} ->
+                    Tks = #{
+                        ?BATCH_INSERT_PART => InsertPart,
+                        ?BATCH_PARAMS_TOKENS => emqx_placeholder:preproc_tmpl(Values)
+                    },
+                    parse_sql_template(T, BatchInsertTks#{Key => Tks});
+                {ok, {_InsertPart, _Values, OnClause}} ->
+                    throw(<<"The 'ON' clause is not supported in SQLServer: ", OnClause/binary>>);
                 {error, Reason} ->
                     ?SLOG(error, #{msg => "split_sql_failed", sql => H, reason => Reason}),
                     parse_sql_template(T, BatchInsertTks)
@@ -583,22 +552,15 @@ apply_template(
         undefined ->
             BatchReqs;
         #{?BATCH_INSERT_PART := BatchInserts, ?BATCH_PARAMS_TOKENS := BatchParamsTks} ->
-            SQL = proc_batch_sql(BatchReqs, BatchInserts, BatchParamsTks, ChannelConf),
+            BatchParams = [proc_msg(BatchParamsTks, Msg, ChannelConf) || {_, Msg} <- BatchReqs],
+            Values = erlang:iolist_to_binary(lists:join($,, BatchParams)),
+            SQL = <<BatchInserts/binary, " values ", Values/binary>>,
             {Key, SQL}
     end;
 apply_template(Query, Templates, _) ->
     %% TODO: more detail information
     ?SLOG(error, #{msg => "apply_sql_template_failed", query => Query, templates => Templates}),
     {error, failed_to_apply_sql_template}.
-
-proc_batch_sql(BatchReqs, BatchInserts, Tokens, ChannelConf) ->
-    Values = erlang:iolist_to_binary(
-        lists:join($,, [
-            proc_msg(Tokens, Msg, ChannelConf)
-         || {_, Msg} <- BatchReqs
-        ])
-    ),
-    <<BatchInserts/binary, " values ", Values/binary>>.
 
 proc_msg(Tokens, Msg, #{undefined_vars_as_null := true}) ->
     emqx_placeholder:proc_sql_param_str2(Tokens, Msg);

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -538,7 +538,7 @@ parse_sql_template([{Key, H} | T], BatchInsertTks) ->
         select ->
             parse_sql_template(T, BatchInsertTks);
         insert ->
-            case emqx_utils_sql:parse_insert(H) of
+            case emqx_utils_sql:split_insert(H) of
                 {ok, {InsertSQL, Params}} ->
                     parse_sql_template(
                         T,

--- a/apps/emqx_mysql/src/emqx_mysql.app.src
+++ b/apps/emqx_mysql/src/emqx_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mysql, [
     {description, "EMQX MySQL Database Connector"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_mysql/src/emqx_mysql.erl
+++ b/apps/emqx_mysql/src/emqx_mysql.erl
@@ -468,10 +468,9 @@ parse_prepare_sql(Key, Query, Acc) ->
 parse_batch_sql(Key, Query, Acc) ->
     case emqx_utils_sql:get_statement_type(Query) of
         insert ->
-            case emqx_utils_sql:parse_insert(Query) of
-                {ok, {Insert, Params}} ->
-                    RowTemplate = emqx_template_sql:parse(Params),
-                    Acc#{{Key, batch} => {Insert, RowTemplate}};
+            case emqx_utils_sql:split_insert(Query) of
+                {ok, SplitedInsert} ->
+                    Acc#{{Key, batch} => parse_splited_sql(SplitedInsert)};
                 {error, Reason} ->
                     ?SLOG(error, #{
                         msg => "parse insert sql statement failed",
@@ -490,6 +489,13 @@ parse_batch_sql(Key, Query, Acc) ->
             }),
             Acc
     end.
+
+parse_splited_sql({Insert, Values, OnClause}) ->
+    RowTemplate = emqx_template_sql:parse(Values),
+    {Insert, RowTemplate, OnClause};
+parse_splited_sql({Insert, Values}) ->
+    RowTemplate = emqx_template_sql:parse(Values),
+    {Insert, RowTemplate}.
 
 proc_sql_params(query, SQLOrKey, Params, _State) ->
     {SQLOrKey, Params};
@@ -511,6 +517,10 @@ proc_sql_params(TypeOrKey, SQLOrData, Params, #{query_templates := Templates}) -
 proc_sql_params(_TypeOrKey, SQLOrData, Params, _State) ->
     {SQLOrData, Params}.
 
+on_batch_insert(InstId, BatchReqs, {InsertPart, RowTemplate, OnClause}, State, ChannelConfig) ->
+    Rows = [render_row(RowTemplate, Msg, ChannelConfig) || {_, Msg} <- BatchReqs],
+    Query = [InsertPart, <<" values ">> | lists:join($,, Rows)] ++ [<<" on ">>, OnClause],
+    on_sql_query(InstId, query, Query, no_params, default_timeout, State);
 on_batch_insert(InstId, BatchReqs, {InsertPart, RowTemplate}, State, ChannelConfig) ->
     Rows = [render_row(RowTemplate, Msg, ChannelConfig) || {_, Msg} <- BatchReqs],
     Query = [InsertPart, <<" values ">> | lists:join($,, Rows)],
@@ -528,14 +538,7 @@ render_row(RowTemplate, Data, ChannelConfig) ->
     {Row, _Errors} = emqx_template_sql:render(RowTemplate, {emqx_jsonish, Data}, RenderOpts),
     Row.
 
-on_sql_query(
-    InstId,
-    SQLFunc,
-    SQLOrKey,
-    Params,
-    Timeout,
-    #{pool_name := PoolName} = State
-) ->
+on_sql_query(InstId, SQLFunc, SQLOrKey, Params, Timeout, #{pool_name := PoolName} = State) ->
     LogMeta = #{connector => InstId, sql => SQLOrKey, state => State},
     ?TRACE("QUERY", "mysql_connector_received", LogMeta),
     ChannelID = maps:get(channel_id, State, no_channel),

--- a/apps/emqx_utils/src/emqx_template_sql.erl
+++ b/apps/emqx_utils/src/emqx_template_sql.erl
@@ -18,6 +18,7 @@
 
 -export([parse/1]).
 -export([parse/2]).
+-export([has_placeholder/1]).
 -export([render/3]).
 -export([render_strict/3]).
 
@@ -63,6 +64,16 @@ parse(String) ->
     template().
 parse(String, Opts) ->
     emqx_template:parse(String, Opts).
+
+-spec has_placeholder(unicode:chardata()) -> boolean().
+has_placeholder(String) ->
+    lists:any(
+        fun
+            ({var, _, _}) -> true;
+            (_) -> false
+        end,
+        parse(String)
+    ).
 
 %% @doc Render an SQL statement template given a set of bindings.
 %% Interpolation generally follows the SQL syntax, strings are escaped according to the

--- a/apps/emqx_utils/src/emqx_utils_sql.erl
+++ b/apps/emqx_utils/src/emqx_utils_sql.erl
@@ -17,7 +17,7 @@
 -module(emqx_utils_sql).
 
 -export([get_statement_type/1]).
--export([parse_insert/1]).
+-export([split_insert/1]).
 
 -export([to_sql_value/1]).
 -export([to_sql_string/2]).
@@ -35,17 +35,20 @@
 -define(INSERT_RE_MP_KEY, insert_re_mp).
 -define(INSERT_RE_BIN, <<
     %% case-insensitive
-    "(?i)^\\s*",
+    "(?i)^\\s*"
     %% Group-1: insert into, table name and columns (when existed).
     %% All space characters suffixed to <TABLE_NAME> will be kept
     %% `INSERT INTO <TABLE_NAME> [(<COLUMN>, ..)]`
-    "(insert\\s+into\\s+[^\\s\\(\\)]+\\s*(?:\\([^\\)]*\\))?)",
+    "(insert\\s+into\\s+[^\\s\\(\\)]+\\s*(?:\\([^\\)]*\\))?)"
     %% Keyword: `VALUES`
-    "\\s*values\\s*",
+    "\\s*values\\s*"
     %% Group-2: literals value(s) or placeholder(s) with round brackets.
     %% And the sub-pattern in brackets does not do any capturing
     %% `([<VALUE> | <PLACEHOLDER>], ..])`
-    "(\\((?:[^()]++|(?2))*\\))",
+    "(\\((?:[^()]++|(?2))*\\))"
+    %% Group-3: match the `ON conflict` or `ON dulicate` clause
+    "\\s*(?:on\\s+(\\S+.*\\S))?"
+    %% Match trailings spaces
     "\\s*$"
 >>).
 
@@ -86,17 +89,35 @@ get_statement_type(Query) ->
     end.
 
 %% @doc Parse an INSERT SQL statement into its INSERT part and the VALUES part.
-%% SQL = <<"INSERT INTO \"abc\" (c1, c2, c3) VALUES (${a}, ${b}, ${c.prop})">>
-%% {ok, {<<"INSERT INTO \"abc\" (c1, c2, c3)">>, <<"(${a}, ${b}, ${c.prop})">>}}
--spec parse_insert(iodata()) ->
-    {ok, {_Statement :: binary(), _Rows :: binary()}} | {error, not_insert_sql}.
-parse_insert(SQL) ->
+%%
+%% SQL = "INSERT INTO \"abc\" (c1, c2, c3) VALUES (${a}, ${b}, ${c.prop})"
+%%   {ok, {<<"INSERT INTO \"abc\" (c1, c2, c3)">>, <<"(${a}, ${b}, ${c.prop})">>}}
+%%
+%% SQL = "INSERT INTO \"abc\" (c1, c2, c3) VALUES (${a}, ${b}, ${c.prop}) ON DUPLICATE KEY UPDATE c1 = ${a}"
+%%   {ok, {<<"INSERT INTO \"abc\" (c1, c2, c3)">>, <<"(${a}, ${b}, ${c.prop})">>,
+%%         <<"DUPLICATE KEY UPDATE c1 = ${a}">>}}
+-spec split_insert(iodata()) ->
+    {ok, {binary(), binary()} | {binary(), binary(), binary()}} | {error, term()}.
+split_insert(SQL) ->
     {ok, MP} = get_insert_mp(),
-    case re:run(SQL, MP, [{capture, all_but_first, binary}]) of
-        {match, [InsertInto, ValuesTemplate]} ->
-            {ok, {InsertInto, ValuesTemplate}};
-        nomatch ->
-            {error, not_insert_sql}
+    try
+        case re:run(SQL, MP, [{capture, all_but_first, binary}]) of
+            {match, [InsertInto, ValuesTemplate]} ->
+                {ok, {assert_no_vars(InsertInto), ValuesTemplate}};
+            {match, [InsertInto, ValuesTemplate, OnClause]} ->
+                {ok, {assert_no_vars(InsertInto), ValuesTemplate, assert_no_vars(OnClause)}};
+            nomatch ->
+                {error, <<"Not an INSERT statement or incorrect SQL syntax">>}
+        end
+    catch
+        throw:{placeholders_not_allowed, _Str} ->
+            {error, <<"Placeholders are only allowed in VALUES part">>}
+    end.
+
+assert_no_vars(Str) ->
+    case emqx_template_sql:has_placeholder(Str) of
+        true -> throw({placeholders_not_allowed, Str});
+        false -> Str
     end.
 
 %% @doc Convert an Erlang term to a value that can be used primarily in

--- a/changes/ee/feat-14118.en.md
+++ b/changes/ee/feat-14118.en.md
@@ -1,0 +1,9 @@
+Support `ON DUPLICATE KEY UPDATE` in mysql actions.
+
+Now the user can specify `ON DUPLICATE KEY UPDATE` in the `mysql` action, e.g.:
+
+```
+INSERT INTO t1 (a,b,c) VALUES (${id},${clientid},${qos}) ON DUPLICATE KEY UPDATE a=a;
+```
+
+Note that the `ON DUPLICATE KEY UPDATE` clause doesn't support placeholders (`${var}`).


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13325

Release version: v/e5.9.0

## Summary

Support the `on duplicate key update` clauses in the mysql integration:

```
INSERT INTO t1 (a,b,c) VALUES (1,2,3) ON DUPLICATE KEY UPDATE c=c+1;
```

**NOTE:** placeholders (${var}) cannot be used as the table name or in the `on duplicate key update` clause

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
