### PR TITLE
fix(variform): intermediate variable reference to undefined or null

### DIFF
--- a/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
+++ b/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
@@ -644,7 +644,7 @@ t_smoke_test_2(_Config) ->
             <<"node">> := NodeBin,
             <<"peername">> := <<"127.0.0.1:", _/binary>>,
             <<"publish_received_at">> := PRAt,
-            <<"username">> := <<"undefined">>,
+            <<"username">> := <<"">>,
             <<"flags">> := #{<<"dup">> := false, <<"retain">> := false},
             <<"timestamp">> := _,
             <<"pub_props">> := #{

--- a/apps/emqx_utils/src/emqx_variform.erl
+++ b/apps/emqx_utils/src/emqx_variform.erl
@@ -286,6 +286,8 @@ resolve_func_name(FuncNameStr) ->
 %% _Opts can be extended in the future. For example, unbound var as 'undfeined'
 resolve_var_value(VarName, Bindings, _Opts) ->
     case emqx_template:lookup_var(split(VarName), Bindings) of
+        {ok, Value} when ?IS_EMPTY(Value) ->
+            <<"">>;
         {ok, Value} ->
             Value;
         {error, _Reason} ->

--- a/apps/emqx_utils/test/emqx_variform_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_tests.erl
@@ -32,6 +32,11 @@ render_test_() ->
         {"direct var reference undefined", fun() ->
             ?assertEqual({ok, <<"">>}, render("a", #{a => undefined}))
         end},
+        {"var reference undefined", fun() ->
+            ?assertEqual(
+                {ok, <<"/c1">>}, render("concat([a, '/', c])", #{a => undefined, c => <<"c1">>})
+            )
+        end},
         {"direct var reference null", fun() ->
             ?assertEqual({ok, <<"">>}, render("a", #{a => null}))
         end},

--- a/changes/ce/fix-14371.en.md
+++ b/changes/ce/fix-14371.en.md
@@ -1,0 +1,1 @@
+Fix clientid override expression to render `undefined` as empty string.


### PR DESCRIPTION

Fixes [EMQX-13540](https://emqx.atlassian.net/browse/EMQX-13540)

Release version: v/e5.8.4

## Summary

when variable is bound but bound as 'undefined' or 'null', it is now rendered as empty string, but not "undefined" or "null"

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13540]: https://emqx.atlassian.net/browse/EMQX-13540?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ