### PR TITLE
revert: emqx-relup havn't tagged

### DIFF
--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -189,7 +189,7 @@ project_app_excluded("apps/" ++ AppStr, ExcludedApps) ->
 
 plugins() ->
     [
-        {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.2.3"}}},
+        {emqx_relup, {git, "https://github.com/emqx/emqx-relup.git", {tag, "0.2.2"}}},
         %% emqx main project does not require port-compiler
         %% pin at root level for deterministic
         {pc, "1.15.0"}


### PR DESCRIPTION
This reverts parts of commit 82983fa0729b3bffef4d0d86f1c9b85eea958c65.

~Fixes <issue-or-jira-number>~

~Release version: v/e5.?~

the change in branch `master`, havn't released.

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- ~[ ] Added tests for the changes~
- ~[ ] Added property-based tests for code which performs user input validation~
- ~[ ] Changed lines covered in coverage report~
- ~[ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- ~[ ] For internal contributor: there is a jira ticket to track this change~
- ~[ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- ~[ ] Schema changes are backward compatible~

## Checklist for CI (.github/workflows) changes

- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
