### PR TITLE
fix(license): allow clients to reconnect even if max_clients reached

### DIFF
--- a/changes/ee/fix-14654.en.md
+++ b/changes/ee/fix-14654.en.md
@@ -1,0 +1,1 @@
+Clients can now reconnect even if the max session limit is exceeded, as long as their old sessions are not yet expired or cleaned up.


### PR DESCRIPTION
Fixes [EMQX-13705](https://emqx.atlassian.net/browse/EMQX-13705)

Release version: v/e5.8.5

## Summary

Allow clients to reconnect even if max_connection (session) limit is reached.
This can happen when a system is close to the license limit and large number of client reconnect concurrently.

## PR Checklist

- [x] Added tests for the changes
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change

[EMQX-13705]: https://emqx.atlassian.net/browse/EMQX-13705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ