### PR TITLE
fix(quic): reload listener also update conn opts and stream opts

### DIFF
--- a/apps/emqx/rebar.config.script
+++ b/apps/emqx/rebar.config.script
@@ -19,7 +19,7 @@ end,
 
 Bcrypt = {bcrypt, {git, "https://github.com/emqx/erlang-bcrypt.git", {tag, "0.6.3"}}},
 Quicer =
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.3"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.4"}}}.
 
 Dialyzer = fun(Config) ->
     {dialyzer, OldDialyzerConfig} = lists:keyfind(dialyzer, 1, Config),

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -197,8 +197,8 @@ is_running(quic, ListenerId, _Conf) ->
             false
     end.
 
-current_conns(ID, ListenOn) ->
-    {ok, #{type := Type, name := Name}} = parse_listener_id(ID),
+current_conns(Id, ListenOn) ->
+    {ok, #{type := Type, name := Name}} = parse_listener_id(Id),
     current_conns(Type, Name, ListenOn).
 
 current_conns(Type, Name, ListenOn) when Type == tcp; Type == ssl ->
@@ -211,8 +211,8 @@ current_conns(quic, Name, _ListenOn) ->
 current_conns(_, _, _) ->
     {error, not_support}.
 
-max_conns(ID, ListenOn) ->
-    {ok, #{type := Type, name := Name}} = parse_listener_id(ID),
+max_conns(Id, ListenOn) ->
+    {ok, #{type := Type, name := Name}} = parse_listener_id(Id),
     max_conns(Type, Name, ListenOn).
 
 max_conns(Type, Name, ListenOn) when Type == tcp; Type == ssl ->
@@ -222,8 +222,8 @@ max_conns(Type, Name, _ListenOn) when Type =:= ws; Type =:= wss ->
 max_conns(_, _, _) ->
     {error, not_support}.
 
-shutdown_count(ID, ListenOn) ->
-    {ok, #{type := Type, name := Name}} = parse_listener_id(ID),
+shutdown_count(Id, ListenOn) ->
+    {ok, #{type := Type, name := Name}} = parse_listener_id(Id),
     shutdown_count(Type, Name, ListenOn).
 
 shutdown_count(Type, Name, ListenOn) when Type == tcp; Type == ssl ->

--- a/changes/ce/fix-14775.en.md
+++ b/changes/ce/fix-14775.en.md
@@ -1,0 +1,1 @@
+QUIC Listener: fix issue where zone configurations are not applied after a config reload.

--- a/mix.exs
+++ b/mix.exs
@@ -1221,7 +1221,7 @@ defmodule EMQXUmbrella.MixProject do
     if enable_quicer?(),
       # in conflict with emqx and emqtt
       do: [
-        {:quicer, github: "emqx/quic", tag: "0.2.3", override: true}
+        {:quicer, github: "emqx/quic", tag: "0.2.4", override: true}
       ],
       else: []
   end

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -36,7 +36,7 @@ assert_otp() ->
     end.
 
 quicer() ->
-    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.3"}}}.
+    {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.2.4"}}}.
 
 jq() ->
     {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.12"}}}.


### PR DESCRIPTION
bumps to quicer-0.2.4.

Enforce updating listener opts (listen opts, conn opts and stream opts) when reloading the quicer listener.
These configs are managed by quicer for efficiency.

Fixes [EMQX-13434](https://emqx.atlassian.net/browse/EMQX-13434)

Release version: v/e5.9

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [x] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-13434]: https://emqx.atlassian.net/browse/EMQX-13434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ