### PR TITLE
feat(retainer): add rate limiter for publishing retained messages

### DIFF
--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.4.3"},
+    {vsn, "0.4.4"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2021-2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2021-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%
 %% Licensed under the Apache License, Version 2.0 (the "License");
 %% you may not use this file except in compliance with the License.
@@ -92,7 +92,10 @@
     failed_to_retain_message,
     handle_resource_metrics_failed,
     socket_receive_paused_by_rate_limit,
-    unrecoverable_resource_error
+    unrecoverable_resource_error,
+    retain_failed_for_rate_exceeded_limit,
+    retained_delete_failed_for_rate_exceeded_limit,
+    retain_failed_for_payload_size_exceeded_limit
 ]).
 
 -define(DEFAULT_RPC_PORT, 5369).

--- a/apps/emqx_node_rebalance/test/emqx_node_rebalance_purge_SUITE.erl
+++ b/apps/emqx_node_rebalance/test/emqx_node_rebalance_purge_SUITE.erl
@@ -363,6 +363,8 @@ t_session_purged(Config) ->
         end,
         Node1Clients ++ Node2Clients
     ),
+    %% Retained messages are persisted asynchronously
+    ct:sleep(500),
 
     ?assertEqual(40, erpc:call(Node2, emqx_retainer, retained_count, [])),
     ?assertEqual(NumClientsNode1, erpc:call(Node1, emqx_delayed, delayed_count, [])),

--- a/apps/emqx_retainer/include/emqx_retainer.hrl
+++ b/apps/emqx_retainer/include/emqx_retainer.hrl
@@ -24,4 +24,10 @@
 -define(TAB_INDEX_META, emqx_retainer_index_meta).
 -define(RETAINER_SHARD, emqx_retainer_shard).
 
+-define(DISPATCHER_LIMITER_ID, emqx_retainer_dispatcher).
+-define(PUBLISHER_LIMITER_ID, emqx_retainer_publisher).
+
+-define(DISPATCHER_POOL, emqx_retainer_dispatcher).
+-define(PUBLISHER_POOL, emqx_retainer_publisher).
+
 -endif.

--- a/apps/emqx_retainer/include/emqx_retainer.hrl
+++ b/apps/emqx_retainer/include/emqx_retainer.hrl
@@ -25,9 +25,7 @@
 -define(RETAINER_SHARD, emqx_retainer_shard).
 
 -define(DISPATCHER_LIMITER_ID, emqx_retainer_dispatcher).
--define(PUBLISHER_LIMITER_ID, emqx_retainer_publisher).
 
 -define(DISPATCHER_POOL, emqx_retainer_dispatcher).
--define(PUBLISHER_POOL, emqx_retainer_publisher).
 
 -endif.

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.29"},
+    {vsn, "5.0.30"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer.app.src
+++ b/apps/emqx_retainer/src/emqx_retainer.app.src
@@ -2,7 +2,7 @@
 {application, emqx_retainer, [
     {description, "EMQX Retainer"},
     % strict semver, bump manually!
-    {vsn, "5.0.30"},
+    {vsn, "5.1.0"},
     {modules, []},
     {registered, [emqx_retainer_sup]},
     {applications, [kernel, stdlib, emqx, emqx_ctl]},

--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -276,7 +276,7 @@ init([]) ->
 handle_call({update_config, NewConf, OldConf}, _, State) ->
     State2 = update_config(State, NewConf, OldConf),
     ok = emqx_retainer_dispatcher:refresh_limiter(NewConf),
-    ok = emqx_retainer_publisher:refresh_limiter(NewConf),
+    ok = emqx_retainer_publisher:refresh_limits(NewConf),
     {reply, ok, State2};
 handle_call(enabled, _From, State = #{enable := Enable}) ->
     {reply, Enable, State};

--- a/apps/emqx_retainer/src/emqx_retainer_app.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_app.erl
@@ -25,21 +25,31 @@
     stop/1
 ]).
 
+%% For testing
+-export([
+    init_buckets/0,
+    delete_buckets/0
+]).
+
 start(_Type, _Args) ->
     ok = emqx_retainer_cli:load(),
-    init_bucket(),
+    init_buckets(),
     emqx_retainer_sup:start_link().
 
 stop(_State) ->
     ok = emqx_retainer_cli:unload(),
-    delete_bucket(),
+    delete_buckets(),
     ok.
 
-init_bucket() ->
+init_buckets() ->
     #{flow_control := FlowControl} = emqx:get_config([retainer]),
-    emqx_limiter_server:add_bucket(
-        ?APP, internal, maps:get(batch_deliver_limiter, FlowControl, undefined)
+    ok = emqx_limiter_server:add_bucket(
+        ?DISPATCHER_LIMITER_ID, internal, maps:get(batch_deliver_limiter, FlowControl, undefined)
+    ),
+    ok = emqx_limiter_server:add_bucket(
+        ?PUBLISHER_LIMITER_ID, internal, maps:get(publish_limiter, FlowControl, undefined)
     ).
 
-delete_bucket() ->
-    emqx_limiter_server:del_bucket(?APP, internal).
+delete_buckets() ->
+    ok = emqx_limiter_server:del_bucket(?DISPATCHER_LIMITER_ID, internal),
+    ok = emqx_limiter_server:del_bucket(?PUBLISHER_LIMITER_ID, internal).

--- a/apps/emqx_retainer/src/emqx_retainer_app.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_app.erl
@@ -45,11 +45,7 @@ init_buckets() ->
     #{flow_control := FlowControl} = emqx:get_config([retainer]),
     ok = emqx_limiter_server:add_bucket(
         ?DISPATCHER_LIMITER_ID, internal, maps:get(batch_deliver_limiter, FlowControl, undefined)
-    ),
-    ok = emqx_limiter_server:add_bucket(
-        ?PUBLISHER_LIMITER_ID, internal, maps:get(publish_limiter, FlowControl, undefined)
     ).
 
 delete_buckets() ->
-    ok = emqx_limiter_server:del_bucket(?DISPATCHER_LIMITER_ID, internal),
-    ok = emqx_limiter_server:del_bucket(?PUBLISHER_LIMITER_ID, internal).
+    ok = emqx_limiter_server:del_bucket(?DISPATCHER_LIMITER_ID, internal).

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -216,7 +216,8 @@ store_retained(State, Msg = #message{topic = Topic}) ->
                     reason => table_is_full
                 },
                 #{topic => Topic}
-            );
+            ),
+            ok;
         false ->
             do_store_retained(Msg, Tokens, ExpiryTime),
             ?tp(message_retained, #{topic => Topic}),

--- a/apps/emqx_retainer/src/emqx_retainer_publisher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_publisher.erl
@@ -1,0 +1,242 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+%% This module uses emqx_htb_limiter to limit the rate of retained messages.
+%% emqx_htb_limiter works as follows:
+%% * we try to consume tokens
+%% * if we hit rate limits, the caller is suspended for at most `max_retry_time` till
+%% there are enough tokens.
+%% ** if we succeed, within the time limit, we get {ok, Limiter}
+%% ** if we fail, we get {drop, Limiter}
+%%
+%% To avoid overflow and to respect the rate limits, we do the following:
+%% * set `max_retry_time` to a 1s (hidden default value)
+%% * if we hit rate limits, and failed to consume tokens we drop the operation (delete or store)
+%% and drop all the accumulated operations as well.
+
+-module(emqx_retainer_publisher).
+
+-behaviour(gen_server).
+
+-include("emqx_retainer.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+%% API
+-export([
+    start_link/2,
+    store_retained/1,
+    delete_message/1,
+    refresh_limiter/0,
+    refresh_limiter/1
+]).
+
+%% gen_server callbacks
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-define(POOL, ?PUBLISHER_POOL).
+
+%% This module is `emqx_retainer` companion
+-elvis([{elvis_style, invalid_dynamic_call, disable}]).
+
+%%--------------------------------------------------------------------
+%% Constants
+%%--------------------------------------------------------------------
+
+-define(DEF_MAX_PAYLOAD_SIZE, (1024 * 1024)).
+-define(MAX_PAYLOAD_SIZE_CONFIG_PATH, [retainer, max_payload_size]).
+-define(PUBLISHER_LIMITER_FULL_CONFIG_PATH, [retainer, flow_control, publish_limiter]).
+-define(PUBLISHER_LIMITER_CONFIG_PATH, [flow_control, publish_limiter]).
+-define(PUBLISHER_LIMITER_EXPOSED_CONFIG_PATH, [retainer, publish_rate]).
+
+%% States
+
+-define(unblocked, unblocked).
+-define(blocked, blocked).
+
+%%--------------------------------------------------------------------
+%% Messages
+%%--------------------------------------------------------------------
+
+-record(store_retained, {
+    message :: emqx_types:message()
+}).
+
+-record(refresh_limiter, {
+    conf :: hocon:config()
+}).
+
+-record(delete_message, {
+    topic :: binary()
+}).
+
+-record(unblock, {}).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec store_retained(emqx_types:message()) -> ok.
+store_retained(Message) ->
+    Worker = gproc_pool:pick_worker(?POOL, self()),
+    gen_server:cast(Worker, #store_retained{message = Message}).
+
+-spec delete_message(binary()) -> ok.
+delete_message(Topic) ->
+    Worker = gproc_pool:pick_worker(?POOL, self()),
+    gen_server:cast(Worker, #delete_message{topic = Topic}).
+
+%% reset the client's limiter after updated the limiter's config
+refresh_limiter() ->
+    Conf = emqx:get_config([retainer]),
+    refresh_limiter(Conf).
+
+refresh_limiter(Conf) ->
+    Workers = gproc_pool:active_workers(?POOL),
+    lists:foreach(
+        fun({_, Pid}) ->
+            gen_server:cast(Pid, #refresh_limiter{conf = Conf})
+        end,
+        Workers
+    ).
+
+-spec start_link(atom(), pos_integer()) -> {ok, pid()}.
+start_link(Pool, Id) ->
+    gen_server:start_link(
+        {local, emqx_utils:proc_name(?MODULE, Id)},
+        ?MODULE,
+        [Pool, Id],
+        []
+    ).
+
+%%--------------------------------------------------------------------
+%% gen_server callbacks
+%%--------------------------------------------------------------------
+
+init([Pool, Id]) ->
+    erlang:process_flag(trap_exit, true),
+    true = gproc_pool:connect_worker(Pool, {Pool, Id}),
+    BucketCfg = emqx:get_config(?PUBLISHER_LIMITER_FULL_CONFIG_PATH, undefined),
+    {ok, Limiter} = emqx_limiter_server:connect(?PUBLISHER_LIMITER_ID, internal, BucketCfg),
+    {ok, #{pool => Pool, id => Id, limiter => Limiter, state => ?unblocked}}.
+
+handle_call(Req, _From, State) ->
+    ?SLOG(error, #{msg => retainer_publisher_unexpected_call, call => Req}),
+    {reply, ignored, State}.
+
+handle_cast(#store_retained{message = #message{topic = Topic}}, #{state := ?blocked} = State) ->
+    ?tp(warning, retain_failed_for_rate_exceeded_limit, #{
+        reason => blocked,
+        topic => Topic,
+        config => format_hocon_path(?PUBLISHER_LIMITER_EXPOSED_CONFIG_PATH)
+    }),
+    {noreply, State};
+handle_cast(#store_retained{message = Message}, #{limiter := Limiter} = State0) ->
+    State1 = maybe_block(State0, store_retained(Message, Limiter)),
+    {noreply, State1};
+handle_cast(#delete_message{topic = Topic}, #{state := ?blocked} = State) ->
+    ?tp(warning, retained_delete_failed_for_rate_exceeded_limit, #{
+        topic => Topic,
+        reason => blocked,
+        config => format_hocon_path(?PUBLISHER_LIMITER_EXPOSED_CONFIG_PATH)
+    }),
+    {noreply, State};
+handle_cast(#delete_message{topic = Topic}, #{limiter := Limiter} = State0) ->
+    State1 = maybe_block(State0, delete_message(Topic, Limiter)),
+    {noreply, State1};
+handle_cast(#refresh_limiter{conf = Conf}, State) ->
+    BucketCfg = emqx_utils_maps:deep_get(?PUBLISHER_LIMITER_CONFIG_PATH, Conf, undefined),
+    {ok, Limiter} = emqx_limiter_server:connect(?PUBLISHER_LIMITER_ID, internal, BucketCfg),
+    {noreply, State#{limiter := Limiter}};
+handle_cast(#unblock{}, State) ->
+    {noreply, unblock(State)};
+handle_cast(Msg, State) ->
+    ?SLOG(error, #{msg => retainer_publisher_unexpected_cast, cast => Msg}),
+    {noreply, State}.
+
+handle_info(Info, State) ->
+    ?SLOG(error, #{msg => retainer_publisher_unexpected_info, info => Info}),
+    {noreply, State}.
+
+terminate(_Reason, #{pool := Pool, id := Id}) ->
+    gproc_pool:disconnect_worker(Pool, {Pool, Id}).
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+store_retained(#message{topic = Topic, payload = Payload} = Msg, Limiter0) ->
+    Size = iolist_size(Payload),
+    case payload_size_limit() of
+        PayloadSizeLimit when PayloadSizeLimit > 0 andalso PayloadSizeLimit < Size ->
+            ?tp(warning, retain_failed_for_payload_size_exceeded_limit, #{
+                topic => Topic,
+                config => format_hocon_path(?MAX_PAYLOAD_SIZE_CONFIG_PATH),
+                size => Size,
+                limit => PayloadSizeLimit
+            }),
+            {ok, Limiter0};
+        _ ->
+            case emqx_htb_limiter:consume(1, Limiter0) of
+                {ok, Limiter1} ->
+                    _ = emqx_retainer:with_backend(
+                        fun(Mod, State) -> Mod:store_retained(State, Msg) end
+                    ),
+                    {ok, Limiter1};
+                {drop, Limiter1} ->
+                    ?tp(warning, retain_failed_for_rate_exceeded_limit, #{
+                        topic => Topic,
+                        config => format_hocon_path(?PUBLISHER_LIMITER_EXPOSED_CONFIG_PATH)
+                    }),
+                    {block, Limiter1}
+            end
+    end.
+
+delete_message(Topic, Limiter0) ->
+    case emqx_htb_limiter:consume(1, Limiter0) of
+        {ok, Limiter1} ->
+            _ = emqx_retainer:with_backend(
+                fun(Mod, State) -> Mod:delete_message(State, Topic) end
+            ),
+            {ok, Limiter1};
+        {drop, Limiter1} ->
+            ?tp(info, retained_delete_failed_for_rate_exceeded_limit, #{
+                topic => Topic,
+                config => format_hocon_path(?PUBLISHER_LIMITER_EXPOSED_CONFIG_PATH)
+            }),
+            {block, Limiter1}
+    end.
+
+payload_size_limit() ->
+    emqx_conf:get(?MAX_PAYLOAD_SIZE_CONFIG_PATH, ?DEF_MAX_PAYLOAD_SIZE).
+
+maybe_block(State, {ok, Limiter}) ->
+    State#{limiter => Limiter};
+maybe_block(State, {block, Limiter}) ->
+    gen_server:cast(self(), #unblock{}),
+    State#{state => ?blocked, limiter => Limiter}.
+
+unblock(State) ->
+    State#{state => ?unblocked}.
+
+format_hocon_path(Path) ->
+    iolist_to_binary(emqx_hocon:format_path(Path)).

--- a/apps/emqx_retainer/src/emqx_retainer_sup.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_sup.erl
@@ -16,15 +16,29 @@
 
 -module(emqx_retainer_sup).
 
--export([start_link/0]).
+-include("emqx_retainer.hrl").
+
+-export([start_link/0, start_worker_sup/0, start_workers/0, stop_workers/0]).
 
 -export([start_gc/2]).
 
 -behaviour(supervisor).
 -export([init/1]).
 
+-define(worker_sup, emqx_retainer_worker_sup).
+-define(root_sup, emqx_retainer_root_sup).
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+-spec start_link() -> supervisor:startchild_ret().
 start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+    supervisor:start_link({local, ?root_sup}, ?MODULE, [?root_sup]).
+
+-spec start_worker_sup() -> supervisor:startchild_ret().
+start_worker_sup() ->
+    supervisor:start_link({local, ?worker_sup}, ?MODULE, [?worker_sup]).
 
 -spec start_gc(emqx_retainer:context(), emqx_retainer_gc:opts()) ->
     supervisor:startchild_ret().
@@ -35,19 +49,35 @@ start_gc(Context, Opts) ->
         restart => temporary,
         type => worker
     },
-    supervisor:start_child(?MODULE, ChildSpec).
+    supervisor:start_child(?worker_sup, ChildSpec).
 
-%%
+-spec start_workers() -> ok.
+start_workers() ->
+    {ok, _} = start_dispatcher(),
+    {ok, _} = start_publisher(),
+    ok.
 
-init([]) ->
-    PoolSpec = emqx_pool_sup:spec([
-        emqx_retainer_dispatcher,
-        hash,
-        emqx_vm:schedulers(),
-        {emqx_retainer_dispatcher, start_link, []}
-    ]),
+-spec stop_workers() -> ok.
+stop_workers() ->
+    ok = stop_publisher(),
+    ok = stop_dispatcher(),
+    ok.
+
+%%--------------------------------------------------------------------
+%% supervisor callbacks
+%%--------------------------------------------------------------------
+
+init([?root_sup]) ->
     {ok,
         {{one_for_one, 10, 3600}, [
+            #{
+                id => worker_sup,
+                start => {?MODULE, start_worker_sup, []},
+                restart => permanent,
+                shutdown => 5000,
+                type => supervisor,
+                modules => [?MODULE]
+            },
             #{
                 id => retainer,
                 start => {emqx_retainer, start_link, []},
@@ -55,6 +85,47 @@ init([]) ->
                 shutdown => 5000,
                 type => worker,
                 modules => [emqx_retainer]
-            },
-            PoolSpec
-        ]}}.
+            }
+        ]}};
+init([?worker_sup]) ->
+    {ok, {{one_for_one, 10, 3600}, []}}.
+
+%%--------------------------------------------------------------------
+%% Private functions
+%%--------------------------------------------------------------------
+
+start_dispatcher() ->
+    ChildSpec = emqx_pool_sup:spec(
+        dispatcher,
+        [
+            ?DISPATCHER_POOL,
+            hash,
+            emqx_vm:schedulers(),
+            {emqx_retainer_dispatcher, start_link, []}
+        ]
+    ),
+    supervisor:start_child(?worker_sup, ChildSpec).
+
+start_publisher() ->
+    ChildSpec = emqx_pool_sup:spec(
+        publisher,
+        [
+            ?PUBLISHER_POOL,
+            hash,
+            emqx_vm:schedulers(),
+            {emqx_retainer_publisher, start_link, []}
+        ]
+    ),
+    supervisor:start_child(?worker_sup, ChildSpec).
+
+stop_dispatcher() ->
+    ok = stop_worker_pool(dispatcher).
+
+stop_publisher() ->
+    ok = stop_worker_pool(publisher).
+
+stop_worker_pool(ChildId) ->
+    case supervisor:terminate_child(?worker_sup, ChildId) of
+        ok -> supervisor:delete_child(?worker_sup, ChildId);
+        {error, not_found} -> ok
+    end.

--- a/apps/emqx_retainer/src/emqx_retainer_sup.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_sup.erl
@@ -74,7 +74,7 @@ init([?root_sup]) ->
                 id => worker_sup,
                 start => {?MODULE, start_worker_sup, []},
                 restart => permanent,
-                shutdown => 5000,
+                shutdown => infinity,
                 type => supervisor,
                 modules => [?MODULE]
             },

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -611,15 +611,15 @@ mock_httpc() ->
     ).
 
 mock_advanced_mqtt_features() ->
-    Context = emqx_retainer:context(),
     lists:foreach(
         fun(N) ->
             Num = integer_to_binary(N),
             Message = emqx_message:make(<<"retained/", Num/binary>>, <<"payload">>),
-            ok = emqx_retainer:store_retained(Context, Message)
+            ok = emqx_retainer_publisher:store_retained(Message)
         end,
         lists:seq(1, 5)
     ),
+    ct:sleep(100),
 
     lists:foreach(
         fun(N) ->

--- a/changes/ce/feat-14454.en.md
+++ b/changes/ce/feat-14454.en.md
@@ -1,3 +1,3 @@
-Introduce `publish_rate` option for the retaner. The option controls the maximum allowed rate of publishing retained messages. The messages that are published over the limit are delivered but not stored as retained.
+Introduce `max_publish_rate` option for the retaner. The option controls the maximum allowed rate of publishing retained messages. The messages that are published over the limit are delivered but not stored as retained.
 
 This option is useful to limit the load on the configured retained message storage.

--- a/changes/ce/feat-14454.en.md
+++ b/changes/ce/feat-14454.en.md
@@ -1,0 +1,3 @@
+Introduce `publish_rate` option for the retaner. The option controls the maximum allowed rate of publishing retained messages. The messages that are published over the limit are delivered but not stored as retained.
+
+This option is useful to limit the load on the configured retained message storage.

--- a/changes/ce/feat-14454.en.md
+++ b/changes/ce/feat-14454.en.md
@@ -1,3 +1,3 @@
-Introduce `max_publish_rate` option for the retaner. The option controls the maximum allowed rate of publishing retained messages. The messages that are published over the limit are delivered but not stored as retained.
+Introduced `max_publish_rate` option for the retainer. The option controls the maximum allowed rate of publishing retained messages in each node. The messages that are published over the limit are delivered but not stored as retained.
 
 This option is useful to limit the load on the configured retained message storage.

--- a/rel/i18n/emqx_retainer_schema.hocon
+++ b/rel/i18n/emqx_retainer_schema.hocon
@@ -60,7 +60,7 @@ http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038
 delivery_rate.desc:
 """The maximum rate of delivering retained messages"""
 
-publish_rate.desc:
+max_publish_rate.desc:
 """The maximum rate of publishing retained messages. Messages that are published over the limit are delivered but not stored as retained."""
 
 msg_expiry_interval_override.desc:

--- a/rel/i18n/emqx_retainer_schema.hocon
+++ b/rel/i18n/emqx_retainer_schema.hocon
@@ -60,6 +60,9 @@ http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc398718038
 delivery_rate.desc:
 """The maximum rate of delivering retained messages"""
 
+publish_rate.desc:
+"""The maximum rate of publishing retained messages. Messages that are published over the limit are delivered but not stored as retained."""
+
 msg_expiry_interval_override.desc:
 """If set, this value will take precedence over any `Message-Expiry-Interval` property specified in retained MQTT messages, allowing messages to expire earlier if necessary.  This override only applies to the garbage collection process: it does not affect the expiry time of messages being written nor that of already written messages while iterating over them.  Therefore, messages that are candidate for garbage collection when overridden may still be visible when subscribing to retained topics."""
 


### PR DESCRIPTION
Fixes [EMQX-13690](https://emqx.atlassian.net/browse/EMQX-13690)

Release version: v/e5.8.5

In this PR, we just add a limiter dropping write operations if the limits are exceeded.

We also
* Remove some unnecessary code.
* Use the backend state (`Context`) in a more orderly manner. Previously,
  * it was set and used from two different places (hook arguments and management gen_server state).
  * its lifetime was not strictly respected: e.g., the dispatcher pool could still use `Context` even after it was closed.

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a [follow-up jira ticket](https://emqx.atlassian.net/browse/EMQX-13736)
- [x] Schema changes are backward compatible



[EMQX-13690]: https://emqx.atlassian.net/browse/EMQX-13690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ