### PR TITLE
feat(quic): bump quicer-0.1.11 and support SSLKEYLOGFILE

### DIFF
--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,7 +19,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.0"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.10"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.11"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -858,6 +858,14 @@ fields("mqtt_quic_listener") ->
                 ?MAX_UINT(16),
                 ?DESC(fields_mqtt_quic_listener_stateless_operation_expiration_ms)
             )},
+        {"sslkeylogfile",
+            sc(
+                string(),
+                #{
+                    desc => ?DESC(fields_mqtt_quic_listener_sslkeylogfile),
+                    importance => ?IMPORTANCE_HIDDEN
+                }
+            )},
         {"ssl_options",
             sc(
                 ref("listener_quic_ssl_opts"),

--- a/changes/ce/feat-14583.en.md
+++ b/changes/ce/feat-14583.en.md
@@ -1,0 +1,10 @@
+QUIC listener now supports dumping TLS secrets to SSLKEYLOGFILE for traffic decryption.
+
+The SSLKEYLOGFILE could be used by wireshark to decrypt live or captured QUIC traffic
+so that the MQTT packets could be decoded.
+
+example:
+
+`EMQX_LISTENERS__QUIC__DEFAULT__SSLKEYLOGFILE=/tmp/EMQX_SSLKEYLOGFILE`
+
+NOTE: This is hidden configuration for troubleshooting only. 

--- a/mix.exs
+++ b/mix.exs
@@ -1226,7 +1226,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.1.10", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.1.11", override: true}
       ],
       else: []
   end

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.10"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.11"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.12"}}}.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -802,6 +802,12 @@ fields_mqtt_quic_listener_stateless_operation_expiration_ms.desc:
 fields_mqtt_quic_listener_stateless_operation_expiration_ms.label:
 """Stateless operation expiration ms"""
 
+fields_mqtt_quic_listener_sslkeylogfile.desc:
+"""Specify the path to the file on the local filesystem where the listener writes TLS session secrets for each connection, enabling decryption of the traffic. This cannot be changed at runtime."""
+
+fields_mqtt_quic_listener_sslkeylogfile.label:
+"""SSLKEYLOGFILE"""
+
 server_ssl_opts_schema_dhfile.desc:
 """Path to a file containing PEM-encoded Diffie-Hellman parameters
 to be used by the server if a cipher suite using Diffie-Hellman


### PR DESCRIPTION
QUIC listener now supports SSLKEYLOGFILE for traffic decryption. 

Fixes [EMQX-13833](https://emqx.atlassian.net/browse/EMQX-13833)

Release version: v/e5.8.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13833]: https://emqx.atlassian.net/browse/EMQX-13833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ