### PR TITLE
feat(rule engine): add `$events/alarm_{,de}activated`

### DIFF
--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -79,6 +79,10 @@
     'session.takeovered'
 ]).
 
+-type rule_engine_conf() :: #{event_topic := emqx_types:topic()}.
+-type transformation_context() :: #{name := binary()}.
+-type validation_context() :: #{name := binary()}.
+
 %%-----------------------------------------------------------------------------
 %% Callbacks
 %%-----------------------------------------------------------------------------
@@ -185,7 +189,14 @@ when
 -callback 'message.dropped'(emqx_types:message(), #{node => node()}, _Reason :: atom()) ->
     callback_result().
 
--callback 'schema.validation_failed'(emqx_types:message(), #{node => node()}, _Ctx :: map()) ->
+-callback 'message.transformation_failed'(
+    emqx_types:message(), transformation_context(), rule_engine_conf()
+) ->
+    callback_result().
+
+-callback 'schema.validation_failed'(
+    emqx_types:message(), validation_context(), rule_engine_conf()
+) ->
     callback_result().
 
 -callback 'message.delivered'(emqx_types:clientinfo(), Msg) -> fold_callback_result(Msg) when

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -81,7 +81,6 @@
     'session.takeovered'
 ]).
 
--type rule_engine_conf() :: #{event_topic := emqx_types:topic()}.
 -type alarm_activated_context() :: #{
     name := binary(),
     details := map(),
@@ -108,10 +107,10 @@
 %%
 %% By default, callbacks are executed in the channel process context.
 
--callback 'alarm.activated'(alarm_activated_context(), rule_engine_conf()) ->
+-callback 'alarm.activated'(alarm_activated_context()) ->
     callback_result().
 
--callback 'alarm.deactivated'(alarm_deactivated_context(), rule_engine_conf()) ->
+-callback 'alarm.deactivated'(alarm_deactivated_context()) ->
     callback_result().
 
 -callback 'client.connect'(emqx_types:conninfo(), Props) ->
@@ -210,14 +209,10 @@ when
 -callback 'message.dropped'(emqx_types:message(), #{node => node()}, _Reason :: atom()) ->
     callback_result().
 
--callback 'message.transformation_failed'(
-    emqx_types:message(), transformation_context(), rule_engine_conf()
-) ->
+-callback 'message.transformation_failed'(emqx_types:message(), transformation_context()) ->
     callback_result().
 
--callback 'schema.validation_failed'(
-    emqx_types:message(), validation_context(), rule_engine_conf()
-) ->
+-callback 'schema.validation_failed'(emqx_types:message(), validation_context()) ->
     callback_result().
 
 -callback 'message.delivered'(emqx_types:clientinfo(), Msg) -> fold_callback_result(Msg) when

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -38,6 +38,8 @@
 %%-----------------------------------------------------------------------------
 
 -define(HOOKPOINTS, [
+    'alarm.activated',
+    'alarm.deactivated',
     'client.connect',
     'client.connack',
     'client.connected',
@@ -80,6 +82,19 @@
 ]).
 
 -type rule_engine_conf() :: #{event_topic := emqx_types:topic()}.
+-type alarm_activated_context() :: #{
+    name := binary(),
+    details := map(),
+    message := binary(),
+    activated_at := integer()
+}.
+-type alarm_deactivated_context() :: #{
+    name := binary(),
+    details := map(),
+    message := binary(),
+    activated_at := integer(),
+    deactivated_at := integer()
+}.
 -type transformation_context() :: #{name := binary()}.
 -type validation_context() :: #{name := binary()}.
 
@@ -92,6 +107,12 @@
 %% after the mandatory ones.
 %%
 %% By default, callbacks are executed in the channel process context.
+
+-callback 'alarm.activated'(alarm_activated_context(), rule_engine_conf()) ->
+    callback_result().
+
+-callback 'alarm.deactivated'(alarm_deactivated_context(), rule_engine_conf()) ->
+    callback_result().
 
 -callback 'client.connect'(emqx_types:conninfo(), Props) ->
     fold_callback_result(Props)

--- a/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
@@ -65,8 +65,8 @@ t_event_name_topic_conversion(_) ->
     Zip = lists:zip(Events, Topics),
     lists:foreach(
         fun({Event, Topic}) ->
-            ?assertEqual(Event, emqx_rule_events:event_name(Topic)),
-            ?assertEqual(Topic, emqx_rule_events:event_topic(Event))
+            ?assertEqual(Event, emqx_rule_events:event_name(Topic), #{topic => Topic}),
+            ?assertEqual(Topic, emqx_rule_events:event_topic(Event), #{event => Event})
         end,
         Zip
     ).

--- a/changes/ce/feat-14627.en.md
+++ b/changes/ce/feat-14627.en.md
@@ -1,0 +1,1 @@
+Added two new rule engine events: `$events/alarm_activated` and `$events/alarm_deactivated`.  These are triggered when alarms are toggled on and off.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13636

Release version: v/e5.8.5

## Summary

With this new event, it's possible for rules to be triggered by alarm toggling without the
need to set `rule_engine.ignore_sys_message = false` and using the existing
`$SYS/broker/+/alarms/+` topic filter.  Using this new event, the frontend may implement
an UX for tying webhooks to alarms.

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
