### PR TITLE
feat(authn): do not allow authentication if auth enabled but no hooks handled auth

### DIFF
--- a/apps/emqx/test/emqx_access_control_SUITE.erl
+++ b/apps/emqx/test/emqx_access_control_SUITE.erl
@@ -30,9 +30,11 @@ init_per_suite(Config) ->
         [{emqx, #{override_env => [{boot_modules, [broker]}]}}],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
+    ok = emqx_access_control:set_default_authn_restrictive(),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
+    ok = emqx_access_control:set_default_authn_permissive(),
     emqx_cth_suite:stop(proplists:get_value(apps, Config)).
 
 init_per_testcase(_, Config) ->

--- a/apps/emqx/test/emqx_access_control_SUITE.erl
+++ b/apps/emqx/test/emqx_access_control_SUITE.erl
@@ -43,7 +43,16 @@ end_per_testcase(_, _Config) ->
     ok = emqx_hooks:del('client.authenticate', {?MODULE, quick_deny_anonymous_authn}).
 
 t_authenticate(_) ->
-    ?assertMatch({ok, _}, emqx_access_control:authenticate(clientinfo())).
+    ClientInfo = clientinfo(),
+    ?assertMatch({error, not_authorized}, emqx_access_control:authenticate(ClientInfo)),
+    ?assertMatch(
+        {error, not_authorized}, emqx_access_control:authenticate(ClientInfo#{enable_authn => true})
+    ),
+    ?assertMatch(
+        {error, not_authorized},
+        emqx_access_control:authenticate(ClientInfo#{enable_authn => quick_deny_anonymous})
+    ),
+    ?assertMatch({ok, _}, emqx_access_control:authenticate(ClientInfo#{enable_authn => false})).
 
 t_authorize(_) ->
     ?assertEqual(allow, emqx_access_control:authorize(clientinfo(), ?AUTHZ_PUBLISH, <<"t">>)).

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_chains_SUITE.erl
@@ -101,10 +101,12 @@ init_per_suite(Config) ->
         ],
         #{work_dir => ?config(priv_dir)}
     ),
+    ok = emqx_access_control:set_default_authn_restrictive(),
     ok = deregister_providers(),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
+    ok = emqx_access_control:set_default_authn_permissive(),
     emqx_cth_suite:stop(?config(apps)),
     ok.
 

--- a/apps/emqx_auth/test/emqx_authn/emqx_authn_init_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authn/emqx_authn_init_SUITE.erl
@@ -38,6 +38,14 @@
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
+init_per_suite(Config) ->
+    emqx_access_control:set_default_authn_restrictive(),
+    Config.
+
+end_per_suite(Config) ->
+    emqx_access_control:set_default_authn_permissive(),
+    Config.
+
 init_per_testcase(_Case, Config) ->
     Apps = emqx_cth_suite:start(
         [
@@ -60,7 +68,7 @@ end_per_testcase(_Case, Config) ->
 
 t_initialize(_Config) ->
     ?assertMatch(
-        {ok, _},
+        {error, not_authorized},
         emqx_access_control:authenticate(?CLIENTINFO)
     ),
     ok = application:start(emqx_auth),

--- a/changes/ce/fix-14556.en.md
+++ b/changes/ce/fix-14556.en.md
@@ -1,0 +1,1 @@
+Fix rarely possible false positive authentication while the node is starting or shutting down.


### PR DESCRIPTION
Fixes [EMQX-13816](https://emqx.atlassian.net/issues/EMQX-13816)

Release version: v/e5.9.0

## Summary

Currently, we have quite a fragile authentication convention. If there are no hooks (or if all hooks fail), we allow (anonymous) authentication. This is convenient for using the `emqx` app without a release, e.g., in tests. But this leads to actual and potential security issues. If, for some reason, `emqx_auth`'s hook fails or is absent (`emqx_auth` app starts, stops, crashes, etc.), then we allow everyone to connect. This proved to happen in practice on a slow node (see the related task).

We change the convention and logic:

* if, for a listener, `enable_authn` is not `false` (default is true), than we **deny authentication if no hooks are installed** or no hooks handled the authentication (e.g. crashed). 
* We stop installing/uninstalling the hook in `emqx_auth_chains`. 

So, the new logic is that we allow authentication if everything is started and working correctly and **explicitly allows authentication**.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [na] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible




[EMQX-13816]: https://emqx.atlassian.net/browse/EMQX-13816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ