### PR TITLE
241206 fix emqx usage print

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -51,109 +51,6 @@ die() {
 }
 
 THIS_SCRIPT="$0"
-# We need to find real directory with emqx files on all platforms
-# even when bin/emqx is symlinked on several levels
-# - readlink -f works perfectly, but `-f` flag has completely different meaning in BSD version,
-#   so we can't use it universally.
-# - `stat -f%R` on MacOS does exactly what `readlink -f` does on Linux, but we can't use it
-#   as a universal solution either because GNU stat has different syntax and this argument is invalid.
-#   Also, version of stat which supports this syntax is only available since MacOS 12
-if [ "$(uname -s)" == 'Darwin' ]; then
-    product_version="$(sw_vers -productVersion | cut -d '.' -f 1)"
-    if [ "$product_version" -ge 12 ]; then
-        # if homebrew coreutils package is installed, GNU version of stat can take precedence,
-        # so we use absolute path to ensure we are calling MacOS default
-        RUNNER_ROOT_DIR="$(cd "$(dirname "$(/usr/bin/stat -f%R "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
-    else
-        # try our best to resolve link on MacOS <= 11
-        RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
-    fi
-else
-    RUNNER_ROOT_DIR="$(cd "$(dirname "$(realpath "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
-fi
-
-COMMAND="${1:-}"
-GREP='grep --color=never'
-
-if [ -z "$COMMAND" ]; then
-    usage 'help'
-    exit 1
-elif [ "$COMMAND" = 'help' ]; then
-    usage 'help'
-    exit 0
-fi
-
-if [ "${2:-}" = 'help' ]; then
-    ## 'ctl' command has its own usage info
-    if [ "$COMMAND" != 'ctl' ]; then
-        usage "$COMMAND"
-        exit 0
-    fi
-fi
-
-## IS_BOOT_COMMAND is set for later to inspect node name and cookie from hocon config (or env variable)
-case "${COMMAND}" in
-    start|console|console_clean|foreground|check_config)
-        IS_BOOT_COMMAND='yes'
-        ;;
-    ertspath)
-        echo "$ERTS_DIR"
-        exit 0
-        ;;
-    root_dir)
-        echo "$RUNNER_ROOT_DIR"
-        exit 0
-        ;;
-    *)
-        IS_BOOT_COMMAND='no'
-        ;;
-esac
-
-RELUP_DIR="relup"
-BASE_RUNNER_ROOT_DIR="${BASE_RUNNER_ROOT_DIR:-$RUNNER_ROOT_DIR}"
-RELUP_PATH="$RUNNER_ROOT_DIR/$RELUP_DIR"
-
-if [ -f "$RELUP_PATH/version" ]; then
-    TARGET_VSN=$(cat "$RELUP_PATH/version")
-    export BASE_RUNNER_ROOT_DIR
-    ## only print for boot commands to avoid messing the CLI outputs
-    if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
-        loginfo "Loading emqx from hot-upgrade dir: $RELUP_PATH"
-    fi
-    exec "$RELUP_PATH/$TARGET_VSN"/bin/emqx "$@"
-fi
-
-# shellcheck disable=SC1090,SC1091
-. "$RUNNER_ROOT_DIR"/releases/emqx_vars
-
-# defined in emqx_vars
-export RUNNER_ROOT_DIR
-export EMQX_ETC_DIR
-export REL_VSN
-export SCHEMA_MOD
-export IS_ENTERPRISE
-
-RUNNER_SCRIPT="$RUNNER_BIN_DIR/$REL_NAME"
-CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
-REL_DIR="$RUNNER_ROOT_DIR/releases/$REL_VSN"
-
-WHOAMI=$(whoami 2>/dev/null || id -u)
-
-# hocon try to read environment variables starting with "EMQX_"
-export HOCON_ENV_OVERRIDE_PREFIX='EMQX_'
-
-export ERTS_DIR="$RUNNER_ROOT_DIR/erts-$ERTS_VSN"
-export BINDIR="$ERTS_DIR/bin"
-export EMU="beam"
-export PROGNAME="erl"
-export ERTS_LIB_DIR="$RUNNER_ROOT_DIR/lib"
-DYNLIBS_DIR="$RUNNER_ROOT_DIR/dynlibs"
-
-assert_node_alive() {
-    if ! relx_nodetool "ping" > /dev/null; then
-        exit 1
-    fi
-}
 
 usage() {
     local command="$1"
@@ -296,6 +193,109 @@ usage() {
     esac
 }
 
+# We need to find real directory with emqx files on all platforms
+# even when bin/emqx is symlinked on several levels
+# - readlink -f works perfectly, but `-f` flag has completely different meaning in BSD version,
+#   so we can't use it universally.
+# - `stat -f%R` on MacOS does exactly what `readlink -f` does on Linux, but we can't use it
+#   as a universal solution either because GNU stat has different syntax and this argument is invalid.
+#   Also, version of stat which supports this syntax is only available since MacOS 12
+if [ "$(uname -s)" == 'Darwin' ]; then
+    product_version="$(sw_vers -productVersion | cut -d '.' -f 1)"
+    if [ "$product_version" -ge 12 ]; then
+        # if homebrew coreutils package is installed, GNU version of stat can take precedence,
+        # so we use absolute path to ensure we are calling MacOS default
+        RUNNER_ROOT_DIR="$(cd "$(dirname "$(/usr/bin/stat -f%R "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
+    else
+        # try our best to resolve link on MacOS <= 11
+        RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
+    fi
+else
+    RUNNER_ROOT_DIR="$(cd "$(dirname "$(realpath "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
+fi
+
+COMMAND="${1:-}"
+GREP='grep --color=never'
+
+if [ -z "$COMMAND" ]; then
+    usage 'help'
+    exit 1
+elif [ "$COMMAND" = 'help' ]; then
+    usage 'help'
+    exit 0
+fi
+
+if [ "${2:-}" = 'help' ]; then
+    ## 'ctl' command has its own usage info
+    if [ "$COMMAND" != 'ctl' ]; then
+        usage "$COMMAND"
+        exit 0
+    fi
+fi
+
+## IS_BOOT_COMMAND is set for later to inspect node name and cookie from hocon config (or env variable)
+case "${COMMAND}" in
+    start|console|console_clean|foreground|check_config)
+        IS_BOOT_COMMAND='yes'
+        ;;
+    ertspath)
+        echo "$ERTS_DIR"
+        exit 0
+        ;;
+    root_dir)
+        echo "$RUNNER_ROOT_DIR"
+        exit 0
+        ;;
+    *)
+        IS_BOOT_COMMAND='no'
+        ;;
+esac
+
+RELUP_DIR="relup"
+BASE_RUNNER_ROOT_DIR="${BASE_RUNNER_ROOT_DIR:-$RUNNER_ROOT_DIR}"
+RELUP_PATH="$RUNNER_ROOT_DIR/$RELUP_DIR"
+
+if [ -f "$RELUP_PATH/version" ]; then
+    TARGET_VSN=$(cat "$RELUP_PATH/version")
+    export BASE_RUNNER_ROOT_DIR
+    ## only print for boot commands to avoid messing the CLI outputs
+    if [ "$IS_BOOT_COMMAND" = 'yes' ]; then
+        loginfo "Loading emqx from hot-upgrade dir: $RELUP_PATH"
+    fi
+    exec "$RELUP_PATH/$TARGET_VSN"/bin/emqx "$@"
+fi
+
+# shellcheck disable=SC1090,SC1091
+. "$RUNNER_ROOT_DIR"/releases/emqx_vars
+
+# defined in emqx_vars
+export RUNNER_ROOT_DIR
+export EMQX_ETC_DIR
+export REL_VSN
+export SCHEMA_MOD
+export IS_ENTERPRISE
+
+RUNNER_SCRIPT="$RUNNER_BIN_DIR/$REL_NAME"
+CODE_LOADING_MODE="${CODE_LOADING_MODE:-embedded}"
+REL_DIR="$RUNNER_ROOT_DIR/releases/$REL_VSN"
+
+WHOAMI=$(whoami 2>/dev/null || id -u)
+
+# hocon try to read environment variables starting with "EMQX_"
+export HOCON_ENV_OVERRIDE_PREFIX='EMQX_'
+
+export ERTS_DIR="$RUNNER_ROOT_DIR/erts-$ERTS_VSN"
+export BINDIR="$ERTS_DIR/bin"
+export EMU="beam"
+export PROGNAME="erl"
+export ERTS_LIB_DIR="$RUNNER_ROOT_DIR/lib"
+DYNLIBS_DIR="$RUNNER_ROOT_DIR/dynlibs"
+
+assert_node_alive() {
+    if ! relx_nodetool "ping" > /dev/null; then
+        exit 1
+    fi
+}
 
 ## backward compatible
 if [ -d "$ERTS_DIR/lib" ]; then

--- a/bin/emqx
+++ b/bin/emqx
@@ -50,6 +50,7 @@ die() {
     exit "$errno"
 }
 
+THIS_SCRIPT="$0"
 # We need to find real directory with emqx files on all platforms
 # even when bin/emqx is symlinked on several levels
 # - readlink -f works perfectly, but `-f` flag has completely different meaning in BSD version,
@@ -62,13 +63,13 @@ if [ "$(uname -s)" == 'Darwin' ]; then
     if [ "$product_version" -ge 12 ]; then
         # if homebrew coreutils package is installed, GNU version of stat can take precedence,
         # so we use absolute path to ensure we are calling MacOS default
-        RUNNER_ROOT_DIR="$(cd "$(dirname "$(/usr/bin/stat -f%R "$0" || echo "$0")")"/..; pwd -P)"
+        RUNNER_ROOT_DIR="$(cd "$(dirname "$(/usr/bin/stat -f%R "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
     else
         # try our best to resolve link on MacOS <= 11
-        RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$0" || echo "$0")")"/..; pwd -P)"
+        RUNNER_ROOT_DIR="$(cd "$(dirname "$(readlink "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
     fi
 else
-    RUNNER_ROOT_DIR="$(cd "$(dirname "$(realpath "$0" || echo "$0")")"/..; pwd -P)"
+    RUNNER_ROOT_DIR="$(cd "$(dirname "$(realpath "$THIS_SCRIPT" || echo "$THIS_SCRIPT")")"/..; pwd -P)"
 fi
 
 COMMAND="${1:-}"
@@ -156,6 +157,7 @@ assert_node_alive() {
 
 usage() {
     local command="$1"
+    local progname="$THIS_SCRIPT"
 
     case "$command" in
     start)
@@ -185,7 +187,7 @@ usage() {
         ;;
     escript)
         echo "Execute a escript using the Erlang runtime from EMQX package installation"
-        echo "For example $REL_NAME escript /path/to/my/escript my_arg1 my_arg2"
+        echo "For example $progname escript /path/to/my/escript my_arg1 my_arg2"
         ;;
     attach)
         echo "This command is applicable when EMQX is started in daemon mode."
@@ -202,14 +204,14 @@ usage() {
         echo "Print path to Erlang runtime bin dir"
         ;;
     rpc)
-        echo "Usage: $REL_NAME rpc MODULE FUNCTION [ARGS, ...]"
+        echo "Usage: $progname rpc MODULE FUNCTION [ARGS, ...]"
         echo "Connect to the EMQX node and make an Erlang RPC"
         echo "This command blocks for at most 60 seconds."
         echo "It exits with non-zero code in case of any RPC failure"
         echo "including connection error and runtime exception"
         ;;
     rpcterms)
-        echo "Usage: $REL_NAME rpcterms MODULE FUNCTION [ARGS, ...]"
+        echo "Usage: $progname rpcterms MODULE FUNCTION [ARGS, ...]"
         echo "Connect to the EMQX node and make an Erlang RPC"
         echo "The result of the RPC call is pretty-printed as an "
         echo "Erlang term"
@@ -227,14 +229,14 @@ usage() {
         echo "List installed EMQX release versions and their status"
         ;;
     unpack)
-        echo "Usage: $REL_NAME unpack [VERSION]"
+        echo "Usage: $progname unpack [VERSION]"
         echo "Unpacks a release package VERSION, it assumes that this"
         echo "release package tarball has already been deployed at one"
         echo "of the following locations:"
         echo "      releases/<relname>-<version>.tar.gz"
         ;;
     install)
-        echo "Usage: $REL_NAME install [VERSION]"
+        echo "Usage: $progname install [VERSION]"
         echo "Installs a release package VERSION, it assumes that this"
         echo "release package tarball has already been deployed at one"
         echo "of the following locations:"
@@ -244,12 +246,12 @@ usage() {
         echo "                      don't make it permanent"
         ;;
     uninstall)
-        echo "Usage: $REL_NAME uninstall [VERSION]"
+        echo "Usage: $progname uninstall [VERSION]"
         echo "Uninstalls a release VERSION, it will only accept"
         echo "versions that are not currently in use"
         ;;
     upgrade)
-        echo "Usage: $REL_NAME upgrade [VERSION]"
+        echo "Usage: $progname upgrade [VERSION]"
         echo "Upgrades the currently running release to VERSION, it assumes"
         echo "that a release package tarball has already been deployed at one"
         echo "of the following locations:"
@@ -259,7 +261,7 @@ usage() {
         echo "                      don't make it permanent"
         ;;
     downgrade)
-        echo "Usage: $REL_NAME downgrade [VERSION]"
+        echo "Usage: $progname downgrade [VERSION]"
         echo "Downgrades the currently running release to VERSION, it assumes"
         echo "that a release package tarball has already been deployed at one"
         echo "of the following locations:"
@@ -272,14 +274,14 @@ usage() {
         echo "Checks the EMQX config without generating any files"
         ;;
     *)
-        echo "Usage: $REL_NAME COMMAND [help]"
+        echo "Usage: $progname COMMAND [help]"
         echo ''
         echo "Commonly used COMMANDs:"
         echo "  start:      Start EMQX in daemon mode"
         echo "  console:    Start EMQX in an interactive Erlang or Elixir shell"
         echo "  foreground: Start EMQX in foreground mode without an interactive shell"
         echo "  stop:       Stop the running EMQX node"
-        echo "  ctl:        Administration commands, execute '$REL_NAME ctl help' for more details"
+        echo "  ctl:        Administration commands, execute '$progname ctl help' for more details"
         echo ''
         echo "More:"
         echo "  Shell attach:     remote_console | attach"
@@ -289,7 +291,7 @@ usage() {
         echo "  Validate Config:  check_config"
         echo "  Advanced:         console_clean | escript | rpc | rpcterms | eval | eval-ex"
         echo ''
-        echo "Execute '$REL_NAME COMMAND help' for more information"
+        echo "Execute '$progname COMMAND help' for more information"
     ;;
     esac
 }

--- a/changes/ce/fix-14357.en.md
+++ b/changes/ce/fix-14357.en.md
@@ -1,0 +1,1 @@
+Fix `bin/emqx help` command.

--- a/scripts/pkg-tests.sh
+++ b/scripts/pkg-tests.sh
@@ -212,6 +212,14 @@ EOF
         echo "Error: cannot locate emqx_vars"
         exit 1
     fi
+    if ! "${bin_dir}/emqx" 'start' 'help'; then
+        echo "ERROR: failed_to_call_help_command"
+        exit 1
+    fi
+    if ! "${bin_dir}/emqx" 'help'; then
+        echo "ERROR: failed_to_call_help_command"
+        exit 1
+    fi
     echo "running ${packagename} start"
     if ! "${bin_dir}/emqx" 'start'; then
         echo "ERROR: failed_to_start_emqx"


### PR DESCRIPTION
Fixes [EMQX-13611](https://emqx.atlassian.net/browse/EMQX-13611)
Release version: v/e5.8.4

## Summary

Define `usage` function before called.
Also change to use `$0` in help prints instead of relying on the variable `$REL_NAME`.

See individual commit diffs for clarity.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13611]: https://emqx.atlassian.net/browse/EMQX-13611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ