### PR TITLE
Perf: emqx_cm and emqx_broker_helper 

### DIFF
--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -167,11 +167,11 @@ init([]) ->
     {ok, #{}}.
 
 handle_call(Req, _From, State) ->
-    ?SLOG(error, #{msg => "emqx_borker_helper_unexpected_call", call => Req}),
+    ?SLOG(error, #{msg => "emqx_broker_helper_unexpected_call", call => Req}),
     {reply, ignored, State}.
 
 handle_cast(Msg, State) ->
-    ?SLOG(error, #{msg => "emqx_borker_helper_unexpected_cast", cast => Msg}),
+    ?SLOG(error, #{msg => "emqx_broker_helper_unexpected_cast", cast => Msg}),
     {noreply, State}.
 
 handle_info({register_sub, SubPid, SubId}, State) ->
@@ -181,7 +181,7 @@ handle_info({'DOWN', _MRef, process, SubPid, _Reason}, State) ->
     ok = collect_and_handle([], [SubPid]),
     {noreply, State};
 handle_info(Info, State) ->
-    ?SLOG(error, #{msg => "emqx_borker_helper_unexpected_info", info => Info}),
+    ?SLOG(error, #{msg => "emqx_broker_helper_unexpected_info", info => Info}),
     {noreply, State}.
 
 terminate(_Reason, _State) ->

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -62,7 +62,7 @@
 -define(SUBSEQ, emqx_subseq).
 -define(SHARD, 1024).
 
--define(BATCH_SIZE, 100000).
+-define(BATCH_SIZE, 1000).
 
 -spec start_link() -> startlink_ret().
 start_link() ->
@@ -72,7 +72,8 @@ start_link() ->
 register_sub(SubPid, SubId) when is_pid(SubPid) ->
     case ets:lookup(?SUBMON, SubPid) of
         [] ->
-            gen_server:cast(?HELPER, {register_sub, SubPid, SubId});
+            _ = erlang:send(?HELPER, {register_sub, SubPid, SubId}),
+            ok;
         [{_, SubId}] ->
             ok;
         _Other ->
@@ -167,20 +168,15 @@ handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "emqx_borker_helper_unexpected_call", call => Req}),
     {reply, ignored, State}.
 
-handle_cast({register_sub, SubPid, SubId}, State) ->
-    true = (SubId =:= undefined) orelse ets:insert(?SUBID, {SubId, SubPid}),
-    _ = erlang:monitor(process, SubPid),
-    true = ets:insert(?SUBMON, {SubPid, SubId}),
-    {noreply, State};
 handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "emqx_borker_helper_unexpected_cast", cast => Msg}),
     {noreply, State}.
 
+handle_info({register_sub, SubPid, SubId}, State) ->
+    ok = collect_and_handle([{SubId, SubPid}], []),
+    {noreply, State};
 handle_info({'DOWN', _MRef, process, SubPid, _Reason}, State) ->
-    SubPids = [SubPid | emqx_utils:drain_down(?BATCH_SIZE)],
-    ok = emqx_pool:async_submit(
-        fun lists:foreach/2, [fun ?MODULE:clean_down/1, SubPids]
-    ),
+    ok = collect_and_handle([], [SubPid]),
     {noreply, State};
 handle_info(Info, State) ->
     ?SLOG(error, #{msg => "emqx_borker_helper_unexpected_info", info => Info}),
@@ -196,6 +192,43 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+
+collect_and_handle(Reg0, Down0) ->
+    {Reg, Down} = collect_messages(Reg0, Down0),
+    ok = handle_down(Down),
+    ok = handle_register(Reg).
+
+collect_messages(Reg, Down) ->
+    collect_messages(Reg, Down, ?BATCH_SIZE).
+
+%% Collect both register_sub and 'DOWN' messages in a loop.
+%% There is no other message sent to this process, so the
+%% 'receive' should not have to scan the mailbox.
+collect_messages(Reg, Down, 0) ->
+    {Reg, Down};
+collect_messages(Reg, Down, N) ->
+    receive
+        {register_sub, Pid, Id} ->
+            collect_messages([{Id, Pid} | Reg], Down, N - 1);
+        {'DOWN', _MRef, process, Pid, _Reason} ->
+            collect_messages(Reg, [Pid | Down], N - 1)
+    after 0 ->
+        {Reg, Down}
+    end.
+
+handle_register(Reg) ->
+    lists:foreach(fun do_handle_register/1, Reg).
+
+do_handle_register({SubId, SubPid}) ->
+    true = (SubId =:= undefined) orelse ets:insert(?SUBID, {SubId, SubPid}),
+    _ = erlang:monitor(process, SubPid),
+    true = ets:insert(?SUBMON, {SubPid, SubId}),
+    ok.
+
+handle_down(SubPids) ->
+    ok = emqx_pool:async_submit(
+        fun lists:foreach/2, [fun ?MODULE:clean_down/1, SubPids]
+    ).
 
 clean_down(SubPid) ->
     try

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -197,8 +197,10 @@ code_change(_OldVsn, State, _Extra) ->
 
 collect_and_handle(Reg0, Down0) ->
     {Reg, Down} = collect_messages(Reg0, Down0),
-    ok = handle_down(Down),
-    ok = handle_register(Reg).
+    %% handle register before handle down to avoid race condition
+    %% because down message is always the last one from a process
+    ok = handle_register(Reg),
+    ok = handle_down(Down).
 
 collect_messages(Reg, Down) ->
     collect_messages(Reg, Down, ?BATCH_SIZE).

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -150,7 +150,6 @@ table_size(Tab) when is_atom(Tab) -> ets:info(Tab, size).
 %%--------------------------------------------------------------------
 
 init([]) ->
-    process_flag(priority, high),
     process_flag(message_queue_data, off_heap),
     %% Helper table
     ok = emqx_utils_ets:new(?HELPER, [{read_concurrency, true}]),

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -150,6 +150,7 @@ table_size(Tab) when is_atom(Tab) -> ets:info(Tab, size).
 %%--------------------------------------------------------------------
 
 init([]) ->
+    process_flag(priority, high),
     process_flag(message_queue_data, off_heap),
     %% Helper table
     ok = emqx_utils_ets:new(?HELPER, [{read_concurrency, true}]),

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -150,6 +150,7 @@ table_size(Tab) when is_atom(Tab) -> ets:info(Tab, size).
 %%--------------------------------------------------------------------
 
 init([]) ->
+    process_flag(message_queue_data, off_heap),
     %% Helper table
     ok = emqx_utils_ets:new(?HELPER, [{read_concurrency, true}]),
     %% Shards: CPU * 32

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -773,6 +773,8 @@ cast(Msg) ->
 %%--------------------------------------------------------------------
 
 init([]) ->
+    process_flag(priority, high),
+    process_flag(message_queue_data, off_heap),
     TabOpts = [public, {write_concurrency, true}],
     ok = emqx_utils_ets:new(?CHAN_TAB, [bag, {read_concurrency, true} | TabOpts]),
     ok = emqx_utils_ets:new(?CHAN_CONN_TAB, [ordered_set, {keypos, #chan_conn.pid} | TabOpts]),

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -198,7 +198,7 @@ register_channel(ClientId, ChanPid, #{conn_mod := ConnMod}) when
     ok = cast({registered, ChanPid}),
     true = ets:insert(?CHAN_TAB, Chan),
     ok = emqx_cm_registry:register_channel(Chan),
-    mark_channel_connected(ChanPid),
+    ok = mark_channel_connected(ChanPid),
     ok.
 
 %% @doc Unregister a channel.
@@ -915,7 +915,6 @@ kick_session_chans(ClientId, ChanPids) ->
 -if(?EMQX_RELEASE_EDITION == ee).
 
 basic_trace_attrs(Pid) ->
-    %% io:format("lookup_client({chan_pid, Pid}): ~p", [lookup_client({chan_pid, Pid})]),
     case lookup_client({chan_pid, Pid}) of
         [] ->
             #{'channel.pid' => iolist_to_binary(io_lib:format("~p", [Pid]))};

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -825,7 +825,7 @@ collect_and_handle(Regs0, Down0) ->
     ok = handle_down_pids(Down).
 
 collect_msgs(Regs, Down, 0) ->
-    {lists:reverse(Regs), lists:reverse(Down)};
+    {Regs, Down};
 collect_msgs(Regs, Down, N) ->
     receive
         {registered, Pid} ->
@@ -833,7 +833,7 @@ collect_msgs(Regs, Down, N) ->
         {'DOWN', _MRef, process, Pid, _Reason} ->
             collect_msgs(Regs, [Pid | Down], N - 1)
     after 0 ->
-        {lists:reverse(Regs), lists:reverse(Down)}
+        {Regs, Down}
     end.
 
 clean_down([]) ->

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -454,17 +454,14 @@ t_connected_client_count_persistent(Config) when is_list(Config) ->
     ?assertEqual(1, emqx_cm:get_connected_client_count()),
     %% abnormal exit of channel process
     ChanPids = emqx_cm:all_channels(),
-    {ok, {ok, [_, _]}} = wait_for_events(
+    {ok, {ok, [_]}} = wait_for_events(
         fun() ->
             lists:foreach(
                 fun(ChanPid) -> exit(ChanPid, kill) end,
                 ChanPids
             )
         end,
-        [
-            emqx_cm_connected_client_count_dec,
-            emqx_cm_process_down
-        ]
+        [emqx_cm_connected_client_count_dec]
     ),
     ?retry(_Sleep = 100, _Retries = 20, ?assertEqual(0, emqx_cm:get_connected_client_count())),
     ok;
@@ -502,11 +499,10 @@ t_connected_client_count_anonymous(Config) when is_list(Config) ->
     ),
     ?assertEqual(2, emqx_cm:get_connected_client_count()),
     %% when first client disconnects, shouldn't affect the second
-    {ok, {ok, [_, _]}} = wait_for_events(
+    {ok, {ok, [_]}} = wait_for_events(
         fun() -> emqtt:disconnect(ConnPid0) end,
         [
-            emqx_cm_connected_client_count_dec,
-            emqx_cm_process_down
+            emqx_cm_connected_client_count_dec
         ]
     ),
     ?assertEqual(1, emqx_cm:get_connected_client_count()),
@@ -520,17 +516,16 @@ t_connected_client_count_anonymous(Config) when is_list(Config) ->
         [emqx_cm_connected_client_count_inc]
     ),
     ?assertEqual(2, emqx_cm:get_connected_client_count()),
-    {ok, {ok, [_, _]}} = wait_for_events(
+    {ok, {ok, [_]}} = wait_for_events(
         fun() -> emqtt:disconnect(ConnPid1) end,
         [
-            emqx_cm_connected_client_count_dec,
-            emqx_cm_process_down
+            emqx_cm_connected_client_count_dec
         ]
     ),
     ?assertEqual(1, emqx_cm:get_connected_client_count()),
     %% abnormal exit of channel process
     Chans = emqx_cm:all_channels(),
-    {ok, {ok, [_, _]}} = wait_for_events(
+    {ok, {ok, [_]}} = wait_for_events(
         fun() ->
             lists:foreach(
                 fun(ChanPid) -> exit(ChanPid, kill) end,
@@ -538,8 +533,7 @@ t_connected_client_count_anonymous(Config) when is_list(Config) ->
             )
         end,
         [
-            emqx_cm_connected_client_count_dec,
-            emqx_cm_process_down
+            emqx_cm_connected_client_count_dec
         ]
     ),
     ?assertEqual(0, emqx_cm:get_connected_client_count()),
@@ -639,16 +633,13 @@ t_connected_client_count_transient_takeover(Config) when is_list(Config) ->
     ?assertEqual(1, emqx_cm:get_connected_client_count()),
     %% abnormal exit of channel process
     [ChanPid] = emqx_cm:all_channels(),
-    {ok, {ok, [_, _]}} =
+    {ok, {ok, [_]}} =
         wait_for_events(
             fun() ->
                 exit(ChanPid, kill),
                 ok
             end,
-            [
-                emqx_cm_connected_client_count_dec_done,
-                emqx_cm_process_down
-            ],
+            [emqx_cm_connected_client_count_dec_done],
             _Timeout = 10000
         ),
     ?assertEqual(0, emqx_cm:get_connected_client_count()),
@@ -759,7 +750,7 @@ authenticate_deny(_Credentials, _Default) ->
     {stop, {error, bad_username_or_password}}.
 
 wait_for_events(Action, Kinds) ->
-    wait_for_events(Action, Kinds, 500).
+    wait_for_events(Action, Kinds, 1000).
 
 wait_for_events(Action, Kinds, Timeout) ->
     wait_for_events(Action, Kinds, Timeout, 0).

--- a/apps/emqx/test/emqx_broker_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_helper_SUITE.erl
@@ -20,8 +20,23 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx, #{
+                override_env => [{boot_modules, [broker]}]
+            }}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
 init_per_testcase(_TestCase, Config) ->
     emqx_broker_helper:start_link(),

--- a/apps/emqx_auth_ext/README.md
+++ b/apps/emqx_auth_ext/README.md
@@ -1,4 +1,4 @@
-# EMQX Extended Auth Library 
+# EMQX Extended Auth Library
 
 Library that extends EMQX authentication capbility for enterprise.
 

--- a/changes/ce/fix-14508.en.md
+++ b/changes/ce/fix-14508.en.md
@@ -1,0 +1,1 @@
+Performance improvement when large number of clients reconnect.


### PR DESCRIPTION
Fixes #14482

Release version: v/e5.8.5

## Summary

Prior to this change, `emqx_utils:drain_down(?BATCH_SIZE)` might repeatedly scan process mailbox to drain the `DOWN` messages in `emqx_broker_helper` and `emqx_cm`.
This PR changes the receive loop to always collect the head of the first `BATCH_SIZE` messages in the mailbox including both register requests and `DOWN` messages.
Also, `BATCH_SIZE` is change from `100,000` to `1000` for smaller term collection.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
