### PR TITLE
fix: limit maximum allowed heap size

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2828,16 +2828,12 @@ to_atom(Bin) when is_binary(Bin) ->
     binary_to_atom(Bin, utf8).
 
 validate_heap_size(Siz) when is_integer(Siz) ->
-    MaxSiz =
-        case erlang:system_info(wordsize) of
-            % arch_64
-            8 -> (1 bsl 59) - 1;
-            % arch_32
-            4 -> (1 bsl 27) - 1
-        end,
+    WordSize = erlang:system_info(wordsize),
+    %% 128 GB
+    MaxSiz = (128 * 1024 * 1024 * 1024) div WordSize,
     case Siz > MaxSiz of
         true ->
-            {error, #{reason => max_heap_size_too_large, maximum => MaxSiz}};
+            {error, #{cause => max_heap_size_too_large, maximum => MaxSiz}};
         false ->
             ok
     end;

--- a/changes/ce/breaking-14703.en.md
+++ b/changes/ce/breaking-14703.en.md
@@ -1,0 +1,1 @@
+Changed the maximum allowed value for `force_shutdown.max_heap_size` to `128GB`.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13901

Release version: v/e5.8.5

## Summary

See linked tickets and its comments for more context.

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [na] Schema changes are backward compatible: no, but it's unlikely anyone set this to more than 129 GB.
