### PR TITLE
fix(dsraft): avoid contacting lost servers during membership changes

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.app.src
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.app.src
@@ -2,7 +2,7 @@
 {application, emqx_ds_builtin_raft, [
     {description, "Raft replication layer for the durable storage"},
     % strict semver, bump manually!
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, gproc, mria, ra, emqx_durable_storage]},

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
@@ -350,8 +350,8 @@ print_status(Nodes, Shards, Transitions) ->
         io:format(
             "(!) ATTENTION~n"
             "(!) One or more shards have replica set where majority of replicas are gone.~n"
-            "(!) Membership changes are compromised, pending transition are likely to never finish.~n"
-            "(!) Please take necessary steps to deal with lost sites, e.g. `emqx ds ctl forget <...>`.~n"
+            "(!) Membership changes are compromised, pending transitions may never finish.~n"
+            "(!) Please take necessary steps to deal with lost sites.~n"
             "(!) Prepare for the possibility of data loss.~n"
         ),
     ok.

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -909,8 +909,9 @@ ds(CMD) ->
     end.
 
 do_ds(["info"]) ->
-    emqx_ds_replication_layer_meta:print_status();
-do_ds(["set_replicas", DBStr | SitesStr]) ->
+    emqx_ds_replication_layer_meta:print_status(),
+    ok;
+do_ds(["set-replicas", DBStr | SitesStr]) ->
     case emqx_utils:safe_to_existing_atom(DBStr) of
         {ok, DB} ->
             Sites = lists:map(fun list_to_binary/1, SitesStr),
@@ -918,11 +919,13 @@ do_ds(["set_replicas", DBStr | SitesStr]) ->
                 {ok, _} ->
                     emqx_ctl:print("ok~n");
                 {error, Description} ->
-                    emqx_ctl:print("Unable to update replicas: ~s~n", [Description])
+                    emqx_ctl:warning("Unable to update replicas: ~s~n", [Description])
             end;
         {error, _} ->
-            emqx_ctl:print("Unknown durable storage")
+            emqx_ctl:warning("Unknown durable storage")
     end;
+do_ds(["set_replicas" | Args]) ->
+    do_ds(["set-replicas" | Args]);
 do_ds(["join", DBStr, Site]) ->
     case emqx_utils:safe_to_existing_atom(DBStr) of
         {ok, DB} ->
@@ -932,10 +935,10 @@ do_ds(["join", DBStr, Site]) ->
                 {ok, _} ->
                     emqx_ctl:print("ok~n");
                 {error, Description} ->
-                    emqx_ctl:print("Unable to update replicas: ~s~n", [Description])
+                    emqx_ctl:warning("Unable to update replicas: ~s~n", [Description])
             end;
         {error, _} ->
-            emqx_ctl:print("Unknown durable storage~n")
+            emqx_ctl:warning("Unknown durable storage~n")
     end;
 do_ds(["leave", DBStr, Site]) ->
     case emqx_utils:safe_to_existing_atom(DBStr) of
@@ -946,26 +949,26 @@ do_ds(["leave", DBStr, Site]) ->
                 {ok, _} ->
                     emqx_ctl:print("ok~n");
                 {error, Description} ->
-                    emqx_ctl:print("Unable to update replicas: ~s~n", [Description])
+                    emqx_ctl:warning("Unable to update replicas: ~s~n", [Description])
             end;
         {error, _} ->
-            emqx_ctl:print("Unknown durable storage~n")
+            emqx_ctl:warning("Unknown durable storage~n")
     end;
 do_ds(["forget", Site]) ->
     case emqx_mgmt_api_ds:forget(list_to_binary(Site), cli) of
         ok ->
             emqx_ctl:print("ok~n");
         {error, Description} ->
-            emqx_ctl:print("Unable to forget site: ~s~n", [Description])
+            emqx_ctl:warning("Unable to forget site: ~s~n", [Description])
     end;
 do_ds(_) ->
     emqx_ctl:usage([
         {"ds info", "Show overview of the embedded durable storage state"},
-        {"ds set_replicas <storage> <site1> <site2> ...",
+        {"ds set-replicas <storage> <site1> <site2> ...",
             "Change the replica set of the durable storage"},
         {"ds join <storage> <site>", "Add site to the replica set of the storage"},
         {"ds leave <storage> <site>", "Remove site from the replica set of the storage"},
-        {"ds forget <site>", "Forcefully remove a site from the list of known sites"}
+        {"ds forget <site>", "Remove a site from the list of known sites"}
     ]).
 
 -else.

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.4.3"},
+    {vsn, "5.5.0"},
     {modules, [
         emqx_utils,
         emqx_utils_api,

--- a/apps/emqx_utils/src/emqx_utils_fmt.erl
+++ b/apps/emqx_utils/src/emqx_utils_fmt.erl
@@ -34,9 +34,9 @@
     | {subcolumns, [[table_cell_simple()]]}
     | {group, [[table_cell()]]}.
 
--type table_props() :: #{}.
--type column_props() :: #{}.
--type cell_props() :: #{}.
+-type table_props() :: #{_ => _}.
+-type column_props() :: #{align => left | right}.
+-type cell_props() :: #{padc => char(), delimiter => string(), _ => _}.
 
 -type formatted_cell() :: unicode:chardata() | {unicode:chardata(), cell_props()}.
 

--- a/apps/emqx_utils/src/emqx_utils_fmt.erl
+++ b/apps/emqx_utils/src/emqx_utils_fmt.erl
@@ -1,0 +1,278 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_utils_fmt).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-export([
+    table/2,
+    table/3
+]).
+
+%%
+
+-type header_cell() :: unicode:chardata() | {unicode:chardata(), column_props()}.
+-type table_cell() :: table_cell_simple() | table_sub_structure().
+-type table_cell_simple() :: unicode:chardata() | atom() | number().
+-type table_sub_structure() ::
+    {subrows, [[table_cell()]]}
+    | {subcolumns, [[table_cell_simple()]]}
+    | {group, [[table_cell()]]}.
+
+-type table_props() :: #{}.
+-type column_props() :: #{}.
+-type cell_props() :: #{}.
+
+-type formatted_cell() :: unicode:chardata() | {unicode:chardata(), cell_props()}.
+
+-define(table_header_props, #{padc => $-, delimiter => "."}).
+-define(table_headcut_props, #{padc => $-}).
+-define(group_header_props, #{padc => $-}).
+-define(table_footer_props, #{padc => $-, delimiter => "`"}).
+
+%%
+
+%% @doc Format a set of rows accompanied by header into a printable, ASCII-delimited
+%% table.
+-spec table(Header :: [header_cell()], Rows :: [[table_cell()]]) ->
+    unicode:chardata().
+table(Header, Rows) ->
+    table(Header, Rows, #{}).
+
+-spec table(Header :: [header_cell()], Rows :: [[table_cell()]], table_props()) ->
+    unicode:chardata().
+table(Header, Rows, _Props) ->
+    {FmtHeader, Columns0} = table_columns(Header),
+    {FmtRows, Columns} = table_rows(Rows, Columns0),
+    [
+        table_tabulate_row([], Columns, ?table_header_props),
+        table_tabulate_row(FmtHeader, Columns, #{}),
+        table_tabulate_row([], Columns, ?table_headcut_props),
+        [table_tabulate_row(FmtRow, Columns, #{}) || FmtRow <- FmtRows],
+        table_tabulate_row([], Columns, ?table_footer_props)
+    ].
+
+%%
+
+table_columns(Header) ->
+    lists:unzip([table_column(C) || C <- Header]).
+
+table_column({Title, Props}) ->
+    Fmt = table_format_title(Title),
+    Width = fmt_width(Fmt),
+    Column = maps:merge(#{width => 1}, Props),
+    {Fmt, table_column_resize(Width, Column)};
+table_column(Title) ->
+    table_column({Title, #{}}).
+
+table_rows(Rows, Columns) ->
+    lists:mapfoldl(fun table_row/2, Columns, Rows).
+
+table_row(CellsIn, ColumnsIn) ->
+    case table_row_expand(CellsIn) of
+        {_Structure, RowsGroup} ->
+            {FmtRows, Columns} = table_rows(RowsGroup, ColumnsIn),
+            {{FmtRows}, Columns};
+        Cells when is_list(Cells) ->
+            lists:unzip(table_cells(Cells, ColumnsIn))
+    end.
+
+%% Expand complex row structures into potentially grouped together list of rows,
+%% i.e. lists of lists of cells.
+table_row_expand([{subrows, SubRowsIn}]) ->
+    SubRows = [table_row_expand(SubRow) || SubRow <- SubRowsIn],
+    {sub, table_flatten_rows(SubRows)};
+table_row_expand([{subcolumns, SubColumns}]) ->
+    SubRows = transpose(SubColumns, ""),
+    {sub, SubRows};
+table_row_expand([{group, Group}]) ->
+    GroupRows = table_row_expand(Group),
+    GroupHeader = [{repeat, {"", ?group_header_props}}],
+    {group, [GroupHeader | table_flatten_rows(GroupRows)]};
+table_row_expand([Cell | CellsIn]) when
+    not is_tuple(Cell);
+    element(1, Cell) =/= subrows,
+    element(1, Cell) =/= subcolumns,
+    element(1, Cell) =/= group
+->
+    case table_row_expand(CellsIn) of
+        {sub, CellsSub} ->
+            {sub, table_cells_expand(Cell, CellsSub)};
+        {group, CellsGrouped} ->
+            {group, table_cells_group(Cell, CellsGrouped)};
+        Cells ->
+            [Cell | Cells]
+    end;
+table_row_expand([]) ->
+    [].
+
+table_flatten_rows({_Section, Rows}) ->
+    table_flatten_rows(Rows);
+table_flatten_rows([{_Section, Rows} | Rest]) ->
+    Rows ++ table_flatten_rows(Rest);
+table_flatten_rows([Row | Rest]) ->
+    [Row | table_flatten_rows(Rest)];
+table_flatten_rows([]) ->
+    [].
+
+table_cells_group(GroupCell, [GroupHeader | SubRows]) ->
+    SubRowsExpanded = [["" | Cells] || Cells <- SubRows],
+    [[{GroupCell, ?group_header_props} | GroupHeader] | SubRowsExpanded].
+
+table_cells_expand(LeftCell, [SubRow1 | SubRowsRest]) ->
+    SubRow1Expanded = [LeftCell | SubRow1],
+    SubRowsExpanded = [["" | SubCells] || SubCells <- SubRowsRest],
+    [SubRow1Expanded | SubRowsExpanded];
+table_cells_expand(LeftCell, []) ->
+    [LeftCell].
+
+%% 1. Formats table cells into text.
+%% 2. Expands "repeated cells" into plain list of cells.
+%% 3. Updates column props, for example resize and specify alignment if column
+%%    cells contain numbers.
+table_cells([{repeat, Cell}] = Cells, Columns = [_ | _]) ->
+    table_cells([Cell | Cells], Columns);
+table_cells([{repeat, _}], []) ->
+    [];
+table_cells([Cell | Cells], [Column | Columns]) ->
+    Fmt = table_format_cell(Cell),
+    [{Fmt, table_column_update(Fmt, Column)} | table_cells(Cells, Columns)];
+table_cells([], [Column | Columns]) ->
+    [{"-", Column} | table_cells([], Columns)];
+table_cells([], []) ->
+    [].
+
+table_column_update(Fmt, Column0) ->
+    Column1 = table_column_resize(fmt_width(Fmt), Column0),
+    Column2 = table_column_realign(fmt_align(Fmt), Column1),
+    Column2.
+
+table_column_resize(Width, Column = #{width := W0}) ->
+    Column#{width := max(Width, W0)}.
+
+table_column_realign(default, Column) ->
+    Column;
+table_column_realign(left, Column) ->
+    Column;
+table_column_realign(right, Column) ->
+    Column#{align => right}.
+
+table_format_title(Title) ->
+    Title.
+
+%% Format cell into text + attach computed props if any.
+table_format_cell(A) when is_atom(A) ->
+    erlang:atom_to_binary(A);
+table_format_cell(N) when is_integer(N) ->
+    Fmt = integer_to_binary(N),
+    {Fmt, #{align => right}};
+table_format_cell(N) when is_number(N) ->
+    Fmt = float_to_binary(N, [short]),
+    {Fmt, #{align => right}};
+table_format_cell({X, Props}) ->
+    case table_format_cell(X) of
+        {Fmt, CellProps} -> {Fmt, maps:merge(CellProps, Props)};
+        Fmt -> {Fmt, Props}
+    end;
+table_format_cell(Text) ->
+    Text.
+
+-spec table_tabulate_row(Row | {[Row]}, [column_props()], cell_props()) ->
+    unicode:chardata()
+when
+    Row :: [formatted_cell()].
+table_tabulate_row({Rows}, Columns, Overrides) ->
+    [table_tabulate_row(Fmts, Columns, Overrides) || Fmts <- Rows];
+table_tabulate_row(Fmts, Columns, Overrides) ->
+    Start = table_tabulate_row_start(Columns, Overrides),
+    table_tabulate_row_end([Start | table_tabulate_cells(Fmts, Columns, Overrides)]).
+
+table_tabulate_row_start([Column | _], Overrides) ->
+    Delim = get_prop(delimiter, Column, Overrides, ":"),
+    Delim.
+
+table_tabulate_row_end(Acc) ->
+    [Acc, $\n].
+
+table_tabulate_cells([Fmt | Rest], [Column | Columns], Overrides) ->
+    PadC = get_fmt_prop(padc, Fmt, Column, Overrides, $\s),
+    Padding = get_fmt_prop(padding, Fmt, Column, Overrides, 1),
+    Delim = get_prop(delimiter, Column, Overrides, ":"),
+    Align = get_fmt_prop(align, Fmt, Column, Overrides, left),
+    Width = maps:get(width, Column),
+    case Align of
+        left -> Dir = trailing;
+        right -> Dir = leading
+    end,
+    Text = fmt_text(Fmt),
+    PadS = lists:duplicate(Padding, PadC),
+    Line = [PadS, string:pad(Text, Width, Dir, PadC), PadS, Delim],
+    Line ++ table_tabulate_cells(Rest, Columns, Overrides);
+table_tabulate_cells([], [], _Overrides) ->
+    [];
+table_tabulate_cells([], Columns, Overrides) ->
+    table_tabulate_cells([<<>>], Columns, Overrides).
+
+get_fmt_prop(Name, {_Fmt, Props1}, Props2, Props3, Default) ->
+    case Props1 of
+        #{Name := V} -> V;
+        #{} -> get_prop(Name, Props2, Props3, Default)
+    end;
+get_fmt_prop(Name, _Fmt, Props2, Props3, Default) ->
+    get_prop(Name, Props2, Props3, Default).
+
+get_prop(Name, Props1, Props2, Default) ->
+    case Props1 of
+        #{Name := V} -> V;
+        #{} -> get_prop(Name, Props2, Default)
+    end.
+
+get_prop(Name, Props, Default) ->
+    maps:get(Name, Props, Default).
+
+fmt_text({Fmt, _Props}) ->
+    Fmt;
+fmt_text(Fmt) ->
+    Fmt.
+
+fmt_align({_Fmt, Props}) ->
+    maps:get(align, Props, left);
+fmt_align(_Fmt) ->
+    left.
+
+fmt_width({Fmt, _Props}) ->
+    fmt_width(Fmt);
+fmt_width(Fmt) ->
+    string:length(Fmt).
+
+%% @doc Transpose list of lists into list of list of their respective elements.
+transpose(Ls, Pad) ->
+    case lists:any(fun(L) -> L =/= [] end, Ls) of
+        true ->
+            Heads = [transpose_head(L, Pad) || L <- Ls],
+            Tails = [transpose_tail(L) || L <- Ls],
+            [Heads | transpose(Tails, Pad)];
+        false ->
+            []
+    end.
+
+transpose_head([H | _], _Pad) -> H;
+transpose_head([], Pad) -> Pad.
+
+transpose_tail([_ | T]) -> T;
+transpose_tail([]) -> [].

--- a/apps/emqx_utils/test/emqx_utils_fmt_tests.erl
+++ b/apps/emqx_utils/test/emqx_utils_fmt_tests.erl
@@ -1,0 +1,89 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_utils_fmt_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+mixed_table_test() ->
+    ?assertEqual(
+        ".---------.---------.----------------.\n"
+        ": 1st     : 2nd     : Third [number] :\n"
+        ":---------:---------:----------------:\n"
+        ": Apple   : Cider   :            4.5 :\n"
+        ": Reddish : Ale     :           6ish :\n"
+        ": España  : Cerveza :              4 :\n"
+        "`---------`---------`----------------`\n",
+        unicode:characters_to_list(
+            emqx_utils_fmt:table(["1st", "2nd", "Third [number]"], [
+                ["Apple", "Cider", 4.5],
+                ["Reddish", "Ale", '6ish'],
+                ["España", "Cerveza", 4]
+            ])
+        )
+    ).
+
+subrows_table_test() ->
+    ?assertEqual(
+        ".---------.---------.-------.--------.\n"
+        ": 1st     : 2nd     : Third : Fourth :\n"
+        ":---------:---------:-------:--------:\n"
+        ": Apple   : Cider   : -     :      - :\n"
+        ": Reddish : Ale     : I     :      6 :\n"
+        ":         :         : II    :    6.7 :\n"
+        ": España  : Cerveza : I     :      3 :\n"
+        ":         :         : Neo   :    3.1 :\n"
+        ":         :         :       :    3.2 :\n"
+        "`---------`---------`-------`--------`\n",
+        unicode:characters_to_list(
+            emqx_utils_fmt:table(["1st", "2nd", "Third", "Fourth"], [
+                ["Apple", "Cider", {subrows, [[]]}],
+                ["Reddish", "Ale", {subrows, [["I", 6], ["II", 6.7]]}],
+                ["España", "Cerveza", {subrows, [["I", 3], ["Neo", {subcolumns, [[3.1, 3.2]]}]]}]
+            ])
+        )
+    ).
+
+subgroup_table_test() ->
+    ?assertEqual(
+        ".---------.---------.-------.--------.\n"
+        ": 1st     : 2nd     : Third : Fourth :\n"
+        ":---------:---------:-------:--------:\n"
+        ":-Apple---:-Cider---:-------:--------:\n"
+        ":         :         : -     :      - :\n"
+        ":-Reddish-:-Ale-----:-------:--------:\n"
+        ":         :         : I     :    6.1 :\n"
+        ":         :         : II    :    6.7 :\n"
+        ":-España--:---------:-------:--------:\n"
+        ":         :-Cerveza-:-------:--------:\n"
+        ":         :         : I     :      3 :\n"
+        ":         :         : Neo   :    3.1 :\n"
+        ":         :         :       :    3.2 :\n"
+        "`---------`---------`-------`--------`\n",
+        unicode:characters_to_list(
+            emqx_utils_fmt:table(["1st", "2nd", "Third", "Fourth"], [
+                ["Apple", "Cider", {group, [[]]}],
+                ["Reddish", "Ale", {group, [{subcolumns, [["I", "II"], [6.1, 6.7]]}]}],
+                [
+                    "España",
+                    {group, [
+                        "Cerveza",
+                        {group, [{subrows, [["I", 3], ["Neo", {subcolumns, [[3.1, 3.2]]}]]}]}
+                    ]}
+                ]
+            ])
+        )
+    ).

--- a/changes/ee/fix-14696.en.md
+++ b/changes/ee/fix-14696.en.md
@@ -1,3 +1,3 @@
 Address a few shortcomings in the DS Raft backend implementation:
-1. Shard membership changes now proceed in rare cases where the current shard replica set consists solely of replicas on "lost" sites, i.e. corresponding to nodes that previously left the cluster.
+1. Shard membership changes now proceed in rare cases where a shard replica set consists solely of replicas on sites corresponding to nodes that previously left the cluster. Refer to [Known Issues](https://github.com/emqx/emqx-docs/blob/release-5.8/en_US/changes/known-issues-5.8.md#e584) for details.
 2. The _Forget site_ operation now has additional safeguards and will fail if the site is part of active shard replica sets or if its corresponding node remains in the cluster.

--- a/changes/ee/fix-14696.en.md
+++ b/changes/ee/fix-14696.en.md
@@ -1,0 +1,3 @@
+Address a few shortcomings in the DS Raft backend implementation:
+1. Shard membership changes now proceed in rare cases where the current shard replica set consists solely of replicas on "lost" sites, i.e. corresponding to nodes that previously left the cluster.
+2. The _Forget site_ operation now has additional safeguards and will fail if the site is part of active shard replica sets or if its corresponding node remains in the cluster.


### PR DESCRIPTION
Part of [EMQX-13886](https://emqx.atlassian.net/browse/EMQX-13886).

Release version: e5.8.5

## Summary

This PR primarily addresses 2 shortcomings in DS Raft backend.
1. Shard membership changes now proceed in rare situations when the current shard replica set is comprised only of replicas located on "lost" sites, which correspond to the nodes that previously left the cluster. More complex disaster scenarios, for example where only majority of the replicas are "lost" but not all, will be addressed in followup PRs.
2. The _Forget site_ operation now includes additional safeguards and will fail if the site is part of active shard replica sets or if corresponding node remains in the cluster. This should guarantee that any unfinished transitions will have enough information to operate on Ra clusters.

See individual commits for details.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible


[EMQX-13886]: https://emqx.atlassian.net/browse/EMQX-13886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ