### PR TITLE
chore: switch to upstream `jiffy` 1.1.2 + refactor use

### DIFF
--- a/apps/emqx/src/emqx_logger_jsonfmt.erl
+++ b/apps/emqx/src/emqx_logger_jsonfmt.erl
@@ -306,10 +306,12 @@ json_obj_root(Data0, Config) ->
                 [time, gl, file, report_cb, msg, '$kind', level, mfa, is_trace], Data0
             )
         ),
-    lists:filter(
-        fun({_, V}) -> V =/= undefined end,
-        [{time, format_ts(Time, Config)}, {level, Level}, {msg, Msg}, {mfa, MFA}]
-    ) ++ Data.
+    Properties =
+        lists:filter(
+            fun({_, V}) -> V =/= undefined end,
+            [{time, format_ts(Time, Config)}, {level, Level}, {msg, Msg}, {mfa, MFA}]
+        ) ++ Data,
+    {Properties}.
 
 format_ts(Ts, #{timestamp_format := rfc3339, time_offset := Offset}) when is_integer(Ts) ->
     iolist_to_binary(

--- a/apps/emqx/test/emqx_common_test_http.erl
+++ b/apps/emqx/test/emqx_common_test_http.erl
@@ -75,7 +75,7 @@ do_request_api(Method, Request, HttpOpts) ->
     end.
 
 get_http_data(ResponseBody) ->
-    emqx_utils_json:decode(ResponseBody, [return_maps]).
+    emqx_utils_json:decode(ResponseBody).
 
 auth_header(#{api_key := ApiKey, api_secret := Secret}) ->
     auth_header(binary_to_list(ApiKey), binary_to_list(Secret)).

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -370,7 +370,7 @@ request(Method, Url, QueryParams, Body) ->
     Opts = #{return_all => true},
     case emqx_mgmt_api_test_util:request_api(Method, Url, QueryParams, AuthHeader, Body, Opts) of
         {ok, {Reason, Headers, BodyR}} ->
-            {ok, {Reason, Headers, emqx_utils_json:decode(BodyR, [return_maps])}};
+            {ok, {Reason, Headers, emqx_utils_json:decode(BodyR)}};
         Error ->
             Error
     end.
@@ -1060,14 +1060,14 @@ do_t_validations(_Config) ->
         ),
     {error, {_, _, ResRaw1}} = update_listener_via_api(ListenerId, ListenerData1),
     #{<<"code">> := <<"BAD_REQUEST">>, <<"message">> := MsgRaw1} =
-        emqx_utils_json:decode(ResRaw1, [return_maps]),
+        emqx_utils_json:decode(ResRaw1),
     ?assertMatch(
         #{
             <<"kind">> := <<"validation_error">>,
             <<"reason">> :=
                 <<"verify must be verify_peer when CRL check is enabled">>
         },
-        emqx_utils_json:decode(MsgRaw1, [return_maps])
+        emqx_utils_json:decode(MsgRaw1)
     ),
 
     ok.

--- a/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_ocsp_cache_SUITE.erl
@@ -395,7 +395,7 @@ request(Method, Url, QueryParams, Body) ->
     Opts = #{return_all => true},
     case emqx_mgmt_api_test_util:request_api(Method, Url, QueryParams, AuthHeader, Body, Opts) of
         {ok, {Reason, Headers, BodyR}} ->
-            {ok, {Reason, Headers, emqx_utils_json:decode(BodyR, [return_maps])}};
+            {ok, {Reason, Headers, emqx_utils_json:decode(BodyR)}};
         Error ->
             Error
     end.
@@ -859,14 +859,14 @@ do_t_validations(_Config) ->
         ),
     {error, {_, _, ResRaw1}} = update_listener_via_api(ListenerId, ListenerData1),
     #{<<"code">> := <<"BAD_REQUEST">>, <<"message">> := MsgRaw1} =
-        emqx_utils_json:decode(ResRaw1, [return_maps]),
+        emqx_utils_json:decode(ResRaw1),
     ?assertMatch(
         #{
             <<"kind">> := <<"validation_error">>,
             <<"reason">> :=
                 <<"The responder URL is required for OCSP stapling">>
         },
-        emqx_utils_json:decode(MsgRaw1, [return_maps])
+        emqx_utils_json:decode(MsgRaw1)
     ),
 
     ListenerData2 =
@@ -884,14 +884,14 @@ do_t_validations(_Config) ->
         ),
     {error, {_, _, ResRaw2}} = update_listener_via_api(ListenerId, ListenerData2),
     #{<<"code">> := <<"BAD_REQUEST">>, <<"message">> := MsgRaw2} =
-        emqx_utils_json:decode(ResRaw2, [return_maps]),
+        emqx_utils_json:decode(ResRaw2),
     ?assertMatch(
         #{
             <<"kind">> := <<"validation_error">>,
             <<"reason">> :=
                 <<"The issuer PEM path is required for OCSP stapling">>
         },
-        emqx_utils_json:decode(MsgRaw2, [return_maps])
+        emqx_utils_json:decode(MsgRaw2)
     ),
 
     ListenerData3a =
@@ -913,7 +913,7 @@ do_t_validations(_Config) ->
     ),
     {error, {_, _, ResRaw3}} = update_listener_via_api(ListenerId, ListenerData3),
     #{<<"code">> := <<"BAD_REQUEST">>, <<"message">> := MsgRaw3} =
-        emqx_utils_json:decode(ResRaw3, [return_maps]),
+        emqx_utils_json:decode(ResRaw3),
     %% we can't remove certfile now, because it has default value.
     ?assertMatch({match, _}, re:run(MsgRaw3, <<"enoent">>)),
     ?assertMatch({match, _}, re:run(MsgRaw3, <<"ocsp\\.issuer_pem">>)),

--- a/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
+++ b/apps/emqx_audit/test/emqx_audit_api_SUITE.erl
@@ -106,7 +106,7 @@ t_http_api(_) ->
                 }
             ]
         },
-        emqx_utils_json:decode(Res1, [return_maps])
+        emqx_utils_json:decode(Res1)
     ),
     ok.
 
@@ -158,7 +158,7 @@ t_cli(_Config) ->
     AuditPath = emqx_mgmt_api_test_util:api_path(["audit"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     {ok, Res} = emqx_mgmt_api_test_util:request_api(get, AuditPath, "limit=1", AuthHeader),
-    #{<<"data">> := Data} = emqx_utils_json:decode(Res, [return_maps]),
+    #{<<"data">> := Data} = emqx_utils_json:decode(Res),
     ?assertMatch(
         [
             #{
@@ -182,7 +182,7 @@ t_cli(_Config) ->
     ?assert(CreateAt < TimeInt + 5000000, CreateAtRaw),
     %% check cli filter
     {ok, Res1} = emqx_mgmt_api_test_util:request_api(get, AuditPath, "from=cli", AuthHeader),
-    #{<<"data">> := Data1} = emqx_utils_json:decode(Res1, [return_maps]),
+    #{<<"data">> := Data1} = emqx_utils_json:decode(Res1),
     ?assertMatch(
         [ShowLogEntry, #{<<"operation_type">> := <<"emqx">>, <<"args">> := [<<"start">>]}],
         Data1
@@ -190,13 +190,13 @@ t_cli(_Config) ->
     {ok, Res2} = emqx_mgmt_api_test_util:request_api(
         get, AuditPath, "from=erlang_console", AuthHeader
     ),
-    ?assertMatch(#{<<"data">> := []}, emqx_utils_json:decode(Res2, [return_maps])),
+    ?assertMatch(#{<<"data">> := []}, emqx_utils_json:decode(Res2)),
 
     %% check created_at filter microsecond
     {ok, Res3} = emqx_mgmt_api_test_util:request_api(
         get, AuditPath, "gte_created_at=" ++ Time, AuthHeader
     ),
-    #{<<"data">> := Data3} = emqx_utils_json:decode(Res3, [return_maps]),
+    #{<<"data">> := Data3} = emqx_utils_json:decode(Res3),
     ?assertEqual(1, erlang:length(Data3)),
     %% check created_at filter rfc3339
     {ok, Res31} = emqx_mgmt_api_test_util:request_api(
@@ -214,7 +214,7 @@ t_cli(_Config) ->
     {ok, Res4} = emqx_mgmt_api_test_util:request_api(
         get, AuditPath, "lte_created_at=" ++ Time, AuthHeader
     ),
-    #{<<"data">> := Data4} = emqx_utils_json:decode(Res4, [return_maps]),
+    #{<<"data">> := Data4} = emqx_utils_json:decode(Res4),
     ?assertEqual(Size, erlang:length(Data4)),
 
     %% check created_at filter rfc3339
@@ -232,12 +232,12 @@ t_cli(_Config) ->
     {ok, Res5} = emqx_mgmt_api_test_util:request_api(
         get, AuditPath, "gte_duration_ms=0", AuthHeader
     ),
-    #{<<"data">> := Data5} = emqx_utils_json:decode(Res5, [return_maps]),
+    #{<<"data">> := Data5} = emqx_utils_json:decode(Res5),
     ?assertEqual(Size + 1, erlang:length(Data5)),
     {ok, Res6} = emqx_mgmt_api_test_util:request_api(
         get, AuditPath, "lte_duration_ms=-1", AuthHeader
     ),
-    ?assertMatch(#{<<"data">> := []}, emqx_utils_json:decode(Res6, [return_maps])),
+    ?assertMatch(#{<<"data">> := []}, emqx_utils_json:decode(Res6)),
     ok.
 
 t_max_size(_Config) ->
@@ -250,7 +250,7 @@ t_max_size(_Config) ->
             AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
             Limit = "limit=1000",
             {ok, Res} = emqx_mgmt_api_test_util:request_api(get, AuditPath, Limit, AuthHeader),
-            #{<<"data">> := Data} = emqx_utils_json:decode(Res, [return_maps]),
+            #{<<"data">> := Data} = emqx_utils_json:decode(Res),
             erlang:length(Data)
         end,
     InitSize = SizeFun(),
@@ -307,7 +307,7 @@ kickout_clients() ->
     %% get /clients
     ClientsPath = emqx_mgmt_api_test_util:api_path(["clients"]),
     {ok, Clients} = emqx_mgmt_api_test_util:request_api(get, ClientsPath),
-    ClientsResponse = emqx_utils_json:decode(Clients, [return_maps]),
+    ClientsResponse = emqx_utils_json:decode(Clients),
     ClientsMeta = maps:get(<<"meta">>, ClientsResponse),
     ClientsPage = maps:get(<<"page">>, ClientsMeta),
     ClientsLimit = maps:get(<<"limit">>, ClientsMeta),
@@ -322,7 +322,7 @@ kickout_clients() ->
     {ok, 204, _} = emqx_mgmt_api_test_util:request_api_with_body(post, KickoutPath, KickoutBody),
 
     {ok, Clients2} = emqx_mgmt_api_test_util:request_api(get, ClientsPath),
-    ClientsResponse2 = emqx_utils_json:decode(Clients2, [return_maps]),
+    ClientsResponse2 = emqx_utils_json:decode(Clients2),
     ?assertMatch(#{<<"data">> := []}, ClientsResponse2).
 
 wait_for_dirty_write_log_done(MaxMs) ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -116,7 +116,7 @@ parse_http_resp_body(<<"application/x-www-form-urlencoded", _/binary>>, Body) ->
     end;
 parse_http_resp_body(<<"application/json", _/binary>>, Body) ->
     try
-        result(emqx_utils_json:decode(Body, [return_maps]))
+        result(emqx_utils_json:decode(Body))
     catch
         _:_ -> error
     end;

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_cache_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_cache_SUITE.erl
@@ -104,7 +104,7 @@ t_node_cache(_) ->
     ),
     ?assertMatch(
         #{<<"enable">> := false},
-        emqx_utils_json:decode(CacheData0, [return_maps])
+        emqx_utils_json:decode(CacheData0)
     ),
     {ok, 200, MetricsData0} = request(
         get,
@@ -112,7 +112,7 @@ t_node_cache(_) ->
     ),
     ?assertMatch(
         #{<<"metrics">> := #{<<"count">> := 0}},
-        emqx_utils_json:decode(MetricsData0, [return_maps])
+        emqx_utils_json:decode(MetricsData0)
     ),
     {ok, 204, _} = request(
         put,
@@ -128,7 +128,7 @@ t_node_cache(_) ->
     ok = emqx_authz_source_registry:register(http, emqx_authz_http),
     ?assertMatch(
         #{<<"enable">> := true},
-        emqx_utils_json:decode(CacheData1, [return_maps])
+        emqx_utils_json:decode(CacheData1)
     ),
     {ok, 204, _} = request(post, uri(["authorization", "sources"]), ?SOURCE_HTTP),
 
@@ -152,7 +152,7 @@ t_node_cache(_) ->
     ),
     ?assertMatch(
         #{<<"metrics">> := #{<<"misses">> := #{<<"value">> := 1}}},
-        emqx_utils_json:decode(MetricsData2, [return_maps])
+        emqx_utils_json:decode(MetricsData2)
     ),
     ok.
 

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_cluster_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_cluster_SUITE.erl
@@ -106,7 +106,7 @@ t_api(Config) ->
     ok.
 
 get_sources(Result) ->
-    maps:get(<<"sources">>, emqx_utils_json:decode(Result, [return_maps])).
+    maps:get(<<"sources">>, emqx_utils_json:decode(Result)).
 
 mk_cluster_spec(Opts) ->
     Apps = [

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_source_http_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_source_http_SUITE.erl
@@ -112,7 +112,7 @@ t_http_headers_api(_) ->
             <<"type">> := <<"http">>,
             <<"headers">> := M
         } when map_size(M) =:= 0,
-        emqx_utils_json:decode(Result1, [return_maps])
+        emqx_utils_json:decode(Result1)
     ),
 
     {ok, 204, _} = request(
@@ -127,7 +127,7 @@ t_http_headers_api(_) ->
             <<"type">> := <<"http">>,
             <<"headers">> := #{<<"a">> := <<"b">>}
         },
-        emqx_utils_json:decode(Result2, [return_maps])
+        emqx_utils_json:decode(Result2)
     ),
 
     {ok, 204, _} = request(put, uri(["authorization", "sources", "http"]), ?SOURCE_HTTP),
@@ -138,7 +138,7 @@ t_http_headers_api(_) ->
             <<"type">> := <<"http">>,
             <<"headers">> := M
         } when map_size(M) =:= 0,
-        emqx_utils_json:decode(Result4, [return_maps])
+        emqx_utils_json:decode(Result4)
     ).
 
 data_dir() -> emqx:data_dir().

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_sources_SUITE.erl
@@ -181,7 +181,7 @@ t_api(_) ->
     {ok, 404, ErrResult} = request(get, uri(["authorization", "sources", "http"]), []),
     ?assertMatch(
         #{<<"code">> := <<"NOT_FOUND">>, <<"message">> := <<"Not found: http">>},
-        emqx_utils_json:decode(ErrResult, [return_maps])
+        emqx_utils_json:decode(ErrResult)
     ),
 
     [
@@ -217,7 +217,7 @@ t_api(_) ->
     {ok, 200, Result3} = request(get, uri(["authorization", "sources", "http"]), []),
     ?assertMatch(
         #{<<"type">> := <<"http">>, <<"enable">> := false},
-        emqx_utils_json:decode(Result3, [return_maps])
+        emqx_utils_json:decode(Result3)
     ),
 
     Keyfile = emqx_common_test_helpers:app_path(
@@ -255,7 +255,7 @@ t_api(_) ->
             <<"total">> := 0,
             <<"nomatch">> := 0
         }
-    } = emqx_utils_json:decode(Status4, [return_maps]),
+    } = emqx_utils_json:decode(Status4),
     ?assertMatch(
         #{
             <<"type">> := <<"mongodb">>,
@@ -267,7 +267,7 @@ t_api(_) ->
                 <<"verify">> := <<"verify_none">>
             }
         },
-        emqx_utils_json:decode(Result4, [return_maps])
+        emqx_utils_json:decode(Result4)
     ),
 
     {ok, Cacert} = file:read_file(Cacertfile),
@@ -299,7 +299,7 @@ t_api(_) ->
                 <<"verify">> := <<"verify_none">>
             }
         },
-        emqx_utils_json:decode(Result5, [return_maps])
+        emqx_utils_json:decode(Result5)
     ),
 
     {ok, 200, Status5_1} = request(get, uri(["authorization", "sources", "mongodb", "status"]), []),
@@ -310,7 +310,7 @@ t_api(_) ->
             <<"total">> := 0,
             <<"nomatch">> := 0
         }
-    } = emqx_utils_json:decode(Status5_1, [return_maps]),
+    } = emqx_utils_json:decode(Status5_1),
 
     #{
         ssl := #{
@@ -357,7 +357,7 @@ t_api(_) ->
             <<"code">> := <<"BAD_REQUEST">>,
             <<"message">> := <<"Type mismatch", _/binary>>
         },
-        emqx_utils_json:decode(TypeMismatch, [return_maps])
+        emqx_utils_json:decode(TypeMismatch)
     ),
 
     lists:foreach(
@@ -445,7 +445,7 @@ t_api(_) ->
                     <<"total">> := 1,
                     <<"nomatch">> := 0
                 }
-            } = emqx_utils_json:decode(Status5, [return_maps])
+            } = emqx_utils_json:decode(Status5)
         end
     ),
 
@@ -471,7 +471,7 @@ t_api(_) ->
                     <<"total">> := 2,
                     <<"nomatch">> := 0
                 }
-            } = emqx_utils_json:decode(Status6, [return_maps])
+            } = emqx_utils_json:decode(Status6)
         end
     ),
 
@@ -497,7 +497,7 @@ t_api(_) ->
                     <<"total">> := 3,
                     <<"nomatch">> := 0
                 }
-            } = emqx_utils_json:decode(Status7, [return_maps])
+            } = emqx_utils_json:decode(Status7)
         end
     ),
     ok.
@@ -742,7 +742,7 @@ t_aggregate_metrics(_) ->
     ).
 
 get_sources(Result) ->
-    maps:get(<<"sources">>, emqx_utils_json:decode(Result, [return_maps])).
+    maps:get(<<"sources">>, emqx_utils_json:decode(Result)).
 
 data_dir() -> emqx:data_dir().
 

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -312,7 +312,7 @@ safely_parse_body(ContentType, Body) ->
     end.
 
 parse_body(<<"application/json", _/binary>>, Body) ->
-    {ok, emqx_utils_json:decode(Body, [return_maps])};
+    {ok, emqx_utils_json:decode(Body)};
 parse_body(<<"application/x-www-form-urlencoded", _/binary>>, Body) ->
     NBody = maps:from_list(cow_qs:parse_qs(Body)),
     {ok, NBody};

--- a/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authn_http_SUITE.erl
@@ -251,7 +251,7 @@ t_no_value_for_placeholder(_Config) ->
             <<"cert_subject">> := <<"">>,
             <<"cert_common_name">> := <<"">>,
             <<"cert_pem">> := <<"">>
-        } = emqx_utils_json:decode(RawBody, [return_maps]),
+        } = emqx_utils_json:decode(RawBody),
         Req = cowboy_req:reply(
             200,
             #{<<"content-type">> => <<"application/json">>},
@@ -843,7 +843,7 @@ samples() ->
                 #{
                     <<"username">> := <<"plain">>,
                     <<"password">> := <<"plain">>
-                } = emqx_utils_json:decode(RawBody, [return_maps]),
+                } = emqx_utils_json:decode(RawBody),
                 Req = cowboy_req:reply(
                     200,
                     #{<<"content-type">> => <<"application/json">>},
@@ -866,7 +866,7 @@ samples() ->
                 #{
                     <<"username">> := <<"plain">>,
                     <<"password">> := <<"plain">>
-                } = emqx_utils_json:decode(RawBody, [return_maps]),
+                } = emqx_utils_json:decode(RawBody),
                 <<"application/json">> = cowboy_req:header(<<"content-type">>, Req0),
                 Req = cowboy_req:reply(
                     200,
@@ -923,7 +923,7 @@ samples() ->
                     <<"cert_common_name">> := <<"cert_common_name_data">>,
                     <<"cert_pem">> := CertPem,
                     <<"the_group">> := <<"g1">>
-                } = emqx_utils_json:decode(RawBody, [return_maps]),
+                } = emqx_utils_json:decode(RawBody),
                 <<"fake_raw_cert_to_be_base64_encoded">> = base64:decode(CertPem),
                 Req = cowboy_req:reply(
                     200,

--- a/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
+++ b/apps/emqx_auth_http/test/emqx_authz_http_SUITE.erl
@@ -338,7 +338,7 @@ t_json_body(_Config) ->
                     <<"qos">> := <<"1">>,
                     <<"retain">> := <<"false">>
                 },
-                emqx_utils_json:decode(RawBody, [return_maps])
+                emqx_utils_json:decode(RawBody)
             ),
             {ok, ?AUTHZ_HTTP_RESP(allow, Req1), State}
         end,
@@ -392,7 +392,7 @@ t_no_rich_actions(_Config) ->
                     <<"qos">> := <<"${qos}">>,
                     <<"retain">> := <<"${retain}">>
                 },
-                emqx_utils_json:decode(RawBody, [return_maps])
+                emqx_utils_json:decode(RawBody)
             ),
             {ok, ?AUTHZ_HTTP_RESP(allow, Req1), State}
         end,
@@ -639,7 +639,7 @@ t_no_value_for_placeholder(_Config) ->
                 #{
                     <<"mountpoint">> := <<"[]">>
                 },
-                emqx_utils_json:decode(RawBody, [return_maps])
+                emqx_utils_json:decode(RawBody)
             ),
             {ok, ?AUTHZ_HTTP_RESP(allow, Req1), State}
         end,
@@ -910,4 +910,4 @@ get_status_api() ->
     Opts = #{return_all => true},
     Res0 = emqx_mgmt_api_test_util:request_api(get, Path, _QParams = [], Auth, _Body = [], Opts),
     {Status, RawBody} = emqx_mgmt_api_test_util:simplify_result(Res0),
-    {Status, emqx_utils_json:decode(RawBody, [return_maps])}.
+    {Status, emqx_utils_json:decode(RawBody)}.

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwks_client.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwks_client.erl
@@ -99,7 +99,7 @@ handle_info(
                 State1;
             {StatusLine, Headers, Body} ->
                 try
-                    JWKS = jose_jwk:from(emqx_utils_json:decode(Body, [return_maps])),
+                    JWKS = jose_jwk:from(emqx_utils_json:decode(Body)),
                     {_, JWKs} = JWKS#jose_jwk.keys,
                     State1#{jwks := JWKs}
                 catch

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -308,7 +308,7 @@ do_verify(_JWT, [], _VerifyClaims) ->
 do_verify(JWT, [JWK | More], VerifyClaims) ->
     try jose_jws:verify(JWK, JWT) of
         {true, Payload, _JWT} ->
-            Claims0 = emqx_utils_json:decode(Payload, [return_maps]),
+            Claims0 = emqx_utils_json:decode(Payload),
             Claims = try_convert_to_num(Claims0, [<<"exp">>, <<"nbf">>]),
             case verify_claims(Claims, VerifyClaims) of
                 ok ->

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mnesia, [
     {description, "EMQX Buitl-in Database Authentication and Authorization"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {mod, {emqx_auth_mnesia_app, []}},
     {applications, [

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -500,7 +500,7 @@ reader_fn(Filename0, Data) ->
     case filename:extension(to_binary(Filename0)) of
         <<".json">> ->
             %% Example: data/user-credentials.json
-            case emqx_utils_json:safe_decode(Data, [return_maps]) of
+            case emqx_utils_json:safe_decode(Data) of
                 {ok, List} when is_list(List) ->
                     emqx_utils_stream:list(List);
                 {ok, _} ->

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -128,7 +128,7 @@ test_authenticator_users(PathPrefix) ->
                     <<"success">> := 0,
                     <<"failed">> := 1
                 }
-            } = emqx_utils_json:decode(PageData0, [return_maps]);
+            } = emqx_utils_json:decode(PageData0);
         ["listeners", 'tcp:default'] ->
             #{
                 <<"metrics">> := #{
@@ -136,7 +136,7 @@ test_authenticator_users(PathPrefix) ->
                     <<"success">> := 0,
                     <<"nomatch">> := 1
                 }
-            } = emqx_utils_json:decode(PageData0, [return_maps])
+            } = emqx_utils_json:decode(PageData0)
     end,
 
     InvalidUsers = [
@@ -159,7 +159,7 @@ test_authenticator_users(PathPrefix) ->
     lists:foreach(
         fun(User) ->
             {ok, 201, UserData} = request(post, UsersUri, User),
-            CreatedUser = emqx_utils_json:decode(UserData, [return_maps]),
+            CreatedUser = emqx_utils_json:decode(UserData),
             ?assertMatch(#{<<"user_id">> := _}, CreatedUser)
         end,
         ValidUsers
@@ -186,7 +186,7 @@ test_authenticator_users(PathPrefix) ->
                     <<"success">> := 1,
                     <<"failed">> := 1
                 }
-            } = emqx_utils_json:decode(PageData01, [return_maps]);
+            } = emqx_utils_json:decode(PageData01);
         ["listeners", 'tcp:default'] ->
             #{
                 <<"metrics">> := #{
@@ -194,7 +194,7 @@ test_authenticator_users(PathPrefix) ->
                     <<"success">> := 1,
                     <<"nomatch">> := 1
                 }
-            } = emqx_utils_json:decode(PageData01, [return_maps])
+            } = emqx_utils_json:decode(PageData01)
     end,
 
     {ok, 200, Page1Data} = request(get, UsersUri ++ "?page=1&limit=2"),
@@ -208,7 +208,7 @@ test_authenticator_users(PathPrefix) ->
                 <<"count">> := 3
             }
     } =
-        emqx_utils_json:decode(Page1Data, [return_maps]),
+        emqx_utils_json:decode(Page1Data),
 
     {ok, 200, Page2Data} = request(get, UsersUri ++ "?page=2&limit=2"),
 
@@ -220,7 +220,7 @@ test_authenticator_users(PathPrefix) ->
                 <<"limit">> := 2,
                 <<"count">> := 3
             }
-    } = emqx_utils_json:decode(Page2Data, [return_maps]),
+    } = emqx_utils_json:decode(Page2Data),
 
     ?assertEqual(2, length(Page1Users)),
     ?assertEqual(1, length(Page2Users)),
@@ -240,7 +240,7 @@ test_authenticator_users(PathPrefix) ->
                 <<"limit">> := 3,
                 <<"count">> := 1
             }
-    } = emqx_utils_json:decode(Super1Data, [return_maps]),
+    } = emqx_utils_json:decode(Super1Data),
 
     ?assertEqual(
         [<<"u2">>],
@@ -257,7 +257,7 @@ test_authenticator_users(PathPrefix) ->
                 <<"limit">> := 3,
                 <<"count">> := 2
             }
-    } = emqx_utils_json:decode(Super2Data, [return_maps]),
+    } = emqx_utils_json:decode(Super2Data),
 
     ?assertEqual(
         [<<"u1">>, <<"u3">>],
@@ -284,7 +284,7 @@ test_authenticator_user(PathPrefix) ->
 
     {ok, 200, UserData} = request(get, UsersUri ++ "/u1"),
 
-    FetchedUser = emqx_utils_json:decode(UserData, [return_maps]),
+    FetchedUser = emqx_utils_json:decode(UserData),
     ?assertMatch(#{<<"user_id">> := <<"u1">>}, FetchedUser),
     ?assertNotMatch(#{<<"password">> := _}, FetchedUser),
 
@@ -334,7 +334,7 @@ test_authenticator_import_users(PathPrefix) ->
         {filename, "user-credentials.json", JSONData}
     ]),
     ?assertMatch(
-        #{<<"total">> := 2, <<"success">> := 2}, emqx_utils_json:decode(Result1, [return_maps])
+        #{<<"total">> := 2, <<"success">> := 2}, emqx_utils_json:decode(Result1)
     ),
 
     {ok, CSVData} = file:read_file(CSVFileName),
@@ -342,7 +342,7 @@ test_authenticator_import_users(PathPrefix) ->
         {filename, "user-credentials.csv", CSVData}
     ]),
     ?assertMatch(
-        #{<<"total">> := 2, <<"success">> := 2}, emqx_utils_json:decode(Result2, [return_maps])
+        #{<<"total">> := 2, <<"success">> := 2}, emqx_utils_json:decode(Result2)
     ),
 
     %% test application/json

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -148,7 +148,7 @@ parse_rule(<<"subscribe">>) ->
 parse_rule(<<"all">>) ->
     {ok, #{<<"action">> => <<"all">>}};
 parse_rule(Bin) when is_binary(Bin) ->
-    case emqx_utils_json:safe_decode(Bin, [return_maps]) of
+    case emqx_utils_json:safe_decode(Bin) of
         {ok, Map} when is_map(Map) ->
             {ok, maps:with([<<"qos">>, <<"action">>, <<"retain">>], Map)};
         {ok, _} ->

--- a/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
+++ b/apps/emqx_auto_subscribe/test/emqx_auto_subscribe_SUITE.erl
@@ -157,7 +157,7 @@ t_update(_) ->
     Auth = emqx_mgmt_api_test_util:auth_header_(),
     Body = [#{topic => ?TOPIC_S}],
     {ok, Response} = emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, Body),
-    ResponseMap = emqx_utils_json:decode(Response, [return_maps]),
+    ResponseMap = emqx_utils_json:decode(Response),
     ?assertEqual(1, erlang:length(ResponseMap)),
 
     BadBody1 = #{topic => ?TOPIC_S},
@@ -193,7 +193,7 @@ t_update(_) ->
     emqtt:disconnect(Client),
 
     {ok, GETResponse} = emqx_mgmt_api_test_util:request_api(get, Path),
-    GETResponseMap = emqx_utils_json:decode(GETResponse, [return_maps]),
+    GETResponseMap = emqx_utils_json:decode(GETResponse),
     ?assertEqual(1, erlang:length(GETResponseMap)),
     ok.
 

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -615,7 +615,7 @@ t_check_dependent_actions_on_delete(Config) ->
     {ok, 400, Body} = request(
         delete, uri(["bridges", BridgeID]) ++ "?also_delete_dep_actions=false", Config
     ),
-    ?assertMatch(#{<<"rules">> := [_ | _]}, emqx_utils_json:decode(Body, [return_maps])),
+    ?assertMatch(#{<<"rules">> := [_ | _]}, emqx_utils_json:decode(Body)),
     %% delete the rule first
     {ok, 204, <<>>} = request(delete, uri(["rules", RuleId]), Config),
     %% then delete the bridge is OK
@@ -1453,7 +1453,7 @@ t_create_with_bad_name(Config) ->
             BadBridgeParams,
             Config
         ),
-    Msg = emqx_utils_json:decode(Msg0, [return_maps]),
+    Msg = emqx_utils_json:decode(Msg0),
     ?assertMatch(
         #{
             <<"kind">> := <<"validation_error">>,
@@ -1548,7 +1548,7 @@ str(S) when is_list(S) -> S;
 str(S) when is_binary(S) -> binary_to_list(S).
 
 json(B) when is_binary(B) ->
-    emqx_utils_json:decode(B, [return_maps]).
+    emqx_utils_json:decode(B).
 
 data_file(Name) ->
     Dir = code:lib_dir(emqx_bridge),

--- a/apps/emqx_bridge/test/emqx_bridge_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_testlib.erl
@@ -135,7 +135,7 @@ list_bridges_api() ->
     Res =
         case emqx_mgmt_api_test_util:request_api(get, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             Error ->
                 Error
         end,
@@ -161,7 +161,7 @@ create_bridge_api(BridgeType, BridgeName, BridgeConfig) ->
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             Error ->
                 Error
         end,
@@ -184,7 +184,7 @@ update_bridge_api(Config, Overrides) ->
     ct:pal("updating bridge (via http): ~p", [Params]),
     Res =
         case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Params, Opts) of
-            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0, [return_maps])};
+            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0)};
             Error -> Error
         end,
     ct:pal("bridge update result: ~p", [Res]),
@@ -199,7 +199,7 @@ get_bridge_api(Config) ->
     ct:pal("getting bridge (via http)", []),
     Res =
         case emqx_mgmt_api_test_util:request_api(get, Path, "", AuthHeader) of
-            {ok, Body0} -> {ok, emqx_utils_json:decode(Body0, [return_maps])};
+            {ok, Body0} -> {ok, emqx_utils_json:decode(Body0)};
             Error -> Error
         end,
     ct:pal("bridge result: ~p", [Res]),
@@ -249,9 +249,9 @@ probe_bridge_api(BridgeType, BridgeName, BridgeConfig) ->
     Res.
 
 try_decode_error(Body0) ->
-    case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+    case emqx_utils_json:safe_decode(Body0) of
         {ok, #{<<"message">> := Msg0} = Body1} ->
-            case emqx_utils_json:safe_decode(Msg0, [return_maps]) of
+            case emqx_utils_json:safe_decode(Msg0) of
                 {ok, Msg1} -> Body1#{<<"message">> := Msg1};
                 {error, _} -> Body1
             end;
@@ -281,7 +281,7 @@ create_rule_and_action(Action, RuleTopic, Opts) ->
     ct:pal("rule action params: ~p", [Params]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
         {ok, Res0} ->
-            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0, [return_maps]),
+            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0),
             on_exit(fun() -> ok = emqx_rule_engine:delete_rule(RuleId) end),
             {ok, Res};
         Error ->

--- a/apps/emqx_bridge/test/emqx_bridge_v1_compatibility_layer_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v1_compatibility_layer_SUITE.erl
@@ -320,7 +320,7 @@ delete_all_bridges() ->
     ok.
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.
@@ -334,7 +334,7 @@ request(Method, Path, Params) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};

--- a/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
@@ -469,7 +469,7 @@ str(S) when is_list(S) -> S;
 str(S) when is_binary(S) -> binary_to_list(S).
 
 json(B) when is_binary(B) ->
-    case emqx_utils_json:safe_decode(B, [return_maps]) of
+    case emqx_utils_json:safe_decode(B) of
         {ok, Term} ->
             Term;
         {error, Reason} = Error ->
@@ -1359,7 +1359,7 @@ t_cascade_delete_actions(Config) ->
         uri([?ACTIONS_ROOT, BridgeID]),
         Config
     ),
-    ?assertMatch(#{<<"rules">> := [_ | _]}, emqx_utils_json:decode(Body, [return_maps])),
+    ?assertMatch(#{<<"rules">> := [_ | _]}, emqx_utils_json:decode(Body)),
     {ok, 200, [_]} = request_json(get, uri([?ACTIONS_ROOT]), Config),
     %% Cleanup
     {ok, 204, _} = request(
@@ -1404,7 +1404,7 @@ t_bad_name(Config) ->
     ),
     ?assertMatch({ok, 400, #{<<"message">> := _}}, Res),
     {ok, 400, #{<<"message">> := Msg0}} = Res,
-    Msg = emqx_utils_json:decode(Msg0, [return_maps]),
+    Msg = emqx_utils_json:decode(Msg0),
     ?assertMatch(
         #{
             <<"kind">> := <<"validation_error">>,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -271,7 +271,7 @@ conf_root_key(Kind) ->
     end.
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.
@@ -285,7 +285,7 @@ request(Method, Path, Params) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};
@@ -316,7 +316,7 @@ list_bridges_api() ->
     Res =
         case emqx_mgmt_api_test_util:request_api(get, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             Error ->
                 Error
         end,
@@ -694,9 +694,9 @@ is_rule_enabled(RuleId) ->
     Enable.
 
 try_decode_error(Body0) ->
-    case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+    case emqx_utils_json:safe_decode(Body0) of
         {ok, #{<<"message">> := Msg0} = Body1} ->
-            case emqx_utils_json:safe_decode(Msg0, [return_maps]) of
+            case emqx_utils_json:safe_decode(Msg0) of
                 {ok, Msg1} -> Body1#{<<"message">> := Msg1};
                 {error, _} -> Body1
             end;
@@ -745,7 +745,7 @@ create_rule_and_action_http(BridgeType, RuleTopic, Config, Opts) ->
     ct:pal("rule action params: ~p", [Params]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
         {ok, Res0} ->
-            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0, [return_maps]),
+            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0),
             AuthHeaderGetter = get_auth_header_getter(),
             on_exit(fun() ->
                 set_auth_header_getter(AuthHeaderGetter),
@@ -769,7 +769,7 @@ api_spec_schemas(Root) ->
     case emqx_mgmt_api_test_util:request_api(Method, Path, "", AuthHeader, Params, Opts) of
         {ok, {{_, 200, _}, _, Res0}} ->
             #{<<"components">> := #{<<"schemas">> := Schemas}} =
-                emqx_utils_json:decode(Res0, [return_maps]),
+                emqx_utils_json:decode(Res0),
             Schemas
     end.
 

--- a/apps/emqx_bridge_azure_blob_storage/test/emqx_bridge_azure_blob_storage_SUITE.erl
+++ b/apps/emqx_bridge_azure_blob_storage/test/emqx_bridge_azure_blob_storage_SUITE.erl
@@ -294,8 +294,8 @@ get_blob(BlobName, Config) ->
 get_and_decode_event(BlobName, Config) ->
     maps:update_with(
         <<"payload">>,
-        fun(Raw) -> emqx_utils_json:decode(Raw, [return_maps]) end,
-        emqx_utils_json:decode(get_blob(BlobName, Config), [return_maps])
+        fun(Raw) -> emqx_utils_json:decode(Raw) end,
+        emqx_utils_json:decode(get_blob(BlobName, Config))
     ).
 
 list_committed_blocks(Config) ->

--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
@@ -296,7 +296,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_couchbase/src/emqx_bridge_couchbase_connector.erl
+++ b/apps/emqx_bridge_couchbase/src/emqx_bridge_couchbase_connector.erl
@@ -350,7 +350,7 @@ do_query(ConnResId, SQL, Args, RequestTTL, MaxRetries, ConnState) ->
     Response.
 
 maybe_decode_json(Raw) ->
-    case emqx_utils_json:safe_decode(Raw, [return_maps]) of
+    case emqx_utils_json:safe_decode(Raw) of
         {ok, JSON} ->
             JSON;
         {error, _} ->

--- a/apps/emqx_bridge_couchbase/test/emqx_bridge_couchbase_SUITE.erl
+++ b/apps/emqx_bridge_couchbase/test/emqx_bridge_couchbase_SUITE.erl
@@ -297,7 +297,7 @@ fetch_with_name(Xs, Name) ->
     end.
 
 maybe_decode_json(Body) ->
-    case emqx_utils_json:safe_decode(Body, [return_maps]) of
+    case emqx_utils_json:safe_decode(Body) of
         {ok, JSON} ->
             JSON;
         {error, _} ->

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -296,7 +296,7 @@ create_rule_and_action_http(Config, Overrides) ->
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -312,7 +312,7 @@ query_by_clientid(Table, ClientId, Config) ->
         {200, <<>>} ->
             #{};
         {200, Resp} ->
-            case emqx_utils_json:decode(Resp, [return_maps]) of
+            case emqx_utils_json:decode(Resp) of
                 [] -> error(no_data);
                 [FirstRow | _] -> FirstRow
             end;

--- a/apps/emqx_bridge_dynamo/test/emqx_bridge_dynamo_SUITE.erl
+++ b/apps/emqx_bridge_dynamo/test/emqx_bridge_dynamo_SUITE.erl
@@ -286,7 +286,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -295,7 +295,7 @@ update_bridge_http(#{<<"type">> := Type, <<"name">> := Name} = Config) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges", BridgeID]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Config) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -304,7 +304,7 @@ get_bridge_http(#{<<"type">> := Type, <<"name">> := Name}) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges", BridgeID]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(get, Path, "", AuthHeader) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.erl
@@ -398,7 +398,7 @@ name_field() ->
     | {error, {wrong_type, term()}}
     | {error, {missing_keys, [binary()]}}.
 service_account_json_validator(Val) ->
-    case emqx_utils_json:safe_decode(Val, [return_maps]) of
+    case emqx_utils_json:safe_decode(Val) of
         {ok, Map} ->
             ExpectedKeys = [
                 <<"type">>,
@@ -433,9 +433,9 @@ service_account_json_converter(Val, #{make_serializable := true}) ->
 service_account_json_converter(Map, _Opts) when is_map(Map) ->
     emqx_utils_json:encode(Map);
 service_account_json_converter(Val, _Opts) ->
-    case emqx_utils_json:safe_decode(Val, [return_maps]) of
+    case emqx_utils_json:safe_decode(Val) of
         {ok, Str} when is_binary(Str) ->
-            emqx_utils_json:decode(Str, [return_maps]);
+            emqx_utils_json:decode(Str);
         _ ->
             Val
     end.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_worker.erl
@@ -627,7 +627,7 @@ do_get_subscription(State) ->
             }),
             {error, Reason};
         {ok, #{status_code := 200, body := RespBody}} ->
-            DecodedBody = emqx_utils_json:decode(RespBody, [return_maps]),
+            DecodedBody = emqx_utils_json:decode(RespBody),
             {ok, DecodedBody};
         {ok, Details} ->
             ?SLOG(warning, #{
@@ -716,7 +716,7 @@ subscription_resource(ProjectId, SubscriptionId) ->
 
 -spec decode_response(binary()) -> [decoded_message()].
 decode_response(RespBody) ->
-    case emqx_utils_json:decode(RespBody, [return_maps]) of
+    case emqx_utils_json:decode(RespBody) of
         #{<<"receivedMessages">> := Msgs0} ->
             lists:map(
                 fun(Msg0 = #{<<"message">> := InnerMsg0}) ->

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_consumer.erl
@@ -98,7 +98,7 @@ query_mode(_Config) -> no_queries.
     {ok, connector_state()} | {error, term()}.
 on_start(ConnectorResId, Config0) ->
     Config = maps:update_with(
-        service_account_json, fun(X) -> emqx_utils_json:decode(X, [return_maps]) end, Config0
+        service_account_json, fun(X) -> emqx_utils_json:decode(X) end, Config0
     ),
     #{service_account_json := #{<<"project_id">> := ProjectId}} = Config,
     case emqx_bridge_gcp_pubsub_client:start(ConnectorResId, Config) of

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -77,7 +77,7 @@ on_start(InstanceId, Config0) ->
         instance_id => InstanceId
     }),
     Config = maps:update_with(
-        service_account_json, fun(X) -> emqx_utils_json:decode(X, [return_maps]) end, Config0
+        service_account_json, fun(X) -> emqx_utils_json:decode(X) end, Config0
     ),
     #{service_account_json := #{<<"project_id">> := ProjectId}} = Config,
     case emqx_bridge_gcp_pubsub_client:start(InstanceId, Config) of

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -381,7 +381,7 @@ create_bridge_api(Config, Overrides) ->
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             Error ->
                 Error
         end,
@@ -444,7 +444,7 @@ receive_published(#{n := N, timeout := Timeout} = Opts, Acc) ->
     receive
         {publish, Msg0 = #{payload := Payload}} ->
             Msg =
-                case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+                case emqx_utils_json:safe_decode(Payload) of
                     {ok, Decoded} -> Msg0#{payload := Decoded};
                     {error, _} -> Msg0
                 end,
@@ -486,7 +486,7 @@ create_rule_and_action_http(Config) ->
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
         {ok, Res = #{<<"id">> := RuleId}} ->
             on_exit(fun() -> ok = emqx_rule_engine:delete_rule(RuleId) end),
-            {ok, emqx_utils_json:decode(Res, [return_maps])};
+            {ok, emqx_utils_json:decode(Res)};
         Error ->
             Error
     end.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -224,7 +224,7 @@ create_bridge_http(Config, GCPPubSubConfigOverrides) ->
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headhers, Res0}} ->
-                {ok, {Status, Headhers, emqx_utils_json:decode(Res0, [return_maps])}};
+                {ok, {Status, Headhers, emqx_utils_json:decode(Res0)}};
             {error, {Status, Headers, Body0}} ->
                 {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
             Error ->
@@ -251,7 +251,7 @@ create_rule_and_action_http(Config) ->
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -490,7 +490,7 @@ assert_valid_request_headers(Headers, ServiceAccountJSON) ->
     end.
 
 assert_valid_request_body(Body) ->
-    BodyMap = emqx_utils_json:decode(Body, [return_maps]),
+    BodyMap = emqx_utils_json:decode(Body),
     ?assertMatch(#{<<"messages">> := [_ | _]}, BodyMap),
     ct:pal("request: ~p", [BodyMap]),
     #{<<"messages">> := Messages} = BodyMap,
@@ -499,7 +499,7 @@ assert_valid_request_body(Body) ->
             ?assertMatch(#{<<"data">> := <<_/binary>>}, Msg),
             #{<<"data">> := Content64} = Msg,
             Content = base64:decode(Content64),
-            Decoded = emqx_utils_json:decode(Content, [return_maps]),
+            Decoded = emqx_utils_json:decode(Content),
             ct:pal("decoded payload: ~p", [Decoded]),
             ?assert(is_map(Decoded)),
             Decoded
@@ -527,12 +527,12 @@ receive_http_request(ServiceAccountJSON) ->
         {http, Headers, Body} ->
             ct:pal("received publish:\n  ~p", [#{headers => Headers, body => Body}]),
             assert_valid_request_headers(Headers, ServiceAccountJSON),
-            #{<<"messages">> := Msgs} = emqx_utils_json:decode(Body, [return_maps]),
+            #{<<"messages">> := Msgs} = emqx_utils_json:decode(Body),
             lists:map(
                 fun(Msg) ->
                     #{<<"data">> := Content64} = Msg,
                     Content = base64:decode(Content64),
-                    Decoded = emqx_utils_json:decode(Content, [return_maps]),
+                    Decoded = emqx_utils_json:decode(Content),
                     Msg#{<<"data">> := Decoded}
                 end,
                 Msgs

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_consumer_SUITE.erl
@@ -149,7 +149,7 @@ t_create_via_http_json_object_service_account(Config0) ->
         <<"service_account_json">>,
         fun(X) ->
             ?assert(is_binary(X), #{json => X}),
-            JSON = emqx_utils_json:decode(X, [return_maps]),
+            JSON = emqx_utils_json:decode(X),
             ?assert(is_map(JSON)),
             JSON
         end,

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_producer_SUITE.erl
@@ -225,7 +225,7 @@ t_create_via_http_json_object_service_account(Config0) ->
         <<"service_account_json">>,
         fun(X) ->
             ?assert(is_binary(X), #{json => X}),
-            JSON = emqx_utils_json:decode(X, [return_maps]),
+            JSON = emqx_utils_json:decode(X),
             ?assert(is_map(JSON)),
             JSON
         end,
@@ -350,7 +350,7 @@ t_jose_jwk_function_clause(Config0) ->
         fun(SABin) ->
             #{<<"private_key">> := PKey0} =
                 SA0 =
-                emqx_utils_json:decode(SABin, [return_maps]),
+                emqx_utils_json:decode(SABin),
             Lines0 = binary:split(PKey0, <<"\n">>),
             NumLines = length(Lines0),
             {Lines1, [_ | Lines2]} = lists:split(NumLines div 2, Lines0),

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_SUITE.erl
@@ -290,7 +290,7 @@ create_rule_and_action_http(Config, Overrides) ->
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -333,7 +333,7 @@ query_by_clientid(Topic, ClientId, Config) ->
             _Retry = 0
         ),
 
-    case emqx_utils_json:decode(RawBody0, [return_maps]) of
+    case emqx_utils_json:decode(RawBody0) of
         #{
             <<"output">> := [
                 #{

--- a/apps/emqx_bridge_hstreamdb/test/emqx_bridge_hstreamdb_SUITE.erl
+++ b/apps/emqx_bridge_hstreamdb/test/emqx_bridge_hstreamdb_SUITE.erl
@@ -570,7 +570,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_SUITE.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_SUITE.erl
@@ -403,7 +403,7 @@ create_rule_and_action_http(Config, Overrides) ->
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -1072,7 +1072,7 @@ merge_kafka_headers(HeadersTks, ExtHeaders, Msg) ->
         [undefined] ->
             ExtHeaders;
         [MaybeJson] when is_binary(MaybeJson) ->
-            case emqx_utils_json:safe_decode(MaybeJson, [return_maps]) of
+            case emqx_utils_json:safe_decode(MaybeJson) of
                 {ok, JsonTerm} when is_map(JsonTerm) ->
                     maps:to_list(JsonTerm) ++ ExtHeaders;
                 {ok, JsonTerm} when is_list(JsonTerm) ->

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -733,7 +733,7 @@ create_bridge_api(Config, Overrides) ->
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             Error ->
                 Error
         end,
@@ -756,7 +756,7 @@ update_bridge_api(Config, Overrides) ->
     ct:pal("updating bridge (via http): ~p", [Params]),
     Res =
         case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Params, Opts) of
-            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0, [return_maps])};
+            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0)};
             Error -> Error
         end,
     ct:pal("bridge update result: ~p", [Res]),
@@ -792,7 +792,7 @@ do_wait_for_expected_published_messages(Messages, Acc, _Timeout) when map_size(M
 do_wait_for_expected_published_messages(Messages0, Acc0, Timeout) ->
     receive
         {publish, Msg0 = #{payload := Payload}} ->
-            case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+            case emqx_utils_json:safe_decode(Payload) of
                 {error, _} ->
                     ct:pal("unexpected message: ~p; discarding", [Msg0]),
                     do_wait_for_expected_published_messages(Messages0, Acc0, Timeout);
@@ -945,7 +945,7 @@ create_rule_and_action_http(Config) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     ct:pal("rule action params: ~p", [Params]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -1229,7 +1229,7 @@ t_start_and_consume_ok(Config) ->
                     <<"offset">> := OffsetReply,
                     <<"headers">> := #{<<"hkey">> := <<"hvalue">>}
                 },
-                emqx_utils_json:decode(PayloadBin, [return_maps]),
+                emqx_utils_json:decode(PayloadBin),
                 #{
                     offset_reply => OffsetReply,
                     kafka_topic => KafkaTopic,
@@ -1342,7 +1342,7 @@ t_multiple_topic_mappings(Config) ->
             %% as configured.
             Payloads =
                 lists:sort([
-                    case emqx_utils_json:safe_decode(P, [return_maps]) of
+                    case emqx_utils_json:safe_decode(P) of
                         {ok, Decoded} -> Decoded;
                         {error, _} -> P
                     end
@@ -1485,7 +1485,7 @@ t_failed_creation_then_fixed(Config) ->
             <<"offset">> := _,
             <<"headers">> := #{<<"hkey">> := <<"hvalue">>}
         },
-        emqx_utils_json:decode(PayloadBin, [return_maps]),
+        emqx_utils_json:decode(PayloadBin),
         #{
             kafka_topic => KafkaTopic,
             payload => Payload
@@ -1670,7 +1670,7 @@ t_bridge_rule_action_source(Config) ->
                     <<"headers">> := #{<<"hkey">> := <<"hvalue">>},
                     <<"topic">> := KafkaTopic
                 },
-                emqx_utils_json:decode(RawPayload, [return_maps])
+                emqx_utils_json:decode(RawPayload)
             ),
             ?retry(
                 _Interval = 200,
@@ -2070,7 +2070,7 @@ t_begin_offset_earliest(Config) ->
             %% the consumers
             Published = receive_published(#{n => NumMessages}),
             Payloads = lists:map(
-                fun(#{payload := P}) -> emqx_utils_json:decode(P, [return_maps]) end,
+                fun(#{payload := P}) -> emqx_utils_json:decode(P) end,
                 Published
             ),
             ?assert(

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -314,7 +314,7 @@ kafka_bridge_rest_api_helper(Config) ->
                 <<"sql">> => <<"SELECT * from \"kafka_bridge_topic/#\"">>
             }
         ),
-        #{<<"id">> := RuleId} = emqx_utils_json:decode(Rule, [return_maps]),
+        #{<<"id">> := RuleId} = emqx_utils_json:decode(Rule),
         BridgeV2Id = emqx_bridge_v2:id(
             list_to_binary(?BRIDGE_TYPE_V2),
             list_to_binary(BridgeName)
@@ -1214,8 +1214,7 @@ api_path(Parts) ->
     ?HOST ++ filename:join([?BASE_PATH | Parts]).
 
 json(Data) ->
-    {ok, Jsx} = emqx_utils_json:safe_decode(Data, [return_maps]),
-    Jsx.
+    emqx_utils_json:decode(Data).
 
 delete_all_bridges() ->
     lists:foreach(

--- a/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_impl_producer_SUITE.erl
@@ -237,7 +237,7 @@ create_bridge_http(Config, KinesisConfigOverrides) ->
     ct:pal("probe result: ~p", [ProbeResult]),
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-            {ok, Res0} -> {ok, emqx_utils_json:decode(Res0, [return_maps])};
+            {ok, Res0} -> {ok, emqx_utils_json:decode(Res0)};
             Error -> Error
         end,
     ct:pal("bridge creation result: ~p", [Res]),
@@ -271,7 +271,7 @@ create_rule_and_action_http(Config) ->
     Path = emqx_mgmt_api_test_util:api_path(["rules"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -958,7 +958,7 @@ t_empty_payload_template(Config) ->
     Data = proplists:get_value(<<"Data">>, Record),
     ?assertMatch(
         #{<<"payload">> := <<"payload">>, <<"topic">> := ?TOPIC},
-        emqx_utils_json:decode(Data, [return_maps])
+        emqx_utils_json:decode(Data)
     ),
     ok.
 

--- a/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
+++ b/apps/emqx_bridge_mongodb/src/emqx_bridge_mongodb_connector.erl
@@ -162,14 +162,14 @@ format_data(PayloadTks, Msg) ->
     case maps:size(PreparedTupleMap) of
         % If no tuples were found simply proceed with the json decoding and be done with it
         0 ->
-            emqx_utils_json:decode(emqx_placeholder:proc_tmpl(PayloadTks, Msg), [return_maps]);
+            emqx_utils_json:decode(emqx_placeholder:proc_tmpl(PayloadTks, Msg));
         _ ->
             % If tuples were found, replace the tuple values with the references created, run
             % the modified message through the json parser, and then at the end replace the
             % references with the actual tuple values.
             ProcessedMessage = replace_message_values_with_references(Msg, PreparedTupleMap),
             DecodedMap = emqx_utils_json:decode(
-                emqx_placeholder:proc_tmpl(PayloadTks, ProcessedMessage), [return_maps]
+                emqx_placeholder:proc_tmpl(PayloadTks, ProcessedMessage)
             ),
             populate_map_with_tuple_values(PreparedTupleMap, DecodedMap)
     end.

--- a/apps/emqx_bridge_mongodb/test/emqx_bridge_mongodb_SUITE.erl
+++ b/apps/emqx_bridge_mongodb/test/emqx_bridge_mongodb_SUITE.erl
@@ -344,7 +344,7 @@ create_bridge_http(Params) ->
             return_all => true
         })
     of
-        {ok, {{_, 201, _}, _, Body}} -> {ok, emqx_utils_json:decode(Body, [return_maps])};
+        {ok, {{_, 201, _}, _, Body}} -> {ok, emqx_utils_json:decode(Body)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_SUITE.erl
@@ -353,7 +353,7 @@ t_mqtt_conn_bridge_ingress_full_context(_Config) ->
             <<"server">> := <<"127.0.0.1:1883">>,
             <<"topic">> := <<"ingress_remote_topic/1">>
         },
-        emqx_utils_json:decode(EncodedPayload, [return_maps])
+        emqx_utils_json:decode(EncodedPayload)
     ),
 
     ok.

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_subscriber_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_subscriber_SUITE.erl
@@ -341,7 +341,7 @@ t_receive_via_rule(Config) ->
                         properties := #{'User-Property' := [{<<"key">>, <<"value">>}]}
                     }}
                 ),
-            Payload = emqx_utils_json:decode(maps:get(payload, Msg), [return_maps]),
+            Payload = emqx_utils_json:decode(maps:get(payload, Msg)),
             ?assertMatch(
                 #{
                     <<"event">> := Hookpoint,
@@ -523,7 +523,7 @@ t_static_clientids(Config) ->
             fun(#{<<"node">> := N}) -> N end,
             fun(#{<<"payload">> := P}) -> P end,
             lists:map(
-                fun(#{payload := P}) -> emqx_utils_json:decode(P, [return_maps]) end,
+                fun(#{payload := P}) -> emqx_utils_json:decode(P) end,
                 Publishes0
             )
         ),

--- a/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_mysql_SUITE.erl
@@ -269,7 +269,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -376,7 +376,7 @@ create_rule_and_action_http(Config) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
         {ok, Res0} ->
-            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0, [return_maps]),
+            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0),
             on_exit(fun() -> ok = emqx_rule_engine:delete_rule(RuleId) end),
             {ok, Res};
         Error ->
@@ -388,7 +388,7 @@ request_api_status(BridgeId) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(get, Path, "", AuthHeader) of
         {ok, Res0} ->
-            #{<<"status">> := Status} = _Res = emqx_utils_json:decode(Res0, [return_maps]),
+            #{<<"status">> := Status} = _Res = emqx_utils_json:decode(Res0),
             {ok, binary_to_existing_atom(Status)};
         Error ->
             Error

--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -312,7 +312,7 @@ create_bridge_api(Config, Overrides) ->
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             {error, {Status, Headers, Body0}} ->
                 {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
             Error ->
@@ -337,7 +337,7 @@ update_bridge_api(Config, Overrides) ->
     ct:pal("updating bridge (via http): ~p", [Params]),
     Res =
         case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Params, Opts) of
-            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0, [return_maps])};
+            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0)};
             Error -> Error
         end,
     ct:pal("bridge update result: ~p", [Res]),
@@ -372,7 +372,7 @@ create_rule_and_action_http(Config) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     ct:pal("rule action params: ~p", [Params]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_pgsql_SUITE.erl
@@ -280,7 +280,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_connector_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_connector_SUITE.erl
@@ -317,7 +317,7 @@ create_bridge_api(Config, Overrides) ->
     Res =
         case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
             {ok, {Status, Headers, Body0}} ->
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0, [return_maps])}};
+                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
             {error, {Status, Headers, Body0}} ->
                 {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
             Error ->
@@ -342,7 +342,7 @@ update_bridge_api(Config, Overrides) ->
     ct:pal("updating bridge (via http): ~p", [Params]),
     Res =
         case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Params, Opts) of
-            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0, [return_maps])};
+            {ok, {_Status, _Headers, Body0}} -> {ok, emqx_utils_json:decode(Body0)};
             Error -> Error
         end,
     ct:pal("bridge update result: ~p", [Res]),
@@ -484,7 +484,7 @@ create_rule_and_action_http(Config) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     ct:pal("rule action params: ~p", [Params]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -504,7 +504,7 @@ flush_consumed() ->
     end.
 
 try_decode_json(Payload) ->
-    case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+    case emqx_utils_json:safe_decode(Payload) of
         {error, _} ->
             Payload;
         {ok, JSON} ->

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_v2_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_v2_SUITE.erl
@@ -363,7 +363,7 @@ flush_consumed() ->
     end.
 
 try_decode_json(Payload) ->
-    case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+    case emqx_utils_json:safe_decode(Payload) of
         {error, _} ->
             Payload;
         {ok, JSON} ->

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_rabbitmq, [
     {description, "EMQX Enterprise RabbitMQ Bridge"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {mod, {emqx_bridge_rabbitmq_app, []}},
     {applications, [

--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_source_worker.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_source_worker.erl
@@ -106,7 +106,7 @@ make_headers(Headers) when is_list(Headers) ->
     maps:from_list([{Key, Value} || {Key, _Type, Value} <- Headers]).
 
 make_payload(Payload) ->
-    case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+    case emqx_utils_json:safe_decode(Payload) of
         {ok, Map} -> Map;
         {error, _} -> Payload
     end.

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_test_utils.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_test_utils.erl
@@ -200,7 +200,7 @@ receive_message_from_rabbitmq(Config) ->
             #'basic.cancel_ok'{consumer_tag = ConsumerTag} =
                 amqp_channel:call(Channel, #'basic.cancel'{consumer_tag = ConsumerTag}),
             Payload = Content#amqp_msg.payload,
-            case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+            case emqx_utils_json:safe_decode(Payload) of
                 {ok, Msg} -> Msg;
                 {error, _} -> ?assert(false, {"Failed to decode the message", Payload})
             end

--- a/apps/emqx_bridge_rocketmq/test/emqx_bridge_rocketmq_SUITE.erl
+++ b/apps/emqx_bridge_rocketmq/test/emqx_bridge_rocketmq_SUITE.erl
@@ -237,7 +237,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.app.src
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_snowflake, [
     {description, "EMQX Enterprise Snowflake Bridge"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl
@@ -617,7 +617,7 @@ process_complete(TransferState0) ->
         } = TransferState,
         case insert_files_request(StagedFiles, HTTPPool, HTTPClientConfig) of
             {ok, 200, _, Body} ->
-                {ok, emqx_utils_json:decode(Body, [return_maps])};
+                {ok, emqx_utils_json:decode(Body)};
             Res ->
                 ?tp("snowflake_insert_files_request_failed", #{response => Res}),
                 %% TODO: retry?
@@ -930,7 +930,7 @@ insert_report_request(HTTPPool, Opts, HTTPClientConfig) ->
     Response = ?MODULE:do_insert_report_request(HTTPPool, Req, RequestTTL, MaxRetries),
     case Response of
         {ok, 200, _Headers, Body0} ->
-            Body = emqx_utils_json:decode(Body0, [return_maps]),
+            Body = emqx_utils_json:decode(Body0),
             {ok, Body};
         _ ->
             {error, Response}
@@ -1055,7 +1055,7 @@ check_snowpipe_user_permission(HTTPPool, ODBCPool, ActionState) ->
             ok;
         {error, {ok, 401, _, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, JSON} -> JSON;
                     {error, _} -> Body0
                 end,
@@ -1097,7 +1097,7 @@ try_get_jwt_failure_details(ODBCPool, ActionResId, RespBody) ->
         {ok, RequestId} ?= get_jwt_error_request_id(Msg),
         {selected, [_ColHeader], [{Val}]} ?= get_login_failure_details(ODBCPool, RequestId),
         true ?= is_list(Val) orelse {error, {not_string, Val}},
-        {ok, Data} ?= emqx_utils_json:safe_decode(Val, [return_maps]),
+        {ok, Data} ?= emqx_utils_json:safe_decode(Val),
         #{failure_details => Data}
     else
         Err ->

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -548,7 +548,7 @@ create_bridge_http(Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_bridge_syskeeper/test/emqx_bridge_syskeeper_SUITE.erl
+++ b/apps/emqx_bridge_syskeeper/test/emqx_bridge_syskeeper_SUITE.erl
@@ -219,7 +219,7 @@ call_create_http(Root, Params) ->
     Path = emqx_mgmt_api_test_util:api_path([Root]),
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -718,7 +718,7 @@ t_create_with_bad_name(Config) ->
         Conf,
         Config
     ),
-    Msg = emqx_utils_json:decode(Msg0, [return_maps]),
+    Msg = emqx_utils_json:decode(Msg0),
     ?assertMatch(#{<<"kind">> := <<"validation_error">>}, Msg),
     ok.
 
@@ -1044,7 +1044,7 @@ str(S) when is_list(S) -> S;
 str(S) when is_binary(S) -> binary_to_list(S).
 
 json(B) when is_binary(B) ->
-    case emqx_utils_json:safe_decode(B, [return_maps]) of
+    case emqx_utils_json:safe_decode(B) of
         {ok, Term} ->
             Term;
         {error, Reason} = Error ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -326,7 +326,7 @@ gen_api_schema_json_iodata(SchemaMod, SchemaInfo, Converter) ->
         ApiSpec0
     ),
     Components = lists:foldl(fun(M, Acc) -> maps:merge(M, Acc) end, #{}, Components0),
-    emqx_utils_json:encode(
+    emqx_utils_json:encode_proplist(
         #{
             info => SchemaInfo,
             paths => ApiSpec,

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -413,8 +413,7 @@ api_path(Parts) ->
     ?HOST ++ filename:join([?BASE_PATH | Parts]).
 
 json(Data) ->
-    {ok, Jsx} = emqx_utils_json:safe_decode(Data, [return_maps]),
-    Jsx.
+    emqx_utils_json:decode(Data).
 
 -if(?EMQX_RELEASE_EDITION == ee).
 filter_req(Req) ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_error_code_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_error_code_SUITE.erl
@@ -110,7 +110,7 @@ request(Url) ->
         {ok, {{"HTTP/1.1", Code, _}, _, Return}} when
             Code >= 200 andalso Code =< 299
         ->
-            {ok, emqx_utils_json:decode(Return, [return_maps])};
+            {ok, emqx_utils_json:decode(Return)};
         {ok, {Reason, _, _}} ->
             {error, Reason}
     end.

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -872,10 +872,10 @@ do_request_api(Method, Request) ->
             Code >= 200 andalso Code =< 299
         ->
             ct:pal("Resp ~p ~p~n", [Code, Return]),
-            {ok, emqx_utils_json:decode(Return, [return_maps])};
+            {ok, emqx_utils_json:decode(Return)};
         {ok, {{"HTTP/1.1", Code, _}, _, Return}} ->
             ct:pal("Resp ~p ~p~n", [Code, Return]),
-            {error, {Code, emqx_utils_json:decode(Return, [return_maps])}};
+            {error, {Code, emqx_utils_json:decode(Return)}};
         {error, Reason} ->
             {error, Reason}
     end.

--- a/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
+++ b/apps/emqx_dashboard_rbac/test/emqx_dashboard_rbac_SUITE.erl
@@ -79,7 +79,7 @@ t_permission(_) ->
             <<"role">> := ?ROLE_VIEWER,
             <<"description">> := ?ADD_DESCRIPTION
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     %% add by viewer
@@ -122,7 +122,7 @@ t_update_role(_) ->
             <<"role">> := ?ROLE_VIEWER,
             <<"description">> := ?ADD_DESCRIPTION
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     %% update role by viewer

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_ldap_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_ldap_SUITE.erl
@@ -306,7 +306,7 @@ ldap_server() ->
     iolist_to_binary(io_lib:format("~s:~B", [?LDAP_HOST, ?LDAP_DEFAULT_PORT])).
 
 decode_json(Data) ->
-    BinJson = emqx_utils_json:decode(Data, [return_maps]),
+    BinJson = emqx_utils_json:decode(Data),
     emqx_utils_maps:unsafe_atom_key_map(BinJson).
 
 request_without_authorization(Method, Url, Body) ->

--- a/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_api_SUITE.erl
+++ b/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_api_SUITE.erl
@@ -300,7 +300,7 @@ api(Method, Path, Data) ->
     case emqx_mgmt_api_test_util:request(Method, uri(Path), Data) of
         {ok, Code, ResponseBody} ->
             Res =
-                case emqx_utils_json:safe_decode(ResponseBody, [return_maps]) of
+                case emqx_utils_json:safe_decode(ResponseBody) of
                     {ok, Decoded} -> Decoded;
                     {error, _} -> ResponseBody
                 end,

--- a/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_mgmt_api_subscription_SUITE.erl
+++ b/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_mgmt_api_subscription_SUITE.erl
@@ -127,7 +127,7 @@ t_list_with_invalid_match_topic(Config) ->
             {error, {R, _H, Body}} = emqx_mgmt_api_test_util:request_api(
                 get, path(), uri_string:compose_query(QS), Headers, [], #{return_all => true}
             ),
-            {error, {R, _H, emqx_utils_json:decode(Body, [return_maps])}}
+            {error, {R, _H, emqx_utils_json:decode(Body)}}
         end
     ),
     ok.
@@ -135,7 +135,7 @@ t_list_with_invalid_match_topic(Config) ->
 request_json(Method, Query, Headers) when is_list(Query) ->
     Qs = uri_string:compose_query(Query),
     {ok, MatchRes} = emqx_mgmt_api_test_util:request_api(Method, path(), Qs, Headers),
-    emqx_utils_json:decode(MatchRes, [return_maps]).
+    emqx_utils_json:decode(MatchRes).
 
 path() ->
     emqx_mgmt_api_test_util:api_path(["subscriptions"]).

--- a/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_api_SUITE.erl
@@ -287,7 +287,7 @@ t_update(Cfg) ->
     ?assertMatch([], emqx_exhook_mgr:running()).
 
 decode_json(Data) ->
-    BinJosn = emqx_utils_json:decode(Data, [return_maps]),
+    BinJosn = emqx_utils_json:decode(Data),
     emqx_utils_maps:unsafe_atom_key_map(BinJosn).
 
 request_api(Method, Url, Auth) ->

--- a/apps/emqx_ft/src/emqx_ft.app.src
+++ b/apps/emqx_ft/src/emqx_ft.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ft, [
     {description, "EMQX file transfer over MQTT"},
-    {vsn, "0.1.15"},
+    {vsn, "0.1.16"},
     {registered, []},
     {mod, {emqx_ft_app, []}},
     {applications, [

--- a/apps/emqx_ft/src/emqx_ft_schema.erl
+++ b/apps/emqx_ft/src/emqx_ft_schema.erl
@@ -358,7 +358,7 @@ emit_enabled(Type, BConf = #{enable := Enabled}) ->
     Enabled andalso throw({Type, BConf}).
 
 decode(SchemaName, Payload) when is_binary(Payload) ->
-    case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+    case emqx_utils_json:safe_decode(Payload) of
         {ok, Map} ->
             decode(SchemaName, Map);
         {error, Error} ->

--- a/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_exporter_fs.erl
@@ -454,7 +454,7 @@ encode_filemeta(Meta) ->
     emqx_utils_json:encode(?PRELUDE(_Vsn = 1, emqx_ft:encode_filemeta(Meta))).
 
 decode_filemeta(Binary) when is_binary(Binary) ->
-    ?PRELUDE(_Vsn = 1, Map) = emqx_utils_json:decode(Binary, [return_maps]),
+    ?PRELUDE(_Vsn = 1, Map) = emqx_utils_json:decode(Binary),
     case emqx_ft:decode_filemeta(Map) of
         {ok, Meta} ->
             Meta;

--- a/apps/emqx_ft/src/emqx_ft_storage_fs.erl
+++ b/apps/emqx_ft/src/emqx_ft_storage_fs.erl
@@ -381,7 +381,7 @@ encode_filemeta(Meta) ->
     emqx_utils_json:encode(?PRELUDE(_Vsn = 1, emqx_ft:encode_filemeta(Meta))).
 
 decode_filemeta(Binary) when is_binary(Binary) ->
-    ?PRELUDE(_Vsn = 1, Map) = emqx_utils_json:decode(Binary, [return_maps]),
+    ?PRELUDE(_Vsn = 1, Map) = emqx_utils_json:decode(Binary),
     case emqx_ft:decode_filemeta(Map) of
         {ok, Meta} ->
             Meta;

--- a/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_api_SUITE.erl
@@ -557,7 +557,7 @@ request_json(Method, Url, Config) ->
 
 json(Body) when is_binary(Body) ->
     try
-        emqx_utils_json:decode(Body, [return_maps])
+        emqx_utils_json:decode(Body)
     catch
         _:_ ->
             error({bad_json, Body})

--- a/apps/emqx_ft/test/emqx_ft_storage_exporter_s3_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_storage_exporter_s3_SUITE.erl
@@ -98,7 +98,7 @@ t_happy_path(Config) ->
             <<"name">> := NameBin,
             <<"size">> := 4
         },
-        emqx_utils_json:decode(metadata_field("filemeta", Meta), [return_maps])
+        emqx_utils_json:decode(metadata_field("filemeta", Meta))
     ).
 
 t_upload_error(Config) ->

--- a/apps/emqx_gateway/src/emqx_gateway_cli.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cli.erl
@@ -74,7 +74,7 @@ gateway(["load", Name, Conf]) ->
     case
         emqx_gateway_conf:load_gateway(
             bin(Name),
-            emqx_utils_json:decode(Conf, [return_maps])
+            emqx_utils_json:decode(Conf)
         )
     of
         {ok, _} ->

--- a/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_api_SUITE.erl
@@ -386,7 +386,7 @@ t_authn_data_mgmt(_) ->
     ),
     ?assertMatch(
         #{<<"total">> := 2, <<"success">> := 2},
-        emqx_utils_json:decode(ImportedResults, [return_maps])
+        emqx_utils_json:decode(ImportedResults)
     ),
 
     CSVFileName = filename:join([Dir, <<"test/data/user-credentials.csv">>]),
@@ -398,7 +398,7 @@ t_authn_data_mgmt(_) ->
     ),
     ?assertMatch(
         #{<<"total">> := 2, <<"success">> := 2},
-        emqx_utils_json:decode(ImportedResults2, [return_maps])
+        emqx_utils_json:decode(ImportedResults2)
     ),
 
     {204, _} = request(delete, "/gateways/stomp/authentication"),
@@ -603,7 +603,7 @@ t_listeners_authn_data_mgmt(_) ->
     ),
     ?assertMatch(
         #{<<"total">> := 2, <<"success">> := 2},
-        emqx_utils_json:decode(ImportedResults, [return_maps])
+        emqx_utils_json:decode(ImportedResults)
     ),
 
     CSVFileName = filename:join([Dir, <<"test/data/user-credentials.csv">>]),
@@ -615,7 +615,7 @@ t_listeners_authn_data_mgmt(_) ->
     ),
     ?assertMatch(
         #{<<"total">> := 2, <<"success">> := 2},
-        emqx_utils_json:decode(ImportedResults2, [return_maps])
+        emqx_utils_json:decode(ImportedResults2)
     ),
 
     ok.

--- a/apps/emqx_gateway/test/emqx_gateway_authn_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_authn_SUITE.erl
@@ -266,7 +266,7 @@ t_case_exproto(_) ->
 
                 Mod:send(Sock, ConnBin),
                 {ok, Recv} = Mod:recv(Sock, 5000),
-                C = ?FUNCTOR(Bin, emqx_utils_json:decode(Bin, [return_maps])),
+                C = ?FUNCTOR(Bin, emqx_utils_json:decode(Bin)),
                 ?assertEqual(C(Expect), C(Recv))
             end
         )

--- a/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_authz_SUITE.erl
@@ -159,7 +159,7 @@ t_case_lwm2m(_) ->
     Test("lwm2m", fun(SubTopic, Msg) ->
         ?assertEqual(true, lists:member(SubTopic, test_mqtt_broker:get_subscrbied_topics())),
         Payload = emqx_message:payload(Msg),
-        Cmd = emqx_utils_json:decode(Payload, [return_maps]),
+        Cmd = emqx_utils_json:decode(Payload),
         ?assertMatch(#{<<"msgType">> := <<"register">>, <<"data">> := _}, Cmd)
     end),
 
@@ -344,7 +344,7 @@ t_case_exproto_publish(_) ->
 
                 Mod:send(Sock, ConnBin),
                 {ok, Recv} = Mod:recv(Sock, 5000),
-                C = ?FUNCTOR(Bin, emqx_utils_json:decode(Bin, [return_maps])),
+                C = ?FUNCTOR(Bin, emqx_utils_json:decode(Bin)),
                 ?assertEqual(C(SvrMod:frame_connack(0)), C(Recv)),
 
                 Send = fun() ->
@@ -381,7 +381,7 @@ t_case_exproto_subscribe(_) ->
 
                 Mod:send(Sock, ConnBin),
                 {ok, Recv} = Mod:recv(Sock, WaitTime),
-                C = ?FUNCTOR(Bin, emqx_utils_json:decode(Bin, [return_maps])),
+                C = ?FUNCTOR(Bin, emqx_utils_json:decode(Bin)),
                 ?assertEqual(C(SvrMod:frame_connack(0)), C(Recv)),
 
                 SubBin = SvrMod:frame_subscribe(Topic, 0),

--- a/apps/emqx_gateway/test/emqx_gateway_test_utils.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_test_utils.erl
@@ -168,7 +168,7 @@ do_request(Mth, Req) ->
                         #{};
                     _ ->
                         emqx_utils_maps:unsafe_atom_key_map(
-                            emqx_utils_json:decode(Resp, [return_maps])
+                            emqx_utils_json:decode(Resp)
                         )
                 end,
             {Code, NResp};

--- a/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_api_SUITE.erl
@@ -100,7 +100,7 @@ t_send_request_api(_) ->
             Req
         ),
         #{<<"token">> := RToken, <<"payload">> := RPayload} =
-            emqx_utils_json:decode(Response, [return_maps]),
+            emqx_utils_json:decode(Response),
         ?assertEqual(Token, RToken),
         ?assertEqual(Payload, RPayload)
     end,

--- a/apps/emqx_gateway_exproto/test/emqx_exproto_echo_svr.erl
+++ b/apps/emqx_gateway_exproto/test/emqx_exproto_echo_svr.erl
@@ -169,7 +169,7 @@ on_received_bytes(Stream, _Md) ->
         fun(Reqs) ->
             lists:foreach(
                 fun(#{conn := Conn, bytes := Bytes}) ->
-                    #{<<"type">> := Type} = Params = emqx_utils_json:decode(Bytes, [return_maps]),
+                    #{<<"type">> := Type} = Params = emqx_utils_json:decode(Bytes),
                     _ = handle_in(Conn, Type, Params)
                 end,
                 Reqs

--- a/apps/emqx_gateway_exproto/test/emqx_exproto_unary_echo_svr.erl
+++ b/apps/emqx_gateway_exproto/test/emqx_exproto_unary_echo_svr.erl
@@ -72,7 +72,7 @@ on_socket_closed(_Req, _Md) ->
     {ok, emqx_exproto_pb:empty_success(), grpc:metadata()}
     | {error, grpc_stream:error_response()}.
 on_received_bytes(#{conn := Conn, bytes := Bytes}, _Md) ->
-    #{<<"type">> := Type} = Params = emqx_utils_json:decode(Bytes, [return_maps]),
+    #{<<"type">> := Type} = Params = emqx_utils_json:decode(Bytes),
     _ = handle_in(Conn, Type, Params),
     {ok, #{}, _Md}.
 

--- a/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
@@ -340,7 +340,7 @@ split_by_pos([E | L], N, A1) ->
 msgs2frame(Messages, Vin, Channel) ->
     lists:filtermap(
         fun(#message{payload = Payload}) ->
-            case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+            case emqx_utils_json:safe_decode(Payload) of
                 {ok, Maps} ->
                     case msg2frame(Maps, Vin) of
                         {error, Reason} ->

--- a/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
+++ b/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
@@ -155,7 +155,7 @@ login_first() ->
             <<"Length">> := 1,
             <<"Id">> := <<"C">>
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     % vehicle login success
     Time = <<12, 12, 29, 12, 19, 20>>,
     {ok, Socket}.
@@ -257,7 +257,7 @@ t_case02_reportinfo_0x01(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case03_reportinfo_0x02(_Config) ->
@@ -317,7 +317,7 @@ t_case03_reportinfo_0x02(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case04_reportinfo_0x03(_Config) ->
@@ -367,7 +367,7 @@ t_case04_reportinfo_0x03(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case05_reportinfo_0x04(_Config) ->
@@ -406,7 +406,7 @@ t_case05_reportinfo_0x04(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case06_reportinfo_0x05(_Config) ->
@@ -445,7 +445,7 @@ t_case06_reportinfo_0x05(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case07_reportinfo_0x06(_Config) ->
@@ -493,7 +493,7 @@ t_case07_reportinfo_0x06(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case08_reportinfo_0x07(_Config) ->
@@ -541,7 +541,7 @@ t_case08_reportinfo_0x07(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case09_reportinfo_0x08(_Config) ->
@@ -599,7 +599,7 @@ t_case09_reportinfo_0x08(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case10_reportinfo_0x09(_Config) ->
@@ -649,7 +649,7 @@ t_case10_reportinfo_0x09(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case11_retx_report0x01(_Config) ->
@@ -700,7 +700,7 @@ t_case11_retx_report0x01(_Config) ->
                 }
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case12_vihecle_logout(_Config) ->
@@ -732,7 +732,7 @@ t_case12_vihecle_logout(_Config) ->
             },
             <<"Seq">> := 1
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     ok.
 
 t_case13_platform_login(_Config) ->
@@ -849,7 +849,7 @@ t_case17_param_query(_Config) ->
                 #{<<"0x02">> := 10}
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
 
     %
     % send PARAM QUERY - Query all of feild
@@ -949,7 +949,7 @@ t_case17_param_query(_Config) ->
             <<"Total">> := 16,
             <<"Params">> := RespMapRecved
         }
-    } = emqx_utils_json:decode(PubedMsg1, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg1),
     ?assertEqual(RespMap, RespMapRecved),
     ok.
 
@@ -1018,7 +1018,7 @@ t_case18_param_setting(_Config) ->
                 #{<<"0x02">> := 200}
             ]
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
     %
     % send PARAM SETTING Request
     %
@@ -1097,7 +1097,7 @@ t_case18_param_setting(_Config) ->
             <<"Total">> := 16,
             <<"Params">> := ParamsMapRecved
         }
-    } = emqx_utils_json:decode(PubedMsg1, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg1),
     ?assertEqual(ParamsMap, ParamsMapRecved),
     ok.
 
@@ -1158,7 +1158,7 @@ t_case19_terminal_ctrl(_Config) ->
             },
             <<"Command">> := 2
         }
-    } = emqx_utils_json:decode(PubedMsg, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg),
 
     %
     % send TERMINAL CTRL - REMOTE UPGRADE
@@ -1231,7 +1231,7 @@ t_case19_terminal_ctrl(_Config) ->
             <<"Command">> := 1,
             <<"Param">> := UpgradeMapsRecved
         }
-    } = emqx_utils_json:decode(PubedMsg1, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg1),
 
     ?assertEqual(UpgradeMaps, UpgradeMapsRecved),
 
@@ -1296,7 +1296,7 @@ t_case19_terminal_ctrl(_Config) ->
             <<"Command">> := 6,
             <<"Param">> := AlarmMapsRecved
         }
-    } = emqx_utils_json:decode(PubedMsg2, [return_maps]),
+    } = emqx_utils_json:decode(PubedMsg2),
 
     ?assertEqual(AlarmMaps, AlarmMapsRecved),
     ok.

--- a/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
+++ b/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_jt808, [
     {description, "JT/T 808 Gateway"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_auth.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_auth.erl
@@ -31,7 +31,7 @@ register(RegFrame, #auth{registry = RegUrl}) ->
     Params = maps:merge(FBody, #{<<"phone">> => Phone}),
     case request(RegUrl, Params) of
         {ok, 200, Body} ->
-            case emqx_utils_json:safe_decode(Body, [return_maps]) of
+            case emqx_utils_json:safe_decode(Body) of
                 {ok, #{<<"code">> := 0, <<"authcode">> := Authcode}} ->
                     {ok, Authcode};
                 {ok, #{<<"code">> := Code}} ->

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -398,7 +398,7 @@ split_by_pos([E | L], N, A1) ->
 msgs2frame(Messages, Channel) ->
     lists:filtermap(
         fun(#message{payload = Payload}) ->
-            case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+            case emqx_utils_json:safe_decode(Payload) of
                 {ok, Map = #{<<"header">> := #{<<"msg_id">> := MsgId}}} ->
                     NewHeader = build_frame_header(MsgId, Channel),
                     Frame = maps:put(<<"header">>, NewHeader, Map),

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -466,7 +466,7 @@ t_case04(_) ->
             },
             <<"body">> => #{<<"id">> => EventReportId}
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -639,7 +639,7 @@ t_case07_dl_0x8302_send_question(_) ->
             },
             <<"body">> => #{<<"seq">> => MsgSn3, <<"id">> => 2}
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -710,7 +710,7 @@ t_case08_dl_0x8500_vehicle_ctrl(_Config) ->
                     }
                 }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -882,7 +882,7 @@ t_case11_dl_0x8106_query_client_param(_Config) ->
                 ]
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     %% timer:sleep(200),
@@ -963,7 +963,7 @@ t_case11_dl_0x8107_query_client_attrib(_Config) ->
                 <<"comm_prop">> => 102
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     % no retrasmition of downlink message
@@ -1031,7 +1031,7 @@ t_case15_dl_0x8201_query_location(_Config) ->
                 <<"params">> => LocationReportJson
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     %% timer:sleep(200),
@@ -1076,7 +1076,7 @@ t_location_report(_) ->
             },
             <<"body">> => LocationReportJson
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     % receive general response
@@ -1183,7 +1183,7 @@ t_case50_ul_0x0303_info_request_cancel(_Config) ->
             },
             <<"body">> => #{<<"id">> => 1, <<"flag">> => 6}
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -1235,7 +1235,7 @@ t_case51_ul_0x0701_waybill_report(_Config) ->
             },
             <<"body">> => #{<<"length">> => 7, <<"data">> => base64:encode(<<"ABCDEFG">>)}
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -1308,7 +1308,7 @@ t_case52_ul_0x0705_can_bus_report(_Config) ->
                 ]
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -1366,7 +1366,7 @@ t_case53_ul_0x0800_multimedia_event_report(_Config) ->
                 <<"channel">> => 103
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -1418,7 +1418,7 @@ t_case54_ul_0x0900_send_transparent_data(_Config) ->
             },
             <<"body">> => #{<<"type">> => 39, <<"data">> => base64:encode(<<"oufwei">>)}
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
     ok = gen_tcp:close(Socket).
 
@@ -1472,7 +1472,7 @@ t_case55_ul_0x0901_send_zip_data(_Config) ->
                 <<"data">> => base64:encode(<<"1234">>)
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     ok = gen_tcp:close(Socket).
@@ -2218,7 +2218,7 @@ t_case27_dl_0x8700_drive_record_capture(_Config) ->
                 <<"data">> => base64:encode(<<"77777">>)
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     % no retrasmition of downlink message
@@ -2337,7 +2337,7 @@ t_case29_dl_0x8702_request_driver_id(_Config) ->
                 <<"cert_expiry">> => <<"20301231">>
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     % no retrasmition of downlink message
@@ -2422,7 +2422,7 @@ t_case30_dl_0x8801_camera_shot(_Config) ->
                 <<"ids">> => [220, 221]
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     % No retrasmition of downlink message
@@ -2521,7 +2521,7 @@ t_case31_dl_0x8802_mm_data_search(_Config) ->
                 ]
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     %% No retrasmition of downlink message
@@ -2705,7 +2705,7 @@ t_case34_dl_0x8805_single_mm_data_ctrl(_Config) ->
                 ]
             }
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
 
     % no retrasmition of downlink message
@@ -2718,8 +2718,6 @@ t_case_dl_invalid_msg(_Config) ->
     {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
     {ok, AuthCode} = client_regi_procedure(Socket),
     ok = client_auth_procedure(Socket, AuthCode),
-    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
-
     DlCommand = #{
         %% missing msg_id
         <<"header">> => #{},

--- a/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
+++ b/apps/emqx_gateway_lwm2m/src/emqx_gateway_lwm2m.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_lwm2m, [
     {description, "LwM2M Gateway"},
-    {vsn, "0.1.8"},
+    {vsn, "0.1.9"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway, emqx_gateway_coap, xmerl]},
     {env, []},

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_message.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_message.erl
@@ -351,7 +351,7 @@ opaque_to_json(BaseName, Binary) ->
     [#{path => BaseName, value => base64:encode(Binary)}].
 
 translate_json(JSONBin) ->
-    JSONTerm = emqx_utils_json:decode(JSONBin, [return_maps]),
+    JSONTerm = emqx_utils_json:decode(JSONBin),
     BaseName = maps:get(<<"bn">>, JSONTerm, <<>>),
     ElementList = maps:get(<<"e">>, JSONTerm, []),
     translate_element(BaseName, ElementList, []).

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -786,7 +786,7 @@ deliver_to_coap(AlternatePath, JsonData, MQTT, CacheMode, WithContext, Session) 
     is_binary(JsonData)
 ->
     try
-        TermData = emqx_utils_json:decode(JsonData, [return_maps]),
+        TermData = emqx_utils_json:decode(JsonData),
         deliver_to_coap(AlternatePath, TermData, MQTT, CacheMode, WithContext, Session)
     catch
         ExClass:Error:ST ->

--- a/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_api_SUITE.erl
+++ b/apps/emqx_gateway_lwm2m/test/emqx_lwm2m_api_SUITE.erl
@@ -349,10 +349,10 @@ no_received_request(ClientId, Path, Action) ->
         <<"codeMsg">> => <<"reply_not_received">>,
         <<"path">> => Path
     },
-    ?assertEqual(NotReceived, emqx_utils_json:decode(Response, [return_maps])).
+    ?assertEqual(NotReceived, emqx_utils_json:decode(Response)).
 normal_received_request(ClientId, Path, Action) ->
     Response = call_lookup_api(ClientId, Path, Action),
-    RCont = emqx_utils_json:decode(Response, [return_maps]),
+    RCont = emqx_utils_json:decode(Response),
     ?assertEqual(list_to_binary(ClientId), maps:get(<<"clientid">>, RCont, undefined)),
     ?assertEqual(Path, maps:get(<<"path">>, RCont, undefined)),
     ?assertEqual(Action, maps:get(<<"action">>, RCont, undefined)),

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
@@ -750,7 +750,7 @@ frame2payload(Frame = #{type := ?OCPP_MSG_TYPE_ID_CALLERROR}) ->
     ).
 
 payload2frame(Payload) when is_binary(Payload) ->
-    payload2frame(emqx_utils_json:decode(Payload, [return_maps]));
+    payload2frame(emqx_utils_json:decode(Payload));
 payload2frame(#{
     <<"MessageTypeId">> := ?OCPP_MSG_TYPE_ID_CALL,
     <<"UniqueId">> := Id,

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_frame.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_frame.erl
@@ -55,7 +55,7 @@ initial_parse_state(_Opts) ->
 
 -spec parse(binary() | list(), parse_state()) -> parse_result().
 parse(Bin, Parser) when is_binary(Bin) ->
-    case emqx_utils_json:safe_decode(Bin, [return_maps]) of
+    case emqx_utils_json:safe_decode(Bin) of
         {ok, Json} ->
             parse(Json, Parser);
         {error, {Position, Reason}} ->

--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -106,7 +106,7 @@ t_license_info(_Config) ->
             <<"start_at">> => <<"2022-01-11">>,
             <<"type">> => <<"trial">>
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
     ok.
 
@@ -120,7 +120,7 @@ t_set_default_license(_Config) ->
     ?assertMatch({ok, 200, _}, Res),
     {ok, 200, Payload} = Res,
     %% assert that it's not the string "default" returned
-    ?assertMatch(#{<<"customer">> := _}, emqx_utils_json:decode(Payload, [return_maps])),
+    ?assertMatch(#{<<"customer">> := _}, emqx_utils_json:decode(Payload)),
     ok.
 
 t_license_upload_key_success(_Config) ->
@@ -144,7 +144,7 @@ t_license_upload_key_success(_Config) ->
             <<"start_at">> => <<"2022-01-11">>,
             <<"type">> => <<"trial">>
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
     ?assertMatch(
         #{max_connections := 999},
@@ -166,7 +166,7 @@ t_license_upload_key_bad_key(_Config) ->
             <<"code">> => <<"BAD_REQUEST">>,
             <<"message">> => <<"Bad license key">>
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
     assert_untouched_license(),
     ok.
@@ -184,7 +184,7 @@ t_license_upload_key_not_json(_Config) ->
             <<"code">> => <<"BAD_REQUEST">>,
             <<"message">> => <<"Invalid request params">>
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ),
     assert_untouched_license(),
     ok.
@@ -289,7 +289,7 @@ validate_setting(Res, ExpectLow, ExpectHigh) ->
             <<"connection_low_watermark">> => ExpectLow,
             <<"connection_high_watermark">> => ExpectHigh
         },
-        emqx_utils_json:decode(Payload, [return_maps])
+        emqx_utils_json:decode(Payload)
     ).
 
 validate_setting(Res, ExpectLow, ExpectHigh, DynMax) ->
@@ -300,4 +300,4 @@ validate_setting(Res, ExpectLow, ExpectHigh, DynMax) ->
         <<"connection_high_watermark">> := ExpectHigh,
         <<"dynamic_max_connections">> := DynMax
     } =
-        emqx_utils_json:decode(Payload, [return_maps]).
+        emqx_utils_json:decode(Payload).

--- a/apps/emqx_machine/test/emqx_machine_SUITE.erl
+++ b/apps/emqx_machine/test/emqx_machine_SUITE.erl
@@ -155,7 +155,7 @@ t_node_status(_Config) ->
             <<"backend">> := _,
             <<"role">> := <<"core">>
         },
-        jsx:decode(JSON)
+        emqx_utils_json:decode(JSON)
     ).
 
 t_open_ports_check(Config) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_alarms_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_alarms_SUITE.erl
@@ -64,7 +64,7 @@ get_alarms(AssertCount, Activated) ->
     Qs = "activated=" ++ Activated,
     Headers = emqx_mgmt_api_test_util:auth_header_(),
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, Path, Qs, Headers),
-    Data = emqx_utils_json:decode(Response, [return_maps]),
+    Data = emqx_utils_json:decode(Response),
     Meta = maps:get(<<"meta">>, Data),
     Page = maps:get(<<"page">>, Meta),
     Limit = maps:get(<<"limit">>, Meta),

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -425,7 +425,7 @@ t_authorize(_Config) ->
             <<"code">> := <<"API_KEY_NOT_ALLOW">>,
             <<"message">> := _
         },
-        emqx_utils_json:decode(Body, [return_maps])
+        emqx_utils_json:decode(Body)
     ),
 
     ?assertMatch(
@@ -557,7 +557,7 @@ list_app() ->
     AuthHeader = emqx_dashboard_SUITE:auth_header_(),
     Path = emqx_mgmt_api_test_util:api_path(["api_key"]),
     case emqx_mgmt_api_test_util:request_api(get, Path, AuthHeader) of
-        {ok, Apps} -> {ok, emqx_utils_json:decode(Apps, [return_maps])};
+        {ok, Apps} -> {ok, emqx_utils_json:decode(Apps)};
         Error -> Error
     end.
 
@@ -565,7 +565,7 @@ read_app(Name) ->
     AuthHeader = emqx_dashboard_SUITE:auth_header_(),
     Path = emqx_mgmt_api_test_util:api_path(["api_key", Name]),
     case emqx_mgmt_api_test_util:request_api(get, Path, AuthHeader) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -583,7 +583,7 @@ create_app(Name, Extra) ->
         enable => true
     },
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, App) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -592,7 +592,7 @@ create_unexpired_app(Name, Params) ->
     Path = emqx_mgmt_api_test_util:api_path(["api_key"]),
     App = maps:merge(#{name => Name, desc => <<"Note"/utf8>>, enable => true}, Params),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, App) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -605,7 +605,7 @@ update_app(Name, Change) ->
     AuthHeader = emqx_dashboard_SUITE:auth_header_(),
     UpdatePath = emqx_mgmt_api_test_util:api_path(["api_key", Name]),
     case emqx_mgmt_api_test_util:request_api(put, UpdatePath, "", AuthHeader, Change) of
-        {ok, Update} -> {ok, emqx_utils_json:decode(Update, [return_maps])};
+        {ok, Update} -> {ok, emqx_utils_json:decode(Update)};
         Error -> Error
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_banned_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_banned_SUITE.erl
@@ -387,7 +387,7 @@ list_banned(Params) ->
             emqx_mgmt_api_test_util:auth_header_()
         )
     of
-        {ok, Apps} -> {ok, emqx_utils_json:decode(Apps, [return_maps])};
+        {ok, Apps} -> {ok, emqx_utils_json:decode(Apps)};
         Error -> Error
     end.
 
@@ -395,7 +395,7 @@ create_banned(Banned) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     Path = emqx_mgmt_api_test_util:api_path(["banned"]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Banned) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -2083,7 +2083,7 @@ request(Method, Path, Params, QueryParams, Config) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};
@@ -2098,7 +2098,7 @@ request(Method, Path, Params, QueryParams, Config) ->
     end.
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.

--- a/apps/emqx_management/test/emqx_mgmt_api_cluster_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_cluster_SUITE.erl
@@ -70,7 +70,7 @@ t_cluster_topology_api_empty_resp(_) ->
     {ok, Resp} = emqx_mgmt_api_test_util:request_api(get, ClusterTopologyPath),
     ?assertEqual(
         [#{<<"core_node">> => atom_to_binary(node()), <<"replicant_nodes">> => []}],
-        emqx_utils_json:decode(Resp, [return_maps])
+        emqx_utils_json:decode(Resp)
     ).
 
 t_cluster_topology_api_replicants(Config) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_2_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_2_SUITE.erl
@@ -132,7 +132,7 @@ get_config(Name) ->
     Path = emqx_mgmt_api_test_util:api_path(["configs", Name]),
     case emqx_mgmt_api_test_util:request_api(get, Path) of
         {ok, Res} ->
-            {ok, emqx_utils_json:decode(Res, [return_maps])};
+            {ok, emqx_utils_json:decode(Res)};
         Error ->
             Error
     end.
@@ -141,7 +141,7 @@ update_config(Name, Change) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     UpdatePath = emqx_mgmt_api_test_util:api_path(["configs", Name]),
     case emqx_mgmt_api_test_util:request_api(put, UpdatePath, "", AuthHeader, Change) of
-        {ok, Update} -> {ok, emqx_utils_json:decode(Update, [return_maps])};
+        {ok, Update} -> {ok, emqx_utils_json:decode(Update)};
         Error -> Error
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_configs_SUITE.erl
@@ -255,7 +255,7 @@ t_configs_node(_) ->
     ?assertEqual(error, ExpType),
     ?assertMatch({{_, 404, _}, _, _}, ExpRes),
     {_, _, Body} = ExpRes,
-    ?assertMatch(#{<<"code">> := <<"NOT_FOUND">>}, emqx_utils_json:decode(Body, [return_maps])),
+    ?assertMatch(#{<<"code">> := <<"NOT_FOUND">>}, emqx_utils_json:decode(Body)),
 
     ?assertMatch({error, {_, 500, _}}, get_configs_with_json("bad_node")),
 
@@ -298,7 +298,7 @@ t_configs_key(_Config) ->
                 }
         }
     },
-    ?assertEqual(ExpectError, emqx_utils_json:decode(Error, [return_maps])),
+    ?assertEqual(ExpectError, emqx_utils_json:decode(Error)),
     ReadOnlyConf = #{
         <<"cluster">> =>
             #{
@@ -487,7 +487,7 @@ get_config(Name) ->
     Path = emqx_mgmt_api_test_util:api_path(["configs", Name]),
     case emqx_mgmt_api_test_util:request_api(get, Path) of
         {ok, Res} ->
-            {ok, emqx_utils_json:decode(Res, [return_maps])};
+            {ok, emqx_utils_json:decode(Res)};
         Error ->
             Error
     end.
@@ -508,8 +508,8 @@ get_configs_with_json(Node, Opts) ->
     Auth = emqx_mgmt_api_test_util:auth_header_(),
     Headers = [{"accept", "application/json"}, Auth],
     case emqx_mgmt_api_test_util:request_api(get, URI, [], Headers, [], Opts) of
-        {ok, {_, _, Res}} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, {_, _, Res}} -> {ok, emqx_utils_json:decode(Res)};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -562,7 +562,7 @@ update_config(Name, Change) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     UpdatePath = emqx_mgmt_api_test_util:api_path(["configs", Name]),
     case emqx_mgmt_api_test_util:request_api(put, UpdatePath, "", AuthHeader, Change) of
-        {ok, Update} -> {ok, emqx_utils_json:decode(Update, [return_maps])};
+        {ok, Update} -> {ok, emqx_utils_json:decode(Update)};
         Error -> Error
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_ds_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_ds_SUITE.erl
@@ -57,7 +57,7 @@ t_get_sites(_) ->
     {ok, Response} = request_api(get, Path),
     ?assertEqual(
         [emqx_ds_replication_layer_meta:this_site()],
-        emqx_utils_json:decode(Response, [return_maps])
+        emqx_utils_json:decode(Response)
     ).
 
 t_get_storages(_) ->
@@ -65,7 +65,7 @@ t_get_storages(_) ->
     {ok, Response} = request_api(get, Path),
     ?assertEqual(
         [<<"messages">>],
-        emqx_utils_json:decode(Response, [return_maps])
+        emqx_utils_json:decode(Response)
     ).
 
 t_get_site(_) ->
@@ -93,7 +93,7 @@ t_get_site(_) ->
                     | _
                 ]
         },
-        emqx_utils_json:decode(Response, [return_maps])
+        emqx_utils_json:decode(Response)
     ).
 
 t_get_db(_) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_listeners_SUITE.erl
@@ -499,8 +499,8 @@ t_update_validation_error_message(Config) when is_list(Config) ->
     Result1 = request(put, NewPath, [], WrongConf1, #{return_all => true}),
     ?assertMatch({error, {{_, 400, _}, _Headers, _Body}}, Result1),
     {error, {{_, _Code, _}, _Headers, Body1}} = Result1,
-    #{<<"message">> := RawMsg1} = emqx_utils_json:decode(Body1, [return_maps]),
-    Msg1 = emqx_utils_json:decode(RawMsg1, [return_maps]),
+    #{<<"message">> := RawMsg1} = emqx_utils_json:decode(Body1),
+    Msg1 = emqx_utils_json:decode(RawMsg1),
     %% No confusing union type errors.
     ?assertNotMatch(#{<<"mismatches">> := _}, Msg1),
     ?assertMatch(
@@ -531,7 +531,7 @@ request(Method, Url, QueryParams, Body) ->
 request(Method, Url, QueryParams, Body, Opts) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(Method, Url, QueryParams, AuthHeader, Body, Opts) of
-        {ok, Res} -> emqx_utils_json:decode(Res, [return_maps]);
+        {ok, Res} -> emqx_utils_json:decode(Res);
         Error -> Error
     end.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_metrics_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_metrics_SUITE.erl
@@ -40,7 +40,7 @@ end_per_suite(Config) ->
 
 t_metrics_api(_) ->
     {ok, MetricsResponse} = request_helper("metrics?aggregate=true"),
-    MetricsFromAPI = emqx_utils_json:decode(MetricsResponse, [return_maps]),
+    MetricsFromAPI = emqx_utils_json:decode(MetricsResponse),
     AggregateMetrics = emqx_mgmt:get_metrics(),
     match_helper(AggregateMetrics, MetricsFromAPI).
 
@@ -56,7 +56,7 @@ t_metrics_api_cluster_partial_fail(_) ->
     ),
     try
         {ok, MetricsResponse} = request_helper("metrics?aggregate=false"),
-        [MetricsFromAPI] = emqx_utils_json:decode(MetricsResponse, [return_maps]),
+        [MetricsFromAPI] = emqx_utils_json:decode(MetricsResponse),
         AggregateMetrics = emqx_mgmt:get_metrics(),
         match_helper(AggregateMetrics#{node => atom_to_binary(node())}, MetricsFromAPI)
     after
@@ -85,7 +85,7 @@ t_metrics_api_cluster_bad_nodename(_) ->
 
 t_single_node_metrics_api(_) ->
     {ok, MetricsResponse} = request_helper("metrics"),
-    [MetricsFromAPI] = emqx_utils_json:decode(MetricsResponse, [return_maps]),
+    [MetricsFromAPI] = emqx_utils_json:decode(MetricsResponse),
     LocalNodeMetrics = maps:from_list(
         emqx_mgmt:get_metrics(node()) ++ [{node, to_bin(node())}]
     ),

--- a/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_nodes_SUITE.erl
@@ -61,7 +61,7 @@ end_per_testcase(_, Config) ->
 t_nodes_api(_) ->
     NodesPath = emqx_mgmt_api_test_util:api_path(["nodes"]),
     {ok, Nodes} = emqx_mgmt_api_test_util:request_api(get, NodesPath),
-    NodesResponse = emqx_utils_json:decode(Nodes, [return_maps]),
+    NodesResponse = emqx_utils_json:decode(Nodes),
     LocalNodeInfo = hd(NodesResponse),
     Node = binary_to_atom(maps:get(<<"node">>, LocalNodeInfo), utf8),
     ?assertEqual(Node, node()),
@@ -76,7 +76,7 @@ t_nodes_api(_) ->
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
     NodeNameResponse =
-        binary_to_atom(maps:get(<<"node">>, emqx_utils_json:decode(NodeInfo, [return_maps])), utf8),
+        binary_to_atom(maps:get(<<"node">>, emqx_utils_json:decode(NodeInfo)), utf8),
     ?assertEqual(node(), NodeNameResponse),
 
     BadNodePath = emqx_mgmt_api_test_util:api_path(["nodes", "badnode"]),
@@ -88,7 +88,7 @@ t_nodes_api(_) ->
 t_log_path(_) ->
     NodePath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_list(node())]),
     {ok, NodeInfo} = emqx_mgmt_api_test_util:request_api(get, NodePath),
-    #{<<"log_path">> := Path} = emqx_utils_json:decode(NodeInfo, [return_maps]),
+    #{<<"log_path">> := Path} = emqx_utils_json:decode(NodeInfo),
     ?assertEqual(
         <<"log">>,
         filename:basename(Path)
@@ -98,7 +98,7 @@ t_node_stats_api(_) ->
     StatsPath = emqx_mgmt_api_test_util:api_path(["nodes", atom_to_binary(node(), utf8), "stats"]),
     SystemStats = emqx_mgmt:get_stats(),
     {ok, StatsResponse} = emqx_mgmt_api_test_util:request_api(get, StatsPath),
-    Stats = emqx_utils_json:decode(StatsResponse, [return_maps]),
+    Stats = emqx_utils_json:decode(StatsResponse),
     Fun =
         fun(Key) ->
             ?assertEqual(maps:get(Key, SystemStats), maps:get(atom_to_binary(Key, utf8), Stats))
@@ -116,7 +116,7 @@ t_node_metrics_api(_) ->
         emqx_mgmt_api_test_util:api_path(["nodes", atom_to_binary(node(), utf8), "metrics"]),
     SystemMetrics = emqx_mgmt:get_metrics(),
     {ok, MetricsResponse} = emqx_mgmt_api_test_util:request_api(get, MetricsPath),
-    Metrics = emqx_utils_json:decode(MetricsResponse, [return_maps]),
+    Metrics = emqx_utils_json:decode(MetricsResponse),
     Fun =
         fun(Key) ->
             ?assertEqual(maps:get(Key, SystemMetrics), maps:get(atom_to_binary(Key, utf8), Metrics))

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -246,14 +246,14 @@ list_plugins(Config) ->
     #{host := Host, auth := Auth} = get_host_and_auth(Config),
     Path = emqx_mgmt_api_test_util:api_path(Host, ["plugins"]),
     case emqx_mgmt_api_test_util:request_api(get, Path, Auth) of
-        {ok, Apps} -> {ok, emqx_utils_json:decode(Apps, [return_maps])};
+        {ok, Apps} -> {ok, emqx_utils_json:decode(Apps)};
         Error -> Error
     end.
 
 describe_plugins(Name) ->
     Path = emqx_mgmt_api_test_util:api_path(["plugins", Name]),
     case emqx_mgmt_api_test_util:request_api(get, Path) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res, [return_maps])};
+        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
         Error -> Error
     end.
 
@@ -307,7 +307,7 @@ update_boot_order(Name, MoveBody, Config) ->
     case emqx_mgmt_api_test_util:request_api(post, Path, "", Auth, MoveBody, Opts) of
         {ok, Res} ->
             Resp =
-                case emqx_utils_json:safe_decode(Res, [return_maps]) of
+                case emqx_utils_json:safe_decode(Res) of
                     {ok, Decoded} -> Decoded;
                     {error, _} -> Res
                 end,
@@ -347,7 +347,7 @@ create_renamed_package(PackagePath, NewNameVsn) ->
     NewPackagePath.
 
 update_release_json(["release.json"], FileContent, NewName) ->
-    ContentMap = emqx_utils_json:decode(FileContent, [return_maps]),
+    ContentMap = emqx_utils_json:decode(FileContent),
     emqx_utils_json:encode(ContentMap#{<<"name">> => NewName});
 update_release_json(_FileName, FileContent, _NewName) ->
     FileContent.

--- a/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
@@ -443,4 +443,4 @@ receive_assert(Topic, Qos, Payload) ->
     end.
 
 decode_json(In) ->
-    emqx_utils_json:decode(In, [return_maps]).
+    emqx_utils_json:decode(In).

--- a/apps/emqx_management/test/emqx_mgmt_api_stats_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_stats_SUITE.erl
@@ -44,7 +44,7 @@ end_per_suite(Config) ->
 t_stats_api(_) ->
     S = emqx_mgmt_api_test_util:api_path(["stats?aggregate=false"]),
     {ok, S1} = emqx_mgmt_api_test_util:request_api(get, S),
-    [Stats1] = emqx_utils_json:decode(S1, [return_maps]),
+    [Stats1] = emqx_utils_json:decode(S1),
     SystemStats1 = emqx_mgmt:get_stats(),
     Fun1 =
         fun(Key) ->
@@ -55,7 +55,7 @@ t_stats_api(_) ->
     StatsPath = emqx_mgmt_api_test_util:api_path(["stats?aggregate=true"]),
     SystemStats = emqx_mgmt:get_stats(),
     {ok, StatsResponse} = emqx_mgmt_api_test_util:request_api(get, StatsPath),
-    Stats = emqx_utils_json:decode(StatsResponse, [return_maps]),
+    Stats = emqx_utils_json:decode(StatsResponse),
     ?assertEqual(erlang:length(maps:keys(SystemStats)), erlang:length(maps:keys(Stats))),
     Fun =
         fun(Key) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
@@ -123,7 +123,7 @@ t_subscription_api(Config) ->
     Path = emqx_mgmt_api_test_util:api_path(["subscriptions"]),
     timer:sleep(100),
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, Path),
-    Data = emqx_utils_json:decode(Response, [return_maps]),
+    Data = emqx_utils_json:decode(Response),
     Meta = maps:get(<<"meta">>, Data),
     ?assertEqual(1, maps:get(<<"page">>, Meta)),
     ?assertEqual(emqx_mgmt:default_row_limit(), maps:get(<<"limit">>, Meta)),
@@ -349,7 +349,7 @@ t_list_with_invalid_match_topic(Config) ->
             {error, {R, _H, Body}} = emqx_mgmt_api_test_util:request_api(
                 get, path(), uri_string:compose_query(QS), Headers, [], #{return_all => true}
             ),
-            {error, {R, _H, emqx_utils_json:decode(Body, [return_maps])}}
+            {error, {R, _H, emqx_utils_json:decode(Body)}}
         end
     ),
     ok.
@@ -357,7 +357,7 @@ t_list_with_invalid_match_topic(Config) ->
 request_json(Method, Query, Headers) when is_list(Query) ->
     Qs = uri_string:compose_query(Query),
     {ok, MatchRes} = emqx_mgmt_api_test_util:request_api(Method, path(), Qs, Headers),
-    emqx_utils_json:decode(MatchRes, [return_maps]).
+    emqx_utils_json:decode(MatchRes).
 
 path() ->
     emqx_mgmt_api_test_util:api_path(["subscriptions"]).
@@ -381,7 +381,7 @@ request(Method, Path, Params, QueryParams) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};
@@ -396,7 +396,7 @@ request(Method, Path, Params, QueryParams) ->
     end.
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -312,7 +312,7 @@ format_multipart_formdata(Data, Params, Name, FileNames, MimeType, Boundary) ->
     erlang:iolist_to_binary([WithPaths, StartBoundary, <<"--">>, LineSeparator]).
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.
@@ -329,7 +329,7 @@ simple_request(Method, Path, Params, AuthHeader) ->
             {Status, Body};
         {error, {{_, Status, _}, _Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};

--- a/apps/emqx_management/test/emqx_mgmt_api_topics_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_topics_SUITE.erl
@@ -225,7 +225,7 @@ t_shared_topics_invalid(_Config) ->
     ),
     ?assertMatch(
         #{<<"code">> := <<"INVALID_PARAMTER">>, <<"message">> := <<"topic_filter_invalid">>},
-        emqx_utils_json:decode(Body, [return_maps])
+        emqx_utils_json:decode(Body)
     ).
 
 t_persistent_topics(_Config) ->
@@ -322,7 +322,7 @@ request_json(Method, Path, QS) ->
     decode_response(request_api(Method, Path, QS)).
 
 decode_response({ok, Response}) ->
-    emqx_utils_json:decode(Response, [return_maps]);
+    emqx_utils_json:decode(Response);
 decode_response({error, Reason}) ->
     error({request_api_error, Reason}).
 

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -783,8 +783,7 @@ api_path(Path) ->
     emqx_mgmt_api_test_util:api_path([Path]).
 
 json(Data) ->
-    {ok, Jsx} = emqx_utils_json:safe_decode(Data, [return_maps]),
-    Jsx.
+    emqx_utils_json:decode(Data).
 
 load() ->
     emqx_trace:start_link().

--- a/apps/emqx_message_transformation/src/emqx_message_transformation.app.src
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation.app.src
@@ -1,6 +1,6 @@
 {application, emqx_message_transformation, [
     {description, "EMQX Message Transformation"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, [emqx_message_transformation_sup, emqx_message_transformation_registry]},
     {mod, {emqx_message_transformation_app, []}},
     {applications, [

--- a/apps/emqx_message_transformation/src/emqx_message_transformation.erl
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation.erl
@@ -397,7 +397,7 @@ message_to_context(#message{} = Message, Payload, Transformation) ->
         node => node(),
         payload => Payload,
         peername => Peername,
-        pub_props => Props,
+        pub_props => Props#{'User-Property' => UserProperties},
         publish_received_at => Message#message.timestamp,
         qos => Message#message.qos,
         retain => emqx_message:get_flag(retain, Message, false),

--- a/apps/emqx_message_transformation/src/emqx_message_transformation.erl
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation.erl
@@ -447,7 +447,7 @@ take_from_context(Context, Message) ->
 decode(Payload, #{type := none}, _Transformation) ->
     {ok, Payload};
 decode(Payload, #{type := json}, Transformation) when is_binary(Payload) ->
-    case emqx_utils_json:safe_decode(Payload, [return_maps]) of
+    case emqx_utils_json:safe_decode(Payload) of
         {ok, JSON} ->
             {ok, JSON};
         {error, Reason} ->

--- a/apps/emqx_message_transformation/src/emqx_message_transformation_bif.erl
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation_bif.erl
@@ -26,7 +26,7 @@ json_encode(X) ->
     end.
 
 json_decode(JSON) ->
-    case emqx_utils_json:safe_decode(JSON, [return_maps]) of
+    case emqx_utils_json:safe_decode(JSON) of
         {ok, X} ->
             X;
         {error, Reason} ->

--- a/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
+++ b/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
@@ -81,7 +81,7 @@ reset_all_global_metrics() ->
     ).
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.
@@ -95,7 +95,7 @@ request(Method, Path, Params) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};
@@ -653,7 +653,7 @@ t_smoke_test_2(_Config) ->
             },
             <<"content_type">> := <<"application/json">>
         } when is_integer(PRAt),
-        emqx_utils_json:decode(Payload0, [return_maps])
+        emqx_utils_json:decode(Payload0)
     ),
     %% Reconnect with an username.
     emqtt:stop(C1),
@@ -683,7 +683,7 @@ t_smoke_test_2(_Config) ->
             },
             <<"content_type">> := <<"application/json">>
         } when is_integer(PRAt),
-        emqx_utils_json:decode(Payload1, [return_maps])
+        emqx_utils_json:decode(Payload1)
     ),
     ok.
 
@@ -1943,7 +1943,7 @@ t_dryrun_transformation(_Config) ->
                     <<"flags">> := #{<<"dup">> := false, <<"retain">> := true},
                     <<"user">> := Username
                 },
-                emqx_utils_json:decode(EncPayloadRes1, [return_maps])
+                emqx_utils_json:decode(EncPayloadRes1)
             ),
 
             %% Bad input: fails to decode

--- a/apps/emqx_modules/test/emqx_delayed_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_api_SUITE.erl
@@ -273,7 +273,7 @@ t_large_payload(_) ->
 %%--------------------------------------------------------------------
 
 decode_json(Data) ->
-    BinJson = emqx_utils_json:decode(Data, [return_maps]),
+    BinJson = emqx_utils_json:decode(Data),
     emqx_utils_maps:unsafe_atom_key_map(BinJson).
 
 clear_all_record() ->

--- a/apps/emqx_modules/test/emqx_rewrite_api_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_rewrite_api_SUITE.erl
@@ -77,7 +77,7 @@ t_mqtt_topic_rewrite(_) ->
 
     ?assertEqual(
         Rules,
-        emqx_utils_json:decode(Result, [return_maps])
+        emqx_utils_json:decode(Result)
     ).
 
 t_mqtt_topic_rewrite_limit(_) ->

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -135,7 +135,7 @@ request(Method, Url, Params) ->
             {ok, {Status, RspBody}};
         {error, {Status, _Headers, Body0}} ->
             RspBody =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};
@@ -150,7 +150,7 @@ request(Method, Url, Params) ->
     end.
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.

--- a/apps/emqx_node_rebalance/test/emqx_node_rebalance_api_SUITE.erl
+++ b/apps/emqx_node_rebalance/test/emqx_node_rebalance_api_SUITE.erl
@@ -517,7 +517,7 @@ api_post(Path, Data) ->
     case request(post, uri(Path), Data) of
         {ok, Code, ResponseBody} ->
             Res =
-                case emqx_utils_json:safe_decode(ResponseBody, [return_maps]) of
+                case emqx_utils_json:safe_decode(ResponseBody) of
                     {ok, Decoded} -> Decoded;
                     {error, _} -> ResponseBody
                 end,

--- a/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_api_SUITE.erl
@@ -91,7 +91,7 @@ t_legacy_prometheus_api(_) ->
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, Path, "", Auth),
 
     OldConf = emqx:get_raw_config([prometheus]),
-    Conf = emqx_utils_json:decode(Response, [return_maps]),
+    Conf = emqx_utils_json:decode(Response),
     %% Always return new config.
     ?assertMatch(
         #{
@@ -129,7 +129,7 @@ t_legacy_prometheus_api(_) ->
     },
     {ok, Response2} = emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, NewConf),
 
-    Conf2 = emqx_utils_json:decode(Response2, [return_maps]),
+    Conf2 = emqx_utils_json:decode(Response2),
     ?assertEqual(NewConf, Conf2),
 
     EnvCollectors = env_collectors(),
@@ -186,7 +186,7 @@ t_prometheus_api(_) ->
     Auth = emqx_mgmt_api_test_util:auth_header_(),
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, Path, "", Auth),
 
-    Conf = emqx_utils_json:decode(Response, [return_maps]),
+    Conf = emqx_utils_json:decode(Response),
     ?assertMatch(
         #{
             <<"push_gateway">> := #{},
@@ -222,7 +222,7 @@ t_prometheus_api(_) ->
     },
     {ok, Response2} = emqx_mgmt_api_test_util:request_api(put, Path, "", Auth, NewConf),
 
-    Conf2 = emqx_utils_json:decode(Response2, [return_maps]),
+    Conf2 = emqx_utils_json:decode(Response2),
     ?assertMatch(NewConf, Conf2),
 
     EnvCollectors = env_collectors(),
@@ -473,7 +473,7 @@ accept_json_header() ->
 request_stats(Headers, Auth) ->
     Path = emqx_mgmt_api_test_util:api_path(["prometheus", "stats"]),
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, Path, "", Headers),
-    Data = emqx_utils_json:decode(Response, [return_maps]),
+    Data = emqx_utils_json:decode(Response),
     ?assertMatch(#{<<"client">> := _, <<"delivery">> := _}, Data),
     {ok, _} = emqx_mgmt_api_test_util:request_api(get, Path, "", Auth),
     ok = meck:expect(mria_rlog, backend, fun() -> rlog end),
@@ -507,7 +507,7 @@ get_stats(Format, Mode) ->
     {ok, Response} = emqx_mgmt_api_test_util:request_api(get, Path, QueryString, Headers),
     case Format of
         json ->
-            emqx_utils_json:decode(Response, [return_maps]);
+            emqx_utils_json:decode(Response);
         prometheus ->
             Response
     end.

--- a/apps/emqx_resource/mix.exs
+++ b/apps/emqx_resource/mix.exs
@@ -28,7 +28,6 @@ defmodule EMQXResource.MixProject do
       {:emqx, in_umbrella: true},
       UMP.common_dep(:ecpool),
       UMP.common_dep(:gproc),
-      UMP.common_dep(:jsx),
       UMP.common_dep(:telemetry),
     ]
   end

--- a/apps/emqx_resource/rebar.config
+++ b/apps/emqx_resource/rebar.config
@@ -11,7 +11,6 @@
 {extra_src_dirs, ["examples"]}.
 
 {deps, [
-    {jsx, {git, "https://github.com/talentdeficit/jsx", {tag, "v3.1.0"}}},
     {emqx, {path, "../emqx"}}
 ]}.
 

--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -8,7 +8,6 @@
         kernel,
         stdlib,
         gproc,
-        jsx,
         ecpool,
         replayq,
         emqx,

--- a/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_api_SUITE.erl
@@ -85,7 +85,7 @@ t_config(_Config) ->
     ),
 
     UpdateConf = fun(Enable) ->
-        RawConf = emqx_utils_json:decode(ConfJson, [return_maps]),
+        RawConf = emqx_utils_json:decode(ConfJson),
         UpdateJson = RawConf#{<<"enable">> := Enable},
         {ok, UpdateResJson} = request_api(
             put,
@@ -94,7 +94,7 @@ t_config(_Config) ->
             auth_header_(),
             UpdateJson
         ),
-        UpdateRawConf = emqx_utils_json:decode(UpdateResJson, [return_maps]),
+        UpdateRawConf = emqx_utils_json:decode(UpdateResJson),
         ?assertEqual(Enable, maps:get(<<"enable">>, UpdateRawConf))
     end,
 
@@ -314,7 +314,7 @@ t_lookup_and_delete(Config) ->
 t_change_storage_type(_Config) ->
     Path = api_path(["mqtt", "retainer"]),
     {ok, ConfJson} = request_api(get, Path),
-    RawConf = emqx_utils_json:decode(ConfJson, [return_maps]),
+    RawConf = emqx_utils_json:decode(ConfJson),
     %% pre-conditions
     ?assertMatch(
         #{
@@ -361,7 +361,7 @@ t_change_storage_type(_Config) ->
         auth_header_(),
         ChangedConf
     ),
-    UpdatedRawConf = emqx_utils_json:decode(UpdateResJson, [return_maps]),
+    UpdatedRawConf = emqx_utils_json:decode(UpdateResJson),
     ?assertMatch(
         #{
             <<"backend">> := #{
@@ -446,7 +446,7 @@ t_retained_sys_messages(_Config) ->
 %%--------------------------------------------------------------------
 
 decode_json(Data) ->
-    BinJson = emqx_utils_json:decode(Data, [return_maps]),
+    BinJson = emqx_utils_json:decode(Data),
     emqx_utils_maps:unsafe_atom_key_map(BinJson).
 
 raw_systopic_conf() ->

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -553,7 +553,7 @@ err_msg(Msg) ->
 encode_nested_error(RuleError, Reason) when is_tuple(Reason) ->
     encode_nested_error(RuleError, element(1, Reason));
 encode_nested_error(RuleError, Reason) ->
-    case emqx_utils_json:safe_encode([{RuleError, Reason}]) of
+    case emqx_utils_json:safe_encode(#{RuleError => Reason}) of
         {ok, Json} ->
             Json;
         _ ->

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -731,7 +731,7 @@ cache_payload(DecodedP) ->
 
 safe_decode_and_cache(MaybeJson) ->
     try
-        cache_payload(emqx_utils_json:decode(MaybeJson, [return_maps]))
+        cache_payload(emqx_utils_json:decode(MaybeJson))
     catch
         _:_ -> error({decode_json_failed, MaybeJson})
     end.

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -928,7 +928,7 @@ t_event_client_disconnected_normal(_Config) ->
         {publish, #{topic := T, payload := Payload}} ->
             ?assertEqual(RepubT, T),
             ?assertMatch(
-                #{<<"reason">> := <<"normal">>}, emqx_utils_json:decode(Payload, [return_maps])
+                #{<<"reason">> := <<"normal">>}, emqx_utils_json:decode(Payload)
             )
     after 1000 ->
         ct:fail(wait_for_repub_disconnected_normal)
@@ -967,7 +967,7 @@ t_event_client_disconnected_kicked(_Config) ->
         {publish, #{topic := T, payload := Payload}} ->
             ?assertEqual(RepubT, T),
             ?assertMatch(
-                #{<<"reason">> := <<"kicked">>}, emqx_utils_json:decode(Payload, [return_maps])
+                #{<<"reason">> := <<"kicked">>}, emqx_utils_json:decode(Payload)
             )
     after 1000 ->
         ct:fail(wait_for_repub_disconnected_kicked)
@@ -1009,7 +1009,7 @@ t_event_client_disconnected_discarded(_Config) ->
         {publish, #{topic := T, payload := Payload}} ->
             ?assertEqual(RepubT, T),
             ?assertMatch(
-                #{<<"reason">> := <<"discarded">>}, emqx_utils_json:decode(Payload, [return_maps])
+                #{<<"reason">> := <<"discarded">>}, emqx_utils_json:decode(Payload)
             )
     after 1000 ->
         ct:fail(wait_for_repub_disconnected_discarded)
@@ -1054,7 +1054,7 @@ t_event_client_disconnected_takenover(_Config) ->
         {publish, #{topic := T, payload := Payload}} ->
             ?assertEqual(RepubT, T),
             ?assertMatch(
-                #{<<"reason">> := <<"takenover">>}, emqx_utils_json:decode(Payload, [return_maps])
+                #{<<"reason">> := <<"takenover">>}, emqx_utils_json:decode(Payload)
             )
     after 1000 ->
         ct:fail(wait_for_repub_disconnected_discarded)
@@ -1097,7 +1097,7 @@ t_event_client_disconnected_takenover_2(_Config) ->
         {publish, #{topic := T, payload := Payload}} ->
             ?assertEqual(RepubT, T),
             ?assertMatch(
-                #{<<"reason">> := <<"normal">>}, emqx_utils_json:decode(Payload, [return_maps])
+                #{<<"reason">> := <<"normal">>}, emqx_utils_json:decode(Payload)
             )
     after 1000 ->
         ct:fail(wait_for_repub_disconnected_discarded)
@@ -1113,7 +1113,7 @@ t_event_client_disconnected_takenover_2(_Config) ->
         {publish, #{topic := T1, payload := Payload1}} ->
             ?assertEqual(RepubT, T1),
             ?assertMatch(
-                #{<<"reason">> := <<"takenover">>}, emqx_utils_json:decode(Payload1, [return_maps])
+                #{<<"reason">> := <<"takenover">>}, emqx_utils_json:decode(Payload1)
             ),
             ct:fail(wait_for_repub_disconnected_discarded)
     after 1000 ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -62,7 +62,7 @@ end_per_testcase(_TestCase, _Config) ->
 %%------------------------------------------------------------------------------
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.
@@ -83,7 +83,7 @@ request(Method, Path, Params, QueryParams0, Opts) when is_list(QueryParams0) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_SUITE.erl
@@ -169,7 +169,7 @@ t_crud_rule_api(_Config) ->
         ),
     ?assertMatch(
         #{<<"select_and_transform_error">> := <<"decode_json_failed">>},
-        emqx_utils_json:decode(SelectAndTransformJsonError, [return_maps])
+        emqx_utils_json:decode(SelectAndTransformJsonError)
     ),
     {400, #{
         code := 'BAD_REQUEST',
@@ -183,7 +183,7 @@ t_crud_rule_api(_Config) ->
         ),
     ?assertMatch(
         #{<<"select_and_transform_error">> := <<"badarg">>},
-        emqx_utils_json:decode(SelectAndTransformBadArgError, [return_maps])
+        emqx_utils_json:decode(SelectAndTransformBadArgError)
     ),
     {400, #{
         code := 'BAD_REQUEST',

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -231,7 +231,7 @@ basic_apply_rule_test_helper(Action, TraceType, StopAfterRender, PayloadEncode) 
     Log1 = binary:split(Log0, <<"\n">>, [global, trim]),
     Log2 = lists:join(<<",\n">>, Log1),
     Log3 = iolist_to_binary(["[", Log2, "]"]),
-    {ok, LogEntries} = emqx_utils_json:safe_decode(Log3, [return_maps]),
+    LogEntries = emqx_utils_json:decode(Log3),
     [#{<<"meta">> := #{<<"rule_trigger_ts">> := [RuleTriggerTime]}} | _] = LogEntries,
     [
         ?assert(lists:member(RuleTriggerTime, maps:get(<<"rule_trigger_ts">>, Meta, [])))
@@ -243,7 +243,7 @@ do_final_log_check(Action, Bin0) when is_binary(Action) ->
     %% The last line in the Bin should be the action_success entry
     Bin1 = string:trim(Bin0),
     LastEntry = unicode:characters_to_binary(lists:last(string:split(Bin1, <<"\n">>, all))),
-    LastEntryJSON = emqx_utils_json:decode(LastEntry, [return_maps]),
+    LastEntryJSON = emqx_utils_json:decode(LastEntry),
     %% Check that lazy formatting of the action result works correctly
     ?assertMatch(
         #{
@@ -418,7 +418,7 @@ t_apply_rule_test_format_action_failed(_Config) ->
             ?assertNotEqual(nomatch, binary:match(Bin0, [<<"action_failed">>])),
             Bin1 = string:trim(Bin0),
             LastEntry = unicode:characters_to_binary(lists:last(string:split(Bin1, <<"\n">>, all))),
-            LastEntryJSON = emqx_utils_json:decode(LastEntry, [return_maps]),
+            LastEntryJSON = emqx_utils_json:decode(LastEntry),
             ?assertMatch(
                 #{
                     <<"level">> := <<"debug">>,
@@ -487,7 +487,7 @@ out_of_service_check_fun(SendErrorMsg, Reason) ->
         io:format("LOG:\n~s", [Bin0]),
         Bin1 = string:trim(Bin0),
         LastEntry = unicode:characters_to_binary(lists:last(string:split(Bin1, <<"\n">>, all))),
-        LastEntryJSON = emqx_utils_json:decode(LastEntry, [return_maps]),
+        LastEntryJSON = emqx_utils_json:decode(LastEntry),
         ?assertMatch(
             #{
                 <<"level">> := <<"debug">>,
@@ -511,7 +511,7 @@ out_of_service_check_fun(SendErrorMsg, Reason) ->
         ),
         %% We should have at least one entry containing Reason
         [ReasonLine | _] = find_lines_with(Bin1, Reason),
-        ReasonEntryJSON = emqx_utils_json:decode(ReasonLine, [return_maps]),
+        ReasonEntryJSON = emqx_utils_json:decode(ReasonLine),
         ?assertMatch(
             #{
                 <<"level">> := <<"debug">>,
@@ -661,7 +661,7 @@ create_rule_with_action(ActionType, ActionName, SQL) ->
     ct:pal("rule action params: ~p", [Params]),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
         {ok, Res0} ->
-            #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0, [return_maps]),
+            #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0),
             emqx_common_test_helpers:on_exit(fun() ->
                 emqx_rule_engine:delete_rule(RuleId)
             end),
@@ -687,7 +687,7 @@ request(Method, Path, Params) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};
@@ -702,7 +702,7 @@ request(Method, Path, Params) ->
     end.
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_SUITE.erl
@@ -141,7 +141,7 @@ create_rule_http(RuleParams, Overrides) ->
     AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
     case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
         {ok, Res0} ->
-            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0, [return_maps]),
+            Res = #{<<"id">> := RuleId} = emqx_utils_json:decode(Res0),
             on_exit(fun() -> ok = emqx_rule_engine:delete_rule(RuleId) end),
             {ok, Res};
         Error ->
@@ -376,7 +376,7 @@ receive_published(Line) ->
             maps:update_with(
                 payload,
                 fun(Raw) ->
-                    case emqx_utils_json:safe_decode(Raw, [return_maps]) of
+                    case emqx_utils_json:safe_decode(Raw) of
                         {ok, Decoded} -> Decoded;
                         {error, _} -> Raw
                     end

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -166,7 +166,7 @@ do_request(Method, Path, Body) ->
         {ok, Code, <<>>} ->
             {ok, Code, <<>>};
         {ok, Code, Res1} ->
-            Res2 = emqx_utils_json:decode(Res1, [return_maps]),
+            Res2 = emqx_utils_json:decode(Res1),
             Res3 = try_decode_error_message(Res2),
             {ok, Code, Res3};
         Error ->
@@ -174,7 +174,7 @@ do_request(Method, Path, Body) ->
     end.
 
 try_decode_error_message(#{<<"message">> := Msg0} = Res0) ->
-    case emqx_utils_json:safe_decode(Msg0, [return_maps]) of
+    case emqx_utils_json:safe_decode(Msg0) of
         {ok, Msg} ->
             Res0#{<<"message">> := Msg};
         {error, _} ->

--- a/apps/emqx_schema_validation/test/emqx_schema_validation_http_api_SUITE.erl
+++ b/apps/emqx_schema_validation/test/emqx_schema_validation_http_api_SUITE.erl
@@ -80,7 +80,7 @@ reset_all_global_metrics() ->
     ).
 
 maybe_json_decode(X) ->
-    case emqx_utils_json:safe_decode(X, [return_maps]) of
+    case emqx_utils_json:safe_decode(X) of
         {ok, Decoded} -> Decoded;
         {error, _} -> X
     end.
@@ -94,7 +94,7 @@ request(Method, Path, Params) ->
             {ok, {Status, Headers, Body}};
         {error, {Status, Headers, Body0}} ->
             Body =
-                case emqx_utils_json:safe_decode(Body0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Body0) of
                     {ok, Decoded0 = #{<<"message">> := Msg0}} ->
                         Msg = maybe_json_decode(Msg0),
                         Decoded0#{<<"message">> := Msg};

--- a/apps/emqx_slow_subs/test/emqx_slow_subs_api_SUITE.erl
+++ b/apps/emqx_slow_subs/test/emqx_slow_subs_api_SUITE.erl
@@ -86,7 +86,7 @@ t_get_history(_) ->
         "page=1&limit=10",
         auth_header_()
     ),
-    #{<<"data">> := [First | _]} = emqx_utils_json:decode(Data, [return_maps]),
+    #{<<"data">> := [First | _]} = emqx_utils_json:decode(Data),
 
     ?assertMatch(
         #{
@@ -141,7 +141,7 @@ t_settting(_) ->
     ?assertEqual(Expect, GetReturn).
 
 decode_json(Data) ->
-    emqx_utils_json:decode(Data, [return_maps]).
+    emqx_utils_json:decode(Data).
 
 request_api(Method, Url, Auth) ->
     request_api(Method, Url, [], Auth, []).

--- a/apps/emqx_telemetry/src/emqx_telemetry.app.src
+++ b/apps/emqx_telemetry/src/emqx_telemetry.app.src
@@ -1,6 +1,6 @@
 {application, emqx_telemetry, [
     {description, "Report telemetry data for EMQX Opensource edition"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, [emqx_telemetry_sup, emqx_telemetry]},
     {mod, {emqx_telemetry_app, []}},
     {applications, [

--- a/apps/emqx_telemetry/src/emqx_telemetry.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry.erl
@@ -367,11 +367,12 @@ get_telemetry(State0 = #state{node_uuid = NodeUUID, cluster_uuid = ClusterUUID})
 
 report_telemetry(State0 = #state{url = URL}) ->
     {State, Data} = get_telemetry(State0),
-    case emqx_utils_json:safe_encode(Data) of
-        {ok, Bin} ->
+    try emqx_utils_json:encode_proplist(Data) of
+        Bin ->
             ok = httpc_request(post, URL, [], Bin),
-            ?tp(debug, telemetry_data_reported, #{});
-        {error, Reason} ->
+            ?tp(debug, telemetry_data_reported, #{})
+    catch
+        error:Reason ->
             %% debug? why?
             ?tp(debug, telemetry_data_encode_error, #{data => Data, reason => Reason})
     end,

--- a/apps/emqx_telemetry/src/emqx_telemetry_api.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry_api.erl
@@ -246,7 +246,7 @@ status(put, #{body := Body}) ->
 data(get, _Request) ->
     case is_enabled() of
         true ->
-            {200, emqx_utils_json:encode(get_telemetry_data())};
+            {200, emqx_utils_json:encode_proplist(get_telemetry_data())};
         false ->
             {404, #{
                 code => ?NOT_FOUND,

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -465,7 +465,6 @@ t_send_after_enable(_) ->
         ),
         receive
             {request, post, _URL, _Headers, Body} ->
-                {ok, Decoded} = emqx_utils_json:safe_decode(Body, [return_maps]),
                 ?assertMatch(
                     #{
                         <<"uuid">> := _,
@@ -491,7 +490,7 @@ t_send_after_enable(_) ->
                                 <<"delayed">> := _
                             }
                     },
-                    Decoded
+                    emqx_utils_json:decode(Body)
                 )
         after 2100 ->
             exit(telemetry_not_reported)

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -455,14 +455,12 @@ t_send_after_enable(_) ->
     ok = emqx_telemetry:stop_reporting(),
     ok = snabbkaffe:start_trace(),
     try
-        ok = emqx_telemetry:start_reporting(),
-        Timeout = 12_000,
         ?assertMatch(
             {ok, _},
             ?wait_async_action(
                 ok = emqx_telemetry:start_reporting(),
                 #{?snk_kind := telemetry_data_reported},
-                Timeout
+                _Timeout = 12_000
             )
         ),
         receive

--- a/apps/emqx_utils/rebar.config
+++ b/apps/emqx_utils/rebar.config
@@ -5,7 +5,7 @@
 ]}.
 
 {deps, [
-    {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}},
+    {jiffy, "1.1.2"},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {erlang_qq, {git, "https://github.com/k32/erlang_qq.git", {tag, "1.0.0"}}}
 ]}.

--- a/apps/emqx_utils/src/emqx_placeholder.erl
+++ b/apps/emqx_utils/src/emqx_placeholder.erl
@@ -303,7 +303,7 @@ lookup_var([Prop | Rest], Data0) ->
             true ->
                 Data0;
             false ->
-                case emqx_utils_json:safe_decode(Data0, [return_maps]) of
+                case emqx_utils_json:safe_decode(Data0) of
                     {ok, Data1} ->
                         Data1;
                     {error, _} ->

--- a/apps/emqx_utils/src/emqx_utils_json.erl
+++ b/apps/emqx_utils/src/emqx_utils_json.erl
@@ -53,8 +53,13 @@
 
 -compile({inline, [is_json/1]}).
 
--type encode_options() :: jiffy:encode_options().
--type decode_options() :: jiffy:decode_options().
+%% See `jiffy:encode_options()`.
+-type encode_options() :: [encode_option()].
+-type encode_option() :: uescape | pretty | force_utf8.
+
+%% See `jiffy:decode_options()`.
+-type decode_options() :: [decode_option()].
+-type decode_option() :: return_maps | return_trailer | dedupe_keys | copy_strings.
 
 -type json_text() :: iolist() | binary().
 -type json_term() :: jiffy:json_value().

--- a/apps/emqx_utils/src/emqx_utils_json.erl
+++ b/apps/emqx_utils/src/emqx_utils_json.erl
@@ -21,6 +21,8 @@
 -export([
     encode/1,
     encode/2,
+    encode_proplist/1,
+    encode_proplist/2,
     safe_encode/1,
     safe_encode/2
 ]).
@@ -35,6 +37,7 @@
 -export([
     decode/1,
     decode/2,
+    decode_proplist/1,
     safe_decode/1,
     safe_decode/2
 ]).
@@ -54,7 +57,8 @@
 -type decode_options() :: jiffy:decode_options().
 
 -type json_text() :: iolist() | binary().
--type json_term() :: jiffy:jiffy_decode_result().
+-type json_term() :: jiffy:json_value().
+-type json_term_proplist() :: jiffy:json_value() | [{atom() | binary(), json_term_proplist()}].
 
 -export_type([json_text/0, json_term/0]).
 -export_type([decode_options/0, encode_options/0]).
@@ -65,6 +69,14 @@ encode(Term) ->
 
 -spec encode(json_term(), encode_options()) -> json_text().
 encode(Term, Opts) ->
+    to_binary(jiffy:encode(Term, Opts)).
+
+-spec encode_proplist(json_term_proplist()) -> json_text().
+encode_proplist(Term) ->
+    encode_proplist(Term, [force_utf8]).
+
+-spec encode_proplist(json_term_proplist(), encode_options()) -> json_text().
+encode_proplist(Term, Opts) ->
     to_binary(jiffy:encode(to_ejson(Term), Opts)).
 
 -spec safe_encode(json_term()) ->
@@ -83,16 +95,21 @@ safe_encode(Term, Opts) ->
     end.
 
 -spec decode(json_text()) -> json_term().
-decode(Json) -> decode(Json, [return_maps]).
+decode(Json) ->
+    decode(Json, [return_maps]).
 
 -spec decode(json_text(), decode_options()) -> json_term().
 decode(Json, Opts) ->
-    from_ejson(jiffy:decode(Json, Opts)).
+    jiffy:decode(Json, Opts).
+
+-spec decode_proplist(json_text()) -> json_term_proplist().
+decode_proplist(Json) ->
+    from_ejson(jiffy:decode(Json, [])).
 
 -spec safe_decode(json_text()) ->
     {ok, json_term()} | {error, Reason :: term()}.
 safe_decode(Json) ->
-    safe_decode(Json, []).
+    safe_decode(Json, [return_maps]).
 
 -spec safe_decode(json_text(), decode_options()) ->
     {ok, json_term()} | {error, Reason :: term()}.
@@ -119,8 +136,6 @@ is_json(Json) ->
     ]}
 ).
 
-to_ejson([{}]) ->
-    {[]};
 to_ejson([{_, _} | _] = L) ->
     {[{K, to_ejson(V)} || {K, V} <- L]};
 to_ejson(L) when is_list(L) ->
@@ -133,7 +148,7 @@ to_ejson(T) ->
 from_ejson(L) when is_list(L) ->
     [from_ejson(E) || E <- L];
 from_ejson({[]}) ->
-    [{}];
+    [];
 from_ejson({L}) ->
     [{Name, from_ejson(Value)} || {Name, Value} <- L];
 from_ejson(T) ->

--- a/apps/emqx_utils/test/emqx_utils_json_SUITE.erl
+++ b/apps/emqx_utils/test/emqx_utils_json_SUITE.erl
@@ -26,7 +26,10 @@
     [
         encode/1,
         decode/1,
-        decode/2
+        decode/2,
+        decode/2,
+        encode_proplist/1,
+        decode_proplist/1
     ]
 ).
 
@@ -63,22 +66,10 @@ t_decode_encode(_) ->
     1.25 = decode(encode(1.25)),
     [] = decode(encode([])),
     [true, 1] = decode(encode([true, 1])),
-    {[]} = decode(encode({[]}), []),
     #{} = decode(encode({[]})),
     {[{<<"foo">>, <<"bar">>}]} = decode(encode({[{foo, bar}]}), []),
     {[{<<"foo">>, <<"bar">>}]} = decode(encode({[{<<"foo">>, <<"bar">>}]}), []),
-    [{[{<<"foo">>, <<"bar">>}]}] = decode(encode([{[{<<"foo">>, <<"bar">>}]}]), []),
     #{<<"foo">> := <<"bar">>} = decode(encode({[{<<"foo">>, <<"bar">>}]})),
-    [
-        {[{<<"a">>, <<"b">>}]},
-        {[{<<"x">>, <<"y">>}]}
-    ] = decode(
-        encode([
-            {[{<<"a">>, <<"b">>}]},
-            {[{<<"x">>, <<"y">>}]}
-        ]),
-        []
-    ),
     #{<<"foo">> := <<"bar">>} = decode(encode(#{<<"foo">> => <<"bar">>})),
     JsonText = <<"{\"bool\":true,\"int\":10,\"foo\":\"bar\"}">>,
     JsonMaps = #{
@@ -94,6 +85,25 @@ t_decode_encode(_) ->
         decode(encode(#{<<"foo">> => {[{<<"bar">>, <<"baz">>}]}}))
     ).
 
+t_decode_encode_proplist(_) ->
+    [] = decode_proplist(encode_proplist([])),
+    [] = decode_proplist(encode_proplist(#{})),
+    [{<<"a">>, <<"foo">>}, {<<"b">>, <<"bar">>}] =
+        decode_proplist(encode_proplist([{a, <<"foo">>}, {b, <<"bar">>}])),
+    [[{<<"foo">>, <<"bar">>}]] =
+        decode_proplist(encode_proplist([[{<<"foo">>, <<"bar">>}]])),
+    [
+        <<"string">>,
+        [{<<"a">>, <<"b">>}],
+        [{<<"x">>, <<"y">>}]
+    ] = decode_proplist(
+        encode_proplist([
+            string,
+            [{<<"a">>, <<"b">>}],
+            [{<<"x">>, <<"y">>}]
+        ])
+    ).
+
 t_safe_decode_encode(_) ->
     safe_encode_decode(null),
     safe_encode_decode(true),
@@ -107,8 +117,6 @@ t_safe_decode_encode(_) ->
     {[]} = safe_encode_decode({[]}, []),
     #{} = safe_encode_decode({[]}),
     {[{<<"foo">>, <<"bar">>}]} = safe_encode_decode({[{foo, bar}]}, []),
-    {[{<<"foo">>, <<"bar">>}]} = safe_encode_decode({[{<<"foo">>, <<"bar">>}]}, []),
-    [{[{<<"foo">>, <<"bar">>}]}] = safe_encode_decode([{[{<<"foo">>, <<"bar">>}]}], []),
     #{<<"foo">> := <<"bar">>} = safe_encode_decode({[{<<"foo">>, <<"bar">>}]}),
     {ok, Json} = emqx_utils_json:safe_encode(#{<<"foo">> => <<"bar">>}),
     {ok, #{<<"foo">> := <<"bar">>}} = emqx_utils_json:safe_decode(Json),

--- a/changes/ce/perf-14582.en.md
+++ b/changes/ce/perf-14582.en.md
@@ -1,0 +1,1 @@
+Avoid pre- and post-processing of internal JSON representation before serialization and after deserialization respectively, in cases where it is completely unnecessary.

--- a/mix.exs
+++ b/mix.exs
@@ -198,7 +198,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ehttpc),
     do: {:ehttpc, github: "emqx/ehttpc", tag: "0.7.0", override: true}
 
-  def common_dep(:jiffy), do: {:jiffy, github: "emqx/jiffy", tag: "1.0.6", override: true}
+  def common_dep(:jiffy), do: {:jiffy, "1.1.2", override: true}
 
   def common_dep(:grpc),
     do:

--- a/rebar.config
+++ b/rebar.config
@@ -79,7 +79,7 @@
     {gun, "2.1.0"},
     {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.7.0"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
-    {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}},
+    {jiffy, "1.1.2"},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-6"}}},

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -191,7 +191,7 @@ plugins() ->
         {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.2.2"}}},
         %% emqx main project does not require port-compiler
         %% pin at root level for deterministic
-        {pc, "v1.14.0"}
+        {pc, "1.15.0"}
     ] ++
         %% test plugins are concatenated to default profile plugins
         %% otherwise rebar3 test profile runs are super slow


### PR DESCRIPTION
Fixes [EMQX-13447](https://emqx.atlassian.net/browse/EMQX-13447).

## Summary

This PR is an attempt to switch to the upstream `jiffy` 1.1.2 with Erlang/OTP-27-ready dependencies.

It also includes a refactoring that attempts to eliminate wasteful (pre/post)processing in `emqx_utils_json`. Motivation: in the overwhelming majority of cases maps are used to represent JSON objects throughout the codebase nowadays. This means that special preprocessing that turns deeply-nested-proplists into `jiffy`-friendly representation is wasteful. This PR thus drops the preprocessing, and instead changes a very few callsites that (often implicitly) rely on `emqx_utils_json` being proplists-friendly.

Note that potential side-effects of this change is loss of explicit JSON field order.

See individual commits for details.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-13447]: https://emqx.atlassian.net/browse/EMQX-13447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ