### PR TITLE
fix(mgmt_api_cluster): Send requests to node that is alive

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_cluster.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cluster.erl
@@ -42,8 +42,8 @@ start_link() ->
 
 -spec invite_async(atom()) -> ok | ignore | {error, {already_started, pid()}}.
 invite_async(Node) ->
-    %% Proxy the invitation task to the leader node
-    JoinTo = mria_membership:leader(),
+    %% Proxy the invitation task to the coordinator node
+    JoinTo = mria_membership:coordinator(),
     case Node =/= JoinTo of
         true ->
             gen_server:call({?MODULE, JoinTo}, {invite_async, Node, JoinTo}, infinity);
@@ -53,8 +53,8 @@ invite_async(Node) ->
 
 -spec invitation_status() -> map().
 invitation_status() ->
-    Leader = mria_membership:leader(),
-    gen_server:call({?MODULE, Leader}, invitation_status, infinity).
+    Coordinator = mria_membership:coordinator(),
+    gen_server:call({?MODULE, Coordinator}, invitation_status, infinity).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/changes/ce/fix-14863.en.md
+++ b/changes/ce/fix-14863.en.md
@@ -1,0 +1,2 @@
+Fix a problem with `cluster/:node/invite_async` REST API.
+Previously, this API could attempt using a down node as the coordinator.


### PR DESCRIPTION
Fixes [EMQX-14014](https://emqx.atlassian.net/browse/EMQX-14014)

Release version: v/e5.8

## Summary

"Async" cluster management API proxies requests through the leader. However, this is incorrect as mnesia leader may be down. This PR ensures that the node coordinating the join is alive. 


## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [x] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-14014]: https://emqx.atlassian.net/browse/EMQX-14014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ