### PR TITLE
ci(macOS): quicer disable dynamic link libcrypto

### DIFF
--- a/.github/actions/package-macos/action.yaml
+++ b/.github/actions/package-macos/action.yaml
@@ -109,6 +109,8 @@ runs:
         APPLE_DEVELOPER_IDENTITY: ${{ inputs.apple_developer_identity }}
         APPLE_DEVELOPER_ID_BUNDLE: ${{ inputs.apple_developer_id_bundle }}
         APPLE_DEVELOPER_ID_BUNDLE_PASSWORD: ${{ inputs.apple_developer_id_bundle_password }}
+        # In above job, OTP is built with --disable-dynamic-ssl-lib and openssl@1.1, QUIC just follow
+        QUICER_TLS_VER: openssl
       shell: bash
       run: |
         export PATH="${{ steps.prepare.outputs.OTP_INSTALL_PATH }}/bin:$PATH"

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ export EMQX_EE_DASHBOARD_VERSION ?= e1.8.4
 
 export EMQX_RELUP ?= true
 export EMQX_REL_FORM ?= tgz
+export QUICER_TLS_VER ?= sys
 
 -include default-profile.mk
 PROFILE ?= emqx

--- a/changes/ce/fix-14624.en.md
+++ b/changes/ce/fix-14624.en.md
@@ -1,0 +1,7 @@
+Fix macOS release package dynamic linking openssl
+
+EMQX zip package may fail to start on macOS because quicer application dynamic links to sys installed openssl which is not signed by 
+EMQX build process.
+
+Now we change to disabled dynamic linking as the OTP we shipped on macOS also disabled dynamic linking of openssl.
+

--- a/env.sh
+++ b/env.sh
@@ -6,4 +6,3 @@ export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-
 export EMQX_DOCKER_BUILD_FROM=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-debian12
 export EMQX_DOCKER_RUN_FROM=debian:12-slim
 export QUICER_DOWNLOAD_FROM_RELEASE=1
-export QUICER_TLS_VER=sys


### PR DESCRIPTION
Fixes [EMQX-13740](https://emqx.atlassian.net/browse/EMQX-13740)

Release version: v/e5.8.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13740]: https://emqx.atlassian.net/browse/EMQX-13740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ