### PR TITLE
241212 max packet size in valid range

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -29,7 +29,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("logger.hrl").
 
--define(MAX_INT_MQTT_PACKET_SIZE, 268435456).
+-define(MAX_INT_MQTT_PACKET_SIZE, 268435455).
 -define(MAX_INT_TIMEOUT_MS, 4294967295).
 %% floor(?MAX_INT_TIMEOUT_MS / 1000).
 -define(MAX_INT_TIMEOUT_S, 4294967).
@@ -92,7 +92,8 @@
 
 -export([
     validate_heap_size/1,
-    validate_packet_size/1,
+    validate_max_packet_size/1,
+    convert_max_packet_size/2,
     user_lookup_fun_tr/2,
     validate_keepalive_multiplier/1,
     non_empty_string/1,
@@ -2818,15 +2819,24 @@ validate_heap_size(Siz) when is_integer(Siz) ->
 validate_heap_size(_SizStr) ->
     {error, invalid_heap_size}.
 
-validate_packet_size(Siz) when is_integer(Siz) andalso Siz < 1 ->
-    {error, #{reason => max_mqtt_packet_size_too_small, minimum => 1}};
-validate_packet_size(Siz) when is_integer(Siz) andalso Siz > ?MAX_INT_MQTT_PACKET_SIZE ->
-    Max = integer_to_list(round(?MAX_INT_MQTT_PACKET_SIZE / 1024 / 1024)) ++ "M",
-    {error, #{reason => max_mqtt_packet_size_too_large, maximum => Max}};
-validate_packet_size(Siz) when is_integer(Siz) ->
+validate_max_packet_size(Siz) when is_integer(Siz) andalso Siz < 1 ->
+    {error, #{cause => max_mqtt_packet_size_too_small, minimum => 1}};
+validate_max_packet_size(Siz) when is_integer(Siz) andalso Siz > ?MAX_INT_MQTT_PACKET_SIZE ->
+    {error, #{
+        cause => max_mqtt_packet_size_too_large,
+        maximum => ?MAX_INT_MQTT_PACKET_SIZE
+    }};
+validate_max_packet_size(Siz) when is_integer(Siz) ->
     ok;
-validate_packet_size(_SizStr) ->
+validate_max_packet_size(_SizStr) ->
     {error, invalid_packet_size}.
+
+%% This is for backward compatibility.
+%% We used to allow setting 256MB, but in fact the limit is one byte less.
+convert_max_packet_size(<<"256MB">>, _) ->
+    ?MAX_INT_MQTT_PACKET_SIZE;
+convert_max_packet_size(X, _) ->
+    X.
 
 validate_keepalive_multiplier(Multiplier) when
     is_number(Multiplier) andalso Multiplier >= 1.0 andalso Multiplier =< 65535.0
@@ -3553,7 +3563,8 @@ mqtt_general() ->
                 bytesize(),
                 #{
                     default => <<"1MB">>,
-                    validator => fun ?MODULE:validate_packet_size/1,
+                    validator => fun ?MODULE:validate_max_packet_size/1,
+                    converter => fun ?MODULE:convert_max_packet_size/2,
                     desc => ?DESC(mqtt_max_packet_size)
                 }
             )},

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -942,3 +942,46 @@ unicode_template_test() ->
         #{<<"root">> => #{<<"template">> => <<"中文"/utf8>>}},
         hocon_tconf:check_plain(Sc, Hocon)
     ).
+
+max_packet_size_test_() ->
+    Sc = emqx_schema,
+    Check = fun(Input) ->
+        {ok, Hocon} = hocon:binary(Input),
+        hocon_tconf:check_plain(Sc, Hocon, #{}, [mqtt])
+    end,
+    [
+        {"one byte less than 256MB", fun() ->
+            ?assertMatch(
+                #{<<"mqtt">> := #{<<"max_packet_size">> := 268435455}},
+                Check(<<"mqtt.max_packet_size = 256MB">>)
+            )
+        end},
+        {"default value", fun() ->
+            ?assertMatch(
+                #{<<"mqtt">> := #{<<"max_packet_size">> := 1048576}},
+                Check(<<"mqtt.max_packet_size = null">>)
+            )
+        end},
+        {"1KB is 1024 bytes", fun() ->
+            ?assertMatch(
+                #{<<"mqtt">> := #{<<"max_packet_size">> := 1024}},
+                Check(<<"mqtt.max_packet_size = 1KB">>)
+            )
+        end},
+        {"257MB is not allowed", fun() ->
+            ?assertThrow(
+                {emqx_schema, [
+                    #{reason := #{cause := max_mqtt_packet_size_too_large, maximum := 268435455}}
+                ]},
+                Check(<<"mqtt.max_packet_size = 257MB">>)
+            )
+        end},
+        {"0 is not allowed", fun() ->
+            ?assertThrow(
+                {emqx_schema, [
+                    #{reason := #{cause := max_mqtt_packet_size_too_small, minimum := 1}}
+                ]},
+                Check(<<"mqtt.max_packet_size = 0">>)
+            )
+        end}
+    ].

--- a/changes/ce/fix-14405.en.md
+++ b/changes/ce/fix-14405.en.md
@@ -1,0 +1,4 @@
+Convert `256MB` to `268435455` bytes for `mqtt.max_packet_size`.
+
+EMQX previously allowed setting `256MB` for `mqtt.max_packet_size` config, which is in fact one byte more than what the protocol spec allows.
+For backward compatibility, `mqtt.max_packet_size=256MB` is still allowed from configurations, but will be silently converted to `268435455`.

--- a/rel/i18n/emqx_bridge_http_schema.hocon
+++ b/rel/i18n/emqx_bridge_http_schema.hocon
@@ -69,7 +69,7 @@ config_path.desc:
 """The URL path for this Action.<br/>
 This path will be appended to the Connector's <code>url</code> configuration to form the full
 URL address.
-Template with variables is allowed in this option. For example, <code>/room/{$room_no}</code>"""
+Template with variables is allowed in this option. For example, <code>/room/${room_no}</code>"""
 
 config_path.label:
 """URL Path"""


### PR DESCRIPTION
Fixes #14400

Release version: v/e5.8.5

## Summary

For 4-bytes var-length integer, the maximum value is
`127 + (127 x 128) + (127 x 128^2) + (127 x 128^3) = 268,435,455`

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
