### PR TITLE
fix: upgrade mysql driver from 1.8.0.0 to 1.8.0.1

### DIFF
--- a/apps/emqx_mysql/mix.exs
+++ b/apps/emqx_mysql/mix.exs
@@ -23,7 +23,7 @@ defmodule EMQXMysql.MixProject do
 
   def deps() do
     [
-      {:mysql, github: "emqx/mysql-otp", tag: "1.8.0.0"},
+      {:mysql, github: "emqx/mysql-otp", tag: "1.8.0.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
     ]

--- a/apps/emqx_mysql/rebar.config
+++ b/apps/emqx_mysql/rebar.config
@@ -3,7 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     %% NOTE: mind ecpool version when updating eredis_cluster version
-    {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.8.0.0"}}},
+    {mysql, {git, "https://github.com/emqx/mysql-otp", {tag, "1.8.0.1"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}}
 ]}.


### PR DESCRIPTION
This is to fix connectivity issue with oceanbase using MySQL protocol.
https://en.oceanbase.com/

see also: https://github.com/emqx/mysql-otp/pull/15
