### PR TITLE
ci: fix schema registry image that is gone

### DIFF
--- a/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
+++ b/.ci/docker-compose-file/docker-compose-confluent-schema-registry.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 ## depends on kafka; see `./docker-file-compose-kafka.yaml`.
 services:
   confluent_schema_registry: &cpsr
-    image: public.ecr.aws/ews-network/confluentinc/cp-schema-registry:7.5.1
+    image: confluentinc/cp-schema-registry:7.5.1
     container_name: confluent_schema_registry
     restart: always
     depends_on:


### PR DESCRIPTION
```
Error response from daemon: repository public.ecr.aws/ews-network/confluentinc/cp-schema-registry not found: name unknown: The repository with name 'confluentinc/cp-schema-registry' does not exist in the registry with id 'ews-network'
```
