### PR TITLE
fix(kafka producer): drop data more aggresively when under high memory stress

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.5"},
+    {wolff, "4.0.6"},
     {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.5"},
+    {wolff, "4.0.6"},
     {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.5"},
+    {wolff, "4.0.6"},
     {kafka_protocol, "4.1.10"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/changes/ee/fix-14631.en.md
+++ b/changes/ee/fix-14631.en.md
@@ -1,0 +1,1 @@
+Now, when enabling Memory Overload Protection in Kafka / Azure Event Hub / Confluent Producer Actions, buffered data will be dropped more aggressively when the system reaches the high memory watermark, reducing the risk of reaching out of memory state.

--- a/mix.exs
+++ b/mix.exs
@@ -206,7 +206,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:cowboy), do: {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true}
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
   def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.6.1", override: true}
-  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.3.10", override: true}
+  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.3.12", override: true}
   def common_dep(:jsx), do: {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true}
   # in conflict by emqtt and hocon
   def common_dep(:getopt), do: {:getopt, "1.0.2", override: true}
@@ -275,7 +275,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.5"}
+  def common_dep(:wolff), do: {:wolff, "4.0.6"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,7 @@
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
-    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.10"}}},
+    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.12"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13830

See also https://github.com/emqx/replayq/pull/20

Release version: e5.8.5

## Summary

## PR Checklist

- [na] ~~Added tests for the changes~~ only updated dependencies
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
