### PR TITLE
fix(jt808): send the default auth code in anonymous mode

### DIFF
--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -443,7 +443,7 @@ handle_out({?MS_GENERAL_RESPONSE, Result, InMsgId}, MsgSn, Channel) ->
 handle_out({?MS_REGISTER_ACK, 0}, MsgSn, Channel = #channel{authcode = Authcode0}) ->
     Authcode =
         case Authcode0 == anonymous of
-            true -> <<>>;
+            true -> <<"anonymous">>;
             false -> Authcode0
         end,
     Frame = #{

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -440,15 +440,15 @@ handle_out({?MS_GENERAL_RESPONSE, Result, InMsgId}, MsgSn, Channel) ->
         <<"body">> => #{<<"seq">> => MsgSn, <<"result">> => Result, <<"id">> => InMsgId}
     },
     {ok, [{outgoing, Frame}], state_inc_sn(Channel)};
-handle_out({?MS_REGISTER_ACK, 0}, MsgSn, Channel = #channel{authcode = Authcode0}) ->
-    Authcode =
-        case Authcode0 == anonymous of
+handle_out({?MS_REGISTER_ACK, 0}, MsgSn, Channel = #channel{authcode = AuthCode0}) ->
+    AuthCode =
+        case AuthCode0 == anonymous of
             true -> <<"anonymous">>;
-            false -> Authcode0
+            false -> AuthCode0
         end,
     Frame = #{
         <<"header">> => build_frame_header(?MS_REGISTER_ACK, Channel),
-        <<"body">> => #{<<"seq">> => MsgSn, <<"result">> => 0, <<"auth_code">> => Authcode}
+        <<"body">> => #{<<"seq">> => MsgSn, <<"result">> => 0, <<"auth_code">> => AuthCode}
     },
     {ok, [{outgoing, Frame}], state_inc_sn(Channel)};
 handle_out({?MS_REGISTER_ACK, ResCode}, MsgSn, Channel) ->
@@ -635,8 +635,8 @@ reset_timer(Name, Channel) ->
 clean_timer(Name, Channel = #channel{timers = Timers}) ->
     Channel#channel{timers = maps:remove(Name, Timers)}.
 
-interval(alive_timer, #channel{keepalive = KeepAlive}) ->
-    emqx_keepalive:info(check_interval, KeepAlive);
+interval(alive_timer, #channel{keepalive = Keepalive}) ->
+    emqx_keepalive:info(check_interval, Keepalive);
 interval(retry_timer, #channel{retx_interval = RetxIntv}) ->
     RetxIntv.
 
@@ -891,8 +891,8 @@ is_driver_id_req_exist(#channel{inflight = Inflight}) ->
 
 register_(Frame, Channel0) ->
     case emqx_jt808_auth:register(Frame, Channel0#channel.auth) of
-        {ok, Authcode} ->
-            {ok, Channel0#channel{authcode = Authcode}};
+        {ok, AuthCode} ->
+            {ok, Channel0#channel{authcode = AuthCode}};
         {error, Reason} ->
             ?SLOG(error, #{msg => "register_failed", reason => Reason}),
             ResCode =
@@ -916,9 +916,9 @@ authenticate(AuthFrame, #channel{authcode = undefined, auth = Auth}) ->
     end;
 authenticate(
     #{<<"body">> := #{<<"code">> := InCode}},
-    #channel{authcode = Authcode}
+    #channel{authcode = AuthCode}
 ) ->
-    InCode == Authcode.
+    InCode == AuthCode.
 
 enrich_conninfo(
     #{<<"header">> := #{<<"phone">> := Phone}},
@@ -999,10 +999,10 @@ replvar(Topic, #channel{clientinfo = #{clientid := ClientId, phone := Phone}}) w
     do_replvar(Topic, #{clientid => ClientId, phone => Phone}).
 
 do_replvar(Topic, Vars) ->
-    ClientID = maps:get(clientid, Vars, undefined),
+    ClientId = maps:get(clientid, Vars, undefined),
     Phone = maps:get(phone, Vars, undefined),
     List = [
-        {?PH_CLIENTID, ClientID},
+        {?PH_CLIENTID, ClientId},
         {?PH_PHONE, Phone}
     ],
     lists:foldl(fun feed_var/2, Topic, List).

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -380,8 +380,9 @@ t_case01_auth(_) ->
 t_case02_anonymous_register_and_auth(_) ->
     {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
 
-    {ok, AuthCode} = client_regi_procedure(Socket, <<>>),
-    ?assertEqual(AuthCode, <<>>),
+    DefaultAuthCode = <<"anonymous">>,
+    {ok, AuthCode} = client_regi_procedure(Socket, DefaultAuthCode),
+    ?assertEqual(AuthCode, DefaultAuthCode),
 
     ok = client_auth_procedure(Socket, AuthCode),
 

--- a/changes/ee/fix-14756.en.md
+++ b/changes/ee/fix-14756.en.md
@@ -1,1 +1,1 @@
-mprove the JT/T 808 gateway so that when anonymous authentication is enabled, the registration response will carry the default authentication code `anonymous`. This is used to avoid the issue where some clients are unable to parse an empty authentication code.
+Improve the JT/T 808 gateway so that when anonymous authentication is enabled, the registration response will carry the default authentication code `anonymous`. This is used to avoid the issue where some clients are unable to parse an empty authentication code.

--- a/changes/ee/fix-14756.en.md
+++ b/changes/ee/fix-14756.en.md
@@ -1,0 +1,1 @@
+mprove the JT/T 808 gateway so that when anonymous authentication is enabled, the registration response will carry the default authentication code `anonymous`. This is used to avoid the issue where some clients are unable to parse an empty authentication code.


### PR DESCRIPTION
Because most of devices can't parse the Register Ack packet with an empty auth code

Fixes https://emqx.atlassian.net/browse/EMQX-13945
Release version: v/e5.8.5 or e5.9.0

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~Added property-based tests for code which performs user input validation~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~Change log has been added to `changes/` dir for user-facing artifacts update~
