### PR TITLE
refactor: delete unused callback from authz source behaviour

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_source.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_source.erl
@@ -41,9 +41,6 @@
 %% An authz backend will not be used after `destroy`.
 -callback destroy(source()) -> ok.
 
-%% Get authz text description.
--callback description() -> string().
-
 %% Authorize client action.
 -callback authorize(
     emqx_types:clientinfo(),

--- a/apps/emqx_auth/src/emqx_authz/sources/emqx_authz_client_info.erl
+++ b/apps/emqx_auth/src/emqx_authz/sources/emqx_authz_client_info.erl
@@ -27,7 +27,6 @@
 
 %% APIs
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -47,9 +46,6 @@
 %%--------------------------------------------------------------------
 %% emqx_authz callbacks
 %%--------------------------------------------------------------------
-
-description() ->
-    "AuthZ with ClientInfo".
 
 create(Source) ->
     Source.

--- a/apps/emqx_auth/src/emqx_authz/sources/emqx_authz_file.erl
+++ b/apps/emqx_auth/src/emqx_authz/sources/emqx_authz_file.erl
@@ -27,7 +27,6 @@
 
 %% APIs
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -48,9 +47,6 @@
 %%------------------------------------------------------------------------------
 %% Authz Source Callbacks
 %%------------------------------------------------------------------------------
-
-description() ->
-    "AuthZ with static rules".
 
 create(#{path := Path} = Source) ->
     {ok, Rules} = validate(Path),

--- a/apps/emqx_auth_http/src/emqx_authz_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http.erl
@@ -24,7 +24,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -60,9 +59,6 @@
     ?VAR_QOS,
     ?VAR_RETAIN
 ]).
-
-description() ->
-    "AuthZ with http".
 
 create(Config) ->
     NConfig = parse_config(Config),

--- a/apps/emqx_auth_ldap/src/emqx_auth_ldap.app.src
+++ b/apps/emqx_auth_ldap/src/emqx_auth_ldap.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_ldap, [
     {description, "EMQX LDAP Authentication and Authorization"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {mod, {emqx_auth_ldap_app, []}},
     {applications, [

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
@@ -35,7 +35,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -50,9 +49,6 @@
 %%------------------------------------------------------------------------------
 %% AuthZ Callbacks
 %%------------------------------------------------------------------------------
-
-description() ->
-    "AuthZ with LDAP".
 
 create(Source) ->
     ResourceId = emqx_authz_utils:make_resource_id(?MODULE),

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap_schema.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap_schema.erl
@@ -52,7 +52,7 @@ fields(ldap) ->
         emqx_ldap:fields(config).
 
 desc(ldap) ->
-    emqx_authz_ldap:description();
+    ?DESC("ldap_struct");
 desc(_) ->
     undefined.
 

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mnesia, [
     {description, "EMQX Buitl-in Database Authentication and Authorization"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {mod, {emqx_auth_mnesia_app, []}},
     {applications, [

--- a/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authz_mnesia.erl
@@ -49,7 +49,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -89,9 +88,6 @@ create_tables() ->
 %%--------------------------------------------------------------------
 %% emqx_authz callbacks
 %%--------------------------------------------------------------------
-
-description() ->
-    "AuthZ with Mnesia".
 
 create(Source) -> Source.
 

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -23,7 +23,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -44,9 +43,6 @@
     ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
-
-description() ->
-    "AuthZ with MongoDB".
 
 create(#{filter := Filter, skip := Skip, limit := Limit} = Source) ->
     ResourceId = emqx_authz_utils:make_resource_id(?MODULE),

--- a/apps/emqx_auth_mysql/src/emqx_auth_mysql.app.src
+++ b/apps/emqx_auth_mysql/src/emqx_auth_mysql.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mysql, [
     {description, "EMQX MySQL Authentication and Authorization"},
-    {vsn, "0.3.0"},
+    {vsn, "0.3.1"},
     {registered, []},
     {mod, {emqx_auth_mysql_app, []}},
     {applications, [

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -25,7 +25,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -46,9 +45,6 @@
     ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
-
-description() ->
-    "AuthZ with Mysql".
 
 create(#{query := SQL} = Source0) ->
     {PrepareSQL, TmplToken} = emqx_auth_utils:parse_sql(SQL, '?', ?ALLOWED_VARS),

--- a/apps/emqx_auth_postgresql/src/emqx_auth_postgresql.app.src
+++ b/apps/emqx_auth_postgresql/src/emqx_auth_postgresql.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_postgresql, [
     {description, "EMQX PostgreSQL Authentication and Authorization"},
-    {vsn, "0.3.0"},
+    {vsn, "0.3.1"},
     {registered, []},
     {mod, {emqx_auth_postgresql_app, []}},
     {applications, [

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -25,7 +25,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -46,9 +45,6 @@
     ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
-
-description() ->
-    "AuthZ with PostgreSQL".
 
 create(#{query := SQL0} = Source) ->
     {SQL, PlaceHolders} = emqx_auth_utils:parse_sql(SQL0, '$n', ?ALLOWED_VARS),

--- a/apps/emqx_auth_redis/src/emqx_auth_redis.app.src
+++ b/apps/emqx_auth_redis/src/emqx_auth_redis.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_redis, [
     {description, "EMQX Redis Authentication and Authorization"},
-    {vsn, "0.3.0"},
+    {vsn, "0.3.1"},
     {registered, []},
     {mod, {emqx_auth_redis_app, []}},
     {applications, [

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -23,7 +23,6 @@
 
 %% AuthZ Callbacks
 -export([
-    description/0,
     create/1,
     update/1,
     destroy/1,
@@ -44,9 +43,6 @@
     ?VAR_ZONE,
     ?VAR_NS_CLIENT_ATTRS
 ]).
-
-description() ->
-    "AuthZ with Redis".
 
 create(#{cmd := CmdStr} = Source) ->
     CmdTemplate = parse_cmd(CmdStr),

--- a/rel/i18n/emqx_authz_ldap_schema.hocon
+++ b/rel/i18n/emqx_authz_ldap_schema.hocon
@@ -24,4 +24,8 @@ query_timeout.desc:
 query_timeout.label:
 """Query Timeout"""
 
+ldap_struct.desc: "LDAP Authorization settings"
+
+ldap_struct.label: "LDAP authorization"
+
 }


### PR DESCRIPTION
Release: v/e5.8.5

In anther task, I noticed that LDAP authz schema had a `desc` field provided by a callback, this made i18n complicated.
Then I realize that this callback is never called anywhere else, so I decided to remove it.