### PR TITLE
fix(http action): correctly initialize resource state

### DIFF
--- a/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_http, [
     {description, "EMQX HTTP Bridge and Connector Application"},
-    {vsn, "0.3.5"},
+    {vsn, "0.3.6"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, ehttpc]},
     {env, [

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -236,7 +236,8 @@ on_start(
         port => Port,
         connect_timeout => ConnectTimeout,
         scheme => Scheme,
-        request => preprocess_request(maps:get(request, Config, undefined))
+        request => preprocess_request(maps:get(request, Config, undefined)),
+        installed_actions => #{}
     },
     case start_pool(InstId, PoolOpts) of
         ok ->

--- a/changes/ce/fix-14318.en.md
+++ b/changes/ce/fix-14318.en.md
@@ -1,0 +1,7 @@
+Fixed the initialization of the HTTP connector state.  When there was incoming traffic being handled by an HTTP action and its underlying connector restarted, cryptic crashes could be seen in the logs mentioning `function_clause`.
+
+Example:
+
+```
+20:42:36.850 [error] msg: "resource_exception", info: #{error => {error, function_clause}, id => <<"action:http:a:connector:http:a">>, name => call_query, ...
+```


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13608

Release version: v/e5.8.4

## Summary


Due to incorrect state initialization, a function clause that was supposed to match incoming messages fails, and later, after the message is transformed according to the wrong clauses, it leads to a cryptic function_clause error.

Adding more context:

```
2024-12-02T16:49:15.039945+00:00 [warning] msg: retrying_inflight_sync, where: {emqx_resource_buffer_worker,482,'emqx@127.0.0.1',<0.5531.0>}, query: {query,{fun emqx_rule_runtime:inc_action_metrics/2,[#{action_id => {bridge_v2,http,a},rule_id => <<"rule_zqm3">>}],#{reply_dropped => true}},{<<"action:http:a:connector:http:a">>,#{flags => #{dup => false,retain => false},id => <<"0006284C5426FF2AF4450000175B0169">>,node => 'emqx@127.0.0.1',timestamp => 1733158154731,peername => <<"172.100.239.1:33228">>,metadata => #{rule_id => <<"rule_zqm3">>},event => 'message.publish',username => undefined,payload => <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">>,topic => <<"t/http">>,peerhost => <<"172.100.239.1">>,client_attrs => #{},clientid => <<"caribdis_bench_pub_3720746245_6">>,qos => 0,pub_props => #{'User-Property' => #{}},publish_received_at => 1733158154731}},true,-576460668807281086,undefined}, stk: {current_stacktrace,[{emqx_resource_buffer_worker,retry_inflight_sync,3,[{file,"src/emqx_resource_buffer_worker.erl"},{line,482}]},{gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1395}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}
2024-12-02T16:49:15.040025+00:00 [error] tag: ERROR, msg: resource_exception, info: #{error => {error,{invalid_request,#{request => #{flags => #{dup => false,retain => false},id => <<"0006284C5426FEE6F4450000175E0169">>,node => 'emqx@127.0.0.1',timestamp => 1733158154731,peername => <<"172.100.239.1:33254">>,metadata => #{rule_id => <<"rule_zqm3">>},event => 'message.publish',username => undefined,payload => <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">>,topic => <<"t/http">>,peerhost => <<"172.100.239.1">>,client_attrs => #{},clientid => <<"caribdis_bench_pub_3711830288_8">>,qos => 0,pub_props => #{'User-Property' => #{}},publish_received_at => 1733158154731},method => <<"action:http:a:connector:http:a">>,base_path => "/"}}},id => <<"action:http:a:connector:http:a">>,name => call_query,request => {<<"action:http:a:connector:http:a">>,#{flags => #{dup => false,retain => false},id => <<"0006284C5426FEE6F4450000175E0169">>,node => 'emqx@127.0.0.1',timestamp => 1733158154731,peername => <<"172.100.239.1:33254">>,metadata => #{rule_id => <<"rule_zqm3">>},event => 'message.publish',username => undefined,payload => <<"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa">>,topic => <<"t/http">>,peerhost => <<"172.100.239.1">>,client_attrs => #{},clientid => <<"caribdis_bench_pub_3711830288_8">>,qos => 0,pub_props => #{'User-Property' => #{}},publish_received_at => 1733158154731}},stacktrace => [{emqx_bridge_http_connector,formalize_request,3,[{file,"src/emqx_bridge_http_connector.erl"},{line,865}]},{emqx_bridge_http_connector,on_query,3,[{file,"src/emqx_bridge_http_connector.erl"},{line,385}]},{emqx_resource_buffer_worker,apply_query_fun,9,[{file,"src/emqx_resource_buffer_worker.erl"},{line,1412}]},{emqx_resource_buffer_worker,call_query2,8,[{file,"src/emqx_resource_buffer_worker.erl"},{line,1250}]},{emqx_resource_buffer_worker,retry_inflight_sync,3,[{file,"src/emqx_resource_buffer_worker.erl"},{line,483}]},{gen_statem,loop_state_callback,11,[{file,"gen_statem.erl"},{line,1395}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}
```

Cause: lack of `installed_actions` key in connector state returned by on_start, and the connector restarting amidst ongoing traffic.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
