### PR TITLE
feat(sessmem): run takeover end phase after returning connack

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -347,6 +347,7 @@ take_conn_info_fields(Fields, ClientInfo, ConnInfo) ->
 -spec handle_in(emqx_types:packet(), channel()) ->
     {ok, channel()}
     | {ok, replies(), channel()}
+    | {continue, replies(), channel()}
     | {shutdown, Reason :: term(), channel()}
     | {shutdown, Reason :: term(), replies(), channel()}.
 handle_in(?CONNECT_PACKET(), Channel = #channel{conn_state = ConnState}) when
@@ -1333,27 +1334,8 @@ handle_out(Type, Data, Channel) ->
 
 return_connack(?CONNACK_PACKET(_RC, _SessPresent) = AckPacket, Channel) ->
     ?EXT_TRACE_ADD_ATTRS(#{'client.connack.reason_code' => _RC}),
-    do_return_connack(AckPacket, Channel).
-
-do_return_connack(AckPacket, Channel) ->
     Replies = [?REPLY_EVENT(connected), ?REPLY_CONNACK(AckPacket)],
-    case maybe_resume_session(Channel) of
-        ignore ->
-            {ok, Replies, Channel};
-        {ok, Publishes, NSession} ->
-            NChannel1 = Channel#channel{
-                resuming = false,
-                pendings = [],
-                session = NSession
-            },
-            {Packets, NChannel2} = do_deliver(Publishes, NChannel1),
-            Outgoing = [?REPLY_OUTGOING(Packets) || length(Packets) > 0],
-            %% NOTE
-            %% Session timers are not restored here, so there's a tiny chance that
-            %% the session becomes stuck, when it already has no place to track new
-            %% messages.
-            {ok, Replies ++ Outgoing, NChannel2}
-    end.
+    {continue, Replies, Channel}.
 
 %%--------------------------------------------------------------------
 %% Deliver publish: broker -> client
@@ -1508,8 +1490,29 @@ handle_call(Req, Channel) ->
 %%--------------------------------------------------------------------
 
 -spec handle_info(Info :: term(), channel()) ->
-    ok | {ok, channel()} | {shutdown, Reason :: term(), channel()}.
+    ok
+    | {ok, channel()}
+    | {ok, replies(), channel()}
+    | {shutdown, Reason :: term(), channel()}.
 
+handle_info(continue, Channel) ->
+    case maybe_resume_session(Channel) of
+        ignore ->
+            ok;
+        {ok, Publishes, NSession} ->
+            NChannel1 = Channel#channel{
+                resuming = false,
+                pendings = [],
+                session = NSession
+            },
+            {Packets, NChannel2} = do_deliver(Publishes, NChannel1),
+            Outgoing = [?REPLY_OUTGOING(Packets) || length(Packets) > 0],
+            %% NOTE
+            %% Session timers are not restored here, so there's a tiny chance that
+            %% the session becomes stuck, when it already has no place to track new
+            %% messages.
+            {ok, Outgoing, NChannel2}
+    end;
 handle_info({subscribe, TopicFilters}, Channel) ->
     ?EXT_TRACE_BROKER_SUBSCRIBE(
         ?EXT_TRACE_ATTR(

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -147,12 +147,6 @@
     (is_binary(CLIENTID) orelse (is_atom(CLIENTID) andalso CLIENTID =/= undefined))
 ).
 
--define(REQ_DOWN_ERR(MOD, PID, ACTION), (#{conn_mod => MOD, stale_pid => PID, action => ACTION})).
-
--define(REQ_DOWN_ERR_CHANNEL_INFO(MOD, PID, ACTION),
-    (?REQ_DOWN_ERR(MOD, PID, ACTION)#{stale_channel => stale_channel_info(PID)})
-).
-
 %% linting overrides
 -elvis([
     {elvis_style, invalid_dynamic_call, #{ignore => [emqx_cm]}},
@@ -479,53 +473,43 @@ request_stepdown(Action, ConnMod, Pid) ->
 
 %% The emqx_connection returns `{Reason, {gen_server, call, _}}` on failure, but
 %% emqx_ws_connection returns `Reason`.
-handle_stepdown_exception(_Err, noproc, _St, ConnMod, Pid, Action) ->
-    ok = ?tp(debug, "ws_session_already_gone", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, {noproc, _}, _St, ConnMod, Pid, Action) ->
-    ok = ?tp(debug, "session_already_gone", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, {shutdown, _}, _St, ConnMod, Pid, Action) ->
-    ok = ?tp(debug, "ws_session_already_shutdown", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, {{shutdown, _}, _}, _St, ConnMod, Pid, Action) ->
-    ok = ?tp(debug, "session_already_shutdown", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, killed, _St, ConnMod, Pid, Action) ->
-    ?tp(debug, "ws_session_already_killed", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, {killed, {gen_server, call, _}}, _St, ConnMod, Pid, Action) ->
-    ?tp(debug, "session_already_killed", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, normal, _St, ConnMod, Pid, Action) ->
-    ?tp(debug, "ws_session_already_stopped_normally", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, {normal, {gen_server, call, _}}, _St, ConnMod, Pid, Action) ->
-    ?tp(debug, "session_already_stopped_normally", ?REQ_DOWN_ERR(ConnMod, Pid, Action)),
-    {error, noproc};
-handle_stepdown_exception(_Err, timeout, _St, ConnMod, Pid, Action) ->
-    ErrInfo = ?REQ_DOWN_ERR_CHANNEL_INFO(ConnMod, Pid, Action),
-    ?tp(warning, "ws_session_stepdown_request_timeout", ErrInfo),
-    ok = force_kill(Pid),
-    {error, timeout};
-handle_stepdown_exception(_Err, {timeout, {gen_server, call, _}}, _St, ConnMod, Pid, Action) ->
-    ErrInfo = ?REQ_DOWN_ERR_CHANNEL_INFO(ConnMod, Pid, Action),
-    ?tp(warning, "session_stepdown_request_timeout", ErrInfo),
-    ok = force_kill(Pid),
-    {error, timeout};
+handle_stepdown_exception(Exit, {Reason, {gen_server, _Call, _}}, _St, ConnMod, Pid, Action) ->
+    handle_stepdown_exception(Exit, Reason, _St, ConnMod, Pid, Action);
 handle_stepdown_exception(Err, Reason, St, ConnMod, Pid, Action) ->
-    ErroInfo = ?REQ_DOWN_ERR_CHANNEL_INFO(ConnMod, Pid, Action)#{
-        error => Err,
-        reason => Reason,
-        stacktrace => St
+    Meta = #{
+        conn_mod => ConnMod,
+        stale_pid => Pid,
+        action => Action
     },
-    ?tp(error, "session_stepdown_request_exception", ErroInfo),
-    ok = force_kill(Pid),
-    {error, unexpected_exception}.
-
-force_kill(Pid) ->
-    exit(Pid, kill),
-    ok.
+    case Reason of
+        noproc ->
+            ok = ?tp(debug, "session_already_gone", Meta),
+            {error, noproc};
+        normal ->
+            ?tp(debug, "session_already_stopped_normally", Meta),
+            {error, noproc};
+        {shutdown, _} ->
+            ok = ?tp(debug, "session_already_shutdown", Meta),
+            {error, noproc};
+        killed ->
+            ?tp(debug, "session_already_killed", Meta),
+            {error, noproc};
+        timeout ->
+            ?tp(warning, "session_stepdown_request_timeout", Meta#{
+                stale_channel => stale_channel_info(Pid)
+            }),
+            _ = exit(Pid, kill),
+            {error, timeout};
+        _ ->
+            ?tp(error, "session_stepdown_request_exception", Meta#{
+                stale_channel => stale_channel_info(Pid),
+                error => Err,
+                reason => Reason,
+                stacktrace => St
+            }),
+            _ = exit(Pid, kill),
+            {error, unexpected_exception}
+    end.
 
 stale_channel_info(Pid) ->
     process_info(Pid, [status, message_queue_len, current_stacktrace]).

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -127,26 +127,14 @@ unregister_channel2(#channel{chid = ClientId} = Record) ->
 %% @doc Lookup the global channels.
 -spec lookup_channels(emqx_types:clientid()) -> list(pid()).
 lookup_channels(ClientId) ->
-    lists:filtermap(
-        fun
-            (#channel{pid = ChanPid}) when is_pid(ChanPid) ->
-                case is_pid_down(ChanPid) of
-                    true ->
-                        false;
-                    _ ->
-                        {true, ChanPid}
-                end;
-            (_) ->
-                false
-        end,
-        mnesia:dirty_read(?CHAN_REG_TAB, ClientId)
-    ).
+    Chans = mnesia:dirty_read(?CHAN_REG_TAB, ClientId),
+    [ChanPid || #channel{pid = ChanPid} <- Chans, is_pid_alive(ChanPid) == true].
 
 %% Return 'true' or 'false' if it's a local pid.
 %% Otherwise return 'unknown'.
-is_pid_down(Pid) when node(Pid) =:= node() ->
-    not erlang:is_process_alive(Pid);
-is_pid_down(_) ->
+is_pid_alive(Pid) when is_pid(Pid) andalso node(Pid) =:= node() ->
+    erlang:is_process_alive(Pid);
+is_pid_alive(_) ->
     unknown.
 
 record(ClientId, ChanPid) ->

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -691,7 +691,7 @@ on_dropped_qos2_msg(PacketId, Msg, RC) ->
 
 %%--------------------------------------------------------------------
 
--spec should_keep(message() | emqx_types:deliver()) -> boolean().
+-spec should_keep(message()) -> boolean().
 should_keep(MsgDeliver) ->
     not is_banned_msg(MsgDeliver).
 

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -104,7 +104,7 @@
     enqueue/3,
     dequeue/2,
     replay/2,
-    dedup/4
+    dedup/2
 ]).
 
 %% Will message handling
@@ -132,7 +132,7 @@
 }).
 
 -type session() :: #session{}.
--type replayctx() :: [emqx_types:message()].
+-type replayctx() :: _TakeoverState.
 
 -type message() :: emqx_types:message().
 -type clientinfo() :: emqx_types:clientinfo().
@@ -217,15 +217,10 @@ open(ClientInfo = #{clientid := ClientId}, ConnInfo, _MaybeWillMsg, Conf) ->
     case emqx_cm:takeover_session_begin(ClientId) of
         {ok, SessionRemote, TakeoverState} ->
             Session0 = resume(ClientInfo, SessionRemote),
-            case emqx_cm:takeover_session_end(TakeoverState) of
-                {ok, Pendings} ->
-                    Session1 = resize_inflight(ConnInfo, Session0),
-                    Session = apply_conf(Conf, Session1),
-                    clean_session(ClientInfo, Session, Pendings);
-                {error, _} ->
-                    % TODO log error?
-                    false
-            end;
+            Session1 = resize_inflight(ConnInfo, Session0),
+            Session2 = apply_conf(Conf, Session1),
+            Session = fliter_remote_session(Session2),
+            {true, Session, TakeoverState};
         none ->
             false
     end.
@@ -244,12 +239,9 @@ apply_conf(Conf, Session = #session{}) ->
         await_rel_timeout = maps:get(await_rel_timeout, Conf)
     }.
 
-clean_session(ClientInfo, Session = #session{mqueue = Q}, Pendings) ->
+fliter_remote_session(Session = #session{mqueue = Q}) ->
     Q1 = emqx_mqueue:filter(fun emqx_session:should_keep/1, Q),
-    Session1 = Session#session{mqueue = Q1},
-    Pendings1 = emqx_session:enrich_delivers(ClientInfo, Pendings, Session),
-    Pendings2 = lists:filter(fun emqx_session:should_keep/1, Pendings1),
-    {true, Session1, Pendings2}.
+    Session#session{mqueue = Q1}.
 
 %%--------------------------------------------------------------------
 %% Info, Stats
@@ -732,7 +724,7 @@ resume(ClientInfo = #{clientid := ClientId}, Session = #session{subscriptions = 
 
 -spec replay(emqx_types:clientinfo(), replayctx(), session()) ->
     {ok, replies(), session()}.
-replay(ClientInfo, Pendings, Session) ->
+replay(ClientInfo, TakeoverState, Session) ->
     %% NOTE
     %% Here, `Pendings` is a list messages that were pending delivery in the remote
     %% session, see `clean_session/3`. It's a replay context that gets passed back
@@ -747,10 +739,23 @@ replay(ClientInfo, Pendings, Session) ->
     %%    is delivered twice.
     %% 2. Replay deliveries of the inflight messages, this time to the new channel.
     %% 3. Deliver the combined pending messages, following the same logic as `deliver/3`.
-    PendingsAll = dedup(ClientInfo, Pendings, emqx_utils:drain_deliver(), Session),
-    {ok, PubsResendQueued, Session1} = replay(ClientInfo, Session),
-    {ok, PubsPending, Session2} = deliver(ClientInfo, PendingsAll, Session1),
-    {ok, append(PubsResendQueued, PubsPending), Session2}.
+    case emqx_cm:takeover_session_end(TakeoverState) of
+        {ok, PendingsRemote0} ->
+            DeliversLocal = emqx_utils:drain_deliver(),
+            PendingsLocal = emqx_session:enrich_delivers(ClientInfo, DeliversLocal, Session),
+            PendingsRemote = filter_remote_pendings(ClientInfo, Session, PendingsRemote0),
+            PendingsAll = dedup(PendingsRemote, PendingsLocal),
+            {ok, PubsResendQueued, Session1} = replay(ClientInfo, Session),
+            {ok, PubsPending, Session2} = deliver(ClientInfo, PendingsAll, Session1),
+            {ok, append(PubsResendQueued, PubsPending), Session2};
+        {error, _} ->
+            % TODO log error?
+            replay(ClientInfo, Session)
+    end.
+
+filter_remote_pendings(ClientInfo, Session, Pendings) ->
+    Pendings1 = emqx_session:enrich_delivers(ClientInfo, Pendings, Session),
+    lists:filter(fun emqx_session:should_keep/1, Pendings1).
 
 -spec replay(emqx_types:clientinfo(), session()) ->
     {ok, replies(), session()}.
@@ -767,15 +772,14 @@ replay(ClientInfo, Session) ->
     {ok, More, Session1} = dequeue(ClientInfo, Session),
     {ok, append(PubsResend, More), Session1}.
 
--spec dedup(clientinfo(), [emqx_types:message()], [emqx_types:deliver()], session()) ->
+-spec dedup([emqx_types:message()], [emqx_types:message()]) ->
     [emqx_types:message()].
-dedup(ClientInfo, Pendings, DeliversLocal, Session) ->
-    PendingsLocal1 = emqx_session:enrich_delivers(ClientInfo, DeliversLocal, Session),
-    PendingsLocal2 = lists:filter(
+dedup(Pendings, PendingsLocal) ->
+    PendingsLocal1 = lists:filter(
         fun(Msg) -> not lists:keymember(Msg#message.id, #message.id, Pendings) end,
-        PendingsLocal1
+        PendingsLocal
     ),
-    append(Pendings, PendingsLocal2).
+    append(Pendings, PendingsLocal1).
 
 append(L1, []) -> L1;
 append(L1, L2) -> L1 ++ L2.

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -624,6 +624,8 @@ with_channel(Fun, Args, State = #state{channel = Channel}) ->
             return(State#state{channel = NChannel});
         {ok, Replies, NChannel} ->
             return(postpone(Replies, State#state{channel = NChannel}));
+        {continue, Replies, NChannel} ->
+            return(postpone(continue, postpone(Replies, State#state{channel = NChannel})));
         {shutdown, Reason, NChannel} ->
             shutdown(Reason, State#state{channel = NChannel});
         {shutdown, Reason, Packet, NChannel} ->
@@ -812,10 +814,10 @@ resume_stats_timer(State = #state{stats_timer = disabled}) ->
 %%--------------------------------------------------------------------
 %% Postpone the packet, cmd or event
 
-postpone(Event, State) when is_tuple(Event) ->
-    enqueue(Event, State);
 postpone(More, State) when is_list(More) ->
-    lists:foldl(fun postpone/2, State, More).
+    lists:foldl(fun postpone/2, State, More);
+postpone(Event, State) ->
+    enqueue(Event, State).
 
 enqueue([Packet], State = #state{postponed = Postponed}) ->
     State#state{postponed = [Packet | Postponed]};

--- a/apps/emqx/src/proto/emqx_cm_proto_v3.erl
+++ b/apps/emqx/src/proto/emqx_cm_proto_v3.erl
@@ -71,16 +71,14 @@ get_chann_conn_mod(ClientId, ChanPid) ->
     | {living, _ConnMod :: atom(), emqx_cm:chan_pid(), emqx_session:session()}
     %% NOTE: v5.3.0
     | {living, _ConnMod :: atom(), emqx_session:session()}
-    | {expired | persistent, emqx_session:session()}
-    | {badrpc, _}.
+    | {expired | persistent, emqx_session:session()}.
 takeover_session(ClientId, ChanPid) ->
-    rpc:call(node(ChanPid), emqx_cm, takeover_session, [ClientId, ChanPid], ?T_TAKEOVER * 2).
+    erpc:call(node(ChanPid), emqx_cm, takeover_session, [ClientId, ChanPid], ?T_TAKEOVER * 2).
 
 -spec takeover_finish(module(), emqx_cm:chan_pid()) ->
     {ok, emqx_types:takeover_data()}
     | {ok, list(emqx_types:deliver())}
-    | {error, term()}
-    | {badrpc, _}.
+    | {error, term()}.
 takeover_finish(ConnMod, ChanPid) ->
     erpc:call(
         node(ChanPid),

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent.app.src
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent.app.src
@@ -1,6 +1,6 @@
 {application, emqx_eviction_agent, [
     {description, "EMQX Eviction Agent"},
-    {vsn, "5.1.10"},
+    {vsn, "5.1.11"},
     {registered, [
         emqx_eviction_agent_sup,
         emqx_eviction_agent,

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent_channel.erl
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent_channel.erl
@@ -252,7 +252,8 @@ open_session(ConnInfo, #{clientid := ClientId} = ClientInfo, MaybeWillMsg) ->
             % already have been thrown away by `emqx_channel:handle_deliver/2`.
             % See also: `emqx_channel:maybe_resume_session/1`, `emqx_session_mem:replay/3`.
             DeliversLocal = emqx_channel:maybe_nack(emqx_utils:drain_deliver()),
-            PendingsAll = emqx_session_mem:dedup(ClientInfo, Pendings, DeliversLocal, Session),
+            PendingsLocal = emqx_session:enrich_delivers(ClientInfo, DeliversLocal, Session),
+            PendingsAll = emqx_session_mem:dedup(Pendings, PendingsLocal),
             NSession = emqx_session_mem:enqueue(ClientInfo, PendingsAll, Session),
             NChannel = Channel#{session => NSession},
             ok = emqx_cm:insert_channel_info(ClientId, info(NChannel), stats(NChannel)),


### PR DESCRIPTION
Fixes [EMQX-13354](https://emqx.atlassian.net/browse/EMQX-13354).

Release version: e5.9

## Summary

See individual commits.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
