### PR TITLE
fix: ensure websocket close reason is atom to avoid crash

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -636,7 +636,7 @@ parse_property(<<16#29, Val, Bin/binary>>, Props, StrictMode) ->
 parse_property(<<16#2A, Val, Bin/binary>>, Props, StrictMode) ->
     parse_property(Bin, Props#{'Shared-Subscription-Available' => Val}, StrictMode);
 parse_property(<<Property:8, _Rest/binary>>, _Props, _StrictMode) ->
-    ?PARSE_ERR(#{invalid_property_code => Property}).
+    ?PARSE_ERR(#{cause => invalid_property_code, property_code => Property}).
 %% TODO: invalid property in specific packet.
 
 parse_variable_byte_integer(Bin) ->

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -1011,6 +1011,10 @@ classify([Cmd = {shutdown, _Reason} | More], Packets, Cmds, Events) ->
     classify(More, Packets, [Cmd | Cmds], Events);
 classify([Cmd = close | More], Packets, Cmds, Events) ->
     classify(More, Packets, [Cmd | Cmds], Events);
+%% cowboy_websocket's close reason must be an atom to avoid crashing the sender process.
+%% The cause reasons come from parse_frame_error.
+classify([{close, #{cause := Cause}} | More], Packets, Cmds, Events) when is_atom(Cause) ->
+    classify(More, Packets, [{close, Cause} | Cmds], Events);
 classify([Cmd = {close, _Reason} | More], Packets, Cmds, Events) ->
     classify(More, Packets, [Cmd | Cmds], Events);
 classify([Event | More], Packets, Cmds, Events) ->

--- a/changes/ce/fix-14223.en.md
+++ b/changes/ce/fix-14223.en.md
@@ -1,0 +1,4 @@
+ensure websocket close reason is atom to avoid crash.
+```
+error: {{case_clause,#{invalid_property_code => 51}},[{cowboy_websocket...
+```


### PR DESCRIPTION
Fixes <issue-or-jira-number>
https://askemq.com/t/topic/10040
cowboy_websocket's close reason must be an atom to avoid crashing the sender process, ensure the cause is atom
https://github.com/emqx/cowboy/blob/master/src/cowboy_websocket.erl#L639-L658

```
2024-11-13T03:28:02.055764+00:00 [error] crasher: initial call: cowboy_clear:connection_process/4, pid: <0.147756968.3>, registered_name: [], error: {{case_clause,#{invalid_property_code => 51}},[{cowboy_websocket,websocket_send_close,2,[{file,"cowboy_websocket.erl"},{line,640}]},{cowboy_websocket,websocket_close,3,[{file,"cowboy_websocket.erl"},{line,623}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,251}]}]}, ancestors: [<0.7416.0>,<0.7415.0>,ranch_sup,<0.6954.0>], message_queue_len: 1, messages: [{outgoing,{mqtt_packet,{mqtt_packet_header,14,false,0,false},{mqtt_packet_disconnect,129,#{}},undefined}}], links: [#Port<0.53368611>,<0.7416.0>], dictionary: [{send_cnt,4},{recv_pkt,6},{rand_seed,{#{type => exsss,next => #Fun<rand.0.65977474>,bits => 58,uniform => #Fun<rand.1.65977474>,uniform_n => #Fun<rand.2.65977474>,jump => #Fun<rand.3.65977474>},[192185370934312160|179409276227859594]}},{recv_oct,794},{authz_cache_size,3},{guid,{1731468427025252,17381930735528,3}},{recv_cnt,7},{{#{action_type => subscribe,qos => 0},<<"client/task/PRUABENI6ZJQ1QUD">>},{allow,1731468379517}},{incoming_bytes,794},{{#{retain => false,action_type => publish,qos => 0},<<"client/version/PRUABENI6ZJQ1QUD">>},{allow,1731468378829}},{outgoing_bytes,42},{incoming_pubs,2},{{#{retain => false,action_type => publish,qos => 0},<<"client/shield/PRUABENI6ZJQ1QUD">>},{allow,1731468427025}},{send_pkt,4},{authz_keys_q,{[{#{retain => false,action_type => publish,qos => 0},<<"client/xxxx">>},{#{action_type => subscribe,qos => 0},<<"client/task/PRUABENI6ZJQ1QUD">>}],[{#{retain => false,action_type => publish,qos => 0},<<"client/version/PRUABENI6ZJQ1QUD">>}]}},{send_oct,42},{'$logger_metadata$',#{peername => "91.200.215.251:443",username => <<"xyz">>,clientid => <<"clientidxxx">>}},{recv_msg,2},{'recv_msg.qos0',2}], trap_exit: true, status: running, heap_size: 1598, stack_size: 28, reductions: 15532; neighbours:
```

Release version: v/e5.8.3

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
