### PR TITLE
chore(kafka producer): change default of `memory_overload_protection` to `true`

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -538,7 +538,7 @@ fields(producer_buffer) ->
             )},
         {memory_overload_protection,
             mk(boolean(), #{
-                default => false,
+                default => true,
                 desc => ?DESC(buffer_memory_overload_protection)
             })}
     ];

--- a/changes/ee/feat-14572.en.md
+++ b/changes/ee/feat-14572.en.md
@@ -1,0 +1,1 @@
+For Kafka, Azure Event Hub and Confluent Producers, the default value of `parameters.buffer.memory_overload_protection` has been changed to true.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13789

Release version: e5.8.5

## Summary

## PR Checklist

- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible
