### PR TITLE
feat: add connected_at field to events/client_disconnected payload

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -1255,6 +1255,7 @@ columns_with_exam('client.disconnected') ->
         {<<"proto_name">>, <<"MQTT">>},
         {<<"proto_ver">>, 5},
         columns_example_props(disconn_props),
+        {<<"connected_at">>, erlang:system_time(millisecond)},
         {<<"disconnected_at">>, erlang:system_time(millisecond)},
         {<<"timestamp">>, erlang:system_time(millisecond)},
         {<<"node">>, node()},

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -451,7 +451,8 @@ eventmsg_disconnected(
         sockname := SockName,
         proto_name := ProtoName,
         proto_ver := ProtoVer,
-        disconnected_at := DisconnectedAt
+        disconnected_at := DisconnectedAt,
+        connected_at := ConnectedAt
     },
     Reason
 ) ->
@@ -467,6 +468,7 @@ eventmsg_disconnected(
             proto_ver => ProtoVer,
             disconn_props => printable_maps(maps:get(disconn_props, ConnInfo, #{})),
             disconnected_at => DisconnectedAt,
+            connected_at => ConnectedAt,
             client_attrs => maps:get(client_attrs, ClientInfo, #{})
         },
         #{}

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_test_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_test_SUITE.erl
@@ -149,7 +149,10 @@ t_ctx_connected(_) ->
 
 t_ctx_disconnected(_) ->
     SQL =
-        <<"SELECT clientid, username, reason, disconnected_at, node FROM \"$events/client_disconnected\"">>,
+        <<
+            "SELECT clientid, username, reason, connected_at, disconnected_at, node"
+            " FROM \"$events/client_disconnected\""
+        >>,
 
     Context =
         #{
@@ -158,7 +161,9 @@ t_ctx_disconnected(_) ->
             reason => <<"normal">>,
             username => <<"u_emqx">>
         },
-    Expected = check_result([clientid, username, reason], [disconnected_at, node], Context),
+    Expected = check_result(
+        [clientid, username, reason], [connected_at, disconnected_at, node], Context
+    ),
     do_test(SQL, Context, Expected).
 
 t_ctx_connack(_) ->

--- a/changes/ce/feat-14869.en.md
+++ b/changes/ce/feat-14869.en.md
@@ -1,0 +1,1 @@
+Added the `connected_at` timestamp field to the `$events/client_disconnected` event payload. Enables tracking the original connection session time for disconnected clients, resolving scenarios where delayed disconnect events might overwrite newer connection states (e.g., frequent reconnections due to unstable networks). 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: v/e5.8.6

In EMQX 5.8.4 Open Source:

System topics ($SYS/brokers/${node}/clients/connected/disconnected) include connected_at in disconnect events, but this field is missing in Rule Engine's $events/client_disconnected events.

When clients reconnect frequently due to poor networks, delayed disconnect events may overwrite newer connection statuses. Example sequence:

Disconnect event (1) contains old connected_at: 1740160813688

New connect event (3) has connected_at: 1740160856111

Without connected_at in disconnect events, business logic cannot determine which connection session the disconnect belongs to.

Root Cause:

Rule Engine's client_disconnected event payload does not include the connected_at timestamp from the original connection session, while the system topics serialize this field correctly.

Proposed Solution:

Add connected_at field to the payload of `$events/client_disconnected` events to match the behavior of system topics.

This also fix https://github.com/emqx/emqx/issues/14837

1. Upon receiving a client_disconnected event, store its connected_at timestamp.
2. For subsequent client_disconnected events:
     - Compare the new event’s connected_at with the stored value.
     - Update the status if the new connected_at is newer.
     - Ignore the event if the new connected_at is older or equal.

## Summary

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] Added property-based tests for code which performs user input validation
- [ ] Changed lines covered in coverage report
- [ ] Change log has been added to `changes/(ce|ee)/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [ ] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
