### PR TITLE
chore: bump `ekka` to 0.19.8

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.7"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.8"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},

--- a/changes/ce/fix-14536.en.md
+++ b/changes/ce/fix-14536.en.md
@@ -1,0 +1,1 @@
+Fix rare race condition causing some of cluster management operations to hang thus rendering cluster changes impossible until node restart, by making global lock guarding cluster joins stricter.

--- a/mix.exs
+++ b/mix.exs
@@ -183,7 +183,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.19.7", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.19.8", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.43.4", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -83,7 +83,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-6"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.7"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.8"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},


### PR DESCRIPTION
Fixes [EMQX-13588](https://emqx.atlassian.net/browse/EMQX-13588).

Release version: v/e5.8.5

## Summary

Includes emqx/mria#184.

Makes global lock guarding `mria:join/1` operations stricter. Otherwise, concurrent joins can ruin each other's lives and make any further cluster operations impossible. This can happen, for example, when a concurrent join stops the entire `mnesia` system while another join is running schema transactions.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-13588]: https://emqx.atlassian.net/browse/EMQX-13588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ