### PR TITLE
ci: allow customizing container name

### DIFF
--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   erlang:
-    hostname: erlang.emqx.net
-    container_name: erlang
+    hostname: ${ERLANG_CONTAINER:-erlang}.emqx.net
+    container_name: ${ERLANG_CONTAINER:-erlang}
     image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-ubuntu22.04}
     env_file:
       - credentials.env

--- a/scripts/ct/run.sh
+++ b/scripts/ct/run.sh
@@ -101,7 +101,7 @@ if [ ! -d "${WHICH_APP}" ]; then
     exit 1
 fi
 
-ERLANG_CONTAINER='erlang'
+ERLANG_CONTAINER=${ERLANG_CONTAINER:-erlang}
 DOCKER_CT_ENVS_FILE="${WHICH_APP}/docker-ct"
 
 if [ -f "${WHICH_APP}/BSL.txt" ]; then
@@ -165,7 +165,7 @@ FILES=( )
 
 for dep in ${CT_DEPS}; do
     case "${dep}" in
-        erlang)
+        "${ERLANG_CONTAINER}")
             FILES+=( '.ci/docker-compose-file/docker-compose.yaml' )
             ;;
         toxiproxy)


### PR DESCRIPTION
When one has multiple local worktrees, it's sometimes desirable to run multiple containers at different OTP versions concurrently.

With this, it's possible to customize the container name for that purpose.

Ex:

```sh
ͳ env ERLANG_CONTAINER=erlang27 DOCKER_CT_RUNNER_IMAGE=ghcr.io/emqx/emqx-builder/5.5-0:1.17.3-27.2-2-ubuntu24.04 PROFILE=emqx-enterprise scripts/ct/run.sh --app apps/emqx_bridge_http --attach
```
