### PR TITLE
fix: qos2 PUBLISH packet should allow DUP=1

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -1166,7 +1166,7 @@ validate_header(?CONNECT, 0, 0, 0) -> ok;
 validate_header(?CONNACK, 0, 0, 0) -> ok;
 validate_header(?PUBLISH, 0, ?QOS_0, _) -> ok;
 validate_header(?PUBLISH, _, ?QOS_1, _) -> ok;
-validate_header(?PUBLISH, 0, ?QOS_2, _) -> ok;
+validate_header(?PUBLISH, _, ?QOS_2, _) -> ok;
 validate_header(?PUBACK, 0, 0, 0) -> ok;
 validate_header(?PUBREC, 0, 0, 0) -> ok;
 validate_header(?PUBREL, 0, 1, 0) -> ok;

--- a/changes/ce/fix-14707.en.md
+++ b/changes/ce/fix-14707.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where, in strict_mode, PUBLISH packets with QoS 2 and the DUP flag set were incorrectly considered invalid packets.


### PR DESCRIPTION
Fixes [EMQX-13927](https://emqx.atlassian.net/browse/EMQX-13927)
Fixes #14688

Release version: v/e5.9.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~[ ] Added property-based tests for code which performs user input validation~
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- [x] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13927]: https://emqx.atlassian.net/browse/EMQX-13927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ