### PR TITLE
Consistently update progress for durable shared subscriptions

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -28,6 +28,7 @@
 {emqx_ds_beamsplitter,1}.
 {emqx_ds_new_streams,1}.
 {emqx_ds_shared_sub,1}.
+{emqx_ds_shared_sub,2}.
 {emqx_eviction_agent,1}.
 {emqx_eviction_agent,2}.
 {emqx_eviction_agent,3}.

--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.4.2"},
+    {vsn, "5.4.3"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs_agent.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs_agent.erl
@@ -40,6 +40,7 @@
 }.
 
 -type stream_lease_event() :: stream_lease() | stream_revoke().
+-type event() :: stream_lease_event().
 
 -type stream_progress() :: #{
     share_topic_filter := share_topic_filter(),
@@ -53,6 +54,7 @@
     subscription/0,
     session_id/0,
     stream_lease_event/0,
+    event/0,
     opts/0
 ]).
 
@@ -65,9 +67,7 @@
     on_unsubscribe/3,
     on_stream_progress/2,
     on_info/2,
-    on_disconnect/2,
-
-    renew_streams/1
+    on_disconnect/2
 ]).
 
 -export([
@@ -85,9 +85,8 @@
 -callback on_subscribe(t(), share_topic_filter(), emqx_types:subopts()) -> t().
 -callback on_unsubscribe(t(), share_topic_filter(), [stream_progress()]) -> t().
 -callback on_disconnect(t(), [stream_progress()]) -> t().
--callback renew_streams(t()) -> {[stream_lease_event()], t()}.
 -callback on_stream_progress(t(), #{share_topic_filter() => [stream_progress()]}) -> t().
--callback on_info(t(), term()) -> t().
+-callback on_info(t(), term()) -> {[event()], t()}.
 
 %%--------------------------------------------------------------------
 %% API
@@ -117,15 +116,11 @@ on_unsubscribe(Agent, ShareTopicFilter, StreamProgresses) ->
 on_disconnect(Agent, StreamProgresses) ->
     ?shared_subs_agent:on_disconnect(Agent, StreamProgresses).
 
--spec renew_streams(t()) -> {[stream_lease_event()], t()}.
-renew_streams(Agent) ->
-    ?shared_subs_agent:renew_streams(Agent).
-
 -spec on_stream_progress(t(), #{share_topic_filter() => [stream_progress()]}) -> t().
 on_stream_progress(Agent, StreamProgress) ->
     ?shared_subs_agent:on_stream_progress(Agent, StreamProgress).
 
--spec on_info(t(), term()) -> t().
+-spec on_info(t(), term()) -> {[event()], t()}.
 on_info(Agent, Info) ->
     ?shared_subs_agent:on_info(Agent, Info).
 

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs_null_agent.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs_null_agent.erl
@@ -15,9 +15,7 @@
     on_unsubscribe/3,
     on_stream_progress/2,
     on_info/2,
-    on_disconnect/2,
-
-    renew_streams/1
+    on_disconnect/2
 ]).
 
 -behaviour(emqx_persistent_session_ds_shared_subs_agent).
@@ -44,11 +42,8 @@ on_unsubscribe(Agent, _TopicFilter, _Progresses) ->
 on_disconnect(Agent, _) ->
     Agent.
 
-renew_streams(Agent) ->
-    {[], Agent}.
-
 on_stream_progress(Agent, _StreamProgress) ->
     Agent.
 
 on_info(Agent, _Info) ->
-    Agent.
+    {[], Agent}.

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs_null_agent.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs_null_agent.erl
@@ -11,10 +11,10 @@
     open/2,
     can_subscribe/3,
 
-    on_subscribe/3,
+    on_subscribe/4,
     on_unsubscribe/3,
     on_stream_progress/2,
-    on_info/2,
+    on_info/3,
     on_disconnect/2
 ]).
 
@@ -33,10 +33,10 @@ open(_Topics, _Opts) ->
 can_subscribe(_Agent, _TopicFilter, _SubOpts) ->
     {error, ?RC_SHARED_SUBSCRIPTIONS_NOT_SUPPORTED}.
 
-on_subscribe(Agent, _TopicFilter, _SubOpts) ->
+on_subscribe(Agent, _SubscriptionId, _TopicFilter, _SubOpts) ->
     Agent.
 
-on_unsubscribe(Agent, _TopicFilter, _Progresses) ->
+on_unsubscribe(Agent, _SubscriptionId, _Progresses) ->
     Agent.
 
 on_disconnect(Agent, _) ->
@@ -45,5 +45,5 @@ on_disconnect(Agent, _) ->
 on_stream_progress(Agent, _StreamProgress) ->
     Agent.
 
-on_info(Agent, _Info) ->
+on_info(Agent, _SubscriptionId, _Info) ->
     {[], Agent}.

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_stream_scheduler.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_stream_scheduler.erl
@@ -354,35 +354,35 @@ on_seqno_release(?QOS_1, SnQ1, S, SchedS0 = #s{bq1 = PrimaryTab0, bq2 = Secondar
     case check_block_status(PrimaryTab0, SecondaryTab, SnQ1, #block.last_seqno_qos2) of
         false ->
             %% This seqno doesn't unlock anything:
-            SchedS0;
+            {[], SchedS0};
         {false, Key, PrimaryTab} ->
             %% It was BQ1:
             Srs = emqx_persistent_session_ds_state:get_stream(Key, S),
-            to_RU(Key, Srs, SchedS0#s{bq1 = PrimaryTab});
+            {[Key], to_RU(Key, Srs, SchedS0#s{bq1 = PrimaryTab})};
         {true, Key, PrimaryTab} ->
             %% It was BQ12:
             ?tp(sessds_stream_state_trans, #{
                 key => Key,
                 to => bq2
             }),
-            SchedS0#s{bq1 = PrimaryTab}
+            {[], SchedS0#s{bq1 = PrimaryTab}}
     end;
 on_seqno_release(?QOS_2, SnQ2, S, SchedS0 = #s{bq2 = PrimaryTab0, bq1 = SecondaryTab}) ->
     case check_block_status(PrimaryTab0, SecondaryTab, SnQ2, #block.last_seqno_qos1) of
         false ->
             %% This seqno doesn't unlock anything:
-            SchedS0;
+            {[], SchedS0};
         {false, Key, PrimaryTab} ->
             %% It was BQ2:
             Srs = emqx_persistent_session_ds_state:get_stream(Key, S),
-            to_RU(Key, Srs, SchedS0#s{bq2 = PrimaryTab});
+            {[Key], to_RU(Key, Srs, SchedS0#s{bq2 = PrimaryTab})};
         {true, Key, PrimaryTab} ->
             %% It was BQ12:
             ?tp(sessds_stream_state_trans, #{
                 key => Key,
                 to => bq1
             }),
-            SchedS0#s{bq2 = PrimaryTab}
+            {[Key], SchedS0#s{bq2 = PrimaryTab}}
     end.
 
 check_block_status(PrimaryTab0, SecondaryTab, PrimaryKey, SecondaryIdx) ->

--- a/apps/emqx/src/emqx_persistent_session_ds/session_internals.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds/session_internals.hrl
@@ -76,8 +76,13 @@
 %% (Erlang) messages that session should forward to the
 %% shared subscription handler.
 -record(shared_sub_message, {
+    subscription_id :: emqx_persistent_session_ds:subscription_id(),
     message :: term()
 }).
--define(shared_sub_message(MSG), #shared_sub_message{message = MSG}).
+-define(shared_sub_message(SUBSCRIPTION_ID, MSG), #shared_sub_message{
+    subscription_id = SUBSCRIPTION_ID,
+    message = MSG
+}).
+-define(shared_sub_message, #shared_sub_message{}).
 
 -endif.

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub.app.src
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ds_shared_sub, [
     {description, "EMQX DS Shared Subscriptions"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, [emqx_ds_shared_sub_sup]},
     {mod, {emqx_ds_shared_sub_app, []}},
     {applications, [

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_group_sm.erl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_group_sm.erl
@@ -27,7 +27,6 @@
     handle_info/2,
 
     %% API
-    fetch_stream_events/1,
     handle_stream_progress/2,
     handle_disconnect/2
 ]).
@@ -49,13 +48,13 @@
 
 -type stream_lease_event() ::
     #{
-        type => lease,
-        stream => emqx_ds:stream(),
-        progress => progress()
+        type := lease,
+        stream := emqx_ds:stream(),
+        progress := progress()
     }
     | #{
-        type => revoke,
-        stream => emqx_ds:stream()
+        type := revoke,
+        stream := emqx_ds:stream()
     }.
 
 %% GroupSM States
@@ -101,7 +100,6 @@
     share_topic_filter => emqx_persistent_session_ds:share_topic_filter(),
     agent => emqx_ds_shared_sub_proto:agent(),
     send_after => fun((non_neg_integer(), term()) -> reference()),
-    stream_lease_events => list(stream_lease_event()),
 
     state => state(),
     state_data => state_data(),
@@ -131,23 +129,6 @@ new(#{
     },
     transition(GSM0, ?connecting, #{}).
 
--spec fetch_stream_events(t()) ->
-    {t(), [emqx_ds_shared_sub_agent:external_lease_event()]}.
-fetch_stream_events(
-    #{
-        state := _State,
-        share_topic_filter := ShareTopicFilter,
-        stream_lease_events := Events0
-    } = GSM
-) ->
-    Events1 = lists:map(
-        fun(Event) ->
-            Event#{share_topic_filter => ShareTopicFilter}
-        end,
-        Events0
-    ),
-    {GSM#{stream_lease_events => []}, Events1}.
-
 -spec handle_disconnect(t(), emqx_ds_shared_sub_proto:agent_stream_progress()) -> t().
 handle_disconnect(#{state := ?connecting} = GSM, _StreamProgresses) ->
     transition(GSM, ?disconnected, #{});
@@ -167,6 +148,7 @@ handle_disconnect(
 %%-----------------------------------------------------------------------
 %% Connecting state
 
+%% State enter callback
 handle_connecting(#{agent := Agent, share_topic_filter := ShareTopicFilter} = GSM) ->
     ?tp(debug, group_sm_enter_connecting, #{
         agent => Agent,
@@ -175,6 +157,8 @@ handle_connecting(#{agent := Agent, share_topic_filter := ShareTopicFilter} = GS
     ok = emqx_ds_shared_sub_registry:leader_wanted(Agent, agent_metadata(GSM), ShareTopicFilter),
     ensure_state_timeout(GSM, find_leader_timeout, ?dq_config(session_find_leader_timeout_ms)).
 
+-spec handle_leader_lease_streams(t(), emqx_ds_shared_sub_proto:leader(), list(emqx_ds_shared_sub_proto:agent_stream_progress()), emqx_ds_shared_sub_proto:version()) ->
+    t() | {list(stream_lease_event()), t()}.
 handle_leader_lease_streams(
     #{state := ?connecting, share_topic_filter := ShareTopicFilter} = GSM0,
     Leader,
@@ -198,6 +182,7 @@ handle_leader_lease_streams(
 handle_leader_lease_streams(GSM, _Leader, _StreamProgresses, _Version) ->
     GSM.
 
+-spec handle_find_leader_timeout(t()) -> t().
 handle_find_leader_timeout(#{agent := Agent, share_topic_filter := ShareTopicFilter} = GSM0) ->
     ?tp(warning, group_sm_find_leader_timeout, #{
         agent => Agent,
@@ -212,6 +197,7 @@ handle_find_leader_timeout(#{agent := Agent, share_topic_filter := ShareTopicFil
 %%-----------------------------------------------------------------------
 %% Replaying state
 
+%% State enter callback
 handle_replaying(GSM0) ->
     GSM1 = ensure_state_timeout(
         GSM0, renew_lease_timeout, ?dq_config(session_renew_lease_timeout_ms)
@@ -221,13 +207,15 @@ handle_replaying(GSM0) ->
     ),
     GSM2.
 
+-spec handle_renew_lease_timeout(t()) -> t().
 handle_renew_lease_timeout(#{agent := Agent, share_topic_filter := ShareTopicFilter} = GSM) ->
     ?tp(warning, renew_lease_timeout, #{agent => Agent, share_topic_filter => ShareTopicFilter}),
-    transition(GSM, ?connecting, #{}).
+    transition_and_revoke_all(GSM, ?connecting, #{}).
 
 %%-----------------------------------------------------------------------
 %% Updating state
 
+%% State enter callback
 handle_updating(GSM0) ->
     GSM1 = ensure_state_timeout(
         GSM0, renew_lease_timeout, ?dq_config(session_renew_lease_timeout_ms)
@@ -240,12 +228,15 @@ handle_updating(GSM0) ->
 %%-----------------------------------------------------------------------
 %% Disconnected state
 
+%% State enter callback
 handle_disconnected(GSM) ->
     GSM.
 
 %%-----------------------------------------------------------------------
 %% Common handlers
 
+-spec handle_leader_update_streams(t(), emqx_ds_shared_sub_proto:version(), emqx_ds_shared_sub_proto:version(), list(emqx_ds_shared_sub_proto:agent_stream_progress())) ->
+    t() | {list(stream_lease_event()), t()}.
 handle_leader_update_streams(
     #{
         id := Id,
@@ -295,7 +286,7 @@ handle_leader_update_streams(
         maps:keys(Streams1)
     ),
     StreamLeaseEvents = AddEvents ++ RevokeEvents,
-    ?tp(debug, shared_sub_group_sm_leader_update_streams, #{
+    ?tp(warning, shared_sub_group_sm_leader_update_streams, #{
         id => Id,
         stream_lease_events => StreamLeaseEvents
     }),
@@ -330,8 +321,9 @@ handle_leader_update_streams(GSM, VersionOld, VersionNew, _StreamProgresses) ->
         version_old => VersionOld,
         version_new => VersionNew
     }),
-    transition(GSM, ?connecting, #{}).
+    transition_and_revoke_all(GSM, ?connecting, #{}).
 
+-spec handle_leader_renew_stream_lease(t(), emqx_ds_shared_sub_proto:version()) -> t().
 handle_leader_renew_stream_lease(
     #{state := ?replaying, state_data := #{version := Version}} = GSM, Version
 ) ->
@@ -346,7 +338,6 @@ handle_leader_renew_stream_lease(
     );
 handle_leader_renew_stream_lease(GSM, _Version) ->
     GSM.
-
 handle_leader_renew_stream_lease(
     #{state := ?replaying, state_data := #{version := Version}} = GSM, VersionOld, VersionNew
 ) when VersionOld =:= Version orelse VersionNew =:= Version ->
@@ -368,7 +359,7 @@ handle_leader_renew_stream_lease(GSM, VersionOld, VersionNew) ->
         version_old => VersionOld,
         version_new => VersionNew
     }),
-    transition(GSM, ?connecting, #{}).
+    transition_and_revoke_all(GSM, ?connecting, #{}).
 
 -spec handle_stream_progress(t(), list(emqx_ds_shared_sub_proto:agent_stream_progress())) ->
     t().
@@ -412,12 +403,13 @@ handle_stream_progress(
 handle_stream_progress(#{state := ?disconnected} = GSM, _StreamProgresses) ->
     GSM.
 
+-spec handle_leader_invalidate(t()) -> t().
 handle_leader_invalidate(#{agent := Agent, share_topic_filter := ShareTopicFilter} = GSM) ->
     ?tp(warning, shared_sub_group_sm_leader_invalidate, #{
         agent => Agent,
         share_topic_filter => ShareTopicFilter
     }),
-    transition(GSM, ?connecting, #{}).
+    transition_and_revoke_all(GSM, ?connecting, #{}).
 
 %%-----------------------------------------------------------------------
 %% Internal API
@@ -432,8 +424,12 @@ handle_state_timeout(GSM, update_stream_state_timeout, _Message) ->
     handle_stream_progress(GSM, []).
 
 handle_info(
-    #{state_timers := Timers} = GSM, #state_timeout{message = Message, name = Name, id = Id} = _Info
+    #{state_timers := Timers} = GSM, #state_timeout{message = Message, name = Name, id = Id} = Info
 ) ->
+    ?tp(debug, shared_sub_group_sm_handle_info, #{
+        info => Info,
+        gsm => GSM
+    }),
     case Timers of
         #{Name := #timer{id = Id}} ->
             handle_state_timeout(GSM, Name, Message);
@@ -441,7 +437,11 @@ handle_info(
             %% Stale timer
             GSM
     end;
-handle_info(GSM, _Info) ->
+handle_info(GSM, Info) ->
+    ?tp(debug, shared_sub_group_sm_handle_info_no_timers, #{
+        info => Info,
+        gsm => GSM
+    }),
     GSM.
 
 %%--------------------------------------------------------------------
@@ -464,10 +464,28 @@ transition(GSM0, NewState, NewStateData, LeaseEvents) ->
     GSM2 = GSM1#{
         state => NewState,
         state_data => NewStateData,
-        state_timers => #{},
-        stream_lease_events => LeaseEvents
+        state_timers => #{}
     },
-    run_enter_callback(GSM2).
+    GSM3 = run_enter_callback(GSM2),
+    case LeaseEvents of
+        [] ->
+            GSM3;
+        _ ->
+            {LeaseEvents, GSM3}
+    end.
+
+transition_and_revoke_all(#{state_data := #{streams := Streams} = StateData} = GSM0, NewState, NewStateData) ->
+    StreamLeaseEvents = lists:map(
+        fun(Stream) ->
+            #{
+                type => revoke,
+                stream => Stream
+            }
+        end,
+        maps:keys(Streams)
+    ),
+    GSM1 = GSM0#{state_data => StateData#{streams => #{}}},
+    transition(GSM1, NewState, NewStateData, StreamLeaseEvents).
 
 agent_metadata(#{id := Id} = _GSM) ->
     #{id => Id}.

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_proto.erl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_proto.erl
@@ -52,16 +52,16 @@
 ]).
 
 -define(log_agent_msg(ToLeader, Msg),
-    ?tp(debug, shared_sub_proto_msg, #{
+    ?tp(warning, 'agent->leader', #{
         to_leader => ToLeader,
-        msg => emqx_ds_shared_sub_proto_format:format_agent_msg(Msg)
+        proto_msg => emqx_ds_shared_sub_proto_format:format_agent_msg(Msg)
     })
 ).
 
 -define(log_leader_msg(ToAgent, Msg),
-    ?tp(debug, shared_sub_proto_msg, #{
+    ?tp(warning, 'leader->agent', #{
         to_agent => ToAgent,
-        msg => emqx_ds_shared_sub_proto_format:format_leader_msg(Msg)
+        proto_msg => emqx_ds_shared_sub_proto_format:format_leader_msg(Msg)
     })
 ).
 

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_proto.erl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_proto.erl
@@ -18,14 +18,24 @@
     leader_renew_stream_lease/3,
     leader_renew_stream_lease/4,
     leader_update_streams/5,
-    leader_invalidate/2
+    leader_invalidate/2,
+
+    leader_lease_streams_v2/5,
+    leader_renew_stream_lease_v2/3,
+    leader_renew_stream_lease_v2/4,
+    leader_update_streams_v2/5,
+    leader_invalidate_v2/2
 ]).
 
 -export([
-    agent/2
+    agent/3
 ]).
 
--type agent() :: ?agent(emqx_persistent_session_ds:id(), pid()).
+-type agent() :: ?agent(
+    emqx_persistent_session_ds_shared_subs_agent:subscription_id(),
+    emqx_persistent_session_ds:id(),
+    pid()
+).
 -type leader() :: pid().
 -type share_topic_filter() :: emqx_persistent_session_ds:share_topic_filter().
 -type group() :: emqx_types:group().
@@ -52,16 +62,16 @@
 ]).
 
 -define(log_agent_msg(ToLeader, Msg),
-    ?tp(warning, 'agent->leader', #{
+    ?tp(debug, agent_to_leader, #{
         to_leader => ToLeader,
-        proto_msg => emqx_ds_shared_sub_proto_format:format_agent_msg(Msg)
+        proto_msg => ?format_agent_msg(Msg)
     })
 ).
 
 -define(log_leader_msg(ToAgent, Msg),
-    ?tp(warning, 'leader->agent', #{
+    ?tp(debug, leader_to_agent, #{
         to_agent => ToAgent,
-        proto_msg => emqx_ds_shared_sub_proto_format:format_leader_msg(Msg)
+        proto_msg => ?format_leader_msg(Msg)
     })
 ).
 
@@ -77,7 +87,7 @@ agent_connect_leader(ToLeader, FromAgent, AgentMetadata, ShareTopicFilter) when
 ->
     send_agent_msg(ToLeader, ?agent_connect_leader(FromAgent, AgentMetadata, ShareTopicFilter));
 agent_connect_leader(ToLeader, FromAgent, AgentMetadata, ShareTopicFilter) ->
-    emqx_ds_shared_sub_proto_v1:agent_connect_leader(
+    emqx_ds_shared_sub_proto_v2:agent_connect_leader(
         ?leader_node(ToLeader), ToLeader, FromAgent, AgentMetadata, ShareTopicFilter
     ).
 
@@ -87,7 +97,7 @@ agent_update_stream_states(ToLeader, FromAgent, StreamProgresses, Version) when
 ->
     send_agent_msg(ToLeader, ?agent_update_stream_states(FromAgent, StreamProgresses, Version));
 agent_update_stream_states(ToLeader, FromAgent, StreamProgresses, Version) ->
-    emqx_ds_shared_sub_proto_v1:agent_update_stream_states(
+    emqx_ds_shared_sub_proto_v2:agent_update_stream_states(
         ?leader_node(ToLeader), ToLeader, FromAgent, StreamProgresses, Version
     ).
 
@@ -101,7 +111,7 @@ agent_update_stream_states(ToLeader, FromAgent, StreamProgresses, VersionOld, Ve
         ToLeader, ?agent_update_stream_states(FromAgent, StreamProgresses, VersionOld, VersionNew)
     );
 agent_update_stream_states(ToLeader, FromAgent, StreamProgresses, VersionOld, VersionNew) ->
-    emqx_ds_shared_sub_proto_v1:agent_update_stream_states(
+    emqx_ds_shared_sub_proto_v2:agent_update_stream_states(
         ?leader_node(ToLeader), ToLeader, FromAgent, StreamProgresses, VersionOld, VersionNew
     ).
 
@@ -110,63 +120,88 @@ agent_disconnect(ToLeader, FromAgent, StreamProgresses, Version) when
 ->
     send_agent_msg(ToLeader, ?agent_disconnect(FromAgent, StreamProgresses, Version));
 agent_disconnect(ToLeader, FromAgent, StreamProgresses, Version) ->
-    emqx_ds_shared_sub_proto_v1:agent_disconnect(
+    emqx_ds_shared_sub_proto_v2:agent_disconnect(
         ?leader_node(ToLeader), ToLeader, FromAgent, StreamProgresses, Version
     ).
 
 %% leader -> agent messages
 
--spec leader_lease_streams(agent(), group(), leader(), list(leader_stream_progress()), version()) ->
+-spec leader_lease_streams_v2(
+    agent(), group(), leader(), list(leader_stream_progress()), version()
+) ->
     ok.
-leader_lease_streams(ToAgent, OfGroup, Leader, Streams, Version) when ?is_local_agent(ToAgent) ->
+leader_lease_streams_v2(ToAgent, OfGroup, Leader, Streams, Version) when ?is_local_agent(ToAgent) ->
     send_leader_msg(ToAgent, ?leader_lease_streams(OfGroup, Leader, Streams, Version));
-leader_lease_streams(ToAgent, OfGroup, Leader, Streams, Version) ->
-    emqx_ds_shared_sub_proto_v1:leader_lease_streams(
+leader_lease_streams_v2(ToAgent, OfGroup, Leader, Streams, Version) ->
+    emqx_ds_shared_sub_proto_v2:leader_lease_streams(
         ?agent_node(ToAgent), ToAgent, OfGroup, Leader, Streams, Version
     ).
 
--spec leader_renew_stream_lease(agent(), group(), version()) -> ok.
-leader_renew_stream_lease(ToAgent, OfGroup, Version) when ?is_local_agent(ToAgent) ->
+-spec leader_renew_stream_lease_v2(agent(), group(), version()) -> ok.
+leader_renew_stream_lease_v2(ToAgent, OfGroup, Version) when ?is_local_agent(ToAgent) ->
     send_leader_msg(ToAgent, ?leader_renew_stream_lease(OfGroup, Version));
-leader_renew_stream_lease(ToAgent, OfGroup, Version) ->
-    emqx_ds_shared_sub_proto_v1:leader_renew_stream_lease(
+leader_renew_stream_lease_v2(ToAgent, OfGroup, Version) ->
+    emqx_ds_shared_sub_proto_v2:leader_renew_stream_lease(
         ?agent_node(ToAgent), ToAgent, OfGroup, Version
     ).
 
--spec leader_renew_stream_lease(agent(), group(), version(), version()) -> ok.
-leader_renew_stream_lease(ToAgent, OfGroup, VersionOld, VersionNew) when ?is_local_agent(ToAgent) ->
+-spec leader_renew_stream_lease_v2(agent(), group(), version(), version()) -> ok.
+leader_renew_stream_lease_v2(ToAgent, OfGroup, VersionOld, VersionNew) when
+    ?is_local_agent(ToAgent)
+->
     send_leader_msg(ToAgent, ?leader_renew_stream_lease(OfGroup, VersionOld, VersionNew));
-leader_renew_stream_lease(ToAgent, OfGroup, VersionOld, VersionNew) ->
-    emqx_ds_shared_sub_proto_v1:leader_renew_stream_lease(
+leader_renew_stream_lease_v2(ToAgent, OfGroup, VersionOld, VersionNew) ->
+    emqx_ds_shared_sub_proto_v2:leader_renew_stream_lease(
         ?agent_node(ToAgent), ToAgent, OfGroup, VersionOld, VersionNew
     ).
 
--spec leader_update_streams(agent(), group(), version(), version(), list(leader_stream_progress())) ->
+-spec leader_update_streams_v2(
+    agent(), group(), version(), version(), list(leader_stream_progress())
+) ->
     ok.
-leader_update_streams(ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew) when
+leader_update_streams_v2(ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew) when
     ?is_local_agent(ToAgent)
 ->
     send_leader_msg(ToAgent, ?leader_update_streams(OfGroup, VersionOld, VersionNew, StreamsNew));
-leader_update_streams(ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew) ->
-    emqx_ds_shared_sub_proto_v1:leader_update_streams(
+leader_update_streams_v2(ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew) ->
+    emqx_ds_shared_sub_proto_v2:leader_update_streams(
         ?agent_node(ToAgent), ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew
     ).
 
--spec leader_invalidate(agent(), group()) -> ok.
-leader_invalidate(ToAgent, OfGroup) when ?is_local_agent(ToAgent) ->
+-spec leader_invalidate_v2(agent(), group()) -> ok.
+leader_invalidate_v2(ToAgent, OfGroup) when ?is_local_agent(ToAgent) ->
     send_leader_msg(ToAgent, ?leader_invalidate(OfGroup));
-leader_invalidate(ToAgent, OfGroup) ->
-    emqx_ds_shared_sub_proto_v1:leader_invalidate(
+leader_invalidate_v2(ToAgent, OfGroup) ->
+    emqx_ds_shared_sub_proto_v2:leader_invalidate(
         ?agent_node(ToAgent), ToAgent, OfGroup
     ).
+
+%% leader -> agent messages, v1, ignore
+
+-spec leader_lease_streams(term(), group(), leader(), list(leader_stream_progress()), version()) ->
+    ok.
+leader_lease_streams(_ToAgent, _OfGroup, _Leader, _Streams, _Version) -> ok.
+
+-spec leader_renew_stream_lease(term(), group(), version()) -> ok.
+leader_renew_stream_lease(_ToAgent, _OfGroup, _Version) -> ok.
+
+-spec leader_renew_stream_lease(term(), group(), version(), version()) -> ok.
+leader_renew_stream_lease(_ToAgent, _OfGroup, _VersionOld, _VersionNew) -> ok.
+
+-spec leader_update_streams(term(), group(), version(), version(), list(leader_stream_progress())) ->
+    ok.
+leader_update_streams(_ToAgent, _OfGroup, _VersionOld, _VersionNew, _StreamsNew) -> ok.
+
+-spec leader_invalidate(term(), group()) -> ok.
+leader_invalidate(_ToAgent, _OfGroup) -> ok.
 
 %%--------------------------------------------------------------------
 %% Internal API
 %%--------------------------------------------------------------------
 
-agent(Id, Pid) ->
-    _ = Id,
-    ?agent(Id, Pid).
+agent(SessionId, SubscriptionId, Pid) ->
+    _ = SessionId,
+    ?agent(SessionId, SubscriptionId, Pid).
 
 send_agent_msg(ToLeader, Msg) ->
     ?log_agent_msg(ToLeader, Msg),
@@ -175,5 +210,7 @@ send_agent_msg(ToLeader, Msg) ->
 
 send_leader_msg(ToAgent, Msg) ->
     ?log_leader_msg(ToAgent, Msg),
-    _ = emqx_persistent_session_ds_shared_subs_agent:send(?agent_pid(ToAgent), Msg),
+    _ = emqx_persistent_session_ds_shared_subs_agent:send(
+        ?agent_pid(ToAgent), ?agent_subscription_id(ToAgent), Msg
+    ),
     ok.

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_proto.hrl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_proto.hrl
@@ -181,23 +181,29 @@
 
 -ifdef(TEST).
 
--define(agent(Id, Pid), {Id, Pid}).
+-define(agent(SessionId, SubscriptionId, Pid), {Pid, SubscriptionId, SessionId}).
 
--define(agent_pid(Agent), element(2, Agent)).
+-define(format_agent_msg(Msg), emqx_ds_shared_sub_proto_format:format_agent_msg(Msg)).
 
--define(agent_node(Agent), node(element(2, Agent))).
+-define(format_leader_msg(Msg), emqx_ds_shared_sub_proto_format:format_leader_msg(Msg)).
 
 %% -ifdef(TEST).
 -else.
 
--define(agent(Id, Pid), Pid).
+-define(agent(_SessionId, SubscriptionId, Pid), {Pid, SubscriptionId}).
 
--define(agent_pid(Agent), Agent).
+-define(format_agent_msg(Msg), Msg).
 
--define(agent_node(Agent), node(Agent)).
+-define(format_leader_msg(Msg), Msg).
 
 %% -ifdef(TEST).
 -endif.
+
+-define(agent_pid(Agent), element(1, Agent)).
+
+-define(agent_subscription_id(Agent), element(2, Agent)).
+
+-define(agent_node(Agent), node(element(1, Agent))).
 
 -define(is_local_agent(Agent), (?agent_node(Agent) =:= node())).
 

--- a/apps/emqx_ds_shared_sub/src/proto/emqx_ds_shared_sub_proto_v2.erl
+++ b/apps/emqx_ds_shared_sub/src/proto/emqx_ds_shared_sub_proto_v2.erl
@@ -1,0 +1,132 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_ds_shared_sub_proto_v2).
+
+-behaviour(emqx_bpapi).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-export([
+    introduced_in/0,
+
+    agent_connect_leader/5,
+    agent_update_stream_states/5,
+    agent_update_stream_states/6,
+    agent_disconnect/5,
+
+    leader_lease_streams/6,
+    leader_renew_stream_lease/4,
+    leader_renew_stream_lease/5,
+    leader_update_streams/6,
+    leader_invalidate/3
+]).
+
+introduced_in() ->
+    "5.8.0".
+
+-spec agent_connect_leader(
+    node(),
+    emqx_ds_shared_sub_proto:leader(),
+    emqx_ds_shared_sub_proto:agent(),
+    emqx_ds_shared_sub_proto:agent_metadata(),
+    emqx_persistent_session_ds:share_topic_filter()
+) -> ok.
+agent_connect_leader(Node, ToLeader, FromAgent, AgentMetadata, ShareTopicFilter) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, agent_connect_leader, [
+        ToLeader, FromAgent, AgentMetadata, ShareTopicFilter
+    ]).
+
+-spec agent_update_stream_states(
+    node(),
+    emqx_ds_shared_sub_proto:leader(),
+    emqx_ds_shared_sub_proto:agent(),
+    list(emqx_ds_shared_sub_proto:agent_stream_progress()),
+    emqx_ds_shared_sub_proto:version()
+) -> ok.
+agent_update_stream_states(Node, ToLeader, FromAgent, StreamProgresses, Version) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, agent_update_stream_states, [
+        ToLeader, FromAgent, StreamProgresses, Version
+    ]).
+
+-spec agent_update_stream_states(
+    node(),
+    emqx_ds_shared_sub_proto:leader(),
+    emqx_ds_shared_sub_proto:agent(),
+    list(emqx_ds_shared_sub_proto:agent_stream_progress()),
+    emqx_ds_shared_sub_proto:version(),
+    emqx_ds_shared_sub_proto:version()
+) -> ok.
+agent_update_stream_states(Node, ToLeader, FromAgent, StreamProgresses, VersionOld, VersionNew) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, agent_update_stream_states, [
+        ToLeader, FromAgent, StreamProgresses, VersionOld, VersionNew
+    ]).
+
+-spec agent_disconnect(
+    node(),
+    emqx_ds_shared_sub_proto:leader(),
+    emqx_ds_shared_sub_proto:agent(),
+    list(emqx_ds_shared_sub_proto:agent_stream_progress()),
+    emqx_ds_shared_sub_proto:version()
+) -> ok.
+agent_disconnect(Node, ToLeader, FromAgent, StreamProgresses, Version) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, agent_disconnect, [
+        ToLeader, FromAgent, StreamProgresses, Version
+    ]).
+
+%% leader -> agent messages
+
+-spec leader_lease_streams(
+    node(),
+    emqx_ds_shared_sub_proto:agent(),
+    emqx_ds_shared_sub_proto:group(),
+    emqx_ds_shared_sub_proto:leader(),
+    list(emqx_ds_shared_sub_proto:leader_stream_progress()),
+    emqx_ds_shared_sub_proto:version()
+) -> ok.
+leader_lease_streams(Node, ToAgent, OfGroup, Leader, Streams, Version) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, leader_lease_streams_v2, [
+        ToAgent, OfGroup, Leader, Streams, Version
+    ]).
+
+-spec leader_renew_stream_lease(
+    node(),
+    emqx_ds_shared_sub_proto:agent(),
+    emqx_ds_shared_sub_proto:group(),
+    emqx_ds_shared_sub_proto:version()
+) -> ok.
+leader_renew_stream_lease(Node, ToAgent, OfGroup, Version) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, leader_renew_stream_lease_v2, [
+        ToAgent, OfGroup, Version
+    ]).
+
+-spec leader_renew_stream_lease(
+    node(),
+    emqx_ds_shared_sub_proto:agent(),
+    emqx_ds_shared_sub_proto:group(),
+    emqx_ds_shared_sub_proto:version(),
+    emqx_ds_shared_sub_proto:version()
+) -> ok.
+leader_renew_stream_lease(Node, ToAgent, OfGroup, VersionOld, VersionNew) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, leader_renew_stream_lease_v2, [
+        ToAgent, OfGroup, VersionOld, VersionNew
+    ]).
+
+-spec leader_update_streams(
+    node(),
+    emqx_ds_shared_sub_proto:agent(),
+    emqx_ds_shared_sub_proto:group(),
+    emqx_ds_shared_sub_proto:version(),
+    emqx_ds_shared_sub_proto:version(),
+    list(emqx_ds_shared_sub_proto:leader_stream_progress())
+) -> ok.
+leader_update_streams(Node, ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, leader_update_streams_v2, [
+        ToAgent, OfGroup, VersionOld, VersionNew, StreamsNew
+    ]).
+
+-spec leader_invalidate(node(), emqx_ds_shared_sub_proto:agent(), emqx_ds_shared_sub_proto:group()) ->
+    ok.
+leader_invalidate(Node, ToAgent, OfGroup) ->
+    erpc:cast(Node, emqx_ds_shared_sub_proto, leader_invalidate_v2, [ToAgent, OfGroup]).

--- a/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_SUITE.erl
@@ -14,13 +14,12 @@
 
 all() ->
     [
-        % {group, declare_explicit},
+        {group, declare_explicit},
         {group, declare_implicit}
     ].
 
 groups() ->
-    % TCs = emqx_common_test_helpers:all(?MODULE),
-    TCs = [t_unsubscribe],
+    TCs = emqx_common_test_helpers:all(?MODULE),
     Groups = [declare_explicit, declare_implicit],
     GroupTCs = [{Group, TC} || TC <- TCs, Group <- groups_per_testcase(TC, Groups)],
     lists:foldl(
@@ -170,7 +169,7 @@ t_destroy_queue_live_clients('init', Config) ->
 t_destroy_queue_live_clients('end', Config) ->
     destroy_queue(Config).
 
-t_destroy_queue_live_clients(Config) ->
+t_destroy_queue_live_clients(_Config) ->
     ConnPub = emqtt_connect_pub(<<"client_pub">>),
 
     ConnShared1 = emqtt_connect_sub(<<"client_shared1">>),

--- a/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_SUITE.erl
@@ -13,10 +13,14 @@
 -include_lib("emqx/include/asserts.hrl").
 
 all() ->
-    [{group, declare_explicit}, {group, declare_implicit}].
+    [
+        % {group, declare_explicit},
+        {group, declare_implicit}
+    ].
 
 groups() ->
-    TCs = emqx_common_test_helpers:all(?MODULE),
+    % TCs = emqx_common_test_helpers:all(?MODULE),
+    TCs = [t_unsubscribe],
     Groups = [declare_explicit, declare_implicit],
     GroupTCs = [{Group, TC} || TC <- TCs, Group <- groups_per_testcase(TC, Groups)],
     lists:foldl(
@@ -816,7 +820,7 @@ verify_received_pubs(Pubs, NPubs, ClientByBid) ->
     Messages = lists:foldl(
         fun(#{payload := Payload, client_pid := Pid}, Acc) ->
             maps:update_with(
-                binary_to_integer(Payload),
+                Payload,
                 fun(Clients) ->
                     [ClientByBid(Pid) | Clients]
                 end,
@@ -829,14 +833,15 @@ verify_received_pubs(Pubs, NPubs, ClientByBid) ->
     ),
 
     Missing = lists:filter(
-        fun(N) -> not maps:is_key(N, Messages) end,
+        fun(N) -> not maps:is_key(integer_to_binary(N), Messages) end,
         lists:seq(1, NPubs)
     ),
     Duplicate = lists:filtermap(
         fun(N) ->
+            NBin = integer_to_binary(N),
             case Messages of
-                #{N := [_]} -> false;
-                #{N := [_ | _] = Clients} -> {true, {N, Clients}};
+                #{NBin := [_]} -> false;
+                #{NBin := [_ | _] = Clients} -> {true, {N, Clients}};
                 _ -> false
             end
         end,


### PR DESCRIPTION
Fixes
[EMQX-13472](https://emqx.atlassian.net/browse/EMQX-13472)
[EMQX-13473](https://emqx.atlassian.net/browse/EMQX-13473)

Release version: e5.8.3

# Summary

The major changes are:
* The stream renewal for shared subs does not require external `renew_streams` call anymore, it is done in `on_info` callback just after the stream lease events are received from the leader. This is an internal change of the shared subs.
* The `on_replay` callback (that reports progress) is called from the two places of the DS session:
  * on seqno release when the iterator span was completely consumed;
  * on stream enqueue (needed only for qos0).
 This change required little changes to the scheduler's interface: we need to catch moments when a stream is fully acked.
* Internal shared subs module refactoring: We eliminate "scheduled actions" machinery by just making each subscription to the same topic a standalone consumer from the leader's perspective. So, in case of quick unsubscribe/subscribe, they (opaquely to each other) may coexist in the session, the old ones handling stream revocation and the new one waiting for stream leases.


[EMQX-13472]: https://emqx.atlassian.net/browse/EMQX-13472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMQX-13473]: https://emqx.atlassian.net/browse/EMQX-13473?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ