### PR TITLE
fix(emqx): bump `mria` to 0.8.12.1

### DIFF
--- a/apps/emqx/mix.exs
+++ b/apps/emqx/mix.exs
@@ -43,6 +43,7 @@ defmodule EMQX.MixProject do
       UMP.common_dep(:gproc),
       UMP.common_dep(:gen_rpc),
       UMP.common_dep(:ekka),
+      UMP.common_dep(:mria),
       UMP.common_dep(:esockd),
       UMP.common_dep(:cowboy),
       UMP.common_dep(:lc),

--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -30,6 +30,8 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.8"}}},
+    % NOTE: switch back to `ekka` provided version once 5.8.6 is released
+    {mria, {git, "https://github.com/emqx/mria", {tag, "0.8.12.1"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.43.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},

--- a/changes/ce/fix-14906.en.md
+++ b/changes/ce/fix-14906.en.md
@@ -1,0 +1,4 @@
+Update Mria to 0.8.12.1 to eliminate occasional warnings caused by unexpected exit signals.
+```
+2025-01-10T20:00:00+00:00 [warning] clientid: C1, msg: emqx_session_mem_unknown_message, message: {'EXIT',<0.123456.0>,normal}
+```

--- a/mix.exs
+++ b/mix.exs
@@ -116,6 +116,7 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:esockd),
       common_dep(:rocksdb),
       common_dep(:ekka),
+      common_dep(:mria),
       common_dep(:gen_rpc),
       common_dep(:grpc),
       common_dep(:minirest),
@@ -184,6 +185,7 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.19.8", override: true}
+  def common_dep(:mria), do: {:mria, github: "emqx/mria", tag: "0.8.12.1", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.43.4", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -84,6 +84,8 @@
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-6"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.19.8"}}},
+    % NOTE: switch back to `ekka` provided version once 5.8.6 is released
+    {mria, {git, "https://github.com/emqx/mria", {tag, "0.8.12.1"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},


### PR DESCRIPTION
Addresses #14541.

Release version: 5.8.6

## Summary

This version uses "link-less" middleman processes, which helps to avoid polluting message queue of calling processes with `{'EXIT', ..., normal}` trapped exit messages.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] ~~Changed lines covered by tests~~
- [x] Change log has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
