### PR TITLE
ci: sign libquicer_nif.dylib for macOS

### DIFF
--- a/scripts/rel/macos-sign-binaries.sh
+++ b/scripts/rel/macos-sign-binaries.sh
@@ -18,7 +18,7 @@ if [ "$(uname)" != 'Darwin' ]; then
 fi
 
 if [ "${APPLE_SIGN_BINARIES:-0}" == 0 ]; then
-n    echo "Signing Apple binaries is disabled, exiting"
+    echo "Signing Apple binaries is disabled, exiting"
     exit 0
 fi
 
@@ -80,6 +80,7 @@ for f in \
         jiffy.so \
         liberocksdb.so \
         libquicer_nif.so \
+        libquicer_nif*.dylib \
         odbcserver \
         otp_test_engine.so \
         sasl_auth.so \


### PR DESCRIPTION
Fixes an issue with notarization of macOS packages.

Release version: v/e5.8.3

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
