### PR TITLE
perf(quic): async abort read for takenover, discarded and kicked sess

### DIFF
--- a/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
+++ b/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 ## depends on kafka; see `./docker-file-compose-kafka.yaml`.
 services:
   confluent_schema_registry: &cpsr
-    image: public.ecr.aws/ews-network/confluentinc/cp-schema-registry:7.5.1
+    image: confluentinc/cp-schema-registry:7.5.1
     container_name: confluent_schema_registry
     restart: always
     depends_on:

--- a/apps/emqx/include/emqx_quic.hrl
+++ b/apps/emqx/include/emqx_quic.hrl
@@ -22,4 +22,8 @@
 -define(MQTT_QUIC_CONN_ERROR_CTRL_STREAM_DOWN, 1).
 -define(MQTT_QUIC_CONN_ERROR_OVERLOADED, 2).
 
+%% Prod SAFE timeout, better than `infinity` or
+%% 5000 (gen_server default timeout)
+%% Covering the unknown scenarios.
+-define(QUIC_SAFE_TIMEOUT, 3000).
 -endif.

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -1312,17 +1312,7 @@ wait_for_quic_stream_close(
         sockstate = read_aborted
     }
 ) ->
-    receive
-        %% We are expecting peer to close the stream
-        {quic, Evtname, Stream, _} when
-            Evtname =:= peer_send_shutdown orelse
-                Evtname =:= peer_send_aborted orelse
-                Evtname =:= stream_closed
-        ->
-            ok
-    after 3000 ->
-        ok
-    end,
+    ok = emqx_quic_stream:wait_for_close(Stream),
     State#state{sockstate = closed}.
 %%--------------------------------------------------------------------
 %% For CT tests

--- a/apps/emqx/src/emqx_quic_stream.erl
+++ b/apps/emqx/src/emqx_quic_stream.erl
@@ -174,7 +174,7 @@ abort_read({quic, _Conn, Stream, _Info}, Reason) ->
 reason_code(takenover) -> ?RC_SESSION_TAKEN_OVER;
 reason_code(discarded) -> ?RC_SESSION_TAKEN_OVER;
 reason_code(kicked) -> ?RC_ADMINISTRATIVE_ACTION;
-reason_code(_) -> 1.
+reason_code(_) -> ?RC_UNSPECIFIED_ERROR.
 
 -spec ensure_ok_or_exit(atom(), list(term())) -> term().
 ensure_ok_or_exit(Fun, Args = [Sock | _]) when is_atom(Fun), is_list(Args) ->

--- a/apps/emqx/src/emqx_types.erl
+++ b/apps/emqx/src/emqx_types.erl
@@ -153,7 +153,7 @@
 -type share() :: #share{}.
 
 -type socktype() :: tcp | udp | ssl | proxy | atom().
--type sockstate() :: idle | running | blocked | closed.
+-type sockstate() :: idle | running | blocked | closed | read_aborted.
 -type conninfo() :: #{
     socktype := socktype(),
     sockname := peername(),

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -218,7 +218,6 @@ t_connect_clean_start(Config) ->
 t_connect_clean_start_unresp_old_client(Config) ->
     ConnFun = ?config(conn_fun, Config),
     ClientID = atom_to_binary(?FUNCTION_NAME),
-    process_flag(trap_exit, true),
     %% GIVEN: a client with clean_start=true
     {ok, Client1} = emqtt:start_link([
         {clientid, ClientID},
@@ -241,8 +240,7 @@ t_connect_clean_start_unresp_old_client(Config) ->
     close_quic_conn_silently(ConnFun, Client1),
     %% THEN: the new client should connect successfully in time < connect_timeout
     {ok, _} = emqtt:ConnFun(Client2),
-    waiting_client_process_exit(Client1),
-    process_flag(trap_exit, false).
+    ok.
 
 close_quic_conn_silently(quic_connect, Client) ->
     %% simulate a unresponsive client that server doesn't know it is disconnected

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -24,6 +24,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("quicer/include/quicer.hrl").
 
 -import(lists, [nth/2]).
 
@@ -55,8 +56,8 @@ all() ->
 groups() ->
     TCs = emqx_common_test_helpers:all(?MODULE),
     [
-        {tcp, [], TCs},
-        {ws, [], TCs},
+        {tcp, [], TCs -- [t_connect_clean_start_unresp_old_client]},
+        {ws, [], TCs -- [t_connect_clean_start_unresp_old_client]},
         {quic, [], TCs}
     ].
 
@@ -207,6 +208,35 @@ t_connect_clean_start(Config) ->
     ok = emqtt:disconnect(Client3),
     waiting_client_process_exit(Client3),
 
+    process_flag(trap_exit, false).
+
+t_connect_clean_start_unresp_old_client(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    ClientID = atom_to_binary(?FUNCTION_NAME),
+    process_flag(trap_exit, true),
+    %% GIVEN: a client with clean_start=true
+    {ok, Client1} = emqtt:start_link([
+        {clientid, ClientID},
+        {proto_ver, v5},
+        {clean_start, true}
+        | Config
+    ]),
+    {ok, _} = emqtt:ConnFun(Client1),
+    %% [MQTT-3.1.2-4]
+    ?assertEqual(0, client_info(session_present, Client1)),
+    {ok, Client2} = emqtt:start_link([
+        {clientid, ClientID},
+        {proto_ver, v5},
+        {clean_start, false},
+        %% ensure fast close < 10ms
+        {connect_timeout, 10}
+        | Config
+    ]),
+    %% WHEN: the client became unresponsive
+    close_quic_conn_silently(ConnFun, Client1),
+    %% THEN: the new client should connect successfully in time < connect_timeout
+    {ok, _} = emqtt:ConnFun(Client2),
+    waiting_client_process_exit(Client1),
     process_flag(trap_exit, false).
 
 t_connect_will_message(Config) ->
@@ -1043,3 +1073,9 @@ t_share_subscribe_no_local(Config) ->
     end,
 
     process_flag(trap_exit, false).
+
+close_quic_conn_silently(quic_connect, Client) ->
+    %% simulate a unresponsive client that server doesn't know it is disconnected
+    {quic, Conn, _Stream} = proplists:get_value(socket, emqtt:info(Client)),
+    _ = quicer:shutdown_connection(Conn, ?QUIC_CONNECTION_SHUTDOWN_FLAG_SILENT, 0, 10),
+    ok.

--- a/changes/ce/perf-14597.en.md
+++ b/changes/ce/perf-14597.en.md
@@ -6,7 +6,7 @@ the old client is **unresponsive**.
 This issue occurred because graceful shutdown relies on cooperative signaling between both endpoints, 
 ensuring the MQTT.DISCONNECT packet is delivered to the peer before the transport is closed.
 
-With this improvments, 
+With this improvement, 
 
 The stream is now half-closed during termination, with the read (recv) operation aborted, while the write (send) operation remains open.
 This adjustment ensures that the MQTT.DISCONNECT packet is still delivered to the peer, signaling the shutdown process from our side, without unnecessary delays.

--- a/changes/ce/perf-14597.en.md
+++ b/changes/ce/perf-14597.en.md
@@ -1,0 +1,19 @@
+MQTT over QUIC: Async abort stream read during Connection Termination. 
+
+When the connection termination process is triggered due to a session being "taken over", "discarded" or "kicked" the previous approach of performing a graceful stream shutdown could result in long blocking periods (up to 3 seconds) if 
+the old client is **unresponsive**.
+
+This issue occurred because graceful shutdown relies on cooperative signaling between both endpoints, 
+ensuring the MQTT.DISCONNECT packet is delivered to the peer before the transport is closed.
+
+With this improvments, 
+
+The stream is now half-closed during termination, with the read (recv) operation aborted, while the write (send) operation remains open.
+This adjustment ensures that the MQTT.DISCONNECT packet is still delivered to the peer, signaling the shutdown process from our side, without unnecessary delays.
+
+Benefits:
+
+1. Reduces potential blocking times when the peer is unreachable/unresponsive.
+2. Maintains proper notification of the termination process to the peer, improving the overall connection shutdown behavior.
+3. Reduces the latency in the session takeover scenario and the clean-start scenario (discard). 
+


### PR DESCRIPTION
Fixes [EMQX-13843](https://emqx.atlassian.net/browse/EMQX-13843)

Release version: v/e5.8.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13843]: https://emqx.atlassian.net/browse/EMQX-13843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ