### PR TITLE
fix: add libmsquic.dylib to the list of signed binaries

### DIFF
--- a/scripts/rel/macos-sign-binaries.sh
+++ b/scripts/rel/macos-sign-binaries.sh
@@ -81,6 +81,7 @@ for f in \
         liberocksdb.so \
         libquicer_nif.so \
         libquicer_nif*.dylib \
+        libmsquic*.dylib \
         odbcserver \
         otp_test_engine.so \
         sasl_auth.so \


### PR DESCRIPTION
Fixes the issue with packaging emqx for macos

```
===> Running hook: scripts/rel/macos-notarize-package.sh
===> Exception updating contents of release tarball error:{1,
                                                      "/var/folders/db/x5_t5x655c9_rftmy0wp2t2w0000gn/T/.tmp_dir-417076329457 ~/work/emqx-platform/emqx-platform\n~/work/emqx-platform/emqx-platform\nSubmitting the package for notarization to Apple (normally takes about a minute)\nProcessing complete\n  id: 50bd8f11-09aa-415c-b636-5e4c650e5003\n  status: Invalid\nNotarization failed\n{\n  \"logFormatVersion\": 1,\n  \"jobId\": \"50bd8f11-09aa-415c-b636-5e4c650e5003\",\n  \"status\": \"Invalid\",\n  \"statusSummary\": \"Archive contains critical validation errors\",\n  \"statusCode\": 4000,\n  \"archiveFilename\": \"emqx-5.8.5-beta.1.zip\",\n  \"uploadDate\": \"2025-02-18T22:08:28.211Z\",\n  \"sha256\": \"98ef3e62cdd3321f35e80b104ccbf45bc67bf808f0376c13ebbf8deb840f7ee2\",\n  \"ticketContents\": null,\n  \"issues\": [\n    {\n      \"severity\": \"error\",\n      \"code\": null,\n      \"path\": \"emqx-5.8.5-beta.1.zip/lib/quicer-0.1.11/priv/lib/libmsquic.dylib\",\n      \"message\": \"The binary is not signed.\",\n      \"docUrl\": \"https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721\",\n      \"architecture\": \"x86_64\"\n    },\n    {\n      \"severity\": \"error\",\n      \"code\": null,\n      \"path\": \"emqx-5.8.5-beta.1.zip/lib/quicer-0.1.11/priv/lib/libmsquic.dylib\",\n      \"message\": \"The signature does not include a secure timestamp.\",\n      \"docUrl\": \"https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733\",\n      \"architecture\": \"x86_64\"\n    },\n    {\n      \"severity\": \"error\",\n      \"code\": null,\n      \"path\": \"emqx-5.8.5-beta.1.zip/lib/quicer-0.1.11/priv/lib/libmsquic.2.dylib\",\n      \"message\": \"The binary is not signed.\",\n      \"docUrl\": \"https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721\",\n      \"architecture\": \"x86_64\"\n    },\n    {\n      \"severity\": \"error\",\n      \"code\": null,\n      \"path\": \"emqx-5.8.5-beta.1.zip/lib/quicer-0.1.11/priv/lib/libmsquic.2.dylib\",\n      \"message\": \"The signature does not include a secure timestamp.\",\n      \"docUrl\": \"https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733\",\n      \"architecture\": \"x86_64\"\n    },\n    {\n      \"severity\": \"error\",\n      \"code\": null,\n      \"path\": \"emqx-5.8.5-beta.1.zip/lib/quicer-0.1.11/priv/lib/libmsquic.2.3.5.dylib\",\n      \"message\": \"The binary is not signed.\",\n      \"docUrl\": \"https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087721\",\n      \"architecture\": \"x86_64\"\n    },\n    {\n      \"severity\": \"error\",\n      \"code\": null,\n      \"path\": \"emqx-5.8.5-beta.1.zip/lib/quicer-0.1.11/priv/lib/libmsquic.2.3.5.dylib\",\n      \"message\": \"The signature does not include a secure timestamp.\",\n      \"docUrl\": \"https://developer.apple.com/documentation/security/notarizing_macos_software_before_distribution/resolving_common_notarization_issues#3087733\",\n      \"architecture\": \"x86_64\"\n    }\n  ]\n}\n"}
make: *** [emqx-enterprise-tgz] Error 1
```

Release version: v/e5.8.5

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
