### PR TITLE
fix: sql split re

### DIFF
--- a/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
+++ b/apps/emqx_bridge_clickhouse/src/emqx_bridge_clickhouse_connector.erl
@@ -110,7 +110,7 @@
     %%     `VALUES [([<VALUE> | <PLACEHOLDER>], ...)]`
     %% Keep Capturing-Group:
     %%     `([<VALUE> | <PLACEHOLDER>], ...) [, ([<VALUE> | <PLACEHOLDER>], ..)]`
-    "(?:values\\s*(\\((?:[^()]++|(?2))*\\)(?:\\s*,\\s*\\((?:[^()]++|(?2)*)\\))*))",
+    "(?:values\\s*(\\((?:[^()]++|(?2))*\\)(?:\\s*,\\s*\\((?:[^()]++|(?2)*)\\))*)\\s*;?\\s*)",
     %% End Group-2
     %% or
     "|",

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_SUITE.erl
@@ -261,6 +261,19 @@ t_parse_insert_sql_template(_Config) ->
             <<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25)  "/utf8>>
         )
     ),
+    %% with `;` suffix, bug-to-bug compatibility
+    ?assertEqual(
+        <<"(${id}, 'Иван', 25)"/utf8>>,
+        parse_insert(
+            <<"INSERT INTO Values_таблица (идентификатор, имя, возраст)   VALUES \t (${id}, 'Иван', 25);  "/utf8>>
+        )
+    ),
+    ?assertEqual(
+        <<"(${id},'李四', 35)"/utf8>>,
+        parse_insert(
+            <<"  inSErt into 表格(标识,名字,年龄)values(${id},'李四', 35) ; "/utf8>>
+        )
+    ),
 
     %% `values` in column name
     ?assertEqual(


### PR DESCRIPTION
Even though sql templates ending with `;` may sometimes fail to work. they should be bug-to-bug compatible.

Fixes [EMQX-13521](https://emqx.atlassian.net/browse/EMQX-13521)

Release version: v/e5.8.4

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~[ ] Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~


[EMQX-13521]: https://emqx.atlassian.net/browse/EMQX-13521?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ