### PR TITLE
fix(cli): plugins list cli should return empty plugins as [] not {}

### DIFF
--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.3.0"},
+    {vsn, "0.3.1"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx, erlavro]},

--- a/apps/emqx_plugins/src/emqx_plugins_cli.erl
+++ b/apps/emqx_plugins/src/emqx_plugins_cli.erl
@@ -75,6 +75,9 @@ ensure_enabled(NameVsn, Position, LogFun) ->
 ensure_disabled(NameVsn, LogFun) ->
     ?PRINT(emqx_plugins:ensure_disabled(NameVsn), LogFun).
 
+%% erlang cannot distinguish between "" and [], so best_effort_json is also helpless.
+to_json([]) ->
+    <<"[]">>;
 to_json(Input) ->
     emqx_logger_jsonfmt:best_effort_json(Input).
 

--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -233,6 +233,7 @@ t_demo_install_start_stop_uninstall(Config) ->
     ),
     ok = emqx_plugins:ensure_uninstalled(NameVsn),
     ?assertEqual([], emqx_plugins:list()),
+    ?assertMatch([<<"[]">>], emqx_plugins_cli:list(fun(_, L) -> L end)),
     ok.
 
 %% help function to create a info file.


### PR DESCRIPTION
Fixes <issue-or-jira-number>
Before:
```
./bin/emqx ctl plugins list
{

}
```
After:
```
./bin/emqx ctl plugins list
[]
```
Release version: v/e5.8.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
