### PR TITLE
refactor(resource): forbid changing resource state from `on_get_status` return, upgrade `mysql-otp` and `ecpool`

### DIFF
--- a/apps/emqx_auth_jwt/rebar.config
+++ b/apps/emqx_auth_jwt/rebar.config
@@ -3,5 +3,6 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
+    {emqx_resource, {path, "../emqx_resource"}},
     {emqx_auth, {path, "../emqx_auth"}}
 ]}.

--- a/apps/emqx_auth_jwt/src/emqx_auth_jwt.app.src
+++ b/apps/emqx_auth_jwt/src/emqx_auth_jwt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_jwt, [
     {description, "EMQX JWT Authentication and Authorization"},
-    {vsn, "0.3.4"},
+    {vsn, "0.3.5"},
     {registered, []},
     {mod, {emqx_auth_jwt_app, []}},
     {applications, [

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwks_connector.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwks_connector.erl
@@ -19,6 +19,7 @@
 -behaviour(emqx_resource).
 
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 
 %% callbacks of behaviour emqx_resource
 -export([
@@ -75,8 +76,8 @@ on_query(_InstId, {update, Opts}, #{pool_name := PoolName}) ->
 
 on_get_status(_InstId, #{pool_name := PoolName}) ->
     case emqx_resource_pool:health_check_workers(PoolName, fun health_check/1) of
-        true -> connected;
-        false -> disconnected
+        true -> ?status_connected;
+        false -> ?status_disconnected
     end.
 
 health_check(Conn) ->

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_blob_storage, [
     {description, "EMQX Enterprise Azure Blob Storage Bridge"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, [emqx_bridge_azure_blob_storage_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -184,13 +184,8 @@ on_stop(_ConnResId, _ConnState) ->
 
 -spec on_get_status(connector_resource_id(), connector_state()) ->
     ?status_connected | ?status_disconnected | {?status_disconnected, connector_state(), term()}.
-on_get_status(_ConnResId, ConnState = #{driver_state := DriverState}) ->
-    case health_check(DriverState) of
-        {Status, Message} ->
-            {Status, ConnState, Message};
-        Status when is_atom(Status) ->
-            Status
-    end.
+on_get_status(_ConnResId, #{driver_state := DriverState}) ->
+    health_check(DriverState).
 
 -spec on_add_channel(
     connector_resource_id(),

--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra.app.src
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_cassandra, [
     {description, "EMQX Enterprise Cassandra Bridge"},
-    {vsn, "0.3.3"},
+    {vsn, "0.3.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
+++ b/apps/emqx_bridge_cassandra/src/emqx_bridge_cassandra_connector.erl
@@ -6,6 +6,7 @@
 
 -behaviour(emqx_resource).
 
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 -include("emqx_bridge_cassandra.hrl").
 -include_lib("typerefl/include/types.hrl").
@@ -356,8 +357,8 @@ exec(PoolName, Query) ->
 
 on_get_status(_InstId, #{pool_name := PoolName}) ->
     case emqx_resource_pool:health_check_workers(PoolName, fun ?MODULE:do_get_status/1) of
-        true -> connected;
-        false -> connecting
+        true -> ?status_connected;
+        false -> ?status_connecting
     end.
 
 do_get_status(Conn) ->

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_clickhouse, [
     {description, "EMQX Enterprise ClickHouse Bridge"},
-    {vsn, "0.4.4"},
+    {vsn, "0.4.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -306,8 +306,8 @@ on_remove_channel(_InstanceId, #{channels := Channels} = State, ChannId) ->
 
 on_get_channel_status(InstanceId, _ChannId, State) ->
     case on_get_status(InstanceId, State) of
-        {connected, _} -> connected;
-        {disconnected, _, _} -> disconnected
+        ?status_connected -> ?status_connected;
+        {?status_disconnected, _} -> ?status_disconnected
     end.
 
 on_get_channels(InstanceId) ->
@@ -319,13 +319,13 @@ on_get_channels(InstanceId) ->
 
 on_get_status(
     _InstanceID,
-    #{pool_name := PoolName, connect_timeout := Timeout} = State
+    #{pool_name := PoolName, connect_timeout := Timeout}
 ) ->
     case do_get_status(PoolName, Timeout) of
         ok ->
-            {connected, State};
+            ?status_connected;
         {error, Reason} ->
-            {disconnected, State, Reason}
+            {?status_disconnected, Reason}
     end.
 
 do_get_status(PoolName, Timeout) ->

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo.app.src
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_dynamo, [
     {description, "EMQX Enterprise Dynamo Bridge"},
-    {vsn, "0.2.4"},
+    {vsn, "0.2.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
+++ b/apps/emqx_bridge_dynamo/src/emqx_bridge_dynamo_connector.erl
@@ -196,7 +196,7 @@ on_format_query_result(Result) ->
 health_check_timeout() ->
     2500.
 
-on_get_status(_InstanceId, #{pool_name := Pool} = State) ->
+on_get_status(_InstanceId, #{pool_name := Pool}) ->
     Health = emqx_resource_pool:health_check_workers(
         Pool,
         {emqx_bridge_dynamo_connector_client, is_connected, [
@@ -207,19 +207,19 @@ on_get_status(_InstanceId, #{pool_name := Pool} = State) ->
     ),
     case Health of
         {error, timeout} ->
-            {?status_connecting, State, <<"timeout_while_checking_connection">>};
+            {?status_connecting, <<"timeout_while_checking_connection">>};
         {ok, Results} ->
-            status_result(Results, State)
+            status_result(Results)
     end.
 
-status_result(Results, State) ->
+status_result(Results) ->
     case lists:filter(fun(Res) -> Res =/= true end, Results) of
         [] when Results =:= [] ->
             ?status_connecting;
         [] ->
             ?status_connected;
         [{false, Error} | _] ->
-            {?status_connecting, State, Error}
+            {?status_connecting, Error}
     end.
 
 %%========================================================================================

--- a/apps/emqx_bridge_es/src/emqx_bridge_es.app.src
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_es, [
     {description, "EMQX Enterprise Elastic Search Bridge"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {modules, [
         emqx_bridge_es,
         emqx_bridge_es_connector

--- a/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
+++ b/apps/emqx_bridge_es/src/emqx_bridge_es_connector.erl
@@ -8,6 +8,7 @@
 -behaviour(emqx_resource).
 
 -include("emqx_bridge_es.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -244,7 +245,7 @@ on_stop(InstanceId, State) ->
     Res.
 
 -spec on_get_status(manager_id(), state()) ->
-    {connected, state()} | {disconnected, state(), term()}.
+    ?status_connected | {?status_disconnected, term()}.
 on_get_status(InstanceId, State) ->
     emqx_bridge_http_connector:on_get_status(InstanceId, State).
 

--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb.app.src
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_hstreamdb, [
     {description, "EMQX Enterprise HStreamDB Bridge"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
+++ b/apps/emqx_bridge_hstreamdb/src/emqx_bridge_hstreamdb_connector.erl
@@ -172,7 +172,7 @@ on_get_status(_InstId, State) ->
         Error ->
             %% We set it to ?status_connecting so that the channels are not deleted.
             %% The producers in the channels contains buffers so we don't want to delete them.
-            {?status_connecting, State, Error}
+            {?status_connecting, Error}
     end.
 
 %% -------------------------------------------------------------------------------------------------

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -16,6 +16,7 @@
 
 -module(emqx_bridge_http_connector).
 
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
@@ -590,14 +591,14 @@ on_get_channels(ResId) ->
 on_get_status(InstId, State) ->
     on_get_status(InstId, State, fun default_health_checker/2).
 
-on_get_status(InstId, #{pool_name := InstId, connect_timeout := Timeout} = State, DoPerWorker) ->
+on_get_status(InstId, #{pool_name := InstId, connect_timeout := Timeout}, DoPerWorker) ->
     case do_get_status(InstId, Timeout, DoPerWorker) of
         ok ->
-            connected;
+            ?status_connected;
         {error, still_connecting} ->
-            connecting;
+            ?status_connecting;
         {error, Reason} ->
-            {disconnected, State, Reason}
+            {?status_disconnected, Reason}
     end.
 
 do_get_status(PoolName, Timeout) ->
@@ -643,14 +644,7 @@ on_get_channel_status(
     _ChannelId,
     State
 ) ->
-    %% N.B.: `on_get_channel_status' expects a different return value than
-    %% `on_get_status'.
-    case on_get_status(InstId, State, fun default_health_checker/2) of
-        {Status, _State, Reason} ->
-            {Status, Reason};
-        Res ->
-            Res
-    end.
+    on_get_status(InstId, State, fun default_health_checker/2).
 
 on_format_query_result({ok, Status, Headers, Body}) ->
     #{

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_influxdb, [
     {description, "EMQX Enterprise InfluxDB Bridge"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
+++ b/apps/emqx_bridge_influxdb/src/emqx_bridge_influxdb_connector.erl
@@ -3,6 +3,7 @@
 %%--------------------------------------------------------------------
 -module(emqx_bridge_influxdb_connector).
 
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 
 -include_lib("hocon/include/hoconsc.hrl").
@@ -221,9 +222,9 @@ on_format_query_result(Result) ->
 on_get_status(_InstId, #{client := Client}) ->
     case influxdb:is_alive(Client) andalso ok =:= influxdb:check_auth(Client) of
         true ->
-            connected;
+            ?status_connected;
         false ->
-            disconnected
+            ?status_disconnected
     end.
 
 transform_bridge_v1_config_to_connector_config(BridgeV1Config) ->

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -224,15 +224,10 @@ on_stop(ConnectorResId, State) ->
 
 -spec on_get_status(connector_resource_id(), connector_state()) ->
     ?status_connected | ?status_disconnected.
-on_get_status(_ConnectorResId, State = #{kafka_client_id := ClientID}) ->
+on_get_status(_ConnectorResId, #{kafka_client_id := ClientID}) ->
     case whereis(ClientID) of
         Pid when is_pid(Pid) ->
-            case check_client_connectivity(Pid) of
-                {Status, Reason} ->
-                    {Status, State, Reason};
-                Status ->
-                    Status
-            end;
+            check_client_connectivity(Pid);
         _ ->
             ?status_disconnected
     end;

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -605,7 +605,7 @@ on_get_status(
         {error, {find_client, _Error}} ->
             ?status_connecting;
         {error, {connectivity, Error}} ->
-            {?status_connecting, State, Error}
+            {?status_connecting, Error}
     end.
 
 on_get_channel_status(
@@ -688,11 +688,11 @@ maybe_check_health_check_topic(ConnResId, #{health_check_topic := Topic} = Conne
             ?status_connected
     catch
         throw:{unhealthy_target, Msg} ->
-            {?status_disconnected, ConnectorState, Msg};
+            {?status_disconnected, Msg};
         throw:#{reason := {connection_down, _} = Reason} ->
-            {?status_disconnected, ConnectorState, Reason};
+            {?status_disconnected, Reason};
         throw:#{reason := Reason} ->
-            {?status_connecting, ConnectorState, Reason}
+            {?status_connecting, Reason}
     end;
 maybe_check_health_check_topic(_ConnResId, _ConnState) ->
     %% Cannot infer further information.  Maybe upgraded from older version.

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kinesis, [
     {description, "EMQX Enterprise Amazon Kinesis Bridge"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mongodb, [
     {description, "EMQX Enterprise MongoDB Bridge"},
-    {vsn, "0.3.4"},
+    {vsn, "0.3.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
@@ -61,13 +61,8 @@ on_get_channel_status(InstanceId, _ChannelId, State) ->
 on_get_channels(InstanceId) ->
     emqx_bridge_v2:get_channels_for_connector(InstanceId).
 
-on_get_status(InstanceId, ConnectorState = #{connector_state := DriverState0}) ->
-    case emqx_mongodb:on_get_status(InstanceId, DriverState0) of
-        {Status, DriverState, Reason} ->
-            {Status, ConnectorState#{connector_state := DriverState}, Reason};
-        Status when is_atom(Status) ->
-            Status
-    end.
+on_get_status(InstanceId, #{connector_state := DriverState0}) ->
+    emqx_mongodb:on_get_status(InstanceId, DriverState0).
 
 on_query(InstanceId, {Channel, Message0}, #{channels := Channels, connector_state := ConnectorState}) ->
     #{

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.2.6"},
+    {vsn, "0.2.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -358,12 +358,7 @@ on_get_status(_ResourceId, State) ->
     Workers = [{Pool, Worker} || {Pool, PN} <- Pools, {_Name, Worker} <- ecpool:workers(PN)],
     try emqx_utils:pmap(fun get_status/1, Workers, ?HEALTH_CHECK_TIMEOUT) of
         Statuses ->
-            case combine_status(Statuses) of
-                {Status, Msg} ->
-                    {Status, State, Msg};
-                Status ->
-                    Status
-            end
+            combine_status(Statuses)
     catch
         exit:timeout ->
             ?status_connecting

--- a/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
+++ b/apps/emqx_bridge_mysql/src/emqx_bridge_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_mysql, [
     {description, "EMQX Enterprise MySQL Bridge"},
-    {vsn, "0.1.9"},
+    {vsn, "0.1.10"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_opents/src/emqx_bridge_opents.app.src
+++ b/apps/emqx_bridge_opents/src/emqx_bridge_opents.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_opents, [
     {description, "EMQX Enterprise OpenTSDB Bridge"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_opents/src/emqx_bridge_opents_connector.erl
+++ b/apps/emqx_bridge_opents/src/emqx_bridge_opents_connector.erl
@@ -185,15 +185,13 @@ on_format_query_result(Result) ->
     Result.
 
 on_get_status(_InstanceId, #{server := Server}) ->
-    Result =
-        case opentsdb_connectivity(Server) of
-            ok ->
-                connected;
-            {error, Reason} ->
-                ?SLOG(error, #{msg => "opents_lost_connection", reason => Reason}),
-                connecting
-        end,
-    Result.
+    case opentsdb_connectivity(Server) of
+        ok ->
+            ?status_connected;
+        {error, Reason} ->
+            ?SLOG(error, #{msg => "opents_lost_connection", reason => Reason}),
+            ?status_connecting
+    end.
 
 on_add_channel(
     _InstanceId,

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_rabbitmq, [
     {description, "EMQX Enterprise RabbitMQ Bridge"},
-    {vsn, "0.2.4"},
+    {vsn, "0.2.5"},
     {registered, []},
     {mod, {emqx_bridge_rabbitmq_app, []}},
     {applications, [

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_s3, [
     {description, "EMQX Enterprise S3 Bridge"},
-    {vsn, "0.1.8"},
+    {vsn, "0.1.9"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
@@ -144,17 +144,17 @@ on_stop(InstId, _State = #{pool_name := PoolName}) ->
 
 -spec on_get_status(_InstanceId :: resource_id(), state()) ->
     health_check_status().
-on_get_status(_InstId, State = #{client_config := Config}) ->
+on_get_status(_InstId, #{client_config := Config}) ->
     case emqx_s3_client:aws_config(Config) of
         {error, Reason} ->
-            {?status_disconnected, State, map_error_details(Reason)};
+            {?status_disconnected, map_error_details(Reason)};
         AWSConfig ->
             try erlcloud_s3:list_buckets(AWSConfig) of
                 Props when is_list(Props) ->
                     ?status_connected
             catch
                 error:Error ->
-                    {?status_disconnected, State, map_error_details(Error)}
+                    {?status_disconnected, map_error_details(Error)}
             end
     end.
 

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.app.src
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_syskeeper, [
     {description, "EMQX Enterprise Data bridge for Syskeeper"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_proxy_server.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_proxy_server.erl
@@ -7,6 +7,7 @@
 -behaviour(gen_statem).
 
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 
 -elvis([{elvis_style, invalid_dynamic_call, disable}]).
 
@@ -105,10 +106,10 @@ on_stop(InstanceId, _State) ->
 on_get_status(_InstanceId, #{listen_on := ListenOn}) ->
     try
         _ = esockd:listener({?MODULE, ListenOn}),
-        connected
+        ?status_connected
     catch
         _:_ ->
-            disconnected
+            ?status_disconnected
     end.
 
 %% -------------------------------------------------------------------------------------------------

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_tdengine, [
     {description, "EMQX Enterprise TDEngine Bridge"},
-    {vsn, "0.2.4"},
+    {vsn, "0.2.5"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
+++ b/apps/emqx_bridge_tdengine/src/emqx_bridge_tdengine_connector.erl
@@ -224,7 +224,7 @@ on_format_query_result({ok, ResultMap}) ->
 on_format_query_result(Result) ->
     Result.
 
-on_get_status(_InstanceId, #{pool_name := PoolName} = State) ->
+on_get_status(_InstanceId, #{pool_name := PoolName}) ->
     case
         emqx_resource_pool:health_check_workers(
             PoolName,
@@ -234,16 +234,16 @@ on_get_status(_InstanceId, #{pool_name := PoolName} = State) ->
         )
     of
         {ok, []} ->
-            {?status_connecting, State, undefined};
+            {?status_connecting, undefined};
         {ok, Values} ->
             case lists:keyfind(error, 1, Values) of
                 false ->
                     ?status_connected;
                 {error, Reason} ->
-                    {?status_connecting, State, enhance_reason(Reason)}
+                    {?status_connecting, enhance_reason(Reason)}
             end;
         {error, Reason} ->
-            {?status_connecting, State, enhance_reason(Reason)}
+            {?status_connecting, enhance_reason(Reason)}
     end.
 
 do_get_status(Conn) ->
@@ -301,14 +301,9 @@ on_get_channels(InstanceId) ->
 on_get_channel_status(InstanceId, ChannelId, #{channels := Channels} = State) ->
     case maps:is_key(ChannelId, Channels) of
         true ->
-            case on_get_status(InstanceId, State) of
-                {Status, _State, Reason} ->
-                    {Status, Reason};
-                Status ->
-                    Status
-            end;
+            on_get_status(InstanceId, State);
         _ ->
-            {error, not_exists}
+            ?status_disconnected
     end.
 
 %%========================================================================================

--- a/apps/emqx_cluster_link/src/emqx_cluster_link.app.src
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link.app.src
@@ -2,7 +2,7 @@
 {application, emqx_cluster_link, [
     {description, "EMQX Cluster Linking"},
     % strict semver, bump manually!
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -281,7 +281,7 @@ on_get_status(_ResourceId, #{pool_name := PoolName} = _State) ->
             combine_status(Statuses)
     catch
         exit:timeout ->
-            connecting
+            ?status_connecting
     end.
 
 get_status(Worker) ->
@@ -312,7 +312,7 @@ combine_status(Statuses) ->
         [Status | _] ->
             Status;
         [] ->
-            disconnected
+            ?status_disconnected
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -249,7 +249,7 @@ init_mocks(_TestCase) ->
             (_, bad_connector_state) ->
                 connecting;
             (_, worst_connector_state) ->
-                {?status_disconnected, worst_connector_state, [
+                {?status_disconnected, [
                     #{
                         host => <<"nope:9092">>,
                         reason => unresolvable_hostname

--- a/apps/emqx_ldap/src/emqx_ldap.app.src
+++ b/apps/emqx_ldap/src/emqx_ldap.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ldap, [
     {description, "EMQX LDAP Connector"},
-    {vsn, "0.1.11"},
+    {vsn, "0.1.12"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -16,6 +16,7 @@
 
 -module(emqx_ldap).
 
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
@@ -204,18 +205,18 @@ on_get_status(InstId, #{pool_name := PoolName} = State) ->
         connected ->
             emqx_ldap_bind_worker:on_get_status(InstId, State);
         disconnected ->
-            disconnected
+            ?status_disconnected
     end.
 
 get_status_with_poolname(PoolName) ->
     case emqx_resource_pool:health_check_workers(PoolName, fun ?MODULE:do_get_status/1) of
         true ->
-            connected;
+            ?status_connected;
         false ->
             %% Note: here can only return `disconnected` not `connecting`
             %% because the LDAP socket/connection can't be reused
             %% searching on a died socket will never return until timeout
-            disconnected
+            ?status_disconnected
     end.
 
 do_get_status(Conn) ->

--- a/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
+++ b/apps/emqx_ldap/src/emqx_ldap_bind_worker.erl
@@ -16,6 +16,7 @@
 
 -module(emqx_ldap_bind_worker).
 
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -107,7 +108,7 @@ on_query(
 on_get_status(_InstId, #{bind_pool_name := PoolName}) ->
     emqx_ldap:get_status_with_poolname(PoolName);
 on_get_status(_InstId, _) ->
-    connected.
+    ?status_connected.
 
 %% ===================================================================
 

--- a/apps/emqx_mongodb/src/emqx_mongodb.app.src
+++ b/apps/emqx_mongodb/src/emqx_mongodb.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mongodb, [
     {description, "EMQX MongoDB Connector"},
-    {vsn, "0.1.8"},
+    {vsn, "0.1.9"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_mongodb/src/emqx_mongodb.erl
+++ b/apps/emqx_mongodb/src/emqx_mongodb.erl
@@ -15,6 +15,7 @@
 %%--------------------------------------------------------------------
 -module(emqx_mongodb).
 
+-include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_connector/include/emqx_connector.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
@@ -299,21 +300,21 @@ on_query(
             {ok, Result}
     end.
 
-on_get_status(InstId, State = #{pool_name := PoolName}) ->
+on_get_status(InstId, #{pool_name := PoolName}) ->
     case health_check(PoolName) of
         ok ->
             ?tp(debug, emqx_connector_mongo_health_check, #{
                 instance_id => InstId,
                 status => ok
             }),
-            connected;
+            ?status_connected;
         {error, Reason} ->
             ?tp(warning, emqx_connector_mongo_health_check, #{
                 instance_id => InstId,
                 reason => Reason,
                 status => failed
             }),
-            {disconnected, State, Reason}
+            {?status_disconnected, Reason}
     end.
 
 health_check(PoolName) ->

--- a/apps/emqx_mysql/mix.exs
+++ b/apps/emqx_mysql/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXMysql.MixProject do
 
   def deps() do
     [
-      {:mysql, github: "emqx/mysql-otp", tag: "1.7.4.3"},
+      {:mysql, github: "emqx/mysql-otp", tag: "1.8.0.0"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
     ]

--- a/apps/emqx_mysql/rebar.config
+++ b/apps/emqx_mysql/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.7.4.3"}}},
+    {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.8.0.0"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.

--- a/apps/emqx_mysql/src/emqx_mysql.app.src
+++ b/apps/emqx_mysql/src/emqx_mysql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mysql, [
     {description, "EMQX MySQL Database Connector"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_postgresql/src/emqx_postgresql.app.src
+++ b/apps/emqx_postgresql/src/emqx_postgresql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_postgresql, [
     {description, "EMQX PostgreSQL Database Connector"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_redis/src/emqx_redis.app.src
+++ b/apps/emqx_redis/src/emqx_redis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_redis, [
     {description, "EMQX Redis Database Connector"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -208,8 +208,7 @@
 %% when calling emqx_resource:health_check/2
 -callback on_get_status(resource_id(), resource_state()) ->
     health_check_status()
-    | {health_check_status(), resource_state()}
-    | {health_check_status(), resource_state(), term()}.
+    | {health_check_status(), Reason :: term()}.
 
 -callback on_get_channel_status(resource_id(), channel_id(), resource_state()) ->
     channel_status()

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -310,7 +310,7 @@ on_get_status(_InstId, #{health_check_error := true}) ->
     ?status_disconnected;
 on_get_status(_InstId, State = #{health_check_error := {msg, Message}}) ->
     ?tp(connector_demo_health_check_error, #{}),
-    {?status_disconnected, State, Message};
+    {?status_disconnected, Message};
 on_get_status(_InstId, #{pid := Pid, health_check_error := {delay, Delay}}) ->
     ?tp(connector_demo_health_check_delay, #{}),
     timer:sleep(Delay),

--- a/changes/ce/fix-14362.en.md
+++ b/changes/ce/fix-14362.en.md
@@ -1,0 +1,1 @@
+Refactored data integration resource manager state machine, which should eliminate a few race conditions that could lead to inconsistent states.

--- a/changes/ee/fix-14362.en.md
+++ b/changes/ee/fix-14362.en.md
@@ -1,0 +1,10 @@
+Updated our MySQL driver, so that some crashes and problems recovering from such crashes are fixed.
+
+For example, such problems would manifest with logs similar to the following:
+
+```
+crasher: initial call: mysql_conn:init/1, pid: <0.8940.0>, registered_name: [], exit: {timeout,[{gen_server,init_it,6,[{file,\"gen_server.erl\"},{line,961}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,241}]}]}
+Supervisor: {<0.8938.0>,ecpool_worker_sup}. Context: start_error. Reason: timeout. Offender: id={worker,1},pid=undefined.
+Generic server <0.23934.0> terminating. Reason: {{case_clause,{error,closed}},[{mysql_protocol,fetch_response,7,[{file,\"mysql_protocol.erl\"},{line,569}]},{mysql_conn,query,4,[{file,\"mysql_conn.erl\"},{line,648}]},{mysql_conn,handle_call,3,[{file,\"mysql_conn.erl\"},{line,316}]},{gen_server,try_handle_call,4,[{file,\"gen_server.erl\"},{line,1131}]},{gen_server,handle_msg,6,[{file,\"gen_server.erl\"},{line,1160}]},{proc_lib,init_p_do_apply,3,[{file,\"proc_lib.erl\"},{line,241}]}]}
+Supervisor: {<0.23913.0>,ecpool_worker_sup}. Context: shutdown. Reason: reached_max_restart_intensity. Offender: id={worker,8}
+```

--- a/mix.exs
+++ b/mix.exs
@@ -205,7 +205,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:cowboy), do: {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true}
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
-  def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.5.12", override: true}
+  def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.6.1", override: true}
   def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.3.10", override: true}
   def common_dep(:jsx), do: {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true}
   # in conflict by emqtt and hocon

--- a/rebar.config
+++ b/rebar.config
@@ -87,7 +87,7 @@
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
-    {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.12"}}},
+    {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.10"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},


### PR DESCRIPTION
Release version: v/e5.8.4

Fixes https://emqx.atlassian.net/browse/EMQX-13514
Fixes https://emqx.atlassian.net/browse/EMQX-13639

## Summary

Since we do health checks asynchronously, this opens up too much space for race conditions where state is clobbered when a connector/resource health check is returned while the state has been changed by other operations.

Consider the following sequence (which happens for MySQL and Postgres connectors, for example):

1. Resource state is S0, and has no channels added yet.
2. A resource health check (HC) starts using `S0` to run.
3. Concurrently, a new channel (action) is added, changing `S0` to `S1` containing the new channel.
4. Resource HC returns with a modified state `S2` based on `S0` which does not contain the new channel.  This state replaces `S1`, and the channel is forever lost.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
  - Issue was tested manually.  Added a recovery automated test case, but it didn't manage capture the original issue. 
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
