### PR TITLE
feat: add a timestamp to the crash_dump file 

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -643,17 +643,6 @@ save_to_override_conf(false = _HasDeprecatedFile, RawConf, Opts) ->
             backup_and_write(FileName, hocon_pp:do(RawConf, Opts))
     end.
 
-%% @private This is the same human-readable timestamp format as
-%% hocon-cli generated app.<time>.config file name.
-now_time() ->
-    Ts = os:system_time(millisecond),
-    {{Y, M, D}, {HH, MM, SS}} = calendar:system_time_to_local_time(Ts, millisecond),
-    Res = io_lib:format(
-        "~0p.~2..0b.~2..0b.~2..0b.~2..0b.~2..0b.~3..0b",
-        [Y, M, D, HH, MM, SS, Ts rem 1000]
-    ),
-    lists:flatten(Res).
-
 %% @private Backup the current config to a file with a timestamp suffix and
 %% then save the new config to the config file.
 backup_and_write(Path, Content) ->
@@ -677,7 +666,7 @@ backup_and_write(Path, Content) ->
     end.
 
 backup_and_replace(Path, TmpPath) ->
-    Backup = Path ++ "." ++ now_time() ++ ".bak",
+    Backup = Path ++ "." ++ emqx_utils_calendar:now_time(millisecond) ++ ".bak",
     case file:rename(Path, Backup) of
         ok ->
             ok = file:rename(TmpPath, Path),

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.4.1"},
+    {vsn, "0.4.2"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1398,13 +1398,16 @@ log_handler_common_confs(Handler, Default) ->
     ].
 
 crash_dump_file_default() ->
-    case os:getenv("EMQX_LOG_DIR") of
-        false ->
-            %% testing, or running emqx app as deps
-            <<"log/erl_crash.dump">>;
-        Dir ->
-            unicode:characters_to_binary(filename:join([Dir, "erl_crash.dump"]), utf8)
-    end.
+    File = "erl_crash." ++ emqx_utils_calendar:now_time(second) ++ ".dump",
+    LogDir =
+        case os:getenv("EMQX_LOG_DIR") of
+            false ->
+                %% testing, or running emqx app as deps
+                "log";
+            Dir ->
+                Dir
+        end,
+    unicode:characters_to_binary(filename:join([LogDir, File]), utf8).
 
 %% utils
 -spec conf_get(string() | [string()], hocon:config()) -> term().

--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.3.0"},
+    {vsn, "0.3.1"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx, erlavro]},

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -1445,7 +1445,7 @@ backup_and_write_hocon_bin(NameVsn, HoconBin) ->
     end.
 
 backup_and_replace(Path, TmpPath) ->
-    Backup = Path ++ "." ++ now_time() ++ ".bak",
+    Backup = Path ++ "." ++ emqx_utils_calendar:now_time(millisecond) ++ ".bak",
     case file:rename(Path, Backup) of
         ok ->
             ok = file:rename(TmpPath, Path),
@@ -1581,17 +1581,6 @@ running_apps() ->
         end,
         application:which_applications(infinity)
     ).
-
-%% @private This is the same human-readable timestamp format as
-%% hocon-cli generated app.<time>.config file name.
-now_time() ->
-    Ts = os:system_time(millisecond),
-    {{Y, M, D}, {HH, MM, SS}} = calendar:system_time_to_local_time(Ts, millisecond),
-    Res = io_lib:format(
-        "~0p.~2..0b.~2..0b.~2..0b.~2..0b.~2..0b.~3..0b",
-        [Y, M, D, HH, MM, SS, Ts rem 1000]
-    ),
-    lists:flatten(Res).
 
 bin_key(Map) when is_map(Map) ->
     maps:fold(fun(K, V, Acc) -> Acc#{bin(K) => V} end, #{}, Map);

--- a/changes/ce/feat-14264.en.md
+++ b/changes/ce/feat-14264.en.md
@@ -1,0 +1,1 @@
+Add a timestamp to the crash_dump file to ensure that it is not overwritten by the next crash dump.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -683,7 +683,8 @@ rpc_mode.label:
 """RPC Mode"""
 
 node_crash_dump_file.desc:
-"""Location of the crash dump file."""
+"""Location of the crash dump file. Defaults to <code>log/erl_crash.YYYY.MM.DD.HH.MM.SS.dump</code>.
+The timestamp is generated when emqx starts."""
 
 node_crash_dump_file.label:
 """Crash Dump File"""


### PR DESCRIPTION
Add a timestamp to the crash_dump file to ensure that it is not overwritten by the next crash dump.

**NOTE:** crash_dump_file is hidden configuration.


```
./bin/emqx eval "emqx_config:get([node,crash_dump_file])."
"/emqx/_build/emqx/rel/emqx/log/erl_crash.2024.11.22.08.17.24.dump"
```

```
cat data/configs/vm.2024.11.22.08.17.23.args
...
-env ERL_CRASH_DUMP_BYTES 104857600
-env ERL_CRASH_DUMP_SECONDS 30
-env ERL_CRASH_DUMP /emqx/_build/emqx/rel/emqx/log/erl_crash.2024.11.22.08.17.24.dump
...
```
Fixes <issue-or-jira-number>

Release version: v/e5.9.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
