### PR TITLE
fix(mqtt source): unsubscribe shared topics

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_subscriber_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_subscriber_SUITE.erl
@@ -241,6 +241,11 @@ create_rule_and_action_http(Config, Opts) ->
         ?config(source_type, Config), <<"">>, Config, Opts
     ).
 
+update_source_api(Config, Overrides) ->
+    simplify_result(
+        emqx_bridge_v2_testlib:update_bridge_api(Config, Overrides)
+    ).
+
 %%------------------------------------------------------------------------------
 %% Testcases
 %%------------------------------------------------------------------------------
@@ -608,4 +613,61 @@ t_no_local(Config) ->
     ?assertReceive({deliver, RemoteTopic, _}),
     ?assertNotReceive({deliver, RemoteTopic, _}),
     ?assertNotReceive({deliver, RuleTopicSubscriber, _}),
+    ok.
+
+t_shared_subscription(Config) ->
+    {201, _} = create_connector_api(Config, #{<<"pool_size">> => 1}),
+    SharedTopic1 = <<"$share/t/test/#">>,
+    {201, _} =
+        create_source_api(Config, #{
+            <<"parameters">> => #{
+                <<"topic">> => SharedTopic1
+            }
+        }),
+    RepublishTopic = <<"share/output">>,
+    {ok, _} = create_rule_and_action_http(Config, #{
+        sql => iolist_to_binary(
+            io_lib:format(
+                "select * from \"~s\"",
+                [hookpoint(Config)]
+            )
+        ),
+        overrides => #{
+            actions => [
+                #{
+                    <<"function">> => <<"republish">>,
+                    <<"args">> =>
+                        #{
+                            <<"topic">> => RepublishTopic,
+                            <<"payload">> => <<"republish_${.payload}">>,
+                            <<"qos">> => 1,
+                            <<"retain">> => false
+                        }
+                }
+            ]
+        }
+    }),
+
+    {ok, Client} = emqtt:start_link([{proto_ver, v5}]),
+    {ok, _} = emqtt:connect(Client),
+    {ok, _, [?RC_GRANTED_QOS_1]} = emqtt:subscribe(Client, RepublishTopic, [{qos, 1}]),
+
+    %% Check that it's working as intended.
+    PublishTopic = <<"test/1">>,
+    {ok, _} = emqtt:publish(Client, PublishTopic, <<"1">>, [{qos, 1}]),
+    ?assertReceive({publish, #{payload := <<"republish_1">>}}),
+    ?assertNotReceive({publish, _}),
+
+    %% Update the shared subscription; should still republish only one message.
+    SharedTopic2 = <<"$share/t/test/1">>,
+    {200, _} = update_source_api(Config, #{
+        <<"parameters">> => #{
+            <<"topic">> => SharedTopic2
+        }
+    }),
+
+    {ok, _} = emqtt:publish(Client, PublishTopic, <<"2">>, [{qos, 1}]),
+    ?assertReceive({publish, #{payload := <<"republish_2">>}}),
+    ?assertNotReceive({publish, _}),
+
     ok.

--- a/changes/ce/fix-14555.en.md
+++ b/changes/ce/fix-14555.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with MQTT Source where shared topics would not be unsubscribed from when removing or updating a source.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13827

Release version: v/e5.8.5

## Summary

Previously, there was a mismatch in the treatment given to the topic that was inserted in the topic index and the one being unsubscribed from, leaving dangling shared subscriptions in the index.

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
