### PR TITLE
Support top n mailbox procs monitoring/alarm

### DIFF
--- a/apps/emqx/src/emqx_broker_mon.erl
+++ b/apps/emqx/src/emqx_broker_mon.erl
@@ -24,7 +24,8 @@
     start_link/0,
 
     get_mnesia_tm_mailbox_size/0,
-    get_broker_pool_max_mailbox_size/0
+    get_broker_pool_max_mailbox_size/0,
+    get_mailbox_size_top_n/0
 ]).
 
 %% `gen_server' API
@@ -39,6 +40,8 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
+-type proc_name() :: binary().
+
 -define(PT_KEY, {?MODULE, atomics}).
 -define(mnesia_tm_mailbox, mnesia_tm_mailbox).
 -define(broker_pool_max_mailbox, broker_pool_max_mailbox).
@@ -46,6 +49,7 @@
     ?mnesia_tm_mailbox => 1,
     ?broker_pool_max_mailbox => 2
 }).
+-define(MAILBOX_LEN_TAB, emqx_proc_mailbox_len).
 
 -ifdef(TEST).
 -define(UPDATE_INTERVAL_MS, persistent_term:get({?MODULE, update_interval}, 10_000)).
@@ -83,11 +87,16 @@ get_broker_pool_max_mailbox_size() ->
             atomics:get(Atomics, Idx)
     end.
 
+-spec get_mailbox_size_top_n() -> [{proc_name(), non_neg_integer()}].
+get_mailbox_size_top_n() ->
+    ets:tab2list(?MAILBOX_LEN_TAB).
+
 %%------------------------------------------------------------------------------
 %% `gen_server' API
 %%------------------------------------------------------------------------------
 
 init(_) ->
+    ets:new(?MAILBOX_LEN_TAB, [named_table, set, public]),
     Atomics = ensure_atomics(),
     State = #{atomics => Atomics},
     start_update_timer(),
@@ -121,11 +130,34 @@ ensure_atomics() ->
     end.
 
 handle_update(State) ->
+    case overall_mailbox_mon_enabled() of
+        true ->
+            ProcsInfo = non_zero_mailbox_procs(overall_mailbox_mon_max_procs()),
+            update_top_n_mailbox_procs(ProcsInfo),
+            toggle_overall_mailbox_alarm(ProcsInfo);
+        false ->
+            ok
+    end,
     MnesiaTMMailbox = update_mnesia_tm_mailbox_size(State),
     BrokerPoolMaxMailbox = update_broker_pool_max_mailbox_size(State),
     toggle_alarm(?mnesia_tm_mailbox, MnesiaTMMailbox),
     toggle_alarm(?broker_pool_max_mailbox, BrokerPoolMaxMailbox),
     ok.
+
+toggle_overall_mailbox_alarm(ProcsInfo) ->
+    Name = <<"process_overload">>,
+    Message = make_top_n_mailbox_alarm_msg(ProcsInfo),
+    case overall_mailbox_alarm_enabled() of
+        true ->
+            case make_top_n_mailbox_alarm_detail(ProcsInfo) of
+                [] ->
+                    ensure_alarm_deactivated(Name, #{}, Message);
+                AlarmMsg ->
+                    _ = emqx_alarm:activate(Name, AlarmMsg, Message)
+            end;
+        false ->
+            ok
+    end.
 
 toggle_alarm(?mnesia_tm_mailbox, MailboxSize) ->
     Name = <<"mnesia_transaction_manager_overload">>,
@@ -178,6 +210,190 @@ update_broker_pool_max_mailbox_size(State) ->
     atomics:put(Atomics, Idx, MailboxSize),
     MailboxSize.
 
+update_top_n_mailbox_procs(ProcsInfo) ->
+    ets:delete_all_objects(?MAILBOX_LEN_TAB),
+    lists:foreach(
+        fun({_Pid, QLen, ProcName}) ->
+            ets:insert(?MAILBOX_LEN_TAB, {ProcName, QLen})
+        end,
+        ProcsInfo
+    ).
+
+non_zero_mailbox_procs(TopN) ->
+    [
+        {Pid, QLen, proc_name(Pid)}
+     || {Pid, QLen, _} <- recon:proc_count(message_queue_len, TopN), QLen > 0
+    ].
+
+make_top_n_mailbox_alarm_msg(ProcsInfo) ->
+    [
+        <<"some processes are overloaded, overloaded procs:">>,
+        [
+            [<<" {">>, ProcName, <<": ">>, integer_to_binary(QLen), <<"}">>]
+         || {_Pid, QLen, ProcName} <- ProcsInfo
+        ]
+    ].
+
+make_top_n_mailbox_alarm_detail([]) ->
+    [];
+make_top_n_mailbox_alarm_detail([{_Pid, QLen, _} | _] = ProcsInfo) ->
+    AlarmTopN = overall_mailbox_alarm_top_n(),
+    case QLen >= overall_mailbox_alarm_threshold() of
+        true ->
+            ProcsToBeAlarm = [Pid || {Pid, _, _} <- lists:sublist(ProcsInfo, 1, AlarmTopN)],
+            format_procs_info(ProcsToBeAlarm, verbose);
+        false ->
+            []
+    end.
+
+format_procs_info(PidL, Type) ->
+    lists:filtermap(
+        fun(Pid) ->
+            case format_proc_info(get_pid(Pid), Type) of
+                undefined -> false;
+                Info -> {true, Info}
+            end
+        end,
+        PidL
+    ).
+
+basic_proc_info(Pid, Name, Init, Dict, QLen, Verbose) ->
+    Info0 = #{
+        pid => list_to_binary(pid_to_list(Pid)),
+        registered_name => reg_name(Name),
+        initial_call => init_call(Init, Dict),
+        label => get_label(Pid)
+    },
+    maybe_peek_messages(Pid, Info0, QLen, Dict, Verbose).
+
+maybe_peek_messages(Pid, Info0, QLen, Dict, verbose) when QLen > 0, QLen < 1000 ->
+    Info = Info0#{message_queue_len => QLen, proc_dict_len => length(Dict)},
+    case erlang:process_info(Pid, messages) of
+        {messages, Messages} ->
+            Info#{
+                messages_first_n => format_messages(
+                    Messages, overall_mailbox_alarm_peek_first_n_msgs()
+                )
+            };
+        _ ->
+            Info
+    end;
+maybe_peek_messages(_Pid, Info0, QLen, Dict, verbose) ->
+    Info0#{message_queue_len => QLen, proc_dict_len => length(Dict)};
+maybe_peek_messages(_Pid, Info, _QLen, _Dict, _) ->
+    Info.
+
+format_proc_info(undefined, _) ->
+    undefined;
+format_proc_info(Pid, verbose) when is_pid(Pid) ->
+    Attrs = [registered_name, initial_call, dictionary, message_queue_len, current_stacktrace],
+    case erlang:process_info(Pid, Attrs) of
+        [
+            {registered_name, Name},
+            {initial_call, Init},
+            {dictionary, Dict},
+            {message_queue_len, QLen},
+            {current_stacktrace, StackTrace}
+        ] ->
+            Info = basic_proc_info(Pid, Name, Init, Dict, QLen, verbose),
+            Info#{
+                current_stacktrace => format_stacktrace(StackTrace),
+                ancestors => format_ancestors(Dict)
+            };
+        undefined ->
+            undefined
+    end;
+format_proc_info(Pid, normal) when is_pid(Pid) ->
+    Attrs = [registered_name, initial_call, dictionary, message_queue_len],
+    case erlang:process_info(Pid, Attrs) of
+        [
+            {registered_name, Name},
+            {initial_call, Init},
+            {dictionary, Dict},
+            {message_queue_len, QLen}
+        ] ->
+            basic_proc_info(Pid, Name, Init, Dict, QLen, normal);
+        undefined ->
+            undefined
+    end.
+
+-spec proc_name(pid()) -> proc_name().
+proc_name(Pid) ->
+    case erlang:process_info(Pid, [registered_name, initial_call, dictionary]) of
+        [{registered_name, Name} | _] when is_atom(Name), Name =/= undefined ->
+            atom_to_binary(Name);
+        [{registered_name, _Name}, {initial_call, Init}, {dictionary, Dict}] ->
+            case get_label(Pid) of
+                undefined -> wrap_pid(init_call(Init, Dict), Pid);
+                Label -> wrap_pid(Label, Pid)
+            end;
+        _ ->
+            wrap_pid("unknown", Pid)
+    end.
+
+wrap_pid(Name, Pid) ->
+    iolist_to_binary([Name, "(", pid_to_list(Pid), ")"]).
+
+reg_name(Name) when is_atom(Name) -> Name;
+reg_name(_) -> undefined.
+
+init_call(Init, Dict) ->
+    case proplists:get_value('$initial_call', Dict) of
+        undefined -> format_mfa(Init);
+        Init1 -> format_mfa(Init1)
+    end.
+
+get_label(Pid) ->
+    case
+        erlang:function_exported(proc_lib, get_label, 1) andalso
+            proc_lib:get_label(Pid)
+    of
+        false -> undefined;
+        undefined -> undefined;
+        Label -> iolist_to_binary(io_lib:format("~p", [Label]))
+    end.
+
+format_messages([], _) -> [];
+format_messages(_Msgs, 0) -> [];
+format_messages([Term | Msgs], N) -> [format_term(Term) | format_messages(Msgs, N - 1)].
+
+format_mfa({M, F, A}) ->
+    iolist_to_binary(io_lib:format("~s:~s/~p", [atom_to_list(M), atom_to_list(F), A])).
+
+format_stacktrace(StackTrace) ->
+    lists:map(fun format_stack/1, StackTrace).
+
+format_stack({M, F, A, Location}) ->
+    #{
+        mfa => format_mfa({M, F, A}),
+        location => format_location(Location)
+    }.
+
+format_location(Location) ->
+    File = proplists:get_value(file, Location, unknown_file),
+    Line = proplists:get_value(line, Location, unknown_line),
+    iolist_to_binary(io_lib:format("~s:~p", [File, Line])).
+
+format_ancestors(Dict) ->
+    case proplists:get_value('$ancestors', Dict) of
+        undefined -> [];
+        Ancestors -> format_procs_info(Ancestors, normal)
+    end.
+
+get_pid(Pid) when is_pid(Pid) -> Pid;
+get_pid(NameOrPid) when is_atom(NameOrPid) ->
+    case erlang:whereis(NameOrPid) of
+        undefined -> undefined;
+        Pid -> Pid
+    end;
+get_pid(_) ->
+    undefined.
+
+format_term(Term) when is_atom(Term); is_integer(Term); is_float(Term) ->
+    Term;
+format_term(Term) ->
+    iolist_to_binary(io_lib:fwrite("~p", [Term], [{chars_limit, 512}])).
+
 read_mnesia_tm_mailbox_size() ->
     maybe
         Pid = whereis(mnesia_tm),
@@ -213,3 +429,21 @@ mnesia_tm_threshold() ->
 
 broker_pool_threshold() ->
     emqx_config:get([sysmon, broker_pool_mailbox_size_alarm_threshold]).
+
+overall_mailbox_mon_enabled() ->
+    emqx_config:get([sysmon, overall_mailbox_size_monitor, enable]).
+
+overall_mailbox_mon_max_procs() ->
+    emqx_config:get([sysmon, overall_mailbox_size_monitor, max_procs]).
+
+overall_mailbox_alarm_enabled() ->
+    overall_mailbox_alarm_threshold() > 0.
+
+overall_mailbox_alarm_threshold() ->
+    emqx_config:get([sysmon, overall_mailbox_size_monitor, alarm_threshold]).
+
+overall_mailbox_alarm_top_n() ->
+    emqx_config:get([sysmon, overall_mailbox_size_monitor, alarm_top_n_procs]).
+
+overall_mailbox_alarm_peek_first_n_msgs() ->
+    emqx_config:get([sysmon, overall_mailbox_size_monitor, alarm_try_peek_first_n_msgs]).

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1498,6 +1498,11 @@ fields("sysmon") ->
                     default => 500,
                     desc => ?DESC("sysmon_broker_pool_mailbox_size_alarm_threshold")
                 }
+            )},
+        {"overall_mailbox_size_monitor",
+            sc(
+                ref("sysmon_overall_mailbox_size_monitor"),
+                #{}
             )}
     ];
 fields("sysmon_vm") ->
@@ -1692,6 +1697,49 @@ fields("sysmon_top") ->
                     mapping => "system_monitor.db_name",
                     default => <<"postgres">>,
                     desc => ?DESC(sysmon_top_db_name)
+                }
+            )}
+    ];
+fields("sysmon_overall_mailbox_size_monitor") ->
+    [
+        {"enable",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(sysmon_overall_mailbox_size_monitor_enable)
+                }
+            )},
+        {"max_procs",
+            sc(
+                range(1, 1000),
+                #{
+                    default => 100,
+                    desc => ?DESC(sysmon_overall_mailbox_size_monitor_max_procs)
+                }
+            )},
+        {"alarm_threshold",
+            sc(
+                range(0, inf),
+                #{
+                    default => 100,
+                    desc => ?DESC(sysmon_overall_mailbox_size_monitor_alarm_threshold)
+                }
+            )},
+        {"alarm_top_n_procs",
+            sc(
+                range(1, 1000),
+                #{
+                    default => 5,
+                    desc => ?DESC(sysmon_overall_mailbox_size_monitor_alarm_top_n_procs)
+                }
+            )},
+        {"alarm_try_peek_first_n_msgs",
+            sc(
+                range(1, 1000),
+                #{
+                    default => 2,
+                    desc => ?DESC(sysmon_overall_mailbox_size_monitor_alarm_try_peek_first_n_msgs)
                 }
             )}
     ];
@@ -2207,6 +2255,9 @@ desc("sysmon_top") ->
     "This part of the configuration is responsible for monitoring\n"
     " the Erlang processes in the VM. This information can be sent to an external\n"
     " PostgreSQL database. This feature is inactive unless the PostgreSQL sink is configured.";
+desc("sysmon_overall_mailbox_size_monitor") ->
+    "This part of the configuration is responsible for monitoring\n"
+    " and alarming the Erlang processes whose mailboxes exceed a specified threshold.";
 desc("alarm") ->
     "Settings for the alarms.";
 desc("trace") ->

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1792,7 +1792,7 @@ socket_tcp_keepalive.label:
 """TCP keepalive options"""
 
   sysmon_mnesia_tm_mailbox_size_alarm_threshold {
-    label: "Size Alarm"
+    label: "Mnesia TM Mailbox Size Alarm"
     desc: """~
     The threshold above which an alarm is raised for the mailbox size of the mnesia transaction manager.  This process handles all transactions in EMQX's internal database mnesia.
 
@@ -1804,7 +1804,7 @@ socket_tcp_keepalive.label:
   }
 
   sysmon_broker_pool_mailbox_size_alarm_threshold {
-    label: "Size Alarm"
+    label: "Broker Pool Mailbox Size Alarm"
     desc: """~
     The threshold above which an alarm is raised for the maximum mailbox size among the broker pool workers.  Broker pool workers handle adding and removing subscriptions, and replication of routing information.
 
@@ -1813,6 +1813,42 @@ socket_tcp_keepalive.label:
     - Review the subscriptions that clients are doing, for example, try to compact topic filters;
     - Check if intra-cluster network bandwidth is reaching a maximum.~"""
   }
+
+sysmon_overall_mailbox_size_monitor_enable.desc:
+"""Enable monitoring of processes with mailboxes exceeding the specified threshold."""
+
+sysmon_overall_mailbox_size_monitor_enable.label:
+"""Overall Mailbox Size Alarm"""
+
+sysmon_overall_mailbox_size_monitor_max_procs.desc:
+"""~
+Maximum number of processes with mailboxes exceeding 0 to monitor.
+Information about these processes can be retrieved as emqx metrics by Prometheus, and they will be included in the alarms when a process's mailbox exceeds the specified threshold.~"""
+
+sysmon_overall_mailbox_size_monitor_max_procs.label:
+"""Max Processes to Monitor"""
+
+sysmon_overall_mailbox_size_monitor_alarm_threshold.desc:
+"""~
+When the mailbox size of an Erlang process exceeds this threshold, an alarm is raised.
+Setting this value to 0 will disable the alarm feature.~"""
+
+sysmon_overall_mailbox_size_monitor_alarm_threshold.label:
+"""Alarm Threshold"""
+
+sysmon_overall_mailbox_size_monitor_alarm_top_n_procs.desc:
+"""~
+The maximum number of Erlang processes with non-zero mailboxes to include in the alarm information.~"""
+
+sysmon_overall_mailbox_size_monitor_alarm_top_n_procs.label:
+"""Proc Num in Alarm"""
+
+sysmon_overall_mailbox_size_monitor_alarm_try_peek_first_n_msgs.desc:
+"""~
+When the mailbox of a process is not too long, try to peek the first N messages in the mailbox and include them in the alarm information.~"""
+
+sysmon_overall_mailbox_size_monitor_alarm_try_peek_first_n_msgs.label:
+"""First N Messages in Alarm"""
 
 config_backup_interval.label:
 """Config Backup Interval"""


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13878

Release version: v/e5.9.0

## Summary

Prometheus:

```
# TYPE emqx_vm_mailbox_size_top_n gauge
# HELP emqx_vm_mailbox_size_top_n
emqx_vm_mailbox_size_top_n{proc_name="emqx_connection:init/4",pid="<0.4958.0>",clientid="mqttjs_be6a3c40",peername="127.0.0.1:58965",rule_id="rule_r9a5",rule_trigger_ts="[1739266964326]"} 1
emqx_vm_mailbox_size_top_n{proc_name="emqx_connection:init/4",pid="<0.4955.0>",clientid="mqttjs_932bc82a",peername="127.0.0.1:58964",rule_id="rule_r9a5",rule_trigger_ts="[1739266963519]"} 1
emqx_vm_mailbox_size_top_n{proc_name="emqx_connection:init/4",pid="<0.4961.0>",clientid="mqttjs_5ed9c7ce",peername="127.0.0.1:58966",rule_id="rule_r9a5",rule_trigger_ts="[1739266964841]"} 1
# TYPE emqx_cluster_nodes_running gauge
```

Alarm:

```
Topic: $SYS/brokers/emqx@127.0.0.1/alarms/activate
QoS: 0

{
  "deactivate_at": "infinity",
  "activate_at": 1739267800625663,
  "activated": true,
  "details": [
    {
      "messages_first_n": [
        "{tcp_closed,#Port<0.22>}"
      ],
      "proc_dict_len": 14,
      "ancestors": [
        {
          "registered_name": "undefined",
          "pid": "<0.4028.0>",
          "label": "undefined",
          "initial_call": "esockd_connection_sup:init/1"
        },
        {
          "registered_name": "undefined",
          "pid": "<0.4027.0>",
          "label": "undefined",
          "initial_call": "supervisor:esockd_listener_sup/1"
        },
        {
          "registered_name": "esockd_sup",
          "pid": "<0.3672.0>",
          "label": "undefined",
          "initial_call": "supervisor:esockd_sup/1"
        },
        {
          "registered_name": "undefined",
          "pid": "<0.3671.0>",
          "label": "undefined",
          "initial_call": "application_master:start_it/4"
        }
      ],
      "registered_name": "undefined",
      "pid": "<0.4917.0>",
      "message_queue_len": 1,
      "label": "undefined",
      "initial_call": "emqx_connection:init/4",
      "current_stacktrace": [
        {
          "location": "timer.erl:235",
          "mfa": "timer:sleep/1"
        },
        {
          "location": "emqx_rule_runtime.erl:695",
          "mfa": "emqx_rule_runtime:do_apply_func/4"
        },
        {
          "location": "emqx_rule_runtime.erl:280",
          "mfa": "emqx_rule_runtime:select_and_transform/3"
        },
        {
          "location": "emqx_rule_runtime.erl:227",
          "mfa": "emqx_rule_runtime:evaluate_select/3"
        },
        {
          "location": "emqx_rule_runtime.erl:214",
          "mfa": "emqx_rule_runtime:do_apply_rule/3"
        },
        {
          "location": "emqx_rule_runtime.erl:87",
          "mfa": "emqx_rule_runtime:apply_rule/3"
        },
        {
          "location": "emqx_rule_runtime.erl:71",
          "mfa": "emqx_rule_runtime:apply_rule_discard_result/3"
        },
        {
          "location": "emqx_rule_runtime.erl:67",
          "mfa": "emqx_rule_runtime:apply_rules/3"
        },
        {
          "location": "emqx_rule_events.erl:170",
          "mfa": "emqx_rule_events:on_message_publish/2"
        },
        {
          "location": "emqx_hooks.erl:200",
          "mfa": "emqx_hooks:safe_execute/2"
        },
        {
          "location": "emqx_hooks.erl:180",
          "mfa": "emqx_hooks:do_run_fold/3"
        },
        {
          "location": "emqx_broker.erl:264",
          "mfa": "emqx_broker:eval_hook_and_publish/2"
        },
        {
          "location": "emqx_channel.erl:707",
          "mfa": "emqx_channel:do_publish/3"
        },
        {
          "location": "emqx_connection.erl:911",
          "mfa": "emqx_connection:with_channel/3"
        },
        {
          "location": "emqx_connection.erl:506",
          "mfa": "emqx_connection:process_msg/2"
        },
        {
          "location": "emqx_connection.erl:457",
          "mfa": "emqx_connection:handle_recv/3"
        },
        {
          "location": "proc_lib.erl:251",
          "mfa": "proc_lib:wake_up/3"
        }
      ]
    },
    {
      "messages_first_n": [
        "{tcp_closed,#Port<0.21>}"
      ],
      "proc_dict_len": 14,
      "ancestors": [
        {
          "registered_name": "undefined",
          "pid": "<0.4028.0>",
          "label": "undefined",
          "initial_call": "esockd_connection_sup:init/1"
        },
        {
          "registered_name": "undefined",
          "pid": "<0.4027.0>",
          "label": "undefined",
          "initial_call": "supervisor:esockd_listener_sup/1"
        },
        {
          "registered_name": "esockd_sup",
          "pid": "<0.3672.0>",
          "label": "undefined",
          "initial_call": "supervisor:esockd_sup/1"
        },
        {
          "registered_name": "undefined",
          "pid": "<0.3671.0>",
          "label": "undefined",
          "initial_call": "application_master:start_it/4"
        }
      ],
      "registered_name": "undefined",
      "pid": "<0.4914.0>",
      "message_queue_len": 1,
      "label": "undefined",
      "initial_call": "emqx_connection:init/4",
      "current_stacktrace": [
        {
          "location": "timer.erl:235",
          "mfa": "timer:sleep/1"
        },
        {
          "location": "emqx_rule_runtime.erl:695",
          "mfa": "emqx_rule_runtime:do_apply_func/4"
        },
        {
          "location": "emqx_rule_runtime.erl:280",
          "mfa": "emqx_rule_runtime:select_and_transform/3"
        },
        {
          "location": "emqx_rule_runtime.erl:227",
          "mfa": "emqx_rule_runtime:evaluate_select/3"
        },
        {
          "location": "emqx_rule_runtime.erl:214",
          "mfa": "emqx_rule_runtime:do_apply_rule/3"
        },
        {
          "location": "emqx_rule_runtime.erl:87",
          "mfa": "emqx_rule_runtime:apply_rule/3"
        },
        {
          "location": "emqx_rule_runtime.erl:71",
          "mfa": "emqx_rule_runtime:apply_rule_discard_result/3"
        },
        {
          "location": "emqx_rule_runtime.erl:67",
          "mfa": "emqx_rule_runtime:apply_rules/3"
        },
        {
          "location": "emqx_rule_events.erl:170",
          "mfa": "emqx_rule_events:on_message_publish/2"
        },
        {
          "location": "emqx_hooks.erl:200",
          "mfa": "emqx_hooks:safe_execute/2"
        },
        {
          "location": "emqx_hooks.erl:180",
          "mfa": "emqx_hooks:do_run_fold/3"
        },
        {
          "location": "emqx_broker.erl:264",
          "mfa": "emqx_broker:eval_hook_and_publish/2"
        },
        {
          "location": "emqx_channel.erl:707",
          "mfa": "emqx_channel:do_publish/3"
        },
        {
          "location": "emqx_connection.erl:911",
          "mfa": "emqx_connection:with_channel/3"
        },
        {
          "location": "emqx_connection.erl:506",
          "mfa": "emqx_connection:process_msg/2"
        },
        {
          "location": "emqx_connection.erl:457",
          "mfa": "emqx_connection:handle_recv/3"
        },
        {
          "location": "proc_lib.erl:251",
          "mfa": "proc_lib:wake_up/3"
        }
      ]
    },
    {
      "messages_first_n": [
        "{tcp_closed,#Port<0.20>}"
      ],
      "proc_dict_len": 14,
      "ancestors": [
        {
          "registered_name": "undefined",
          "pid": "<0.4028.0>",
          "label": "undefined",
          "initial_call": "esockd_connection_sup:init/1"
        },
        {
          "registered_name": "undefined",
          "pid": "<0.4027.0>",
          "label": "undefined",
          "initial_call": "supervisor:esockd_listener_sup/1"
        },
        {
          "registered_name": "esockd_sup",
          "pid": "<0.3672.0>",
          "label": "undefined",
          "initial_call": "supervisor:esockd_sup/1"
        },
        {
          "registered_name": "undefined",
          "pid": "<0.3671.0>",
          "label": "undefined",
          "initial_call": "application_master:start_it/4"
        }
      ],
      "registered_name": "undefined",
      "pid": "<0.4911.0>",
      "message_queue_len": 1,
      "label": "undefined",
      "initial_call": "emqx_connection:init/4",
      "current_stacktrace": [
        {
          "location": "timer.erl:235",
          "mfa": "timer:sleep/1"
        },
        {
          "location": "emqx_rule_runtime.erl:695",
          "mfa": "emqx_rule_runtime:do_apply_func/4"
        },
        {
          "location": "emqx_rule_runtime.erl:280",
          "mfa": "emqx_rule_runtime:select_and_transform/3"
        },
        {
          "location": "emqx_rule_runtime.erl:227",
          "mfa": "emqx_rule_runtime:evaluate_select/3"
        },
        {
          "location": "emqx_rule_runtime.erl:214",
          "mfa": "emqx_rule_runtime:do_apply_rule/3"
        },
        {
          "location": "emqx_rule_runtime.erl:87",
          "mfa": "emqx_rule_runtime:apply_rule/3"
        },
        {
          "location": "emqx_rule_runtime.erl:71",
          "mfa": "emqx_rule_runtime:apply_rule_discard_result/3"
        },
        {
          "location": "emqx_rule_runtime.erl:67",
          "mfa": "emqx_rule_runtime:apply_rules/3"
        },
        {
          "location": "emqx_rule_events.erl:170",
          "mfa": "emqx_rule_events:on_message_publish/2"
        },
        {
          "location": "emqx_hooks.erl:200",
          "mfa": "emqx_hooks:safe_execute/2"
        },
        {
          "location": "emqx_hooks.erl:180",
          "mfa": "emqx_hooks:do_run_fold/3"
        },
        {
          "location": "emqx_broker.erl:264",
          "mfa": "emqx_broker:eval_hook_and_publish/2"
        },
        {
          "location": "emqx_channel.erl:707",
          "mfa": "emqx_channel:do_publish/3"
        },
        {
          "location": "emqx_connection.erl:911",
          "mfa": "emqx_connection:with_channel/3"
        },
        {
          "location": "emqx_connection.erl:506",
          "mfa": "emqx_connection:process_msg/2"
        },
        {
          "location": "emqx_connection.erl:457",
          "mfa": "emqx_connection:handle_recv/3"
        },
        {
          "location": "proc_lib.erl:251",
          "mfa": "proc_lib:wake_up/3"
        }
      ]
    }
  ],
  "name": "process_overload",
  "message": "some processes are overloaded, overloaded procs: {emqx_connection:init/4: 1} {emqx_connection:init/4: 1} {emqx_connection:init/4: 1}"
}
```

Deactivate Alarm:
```
Topic: $SYS/brokers/emqx@127.0.0.1/alarms/deactivate
QoS: 0

{
  "deactivate_at": 1739267820652842,
  "activate_at": 1739267800625663,
  "activated": false,
  "details": {},
  "name": "process_overload",
  "message": "some processes are overloaded"
}
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
