### PR TITLE
fix(iotdb): Enhanced error handling for invalid data

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -96,6 +96,7 @@
     user_lookup_fun_tr/2,
     validate_keepalive_multiplier/1,
     non_empty_string/1,
+    non_empty_array/1,
     validations/0,
     naive_env_interpolation/1,
     ensure_unicode_path/2,
@@ -2971,6 +2972,13 @@ non_empty_string(<<>>) -> {error, empty_string_not_allowed};
 non_empty_string("") -> {error, empty_string_not_allowed};
 non_empty_string(S) when is_binary(S); is_list(S) -> ok;
 non_empty_string(_) -> {error, invalid_string}.
+
+non_empty_array([]) ->
+    {error, empty_array_not_allowed};
+non_empty_array(List) when is_list(List) ->
+    ok;
+non_empty_array(_) ->
+    {error, invalid_data}.
 
 %% @doc Make schema for 'server' or 'servers' field.
 %% for each field, there are three passes:

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb.erl
@@ -89,7 +89,8 @@ fields(action_parameters) ->
                 array(ref(?MODULE, action_parameters_data)),
                 #{
                     desc => ?DESC("action_parameters_data"),
-                    default => []
+                    required => true,
+                    validator => fun emqx_schema:non_empty_array/1
                 }
             )}
     ] ++

--- a/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
+++ b/apps/emqx_bridge_iotdb/src/emqx_bridge_iotdb_connector.erl
@@ -3,6 +3,8 @@
 %%--------------------------------------------------------------------
 -module(emqx_bridge_iotdb_connector).
 
+-feature(maybe_expr, enable).
+
 -behaviour(emqx_connector_examples).
 
 -behaviour(emqx_resource).
@@ -711,14 +713,14 @@ parse_payload(UnparsedPayload) when is_binary(UnparsedPayload) ->
         Term when is_map(Term) -> {ok, Term};
         _ ->
             %% a plain text will be returned as it is, but here we hope it is a map
-            {error, invalid_data}
+            {error, {invalid_data, <<"The payload is not a JSON data">>}}
     catch
         _:_ ->
-            {error, invalid_data}
+            {error, {invalid_data, <<"The payload is not a valid JSON data">>}}
     end.
 
 iot_timestamp(Timestamp, _, _) when is_integer(Timestamp) ->
-    Timestamp;
+    {ok, Timestamp};
 iot_timestamp(TimestampTkn, Msg, Nows) ->
     iot_timestamp(emqx_placeholder:proc_tmpl(TimestampTkn, Msg), Nows).
 
@@ -726,15 +728,20 @@ iot_timestamp(TimestampTkn, Msg, Nows) ->
 %% but an instance only supports one time unit,
 %% and the time unit cannot be changed after the database is started.
 iot_timestamp(<<"now_us">>, #{now_us := NowUs}) ->
-    NowUs;
+    {ok, NowUs};
 iot_timestamp(<<"now_ns">>, #{now_ns := NowNs}) ->
-    NowNs;
+    {ok, NowNs};
 iot_timestamp(Timestamp, #{now_ms := NowMs}) when
     Timestamp =:= <<"now">>; Timestamp =:= <<"now_ms">>; Timestamp =:= <<>>
 ->
-    NowMs;
+    {ok, NowMs};
 iot_timestamp(Timestamp, _) when is_binary(Timestamp) ->
-    binary_to_integer(Timestamp).
+    case string:to_integer(Timestamp) of
+        {Timestamp1, <<>>} ->
+            {ok, Timestamp1};
+        _ ->
+            {error, {invalid_data, <<"Timestamp is undefined or not a integer">>}}
+    end.
 
 proc_value(<<"TEXT">>, ValueTkn, Msg) ->
     case emqx_placeholder:proc_tmpl(ValueTkn, Msg) of
@@ -802,7 +809,7 @@ convert_float(undefined) ->
 device_id(Message, Payload, Channel) ->
     case maps:get(device_id, Channel, []) of
         [] ->
-            maps:get(<<"device_id">>, Payload, undefined);
+            maps:get(<<"device_id">>, Payload, <<"undefined">>);
         DeviceIdTkn ->
             emqx_placeholder:proc_tmpl(DeviceIdTkn, Message)
     end.
@@ -909,40 +916,36 @@ do_render_record([{_, Msg} | Msgs], Channel, Acc) ->
     end.
 
 render_channel_record(#{data := DataTemplate} = Channel, Msg) ->
-    case parse_payload(get_payload(Msg)) of
-        {ok, Payload} ->
-            case device_id(Msg, Payload, Channel) of
-                undefined ->
-                    {error, device_id_missing};
-                DeviceId ->
-                    #{timestamp := TimestampTkn} = hd(DataTemplate),
-                    NowNS = erlang:system_time(nanosecond),
-                    Nows = #{
-                        now_ms => erlang:convert_time_unit(NowNS, nanosecond, millisecond),
-                        now_us => erlang:convert_time_unit(NowNS, nanosecond, microsecond),
-                        now_ns => NowNS
-                    },
-                    case
-                        proc_record_data(
-                            DataTemplate,
-                            Msg,
-                            [],
-                            [],
-                            []
-                        )
-                    of
-                        {ok, MeasurementAcc, TypeAcc, ValueAcc} ->
-                            {ok, #{
-                                timestamp => iot_timestamp(TimestampTkn, Msg, Nows),
-                                measurements => MeasurementAcc,
-                                data_types => TypeAcc,
-                                values => ValueAcc,
-                                device_id => DeviceId
-                            }};
-                        Error ->
-                            Error
-                    end
-            end;
+    maybe
+        {ok, Payload} ?= parse_payload(get_payload(Msg)),
+        DeviceId = device_id(Msg, Payload, Channel),
+        true ?= (<<"undefined">> =/= DeviceId),
+        #{timestamp := TimestampTkn} = hd(DataTemplate),
+        NowNS = erlang:system_time(nanosecond),
+        Nows = #{
+            now_ms => erlang:convert_time_unit(NowNS, nanosecond, millisecond),
+            now_us => erlang:convert_time_unit(NowNS, nanosecond, microsecond),
+            now_ns => NowNS
+        },
+        {ok, MeasurementAcc, TypeAcc, ValueAcc} ?=
+            proc_record_data(
+                DataTemplate,
+                Msg,
+                [],
+                [],
+                []
+            ),
+        {ok, Timestamp} ?= iot_timestamp(TimestampTkn, Msg, Nows),
+        {ok, #{
+            timestamp => Timestamp,
+            measurements => MeasurementAcc,
+            data_types => TypeAcc,
+            values => ValueAcc,
+            device_id => DeviceId
+        }}
+    else
+        false ->
+            {error, {invalid_data, <<"Can not find the device ID">>}};
         Error ->
             Error
     end.
@@ -972,9 +975,9 @@ proc_record_data(
     catch
         throw:Reason ->
             {error, Reason};
-        Error:Reason:Stacktrace ->
-            ?SLOG(debug, #{exception => Error, reason => Reason, stacktrace => Stacktrace}),
-            {error, invalid_data}
+        Error:Reason ->
+            ?SLOG(debug, #{exception => Error, reason => Reason}),
+            {error, {invalid_data, Reason}}
     end;
 proc_record_data([], _Msg, MeasurementAcc, TypeAcc, ValueAcc) ->
     {ok, MeasurementAcc, TypeAcc, ValueAcc}.

--- a/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
+++ b/apps/emqx_bridge_iotdb/test/emqx_bridge_iotdb_impl_SUITE.erl
@@ -280,19 +280,7 @@ is_error_check(Reason) ->
 action_config(TestCase, Name, Config) ->
     Type = ?config(bridge_type, Config),
     QueryMode = query_mode(TestCase),
-    DataTemplate =
-        case TestCase of
-            t_template ->
-                <<"">>;
-            _ ->
-                emqx_utils_json:encode(
-                    #{
-                        <<"measurement">> => <<"${payload.measurement}">>,
-                        <<"data_type">> => test_case_data_type(TestCase),
-                        <<"value">> => <<"${payload.value}">>
-                    }
-                )
-        end,
+    DataTemplate = data_template_config(TestCase),
     ConfigString =
         io_lib:format(
             "actions.~s.~s {\n"
@@ -434,10 +422,11 @@ t_sync_query_fail(Config) ->
     ).
 
 t_sync_device_id_missing(Config) ->
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
     emqx_bridge_v2_testlib:t_sync_query(
         Config,
         make_message_fun(iotdb_topic(Config), #{foo => bar}),
-        is_error_check(device_id_missing),
+        IsInvalidData,
         iotdb_bridge_on_query
     ).
 
@@ -477,10 +466,11 @@ t_extract_device_id_from_rule_engine_message(Config) ->
     ok.
 
 t_async_device_id_missing(Config) ->
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
     emqx_bridge_v2_testlib:t_async_query(
         Config,
         make_message_fun(iotdb_topic(Config), #{foo => bar}),
-        is_error_check(device_id_missing),
+        IsInvalidData,
         iotdb_bridge_on_query_async
     ).
 
@@ -622,9 +612,9 @@ t_sync_query_unmatched_type(Config) ->
     DeviceId = iotdb_device(Config),
     Payload = make_iotdb_payload(DeviceId, "temp", "boolean", "not boolean"),
     MakeMessageFun = make_message_fun(iotdb_topic(Config), Payload),
-    IsInvalidType = fun(Result) -> ?assertMatch({error, invalid_data}, Result) end,
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
     ok = emqx_bridge_v2_testlib:t_sync_query(
-        Config, MakeMessageFun, IsInvalidType, iotdb_bridge_on_query
+        Config, MakeMessageFun, IsInvalidData, iotdb_bridge_on_query
     ).
 
 t_thrift_auto_recon(Config) ->
@@ -645,20 +635,52 @@ t_sync_query_with_lowercase(Config) ->
     ).
 
 t_sync_query_plain_text(Config) ->
-    IsInvalidType = fun(Result) -> ?assertMatch({error, invalid_data}, Result) end,
-
-    Payload1 = <<"this is a text">>,
-    MakeMessageFun1 = make_message_fun(iotdb_topic(Config), Payload1),
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
+    Payload = <<"this is a text">>,
+    MakeMessageFun = make_message_fun(iotdb_topic(Config), Payload),
     ok = emqx_bridge_v2_testlib:t_sync_query(
-        Config, MakeMessageFun1, IsInvalidType, iotdb_bridge_on_query
+        Config, MakeMessageFun, IsInvalidData, iotdb_bridge_on_query
     ).
 
 t_sync_query_invalid_json(Config) ->
-    IsInvalidType = fun(Result) -> ?assertMatch({error, invalid_data}, Result) end,
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
     Payload2 = <<"{\"msg\":}">>,
-    MakeMessageFun2 = make_message_fun(iotdb_topic(Config), Payload2),
+    MakeMessageFun = make_message_fun(iotdb_topic(Config), Payload2),
     ok = emqx_bridge_v2_testlib:t_sync_query(
-        Config, MakeMessageFun2, IsInvalidType, iotdb_bridge_on_query
+        Config, MakeMessageFun, IsInvalidData, iotdb_bridge_on_query
+    ).
+
+t_sync_query_invalid_timestamp(Config) ->
+    DeviceId = iotdb_device(Config),
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
+    Payload = make_iotdb_payload(DeviceId, "temp", "int32", "36", <<"this is a string">>),
+    MakeMessageFun = make_message_fun(iotdb_topic(Config), Payload),
+    ok = emqx_bridge_v2_testlib:t_sync_query(
+        Config, MakeMessageFun, IsInvalidData, iotdb_bridge_on_query
+    ).
+
+t_sync_query_missing_timestamp(Config) ->
+    DeviceId = iotdb_device(Config),
+    IsInvalidData = fun(Result) -> ?assertMatch({error, {invalid_data, _}}, Result) end,
+    Payload = make_iotdb_payload(DeviceId, "temp", "int32", "36"),
+    MakeMessageFun = make_message_fun(iotdb_topic(Config), Payload),
+    ok = emqx_bridge_v2_testlib:t_sync_query(
+        Config, MakeMessageFun, IsInvalidData, iotdb_bridge_on_query
+    ).
+
+t_sync_query_templated_timestamp(Config) ->
+    Ts = erlang:system_time(millisecond) - rand:uniform(864000),
+    DeviceId = iotdb_device(Config),
+    Payload = make_iotdb_payload(DeviceId, "temp", "int32", "36", Ts),
+    MakeMessageFun = make_message_fun(iotdb_topic(Config), Payload),
+    ok = emqx_bridge_v2_testlib:t_sync_query(
+        Config, MakeMessageFun, fun is_success_check/1, iotdb_bridge_on_query
+    ),
+    Query = <<"select temp from ", DeviceId/binary>>,
+    {ok, {{_, 200, _}, _, IoTDBResult}} = iotdb_query(Config, Query),
+    ?assertMatch(
+        #{<<"timestamps">> := [Ts]},
+        emqx_utils_json:decode(IoTDBResult)
     ).
 
 is_empty(null) -> true;
@@ -697,3 +719,27 @@ test_case_data_type(t_sync_query_with_lowercase) ->
     <<"int32">>;
 test_case_data_type(_) ->
     <<"int32">>.
+
+data_template_config(t_template) ->
+    <<"">>;
+data_template_config(TestCase) when
+    TestCase =:= t_sync_query_invalid_timestamp;
+    TestCase =:= t_sync_query_missing_timestamp;
+    TestCase =:= t_sync_query_templated_timestamp
+->
+    emqx_utils_json:encode(
+        #{
+            <<"timestamp">> => <<"${payload.timestamp}">>,
+            <<"measurement">> => <<"${payload.measurement}">>,
+            <<"data_type">> => test_case_data_type(TestCase),
+            <<"value">> => <<"${payload.value}">>
+        }
+    );
+data_template_config(TestCase) ->
+    emqx_utils_json:encode(
+        #{
+            <<"measurement">> => <<"${payload.measurement}">>,
+            <<"data_type">> => test_case_data_type(TestCase),
+            <<"value">> => <<"${payload.value}">>
+        }
+    ).


### PR DESCRIPTION
Fixes EMQX-13531

1. Enhances error reporting
2. Handling `Device ID` or `Timestamp` exceptions
3. Validate the data template  at setup time, it can no longer be empty
     prior this fix, this is a soft limit and just warning at runtime, but it is not a good way, users may try to do everything they can, and confuse with the result

Release version: v/e5.8.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
