### PR TITLE
fix: throttle wanring log dropped_qos0_msg,

### DIFF
--- a/apps/emqx/src/emqx_session_events.erl
+++ b/apps/emqx/src/emqx_session_events.erl
@@ -48,10 +48,10 @@ handle_event(ClientInfo, {dropped, Msg, #{reason := qos0_msg, logctx := Ctx}}) -
     ok = emqx_metrics:inc('delivery.dropped'),
     ok = emqx_metrics:inc('delivery.dropped.qos0_msg'),
     ok = inc_pd('send_msg.dropped', 1),
-    ?SLOG(
+    ?SLOG_THROTTLE(
         warning,
         Ctx#{
-            msg => "dropped_qos0_msg",
+            msg => dropped_qos0_msg,
             payload => Msg#message.payload
         },
         #{topic => Msg#message.topic}

--- a/apps/emqx_conf/src/emqx_conf.app.src
+++ b/apps/emqx_conf/src/emqx_conf.app.src
@@ -1,6 +1,6 @@
 {application, emqx_conf, [
     {description, "EMQX configuration management"},
-    {vsn, "0.4.4"},
+    {vsn, "0.4.5"},
     {registered, []},
     {mod, {emqx_conf_app, []}},
     {applications, [kernel, stdlib]},

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -87,6 +87,7 @@
     cannot_publish_to_topic_due_to_quota_exceeded,
     connection_rejected_due_to_license_limit_reached,
     data_bridge_buffer_overflow,
+    dropped_qos0_msg,
     dropped_msg_due_to_mqueue_is_full,
     external_broker_crashed,
     failed_to_fetch_crl,

--- a/changes/ce/fix-14800.en.md
+++ b/changes/ce/fix-14800.en.md
@@ -1,0 +1,1 @@
+Throttle warning level log `dropped_qos0_msg`.


### PR DESCRIPTION

Release version: v/e5.8.6

## Summary

`dropped_msg_due_to_mqueue_is_full` was changed to throttled log in 5.6.0
`dropped_qos0_msg` was not for unknown reason, looks like it was missed.