### PR TITLE
fix: upgrade wolff to 4.0.9

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.8"},
+    {wolff, "4.0.9"},
     {kafka_protocol, "4.2.3"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.8"},
+    {wolff, "4.0.9"},
     {kafka_protocol, "4.2.3"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.8"},
+    {wolff, "4.0.9"},
     {kafka_protocol, "4.2.3"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.3.1"},

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.5.3"},
+    {vsn, "0.5.4"},
     {registered, [emqx_bridge_kafka_sup, emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -582,7 +582,9 @@ on_kafka_ack(_Partition, message_too_large, ReplyFnAndArgs) ->
     %% wolff should bump the message 'dropped' counter with handle_telemetry_event/4.
     %% however 'dropped' is not mapped to EMQX metrics name
     %% so we reply error here
-    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, message_too_large}).
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, message_too_large});
+on_kafka_ack(_Partition, partition_lost, ReplyFnAndArgs) ->
+    emqx_resource:apply_reply_fun(ReplyFnAndArgs, {error, partition_lost}).
 
 %% Note: since wolff client has its own replayq that is not managed by
 %% `emqx_resource_buffer_worker', we must avoid returning `disconnected' here.  Otherwise,

--- a/mix.exs
+++ b/mix.exs
@@ -206,7 +206,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:cowboy), do: {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true}
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
   def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.6.1", override: true}
-  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.4.0", override: true}
+  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.4.1", override: true}
   def common_dep(:jsx), do: {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true}
   # in conflict by emqtt and hocon
   def common_dep(:getopt), do: {:getopt, "1.0.2", override: true}
@@ -275,7 +275,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.8"}
+  def common_dep(:wolff), do: {:wolff, "4.0.9"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,7 @@
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
-    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.0"}}},
+    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.1"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x


### PR DESCRIPTION
fixes:[EMQX-13991](https://emqx.atlassian.net/browse/EMQX-13991)
this is a follow-up fix for
https://github.com/emqx/emqx/pull/14767

previously the messages in lost partitions are silently discarded, this fix makes sure the error counters are incremented

log example
```
2025-03-06T21:06:00.872345+01:00 [error] msg: stop_producers_for_lost_partitions, partitions: [3,4], producer_id: <<"action:kafka_producer:a:connector:kafka_producer:a">>
2025-03-06T21:06:00.873452+01:00 [error] tag: RESOURCE, msg: unrecoverable_resource_error, reason: partition_lost, resource_id: <<"action:kafka_producer:a:connector:kafka_producer:a">>
2025-03-06T21:06:00.873562+01:00 [error] tag: RESOURCE, msg: unrecoverable_resource_error, reason: partition_lost, resource_id: <<"action:kafka_producer:a:connector:kafka_producer:a">>
2025-03-06T21:06:29.075350+01:00 [warning] msg: log_events_throttled_during_last_period, period: 1 minutes, 0 seconds, dropped: #{<<"unrecoverable_resource_error:action:kafka_producer:a:connector:kafka_producer:a">> => 126}
```

[EMQX-13991]: https://emqx.atlassian.net/browse/EMQX-13991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ