### PR TITLE
fix(ctl): refuse to leave cluster if responsible for DS data

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer_meta.erl
@@ -272,11 +272,12 @@ node(Site) ->
             undefined
     end.
 
--spec node_status(node()) -> running | stopped | lost.
+-spec node_status(node()) -> up | down | lost.
 node_status(Node) ->
     case mria:cluster_status(Node) of
-        false -> lost;
-        Status -> Status
+        running -> up;
+        stopped -> down;
+        false -> lost
     end.
 
 -spec forget_site(site()) -> ok | {error, _Reason}.
@@ -289,12 +290,12 @@ forget_site(Site) ->
     else
         [] ->
             {error, nonexistent_site};
-        running ->
-            {error, site_online};
-        stopped ->
+        up ->
+            {error, site_up};
+        down ->
             %% Node is stopped, reject the request.
             %% If it's gone, it should leave the cluster first.
-            {error, site_temporarily_offline}
+            {error, site_temporarily_down}
     end.
 
 %%===============================================================================
@@ -404,15 +405,15 @@ format_transition({del, Site}, Nodes) ->
 
 format_node_status(Status) ->
     case Status of
-        running -> "    up";
-        stopped -> "(x) down";
+        up -> "    up";
+        down -> "(x) down";
         lost -> "(!) LOST"
     end.
 
 format_node_marker(Status) ->
     case Status of
-        running -> "";
-        stopped -> " (x)";
+        up -> "";
+        down -> " (x)";
         lost -> " (!)"
     end.
 

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
@@ -1,0 +1,116 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_ds_raft_test_helpers).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("stdlib/include/assert.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-define(ON(NODES, BODY),
+    emqx_ds_test_helpers:on(NODES, fun() -> BODY end)
+).
+
+%%
+
+-spec assert_db_open([node()], emqx_ds:db(), emqx_ds:create_db_opts()) -> _Ok.
+assert_db_open(Nodes, DB, Opts) ->
+    ?assertEqual(
+        [{ok, ok} || _ <- Nodes],
+        erpc:multicall(Nodes, emqx_ds, open_db, [DB, Opts])
+    ),
+    wait_db_bootstrapped(Nodes, DB).
+
+wait_db_bootstrapped(Nodes, DB) ->
+    wait_db_bootstrapped(Nodes, DB, infinity, infinity).
+
+wait_db_bootstrapped(Nodes, DB, Timeout, BackInTime) ->
+    SRefs = [
+        snabbkaffe:subscribe(
+            ?match_event(#{
+                ?snk_kind := emqx_ds_replshard_bootstrapped,
+                ?snk_meta := #{node := Node},
+                db := DB,
+                shard := Shard
+            }),
+            1,
+            Timeout,
+            BackInTime
+        )
+     || Node <- Nodes,
+        Shard <- ?ON(Node, emqx_ds_replication_layer_meta:my_shards(DB))
+    ],
+    lists:foreach(
+        fun({ok, SRef}) ->
+            ?assertMatch({ok, [_]}, snabbkaffe:receive_events(SRef))
+        end,
+        SRefs
+    ).
+
+-spec assert_db_stable([node()], emqx_ds:db()) -> _Ok.
+assert_db_stable([Node | _], DB) ->
+    Shards = ?ON(Node, emqx_ds_replication_layer_meta:shards(DB)),
+    ?assertMatch(
+        _Leadership = [_ | _],
+        ?ON(Node, db_leadership(DB, Shards))
+    ).
+
+db_leadership(DB, Shards) ->
+    Leadership = [{S, shard_leadership(DB, S)} || S <- Shards],
+    Inconsistent = [SL || SL = {_, Leaders} <- Leadership, map_size(Leaders) > 1],
+    case Inconsistent of
+        [] ->
+            Leadership;
+        [_ | _] ->
+            {error, inconsistent, Inconsistent}
+    end.
+
+shard_leadership(DB, Shard) ->
+    ReplicaSet = emqx_ds_replication_layer_meta:replica_set(DB, Shard),
+    Nodes = [emqx_ds_replication_layer_meta:node(Site) || Site <- ReplicaSet],
+    lists:foldl(
+        fun({Site, SN}, Acc) -> Acc#{shard_leader(SN, DB, Shard, Site) => SN} end,
+        #{},
+        lists:zip(ReplicaSet, Nodes)
+    ).
+
+shard_leader(Node, DB, Shard, Site) ->
+    shard_server_info(Node, DB, Shard, Site, leader).
+
+shard_readiness(Node, DB, Shard, Site) ->
+    shard_server_info(Node, DB, Shard, Site, readiness).
+
+shard_server_info(Node, DB, Shard, Site, Info) ->
+    ?ON(
+        Node,
+        emqx_ds_replication_layer_shard:server_info(
+            Info,
+            emqx_ds_replication_layer_shard:shard_server(DB, Shard, Site)
+        )
+    ).
+
+-spec db_transitions(emqx_ds:db()) ->
+    [{emqx_ds_replication_layer:shard_id(), emqx_ds_replication_layer_meta:transition()}].
+db_transitions(DB) ->
+    Shards = emqx_ds_replication_layer_meta:shards(DB),
+    [
+        {S, T}
+     || S <- Shards, T <- emqx_ds_replication_layer_meta:replica_set_transitions(DB, S)
+    ].
+
+wait_db_transitions_done(DB) ->
+    ?retry(1000, 20, ?assertEqual([], db_transitions(DB))).

--- a/apps/emqx_management/src/emqx_mgmt_api_ds.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_ds.erl
@@ -57,6 +57,13 @@
     check_db_exists/2
 ]).
 
+-type sites_shard() :: #{
+    storage := emqx_ds:db(),
+    id := binary(),
+    status => up | down | lost,
+    transition => joining | leaving
+}.
+
 -include_lib("emqx/include/logger.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
@@ -446,7 +453,7 @@ forget(Site, Via) ->
     }),
     meta_result_to_binary(emqx_ds_replication_layer_meta:forget_site(Site)).
 
--spec shards_of_this_site() -> [ShardInfo :: #{}].
+-spec shards_of_this_site() -> [sites_shard()].
 shards_of_this_site() ->
     try emqx_ds_replication_layer_meta:this_site() of
         Site -> shards_of_site(Site)
@@ -454,7 +461,7 @@ shards_of_this_site() ->
         error:badarg -> []
     end.
 
--spec shards_of_site(emqx_ds_replication_layer_meta:site()) -> [ShardInfo :: #{}].
+-spec shards_of_site(emqx_ds_replication_layer_meta:site()) -> [sites_shard()].
 shards_of_site(Site) ->
     lists:flatmap(
         fun({DB, Shard}) ->

--- a/apps/emqx_management/src/emqx_mgmt_api_ds.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_ds.erl
@@ -439,7 +439,7 @@ shards_of_this_site() ->
         error:badarg -> []
     end.
 
--pec shards_of_site(emqx_ds_replication_layer_meta:site()) -> [ShardInfo :: #{}].
+-spec shards_of_site(emqx_ds_replication_layer_meta:site()) -> [ShardInfo :: #{}].
 shards_of_site(Site) ->
     lists:flatmap(
         fun({DB, Shard}) ->
@@ -466,9 +466,6 @@ shards_of_site(Site) ->
 %%================================================================================
 %% Internal functions
 %%================================================================================
-
-%% site_info(Site) ->
-%%     #{}.
 
 disabled_schema() ->
     emqx_dashboard_swagger:error_codes(['NOT_FOUND'], <<"Durable storage is disabled">>).
@@ -566,10 +563,10 @@ meta_error_to_binary({lost_sites, LostSites}) ->
     iolist_to_binary(["Replication still targets lost sites: " | lists:join(", ", LostSites)]);
 meta_error_to_binary({too_few_sites, _Sites}) ->
     <<"Replica sets would become too small">>;
-meta_error_to_binary(site_online) ->
-    <<"Site is online">>;
-meta_error_to_binary(site_temporarily_offline) ->
-    <<"Site is considered temporarily offline">>;
+meta_error_to_binary(site_up) ->
+    <<"Site is up and running">>;
+meta_error_to_binary(site_temporarily_down) ->
+    <<"Site is considered temporarily down">>;
 meta_error_to_binary(Err) ->
     emqx_utils:format("Error: ~p", [Err]).
 

--- a/apps/emqx_management/src/emqx_mgmt_api_ds.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_ds.erl
@@ -469,12 +469,7 @@ shards_of_site(Site) ->
                         id => Shard,
                         status => maps:get(status, Info)
                     },
-                    case TransitionSet of
-                        #{Site := T} ->
-                            [S#{transition => meta_to_transition(T)}];
-                        #{} ->
-                            [S]
-                    end;
+                    [annotate_transition(Site, TransitionSet, S)];
                 _ ->
                     case TransitionSet of
                         #{Site := add} ->
@@ -483,12 +478,7 @@ shards_of_site(Site) ->
                                 id => Shard,
                                 transition => joining
                             },
-                            case TargetSet of
-                                #{Site := Info} ->
-                                    [S#{status => maps:get(status, Info)}];
-                                #{} ->
-                                    [S]
-                            end;
+                            [annotate_target_status(Site, TargetSet, S)];
                         _ ->
                             []
                     end
@@ -507,6 +497,22 @@ get_transition_set(ShardInfo) ->
         #{},
         maps:get(transitions, ShardInfo, [])
     ).
+
+annotate_transition(Site, TransitionSet, Acc) ->
+    case TransitionSet of
+        #{Site := T} ->
+            Acc#{transition => meta_to_transition(T)};
+        #{} ->
+            Acc
+    end.
+
+annotate_target_status(Site, TargetSet, Acc) ->
+    case TargetSet of
+        #{Site := Info} ->
+            Acc#{status => maps:get(status, Info)};
+        #{} ->
+            Acc
+    end.
 
 %%================================================================================
 %% Internal functions

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -114,8 +114,9 @@ cluster(["join", SNode]) ->
             Error
     end;
 cluster(["leave"]) ->
-    case cluster_leave_safeguards() of
-        [] ->
+    Safeguards = cluster_leave_safeguards(),
+    case length(Safeguards) of
+        0 ->
             _ = maybe_disable_autocluster(),
             case ekka:leave() of
                 ok ->
@@ -125,7 +126,7 @@ cluster(["leave"]) ->
                     emqx_ctl:print("Failed to leave the cluster: ~0p~n", [Reason]),
                     Error
             end;
-        Safeguards ->
+        _ ->
             lists:foreach(
                 fun
                     (nonempty_ds_site) ->

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -175,14 +175,7 @@ cluster(_) ->
     ]).
 
 cluster_leave_safeguards() ->
-    cluster_leave_safeguards(ds).
-
-cluster_leave_safeguards(ds) ->
-    case emqx_mgmt_api_ds:is_enabled() andalso emqx_mgmt_api_ds:shards_of_this_site() of
-        [_ | _] -> [nonempty_ds_site];
-        [] -> [];
-        false -> []
-    end.
+    ds_cluster_leave_safeguards().
 
 %% sort lists for deterministic output
 sort_map_list_fields(Map) when is_map(Map) ->
@@ -967,7 +960,7 @@ collect_data_export_args(Args, _Acc) ->
     {error, io_lib:format("unknown arguments: ~p", [Args])}.
 
 %%--------------------------------------------------------------------
-%% @doc Durable storage command
+%% @doc Durable storage
 
 -if(?EMQX_RELEASE_EDITION == ee).
 
@@ -1042,10 +1035,20 @@ do_ds(_) ->
         {"ds forget <site>", "Remove a site from the list of known sites"}
     ]).
 
+ds_cluster_leave_safeguards() ->
+    case emqx_mgmt_api_ds:is_enabled() andalso emqx_mgmt_api_ds:shards_of_this_site() of
+        [_ | _] -> [nonempty_ds_site];
+        [] -> [];
+        false -> []
+    end.
+
 -else.
 
 ds(_Cmd) ->
     emqx_ctl:usage([{"ds", "DS CLI is not available in this edition of EMQX"}]).
+
+ds_cluster_leave_safeguards() ->
+    [].
 
 -endif.
 

--- a/apps/emqx_management/test/emqx_mgmt_api_ds_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_ds_SUITE.erl
@@ -20,8 +20,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx/include/asserts.hrl").
 
--import(emqx_mgmt_api_test_util, [api_path/1, request_api/2, request_api_with_body/3]).
+-define(ON(NODE, BODY),
+    emqx_ds_test_helpers:on(NODE, fun() -> BODY end)
+).
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
@@ -29,23 +32,31 @@ all() ->
 init_per_suite(Config) ->
     case emqx_ds_test_helpers:skip_if_norepl() of
         false ->
-            Apps = emqx_cth_suite:start(
+            AppSpecs = [
+                emqx_conf,
+                {emqx, "durable_sessions.enable = true"},
+                emqx_management
+            ],
+            DashboardSpecs = [
+                emqx_mgmt_api_test_util:emqx_dashboard()
+            ],
+            Cluster = emqx_cth_cluster:start(
                 [
-                    emqx_conf,
-                    {emqx, "durable_sessions.enable = true"},
-                    emqx_management,
-                    {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
+                    {emqx_mgmt_api_ds_SUITE1, #{apps => AppSpecs ++ DashboardSpecs}},
+                    {emqx_mgmt_api_ds_SUITE2, #{apps => AppSpecs}}
                 ],
                 #{work_dir => emqx_cth_suite:work_dir(Config)}
             ),
-            {ok, _} = emqx_common_test_http:create_default_app(),
-            [{suite_apps, Apps} | Config];
+            [N1 | _] = Cluster,
+            Sites = [?ON(N, emqx_ds_replication_layer_meta:this_site()) || N <- Cluster],
+            ApiAuth = ?ON(N1, emqx_common_test_http:default_auth_header()),
+            [{cluster, Cluster}, {sites, Sites}, {api_auth, ApiAuth} | Config];
         Yes ->
             Yes
     end.
 
 end_per_suite(Config) ->
-    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+    ok = emqx_cth_cluster:stop(?config(cluster, Config)).
 
 init_per_testcase(_, Config) ->
     Config.
@@ -53,36 +64,34 @@ init_per_testcase(_, Config) ->
 end_per_testcase(_, Config) ->
     Config.
 
-t_get_sites(_) ->
-    Path = api_path(["ds", "sites"]),
-    {ok, Response} = request_api(get, Path),
-    ?assertEqual(
-        [emqx_ds_replication_layer_meta:this_site()],
+t_get_sites(Config) ->
+    {ok, Response} = request_api(get, ["ds", "sites"], Config),
+    ?assertSameSet(
+        ?config(sites, Config),
         emqx_utils_json:decode(Response)
     ).
 
-t_get_storages(_) ->
-    Path = api_path(["ds", "storages"]),
-    {ok, Response} = request_api(get, Path),
+t_get_storages(Config) ->
+    {ok, Response} = request_api(get, ["ds", "storages"], Config),
     ?assertEqual(
         [<<"messages">>],
         emqx_utils_json:decode(Response)
     ).
 
-t_get_site(_) ->
+t_get_site(Config) ->
     %% Unknown sites must result in error 404:
-    Path404 = api_path(["ds", "sites", "unknown_site"]),
     ?assertMatch(
         {error, {_, 404, _}},
-        request_api(get, Path404)
+        request_api(get, ["ds", "sites", "unknown_site"], Config)
     ),
-    %% Valid path:
-    Path = api_path(["ds", "sites", emqx_ds_replication_layer_meta:this_site()]),
-    {ok, Response} = request_api(get, Path),
-    ThisNode = atom_to_binary(node()),
+    %% Valid request:
+    [N1 | _] = ?config(cluster, Config),
+    [S1 | _] = ?config(sites, Config),
+    N1Bin = atom_to_binary(N1),
+    {ok, Resp1} = request_api(get, ["ds", "sites", S1], Config),
     ?assertMatch(
         #{
-            <<"node">> := ThisNode,
+            <<"node">> := N1Bin,
             <<"up">> := true,
             <<"shards">> :=
                 [
@@ -94,20 +103,64 @@ t_get_site(_) ->
                     | _
                 ]
         },
-        emqx_utils_json:decode(Response)
-    ).
+        emqx_utils_json:decode(Resp1)
+    ),
+    %% Transitions are reported:
+    ?assertMatch(
+        {ok, "OK"},
+        request_api(delete, ["ds", "storages", "messages", "replicas", S1], Config)
+    ),
+    {ok, Resp2} = request_api(get, ["ds", "sites", S1], Config),
+    ?assertMatch(
+        #{
+            <<"shards">> :=
+                [
+                    #{
+                        <<"storage">> := <<"messages">>,
+                        <<"id">> := _,
+                        <<"status">> := <<"up">>,
+                        <<"transition">> := <<"leaving">>
+                    }
+                    | _
+                ]
+        },
+        emqx_utils_json:decode(Resp2)
+    ),
+    %% Wait until transitions are complete:
+    ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(messages)),
+    %% Restore initial allocation:
+    ?assertMatch(
+        {ok, "OK"},
+        request_api(put, ["ds", "storages", "messages", "replicas", S1], Config)
+    ),
+    {ok, Resp3} = request_api(get, ["ds", "sites", S1], Config),
+    ?assertMatch(
+        #{
+            <<"shards">> :=
+                [
+                    #{
+                        <<"storage">> := <<"messages">>,
+                        <<"id">> := _,
+                        <<"status">> := <<"up">>,
+                        <<"transition">> := <<"joining">>
+                    }
+                    | _
+                ]
+        },
+        emqx_utils_json:decode(Resp3)
+    ),
+    ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(messages)).
 
-t_get_db(_) ->
+t_get_db(Config) ->
+    [N1 | _] = ?config(cluster, Config),
+    [S1, S2] = lists:sort(?config(sites, Config)),
     %% Unknown DBs must result in error 404:
-    Path404 = api_path(["ds", "storages", "unknown_ds"]),
     ?assertMatch(
         {error, {_, 404, _}},
-        request_api(get, Path404)
+        request_api(get, ["ds", "storages", "unknown_ds"], Config)
     ),
-    %% Valid path:
-    Path = api_path(["ds", "storages", "messages"]),
-    {ok, Response} = request_api(get, Path),
-    ThisSite = emqx_ds_replication_layer_meta:this_site(),
+    %% Valid request:
+    {ok, Resp1} = request_api(get, ["ds", "storages", "messages"], Config),
     ?assertMatch(
         #{
             <<"name">> := <<"messages">>,
@@ -117,76 +170,139 @@ t_get_db(_) ->
                         <<"id">> := _,
                         <<"replicas">> :=
                             [
-                                #{
-                                    <<"site">> := ThisSite,
-                                    <<"status">> := <<"up">>
-                                }
-                                | _
+                                #{<<"site">> := S1, <<"status">> := <<"up">>},
+                                #{<<"site">> := S2, <<"status">> := <<"up">>}
                             ]
                     }
                     | _
                 ]
         },
-        emqx_utils_json:decode(Response)
-    ).
+        emqx_utils_json:decode(Resp1)
+    ),
+    %% Transitions are reported:
+    ?assertMatch(
+        {ok, "OK"},
+        request_api(delete, ["ds", "storages", "messages", "replicas", S1], Config)
+    ),
+    {ok, Resp2} = request_api(get, ["ds", "storages", "messages"], Config),
+    ?assertMatch(
+        #{
+            <<"shards">> :=
+                [
+                    #{
+                        <<"transitions">> :=
+                            [#{<<"site">> := S1, <<"transition">> := <<"leaving">>}]
+                    }
+                    | _
+                ]
+        },
+        emqx_utils_json:decode(Resp2)
+    ),
+    %% Wait until transitions are complete:
+    ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(messages)),
+    %% Restore initial allocation:
+    ?assertMatch(
+        {ok, "OK"},
+        request_api(put, ["ds", "storages", "messages", "replicas", S1], Config)
+    ),
+    {ok, Resp3} = request_api(get, ["ds", "storages", "messages"], Config),
+    ?assertMatch(
+        #{
+            <<"shards">> :=
+                [
+                    #{
+                        <<"transitions">> :=
+                            [#{<<"site">> := S1, <<"transition">> := <<"joining">>}]
+                    }
+                    | _
+                ]
+        },
+        emqx_utils_json:decode(Resp3)
+    ),
+    ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(messages)).
 
-t_get_replicas(_) ->
+t_get_replicas(Config) ->
     %% Unknown DBs must result in error 404:
-    Path404 = api_path(["ds", "storages", "unknown_ds", "replicas"]),
     ?assertMatch(
         {error, {_, 404, _}},
-        request_api(get, Path404)
+        request_api(get, ["ds", "storages", "unknown_ds", "replicas"], Config)
     ),
     %% Valid path:
-    Path = api_path(["ds", "storages", "messages", "replicas"]),
-    {ok, Response} = request_api(get, Path),
-    ThisSite = emqx_ds_replication_layer_meta:this_site(),
-    ?assertEqual(
-        [ThisSite],
+    {ok, Response} = request_api(get, ["ds", "storages", "messages", "replicas"], Config),
+    Sites = ?config(sites, Config),
+    ?assertSameSet(
+        Sites,
         emqx_utils_json:decode(Response)
     ).
 
-t_put_replicas(_) ->
-    Path = api_path(["ds", "storages", "messages", "replicas"]),
+t_put_replicas(Config) ->
     %% Error cases:
     ?assertMatch(
         {ok, 400, #{<<"message">> := <<"Unknown sites: invalid_site">>}},
-        parse_error(request_api_with_body(put, Path, [<<"invalid_site">>]))
+        parse_error(
+            request_api(
+                put,
+                ["ds", "storages", "messages", "replicas"],
+                [<<"invalid_site">>],
+                Config
+            )
+        )
     ),
     %% Success case:
+    [S1 | _] = ?config(sites, Config),
     ?assertMatch(
         {ok, 202, <<"OK">>},
-        request_api_with_body(put, Path, [emqx_ds_replication_layer_meta:this_site()])
+        request_api(put, ["ds", "storages", "messages", "replicas"], [S1], Config)
     ).
 
-t_join(_) ->
-    Path400 = api_path(["ds", "storages", "messages", "replicas", "unknown_site"]),
+t_join(Config) ->
+    ReplicasApiPath = ["ds", "storages", "messages", "replicas"],
     ?assertMatch(
-        {error, {_, 400, _}},
-        parse_error(request_api(put, Path400))
+        {ok, 400, #{<<"message">> := <<"Unknown sites: unknown_site">>}},
+        parse_error(request_api(put, ReplicasApiPath ++ ["unknown_site"], <<>>, Config))
     ),
-    ThisSite = emqx_ds_replication_layer_meta:this_site(),
-    Path = api_path(["ds", "storages", "messages", "replicas", ThisSite]),
+    [S1 | _] = ?config(sites, Config),
     ?assertMatch(
         {ok, "OK"},
-        request_api(put, Path)
+        request_api(put, ReplicasApiPath ++ [S1], Config)
     ).
 
-t_leave(_) ->
-    ThisSite = emqx_ds_replication_layer_meta:this_site(),
-    Path = api_path(["ds", "storages", "messages", "replicas", ThisSite]),
+t_leave(Config) ->
+    ReplicasApiPath = ["ds", "storages", "messages", "replicas"],
+    [S1, S2] = ?config(sites, Config),
     ?assertMatch(
-        {error, {_, 400, _}},
-        request_api(delete, Path)
-    ).
+        {ok, "OK"},
+        request_api(delete, ReplicasApiPath ++ [S1], Config)
+    ),
+    %% Leaving the last site is prohibited:
+    ?assertMatch(
+        {ok, 400, #{<<"message">> := <<"Replica sets would become too small">>}},
+        parse_error(request_api(delete, ReplicasApiPath ++ [S2], <<>>, Config))
+    ),
+    %% Restore initial allocation:
+    ?assertMatch(
+        {ok, "OK"},
+        request_api(put, ReplicasApiPath ++ [S1], Config)
+    ),
+    [N1 | _] = ?config(cluster, Config),
+    ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(messages)).
 
-t_leave_notfound(_) ->
+t_leave_notfound(Config) ->
     Site = "not_part_of_replica_set",
-    Path = api_path(["ds", "storages", "messages", "replicas", Site]),
     ?assertMatch(
         {error, {_, 404, _}},
-        request_api(delete, Path)
+        request_api(delete, ["ds", "storages", "messages", "replicas", Site], Config)
     ).
+
+%%
+
+request_api(Method, ApiPath, Config) ->
+    Url = emqx_mgmt_api_test_util:api_path(ApiPath),
+    emqx_mgmt_api_test_util:request_api(Method, Url, ?config(api_auth, Config)).
+
+request_api(Method, ApiPath, Body, Config) ->
+    Url = emqx_mgmt_api_test_util:api_path(ApiPath),
+    emqx_mgmt_api_test_util:request_api_with_body(Method, Url, ?config(api_auth, Config), Body).
 
 parse_error({ok, Code, JSON}) ->
     {ok, Code, emqx_utils_json:decode(JSON)};

--- a/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_test_util.erl
@@ -86,8 +86,11 @@ uri(Host, Parts) ->
 
 %% compatible_mode will return as same as 'emqx_dashboard_api_test_helpers:request'
 request_api_with_body(Method, Url, Body) ->
+    request_api_with_body(Method, Url, auth_header_(), Body).
+
+request_api_with_body(Method, Url, AuthOrHeaders, Body) ->
     Opts = #{compatible_mode => true, httpc_req_opts => [{body_format, binary}]},
-    request_api(Method, Url, [], auth_header_(), Body, Opts).
+    request_api(Method, Url, [], AuthOrHeaders, Body, Opts).
 
 request_api(Method, Url) ->
     request_api(Method, Url, auth_header_()).

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -20,6 +20,11 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/test_macros.hrl").
+
+-define(ON(NODES, BODY),
+    emqx_ds_test_helpers:on(NODES, fun() -> BODY end)
+).
 
 all() ->
     All = emqx_common_test_helpers:all(?MODULE),
@@ -45,46 +50,15 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(apps, Config)).
 
-init_per_testcase(t_autocluster_leave = TC, Config) ->
-    [Core1, Core2, Repl1, Repl2] =
-        Nodes = [
-            t_autocluster_leave_core1,
-            t_autocluster_leave_core2,
-            t_autocluster_leave_replicant1,
-            t_autocluster_leave_replicant2
-        ],
-
-    NodeNames = [emqx_cth_cluster:node_name(N) || N <- Nodes],
-    AppSpec = [
-        emqx,
-        {emqx_conf, #{
-            config => #{
-                cluster => #{
-                    discovery_strategy => static,
-                    static => #{seeds => NodeNames}
-                }
-            }
-        }},
-        emqx_management
-    ],
-    Cluster = emqx_cth_cluster:start(
-        [
-            {Core1, #{role => core, apps => AppSpec}},
-            {Core2, #{role => core, apps => AppSpec}},
-            {Repl1, #{role => replicant, apps => AppSpec}},
-            {Repl2, #{role => replicant, apps => AppSpec}}
-        ],
-        #{work_dir => emqx_cth_suite:work_dir(TC, Config)}
-    ),
-    [{cluster, Cluster} | Config];
-init_per_testcase(_TC, Config) ->
-    Config.
-
-end_per_testcase(_TC, Config) ->
-    case ?config(cluster, Config) of
-        undefined -> ok;
-        Cluster -> emqx_cth_cluster:stop(Cluster)
+init_per_testcase(TC, Config) ->
+    try
+        emqx_common_test_helpers:init_per_testcase(?MODULE, TC, Config)
+    catch
+        throw:{skip, Reason} -> {skip, Reason}
     end.
+
+end_per_testcase(TC, Config) ->
+    emqx_common_test_helpers:end_per_testcase(?MODULE, TC, Config).
 
 t_status(_Config) ->
     emqx_ctl:run_command([]),
@@ -319,10 +293,43 @@ t_admin(_Config) ->
     %% admins del <Username>                          # Delete dashboard user
     ok.
 
+t_autocluster_leave('init', Config) ->
+    ok = skip_if_oss(),
+    [Core1, Core2, Repl1, Repl2] =
+        Nodes = [
+            t_autocluster_leave_core1,
+            t_autocluster_leave_core2,
+            t_autocluster_leave_replicant1,
+            t_autocluster_leave_replicant2
+        ],
+    NodeNames = [emqx_cth_cluster:node_name(N) || N <- Nodes],
+    AppSpec = [
+        emqx,
+        {emqx_conf, #{
+            config => #{
+                cluster => #{
+                    discovery_strategy => static,
+                    static => #{seeds => NodeNames}
+                }
+            }
+        }},
+        emqx_management
+    ],
+    Cluster = emqx_cth_cluster:start(
+        [
+            {Core1, #{role => core, apps => AppSpec}},
+            {Core2, #{role => core, apps => AppSpec}},
+            {Repl1, #{role => replicant, apps => AppSpec}},
+            {Repl2, #{role => replicant, apps => AppSpec}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    [{cluster, Cluster} | Config];
+t_autocluster_leave('end', Config) ->
+    emqx_cth_cluster:stop(?config(cluster, Config)).
+
 t_autocluster_leave(Config) ->
     [Core1, Core2, Repl1, Repl2] = Cluster = ?config(cluster, Config),
-    %% Mria membership updates are async, makes sense to wait a little
-    timer:sleep(300),
     ClusterView = [lists:sort(rpc:call(N, emqx, running_nodes, [])) || N <- Cluster],
     [View1, View2, View3, View4] = ClusterView,
     ?assertEqual(lists:sort(Cluster), View1),
@@ -363,9 +370,89 @@ t_autocluster_leave(Config) ->
         )
     ).
 
+t_leave_rejected_ds_nonempty('init', Config) ->
+    ok = skip_if_norepl(),
+    ok = snabbkaffe:start_trace(),
+    AppSpec = [
+        emqx_conf,
+        {emqx,
+            "durable_sessions.enable = true \n"
+            "durable_storage.messages.backend = builtin_raft \n"
+            "durable_storage.messages.n_sites = 2 \n"},
+        emqx_management
+    ],
+    NodeSpecs = emqx_cth_cluster:mk_nodespecs(
+        [
+            {t_leave_rejected_ds_nonempty1, #{role => core, apps => AppSpec}},
+            {t_leave_rejected_ds_nonempty2, #{role => core, apps => AppSpec}}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+    ),
+    Cluster = emqx_cth_cluster:start(NodeSpecs),
+    [{cluster, Cluster}, {nodespecs, NodeSpecs} | Config];
+t_leave_rejected_ds_nonempty('end', Config) ->
+    ok = snabbkaffe:stop(),
+    emqx_cth_cluster:stop(?config(cluster, Config)).
+
+t_leave_rejected_ds_nonempty(Config) ->
+    _Specs = [_, NS2] = ?config(nodespecs, Config),
+    Nodes = [N1, N2] = ?config(cluster, Config),
+    S2 = ?ON(N2, emqx_ds_replication_layer_meta:this_site()),
+    DB = messages,
+    DBArg = "messages",
+    S2Arg = binary_to_list(S2),
+
+    %% Ensure DS has been bootstrapped.
+    ok = emqx_ds_raft_test_helpers:wait_db_bootstrapped(Nodes, DB),
+    ?ON(N1, emqx_mgmt_cli:ds(["info"])),
+
+    %% Should not be possible to leave, because there are shard replicas.
+    ?assertEqual(
+        {error, [nonempty_ds_site]},
+        ?ON(N2, emqx_mgmt_cli:cluster(["leave"]))
+    ),
+
+    %% Ask to leave DS DB replication, wait until transitions are finished.
+    ?assertEqual(ok, ?ON(N1, emqx_mgmt_cli:ds(["leave", DBArg, S2Arg]))),
+    ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(DB)),
+
+    %% Now leave the cluster again, wait until N1 forgets about S2.
+    ?assertEqual(ok, ?ON(N2, emqx_mgmt_cli:cluster(["leave"]))),
+    ?retry(500, 10, undefined = ?ON(N1, emqx_ds_replication_layer_meta:node(S2))),
+    ?ON(N1, emqx_mgmt_cli:ds(["info"])),
+
+    %% Join the cluster again.
+    ?assertEqual(ok, ?ON(N2, emqx_mgmt_cli:cluster(["join", atom_to_list(N1)]))),
+    [N2] = emqx_cth_cluster:restart(NS2),
+    % ?retry(500, 10, N2 = ?ON(N1, emqx_ds_replication_layer_meta:node(S2))),
+    ?ON(N1, emqx_mgmt_cli:ds(["info"])),
+
+    %% Ask to be DS DB replication site again.
+    ?assertEqual(ok, ?ON(N1, emqx_mgmt_cli:ds(["join", DBArg, S2Arg]))),
+    %% Should not be possible to leave, even if transitions are still in-progress.
+    ?assertEqual(
+        {error, [nonempty_ds_site]},
+        ?ON(N1, emqx_mgmt_cli:cluster(["leave"]))
+    ).
+
 t_exclusive(_Config) ->
     emqx_ctl:run_command(["exclusive", "list"]),
     emqx_ctl:run_command(["exclusive", "delete", "t/1"]),
     ok.
 
-format(Str, Opts) -> io:format("str:~s: Opts:~p", [Str, Opts]).
+%%
+
+skip_if_oss() ->
+    case emqx_cth_suite:skip_if_oss() of
+        false -> ok;
+        Skip -> throw(Skip)
+    end.
+
+skip_if_norepl() ->
+    case emqx_ds_test_helpers:skip_if_norepl() of
+        false -> ok;
+        Skip -> throw(Skip)
+    end.
+
+format(Str, Opts) ->
+    io:format("str:~s: Opts:~p", [Str, Opts]).

--- a/changes/ee/feat-14766.en.md
+++ b/changes/ee/feat-14766.en.md
@@ -1,0 +1,1 @@
+Added safeguards to `emqx ctl cluster leave` command to prevent nodes responsible for Durable Storage data replication from leaving the cluster.


### PR DESCRIPTION
Fixes [EMQX-13910](https://emqx.atlassian.net/browse/EMQX-13910).
Partially addresses [EMQX-13909](https://emqx.atlassian.net/browse/EMQX-13909).

Release version: e5.9

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible


[EMQX-13910]: https://emqx.atlassian.net/browse/EMQX-13910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMQX-13909]: https://emqx.atlassian.net/browse/EMQX-13909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ