### PR TITLE
Revert "docs: fix config doc for Kafka/Pulsar producer high mem threshold"

### DIFF
--- a/rel/i18n/emqx_bridge_pulsar.hocon
+++ b/rel/i18n/emqx_bridge_pulsar.hocon
@@ -43,6 +43,7 @@ authentication.label:
 buffer_memory_overload_protection.desc:
 """Applicable when buffer mode is set to <code>memory</code>
 EMQX will drop old buffered messages under high memory pressure.
+The high memory threshold is defined in config <code>sysmon.os.sysmem_high_watermark</code>.
  NOTE: This config only works on Linux."""
 buffer_memory_overload_protection.label:
 """Memory Overload Protection"""


### PR DESCRIPTION
Reverts emqx/emqx#14594

The config is now respected after this fix is merged: https://github.com/emqx/emqx/pull/14609