### PR TITLE
250315 refactor resource id for authn authz

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -25,7 +25,7 @@
 -export([
     cleanup_resources/0,
     make_resource_id/1,
-    create_resource/3,
+    create_resource/4,
     update_resource/2,
     remove_resource/1,
     update_config/2,
@@ -52,12 +52,12 @@
 %% APIs
 %%--------------------------------------------------------------------
 
-create_resource(ResourceId, Module, Config) ->
+create_resource(ResourceId, Module, Config, Type) ->
     Result = emqx_resource:create_local(
         ResourceId,
         ?AUTHZ_RESOURCE_GROUP,
         Module,
-        Config,
+        Config#{owner_id => Type},
         ?DEFAULT_RESOURCE_OPTS
     ),
     start_resource_if_enabled(Result, ResourceId, Config).

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -26,7 +26,7 @@
     cleanup_resources/0,
     make_resource_id/1,
     create_resource/4,
-    update_resource/2,
+    update_resource/3,
     remove_resource/1,
     update_config/2,
     vars_for_rule_query/2,
@@ -42,8 +42,9 @@
     cached_simple_sync_query/3
 ]).
 
--define(DEFAULT_RESOURCE_OPTS, #{
-    start_after_created => false
+-define(DEFAULT_RESOURCE_OPTS(Type), #{
+    start_after_created => false,
+    owner_id => Type
 }).
 
 -include_lib("emqx/include/logger.hrl").
@@ -57,19 +58,19 @@ create_resource(ResourceId, Module, Config, Type) ->
         ResourceId,
         ?AUTHZ_RESOURCE_GROUP,
         Module,
-        Config#{owner_id => Type},
-        ?DEFAULT_RESOURCE_OPTS
+        Config,
+        ?DEFAULT_RESOURCE_OPTS(Type)
     ),
     start_resource_if_enabled(Result, ResourceId, Config).
 
-update_resource(Module, #{annotations := #{id := ResourceId}} = Config) ->
+update_resource(Module, #{annotations := #{id := ResourceId}} = Config, Type) ->
     Result =
         case
             emqx_resource:recreate_local(
                 ResourceId,
                 Module,
                 Config,
-                ?DEFAULT_RESOURCE_OPTS
+                ?DEFAULT_RESOURCE_OPTS(Type)
             )
         of
             {ok, _} -> {ok, ResourceId};

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -93,7 +93,7 @@ cleanup_resources() ->
     ).
 
 make_resource_id(Name) ->
-    NameBin = emqx_utils_conv:bin(Name),
+    NameBin = iolist_to_binary(["authz:", emqx_utils_conv:bin(Name)]),
     emqx_resource:generate_id(NameBin).
 
 update_config(Path, ConfigRequest) ->

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -25,7 +25,6 @@
 -export([
     cleanup_resources/0,
     make_resource_id/1,
-    create_resource/2,
     create_resource/3,
     update_resource/2,
     remove_resource/1,
@@ -52,10 +51,6 @@
 %%--------------------------------------------------------------------
 %% APIs
 %%--------------------------------------------------------------------
-
-create_resource(Module, Config) ->
-    ResourceId = make_resource_id(Module),
-    create_resource(ResourceId, Module, Config).
 
 create_resource(ResourceId, Module, Config) ->
     Result = emqx_resource:create_local(

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -65,7 +65,15 @@ create(Config0) ->
 update(Config0, #{resource_id := ResourceId} = _State) ->
     with_validated_config(Config0, fun(Config, NState) ->
         % {Config, NState} = parse_config(Config0),
-        case emqx_authn_utils:update_resource(emqx_bridge_http_connector, Config, ResourceId) of
+        case
+            emqx_authn_utils:update_resource(
+                emqx_bridge_http_connector,
+                Config,
+                ResourceId,
+                ?AUTHN_MECHANISM_BIN,
+                ?AUTHN_BACKEND_BIN
+            )
+        of
             {error, Reason} ->
                 error({load_config_error, Reason});
             {ok, _} ->

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -50,7 +50,7 @@ create(_AuthenticatorID, Config) ->
 
 create(Config0) ->
     with_validated_config(Config0, fun(Config, State) ->
-        ResourceId = emqx_authn_utils:make_resource_id(<<"http">>),
+        ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_BACKEND_BIN),
         % {Config, State} = parse_config(Config0),
         {ok, _Data} = emqx_authn_utils:create_resource(
             ResourceId,

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -16,10 +16,6 @@
 
 -module(emqx_authn_http).
 
--include_lib("emqx_auth/include/emqx_authn.hrl").
--include_lib("emqx/include/logger.hrl").
--include_lib("snabbkaffe/include/trace.hrl").
-
 -behaviour(emqx_authn_provider).
 
 -export([
@@ -38,6 +34,11 @@
     safely_parse_body/2
 ]).
 
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+-include("emqx_auth_http.hrl").
+
 -define(DEFAULT_CONTENT_TYPE, <<"application/json">>).
 
 %%------------------------------------------------------------------------------
@@ -49,12 +50,14 @@ create(_AuthenticatorID, Config) ->
 
 create(Config0) ->
     with_validated_config(Config0, fun(Config, State) ->
-        ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+        ResourceId = emqx_authn_utils:make_resource_id(<<"http">>),
         % {Config, State} = parse_config(Config0),
         {ok, _Data} = emqx_authn_utils:create_resource(
             ResourceId,
             emqx_bridge_http_connector,
-            Config
+            Config,
+            ?AUTHN_MECHANISM_BIN,
+            ?AUTHN_BACKEND_BIN
         ),
         {ok, State#{resource_id => ResourceId}}
     end).

--- a/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
@@ -40,7 +40,9 @@ create(_AuthenticatorID, Config) ->
 
 create(Config0) ->
     emqx_authn_http:with_validated_config(Config0, fun(Config, State) ->
-        ResourceId = emqx_authn_utils:make_resource_id(<<"scram-restapi">>),
+        ResourceId = emqx_authn_utils:make_resource_id(
+            iolist_to_binary([?AUTHN_MECHANISM_SCRAM_BIN, ":", ?AUTHN_BACKEND_BIN])
+        ),
         % {Config, State} = parse_config(Config0),
         {ok, _Data} = emqx_authn_utils:create_resource(
             ResourceId,

--- a/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
@@ -55,7 +55,15 @@ create(Config0) ->
 update(Config0, #{resource_id := ResourceId} = _State) ->
     emqx_authn_http:with_validated_config(Config0, fun(Config, NState) ->
         % {Config, NState} = parse_config(Config0),
-        case emqx_authn_utils:update_resource(emqx_bridge_http_connector, Config, ResourceId) of
+        case
+            emqx_authn_utils:update_resource(
+                emqx_bridge_http_connector,
+                Config,
+                ResourceId,
+                ?AUTHN_MECHANISM_SCRAM_BIN,
+                ?AUTHN_BACKEND_BIN
+            )
+        of
             {error, Reason} ->
                 error({load_config_error, Reason});
             {ok, _} ->

--- a/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_scram_restapi.erl
@@ -12,10 +12,6 @@
 
 -feature(maybe_expr, enable).
 
--include("emqx_auth_http.hrl").
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx_auth/include/emqx_authn.hrl").
-
 -behaviour(emqx_authn_provider).
 
 -export([
@@ -31,6 +27,10 @@
     <<"salt">>
 ]).
 
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include("emqx_auth_http.hrl").
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -40,12 +40,14 @@ create(_AuthenticatorID, Config) ->
 
 create(Config0) ->
     emqx_authn_http:with_validated_config(Config0, fun(Config, State) ->
-        ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+        ResourceId = emqx_authn_utils:make_resource_id(<<"scram-restapi">>),
         % {Config, State} = parse_config(Config0),
         {ok, _Data} = emqx_authn_utils:create_resource(
             ResourceId,
             emqx_bridge_http_connector,
-            Config
+            Config,
+            ?AUTHN_MECHANISM_SCRAM_BIN,
+            ?AUTHN_BACKEND_BIN
         ),
         {ok, merge_scram_conf(Config, State#{resource_id => ResourceId})}
     end).

--- a/apps/emqx_auth_http/src/emqx_authz_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http.erl
@@ -75,7 +75,7 @@ create(Config) ->
 
 update(Config) ->
     #{annotations := Annotations} = NConfig = parse_config(Config),
-    case emqx_authz_utils:update_resource(emqx_bridge_http_connector, NConfig) of
+    case emqx_authz_utils:update_resource(emqx_bridge_http_connector, NConfig, ?AUTHZ_TYPE) of
         {error, Reason} -> error({load_config_error, Reason});
         {ok, Id} -> NConfig#{annotations => Annotations#{id => Id}}
     end.

--- a/apps/emqx_auth_http/src/emqx_authz_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http.erl
@@ -64,7 +64,7 @@
 
 create(Config) ->
     #{annotations := Annotations} = NConfig = parse_config(Config),
-    ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHZ_TYPE),
     {ok, _Data} = emqx_authz_utils:create_resource(
         ResourceId,
         emqx_bridge_http_connector,

--- a/apps/emqx_auth_http/src/emqx_authz_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http.erl
@@ -16,10 +16,6 @@
 
 -module(emqx_authz_http).
 
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx/include/emqx_placeholder.hrl").
--include_lib("snabbkaffe/include/snabbkaffe.hrl").
-
 -behaviour(emqx_authz_source).
 
 %% AuthZ Callbacks
@@ -30,6 +26,11 @@
     authorize/4,
     format_for_api/1
 ]).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_placeholder.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include("emqx_auth_http.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -67,7 +68,8 @@ create(Config) ->
     {ok, _Data} = emqx_authz_utils:create_resource(
         ResourceId,
         emqx_bridge_http_connector,
-        NConfig
+        NConfig,
+        ?AUTHZ_TYPE
     ),
     NConfig#{annotations => Annotations#{id => ResourceId}}.
 

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -16,17 +16,18 @@
 
 -module(emqx_authn_jwt).
 
--include_lib("emqx_auth/include/emqx_authn.hrl").
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx/include/emqx_placeholder.hrl").
--include_lib("jose/include/jose_jwk.hrl").
-
 -export([
     create/2,
     update/2,
     authenticate/2,
     destroy/1
 ]).
+
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_placeholder.hrl").
+-include_lib("jose/include/jose_jwk.hrl").
+-include("emqx_auth_jwt.hrl").
 
 -define(ALLOWED_VARS, [
     ?VAR_CLIENTID,
@@ -173,7 +174,7 @@ create_authn_public_key(
     end.
 
 create_authn_public_key_with_jwks(Config) ->
-    ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_TYPE),
     {ok, _Data} = emqx_resource:create_local(
         ResourceId,
         ?AUTHN_RESOURCE_GROUP,

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
@@ -46,7 +46,11 @@ do_create(Config0) ->
 
 update(Config, #{resource_id := ResourceId} = _State) ->
     NState = parse_config(Config),
-    case emqx_authn_utils:update_resource(emqx_ldap, Config, ResourceId) of
+    case
+        emqx_authn_utils:update_resource(
+            emqx_ldap, Config, ResourceId, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+        )
+    of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, _} ->

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
@@ -36,7 +36,7 @@ create(_AuthenticatorID, Config) ->
     do_create(Config).
 
 do_create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(<<"ldap">>),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_BACKEND_BIN),
     Config = filter_placeholders(Config0),
     State = parse_config(Config),
     {ok, _Data} = emqx_authn_utils:create_resource(

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
@@ -16,33 +16,32 @@
 
 -module(emqx_authn_ldap).
 
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx_auth/include/emqx_authn.hrl").
-
 -behaviour(emqx_authn_provider).
 
 -export([
     create/2,
     update/2,
     authenticate/2,
-    destroy/1,
-    do_create/2
+    destroy/1
 ]).
 
--import(proplists, [get_value/2, get_value/3]).
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include("emqx_auth_ldap.hrl").
 
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
 
 create(_AuthenticatorID, Config) ->
-    do_create(?MODULE, Config).
+    do_create(Config).
 
-do_create(Module, Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(Module),
+do_create(Config0) ->
+    ResourceId = emqx_authn_utils:make_resource_id(<<"ldap">>),
     Config = filter_placeholders(Config0),
     State = parse_config(Config),
-    {ok, _Data} = emqx_authn_utils:create_resource(ResourceId, emqx_ldap, Config),
+    {ok, _Data} = emqx_authn_utils:create_resource(
+        ResourceId, emqx_ldap, Config, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+    ),
     {ok, State#{resource_id => ResourceId}}.
 
 update(Config, #{resource_id := ResourceId} = _State) ->

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
@@ -62,7 +62,7 @@
 %%------------------------------------------------------------------------------
 
 create(Source0) ->
-    ResourceId = emqx_authz_utils:make_resource_id(ldap),
+    ResourceId = emqx_authz_utils:make_resource_id(?AUTHZ_TYPE),
     Source = filter_placeholders(Source0),
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_ldap, Source, ?AUTHZ_TYPE),
     Annotations = new_annotations(#{id => ResourceId}, Source),

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
@@ -69,7 +69,7 @@ create(Source0) ->
     Source#{annotations => Annotations}.
 
 update(Source) ->
-    case emqx_authz_utils:update_resource(emqx_ldap, Source) of
+    case emqx_authz_utils:update_resource(emqx_ldap, Source, ?AUTHZ_TYPE) of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, Id} ->

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
@@ -27,11 +27,6 @@
 %%--------------------------------------------------------------------
 
 -module(emqx_authz_ldap).
-
--include_lib("emqx/include/emqx_placeholder.hrl").
--include_lib("emqx/include/logger.hrl").
--include_lib("eldap/include/eldap.hrl").
-
 -behaviour(emqx_authz_source).
 
 %% AuthZ Callbacks
@@ -41,6 +36,11 @@
     destroy/1,
     authorize/4
 ]).
+
+-include_lib("emqx/include/emqx_placeholder.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("eldap/include/eldap.hrl").
+-include("emqx_auth_ldap.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -64,7 +64,7 @@
 create(Source0) ->
     ResourceId = emqx_authz_utils:make_resource_id(ldap),
     Source = filter_placeholders(Source0),
-    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_ldap, Source),
+    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_ldap, Source, ?AUTHZ_TYPE),
     Annotations = new_annotations(#{id => ResourceId}, Source),
     Source#{annotations => Annotations}.
 

--- a/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authz_ldap.erl
@@ -62,7 +62,7 @@
 %%------------------------------------------------------------------------------
 
 create(Source0) ->
-    ResourceId = emqx_authz_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authz_utils:make_resource_id(ldap),
     Source = filter_placeholders(Source0),
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_ldap, Source),
     Annotations = new_annotations(#{id => ResourceId}, Source),

--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
@@ -21,6 +21,7 @@
 -include_lib("emqx_auth/include/emqx_authn.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include("emqx_auth_ldap.hrl").
 
 -define(LDAP_HOST, "ldap").
 -define(LDAP_DEFAULT_PORT, 389).
@@ -54,12 +55,12 @@ init_per_suite(Config) ->
             Apps = emqx_cth_suite:start([emqx, emqx_conf, emqx_auth, emqx_auth_ldap], #{
                 work_dir => ?config(priv_dir, Config)
             }),
-            {ok, _} = emqx_resource:create_local(
+            {ok, _Data} = emqx_authn_utils:create_resource(
                 ?LDAP_RESOURCE,
-                ?AUTHN_RESOURCE_GROUP,
                 emqx_ldap,
                 ldap_config(),
-                #{}
+                ?AUTHN_MECHANISM_BIN,
+                ?AUTHN_BACKEND_BIN
             ),
             [{apps, Apps} | Config];
         false ->
@@ -71,7 +72,7 @@ end_per_suite(Config) ->
         [authentication],
         ?GLOBAL
     ),
-    ok = emqx_resource:remove_local(?LDAP_RESOURCE),
+    ok = emqx_authn_ldap:destroy(#{resource_id => ?LDAP_RESOURCE}),
     ok = emqx_cth_suite:stop(?config(apps, Config)).
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
@@ -34,7 +34,7 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(<<"mogodb">>),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_BACKEND_BIN),
     {Config, State} = parse_config(Config0),
     {ok, _Data} = emqx_authn_utils:create_resource(
         ResourceId,

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
@@ -16,14 +16,15 @@
 
 -module(emqx_authn_mongodb).
 
--include_lib("emqx_auth/include/emqx_authn.hrl").
-
 -export([
     create/2,
     update/2,
     authenticate/2,
     destroy/1
 ]).
+
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include("emqx_auth_mongodb.hrl").
 
 %%------------------------------------------------------------------------------
 %% APIs
@@ -33,12 +34,14 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authn_utils:make_resource_id(<<"mogodb">>),
     {Config, State} = parse_config(Config0),
     {ok, _Data} = emqx_authn_utils:create_resource(
         ResourceId,
         emqx_mongodb,
-        Config
+        Config,
+        ?AUTHN_MECHANISM_BIN,
+        ?AUTHN_BACKEND_BIN
     ),
     {ok, State#{resource_id => ResourceId}}.
 

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
@@ -47,7 +47,11 @@ create(Config0) ->
 
 update(Config0, #{resource_id := ResourceId} = _State) ->
     {Config, NState} = parse_config(Config0),
-    case emqx_authn_utils:update_resource(emqx_mongodb, Config, ResourceId) of
+    case
+        emqx_authn_utils:update_resource(
+            emqx_mongodb, Config, ResourceId, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+        )
+    of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, _} ->

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -59,7 +59,7 @@ update(#{filter := Filter, skip := Skip, limit := Limit} = Source) ->
         emqx_utils_maps:binary_key_map(Filter), ?ALLOWED_VARS
     ),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    case emqx_authz_utils:update_resource(emqx_mongodb, Source) of
+    case emqx_authz_utils:update_resource(emqx_mongodb, Source, ?AUTHZ_TYPE) of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, Id} ->

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -37,7 +37,7 @@
 -define(ALLOWED_VARS, ?AUTHZ_DEFAULT_ALLOWED_VARS).
 
 create(#{filter := Filter, skip := Skip, limit := Limit} = Source) ->
-    ResourceId = emqx_authz_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authz_utils:make_resource_id(mongodb),
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mongodb, Source),
     {Vars, FilterTemp} = emqx_auth_template:parse_deep(
         emqx_utils_maps:binary_key_map(Filter), ?ALLOWED_VARS

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -16,9 +16,6 @@
 
 -module(emqx_authz_mongodb).
 
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx_auth/include/emqx_authz.hrl").
-
 -behaviour(emqx_authz_source).
 
 %% AuthZ Callbacks
@@ -29,6 +26,10 @@
     authorize/4
 ]).
 
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_auth/include/emqx_authz.hrl").
+-include("emqx_auth_mongodb.hrl").
+
 -ifdef(TEST).
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -38,7 +39,7 @@
 
 create(#{filter := Filter, skip := Skip, limit := Limit} = Source) ->
     ResourceId = emqx_authz_utils:make_resource_id(mongodb),
-    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mongodb, Source),
+    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mongodb, Source, ?AUTHZ_TYPE),
     {Vars, FilterTemp} = emqx_auth_template:parse_deep(
         emqx_utils_maps:binary_key_map(Filter), ?ALLOWED_VARS
     ),

--- a/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authz_mongodb.erl
@@ -38,7 +38,7 @@
 -define(ALLOWED_VARS, ?AUTHZ_DEFAULT_ALLOWED_VARS).
 
 create(#{filter := Filter, skip := Skip, limit := Limit} = Source) ->
-    ResourceId = emqx_authz_utils:make_resource_id(mongodb),
+    ResourceId = emqx_authz_utils:make_resource_id(?AUTHZ_TYPE),
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mongodb, Source, ?AUTHZ_TYPE),
     {Vars, FilterTemp} = emqx_auth_template:parse_deep(
         emqx_utils_maps:binary_key_map(Filter), ?ALLOWED_VARS

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -47,7 +47,11 @@ create(Config0) ->
 
 update(Config0, #{resource_id := ResourceId} = _State) ->
     {Config, NState} = parse_config(Config0),
-    case emqx_authn_utils:update_resource(emqx_mysql, Config, ResourceId) of
+    case
+        emqx_authn_utils:update_resource(
+            emqx_mysql, Config, ResourceId, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+        )
+    of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, _} ->

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -38,7 +38,7 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(<<"mysql">>),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_BACKEND_BIN),
     {Config, State} = parse_config(Config0),
     {ok, _Data} = emqx_authn_utils:create_resource(
         ResourceId, emqx_mysql, Config, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -16,8 +16,6 @@
 
 -module(emqx_authn_mysql).
 
--include_lib("emqx_auth/include/emqx_authn.hrl").
--include_lib("emqx/include/logger.hrl").
 -behaviour(emqx_authn_provider).
 
 -define(PREPARE_KEY, ?MODULE).
@@ -29,6 +27,9 @@
     destroy/1
 ]).
 
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include("emqx_auth_mysql.hrl").
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -37,9 +38,11 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authn_utils:make_resource_id(<<"mysql">>),
     {Config, State} = parse_config(Config0),
-    {ok, _Data} = emqx_authn_utils:create_resource(ResourceId, emqx_mysql, Config),
+    {ok, _Data} = emqx_authn_utils:create_resource(
+        ResourceId, emqx_mysql, Config, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+    ),
     {ok, State#{resource_id => ResourceId}}.
 
 update(Config0, #{resource_id := ResourceId} = _State) ->

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -55,7 +55,7 @@ update(#{query := SQL} = Source0) ->
     {Vars, PrepareSQL, TmplToken} = emqx_auth_template:parse_sql(SQL, '?', ?ALLOWED_VARS),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
     Source = Source0#{prepare_statement => #{?PREPARE_KEY => PrepareSQL}},
-    case emqx_authz_utils:update_resource(emqx_mysql, Source) of
+    case emqx_authz_utils:update_resource(emqx_mysql, Source, ?AUTHZ_TYPE) of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, Id} ->

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -42,7 +42,7 @@
 create(#{query := SQL} = Source0) ->
     {Vars, PrepareSQL, TmplToken} = emqx_auth_template:parse_sql(SQL, '?', ?ALLOWED_VARS),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    ResourceId = emqx_authz_utils:make_resource_id(mysql),
+    ResourceId = emqx_authz_utils:make_resource_id(?AUTHZ_TYPE),
     Source = Source0#{prepare_statement => #{?PREPARE_KEY => PrepareSQL}},
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mysql, Source, ?AUTHZ_TYPE),
     Source#{

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -41,7 +41,7 @@
 create(#{query := SQL} = Source0) ->
     {Vars, PrepareSQL, TmplToken} = emqx_auth_template:parse_sql(SQL, '?', ?ALLOWED_VARS),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    ResourceId = emqx_authz_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authz_utils:make_resource_id(mysql),
     Source = Source0#{prepare_statement => #{?PREPARE_KEY => PrepareSQL}},
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mysql, Source),
     Source#{

--- a/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authz_mysql.erl
@@ -16,9 +16,6 @@
 
 -module(emqx_authz_mysql).
 
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx_auth/include/emqx_authz.hrl").
-
 -behaviour(emqx_authz_source).
 
 -define(PREPARE_KEY, ?MODULE).
@@ -30,6 +27,10 @@
     destroy/1,
     authorize/4
 ]).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_auth/include/emqx_authz.hrl").
+-include("emqx_auth_mysql.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -43,7 +44,7 @@ create(#{query := SQL} = Source0) ->
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
     ResourceId = emqx_authz_utils:make_resource_id(mysql),
     Source = Source0#{prepare_statement => #{?PREPARE_KEY => PrepareSQL}},
-    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mysql, Source),
+    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_mysql, Source, ?AUTHZ_TYPE),
     Source#{
         annotations => #{
             id => ResourceId, tmpl_token => TmplToken, cache_key_template => CacheKeyTemplate

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -16,10 +16,6 @@
 
 -module(emqx_authn_postgresql).
 
--include_lib("emqx_auth/include/emqx_authn.hrl").
--include_lib("emqx/include/logger.hrl").
--include_lib("epgsql/include/epgsql.hrl").
-
 -behaviour(emqx_authn_provider).
 
 -export([
@@ -34,6 +30,10 @@
 -compile(nowarn_export_all).
 -endif.
 
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
+-include("emqx_auth_postgresql.hrl").
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -42,12 +42,14 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authn_utils:make_resource_id(<<"postgres">>),
     {Config, State} = parse_config(Config0, ResourceId),
     {ok, _Data} = emqx_authn_utils:create_resource(
         ResourceId,
         emqx_postgresql,
-        Config
+        Config,
+        ?AUTHN_MECHANISM_BIN,
+        ?AUTHN_BACKEND_BIN
     ),
     {ok, State#{resource_id => ResourceId}}.
 

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -55,7 +55,11 @@ create(Config0) ->
 
 update(Config0, #{resource_id := ResourceId} = _State) ->
     {Config, NState} = parse_config(Config0, ResourceId),
-    case emqx_authn_utils:update_resource(emqx_postgresql, Config, ResourceId) of
+    case
+        emqx_authn_utils:update_resource(
+            emqx_postgresql, Config, ResourceId, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+        )
+    of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, _} ->

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -42,7 +42,7 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(<<"postgres">>),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_BACKEND_BIN),
     {Config, State} = parse_config(Config0, ResourceId),
     {ok, _Data} = emqx_authn_utils:create_resource(
         ResourceId,

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -60,7 +60,8 @@ update(#{query := SQL0, annotations := #{id := ResourceId}} = Source) ->
     case
         emqx_authz_utils:update_resource(
             emqx_postgresql,
-            Source#{prepare_statement => #{ResourceId => SQL}}
+            Source#{prepare_statement => #{ResourceId => SQL}},
+            ?AUTHZ_TYPE
         )
     of
         {error, Reason} ->

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -16,11 +16,6 @@
 
 -module(emqx_authz_postgresql).
 
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx_auth/include/emqx_authz.hrl").
-
--include_lib("epgsql/include/epgsql.hrl").
-
 -behaviour(emqx_authz_source).
 
 %% AuthZ Callbacks
@@ -30,6 +25,11 @@
     destroy/1,
     authorize/4
 ]).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_auth/include/emqx_authz.hrl").
+-include_lib("epgsql/include/epgsql.hrl").
+-include("emqx_auth_postgresql.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -45,7 +45,8 @@ create(#{query := SQL0} = Source) ->
     {ok, _Data} = emqx_authz_utils:create_resource(
         ResourceId,
         emqx_postgresql,
-        Source#{prepare_statement => #{ResourceId => SQL}}
+        Source#{prepare_statement => #{ResourceId => SQL}},
+        ?AUTHZ_TYPE
     ),
     Source#{
         annotations => #{

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -41,7 +41,7 @@
 create(#{query := SQL0} = Source) ->
     {Vars, SQL, Placeholders} = emqx_auth_template:parse_sql(SQL0, '$n', ?ALLOWED_VARS),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    ResourceId = emqx_authz_utils:make_resource_id(emqx_postgresql),
+    ResourceId = emqx_authz_utils:make_resource_id(postgres),
     {ok, _Data} = emqx_authz_utils:create_resource(
         ResourceId,
         emqx_postgresql,

--- a/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authz_postgresql.erl
@@ -41,7 +41,7 @@
 create(#{query := SQL0} = Source) ->
     {Vars, SQL, Placeholders} = emqx_auth_template:parse_sql(SQL0, '$n', ?ALLOWED_VARS),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    ResourceId = emqx_authz_utils:make_resource_id(postgres),
+    ResourceId = emqx_authz_utils:make_resource_id(?AUTHZ_TYPE),
     {ok, _Data} = emqx_authz_utils:create_resource(
         ResourceId,
         emqx_postgresql,

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -16,9 +16,6 @@
 
 -module(emqx_authn_redis).
 
--include_lib("emqx_auth/include/emqx_authn.hrl").
--include_lib("emqx/include/logger.hrl").
-
 -behaviour(emqx_authn_provider).
 
 -export([
@@ -28,6 +25,9 @@
     destroy/1
 ]).
 
+-include_lib("emqx_auth/include/emqx_authn.hrl").
+-include("emqx_auth_redis.hrl").
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -36,7 +36,7 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authn_utils:make_resource_id(<<"redis">>),
     case parse_config(Config0) of
         {error, _} = Res ->
             Res;
@@ -44,7 +44,9 @@ create(Config0) ->
             {ok, _Data} = emqx_authn_utils:create_resource(
                 ResourceId,
                 emqx_redis,
-                Config
+                Config,
+                ?AUTHN_MECHANISM_BIN,
+                ?AUTHN_BACKEND_BIN
             ),
             {ok, State#{resource_id => ResourceId}}
     end.

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -53,7 +53,11 @@ create(Config0) ->
 
 update(Config0, #{resource_id := ResourceId} = _State) ->
     {Config, NState} = parse_config(Config0),
-    case emqx_authn_utils:update_resource(emqx_redis, Config, ResourceId) of
+    case
+        emqx_authn_utils:update_resource(
+            emqx_redis, Config, ResourceId, ?AUTHN_MECHANISM_BIN, ?AUTHN_BACKEND_BIN
+        )
+    of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, _} ->

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -36,7 +36,7 @@ create(_AuthenticatorID, Config) ->
     create(Config).
 
 create(Config0) ->
-    ResourceId = emqx_authn_utils:make_resource_id(<<"redis">>),
+    ResourceId = emqx_authn_utils:make_resource_id(?AUTHN_BACKEND_BIN),
     case parse_config(Config0) of
         {error, _} = Res ->
             Res;

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -39,7 +39,7 @@
 create(#{cmd := CmdStr} = Source) ->
     {Vars, CmdTemplate} = parse_cmd(CmdStr),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    ResourceId = emqx_authz_utils:make_resource_id(redis),
+    ResourceId = emqx_authz_utils:make_resource_id(?AUTHZ_TYPE),
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_redis, Source, ?AUTHZ_TYPE),
     Source#{
         annotations => #{id => ResourceId, cache_key_template => CacheKeyTemplate},

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -15,10 +15,6 @@
 %%--------------------------------------------------------------------
 
 -module(emqx_authz_redis).
-
--include_lib("emqx/include/logger.hrl").
--include_lib("emqx_auth/include/emqx_authz.hrl").
-
 -behaviour(emqx_authz_source).
 
 %% AuthZ Callbacks
@@ -28,6 +24,10 @@
     destroy/1,
     authorize/4
 ]).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_auth/include/emqx_authz.hrl").
+-include("emqx_auth_redis.hrl").
 
 -ifdef(TEST).
 -compile(export_all).
@@ -40,7 +40,7 @@ create(#{cmd := CmdStr} = Source) ->
     {Vars, CmdTemplate} = parse_cmd(CmdStr),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
     ResourceId = emqx_authz_utils:make_resource_id(redis),
-    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_redis, Source),
+    {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_redis, Source, ?AUTHZ_TYPE),
     Source#{
         annotations => #{id => ResourceId, cache_key_template => CacheKeyTemplate},
         cmd_template => CmdTemplate

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -49,7 +49,7 @@ create(#{cmd := CmdStr} = Source) ->
 update(#{cmd := CmdStr} = Source) ->
     {Vars, CmdTemplate} = parse_cmd(CmdStr),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    case emqx_authz_utils:update_resource(emqx_redis, Source) of
+    case emqx_authz_utils:update_resource(emqx_redis, Source, ?AUTHZ_TYPE) of
         {error, Reason} ->
             error({load_config_error, Reason});
         {ok, Id} ->

--- a/apps/emqx_auth_redis/src/emqx_authz_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authz_redis.erl
@@ -39,7 +39,7 @@
 create(#{cmd := CmdStr} = Source) ->
     {Vars, CmdTemplate} = parse_cmd(CmdStr),
     CacheKeyTemplate = emqx_auth_template:cache_key_template(Vars),
-    ResourceId = emqx_authz_utils:make_resource_id(?MODULE),
+    ResourceId = emqx_authz_utils:make_resource_id(redis),
     {ok, _Data} = emqx_authz_utils:create_resource(ResourceId, emqx_redis, Source),
     Source#{
         annotations => #{id => ResourceId, cache_key_template => CacheKeyTemplate},

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -118,7 +118,9 @@
     inflight_window => pos_integer(),
     %% Only for `emqx_resource_manager' usage.  If false, prevents spawning buffer
     %% workers, regardless of resource query mode.
-    spawn_buffer_workers => boolean()
+    spawn_buffer_workers => boolean(),
+    %% used only for authn authz resources to indicate the owner authenticator or authorizer
+    owner_id => binary() | atom()
 }.
 -type query_result() ::
     ok

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -176,7 +176,7 @@
                     tag => tag(DATA#data.group, DATA#data.type)
                 }
             );
-        false ->
+        _ ->
             ?SLOG(LEVEL, maps:merge(FIELDS, #{resource_id => DATA#data.id}), #{
                 tag => tag(DATA#data.group, DATA#data.type)
             })

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -117,7 +117,6 @@
         resource := [gen_statem:from()],
         channel := #{channel_id() => [gen_statem:from()]}
     },
-    owner_id = undefined,
     extra
 }).
 
@@ -167,11 +166,11 @@
 
 %% If owner_id exists, log owner ID, otherwise log resource_id
 -define(LOG(LEVEL, FIELDS, DATA),
-    case is_binary(DATA#data.owner_id) of
-        true ->
+    case maps:get(owner_id, DATA#data.opts, undefined) of
+        OWNER_ID when is_binary(OWNER_ID) ->
             ?SLOG(
                 LEVEL,
-                maps:merge(FIELDS, #{owner_id => DATA#data.owner_id, internal_resid => DATA#data.id}),
+                maps:merge(FIELDS, #{owner_id => OWNER_ID, internal_resid => DATA#data.id}),
                 #{
                     tag => tag(DATA#data.group, DATA#data.type)
                 }
@@ -699,8 +698,7 @@ start_link(ResId, Group, ResourceType, Config, Opts) ->
         opts = Opts,
         state = undefined,
         error = undefined,
-        added_channels = #{},
-        owner_id = maps:get(owner_id, Opts, undefined)
+        added_channels = #{}
     },
     gen_statem:start_link(?REF(ResId), ?MODULE, {Data, Opts}, []).
 

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -144,7 +144,7 @@ on_stop(InstId, #{stop_error := {ask, HowToStop}} = State) ->
         continue ->
             on_stop(InstId, maps:remove(stop_error, State))
     end;
-on_stop(InstId, #{pid := Pid}) ->
+on_stop(_InstId, #{pid := Pid}) ->
     stop_counter_process(Pid).
 
 on_query(_InstId, get_state, State) ->
@@ -422,7 +422,7 @@ on_add_channel(ConnResId, #{add_channel_agent := Agent} = ConnSt0, ChanId, ChanC
 on_add_channel(ConnResId, ConnSt0, ChanId, ChanCfg) ->
     do_on_add_channel(ConnResId, ConnSt0, ChanId, ChanCfg).
 
-do_on_add_channel(ConnResId, ConnSt0, ChanId, ChanCfg) ->
+do_on_add_channel(_ConnResId, ConnSt0, ChanId, ChanCfg) ->
     ConnSt = emqx_utils_maps:deep_put([channels, ChanId], ConnSt0, ChanCfg),
     ?tp(added_channel, #{}),
     {ok, ConnSt}.
@@ -452,7 +452,7 @@ on_remove_channel(ConnResId, #{remove_channel_agent := Agent} = ConnSt0, ChanId)
 on_remove_channel(ConnResId, ConnSt0, ChanId) ->
     do_on_remove_channel(ConnResId, ConnSt0, ChanId).
 
-do_on_remove_channel(ConnResId, ConnSt0, ChanId) ->
+do_on_remove_channel(_ConnResId, ConnSt0, ChanId) ->
     ConnSt = emqx_utils_maps:deep_remove([channels, ChanId], ConnSt0),
     {ok, ConnSt}.
 


### PR DESCRIPTION
Release version: 5.9.0

## Summary

This is pure refactoring to improve logging data (in order to help AI to parse the log fields).
Previously the `resource_id` in the logs does not quite align with the authenticator ID (which is of format `MECHANISM:BACKEND`).

This PR changes the internal format of the resource ID to `authn:TYPE:NUMBER` such as `authn:postgres:1` and the `owner_id` to `MECHANISM:BACKEND` such as `password_based:postgres`.

Same for authz connectors.
- `authz:TYPE:NUMBER` for internal resource ID such as `auth:mysql:2`
- `TYPE` for `owner_id`, such as `mysql`.

