### PR TITLE
test: fix flaky tests

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -229,6 +229,18 @@ end_per_testcase(_TestCase, Config) ->
         proplists:get_value(tc_apps, Config)
     ),
     catch meck:unload([emqx_crl_cache]),
+    case whereis(emqx_crl_cache) of
+        Pid when is_pid(Pid) ->
+            MRef = monitor(process, Pid),
+            unlink(Pid),
+            exit(Pid, kill),
+            receive
+                {'DOWN', MRef, process, Pid, _} ->
+                    ok
+            end;
+        _ ->
+            ok
+    end,
     ok.
 
 %%--------------------------------------------------------------------
@@ -874,6 +886,7 @@ t_revoked(Config) ->
     ClientCert = filename:join(DataDir, "client-revoked.cert.pem"),
     ClientKey = filename:join(DataDir, "client-revoked.key.pem"),
     {ok, C} = emqtt:start_link([
+        {connect_timeout, 2},
         {ssl, true},
         {ssl_opts, [
             {certfile, ClientCert},

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_consumer_SUITE.erl
@@ -560,13 +560,23 @@ t_pretty_api_dry_run_reason(Config) ->
                 ),
                 ?assertMatch({400, _}, Res),
                 {400, #{<<"message">> := Msg}} = Res,
-                ?assertEqual(
-                    match,
-                    re:run(Msg, <<"Leader for partition . unavailable; reason: ">>, [
-                        {capture, none}
-                    ]),
-                    #{message => Msg}
-                )
+                LeaderUnavailable =
+                    match ==
+                        re:run(
+                            Msg,
+                            <<"Leader for partition . unavailable; reason: ">>,
+                            [{capture, none}]
+                        ),
+                %% In CI, if this tests runs soon enough, Kafka may not be stable yet, and
+                %% this failure might occur.
+                CoordinatorFailure =
+                    match ==
+                        re:run(
+                            Msg,
+                            <<"shutdown,coordinator_failure">>,
+                            [{capture, none}]
+                        ),
+                ?assert(LeaderUnavailable or CoordinatorFailure, #{message => Msg})
             end),
             %% Wait for recovery; avoids affecting other test cases due to Kafka restabilizing...
             ?retry(

--- a/scripts/ct/run.sh
+++ b/scripts/ct/run.sh
@@ -362,7 +362,7 @@ fi
 set +e
 
 if [ "$STOP" = 'yes' ]; then
-    $DC down --remove-orphans
+    $DC down -t 0 --remove-orphans
 elif [ "$ATTACH" = 'yes' ]; then
     docker exec -it "$ERLANG_CONTAINER" bash
 elif [ "$CONSOLE" = 'yes' ]; then


### PR DESCRIPTION
```
=== === Reason: {assertException,
                  [{unexpected_exception,
                    {error,connack_timeout,
                     [{emqx_listeners_SUITE,emqtt_connect,
                       [#{ssl => true,
                          hosts => [{"127.0.0.1",32857}],
                          connect_timeout => 1,
                          ssl_opts =>
                           [{cacertfile,
                             "/__w/emqx-platform/emqx-platform/apps/emqx/_build/standalone_test+test/logs/ct_run.test@127.0.0.1.2024-12-11_13.52.31/lib.emqx.emqx_listeners_SUITE.logs/run.2024-12-11_13.54.19/log_private/ca-next.pem"},
                            {verify,verify_peer},
                            {customize_hostname_check,
                             [{match_fun,
                               #Fun<emqx_listeners_SUITE.10.13838054>}]}]}],
```

Also, there's a bug in `cth_readable 1.5.1` in `cth_readable_helpers`:

```
Call to CTH failed: error:{{badmatch,
                               ["[","{","error",[],"{","ssl_error",[],
                                "_Socket",[],"{","tls_alert",[],"{",
                                "certificate_required",[],"_","}","}","}","}",
                                "{","error",[],"closed","}","]"]},
                           [{cth_readable_helpers,extract_exception_pattern,
                                1,
                                [{file,
                                     "/__w/rebar3/rebar3/_build/default/lib/cth_readable/src/cth_readable_helpers.erl"},
                                 {line,162}]},
                            {cth_readable_helpers,maybe_eunit_format,1,
                                [{file,
                                     "/__w/rebar3/rebar3/_build/default/lib/cth_readable/src/cth_readable_helpers.erl"},
                                 {line,98}]},
```

Release version: v/e5.8.4
