### PR TITLE
fix(kafka): upgrade Kafka producer lib wolff from 4.0.4 to 4.0.5

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.4"},
+    {wolff, "4.0.5"},
     {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.4"},
+    {wolff, "4.0.5"},
     {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.4"},
+    {wolff, "4.0.5"},
     {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/changes/ee/fix-14552.en.md
+++ b/changes/ee/fix-14552.en.md
@@ -1,0 +1,3 @@
+Fixed Kafka producer `unexpected_id` crash after buffer overflow happend while Kafka service is down.
+
+This bug was introduced in EMQX Enterprise version 5.8.1.

--- a/mix.exs
+++ b/mix.exs
@@ -275,7 +275,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.4"}
+  def common_dep(:wolff), do: {:wolff, "4.0.5"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),


### PR DESCRIPTION
Fixes [EEC-1138](https://emqx.atlassian.net/browse/EEC-1138)

Release version: v/e5.8.5

## Summary

EMQX 5.8.1 (`wolff-4.0.1`) introduced a bug where the producer process may crash with `unexpected_id` error if buffer overflow happend while there are inflight requests.

## PR Checklist

- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change



[EEC-1138]: https://emqx.atlassian.net/browse/EEC-1138?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ