### PR TITLE
fix(rule metrics): increase `failed` rule metric when internal buffer actions drop messages

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -574,18 +574,17 @@ do_send_msg(async, KafkaTopic, KafkaMessage, Producers, AsyncReplyFn) ->
 
 %% Wolff producer never gives up retrying
 %% so there can only be 'ok' results.
-on_kafka_ack(_Partition, Offset, {ReplyFn, Args}) when is_integer(Offset) ->
-    %% the ReplyFn is emqx_rule_runtime:inc_action_metrics/2
-    apply(ReplyFn, Args ++ [ok]);
-on_kafka_ack(_Partition, buffer_overflow_discarded, _Callback) ->
+on_kafka_ack(_Partition, Offset, ReplyFnAndArgs) when is_integer(Offset) ->
+    %% `emqx_rule_runtime:inc_action_metrics/2' is embedded inside reply function
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, ok);
+on_kafka_ack(_Partition, buffer_overflow_discarded, ReplyFnAndArgs) ->
     %% wolff should bump the dropped_queue_full counter in handle_telemetry_event/4
-    %% so there is no need to apply the callback here
-    ok;
-on_kafka_ack(_Partition, message_too_large, {ReplyFn, Args}) ->
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, buffer_overflow});
+on_kafka_ack(_Partition, message_too_large, ReplyFnAndArgs) ->
     %% wolff should bump the message 'dropped' counter with handle_telemetry_event/4.
     %% however 'dropped' is not mapped to EMQX metrics name
     %% so we reply error here
-    apply(ReplyFn, Args ++ [{error, message_too_large}]).
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, message_too_large}).
 
 %% Note: since wolff client has its own replayq that is not managed by
 %% `emqx_resource_buffer_worker', we must avoid returning `disconnected' here.  Otherwise,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.2.7"},
+    {vsn, "0.2.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -272,13 +272,10 @@ on_format_query_result({ok, Info}) ->
 on_format_query_result(Result) ->
     Result.
 
-on_pulsar_ack(_ReplyFnAndArgs, {error, Reason}) when
-    Reason =:= expired;
-    Reason =:= overflow
-->
-    %% We already bumped the dropped counter in `handle_telemetry_event/4', so no need to
-    %% call the wrapping callback here (it would bump the failure counter).
-    ok;
+on_pulsar_ack(ReplyFnAndArgs, {error, overflow}) ->
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, buffer_overflow});
+on_pulsar_ack(ReplyFnAndArgs, {error, expired}) ->
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, request_expired});
 on_pulsar_ack(ReplyFnAndArgs, Result) ->
     emqx_resource:apply_reply_fun(ReplyFnAndArgs, Result).
 

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -63,6 +63,8 @@
     expire_at => infinity | integer(),
     async_reply_fun => reply_fun(),
     simple_query => boolean(),
+    %% Set only by actions that use internal buffering (Kafka, Pulsar).
+    internal_buffer => boolean(),
     reply_to => reply_fun(),
     %% Called `query_mode' due to legacy reasons...
     query_mode => query_kind(),

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -402,7 +402,9 @@ query(ResId, Request, Opts) ->
             %% as Kafka and Pulsar producers.
             %% TODO(5.1.1): pass Resource instead of ResId to simple APIs
             %% so the buffer worker does not need to lookup the cache again
-            emqx_resource_buffer_worker:simple_async_query(ResId, Request, Opts);
+            emqx_resource_buffer_worker:simple_async_internal_buffer_query(
+                ResId, Request, Opts
+            );
         {ok, {simple_sync_internal_buffer, _}} ->
             %% This is for bridges/connectors that have internal buffering, such
             %% as Kafka and Pulsar producers.

--- a/changes/ee/fix-14563.en.md
+++ b/changes/ee/fix-14563.en.md
@@ -1,0 +1,1 @@
+Fix rule's 'failed' counters for messages which are dropped by Kafka and Pulsar producer actions due to buffer overflow or request expiry.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13828

Release version: e5.8.5

## Summary

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
