### PR TITLE
fix(pulsar action): actually support `memory_overload_protection` option

### DIFF
--- a/apps/emqx_bridge_pulsar/mix.exs
+++ b/apps/emqx_bridge_pulsar/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXBridgePulsar.MixProject do
     [
       UMP.common_dep(:crc32cer),
       UMP.common_dep(:snappyer),
-      {:pulsar, github: "emqx/pulsar-client-erl", tag: "2.0.1"},
+      {:pulsar, github: "emqx/pulsar-client-erl", tag: "2.1.0"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/apps/emqx_bridge_pulsar/rebar.config
+++ b/apps/emqx_bridge_pulsar/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {pulsar, {git, "https://github.com/emqx/pulsar-client-erl.git", {tag, "2.0.1"}}},
+    {pulsar, {git, "https://github.com/emqx/pulsar-client-erl.git", {tag, "2.1.0"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.2.8"},
+    {vsn, "0.2.9"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -410,6 +410,7 @@ start_producer(ConnResId, ActionResId, ClientId, ClientOpts, Params) ->
         },
         compression := Compression,
         max_batch_bytes := MaxBatchBytes,
+        max_inflight := MaxInflight,
         pulsar_topic := PulsarTopic,
         retention_period := RetentionPeriod,
         send_buffer := SendBuffer,
@@ -431,7 +432,7 @@ start_producer(ConnResId, ActionResId, ClientId, ClientOpts, Params) ->
         replayq_offload_mode => OffloadMode,
         replayq_max_total_bytes => PerPartitionLimit,
         replayq_seg_bytes => SegmentBytes,
-        drop_if_highmem => MemOLP
+        drop_if_high_mem => MemOLP
     },
     ProducerName = producer_name(ConnResId, ActionResId),
     ?tp(pulsar_producer_capture_name, #{producer_name => ProducerName}),
@@ -441,6 +442,7 @@ start_producer(ConnResId, ActionResId, ClientId, ClientOpts, Params) ->
             compression => Compression,
             conn_opts => ConnOpts,
             max_batch_bytes => MaxBatchBytes,
+            max_inflight => MaxInflight,
             name => ProducerName,
             retention_period => RetentionPeriod,
             ssl_opts => SSLOpts,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_pubsub_schema.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_pubsub_schema.erl
@@ -46,6 +46,10 @@ fields(action_parameters) ->
         {sync_timeout,
             ?HOCON(emqx_schema:timeout_duration_ms(), #{
                 default => <<"3s">>, desc => ?DESC("producer_sync_timeout")
+            })},
+        {max_inflight,
+            ?HOCON(pos_integer(), #{
+                default => 10, desc => ?DESC("producer_max_inflight")
             })}
     ] ++ emqx_bridge_pulsar:fields(producer_opts);
 fields(producer_pulsar_message) ->

--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_v2_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_v2_SUITE.erl
@@ -216,6 +216,7 @@ action_config(ConnectorName, Config) ->
         <<"parameters">> => #{
             <<"retention_period">> => <<"infinity">>,
             <<"max_batch_bytes">> => <<"1MB">>,
+            <<"max_inflight">> => 100,
             <<"batch_size">> => 100,
             <<"strategy">> => <<"random">>,
             <<"buffer">> => #{
@@ -732,9 +733,10 @@ t_telemetry_metrics(Config) when is_list(Config) ->
                     }
                 }),
             emqx_common_test_helpers:with_failure(down, ProxyName, ProxyHost, ProxyPort, fun() ->
+                ct:sleep(500),
                 SendMessage(),
                 ?retry(
-                    100,
+                    500,
                     10,
                     ?assertMatch(
                         #{
@@ -774,7 +776,6 @@ t_telemetry_metrics(Config) when is_list(Config) ->
                     },
                     emqx_resource:get_metrics(ActionResId2)
                 ),
-                ct:sleep(20),
                 ok
             end),
             %% After connection is restored, the request is already expired
@@ -1050,10 +1051,11 @@ t_expired_rule_metrics(Config) when is_list(Config) ->
     %% Helper to ensure a message is enqueued before letting it be sent to Pulsar.
     Enqueue = fun() ->
         emqx_common_test_helpers:with_failure(down, ProxyName, ProxyHost, ProxyPort, fun() ->
+            ct:sleep(500),
             emqx:publish(emqx_message:make(RuleTopic, <<"aaaaaaaaaaaaaa">>)),
             receive
                 enqueued -> ok
-            after 1_000 -> ct:fail("didn't enqueue message!")
+            after 5_000 -> ct:fail("didn't enqueue message!")
             end
         end)
     end,

--- a/changes/ee/fix-14796.en.md
+++ b/changes/ee/fix-14796.en.md
@@ -2,3 +2,5 @@ Fix Pulsar producer inflight state leak.
 
 Prior to this fix, Pulsar client's inflight state may sometimes leak, cause the connector's inflight counter never go back to zero.
 This fix also included a performance improvement for Pulsar and Kafka producers on x86.
+
+Also, implemented actual support for the `buffer.memory_overload_protection` for Pulsar Action.  Before this fix, this configuration didn't actually have any effect.

--- a/mix.exs
+++ b/mix.exs
@@ -206,7 +206,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:cowboy), do: {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true}
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
   def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.6.1", override: true}
-  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.3.12", override: true}
+  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.4.0", override: true}
   def common_dep(:jsx), do: {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true}
   # in conflict by emqtt and hocon
   def common_dep(:getopt), do: {:getopt, "1.0.2", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,7 @@
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
-    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.3.12"}}},
+    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.0"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x

--- a/rel/i18n/emqx_bridge_pulsar.hocon
+++ b/rel/i18n/emqx_bridge_pulsar.hocon
@@ -43,6 +43,7 @@ authentication.label:
 buffer_memory_overload_protection.desc:
 """Applicable when buffer mode is set to <code>memory</code>
 EMQX will drop old buffered messages under high memory pressure.
+The high memory threshold is defined in config <code>sysmon.os.sysmem_high_watermark</code>.
  NOTE: This config only works on Linux."""
 buffer_memory_overload_protection.label:
 """Memory Overload Protection"""

--- a/rel/i18n/emqx_bridge_pulsar_pubsub_schema.hocon
+++ b/rel/i18n/emqx_bridge_pulsar_pubsub_schema.hocon
@@ -35,4 +35,10 @@ producer_pulsar_message.desc:
 producer_pulsar_message.label:
 """Pulsar Message Template"""
 
+producer_max_inflight.desc:
+"""The maximum number of message batches that the producer can send to each partition before it must wait for a receipt.
+Setting a higher number can enhance throughput."""
+producer_max_inflight.label:
+"""Max Inflight"""
+
 }


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13853

Release version: e5.8.6

## Summary

Previously, this option didn't have any effects on the driver.

See also https://github.com/emqx/pulsar-client-erl/pull/75

## PR Checklist

- [na] ~~Added tests for the changes~~ tested manually
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Schema changes are backward compatible
