### PR TITLE
feat: rule func `str_utf16_le/1` and `sqlserver_bin2hexstr/1`

### DIFF
--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_sqlserver, [
     {description, "EMQX Enterprise SQL Server Bridge"},
-    {vsn, "0.2.6"},
+    {vsn, "0.2.7"},
     {registered, []},
     {applications, [kernel, stdlib, emqx_resource, odbc]},
     {env, [

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -601,9 +601,9 @@ proc_batch_sql(BatchReqs, BatchInserts, Tokens, ChannelConf) ->
     <<BatchInserts/binary, " values ", Values/binary>>.
 
 proc_msg(Tokens, Msg, #{undefined_vars_as_null := true}) ->
-    emqx_placeholder:proc_sql_param_str2(Tokens, Msg);
+    emqx_placeholder:proc_sqlserver_param_str2(Tokens, Msg);
 proc_msg(Tokens, Msg, _) ->
-    emqx_placeholder:proc_sql_param_str(Tokens, Msg).
+    emqx_placeholder:proc_sqlserver_param_str(Tokens, Msg).
 
 to_bin(List) when is_list(List) ->
     unicode:characters_to_binary(List, utf8).

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -109,6 +109,7 @@
 -export([
     str/1,
     str_utf8/1,
+    str_utf16_le/1,
     bool/1,
     int/1,
     float/1,
@@ -116,7 +117,8 @@
     float2str/2,
     map/1,
     bin2hexstr/1,
-    hexstr2bin/1
+    hexstr2bin/1,
+    sqlserver_hexbin/1
 ]).
 
 %% Data Type Validation Funcs
@@ -713,6 +715,11 @@ str_utf8(Data) when is_binary(Data); is_list(Data) ->
 str_utf8(Data) ->
     unicode:characters_to_binary(str(Data)).
 
+str_utf16_le(Data) when is_binary(Data); is_list(Data) ->
+    unicode:characters_to_binary(Data, utf8, {utf16, little});
+str_utf16_le(Data) ->
+    unicode:characters_to_binary(str(Data), utf8, {utf16, little}).
+
 bool(Data) ->
     emqx_utils_conv:bool(Data).
 
@@ -748,6 +755,9 @@ bin2hexstr(Bin) ->
 
 hexstr2bin(Str) ->
     emqx_variform_bif:hexstr2bin(Str).
+
+sqlserver_hexbin(Str) ->
+    <<"0x", (emqx_variform_bif:bin2hexstr(Str))/binary>>.
 
 %%------------------------------------------------------------------------------
 %% NULL Funcs

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -223,9 +223,37 @@ t_hexstr2bin(_) ->
     ?assertEqual(<<1, 2>>, emqx_rule_funcs:hexstr2bin(<<"0102">>)),
     ?assertEqual(<<17, 33>>, emqx_rule_funcs:hexstr2bin(<<"1121">>)).
 
+t_hexstr2bin_with_prefix(_) ->
+    ?assertEqual(<<6, 54, 79>>, emqx_rule_funcs:hexstr2bin(<<"0x6364f">>, <<"0x">>)),
+    ?assertEqual(<<10>>, emqx_rule_funcs:hexstr2bin(<<"0Xa">>, <<"0X">>)),
+    ?assertEqual(<<15>>, emqx_rule_funcs:hexstr2bin(<<"0bf">>, <<"0b">>)),
+    ?assertEqual(<<5>>, emqx_rule_funcs:hexstr2bin(<<"0B5">>, <<"0B">>)),
+    ?assertEqual(<<1, 2>>, emqx_rule_funcs:hexstr2bin(<<"0x0102">>, <<"0x">>)),
+    ?assertEqual(<<17, 33>>, emqx_rule_funcs:hexstr2bin(<<"0X1121">>, <<"0X">>)).
+
+t_hexstr2bin_with_invalid_prefix(_) ->
+    [
+        begin
+            ?assertError(binary_prefix_unmatch, emqx_rule_funcs:hexstr2bin(HexStr, Prefix))
+        end
+     || {HexStr, Prefix} <- [
+            {<<"0x6364f">>, <<"ab">>},
+            {<<"0Xa">>, <<"ef">>},
+            {<<"0bf">>, <<"你好👋"/utf8>>},
+            {<<"0B5">>, <<"🐸"/utf8>>}
+        ]
+    ].
+
 t_bin2hexstr(_) ->
     ?assertEqual(<<"0102">>, emqx_rule_funcs:bin2hexstr(<<1, 2>>)),
     ?assertEqual(<<"1121">>, emqx_rule_funcs:bin2hexstr(<<17, 33>>)).
+
+t_bin2hexstr_with_prefix(_) ->
+    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:bin2hexstr(<<1, 2>>, <<"0x">>)),
+    ?assertEqual(<<"0X0102">>, emqx_rule_funcs:bin2hexstr(<<1, 2>>, <<"0X">>)),
+    ?assertEqual(<<"0b1121">>, emqx_rule_funcs:bin2hexstr(<<17, 33>>, <<"0b">>)),
+    ?assertEqual(<<"0B1121">>, emqx_rule_funcs:bin2hexstr(<<17, 33>>, <<"0B">>)),
+    ?assertEqual(<<"🧠0102"/utf8>>, emqx_rule_funcs:bin2hexstr(<<1, 2>>, <<"🧠"/utf8>>)).
 
 t_bin2hexstr_not_even_bytes(_) ->
     ?assertEqual(<<"0102">>, emqx_rule_funcs:bin2hexstr(<<1:5, 2>>)),
@@ -240,20 +268,20 @@ t_bin2hexstr_not_even_bytes(_) ->
     ?assertEqual(<<"1121">>, emqx_rule_funcs:bin2hexstr(<<17, 33>>)),
     ?assertEqual(<<"01121">>, emqx_rule_funcs:bin2hexstr(<<17:9, 33>>)).
 
-t_sqlserver_hexbin(_) ->
-    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:sqlserver_hexbin(<<1, 2>>)),
-    ?assertEqual(<<"0x1121">>, emqx_rule_funcs:sqlserver_hexbin(<<17, 33>>)),
-    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:5, 2>>)),
-    ?assertEqual(<<"0x1002">>, emqx_rule_funcs:sqlserver_hexbin(<<16:5, 2>>)),
-    ?assertEqual(<<"0x1002">>, emqx_rule_funcs:sqlserver_hexbin(<<16:8, 2>>)),
-    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:4, 2>>)),
-    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:3, 2>>)),
-    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:1, 2>>)),
-    ?assertEqual(<<"0x002">>, emqx_rule_funcs:sqlserver_hexbin(<<2:1, 2>>)),
-    ?assertEqual(<<"0x02">>, emqx_rule_funcs:sqlserver_hexbin(<<2>>)),
-    ?assertEqual(<<"0x2">>, emqx_rule_funcs:sqlserver_hexbin(<<2:2>>)),
-    ?assertEqual(<<"0x1121">>, emqx_rule_funcs:sqlserver_hexbin(<<17, 33>>)),
-    ?assertEqual(<<"0x01121">>, emqx_rule_funcs:sqlserver_hexbin(<<17:9, 33>>)).
+t_sqlserver_bin2hexstr(_) ->
+    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<1, 2>>)),
+    ?assertEqual(<<"0x1121">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<17, 33>>)),
+    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<1:5, 2>>)),
+    ?assertEqual(<<"0x1002">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<16:5, 2>>)),
+    ?assertEqual(<<"0x1002">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<16:8, 2>>)),
+    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<1:4, 2>>)),
+    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<1:3, 2>>)),
+    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<1:1, 2>>)),
+    ?assertEqual(<<"0x002">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<2:1, 2>>)),
+    ?assertEqual(<<"0x02">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<2>>)),
+    ?assertEqual(<<"0x2">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<2:2>>)),
+    ?assertEqual(<<"0x1121">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<17, 33>>)),
+    ?assertEqual(<<"0x01121">>, emqx_rule_funcs:sqlserver_bin2hexstr(<<17:9, 33>>)).
 
 t_hex_convert(_) ->
     ?PROPTEST(hex_convert).

--- a/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_funcs_SUITE.erl
@@ -125,6 +125,28 @@ t_str(_) ->
     ?assertEqual(<<"true">>, emqx_rule_funcs:str_utf8(true)),
     ?assertError(_, emqx_rule_funcs:str_utf8({a, v})).
 
+t_str_utf16_le(_) ->
+    ?assertEqual(<<"abc"/utf16-little>>, emqx_rule_funcs:str_utf16_le("abc")),
+    ?assertEqual(<<"abc"/utf16-little>>, emqx_rule_funcs:str_utf16_le(abc)),
+    ?assertEqual(<<"{\"a\":1}"/utf16-little>>, emqx_rule_funcs:str_utf16_le(#{a => 1})),
+    ?assertEqual(<<"1"/utf16-little>>, emqx_rule_funcs:str_utf16_le(1)),
+    ?assertEqual(<<"2.0"/utf16-little>>, emqx_rule_funcs:str_utf16_le(2.0)),
+    ?assertEqual(<<"true"/utf16-little>>, emqx_rule_funcs:str_utf16_le(true)),
+    ?assertError(_, emqx_rule_funcs:str_utf16_le({a, v})),
+
+    ?assertEqual(<<"abc"/utf16-little>>, emqx_rule_funcs:str_utf16_le("abc")),
+    ?assertEqual(<<"abc 你好"/utf16-little>>, emqx_rule_funcs:str_utf16_le("abc 你好")),
+    ?assertEqual(<<"abc 你好"/utf16-little>>, emqx_rule_funcs:str_utf16_le(<<"abc 你好"/utf8>>)),
+    ?assertEqual(<<"abc"/utf16-little>>, emqx_rule_funcs:str_utf16_le(abc)),
+    ?assertEqual(
+        <<"{\"a\":\"abc 你好\"}"/utf16-little>>,
+        emqx_rule_funcs:str_utf16_le(#{a => <<"abc 你好"/utf8>>})
+    ),
+    ?assertEqual(<<"1"/utf16-little>>, emqx_rule_funcs:str_utf16_le(1)),
+    ?assertEqual(<<"2.0"/utf16-little>>, emqx_rule_funcs:str_utf16_le(2.0)),
+    ?assertEqual(<<"true"/utf16-little>>, emqx_rule_funcs:str_utf16_le(true)),
+    ?assertError(_, emqx_rule_funcs:str_utf16_le({a, v})).
+
 t_int(_) ->
     ?assertEqual(1, emqx_rule_funcs:int("1")),
     ?assertEqual(1, emqx_rule_funcs:int(<<"1.0">>)),
@@ -217,6 +239,21 @@ t_bin2hexstr_not_even_bytes(_) ->
     ?assertEqual(<<"2">>, emqx_rule_funcs:bin2hexstr(<<2:2>>)),
     ?assertEqual(<<"1121">>, emqx_rule_funcs:bin2hexstr(<<17, 33>>)),
     ?assertEqual(<<"01121">>, emqx_rule_funcs:bin2hexstr(<<17:9, 33>>)).
+
+t_sqlserver_hexbin(_) ->
+    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:sqlserver_hexbin(<<1, 2>>)),
+    ?assertEqual(<<"0x1121">>, emqx_rule_funcs:sqlserver_hexbin(<<17, 33>>)),
+    ?assertEqual(<<"0x0102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:5, 2>>)),
+    ?assertEqual(<<"0x1002">>, emqx_rule_funcs:sqlserver_hexbin(<<16:5, 2>>)),
+    ?assertEqual(<<"0x1002">>, emqx_rule_funcs:sqlserver_hexbin(<<16:8, 2>>)),
+    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:4, 2>>)),
+    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:3, 2>>)),
+    ?assertEqual(<<"0x102">>, emqx_rule_funcs:sqlserver_hexbin(<<1:1, 2>>)),
+    ?assertEqual(<<"0x002">>, emqx_rule_funcs:sqlserver_hexbin(<<2:1, 2>>)),
+    ?assertEqual(<<"0x02">>, emqx_rule_funcs:sqlserver_hexbin(<<2>>)),
+    ?assertEqual(<<"0x2">>, emqx_rule_funcs:sqlserver_hexbin(<<2:2>>)),
+    ?assertEqual(<<"0x1121">>, emqx_rule_funcs:sqlserver_hexbin(<<17, 33>>)),
+    ?assertEqual(<<"0x01121">>, emqx_rule_funcs:sqlserver_hexbin(<<17:9, 33>>)).
 
 t_hex_convert(_) ->
     ?PROPTEST(hex_convert).

--- a/apps/emqx_utils/src/emqx_placeholder.erl
+++ b/apps/emqx_utils/src/emqx_placeholder.erl
@@ -183,17 +183,14 @@ preproc_sql(Sql, Opts) ->
 proc_sql(Tokens, Data) ->
     proc_tmpl(Tokens, Data, #{return => rawlist, var_trans => fun sql_data/1}).
 
+%% func `proc_sql_param_str/2` and `proc_sql_param_str2/2` are only used by sqlserver bridge
 -spec proc_sql_param_str(tmpl_token(), map()) -> binary().
 proc_sql_param_str(Tokens, Data) ->
-    % NOTE
-    % This is a bit misleading: currently, escaping logic in `quote_sql/1` likely
-    % won't work with pgsql since it does not support C-style escapes by default.
-    % https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
-    proc_param_str(Tokens, Data, fun quote_sql/1).
+    proc_param_str(Tokens, Data, fun quote_sqlserver/1).
 
 -spec proc_sql_param_str2(tmpl_token(), map()) -> binary().
 proc_sql_param_str2(Tokens, Data) ->
-    proc_param_str(Tokens, Data, fun quote_sql2/1).
+    proc_param_str(Tokens, Data, fun quote_sqlserver2/1).
 
 -spec proc_cql_param_str(tmpl_token(), map()) -> binary().
 proc_cql_param_str(Tokens, Data) ->
@@ -290,6 +287,14 @@ quote_mysql(Str) ->
 -spec quote_mysql2(_Value) -> iolist().
 quote_mysql2(Str) ->
     emqx_utils_sql:to_sql_string(Str, #{escaping => mysql}).
+
+-spec quote_sqlserver(_Str) -> iolist().
+quote_sqlserver(Str) ->
+    emqx_utils_sql:to_sql_string(Str, #{escaping => sqlserver, undefined => <<"undefined">>}).
+
+-spec quote_sqlserver2(_Str) -> iolist().
+quote_sqlserver2(Str) ->
+    emqx_utils_sql:to_sql_string(Str, #{escaping => sqlserver}).
 
 lookup_var(Var, Value) when Var == ?PH_VAR_THIS orelse Var == [] ->
     Value;

--- a/apps/emqx_utils/src/emqx_placeholder.erl
+++ b/apps/emqx_utils/src/emqx_placeholder.erl
@@ -29,8 +29,8 @@
     preproc_sql/1,
     preproc_sql/2,
     proc_sql/2,
-    proc_sql_param_str/2,
-    proc_sql_param_str2/2,
+    proc_sqlserver_param_str/2,
+    proc_sqlserver_param_str2/2,
     proc_cql_param_str/2,
     proc_param_str/3,
     preproc_tmpl_deep/1,
@@ -183,13 +183,12 @@ preproc_sql(Sql, Opts) ->
 proc_sql(Tokens, Data) ->
     proc_tmpl(Tokens, Data, #{return => rawlist, var_trans => fun sql_data/1}).
 
-%% func `proc_sql_param_str/2` and `proc_sql_param_str2/2` are only used by sqlserver bridge
--spec proc_sql_param_str(tmpl_token(), map()) -> binary().
-proc_sql_param_str(Tokens, Data) ->
+-spec proc_sqlserver_param_str(tmpl_token(), map()) -> binary().
+proc_sqlserver_param_str(Tokens, Data) ->
     proc_param_str(Tokens, Data, fun quote_sqlserver/1).
 
--spec proc_sql_param_str2(tmpl_token(), map()) -> binary().
-proc_sql_param_str2(Tokens, Data) ->
+-spec proc_sqlserver_param_str2(tmpl_token(), map()) -> binary().
+proc_sqlserver_param_str2(Tokens, Data) ->
     proc_param_str(Tokens, Data, fun quote_sqlserver2/1).
 
 -spec proc_cql_param_str(tmpl_token(), map()) -> binary().

--- a/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
@@ -120,13 +120,14 @@ t_preproc_sqlserver_sql(_) ->
         b => 1,
         c => 1.0,
         d => #{d1 => <<"hi">>},
-        hex_str => <<"0x0010">>
+        hex_str => <<"0x0010">>,
+        not_hex => <<"0xabcdefghijk_你好🐸"/utf8>>
     },
     ParamsTokens = emqx_placeholder:preproc_tmpl(
-        <<"a:${a},b:${b},c:${c},d:${d},hex_str:${hex_str}"/utf8>>
+        <<"a:${a},b:${b},c:${c},d:${d},hex_str:${hex_str},not_hex:${not_hex}"/utf8>>
     ),
     ?assertEqual(
-        <<"a:'abc_hello你好👋',b:1,c:1.0,d:'{\"d1\":\"hi\"}',hex_str:0x0010"/utf8>>,
+        <<"a:'abc_hello你好👋',b:1,c:1.0,d:'{\"d1\":\"hi\"}',hex_str:0x0010,not_hex:'0xabcdefghijk_你好🐸'"/utf8>>,
         emqx_placeholder:proc_sql_param_str(ParamsTokens, Selected)
     ).
 

--- a/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
@@ -114,6 +114,22 @@ t_preproc_sql3(_) ->
         emqx_placeholder:proc_sql_param_str(ParamsTokens, Selected)
     ).
 
+t_preproc_sqlserver_sql(_) ->
+    Selected = #{
+        a => <<"abc_hello你好👋"/utf8>>,
+        b => 1,
+        c => 1.0,
+        d => #{d1 => <<"hi">>},
+        hex_str => <<"0x0010">>
+    },
+    ParamsTokens = emqx_placeholder:preproc_tmpl(
+        <<"a:${a},b:${b},c:${c},d:${d},hex_str:${hex_str}"/utf8>>
+    ),
+    ?assertEqual(
+        <<"a:'abc_hello你好👋',b:1,c:1.0,d:'{\"d1\":\"hi\"}',hex_str:0x0010"/utf8>>,
+        emqx_placeholder:proc_sql_param_str(ParamsTokens, Selected)
+    ).
+
 t_preproc_mysql1(_) ->
     %% with apostrophes
     %% https://github.com/emqx/emqx/issues/4135

--- a/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_placeholder_SUITE.erl
@@ -106,12 +106,12 @@ t_preproc_sql2(_) ->
     ?assertEqual(<<"a:$a,b:b},c:{c},d:${d">>, PrepareStatement),
     ?assertEqual([], emqx_placeholder:proc_sql(ParamsTokens, Selected)).
 
-t_preproc_sql3(_) ->
+t_preproc_sqlserver(_) ->
     Selected = #{a => <<"1">>, b => 1, c => 1.0, d => #{d1 => <<"hi">>}},
     ParamsTokens = emqx_placeholder:preproc_tmpl(<<"a:${a},b:${b},c:${c},d:${d}">>),
     ?assertEqual(
         <<"a:'1',b:1,c:1.0,d:'{\"d1\":\"hi\"}'">>,
-        emqx_placeholder:proc_sql_param_str(ParamsTokens, Selected)
+        emqx_placeholder:proc_sqlserver_param_str(ParamsTokens, Selected)
     ).
 
 t_preproc_sqlserver_sql(_) ->
@@ -128,7 +128,7 @@ t_preproc_sqlserver_sql(_) ->
     ),
     ?assertEqual(
         <<"a:'abc_hello你好👋',b:1,c:1.0,d:'{\"d1\":\"hi\"}',hex_str:0x0010,not_hex:'0xabcdefghijk_你好🐸'"/utf8>>,
-        emqx_placeholder:proc_sql_param_str(ParamsTokens, Selected)
+        emqx_placeholder:proc_sqlserver_param_str(ParamsTokens, Selected)
     ).
 
 t_preproc_mysql1(_) ->

--- a/changes/feat-14409.en.md
+++ b/changes/feat-14409.en.md
@@ -1,0 +1,7 @@
+Add two rule functions to convert UTF-8 strings to UTF-16-little-endian for compatibility with SQL Server versions that do not support UTF-8.
+
+- Convert a UTF-8 string to UTF-16-little-endian.
+  `str_utf16_le/1`
+
+- Convert any string or Binary to SQL Server hex binary format with `0x` prefix.
+  `sqlserver_bin2hexstr/1`


### PR DESCRIPTION
Fixes [EMQX-13661](https://emqx.atlassian.net/browse/EMQX-13661)

Release version: v/e5.8.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~[ ] Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~


[EMQX-13661]: https://emqx.atlassian.net/browse/EMQX-13661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ