### PR TITLE
Cherry-pick  #14756 and Add ignore_unsupported_frames option

### DIFF
--- a/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
+++ b/apps/emqx_gateway_jt808/src/emqx_gateway_jt808.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_jt808, [
     {description, "JT/T 808 Gateway"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -443,7 +443,7 @@ handle_out({?MS_GENERAL_RESPONSE, Result, InMsgId}, MsgSn, Channel) ->
 handle_out({?MS_REGISTER_ACK, 0}, MsgSn, Channel = #channel{authcode = Authcode0}) ->
     Authcode =
         case Authcode0 == anonymous of
-            true -> <<>>;
+            true -> <<"anonymous">>;
             false -> Authcode0
         end,
     Frame = #{

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -440,15 +440,15 @@ handle_out({?MS_GENERAL_RESPONSE, Result, InMsgId}, MsgSn, Channel) ->
         <<"body">> => #{<<"seq">> => MsgSn, <<"result">> => Result, <<"id">> => InMsgId}
     },
     {ok, [{outgoing, Frame}], state_inc_sn(Channel)};
-handle_out({?MS_REGISTER_ACK, 0}, MsgSn, Channel = #channel{authcode = Authcode0}) ->
-    Authcode =
-        case Authcode0 == anonymous of
+handle_out({?MS_REGISTER_ACK, 0}, MsgSn, Channel = #channel{authcode = AuthCode0}) ->
+    AuthCode =
+        case AuthCode0 == anonymous of
             true -> <<"anonymous">>;
-            false -> Authcode0
+            false -> AuthCode0
         end,
     Frame = #{
         <<"header">> => build_frame_header(?MS_REGISTER_ACK, Channel),
-        <<"body">> => #{<<"seq">> => MsgSn, <<"result">> => 0, <<"auth_code">> => Authcode}
+        <<"body">> => #{<<"seq">> => MsgSn, <<"result">> => 0, <<"auth_code">> => AuthCode}
     },
     {ok, [{outgoing, Frame}], state_inc_sn(Channel)};
 handle_out({?MS_REGISTER_ACK, ResCode}, MsgSn, Channel) ->
@@ -635,8 +635,8 @@ reset_timer(Name, Channel) ->
 clean_timer(Name, Channel = #channel{timers = Timers}) ->
     Channel#channel{timers = maps:remove(Name, Timers)}.
 
-interval(alive_timer, #channel{keepalive = KeepAlive}) ->
-    emqx_keepalive:info(check_interval, KeepAlive);
+interval(alive_timer, #channel{keepalive = Keepalive}) ->
+    emqx_keepalive:info(check_interval, Keepalive);
 interval(retry_timer, #channel{retx_interval = RetxIntv}) ->
     RetxIntv.
 
@@ -891,8 +891,8 @@ is_driver_id_req_exist(#channel{inflight = Inflight}) ->
 
 register_(Frame, Channel0) ->
     case emqx_jt808_auth:register(Frame, Channel0#channel.auth) of
-        {ok, Authcode} ->
-            {ok, Channel0#channel{authcode = Authcode}};
+        {ok, AuthCode} ->
+            {ok, Channel0#channel{authcode = AuthCode}};
         {error, Reason} ->
             ?SLOG(error, #{msg => "register_failed", reason => Reason}),
             ResCode =
@@ -916,9 +916,9 @@ authenticate(AuthFrame, #channel{authcode = undefined, auth = Auth}) ->
     end;
 authenticate(
     #{<<"body">> := #{<<"code">> := InCode}},
-    #channel{authcode = Authcode}
+    #channel{authcode = AuthCode}
 ) ->
-    InCode == Authcode.
+    InCode == AuthCode.
 
 enrich_conninfo(
     #{<<"header">> := #{<<"phone">> := Phone}},
@@ -999,10 +999,10 @@ replvar(Topic, #channel{clientinfo = #{clientid := ClientId, phone := Phone}}) w
     do_replvar(Topic, #{clientid => ClientId, phone => Phone}).
 
 do_replvar(Topic, Vars) ->
-    ClientID = maps:get(clientid, Vars, undefined),
+    ClientId = maps:get(clientid, Vars, undefined),
     Phone = maps:get(phone, Vars, undefined),
     List = [
-        {?PH_CLIENTID, ClientID},
+        {?PH_CLIENTID, ClientId},
         {?PH_PHONE, Phone}
     ],
     lists:foldl(fun feed_var/2, Topic, List).

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_schema.erl
@@ -60,7 +60,12 @@ fields(jt808_proto) ->
                 #{desc => ?DESC(jt808_auth)}
             )},
         {up_topic, fun up_topic/1},
-        {dn_topic, fun dn_topic/1}
+        {dn_topic, fun dn_topic/1},
+        {ignore_unsupported_frames,
+            sc(
+                hoconsc:union([true, false]),
+                #{desc => ?DESC(ignore_unsupported_frames), default => true}
+            )}
     ];
 fields(anonymous_true) ->
     [

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -2808,6 +2808,67 @@ test_invalid_config(CreateOrUpdate, AnonymousAllowed) ->
         UpdateResult
     ).
 
+t_ignore_unsupported_frames_default(_Config) ->
+    %% default value is true
+    ?assertEqual(true, emqx_config:get([gateway, jt808, proto, ignore_unsupported_frames])),
+
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_procedure(Socket, AuthCode),
+
+    %% send unsupported frame
+    ok = gen_tcp:send(Socket, unsupported_frame_packet()),
+    %% nothing to happen
+
+    %% send heartbeat
+    PhoneBCD = <<16#00, 16#01, 16#23, 16#45, 16#67, 16#89>>,
+    MsgId = ?MC_HEARTBEAT,
+    MsgSn = 78,
+    Size = 0,
+    Header =
+        <<MsgId:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size), PhoneBCD/binary,
+            MsgSn:?WORD>>,
+    S1 = gen_packet(Header, <<>>),
+
+    ok = gen_tcp:send(Socket, S1),
+    %% timer:sleep(200),
+    {ok, Packet} = gen_tcp:recv(Socket, 0, 500),
+
+    GenAckPacket = <<MsgSn:?WORD, MsgId:?WORD, 0>>,
+    Size2 = size(GenAckPacket),
+    MsgId2 = ?MS_GENERAL_RESPONSE,
+    MsgSn2 = 2,
+    Header2 =
+        <<MsgId2:?WORD, ?RESERVE:2, ?NO_FRAGMENT:1, ?NO_ENCRYPT:3, ?MSG_SIZE(Size2),
+            PhoneBCD/binary, MsgSn2:?WORD>>,
+    S2 = gen_packet(Header2, GenAckPacket),
+    ?assertEqual(S2, Packet),
+
+    ok = gen_tcp:close(Socket).
+
+t_ignore_unsupported_frames_set_to_false(_Config) ->
+    RawConfig = emqx_config:get_raw([gateway, jt808]),
+    RawConfig1 = emqx_utils_maps:deep_put(
+        [<<"proto">>, <<"ignore_unsupported_frames">>], RawConfig, false
+    ),
+    {ok, _} = emqx_gateway_conf:update_gateway(jt808, RawConfig1),
+
+    {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
+    {ok, AuthCode} = client_regi_procedure(Socket),
+    ok = client_auth_procedure(Socket, AuthCode),
+
+    %% send unsupported frame
+    ok = gen_tcp:send(Socket, unsupported_frame_packet()),
+    %% socket should be closed
+    {error, closed} = gen_tcp:recv(Socket, 0, 1000),
+
+    ok = gen_tcp:close(Socket),
+
+    %% restore config
+    {ok, _} = emqx_gateway_conf:update_gateway(jt808, RawConfig),
+
+    ok.
+
 create_or_update(create, InvalidConfig) ->
     emqx_gateway_conf:load_gateway(jt808, InvalidConfig);
 create_or_update(update, InvalidConfig) ->
@@ -2854,3 +2915,12 @@ raw_jt808_config() ->
             },
         <<"retry_interval">> => <<"8s">>
     }.
+
+unsupported_frame_packet() ->
+    <<126, 2, 5, 0, 128, 1, 137, 112, 19, 0, 64, 1, 98, 72, 66, 77, 54, 48, 49, 67, 86, 77, 48, 49,
+        49, 77, 50, 50, 48, 50, 53, 45, 48, 49, 45, 49, 55, 253, 255, 2, 0, 255, 127, 0, 128, 80,
+        17, 1, 54, 69, 67, 56, 48, 48, 77, 0, 0, 0, 0, 0, 0, 0, 0, 0, 56, 54, 56, 48, 49, 57, 48,
+        55, 51, 55, 48, 52, 51, 56, 48, 52, 54, 48, 49, 49, 51, 56, 55, 49, 49, 48, 49, 53, 55, 52,
+        56, 57, 56, 54, 49, 49, 50, 52, 50, 51, 51, 48, 56, 49, 51, 49, 53, 55, 57, 53, 0, 0, 76,
+        67, 48, 68, 55, 52, 67, 52, 49, 80, 48, 50, 49, 49, 50, 54, 48, 4, 20, 164, 132, 0, 0, 0, 0,
+        66, 126>>.

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -380,8 +380,9 @@ t_case01_auth(_) ->
 t_case02_anonymous_register_and_auth(_) ->
     {ok, Socket} = gen_tcp:connect({127, 0, 0, 1}, ?PORT, [binary, {active, false}]),
 
-    {ok, AuthCode} = client_regi_procedure(Socket, <<>>),
-    ?assertEqual(AuthCode, <<>>),
+    DefaultAuthCode = <<"anonymous">>,
+    {ok, AuthCode} = client_regi_procedure(Socket, DefaultAuthCode),
+    ?assertEqual(AuthCode, DefaultAuthCode),
 
     ok = client_auth_procedure(Socket, AuthCode),
 

--- a/changes/ee/feat-14855.en.md
+++ b/changes/ee/feat-14855.en.md
@@ -1,0 +1,1 @@
+Add a new configuration item **ignore_unsupported_frames** to the JT/T 808 gateway to prevent devices from being disconnected due to reporting messages that the gateway cannot parse.

--- a/changes/ee/fix-14756.en.md
+++ b/changes/ee/fix-14756.en.md
@@ -1,1 +1,1 @@
-mprove the JT/T 808 gateway so that when anonymous authentication is enabled, the registration response will carry the default authentication code `anonymous`. This is used to avoid the issue where some clients are unable to parse an empty authentication code.
+Improve the JT/T 808 gateway so that when anonymous authentication is enabled, the registration response will carry the default authentication code `anonymous`. This is used to avoid the issue where some clients are unable to parse an empty authentication code.

--- a/changes/ee/fix-14756.en.md
+++ b/changes/ee/fix-14756.en.md
@@ -1,0 +1,1 @@
+mprove the JT/T 808 gateway so that when anonymous authentication is enabled, the registration response will carry the default authentication code `anonymous`. This is used to avoid the issue where some clients are unable to parse an empty authentication code.

--- a/rel/i18n/emqx_jt808_schema.hocon
+++ b/rel/i18n/emqx_jt808_schema.hocon
@@ -21,6 +21,12 @@ jt808_up_topic.desc:
 jt808_dn_topic.desc:
 """The topic of the JT/T 808 protocol downstream message."""
 
+ignore_unsupported_frames.desc:
+"""Whether to ignore unsupported frames. <br/>
+- <code>true</code>, unsupported frames will be logged and ignored. <br/>
+- <code>false</code>, the gateway will disconnect the client when receiving an unsupported frame.<br/>
+The default value is false."""
+
 retry_interval.desc:
 """Re-send time interval"""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14000

Cherry-pick https://github.com/emqx/emqx/pull/14756 to 5.8.6
And add the `ignore_unsupported_frames` to avoid disconnecting JT/T 808 devices that have implemented with customized message typs

Release version: v/e5.8.6

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- ~Added property-based tests for code which performs user input validation~
- ~Changed lines covered in coverage report~
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- ~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- ~If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
-~Change log has been added to `changes/` dir for user-facing artifacts update~
