### PR TITLE
feat: support authentication hook callback to check connection quota

### DIFF
--- a/apps/emqx/src/emqx_reason_codes.erl
+++ b/apps/emqx/src/emqx_reason_codes.erl
@@ -191,4 +191,5 @@ connack_error(server_unavailable) -> ?RC_SERVER_UNAVAILABLE;
 connack_error(server_busy) -> ?RC_SERVER_BUSY;
 connack_error(banned) -> ?RC_BANNED;
 connack_error(bad_authentication_method) -> ?RC_BAD_AUTHENTICATION_METHOD;
+connack_error(quota_exceeded) -> ?RC_QUOTA_EXCEEDED;
 connack_error(_) -> ?RC_UNSPECIFIED_ERROR.

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_SUITE.erl
@@ -329,3 +329,28 @@ t_update_conf(Config) when is_list(Config) ->
 parse(Bytes) ->
     {ok, Frame, <<>>, {none, _}} = emqx_frame:parse(Bytes),
     Frame.
+
+authenticate_return_quota_exceeded_hook(_, _) ->
+    {stop, {error, quota_exceeded}}.
+
+t_authenticate_return_quota_exceeded({init, Config}) ->
+    Priority = 0,
+    ok = emqx_hooks:put(
+        'client.authenticate', {?MODULE, authenticate_return_quota_exceeded_hook, []}, Priority
+    ),
+    Config;
+t_authenticate_return_quota_exceeded({'end', _Config}) ->
+    ok = emqx_hooks:del('client.authenticate', {?MODULE, authenticate_return_quota_exceeded_hook});
+t_authenticate_return_quota_exceeded(Config) when is_list(Config) ->
+    {ok, Client} = emqtt:start_link([
+        {clientid, <<"tests-cli1">>},
+        {password, <<"pass">>},
+        {proto_ver, v5}
+    ]),
+    _ = monitor(process, Client),
+    _ = unlink(Client),
+    ?assertMatch({error, {quota_exceeded, _}}, emqtt:connect(Client)),
+    receive
+        {'DOWN', _, process, Client, Reason} ->
+            ?assertEqual({shutdown, quota_exceeded}, Reason)
+    end.

--- a/changes/ce/feat-14341.en.md
+++ b/changes/ce/feat-14341.en.md
@@ -1,0 +1,1 @@
+Support `quota_exceeded` error reason from `client.authenticate` hook point callback.


### PR DESCRIPTION
Release version: v/e5.9.0

## Summary

This will allow multi-tenancy feature to support per-namespace session count limit.
Multi-tenancy session count limit cannot be done before client-attributes are initialized, hence cannot do it in the `client.connect` hook callback like license checks.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
~~- [ ] Added property-based tests for code which performs user input validation~~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
~~- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
~~- [ ] Schema changes are backward compatible~~

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
