### PR TITLE
refactor: delete deprecated ldap config schema

### DIFF
--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
@@ -70,18 +70,6 @@ authenticate(Credential, #{method := #{type := Type}} = State) ->
             emqx_authn_ldap_bind:authenticate(Credential, State)
     end.
 
-%% it used the deprecated config form
-parse_config(
-    #{password_attribute := PasswordAttr, is_superuser_attribute := IsSuperuserAttr} = Config0
-) ->
-    Config = maps:without([password_attribute, is_superuser_attribute], Config0),
-    parse_config(Config#{
-        method => #{
-            type => hash,
-            password_attribute => PasswordAttr,
-            is_superuser_attribute => IsSuperuserAttr
-        }
-    });
 parse_config(
     #{base_dn := BaseDN, filter := Filter, query_timeout := QueryTimeout, method := Method}
 ) ->

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap_schema.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap_schema.erl
@@ -32,7 +32,7 @@
 namespace() -> "authn".
 
 refs() ->
-    [?R_REF(ldap), ?R_REF(ldap_deprecated)].
+    [?R_REF(ldap)].
 
 select_union_member(#{<<"mechanism">> := ?AUTHN_MECHANISM_BIN, <<"backend">> := ?AUTHN_BACKEND_BIN}) ->
     refs();
@@ -44,12 +44,6 @@ select_union_member(#{<<"backend">> := ?AUTHN_BACKEND_BIN}) ->
 select_union_member(_) ->
     undefined.
 
-fields(ldap_deprecated) ->
-    common_fields() ++
-        [
-            {password_attribute, password_attribute()},
-            {is_superuser_attribute, is_superuser_attribute()}
-        ];
 fields(ldap) ->
     common_fields() ++
         [
@@ -79,8 +73,6 @@ common_fields() ->
 
 desc(ldap) ->
     ?DESC(ldap);
-desc(ldap_deprecated) ->
-    ?DESC(ldap_deprecated);
 desc(hash_method) ->
     ?DESC(hash_method);
 desc(bind_method) ->

--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
@@ -71,29 +71,6 @@ end_per_suite(Config) ->
 %% Tests
 %%------------------------------------------------------------------------------
 
-t_create_with_deprecated_cfg(_Config) ->
-    AuthConfig = deprecated_raw_ldap_auth_config(),
-
-    {ok, _} = emqx:update_config(
-        ?PATH,
-        {create_authenticator, ?GLOBAL, AuthConfig}
-    ),
-
-    {ok, [#{provider := emqx_authn_ldap, state := State}]} = emqx_authn_chains:list_authenticators(
-        ?GLOBAL
-    ),
-    ?assertMatch(
-        #{
-            method := #{
-                type := hash,
-                is_superuser_attribute := _,
-                password_attribute := "not_the_default_value"
-            }
-        },
-        State
-    ),
-    emqx_authn_test_lib:delete_config(?ResourceID).
-
 t_create(_Config) ->
     AuthConfig = raw_ldap_auth_config(),
 
@@ -367,19 +344,6 @@ raw_ldap_auth_config() ->
         <<"mechanism">> => <<"password_based">>,
         <<"backend">> => <<"ldap">>,
         <<"server">> => ldap_server(),
-        <<"base_dn">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
-        <<"username">> => <<"cn=root,dc=emqx,dc=io">>,
-        <<"password">> => <<"public">>,
-        <<"pool_size">> => 8
-    }.
-
-deprecated_raw_ldap_auth_config() ->
-    #{
-        <<"mechanism">> => <<"password_based">>,
-        <<"backend">> => <<"ldap">>,
-        <<"server">> => ldap_server(),
-        <<"is_superuser_attribute">> => <<"isSuperuser">>,
-        <<"password_attribute">> => <<"not_the_default_value">>,
         <<"base_dn">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
         <<"username">> => <<"cn=root,dc=emqx,dc=io">>,
         <<"password">> => <<"public">>,

--- a/changes/ee/breaking-14865.en.md
+++ b/changes/ee/breaking-14865.en.md
@@ -1,0 +1,9 @@
+Dropped old LDAP authentication config layout (deprecated since v5.4).
+Move `password_attribute` and `is_superuser_attribute` under the `method` block:
+  ```hcl
+  method {
+    type = hash
+    password_attribute = "userPassword"
+    is_superuser_attribute = "isSuperuser"
+  }
+  ```

--- a/rel/i18n/emqx_authn_ldap_schema.hocon
+++ b/rel/i18n/emqx_authn_ldap_schema.hocon
@@ -3,9 +3,6 @@ emqx_authn_ldap_schema {
 ldap.desc:
 """Configuration of authenticator using LDAP as authentication data source."""
 
-ldap_deprecated.desc:
-"""This is a deprecated form, and you should avoid using it."""
-
 password_attribute.desc:
 """Indicates which attribute is used to represent the user's password."""
 


### PR DESCRIPTION
The `ldap_deprecated` was added in 5.4.0. Now it's deleted.