### PR TITLE
ci: fix arm64 docker image upload

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -55,7 +55,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ${{ github.repository_owner == 'emqx' && fromJSON(format('["self-hosted","ephemeral","linux","{0}"]', matrix.arch)) || 'ubuntu-22.04' }}
+    runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
     outputs:
       PKG_VSN: ${{ steps.build.outputs.PKG_VSN }}
 
@@ -66,7 +66,7 @@ jobs:
           - ${{ inputs.profile }}
           - ${{ inputs.profile }}-elixir
         arch:
-          - x64
+          - amd64
           - arm64
 
     steps:
@@ -82,16 +82,16 @@ jobs:
           ./scripts/buildx.sh --profile ${{ matrix.profile }} --pkgtype tgz --builder "$EMQX_DOCKER_BUILD_FROM"
           PKG_VSN=$(docker run --rm -v $(pwd):$(pwd) -w $(pwd) -u $(id -u) "$EMQX_DOCKER_BUILD_FROM" ./pkg-vsn.sh "${{ matrix.profile }}")
           echo "PKG_VSN=$PKG_VSN" >> "$GITHUB_OUTPUT"
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
-          name: "${{ matrix.profile }}-${{ matrix.arch == 'x64' && 'amd64' || 'arm64' }}.tar.gz"
+          name: "${{ matrix.profile }}-${{ matrix.arch }}.tar.gz"
           path: "_packages/emqx*/emqx-*.tar.gz"
           retention-days: 7
           overwrite: true
           if-no-files-found: error
 
   docker:
-    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || fromJSON('["self-hosted","ephemeral","linux","x64"]') }}
+    runs-on: ${{ endsWith(github.repository, '/emqx') && 'ubuntu-22.04' || 'aws-ubuntu22.04-amd64' }}
     needs:
       - build
     defaults:
@@ -118,7 +118,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.ref }}
 
-      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
         with:
           pattern: "${{ matrix.profile[0] }}-*.tar.gz"
           path: _packages
@@ -137,8 +137,8 @@ jobs:
           sudo mv daemon.json /etc/docker/daemon.json
           sudo systemctl restart docker
 
-      - uses: docker/setup-qemu-action@4574d27a4764455b42196d70a065bc6853246a25 # v3.4.0
-      - uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
       - name: Login to hub.docker.com
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -167,6 +167,13 @@ jobs:
           cat .emqx_docker_image_tags
           echo "==========="
           echo "_EMQX_DOCKER_IMAGE_TAG=$(head -n 1 .emqx_docker_image_tags)" >> $GITHUB_ENV
+          head -n 1 .emqx_docker_image_tags > docker-image-tag
+
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: "${{ env.PROFILE }}-docker-image-tag"
+          path: "docker-image-tag"
+          retention-days: 7
 
       - name: Verify that size of docker image is less than 300 MB
         run: |
@@ -201,7 +208,7 @@ jobs:
         run: |
           docker save "${_EMQX_DOCKER_IMAGE_TAG}" | gzip > $PROFILE-docker-$PKG_VSN.tar.gz
 
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
         with:
           name: "${{ env.PROFILE }}-docker"
           path: "${{ env.PROFILE }}-docker-${{ env.PKG_VSN }}.tar.gz"
@@ -217,15 +224,53 @@ jobs:
         run: |
           ./build ${PROFILE} docker
 
+
+  upload:
+    runs-on: ${{ github.repository_owner == 'emqx' && format('aws-ubuntu22.04-{0}', matrix.arch) || (matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04') }}
+    if: inputs.publish || github.repository_owner != 'emqx'
+
+    needs:
+      - build
+      - docker
+
+    strategy:
+      fail-fast: false
+      matrix:
+        profile:
+          - ${{ inputs.profile }}
+          - ${{ inputs.profile }}-elixir
+        arch:
+          - amd64
+          - arm64
+    env:
+      PKG_VSN: ${{ needs.build.outputs.PKG_VSN }}
+      FILENAME: "${{ matrix.profile }}-${{ needs.build.outputs.PKG_VSN }}-docker-${{ matrix.arch }}.tar.gz"
+
+    steps:
+      - uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # v4.1.9
+        with:
+          name: "${{ matrix.profile }}-docker-image-tag"
+
+      - name: export docker image to .tar.gz
+        run: |
+          set -xeuo pipefail
+
+          export _EMQX_DOCKER_IMAGE_TAG=$(cat docker-image-tag)
+          docker pull "${_EMQX_DOCKER_IMAGE_TAG}"
+          docker save "${_EMQX_DOCKER_IMAGE_TAG}" | gzip > "$FILENAME"
+
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        with:
+          name: ${{ matrix.profile }}-docker-image-${{ matrix.arch }}
+          path: ${{ env.FILENAME }}
+
       - uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722 # v4.1.0
-        if: inputs.publish || github.repository_owner != 'emqx'
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_DEFAULT_REGION }}
 
       - name: upload to aws s3
-        if: inputs.publish || github.repository_owner != 'emqx'
         env:
           AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
           AWS_CLOUDFRONT_ID: ${{ secrets.AWS_CLOUDFRONT_ID }}
@@ -240,11 +285,5 @@ jobs:
               echo "unknown profile $ORIG_PROFILE"
               exit 1
           fi
-          docker pull --platform linux/amd64 "${_EMQX_DOCKER_IMAGE_TAG}"
-          docker save "${_EMQX_DOCKER_IMAGE_TAG}" | gzip > "$PROFILE-$PKG_VSN-docker-amd64.tar.gz"
-          docker pull --platform linux/arm64 "${_EMQX_DOCKER_IMAGE_TAG}"
-          docker save "${_EMQX_DOCKER_IMAGE_TAG}" | gzip > "$PROFILE-$PKG_VSN-docker-arm64.tar.gz"
-          ls -lh
-          aws s3 cp "$PROFILE-$PKG_VSN-docker-amd64.tar.gz" "s3://$AWS_S3_BUCKET/$s3dir/"
-          aws s3 cp "$PROFILE-$PKG_VSN-docker-arm64.tar.gz" "s3://$AWS_S3_BUCKET/$s3dir/"
+          aws s3 cp "$FILENAME" "s3://$AWS_S3_BUCKET/$s3dir/"
           aws cloudfront create-invalidation --distribution-id "$AWS_CLOUDFRONT_ID" --paths "/$s3dir/*docker*"


### PR DESCRIPTION
Fixes issue with arm64 docker images.
Port of docker build changes in #14825.

Release version: v/e5.8.6

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
