### PR TITLE
chore: bump dashboard version to e1.8.6-beta.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include env.sh
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= v1.10.5
-export EMQX_EE_DASHBOARD_VERSION ?= e1.8.6-beta.1
+export EMQX_EE_DASHBOARD_VERSION ?= e1.8.6-beta.2
 
 export EMQX_RELUP ?= true
 export EMQX_REL_FORM ?= tgz


### PR DESCRIPTION
Release version: v/e5.8.6