### PR TITLE
docs: return bytesize in max_heap validation error message

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2833,7 +2833,8 @@ validate_heap_size(Siz) when is_integer(Siz) ->
     MaxSiz = (128 * 1024 * 1024 * 1024) div WordSize,
     case Siz > MaxSiz of
         true ->
-            {error, #{cause => max_heap_size_too_large, maximum => MaxSiz}};
+            %% Turn back into bytesize for error message...
+            {error, #{cause => max_heap_size_too_large, maximum => MaxSiz * WordSize}};
         false ->
             ok
     end;

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -984,6 +984,7 @@ max_packet_size_test_() ->
 max_heap_size_test_() ->
     WordSize = erlang:system_info(wordsize),
     MaxWords = 128 * 1024 * 1024 * 1024 div WordSize,
+    MaxBytes = MaxWords * WordSize,
     DefaultWords = 32 * 1024 * 1024 div WordSize,
     Sc = emqx_schema,
     Check = fun(Input) ->
@@ -1013,7 +1014,7 @@ max_heap_size_test_() ->
         {"129GB is not allowed",
             ?_assertThrow(
                 {emqx_schema, [
-                    #{reason := #{cause := max_heap_size_too_large, maximum := MaxWords}}
+                    #{reason := #{cause := max_heap_size_too_large, maximum := MaxBytes}}
                 ]},
                 Check(<<"force_shutdown.max_heap_size = 129GB">>)
             )},


### PR DESCRIPTION
Fixes (again) https://emqx.atlassian.net/browse/EMQX-13901

Release version: v/e5.8.5
