### PR TITLE
fix(mqtt action): make `tcp_closed` and `closed` recoverable errors

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -407,6 +407,10 @@ handle_send_result({ok, Reply}) ->
 handle_send_result({error, Reason}) ->
     {error, classify_error(Reason)}.
 
+classify_reply(Reply = #{reason_code := ?RC_PACKET_IDENTIFIER_IN_USE}) ->
+    %% If `emqtt' client restarted, it may re-use packet ids that the remote broker still
+    %% has memory of.  We should retry.
+    {recoverable_error, Reply};
 classify_reply(Reply = #{reason_code := _}) ->
     {unrecoverable_error, Reply}.
 
@@ -419,6 +423,12 @@ classify_error({disconnected, _RC, _} = Reason) ->
 classify_error({shutdown, _} = Reason) ->
     {recoverable_error, Reason};
 classify_error(shutdown = Reason) ->
+    {recoverable_error, Reason};
+classify_error(closed = Reason) ->
+    {recoverable_error, Reason};
+classify_error(tcp_closed = Reason) ->
+    {recoverable_error, Reason};
+classify_error(einval = Reason) ->
     {recoverable_error, Reason};
 classify_error({unrecoverable_error, _Reason} = Error) ->
     Error;

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_egress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_egress.erl
@@ -19,6 +19,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
 
 -export([
     config/1,
@@ -45,6 +46,7 @@ config(#{remote := RC = #{}} = Conf) ->
 -spec send(pid(), emqx_trace:rendered_action_template_ctx(), message(), egress()) ->
     ok | {error, {unrecoverable_error, term()}}.
 send(Pid, TraceRenderedCTX, MsgIn, Egress) ->
+    ?tp("mqtt_action_about_to_publish", #{}),
     try
         emqtt:publish(Pid, export_msg(MsgIn, Egress, TraceRenderedCTX))
     catch
@@ -55,6 +57,7 @@ send(Pid, TraceRenderedCTX, MsgIn, Egress) ->
 -spec send_async(pid(), emqx_trace:rendered_action_template_ctx(), message(), callback(), egress()) ->
     {ok, pid()} | {error, {unrecoverable_error, term()}}.
 send_async(Pid, TraceRenderedCTX, MsgIn, Callback, Egress) ->
+    ?tp("mqtt_action_about_to_publish", #{}),
     try
         ok = emqtt:publish_async(
             Pid, export_msg(MsgIn, Egress, TraceRenderedCTX), _Timeout = infinity, Callback

--- a/changes/ce/fix-14671.en.md
+++ b/changes/ce/fix-14671.en.md
@@ -1,0 +1,1 @@
+Fixed an issue with MQTT Action where messages could fail to be sent and retried in the event of a rare race condition linked to MQTT Connector having its connection closed.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13880

Release version: v/e5.8.5

## Summary

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
