### PR TITLE
fix(sqlserver action): handle concurrent connection close during request

### DIFF
--- a/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
+++ b/apps/emqx_bridge_sqlserver/test/emqx_bridge_sqlserver_SUITE.erl
@@ -430,9 +430,11 @@ t_bad_parameter(Config) ->
 %%------------------------------------------------------------------------------
 
 common_init(ConfigT) ->
+    ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
+    ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
     Host = os:getenv("SQLSERVER_HOST", "toxiproxy"),
     Port = list_to_integer(os:getenv("SQLSERVER_PORT", str(?SQLSERVER_DEFAULT_PORT))),
-
+    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
     Config0 = [
         {sqlserver_host, Host},
         {sqlserver_port, Port},
@@ -441,14 +443,9 @@ common_init(ConfigT) ->
         {batch_size, batch_size(ConfigT)}
         | ConfigT
     ],
-
     BridgeType = proplists:get_value(bridge_type, Config0, <<"sqlserver">>),
     case emqx_common_test_helpers:is_tcp_server_available(Host, Port) of
         true ->
-            % Setup toxiproxy
-            ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
-            ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
-            emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
             Apps = emqx_cth_suite:start(
                 [
                     emqx_conf,


### PR DESCRIPTION
Port from https://github.com/emqx/emqx/pull/14867

```
%%% emqx_bridge_sqlserver_SUITE ==> sync.without_batch.t_write_failure: FAILED
%%% emqx_bridge_sqlserver_SUITE ==>
Failure/Error: ?assertMatch({ error , { resource_error , # { reason := timeout } } }, send_message ( Config , SentData ))
  expected: = { error , { resource_error , # { reason := timeout } } }
       got: {error,
                {unrecoverable_error,
                    {invalid_request,
                        "[Microsoft][ODBC Driver 18 for SQL Server]TCP Provider: Error code 0x2746[Microsoft][ODBC Driver 18 for SQL Server]Communication link failure SQLSTATE IS: 08S01"}}}
      line: 326
```

See also:

https://learn.microsoft.com/en-us/sql/relational-databases/errors-events/mssqlserver-17194-database-engine-error?view=sql-server-ver16

Release version: 5.8.6
