### PR TITLE
feat: add cURL to docker image

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -50,7 +50,7 @@ COPY deploy/docker/docker-entrypoint.sh /usr/bin/
 
 RUN set -eu; \
     apt-get update; \
-    apt-get install -y --no-install-recommends ca-certificates procps $(echo "${EXTRA_DEPS}" | tr ',' ' '); \
+    apt-get install -y --no-install-recommends ca-certificates procps curl $(echo "${EXTRA_DEPS}" | tr ',' ' '); \
     rm -rf /var/lib/apt/lists/*; \
     groupadd -r -g 1000 emqx; \
     useradd -r -m -u 1000 -g emqx emqx;


### PR DESCRIPTION
Add cURL back to the docker image.
NOTE: adding 5MB to the image size.