### PR TITLE
fix: handle clients replying with `PUBREC`/`PUBCOMP` / `PUBACK` when QoS is 1 / 2

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -1494,6 +1494,8 @@ update_seqno(
                 inflight := Inflight,
                 stream_scheduler_s := SchedS
             }};
+        {error, undefined = _Expected} ->
+            {error, ?RC_PROTOCOL_ERROR};
         {error, Expected} ->
             ?SLOG(warning, #{
                 msg => "out-of-order_commit",

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -405,7 +405,7 @@ is_awaiting_full(#session{
     | {error, emqx_types:reason_code()}.
 puback(ClientInfo, PacketId, Session = #session{inflight = Inflight}) ->
     case emqx_inflight:lookup(PacketId, Inflight) of
-        {value, #inflight_data{phase = wait_ack, message = #message{qos = 1} = Msg}} ->
+        {value, #inflight_data{phase = wait_ack, message = #message{qos = ?QOS_1} = Msg}} ->
             Inflight1 = emqx_inflight:delete(PacketId, Inflight),
             Session1 = Session#session{inflight = Inflight1},
             {ok, Replies, Session2} = dequeue(ClientInfo, Session1),
@@ -427,7 +427,7 @@ puback(ClientInfo, PacketId, Session = #session{inflight = Inflight}) ->
     | {error, emqx_types:reason_code()}.
 pubrec(PacketId, Session = #session{inflight = Inflight}) ->
     case emqx_inflight:lookup(PacketId, Inflight) of
-        {value, #inflight_data{phase = wait_ack, message = #message{qos = 2} = Msg} = Data} ->
+        {value, #inflight_data{phase = wait_ack, message = #message{qos = ?QOS_2} = Msg} = Data} ->
             Update = Data#inflight_data{phase = wait_comp},
             Inflight1 = emqx_inflight:update(PacketId, Update, Inflight),
             {ok, without_inflight_insert_ts(Msg), Session#session{inflight = Inflight1}};
@@ -464,12 +464,12 @@ pubrel(PacketId, Session = #session{awaiting_rel = AwaitingRel}) ->
     | {error, emqx_types:reason_code()}.
 pubcomp(ClientInfo, PacketId, Session = #session{inflight = Inflight}) ->
     case emqx_inflight:lookup(PacketId, Inflight) of
-        {value, #inflight_data{phase = wait_comp, message = #message{qos = 2} = Msg}} ->
+        {value, #inflight_data{phase = wait_comp, message = #message{qos = ?QOS_2} = Msg}} ->
             Inflight1 = emqx_inflight:delete(PacketId, Inflight),
             Session1 = Session#session{inflight = Inflight1},
             {ok, Replies, Session2} = dequeue(ClientInfo, Session1),
             {ok, without_inflight_insert_ts(Msg), Replies, Session2};
-        {value, #inflight_data{message = #message{qos = QoS}}} when QoS =/= 2 ->
+        {value, #inflight_data{message = #message{qos = QoS}}} when QoS =/= ?QOS_2 ->
             {error, ?RC_PROTOCOL_ERROR};
         {value, _Other} ->
             {error, ?RC_PACKET_IDENTIFIER_IN_USE};

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -405,11 +405,13 @@ is_awaiting_full(#session{
     | {error, emqx_types:reason_code()}.
 puback(ClientInfo, PacketId, Session = #session{inflight = Inflight}) ->
     case emqx_inflight:lookup(PacketId, Inflight) of
-        {value, #inflight_data{phase = wait_ack, message = Msg}} ->
+        {value, #inflight_data{phase = wait_ack, message = #message{qos = 1} = Msg}} ->
             Inflight1 = emqx_inflight:delete(PacketId, Inflight),
             Session1 = Session#session{inflight = Inflight1},
             {ok, Replies, Session2} = dequeue(ClientInfo, Session1),
             {ok, without_inflight_insert_ts(Msg), Replies, Session2};
+        {value, #inflight_data{phase = wait_ack, message = _DifferentQoSMsg}} ->
+            {error, ?RC_PROTOCOL_ERROR};
         {value, _} ->
             {error, ?RC_PACKET_IDENTIFIER_IN_USE};
         none ->
@@ -425,10 +427,12 @@ puback(ClientInfo, PacketId, Session = #session{inflight = Inflight}) ->
     | {error, emqx_types:reason_code()}.
 pubrec(PacketId, Session = #session{inflight = Inflight}) ->
     case emqx_inflight:lookup(PacketId, Inflight) of
-        {value, #inflight_data{phase = wait_ack, message = Msg} = Data} ->
+        {value, #inflight_data{phase = wait_ack, message = #message{qos = 2} = Msg} = Data} ->
             Update = Data#inflight_data{phase = wait_comp},
             Inflight1 = emqx_inflight:update(PacketId, Update, Inflight),
             {ok, without_inflight_insert_ts(Msg), Session#session{inflight = Inflight1}};
+        {value, #inflight_data{phase = wait_ack, message = _DifferentQoSMsg}} ->
+            {error, ?RC_PROTOCOL_ERROR};
         {value, _} ->
             {error, ?RC_PACKET_IDENTIFIER_IN_USE};
         none ->
@@ -460,11 +464,13 @@ pubrel(PacketId, Session = #session{awaiting_rel = AwaitingRel}) ->
     | {error, emqx_types:reason_code()}.
 pubcomp(ClientInfo, PacketId, Session = #session{inflight = Inflight}) ->
     case emqx_inflight:lookup(PacketId, Inflight) of
-        {value, #inflight_data{phase = wait_comp, message = Msg}} ->
+        {value, #inflight_data{phase = wait_comp, message = #message{qos = 2} = Msg}} ->
             Inflight1 = emqx_inflight:delete(PacketId, Inflight),
             Session1 = Session#session{inflight = Inflight1},
             {ok, Replies, Session2} = dequeue(ClientInfo, Session1),
             {ok, without_inflight_insert_ts(Msg), Replies, Session2};
+        {value, #inflight_data{message = #message{qos = QoS}}} when QoS =/= 2 ->
+            {error, ?RC_PROTOCOL_ERROR};
         {value, _Other} ->
             {error, ?RC_PACKET_IDENTIFIER_IN_USE};
         none ->

--- a/apps/emqx_auth_http/test/emqx_authn_scram_restapi_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_scram_restapi_SUITE.erl
@@ -124,7 +124,7 @@ t_authenticate(_Config) ->
     ok = emqx_config:put([mqtt, idle_timeout], 500),
 
     {ok, Pid} = create_connection(Username, Password),
-    emqx_authn_mqtt_test_client:stop(Pid).
+    emqx_mqtt_test_client:stop(Pid).
 
 t_authenticate_bad_props(_Config) ->
     Username = <<"u">>,
@@ -133,7 +133,7 @@ t_authenticate_bad_props(_Config) ->
     set_user_handler(Username, Password),
     init_auth(),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -144,7 +144,7 @@ t_authenticate_bad_props(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet().
 
@@ -155,7 +155,7 @@ t_authenticate_bad_username(_Config) ->
     set_user_handler(Username, Password),
     init_auth(),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(<<"badusername">>),
 
@@ -169,7 +169,7 @@ t_authenticate_bad_username(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet().
 
@@ -180,7 +180,7 @@ t_authenticate_bad_password(_Config) ->
     set_user_handler(Username, Password),
     init_auth(),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
@@ -194,7 +194,7 @@ t_authenticate_bad_password(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?AUTH_PACKET(
         ?RC_CONTINUE_AUTHENTICATION,
@@ -219,7 +219,7 @@ t_authenticate_bad_password(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, AuthContinuePacket),
+    ok = emqx_mqtt_test_client:send(Pid, AuthContinuePacket),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet().
 
@@ -232,7 +232,7 @@ t_destroy(_Config) ->
 
     ok = emqx_config:put([mqtt, idle_timeout], 500),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -243,22 +243,22 @@ t_destroy(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ok = ct:sleep(1000),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet(),
 
-    %% emqx_authn_mqtt_test_client:stop(Pid),
+    %% emqx_mqtt_test_client:stop(Pid),
 
     emqx_authn_test_lib:delete_authenticators(
         [authentication],
         ?GLOBAL
     ),
 
-    {ok, Pid2} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid2} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid2, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid2, ConnectPacket),
 
     ok = ct:sleep(1000),
 
@@ -289,7 +289,7 @@ t_acl(_Config) ->
             Cases
         )
     after
-        ok = emqx_authn_mqtt_test_client:stop(Pid)
+        ok = emqx_mqtt_test_client:stop(Pid)
     end.
 
 t_auth_expire(_Config) ->
@@ -433,7 +433,7 @@ receive_packet() ->
     end.
 
 create_connection(Username, Password) ->
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
@@ -447,7 +447,7 @@ create_connection(Username, Password) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     %% Intentional sleep to trigger idle timeout for the connection not yet authenticated
     ok = ct:sleep(1000),
@@ -475,7 +475,7 @@ create_connection(Username, Password) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, AuthContinuePacket),
+    ok = emqx_mqtt_test_client:send(Pid, AuthContinuePacket),
 
     ?CONNACK_PACKET(
         ?RC_SUCCESS,
@@ -502,7 +502,7 @@ test_acl({deny, Topic}, C) ->
 send_subscribe(Client, Topic) ->
     TopicOpts = #{nl => 0, rap => 0, rh => 0, qos => 0},
     Packet = ?SUBSCRIBE_PACKET(1, [{Topic, TopicOpts}]),
-    emqx_authn_mqtt_test_client:send(Client, Packet),
+    emqx_mqtt_test_client:send(Client, Packet),
     timer:sleep(200),
 
     ?SUBACK_PACKET(1, ReasonCode) = receive_packet(),

--- a/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
@@ -105,7 +105,7 @@ t_authenticate(_Config) ->
 
     ok = emqx_config:put([mqtt, idle_timeout], 500),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
@@ -119,7 +119,7 @@ t_authenticate(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     %% Intentional sleep to trigger idle timeout for the connection not yet authenticated
     ok = ct:sleep(1000),
@@ -147,7 +147,7 @@ t_authenticate(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, AuthContinuePacket),
+    ok = emqx_mqtt_test_client:send(Pid, AuthContinuePacket),
 
     ?CONNACK_PACKET(
         ?RC_SUCCESS,
@@ -166,7 +166,7 @@ t_authenticate_bad_props(_Config) ->
 
     init_auth(Username, Password, Algorithm),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ConnectPacket = ?CONNECT_PACKET(
         #mqtt_packet_connect{
@@ -177,7 +177,7 @@ t_authenticate_bad_props(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet().
 
@@ -188,7 +188,7 @@ t_authenticate_bad_username(_Config) ->
 
     init_auth(Username, Password, Algorithm),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(<<"badusername">>),
 
@@ -202,7 +202,7 @@ t_authenticate_bad_username(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet().
 
@@ -213,7 +213,7 @@ t_authenticate_bad_password(_Config) ->
 
     init_auth(Username, Password, Algorithm),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
@@ -227,7 +227,7 @@ t_authenticate_bad_password(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?AUTH_PACKET(
         ?RC_CONTINUE_AUTHENTICATION,
@@ -252,7 +252,7 @@ t_authenticate_bad_password(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, AuthContinuePacket),
+    ok = emqx_mqtt_test_client:send(Pid, AuthContinuePacket),
 
     ?CONNACK_PACKET(?RC_NOT_AUTHORIZED) = receive_packet().
 
@@ -331,7 +331,7 @@ t_update_user_keys(_Config) ->
 
     ok = emqx_config:put([mqtt, idle_timeout], 500),
 
-    {ok, Pid} = emqx_authn_mqtt_test_client:start_link("127.0.0.1", 1883),
+    {ok, Pid} = emqx_mqtt_test_client:start_link("127.0.0.1", 1883),
 
     ClientFirstMessage = sasl_auth_scram:client_first_message(Username),
 
@@ -345,7 +345,7 @@ t_update_user_keys(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, ConnectPacket),
+    ok = emqx_mqtt_test_client:send(Pid, ConnectPacket),
 
     ?AUTH_PACKET(
         ?RC_CONTINUE_AUTHENTICATION,
@@ -370,7 +370,7 @@ t_update_user_keys(_Config) ->
         }
     ),
 
-    ok = emqx_authn_mqtt_test_client:send(Pid, AuthContinuePacket),
+    ok = emqx_mqtt_test_client:send(Pid, AuthContinuePacket),
 
     ?CONNACK_PACKET(
         ?RC_SUCCESS,

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -776,6 +776,8 @@ handle_in(
                         Publishes,
                         Channel#channel{session = NSession}
                     );
+                {error, ?RC_PROTOCOL_ERROR} ->
+                    handle_out(disconnect, ?RC_PROTOCOL_ERROR, Channel);
                 {error, ?RC_PACKET_IDENTIFIER_IN_USE} ->
                     ?SLOG(warning, #{
                         msg => "commit_puback_failed",

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -2209,11 +2209,18 @@ t_register_subs_resume_off(_) ->
         emqx_message:make(test, ?QOS_2, <<"topic-b">>, <<"test-b">>)
     ),
 
-    <<_, ?SN_PUBLISH, 2#00100000, TopicIdA:16, MsgId1:16, "test-a">> = receive_response(Socket),
+    QoS1Flags = 2#00100000,
+    QoS2Flags = 2#01000000,
+
+    %% This is a QoS 1 message
+    <<_, ?SN_PUBLISH, QoS1Flags, TopicIdA:16, MsgId1:16, "test-a">> = receive_response(Socket),
     send_puback_msg(Socket, TopicIdA, MsgId1, ?SN_RC_ACCEPTED),
 
-    <<_, ?SN_PUBLISH, 2#01000000, TopicIdB:16, MsgId2:16, "test-b">> = receive_response(Socket),
-    send_puback_msg(Socket, TopicIdB, MsgId2, ?SN_RC_ACCEPTED),
+    %% This is a QoS 2 message
+    <<_, ?SN_PUBLISH, QoS2Flags, TopicIdB:16, MsgId2:16, "test-b">> = receive_response(Socket),
+    send_pubrec_msg(Socket, MsgId2),
+    %% discard PUBREL message
+    <<_, ?SN_PUBREL, MsgId2:16>> = receive_response(Socket),
 
     send_disconnect_msg(Socket, undefined),
     ?assertMatch(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
@@ -2236,8 +2243,11 @@ t_register_subs_resume_off(_) ->
 
     %% qos1
 
+    %% receive PUBREL for `test-b' again
+    <<_, ?SN_PUBREL, MsgId2:16>> = receive_response(NSocket),
+    send_pubcomp_msg(NSocket, MsgId2),
     %% received the resume messages
-    <<_, ?SN_PUBLISH, 2#00100000, TopicIdA:16, MsgIdA0:16, "m1">> = receive_response(NSocket),
+    <<_, ?SN_PUBLISH, QoS1Flags, TopicIdA:16, MsgIdA0:16, "m1">> = receive_response(NSocket),
     %% only one qos1/qos2 inflight
     ?assertEqual(udp_receive_timeout, receive_response(NSocket)),
     send_puback_msg(NSocket, TopicIdA, MsgIdA0, ?SN_RC_INVALID_TOPIC_ID),
@@ -2245,17 +2255,17 @@ t_register_subs_resume_off(_) ->
     <<_, ?SN_REGISTER, TopicIdA:16, RegMsgIdA:16, "topic-a">> = receive_response(NSocket),
     send_regack_msg(NSocket, TopicIdA, RegMsgIdA),
     %% received the replay messages
-    <<_, ?SN_PUBLISH, 2#00100000, TopicIdA:16, MsgIdA1:16, "m1">> = receive_response(NSocket),
+    <<_, ?SN_PUBLISH, QoS1Flags, TopicIdA:16, MsgIdA1:16, "m1">> = receive_response(NSocket),
     send_puback_msg(NSocket, TopicIdA, MsgIdA1, ?SN_RC_ACCEPTED),
 
-    <<_, ?SN_PUBLISH, 2#00100000, TopicIdA:16, MsgIdA2:16, "m2">> = receive_response(NSocket),
+    <<_, ?SN_PUBLISH, QoS1Flags, TopicIdA:16, MsgIdA2:16, "m2">> = receive_response(NSocket),
     send_puback_msg(NSocket, TopicIdA, MsgIdA2, ?SN_RC_ACCEPTED),
 
-    <<_, ?SN_PUBLISH, 2#00100000, TopicIdA:16, MsgIdA3:16, "m3">> = receive_response(NSocket),
+    <<_, ?SN_PUBLISH, QoS1Flags, TopicIdA:16, MsgIdA3:16, "m3">> = receive_response(NSocket),
     send_puback_msg(NSocket, TopicIdA, MsgIdA3, ?SN_RC_ACCEPTED),
 
     %% qos2
-    <<_, ?SN_PUBLISH, 2#01000000, TopicIdB:16, MsgIdB0:16, "m1">> = receive_response(NSocket),
+    <<_, ?SN_PUBLISH, QoS2Flags, TopicIdB:16, MsgIdB0:16, "m1">> = receive_response(NSocket),
     %% only one qos1/qos2 inflight
     ?assertEqual(udp_receive_timeout, receive_response(NSocket)),
     send_puback_msg(NSocket, TopicIdB, MsgIdB0, ?SN_RC_INVALID_TOPIC_ID),
@@ -2263,16 +2273,20 @@ t_register_subs_resume_off(_) ->
     <<_, ?SN_REGISTER, TopicIdB:16, RegMsgIdB:16, "topic-b">> = receive_response(NSocket),
     send_regack_msg(NSocket, TopicIdB, RegMsgIdB),
     %% received the replay messages
-    <<_, ?SN_PUBLISH, 2#01000000, TopicIdB:16, MsgIdB1:16, "m1">> = receive_response(NSocket),
+    <<_, ?SN_PUBLISH, QoS2Flags, TopicIdB:16, MsgIdB1:16, "m1">> = receive_response(NSocket),
     send_pubrec_msg(NSocket, MsgIdB1),
     <<_, ?SN_PUBREL, MsgIdB1:16>> = receive_response(NSocket),
     send_pubcomp_msg(NSocket, MsgIdB1),
 
-    <<_, ?SN_PUBLISH, 2#01000000, TopicIdB:16, MsgIdB2:16, "m2">> = receive_response(NSocket),
-    send_puback_msg(NSocket, TopicIdB, MsgIdB2, ?SN_RC_ACCEPTED),
+    <<_, ?SN_PUBLISH, QoS2Flags, TopicIdB:16, MsgIdB2:16, "m2">> = receive_response(NSocket),
+    send_pubrec_msg(NSocket, MsgIdB2),
+    <<_, ?SN_PUBREL, MsgIdB2:16>> = receive_response(NSocket),
+    send_pubcomp_msg(NSocket, MsgIdB2),
 
-    <<_, ?SN_PUBLISH, 2#01000000, TopicIdB:16, MsgIdB3:16, "m3">> = receive_response(NSocket),
-    send_puback_msg(NSocket, TopicIdB, MsgIdB3, ?SN_RC_ACCEPTED),
+    <<_, ?SN_PUBLISH, QoS2Flags, TopicIdB:16, MsgIdB3:16, "m3">> = receive_response(NSocket),
+    send_pubrec_msg(NSocket, MsgIdB3),
+    <<_, ?SN_PUBREL, MsgIdB3:16>> = receive_response(NSocket),
+    send_pubcomp_msg(NSocket, MsgIdB3),
 
     %% no more messages
     ?assertEqual(udp_receive_timeout, receive_response(NSocket)),

--- a/changes/ce/fix-14122.en.md
+++ b/changes/ce/fix-14122.en.md
@@ -1,0 +1,3 @@
+Fixed handling of `PUBACK` and `PUBREC`/`PUBCOMP` when the published message has QoS 2 and 1, repectively.
+
+Prior to this fix, the broker would accept `PUBACK` and `PUBREC`/`PUBCOMP` packets from clients referencing packet identifiers that corresponded to messages with QoS 2 and 1, respectively.  Now, the broker will disconnect clients that behave like this.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-9314

Fixes https://github.com/emqx/emqx/issues/10215

Release version: v/e5.9.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
