### PR TITLE
fix: reannounce BPAPIs when replicant join fresh core

### DIFF
--- a/apps/emqx/src/bpapi/emqx_bpapi.erl
+++ b/apps/emqx/src/bpapi/emqx_bpapi.erl
@@ -20,6 +20,7 @@
     start/0,
     announce/2,
     supported_version/1, supported_version/2,
+    supported_apis/1,
     versions_file/1
 ]).
 
@@ -82,6 +83,21 @@ supported_version(Node, API) ->
 -spec supported_version(api()) -> api_version().
 supported_version(API) ->
     ets:lookup_element(?TAB, {?multicall, API}, #?TAB.version).
+
+-spec supported_apis(node()) -> [{api(), api_version()}].
+supported_apis(Node) ->
+    try
+        %% Make dialyzer happy...
+        MS = erlang:make_tuple(
+            record_info(size, ?TAB),
+            '_',
+            [{1, ?TAB}, {#?TAB.key, {Node, '$1'}}, {#?TAB.version, '$2'}]
+        ),
+        lists:flatten(ets:match(?TAB, MS))
+    catch
+        error:badarg ->
+            []
+    end.
 
 -spec announce(node(), atom()) -> ok.
 announce(Node, App) ->

--- a/apps/emqx/src/bpapi/emqx_bpapi.erl
+++ b/apps/emqx/src/bpapi/emqx_bpapi.erl
@@ -87,13 +87,7 @@ supported_version(API) ->
 -spec supported_apis(node()) -> [{api(), api_version()}].
 supported_apis(Node) ->
     try
-        %% Make dialyzer happy...
-        MS = erlang:make_tuple(
-            record_info(size, ?TAB),
-            '_',
-            [{1, ?TAB}, {#?TAB.key, {Node, '$1'}}, {#?TAB.version, '$2'}]
-        ),
-        lists:flatten(ets:match(?TAB, MS))
+        lists:flatten(ets:match(?TAB, {?TAB, {Node, '$1'}, '$2'}))
     catch
         error:badarg ->
             []

--- a/apps/emqx/src/bpapi/emqx_bpapi.hrl
+++ b/apps/emqx/src/bpapi/emqx_bpapi.hrl
@@ -21,8 +21,10 @@
 -define(multicall, multicall).
 
 -record(?TAB, {
-    key :: {node() | ?multicall, emqx_bpapi:api()},
-    version :: emqx_bpapi:api_version()
+    %% {node() | ?multicall, emqx_bpapi:api()},
+    key,
+    %% emqx_bpapi:api_version()
+    version
 }).
 
 -endif.

--- a/apps/emqx/src/emqx_kernel_sup.erl
+++ b/apps/emqx/src/emqx_kernel_sup.erl
@@ -41,7 +41,8 @@ init([]) ->
             child_spec(emqx_ocsp_cache, worker),
             child_spec(emqx_crl_cache, worker),
             child_spec(emqx_tls_lib_sup, supervisor),
-            child_spec(emqx_log_throttler, worker)
+            child_spec(emqx_log_throttler, worker),
+            child_spec(emqx_bpapi_replicant_checker, worker)
         ]
     }}.
 

--- a/apps/emqx/test/emqx_bpapi_SUITE.erl
+++ b/apps/emqx/test/emqx_bpapi_SUITE.erl
@@ -21,7 +21,10 @@
 
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include("../src/bpapi/emqx_bpapi.hrl").
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
@@ -51,6 +54,57 @@ t_announce(Config) ->
     ?assertMatch(2, emqx_bpapi:supported_version(FakeNode, api1)),
     ?assertMatch(2, emqx_bpapi:supported_version(api2)),
     ?assertMatch(2, emqx_bpapi:supported_version(api1)).
+
+%% Assert that, if a replicant is initially part of a cluster, but then re-connects to a
+%% fresh core node with no memory of the replicant, it correctly re-announces its BPAPIs.
+t_replicant_joins_fresh_core(Config) ->
+    BPAPI = emqx_broker,
+    AppSpecs = [emqx],
+    ClusterSpec = [
+        {bpapi_core, #{apps => AppSpecs, role => core}},
+        {bpapi_replicant, #{apps => AppSpecs, role => replicant}}
+    ],
+    [CoreSpec, ReplicantSpec] =
+        emqx_cth_cluster:mk_nodespecs(
+            ClusterSpec,
+            #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+        ),
+    [Core, Replicant] = Nodes = emqx_cth_cluster:start([CoreSpec, ReplicantSpec]),
+    try
+        snabbkaffe:start_trace(),
+        %% 1) Replicant has its BPAPIs correctly announced.
+        ?assertNotEqual(undefined, ?ON(Replicant, emqx_bpapi:supported_version(Replicant, BPAPI))),
+        ?assertNotEqual([], ?ON(Replicant, emqx_bpapi:supported_apis(Replicant))),
+        %% 2) Core node is stopped.  This will make the replicant disconnected from any core.
+        ct:pal("stopping core"),
+        {ok, {ok, _}} =
+            ?wait_async_action(
+                emqx_cth_cluster:stop([Core]),
+                #{
+                    ?snk_kind := cm_registry_node_down,
+                    ?snk_meta := #{node := Replicant}
+                }
+            ),
+        %% 3) A _fresh_ core node is (re)started and replicant connects to it, taking all
+        %% table contents from this fresh core node.  This core node does not know about
+        %% the replicant's BPAPI in its newly created BPAPI table.  The replicant should
+        %% re-announce its BPAPIs.
+        ct:pal("cleaning core"),
+        #{work_dir := CoreWorkDir} = CoreSpec,
+        ok = file:del_dir_r(CoreWorkDir),
+        ct:pal("restarting core"),
+        [Core] = emqx_cth_cluster:restart([CoreSpec]),
+        ct:pal("waiting to stabilize"),
+        ?block_until(#{?snk_kind := "bpapi_replicant_checker_reannounced"}, 5_000),
+        %% Retry is needed because, even after the transaction, ETS needs a moment to make
+        %% the APIs available.
+        ?retry(500, 10, ?assertNotEqual([], ?ON(Replicant, emqx_bpapi:supported_apis(Replicant)))),
+        ?assertNotEqual(undefined, ?ON(Replicant, emqx_bpapi:supported_version(Replicant, BPAPI))),
+        ok
+    after
+        emqx_cth_cluster:stop(Nodes),
+        snabbkaffe:stop()
+    end.
 
 fake_records() ->
     [

--- a/changes/ce/fix-14662.en.md
+++ b/changes/ce/fix-14662.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where a running replicant node that rejoined a cluster in which all core nodes had their internal database wiped out would fail to participate in some RPC calls.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13879

Release version: v/e5.8.5

## Summary

1) Initially start a core node, and then a replicant that has that core as seed. 2) Wait until the replicant is fully started and functional.  At this point,
   emqx_bpapi:supported_version works fine.
3) Stop the core node and wait until the replicant notices that.  The API still works at
   this point.
4) Start a fresh core node with no record of the replicant and wait until the replicant
   reconnects.  At this point, BPAPI for the replicant is broken.


## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
