### PR TITLE
JT/T808: Fixed a json encode error

### DIFF
--- a/apps/emqx_gateway_jt808/test/emqx_jt808_parser_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_parser_SUITE.erl
@@ -689,6 +689,23 @@ t_case15_custome_client_query_ack(_) ->
     ?assertEqual(#{data => <<>>, phase => searching_head_hex7e}, State),
     _ = emqx_utils_json:encode(Packet).
 
+t_throw_error_if_parse_failed(_) ->
+    Bin =
+        <<126, 2, 5, 0, 128, 1, 137, 96, 146, 0, 51, 3, 64, 72, 66, 77, 54, 48, 49, 67, 86, 77, 48,
+            53, 54, 51, 52, 50, 48, 50, 52, 45, 48, 56, 45, 49, 54, 253, 255, 2, 0, 255, 127, 0,
+            128, 80, 17, 1, 54, 69, 67, 56, 48, 48, 77, 58, 32, 49, 44, 34, 51, 50, 51, 65, 56, 54,
+            56, 48, 49, 57, 48, 55, 51, 55, 48, 51, 50, 50, 54, 52, 54, 48, 48, 56, 56, 53, 53, 52,
+            49, 48, 48, 52, 57, 56, 56, 57, 56, 54, 48, 56, 49, 53, 50, 54, 50, 51, 56, 48, 49, 49,
+            48, 52, 57, 56, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 0,
+            0, 0, 0, 207, 126>>,
+    Parser = emqx_jt808_frame:initial_parse_state(#{}),
+    try emqx_jt808_frame:parse(Bin, Parser) of
+        _ -> ?assert(false)
+    catch
+        error:invalid_message ->
+            ok
+    end.
+
 encode(Header, Body) ->
     S1 = <<Header/binary, Body/binary>>,
     Crc = make_crc(S1, undefined),

--- a/changes/ee/fix-14276.en.md
+++ b/changes/ee/fix-14276.en.md
@@ -1,0 +1,1 @@
+Improve error logging when JT/T808 message parsing fails


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13530

Release version: v/e5.8.3

Before this fix:
```
{"time":"2024-11-25T05:45:47.255611+00:00","level":"error","msg":"supervisor: {esockd_connection_sup,<0.43610.0>}, errorContext: connection_crashed, reason: #{context => {invalid_ejson,{error,invalid_message}},stacktrace => [{jiffy,encode,2,[{file,\"jiffy.erl\"},{line,100}]},{emqx_utils_json,encode,1,[{file,\"emqx_utils_json.erl\"},{line,68}]},{emqx_jt808_channel,do_publish,2,[{file,\"emqx_jt808_channel.erl\"},{line,348}]},{emqx_jt808_channel,do_handle_in,2,[{file,\"emqx_jt808_channel.erl\"},{line,333}]},{emqx_gateway_conn,with_channel,3,[{file,\"emqx_gateway_conn.erl\"},{line,790}]},{emqx_gateway_conn,process_msg,2,[{file,\"emqx_gateway_conn.erl\"},{line,427}]},{emqx_gateway_conn,process_msg,2,[{file,\"emqx_gateway_conn.erl\"},{line,433}]},{emqx_gateway_conn,handle_recv,3,[{file,\"emqx_gateway_conn.erl\"},{line,390}]},{proc_lib,wake_up,3,[{file,\"proc_lib.erl\"},{line,251}]}],exception => error}, offender: [{pid,<0.43610.0>},{name,connection},{mfargs,{emqx_gateway_conn,start_link,[#{message_queue_len => 10,ctx => #{cm => <0.4613.0>,gwname => jt808},proto => #{auth => #{allow_anonymous => true},dn_topic => <<\"jt808/${clientid}/${phone}/dn\">>,up_topic => <<\"jt808/${clientid}/${phone}/up\">>},enable => true,frame => #{max_length => 8192},listener => {jt808,tcp,default},proxy_protocol => false,access_rules => [],proxy_protocol_timeout => 3000,idle_timeout => 30000,enable_authn => true,mountpoint => <<>>,retry_interval => 8000,enable_stats => true,max_retry_times => 3,frame_mod => emqx_jt808_frame,chann_mod => emqx_jt808_channel}]}}]","domain":["supervisor_report"],"pid":"<0.4629.0>","error_logger":{"type":"supervisor_report","tag":"error_report"}}
```

After this fixes, it's more easy to understand what happen
```
2024-11-25T15:25:09.836603+08:00 [error] msg: parse_frame_failed, peername: 127.0.0.1:52920, reason: invalid_message, stacktrace: [{emqx_jt808_frame,parse_message_body,2,[{file,"emqx_jt808_frame.erl"},{line,299}]},{emqx_jt808_frame,parse_message,1,[{file,"emqx_jt808_frame.erl"},{line,130}]},{emqx_jt808_frame,escape_frame,2,[{file,"emqx_jt808_frame.erl"},{line,99}]},{emqx_gateway_conn,parse_incoming,3,[{file,"emqx_gateway_conn.erl"},{line,731}]},{emqx_gateway_conn,parse_incoming,2,[{file,"emqx_gateway_conn.erl"},{line,724}]},{emqx_gateway_conn,process_msg,2,[{file,"emqx_gateway_conn.erl"},{line,427}]},{emqx_gateway_conn,handle_recv,3,[{file,"emqx_gateway_conn.erl"},{line,390}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,251}]}], at_state: #{data => <<>>,phase => searching_head_hex7e}, input_bytes: <<126,2,5,0,128,1,137,96,146,0,51,3,64,72,66,77,54,48,49,67,86,77,48,53,54,51,52,50,48,50,52,45,48,56,45,49,54,253,255,2,0,255,127,0,128,80,17,1,54,69,67,56,48,48,77,58,32,49,44,34,51,50,51,65,56,54,56,48,49,57,48,55,51,55,48,51,50,50,54,52,54,48,48,56,56,53,53,52,49,48,48,52,57,56,56,57,56,54,48,...>>
```

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~Added property-based tests for code which performs user input validation~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
