### PR TITLE
fix(sessds): cleanup renew streams timer

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -693,9 +693,10 @@ handle_timeout(ClientInfo, expire_awaiting_rel, Session) ->
 handle_timeout(
     _ClientInfo,
     ?TIMER_RENEW_STREAMS,
-    Session
+    Session0
 ) ->
-    {ok, [], renew_streams(all, Session)};
+    Session = renew_streams(all, Session0),
+    {ok, [], Session#{?TIMER_RENEW_STREAMS := undefined}};
 handle_timeout(_ClientInfo, Timeout, Session) ->
     ?SLOG(warning, #{msg => "unknown_ds_timeout", timeout => Timeout}),
     {ok, [], Session}.


### PR DESCRIPTION
Cleanup timer to allow it be rescheduled.

The platform has the corresponding failing tests.