### PR TITLE
250109 refactor emqx_cm connection module register with pid

### DIFF
--- a/apps/emqx/include/emqx_cm.hrl
+++ b/apps/emqx/include/emqx_cm.hrl
@@ -39,4 +39,11 @@
     pid :: pid() | non_neg_integer() | '$1'
 }).
 
+%% Map from channel pid to connection module and client ID.
+-record(chan_conn, {
+    pid :: pid(),
+    mod :: module(),
+    clientid :: emqx_types:clientid()
+}).
+
 -endif.

--- a/apps/emqx/include/emqx_cm.hrl
+++ b/apps/emqx/include/emqx_cm.hrl
@@ -41,9 +41,9 @@
 
 %% Map from channel pid to connection module and client ID.
 -record(chan_conn, {
-    pid :: pid(),
-    mod :: module(),
-    clientid :: emqx_types:clientid()
+    pid :: pid() | '_' | '$1',
+    mod :: module() | '_',
+    clientid :: emqx_types:clientid() | '_'
 }).
 
 -endif.

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -196,7 +196,7 @@ register_channel(ClientId, ChanPid, #{conn_mod := ConnMod}) when
     %% cast (for process monitor) before inserting ets tables
     cast({registered, Chan}),
     true = ets:insert(?CHAN_TAB, Chan),
-    true = ets:insert(?CHAN_CONN_TAB, {Chan, ConnMod}),
+    true = ets:insert(?CHAN_CONN_TAB, {ChanPid, ConnMod}),
     ok = emqx_cm_registry:register_channel(Chan),
     mark_channel_connected(ChanPid),
     ok.
@@ -210,7 +210,7 @@ unregister_channel(ClientId) when ?IS_CLIENTID(ClientId) ->
 %% @private
 do_unregister_channel({_ClientId, ChanPid} = Chan) ->
     ok = emqx_cm_registry:unregister_channel(Chan),
-    true = ets:delete(?CHAN_CONN_TAB, Chan),
+    true = ets:delete(?CHAN_CONN_TAB, ChanPid),
     true = ets:delete(?CHAN_INFO_TAB, Chan),
     ets:delete_object(?CHAN_TAB, Chan),
     ok = emqx_hooks:run('cm.channel.unregistered', [ChanPid]),
@@ -698,10 +698,7 @@ live_connection_stream(ConnModules) ->
         (undefined) -> ets:select(?CHAN_CONN_TAB, Ms, ?CHAN_INFO_SELECT_LIMIT);
         (Cont) -> ets:select(Cont)
     end),
-    emqx_utils_stream:filter(
-        fun({_ClientId, ChanPid}) -> is_channel_connected(ChanPid) end,
-        AllConnStream
-    ).
+    emqx_utils_stream:filter(fun is_channel_connected/1, AllConnStream).
 
 live_connection_ms(ConnModule) ->
     {{{'$1', '$2'}, ConnModule}, [], [{{'$1', '$2'}}]}.
@@ -777,7 +774,7 @@ cast(Msg) -> gen_server:cast(?CM, Msg).
 init([]) ->
     TabOpts = [public, {write_concurrency, true}],
     ok = emqx_utils_ets:new(?CHAN_TAB, [bag, {read_concurrency, true} | TabOpts]),
-    ok = emqx_utils_ets:new(?CHAN_CONN_TAB, [bag | TabOpts]),
+    ok = emqx_utils_ets:new(?CHAN_CONN_TAB, [{write_concurrency, true} | TabOpts]),
     ok = emqx_utils_ets:new(?CHAN_INFO_TAB, [ordered_set, compressed | TabOpts]),
     ok = emqx_utils_ets:new(?CHAN_LIVE_TAB, [ordered_set, {write_concurrency, true} | TabOpts]),
     ok = emqx_stats:update_interval(chan_stats, fun ?MODULE:stats_fun/0),
@@ -839,12 +836,14 @@ update_stats({Tab, Stat, MaxStat}) ->
         Size -> emqx_stats:setstat(Stat, MaxStat, Size)
     end.
 
+%% This function is mostly called locally, but also exported for RPC (from older versions).
+%% The first arg ClientId is no longer used since 5.8.5, but the function is still `/2`
+%% for backward compatibility.
 -spec do_get_chann_conn_mod(emqx_types:clientid(), chan_pid()) ->
     module() | undefined.
-do_get_chann_conn_mod(ClientId, ChanPid) ->
-    Chan = {ClientId, ChanPid},
+do_get_chann_conn_mod(_ClientId, ChanPid) ->
     try
-        [ConnMod] = ets:lookup_element(?CHAN_CONN_TAB, Chan, 2),
+        [ConnMod] = ets:lookup_element(?CHAN_CONN_TAB, ChanPid, 2),
         ConnMod
     catch
         error:badarg -> undefined

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -1080,7 +1080,7 @@ check_max_connection(Type, Listener) ->
         infinity ->
             allow;
         Max ->
-            MatchSpec = [{{'_', emqx_ws_connection}, [], [true]}],
+            MatchSpec = [{#chan_conn{mod = emqx_ws_connection, _ = '_'}, [], [true]}],
             Curr = ets:select_count(?CHAN_CONN_TAB, MatchSpec),
             case Curr >= Max of
                 false ->

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -219,7 +219,7 @@ t_open_session_race_condition(_) ->
 
     ?assertMatch([_], ets:lookup(?CHAN_TAB, ClientId)),
     ?assertEqual([Winner], emqx_cm:lookup_channels(ClientId)),
-    ?assertMatch([_], ets:lookup(?CHAN_CONN_TAB, {ClientId, Winner})),
+    ?assertMatch([_], ets:lookup(?CHAN_CONN_TAB, Winner)),
     ?assertMatch([_], ets:lookup(?CHAN_REG_TAB, ClientId)),
 
     exit(Winner, kill),

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent.app.src
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent.app.src
@@ -1,6 +1,6 @@
 {application, emqx_eviction_agent, [
     {description, "EMQX Eviction Agent"},
-    {vsn, "5.1.9"},
+    {vsn, "5.1.10"},
     {registered, [
         emqx_eviction_agent_sup,
         emqx_eviction_agent,

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent.erl
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent.erl
@@ -335,10 +335,7 @@ stream_count(Stream) ->
     emqx_utils_stream:fold(fun(_, Acc) -> Acc + 1 end, 0, Stream).
 
 connection_pid_stream() ->
-    emqx_utils_stream:map(
-        fun({_ClientId, ChanPid}) -> ChanPid end,
-        connection_stream()
-    ).
+    connection_stream().
 
 do_evict_connections(ChanPidStream, ServerReference) ->
     ok = emqx_utils_stream:foreach(


### PR DESCRIPTION
Release version: v/e5.8.5

## Summary

Client ID as key was never needed in the `CHAN_CONN_TAB` table.
It is now stored in the table as a value field (for use in the next PR).

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [~] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [~] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
  This does not impact user experience. Will add a changelog in the next PR.
- [~] For internal contributor: there is a jira ticket to track this change
- [~] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
