### PR TITLE
feat(new mix build): add classic and incremental dialyzer support

### DIFF
--- a/apps/emqx/test/emqx_bpapi_static_checks.erl
+++ b/apps/emqx/test/emqx_bpapi_static_checks.erl
@@ -270,7 +270,8 @@ get_param_types(Signatures, From, {M, F, A}) ->
 
 dump() ->
     RootDir = project_root_dir(),
-    TryRelDir = RootDir ++ "/_build/check/lib",
+    BuildProfile = os:getenv("BPAPI_BUILD_PROFILE", "check"),
+    TryRelDir = filename:join([RootDir, "_build", BuildProfile, "lib"]),
     case {filelib:wildcard(RootDir ++ "/*_plt"), filelib:wildcard(TryRelDir)} of
         {[PLT | _], [RelDir | _]} ->
             dump(#{

--- a/apps/emqx_machine/mix.exs
+++ b/apps/emqx_machine/mix.exs
@@ -20,7 +20,11 @@ defmodule EMQXMachine.MixProject do
 
   # Run "mix help compile.app" to learn about applications
   def application do
-    [extra_applications: UMP.extra_applications(), mod: {:emqx_machine_app, []}]
+    [
+      extra_applications: UMP.extra_applications(),
+      included_applications: [:system_monitor],
+      mod: {:emqx_machine_app, []},
+    ]
   end
 
   def deps() do

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.dialyzer.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.dialyzer.ex
@@ -2,6 +2,7 @@ defmodule Mix.Tasks.Emqx.Dialyzer do
   use Mix.Task
 
   alias Mix.Tasks.Emqx.Ct, as: ECt
+  alias EMQXUmbrella.MixProject, as: UMP
 
   @requirements ["compile", "loadpaths"]
 
@@ -36,7 +37,11 @@ defmodule Mix.Tasks.Emqx.Dialyzer do
   )
 
   @impl true
-  def run(_args) do
+  def run(args) do
+    %{
+      mode: mode
+    } = parse_args!(args)
+
     ECt.add_to_path_and_cache(:dialyzer)
 
     %{
@@ -63,39 +68,43 @@ defmodule Mix.Tasks.Emqx.Dialyzer do
       |> Enum.map(&to_charlist/1)
     warning_apps = Enum.sort(umbrella_apps)
 
-    try do
-      :dialyzer.run(
-        analysis_type: :incremental,
-        warnings: [
+    plt = to_charlist(plt_path(mode))
+
+    context = %{
+      mode: mode,
+      warnings: [
           :unmatched_returns,
           :error_handling
         ],
-        # plt_location: ~c".",
-        # plt_prefix: ~c"emqx_dialyzer",
-        warning_files: warning_files,
-        warning_files_rec: warning_files,
-        # apps: umbrella_apps ++ dep_apps,
-        # warning_apps: warning_apps,
-        get_warnings: false,
-        files: files,
-        files_rec: files
-      )
+      warning_files: warning_files,
+      umbrella_files: umbrella_files,
+      files: files,
+    }
+
+    try do
+      case mode do
+        :classic ->
+          run_dialyzer_classic(context)
+
+        :incremental ->
+          run_dialyzer_incremental(context)
+      end
       |> Enum.map(& :dialyzer.format_warning(&1, filename_opt: :fullpath, indent_opt: false))
       |> tap(&IO.puts/1)
       |> case do
            [] ->
-             Mix.shell().info("ok")
+             Mix.shell().info("Ok")
 
            [_ | _] ->
-             Mix.raise("Errors found!")
+             Mix.raise("Errors found!  See output above for details.")
          end
     catch
       {:dialyzer_error, msg} ->
-        {:dialyzer_error, to_string(msg)}
+        Mix.raise("Dialyzer error:\n\n#{inspect(msg, pretty: true)}")
+
       err ->
-        {:throw, err}
+        Mix.raise("Error runnin dialyzer:\n\n#{inspect(err, pretty: true)}")
     end
-    |> IO.inspect(limit: :infinity)
   end
 
   defp resolve_apps() do
@@ -178,5 +187,115 @@ defmodule Mix.Tasks.Emqx.Dialyzer do
             ]))
         :error
     end
+  end
+
+  defp parse_args!(args) do
+    {opts, _rest} = OptionParser.parse!(
+      args,
+      strict: [
+        mode: :string,
+      ]
+    )
+    mode =
+      opts
+      |> Keyword.get(:mode, "classic")
+      |> String.to_atom()
+
+    case mode do
+      :classic ->
+        :ok
+
+      :incremental ->
+        :ok
+
+      _ ->
+        Mix.raise("Unknown mode: #{mode}; valid values are: classic, incremental")
+    end
+
+    %{
+      mode: mode
+    }
+  end
+
+  defp plt_path(mode) do
+    otp_version = UMP.otp_release()
+    mode_slug = if mode == :incremental do
+      "_incremental"
+    else
+      ""
+    end
+
+    Mix.Project.project_file()
+    |> Path.dirname()
+    |> Path.join("emqx_dialyzer_#{otp_version}_plt#{mode_slug}")
+  end
+
+  def run_dialyzer_classic(context) do
+    # Creating a full PLT straight away, instead of building a initial PLT with only OTP
+    # modules.
+    %{
+      mode: mode,
+      files: files,
+      warnings: warnings,
+      warning_files: warning_files,
+    } = context
+    plt = mode |> plt_path() |> to_charlist()
+
+    Mix.shell().info("Running dialyzer in #{mode} mode and PLT #{plt}")
+
+    Mix.shell().info("Building initial PLT...")
+    {time, _} = :timer.tc(fn ->
+      :dialyzer.run(
+        analysis_type: :plt_build,
+        output_plt: plt,
+        get_warnings: false,
+        files: files,
+        files_rec: files,
+      )
+    end, :millisecond)
+    Mix.shell().info("Built initial PLT in #{time / 1_000} s")
+
+    Mix.shell().info("Running success typing analysis...")
+    {time, res} = :timer.tc(fn ->
+      :dialyzer.run(
+        analysis_type: :succ_typings,
+        warnings: warnings,
+        init_plt: plt,
+        get_warnings: true,
+        files: warning_files
+      )
+    end, :millisecond)
+    Mix.shell().info("Ran success typing analysis in #{time / 1_000} s")
+
+    res
+  end
+
+  def run_dialyzer_incremental(context) do
+    %{
+      mode: mode,
+      files: files,
+      warnings: warnings,
+      warning_files: warning_files,
+    } = context
+    plt = mode |> plt_path() |> to_charlist()
+
+    Mix.shell().info("Running dialyzer in #{mode} mode and PLT #{plt}")
+
+    {time, res} = :timer.tc(fn ->
+      :dialyzer.run(
+        analysis_type: :incremental,
+        warnings: warnings,
+        init_plt: plt,
+        output_plt: plt,
+        warning_files: warning_files,
+        warning_files_rec: warning_files,
+        get_warnings: false,
+        files: files,
+        files_rec: files,
+      )
+    end, :millisecond)
+    Mix.shell().info("Ran incremental analysis in #{time / 1_000} s")
+
+    res
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1348,7 +1348,7 @@ defmodule EMQXUmbrella.MixProject do
   # the exact OTP version.
   # https://www.erlang.org/doc/man/erlang.html#system_info_otp_release
   # https://github.com/erlang/rebar3/blob/e3108ac187b88fff01eca6001a856283a3e0ec87/src/rebar_utils.erl#L572-L577
-  defp otp_release() do
+  def otp_release() do
     major_version = System.otp_release()
     root_dir = to_string(:code.root_dir())
 


### PR DESCRIPTION
Affects only new mix build.

### Running with incremental mode

```sh
# Running for the first time, with no PLT file
ͳ env NEW_MIX_BUILD=1 PROFILE=emqx-enterprise mix dialyzer --mode incremental
# ... snip ...
Running dialyzer in incremental mode and PLT /emqx/emqx_dialyzer_26.2.5.2-1_plt_incremental
Ran incremental analysis in 74.837 s

Ok

# Running again, no code changes
ͳ env NEW_MIX_BUILD=1 PROFILE=emqx-enterprise mix dialyzer --mode incremental
# ... snip ...
Running dialyzer in incremental mode and PLT /emqx/emqx_dialyzer_26.2.5.2-1_plt_incremental
Ran incremental analysis in 2.082 s

Ok
```

### Running in classic mode

Produces a PLT file that our static checks suite accepts (when run by `mix ct` and setting `BPAPI_BUILD_PROFILE` accordingly):

```sh
ͳ env NEW_MIX_BUILD=1 PROFILE=emqx-enterprise mix dialyzer --mode classic
# ... snip ...
Running dialyzer in classic mode and PLT /emqx/emqx_dialyzer_26.2.5.2-1_plt
Building initial PLT...
Built initial PLT in 61.451 s
Running success typing analysis...
Ran success typing analysis in 21.855 s

Ok
```