### PR TITLE
250211 add missing changelogs

### DIFF
--- a/changes/ce/feat-13350.md
+++ b/changes/ce/feat-13350.md
@@ -1,1 +1,0 @@
-Support for getting the Server Name of the client connected and storing it in the client information as `peersni`.

--- a/changes/ce/feat-13862.md
+++ b/changes/ce/feat-13862.md
@@ -1,9 +1,0 @@
-## Breaking changes
-
-Add the detailed results to the user import interface, for example:
-
-```
-{"total": 2, "success": 2, "override": 0, "skipped": 0, "failed": 0}
-```
-
-In previous versions, after the import is completed, only a 204 HTTP Code would be returned.

--- a/changes/ce/fix-12902.md
+++ b/changes/ce/fix-12902.md
@@ -1,1 +1,0 @@
-Pass the Content-type of MQTT message to the Stomp message.

--- a/changes/ce/fix-12976.md
+++ b/changes/ce/fix-12976.md
@@ -1,1 +1,0 @@
-Fix the `client.disconnected` event being triggered when taking over a session that the socket has been disconnected before.

--- a/changes/e5.6.0.en.md
+++ b/changes/e5.6.0.en.md
@@ -168,6 +168,10 @@
 
   - `rfc3339`: Uses RFC3339 compliant format for date-time strings. For example, `2024-03-26T11:52:19.777087+00:00`.
 
+- [#12417](https://github.com/emqx/emqx/pull/12417) Added support for specifying the expiration time of MQTT messages via configuration file.
+
+See the description of the `message_expiry_interval` configuration in the `mqtt.conf.example` file for more details.
+
 ## Bug Fixes
 
 - [#11868](https://github.com/emqx/emqx/pull/11868) Fixed a bug where will messages were not published after session takeover.

--- a/changes/e5.7.0.en.md
+++ b/changes/e5.7.0.en.md
@@ -191,6 +191,8 @@ Fix the `$queue` shared topics format error in endpoint `/topics`.
 
 #### Gateways
 
+- [#12902](https://github.com/emqx/emqx/pull/12902) Pass the Content-type of MQTT message to the Stomp message.
+
 - [#12909](https://github.com/emqx/emqx/pull/12909) Fixed UDP listener process handling on errors or closure, The fix ensures the UDP listener is cleanly stopped and restarted as needed if these error conditions occur.
 
 - [#13001](https://github.com/emqx/emqx/pull/13001) Fixed an issue where the syskeeper forwarder would never reconnect when the connection was lost.

--- a/changes/e5.7.0.en.md
+++ b/changes/e5.7.0.en.md
@@ -135,6 +135,8 @@ Note: This is a breaking change. This option is enabled by default, so the defau
 - [#12855](https://github.com/emqx/emqx/pull/12855) Fix when the client subscribes/unsubscribes to a shared topic, the system topic messages for Client subscribed/unsubscribed notification cannot be serialized correctly.
 Fix the `$queue` shared topics format error in endpoint `/topics`.
 
+- [#12976](https://github.com/emqx/emqx/pull/12976) Fix the `client.disconnected` event being triggered when taking over a session that the socket has been disconnected before.
+
 #### Data Processing and Integration
 
 - [#12653](https://github.com/emqx/emqx/pull/12653) The rule engine function `bin2hexstr` now supports bitstring inputs with a bit size that is not divisible by 8. Such bitstrings can be returned by the rule engine function `subbits`.

--- a/changes/e5.7.0.en.md
+++ b/changes/e5.7.0.en.md
@@ -195,6 +195,10 @@ Fix the `$queue` shared topics format error in endpoint `/topics`.
 
 - [#12902](https://github.com/emqx/emqx/pull/12902) Pass the Content-type of MQTT message to the Stomp message.
 
+- [#12892](https://github.com/emqx/emqx/pull/12892) Fix an error in OCPP gateway's handling of downstream BootNotification.
+
+  Also fixed the `gateways/ocpp/listeners` endpoint to return the correct number of current connections.
+
 - [#12909](https://github.com/emqx/emqx/pull/12909) Fixed UDP listener process handling on errors or closure, The fix ensures the UDP listener is cleanly stopped and restarted as needed if these error conditions occur.
 
 - [#13001](https://github.com/emqx/emqx/pull/13001) Fixed an issue where the syskeeper forwarder would never reconnect when the connection was lost.

--- a/changes/e5.8.0.en.md
+++ b/changes/e5.8.0.en.md
@@ -14,6 +14,8 @@
 
 ### Authentication and Authorization
 
+- [#13350](https://github.com/emqx/emqx/pull/13350) Support for getting the Server Name of the client connected and storing it in the client information as `peersni`.
+
 - [#12418](https://github.com/emqx/emqx/pull/12418) Enhanced JWT authentication to support claims verification using a list of objects:
 
   ```

--- a/changes/ee/feat-12417.md
+++ b/changes/ee/feat-12417.md
@@ -1,3 +1,0 @@
-Added support for specifying the expiration time of MQTT messages via configuration file.
-
-See the description of the `message_expiry_interval` configuration in the `mqtt.conf.example` file for more details.

--- a/changes/ee/feat-13650.md
+++ b/changes/ee/feat-13650.md
@@ -1,1 +1,0 @@
-Supports integration with [Datalayers](https://docs.datalayers.cn/datalayers/latest/)

--- a/changes/ee/feat-14034.md
+++ b/changes/ee/feat-14034.md
@@ -1,1 +1,0 @@
-Expose the `pool_size` parameter of Influxdb and Datalayers connectors to configurable. Previously it fixed to the number of CPU cores of the operating system.

--- a/changes/ee/fix-12892.md
+++ b/changes/ee/fix-12892.md
@@ -1,3 +1,0 @@
-Fix an error in OCPP gateway's handling of downstream BootNotification.
-
-Fix the `gateways/ocpp/listeners` endpoint to return the correct number of current connections.

--- a/changes/ee/fix-13755.md
+++ b/changes/ee/fix-13755.md
@@ -1,1 +1,0 @@
-Refactoring the Datalayers data integration implementation to increase code reuse.

--- a/changes/ee/fix-13881.md
+++ b/changes/ee/fix-13881.md
@@ -1,1 +1,0 @@
-Fix the issue of data loss when enabling batch writing in SQL Server Sink.

--- a/changes/ee/fix-13964.md
+++ b/changes/ee/fix-13964.md
@@ -1,1 +1,0 @@
-Fix the issue of data loss when enabling batch writing in DynamoDB Sink

--- a/changes/ee/fix-14045.md
+++ b/changes/ee/fix-14045.md
@@ -1,1 +1,0 @@
-Fix an issue where License could not be viewed through the Dashboard after updating from the command line.

--- a/changes/ee/fix-14149.md
+++ b/changes/ee/fix-14149.md
@@ -1,1 +1,0 @@
-Failed to create ClickHouse bridges using the old `/bridges` API due to `#{reason => unknown_fields, unknown => "undefined_vars_as_null"}`.

--- a/changes/ee/fix-14294.md
+++ b/changes/ee/fix-14294.md
@@ -1,1 +1,0 @@
-Improve logs in `mysql_conn` to remove OTP crash reports.

--- a/changes/v5.6.0.en.md
+++ b/changes/v5.6.0.en.md
@@ -145,6 +145,10 @@
 - [#12392](https://github.com/emqx/emqx/pull/12392)
   New WebSocket listener option: `validate_utf8` for performance tuning.
 
+- [#12417](https://github.com/emqx/emqx/pull/12417) Added support for specifying the expiration time of MQTT messages via configuration file.
+
+See the description of the `message_expiry_interval` configuration in the `mqtt.conf.example` file for more details.
+
 ## Bug Fixes
 
 - [#11868](https://github.com/emqx/emqx/pull/11868) Fixed a bug where will messages were not published after session takeover.

--- a/changes/v5.7.0.en.md
+++ b/changes/v5.7.0.en.md
@@ -104,6 +104,8 @@ Note: This is a breaking change. This option is enabled by default, so the defau
 - [#12855](https://github.com/emqx/emqx/pull/12855) Fix when the client subscribes/unsubscribes to a shared topic, the system topic messages for Client subscribed/unsubscribed notification cannot be serialized correctly.
 Fix the `$queue` shared topics format error in endpoint `/topics`.
 
+- [#12976](https://github.com/emqx/emqx/pull/12976) Fix the `client.disconnected` event being triggered when taking over a session that the socket has been disconnected before.
+
 #### Data Processing and Integration
 
 - [#12653](https://github.com/emqx/emqx/pull/12653) The rule engine function `bin2hexstr` now supports bitstring inputs with a bit size that is not divisible by 8. Such bitstrings can be returned by the rule engine function `subbits`.

--- a/changes/v5.7.0.en.md
+++ b/changes/v5.7.0.en.md
@@ -153,6 +153,8 @@ Fix the `$queue` shared topics format error in endpoint `/topics`.
 
 #### Gateways
 
+- [#12902](https://github.com/emqx/emqx/pull/12902) Pass the Content-type of MQTT message to the Stomp message.
+
 - [#12909](https://github.com/emqx/emqx/pull/12909) Fixed UDP listener process handling on errors or closure, The fix ensures the UDP listener is cleanly stopped and restarted as needed if these error conditions occur.
 
 - [#13001](https://github.com/emqx/emqx/pull/13001) Fixed an issue where the syskeeper forwarder would never reconnect when the connection was lost.

--- a/changes/v5.8.2.en.md
+++ b/changes/v5.8.2.en.md
@@ -25,6 +25,14 @@ Make sure to check the breaking changes and known issues before upgrading to EMQ
 
   Additionally, a `node` parameter was added to the `/api/v5/monitor_current` API, allowing targeted queries to a single node instead of the entire cluster. For instance, using `?aggregate=false&node=emqx@node1.domain.name` will return data exclusively for the specified node.
 
+- [#13862](https://github.com/emqx/emqx/pull/13862) Add the detailed results to the user import interface, for example:
+
+  ```
+  {"total": 2, "success": 2, "override": 0, "skipped": 0, "failed": 0}
+  ```
+
+  In previous versions, after the import is completed, only a 204 HTTP Code would be returned.
+
 ### Security
 
 - [#13923](https://github.com/emqx/emqx/pull/13923) Added `zone` support in authentication, authorization, and mountpoint templates.


### PR DESCRIPTION
A few changelog files were named wrong.
Add them to the compiled release notes and delete the original file.