### PR TITLE
test(mqtt v5 protocol): attempt to fix flaky test

### DIFF
--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -242,8 +242,8 @@ t_connect_clean_start_unresp_old_client(Config) ->
     %% THEN: the new client should connect successfully in time < connect_timeout
     {ok, _} = emqtt:ConnFun(Client2),
     ok = emqtt:disconnect(Client2),
-    waiting_client_process_exit(Client1),
-    waiting_client_process_exit(Client2),
+    ?assertReceive({'EXIT', Client1, _}),
+    ?assertReceive({'EXIT', Client2, _}),
     ok.
 
 close_quic_conn_silently(quic_connect, Client) ->

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -572,7 +572,9 @@ t_local(Config) when is_list(Config) ->
         <<"sticky_group">> => sticky
     },
 
-    Node = start_peer('local_shared_sub_local_1', 21999),
+    %% Use a different base port for each test case to avoid flakiness
+    BasePort = 21999,
+    Node = start_peer('local_shared_sub_local_1', BasePort),
     ok = ensure_group_config(GroupConfig),
     ok = ensure_group_config(Node, GroupConfig),
 
@@ -581,7 +583,7 @@ t_local(Config) when is_list(Config) ->
     ClientId2 = <<"ClientId2">>,
 
     {ok, ConnPid1} = emqtt:start_link([{clientid, ClientId1}]),
-    {ok, ConnPid2} = emqtt:start_link([{clientid, ClientId2}, {port, 21999}]),
+    {ok, ConnPid2} = emqtt:start_link([{clientid, ClientId2}, {port, get_tcp_mqtt_port(Node)}]),
 
     {ok, _} = emqtt:connect(ConnPid1),
     {ok, _} = emqtt:connect(ConnPid2),
@@ -625,7 +627,9 @@ t_remote(Config) when is_list(Config) ->
         <<"sticky_group">> => sticky
     },
 
-    Node = start_peer('remote_shared_sub_remote_1', 21999),
+    %% Use a different base port for each test case to avoid flakiness
+    BasePort = 22999,
+    Node = start_peer('remote_shared_sub_remote_1', BasePort),
     ok = ensure_group_config(GroupConfig),
     ok = ensure_group_config(Node, GroupConfig),
 
@@ -634,7 +638,9 @@ t_remote(Config) when is_list(Config) ->
     ClientIdRemote = <<"ClientId2">>,
 
     {ok, ConnPidLocal} = emqtt:start_link([{clientid, ClientIdLocal}]),
-    {ok, ConnPidRemote} = emqtt:start_link([{clientid, ClientIdRemote}, {port, 21999}]),
+    {ok, ConnPidRemote} = emqtt:start_link([
+        {clientid, ClientIdRemote}, {port, get_tcp_mqtt_port(Node)}
+    ]),
 
     try
         {ok, ClientPidLocal} = emqtt:connect(ConnPidLocal),
@@ -674,7 +680,9 @@ t_local_fallback(Config) when is_list(Config) ->
     Topic = <<"local_foo/bar">>,
     ClientId1 = <<"ClientId1">>,
     ClientId2 = <<"ClientId2">>,
-    Node = start_peer('local_fallback_shared_sub_1', 11888),
+    %% Use a different base port for each test case to avoid flakiness
+    BasePort = 11888,
+    Node = start_peer('local_fallback_shared_sub_1', BasePort),
 
     {ok, ConnPid1} = emqtt:start_link([{clientid, ClientId1}]),
     {ok, _} = emqtt:connect(ConnPid1),
@@ -702,12 +710,14 @@ t_stats(Config) when is_list(Config) ->
         <<"round_robin_group">> => round_robin,
         <<"sticky_group">> => sticky
     },
-    Node = start_peer('local_shared_sub_stats_1', 21999),
+    %% Use a different base port for each test case to avoid flakiness
+    BasePort = 23999,
+    Node = start_peer('local_shared_sub_stats_1', BasePort),
     ok = ensure_group_config(GroupConfig),
     ok = ensure_group_config(Node, GroupConfig),
     SharedTopic = format_share(<<"local_group">>, <<"local_foo/bar">>),
     ClientId1 = <<"ClientId1">>,
-    {ok, ConnPid1} = emqtt:start_link([{clientid, ClientId1}, {port, 21999}]),
+    {ok, ConnPid1} = emqtt:start_link([{clientid, ClientId1}, {port, get_tcp_mqtt_port(Node)}]),
     {ok, _} = emqtt:connect(ConnPid1),
     emqtt:subscribe(ConnPid1, {SharedTopic, 0}),
     ct:sleep(100),
@@ -1373,6 +1383,10 @@ setup_node(Node, Port) ->
     Node = emqx_rpc:call(Node, erlang, node, []),
     rpc:call(Node, mria, join, [node()]),
     ok.
+
+get_tcp_mqtt_port(Node) ->
+    {_Host, Port} = erpc:call(Node, emqx_config, get, [[listeners, tcp, default, bind]]),
+    Port.
 
 pair_gen_rpc(Node, LocalPort, RemotePort) ->
     _ = rpc:call(Node, application, load, [gen_rpc]),


### PR DESCRIPTION
```
Testing lib.emqx.emqx_mqtt_protocol_v5_SUITE: *** FAILED test case 63 of 85 ***
%%% emqx_mqtt_protocol_v5_SUITE ==> quic.t_connect_clean_start_unresp_old_client: FAILED
%%% emqx_mqtt_protocol_v5_SUITE ==> {{got_another_message,{'EXIT',<0.140232.0>,normal}},
 [{emqx_mqtt_protocol_v5_SUITE,waiting_client_process_exit,1,
                               [{file,"/__w/emqx/emqx/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl"},
                                {line,143}]},
  {emqx_mqtt_protocol_v5_SUITE,t_connect_clean_start_unresp_old_client,1,
                               [{file,"/__w/emqx/emqx/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl"},
                                {line,245}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1793}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1302}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1234}]}]}
```

Also attempts another fix for shared sub suite, as https://github.com/emqx/emqx/pull/14862 was not enough to fix the flakiness.