### PR TITLE
fix: OTP from 26.2.5.2-1 to 26.2.5.2-3

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04
+    image:  ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-ubuntu22.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-ubuntu22.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-ubuntu22.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -55,7 +55,7 @@ on:
       otp_vsn:
         required: false
         type: string
-        default: '26.2.5.2-1'
+        default: '26.2.5.2-3'
       elixir_vsn:
         required: false
         type: string
@@ -63,7 +63,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '5.3-13'
+        default: '5.4-4'
 
 permissions:
   contents: read

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.2.5.2-1
+erlang 26.2.5.2-3
 elixir 1.15.7-otp-26

--- a/changes/ce/fix-14548.en.md
+++ b/changes/ce/fix-14548.en.md
@@ -1,0 +1,6 @@
+Fix datbase schema merge crash issue.
+
+`** FATAL ** Failed to merge schema: {aborted,function_clause}`
+
+Fixed an issue where a node was down would crash upon reboot if a new node joined the cluster while it's down.
+Now, nodes can restart smoothly without needing to rejoin the cluster.

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-debian12
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-debian12
 ARG RUN_FROM=debian:12-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=5.3-13
-export OTP_VSN=26.2.5.2-1
+export EMQX_BUILDER_VSN=5.4-4
+export OTP_VSN=26.2.5.2-3
 export ELIXIR_VSN=1.15.7
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu22.04
 export EMQX_DOCKER_BUILD_FROM=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-debian12

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -36,7 +36,7 @@ help() {
     echo ""
     echo "--builder <BUILDER>:"
     echo "    Docker image to use for building"
-    echo "    E.g. ghcr.io/emqx/emqx-builder/5.3-13:1.15.7-26.2.5.2-1-debian12"
+    echo "    E.g. ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-debian12"
     echo "    For hot upgrading tar.gz, specify a builder image with the same OS distribution as the running one."
     echo "    Specifically, for EMQX's docker containers hot upgrading, please use the debian12-based builder. "
 }


### PR DESCRIPTION
Fixes [EMQX-12290](https://emqx.atlassian.net/browse/EMQX-12290)

Release version: v/e5.8.5

## Summary

Fix OTP for the crash like below:

> ** FATAL ** Failed to merge schema: {aborted,function_clause}

See also: https://github.com/emqx/otp/pull/66

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change



[EMQX-12290]: https://emqx.atlassian.net/browse/EMQX-12290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ