### PR TITLE
fix(emqx): ignore case in hexadecimal password hash comparisons

### DIFF
--- a/apps/emqx/src/emqx_passwd.erl
+++ b/apps/emqx/src/emqx_passwd.erl
@@ -66,7 +66,7 @@ check_pass(Algo, Hash, Password) ->
 
 do_check_pass({pbkdf2, MacFun, Salt, Iterations, DKLength}, PasswordHash, Password) ->
     HashPasswd = pbkdf2(MacFun, Password, Salt, Iterations, DKLength),
-    compare_secure(hex(HashPasswd), PasswordHash);
+    compare_secure_caseless(hex(HashPasswd), PasswordHash);
 do_check_pass({bcrypt, Salt}, PasswordHash, Password) ->
     case bcrypt:hashpw(Password, Salt) of
         {ok, HashPasswd} ->
@@ -76,7 +76,7 @@ do_check_pass({bcrypt, Salt}, PasswordHash, Password) ->
     end;
 do_check_pass({_SimpleHash, _Salt, _SaltPosition} = HashParams, PasswordHash, Password) ->
     Hash = hash(HashParams, Password),
-    compare_secure(Hash, PasswordHash).
+    compare_secure_caseless(Hash, PasswordHash).
 
 -spec hash(hash_params(), password()) -> password_hash().
 hash({pbkdf2, MacFun, Salt, Iterations, DKLength}, Password) when Iterations > 0 ->
@@ -115,6 +115,11 @@ hash_data(sha512, Data) when is_binary(Data) ->
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------
+
+compare_secure_caseless(X, Y) when is_binary(X), is_binary(Y) ->
+    compare_secure_caseless(binary_to_list(X), binary_to_list(Y));
+compare_secure_caseless(X, Y) ->
+    compare_secure(string:lowercase(X), string:lowercase(Y)).
 
 compare_secure(X, Y) when is_binary(X), is_binary(Y) ->
     compare_secure(binary_to_list(X), binary_to_list(Y));

--- a/apps/emqx/test/emqx_passwd_SUITE.erl
+++ b/apps/emqx/test/emqx_passwd_SUITE.erl
@@ -96,6 +96,8 @@ t_hash(_) ->
     ),
     Sha512 = emqx_passwd:hash({sha512, Salt, suffix}, Password),
     true = emqx_passwd:check_pass({sha512, Salt, suffix}, Sha512, Password),
+    %% Case is ignored for comparisons.
+    true = emqx_passwd:check_pass({sha512, Salt, suffix}, string:uppercase(Sha512), Password),
     false = emqx_passwd:check_pass({sha512, Salt, suffix}, Sha512, WrongPassword),
     ?assertEqual(
         emqx_passwd:hash_data(sha512, Password),
@@ -120,6 +122,10 @@ t_hash(_) ->
     >>,
     _Pbkdf2 = emqx_passwd:hash({pbkdf2, sha, Pbkdf2Salt, 2, 32}, Password),
     true = emqx_passwd:check_pass({pbkdf2, sha, Pbkdf2Salt, 2, 32}, Pbkdf2, Password),
+    %% Case is ignored for comparisons.
+    true = emqx_passwd:check_pass(
+        {pbkdf2, sha, Pbkdf2Salt, 2, 32}, string:uppercase(Pbkdf2), Password
+    ),
     false = emqx_passwd:check_pass({pbkdf2, sha, Pbkdf2Salt, 2, 32}, Pbkdf2, WrongPassword),
     ?assertException(
         error, _, emqx_passwd:check_pass({pbkdf2, sha, Pbkdf2Salt, 2, BadDKlen}, Pbkdf2, Password)

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
@@ -91,7 +91,7 @@ fields(pbkdf2) ->
                     desc =>
                         "PBKDF2 password hashing. "
                         "Hashes are computed according to the PKCS #5 standard, and represented as "
-                        "hexadecimal strings (with letter digits in lowercase)."
+                        "hexadecimal strings."
                 }
             )},
         {mac_fun,

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_password_hashing.erl
@@ -84,20 +84,30 @@ fields(bcrypt) ->
     [{name, sc(bcrypt, #{required => true, desc => "BCRYPT password hashing."})}];
 fields(pbkdf2) ->
     [
-        {name, sc(pbkdf2, #{required => true, desc => "PBKDF2 password hashing."})},
+        {name,
+            sc(
+                pbkdf2, #{
+                    required => true,
+                    desc =>
+                        "PBKDF2 password hashing. "
+                        "Hashes are computed according to the PKCS #5 standard, and represented as "
+                        "hexadecimal strings (with letter digits in lowercase)."
+                }
+            )},
         {mac_fun,
             sc(
                 hoconsc:enum([md4, md5, ripemd160, sha, sha224, sha256, sha384, sha512]),
                 #{
                     required => true,
                     desc =>
-                        "Specifies mac_fun for PBKDF2 hashing algorithm and md4, md5, ripemd160 are no longer supported since 5.8.3"
+                        "Specifies which HMAC function to use in PBKDF2 algorithm. "
+                        "Note that `md4`, `md5`, `ripemd160` are no longer supported since 5.8.3."
                 }
             )},
         {iterations,
             sc(
                 pos_integer(),
-                #{required => true, desc => "Iteration count for PBKDF2 hashing algorithm."}
+                #{required => true, desc => "Number of iterations of PBKDF2 algorithm."}
             )},
         {dk_length, fun dk_length/1}
     ];
@@ -150,7 +160,7 @@ dk_length(type) ->
 dk_length(required) ->
     false;
 dk_length(desc) ->
-    "Derived length for PBKDF2 hashing algorithm. If not specified, "
+    "Derived key length for PBKDF2 hashing algorithm, in bytes. If not specified, "
     "calculated automatically based on `mac_fun`.";
 dk_length(_) ->
     undefined.

--- a/changes/ce/fix-14585.en.md
+++ b/changes/ce/fix-14585.en.md
@@ -1,0 +1,1 @@
+Use case-insensitive comparisons when comparing password hashes with strings obtained from external sources.


### PR DESCRIPTION
Port of #14585.

Release version: v5.8.5.

## Summary

See individual commits.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible