### PR TITLE
chore: improve the log msg when API path not_found

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_not_found.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_not_found.erl
@@ -22,7 +22,15 @@
 
 init(Req0, State) ->
     RedactedReq = emqx_utils:redact(Req0),
-    ?SLOG(warning, #{msg => "unexpected_api_access", request => RedactedReq}),
+    ?SLOG(notice, #{
+        msg => "api_path_not_found",
+        path => cowboy_req:path(RedactedReq),
+        scheme => cowboy_req:scheme(RedactedReq),
+        method => cowboy_req:method(RedactedReq),
+        headers => cowboy_req:headers(RedactedReq),
+        query_string => cowboy_req:qs(RedactedReq),
+        peer => cowboy_req:peer(RedactedReq)
+    }),
     CT = ct(cowboy_req:header(<<"accept">>, Req0, <<"text/html">>)),
     Req = cowboy_req:reply(
         404,


### PR DESCRIPTION
Release version: v/e5.9.0

## Summary

Improve the log messages on API path not_found:
- Change to `notice` level;
- Minimize the fields to be printed;
- Change log-msg from `unexpected_api_access` to `api_path_not_found`

Here is a log example before this PR:
```
2024-11-04T10:57:16.984927+08:00 [warning] msg: unexpected_api_access, request: #{pid => <0.4764.0>,port => 18083,scheme => <<"http">>,version => 'HTTP/1.1',path => <<"/api/v5/abc">>,host => <<"localhost">>,peer => {{127,0,0,1},49988},sock => {{127,0,0,1},18083},bindings => #{},ref => 'http:dashboard',cert => undefined,headers => #{<<"accept">> => <<"*/*">>,<<"host">> => <<"localhost:18083">>,<<"user-agent">> => <<"curl/7.79.1">>},method => <<"GET">>,body_length => 0,path_info => undefined,qs => <<>>,streamid => 1,has_body => false,host_info => undefined}
```

And the log after this PR:

```
2024-11-04T10:55:47.215283+08:00 [notice] msg: api_path_not_found, scheme: <<"http">>, path: <<"/api/v5/abc">>, peer: {{127,0,0,1},49885}, headers: #{<<"accept">> => <<"*/*">>,<<"host">> => <<"localhost:18083">>,<<"user-agent">> => <<"curl/7.79.1">>}, method: <<"GET">>, query_string: <<>>
```


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
