### PR TITLE
chore: bump `emqtt` -> 1.14.4

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -46,7 +46,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.2"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.4"}}}
         ]},
         {extra_src_dirs, [
             {"test", [recursive]},
@@ -58,7 +58,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.2"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.4"}}}
         ]},
         {extra_src_dirs, [{"test", [recursive]}]}
     ]}

--- a/apps/emqx_retainer/rebar.config
+++ b/apps/emqx_retainer/rebar.config
@@ -30,7 +30,7 @@
 {profiles, [
     {test, [
         {deps, [
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.2"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.4"}}}
         ]}
     ]}
 ]}.

--- a/mix.exs
+++ b/mix.exs
@@ -246,7 +246,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:emqtt),
     do:
       {:emqtt,
-       github: "emqx/emqtt", tag: "1.14.2", override: true, system_env: maybe_no_quic_env()}
+       github: "emqx/emqtt", tag: "1.14.4", override: true, system_env: maybe_no_quic_env()}
 
   def common_dep(:typerefl),
     do: {:typerefl, github: "ieQu1/typerefl", tag: "0.9.6", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -91,7 +91,7 @@
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.1"}}},
-    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.2"}}},
+    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.4"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x
     {observer_cli, "1.8.2"},


### PR DESCRIPTION
Basically fixes flaky tests:

- https://github.com/emqx/emqx/pull/14861
- https://github.com/emqx/emqx/actions/runs/13928128336/job/38980458444?pr=14894#step:5:343

See also:
- https://github.com/emqx/emqtt/pull/279
- https://github.com/emqx/emqtt/pull/280


Release version: 5.9
