### PR TITLE
chore: Kafka producer handle Kafka fewer partitions

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,8 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.6"},
-    {kafka_protocol, "4.1.10"},
+    {wolff, "4.0.7"},
+    {kafka_protocol, "4.2.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,8 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.6"},
-    {kafka_protocol, "4.1.10"},
+    {wolff, "4.0.7"},
+    {kafka_protocol, "4.2.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},
     {snappyer, "1.2.10"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,8 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.6"},
-    {kafka_protocol, "4.1.10"},
+    {wolff, "4.0.7"},
+    {kafka_protocol, "4.2.2"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},
     {snappyer, "1.2.10"},

--- a/mix.exs
+++ b/mix.exs
@@ -279,11 +279,11 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.6"}
+  def common_dep(:wolff), do: {:wolff, "4.0.7"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),
-    do: {:kafka_protocol, "4.1.10", override: true}
+    do: {:kafka_protocol, "4.2.2", override: true}
 
   def common_dep(:brod), do: {:brod, "4.3.1"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override


### PR DESCRIPTION
Fixes [EEC-1145](https://emqx.atlassian.net/browse/EEC-1145)

Release version: v/e5.9.0

## Summary

Upgrade Kafka producer library to `wolff-4.0.7` to handle Kafka topic recreation with fewer partitions.
Prior to this fix, it only handles the case when the Kafka topic get more partitions.