### PR TITLE
test: attempt to fix flaky test

### DIFF
--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -106,13 +106,15 @@ when
     }.
 start(Nodes, ClusterOpts) ->
     NodeSpecs = mk_nodespecs(Nodes, ClusterOpts),
-    start(NodeSpecs).
+    StartOpts = get_start_opts(ClusterOpts),
+    emqx_common_test_helpers:clear_screen(),
+    perform(start, NodeSpecs, StartOpts).
 
 start(NodeSpecs) ->
     emqx_common_test_helpers:clear_screen(),
-    perform(start, NodeSpecs).
+    perform(start, NodeSpecs, _StartOpts = #{}).
 
-perform(Act, NodeSpecs) ->
+perform(Act, NodeSpecs, Opts) ->
     ct:pal("~ping nodes: ~p", [Act, NodeSpecs]),
     % 1. Start bare nodes with only basic applications running
     ok = start_nodes_init(NodeSpecs, ?TIMEOUT_NODE_START_MS),
@@ -130,7 +132,8 @@ perform(Act, NodeSpecs) ->
     end,
     % 3. Start applications after cluster is formed
     % Cluster-joins are complete, so they shouldn't restart in the background anymore.
-    _ = emqx_utils:pmap(fun run_node_phase_apps/1, NodeSpecs, ?TIMEOUT_APPS_START_MS),
+    StartTimeout = maps:get(start_apps_timeout, Opts, ?TIMEOUT_APPS_START_MS),
+    _ = emqx_utils:pmap(fun run_node_phase_apps/1, NodeSpecs, StartTimeout),
     Nodes = [Node || #{name := Node} <- NodeSpecs],
     %% 4. Wait for the nodes to cluster
     _Ok = WaitClustered andalso wait_clustered(Nodes, ?TIMEOUT_CLUSTER_WAIT_MS),
@@ -172,9 +175,12 @@ restart(NodeSpecs = [_ | _]) ->
     Nodes = [maps:get(name, Spec) || Spec <- NodeSpecs],
     ct:pal("Stopping peer nodes: ~p", [Nodes]),
     ok = stop(Nodes),
-    perform(restart, NodeSpecs);
+    perform(restart, NodeSpecs, _Opts = #{});
 restart(NodeSpec = #{}) ->
     restart([NodeSpec]).
+
+get_start_opts(ClusterOpts) ->
+    maps:with([start_apps_timeout], ClusterOpts).
 
 mk_nodespecs(Nodes, ClusterOpts) ->
     NodeSpecs = lists:zipwith(

--- a/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl
@@ -353,7 +353,10 @@ cluster(TC, Config) ->
             {node_name(TC, core, 2), #{role => core, apps => apps_spec(18086, TC)}},
             {node_name(TC, replicant, 1), #{role => replicant, apps => apps_spec(18087, TC)}}
         ],
-        #{work_dir => emqx_cth_suite:work_dir(TC, Config)}
+        #{
+            work_dir => emqx_cth_suite:work_dir(TC, Config),
+            start_apps_timeout => 60_000
+        }
     ),
     Nodes.
 

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -808,7 +808,10 @@ cluster(TC, Config) ->
             {data_backup_core2, #{role => core, apps => apps_to_start()}},
             {data_backup_replicant, #{role => replicant, apps => apps_to_start()}}
         ],
-        #{work_dir => emqx_cth_suite:work_dir(TC, Config)}
+        #{
+            work_dir => emqx_cth_suite:work_dir(TC, Config),
+            start_apps_timeout => 60_000
+        }
     ),
     Nodes.
 


### PR DESCRIPTION
```
Testing lib.emqx_management.emqx_mgmt_api_data_backup_SUITE: *** SKIPPED test case 7 of 11 ***

...

%%% emqx_mgmt_api_data_backup_SUITE ==> t_import_ce_backup: SKIPPED
%%% emqx_mgmt_api_data_backup_SUITE ==> {tc_auto_skip,
    {failed,
        {emqx_mgmt_api_data_backup_SUITE,init_per_testcase,
            {timeout,
                [{emqx_utils,nolink_apply,2,
                     [{file,"/emqx/apps/emqx_utils/src/emqx_utils.erl"},
                      {line,534}]},
                 {emqx_cth_cluster,perform,2,
                     [{file,"/emqx/apps/emqx/test/emqx_cth_cluster.erl"},
                      {line,133}]},
                 {emqx_mgmt_api_data_backup_SUITE,do_init_per_testcase,2,
                     [{file,
                          "/emqx/apps/emqx_management/test/emqx_mgmt_api_data_backup_SUITE.erl"},
                      {line,168}]},
                 {test_server,do_init_per_testcase,2,
                     [{file,"test_server.erl"},{line,1563}]},
                 {test_server,run_test_case_eval1,6,
                     [{file,"test_server.erl"},{line,1264}]},
                 {test_server,run_test_case_eval,9,
                     [{file,"test_server.erl"},{line,1234}]}]}}}}
Testing lib.emqx_management.emqx_mgmt_api_data_backup_SUITE: *** SKIPPED test case 8 of 11 ***
```
