### PR TITLE
chore: lower default per-partition buffer limit to 256 MB for Kafka/Pulsar actions

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.erl
@@ -529,7 +529,7 @@ fields(producer_buffer) ->
         {per_partition_limit,
             mk(
                 emqx_schema:bytesize(),
-                #{default => <<"2GB">>, desc => ?DESC(buffer_per_partition_limit)}
+                #{default => <<"256MB">>, desc => ?DESC(buffer_per_partition_limit)}
             )},
         {segment_bytes,
             mk(

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.erl
@@ -127,7 +127,7 @@ fields(producer_buffer) ->
         {per_partition_limit,
             mk(
                 emqx_schema:bytesize(),
-                #{default => <<"2GB">>, desc => ?DESC("buffer_per_partition_limit")}
+                #{default => <<"256MB">>, desc => ?DESC("buffer_per_partition_limit")}
             )},
         {segment_bytes,
             mk(

--- a/changes/ee/feat-14626.en.md
+++ b/changes/ee/feat-14626.en.md
@@ -1,0 +1,1 @@
+Changed the default per-partition buffer size to 256 MB for the Kafka and Pulsar actions.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13852

Release version: e5.8.5

## Summary

## PR Checklist

- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible
