### PR TITLE
docs: remove '0 means disable' comment from example configs

### DIFF
--- a/rel/config/examples/dashboard-with-http.conf.example
+++ b/rel/config/examples/dashboard-with-http.conf.example
@@ -10,7 +10,7 @@ dashboard {
     cors = false
 
     listeners.http {
-        ## Port or Address to listen on, 0 means disable
+        # bind = 0 to disable this listener
         bind = "0.0.0.0:18083" ## or just a port number, e.g. 18083
 
         ## Socket acceptor pool size for TCP protocols

--- a/rel/config/examples/dashboard-with-https.conf.example
+++ b/rel/config/examples/dashboard-with-https.conf.example
@@ -10,7 +10,7 @@ dashboard {
     cors = false
 
     listeners.https {
-        ## Port or Address to listen on, 0 means disable
+        # bind = 0 to disable this listener
         bind = "0.0.0.0:18084" ## or just a port number, e.g. 18084
 
         ssl_options {

--- a/rel/config/examples/listeners.quic.conf.example
+++ b/rel/config/examples/listeners.quic.conf.example
@@ -1,7 +1,6 @@
 ## MQTT over QUIC Listener
 
 listeners.quic.my_quick_listener_name {
-    ## Port or Address to listen on, 0 means disable
     bind = 14567 ## or with an IP, e.g. "127.0.0.1:14567"
 
     ## When publishing or subscribing, prefix all topics with a mountpoint string

--- a/rel/config/examples/listeners.ssl.conf.example
+++ b/rel/config/examples/listeners.ssl.conf.example
@@ -1,7 +1,6 @@
 ## MQTT over TLS(SSL) Listener
 
 listeners.ssl.my_ssl_listener_name {
-    ## Port or Address to listen on, 0 means disable
     bind = 8883 ## or with an IP e.g. "127.0.0.1:8883"
     acceptors = 16
     enable_authn = true

--- a/rel/config/examples/listeners.tcp.conf.example
+++ b/rel/config/examples/listeners.tcp.conf.example
@@ -1,7 +1,6 @@
 ## MQTT over TCP Listener
 
 listeners.tcp.my_tcp_listener_name {
-    ## Port or Address to listen on, 0 means disable
     bind = 1883 ## or with an IP e.g. "127.0.0.1:1883"
 
     ## Enable the Proxy Protocol V1/2 if the EMQX cluster is deployed behind HAProxy or Nginx

--- a/rel/config/examples/listeners.ws.conf.example
+++ b/rel/config/examples/listeners.ws.conf.example
@@ -1,7 +1,6 @@
 ## MQTT over WebSocket (HTTP) Listener
 
 listeners.ws.my_ws_listener_name {
-    ## Port or Address to listen on, 0 means disable
     bind = "0.0.0.0:8083" # or just a port number, e.g. 8083
     enable_authn = true
     max_connections = infinity

--- a/rel/config/examples/listeners.wss.conf.example
+++ b/rel/config/examples/listeners.wss.conf.example
@@ -1,7 +1,6 @@
 ## MQTT over Secured Websocket (HTTPS) Listener
 
 listeners.wss.my_wss_listener_name = {
-    ## Port or Address to listen on, 0 means disable
     bind = 8084 ## or with an IP, e.g. "127.0.0.1:8084"
     enable_authn = true
     max_connections = infinity


### PR DESCRIPTION
Release: v/e5.8.3

`bind=0` to disable listener only applicable to dashboard listeners.
For MQTT listeners, `bind=0` will lead to a random port number, no intention to change this behavior nor document this behavior for now.