### PR TITLE
fix(otel): override sub qos upgrade/downgrade

### DIFF
--- a/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
+++ b/apps/emqx_opentelemetry/src/emqx_opentelemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_opentelemetry, [
     {description, "OpenTelemetry for EMQX Broker"},
-    {vsn, "0.2.8"},
+    {vsn, "0.2.9"},
     {registered, []},
     {mod, {emqx_otel_app, []}},
     {applications, [

--- a/apps/emqx_opentelemetry/src/emqx_otel_trace.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_trace.erl
@@ -765,7 +765,9 @@ stop_outgoing_trace(Packet, Attrs) when is_record(Packet, mqtt_packet) ->
     %% Maybe awaiting for next Packet
     %% The current outgoing Packet SHOULD NOT be modified
     ok = outgoing_maybe_awaiting_next(Packet, Attrs),
-    end_span(get_ctx(Packet));
+    Ctx = get_ctx(Packet),
+    ok = add_span_attrs(#{'message.qos' => emqx_packet:qos(Packet)}, Ctx),
+    end_span(Ctx);
 stop_outgoing_trace(Any, _Attrs) ->
     end_span(get_ctx(Any)).
 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Override the `message.qos` attribute when msg delivered.
The real QoS might different from the raw message's. 
QoS upgrade: enabled `mqtt.upgrade_qos`
QoS downgrade: client subscribed lower qos than message's

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
