### PR TITLE
feat(jwt_auth): make will msg be sent in case of disconnetion on auth expire

### DIFF
--- a/changes/ce/fix-14192.en.md
+++ b/changes/ce/fix-14192.en.md
@@ -1,0 +1,1 @@
+Allow will messages to be sent by the clients that disconnect because of authentication/authorization expiration. Previously, such clients could not send a will message because the sending occurred just after the authorization expiration, so the message could not pass the authorization rules.


### PR DESCRIPTION
Fixes [EMQX-12708](https://emqx.atlassian.net/browse/EMQX-12708)

Release version: v/e5.8.3

## Summary

The problem description is quite simple:
* JWT authenticator provides both **authentication** and **authorization rules** that we put into the `clientinfo`.
* They both have the same expiration deadline (the exp of JWT).
* We schedule a disconnect timer for the connection after the successful JWT auth, so that client is kicked when its auth expires.
* We kick the client, and its will message cannot pass the authz checks because they have just expired (together with the auth).

A straightforward solution is to add some thresholds to authz expiration deadline to give the will message a chance to pass authorization. However, since the disconnection is triggered by a timer, the event may be arbitrarily late if the connection is under load, leading to unstable behavior: most of the time, the messages are not lost, but sometimes they are.

The funny part is that the JWT auth does not "recognize" the message the sending of which it induced itself 😅 because the information is lost several times:
* The connection does not know which authenticator set the authz rules and the expiration time.
* When the expiration timer triggers disconnect, the code that sends the will message does not know the reason for sending.
* Finally, the called authorization app does not have enough context — it does not know at all that it was called for a will message and for which reason the will message is sent.

In the proposed solution, we try to prevent expiration data loss so that the authorizer at least receives back the exact data that it set:
* We make the connection expiration timer more specific — it becomes the "auth expiration" timer set from the `auth_expire_at` value returned from authenticators;
* then, handling the timer, we introduce a specific `maybe_publish_will_msg` reason: `auth_expired`;
* so in `maybe_publish_will_msg` with `auth_expired` argument, we know that we are sending the will message maybe a bit later than the desired moment `auth_expire_at`. 
* finally, we inject this moment as the time into the authorization context (`clientinfo`). This allows the authorizer to work without a side effect (fetching time) and compare the expiration moment with itself.

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible

[EMQX-12708]: https://emqx.atlassian.net/browse/EMQX-12708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ