### PR TITLE
fix(resource manager): avoid zombie resource after HTTP API request is forcefully killed

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -547,11 +547,11 @@ start_link(ResId, Group, ResourceType, Config, Opts) ->
 init({DataIn, Opts}) ->
     process_flag(trap_exit, true),
     Data = DataIn#data{pid = self()},
+    emqx_resource_cache_cleaner:add(Data#data.id, self()),
     case maps:get(start_after_created, Opts, ?START_AFTER_CREATED) of
         true ->
             %% init the cache so that lookup/1 will always return something
             UpdatedData = update_state(Data#data{status = ?status_connecting}),
-            emqx_resource_cache_cleaner:add(Data#data.id, self()),
             {ok, ?state_connecting, UpdatedData, {next_event, internal, start_resource}};
         false ->
             %% init the cache so that lookup/1 will always return something

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -249,6 +249,9 @@ create_dry_run(ResId, ResourceType, Config, OnReadyCallback) ->
             true -> maps:get(resource_opts, Config, #{});
             false -> #{}
         end,
+    %% Ensure that the dry run resource is terminated, even if this process is forcefully
+    %% killed (e.g.: cowboy / HTTP API request times out).
+    emqx_resource_cache_cleaner:add_dry_run(ResId, self()),
     ok = emqx_resource_manager_sup:ensure_child(
         ResId, <<"dry_run">>, ResourceType, Config, Opts
     ),
@@ -547,7 +550,7 @@ start_link(ResId, Group, ResourceType, Config, Opts) ->
 init({DataIn, Opts}) ->
     process_flag(trap_exit, true),
     Data = DataIn#data{pid = self()},
-    emqx_resource_cache_cleaner:add(Data#data.id, self()),
+    emqx_resource_cache_cleaner:add_cache(Data#data.id, self()),
     case maps:get(start_after_created, Opts, ?START_AFTER_CREATED) of
         true ->
             %% init the cache so that lookup/1 will always return something

--- a/changes/ce/fix-14172.en.md
+++ b/changes/ce/fix-14172.en.md
@@ -1,0 +1,1 @@
+Fixed a potential race condition where testing a connector using the HTTP API could leave lingering resources if the HTTP request timed out.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13079

Release version: v/e5.8.3

## Summary

There's race condition where a dry run request takes too long, and the HTTP API request
process is then forcefully killed by `cowboy_children` before it has the chance to
properly cleanup and remove the dry run/probe resource.  This leaves a dry run resource
instance running that is never cleaned up.


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
