### PR TITLE
fix(gcp pubsub action): retry `normal` error reasons

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -444,6 +444,9 @@ handle_result({error, Reason}, _Request, QueryMode, ConnResId) when
     Reason =:= econnrefused;
     %% this comes directly from `gun'...
     Reason =:= {closed, "The connection was lost."};
+    %% The normal reason happens when the HTTP connection times out before
+    %% the request has been fully processed
+    Reason =:= normal;
     Reason =:= timeout
 ->
     ?tp(


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13937

Release version: e5.8.5

## Summary

Sometimes a `normal` error reason is returned by `ehttpc` when the HTTP connection times out before the request has been fully processed.

