### PR TITLE
chore(plugins): require explicit CLI authorization to install packages

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -71,6 +71,7 @@
 {emqx_persistent_session_ds,1}.
 {emqx_plugins,1}.
 {emqx_plugins,2}.
+{emqx_plugins,3}.
 {emqx_prometheus,1}.
 {emqx_prometheus,2}.
 {emqx_resource,1}.

--- a/apps/emqx_management/src/emqx_management.app.src
+++ b/apps/emqx_management/src/emqx_management.app.src
@@ -2,7 +2,7 @@
 {application, emqx_management, [
     {description, "EMQX Management API and CLI"},
     % strict semver, bump manually!
-    {vsn, "5.3.5"},
+    {vsn, "5.3.6"},
     {modules, []},
     {registered, [emqx_management_sup]},
     {applications, [

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -458,7 +458,9 @@ do_install_package(NameVsn, FileName, Bin) ->
             Msg = iolist_to_binary([
                 <<"Package is not allowed installation;">>,
                 <<" first allow it to be installed by running:">>,
-                <<" `emqx ctl plugins allow NAME-VSN`">>
+                <<" `emqx ctl plugins allow ">>,
+                NameVsn,
+                <<"`">>
             ]),
             {403, #{code => 'FORBIDDEN', message => Msg}}
     end.

--- a/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_plugins.erl
@@ -120,7 +120,7 @@ schema("/plugins/install") ->
             responses => #{
                 204 => <<"Install plugin successfully">>,
                 400 => emqx_dashboard_swagger:error_codes(
-                    ['UNEXPECTED_ERROR', 'ALREADY_INSTALLED', 'BAD_PLUGIN_INFO']
+                    ['UNEXPECTED_ERROR', 'ALREADY_INSTALLED', 'BAD_PLUGIN_INFO', 'FORBIDDEN']
                 )
             }
         }
@@ -418,7 +418,7 @@ upload_install(post, #{body := #{<<"plugin">> := Plugin}}) when is_map(Plugin) -
                     AppDir = filename:join(emqx_plugins:install_dir(), AppName),
                     case filelib:wildcard(AppDir ++ ?VSN_WILDCARD) of
                         [] ->
-                            do_install_package(FileName, Bin);
+                            do_install_package(NameVsn, FileName, Bin);
                         OtherVsn ->
                             {400, #{
                                 code => 'ALREADY_INSTALLED',
@@ -450,6 +450,19 @@ upload_install(post, #{}) ->
             <<"form-data should be `plugin=@packagename-vsn.tar.gz;type=application/x-gzip`">>
     }}.
 
+do_install_package(NameVsn, FileName, Bin) ->
+    case emqx_plugins:is_allowed_installation(NameVsn) of
+        true ->
+            do_install_package(FileName, Bin);
+        false ->
+            Msg = iolist_to_binary([
+                <<"Package is not allowed installation;">>,
+                <<" first allow it to be installed by running:">>,
+                <<" `emqx ctl plugins allow NAME-VSN`">>
+            ]),
+            {403, #{code => 'FORBIDDEN', message => Msg}}
+    end.
+
 do_install_package(FileName, Bin) ->
     %% TODO: handle bad nodes
     Nodes = emqx:running_nodes(),
@@ -477,19 +490,19 @@ do_install_package(FileName, Bin) ->
             }}
     end.
 
-plugin(get, #{bindings := #{name := Name}}) ->
+plugin(get, #{bindings := #{name := NameVsn}}) ->
     Nodes = emqx:running_nodes(),
-    {Plugins, _} = emqx_mgmt_api_plugins_proto_v3:describe_package(Nodes, Name),
+    {Plugins, _} = emqx_mgmt_api_plugins_proto_v3:describe_package(Nodes, NameVsn),
     case format_plugins(Plugins) of
         [Plugin] -> {200, Plugin};
-        [] -> {404, #{code => 'NOT_FOUND', message => Name}}
+        [] -> {404, #{code => 'NOT_FOUND', message => NameVsn}}
     end;
-plugin(delete, #{bindings := #{name := Name}}) ->
-    Res = emqx_mgmt_api_plugins_proto_v3:delete_package(Name),
+plugin(delete, #{bindings := #{name := NameVsn}}) ->
+    Res = emqx_mgmt_api_plugins_proto_v3:delete_package(NameVsn),
     return(204, Res).
 
-update_plugin(put, #{bindings := #{name := Name, action := Action}}) ->
-    Res = emqx_mgmt_api_plugins_proto_v3:ensure_action(Name, Action),
+update_plugin(put, #{bindings := #{name := NameVsn, action := Action}}) ->
+    Res = emqx_mgmt_api_plugins_proto_v3:ensure_action(NameVsn, Action),
     return(204, Res).
 
 plugin_config(get, #{bindings := #{name := NameVsn}}) ->
@@ -588,17 +601,18 @@ describe_package(NameVsn) ->
     end.
 
 %% Tip: Don't delete delete_package/1, use before v571 cluster_rpc
-delete_package(Name) ->
-    delete_package(Name, #{}).
+delete_package(NameVsn) ->
+    delete_package(NameVsn, #{}).
 
 %% For RPC plugin delete
-delete_package(Name, _Opts) ->
-    case emqx_plugins:ensure_stopped(Name) of
+delete_package(NameVsn, _Opts) ->
+    _ = emqx_plugins:forget_allowed_installation(NameVsn),
+    case emqx_plugins:ensure_stopped(NameVsn) of
         ok ->
-            _ = emqx_plugins:ensure_disabled(Name),
-            _ = emqx_plugins:ensure_uninstalled(Name),
-            _ = emqx_plugins:delete_package(Name),
-            _ = file:delete(emqx_plugins:md5sum_file(Name)),
+            _ = emqx_plugins:ensure_disabled(NameVsn),
+            _ = emqx_plugins:ensure_uninstalled(NameVsn),
+            _ = emqx_plugins:delete_package(NameVsn),
+            _ = file:delete(emqx_plugins:md5sum_file(NameVsn)),
             ok;
         Error ->
             Error

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -305,6 +305,8 @@ plugins(["describe", NameVsn]) ->
     emqx_plugins_cli:describe(NameVsn, fun emqx_ctl:print/2);
 plugins(["allow", NameVsn]) ->
     emqx_plugins_cli:allow_installation(NameVsn, fun emqx_ctl:print/2);
+plugins(["disallow", NameVsn]) ->
+    emqx_plugins_cli:disallow_installation(NameVsn, fun emqx_ctl:print/2);
 plugins(["install", NameVsn]) ->
     emqx_plugins_cli:ensure_installed(NameVsn, fun emqx_ctl:print/2);
 plugins(["uninstall", NameVsn]) ->
@@ -333,6 +335,8 @@ plugins(_) ->
             {"plugins describe  Name-Vsn", "Describe an installed plugins"},
             {"plugins allow     Name-Vsn",
                 "Allows installation of a plugin in the cluster from Dashboard or API"},
+            {"plugins disallow  Name-Vsn",
+                "Disallows installation of a plugin in the cluster from Dashboard or API"},
             {"plugins install   Name-Vsn",
                 "Install a plugin package placed\n"
                 "in plugin's install_dir"},

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -303,6 +303,8 @@ plugins(["list"]) ->
     emqx_plugins_cli:list(fun emqx_ctl:print/2);
 plugins(["describe", NameVsn]) ->
     emqx_plugins_cli:describe(NameVsn, fun emqx_ctl:print/2);
+plugins(["allow", NameVsn]) ->
+    emqx_plugins_cli:allow_installation(NameVsn, fun emqx_ctl:print/2);
 plugins(["install", NameVsn]) ->
     emqx_plugins_cli:ensure_installed(NameVsn, fun emqx_ctl:print/2);
 plugins(["uninstall", NameVsn]) ->
@@ -329,6 +331,7 @@ plugins(_) ->
             {"plugins <command> [Name-Vsn]", "e.g. 'start emqx_plugin_template-5.0-rc.1'"},
             {"plugins list", "List all installed plugins"},
             {"plugins describe  Name-Vsn", "Describe an installed plugins"},
+            {"plugins allow     Name-Vsn", "Allows installation of a plugin in the cluster"},
             {"plugins install   Name-Vsn",
                 "Install a plugin package placed\n"
                 "in plugin's install_dir"},

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -331,7 +331,8 @@ plugins(_) ->
             {"plugins <command> [Name-Vsn]", "e.g. 'start emqx_plugin_template-5.0-rc.1'"},
             {"plugins list", "List all installed plugins"},
             {"plugins describe  Name-Vsn", "Describe an installed plugins"},
-            {"plugins allow     Name-Vsn", "Allows installation of a plugin in the cluster"},
+            {"plugins allow     Name-Vsn",
+                "Allows installation of a plugin in the cluster from Dashboard or API"},
             {"plugins install   Name-Vsn",
                 "Install a plugin package placed\n"
                 "in plugin's install_dir"},

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -27,6 +27,8 @@
 
 -define(CLUSTER_API_SERVER(PORT), ("http://127.0.0.1:" ++ (integer_to_list(PORT)))).
 
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
 -import(emqx_common_test_helpers, [on_exit/1]).
 
 all() ->
@@ -40,7 +42,9 @@ init_per_suite(Config) ->
         [
             emqx_conf,
             emqx_plugins,
-            emqx_management,
+            {emqx_management, #{
+                after_start => fun emqx_mgmt_cli:load/0
+            }},
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
@@ -79,6 +83,9 @@ t_plugins(Config) ->
     NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
     ok = emqx_plugins:ensure_uninstalled(NameVsn),
     ok = emqx_plugins:delete_package(NameVsn),
+    %% Must allow via CLI first.
+    ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
+    ok = allow_installation(NameVsn),
     ok = install_plugin(PackagePath),
     {ok, StopRes} = describe_plugins(NameVsn),
     Node = atom_to_binary(node()),
@@ -112,6 +119,8 @@ t_plugins(Config) ->
         StopRes2
     ),
     {ok, []} = uninstall_plugin(NameVsn),
+    %% Should forget that we allowed installation after uninstall
+    ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
     ok.
 
 t_install_plugin_matching_exisiting_name(Config) ->
@@ -128,6 +137,8 @@ t_install_plugin_matching_exisiting_name(Config) ->
     %% First, install plugin "emqx_plugin_template_a", then:
     %% "emqx_plugin_template" which matches the beginning
     %% of the previously installed plugin name
+    ok = allow_installation(NameVsn),
+    ok = allow_installation(NameVsn1),
     ok = install_plugin(PackagePath1),
     ok = install_plugin(PackagePath),
     {ok, _} = describe_plugins(NameVsn),
@@ -150,6 +161,8 @@ t_bad_plugin(Config) ->
     %% rename plugin tarball
     file:copy(PackagePathOrig, PackagePath),
     file:delete(PackagePathOrig),
+    NameVsn = filename:basename(PackagePath, ?PACKAGE_SUFFIX),
+    ok = allow_installation(NameVsn),
     {ok, {{"HTTP/1.1", 400, "Bad Request"}, _, _}} = install_plugin(PackagePath),
     ?assertEqual(
         {error, enoent},
@@ -170,6 +183,7 @@ t_delete_non_existing(_Config) ->
     ok.
 
 t_cluster_update_order(Config) ->
+    [N1 | _] = ?config(cluster, Config),
     DemoShDir = proplists:get_value(demo_sh_dir, Config),
     PackagePath1 = get_demo_plugin_package(DemoShDir),
     NameVsn1 = filename:basename(PackagePath1, ?PACKAGE_SUFFIX),
@@ -179,6 +193,10 @@ t_cluster_update_order(Config) ->
     Name1 = list_to_binary(?EMQX_PLUGIN_TEMPLATE_NAME),
     Name2 = list_to_binary(Name2Str),
 
+    ?ON(N1, begin
+        ok = allow_installation(NameVsn1),
+        ok = allow_installation(NameVsn2)
+    end),
     ok = install_plugin(Config, PackagePath1),
     ok = install_plugin(Config, PackagePath2),
     %% to get them configured...
@@ -371,7 +389,9 @@ app_specs(_Config) ->
     [
         emqx,
         emqx_conf,
-        emqx_management,
+        {emqx_management, #{
+            after_start => fun emqx_mgmt_cli:load/0
+        }},
         emqx_plugins
     ].
 
@@ -399,3 +419,6 @@ get_host_and_auth(Config) when is_list(Config) ->
     Host = ?CLUSTER_API_SERVER(APIPort),
     Auth = emqx_common_test_http:auth_header(API),
     #{host => Host, auth => Auth}.
+
+allow_installation(NameVsn) ->
+    emqx_ctl:run_command(["plugins", "allow", NameVsn]).

--- a/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_plugins_SUITE.erl
@@ -86,6 +86,11 @@ t_plugins(Config) ->
     %% Must allow via CLI first.
     ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
     ok = allow_installation(NameVsn),
+    %% Test disallow
+    ok = disallow_installation(NameVsn),
+    ?assertMatch({ok, {{_, 403, _}, _, _}}, install_plugin(PackagePath)),
+    %% Now really allow it.
+    ok = allow_installation(NameVsn),
     ok = install_plugin(PackagePath),
     {ok, StopRes} = describe_plugins(NameVsn),
     Node = atom_to_binary(node()),
@@ -422,3 +427,6 @@ get_host_and_auth(Config) when is_list(Config) ->
 
 allow_installation(NameVsn) ->
     emqx_ctl:run_command(["plugins", "allow", NameVsn]).
+
+disallow_installation(NameVsn) ->
+    emqx_ctl:run_command(["plugins", "disallow", NameVsn]).

--- a/apps/emqx_plugins/src/emqx_plugins.app.src
+++ b/apps/emqx_plugins/src/emqx_plugins.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_plugins, [
     {description, "EMQX Plugin Management"},
-    {vsn, "0.3.1"},
+    {vsn, "0.3.2"},
     {modules, []},
     {mod, {emqx_plugins_app, []}},
     {applications, [kernel, stdlib, emqx, erlavro]},

--- a/apps/emqx_plugins/src/emqx_plugins.erl
+++ b/apps/emqx_plugins/src/emqx_plugins.erl
@@ -37,6 +37,10 @@
 
 %% Package operations
 -export([
+    allow_installation/1,
+    forget_allowed_installation/1,
+    is_allowed_installation/1,
+
     ensure_installed/0,
     ensure_installed/1,
     ensure_installed/2,
@@ -153,6 +157,28 @@ app_dir(AppName, Apps) ->
         _ ->
             {error, not_found}
     end.
+
+%% Note: this is only used for the HTTP API.
+%% We could use `application:set_env', but the typespec for it makes dialyzer sad when it
+%% seems a non-atom key...
+-spec allow_installation(binary() | string()) -> ok.
+allow_installation(NameVsn0) ->
+    NameVsn = bin(NameVsn0),
+    _ = persistent_term:put({?MODULE, NameVsn}, true),
+    ok.
+
+%% Note: this is only used for the HTTP API.
+-spec is_allowed_installation(binary() | string()) -> boolean().
+is_allowed_installation(NameVsn0) ->
+    NameVsn = bin(NameVsn0),
+    persistent_term:get({?MODULE, NameVsn}, false).
+
+%% Note: this is only used for the HTTP API.
+-spec forget_allowed_installation(binary() | string()) -> ok.
+forget_allowed_installation(NameVsn0) ->
+    NameVsn = bin(NameVsn0),
+    _ = persistent_term:erase({?MODULE, NameVsn}),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Package operations

--- a/apps/emqx_plugins/src/proto/emqx_plugins_proto_v3.erl
+++ b/apps/emqx_plugins/src/proto/emqx_plugins_proto_v3.erl
@@ -1,0 +1,36 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+-module(emqx_plugins_proto_v3).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    allow_installation/2
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-define(TIMEOUT, 25_000).
+
+introduced_in() ->
+    "5.8.6".
+
+-spec allow_installation([node()], binary() | string()) ->
+    emqx_rpc:erpc_multicall(ok | {error, term()}).
+allow_installation(Nodes, NameVsn) ->
+    erpc:multicall(Nodes, emqx_plugins, allow_installation, [NameVsn], ?TIMEOUT).

--- a/apps/emqx_plugins/src/proto/emqx_plugins_proto_v3.erl
+++ b/apps/emqx_plugins/src/proto/emqx_plugins_proto_v3.erl
@@ -20,7 +20,8 @@
 -export([
     introduced_in/0,
 
-    allow_installation/2
+    allow_installation/2,
+    disallow_installation/2
 ]).
 
 -include_lib("emqx/include/bpapi.hrl").
@@ -34,3 +35,8 @@ introduced_in() ->
     emqx_rpc:erpc_multicall(ok | {error, term()}).
 allow_installation(Nodes, NameVsn) ->
     erpc:multicall(Nodes, emqx_plugins, allow_installation, [NameVsn], ?TIMEOUT).
+
+-spec disallow_installation([node()], binary() | string()) ->
+    emqx_rpc:erpc_multicall(ok | {error, term()}).
+disallow_installation(Nodes, NameVsn) ->
+    erpc:multicall(Nodes, emqx_plugins, forget_allowed_installation, [NameVsn], ?TIMEOUT).

--- a/changes/ce/fix-14802.en.md
+++ b/changes/ce/fix-14802.en.md
@@ -1,0 +1,3 @@
+Added new `emqx ctl plugins allow NAME-VSN` CLI command for plugins.
+
+Now, it is required to run thist command in the CLI before attempting to install a package via the HTTP API, to harden security.

--- a/changes/ce/fix-14802.en.md
+++ b/changes/ce/fix-14802.en.md
@@ -1,3 +1,3 @@
 Added new `emqx ctl plugins allow NAME-VSN` CLI command for plugins.
 
-Now, it is required to run thist command in the CLI before attempting to install a package via the HTTP API, to harden security.
+Now, it is required to run this command in the CLI before attempting to install a package via the HTTP API, to harden security.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-13979

Release version: v/e5.8.6

## Summary

After discussions, the solution to the potential issue was to require explicit authorization to install a plugin (at specific version) via the CLI before HTTP API accepts the package.

## PR Checklist

- [x] Added tests for the changes
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket  --  https://emqx.atlassian.net/browse/EMQX-13988
