### PR TITLE
feat(ds): choose safe storage layout defaults in non-append-only DBs

### DIFF
--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.app.src
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.app.src
@@ -2,7 +2,7 @@
 {application, emqx_ds_builtin_local, [
     {description, "A DS backend that stores all data locally and thus doesn't support clustering."},
     % strict semver, bump manually!
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, gproc, mria, rocksdb, emqx_durable_storage, emqx_utils]},

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -123,8 +123,8 @@
 -spec open_db(emqx_ds:db(), db_opts()) -> ok | {error, _}.
 open_db(DB, CreateOpts0) ->
     %% Rename `append_only' flag to `force_monotonic_timestamps':
-    {AppendOnly, CreateOpts1} = maps:take(append_only, CreateOpts0),
-    CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts1),
+    AppendOnly = maps:get(append_only, CreateOpts0),
+    CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts0),
     case emqx_ds_builtin_local_sup:start_db(DB, CreateOpts) of
         {ok, _} ->
             ok;

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -196,8 +196,8 @@ list_shards(DB) ->
 -spec open_db(emqx_ds:db(), builtin_db_opts()) -> ok | {error, _}.
 open_db(DB, CreateOpts0) ->
     %% Rename `append_only' flag to `force_monotonic_timestamps':
-    {AppendOnly, CreateOpts1} = maps:take(append_only, CreateOpts0),
-    CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts1),
+    AppendOnly = maps:get(append_only, CreateOpts0),
+    CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts0),
     case emqx_ds_builtin_raft_sup:start_db(DB, CreateOpts) of
         {ok, _} ->
             ok;

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
@@ -520,15 +520,15 @@ open_db_trans(DB, CreateOpts) ->
         [#?META_TAB{db_props = Opts}] ->
             case maps:merge(CreateOpts, Opts) of
                 Opts ->
-                    ok;
+                    Opts;
                 UpdatedOpts ->
                     %% NOTE
                     %% Preserve any new options not yet present in the DB. This is
                     %% most likely because `Opts` is outdated, written by earlier
                     %% EMQX version.
-                    mnesia:write(#?META_TAB{db = DB, db_props = UpdatedOpts})
-            end,
-            Opts
+                    mnesia:write(#?META_TAB{db = DB, db_props = UpdatedOpts}),
+                    UpdatedOpts
+            end
     end.
 
 -spec allocate_shards_trans(emqx_ds:db()) -> [emqx_ds_replication_layer:shard_id()].

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -50,6 +50,7 @@
 
 -export_type([
     create_db_opts/0,
+    db_opts/0,
     db/0,
     time/0,
     topic_filter/0,
@@ -253,6 +254,12 @@
         %% Backend-specific options:
         _ => _
     }.
+
+-type db_opts() :: #{
+    %% See respective `create_db_opts()` fields.
+    append_only => boolean(),
+    atomic_batches => boolean()
+}.
 
 -type poll_opts() ::
     #{

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_bitfield_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_bitfield_lts.erl
@@ -25,7 +25,7 @@
 
 %% behavior callbacks:
 -export([
-    create/5,
+    create/6,
     open/5,
     drop/5,
     prepare_batch/4,
@@ -202,10 +202,11 @@
     rocksdb:db_handle(),
     emqx_ds_storage_layer:gen_id(),
     options(),
-    _PrevGeneration :: s() | undefined
+    _PrevGeneration :: s() | undefined,
+    emqx_ds:db_opts()
 ) ->
     {schema(), emqx_ds_storage_layer:cf_refs()}.
-create(_ShardId, DBHandle, GenId, Options, SPrev) ->
+create(_ShardId, DBHandle, GenId, Options, SPrev, _DBOpts) ->
     %% Get options:
     BitsPerTopicLevel = maps:get(bits_per_wildcard_level, Options, 64),
     TopicIndexBytes = maps:get(topic_index_bytes, Options, 4),

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -258,6 +258,13 @@
 %% Shard (runtime):
 -type shard() :: shard(generation()).
 
+%% Which DB options to provide to the storage layout module:
+%% See `emqx_ds:db_opts()`.
+-define(STORAGE_LAYOUT_DB_OPTS, [
+    append_only,
+    atomic_batches
+]).
+
 -define(GLOBAL(K), <<"G/", K/binary>>).
 
 -type options() :: map().
@@ -278,7 +285,8 @@
     rocksdb:db_handle(),
     gen_id(),
     Options :: map(),
-    generation_data() | undefined
+    generation_data() | undefined,
+    emqx_ds:db_opts()
 ) ->
     {_Schema, cf_refs()}.
 
@@ -810,6 +818,7 @@ start_link(Shard = {_, _}, Options) ->
 -record(s, {
     shard_id :: shard_id(),
     db :: rocksdb:db_handle(),
+    db_opts :: emqx_ds:db_opts(),
     cf_refs :: cf_refs(),
     cf_need_flush :: gen_id(),
     schema :: shard_schema(),
@@ -831,8 +840,7 @@ init({ShardId, Options}) ->
     {Schema, CFRefs} =
         case get_schema_persistent(DB) of
             not_found ->
-                Prototype = maps:get(storage, Options),
-                create_new_shard_schema(ShardId, DB, CFRefs0, Prototype);
+                create_new_shard_schema(ShardId, DB, CFRefs0, Options);
             Scm ->
                 {Scm, CFRefs0}
         end,
@@ -841,6 +849,7 @@ init({ShardId, Options}) ->
     S = #s{
         shard_id = ShardId,
         db = DB,
+        db_opts = filter_layout_db_opts(Options),
         cf_refs = CFRefs,
         cf_need_flush = CurrentGenId,
         schema = Schema,
@@ -990,13 +999,23 @@ open_shard(ShardId, DB, CFRefs, ShardSchema) ->
 
 -spec handle_add_generation(server_state(), emqx_ds:time()) ->
     server_state() | {error, overlaps_existing_generations}.
-handle_add_generation(S0, Since) ->
-    #s{shard_id = ShardId, db = DB, schema = Schema0, shard = Shard0, cf_refs = CFRefs0} = S0,
+handle_add_generation(
+    S0 = #s{
+        shard_id = ShardId,
+        db = DB,
+        db_opts = DBOpts,
+        schema = Schema0,
+        shard = Shard0,
+        cf_refs = CFRefs0
+    },
+    Since
+) ->
     Schema1 = update_last_until(Schema0, Since),
     Shard1 = update_last_until(Shard0, Since),
     case Schema1 of
         _Updated = #{} ->
-            {GenId, Schema, NewCFRefs} = new_generation(ShardId, DB, Schema1, Shard0, Since),
+            {GenId, Schema, NewCFRefs} =
+                new_generation(ShardId, DB, Schema1, Shard0, Since, DBOpts),
             CFRefs = NewCFRefs ++ CFRefs0,
             Key = ?GEN_KEY(GenId),
             Generation = open_generation(ShardId, DB, CFRefs, GenId, maps:get(Key, Schema)),
@@ -1097,32 +1116,30 @@ open_generation(ShardId, DB, CFRefs, GenId, GenSchema) ->
     RuntimeData = Mod:open(ShardId, DB, GenId, CFRefs, Schema),
     GenSchema#{data => RuntimeData}.
 
--spec create_new_shard_schema(shard_id(), rocksdb:db_handle(), cf_refs(), prototype()) ->
+-spec create_new_shard_schema(shard_id(), rocksdb:db_handle(), cf_refs(), emqx_ds:create_db_opts()) ->
     {shard_schema(), cf_refs()}.
-create_new_shard_schema(ShardId, DB, CFRefs, Prototype) ->
+create_new_shard_schema(ShardId, DB, CFRefs, Options = #{storage := Prototype}) ->
     ?tp(notice, ds_create_new_shard_schema, #{shard => ShardId, prototype => Prototype}),
     %% TODO: read prototype from options/config
     Schema0 = #{
         current_generation => 0,
         prototype => Prototype
     },
-    {_NewGenId, Schema, NewCFRefs} = new_generation(ShardId, DB, Schema0, _Since = 0),
+    DBOpts = filter_layout_db_opts(Options),
+    {_NewGenId, Schema, NewCFRefs} =
+        new_generation(ShardId, DB, Schema0, undefined, _Since = 0, DBOpts),
     {Schema, NewCFRefs ++ CFRefs}.
-
--spec new_generation(shard_id(), rocksdb:db_handle(), shard_schema(), emqx_ds:time()) ->
-    {gen_id(), shard_schema(), cf_refs()}.
-new_generation(ShardId, DB, Schema0, Since) ->
-    new_generation(ShardId, DB, Schema0, undefined, Since).
 
 -spec new_generation(
     shard_id(),
     rocksdb:db_handle(),
     shard_schema(),
     shard() | undefined,
-    emqx_ds:time()
+    emqx_ds:time(),
+    emqx_ds:db_opts()
 ) ->
     {gen_id(), shard_schema(), cf_refs()}.
-new_generation(ShardId, DB, Schema0, Shard0, Since) ->
+new_generation(ShardId, DB, Schema0, Shard0, Since, DBOpts) ->
     #{current_generation := PrevGenId, prototype := {Mod, ModConf}} = Schema0,
     case Shard0 of
         #{?GEN_KEY(PrevGenId) := #{module := Mod} = PrevGen} ->
@@ -1132,8 +1149,9 @@ new_generation(ShardId, DB, Schema0, Shard0, Since) ->
         _ ->
             PrevRuntimeData = undefined
     end,
+    %% Provide a small subset of DB options to the storage layout module.
     GenId = next_generation_id(PrevGenId),
-    {GenData, NewCFRefs} = Mod:create(ShardId, DB, GenId, ModConf, PrevRuntimeData),
+    {GenData, NewCFRefs} = Mod:create(ShardId, DB, GenId, ModConf, PrevRuntimeData, DBOpts),
     GenSchema = #{
         module => Mod,
         data => GenData,
@@ -1283,6 +1301,9 @@ handle_event(Shard, Time, ?storage_event(GenId, Event)) ->
 handle_event(Shard, Time, Event) ->
     GenId = generation_current(Shard),
     handle_event(Shard, Time, ?mk_storage_event(GenId, Event)).
+
+filter_layout_db_opts(Options) ->
+    maps:with(?STORAGE_LAYOUT_DB_OPTS, Options).
 
 %%--------------------------------------------------------------------------------
 

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_reference.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_reference.erl
@@ -30,7 +30,7 @@
 
 %% behavior callbacks:
 -export([
-    create/5,
+    create/6,
     open/5,
     drop/5,
     prepare_batch/4,
@@ -98,7 +98,7 @@
 %% behavior callbacks
 %%================================================================================
 
-create(_ShardId, DBHandle, GenId, _Options, _SPrev) ->
+create(_ShardId, DBHandle, GenId, _Options, _SPrev, _DBOpts) ->
     CFName = data_cf(GenId),
     {ok, CFHandle} = rocksdb:create_column_family(DBHandle, CFName, []),
     Schema = #schema{},

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_reference.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_reference.erl
@@ -57,8 +57,6 @@
 
 -include_lib("emqx_utils/include/emqx_message.hrl").
 
--define(DB_KEY(TIMESTAMP), <<TIMESTAMP:64>>).
-
 %%================================================================================
 %% Type declarations
 %%================================================================================
@@ -71,7 +69,8 @@
 %% Runtime state:
 -record(s, {
     db :: rocksdb:db_handle(),
-    cf :: rocksdb:cf_handle()
+    cf :: rocksdb:cf_handle(),
+    topic_hash_bytes :: non_neg_integer()
 }).
 
 -record(stream, {}).
@@ -98,16 +97,27 @@
 %% behavior callbacks
 %%================================================================================
 
-create(_ShardId, DBHandle, GenId, _Options, _SPrev, _DBOpts) ->
+create(_ShardId, DBHandle, GenId, _Options, _SPrev, DBOpts) ->
     CFName = data_cf(GenId),
     {ok, CFHandle} = rocksdb:create_column_family(DBHandle, CFName, []),
-    Schema = #schema{},
+    case DBOpts of
+        #{append_only := true} -> THB = 0;
+        _NonAppendOnly -> THB = 8
+    end,
+    Schema = #{
+        topic_hash_bytes => THB
+    },
     {Schema, [{CFName, CFHandle}]}.
 
-open({DB, _}, DBHandle, GenId, CFRefs, #schema{}) ->
+open({DB, _}, DBHandle, GenId, CFRefs, Schema) ->
     {_, CF} = lists:keyfind(data_cf(GenId), 1, CFRefs),
     emqx_ds_new_streams:notify_new_stream(DB, ['#']),
-    #s{db = DBHandle, cf = CF}.
+    #s{db = DBHandle, cf = CF, topic_hash_bytes = schema_topic_hash_bytes(Schema)}.
+
+schema_topic_hash_bytes(#{topic_hash_bytes := THB}) ->
+    THB;
+schema_topic_hash_bytes(#schema{}) ->
+    0.
 
 drop(_ShardId, DBHandle, _GenId, _CFRefs, #s{cf = CFHandle}) ->
     ok = rocksdb:drop_column_family(DBHandle, CFHandle),
@@ -123,11 +133,11 @@ commit_batch(_ShardId, S = #s{db = DB}, Batch, Options) ->
     rocksdb:release_batch(BatchHandle),
     Res.
 
-process_batch_operation(S, {TS, Msg = #message{}}, BatchHandle) ->
+process_batch_operation(S, {TS, Msg = #message{topic = Topic}}, BatchHandle) ->
     Val = encode_message(Msg),
-    rocksdb:batch_put(BatchHandle, S#s.cf, ?DB_KEY(TS), Val);
-process_batch_operation(S, {delete, #message_matcher{timestamp = TS}}, BatchHandle) ->
-    rocksdb:batch_delete(BatchHandle, S#s.cf, ?DB_KEY(TS)).
+    rocksdb:batch_put(BatchHandle, S#s.cf, db_key(S, TS, Topic), Val);
+process_batch_operation(S, {delete, #message_matcher{timestamp = TS, topic = Topic}}, BatchHandle) ->
+    rocksdb:batch_delete(BatchHandle, S#s.cf, db_key(S, TS, Topic)).
 
 get_streams(_Shard, _Data, _TopicFilter, _StartTime) ->
     [#stream{}].
@@ -215,8 +225,8 @@ delete_next(_Shard, #s{db = DB, cf = CF}, It0, Selector, BatchSize, _Now, IsCurr
             {ok, It, NumDeleted, NumIterated}
     end.
 
-lookup_message(_ShardId, #s{db = DB, cf = CF}, #message_matcher{timestamp = TS}) ->
-    case rocksdb:get(DB, CF, ?DB_KEY(TS), _ReadOpts = []) of
+lookup_message(_ShardId, S = #s{db = DB, cf = CF}, #message_matcher{timestamp = TS, topic = Topic}) ->
+    case rocksdb:get(DB, CF, db_key(S, TS, Topic), _ReadOpts = []) of
         {ok, Val} ->
             decode_message(Val);
         not_found ->
@@ -270,7 +280,7 @@ do_next(_, _, _, _, 0, Key, Acc) ->
     {Key, Acc};
 do_next(TopicFilter, StartTime, IT, Action, NLeft, Key0, Acc) ->
     case rocksdb:iterator_move(IT, Action) of
-        {ok, Key = <<TS:64>>, Blob} ->
+        {ok, Key = <<TS:64, _TopicHashOpt/bytes>>, Blob} ->
             Msg = #message{topic = Topic} = decode_message(Blob),
             TopicWords = emqx_topic:words(Topic),
             case emqx_topic:match(TopicWords, TopicFilter) andalso TS >= StartTime of
@@ -341,6 +351,12 @@ do_delete_next(
         {error, invalid_iterator} ->
             {Key0, {AccDel, AccIter}}
     end.
+
+db_key(#s{topic_hash_bytes = 0}, TS, _Topic) ->
+    <<TS:64>>;
+db_key(#s{topic_hash_bytes = THB}, TS, Topic) ->
+    <<Hash:THB/bytes, _/bytes>> = erlang:md5(Topic),
+    <<TS:64, Hash/bytes>>.
 
 encode_message(Msg) ->
     term_to_binary(Msg).

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_skipstream_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_skipstream_lts.erl
@@ -22,7 +22,7 @@
 
 %% behavior callbacks:
 -export([
-    create/5,
+    create/6,
     open/5,
     drop/5,
     prepare_batch/4,
@@ -107,7 +107,6 @@
         %% Default is 0. Setting to non-zero makes sense if you plan to use this layout
         %% in non-append-only DBs.
         master_hash_bytes => pos_integer(),
-        keep_message_id := boolean(),
         serialization_schema := emqx_ds_msg_serializer:schema(),
         with_guid := boolean(),
         lts_threshold_spec => emqx_ds_lts:threshold_spec()
@@ -159,10 +158,15 @@
 %% behavior callbacks
 %%================================================================================
 
-create(_ShardId, DBHandle, GenId, Schema0, SPrev) ->
+create(_ShardId, DBHandle, GenId, Schema0, SPrev, DBOpts) ->
     Defaults = #{
         wildcard_hash_bytes => 8,
         topic_index_bytes => 8,
+        master_hash_bytes =>
+            case DBOpts of
+                #{append_only := true} -> 0;
+                #{} = _NonAppendOnly -> 8
+            end,
         serialization_schema => asn1,
         with_guid => false,
         lts_threshold_spec => ?DEFAULT_LTS_THRESHOLD

--- a/apps/emqx_durable_storage/test/emqx_ds_storage_layout_SUITE.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_storage_layout_SUITE.erl
@@ -43,16 +43,15 @@ all() ->
     [
         {group, bitfield_lts},
         {group, skipstream_lts},
-        {group, skipstream_lts_master_hash}
+        {group, skipstream_lts_master_hash},
+        {group, reference}
     ].
 
 init_per_group(Group, Config) ->
     LayoutConf =
         case Group of
             reference ->
-                {emqx_ds_storage_reference, #{
-                    lts_threshold_spec => ?LTS_THRESHOLD
-                }};
+                {emqx_ds_storage_reference, #{}};
             skipstream_lts ->
                 {emqx_ds_storage_skipstream_lts, #{
                     with_guid => true,
@@ -142,6 +141,10 @@ t_iterate(_Config) ->
     ok.
 
 %% Smoke test for deleting messages.
+t_delete(groups, _AllGroups) ->
+    %% NOTE: Subtly broken in general, but fails explicitly with `reference` layout.
+    [bitfield_lts, skipstream_lts].
+
 t_delete(_Config) ->
     %% Prepare data:
     TopicToDelete = <<"foo/bar/baz">>,
@@ -170,6 +173,10 @@ t_delete(_Config) ->
 
 %% Smoke test that verifies that concrete topics are mapped to
 %% individual streams, unless there's too many of them.
+t_get_streams(groups, _AllGroups) ->
+    %% NOTE: Relevant only to LTS-based layouts.
+    [bitfield_lts, skipstream_lts].
+
 t_get_streams(Config) ->
     %% Prepare data (without wildcards):
     Topics = [<<"foo/bar">>, <<"foo/bar/baz">>, <<"a">>],
@@ -220,6 +227,10 @@ t_get_streams(Config) ->
     ?assert(lists:member(FooBarBaz, AllStreams)),
     ?assert(lists:member(A, AllStreams)),
     ok.
+
+t_new_generation_inherit_trie(groups, _AllGroups) ->
+    %% NOTE: Relevant only to LTS-based layouts.
+    [bitfield_lts, skipstream_lts].
 
 t_new_generation_inherit_trie(Config) ->
     %% This test checks that we inherit the previous generation's LTS when creating a new

--- a/apps/emqx_durable_storage/test/emqx_ds_storage_layout_SUITE.erl
+++ b/apps/emqx_durable_storage/test/emqx_ds_storage_layout_SUITE.erl
@@ -344,20 +344,15 @@ t_replay_special_topics(_Config) ->
     ?assert(check(?SHARD, <<"+/test/#">>, 0, Batch1 ++ Batch2)),
     check(?SHARD, <<"$SYS/test/#">>, 0, []).
 
-t_replay_nonunique_ts(groups, _AllGroups) ->
-    %% NOTE
-    %% Only those 2 layouts support messages with non-unique timestamps (e.g. when a DB is
-    %% non-append-only), and even then there's no guarantee because of possibility of
-    %% hash collisions.
-    [bitfield_lts, skipstream_lts_master_hash];
+%% Verify that select storage layouts work properly in non-append-only context
+%% (single generation only):
+%% 1. Message timestamp is respected.
+%% 2. Message timestamp and topic uniquely identifies a message.
 t_replay_nonunique_ts(db_config, _Config) ->
+    %% NOTE: Layouts are expected to pick safe defaults for non-append-only DBs.
     #{append_only => false}.
 
 t_replay_nonunique_ts(_Config) ->
-    %% Verify that select storage layouts work properly in non-append-only context
-    %% (single generation only):
-    %% 1. Message timestamp is respected.
-    %% 2. Message timestamp and topic uniquely identifies a message.
     %% Create concrete topics:
     Topics = [<<"foo/bar">>, <<"foo/bar/baz">>, <<"foo/bar/xyz">>],
     Timestamps = lists:seq(100, 500, 100),


### PR DESCRIPTION
Followup to #14064.

Release version: v5.9 (?)

## Summary

Storage layout `create/6` callback now accepts a small subset of DB-wide options (namely, `append_only` and `atomic_batches`). Those options should help storage layout to choose safe defaults for parameters. For example, skipstream-lts layout uses them to pick non-zero `master_hash_bytes` by default in non-append-only contexts.

See individual commits for details.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
