### PR TITLE
fix(sqlserver): try to infer connected instance name

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -55,7 +55,7 @@
 -type cipher() :: map().
 -type port_number() :: 1..65535.
 -type server_parse_option() :: #{
-    default_port => port_number(),
+    default_port => integer(),
     no_port => boolean(),
     supported_schemes => [string()],
     default_scheme => string()
@@ -87,7 +87,7 @@
 
 -type parsed_server() :: #{
     hostname := string(),
-    port => port_number(),
+    port => integer(),
     scheme => string()
 }.
 

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_tests.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_tests.erl
@@ -1,0 +1,159 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_sqlserver_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-include("emqx_bridge_sqlserver.hrl").
+
+-define(CONNECTOR_TYPE_BIN, <<"sqlserver">>).
+-define(CONNECTOR_NAME, <<"mysqlserver">>).
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+parse_and_check_connector(InnerConfig) ->
+    emqx_bridge_v2_testlib:parse_and_check_connector(
+        ?CONNECTOR_TYPE_BIN,
+        ?CONNECTOR_NAME,
+        InnerConfig
+    ).
+
+connector_config(Overrides) ->
+    Base = #{
+        <<"database">> => <<"mqtt">>,
+        <<"driver">> => <<"ms-sql">>,
+        <<"enable">> => true,
+        <<"password">> => <<"secretpass">>,
+        <<"pool_size">> => 8,
+        <<"resource_opts">> =>
+            #{
+                <<"health_check_interval">> => <<"15s">>,
+                <<"start_after_created">> => true,
+                <<"start_timeout">> => <<"5s">>
+            },
+        <<"server">> => <<"127.0.0.2:1433">>,
+        <<"username">> => <<"root">>
+    },
+    emqx_utils_maps:deep_merge(Base, Overrides).
+
+parse_server(Str) ->
+    emqx_bridge_sqlserver_connector:parse_server(Str).
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+server_schema_test_() ->
+    [
+        {"only server, no named instance, no port: IP",
+            ?_assertMatch(
+                #{},
+                parse_and_check_connector(connector_config(#{<<"server">> => <<"127.0.0.2">>}))
+            )},
+        {"only server, no named instance, no port: name",
+            ?_assertMatch(
+                #{},
+                parse_and_check_connector(connector_config(#{<<"server">> => <<"sqlserver">>}))
+            )},
+        {"server and port, no named instance: IP",
+            ?_assertMatch(
+                #{},
+                parse_and_check_connector(connector_config(#{<<"server">> => <<"127.0.0.2:1434">>}))
+            )},
+        {"server and port, no named instance: name",
+            ?_assertMatch(
+                #{},
+                parse_and_check_connector(connector_config(#{<<"server">> => <<"sqlserver:1434">>}))
+            )},
+        {"server and named instance, no port: IP",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := "must_explicitly_define_port_when_using_named_instances",
+                        kind := validation_error
+                    }
+                ]},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"127.0.0.2\\NamedInstance">>})
+                )
+            )},
+        {"server and named instance, no port: name",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := "must_explicitly_define_port_when_using_named_instances",
+                        kind := validation_error
+                    }
+                ]},
+                parse_and_check_connector(
+                    connector_config(#{<<"server">> => <<"sqlserver\\NamedInstance">>})
+                )
+            )},
+        {"server, named instance, port: IP",
+            ?_assertMatch(
+                #{},
+                parse_and_check_connector(
+                    connector_config(#{
+                        <<"server">> =>
+                            <<"127.0.0.2\\NamedInstance:52000">>
+                    })
+                )
+            )},
+        {"server, named instance, port: name",
+            ?_assertMatch(
+                #{},
+                parse_and_check_connector(
+                    connector_config(#{
+                        <<"server">> =>
+                            <<"sqlserver\\NamedInstance:52000">>
+                    })
+                )
+            )}
+    ].
+
+server_parse_test_() ->
+    [
+        {"only server, no named instance, no port: IP",
+            ?_assertMatch(
+                #{hostname := "127.0.0.2", port := ?SQLSERVER_DEFAULT_PORT},
+                parse_server(<<"127.0.0.2">>)
+            )},
+        {"only server, no named instance, no port: name",
+            ?_assertMatch(
+                #{hostname := "sqlserver", port := ?SQLSERVER_DEFAULT_PORT},
+                parse_server(<<"sqlserver">>)
+            )},
+        {"server and port, no named instance: IP",
+            ?_assertMatch(
+                #{hostname := "127.0.0.2", port := 1434},
+                parse_server(<<"127.0.0.2:1434">>)
+            )},
+        {"server and port, no named instance: name",
+            ?_assertMatch(
+                #{hostname := "sqlserver", port := 1434},
+                parse_server(<<"sqlserver:1434">>)
+            )},
+        {"server and named instance, no port: IP",
+            ?_assertThrow(
+                "must_explicitly_define_port_when_using_named_instances",
+                parse_server(<<"127.0.0.2\\NamedInstance">>)
+            )},
+        {"server and named instance, no port: name",
+            ?_assertThrow(
+                "must_explicitly_define_port_when_using_named_instances",
+                parse_server(<<"sqlserver\\NamedInstance">>)
+            )},
+        {"server, named instance, port: IP",
+            ?_assertMatch(
+                #{hostname := "127.0.0.2", port := 52000, instance_name := "NamedInstance"},
+                parse_server(<<"127.0.0.2\\NamedInstance:52000">>)
+            )},
+        {"server, named instance, port: name",
+            ?_assertMatch(
+                #{hostname := "sqlserver", port := 52000, instance_name := "NamedInstance"},
+                parse_server(<<"sqlserver\\NamedInstance:52000">>)
+            )}
+    ].

--- a/changes/ee/breaking-14765.en.md
+++ b/changes/ee/breaking-14765.en.md
@@ -1,0 +1,5 @@
+Added extra validation for using Named Instances in SQL Server Connector.  Previously, we could not infer when the user furnished an explicit port for SQL Server, and always added the default port if not explicitly defined.
+
+For Named Instances, we need to explicitly define a port to connect to when connecting with the ODBC driver. And the driver happily connects to whatever instance is running on that port, completely ignoring the given Instance Name, if any.
+
+Now, we impose that the port is to be explicitly defined when an instance name is given, and we also attempt to infer differences between desired and connected instance names during health checks.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13954

Release version: e5.9.0

## Summary

Previously, we could not infer when the user furnished an explicit port for SQL Server, and always added the default port if not explicitly defined.

For Named Instances, we need to explicitly define a port to connect to when connecting with the ODBC driver.  And the driver happily connects to whatever instance is running on that port, completely ignoring the given Instance Name, if any.

Here, we demand that the port is explicitly defined when an instance name is given, and we also attempt to infer differences between desired and connected instance names during health checks.

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket  -- https://github.com/emqx/emqx-docs/pull/2841
- [na] ~~Schema changes are backward compatible~~  if anyone uses named instances without port, they'll fail the validation.
