### PR TITLE
fix(message transformation & schema validation): use correct order when finding matches

### DIFF
--- a/apps/emqx_message_transformation/src/emqx_message_transformation_registry.erl
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation_registry.erl
@@ -109,15 +109,17 @@ matching_transformations(Topic) ->
             fun(M) ->
                 case emqx_topic_index:get_record(M, ?TRANSFORMATION_TOPIC_INDEX) of
                     [Name] ->
-                        [Name];
+                        Pos = emqx_topic_index:get_id(M),
+                        [{Pos, Name}];
                     _ ->
                         []
                 end
             end,
             emqx_topic_index:matches(Topic, ?TRANSFORMATION_TOPIC_INDEX, [unique])
         ),
+    Transformations1 = lists:keysort(1, Transformations0),
     lists:flatmap(
-        fun(Name) ->
+        fun({_Pos, Name}) ->
             case lookup(Name) of
                 {ok, Transformation} ->
                     [Transformation];
@@ -125,7 +127,7 @@ matching_transformations(Topic) ->
                     []
             end
         end,
-        Transformations0
+        Transformations1
     ).
 
 -spec metrics_worker_spec() -> supervisor:child_spec().

--- a/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
+++ b/apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl
@@ -2041,3 +2041,19 @@ t_non_binary_input_for_decoder(_Config) ->
         end
     ),
     ok.
+
+%% Checks that index/config order is indeed preserved when we have "many" (> 32)
+%% transformations.
+t_many_transformations_order(_Config) ->
+    Names = lists:map(
+        fun(N) ->
+            Name = integer_to_binary(50 - N),
+            Transformation = transformation(Name, [dummy_operation()]),
+            {201, _} = insert(Transformation),
+            Name
+        end,
+        lists:seq(1, 50)
+    ),
+    Topic = <<"t/a">>,
+    ?assertIndexOrder(Names, Topic),
+    ok.

--- a/apps/emqx_schema_validation/src/emqx_schema_validation_registry.erl
+++ b/apps/emqx_schema_validation/src/emqx_schema_validation_registry.erl
@@ -105,15 +105,17 @@ matching_validations(Topic) ->
             fun(M) ->
                 case emqx_topic_index:get_record(M, ?VALIDATION_TOPIC_INDEX) of
                     [Name] ->
-                        [Name];
+                        Pos = emqx_topic_index:get_id(M),
+                        [{Pos, Name}];
                     _ ->
                         []
                 end
             end,
             emqx_topic_index:matches(Topic, ?VALIDATION_TOPIC_INDEX, [unique])
         ),
+    Validations1 = lists:keysort(1, Validations0),
     lists:flatmap(
-        fun(Name) ->
+        fun({_Pos, Name}) ->
             case lookup(Name) of
                 {ok, Validation} ->
                     [Validation];
@@ -121,7 +123,7 @@ matching_validations(Topic) ->
                     []
             end
         end,
-        Validations0
+        Validations1
     ).
 
 -spec metrics_worker_spec() -> supervisor:child_spec().

--- a/apps/emqx_schema_validation/test/emqx_schema_validation_http_api_SUITE.erl
+++ b/apps/emqx_schema_validation/test/emqx_schema_validation_http_api_SUITE.erl
@@ -1551,3 +1551,19 @@ t_republish_action_failure(_Config) ->
         []
     ),
     ok.
+
+%% Checks that index/config order is indeed preserved when we have "many" (> 32)
+%% validations.
+t_many_validations_order(_Config) ->
+    Names = lists:map(
+        fun(N) ->
+            Name = integer_to_binary(50 - N),
+            Validation = validation(Name, [sql_check()]),
+            {201, _} = insert(Validation),
+            Name
+        end,
+        lists:seq(1, 50)
+    ),
+    Topic = <<"t/a">>,
+    ?assertIndexOrder(Names, Topic),
+    ok.

--- a/changes/ee/fix-14622.en.md
+++ b/changes/ee/fix-14622.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where Message Transformations and Schema Validations could run in an arbitrary order when there were more than 32 transformations/validations that matched a topic.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13859

Fixes bug introduced by https://github.com/emqx/emqx/pull/13199/commits/5629fe60c12d0d7e94f3e95a6c05ee8b6a99ad55

Release version: e5.8.5

## Summary

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
