### PR TITLE
250207 fix mqtt.max_packet_size display

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2859,7 +2859,7 @@ validate_max_packet_size(_SizStr) ->
 %% This is for backward compatibility.
 %% We used to allow setting 256MB, but in fact the limit is one byte less.
 convert_max_packet_size(<<"256MB">>, _) ->
-    ?MAX_INT_MQTT_PACKET_SIZE;
+    iolist_to_binary([integer_to_list(?MAX_INT_MQTT_PACKET_SIZE), "B"]);
 convert_max_packet_size(X, _) ->
     X.
 


### PR DESCRIPTION
Fixes [EMQX-13874](https://emqx.atlassian.net/browse/EMQX-13874)

Release version: v/e5.8.5

## Summary

Dashboard does not like integer format for this config.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Changed line covered by existing tests.
- [~] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
  this is a follow up fix for PR https://github.com/emqx/emqx/pull/14405
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible



[EMQX-13874]: https://emqx.atlassian.net/browse/EMQX-13874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ