### PR TITLE
feat(router): require node to cleanup routes on restart

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -408,14 +408,18 @@ do_route2({To, Group}, Delivery) when is_tuple(Group); is_binary(Group) ->
 aggre([]) ->
     [];
 aggre([#route{topic = To, dest = Node}]) when is_atom(Node) ->
-    [{To, Node}];
+    [{To, Node} || emqx_router_helper:is_routable(Node)];
 aggre([#route{topic = To, dest = {Group, _Node}}]) ->
     [{To, Group}];
 aggre(Routes) ->
     aggre(Routes, false, []).
 
 aggre([#route{topic = To, dest = Node} | Rest], Dedup, Acc) when is_atom(Node) ->
-    aggre(Rest, Dedup, [{To, Node} | Acc]);
+    case emqx_router_helper:is_routable(Node) of
+        true -> NAcc = [{To, Node} | Acc];
+        false -> NAcc = Acc
+    end,
+    aggre(Rest, Dedup, NAcc);
 aggre([#route{topic = To, dest = {Group, _Node}} | Rest], _Dedup, Acc) ->
     aggre(Rest, true, [{To, Group} | Acc]);
 aggre([], false, Acc) ->
@@ -442,7 +446,10 @@ forward(Node, To, Delivery = #delivery{message = _Msg}, RpcMode) ->
 
 %% @doc Forward message to another node.
 -spec do_forward(
-    node(), emqx_types:topic() | emqx_types:share(), emqx_types:delivery(), RpcMode :: sync | async
+    node(),
+    emqx_types:topic() | emqx_types:share(),
+    emqx_types:delivery(),
+    RpcMode :: sync | async
 ) ->
     emqx_types:deliver_result().
 do_forward(Node, To, Delivery, async) ->

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -58,9 +58,9 @@
 
 %% How often to reconcile nodes state? (ms)
 %% Introduce some jitter to avoid concerted firing on different nodes.
--define(RECONCILE_INTERVAL, {10 * 60_000, '±', 30_000}).
+-define(RECONCILE_INTERVAL, {2 * 60_000, '±', 15_000}).
 %% How soon should a dead node be purged? (ms)
--define(PURGE_DEAD_TIMEOUT, 60 * 60_000).
+-define(PURGE_DEAD_TIMEOUT, 15 * 60_000).
 %% How soon should a left node be purged? (ms)
 %% This is a fallback, left node is expected to be purged right away.
 -define(PURGE_LEFT_TIMEOUT, 15_000).

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -357,7 +357,7 @@ schedule_purge_left(Node) ->
 handle_purge(Node, State) ->
     try purge_dead_node_trans(Node) of
         true ->
-            ?tp(debug, emqx_router_node_purged, #{node => Node}),
+            ?tp(info, emqx_router_node_purged, #{node => Node}),
             forget_node(Node);
         false ->
             ?tp(debug, emqx_router_node_purge_skipped, #{node => Node}),

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -64,6 +64,15 @@
 %% This is a fallback, left node is expected to be purged right away.
 -define(PURGE_LEFT_TIMEOUT, 15_000).
 
+-ifdef(TEST).
+-undef(RECONCILE_INTERVAL).
+-undef(PURGE_DEAD_TIMEOUT).
+-undef(PURGE_LEFT_TIMEOUT).
+-define(RECONCILE_INTERVAL, {2_000, '±', 500}).
+-define(PURGE_DEAD_TIMEOUT, 3_000).
+-define(PURGE_LEFT_TIMEOUT, 1_000).
+-endif.
+
 %%--------------------------------------------------------------------
 %% Mnesia bootstrap
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -60,8 +60,8 @@
     start_link/0,
     monitor/1,
     is_routable/1,
-    purge/0,
-    purge_force/0
+    schedule_purge/0,
+    schedule_force_purge/0
 ]).
 
 %% Internal export
@@ -149,15 +149,15 @@ is_routable(Node) ->
     end.
 
 %% @doc Schedule dead node purges.
--spec purge() -> scheduled.
-purge() ->
+-spec schedule_purge() -> scheduled.
+schedule_purge() ->
     TS = erlang:monotonic_time(millisecond),
     gen_server:call(?MODULE, {purge, TS}).
 
 %% @doc Force dead node purges, regardless of for how long nodes are down.
 %% Mostly for testing purposes.
--spec purge_force() -> scheduled.
-purge_force() ->
+-spec schedule_force_purge() -> scheduled.
+schedule_force_purge() ->
     TS = erlang:monotonic_time(millisecond),
     gen_server:call(?MODULE, {purge, TS + ?PURGE_DEAD_TIMEOUT * 2}).
 

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -240,6 +240,8 @@ handle_membership_event({node, leaving, Node}, State) ->
 handle_membership_event({node, up, Node}, State) ->
     _ = record_node_alive(Node),
     State;
+handle_membership_event({mnesia, up, Node}, State = #{last_membership := Membership}) ->
+    State#{last_membership := lists:usort([Node | Membership])};
 handle_membership_event(_Event, State) ->
     State.
 

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -336,20 +336,25 @@ choose_timeout(Baseline) ->
 
 %%
 
+-spec am_core() -> boolean().
 am_core() ->
     mria_config:whoami() =/= replicant.
 
+-spec cores() -> [node()].
 cores() ->
     %% Include stopped nodes as well.
     mria_membership:nodelist().
 
+-spec pick_responsible(_Task) -> node().
 pick_responsible(Task) ->
     %% Pick a responsible core node.
     %% We expect the same node to be picked as responsible across the cluster (unless
     %% the cluster is highly turbulent).
     Nodes = lists:sort(mria_membership:running_core_nodelist()),
-    N = length(Nodes),
-    N > 0 andalso lists:nth(1 + erlang:phash2(Task, N), Nodes).
+    case length(Nodes) of
+        0 -> node();
+        N -> lists:nth(1 + erlang:phash2(Task, N), Nodes)
+    end.
 
 %%
 

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -96,7 +96,6 @@
 -define(SERVER, ?MODULE).
 
 -define(SHARED_SUB_QOS1_DISPATCH_TIMEOUT_SECONDS, 5).
--define(IS_REMOTE_PID(Pid), (is_pid(Pid) andalso node(Pid) =/= node())).
 -define(ACK, shared_sub_ack).
 -define(NACK(Reason), {shared_sub_nack, Reason}).
 -define(NO_ACK, no_ack).
@@ -556,10 +555,12 @@ is_active_sub(Pid, FailedSubs, All) ->
         is_alive_sub(Pid).
 
 %% erlang:is_process_alive/1 does not work with remote pid.
+is_alive_sub(Pid) when node(Pid) == node() ->
+    %% The race is when the pid is actually down cleanup_down is not evaluated yet.
+    erlang:is_process_alive(Pid);
 is_alive_sub(Pid) ->
     %% When process is not local, the best guess is it's alive.
-    %% The race is when the pid is actually down cleanup_down is not evaluated yet
-    ?IS_REMOTE_PID(Pid) orelse erlang:is_process_alive(Pid).
+    emqx_router_helper:is_routable(node(Pid)).
 
 delete_route_if_needed({Group, Topic} = GroupTopic) ->
     if_no_more_subscribers(GroupTopic, fun() ->

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -141,7 +141,7 @@ t_membership_node_leaving(_Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {_, {ok, _}} = ?wait_async_action(
         ?ROUTER_HELPER ! {membership, {node, leaving, AnotherNode}},
-        #{?snk_kind := emqx_router_node_purged, node := AnotherNode},
+        #{?snk_kind := router_node_routing_table_purged, node := AnotherNode},
         1_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
@@ -158,7 +158,7 @@ t_cluster_node_leaving(Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {ok, {ok, _}} = ?wait_async_action(
         erpc:call(ClusterNode, ekka, leave, []),
-        #{?snk_kind := emqx_router_node_purged, node := ClusterNode},
+        #{?snk_kind := router_node_routing_table_purged, node := ClusterNode},
         3_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
@@ -175,7 +175,7 @@ t_cluster_node_down(Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {ok, SRef} = snabbkaffe:subscribe(
         %% Should be purged after ~2 reconciliations.
-        ?match_event(#{?snk_kind := emqx_router_node_purged, node := ClusterNode}),
+        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
         1,
         10_000
     ),
@@ -194,7 +194,7 @@ t_cluster_node_force_leave(Config) ->
     emqx_router:add_route(<<"test/e/f">>, node()),
     ?assertMatch([_, _], emqx_router:topics()),
     {ok, SRef} = snabbkaffe:subscribe(
-        ?match_event(#{?snk_kind := emqx_router_node_purged, node := ClusterNode}),
+        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
         1,
         10_000
     ),

--- a/changes/ce/fix-14248.en.md
+++ b/changes/ce/fix-14248.en.md
@@ -1,0 +1,1 @@
+Fixed a class of issues where intermittent connectivity issues between cluster nodes could potentially cause partial loss of cluster-wide routing table state.


### PR DESCRIPTION
Fixes [EMQX-11852](https://emqx.atlassian.net/browse/EMQX-11852).

Release version: v5.8.4

## Summary

Tolerate transient connectivity issues. It's now assumed that receiving a `{node, down, ...}` event does not mean that the node in question is dead, but that it has experienced connectivity loss.

Now, the router helper:
* Cleans any leftover routes from previous incarnations upon restart.
* Consequently, expects cluster nodes to clean up themselves upon restart.
* Cleans routes of a cluster node that decided to leave upon receiving such event.
* Cleans routes of cluster nodes that are down for more than 1 hour.

Notable consequences of these changes are:
* Global routing table will hold offline nodes' entries for a while, instead of cleaning them up as soon as node is considered offline.
* Node startup sequence now includes an additional step of cleaning up route leftovers from its previous incarnation.
    Currently, this boils down to what essentially a full-scan, so the time it takes the node to start now depends on the size of the routing table. However, when running under emqx/otp this full-scan should use optimized implementation. The same is true when Mria autoheal is involved.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible


[EMQX-11852]: https://emqx.atlassian.net/browse/EMQX-11852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ