### PR TITLE
241113 upgrade to esockd 5.13.0

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -28,7 +28,7 @@
     {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.3"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
-    {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.12.0"}}},
+    {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.7"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.4"}}},

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -825,12 +825,30 @@ ssl_opts(Opts) ->
     emqx_tls_lib:to_server_opts(tls, maps:get(ssl_options, Opts, #{})).
 
 tcp_opts(Opts) ->
-    maps:to_list(
-        maps:without(
-            [active_n, keepalive],
-            maps:get(tcp_options, Opts, #{})
-        )
-    ).
+    TcpOpts = maps:to_list(maps:get(tcp_options, Opts, #{})),
+    lists:flatten(lists:map(fun tcp_opt/1, TcpOpts)).
+
+tcp_opt({active_n, _}) ->
+    %% The `active_n' option is ignored for listener socket.
+    %% For accepted sockets, `active_n' is set by socket owner processes.
+    [];
+tcp_opt({keepalive, _String}) ->
+    %% emqx_schema:tcp_keepalive_opts(String);
+    %% esockd only supports key-value paris, NOT options like [{raw, 6, 4, ...}]
+    %% so we ignore it here but set it in emqx_connection process like `active_n'
+    [];
+tcp_opt({nolinger, Bool}) ->
+    case Bool of
+        true ->
+            {linger, {true, 0}};
+        false ->
+            %% cannot return [] here
+            %% because we need to be able to set {true, 0}
+            %% but also be able to revert it on the fly
+            {linger, {false, 0}}
+    end;
+tcp_opt(Opt) ->
+    Opt.
 
 foreach_listeners(Do) ->
     lists:foreach(

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -34,7 +34,8 @@
     max_conns/2,
     id_example/0,
     default_max_conn/0,
-    shutdown_count/2
+    shutdown_count/2,
+    tcp_opts/1
 ]).
 
 -export([

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1052,6 +1052,14 @@ fields("tcp_opts") ->
                     desc => ?DESC(fields_tcp_opts_nodelay)
                 }
             )},
+        {"nolinger",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(fields_tcp_opts_nolinger)
+                }
+            )},
         {"reuseaddr",
             sc(
                 boolean(),

--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
     {applications, [

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -533,16 +533,16 @@ esockd_opts(Type, Opts0) when ?IS_ESOCKD_LISTENER(Type) ->
     maps:to_list(
         case Type of
             tcp ->
-                Opts2#{tcp_options => sock_opts(tcp_options, Opts0)};
+                Opts2#{tcp_options => tcp_opts(Opts0)};
             ssl ->
                 Opts2#{
-                    tcp_options => sock_opts(tcp_options, Opts0),
+                    tcp_options => tcp_opts(Opts0),
                     ssl_options => ssl_opts(ssl_options, Opts0)
                 };
             udp ->
-                Opts2#{udp_options => sock_opts(udp_options, Opts0)};
+                Opts2#{udp_options => udp_opts(Opts0)};
             dtls ->
-                UDPOpts = sock_opts(udp_options, Opts0),
+                UDPOpts = udp_opts(Opts0),
                 DTLSOpts = ssl_opts(dtls_options, Opts0),
                 Opts2#{
                     udp_options => UDPOpts,
@@ -551,11 +551,14 @@ esockd_opts(Type, Opts0) when ?IS_ESOCKD_LISTENER(Type) ->
         end
     ).
 
-sock_opts(Name, Opts) ->
+tcp_opts(Opts) ->
+    emqx_listeners:tcp_opts(Opts).
+
+udp_opts(Opts) ->
     maps:to_list(
         maps:without(
-            [active_n, keepalive],
-            maps:get(Name, Opts, #{})
+            [active_n],
+            maps:get(udp_options, Opts, #{})
         )
     ).
 
@@ -606,10 +609,10 @@ ranch_opts(Type, ListenOn, Opts) ->
     SocketOpts1 =
         case Type of
             wss ->
-                sock_opts(tcp_options, Opts) ++
+                tcp_opts(Opts) ++
                     proplists:delete(handshake_timeout, ssl_opts(ssl_options, Opts));
             ws ->
-                sock_opts(tcp_options, Opts)
+                tcp_opts(Opts)
         end,
     SocketOpts = ip_port(ListenOn) ++ proplists:delete(reuseaddr, SocketOpts1),
     #{

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -566,6 +566,7 @@ ssl_opts(Name, Opts) ->
     SSLOpts = maps:get(Name, Opts, #{}),
     emqx_utils:run_fold(
         [
+            fun ensure_dtls_protocol/2,
             fun ssl_opts_crl_config/2,
             fun ssl_opts_drop_unsupported/2,
             fun ssl_partial_chain/2,
@@ -575,6 +576,11 @@ ssl_opts(Name, Opts) ->
         SSLOpts,
         Name
     ).
+
+ensure_dtls_protocol(SSLOpts, dtls_options) ->
+    SSLOpts#{protocol => dtls};
+ensure_dtls_protocol(SSLOpts, _) ->
+    SSLOpts.
 
 ssl_opts_crl_config(#{enable_crl_check := true} = SSLOpts, _Name) ->
     HTTPTimeout = emqx_config:get([crl_cache, http_timeout], timer:seconds(15)),

--- a/apps/emqx_management/src/emqx_mgmt.erl
+++ b/apps/emqx_management/src/emqx_mgmt.erl
@@ -151,10 +151,7 @@ node_info() ->
         memory_used => erlang:round(Total * UsedRatio),
         process_available => erlang:system_info(process_limit),
         process_used => erlang:system_info(process_count),
-
-        max_fds => proplists:get_value(
-            max_fds, lists:usort(lists:flatten(erlang:system_info(check_io)))
-        ),
+        max_fds => esockd:ulimit(),
         connections => ets:info(?CHAN_TAB, size),
         live_connections => ets:info(?CHAN_LIVE_TAB, size),
         cluster_sessions => ets:info(?CHAN_REG_TAB, size),

--- a/changes/ce/feat-14219.en.md
+++ b/changes/ce/feat-14219.en.md
@@ -1,0 +1,16 @@
+Enhanced Connection Rate Limiter for Improved System Resilience
+
+- **Improved system stability and responsiveness under high connection rates.**  
+  Previously, listener acceptors would ignore new connection attempts when the rate limit was exceeded, potentially resulting in an unrecoverable state if a large number of clients connected or reconnected frequently within a short period. Listeners now accept pending connections but immediately close them if the rate limit is reached, reducing resource strain and increasing system resilience during peak loads.
+
+- **A new listener option, `nolinger`, has been introduced.**  
+  When set to `true`, a TCP-RST is sent immediately upon socket closure, helping to mitigate SYN flood attacks and further enhancing connection-handling efficiency.
+
+- **MQTT listeners' `max_connection` config value is now capped by system limits.**  
+  It cannot exceed system limits: `ulimit` from the OS and `node.process_limit`.  
+  - If configured to `infinity` or a value greather than system limit, it is automatically adjusted to the system limit.  
+
+- **SSL listeners' `ssl_options` config value is now validated before changes.**  
+  Previously, invalid SSL options, such as unsupported TLS versions, could be accepted when configuring/reconfiguring a listener, causing clients to fail to connect after the change. Now, such invalid options are detected early:  
+  - If a listener is configured with invalid SSL options, the node will fail to boot.  
+  - If invalid SSL options are requested via the dashboard or config API, the request will fail with status code `400`.

--- a/mix.exs
+++ b/mix.exs
@@ -185,7 +185,7 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.19.7", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.12.0", override: true}
+  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.43.4", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.3", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -81,7 +81,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
-    {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.12.0"}}},
+    {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.7"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -262,12 +262,6 @@ already established connections."""
 common_ssl_opts_schema_cacertfile.label:
 """CACertfile"""
 
-common_ssl_opts_schema_cacerts.desc:
-"""When enabled, uses the system trusted CA certificates for establishing to TLS connections."""
-
-common_ssl_opts_schema_cacerts.label:
-"""Use System CA Certificates"""
-
 fields_ws_opts_mqtt_path.desc: """~
     WebSocket's MQTT protocol path. By default, the full URL for the WebSocket client to connect is:
     `ws://{host}:{port}/mqtt`.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -986,7 +986,7 @@ fields_tcp_opts_nodelay.label:
 """No Delay"""
 
 fields_tcp_opts_nolinger.desc:
-"""When enabled, `SO_LINGER` flag is set as `{l_onoff=1, l_linger=0}`, which means the TCP socket to close immediately by sending a reset (RST) packet,
+"""When enabled, `SO_LINGER` flag is set as `(onoff=1, linger=0)`, which means the TCP socket is to be closed immediately by sending a TCP-RST packet,
 discarding any unsent data and skipping the graceful close steps, including CLOSE_WAIT, FIN_WAIT, and TIME_WAIT."""
 
 fields_tcp_opts_nolinger.label:

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -985,10 +985,18 @@ NOTE: when changing from/to `global` lock, it requires all nodes in the cluster 
   - `global`: updates are protected with a global lock. Recommended for large clusters."""
 
 fields_tcp_opts_nodelay.desc:
-"""The TCP_NODELAY flag for the connections."""
+"""The `TCP_NODELAY` flag for the connections.
+When set to `true`, data is sent immediately, regardless of size."""
 
 fields_tcp_opts_nodelay.label:
-"""TCP_NODELAY"""
+"""No Delay"""
+
+fields_tcp_opts_nolinger.desc:
+"""When enabled, `SO_LINGER` flag is set as `{l_onoff=1, l_linger=0}`, which means the TCP socket to close immediately by sending a reset (RST) packet,
+discarding any unsent data and skipping the graceful close steps, including CLOSE_WAIT, FIN_WAIT, and TIME_WAIT."""
+
+fields_tcp_opts_nolinger.label:
+"""No Linger"""
 
 fields_tcp_opts_keepalive.desc:
 """Enable TCP keepalive for MQTT connections over TCP or SSL.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/14145
Fixes [EMQX-13498](https://emqx.atlassian.net/browse/EMQX-13498)

Release version: v/e5.8.3

## Summary

Enhanced connection rate limiter for improved system resilience.

Enhanced the connection rate limiter to improve system stability and responsiveness under high connection loads.

Previously, listener acceptors would ignore new connection attempts when the rate limit was exceeded,
potentially resulting in an unrecoverable state if a large number of clients connected or reconnected frequently within a short period.

Listeners now accept pending connections but immediately close them if the rate limit is reached,
reducing resource strain and increasing system resilience during peak loads.

In addition, a new listener option, `nolinger`, has been introduced.
When set to `true`, a TCP reset (TCP-RST) is sent immediately upon socket closure,
helping to mitigate SYN flood attacks and further enhancing connection handling efficiency.

see also: https://github.com/emqx/esockd/pull/196

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13498]: https://emqx.atlassian.net/browse/EMQX-13498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ