### PR TITLE
fix(resource manager): correctly handle channel updates

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -68,6 +68,7 @@
     disable_enable/3,
     disable_enable/4,
     health_check/2,
+    health_check/3,
     send_message/4,
     query/4,
     start/2,

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -387,7 +387,16 @@ kafka_bridge_rest_api_helper(Config) ->
         ?assertEqual(1, emqx_resource_metrics:success_get(BridgeV2Id)),
         ?assertEqual(3, emqx_metrics_worker:get(rule_metrics, RuleId, 'actions.success'))
     after
-        delete_all_bridges()
+        delete_all_bridges(),
+        %% also wait for the dry-runs to terminate
+        ?retry(
+            _Sleep = 50,
+            _Attempts = 10,
+            begin
+                ?assertEqual([], supervisor:which_children(wolff_client_sup)),
+                ?assertEqual([], supervisor:which_children(wolff_producers_sup))
+            end
+        )
     end,
     ok.
 

--- a/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
+++ b/apps/emqx_bridge_sqlserver/src/emqx_bridge_sqlserver_connector.erl
@@ -19,6 +19,8 @@
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 
+-elvis([{elvis_text_style, line_length, #{skip_comments => whole_line}}]).
+
 %%====================================================================
 %% Exports
 %%====================================================================
@@ -501,6 +503,9 @@ do_query(ResourceId, Query, ApplyMode, State) ->
         end,
     handle_result(Result, ResourceId, Query).
 
+handle_result({error, {recoverable_error, _} = Reason} = Result, _ResourceId, _Query) ->
+    ?tp(sqlserver_connector_query_return, #{error => Reason}),
+    Result;
 handle_result({error, Reason}, ResourceId, Query) ->
     ?tp(sqlserver_connector_query_return, #{error => Reason}),
     ?SLOG(error, #{
@@ -526,13 +531,32 @@ worker_do_insert(Conn, SQL, #{resource_opts := ResourceOpts, pool_name := Resour
             {updated, _} ->
                 ok;
             {error, ErrStr} ->
-                ?SLOG(error, LogMeta#{msg => "invalid_request", reason => ErrStr}),
-                {error, {unrecoverable_error, {invalid_request, ErrStr}}}
+                {LogLevel, Err} =
+                    case is_connection_closed_error(ErrStr) of
+                        true ->
+                            {info, {recoverable_error, <<"connection_closed">>}};
+                        false ->
+                            {error, {unrecoverable_error, {invalid_request, ErrStr}}}
+                    end,
+                ?SLOG(LogLevel, LogMeta#{msg => "invalid_request", reason => ErrStr}),
+                {error, Err}
         end
     catch
         _Type:Reason:St ->
             ?SLOG(error, LogMeta#{msg => "invalid_request", reason => Reason, stacktrace => St}),
             {error, {unrecoverable_error, {invalid_request, Reason}}}
+    end.
+
+%% Potential race condition: if an insert request is made while the connection is being
+%% cut by the remote server, this error might be returned.
+%% References:
+%% https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-17194-database-engine-error?view=sql-server-ver16
+is_connection_closed_error(MsgStr) ->
+    case re:run(MsgStr, <<"0x2746[^0-9a-fA-F]?">>, [{capture, none}]) of
+        match ->
+            true;
+        nomatch ->
+            false
     end.
 
 -spec execute(connection_reference(), sql()) ->

--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -472,9 +472,11 @@ t_named_instance_mismatch(Config) ->
 %%------------------------------------------------------------------------------
 
 common_init(ConfigT) ->
+    ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
+    ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
     Host = os:getenv("SQLSERVER_HOST", "toxiproxy"),
     Port = list_to_integer(os:getenv("SQLSERVER_PORT", str(?SQLSERVER_DEFAULT_PORT))),
-
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
     Config0 = [
         {sqlserver_host, Host},
         {sqlserver_port, Port},
@@ -483,14 +485,9 @@ common_init(ConfigT) ->
         {batch_size, batch_size(ConfigT)}
         | ConfigT
     ],
-
     BridgeType = proplists:get_value(bridge_type, Config0, <<"sqlserver">>),
     case emqx_common_test_helpers:is_tcp_server_available(Host, Port) of
         true ->
-            % Setup toxiproxy
-            ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
-            ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
-            emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
             Apps = emqx_cth_suite:start(
                 [
                     emqx_conf,

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -2251,10 +2251,10 @@ collect_and_handle_channel_operations_connected(Op, Data0) ->
         fun
             (#add_channel{channel_id = ChannelId, config = Config}, {AccActions, AccData}) ->
                 {Actions, Data} = handle_add_channel(From, AccData, ChannelId, Config),
-                {Actions ++ AccActions, Data};
+                {AccActions ++ Actions, Data};
             (#remove_channel{channel_id = ChannelId}, {AccActions, AccData}) ->
                 {Actions, Data} = handle_remove_channel(From, ChannelId, AccData),
-                {Actions ++ AccActions, Data}
+                {AccActions ++ Actions, Data}
         end,
         {[], Data0},
         Ops
@@ -2268,10 +2268,10 @@ collect_and_handle_channel_operations_not_connected(Op, State, Data0) ->
             (#add_channel{channel_id = ChannelId, config = Config}, {AccActions, AccData}) ->
                 {Actions, Data} =
                     handle_add_channel_not_connected(From, ChannelId, Config, State, AccData),
-                {Actions ++ AccActions, Data};
+                {AccActions ++ Actions, Data};
             (#remove_channel{channel_id = ChannelId}, {AccActions, AccData}) ->
                 {Actions, Data} = handle_remove_channel(From, ChannelId, AccData),
-                {Actions ++ AccActions, Data}
+                {AccActions ++ Actions, Data}
         end,
         {[], Data0},
         Ops

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -172,8 +172,10 @@
 
 -type generic_timeout_cancel(Id) :: {{timeout, Id}, cancel}.
 
-%% calls/casts/generic timeouts
--record(add_channel, {channel_id :: channel_id(), config :: map()}).
+-type channel_config() :: map().
+
+%% calls/casts/generic timeouts/internal events
+-record(add_channel, {channel_id :: channel_id(), config :: channel_config()}).
 -record(remove_channel, {channel_id :: channel_id()}).
 -record(start_channel_health_check, {channel_id :: channel_id()}).
 -record(retry_add_channel, {channel_id :: channel_id()}).
@@ -758,11 +760,6 @@ handle_event(internal, start_resource, ?state_connecting, Data) ->
 handle_event(state_timeout, health_check, ?state_connecting, Data) ->
     start_resource_health_check(Data);
 handle_event(
-    {call, From}, #remove_channel{channel_id = ChannelId}, ?state_connecting = _State, Data0
-) ->
-    {Actions, Data} = handle_remove_channel(From, ChannelId, Data0),
-    {keep_state, Data, Actions};
-handle_event(
     cast, #remove_channel{channel_id = _ChannelId} = Op, ?state_connecting = State, Data0
 ) ->
     {Actions, Data} = collect_and_handle_channel_operations_not_connected(Op, State, Data0),
@@ -794,11 +791,6 @@ handle_event(
     Data0
 ) ->
     {Actions, Data} = collect_and_handle_channel_operations_connected(Op, Data0),
-    {keep_state, Data, Actions};
-handle_event(
-    {call, From}, #remove_channel{channel_id = ChannelId}, ?state_connected = _State, Data0
-) ->
-    {Actions, Data} = handle_remove_channel(From, ChannelId, Data0),
     {keep_state, Data, Actions};
 handle_event(
     cast, #remove_channel{channel_id = _ChannelId} = Op, ?state_connected = _State, Data0

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -3924,12 +3924,12 @@ t_retry_remove_channel(_Config) ->
             ChanId = <<"action:atype:aname:", ConnResId/binary>>,
             ct:pal("testing async retries"),
             ok =
-                emqx_resource_manager:add_channel(
+                add_channel(
                     ConnResId,
                     ChanId,
                     #{health_check_delay => 500}
                 ),
-            ok = emqx_resource_manager:remove_channel_async(ConnResId, ChanId),
+            ok = remove_channel_async(ConnResId, ChanId),
             RetryTimeout = 2_000,
             Timeout = RetryTimeout + 1_000,
             %% Should then retry asynchronously
@@ -3939,7 +3939,7 @@ t_retry_remove_channel(_Config) ->
                     Alias1 ! {Alias1, {error, oops_again}}
             after Timeout -> ct:fail("didn't retry removing channel async")
             end,
-            ?assertMatch({ok, [_]}, emqx_resource_manager:get_channels(ConnResId)),
+            ?assertMatch(#{ChanId := _}, emqx_resource_manager:get_channel_configs(ConnResId)),
             %% Now should try again, and we'll let it succeed.
             receive
                 {waiting_remove_channel_result, Alias2, ConnResId, ChanId} ->
@@ -3947,7 +3947,7 @@ t_retry_remove_channel(_Config) ->
                     Alias2 ! {Alias2, continue}
             after Timeout -> ct:fail("didn't retry removing channel async 2")
             end,
-            ?assertMatch({ok, []}, emqx_resource_manager:get_channels(ConnResId)),
+            ?assertEqual(#{}, emqx_resource_manager:get_channel_configs(ConnResId)),
             %% Now, let's see that adding the channel again while it's retrying to remove should
             %% cancel such timer.
             ct:pal("mailbox:\n  ~p", [?drainMailbox()]),
@@ -3958,33 +3958,233 @@ t_retry_remove_channel(_Config) ->
             ct:pal("adding channel"),
             {ok, {ok, _}} =
                 ?wait_async_action(
-                    emqx_resource_manager:add_channel(
+                    add_channel(
                         ConnResId,
                         ChanId,
                         #{health_check_delay => 500}
                     ),
                     #{?snk_kind := added_channel}
                 ),
-            ?assertMatch({ok, [_]}, emqx_resource_manager:get_channels(ConnResId)),
+            ?assertMatch(#{ChanId := _}, emqx_resource_manager:get_channel_configs(ConnResId)),
             ct:pal("removing channel async"),
-            ok = emqx_resource_manager:remove_channel_async(ConnResId, ChanId),
+            ok = remove_channel_async(ConnResId, ChanId),
             ct:pal("waiting for attempt"),
             ?assertReceive({attempted_to_remove_channel, ConnResId, ChanId}, Timeout),
-            ?assertMatch({ok, [_]}, emqx_resource_manager:get_channels(ConnResId)),
+            ?assertMatch(#{ChanId := _}, emqx_resource_manager:get_channel_configs(ConnResId)),
             %% Now add again while the timer is going on.
             ct:pal("adding channel again"),
             ok =
-                emqx_resource_manager:add_channel(
+                add_channel(
                     ConnResId,
                     ChanId,
                     #{health_check_delay => 500}
                 ),
             %% Should stop trying to remove
             ?assertNotReceive({attempted_to_remove_channel, ConnResId, ChanId}, Timeout),
-            ?assertMatch({ok, [_]}, emqx_resource_manager:get_channels(ConnResId)),
+            ?assertMatch(#{ChanId := _}, emqx_resource_manager:get_channel_configs(ConnResId)),
             ok
         end,
         []
+    ),
+    ok.
+
+%% Checks that, if a channel is already installed, and we receive a remove and an add
+%% request (as happens in an config update operation), we do update the channel by
+%% removing and re-adding it with the new config to the resource state.
+t_compress_channel_operations_existing_channel() ->
+    [{matrix, true}].
+t_compress_channel_operations_existing_channel(matrix) ->
+    [[connected], [connecting], [disconnected]];
+t_compress_channel_operations_existing_channel(Config) when is_list(Config) ->
+    [ConnectorStatus] = group_path(Config, [connected]),
+    TestPid = self(),
+    ?check_trace(
+        begin
+            ConnResId = <<"connector:ctype:c">>,
+            {ok, ChanAgent} = emqx_utils_agent:start_link(#{
+                add_channel => [
+                    continue,
+                    {notify, TestPid, continue}
+                ],
+                remove_channel => [
+                    {notify, TestPid, {error, oops}},
+                    {notify, TestPid, continue}
+                ]
+            }),
+            AgentState0 = #{
+                resource_health_check => connected,
+                channel_health_check => connected
+            },
+            {ok, HCAgent} = emqx_utils_agent:start_link(AgentState0),
+            ?tpal("creating connector resource"),
+            {ok, _} =
+                create(
+                    ConnResId,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{
+                        name => test_resource,
+                        remove_channel_agent => ChanAgent,
+                        add_channel_agent => ChanAgent,
+                        health_check_agent => HCAgent
+                    },
+                    #{
+                        health_check_interval => 100,
+                        start_timeout => 100
+                    }
+                ),
+            ?assertMatch({ok, connected}, emqx_resource:health_check(ConnResId)),
+
+            ChanId = action_res_id(ConnResId),
+
+            ?tpal("creating channel"),
+            HCInterval1 = 500,
+            ChanConfig1 = #{
+                enable => true,
+                resource_opts => #{health_check_interval => HCInterval1}
+            },
+            ok = add_channel(ConnResId, ChanId, ChanConfig1),
+            ?assertMatch(
+                #{status := connected, error := undefined},
+                emqx_resource:channel_health_check(ConnResId, ChanId)
+            ),
+            ?assertEqual(
+                #{ChanId => ChanConfig1},
+                emqx_resource_manager:get_channel_configs(ConnResId)
+            ),
+            ?assertEqual(
+                {ok, [{ChanId, ChanConfig1}]},
+                emqx_resource_manager:get_channels(ConnResId)
+            ),
+
+            %% Set desired connector resource status
+            ?tpal("changing connector status"),
+            _ = emqx_utils_agent:get_and_update(HCAgent, fun(Old) ->
+                {unused, Old#{resource_health_check := ConnectorStatus}}
+            end),
+            ?retry(
+                100, 10, ?assertMatch({ok, ConnectorStatus}, emqx_resource:health_check(ConnResId))
+            ),
+
+            %% We suspend the process so operations are stacked on its mailbox.
+            ?tpal("suspending resource manager process"),
+            Pid = emqx_resource_manager:where(ConnResId),
+            ok = sys:suspend(Pid),
+
+            %% We mock the module so we may count the calls to add/remove channel
+            %% callbacks.
+            on_exit(fun() -> meck:unload() end),
+            ok = meck:new(?TEST_RESOURCE, [passthrough]),
+
+            %% Stack config update ops in its mailbox
+            ?tpal("sending async channel operations"),
+            ok = remove_channel_async(ConnResId, ChanId),
+            HCInterval2 = HCInterval1 + 200,
+            ChanConfig2 = emqx_utils_maps:deep_put(
+                [resource_opts, health_check_interval],
+                ChanConfig1,
+                HCInterval2
+            ),
+            ok = add_channel_async(ConnResId, ChanId, ChanConfig2),
+
+            %% Restore connected status to connector so that it may actually modify
+            %% internal state, if not updated yet.
+            _ = emqx_utils_agent:get_and_update(HCAgent, fun(Old) ->
+                {unused, Old#{resource_health_check := connected}}
+            end),
+            %% Resume and make a call so that messages are processed
+            ?tpal("changing status and resuming resource manager process"),
+            ok = sys:resume(Pid),
+            ?retry(
+                100,
+                10,
+                ?assertMatch(
+                    {ok, connected},
+                    emqx_resource:health_check(ConnResId)
+                )
+            ),
+
+            %% Related to retry operation interval
+            ?tpal("waiting for channel removal attempts"),
+            Timeout = 3_000,
+            %% Should have tried at least once to remove...
+            ?assertReceive({attempted_to_remove_channel, ConnResId, ChanId}, Timeout),
+            %% ... and later succeeded (only retries if resource doesn't to disconnected,
+            %% in which case it'll attempt to remove only once)
+            case ConnectorStatus of
+                disconnected ->
+                    ok;
+                _ ->
+                    ?assertReceive({attempted_to_remove_channel, ConnResId, ChanId}, Timeout)
+            end,
+            ?assertReceive({attempted_to_add_channel, ConnResId, ChanId, ChanConfig2}, Timeout),
+
+            %% We must eventually observe the new configuration in the channel.
+            ?tpal("checking channels configs"),
+            ?retry(
+                200,
+                10,
+                ?assertEqual(
+                    #{ChanId => ChanConfig2},
+                    emqx_resource_manager:get_channel_configs(ConnResId)
+                )
+            ),
+            ?retry(
+                200,
+                10,
+                ?assertEqual(
+                    {ok, [{ChanId, ChanConfig2}]},
+                    emqx_resource_manager:get_channels(ConnResId)
+                )
+            ),
+
+            ChanConfig2
+        end,
+        [
+            log_consistency_prop(),
+            fun(FinalConfig, _Trace) ->
+                History = meck:history(?TEST_RESOURCE),
+                Calls = [
+                    {Fn, Args, Res}
+                 || {_Pid, {?TEST_RESOURCE, Fn, Args}, Res} <- History,
+                    lists:member(Fn, [on_add_channel, on_remove_channel])
+                ],
+                case ConnectorStatus of
+                    disconnected ->
+                        %% Depending on whether the channel operations are performed while
+                        %% still disconnected or when the resource reconnects, we may not
+                        %% see the first removal (for the latter case).
+                        case Calls of
+                            [
+                                {on_remove_channel, _, {error, _}},
+                                {on_add_channel, [_ConnResId, _ConnState, _ChanId, FinalConfig], _}
+                            ] ->
+                                ok;
+                            [
+                                {on_remove_channel, _, {error, _}},
+                                %% Retry
+                                {on_remove_channel, _, {ok, _}},
+                                {on_add_channel, [_ConnResId, _ConnState, _ChanId, FinalConfig], _}
+                            ] ->
+                                ok;
+                            _ ->
+                                error({"unexpected (disconnected) history", Calls})
+                        end;
+                    _ ->
+                        ?assertMatch(
+                            [
+                                {on_remove_channel, _, {error, _}},
+                                %% Retry
+                                {on_remove_channel, _, {ok, _}},
+                                {on_add_channel, [_ConnResId, _ConnState, _ChanId, ChanConfig], _}
+                            ] when ChanConfig == FinalConfig,
+                            Calls,
+                            #{final_config => FinalConfig}
+                        )
+                end,
+                ok
+            end
+        ]
     ),
     ok.
 
@@ -3994,7 +4194,8 @@ t_retry_remove_channel(_Config) ->
 
 %% Verifies that we compress operations for a given channel id that may happen to stack up
 %% while the resource manager process is stuck on a call.
-t_compress_channel_operations(_Config) ->
+t_prop_compress_channel_operations(_Config) ->
+    ct:timetrap({seconds, 60}),
     ?assert(
         proper:quickcheck(prop_compress_channel_operations(), [{numtests, 100}, {to_file, user}])
     ),
@@ -4038,30 +4239,29 @@ prop_compress_channel_operations() ->
             ),
             %% Resume and let it process everything.
             ok = sys:resume(Pid),
-            %% To force processing of the mailbox, and trigger channel ops.
-            ?assertMatch({ok, ConnStatus}, emqx_resource:health_check(ConnResId)),
-            Channels = emqx_resource_manager:get_channel_configs(ConnResId),
-            {ok, InStateChannelsList} = emqx_resource_manager:get_channels(ConnResId),
-            InStateChannels = maps:from_list(InStateChannelsList),
+            %% To force processing of the mailbox, and trigger channel ops.  Must go to
+            %% `?status_connected` to actually process state changing operations.
+            _ = emqx_utils_agent:get_and_update(Agent, fun(Old) ->
+                {unused, Old#{resource_health_check := connected}}
+            end),
+            ?retry(100, 10, ?assertMatch({ok, connected}, emqx_resource:health_check(ConnResId))),
+            {ok, InConfigChannelsList} = emqx_resource_manager:get_channels(ConnResId),
+            InConfigChannels = maps:from_list(InConfigChannelsList),
+            InStateChannels = emqx_resource_manager:get_channel_configs(ConnResId),
             {ok, _Group, ResData} = emqx_resource_manager:lookup_cached(ConnResId),
             History = meck:history(?TEST_RESOURCE),
             ok = meck:unload(?TEST_RESOURCE),
             ok = emqx_resource:remove_local(ConnResId),
+            emqx_connector_demo:clear_emulated_config(ConnResId),
             ExpectedOps = process_commands_expectation(Commands),
             ExpectedChannels = maps:filter(fun(_, V) -> V /= del end, ExpectedOps),
             %% Even if not added yet to the resource state, the known channel configs must
             %% be the latest received additions, or the channel should be absent from
             %% installed channels.
-            HasExpectedConfigs = ExpectedChannels =:= Channels,
+            HasExpectedConfigs = ExpectedChannels =:= InConfigChannels,
             %% If the resource status is connected, then the channel must also be in the
             %% connector resource state.
-            IsInExpectedResState =
-                case ConnStatus of
-                    ?status_connected ->
-                        ExpectedChannels =:= InStateChannels;
-                    _ ->
-                        true
-                end,
+            IsInExpectedResState = ExpectedChannels =:= InStateChannels,
             %% We compress the operations so that operations that cancel out are not
             %% executed needlessly.  We can only know which calls were made from the
             %% callback module in the connected status.
@@ -4085,7 +4285,7 @@ prop_compress_channel_operations() ->
                     "Connector status:\n  ~s\n\n"
                     "Commands:\n  ~p\n\n"
                     "Expected Channels:\n  ~p\n\n"
-                    "Channels:\n  ~p\n\n"
+                    "Channels in config:\n  ~p\n\n"
                     "Channels in state:\n  ~p\n\n"
                     "Expected op count:\n  ~p\n\n"
                     "Actual op count:\n  ~p\n\n"
@@ -4095,7 +4295,7 @@ prop_compress_channel_operations() ->
                         ConnStatus,
                         Commands,
                         ExpectedChannels,
-                        Channels,
+                        InConfigChannels,
                         InStateChannels,
                         ExpectedOpCount,
                         ActualOpCount,
@@ -4135,10 +4335,10 @@ channel_num_to_id(N) ->
 
 exec_channel_operation({N, {add, ChannelConf}}, ConnResId) ->
     ChannelId = channel_num_to_id(N),
-    ok = emqx_resource_manager:add_channel_async(ConnResId, ChannelId, ChannelConf);
+    ok = add_channel_async(ConnResId, ChannelId, ChannelConf);
 exec_channel_operation({N, del}, ConnResId) ->
     ChannelId = channel_num_to_id(N),
-    ok = emqx_resource_manager:remove_channel_async(ConnResId, ChannelId).
+    ok = remove_channel_async(ConnResId, ChannelId).
 
 channel_op_gen() ->
     frequency([{2, add_channel_gen()}, {1, del}]).
@@ -4414,7 +4614,19 @@ create(Id, Group, Type, Config) ->
 create(Id, Group, Type, Config, Opts) ->
     Res = emqx_resource:create_local(Id, Group, Type, Config, Opts),
     on_exit(fun() -> emqx_resource:remove_local(Id) end),
+    case Type of
+        ?TEST_RESOURCE ->
+            on_exit(fun() -> emqx_connector_demo:clear_emulated_config(Id) end);
+        _ ->
+            ok
+    end,
     Res.
+
+add_channel_emualte_config(ConnResId, ChanId, ChanConfig, Mode) ->
+    emqx_connector_demo:add_channel_emualte_config(ConnResId, ChanId, ChanConfig, Mode).
+
+remove_channel_emualte_config(ConnResId, ChanId, Mode) ->
+    emqx_connector_demo:remove_channel_emualte_config(ConnResId, ChanId, Mode).
 
 dryrun(Id, Type, Config) ->
     TestPid = self(),
@@ -4439,12 +4651,27 @@ action_res_id(ConnResId) ->
     <<"action:atype:aname:", ConnResId/binary>>.
 
 add_channel(ConnResId, ChanId, Config) ->
+    do_add_channel(ConnResId, ChanId, Config, sync).
+
+add_channel_async(ConnResId, ChanId, Config) ->
+    do_add_channel(ConnResId, ChanId, Config, async).
+
+do_add_channel(ConnResId, ChanId, Config, Mode) ->
     ok = emqx_resource:create_metrics(ChanId),
     on_exit(fun() -> emqx_resource:clear_metrics(ChanId) end),
     ResourceOpts = emqx_resource:fetch_creation_opts(Config),
     on_exit(fun() -> emqx_resource_buffer_worker_sup:stop_workers(ChanId, ResourceOpts) end),
     ok = emqx_resource_buffer_worker_sup:start_workers(ChanId, ResourceOpts),
-    emqx_resource_manager:add_channel(ConnResId, ChanId, Config).
+    emqx_connector_demo:add_channel_emulate_config(ConnResId, ChanId, Config, Mode).
+
+remove_channel(ConnResId, ChanId) ->
+    do_remove_channel(ConnResId, ChanId, sync).
+
+remove_channel_async(ConnResId, ChanId) ->
+    do_remove_channel(ConnResId, ChanId, async).
+
+do_remove_channel(ConnResId, ChanId, Mode) ->
+    emqx_connector_demo:remove_channel_emulate_config(ConnResId, ChanId, Mode).
 
 group_path(Config, Default) ->
     case emqx_common_test_helpers:group_path(Config) of

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -4409,7 +4409,7 @@ gauge_metric_set_fns() ->
     ].
 
 create(Id, Group, Type, Config) ->
-    emqx_resource:create_local(Id, Group, Type, Config, #{}).
+    create(Id, Group, Type, Config, #{}).
 
 create(Id, Group, Type, Config, Opts) ->
     Res = emqx_resource:create_local(Id, Group, Type, Config, Opts),

--- a/scripts/install-msodbc-driver.sh
+++ b/scripts/install-msodbc-driver.sh
@@ -3,14 +3,14 @@
 # Install the MS SQL Server ODBC driver on a Debian-based system.
 # https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server
 
-set -euo pipefail
+set -xeuo pipefail
 
 if [ ! -f /etc/debian_version ]; then
   echo "This script is only intended for Debian-based systems"
   exit 1
 fi
 
-apt-get -qq update && apt-get install -yqq curl gpg
+apt-get -qq update && env DEBIAN_FRONTEND=noninteractive apt-get install -yqq curl gpg
 
 # shellcheck disable=SC1091
 . /etc/os-release
@@ -18,11 +18,11 @@ apt-get -qq update && apt-get install -yqq curl gpg
 # ubuntu
 curl -fsSL https://packages.microsoft.com/keys/microsoft.asc > /etc/apt/trusted.gpg.d/microsoft.asc
 # debian
-curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --batch --yes --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
 curl -fsSL "https://packages.microsoft.com/config/${ID}/${VERSION_ID}/prod.list" > /etc/apt/sources.list.d/mssql-release.list
 
 apt-get -qq update
-ACCEPT_EULA=Y apt-get install -yqq msodbcsql18 unixodbc-dev
+env DEBIAN_FRONTEND=noninteractive ACCEPT_EULA=Y apt-get install -yqq msodbcsql18 unixodbc-dev
 ## and not needed to modify /etc/odbcinst.ini
 ## docker-compose will mount one in .ci/docker-compose-file/odbc
 sed -i 's/ODBC Driver 18 for SQL Server/ms-sql/g' /etc/odbcinst.ini

--- a/scripts/install-snowflake-driver.sh
+++ b/scripts/install-snowflake-driver.sh
@@ -33,7 +33,7 @@ fi
 if [[ -f "${FILE}" && $(echo "$SHA256 *$FILE" | sha256sum -c) ]]; then
     echo "Snowflake ODBC driver package is already downloaded"
 else
-    apt-get -qq update && apt-get install -yqq curl
+    apt-get -qq update && env DEBIAN_FRONTEND=noninteractive apt-get install -yqq curl
     curl -fsSL -O --retry 5 "$URL"
     echo "$SHA256 *$FILE" | sha256sum -c
 fi


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14016

Release version: v/e5.9.0

## Summary


Now that we perform channel changes (add/remove) asynchronously during config updates,
there’s a chance that we may not reset the metrics when updating an action/source.

An example caught in CI:

https://github.com/emqx/emqx/actions/runs/13839069149/job/38722213036?pr=14860#step:4:680

```
%%% emqx_bridge_v2_kafka_producer_SUITE ==> t_overflow_rule_metrics: FAILED
%%% emqx_bridge_v2_kafka_producer_SUITE ==> 
Failure/Error: ?assertMatch(# { counters := # { dropped := 1 , 'dropped.queue_full' := 1 , 'dropped.expired' := 0 , 'dropped.other' := 0 , matched := 1 , success := 0 , failed := 0 , late_reply := 0 , retried := 0 } }, emqx_bridge_v2 : get_metrics ( Type , ActionName ))
  expected: = # { counters := # { dropped := 1 , 'dropped.queue_full' := 1 , 'dropped.expired' := 0 , 'dropped.other' := 0 , matched := 1 , success := 0 , failed := 0 , late_reply := 0 , retried := 0 } }
       got: #{counters =>
                  #{dropped => 2,success => 0,matched => 2,failed => 0,
                    received => 0,retried => 0,'retried.success' => 0,
                    'retried.failed' => 0,late_reply => 0,
                    'dropped.expired' => 0,'dropped.queue_full' => 2,
                    'dropped.resource_not_found' => 0,
                    'dropped.resource_stopped' => 0,'dropped.other' => 0},
              rate => #{matched => #{max => 2.0,current => 2.0,last5m => 2.0}},
              gauges => #{queuing => 0,queuing_bytes => 0},
              slides => #{},hists => #{}}
      line: 1687
```

Possible timeline:

1) `emqx_resource_manager:remove_channel_async` is called.  We don’t drop the metrics at
   this point; that’s done by the resource manager when it actually removes the channel.
2) In an update, `emqx_bridge_v2:install_bridge_v2` is called just after that, and it
   immediately creates the metrics outside the resource manager request.
3) This “create metrics” will preserve the old counters, and if the removal request is
   compressed together with the add request internally by the resource manager, it may not
   drop the metrics (which would also lead to problems…)

The causes were actually bad handling of updated channel configurations:

* When a connector resource goes `disconnected` and back to `connected`, it completely
  wipes the resource state, while we considered the channel to be installed in resource
  manager, which led to inconsistencies.
* If: a channel was already added and a new `#add_channel{}` request arrived later (or if
  a remove/add pair was present but remove failed), it wouldn't update the channel.


## PR Checklist

- [x] Added tests for the changes
- [na] ~~Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~ this async config change change is unreleased.
- [x] For internal contributor: there is a jira ticket to track this change
