### PR TITLE
try fix flaky test:  quic client addr change

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -45,7 +45,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}}
         ]},
         {extra_src_dirs, [
             {"test", [recursive]},
@@ -57,7 +57,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}}
         ]},
         {extra_src_dirs, [{"test", [recursive]}]}
     ]}

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -218,6 +218,7 @@ t_connect_clean_start(Config) ->
 t_connect_clean_start_unresp_old_client(Config) ->
     ConnFun = ?config(conn_fun, Config),
     ClientID = atom_to_binary(?FUNCTION_NAME),
+    process_flag(trap_exit, true),
     %% GIVEN: a client with clean_start=true
     {ok, Client1} = emqtt:start_link([
         {clientid, ClientID},
@@ -240,6 +241,9 @@ t_connect_clean_start_unresp_old_client(Config) ->
     close_quic_conn_silently(ConnFun, Client1),
     %% THEN: the new client should connect successfully in time < connect_timeout
     {ok, _} = emqtt:ConnFun(Client2),
+    ok = emqtt:disconnect(Client2),
+    waiting_client_process_exit(Client1),
+    waiting_client_process_exit(Client2),
     ok.
 
 close_quic_conn_silently(quic_connect, Client) ->

--- a/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
+++ b/apps/emqx/test/emqx_quic_multistreams_SUITE.erl
@@ -843,9 +843,15 @@ t_conn_change_client_addr(Config) ->
     ?assertEqual(
         ok, quicer:setopt(Conn, local_address, "127.0.0.1:" ++ integer_to_list(NewPort))
     ),
-    {ok, NewAddr} = quicer:sockname(Conn),
-    ct:pal("NewAddr: ~p, Old Addr: ~p", [NewAddr, OldAddr]),
-    ?assertNotEqual(OldAddr, NewAddr),
+
+    ?retry(
+        _Delay = 50,
+        _attempt = 20,
+        fun() ->
+            {ok, NewAddr} = quicer:sockname(Conn),
+            ?assertNotEqual(OldAddr, NewAddr)
+        end
+    ),
     ?assert(is_list(emqtt:info(C))),
     ok = emqtt:disconnect(C).
 

--- a/apps/emqx_retainer/rebar.config
+++ b/apps/emqx_retainer/rebar.config
@@ -30,7 +30,7 @@
 {profiles, [
     {test, [
         {deps, [
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}}
         ]}
     ]}
 ]}.

--- a/mix.exs
+++ b/mix.exs
@@ -242,7 +242,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:emqtt),
     do:
       {:emqtt,
-       github: "emqx/emqtt", tag: "1.13.5", override: true, system_env: maybe_no_quic_env()}
+       github: "emqx/emqtt", tag: "1.13.6", override: true, system_env: maybe_no_quic_env()}
 
   def common_dep(:typerefl),
     do: {:typerefl, github: "ieQu1/typerefl", tag: "0.9.1", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -89,7 +89,7 @@
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.0"}}},
-    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.5"}}},
+    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x
     {observer_cli, "1.7.5"},


### PR DESCRIPTION
Try fix flaky tests:
 emqx_mqtt_protocol_v5_SUITE:t_connect_idle_timeout
 emqx_mqtt_protocol_v5_SUITE:t_connect_clean_start_unresp_old_client
 emqx_quic_multistreams_SUITE:t_conn_change_client_addr
and other flaky tests cased by emqtt (quic).
 

Release version: v/e5.?

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
