### PR TITLE
fix: add trace logs for protocol_error

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.5.1"},
+    {vsn, "5.5.2"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/changes/ce/fix-14793.en.md
+++ b/changes/ce/fix-14793.en.md
@@ -1,0 +1,5 @@
+Add trace log for `protocol_error`.
+
+Previously if a client sends invalid or unexpected MQTT packets to cause a `protocol_error` in EMQX, the detailed reason is not traced.
+For example, if a client send two `CONNECT` packets, for the second one, EMQX may log `socket_force_closed` with `protocol_error`, but hard to tell why.
+Now EMQX will log `unexpected_connect_packet` with `conn_state=connected` before `socket_force_closed`.


### PR DESCRIPTION
Fixes [EMQX-13972](https://emqx.atlassian.net/browse/EMQX-13972)

Release version: v/e5.8.6

## Summary
Add trace log for `protocol_error`.

Previously when client send invalid or unexpected packets to cause a `protocol_error` in EMQX, the detailed reason is not traced.
For example, if a client send two `CONNECT` packets, for the second one, EMQX may log `socket_force_closed` with `protocol_error`, but hard to tell why.
Now EMQX will log `unexpected_connect_packet` with `conn_satet=connected` before `socket_force_closed`.

```
[MQTT] actia@127.0.0.1:53490 msg: mqtt_packet_received, packet: CONNECT(Q0, R0, D0, ClientId=actia, ProtoName=MQTT, ProtoVsn=4, CleanStart=true, KeepAlive=60, Username=undefined, Password=)
[MQTT] actia@127.0.0.1:53490 msg: mqtt_packet_sent, packet: CONNACK(Q0, R0, D0, AckFlags=0, ReasonCode=0)
[MQTT] actia@127.0.0.1:53490 msg: unexpected_connect_packet, conn_satet: connected
[SOCKET] actia@127.0.0.1:53490 msg: socket_force_closed, reason: protocol_error
[SOCKET] actia@127.0.0.1:53490 msg: emqx_connection_terminated, reason: {shutdown,protocol_error}
```

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change



[EMQX-13972]: https://emqx.atlassian.net/browse/EMQX-13972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ