### PR TITLE
fix(kafka consumer): deprecate `health_check_topic`

### DIFF
--- a/changes/ee/fix-14121.en.md
+++ b/changes/ee/fix-14121.en.md
@@ -1,0 +1,1 @@
+Deprecated the `health_check_topic` configuration for Kafka Consumer Connector to avoid further confusion.  This parameters was never actually used for this connector type.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13401

Release version: e5.9.0

## Summary

This field was accidentally added to the consumer schema because it was added to the shared, v1 field in the shared schema module.  It never worked for the consumer connector, as it uses a different library for interfacing with Kafka that does not need a topic to health check.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
