### PR TITLE
fix(mix): use correct dependency application name

### DIFF
--- a/apps/emqx_bridge_tablestore/mix.exs
+++ b/apps/emqx_bridge_tablestore/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXBridgeTablestore.MixProject do
 
   def deps() do
     [
-      UMP.common_dep(:tablestore),
+      UMP.common_dep(:ots_erl),
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/mix.exs
+++ b/mix.exs
@@ -269,8 +269,8 @@ defmodule EMQXUmbrella.MixProject do
       system_env: emqx_app_system_env()
     }
 
-  def common_dep(:tablestore),
-    do: {:tablestore, github: "emqx/ots_erl", tag: "0.2.2", override: true}
+  def common_dep(:ots_erl),
+    do: {:ots_erl, github: "emqx/ots_erl", tag: "0.2.2", override: true}
 
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}


### PR DESCRIPTION
```
===> Analyzing applications...
===> Compiling ots_erl
Unchecked dependencies for environment emqx-enterprise-test:
* tablestore (https://github.com/emqx/ots_erl.git - 0.2.2)
  could not find an app file at "_build/emqx-enterprise-test/lib/tablestore/ebin/tablestore.app". Another app file was found in the same directory "_build/emqx-enterprise-test/lib/tablestore/ebin/ots_erl.app", try changing the dependency name to :ots_erl
** (Mix) Can't continue due to errors on dependencies
```
