### PR TITLE
refactor: prepare for action fallbacks (r58)

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.2.8"},
+    {vsn, "0.2.9"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -1169,7 +1169,7 @@ t_query_uses_action_query_mode(_Config) ->
     %% when querying the resource.
 
     %% Set one query mode for the connector...
-    meck:new(con_mod(), [passthrough, no_history, non_strict]),
+    meck:new(con_mod(), [passthrough, no_history]),
     on_exit(fun() -> catch meck:unload([con_mod()]) end),
     meck:expect(con_mod(), query_mode, 1, sync),
     meck:expect(con_mod(), callback_mode, 0, always_sync),

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -22,14 +22,17 @@ end).
 
 %% ct setup helpers
 
+%% Deprecated: better to inline the setup in the test suite.
 init_per_suite(Config, Apps) ->
     [{start_apps, Apps} | Config].
 
+%% Deprecated: better to inline the setup in the test suite.
 end_per_suite(Config) ->
     Apps = ?config(apps, Config),
-    emqx_cth_suite:stop(Apps),
+    emqx_maybe:apply(fun emqx_cth_suite:stop/1, Apps),
     ok.
 
+%% Deprecated: better to inline the setup in the test suite.
 init_per_group(TestGroup, BridgeType, Config) ->
     ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
     ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
@@ -50,6 +53,7 @@ init_per_group(TestGroup, BridgeType, Config) ->
         | Config
     ].
 
+%% Deprecated: better to inline the setup in the test suite.
 end_per_group(Config) ->
     Apps = ?config(apps, Config),
     ProxyHost = ?config(proxy_host, Config),
@@ -58,6 +62,7 @@ end_per_group(Config) ->
     emqx_cth_suite:stop(Apps),
     ok.
 
+%% Deprecated: better to inline the setup in the test suite.
 init_per_testcase(TestCase, Config0, BridgeConfigCb) ->
     ct:timetrap(timer:seconds(60)),
     delete_all_bridges_and_connectors(),
@@ -80,6 +85,7 @@ init_per_testcase(TestCase, Config0, BridgeConfigCb) ->
         | Config
     ].
 
+%% Deprecated: better to inline the setup in the test suite.
 end_per_testcase(_Testcase, Config) ->
     case proplists:get_bool(skip_does_not_apply, Config) of
         true ->

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -848,14 +848,6 @@ t_invalid_partition_count_metrics(Config) ->
             {ok, {{_, 201, _}, _, #{}}} =
                 emqx_bridge_v2_testlib:create_connector_api(ConnectorParams),
 
-            {ok, {{_, 201, _}, _, #{}}} =
-                emqx_bridge_v2_testlib:create_action_api(ActionParams),
-            RuleTopic = <<"t/a">>,
-            {ok, #{<<"id">> := RuleId}} =
-                emqx_bridge_v2_testlib:create_rule_and_action_http(Type, RuleTopic, [
-                    {bridge_name, ActionName}
-                ]),
-
             {ok, C} = emqtt:start_link([]),
             {ok, _} = emqtt:connect(C),
 
@@ -867,6 +859,14 @@ t_invalid_partition_count_metrics(Config) ->
             ok = meck:new(emqx_bridge_kafka_impl_producer, [passthrough, no_history]),
             on_exit(fun() -> catch meck:unload() end),
             ok = meck:expect(emqx_bridge_kafka_impl_producer, query_mode, 1, simple_sync),
+
+            {ok, {{_, 201, _}, _, #{}}} =
+                emqx_bridge_v2_testlib:create_action_api(ActionParams),
+            RuleTopic = <<"t/a">>,
+            {ok, #{<<"id">> := RuleId}} =
+                emqx_bridge_v2_testlib:create_rule_and_action_http(Type, RuleTopic, [
+                    {bridge_name, ActionName}
+                ]),
 
             %% Simulate `invalid_partition_count'
             emqx_common_test_helpers:with_mock(

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -64,7 +64,8 @@
     simple_query => boolean(),
     reply_to => reply_fun(),
     query_mode => query_mode(),
-    connector_resource_id => resource_id()
+    connector_resource_id => resource_id(),
+    is_fallback => boolean()
 }.
 -type resource_data() :: #{
     id := resource_id(),

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -32,7 +32,6 @@
 -type raw_resource_config() :: binary() | raw_term_resource_config().
 -type raw_term_resource_config() :: #{binary() => term()} | [raw_term_resource_config()].
 -type resource_config() :: term().
--type resource_spec() :: map().
 -type resource_state() :: term().
 %% Note: the `stopped' status can only be emitted by `emqx_resource_manager'...  Modules
 %% implementing `emqx_resource' behavior should not return it.

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -41,7 +41,8 @@
 -type health_check_status() :: ?status_connected | ?status_disconnected | ?status_connecting.
 -type channel_status() :: ?status_connected | ?status_connecting | ?status_disconnected.
 -type callback_mode() :: always_sync | async_if_possible.
--type query_mode() ::
+-type query_mode() :: resource_query_mode().
+-type resource_query_mode() ::
     simple_sync
     | simple_async
     | simple_sync_internal_buffer
@@ -49,6 +50,7 @@
     | sync
     | async
     | no_queries.
+-type query_kind() :: sync | async.
 -type result() :: term().
 -type reply_fun() ::
     {fun((...) -> any()), Args :: [term()]}
@@ -63,7 +65,8 @@
     async_reply_fun => reply_fun(),
     simple_query => boolean(),
     reply_to => reply_fun(),
-    query_mode => query_mode(),
+    %% Called `query_mode' due to legacy reasons...
+    query_mode => query_kind(),
     connector_resource_id => resource_id(),
     is_fallback => boolean()
 }.
@@ -71,7 +74,7 @@
     id := resource_id(),
     mod := module(),
     callback_mode := callback_mode(),
-    query_mode := query_mode(),
+    query_mode := resource_query_mode(),
     config := resource_config(),
     error := term(),
     status := resource_status(),
@@ -103,7 +106,7 @@
     batch_size => pos_integer(),
     batch_time => pos_integer(),
     max_buffer_bytes => pos_integer(),
-    query_mode => query_mode(),
+    query_mode => resource_query_mode(),
     resume_interval => pos_integer(),
     inflight_window => pos_integer(),
     %% Only for `emqx_resource_manager' usage.  If false, prevents spawning buffer

--- a/apps/emqx_resource/include/emqx_resource_buffer_worker_internal.hrl
+++ b/apps/emqx_resource/include/emqx_resource_buffer_worker_internal.hrl
@@ -15,7 +15,12 @@
 %%--------------------------------------------------------------------
 -ifndef(RESOURCE_BUFFER_WORKER_INTERNAL_HRL).
 -define(RESOURCE_BUFFER_WORKER_INTERNAL_HRL, true).
+
 -define(QUERY(FROM, REQUEST, SENT, EXPIRE_AT, REQ_CONTEXT, TRACE_CTX),
     {query, FROM, REQUEST, SENT, EXPIRE_AT, REQ_CONTEXT, TRACE_CTX}
 ).
+
+-define(ack, ack).
+-define(nack, nack).
+
 -endif.

--- a/apps/emqx_resource/include/emqx_resource_buffer_worker_internal.hrl
+++ b/apps/emqx_resource/include/emqx_resource_buffer_worker_internal.hrl
@@ -1,0 +1,21 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-ifndef(RESOURCE_BUFFER_WORKER_INTERNAL_HRL).
+-define(RESOURCE_BUFFER_WORKER_INTERNAL_HRL, true).
+-define(QUERY(FROM, REQUEST, SENT, EXPIRE_AT, REQ_CONTEXT, TRACE_CTX),
+    {query, FROM, REQUEST, SENT, EXPIRE_AT, REQ_CONTEXT, TRACE_CTX}
+).
+-endif.

--- a/apps/emqx_resource/include/emqx_resource_runtime.hrl
+++ b/apps/emqx_resource/include/emqx_resource_runtime.hrl
@@ -39,6 +39,7 @@
 -record(rt, {
     st_err :: st_err(),
     cb :: cb(),
+    query_mode :: emqx_resource:resource_query_mode(),
     channel_status :: ?NO_CHANNEL | channel_status()
 }).
 

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -109,6 +109,7 @@
     %% stop the instance
     call_stop/3,
     %% get the query mode of the resource
+    query_mode/2,
     query_mode/3,
     %% Add channel to resource
     call_add_channel/5,
@@ -147,6 +148,8 @@
 
 -export_type([
     query_mode/0,
+    query_kind/0,
+    resource_query_mode/0,
     resource_id/0,
     channel_id/0,
     resource_data/0,
@@ -273,6 +276,8 @@
         end
     end)()
 ).
+
+-type channel_config() :: map().
 
 -spec list_types() -> [module()].
 list_types() ->
@@ -632,11 +637,16 @@ call_stop(ResId, Mod, ResourceState) ->
         Res
     end).
 
--spec query_mode(module(), term(), creation_opts()) -> resource_query_mode().
-query_mode(Mod, Config, Opts) ->
+-spec query_mode(module(), channel_config()) -> resource_query_mode().
+query_mode(Mod, ChannelConfig) ->
+    ResourceOpts = fetch_creation_opts(ChannelConfig),
+    query_mode(Mod, ChannelConfig, ResourceOpts).
+
+-spec query_mode(module(), channel_config(), creation_opts()) -> resource_query_mode().
+query_mode(Mod, ChannelConfig, Opts) ->
     case erlang:function_exported(Mod, query_mode, 1) of
         true ->
-            Mod:query_mode(Config);
+            Mod:query_mode(ChannelConfig);
         false ->
             maps:get(query_mode, Opts, sync)
     end.

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -215,7 +215,7 @@
     | {channel_status(), Reason :: term()}
     | {error, term()}.
 
--callback query_mode(Config :: term()) -> query_mode().
+-callback query_mode(Config :: term()) -> resource_query_mode().
 
 -callback query_opts(Config :: term()) -> #{timeout => timeout()}.
 
@@ -632,7 +632,7 @@ call_stop(ResId, Mod, ResourceState) ->
         Res
     end).
 
--spec query_mode(module(), term(), creation_opts()) -> query_mode().
+-spec query_mode(module(), term(), creation_opts()) -> resource_query_mode().
 query_mode(Mod, Config, Opts) ->
     case erlang:function_exported(Mod, query_mode, 1) of
         true ->

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -510,7 +510,7 @@ retry_inflight_sync(Ref, QueryOrBatch, Data0) ->
             %% `inflight_drop' to avoid the race condition when an
             %% inflight request might get completed concurrently with
             %% the retry, bumping them twice.  Since both inflight
-            %% requests (repeated and original) have the safe `Ref',
+            %% requests (repeated and original) have the same `Ref',
             %% we bump the counter when removing it from the table.
             IsAcked andalso PostFn(),
             ?tp(
@@ -1224,8 +1224,8 @@ handle_async_worker_down(Data0, Pid) ->
 call_query(QM, Id, Index, Ref, Query, QueryOpts) ->
     ?tp(call_query_enter, #{id => Id, query => Query, query_mode => QM}),
     case emqx_resource_cache:get_runtime(Id) of
-        %% This seems to be the only place where the `rm_status_stopped' status matters,
-        %% to distinguish from the `disconnected' status.
+        %% This seems to be the only place where the `rm_status_stopped' state matters,
+        %% to distinguish from the `disconnected' state.
         {ok, #rt{st_err = #{status := ?rm_status_stopped}}} ->
             Result = ?RESOURCE_ERROR(stopped, "resource stopped or disabled"),
             maybe_reply_to(Result, QueryOpts);

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -186,7 +186,7 @@ simple_sync_query(Id, Request, QueryOpts0) ->
         ?SIMPLE_QUERY(ReplyTo, Request, RequestContext, TraceCtx),
         QueryOpts
     ),
-    _ = handle_query_result(Id, Result, _HasBeenSent = false),
+    _ = handle_simple_query_result(Id, Result, _HasBeenSent = false),
     Result.
 
 %% simple async-query the resource without batching and queuing.
@@ -206,7 +206,7 @@ simple_async_query(Id, Request, QueryOpts0) ->
         ?SIMPLE_QUERY(ReplyTo, Request, RequestContext, TraceCtx),
         QueryOpts
     ),
-    _ = handle_query_result(Id, Result, _HasBeenSent = false),
+    _ = handle_simple_query_result(Id, Result, _HasBeenSent = false),
     Result.
 
 %% This is a hack to handle cases where the underlying connector has internal buffering
@@ -980,7 +980,7 @@ batch_reply_dropped(Batch, Result) ->
 
 %% This is only called by `simple_{,a}sync_query', so we can bump the
 %% counters here.
-handle_query_result(Id, Result, HasBeenSent) ->
+handle_simple_query_result(Id, Result, HasBeenSent) ->
     {ShouldBlock, PostFn, DeltaCounters} = handle_query_result_pure(Id, Result, HasBeenSent, #{}),
     PostFn(),
     %% TODO: maybe trigger fallback actions

--- a/apps/emqx_resource/src/emqx_resource_cache.erl
+++ b/apps/emqx_resource/src/emqx_resource_cache.erl
@@ -304,19 +304,19 @@ make_resource_data(ID, Connector, Channels) ->
         state => State
     }.
 
-find_channels(ConnectorID) ->
-    MS = ets:fun2ms(fun(#channel{id = {Cid, _}} = C) when Cid =:= ConnectorID -> C end),
+find_channels(ConnectorId) ->
+    MS = ets:fun2ms(fun(#channel{id = {Cid, _}} = C) when Cid =:= ConnectorId -> C end),
     List = ets:select(?CACHE, MS),
     lists:foldl(
         fun(
             #channel{
-                id = {ConnectorId, ChannelId},
+                id = {ConnectorId0, ChannelId},
                 status = Status,
                 error = Error
             },
             Acc
         ) ->
-            Key = iolist_to_binary([ChannelId, ":", ConnectorId]),
+            Key = iolist_to_binary([ChannelId, ":", ConnectorId0]),
             Acc#{Key => #{status => Status, error => Error}}
         end,
         #{},


### PR DESCRIPTION
Part of https://emqx.atlassian.net/browse/EMQX-12966

Release version: v/e5.8.5

## Summary

These are several internal refactoring that will be used for implementing Action Fallbacks.

The changes herein do not affect the current behavior of bridges.

This PR targets `release-58`, since this is an internal refactoring and doesn't affect behavior, to minimize divergence between branches.

## PR Checklist

- [na] ~~Added tests for the changes~~ internal refactoring only.
- [na] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] For internal contributor: there is a jira ticket to track this change