### PR TITLE
mqtt-source-bridge-stop-error

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ce/fix-14265.en.md
+++ b/changes/ce/fix-14265.en.md
@@ -1,0 +1,1 @@
+If the MQTT Source action fails to subscribe successfully, a `badkey` error will occur when stopping the connector.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13563

Release version: v/e5.8.3

## Summary

See the error log:

```
2024-11-22T13:57:14.140177+08:00 [warning] tag: CONNECTOR/MQTT, msg: remove_channel_failed, reason: #{reason => {badkey,<<"source:mqtt:source-mqtt-act:connector:mqtt:mqtt-conn">>},stacktrace => [{erlang,map_get,[<<"source:mqtt:source-mqtt-act:connector:mqtt:mqtt-conn">>,#{}],[{error_info,#{module => erl_erts_errors}}]},{emqx_bridge_mqtt_connector,on_remove_channel,3,[{file,"emqx_bridge_mqtt_connector.erl"},{line,178}]},{emqx_resource,call_remove_channel,4,[{file,"emqx_resource.erl"},{line,579}]},{emqx_resource_manager,remove_channels_in_list,3,[{file,"emqx_resource_manager.erl"},{line,948}]},{emqx_resource_manager,stop_resource,1,[{file,"emqx_resource_manager.erl"},{line,910}]},{emqx_resource_manager,handle_remove_event,3,[{file,"emqx_resource_manager.erl"},{line,780}]},{gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1397}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}],exception => error}, type: mqtt, group: <<"connector">>, resource_id: <<"connector:mqtt:mqtt-conn">>, channel_id: <<"source:mqtt:source-mqtt-act:connector:mqtt:mqtt-conn">>
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
