### PR TITLE
fix: lower kick shutdown timeout

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -86,7 +86,7 @@
     %% TCP/TLS Transport
     transport :: esockd:transport(),
     %% TCP/TLS Socket
-    socket :: esockd:socket(),
+    socket :: esockd:socket() | emqx_quic_stream:socket(),
     %% Peername of the connection
     peername :: emqx_types:peername(),
     %% Sockname of the connection
@@ -1266,9 +1266,17 @@ set_tcp_keepalive({Type, Id}) ->
     end.
 
 -spec graceful_shutdown_transport(atom(), state()) -> state().
+graceful_shutdown_transport(
+    kicked,
+    S = #state{
+        transport = emqx_quic_stream,
+        socket = Socket
+    }
+) ->
+    _ = emqx_quic_stream:shutdown(Socket, read_write, 1000),
+    S#state{sockstate = closed};
 graceful_shutdown_transport(_Reason, S = #state{transport = Transport, socket = Socket}) ->
-    %% @TODO Reason is reserved for future use, quic transport
-    Transport:shutdown(Socket, read_write),
+    _ = Transport:shutdown(Socket, read_write),
     S#state{sockstate = closed}.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_quic_stream.erl
+++ b/apps/emqx/src/emqx_quic_stream.erl
@@ -33,6 +33,7 @@
     getstat/2,
     fast_close/1,
     shutdown/2,
+    shutdown/3,
     ensure_ok_or_exit/2,
     send/2,
     setopts/2,
@@ -62,7 +63,7 @@
 
 -export_type([socket/0]).
 
--opaque socket() :: {quic, connection_handle(), stream_handle(), socket_info()}.
+-type socket() :: {quic, connection_handle(), stream_handle(), socket_info()}.
 
 -type socket_info() :: #{
     is_orphan => boolean(),
@@ -153,9 +154,12 @@ fast_close({quic, _Conn, Stream, _Info}) ->
     % quicer:async_shutdown_connection(Conn, ?QUIC_CONNECTION_SHUTDOWN_FLAG_NONE, 0),
     ok.
 
-shutdown({quic, _Conn, Stream, _Info}, read_write) ->
+shutdown(Socket, Dir) ->
+    shutdown(Socket, Dir, 3000).
+
+shutdown({quic, _Conn, Stream, _Info}, read_write, Timeout) ->
     %% A graceful shutdown means both side shutdown the read and write gracefully.
-    quicer:shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL, 1, 5000).
+    quicer:shutdown_stream(Stream, ?QUIC_STREAM_SHUTDOWN_FLAG_GRACEFUL, 1, Timeout).
 
 -spec ensure_ok_or_exit(atom(), list(term())) -> term().
 ensure_ok_or_exit(Fun, Args = [Sock | _]) when is_atom(Fun), is_list(Args) ->

--- a/changes/ce/fix-14258.en.md
+++ b/changes/ce/fix-14258.en.md
@@ -1,0 +1,15 @@
+Lower QUIC connection shutdown timeout.
+
+For QUIC connection graceful shutdown, we used to have 5s timeout.
+
+If the client is unresponsive for graceful shutdown, EMQX may generate some warning logs:
+
+```
+[warning] msg: session_stepdown_request_timeout, action: discard, 
+```
+or 
+
+timeout the dashboard if kick the client via dashboard. 
+
+Now lower it to 1s for reason `kick` and 3s for the others.
+


### PR DESCRIPTION
Fixes:
  [EMQX-13214](https://emqx.atlassian.net/browse/EMQX-13214)
  [EMQX-13437](https://emqx.atlassian.net/browse/EMQX-13437)

To mitigate the loggings:

```
[warning] msg: session_stepdown_request_timeout, action: discard ...
[{status,running},{message_queue_len,1},{current_stacktrace,[{quicer,shutdown_stream,4,[{file,"quicer.erl"}
```

- kick: 1s
- others: 3s

Release version: v/e5.8.3

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13214]: https://emqx.atlassian.net/browse/EMQX-13214?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMQX-13437]: https://emqx.atlassian.net/browse/EMQX-13437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ