### PR TITLE
ci(helm): fix flaky test

### DIFF
--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -138,7 +138,7 @@ jobs:
         done
     - name: Setup 18083 port forwarding
       run: |
-        nohup kubectl port-forward service/${EMQX_NAME} 18083:18083 > /dev/null &
+        nohup bash -c "while true; do kubectl port-forward service/${EMQX_NAME} 18083:18083 ; done" &
     - name: Get auth token
       run: |
         curl --head -X GET --retry 10 --retry-connrefused --retry-delay 6 http://localhost:18083/status


### PR DESCRIPTION
Sometimes, `kubectl port-forward` terminates itself if the service is not available or the only endpoint becomes unresponsive, or there're other instabilities.

Potential example: https://github.com/emqx/emqx/actions/runs/12418695854/job/34673287762#step:14:1
