### PR TITLE
refactor: call crypto:pbkdf2_hmac

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -33,7 +33,6 @@
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
-    {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.6"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}}
 ]}.

--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -140,10 +140,17 @@ compare_secure([], [], Result) ->
     Result == 0.
 
 pbkdf2(MacFun, Password, Salt, Iterations, undefined) ->
-    pbkdf2:pbkdf2(MacFun, Password, Salt, Iterations);
+    DKLength = dk_length(MacFun),
+    pbkdf2(MacFun, Password, Salt, Iterations, DKLength);
 pbkdf2(MacFun, Password, Salt, Iterations, DKLength) ->
-    pbkdf2:pbkdf2(MacFun, Password, Salt, Iterations, DKLength).
+    crypto:pbkdf2_hmac(MacFun, Password, Salt, Iterations, DKLength).
 
 hex(X) when is_binary(X) ->
-    %% TODO: change to binary:encode_hex(X, lowercase) when OTP version is always > 25
+    %% TODO: change to binary:encode_hex(X, lowercase) when OTP version is always >= 26
     string:lowercase(binary:encode_hex(X)).
+
+dk_length(sha) -> 20;
+dk_length(sha224) -> 28;
+dk_length(sha256) -> 32;
+dk_length(sha384) -> 48;
+dk_length(sha512) -> 64.

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
@@ -87,8 +87,12 @@ fields(pbkdf2) ->
         {name, sc(pbkdf2, #{required => true, desc => "PBKDF2 password hashing."})},
         {mac_fun,
             sc(
-                hoconsc:enum([md4, md5, ripemd160, sha, sha224, sha256, sha384, sha512]),
-                #{required => true, desc => "Specifies mac_fun for PBKDF2 hashing algorithm."}
+                hoconsc:enum([sha, sha224, sha256, sha384, sha512]),
+                #{
+                    required => false,
+                    default => sha,
+                    desc => "The hash algorithm used by HMAC."
+                }
             )},
         {iterations,
             sc(

--- a/mix.exs
+++ b/mix.exs
@@ -121,7 +121,6 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:minirest),
       common_dep(:ecpool),
       common_dep(:replayq),
-      common_dep(:pbkdf2),
       # maybe forbid to fetch quicer
       common_dep(:emqtt),
       common_dep(:rulesql),
@@ -232,9 +231,6 @@ defmodule EMQXUmbrella.MixProject do
     do: {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2", override: true}
 
   def common_dep(:rulesql), do: {:rulesql, github: "emqx/rulesql", tag: "0.2.1"}
-
-  def common_dep(:pbkdf2),
-    do: {:pbkdf2, github: "emqx/erlang-pbkdf2", tag: "2.0.4", override: true}
 
   def common_dep(:bcrypt),
     do: {:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.2", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -89,7 +89,6 @@
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.10"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.10"}}},
-    {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x


### PR DESCRIPTION
Release version: v/e5.9.0

## Summary

- stop using the pbkdf2 dependency, call crypto:pbkdf2_hmac/5 
- no longer support md4, md5 and ripemd160 hmac digest hash algorithms

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
