### PR TITLE
fix(s3 connector): stop hackney pool

### DIFF
--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_s3, [
     {description, "EMQX Enterprise S3 Bridge"},
-    {vsn, "0.1.9"},
+    {vsn, "0.1.10"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3_connector.erl
@@ -128,19 +128,10 @@ on_start(InstId, Config) ->
 
 -spec on_stop(_InstanceId :: resource_id(), state()) ->
     ok.
-on_stop(InstId, _State = #{pool_name := PoolName}) ->
-    case ehttpc_sup:stop_pool(PoolName) of
-        ok ->
-            ?tp(s3_bridge_stopped, #{instance_id => InstId}),
-            ok;
-        {error, Reason} ->
-            ?SLOG(error, #{
-                msg => "s3_connector_http_pool_stop_fail",
-                pool_name => PoolName,
-                reason => Reason
-            }),
-            ok
-    end.
+on_stop(_InstId, _State = #{pool_name := PoolName}) ->
+    Res = emqx_s3_client_http:stop_pool(PoolName),
+    ?tp(s3_bridge_stopped, #{instance_id => _InstId}),
+    Res.
 
 -spec on_get_status(_InstanceId :: resource_id(), state()) ->
     health_check_status().

--- a/changes/ee/fix-14567.en.md
+++ b/changes/ee/fix-14567.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where S3 HTTP pool would not be stopped after disabling or removing the S3 Connector.


### PR DESCRIPTION
`emqx_s3_client_http` now uses `hackney`.

Release version: e5.8.5
