### PR TITLE
feat: add clientid override

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -360,6 +360,8 @@ handle_in(?CONNECT_PACKET(ConnPkt) = Packet, Channel) ->
                 fun run_conn_hooks/2,
                 fun check_connect/2,
                 fun enrich_client/2,
+                %% set_log_meta should happen after enrich_client
+                %% because client ID assign and override
                 fun set_log_meta/2,
                 fun check_banned/2,
                 fun count_flapping_event/2
@@ -1661,7 +1663,9 @@ enrich_client(ConnPkt, Channel = #channel{clientinfo = ClientInfo}) ->
             fun maybe_username_as_clientid/2,
             fun maybe_assign_clientid/2,
             %% attr init should happen after clientid and username assign
-            fun maybe_set_client_initial_attrs/2
+            fun maybe_set_client_initial_attrs/2,
+            %% clientid override should happen after client_attrs is initialized
+            fun maybe_override_clientid/2
         ],
         ConnPkt,
         ClientInfo
@@ -1716,11 +1720,16 @@ get_client_attrs_init_config(Zone) ->
     get_mqtt_conf(Zone, client_attrs_init, []).
 
 maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
-    Inits = get_client_attrs_init_config(Zone),
-    UserProperty = get_user_property_as_map(ConnPkt),
-    {ok, initialize_client_attrs(Inits, ClientInfo#{user_property => UserProperty})}.
+    case get_client_attrs_init_config(Zone) of
+        [] ->
+            {ok, ClientInfo};
+        Inits ->
+            UserProperty = get_user_property_as_map(ConnPkt),
+            ClientInfo1 = initialize_client_attrs(Inits, ClientInfo#{user_property => UserProperty}),
+            {ok, maps:remove(user_property, ClientInfo1)}
+    end.
 
-initialize_client_attrs(Inits, ClientInfo) ->
+initialize_client_attrs(Inits, #{clientid := ClientId} = ClientInfo) ->
     lists:foldl(
         fun(#{expression := Variform, set_as_attr := Name}, Acc) ->
             Attrs = maps:get(client_attrs, Acc, #{}),
@@ -1731,6 +1740,8 @@ initialize_client_attrs(Inits, ClientInfo) ->
                         #{
                             msg => "client_attr_rednered_to_empty_string",
                             set_as_attr => Name
+                        }#{
+                            clientid => ClientId
                         }
                     ),
                     Acc;
@@ -1741,7 +1752,8 @@ initialize_client_attrs(Inits, ClientInfo) ->
                             msg => "client_attr_initialized",
                             set_as_attr => Name,
                             attr_value => Value
-                        }
+                        },
+                        #{clientid => ClientId}
                     ),
                     Acc#{client_attrs => Attrs#{Name => Value}};
                 {error, Reason} ->
@@ -1750,7 +1762,8 @@ initialize_client_attrs(Inits, ClientInfo) ->
                         #{
                             msg => "client_attr_initialization_failed",
                             reason => Reason
-                        }
+                        },
+                        #{clientid => ClientId}
                     ),
                     Acc
             end
@@ -1758,6 +1771,41 @@ initialize_client_attrs(Inits, ClientInfo) ->
         ClientInfo,
         Inits
     ).
+
+maybe_override_clientid(_ConnPkt, #{zone := Zone} = ClientInfo) ->
+    Expression = get_mqtt_conf(Zone, clientid_override, disabled),
+    {ok, override_clientid(Expression, ClientInfo)}.
+
+override_clientid(disabled, ClientInfo) ->
+    ClientInfo;
+override_clientid(Expression, #{clientid := OrigClientId} = ClientInfo) ->
+    case emqx_variform:render(Expression, ClientInfo) of
+        {ok, <<>>} ->
+            ?SLOG(
+                warning,
+                #{
+                    msg => "clientid_override_expression_returned_empty_string"
+                },
+                #{clientid => OrigClientId}
+            ),
+            ClientInfo;
+        {ok, ClientId} ->
+            % Must add 'clientid' log meta for trace log filter
+            ?TRACE("MQTT", "clientid_overriden", #{
+                clientid => ClientId, original_clientid => OrigClientId
+            }),
+            ClientInfo#{clientid => ClientId};
+        {error, Reason} ->
+            ?SLOG(
+                warning,
+                #{
+                    msg => "clientid_override_expression_failed",
+                    reason => Reason
+                },
+                #{clientid => OrigClientId}
+            ),
+            ClientInfo
+    end.
 
 get_user_property_as_map(#mqtt_packet_connect{properties = #{'User-Property' := UserProperty}}) when
     is_list(UserProperty)

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1791,7 +1791,7 @@ override_clientid(Expression, #{clientid := OrigClientId} = ClientInfo) ->
             ClientInfo;
         {ok, ClientId} ->
             % Must add 'clientid' log meta for trace log filter
-            ?TRACE("MQTT", "clientid_overriden", #{
+            ?TRACE("MQTT", "clientid_overridden", #{
                 clientid => ClientId, original_clientid => OrigClientId
             }),
             ClientInfo#{clientid => ClientId};

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1811,6 +1811,13 @@ fields("banned") ->
             )}
     ].
 
+compile_variform_allow_disabled(disabled, _Opts) ->
+    disabled;
+compile_variform_allow_disabled(<<"disabled">>, _Opts) ->
+    disabled;
+compile_variform_allow_disabled(Expression, Opts) ->
+    compile_variform(Expression, Opts).
+
 compile_variform(undefined, _Opts) ->
     undefined;
 compile_variform(Expression, #{make_serializable := true}) ->
@@ -3725,6 +3732,15 @@ mqtt_general() ->
                 #{
                     default => [],
                     desc => ?DESC("client_attrs_init")
+                }
+            )},
+        {"clientid_override",
+            sc(
+                hoconsc:union([disabled, typerefl:alias("string", any())]),
+                #{
+                    default => disabled,
+                    desc => ?DESC("clientid_override"),
+                    converter => fun compile_variform_allow_disabled/2
                 }
             )}
     ].

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -456,7 +456,8 @@ zone_global_defaults() ->
                 upgrade_qos => false,
                 use_username_as_clientid => false,
                 wildcard_subscription => true,
-                client_attrs_init => []
+                client_attrs_init => [],
+                clientid_override => disabled
             },
         overload_protection =>
             #{

--- a/changes/ce/feat-14195.en.md
+++ b/changes/ce/feat-14195.en.md
@@ -1,0 +1,4 @@
+Support clientid override.
+
+EMQX now allows custom client ID overrides with `clientid_override={Expression}`, offering more flexibility.
+This deprecates the `use_userid_as_clientid` and `peer_cert_as_clientid` options, which remain available for compatibility until version 6.0.

--- a/changes/ce/feat-14195.en.md
+++ b/changes/ce/feat-14195.en.md
@@ -1,4 +1,4 @@
 Support clientid override.
 
-EMQX now allows custom client ID overrides with `clientid_override={Expression}`, offering more flexibility.
+EMQX now allows custom client ID overrides with `mqtt.clientid_override={Expression}`, offering more flexibility.
 This deprecates the `use_userid_as_clientid` and `peer_cert_as_clientid` options, which remain available for compatibility until version 6.0.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1713,6 +1713,24 @@ client_attrs_init_set_as_attr {
     The extracted attribute will be stored in the `client_attrs` property with this name."""
 }
 
+clientid_override {
+  label: "Client ID Override Expression"
+  desc: """~
+    A one line expression to evaluate a set of predefined string functions (like in the rule engine SQL statements).
+    The expression can be a function call with nested calls as its arguments, or direct variable reference.
+    So far, it does not provide user-defined variable binding (like `var a=1`) or user-defined functions.
+    As an example, to extract the prefix of client ID delimited by a dot: `nth(1, tokens(username, '.'))`.
+
+    The variables pre-bound variables are:
+    - `cn`: Client's TLS certificate common name.
+    - `dn`: Client's TLS certificate distinguished name (the subject).
+    - `clientid`: The original MQTT Client ID.
+    - `username`: MQTT Client's username.
+    - `client_attrs.{NAME}`: Client attributes initialized by per config `client_attrs_init`.
+
+    You can read more about variform expressions in EMQX docs."""
+}
+
 banned_bootstrap_file.desc:
 """The bootstrap file is a CSV file used to batch loading banned data when initializing a single node or cluster, in other words, the import operation is performed only if there is no data in the database.
 


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/discussions/13995
Release version: v/e5.8.3

## Summary

This small feature should allow us to provide better multi-tenancy support before 5.9.

e.g.

```
# Use username as tenant ID / topic namespace.
listeners.tcp.default.mountpoint="${username}/"
# Override client ID with username prefix to avoid ID clashing from different tenants.
mqtt.clientid_ovrride = "concat([username, '-', clientid])"
```

TODO(Enterprise only multi-tenancy features):

- `client_attrs.tns` as the conventional multi-tenancy activation attribute, when this attribute exists:
  - automatic mount topic prefix
  - automatic override client ID
- ClientID index from `tns` to `[clientid]`
  - per-tenant client count
  - per-tenant client count limit
  - per-tenant message rate limit

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
