### PR TITLE
test(conf app suite): fix flaky test

### DIFF
--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -41,9 +41,7 @@
 -export([start/1, start/2, restart/1]).
 -export([stop/1, stop_node/1]).
 
--export([start_bare_nodes/1, start_bare_nodes/2]).
-
--export([join/2]).
+-export([join_cluster/2]).
 
 -export([share_load_module/2]).
 -export([node_name/1, mk_nodespecs/2]).
@@ -90,6 +88,9 @@
     % If set to `undefined` this node won't try to join the cluster
     % Default: no (first core node is used to join to by default)
     join_to => node() | undefined,
+
+    %% Options that may affect `emqx_cth_peer:start{,_link}', such as `shutdown'.
+    start_opts => #{},
 
     %% Working directory
     %% If this directory is not empty, starting up the node applications will fail
@@ -218,6 +219,7 @@ mk_init_nodespec(N, Name, NodeOpts, ClusterOpts) ->
         role => core,
         apps => [],
         base_port => BasePort,
+        start_opts => maps:get(start_opts, ClusterOpts, #{}),
         work_dir => filename:join([WorkDir, Node])
     },
     maps:merge(Defaults, NodeOpts).
@@ -346,29 +348,29 @@ allocate_listener_ports(Types, Spec) ->
     lists:foldl(fun maps:merge/2, #{}, [allocate_listener_port(Type, Spec) || Type <- Types]).
 
 start_nodes_init(Specs, Timeout) ->
-    Names = lists:map(fun(#{name := Name}) -> Name end, Specs),
-    _Nodes = start_bare_nodes(Names, Timeout),
+    _Nodes = start_bare_nodes(Specs, Timeout),
     lists:foreach(fun node_init/1, Specs).
 
-start_bare_nodes(Names) ->
-    start_bare_nodes(Names, ?TIMEOUT_NODE_START_MS).
-
-start_bare_nodes(Names, Timeout) ->
+start_bare_nodes(Specs, Timeout) ->
     Args = erl_flags(),
     Envs = [],
     Waits = lists:map(
-        fun(Name) ->
+        fun(#{name := Name} = Spec) ->
             WaitTag = {boot_complete, Name},
             WaitBoot = {self(), WaitTag},
-            {ok, _} = emqx_cth_peer:start(Name, Args, Envs, WaitBoot),
+            Opts = peer_start_opts(Spec),
+            {ok, _} = emqx_cth_peer:start(Name, Args, Envs, WaitBoot, Opts),
             WaitTag
         end,
-        Names
+        Specs
     ),
     Deadline = deadline(Timeout),
     Nodes = wait_boot_complete(Waits, Deadline),
     lists:foreach(fun(Node) -> pong = net_adm:ping(Node) end, Nodes),
     Nodes.
+
+peer_start_opts(Spec) ->
+    maps:get(start_opts, Spec, #{}).
 
 deadline(Timeout) ->
     erlang:monotonic_time() + erlang:convert_time_unit(Timeout, millisecond, native).

--- a/apps/emqx/test/emqx_cth_peer.erl
+++ b/apps/emqx/test/emqx_cth_peer.erl
@@ -19,8 +19,8 @@
 
 -module(emqx_cth_peer).
 
--export([start/2, start/3, start/4]).
--export([start_link/2, start_link/3, start_link/4]).
+-export([start/2, start/3, start/4, start/5]).
+-export([start_link/2, start_link/3, start_link/4, start_link/5]).
 -export([stop/1]).
 -export([kill/1]).
 
@@ -31,7 +31,10 @@ start(Name, Args, Envs) ->
     start(Name, Args, Envs, timer:seconds(20)).
 
 start(Name, Args, Envs, Timeout) when is_atom(Name) ->
-    do_start(Name, Args, Envs, Timeout, start).
+    start(Name, Args, Envs, Timeout, _Opts = #{}).
+
+start(Name, Args, Envs, Timeout, #{} = Opts) when is_atom(Name) ->
+    do_start(Name, Args, Envs, Timeout, start, Opts).
 
 start_link(Name, Args) ->
     start_link(Name, Args, []).
@@ -39,20 +42,27 @@ start_link(Name, Args) ->
 start_link(Name, Args, Envs) ->
     start_link(Name, Args, Envs, timer:seconds(20)).
 
-start_link(Name, Args, Envs, Timeout) when is_atom(Name) ->
-    do_start(Name, Args, Envs, Timeout, start_link).
+start_link(Name, Args, Envs, TimeoutOrWaitBoot) when is_atom(Name) ->
+    start_link(Name, Args, Envs, TimeoutOrWaitBoot, _Opts = #{}).
 
-do_start(Name0, Args, Envs, Timeout, Func) when is_atom(Name0) ->
+start_link(Name, Args, Envs, TimeoutOrWaitBoot, #{} = Opts) when is_atom(Name) ->
+    do_start(Name, Args, Envs, TimeoutOrWaitBoot, start_link, Opts).
+
+do_start(Name0, Args, Envs, TimeoutOrWaitBoot, Func, Opts0) when is_atom(Name0) ->
     {Name, Host} = parse_node_name(Name0),
-    {ok, Pid, Node} = peer:Func(#{
-        name => Name,
-        host => Host,
-        args => Args,
-        env => Envs,
-        wait_boot => Timeout,
-        longnames => true,
-        shutdown => {halt, 1000}
-    }),
+    Opts = maps:merge(
+        #{
+            name => Name,
+            host => Host,
+            args => Args,
+            env => Envs,
+            wait_boot => TimeoutOrWaitBoot,
+            longnames => true,
+            shutdown => {halt, 1_000}
+        },
+        Opts0
+    ),
+    {ok, Pid, Node} = peer:Func(Opts),
     true = register(Node, Pid),
     {ok, Node}.
 

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -74,6 +74,7 @@ t_copy_new_data_dir(Config) ->
         {[ok, ok, ok], []} = rpc:multicall(Nodes, application, stop, [emqx_conf]),
         {[ok, ok, ok], []} = rpc:multicall(Nodes, ?MODULE, set_data_dir_env, []),
         ok = rpc:call(First, application, start, [emqx_conf]),
+        ct:sleep(500),
         {[ok, ok], []} = rpc:multicall(Rest, application, start, [emqx_conf]),
         ?retry(200, 10, ok = assert_data_copy_done(Nodes, File))
     after

--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -243,7 +243,14 @@ cluster(TC, Specs, Config) ->
     ],
     emqx_cth_cluster:mk_nodespecs(
         [{Name, #{apps => Apps}} || Name <- Specs],
-        #{work_dir => emqx_cth_suite:work_dir(TC, Config)}
+        #{
+            work_dir => emqx_cth_suite:work_dir(TC, Config),
+            start_opts => #{
+                %% Call `init:stop' instead of `erlang:halt/0' for clean mnesia
+                %% shutdown and restart
+                shutdown => 5_000
+            }
+        }
     ).
 
 cluster_spec(Num) ->


### PR DESCRIPTION
Port of test-only changes from https://github.com/emqx/emqx/pull/14778


Some cluster test suites expect node restarts.  If we don't give enough time for applications (in particular, `mnesia`) to shutdown gracefully, tests may fail when restarting the node with errors such as:

```
=ERROR REPORT==== 26-Feb-2025::10:57:39.847612 ===
Mnesia('emqx_conf_app_SUITE1@127.0.0.1'): ** ERROR ** (ignoring core) ** FATAL ** Cannot load table emqx_activated_alarm from disc: {not_loaded,
                                                                                                                                     storage_unknown}
```

```
=ERROR REPORT==== 26-Feb-2025::09:17:12.062487 ===
Mnesia('emqx_conf_app_SUITE1@127.0.0.1'): ** ERROR ** (core dumped to file: "/__w/emqx/emqx/_build/test/logs/ct_run.test@127.0.0.1.2025-02-26_09.15.13/lib.emqx_conf.emqx_conf_app_SUITE.logs/run.2025-02-26_09.17.04/log_private/emqx_conf_app_SUITE_data/t_copy_conf_override_on_restarts/emqx_conf_app_SUITE1@127.0.0.1/MnesiaCore.emqx_conf_app_SUITE1@127.0.0.1_1740_561432_59380")
 ** FATAL ** Cannot load table emqx_exclusive_subscription_v2 from disc: {not_loaded,
                                                                          storage_unknown}
```

Also attempts to fix another flaky test in the same suite.

```
%%% emqx_conf_app_SUITE ==> t_copy_new_data_dir: FAILED
%%% emqx_conf_app_SUITE ==>
Failure/Error: ?assertEqual({ok,<<...>>}, file : read_file ( NodeDataDir ++ "/certs/fake-cert" ))
  expected: {ok,<<"/__w/emqx/emqx/_build/test/logs/ct_run.test@127.0.0.1.2025-03-12_14.06.41/lib.emqx_conf.emqx_conf_app_SUITE.logs/run.2025-03-12_14.08.34/log_private/emqx_conf_app_SUITE_data/t_copy_new_data_dir/emqx_conf_app_SUITE4@127.0.0.1">>}
       got: {error,enoent}
      line: 187
   comment: #{node => 'emqx_conf_app_SUITE6@127.0.0.1'}
```
