### PR TITLE
refactor(license): rename max_connections to max_sessions

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -367,12 +367,12 @@ merge_samplers(SinceTime, Increment0, Base) ->
         end,
     maps:fold(fun merge_samplers_loop/3, Base, Increment).
 
-merge_samplers_loop(TS, Increment, Base) when is_map(Increment) ->
-    case maps:get(TS, Base, undefined) of
+merge_samplers_loop(Ts, Increment, Base) when is_map(Increment) ->
+    case maps:get(Ts, Base, undefined) of
         undefined ->
-            Base#{TS => Increment};
+            Base#{Ts => Increment};
         BaseSample when is_map(BaseSample) ->
-            Base#{TS => merge_sampler_maps(Increment, BaseSample)}
+            Base#{Ts => merge_sampler_maps(Increment, BaseSample)}
     end.
 
 merge_sampler_maps(M1, M2) when is_map(M1) andalso is_map(M2) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -741,7 +741,7 @@ non_rate_value() ->
 -if(?EMQX_RELEASE_EDITION == ee).
 license_quota() ->
     case emqx_license_checker:limits() of
-        {ok, #{max_connections := Quota}} ->
+        {ok, #{max_sessions := Quota}} ->
             #{license_quota => Quota};
         {error, no_license} ->
             #{license_quota => 0}

--- a/apps/emqx_license/src/emqx_license.erl
+++ b/apps/emqx_license/src/emqx_license.erl
@@ -84,20 +84,20 @@ exec_config_update(Param) ->
 
 check(#{clientid := ClientId}, AckProps) ->
     case emqx_license_checker:limits() of
-        {ok, #{max_connections := ?ERR_EXPIRED}} ->
+        {ok, #{max_sessions := ?ERR_EXPIRED}} ->
             ?SLOG_THROTTLE(error, #{msg => connection_rejected_due_to_license_expired}, #{
                 tag => "LICENSE"
             }),
             {stop, {error, ?RC_QUOTA_EXCEEDED}};
-        {ok, #{max_connections := ?ERR_MAX_UPTIME}} ->
+        {ok, #{max_sessions := ?ERR_MAX_UPTIME}} ->
             ?SLOG_THROTTLE(
                 error, #{msg => connection_rejected_due_to_trial_license_uptime_limit}, #{
                     tag => "LICENSE"
                 }
             ),
             {stop, {error, ?RC_QUOTA_EXCEEDED}};
-        {ok, #{max_connections := MaxClients}} ->
-            case is_max_clients_exceeded(MaxClients) andalso is_new_client(ClientId) of
+        {ok, #{max_sessions := MaxSessions}} ->
+            case is_max_clients_exceeded(MaxSessions) andalso is_new_client(ClientId) of
                 true ->
                     ?SLOG_THROTTLE(
                         error,

--- a/apps/emqx_license/src/emqx_license_checker.erl
+++ b/apps/emqx_license/src/emqx_license_checker.erl
@@ -34,8 +34,8 @@
     purge/0,
     limits/0,
     print_warnings/1,
-    get_max_connections/1,
-    get_dynamic_max_connections/0
+    get_max_sessions/1,
+    get_dynamic_max_sessions/0
 ]).
 
 %% gen_server callbacks
@@ -50,7 +50,7 @@
 
 -define(LICENSE_TAB, emqx_license).
 
--type limits() :: #{max_connections := non_neg_integer() | ?ERR_EXPIRED | ?ERR_MAX_UPTIME}.
+-type limits() :: #{max_sessions := non_neg_integer() | ?ERR_EXPIRED | ?ERR_MAX_UPTIME}.
 -type license() :: emqx_license_parser:license().
 -type fetcher() :: fun(() -> {ok, license()} | {error, term()}).
 
@@ -125,9 +125,9 @@ handle_call({update, License}, _From, #{license := Old} = State0) ->
 handle_call(dump, _From, #{license := License} = State) ->
     Dump0 = emqx_license_parser:dump(License),
     %% resolve the current dynamic limit
-    MaybeDynamic = get_max_connections(License),
-    Dump = lists:keyreplace(max_connections, 1, Dump0, {max_connections, MaybeDynamic}),
-    {reply, max_sessions(Dump), State};
+    MaybeDynamic = get_max_sessions(License),
+    Dump = lists:keyreplace(max_sessions, 1, Dump0, {max_sessions, MaybeDynamic}),
+    {reply, Dump, State};
 handle_call(expiry_epoch, _From, #{license := License} = State) ->
     ExpiryEpoch = date_to_expiry_epoch(emqx_license_parser:expiry_date(License)),
     {reply, ExpiryEpoch, State};
@@ -222,7 +222,7 @@ check_license(#{license := License, start_time := StartTime} = _State) ->
     DaysLeft = days_left(License),
     IsOverdue = is_overdue(License, DaysLeft),
     IsMaxUptimeReached = is_max_uptime_reached(License, StartTime),
-    #{max_connections := MaxConn} =
+    #{max_sessions := MaxConn} =
         Limits = limits(License, #{
             is_overdue => IsOverdue,
             is_max_uptime_reached => IsMaxUptimeReached
@@ -240,35 +240,36 @@ warn_evaluation(_License, _IsOverdue, _MaxConn) ->
 
 limits(_License, #{is_overdue := true}) ->
     #{
-        max_connections => ?ERR_EXPIRED
+        max_sessions => ?ERR_EXPIRED
     };
 limits(_License, #{is_max_uptime_reached := true}) ->
     #{
-        max_connections => ?ERR_MAX_UPTIME
+        max_sessions => ?ERR_MAX_UPTIME
     };
 limits(License, #{}) ->
     #{
-        max_connections => get_max_connections(License)
+        max_sessions => get_max_sessions(License)
     }.
 
-%% @doc Return the max_connections limit defined in license.
+%% @doc Return the max_sessions limit defined in license.
 %% For business-critical type, it returns the dynamic value set in config.
--spec get_max_connections(license()) -> non_neg_integer().
-get_max_connections(License) ->
-    Max = emqx_license_parser:max_connections(License),
+-spec get_max_sessions(license()) -> non_neg_integer().
+get_max_sessions(License) ->
+    Max = emqx_license_parser:max_sessions(License),
     Dyn =
         case emqx_license_parser:customer_type(License) of
             ?BUSINESS_CRITICAL_CUSTOMER ->
-                min(get_dynamic_max_connections(), Max);
+                min(get_dynamic_max_sessions(), Max);
             _ ->
                 Max
         end,
     min(Max, Dyn).
 
-%% @doc Get the dynamic max_connections limit set in config.
+%% @doc Get the dynamic max_sessions limit set in config.
 %% It's only meaningful for business-critical license.
--spec get_dynamic_max_connections() -> non_neg_integer().
-get_dynamic_max_connections() ->
+-spec get_dynamic_max_sessions() -> non_neg_integer().
+get_dynamic_max_sessions() ->
+    %% For config backward compatibility
     emqx_conf:get([license, dynamic_max_connections]).
 
 days_left(License) ->
@@ -334,10 +335,3 @@ print_expiry_warning(#{warn_expiry := {true, Days}}) ->
     io:format(?EXPIRY_LOG, [Days]);
 print_expiry_warning(_) ->
     ok.
-
-%% Add max_sessions but not replace max_connections for backward compatibility
-%% TODO(5.9): change max_connections to max_sessions
-max_sessions(InfoList) ->
-    {_, Max} = lists:keyfind(max_connections, 1, InfoList),
-    %% keep max_sessions to the end
-    InfoList ++ [{max_sessions, Max}].

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -30,9 +30,6 @@ license(["update", EncodedLicense]) ->
 license(["info"]) ->
     lists:foreach(
         fun
-            ({max_connections, _V}) ->
-                %% max_sessions will be printed
-                ok;
             ({K, V}) when is_binary(V); is_atom(V); is_list(V) ->
                 ?PRINT("~-16s: ~s~n", [K, V]);
             ({K, V}) ->

--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -189,4 +189,6 @@ get_setting() ->
     end.
 
 license_info() ->
-    maps:from_list(emqx_license_checker:dump()).
+    #{max_sessions := Max} = Dump = maps:from_list(emqx_license_checker:dump()),
+    %% For API backward compatibility
+    Dump#{max_connections => Max}.

--- a/apps/emqx_license/src/emqx_license_parser.erl
+++ b/apps/emqx_license/src/emqx_license_parser.erl
@@ -60,7 +60,7 @@
     customer_type/1,
     license_type/1,
     expiry_date/1,
-    max_connections/1,
+    max_sessions/1,
     max_uptime_seconds/1,
     is_business_critical/1
 ]).
@@ -88,7 +88,7 @@
 
 -callback expiry_date(license_data()) -> calendar:date().
 
--callback max_connections(license_data()) -> non_neg_integer().
+-callback max_sessions(license_data()) -> non_neg_integer().
 
 -callback max_uptime_seconds(license_data()) -> non_neg_integer() | infinity.
 
@@ -154,9 +154,9 @@ expiry_date(#{module := Module, data := LicenseData}) ->
 max_uptime_seconds(#{module := Module, data := LicenseData}) ->
     Module:max_uptime_seconds(LicenseData).
 
--spec max_connections(license()) -> non_neg_integer().
-max_connections(#{module := Module, data := LicenseData}) ->
-    Module:max_connections(LicenseData).
+-spec max_sessions(license()) -> non_neg_integer().
+max_sessions(#{module := Module, data := LicenseData}) ->
+    Module:max_sessions(LicenseData).
 
 -spec is_business_critical(license() | raw_license()) -> boolean().
 is_business_critical(#{module := Module, data := LicenseData}) ->

--- a/apps/emqx_license/src/emqx_license_parser_v20220101.erl
+++ b/apps/emqx_license/src/emqx_license_parser_v20220101.erl
@@ -26,7 +26,7 @@
     customer_type/1,
     license_type/1,
     expiry_date/1,
-    max_connections/1,
+    max_sessions/1,
     max_uptime_seconds/1
 ]).
 
@@ -53,7 +53,7 @@ dump(
         email := Email,
         deployment := Deployment,
         date_start := DateStart,
-        max_connections := MaxConns
+        max_sessions := MaxSessions
     } = License
 ) ->
     DateExpiry = expiry_date(License),
@@ -64,7 +64,7 @@ dump(
         {customer, Customer},
         {email, Email},
         {deployment, Deployment},
-        {max_connections, MaxConns},
+        {max_sessions, MaxSessions},
         {start_at, format_date(DateStart)},
         {expiry_at, format_date(DateExpiry)},
         {type, format_type(Type)},
@@ -76,13 +76,13 @@ summary(
     #{
         deployment := Deployment,
         date_start := DateStart,
-        max_connections := MaxConns
+        max_sessions := MaxSessions
     } = License
 ) ->
     DateExpiry = expiry_date(License),
     #{
         deployment => Deployment,
-        max_connections => MaxConns,
+        max_sessions => MaxSessions,
         start_at => format_date(DateStart),
         expiry_at => format_date(DateExpiry)
     }.
@@ -104,8 +104,8 @@ max_uptime_seconds(License) ->
             infinity
     end.
 
-max_connections(#{max_connections := MaxConns}) ->
-    MaxConns.
+max_sessions(#{max_sessions := MaxSessions}) ->
+    MaxSessions.
 
 %%------------------------------------------------------------------------------
 %% Private functions
@@ -141,7 +141,7 @@ parse_payload(Payload) ->
         string:split(string:trim(Payload), <<"\n">>, all)
     ),
     case Lines of
-        [?LICENSE_VERSION, Type, CType, Customer, Email, Deployment, DateStart, Days, MaxConns] ->
+        [?LICENSE_VERSION, Type, CType, Customer, Email, Deployment, DateStart, Days, MaxSessions] ->
             collect_fields([
                 {type, parse_type(Type)},
                 {customer_type, parse_customer_type(CType)},
@@ -150,9 +150,9 @@ parse_payload(Payload) ->
                 {deployment, {ok, Deployment}},
                 {date_start, parse_date_start(DateStart)},
                 {days, parse_days(Days)},
-                {max_connections, parse_max_connections(MaxConns)}
+                {max_sessions, parse_max_sessions(MaxSessions)}
             ]);
-        [_Version, _Type, _CType, _Customer, _Email, _Deployment, _DateStart, _Days, _MaxConns] ->
+        [_Version, _Type, _CType, _Customer, _Email, _Deployment, _DateStart, _Days, _MaxSessions] ->
             {error, invalid_version};
         _ ->
             {error, unexpected_number_of_fields}
@@ -190,9 +190,9 @@ parse_days(DaysStr) ->
         _ -> {error, invalid_int_value}
     end.
 
-parse_max_connections(MaxConnStr) ->
-    case parse_int(MaxConnStr) of
-        {ok, MaxConns} when MaxConns > 0 -> {ok, MaxConns};
+parse_max_sessions(MaxSessionsStr) ->
+    case parse_int(MaxSessionsStr) of
+        {ok, MaxSessions} when MaxSessions > 0 -> {ok, MaxSessions};
         _ -> {error, invalid_connection_limit}
     end.
 

--- a/apps/emqx_license/src/emqx_license_resources.erl
+++ b/apps/emqx_license/src/emqx_license_resources.erl
@@ -92,7 +92,7 @@ code_change(_OldVsn, State, _Extra) ->
 connection_quota_early_alarm() ->
     connection_quota_early_alarm(emqx_license_checker:limits()).
 
-connection_quota_early_alarm({ok, #{max_connections := Max}}) when is_integer(Max) ->
+connection_quota_early_alarm({ok, #{max_sessions := Max}}) when is_integer(Max) ->
     Count = cached_connection_count(),
     Low = emqx_conf:get([license, connection_low_watermark], 0.75),
     High = emqx_conf:get([license, connection_high_watermark], 0.80),

--- a/apps/emqx_license/src/emqx_license_schema.erl
+++ b/apps/emqx_license/src/emqx_license_schema.erl
@@ -49,7 +49,7 @@ fields(key_license) ->
         }},
         %% This feature is not made GA yet, hence hidden.
         %% When license is issued to cutomer-type BUSINESS_CRITICAL (code 3)
-        %% This config is taken as the real max_connections limit.
+        %% This config is taken as the real max_sessions limit.
         {dynamic_max_connections, #{
             type => non_neg_integer(),
             default => default(dynamic_max_connections),

--- a/apps/emqx_license/test/emqx_license_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_SUITE.erl
@@ -178,10 +178,10 @@ t_import_config(_Config) ->
         emqx_license:import_config(#{<<"license">> => #{<<"key">> => <<"default">>}})
     ),
     ?assertEqual(default, emqx:get_config([license, key])),
-    ?assertMatch({ok, #{max_connections := 10}}, emqx_license_checker:limits()),
+    ?assertMatch({ok, #{max_sessions := 10}}, emqx_license_checker:limits()),
 
     %% Import to a new license
-    EncodedLicense = emqx_license_test_lib:make_license(#{max_connections => "100"}),
+    EncodedLicense = emqx_license_test_lib:make_license(#{max_sessions => "100"}),
     ?assertMatch(
         {ok, #{root_key := license, changed := _}},
         emqx_license:import_config(
@@ -195,7 +195,7 @@ t_import_config(_Config) ->
             }
         )
     ),
-    ?assertMatch({ok, #{max_connections := 100}}, emqx_license_checker:limits()),
+    ?assertMatch({ok, #{max_sessions := 100}}, emqx_license_checker:limits()),
     ?assertMatch(
         #{connection_low_watermark := 0.2, connection_high_watermark := 0.5},
         emqx:get_config([license])

--- a/apps/emqx_license/test/emqx_license_checker_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_checker_SUITE.erl
@@ -103,7 +103,7 @@ t_update(_Config) ->
     #{} = emqx_license_checker:update(License),
 
     ?assertMatch(
-        {ok, #{max_connections := 123}},
+        {ok, #{max_sessions := 123}},
         emqx_license_checker:limits()
     ).
 
@@ -148,7 +148,7 @@ t_expired_trial(_Config) ->
     #{} = emqx_license_checker:update(License),
 
     ?assertMatch(
-        {ok, #{max_connections := ?ERR_EXPIRED}},
+        {ok, #{max_sessions := ?ERR_EXPIRED}},
         emqx_license_checker:limits()
     ).
 
@@ -173,7 +173,7 @@ t_max_uptime_reached(_Config) ->
     #{} = emqx_license_checker:update(License),
 
     ?assertMatch(
-        {ok, #{max_connections := ?ERR_MAX_UPTIME}},
+        {ok, #{max_sessions := ?ERR_MAX_UPTIME}},
         emqx_license_checker:limits()
     ),
 
@@ -201,7 +201,7 @@ t_overexpired_small_client(_Config) ->
     #{} = emqx_license_checker:update(License),
 
     ?assertMatch(
-        {ok, #{max_connections := expired}},
+        {ok, #{max_sessions := expired}},
         emqx_license_checker:limits()
     ).
 
@@ -227,7 +227,7 @@ t_overexpired_medium_client(_Config) ->
     #{} = emqx_license_checker:update(License),
 
     ?assertMatch(
-        {ok, #{max_connections := 123}},
+        {ok, #{max_sessions := 123}},
         emqx_license_checker:limits()
     ).
 
@@ -253,7 +253,7 @@ t_recently_expired_small_client(_Config) ->
     #{} = emqx_license_checker:update(License),
 
     ?assertMatch(
-        {ok, #{max_connections := 123}},
+        {ok, #{max_sessions := 123}},
         emqx_license_checker:limits()
     ).
 

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -54,7 +54,7 @@ t_update(_Config) ->
     _ = emqx_license_cli:license(["update", "Invalid License Value"]).
 
 t_conf_update(_Config) ->
-    LicenseKey = emqx_license_test_lib:make_license(#{max_connections => "123"}),
+    LicenseKey = emqx_license_test_lib:make_license(#{max_sessions => "123"}),
     Conf = #{
         <<"connection_high_watermark">> => <<"50%">>,
         <<"connection_low_watermark">> => <<"45%">>,
@@ -73,7 +73,6 @@ t_conf_update(_Config) ->
     Dump = maps:from_list(emqx_license_checker:dump()),
     ?assertMatch(
         #{
-            max_connections := 123,
             max_sessions := 123
         },
         Dump

--- a/apps/emqx_license/test/emqx_license_parser_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_parser_SUITE.erl
@@ -217,7 +217,7 @@ t_dump(_Config) ->
             {customer, <<"Foo">>},
             {email, <<"contact@foo.com">>},
             {deployment, <<"default-deployment">>},
-            {max_connections, 10},
+            {max_sessions, 10},
             {start_at, <<"2022-01-11">>},
             {expiry_at, <<"2295-10-27">>},
             {type, <<"trial">>},
@@ -237,10 +237,10 @@ t_license_type(_Config) ->
 
     ?assertEqual(0, emqx_license_parser:license_type(License)).
 
-t_max_connections(_Config) ->
+t_max_sessions(_Config) ->
     {ok, License} = emqx_license_parser:parse(sample_license(), public_key_pem()),
 
-    ?assertEqual(10, emqx_license_parser:max_connections(License)).
+    ?assertEqual(10, emqx_license_parser:max_sessions(License)).
 
 t_max_uptime_seconds(_Config) ->
     {ok, LicenseEvaluation} = emqx_license_parser:parse(

--- a/apps/emqx_license/test/emqx_license_test_lib.erl
+++ b/apps/emqx_license/test/emqx_license_test_lib.erl
@@ -41,7 +41,7 @@ make_license(Values0 = #{}) ->
         deployment => "bar-deployment",
         start_date => "20220111",
         days => "100000",
-        max_connections => "10"
+        max_sessions => "10"
     },
     Values1 = maps:merge(Defaults, Values0),
     Keys = [
@@ -53,7 +53,7 @@ make_license(Values0 = #{}) ->
         deployment,
         start_date,
         days,
-        max_connections
+        max_sessions
     ],
     Values = lists:map(fun(K) -> maps:get(K, Values1) end, Keys),
     make_license(Values);


### PR DESCRIPTION
Release: e5.9.0

This is a follow up fix for the quick fix made into 5.8.5.

## Summary
- Refactored internal APIs from `max_connections` to `max_sessions`.
- The config keys are not renamed, e.g. `connection_..._watermark ` and `dynamic_max_connections`.
- The PUT API for license settings is not changed, e.g. `connection_..._watermark ` and `dynamic_max_connections`.
- The GET API for license info retrieval has `max_connections` added alongside `max_sessions`.
