### PR TITLE
feat(rabbitmq): expose some meta info into the rule engine for the source action

### DIFF
--- a/changes/ee/feat-14176.en.md
+++ b/changes/ee/feat-14176.en.md
@@ -1,0 +1,5 @@
+Some metadata was exposed to the rule engine for RabbitMQ source actions, including `queue`, `exchange` and the `routing_key`.
+
+Here is an example:
+`select *, queue as payload.queue, exchange as payload.exchange, routing_key as payload.routing_key from "$bridges/rabbitmq:test"`
+


### PR DESCRIPTION

includes the `queue`, `exchange`, `routing_key`

Fixes EMQX-13413

Release version: v/e5.8.3

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
