### PR TITLE
fix(mgmt): drop incorrect but inactive clause in paging accumulation

### DIFF
--- a/changes/ce/fix-14317.en.md
+++ b/changes/ce/fix-14317.en.md
@@ -1,0 +1,1 @@
+Prevent potential issues where APIs involving paging may return empty pages, in case the internal APIs will be subtly misused in the future.


### PR DESCRIPTION
Release version: v5.8.4 (?)

## Summary

This will make paging accumulation work in more general cases (as shown by the proptest). Before this commit, feeding node-query results containing more than `Limit` number of rows produced incorrect results. However, there is no evidence this incorrect codepath was ever active.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
