### PR TITLE
fix(rule engine api): add missing schema for `alarm.{,de}activated`

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -33,9 +33,20 @@
 check_params(Params, Tag) ->
     BTag = atom_to_binary(Tag),
     Opts = #{atom_key => true, required => false},
-    try hocon_tconf:check_plain(?MODULE, #{BTag => Params}, Opts, [Tag]) of
+    SchemaMod = ?MODULE,
+    try hocon_tconf:check_plain(SchemaMod, #{BTag => Params}, Opts, [Tag]) of
         #{Tag := Checked} -> {ok, Checked}
     catch
+        throw:{SchemaMod, [Reason]} ->
+            ?SLOG(
+                info,
+                #{
+                    msg => "check_rule_params_failed",
+                    reason => Reason
+                },
+                #{tag => ?TAG}
+            ),
+            {error, Reason};
         throw:Reason ->
             ?SLOG(
                 info,

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -344,6 +344,7 @@ fields("ctx_schema_validation_failed") ->
     Event = 'schema.validation_failed',
     [
         {"event_type", event_type_sc(Event)},
+        {"event", event_sc(Event)},
         {"validation", sc(binary(), #{desc => ?DESC("event_validation")})}
         | msg_event_common_fields()
     ];
@@ -351,6 +352,7 @@ fields("ctx_message_transformation_failed") ->
     Event = 'message.transformation_failed',
     [
         {"event_type", event_type_sc(Event)},
+        {"event", event_sc(Event)},
         {"transformation", sc(binary(), #{desc => ?DESC("event_transformation")})}
         | msg_event_common_fields()
     ].

--- a/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_api_schema.erl
@@ -27,6 +27,10 @@
 
 -export([namespace/0, roots/0, fields/1]).
 
+-ifdef(TEST).
+-export([event_to_event_type/1]).
+-endif.
+
 -type tag() :: rule_creation | rule_test | rule_engine | rule_apply_test.
 
 -spec check_params(map(), tag()) -> {ok, map()} | {error, term()}.
@@ -355,6 +359,27 @@ fields("ctx_message_transformation_failed") ->
         {"event", event_sc(Event)},
         {"transformation", sc(binary(), #{desc => ?DESC("event_transformation")})}
         | msg_event_common_fields()
+    ];
+fields("ctx_alarm_activated") ->
+    Event = 'alarm.activated',
+    [
+        {"event_type", event_type_sc(Event)},
+        {"event", event_sc(Event)},
+        {"name", sc(binary(), #{desc => ?DESC("alarm_name")})},
+        {"message", sc(binary(), #{desc => ?DESC("alarm_message")})},
+        {"details", sc(map(), #{desc => ?DESC("alarm_details")})},
+        {"activated_at", sc(integer(), #{desc => ?DESC("alarm_activated_at")})}
+    ];
+fields("ctx_alarm_deactivated") ->
+    Event = 'alarm.deactivated',
+    [
+        {"event_type", event_type_sc(Event)},
+        {"event", event_sc(Event)},
+        {"name", sc(binary(), #{desc => ?DESC("alarm_name")})},
+        {"message", sc(binary(), #{desc => ?DESC("alarm_message")})},
+        {"details", sc(map(), #{desc => ?DESC("alarm_details")})},
+        {"activated_at", sc(integer(), #{desc => ?DESC("alarm_activated_at")})},
+        {"deactivated_at", sc(integer(), #{desc => ?DESC("alarm_deactivated_at")})}
     ].
 
 rule_input_message_context() ->
@@ -383,7 +408,9 @@ rule_test_context_refs() ->
         ref("ctx_bridge_mqtt"),
         ref("ctx_delivery_dropped"),
         ref("ctx_schema_validation_failed"),
-        ref("ctx_message_transformation_failed")
+        ref("ctx_message_transformation_failed"),
+        ref("ctx_alarm_activated"),
+        ref("ctx_alarm_deactivated")
     ].
 
 rule_test_context_union(Refs) ->

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -946,7 +946,7 @@ event_info_client_disconnected() ->
         'client.disconnected',
         {<<"client disconnected">>, <<"连接断开"/utf8>>},
         {<<"client disconnected">>, <<"连接断开"/utf8>>},
-        <<"SELECT * FROM \"$events/client_disconnected\" WHERE topic =~ 't/#'">>
+        <<"SELECT * FROM \"$events/client_disconnected\"">>
     ).
 event_info_client_connack() ->
     event_info_common(

--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -212,10 +212,6 @@ is_test_runtime_env() ->
 
 %% Most events have the original `topic' input, but their own topic (i.e.: `$events/...')
 %% is different from `topic'.
-get_in_topic(#{event_type := schema_validation_failed}) ->
-    <<"$events/schema_validation_failed">>;
-get_in_topic(#{event_type := message_transformation_failed}) ->
-    <<"$events/message_transformation_failed">>;
 get_in_topic(Context) ->
     case maps:find(event_topic, Context) of
         {ok, EventTopic} ->

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_test_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_test_SUITE.erl
@@ -109,7 +109,7 @@ t_ctx_acked(_) ->
         username => <<"u_emqx_2">>
     },
 
-    Expected = with_node_timestampe([from_clientid, from_username, topic, qos], Context),
+    Expected = with_node_timestamp([from_clientid, from_username, topic, qos], Context),
 
     do_test(SQL, Context, Expected).
 
@@ -128,7 +128,7 @@ t_ctx_droped(_) ->
         username => <<"u_emqx">>
     },
 
-    Expected = with_node_timestampe([reason, topic, qos], Context),
+    Expected = with_node_timestamp([reason, topic, qos], Context),
     do_test(SQL, Context, Expected).
 
 t_ctx_connected(_) ->
@@ -318,7 +318,7 @@ test_rule_params(Sql, Context) ->
         }
     }.
 
-with_node_timestampe(Keys, Context) ->
+with_node_timestamp(Keys, Context) ->
     check_result(Keys, [node, timestamp], Context).
 
 check_result(Keys, Exists, Context) ->


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13915

Release version: v/e5.8.5

## Summary

Also improves error messages when it fails to find the event type.

![image](https://github.com/user-attachments/assets/c10053e0-3ace-40b5-a9cd-d1ffac8c8623)


## PR Checklist

- [x] Added tests for the changes
- [na] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~ new, unreleased feature
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible
