### PR TITLE
fix(bridge v2): add missing feature toggle

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -15,6 +15,8 @@
 %%--------------------------------------------------------------------
 -module(emqx_bridge_v2).
 
+-feature(maybe_expr, enable).
+
 -behaviour(emqx_config_handler).
 -behaviour(emqx_config_backup).
 


### PR DESCRIPTION
For some reason, CI passed just fine in the originating PR even without this feature enabled.
