### PR TITLE
chore: upgrade replayq from 0.3.9 to 0.3.10

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,8 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.3"},
-    {kafka_protocol, "4.1.9"},
+    {wolff, "4.0.4"},
+    {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,8 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.3"},
-    {kafka_protocol, "4.1.9"},
+    {wolff, "4.0.4"},
+    {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,8 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.3"},
-    {kafka_protocol, "4.1.9"},
+    {wolff, "4.0.4"},
+    {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},
     {snappyer, "1.2.10"},

--- a/changes/ee/fix-14181.en.md
+++ b/changes/ee/fix-14181.en.md
@@ -1,0 +1,4 @@
+Made Kafka and Pulsar producers tolerate corrupted COMMIT file.
+
+For disk mode buffers, if the COMMIT file is corrupted, it will be ignored.
+This means the producer may replay some already sent messages, but shold not crash.

--- a/mix.exs
+++ b/mix.exs
@@ -207,7 +207,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:cowboy), do: {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true}
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
   def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.5.10", override: true}
-  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.3.9", override: true}
+  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.3.10", override: true}
   def common_dep(:jsx), do: {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true}
   # in conflict by emqtt and hocon
   def common_dep(:getopt), do: {:getopt, "1.0.2", override: true}
@@ -276,11 +276,11 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.3"}
+  def common_dep(:wolff), do: {:wolff, "4.0.4"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),
-    do: {:kafka_protocol, "4.1.9", override: true}
+    do: {:kafka_protocol, "4.1.10", override: true}
 
   def common_dep(:brod), do: {:brod, "4.3.1"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,7 @@
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.10"}}},
-    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.9"}}},
+    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.10"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.0"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},


### PR DESCRIPTION
Release version: e5.8.3

## Summary

 - replayq from 0.3.9 to 0.3.10, v0.3.10 tolerates corrupted COMMIT file
 - kafka_protocol from 4.1.9 to 4.1.10, to fix a rare timeout issue
      only happens when 5s is not long enough to discover partition lader
      and then connect
 - wolff from 4.0.3 to 4.0.4 only to keep the versions consistent


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
