### PR TITLE
feat: quicer 0.2.3

### DIFF
--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,7 +19,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.3"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.11"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.3"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/apps/emqx/src/emqx_quic_connection.erl
+++ b/apps/emqx/src/emqx_quic_connection.erl
@@ -123,7 +123,8 @@ new_conn(
             ),
             receive
                 {CtrlPid, stream_acceptor_ready} ->
-                    ok = quicer:async_handshake(Conn),
+                    %% Apply latest config during handshake
+                    ok = quicer:async_handshake(Conn, S),
                     {ok, S#{conn := Conn, ctrl_pid := CtrlPid}};
                 {'EXIT', _Pid, _Reason} ->
                     {stop, stream_accept_error, S}

--- a/apps/emqx/src/emqx_quic_connection.erl
+++ b/apps/emqx/src/emqx_quic_connection.erl
@@ -265,7 +265,13 @@ handle_call(
         %% we dont care about the return val here.
         %% note, this is only used after control stream pass the validation. The data streams
         %%       that are called here are assured to be inactived (data processing hasn't been started).
-        catch emqx_quic_data_stream:activate_data(OwnerPid, ActivateData)
+        try emqx_quic_data_stream:activate_data(OwnerPid, ActivateData) of
+            _ ->
+                ok
+        catch
+            _:_ ->
+                ok
+        end
      || {OwnerPid, _Stream} <- Streams
     ],
     {reply, ok, S#{

--- a/changes/ce/feat-14431.en.md
+++ b/changes/ce/feat-14431.en.md
@@ -1,0 +1,5 @@
+Switch to newer QUIC stack: quicer 0.2.3, 
+
+- msquic 2.3.8 + patches
+- Advance resource management
+- Prepare to support more dynamic config changes on the listeners

--- a/mix.exs
+++ b/mix.exs
@@ -1221,7 +1221,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.1.11", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.2.3", override: true}
       ],
       else: []
   end

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.11"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.3"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.12"}}}.
@@ -189,7 +189,7 @@ project_app_excluded("apps/" ++ AppStr, ExcludedApps) ->
 
 plugins() ->
     [
-        {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.2.2"}}},
+        {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.2.3"}}},
         %% emqx main project does not require port-compiler
         %% pin at root level for deterministic
         {pc, "1.15.0"}


### PR DESCRIPTION
I have done my testing of quicer 0.2 branch. It is safe to bump it for EMQX 5.9 now.

Release version: v/e5.9

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
