### PR TITLE
fix: load auto_subscribe from cli failed

### DIFF
--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auto_subscribe, [
     {description, "Auto subscribe Application"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {mod, {emqx_auto_subscribe_app, []}},
     {applications, [

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.erl
@@ -25,6 +25,7 @@
 -define(HOOK_POINT, 'client.connected').
 
 -define(MAX_AUTO_SUBSCRIBE, 20).
+-define(ROOT_KEY, auto_subscribe).
 
 -export([load/0, unload/0]).
 
@@ -47,22 +48,22 @@
 ]).
 
 load() ->
-    ok = emqx_conf:add_handler([auto_subscribe], ?MODULE),
+    ok = emqx_conf:add_handler([?ROOT_KEY], ?MODULE),
     update_hook().
 
 unload() ->
-    emqx_conf:remove_handler([auto_subscribe]).
+    emqx_conf:remove_handler([?ROOT_KEY]).
 
 max_limit() ->
     ?MAX_AUTO_SUBSCRIBE.
 
 list() ->
-    format(emqx_conf:get([auto_subscribe, topics], [])).
+    format(emqx_conf:get([?ROOT_KEY, topics], [])).
 
 update(Topics) when length(Topics) =< ?MAX_AUTO_SUBSCRIBE ->
     case
         emqx_conf:update(
-            [auto_subscribe],
+            [?ROOT_KEY],
             #{<<"topics">> => Topics},
             #{rawconf_with_defaults => true, override_to => cluster}
         )
@@ -75,7 +76,7 @@ update(Topics) when length(Topics) =< ?MAX_AUTO_SUBSCRIBE ->
 update(_Topics) ->
     {error, quota_exceeded}.
 
-post_config_update([auto_subscribe], _Req, NewConf, _OldConf, _AppEnvs) ->
+post_config_update([?ROOT_KEY], _Req, NewConf, _OldConf, _AppEnvs) ->
     update_hook(NewConf).
 
 %%------------------------------------------------------------------------------
@@ -99,26 +100,26 @@ on_client_connected(_, _, _) ->
 
 -spec get_basic_usage_info() -> #{auto_subscribe_count => non_neg_integer()}.
 get_basic_usage_info() ->
-    AutoSubscribe = emqx_conf:get([auto_subscribe, topics], []),
+    AutoSubscribe = emqx_conf:get([?ROOT_KEY, topics], []),
     #{auto_subscribe_count => length(AutoSubscribe)}.
 
 %%------------------------------------------------------------------------------
 %% Data backup
 %%------------------------------------------------------------------------------
 
-import_config(#{<<"auto_subscribe">> := #{<<"topics">> := Topics}} = AutoSubscribe) ->
-    ConfPath = [auto_subscribe],
-    OldTopics = emqx:get_raw_config(ConfPath, []),
+import_config(#{<<"auto_subscribe">> := #{<<"topics">> := Topics} = AutoSubscribe}) ->
+    ConfPath = [?ROOT_KEY],
+    OldTopics = emqx:get_raw_config(ConfPath ++ [topics], []),
     KeyFun = fun(#{<<"topic">> := T}) -> T end,
     MergedTopics = emqx_utils:merge_lists(OldTopics, Topics, KeyFun),
     Conf = AutoSubscribe#{<<"topics">> => MergedTopics},
     case emqx_conf:update(ConfPath, Conf, #{override_to => cluster}) of
-        {ok, #{raw_config := NewTopics}} ->
+        {ok, #{raw_config := #{<<"topics">> := NewTopics}}} ->
             Changed = maps:get(changed, emqx_utils:diff_lists(NewTopics, OldTopics, KeyFun)),
             Changed1 = [ConfPath ++ [T] || {#{<<"topic">> := T}, _} <- Changed],
-            {ok, #{root_key => auto_subscribe, changed => Changed1}};
+            {ok, #{root_key => ?ROOT_KEY, changed => Changed1}};
         Error ->
-            {error, #{root_key => auto_subscribe, reason => Error}}
+            {error, #{root_key => ?ROOT_KEY, reason => Error}}
     end;
 import_config(_RawConf) ->
     {ok, #{root_key => auto_subscribe, changed => []}}.
@@ -139,7 +140,7 @@ format(Rule = #{topic := Topic}) when is_map(Rule) ->
     }.
 
 update_hook() ->
-    update_hook(emqx_conf:get([auto_subscribe], #{topics => []})).
+    update_hook(emqx_conf:get([?ROOT_KEY], #{topics => []})).
 
 update_hook(Config) ->
     {TopicHandler, Options} = emqx_auto_subscribe_handler:init(Config),

--- a/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.erl
+++ b/apps/emqx_auto_subscribe/src/emqx_auto_subscribe.erl
@@ -47,11 +47,11 @@
 ]).
 
 load() ->
-    ok = emqx_conf:add_handler([auto_subscribe, topics], ?MODULE),
+    ok = emqx_conf:add_handler([auto_subscribe], ?MODULE),
     update_hook().
 
 unload() ->
-    emqx_conf:remove_handler([auto_subscribe, topics]).
+    emqx_conf:remove_handler([auto_subscribe]).
 
 max_limit() ->
     ?MAX_AUTO_SUBSCRIBE.
@@ -62,12 +62,12 @@ list() ->
 update(Topics) when length(Topics) =< ?MAX_AUTO_SUBSCRIBE ->
     case
         emqx_conf:update(
-            [auto_subscribe, topics],
-            Topics,
+            [auto_subscribe],
+            #{<<"topics">> => Topics},
             #{rawconf_with_defaults => true, override_to => cluster}
         )
     of
-        {ok, #{raw_config := NewTopics}} ->
+        {ok, #{raw_config := #{<<"topics">> := NewTopics}}} ->
             {ok, NewTopics};
         {error, Reason} ->
             {error, Reason}
@@ -75,9 +75,8 @@ update(Topics) when length(Topics) =< ?MAX_AUTO_SUBSCRIBE ->
 update(_Topics) ->
     {error, quota_exceeded}.
 
-post_config_update(_KeyPath, _Req, NewTopics, _OldConf, _AppEnvs) ->
-    Config = emqx_conf:get([auto_subscribe], #{}),
-    update_hook(Config#{topics => NewTopics}).
+post_config_update([auto_subscribe], _Req, NewConf, _OldConf, _AppEnvs) ->
+    update_hook(NewConf).
 
 %%------------------------------------------------------------------------------
 %% hook
@@ -107,12 +106,13 @@ get_basic_usage_info() ->
 %% Data backup
 %%------------------------------------------------------------------------------
 
-import_config(#{<<"auto_subscribe">> := #{<<"topics">> := Topics}}) ->
-    ConfPath = [auto_subscribe, topics],
+import_config(#{<<"auto_subscribe">> := #{<<"topics">> := Topics}} = AutoSubscribe) ->
+    ConfPath = [auto_subscribe],
     OldTopics = emqx:get_raw_config(ConfPath, []),
     KeyFun = fun(#{<<"topic">> := T}) -> T end,
     MergedTopics = emqx_utils:merge_lists(OldTopics, Topics, KeyFun),
-    case emqx_conf:update(ConfPath, MergedTopics, #{override_to => cluster}) of
+    Conf = AutoSubscribe#{<<"topics">> => MergedTopics},
+    case emqx_conf:update(ConfPath, Conf, #{override_to => cluster}) of
         {ok, #{raw_config := NewTopics}} ->
             Changed = maps:get(changed, emqx_utils:diff_lists(NewTopics, OldTopics, KeyFun)),
             Changed1 = [ConfPath ++ [T] || {#{<<"topic">> := T}, _} <- Changed],
@@ -139,7 +139,7 @@ format(Rule = #{topic := Topic}) when is_map(Rule) ->
     }.
 
 update_hook() ->
-    update_hook(emqx_conf:get([auto_subscribe], #{})).
+    update_hook(emqx_conf:get([auto_subscribe], #{topics => []})).
 
 update_hook(Config) ->
     {TopicHandler, Options} = emqx_auto_subscribe_handler:init(Config),

--- a/changes/ce/fix-14272.en.md
+++ b/changes/ce/fix-14272.en.md
@@ -1,0 +1,1 @@
+`auto_subscribe` configuration loaded via CLI shows success but fails to take effect.


### PR DESCRIPTION
Fix: auto_subscribe configuration loaded via CLI shows success but fails to take effect(ADD TO HOOKS).

```
cat auto_subscribe.conf
auto_subscribe.topics = [{topic = "cmd/${clientid}/zbsend", qos = 0, rh = 0, rap = 0, nl = 0},{topic = "cmd/${clientid}/#", qos = 0,rh = 0, rap = 0, nl = 0}]
```
```
./bin/emqx ctl conf load auto_subscribe.conf
load auto_subscribe on cluster ok
```
1. Connect an MQTT client with username and client ID
2. Verify the client is automatically subscribed to the configured topics
3. Check the subscription list matches the expected topics
4. Disconnect the client cleanly

Release version: v/e5.8.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
