### PR TITLE
fix: do not redact secret value when it is file path

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -3422,7 +3422,8 @@ naive_env_interpolation(Other) ->
     Other.
 
 split_path(Path) ->
-    split_path(Path, []).
+    {Name0, Tail} = split_path(Path, []),
+    {string:trim(Name0, both, "{}"), Tail}.
 
 split_path([], Acc) ->
     {lists:reverse(Acc), []};
@@ -3431,8 +3432,7 @@ split_path([Char | Rest], Acc) when Char =:= $/ orelse Char =:= $\\ ->
 split_path([Char | Rest], Acc) ->
     split_path(Rest, [Char | Acc]).
 
-resolve_env(Name0) ->
-    Name = string:trim(Name0, both, "{}"),
+resolve_env(Name) ->
     Value = os:getenv(Name),
     case Value =/= false andalso Value =/= "" of
         true ->

--- a/apps/emqx/src/emqx_schema_secret.erl
+++ b/apps/emqx/src/emqx_schema_secret.erl
@@ -71,8 +71,8 @@ convert_secret(Secret, #{}) ->
     end.
 
 -spec wrap(source()) -> emqx_secret:t(t()).
-wrap(<<"file://", Filename/binary>>) ->
-    emqx_secret:wrap_load({file, Filename});
+wrap(<<"file://", _Filename/binary>> = Secret) ->
+    emqx_secret:wrap_load({file, Secret});
 wrap(Secret) ->
     emqx_secret:wrap(Secret).
 

--- a/apps/emqx/src/emqx_secret_loader.erl
+++ b/apps/emqx/src/emqx_secret_loader.erl
@@ -22,9 +22,13 @@
 
 -export_type([source/0]).
 
--type source() :: {file, file:filename_all()}.
+-type source() :: {file, string() | binary()}.
 
 -spec load(source()) -> binary() | no_return().
+load({file, <<"file://", Path/binary>>}) ->
+    file(Path);
+load({file, "file://" ++ Path}) ->
+    file(Path);
 load({file, Filename}) ->
     file(Filename).
 

--- a/apps/emqx/src/emqx_secret_loader.erl
+++ b/apps/emqx/src/emqx_secret_loader.erl
@@ -28,12 +28,11 @@
 load({file, <<"file://", Path/binary>>}) ->
     file(Path);
 load({file, "file://" ++ Path}) ->
-    file(Path);
-load({file, Filename}) ->
-    file(Filename).
+    file(Path).
 
 -spec file(file:filename_all()) -> binary() | no_return().
-file(Filename) ->
+file(Filename0) ->
+    Filename = emqx_schema:naive_env_interpolation(Filename0),
     case file:read_file(Filename) of
         {ok, Secret} ->
             string:trim(Secret, trailing);

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -169,9 +169,11 @@ do_redact_v("file://" ++ _ = V) ->
     V;
 do_redact_v(B) when is_binary(B) ->
     <<?REDACT_VAL>>;
-do_redact_v(F) when is_function(F, 0) ->
-    %% this can happen in logs
+do_redact_v(L) when is_list(L) ->
+    ?REDACT_VAL;
+do_redact_v(F) ->
     try
+        %% this can happen in logs
         case emqx_secret:term(F) of
             {file, File} ->
                 File;
@@ -180,10 +182,9 @@ do_redact_v(F) when is_function(F, 0) ->
         end
     catch
         _:_ ->
+            %% most of the time
             ?REDACT_VAL
-    end;
-do_redact_v(_) ->
-    ?REDACT_VAL.
+    end.
 
 deobfuscate(NewConf, OldConf) ->
     deobfuscate(NewConf, OldConf, fun(_) -> false end).

--- a/apps/emqx_utils/src/emqx_utils_redact.erl
+++ b/apps/emqx_utils/src/emqx_utils_redact.erl
@@ -155,13 +155,18 @@ redact_v(V) when is_binary(V) ->
         [{var, _}] ->
             V;
         _ ->
-            <<?REDACT_VAL>>
+            do_redact_v(V)
     end;
 redact_v([{str, Bin}]) when is_binary(Bin) ->
     %% The HOCON schema system may generate sensitive values with this format
-    [{str, <<?REDACT_VAL>>}];
-redact_v(_V) ->
-    ?REDACT_VAL.
+    [{str, do_redact_v(Bin)}];
+redact_v(V) ->
+    do_redact_v(V).
+
+do_redact_v(<<"file://", _/binary>> = V) -> V;
+do_redact_v("file://" ++ _ = V) -> V;
+do_redact_v(B) when is_binary(B) -> <<?REDACT_VAL>>;
+do_redact_v(_) -> ?REDACT_VAL.
 
 deobfuscate(NewConf, OldConf) ->
     deobfuscate(NewConf, OldConf, fun(_) -> false end).

--- a/apps/emqx_utils/test/emqx_utils_redact_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_redact_tests.erl
@@ -50,14 +50,28 @@ no_redact_file_paths_test() ->
         #{
             password => <<"file:///abs/path/a">>,
             <<"secret">> => <<"file://relative/path/b">>,
-            account_key => "file://string/path/x",
-            private_key => "file://string/path/y"
+            account_key => "file://string/path/x"
         },
         redact(#{
             password => <<"file:///abs/path/a">>,
             <<"secret">> => <<"file://relative/path/b">>,
-            account_key => "file://string/path/x",
-            private_key => "file://string/path/y"
+            account_key => "file://string/path/x"
+        })
+    ).
+
+no_redact_wrapped_file_paths_test() ->
+    ?assertEqual(
+        #{password => <<"file:///abs/path/a">>},
+        redact(#{
+            password => emqx_secret:wrap_load({file, <<"file:///abs/path/a">>})
+        })
+    ).
+
+redact_wrapped_secret_test() ->
+    ?assertEqual(
+        #{password => <<"******">>},
+        redact(#{
+            password => emqx_secret:wrap(<<"aaa">>)
         })
     ).
 

--- a/changes/ce/fix-14267.en.md
+++ b/changes/ce/fix-14267.en.md
@@ -1,0 +1,1 @@
+Do not redact secrets in logs and HTTP responses when the secret string is a file path (`file:///path/to/the/secret`).


### PR DESCRIPTION
Release version: v/e5.8.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
