### PR TITLE
feat: return cluster name in /status HTTP ednpoint

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api_status.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_status.erl
@@ -130,6 +130,7 @@ do_get_status(AppStatus, <<"json">>) ->
     BrokerStatus = broker_status(),
     emqx_utils_json:encode(#{
         node_name => atom_to_binary(node(), utf8),
+        cluster => atom_to_binary(cluster(), utf8),
         rel_vsn => vsn(),
         broker_status => atom_to_binary(BrokerStatus),
         app_status => atom_to_binary(AppStatus)
@@ -157,3 +158,6 @@ application_status() ->
         false -> not_running;
         {value, _Val} -> running
     end.
+
+cluster() ->
+    emqx_config:get([cluster, name]).

--- a/changes/ce/feat-14254.en.md
+++ b/changes/ce/feat-14254.en.md
@@ -1,0 +1,1 @@
+Return cluster name in `/status` HTTP endpoint.


### PR DESCRIPTION
The status API does not require authentication.
This will help dashboard to display cluster name before login.

Release version: v/e5.9.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
