### PR TITLE
test(sqlserver): fix flaky test

### DIFF
--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -47,7 +47,7 @@
 -define(SQL_SERVER_USERNAME, "sa").
 -define(SQL_SERVER_PASSWORD, "mqtt_public1").
 -define(BATCH_SIZE, 10).
--define(REQUEST_TIMEOUT_MS, 500).
+-define(REQUEST_TIMEOUT_MS, 2_000).
 
 -define(WORKER_POOL_SIZE, 4).
 


### PR DESCRIPTION
Ex:

```
%%% emqx_bridge_sqlserver_SUITE ==> async.without_batch.init_per_group: FAILED
%%% emqx_bridge_sqlserver_SUITE ==> timeout

Error: -18T18:57:34.508735+00:00 [error] Generic server <0.411239.0> terminating. Reason: {stopped,{'EXIT',<0.410524.0>,{#Ref<0.4002057353.419692545.65779>,5044239,{'EXIT',timeout},[{odbc,call,1030},{emqx_bridge_sqlserver_SUITE,connect_and_create_db_and_table,642},{emqx_bridge_sqlserver_SUITE,common_init,464},{test_server,ts_tc,1793},{test_server,run_test_case_eval1,1390},{test_server,run_test_case_eval,1234}],[]}}}. Last message: {'DOWN',#Ref<0.4002057353.419168258.187269>,process,<0.410524.0>,{#Ref<0.4002057353.419692545.65779>,5044239,{'EXIT',timeout},[{odbc,call,1030},{emqx_bridge_sqlserver_SUITE,connect_and_create_db_and_table,642},{emqx_bridge_sqlserver_SUITE,common_init,464},{test_server,ts_tc,1793},{test_server,run_test_case_eval1,1390},{test_server,run_test_case_eval,1234}],[]}}. State: {state,#Port<0.971>,undefined,<0.410524.0>,undefined,on,true,true,on,connected,undefined,1,[#Port<0.969>,#Port<0.970>],#Port<0.972>,#Port<0.973>}.
```
