### PR TITLE
feat(quic): bump to quicer 0.1.9

### DIFF
--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -25,7 +25,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.0"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.6"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.9"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/changes/ce/feat-14283.en.md
+++ b/changes/ce/feat-14283.en.md
@@ -1,0 +1,7 @@
+Improve QUIC transport, bump quicer to 0.1.9.
+
+- Early release remote stream resource in the abnormal scenario.
+- Bring in more troubleshooting APIs
+
+ref: 
+https://github.com/emqx/quic/compare/0.1.6...0.1.9

--- a/mix.exs
+++ b/mix.exs
@@ -1211,7 +1211,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.1.6", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.1.9", override: true}
       ],
       else: []
   end

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.6"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.9"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.12"}}}.


### PR DESCRIPTION
Various updates for QUIC transport

notable changes: 
- remote stream process is now monitored by NIF, free the stream resource earlier.
- added a few more APIs for debugging.


https://github.com/emqx/quic/compare/0.1.6...0.1.9

Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
