### PR TITLE
fix(ds msg serializer): handle missing properties when deserializing

### DIFF
--- a/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl
@@ -371,6 +371,7 @@ asn1_deserialize_misc(MiscData, Message0) ->
                     fun(Props) ->
                         maps:put(binary_to_term(Key), binary_to_term(Val), Props)
                     end,
+                    #{binary_to_term(Key) => binary_to_term(Val)},
                     Headers0
                 ),
                 Acc#message{headers = Headers};
@@ -381,6 +382,7 @@ asn1_deserialize_misc(MiscData, Message0) ->
                     fun(Props) ->
                         maps:put(Key, Val, Props)
                     end,
+                    #{Key => Val},
                     Headers0
                 ),
                 Acc#message{headers = Headers};

--- a/apps/emqx_durable_storage/src/emqx_durable_storage.app.src
+++ b/apps/emqx_durable_storage/src/emqx_durable_storage.app.src
@@ -2,7 +2,7 @@
 {application, emqx_durable_storage, [
     {description, "Message persistence and subscription replays for EMQX"},
     % strict semver, bump manually!
-    {vsn, "0.4.2"},
+    {vsn, "0.4.3"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, rocksdb, gproc, mria, emqx_utils, gen_rpc]},


### PR DESCRIPTION
During deserialization, the `properties` key may be still missing from the headers.

Ex:
```
Error: -11T13:57:04.835972+00:00 [error] Generic server <0.460010.0> terminating. Reason: {{badkey,properties},[{maps,update_with,[properties,#Fun<emqx_ds_msg_serializer.6.27087686>,#{}],[{file,"maps.erl"},{line,283}]},{emqx_ds_msg_serializer,'-asn1_deserialize_misc/2-fun-2-',2,[{file,"/emqx/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl"},{line,369}]},{lists,foldl,3,[{file,"lists.erl"},{line,1594}]},{emqx_ds_fdb_layout_skipstream_v1,'-scan_stream/6-fun-0-',2,[{file,"/emqx/apps/emqx_ds_fdb_backend/src/emqx_ds_fdb_layout_skipstream_v1.erl"},{line,282}]},{lists,map,2,[{file,"lists.erl"},{line,1559}]},{emqx_ds_fdb_layout_skipstream_v1,scan_stream,6,[{file,"/emqx/apps/emqx_ds_fdb_backend/src/emqx_ds_fdb_layout_skipstream_v1.erl"},{line,280}]},{emqx_ds_fdb_layout,scan_stream,7,[{file,"/emqx/apps/emqx_ds_fdb_backend/src/emqx_ds_fdb_layout.erl"},{line,118}]},{emqx_ds_beamformer,do_fulfill_pending,2,[{file,"/emqx/apps/emqx_durable_storage/src/emqx_ds_beamformer.erl"},{line,468}]},{emqx_ds_beamformer,fulfill_pending,1,[{file,"/emqx/apps/emqx_durable_storage/src/emqx_ds_beamformer.erl"},{line,449}]},{emqx_ds_beamformer,handle_info,2,[{file,"/emqx/apps/emqx_durable_storage/src/emqx_ds_beamformer.erl"},{line,363}]},{gen_server,try_handle_info,3,[{file,"gen_server.erl"},{line,1095}]},{gen_server,handle_msg,6,[{file,"gen_server.erl"},{line,1183}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,241}]}]}. Last message: fulfill_loop. State: {s,emqx_ds_fdb_rgen,<<109,101,115,115,97,103,101,115,47,7>>,{messages,7},1,#Ref<0.2896446990.3106013185.144873>,100000,#Ref<0.2896446990.3106013185.144874>,true,100}.
```

Release version: v/e5.8.4
