### PR TITLE
test: add debug logs for investigating flakiness

### DIFF
--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -52,6 +52,8 @@ init_per_testcase(TestCase, Config) when
     ServerPid = start_crl_server(CRLPem),
     IsCached = lists:member(TestCase, [t_filled_cache, t_revoked]),
     Apps = start_emqx_with_crl_cache(#{is_cached => IsCached}, TestCase, Config),
+    %% Debugging CI flaky failures
+    emqx_logger:set_log_level(debug),
     [
         {crl_pem, CRLPem},
         {crl_der, CRLDer},


### PR DESCRIPTION
Even after https://github.com/emqx/emqx/pull/14861, the problem still happens.

The server does recognize the certificate as revoked, but the `emqtt` process sometimes hangs and doesn't seem to receive the SSL error / SSL socket closed event.
