### PR TITLE
docs: fix config doc for Kafka/Pulsar producer high mem threshold

### DIFF
--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -214,7 +214,7 @@ actions.desc:
 
 buffer_memory_overload_protection.desc:
 """Applicable when buffer mode is set to <code>memory</code>
-EMQX will drop old buffered messages under high memory pressure. The high memory threshold is defined in config <code>sysmon.os.sysmem_high_watermark</code>. NOTE: This config only works on Linux."""
+EMQX will drop old buffered messages under high memory pressure. NOTE: This config only works on Linux."""
 
 buffer_memory_overload_protection.label:
 """Memory Overload Protection"""

--- a/rel/i18n/emqx_bridge_confluent_producer.hocon
+++ b/rel/i18n/emqx_bridge_confluent_producer.hocon
@@ -214,7 +214,7 @@ actions.desc:
 
 buffer_memory_overload_protection.desc:
 """Applicable when buffer mode is set to <code>memory</code>
-EMQX will drop old buffered messages under high memory pressure. The high memory threshold is defined in config <code>sysmon.os.sysmem_high_watermark</code>. NOTE: This config only works on Linux."""
+EMQX will drop old buffered messages under high memory pressure. NOTE: This config only works on Linux."""
 
 buffer_memory_overload_protection.label:
 """Memory Overload Protection"""

--- a/rel/i18n/emqx_bridge_kafka.hocon
+++ b/rel/i18n/emqx_bridge_kafka.hocon
@@ -274,7 +274,7 @@ authentication.label:
 
 buffer_memory_overload_protection.desc:
 """Applicable when buffer mode is set to <code>memory</code>
-EMQX will drop old buffered messages under high memory pressure. The high memory threshold is defined in config <code>sysmon.os.sysmem_high_watermark</code>. NOTE: This config only works on Linux."""
+EMQX will drop old buffered messages under high memory pressure. NOTE: This config only works on Linux."""
 
 buffer_memory_overload_protection.label:
 """Memory Overload Protection"""

--- a/rel/i18n/emqx_bridge_pulsar.hocon
+++ b/rel/i18n/emqx_bridge_pulsar.hocon
@@ -43,7 +43,6 @@ authentication.label:
 buffer_memory_overload_protection.desc:
 """Applicable when buffer mode is set to <code>memory</code>
 EMQX will drop old buffered messages under high memory pressure.
-The high memory threshold is defined in config <code>sysmon.os.sysmem_high_watermark</code>.
  NOTE: This config only works on Linux."""
 buffer_memory_overload_protection.label:
 """Memory Overload Protection"""


### PR DESCRIPTION
The config `sysmon.os.sysmem_high_watermark` is only relevant for alarms but not to Kafka/Pulsar producers
