### PR TITLE
fix(stomp): fix heartbeat reset

### DIFF
--- a/apps/emqx_gateway_stomp/src/emqx_stomp_heartbeat.erl
+++ b/apps/emqx_gateway_stomp/src/emqx_stomp_heartbeat.erl
@@ -86,19 +86,26 @@ check(
         NewVal =/= OldVal ->
             {ok, HrtBter#heartbeater{statval = NewVal, repeat = 0}};
         Repeat < 1 ->
+            %% Allow the first check to pass
+            %% This is to compensate network latency etc for the heartbeat.
+            %% On average (normal distribution of the timing of when check
+            %% happen during the heartbeat interval), it allows the connection
+            %% to idle for 1.5x heartbeat interval.
             {ok, HrtBter#heartbeater{repeat = Repeat + 1}};
         true ->
             {error, timeout}
     end.
 
+%% @doc Call this when heartbeat is receved or sent.
 -spec reset(name(), pos_integer(), heartbeat()) ->
     heartbeat().
 reset(Name, NewVal, HrtBt) ->
     HrtBter = maps:get(Name, HrtBt),
     HrtBt#{Name => reset(NewVal, HrtBter)}.
 
+%% Set counter back to zero (the initial state)
 reset(NewVal, HrtBter) ->
-    HrtBter#heartbeater{statval = NewVal, repeat = 1}.
+    HrtBter#heartbeater{statval = NewVal, repeat = 0}.
 
 -spec info(heartbeat()) -> map().
 info(HrtBt) ->

--- a/changes/ce/fix-14653.en.md
+++ b/changes/ce/fix-14653.en.md
@@ -1,0 +1,4 @@
+Fix stomp gateway keepalive.
+
+Prior to this fix, stomp connection heatbeat cannot keep the connection alive if the heartbeat packet is received slightly later than the check timer.
+This commit makes it to tolerate some delay, on average one can expect the connection close to happen around 1.5x heartbeat interval.


### PR DESCRIPTION
Fixes https://github.com/emqx/emqx/issues/12911

Release version: v/e5.8.5

## Summary

prior to this fix, stomp connection heatbeat cannot keep the connection alive if the heartbeat packet is received slightly later than the check timer.
this commit makes it to tolerate some delay, on average one can expect the connection close to happen around 1.5x heartbeat interval

## PR Checklist

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
