### PR TITLE
fix(ds): Limit number and size of RocksDB info log files

### DIFF
--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -1182,6 +1182,12 @@ rocksdb_open(Shard, Options) ->
     DBOptions = [
         {create_if_missing, true},
         {create_missing_column_families, true},
+        %% Info log file management:
+        %%    Maximal log files:
+        {keep_log_file_num, 10},
+        %%    Create a new log file when the old one exceeds:
+        %%    `max_log_file_size' (1MB):
+        {max_log_file_size, 16#100000},
         %% NOTE
         %% With WAL-less writes, it's important to have CFs flushed atomically.
         %% For example, bitfield-lts backend needs data + trie CFs to be consistent.

--- a/changes/ce/fix-14674.en.md
+++ b/changes/ce/fix-14674.en.md
@@ -1,0 +1,1 @@
+Limit number and size of RocksDB info log files created by EMQX durable storage.

--- a/elvis.config
+++ b/elvis.config
@@ -14,6 +14,7 @@
                         {elvis_style, macro_names, disable},
                         {elvis_style, function_naming_convention, disable},
                         {elvis_style, state_record_and_type, disable},
+                        {elvis_style, export_used_types, disable},
                         {elvis_style, no_common_caveats_call, #{}},
                         {elvis_style, no_debug_call, #{
                             debug_functions => [


### PR DESCRIPTION
Fixes EMQX-13851

Release version: v/e5.9

## Summary

Prevent the RocksDB logs from growing out of control.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
