### PR TITLE
fix(clients mgmt api): handle potential race condition when formatting/fetching kicked clients

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1858,7 +1858,13 @@ format_channel_info(WhichNode, {_, ClientInfo0, ClientStats}, Opts) ->
         )
     );
 format_channel_info(undefined, {ClientId, PSInfo0 = #{}}, _Opts) ->
-    format_persistent_session_info(ClientId, PSInfo0).
+    format_persistent_session_info(ClientId, PSInfo0);
+format_channel_info(undefined, {ClientId, undefined = _PSInfo}, _Opts) ->
+    %% Durable session missing its metadata: possibly a race condition, such as the client
+    %% being kicked while the API is enumerating clients.  There's nothing much to do, we
+    %% just return an almost empty map to avoid crashing this function.  The client may
+    %% just retry listing in such cases.
+    #{clientid => ClientId}.
 
 format_persistent_session_info(
     _ClientId,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13387

Release version: v/e5.8.3

## Summary

Durable session missing its metadata: possibly a race condition, such as the client being kicked while the API is enumerating clients.  There's nothing much to do, we just return an empty map to avoid crashing this function.  The client may just retry listing in such cases.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
