### PR TITLE
The data/patches dir not work

### DIFF
--- a/apps/emqx/etc/vm.args.cloud
+++ b/apps/emqx/etc/vm.args.cloud
@@ -119,6 +119,9 @@
 ## See: http://erlang.org/doc/man/erl.html
 -shutdown_time 30000
 
+## Disable the code path caching feature to allow adding dynamic patch path using `-pa`.
+-cache_boot_paths false
+
 ## patches dir
 -pa "{{ platform_data_dir }}/patches"
 

--- a/dev
+++ b/dev
@@ -348,6 +348,7 @@ $ERL_NAME_ARG $EMQX_NODE_NAME
 +SDio 8
 -shutdown_time 30000
 -pa '$EMQX_DATA_DIR/patches'
+-cache_boot_paths false
 -mnesia dump_log_write_threshold 5000
 -mnesia dump_log_time_threshold 60000
 -os_mon start_disksup false


### PR DESCRIPTION
Release version: v/e5.8.3

## Summary

The `-pa data/patches` init args was not working due to the `cache_boot_paths` feature. See the OTP changes here https://github.com/erlang/otp/pull/6729

I'd like to disable the feature as it may causes more problems than we know. One of other solutions is to run `code:set_path("data/patches", nocache)` on emqx boot.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
