### PR TITLE
fix(jt808): avoid funcation_clause error

### DIFF
--- a/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
+++ b/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_jt808, [
     {description, "JT/T 808 Gateway"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -411,7 +411,7 @@ msgs2frame(Messages, Channel) ->
                         Channel
                     ),
                     false;
-                {error, Reason} ->
+                {error, _Reason} ->
                     tp(
                         error,
                         invalid_dl_message,

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -11,6 +11,8 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
 %% behaviour callbacks
 -export([
     info/1,
@@ -397,13 +399,25 @@ msgs2frame(Messages, Channel) ->
     lists:filtermap(
         fun(#message{payload = Payload}) ->
             case emqx_utils_json:safe_decode(Payload, [return_maps]) of
-                {ok, Map} ->
-                    MsgId = msgid(Map),
+                {ok, Map = #{<<"header">> := #{<<"msg_id">> := MsgId}}} ->
                     NewHeader = build_frame_header(MsgId, Channel),
                     Frame = maps:put(<<"header">>, NewHeader, Map),
                     {true, Frame};
+                {ok, _} ->
+                    tp(
+                        error,
+                        invalid_dl_message,
+                        #{reasons => "missing_msg_id", payload => Payload},
+                        Channel
+                    ),
+                    false;
                 {error, Reason} ->
-                    log(error, #{msg => "json_decode_error", reason => Reason}, Channel),
+                    tp(
+                        error,
+                        invalid_dl_message,
+                        #{reason => "invalid_json", payload => Payload},
+                        Channel
+                    ),
                     false
             end
         end,
@@ -1046,6 +1060,14 @@ metrics_inc(Name, #channel{ctx = Ctx}, Oct) ->
 
 log(Level, Meta, #channel{clientinfo = #{clientid := ClientId, username := Username}} = _Channel) ->
     ?SLOG(Level, Meta#{clientid => ClientId, username => Username}).
+
+tp(
+    Level,
+    Key,
+    Meta,
+    #channel{clientinfo = #{clientid := ClientId, username := Username}} = _Channel
+) ->
+    ?tp(Level, Key, Meta#{clientid => ClientId, username => Username}).
 
 reply(Reply, Channel) ->
     {reply, Reply, Channel}.

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -12,6 +12,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
 -define(FRM_FLAG, 16#7e:8).
 -define(RESERVE, 0).
 -define(NO_FRAGMENT, 0).
@@ -106,6 +108,7 @@ init_per_testcase(Case, Config) when
     Apps = boot_apps(Case, <<>>, Config),
     [{suite_apps, Apps} | Config];
 init_per_testcase(Case, Config) ->
+    snabbkaffe:start_trace(),
     Apps = boot_apps(Case, ?CONF_DEFAULT, Config),
     [{suite_apps, Apps} | Config].
 
@@ -116,6 +119,7 @@ end_per_testcase(_Case, Config) ->
         exit:noproc ->
             ok
     end,
+    snabbkaffe:stop(),
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)),
     ok.
 
@@ -2707,6 +2711,29 @@ t_case34_dl_0x8805_single_mm_data_ctrl(_Config) ->
     % no retrasmition of downlink message
     %%timer:sleep(10000),
     {error, timeout} = gen_tcp:recv(Socket, 0, 500),
+
+    ok = gen_tcp:close(Socket).
+
+t_case_dl_invalid_msg(_Config) ->
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_procedure(Socket, AuthCode),
+    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+
+    DlCommand = #{
+        %% missing msg_id
+        <<"header">> => #{},
+        <<"body">> => #{
+            <<"id">> => 30,
+            <<"flag">> => 40
+        }
+    },
+
+    emqx:publish(emqx_message:make(?JT808_DN_TOPIC, emqx_utils_json:encode(DlCommand))),
+    ?block_until(#{?snk_kind := invalid_dl_message}),
+
+    emqx:publish(emqx_message:make(?JT808_DN_TOPIC, <<"invliad_json_str">>)),
+    ?block_until(#{?snk_kind := invalid_dl_message}),
 
     ok = gen_tcp:close(Socket).
 

--- a/changes/ee/fix-14445.en.md
+++ b/changes/ee/fix-14445.en.md
@@ -1,0 +1,1 @@
+Fixed the JT/T 808 client issue where the connection was disconnected due to receiving an incorrect downstream control message.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13602

Release version: v/e5.8.4

Before this fix, the connection process will be crashed once it received an invalid message
```
2024-12-02T07:19:12.404064+00:00 [error] crasher: initial call: emqx_gateway_conn:init/6, pid: <0.82884.0>, registered_name: [], exit: {#{context => function_clause,stacktrace => [{emqx_jt808_channel,msgid,[#{<<"msg">> => <<"hello">>}],[{file,"emqx_jt808_channel.erl"},{line,846}]},{emqx_jt808_channel,'-msgs2frame/2-fun-0-',2,[{file,"emqx_jt808_channel.erl"},{line,401}]},{lists,filtermap_1,2,[{file,"lists.erl"},{line,1661}]},{emqx_jt808_channel,handle_deliver,2,[{file,"emqx_jt808_channel.erl"},{line,380}]},{emqx_gateway_conn,with_channel,3,[{file,"emqx_gateway_conn.erl"},{line,772}]},{emqx_gateway_conn,process_msg,2,[{file,"emqx_gateway_conn.erl"},{line,427}]},{emqx_gateway_conn,handle_recv,3,[{file,"emqx_gateway_conn.erl"},{line,390}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,251}]}],exception => error},[{emqx_gateway_conn,terminate,2,[{file,"emqx_gateway_conn.erl"},{line,615}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,251}]}]}, ancestors: [<0.77393.0>,<0.77392.0>,esockd_sup,<0.3526.0>], message_queue_len: 0, messages: [], links: [<0.77393.0>], dictionary: [{recv_pkt,42},{outgoing_pubs,42},{recv_msg,42},{outgoing_bytes,838},{'$logger_metadata$',#{peername => "10.50.3.1:37314",clientid => <<"002319696095">>}},{send_msg,42},{incoming_pubs,42},{guid,{1733123952403744,202254305018820,9}},{send_pkt,42},{incoming_bytes,869}], trap_exit: false, status: running, heap_size: 2586, stack_size: 28, reductions: 853993; neighbours:
```

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~Added property-based tests for code which performs user input validation~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] Change log has been added to `changes/` dir for user-facing artifacts update
