### PR TITLE
fix(config): do not set default values in base.hocon

### DIFF
--- a/apps/emqx_conf/etc/base.hocon
+++ b/apps/emqx_conf/etc/base.hocon
@@ -16,9 +16,9 @@
 ## Read more about configs here: {{ emqx_configuration_doc_log }}
 log {
     file {
-        level = warning
+        # level = warning
     }
     console {
-        level = warning
+        # level = warning
     }
 }


### PR DESCRIPTION
Fixes [EMQX-13749](https://emqx.atlassian.net/browse/EMQX-13749)

Release version: v/e5.8.5

## Summary

Otherwise the config may mask environment variable overrides when using alias.
e.g. `env EMQX_LOG__CONSOLE_HANDLER__LEVEL="info"` will not take effect because if a config value is found, it will not try to read alias.
`env EMQX_LOG__CONSOLE__LEVEL="info"` works fine even without this fix though.


[EMQX-13749]: https://emqx.atlassian.net/browse/EMQX-13749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ