### PR TITLE
chore: bump ehttpc to 0.7.1 and observer_cli to 1.8.2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -196,7 +196,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ranch), do: {:ranch, github: "emqx/ranch", tag: "1.8.1-emqx-1", override: true}
 
   def common_dep(:ehttpc),
-    do: {:ehttpc, github: "emqx/ehttpc", tag: "0.7.0", override: true}
+    do: {:ehttpc, github: "emqx/ehttpc", tag: "0.7.1", override: true}
 
   def common_dep(:jiffy), do: {:jiffy, "1.1.2", override: true}
 
@@ -231,7 +231,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:uuid), do: {:uuid, github: "okeuday/uuid", tag: "v2.0.6", override: true}
   def common_dep(:redbug), do: {:redbug, github: "emqx/redbug", tag: "2.0.10"}
-  def common_dep(:observer_cli), do: {:observer_cli, "1.8.0"}
+  def common_dep(:observer_cli), do: {:observer_cli, "1.8.2"}
 
   def common_dep(:jose),
     do: {:jose, github: "potatosalad/erlang-jose", tag: "1.11.2", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -77,7 +77,7 @@
     {gpb, "4.21.1"},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.6"}}},
     {gun, "2.1.0"},
-    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.7.0"}}},
+    {ehttpc, {git, "https://github.com/emqx/ehttpc", {tag, "0.7.1"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {jiffy, "1.1.2"},
     {cowlib, "2.13.0"},
@@ -94,7 +94,7 @@
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.0"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x
-    {observer_cli, "1.8.0"},
+    {observer_cli, "1.8.2"},
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.6"}}},
     {getopt, "1.0.2"},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},


### PR DESCRIPTION
Fixes <issue-or-jira-number>

https://github.com/emqx/ehttpc/pull/62

https://github.com/zhongwencool/observer_cli/releases/tag/v1.8.2

Release version: v/e5.9.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
