### PR TITLE
perf(emqx): put immutable part of connection state into `#ctx` record

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -72,7 +72,7 @@
 ]).
 
 %% Internal callback
--export([wakeup_from_hib/2, recvloop/2, get_state/1]).
+-export([wakeup_from_hib/2, recvloop/2]).
 
 %% Export for CT
 -export([set_field/3]).
@@ -232,6 +232,12 @@ info(limiter, #state{limiter = Limiter}) ->
     Limiter;
 info(limiter_timer, #state{limiter_timer = Timer}) ->
     Timer;
+info(transport, #state{transport = Transport}) ->
+    Transport;
+info(socket, #state{socket = Socket}) ->
+    Socket;
+info(channel, #state{channel = Channel}) ->
+    Channel;
 info({channel, Info}, #state{channel = Channel}) ->
     emqx_channel:info(Info, Channel).
 
@@ -1271,23 +1277,6 @@ graceful_shutdown_transport(_Reason, S = #state{transport = Transport, socket = 
     Transport:shutdown(Socket, read_write),
     S#state{sockstate = closed}.
 
-%%--------------------------------------------------------------------
-%% For CT tests
-%%--------------------------------------------------------------------
-
-set_field(Name, Value, State) ->
-    Pos = emqx_utils:index_of(Name, record_info(fields, state)),
-    setelement(Pos + 1, State, Value).
-
-get_state(Pid) ->
-    State = sys:get_state(Pid),
-    maps:from_list(
-        lists:zip(
-            record_info(fields, state),
-            tl(tuple_to_list(State))
-        )
-    ).
-
 -compile({inline, [get_active_n/1, get_active_n/2]}).
 get_active_n(#ctx{listener = {Type, Listener}}) ->
     get_active_n(Type, Listener).
@@ -1296,3 +1285,11 @@ get_active_n(quic, _Listener) ->
     ?ACTIVE_N;
 get_active_n(Type, Listener) ->
     emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n]).
+
+%%--------------------------------------------------------------------
+%% For CT tests
+%%--------------------------------------------------------------------
+
+set_field(Name, Value, State) ->
+    Pos = emqx_utils:index_of(Name, record_info(fields, state)),
+    setelement(Pos + 1, State, Value).

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -1467,7 +1467,7 @@ try_get_live_session(ClientId) ->
     case emqx_cm:lookup_channels(local, ClientId) of
         [Pid] ->
             try
-                #{channel := ChanState} = emqx_connection:get_state(Pid),
+                ChanState = emqx_connection:info(channel, sys:get_state(Pid)),
                 case emqx_channel:info(impl, ChanState) of
                     ?MODULE ->
                         {Pid, emqx_channel:info(session_state, ChanState)};

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -557,11 +557,11 @@ t_cancel_congestion_alarm(_) ->
     ),
     with_conn(
         fun(Pid) ->
-            #{
-                channel := Channel,
-                transport := Transport,
-                socket := Socket
-            } = emqx_connection:get_state(Pid),
+            [
+                {channel, Channel},
+                {transport, Transport},
+                {socket, Socket}
+            ] = emqx_connection:info([channel, transport, socket], sys:get_state(Pid)),
             %% precondition
             Zone = emqx_channel:info(zone, Channel),
             true = emqx_config:get_zone_conf(Zone, [conn_congestion, enable_alarm]),

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -188,10 +188,10 @@ t_process_msg(_) ->
     ).
 
 t_ensure_stats_timer(_) ->
-    NStats = emqx_connection:ensure_stats_timer(100, st()),
-    Stats_timer = emqx_connection:info(stats_timer, NStats),
-    ?assert(is_reference(Stats_timer)),
-    ?assertEqual(NStats, emqx_connection:ensure_stats_timer(100, NStats)).
+    NStats = emqx_connection:ensure_stats_timer(st()),
+    StatsTimer = emqx_connection:info(stats_timer, NStats),
+    ?assert(is_reference(StatsTimer)),
+    ?assertEqual(NStats, emqx_connection:ensure_stats_timer(NStats)).
 
 t_cancel_stats_timer(_) ->
     NStats = emqx_connection:cancel_stats_timer(st(#{stats_timer => make_ref()})),

--- a/apps/emqx/test/emqx_mqtt_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_SUITE.erl
@@ -243,9 +243,10 @@ do_async_set_keepalive(OptKeepIdle, OptKeepInterval, OptKeepCount) ->
         100
     ),
     [Pid] = emqx_cm:lookup_channels(ClientID),
-    State = emqx_connection:get_state(Pid),
-    Transport = maps:get(transport, State),
-    Socket = maps:get(socket, State),
+    [
+        {socket, Socket},
+        {transport, Transport}
+    ] = emqx_connection:info([socket, transport], sys:get_state(Pid)),
     ?assert(is_port(Socket)),
     Opts = [{raw, 6, OptKeepIdle, 4}, {raw, 6, OptKeepInterval, 4}, {raw, 6, OptKeepCount, 4}],
     {ok, [

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1105,7 +1105,10 @@ t_keepalive(Config) ->
     [Pid] = emqx_cm:lookup_channels(list_to_binary(ClientId)),
     %% will reset to max keepalive if keepalive > max keepalive
     #{conninfo := #{keepalive := InitKeepalive}} = emqx_connection:info(Pid),
-    ?assertMatch({keepalive, _, _, _, _, 65536500}, element(5, element(9, sys:get_state(Pid)))),
+    ?assertMatch(
+        #{max_idle_millisecond := 65536500},
+        emqx_connection:info({channel, keepalive}, sys:get_state(Pid))
+    ),
 
     ?assertMatch(
         {ok, {?HTTP200, _, #{<<"keepalive">> := 11}}},


### PR DESCRIPTION
Fixes [EMQX-13430](https://emqx.atlassian.net/browse/EMQX-13430).

Release version: v5.9.0

## Summary

See individual commits.

Resource utilization impact TBA.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
