### PR TITLE
detach perf test and rerun apps version check workflows

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -105,15 +105,6 @@ jobs:
       builder_vsn: ${{ needs.init.outputs.BUILDER_VSN }}
     secrets: inherit
 
-  performance_test:
-    if: needs.prepare.outputs.release == 'true'
-    needs:
-      - init
-      - prepare
-      - build_packages
-    uses: ./.github/workflows/performance_test.yaml
-    secrets: inherit
-
   build_and_push_docker_images:
     if: needs.prepare.outputs.release == 'true'
     needs:
@@ -177,6 +168,19 @@ jobs:
             _build/docgen/${{ matrix.profile }}/*.hocon
           retention-days: 7
 
+  performance_test:
+    if: needs.prepare.outputs.release == 'true'
+    needs:
+      - init
+      - prepare
+      - build_packages
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
+    steps:
+      - name: Trigger performance test
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh --repo ${{ github.repository }} workflow run performance_test.yaml -f version=${GITHUB_REF_NAME##[v|e]} 
   update_emqx_i18n:
     if: needs.prepare.outputs.release == 'true'
     needs:

--- a/.github/workflows/performance_test.yaml
+++ b/.github/workflows/performance_test.yaml
@@ -1,25 +1,12 @@
 name: Performance Test
 
 on:
-  workflow_call:
-    secrets:
-      AWS_ACCESS_KEY_PERF_TEST:
-        required: true
-      AWS_SECRET_ACCESS_KEY_PERF_TEST:
-        required: true
-      AWS_DEFAULT_REGION_PERF_TEST:
-        required: true
-      SLACK_BOT_TOKEN:
-        required: true
-      SLACK_PERFTEST_CHANNEL_ID:
-        required: true
-      EMQX_ENTERPRISE_LICENSE:
-        required: true
   workflow_dispatch:
     inputs:
-      emqx_version:
+      version:
         required: false
-        default: '5.8.0'
+      download_url:
+        required: false
 
 permissions:
   contents: read
@@ -37,35 +24,61 @@ jobs:
         shell: bash
 
     steps:
+    - name: Checkout tf-emqx-performance-test
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      with:
+        repository: emqx/tf-emqx-performance-test
+        ref: v0.3.2
+
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+      with:
+        terraform_version: 1.6.4
+        terraform_wrapper: false
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+
+    - run: pip install -r requirements.txt
+
+    - name: Download emqx package (custom URL)
+      if: github.event.inputs.version == '' && github.event.inputs.download_url != ''
+      run: |
+        wget "${{ github.event.inputs.download_url }}"
+
+    - uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
+
+    - name: Download emqx package (specific version)
+      env:
+        AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+      if: github.event.inputs.version != '' && github.event.inputs.download_url == ''
+      run: |
+        version=${{ github.event.inputs.version }}
+        aws s3 cp s3://$AWS_S3_BUCKET/emqx-ee/${version}/emqx-enterprise-${version}-ubuntu22.04-amd64.deb .
+
+    - name: Download emqx package (latest version)
+      if: github.event.inputs.version == '' && github.event.inputs.download_url == ''
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -xeuo pipefail
+        # get latest emqx version
+        version=$(gh release list --repo emqx/emqx --limit 1 --json tagName --jq '.[] | .tagName')
+        # remove 'v' prefix from the version
+        version=${version:1}
+        wget https://www.emqx.com/en/downloads/enterprise/${version}/emqx-enterprise-${version}-ubuntu22.04-amd64.deb
+
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
       with:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PERF_TEST }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_PERF_TEST }}
         aws-region: ${{ secrets.AWS_DEFAULT_REGION_PERF_TEST }}
-    - name: Checkout tf-emqx-performance-test
-      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      with:
-        repository: emqx/tf-emqx-performance-test
-        ref: v0.3.2
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
-      with:
-        terraform_version: 1.6.4
-        terraform_wrapper: false
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - run: pip install -r requirements.txt
-    - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
-      if: github.event_name != 'workflow_dispatch'
-      with:
-        pattern: "emqx-enterprise-ubuntu22.04-amd64-*"
-    - name: Download emqx package
-      if: github.event_name == 'workflow_dispatch'
-      run: |
-        version=${{ github.event.inputs.emqx_version }}
-        wget https://www.emqx.com/en/downloads/enterprise/${version}/emqx-enterprise-${version}-ubuntu22.04-amd64.deb
 
     - name: Create infrastructure
       id: infra
@@ -100,7 +113,7 @@ jobs:
     - name: Report failure
       if: failure()
       run: |
-        jq -n '[{"color": "#ff0000", "fields": [{"title": "Infrastructure creation failed", "short": false}]}]' > attachments.json
+        jq -n '[{"color": "#ff0000", "fields": [{"title": "Failed to provision infrastructure", "short": false}]}]' > attachments.json
         jq -n --argjson attachments "$(<attachments.json)" '{"attachments": $attachments}' > slack-payload.json
 
     - name: Run benchmark

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,21 +122,3 @@ jobs:
           push "amazon/2" "packages/$PROFILE-$VERSION-amzn2-arm64.rpm"
           push "amazon/2023" "packages/$PROFILE-$VERSION-amzn2023-amd64.rpm"
           push "amazon/2023" "packages/$PROFILE-$VERSION-amzn2023-arm64.rpm"
-
-  rerun-apps-version-check:
-    runs-on: ubuntu-22.04
-    if: github.repository_owner == 'emqx' && github.event_name == 'release'
-    needs:
-      - upload
-    permissions:
-      pull-requests: read
-      checks: write
-      actions: write
-    steps:
-      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
-      - name: trigger re-run of app versions check on open PRs
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          python3 scripts/rerun-apps-version-check.py

--- a/.github/workflows/rerun-apps-version-check.yaml
+++ b/.github/workflows/rerun-apps-version-check.yaml
@@ -1,0 +1,28 @@
+name: Rerun apps version check
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Upload release assets"
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  rerun-apps-version-check:
+    runs-on: ubuntu-22.04
+    if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: read
+      checks: write
+      actions: write
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+      - name: trigger re-run of app versions check on open PRs
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/rerun-apps-version-check.py


### PR DESCRIPTION
1. Fix some issues in perf test workflow, and detach it from push entrypoint, so that it does not fail when performance test fails
2. Move rerun-apps-version-check to a separate workflow so that it does not fail release workflow.