### PR TITLE
fix: bin/nodetool eval rpc case clause

### DIFF
--- a/bin/nodetool
+++ b/bin/nodetool
@@ -78,10 +78,10 @@ do(Args) ->
         {true, pong} ->
             ok;
         {false, pong} ->
-            io:format(standard_error, "Failed to connect to node ~p\n", [TargetNode]),
+            io:format(standard_error, "Failed to connect to node ~p~n", [TargetNode]),
             halt(1);
         {_, pang} ->
-            io:format(standard_error, "Node ~p not responding to pings.\n", [TargetNode]),
+            io:format(standard_error, "Node ~p not responding to pings.~n", [TargetNode]),
             halt(1)
     end,
 
@@ -91,11 +91,11 @@ do(Args) ->
     logger:set_primary_config(level, none),
     case RestArgs of
         ["getpid"] ->
-            io:format("~p\n", [list_to_integer(rpc:call(TargetNode, os, getpid, []))]);
+            io:format("~p~n", [list_to_integer(rpc:call(TargetNode, os, getpid, []))]);
         ["ping"] ->
             %% If we got this far, the node already responded to a ping, so just dump
             %% a "pong"
-            io:format("pong\n");
+            io:format("pong~n");
         ["stop"] ->
             Pid = start_shutdown_status(),
             Res = rpc:call(TargetNode, emqx_machine, graceful_shutdown, [], ?SHUTDOWN_TIMEOUT_MS),
@@ -106,7 +106,7 @@ do(Args) ->
                 {badrpc, timeout} ->
                     io:format(
                         "EMQX is still shutting down, it failed to stop gracefully "
-                        "within the configured timeout of: ~ps\n",
+                        "within the configured timeout of: ~ps~n",
                         [erlang:convert_time_unit(?SHUTDOWN_TIMEOUT_MS, millisecond, second)]
                     ),
                     halt(1);
@@ -131,10 +131,10 @@ do(Args) ->
                 {error, cmd_not_found} ->
                     halt(1);
                 {error, Reason} ->
-                    io:format("RPC to ~s error: ~p\n", [TargetNode, Reason]),
+                    io:format("RPC to ~s error: ~p~n", [TargetNode, Reason]),
                     halt(1);
                 {badrpc, Reason} ->
-                    io:format("RPC to ~s failed: ~p\n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
                     halt(1);
                 _ ->
                     halt(1)
@@ -148,7 +148,7 @@ do(Args) ->
                 ok ->
                     ok;
                 {badrpc, Reason} ->
-                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
                     halt(1);
                 _ ->
                     halt(1)
@@ -164,10 +164,10 @@ do(Args) ->
                 )
             of
                 {badrpc, Reason} ->
-                    io:format("RPC to ~p failed: ~p\n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
                     halt(1);
                 Other ->
-                    io:format("~p\n", [Other])
+                    io:format("~p~n", [Other])
             end;
         ["eval" | ListOfArgs] ->
             % parse args locally in the remsh node
@@ -177,16 +177,16 @@ do(Args) ->
                 {ok, Value} ->
                     io:format("~p~n", [Value]);
                 {error, Reason} ->
-                    io:format("RPC to ~s error: ~p\n", [TargetNode, Reason]),
+                    io:format("RPC to ~s error: ~p~n", [TargetNode, Reason]),
                     halt(1);
                 {badrpc, Reason} ->
-                    io:format("RPC to ~p failed: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
                     halt(1)
             end;
         Other ->
             io:format("Other: ~p~n", [Other]),
             io:format(
-                "Usage: nodetool getpid|ping|stop|rpc|rpc_infinity|rpcterms|eval|cold_eval [Terms] [RPC]\n"
+                "Usage: nodetool getpid|ping|stop|rpc|rpc_infinity|rpcterms|eval|cold_eval [Terms] [RPC]~n"
             )
     end,
     net_kernel:stop().
@@ -200,7 +200,7 @@ stop_shutdown_status(Pid) ->
 
 shutdown_status_loop() ->
     timer:sleep(10_000),
-    io:format("EMQX is shutting down, please wait...\n", []),
+    io:format("EMQX is shutting down, please wait...~n", []),
     shutdown_status_loop().
 
 parse_eval_args(Args) ->

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -131,10 +131,10 @@ do(Args) ->
                 {error, cmd_not_found} ->
                     halt(1);
                 {error, Reason} ->
-                    io:format("RPC to ~s error: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s error: ~0p~n", [TargetNode, Reason]),
                     halt(1);
                 {badrpc, Reason} ->
-                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~0p~n", [TargetNode, Reason]),
                     halt(1);
                 _ ->
                     halt(1)
@@ -148,7 +148,7 @@ do(Args) ->
                 ok ->
                     ok;
                 {badrpc, Reason} ->
-                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~0p~n", [TargetNode, Reason]),
                     halt(1);
                 _ ->
                     halt(1)
@@ -164,7 +164,7 @@ do(Args) ->
                 )
             of
                 {badrpc, Reason} ->
-                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~0p~n", [TargetNode, Reason]),
                     halt(1);
                 Other ->
                     io:format("~p~n", [Other])
@@ -177,10 +177,10 @@ do(Args) ->
                 {ok, Value} ->
                     io:format("~p~n", [Value]);
                 {error, Reason} ->
-                    io:format("RPC to ~s error: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s error: ~0p~n", [TargetNode, Reason]),
                     halt(1);
                 {badrpc, Reason} ->
-                    io:format("RPC to ~s failed: ~p~n", [TargetNode, Reason]),
+                    io:format("RPC to ~s failed: ~0p~n", [TargetNode, Reason]),
                     halt(1)
             end;
         Other ->

--- a/bin/nodetool
+++ b/bin/nodetool
@@ -176,6 +176,9 @@ do(Args) ->
             case rpc:call(TargetNode, emqx_ctl, run_command, [eval_erl, Parsed], infinity) of
                 {ok, Value} ->
                     io:format("~p~n", [Value]);
+                {error, Reason} ->
+                    io:format("RPC to ~s error: ~p\n", [TargetNode, Reason]),
+                    halt(1);
                 {badrpc, Reason} ->
                     io:format("RPC to ~p failed: ~p~n", [TargetNode, Reason]),
                     halt(1)


### PR DESCRIPTION
Fixes <issue-or-jira-number>

```bash
$ emqx eval 'emqx:get_config([logs]).'
escript: exception error: no case clause matching {error,{config_not_found,[logs]}}
  in function  nodetool__escript__1732__246864__885259__2:do/1 {FILE_PATH}
  in call from escript:start/1 (escript.erl, line 277)
  in call from init:start_em/1 
  in call from init:do_boot/3 
```

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
