### PR TITLE
fix: max_connections -> max_sessions in licnse info ctl command output

### DIFF
--- a/apps/emqx_license/src/emqx_license_checker.erl
+++ b/apps/emqx_license/src/emqx_license_checker.erl
@@ -123,7 +123,7 @@ handle_call(dump, _From, #{license := License} = State) ->
     %% resolve the current dynamic limit
     MaybeDynamic = get_max_connections(License),
     Dump = lists:keyreplace(max_connections, 1, Dump0, {max_connections, MaybeDynamic}),
-    {reply, Dump, State};
+    {reply, max_sessions(Dump), State};
 handle_call(expiry_epoch, _From, #{license := License} = State) ->
     ExpiryEpoch = date_to_expiry_epoch(emqx_license_parser:expiry_date(License)),
     {reply, ExpiryEpoch, State};
@@ -311,3 +311,10 @@ print_expiry_warning(#{warn_expiry := {true, Days}}) ->
     io:format(?EXPIRY_LOG, [Days]);
 print_expiry_warning(_) ->
     ok.
+
+%% Add max_sessions but not replace max_connections for backward compatibility
+%% TODO(5.9): change max_connections to max_sessions
+max_sessions(InfoList) ->
+    {_, Max} = lists:keyfind(max_connections, 1, InfoList),
+    %% keep max_sessions to the end
+    InfoList ++ [{max_sessions, Max}].

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -30,6 +30,9 @@ license(["update", EncodedLicense]) ->
 license(["info"]) ->
     lists:foreach(
         fun
+            ({max_connections, _V}) ->
+                %% max_sessions will be printed
+                ok;
             ({K, V}) when is_binary(V); is_atom(V); is_list(V) ->
                 ?PRINT("~-16s: ~s~n", [K, V]);
             ({K, V}) ->

--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -115,7 +115,7 @@ sample_license_info_response() ->
         email => "contact@foo.com",
         expiry => false,
         expiry_at => "2295-10-27",
-        max_connections => 10,
+        max_sessions => 10,
         start_at => "2022-01-11",
         type => "trial"
     }.
@@ -125,8 +125,7 @@ error_msg(Code, Msg) ->
 
 %% read license info
 '/license'(get, _Params) ->
-    License = maps:from_list(emqx_license_checker:dump()),
-    {200, License};
+    {200, license_info()};
 %% set/update license
 '/license'(post, #{body := #{<<"key">> := Key}}) ->
     case emqx_license:update_key(Key) of
@@ -142,8 +141,7 @@ error_msg(Code, Msg) ->
             {400, error_msg(?BAD_REQUEST, <<"Bad license key">>)};
         {ok, _} ->
             ?SLOG(info, #{msg => "updated_license_key"}, #{tag => "LICENSE"}),
-            License = maps:from_list(emqx_license_checker:dump()),
-            {200, License}
+            {200, license_info()}
     end;
 '/license'(post, _Params) ->
     {400, error_msg(?BAD_REQUEST, <<"Invalid request params">>)}.
@@ -189,3 +187,6 @@ get_setting() ->
         false ->
             maps:remove(<<"dynamic_max_connections">>, Result)
     end.
+
+license_info() ->
+    maps:from_list(emqx_license_checker:dump()).

--- a/apps/emqx_license/test/emqx_license_checker_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_checker_SUITE.erl
@@ -67,20 +67,23 @@ t_dump(_Config) ->
 
     #{} = emqx_license_checker:update(License),
 
-    ?assertEqual(
-        [
-            {customer, <<"Foo">>},
-            {email, <<"contact@foo.com">>},
-            {deployment, <<"bar">>},
-            {max_connections, 10},
-            {start_at, <<"2022-01-11">>},
-            {expiry_at, <<"2295-10-27">>},
-            {type, <<"trial">>},
-            {customer_type, 10},
-            {expiry, false}
-        ],
-        emqx_license_checker:dump()
+    ?assertMatch(
+        #{
+            customer := <<"Foo">>,
+            email := <<"contact@foo.com">>,
+            deployment := <<"bar">>,
+            max_sessions := 10,
+            start_at := <<"2022-01-11">>,
+            expiry_at := <<"2295-10-27">>,
+            type := <<"trial">>,
+            customer_type := 10,
+            expiry := false
+        },
+        license_info()
     ).
+
+license_info() ->
+    maps:from_list(emqx_license_checker:dump()).
 
 t_update(_Config) ->
     License = mk_license(

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -70,8 +70,12 @@ t_conf_update(_Config) ->
         },
         emqx:get_config([license])
     ),
+    Dump = maps:from_list(emqx_license_checker:dump()),
     ?assertMatch(
-        #{max_connections := 123},
-        maps:from_list(emqx_license_checker:dump())
+        #{
+            max_connections := 123,
+            max_sessions := 123
+        },
+        Dump
     ),
     ok.

--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -94,17 +94,17 @@ t_license_info(_Config) ->
     Res = request(get, uri(["license"]), []),
     ?assertMatch({ok, 200, _}, Res),
     {ok, 200, Payload} = Res,
-    ?assertEqual(
+    ?assertMatch(
         #{
-            <<"customer">> => <<"Foo">>,
-            <<"customer_type">> => 10,
-            <<"deployment">> => <<"bar-deployment">>,
-            <<"email">> => <<"contact@foo.com">>,
-            <<"expiry">> => false,
-            <<"expiry_at">> => <<"2295-10-27">>,
-            <<"max_connections">> => 100,
-            <<"start_at">> => <<"2022-01-11">>,
-            <<"type">> => <<"trial">>
+            <<"customer">> := <<"Foo">>,
+            <<"customer_type">> := 10,
+            <<"deployment">> := <<"bar-deployment">>,
+            <<"email">> := <<"contact@foo.com">>,
+            <<"expiry">> := false,
+            <<"expiry_at">> := <<"2295-10-27">>,
+            <<"max_sessions">> := 100,
+            <<"start_at">> := <<"2022-01-11">>,
+            <<"type">> := <<"trial">>
         },
         emqx_utils_json:decode(Payload, [return_maps])
     ),
@@ -132,17 +132,17 @@ t_license_upload_key_success(_Config) ->
     ),
     ?assertMatch({ok, 200, _}, Res),
     {ok, 200, Payload} = Res,
-    ?assertEqual(
+    ?assertMatch(
         #{
-            <<"customer">> => <<"Foo">>,
-            <<"customer_type">> => 10,
-            <<"deployment">> => <<"bar-deployment">>,
-            <<"email">> => <<"contact@foo.com">>,
-            <<"expiry">> => false,
-            <<"expiry_at">> => <<"2295-10-27">>,
-            <<"max_connections">> => 999,
-            <<"start_at">> => <<"2022-01-11">>,
-            <<"type">> => <<"trial">>
+            <<"customer">> := <<"Foo">>,
+            <<"customer_type">> := 10,
+            <<"deployment">> := <<"bar-deployment">>,
+            <<"email">> := <<"contact@foo.com">>,
+            <<"expiry">> := false,
+            <<"expiry_at">> := <<"2295-10-27">>,
+            <<"max_sessions">> := 999,
+            <<"start_at">> := <<"2022-01-11">>,
+            <<"type">> := <<"trial">>
         },
         emqx_utils_json:decode(Payload, [return_maps])
     ),


### PR DESCRIPTION
Fixes [EMQX-13549](https://emqx.atlassian.net/browse/EMQX-13549)

Release version: v/e5.8.5

A follow up for https://github.com/emqx/emqx/pull/14568.
This is a temporary fix for 5.8.5, a proper fix to change max_connections to max_sessions in all places will need some compatibility code for APIs which is more suitable for version 5.9

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [~] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible


[EMQX-13549]: https://emqx.atlassian.net/browse/EMQX-13549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ