### PR TITLE
fix(pulsar): correctly handle timeout during health check

### DIFF
--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -175,7 +175,7 @@ on_get_status(_InstanceId, State = #{}) ->
                 true -> ?status_connected;
                 false -> ?status_connecting
             catch
-                error:timeout ->
+                exit:{timeout, _} ->
                     ?status_connecting;
                 exit:{noproc, _} ->
                     ?status_connecting

--- a/changes/ee/fix-14120.en.md
+++ b/changes/ee/fix-14120.en.md
@@ -1,0 +1,5 @@
+Fixed handling of timeouts during Pulsar Connector health checks, that could lead to log noise.  For example:
+
+```
+2024-10-31T12:41:41.014678+00:00 [error] tag: CONNECTOR/PULSAR, msg: health_check_exception, reason: #{reason => {timeout,{gen_server,call,[<0.5877.0>,get_status,5000]}},stacktrace => [{gen_server,call,3,[{file,"gen_server.erl"},{line,419}]},{emqx_bridge_pulsar_connector,on_get_status,2,[{file,"src/emqx_bridge_pulsar_connector.erl"},{line,174}]},{emqx_resource,call_health_check,3,[{file,"src/emqx_resource.erl"},{line,550}]},{emqx_resource_manager,worker_resource_health_check,1,[{file,"src/emqx_resource_manager.erl"},{line,1149}]}],exception => exit}, resource_id: <<"connector:pulsar:a">>
+```


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13402

Release version: e5.8.2

## Summary

`pulsar_client:get_status` call actually exits with `{timeout, _}` rather than raising an error.

```
2024-10-31T12:41:41.014678+00:00 [error] tag: CONNECTOR/PULSAR, msg: health_check_exception, reason: #{reason => {timeout,{gen_server,call,[<0.5877.0>,get_status,5000]}},stacktrace => [{gen_server,call,3,[{file,"gen_server.erl"},{line,419}]},{emqx_bridge_pulsar_connector,on_get_status,2,[{file,"src/emqx_bridge_pulsar_connector.erl"},{line,174}]},{emqx_resource,call_health_check,3,[{file,"src/emqx_resource.erl"},{line,550}]},{emqx_resource_manager,worker_resource_health_check,1,[{file,"src/emqx_resource_manager.erl"},{line,1149}]}],exception => exit}, resource_id: <<"connector:pulsar:a">>
```

After the fix, no such logs should be seen.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~~[ ] Added tests for the changes~~ tested manually
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
