### PR TITLE
chore: bump to emqtt 1.14.1

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -46,7 +46,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.0"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.1"}}}
         ]},
         {extra_src_dirs, [
             {"test", [recursive]},
@@ -58,7 +58,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.0"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.1"}}}
         ]},
         {extra_src_dirs, [{"test", [recursive]}]}
     ]}

--- a/apps/emqx_retainer/rebar.config
+++ b/apps/emqx_retainer/rebar.config
@@ -30,7 +30,7 @@
 {profiles, [
     {test, [
         {deps, [
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.0"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.1"}}}
         ]}
     ]}
 ]}.

--- a/mix.exs
+++ b/mix.exs
@@ -248,7 +248,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:emqtt),
     do:
       {:emqtt,
-       github: "emqx/emqtt", tag: "1.14.0", override: true, system_env: maybe_no_quic_env()}
+       github: "emqx/emqtt", tag: "1.14.1", override: true, system_env: maybe_no_quic_env()}
 
   def common_dep(:typerefl),
     do: {:typerefl, github: "ieQu1/typerefl", tag: "0.9.6", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -91,7 +91,7 @@
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.12"}}},
-    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.0"}}},
+    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.1"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x
     {observer_cli, "1.8.2"},


### PR DESCRIPTION
fix flaky tests about client not recving MQTT.disconnect after connection graceful shutdown.
Fixes <issue-or-jira-number>

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
