### PR TITLE
fix(new mix build): update iotdb driver version

### DIFF
--- a/apps/emqx_bridge_iotdb/mix.exs
+++ b/apps/emqx_bridge_iotdb/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXBridgeIotdb.MixProject do
 
   def deps() do
     [
-      {:iotdb, github: "emqx/iotdb-client-erl", tag: "0.1.5"},
+      {:iotdb, github: "emqx/iotdb-client-erl", tag: "0.2.0"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},


### PR DESCRIPTION
This affects only the new mix build.  No changes for any released version.