### PR TITLE
test(crl cache): attempt to fix flaky test

### DIFF
--- a/apps/emqx/src/emqx_ssl_crl_cache.erl
+++ b/apps/emqx/src/emqx_ssl_crl_cache.erl
@@ -65,6 +65,8 @@
 -include_lib("ssl/src/ssl_internal.hrl").
 -include_lib("public_key/include/public_key.hrl").
 
+-include_lib("snabbkaffe/include/trace.hrl").
+
 -include("logger.hrl").
 
 -behaviour(ssl_crl_cache_api).
@@ -177,7 +179,9 @@ do_insert(URI, CRLs) ->
     case uri_string:normalize(URI, [return_map]) of
         #{scheme := "http", path := _} ->
             Key = cache_key(URI),
-            ssl_manager:insert_crls(Key, CRLs);
+            Res = ssl_manager:insert_crls(Key, CRLs),
+            ?tp("emqx_ssl_crl_cache_inserted", #{key => Key}),
+            Res;
         _ ->
             {error, {only_http_distribution_points_supported, URI}}
     end.

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -348,7 +348,11 @@ start_emqx_with_crl_cache(#{is_cached := IsCached} = Opts, TC, Config) ->
     case IsCached of
         true ->
             %% wait the cache to be filled
-            emqx_crl_cache:refresh(?DEFAULT_URL),
+            {_, {ok, _}} =
+                ?wait_async_action(
+                    emqx_crl_cache:refresh(?DEFAULT_URL),
+                    #{?snk_kind := "emqx_ssl_crl_cache_inserted"}
+                ),
             ?assertReceive({http_get, <<?DEFAULT_URL>>});
         false ->
             %% ensure cache is empty


### PR DESCRIPTION
```
%%% emqx_crl_cache_SUITE ==> t_revoked: FAILED
%%% emqx_crl_cache_SUITE ==> {{case_clause,{error,connack_timeout}},
 [{emqx_crl_cache_SUITE,t_revoked,1,
                        [{file,"/__w/emqx/emqx/apps/emqx/test/emqx_crl_cache_SUITE.erl"},
                         {line,899}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```
