### PR TITLE
chore(ci): remove version from docker compose files

### DIFF
--- a/.ci/docker-compose-file/docker-compose-azurite.yaml
+++ b/.ci/docker-compose-file/docker-compose-azurite.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   azurite:
     container_name: azurite

--- a/.ci/docker-compose-file/docker-compose-cassandra.yaml
+++ b/.ci/docker-compose-file/docker-compose-cassandra.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 x-cassandra: &cassandra
   restart: always
   image: public.ecr.aws/docker/library/cassandra:${CASSANDRA_TAG:-3.11}

--- a/.ci/docker-compose-file/docker-compose-clickhouse.yaml
+++ b/.ci/docker-compose-file/docker-compose-clickhouse.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   clickhouse:
     container_name: clickhouse

--- a/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
+++ b/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 ## depends on kafka; see `./docker-file-compose-kafka.yaml`.
 services:
   confluent_schema_registry: &cpsr

--- a/.ci/docker-compose-file/docker-compose-couchbase.yaml
+++ b/.ci/docker-compose-file/docker-compose-couchbase.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   couchbase:
     container_name: couchbase

--- a/.ci/docker-compose-file/docker-compose-datalayers-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-datalayers-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   datalayers_server_tcp:
     container_name: datalayers_tcp

--- a/.ci/docker-compose-file/docker-compose-datalayers-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-datalayers-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   datalayers_server_tls:
     container_name: datalayers_tls

--- a/.ci/docker-compose-file/docker-compose-datalayers.yaml
+++ b/.ci/docker-compose-file/docker-compose-datalayers.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   datalayers_server_tcp:
     container_name: datalayers_tcp

--- a/.ci/docker-compose-file/docker-compose-dynamo.yaml
+++ b/.ci/docker-compose-file/docker-compose-dynamo.yaml
@@ -1,14 +1,12 @@
-version: '3.9'
-
 services:
   dynamodb-local:
-    container_name: dynamo 
+    container_name: dynamo
     image: public.ecr.aws/aws-dynamodb-local/aws-dynamodb-local:${DYNAMO_TAG}
     restart: always
     ports:
       - "8000:8000"
     environment:
-      AWS_ACCESS_KEY_ID: root 
+      AWS_ACCESS_KEY_ID: root
       AWS_SECRET_ACCESS_KEY: public
       AWS_DEFAULT_REGION: us-west-2
     networks:

--- a/.ci/docker-compose-file/docker-compose-emqx-cluster.yaml
+++ b/.ci/docker-compose-file/docker-compose-emqx-cluster.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 x-default-emqx: &default-emqx
     image: ${_EMQX_DOCKER_IMAGE_TAG}
     env_file:

--- a/.ci/docker-compose-file/docker-compose-gcp-emulator.yaml
+++ b/.ci/docker-compose-file/docker-compose-gcp-emulator.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   gcp_emulator:
     container_name: gcp_emulator

--- a/.ci/docker-compose-file/docker-compose-greptimedb.yaml
+++ b/.ci/docker-compose-file/docker-compose-greptimedb.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   greptimedb:
     container_name: greptimedb

--- a/.ci/docker-compose-file/docker-compose-influxdb-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-influxdb-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   influxdb_server_tcp:
     container_name: influxdb_tcp

--- a/.ci/docker-compose-file/docker-compose-influxdb-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-influxdb-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   influxdb_server_tls:
     container_name: influxdb_tls

--- a/.ci/docker-compose-file/docker-compose-iotdb.yaml
+++ b/.ci/docker-compose-file/docker-compose-iotdb.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   iotdb_1_3_0:
     container_name: iotdb130

--- a/.ci/docker-compose-file/docker-compose-kafka.yaml
+++ b/.ci/docker-compose-file/docker-compose-kafka.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   zookeeper:
     image: public.ecr.aws/docker/library/zookeeper:3.6

--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   kdc:
     hostname: kdc.emqx.net

--- a/.ci/docker-compose-file/docker-compose-kinesis.yaml
+++ b/.ci/docker-compose-file/docker-compose-kinesis.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   kinesis:
     container_name: kinesis

--- a/.ci/docker-compose-file/docker-compose-ldap.yaml
+++ b/.ci/docker-compose-file/docker-compose-ldap.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   ldap_server:
     container_name: ldap

--- a/.ci/docker-compose-file/docker-compose-minio-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-minio-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   minio:
     hostname: minio
@@ -20,7 +18,7 @@ services:
       retries: 3
     networks:
       emqx_bridge:
-        aliases: 
+        aliases:
           - minio.net
           - test1.minio.net
           - test2.minio.net

--- a/.ci/docker-compose-file/docker-compose-minio-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-minio-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.7'
-
 services:
   minio_tls:
     hostname: minio-tls

--- a/.ci/docker-compose-file/docker-compose-mongo-single-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-single-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mongo_server:
     container_name: mongo

--- a/.ci/docker-compose-file/docker-compose-mongo-single-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-single-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mongo_server_tls:
     container_name: mongo-tls
@@ -27,4 +25,3 @@ services:
           --tlsCAFile /etc/certs/cacert.pem \
           --tlsDisabledProtocols TLS1_0,TLS1_1 \
           --setParameter opensslCipherConfig='HIGH:!EXPORT:!aNULL:!DHE:!kDHE@STRENGTH'
-

--- a/.ci/docker-compose-file/docker-compose-mysql-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mysql-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mysql_server:
     container_name: mysql

--- a/.ci/docker-compose-file/docker-compose-mysql-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-mysql-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mysql_server_tls:
     container_name: mysql-tls
@@ -34,4 +32,3 @@ services:
       - --require-secure-transport=ON
       - --tls-version=TLSv1.2,TLSv1.3
       - --ssl-cipher=ECDHE-RSA-AES256-GCM-SHA384
-

--- a/.ci/docker-compose-file/docker-compose-opents.yaml
+++ b/.ci/docker-compose-file/docker-compose-opents.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   opents_server:
     container_name: opents

--- a/.ci/docker-compose-file/docker-compose-oracle.yaml
+++ b/.ci/docker-compose-file/docker-compose-oracle.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   oracle_server:
     container_name: oracle

--- a/.ci/docker-compose-file/docker-compose-otel.yaml
+++ b/.ci/docker-compose-file/docker-compose-otel.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   jaeger-all-in-one:
     image: jaegertracing/all-in-one:1.51.0

--- a/.ci/docker-compose-file/docker-compose-pgsql-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-pgsql-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   pgsql_server:
     container_name: pgsql

--- a/.ci/docker-compose-file/docker-compose-pgsql-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-pgsql-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   pgsql_server_tls:
     container_name: pgsql-tls

--- a/.ci/docker-compose-file/docker-compose-pulsar.yaml
+++ b/.ci/docker-compose-file/docker-compose-pulsar.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   pulsar:
     container_name: pulsar

--- a/.ci/docker-compose-file/docker-compose-python.yaml
+++ b/.ci/docker-compose-file/docker-compose-python.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   python:
     container_name: python

--- a/.ci/docker-compose-file/docker-compose-rabbitmq.yaml
+++ b/.ci/docker-compose-file/docker-compose-rabbitmq.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   rabbitmq:
     container_name: rabbitmq

--- a/.ci/docker-compose-file/docker-compose-redis-cluster-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-cluster-tcp.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
 
   redis-cluster-1: &redis-node
@@ -54,4 +53,3 @@ services:
       - redis-cluster-4
       - redis-cluster-5
       - redis-cluster-6
-

--- a/.ci/docker-compose-file/docker-compose-redis-cluster-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-cluster-tls.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 services:
 
   redis-cluster-tls-1: &redis-node
@@ -56,4 +55,3 @@ services:
       - redis-cluster-tls-4
       - redis-cluster-tls-5
       - redis-cluster-tls-6
-

--- a/.ci/docker-compose-file/docker-compose-redis-single-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-single-tcp.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   redis_server:
     container_name: redis

--- a/.ci/docker-compose-file/docker-compose-redis-single-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-single-tls.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   redis_server_tls:
     container_name: redis-tls

--- a/.ci/docker-compose-file/docker-compose-rocketmq-ssl.yaml
+++ b/.ci/docker-compose-file/docker-compose-rocketmq-ssl.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mqnamesrvssl:
     image: apache/rocketmq:4.9.4

--- a/.ci/docker-compose-file/docker-compose-rocketmq.yaml
+++ b/.ci/docker-compose-file/docker-compose-rocketmq.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   mqnamesrv:
     image: apache/rocketmq:4.9.4
@@ -9,12 +7,12 @@ services:
     volumes:
       - ./rocketmq/logs:/opt/logs
       - ./rocketmq/store:/opt/store
-    command: ./mqnamesrv 
+    command: ./mqnamesrv
     networks:
       - emqx_bridge
 
   mqbroker:
-    image: apache/rocketmq:4.9.4 
+    image: apache/rocketmq:4.9.4
     container_name: rocketmq_broker
 #    ports:
 #      - 10909:10909

--- a/.ci/docker-compose-file/docker-compose-tdengine-restful.yaml
+++ b/.ci/docker-compose-file/docker-compose-tdengine-restful.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   tdengine_server:
     container_name: tdengine

--- a/scripts/test/influx/docker-compose.yaml
+++ b/scripts/test/influx/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 services:
   influxdb_server:
     container_name: influxdb_server


### PR DESCRIPTION
To get rid of
```
docker-compose.yml: `version` is obsolete
```

warnings