### PR TITLE
ci: bump `coveralls-erl` -> v2.2.0-emqx-5

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -199,7 +199,7 @@ plugins() ->
 test_plugins() ->
     [
         {rebar3_proper, "0.12.1"},
-        {coveralls, {git, "https://github.com/emqx/coveralls-erl", {tag, "v2.2.0-emqx-4"}}}
+        {coveralls, {git, "https://github.com/emqx/coveralls-erl", {tag, "v2.2.0-emqx-5"}}}
     ].
 
 test_deps() ->


### PR DESCRIPTION
... To retry any 5xx error.

See https://github.com/emqx/coveralls-erl/pull/6
