### PR TITLE
fix(resource manager): do not start resource health checks when disconnected

### DIFF
--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
@@ -158,7 +158,7 @@ t_authenticate_timeout_cause_reconnect(_Config) ->
         ),
         ok = wait_for_ldap_pid(1000),
         [#{id := ResourceID}] = emqx_resource_manager:list_all(),
-        ?retry(1_000, 10, {ok, connected} = emqx_resource_manager:health_check(ResourceID)),
+        ?retry(1_000, 20, {ok, connected} = emqx_resource_manager:health_check(ResourceID)),
         %% turn back to normal
         meck:expect(
             eldap,

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -1197,6 +1197,11 @@ t_start_stop(Config, StopTracePoint) ->
                     5_000
                 )
             ),
+            ?retry(
+                _Sleep = 1_000,
+                _Attempts = 20,
+                ?assertEqual({error, resource_is_stopped}, health_check_connector(Config))
+            ),
 
             ResourceId = emqx_bridge_resource:resource_id(conf_root_key(Kind), Type, Name),
             #{resource_id => ResourceId}

--- a/apps/emqx_bridge_mysql/test/emqx_bridge_v2_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_v2_mysql_SUITE.erl
@@ -154,7 +154,7 @@ connector_config(Name, Config) ->
             <<"username">> => Username,
             <<"password">> => iolist_to_binary(["file://", PassFile]),
             <<"resource_opts">> => #{
-                <<"health_check_interval">> => <<"15s">>,
+                <<"health_check_interval">> => <<"1s">>,
                 <<"start_after_created">> => true,
                 <<"start_timeout">> => <<"5s">>
             }
@@ -187,7 +187,7 @@ bridge_config(Name, ConnectorId) ->
                 <<"batch_time">> => <<"0ms">>,
                 <<"buffer_mode">> => <<"memory_only">>,
                 <<"buffer_seg_bytes">> => <<"10MB">>,
-                <<"health_check_interval">> => <<"15s">>,
+                <<"health_check_interval">> => <<"1s">>,
                 <<"inflight_window">> => 100,
                 <<"max_buffer_bytes">> => <<"256MB">>,
                 <<"metrics_flush_interval">> => <<"1s">>,

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1911,7 +1911,17 @@ handle_channel_health_check_worker_down_new_channels_and_status(
     %% updated while the health check was in progress. We can still reply with
     %% NewStatus because the health check must have been issued before the
     %% configuration changed or the channel got removed.
-    {AddedChannels, NewStatus}.
+    {AddedChannels, NewStatus};
+handle_channel_health_check_worker_down_new_channels_and_status(
+    _ChannelId,
+    ErrorExitResult,
+    _CurrentStatus,
+    AddedChannels
+) ->
+    %% This shouldn't happen normally.  If something not wrapped in `{ok, _}' arrives, it
+    %% means that the health check worker was killed (externally) before reaching
+    %% `exit({ok, Result})'.
+    {AddedChannels, {error, ErrorExitResult}}.
 
 reply_pending_channel_health_check_callers(
     ChannelId, Status0, Data0 = #data{hc_pending_callers = Pending0}

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -44,6 +44,10 @@ end).
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
+%%------------------------------------------------------------------------------
+%% CT Boilerplate
+%%------------------------------------------------------------------------------
+
 all() ->
     All0 = emqx_common_test_helpers:all(?MODULE),
     All = All0 -- matrix_cases(),
@@ -98,7 +102,730 @@ end_per_suite(Config) ->
     ok.
 
 %%------------------------------------------------------------------------------
-%% Tests
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+inc_counter_in_parallel(N) ->
+    inc_counter_in_parallel(N, {inc_counter, 1}, #{}).
+
+inc_counter_in_parallel(N, Opts0) ->
+    inc_counter_in_parallel(N, {inc_counter, 1}, Opts0).
+
+inc_counter_in_parallel(N, Query, Opts) ->
+    Parent = self(),
+    Pids = [
+        erlang:spawn(fun() ->
+            emqx_resource:query(?ID, maybe_apply(Query), maybe_apply(Opts)),
+            Parent ! {complete, self()}
+        end)
+     || _ <- lists:seq(1, N)
+    ],
+    [
+        receive
+            {complete, Pid} -> ok
+        after 1000 ->
+            ct:fail({wait_for_query_timeout, Pid})
+        end
+     || Pid <- Pids
+    ],
+    ok.
+
+inc_counter_in_parallel_increasing(N, StartN, Opts) ->
+    Parent = self(),
+    Pids = [
+        erlang:spawn(fun() ->
+            emqx_resource:query(?ID, {inc_counter, M}, maybe_apply(Opts)),
+            Parent ! {complete, self()}
+        end)
+     || M <- lists:seq(StartN, StartN + N - 1)
+    ],
+    [
+        receive
+            {complete, Pid} -> ok
+        after 1000 ->
+            ct:fail({wait_for_query_timeout, Pid})
+        end
+     || Pid <- Pids
+    ].
+
+maybe_apply(FunOrTerm) ->
+    maybe_apply(FunOrTerm, []).
+
+maybe_apply(Fun, Args) when is_function(Fun) ->
+    erlang:apply(Fun, Args);
+maybe_apply(Term, _Args) ->
+    Term.
+
+bin_config() ->
+    <<"\"name\": \"test_resource\"">>.
+
+config() ->
+    {ok, Config} = hocon:binary(bin_config()),
+    Config.
+
+tap_metrics(Line) ->
+    #{counters := C, gauges := G} = emqx_resource:get_metrics(?ID),
+    ct:pal("metrics (l. ~b): ~p", [Line, #{counters => C, gauges => G}]),
+    #{counters => C, gauges => G}.
+
+install_telemetry_handler(TestCase) ->
+    Tid = ets:new(TestCase, [ordered_set, public]),
+    HandlerId = TestCase,
+    TestPid = self(),
+    _ = telemetry:attach_many(
+        HandlerId,
+        emqx_resource_metrics:events(),
+        fun(EventName, Measurements, Metadata, _Config) ->
+            Data = #{
+                name => EventName,
+                measurements => Measurements,
+                metadata => Metadata
+            },
+            ets:insert(Tid, {erlang:monotonic_time(), Data}),
+            TestPid ! {telemetry, Data},
+            ok
+        end,
+        unused_config
+    ),
+    on_exit(fun() ->
+        telemetry:detach(HandlerId),
+        ets:delete(Tid)
+    end),
+    put({?MODULE, telemetry_table}, Tid),
+    Tid.
+
+wait_until_gauge_is(
+    GaugeName,
+    #{
+        expected_value := ExpectedValue,
+        timeout := Timeout,
+        max_events := MaxEvents
+    }
+) ->
+    Events = receive_all_events(GaugeName, Timeout, MaxEvents),
+    case length(Events) > 0 andalso lists:last(Events) of
+        #{measurements := #{gauge_set := ExpectedValue}} ->
+            ok;
+        #{measurements := #{gauge_set := Value}} ->
+            ct:fail(
+                "gauge ~p didn't reach expected value ~p; last value: ~p",
+                [GaugeName, ExpectedValue, Value]
+            );
+        false ->
+            ct:pal("no ~p gauge events received!", [GaugeName])
+    end.
+
+receive_all_events(EventName, Timeout) ->
+    receive_all_events(EventName, Timeout, _MaxEvents = 50, _Count = 0, _Acc = []).
+
+receive_all_events(EventName, Timeout, MaxEvents) ->
+    receive_all_events(EventName, Timeout, MaxEvents, _Count = 0, _Acc = []).
+
+receive_all_events(_EventName, _Timeout, MaxEvents, Count, Acc) when Count >= MaxEvents ->
+    lists:reverse(Acc);
+receive_all_events(EventName, Timeout, MaxEvents, Count, Acc) ->
+    receive
+        {telemetry, #{name := [_, _, EventName]} = Event} ->
+            ct:pal("telemetry event: ~p", [Event]),
+            receive_all_events(EventName, Timeout, MaxEvents, Count + 1, [Event | Acc])
+    after Timeout ->
+        lists:reverse(Acc)
+    end.
+
+wait_telemetry_event(EventName) ->
+    wait_telemetry_event(EventName, #{timeout => 5_000, n_events => 1}).
+
+wait_telemetry_event(
+    EventName,
+    Opts0
+) ->
+    DefaultOpts = #{timeout => 5_000, n_events => 1},
+    #{timeout := Timeout, n_events := NEvents} = maps:merge(DefaultOpts, Opts0),
+    wait_n_events(NEvents, Timeout, EventName).
+
+wait_n_events(NEvents, _Timeout, _EventName) when NEvents =< 0 ->
+    ok;
+wait_n_events(NEvents, Timeout, EventName) ->
+    TelemetryTable = get({?MODULE, telemetry_table}),
+    receive
+        {telemetry, #{name := [_, _, EventName]}} ->
+            wait_n_events(NEvents - 1, Timeout, EventName)
+    after Timeout ->
+        RecordedEvents = ets:tab2list(TelemetryTable),
+        ct:pal("recorded events: ~p", [RecordedEvents]),
+        error({timeout_waiting_for_telemetry, EventName})
+    end.
+
+assert_sync_retry_fail_then_succeed_inflight(Trace) ->
+    ?assert(
+        ?strict_causality(
+            #{?snk_kind := buffer_worker_flush_nack, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            Trace
+        )
+    ),
+    %% not strict causality because it might retry more than once
+    %% before restoring the resource health.
+    ?assert(
+        ?causality(
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
+            Trace
+        )
+    ),
+    ok.
+
+assert_async_retry_fail_then_succeed_inflight(Trace) ->
+    ?assert(
+        ?strict_causality(
+            #{?snk_kind := handle_async_reply, action := nack},
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            Trace
+        )
+    ),
+    %% not strict causality because it might retry more than once
+    %% before restoring the resource health.
+    ?assert(
+        ?causality(
+            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
+            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
+            Trace
+        )
+    ),
+    ok.
+
+trace_between_span(Trace0, Marker) ->
+    {Trace1, [_ | _]} = ?split_trace_at(#{?snk_kind := Marker, ?snk_span := {complete, _}}, Trace0),
+    {[_ | _], [_ | Trace2]} = ?split_trace_at(#{?snk_kind := Marker, ?snk_span := start}, Trace1),
+    Trace2.
+
+wait_until_all_marked_as_retriable(NumExpected) when NumExpected =< 0 ->
+    ok;
+wait_until_all_marked_as_retriable(NumExpected) ->
+    Seen = #{},
+    do_wait_until_all_marked_as_retriable(NumExpected, Seen).
+
+do_wait_until_all_marked_as_retriable(NumExpected, _Seen) when NumExpected =< 0 ->
+    ok;
+do_wait_until_all_marked_as_retriable(NumExpected, Seen) ->
+    Res = ?block_until(
+        #{?snk_kind := buffer_worker_async_agent_down, ?snk_meta := #{pid := P}} when
+            not is_map_key(P, Seen),
+        10_000
+    ),
+    case Res of
+        {timeout, Evts} ->
+            ct:pal("events so far:\n  ~p", [Evts]),
+            ct:fail("timeout waiting for events");
+        {ok, #{num_affected := NumAffected, ?snk_meta := #{pid := Pid}}} ->
+            ct:pal("affected: ~p; pid: ~p", [NumAffected, Pid]),
+            case NumAffected >= NumExpected of
+                true ->
+                    ok;
+                false ->
+                    do_wait_until_all_marked_as_retriable(NumExpected - NumAffected, Seen#{
+                        Pid => true
+                    })
+            end
+    end.
+
+counter_metric_inc_fns() ->
+    Mod = emqx_resource_metrics,
+    [
+        fun Mod:Fn/1
+     || {Fn, 1} <- Mod:module_info(functions),
+        case string:find(atom_to_list(Fn), "_inc", trailing) of
+            "_inc" -> true;
+            _ -> false
+        end
+    ].
+
+gauge_metric_set_fns() ->
+    Mod = emqx_resource_metrics,
+    [
+        fun Mod:Fn/3
+     || {Fn, 3} <- Mod:module_info(functions),
+        case string:find(atom_to_list(Fn), "_set", trailing) of
+            "_set" -> true;
+            _ -> false
+        end
+    ].
+
+create(Id, Group, Type, Config) ->
+    create(Id, Group, Type, Config, #{}).
+
+create(Id, Group, Type, Config, Opts) ->
+    Res = emqx_resource:create_local(Id, Group, Type, Config, Opts),
+    on_exit(fun() -> emqx_resource:remove_local(Id) end),
+    case Type of
+        ?TEST_RESOURCE ->
+            on_exit(fun() -> emqx_connector_demo:clear_emulated_config(Id) end);
+        _ ->
+            ok
+    end,
+    Res.
+
+add_channel_emualte_config(ConnResId, ChanId, ChanConfig, Mode) ->
+    emqx_connector_demo:add_channel_emualte_config(ConnResId, ChanId, ChanConfig, Mode).
+
+remove_channel_emualte_config(ConnResId, ChanId, Mode) ->
+    emqx_connector_demo:remove_channel_emualte_config(ConnResId, ChanId, Mode).
+
+dryrun(Id, Type, Config) ->
+    TestPid = self(),
+    OnReady = fun(ResId) -> TestPid ! {resource_ready, ResId} end,
+    emqx_resource:create_dry_run_local(Id, Type, Config, OnReady).
+
+log_consistency_prop() ->
+    {"check state and cache consistency", fun ?MODULE:log_consistency_prop/1}.
+log_consistency_prop(Trace) ->
+    ?assertEqual([], ?of_kind("inconsistent_status", Trace)),
+    ?assertEqual([], ?of_kind("inconsistent_cache", Trace)),
+    ok.
+
+connector_res_id(Name) ->
+    %% Needs to have this form to satifisfy internal, implicit requirements of
+    %% `emqx_resource_cache'.
+    <<"connector:ctype:", Name/binary>>.
+
+action_res_id(ConnResId) ->
+    %% Needs to have this form to satifisfy internal, implicit requirements of
+    %% `emqx_resource_cache'.
+    <<"action:atype:aname:", ConnResId/binary>>.
+
+add_channel(ConnResId, ChanId, Config) ->
+    do_add_channel(ConnResId, ChanId, Config, sync).
+
+add_channel_async(ConnResId, ChanId, Config) ->
+    do_add_channel(ConnResId, ChanId, Config, async).
+
+do_add_channel(ConnResId, ChanId, Config, Mode) ->
+    ok = emqx_resource:create_metrics(ChanId),
+    on_exit(fun() -> emqx_resource:clear_metrics(ChanId) end),
+    ResourceOpts = emqx_resource:fetch_creation_opts(Config),
+    on_exit(fun() -> emqx_resource_buffer_worker_sup:stop_workers(ChanId, ResourceOpts) end),
+    ok = emqx_resource_buffer_worker_sup:start_workers(ChanId, ResourceOpts),
+    emqx_connector_demo:add_channel_emulate_config(ConnResId, ChanId, Config, Mode).
+
+remove_channel(ConnResId, ChanId) ->
+    do_remove_channel(ConnResId, ChanId, sync).
+
+remove_channel_async(ConnResId, ChanId) ->
+    do_remove_channel(ConnResId, ChanId, async).
+
+do_remove_channel(ConnResId, ChanId, Mode) ->
+    emqx_connector_demo:remove_channel_emulate_config(ConnResId, ChanId, Mode).
+
+group_path(Config, Default) ->
+    case emqx_common_test_helpers:group_path(Config) of
+        [] -> Default;
+        Path -> Path
+    end.
+
+fallback_actions_batch_opts(no_batch) ->
+    #{
+        resource_opts => #{batch_time => 0, batch_size => 1},
+        n_reqs => 1
+    };
+fallback_actions_batch_opts(batch) ->
+    #{
+        resource_opts => #{batch_time => 100, batch_size => 100},
+        n_reqs => 10
+    }.
+
+fallback_action_query(ConnResId, ChanId, FallbackFn, Ctx, #{query_mode := async} = QueryOpts0) ->
+    AdjustQueryOptsFn = maps:get(adjust_query_opts, Ctx, fun(_Ctx, QO) -> QO end),
+    Alias = alias([reply]),
+    ReplyTo = {
+        fun(ReplyCallerContext) ->
+            Alias ! {Alias, ReplyCallerContext}
+        end,
+        [],
+        #{reply_dropped => true}
+    },
+    QueryOpts1 = maps:merge(
+        #{connector_resource_id => ConnResId},
+        QueryOpts0#{reply_to => ReplyTo}
+    ),
+    QueryOpts = AdjustQueryOptsFn(Ctx, QueryOpts1),
+    Req = #{q => ask, fn => FallbackFn, ctx => Ctx},
+    ct:pal("~p sending query\n  ~p", [self(), #{query_opts => QueryOpts, ctx => Ctx}]),
+    Res = emqx_resource:query(
+        ChanId,
+        {ChanId, Req},
+        QueryOpts
+    ),
+    case Res of
+        ok ->
+            ok;
+        {async_return, {ok, _Pid}} ->
+            %% Simple async queries do not massage the returned value to stip the
+            %% `{async_return, _}' tag.
+            ok
+    end,
+    ct:pal("~p waiting for reply", [self()]),
+    receive
+        {Alias, ReplyCallerContext} ->
+            ct:pal("~p received async reply:\n  ~p", [self(), ReplyCallerContext]),
+            case ReplyCallerContext of
+                #{result := Result} ->
+                    Result;
+                Result ->
+                    %% If expired, it's a simple tuple
+                    Result
+            end
+    after 1_000 -> ct:fail("~p timed out waiting for reply", [self()])
+    end;
+fallback_action_query(ConnResId, ChanId, FallbackFn, Ctx, #{query_mode := sync} = QueryOpts0) ->
+    AdjustQueryOptsFn = maps:get(adjust_query_opts, Ctx, fun(QO) -> QO end),
+    QueryOpts1 = maps:merge(
+        #{connector_resource_id => ConnResId},
+        QueryOpts0
+    ),
+    QueryOpts = AdjustQueryOptsFn(QueryOpts1),
+    Req = #{q => ask, fn => FallbackFn, ctx => Ctx},
+    ct:pal("~p sending query\n  ~p", [self(), #{query_opts => QueryOpts, ctx => Ctx}]),
+    emqx_resource:query(
+        ChanId,
+        {ChanId, Req},
+        QueryOpts
+    ).
+
+fallback_query_wait_async(N, RequestQueryKind, QueryOpts, Ctx) ->
+    #{
+        conn_res_id := ConnResId,
+        chan_id := ChanId,
+        mk_event_matcher := MkEventMatcher,
+        fallback_fn := FallbackFn
+    } = Ctx,
+    AssertExpectedCallMode = maps:get(assert_expected_callmode, Ctx, true),
+    ReqCtx = Ctx#{req_n => N},
+    case AssertExpectedCallMode of
+        true ->
+            ct:pal("~p sending request ~b", [self(), N]),
+            EventMatcher = MkEventMatcher(RequestQueryKind),
+            {Result, {ok, _}} =
+                snabbkaffe:wait_async_action(
+                    fun() ->
+                        fallback_action_query(
+                            ConnResId, ChanId, FallbackFn, ReqCtx, QueryOpts#{
+                                query_mode => RequestQueryKind
+                            }
+                        )
+                    end,
+                    EventMatcher,
+                    infinity
+                );
+        false ->
+            Result = fallback_action_query(
+                ConnResId, ChanId, FallbackFn, ReqCtx, QueryOpts#{
+                    query_mode => RequestQueryKind
+                }
+            )
+    end,
+    ct:pal("~p received reply ~b:\n  ~p", [self(), N, Result]),
+    Result.
+
+fallback_send_many(RequestQueryKind, Ctx) ->
+    #{n_reqs := NReqs} = Ctx,
+    BaseQueryOpts = maps:get(base_query_opts, Ctx),
+    QueryOpts0 = maps:get(query_opts, Ctx, #{}),
+    QueryOpts = emqx_utils_maps:deep_merge(BaseQueryOpts, QueryOpts0),
+    Results = emqx_utils:pmap(
+        fun(N) ->
+            fallback_query_wait_async(N, RequestQueryKind, QueryOpts, Ctx)
+        end,
+        lists:seq(1, NReqs)
+    ),
+    Results.
+
+assert_all_queries_triggered_fallbacks(Ctx) ->
+    #{n_reqs := NReqs} = Ctx,
+    lists:foreach(
+        fun(N) ->
+            ?assertReceive(
+                {fallback_called, #{n := 1, request := #{ctx := #{req_n := N}}}}
+            ),
+            ?assertReceive({fallback_called, #{n := 2, request := #{ctx := #{req_n := N}}}})
+        end,
+        lists:seq(1, NReqs)
+    ),
+    ?assertNotReceive({fallback_called, _}),
+    ok.
+
+merge_maps(Maps) ->
+    lists:foldl(fun emqx_utils_maps:deep_merge/2, #{}, Maps).
+
+%% Poor man's `timer:apply_after', prior to OTP 27.
+apply_after(Time, Fn) ->
+    spawn(fun() ->
+        timer:sleep(Time),
+        Fn()
+    end).
+
+fallback_actions_basic_setup(ConnName, ChanQueryMode, CallbackMode, ShouldBatch) ->
+    fallback_actions_basic_setup(ConnName, ChanQueryMode, CallbackMode, ShouldBatch, _Opts = #{}).
+
+fallback_actions_basic_setup(ConnName, ChanQueryMode, CallbackMode, ShouldBatch, Opts) ->
+    ChanResourceOptsOverride = maps:get(chan_resource_opts_override, Opts, #{}),
+    emqx_connector_demo:set_callback_mode(CallbackMode),
+    #{
+        resource_opts := ResourceOpts0,
+        n_reqs := NReqs
+    } = fallback_actions_batch_opts(ShouldBatch),
+    MkEventMatcher = fun(RequestQueryKind) ->
+        QMSummary = emqx_resource_manager:summarize_query_mode(ChanQueryMode, RequestQueryKind),
+        case {ShouldBatch, CallbackMode, QMSummary} of
+            {no_batch, always_sync, _} ->
+                ?match_event(#{?snk_kind := call_query});
+            {batch, always_sync, _} ->
+                ?match_event(#{?snk_kind := call_batch_query});
+            {no_batch, async_if_possible, #{is_simple := false, has_internal_buffer := false}} ->
+                ?match_event(#{?snk_kind := call_query_async});
+            {batch, async_if_possible, #{is_simple := false, has_internal_buffer := false}} ->
+                ?match_event(#{?snk_kind := call_batch_query_async});
+            {no_batch, async_if_possible, #{has_internal_buffer := true}} ->
+                ?match_event(#{?snk_kind := call_query_async});
+            {no_batch, async_if_possible, #{is_simple := true, requested_query_kind := sync}} ->
+                ?match_event(#{?snk_kind := call_query});
+            {no_batch, async_if_possible, #{is_simple := true, requested_query_kind := async}} ->
+                ?match_event(#{?snk_kind := call_query_async})
+        end
+    end,
+    ConnResId = connector_res_id(ConnName),
+    {ok, _} =
+        create(
+            ConnResId,
+            ?DEFAULT_RESOURCE_GROUP,
+            ?TEST_RESOURCE,
+            #{name => test_resource},
+            #{
+                health_check_interval => 100,
+                start_timeout => 100
+            }
+        ),
+    ChanId = action_res_id(ConnResId),
+    ChanResourceOpts = merge_maps([
+        #{
+            health_check_interval => 100,
+            worker_pool_size => 1
+        },
+        ResourceOpts0,
+        ChanResourceOptsOverride
+    ]),
+    ok =
+        add_channel(
+            ConnResId,
+            ChanId,
+            #{
+                force_query_mode => ChanQueryMode,
+                resource_opts => ChanResourceOpts
+            }
+        ),
+    FallbackFn = maps:get(
+        fallback_fn,
+        Opts,
+        fun(_Ctx) ->
+            {error, {unrecoverable_error, fallback_time}}
+        end
+    ),
+    TestPid = self(),
+    FallbackAction = fun(Ctx) ->
+        ct:pal("fallback triggered:\n  ~p", [Ctx]),
+        TestPid ! {fallback_called, Ctx},
+        ok
+    end,
+    MkFallback = fun(N) -> fun(Ctx) -> FallbackAction(Ctx#{n => N}) end end,
+    QueryOpts = #{
+        ?fallback_actions => [
+            MkFallback(1),
+            MkFallback(2)
+        ]
+    },
+    #{
+        base_query_opts => QueryOpts,
+        mk_fallback => MkFallback,
+        fallback_action => FallbackAction,
+        conn_res_id => ConnResId,
+        chan_id => ChanId,
+        mk_event_matcher => MkEventMatcher,
+        chan_resource_opts => ChanResourceOpts,
+        n_reqs => NReqs,
+        fallback_fn => FallbackFn
+    }.
+
+%%------------------------------------------------------------------------------
+%% Properties
+%%------------------------------------------------------------------------------
+
+%% Verifies that we compress operations for a given channel id that may happen to stack up
+%% while the resource manager process is stuck on a call.
+t_prop_compress_channel_operations(_Config) ->
+    ct:timetrap({seconds, 60}),
+    ?assert(
+        proper:quickcheck(prop_compress_channel_operations(), [{numtests, 100}, {to_file, user}])
+    ),
+    ok.
+
+prop_compress_channel_operations() ->
+    ?FORALL(
+        {ConnStatus, Commands},
+        {resource_status_gen(), list({range(1, 3), channel_op_gen()})},
+        begin
+            ConnResId = <<"connector:ctype:c">>,
+            AgentState0 = #{
+                resource_health_check => ConnStatus,
+                channel_health_check => connected
+            },
+            {ok, Agent} = emqx_utils_agent:start_link(AgentState0),
+            %% We mock the module so we may count the calls to add/remove channel
+            %% callbacks.
+            ok = meck:new(?TEST_RESOURCE, [passthrough]),
+            {ok, _} =
+                create(
+                    ConnResId,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{
+                        name => test_resource,
+                        health_check_agent => Agent
+                    },
+                    #{
+                        health_check_interval => 100,
+                        start_timeout => 100
+                    }
+                ),
+            ?assertMatch({ok, ConnStatus}, emqx_resource:health_check(ConnResId)),
+            %% We suspend the process so operations are stacked on its mailbox.
+            Pid = emqx_resource_manager:where(ConnResId),
+            ok = sys:suspend(Pid),
+            lists:foreach(
+                fun(Command) -> exec_channel_operation(Command, ConnResId) end,
+                Commands
+            ),
+            %% Resume and let it process everything.
+            ok = sys:resume(Pid),
+            %% To force processing of the mailbox, and trigger channel ops.  Must go to
+            %% `?status_connected` to actually process state changing operations.
+            _ = emqx_utils_agent:get_and_update(Agent, fun(Old) ->
+                {unused, Old#{resource_health_check := connected}}
+            end),
+            ?retry(100, 10, ?assertMatch({ok, connected}, emqx_resource:health_check(ConnResId))),
+            {ok, InConfigChannelsList} = emqx_resource_manager:get_channels(ConnResId),
+            InConfigChannels = maps:from_list(InConfigChannelsList),
+            InStateChannels = emqx_resource_manager:get_channel_configs(ConnResId),
+            {ok, _Group, ResData} = emqx_resource_manager:lookup_cached(ConnResId),
+            History = meck:history(?TEST_RESOURCE),
+            ok = meck:unload(?TEST_RESOURCE),
+            ok = emqx_resource:remove_local(ConnResId),
+            emqx_connector_demo:clear_emulated_config(ConnResId),
+            ExpectedOps = process_commands_expectation(Commands),
+            ExpectedChannels = maps:filter(fun(_, V) -> V /= del end, ExpectedOps),
+            %% Even if not added yet to the resource state, the known channel configs must
+            %% be the latest received additions, or the channel should be absent from
+            %% installed channels.
+            HasExpectedConfigs = ExpectedChannels =:= InConfigChannels,
+            %% If the resource status is connected, then the channel must also be in the
+            %% connector resource state.
+            IsInExpectedResState = ExpectedChannels =:= InStateChannels,
+            %% We compress the operations so that operations that cancel out are not
+            %% executed needlessly.  We can only know which calls were made from the
+            %% callback module in the connected status.
+            ExpectedOpCount = map_size(ExpectedOps),
+            ActualOpCount = lists:sum([
+                1
+             || {_Pid, {?TEST_RESOURCE, Fn, _Args}, _Res} <- History,
+                lists:member(Fn, [on_add_channel, on_remove_channel])
+            ]),
+            IsCompressedAsExpected =
+                case ConnStatus of
+                    ?status_connected ->
+                        %% One op per distinct channel
+                        ExpectedOpCount =:= ActualOpCount;
+                    _ ->
+                        true
+                end,
+            ?WHENFAIL(
+                io:format(
+                    user,
+                    "Connector status:\n  ~s\n\n"
+                    "Commands:\n  ~p\n\n"
+                    "Expected Channels:\n  ~p\n\n"
+                    "Channels in config:\n  ~p\n\n"
+                    "Channels in state:\n  ~p\n\n"
+                    "Expected op count:\n  ~p\n\n"
+                    "Actual op count:\n  ~p\n\n"
+                    "Module call history:\n  ~p\n\n"
+                    "Resource:\n  ~p\n\n",
+                    [
+                        ConnStatus,
+                        Commands,
+                        ExpectedChannels,
+                        InConfigChannels,
+                        InStateChannels,
+                        ExpectedOpCount,
+                        ActualOpCount,
+                        History,
+                        ResData
+                    ]
+                ),
+                aggregate(
+                    [ConnStatus],
+                    aggregate(
+                        Commands,
+                        HasExpectedConfigs andalso
+                            IsInExpectedResState andalso
+                            IsCompressedAsExpected
+                    )
+                )
+            )
+        end
+    ).
+
+process_commands_expectation(Commands) ->
+    lists:foldl(
+        fun
+            ({N, {add, ChannelConf}}, ModelState) ->
+                ChannelId = channel_num_to_id(N),
+                ModelState#{ChannelId => ChannelConf};
+            ({N, del}, ModelState) ->
+                ChannelId = channel_num_to_id(N),
+                maps:remove(ChannelId, ModelState)
+        end,
+        #{},
+        Commands
+    ).
+
+channel_num_to_id(N) ->
+    <<"action:atype:", (integer_to_binary(N))/binary, ":connector:ctype:c">>.
+
+exec_channel_operation({N, {add, ChannelConf}}, ConnResId) ->
+    ChannelId = channel_num_to_id(N),
+    ok = add_channel_async(ConnResId, ChannelId, ChannelConf);
+exec_channel_operation({N, del}, ConnResId) ->
+    ChannelId = channel_num_to_id(N),
+    ok = remove_channel_async(ConnResId, ChannelId).
+
+channel_op_gen() ->
+    frequency([{2, add_channel_gen()}, {1, del}]).
+
+add_channel_gen() ->
+    ?LET(
+        HealthCheckInterval,
+        range(1, 10),
+        {add, #{resource_opts => #{health_check_interval => HealthCheckInterval}}}
+    ).
+
+resource_status_gen() ->
+    %% Stopped is a more special state, which is not entered automatically
+    oneof([
+        ?status_connected,
+        ?status_connecting,
+        ?status_disconnected
+    ]).
+
+%%------------------------------------------------------------------------------
+%% Test cases
 %%------------------------------------------------------------------------------
 
 t_list_types(_) ->
@@ -4187,726 +4914,3 @@ t_compress_channel_operations_existing_channel(Config) when is_list(Config) ->
         ]
     ),
     ok.
-
-%%------------------------------------------------------------------------------
-%% Properties
-%%------------------------------------------------------------------------------
-
-%% Verifies that we compress operations for a given channel id that may happen to stack up
-%% while the resource manager process is stuck on a call.
-t_prop_compress_channel_operations(_Config) ->
-    ct:timetrap({seconds, 60}),
-    ?assert(
-        proper:quickcheck(prop_compress_channel_operations(), [{numtests, 100}, {to_file, user}])
-    ),
-    ok.
-
-prop_compress_channel_operations() ->
-    ?FORALL(
-        {ConnStatus, Commands},
-        {resource_status_gen(), list({range(1, 3), channel_op_gen()})},
-        begin
-            ConnResId = <<"connector:ctype:c">>,
-            AgentState0 = #{
-                resource_health_check => ConnStatus,
-                channel_health_check => connected
-            },
-            {ok, Agent} = emqx_utils_agent:start_link(AgentState0),
-            %% We mock the module so we may count the calls to add/remove channel
-            %% callbacks.
-            ok = meck:new(?TEST_RESOURCE, [passthrough]),
-            {ok, _} =
-                create(
-                    ConnResId,
-                    ?DEFAULT_RESOURCE_GROUP,
-                    ?TEST_RESOURCE,
-                    #{
-                        name => test_resource,
-                        health_check_agent => Agent
-                    },
-                    #{
-                        health_check_interval => 100,
-                        start_timeout => 100
-                    }
-                ),
-            ?assertMatch({ok, ConnStatus}, emqx_resource:health_check(ConnResId)),
-            %% We suspend the process so operations are stacked on its mailbox.
-            Pid = emqx_resource_manager:where(ConnResId),
-            ok = sys:suspend(Pid),
-            lists:foreach(
-                fun(Command) -> exec_channel_operation(Command, ConnResId) end,
-                Commands
-            ),
-            %% Resume and let it process everything.
-            ok = sys:resume(Pid),
-            %% To force processing of the mailbox, and trigger channel ops.  Must go to
-            %% `?status_connected` to actually process state changing operations.
-            _ = emqx_utils_agent:get_and_update(Agent, fun(Old) ->
-                {unused, Old#{resource_health_check := connected}}
-            end),
-            ?retry(100, 10, ?assertMatch({ok, connected}, emqx_resource:health_check(ConnResId))),
-            {ok, InConfigChannelsList} = emqx_resource_manager:get_channels(ConnResId),
-            InConfigChannels = maps:from_list(InConfigChannelsList),
-            InStateChannels = emqx_resource_manager:get_channel_configs(ConnResId),
-            {ok, _Group, ResData} = emqx_resource_manager:lookup_cached(ConnResId),
-            History = meck:history(?TEST_RESOURCE),
-            ok = meck:unload(?TEST_RESOURCE),
-            ok = emqx_resource:remove_local(ConnResId),
-            emqx_connector_demo:clear_emulated_config(ConnResId),
-            ExpectedOps = process_commands_expectation(Commands),
-            ExpectedChannels = maps:filter(fun(_, V) -> V /= del end, ExpectedOps),
-            %% Even if not added yet to the resource state, the known channel configs must
-            %% be the latest received additions, or the channel should be absent from
-            %% installed channels.
-            HasExpectedConfigs = ExpectedChannels =:= InConfigChannels,
-            %% If the resource status is connected, then the channel must also be in the
-            %% connector resource state.
-            IsInExpectedResState = ExpectedChannels =:= InStateChannels,
-            %% We compress the operations so that operations that cancel out are not
-            %% executed needlessly.  We can only know which calls were made from the
-            %% callback module in the connected status.
-            ExpectedOpCount = map_size(ExpectedOps),
-            ActualOpCount = lists:sum([
-                1
-             || {_Pid, {?TEST_RESOURCE, Fn, _Args}, _Res} <- History,
-                lists:member(Fn, [on_add_channel, on_remove_channel])
-            ]),
-            IsCompressedAsExpected =
-                case ConnStatus of
-                    ?status_connected ->
-                        %% One op per distinct channel
-                        ExpectedOpCount =:= ActualOpCount;
-                    _ ->
-                        true
-                end,
-            ?WHENFAIL(
-                io:format(
-                    user,
-                    "Connector status:\n  ~s\n\n"
-                    "Commands:\n  ~p\n\n"
-                    "Expected Channels:\n  ~p\n\n"
-                    "Channels in config:\n  ~p\n\n"
-                    "Channels in state:\n  ~p\n\n"
-                    "Expected op count:\n  ~p\n\n"
-                    "Actual op count:\n  ~p\n\n"
-                    "Module call history:\n  ~p\n\n"
-                    "Resource:\n  ~p\n\n",
-                    [
-                        ConnStatus,
-                        Commands,
-                        ExpectedChannels,
-                        InConfigChannels,
-                        InStateChannels,
-                        ExpectedOpCount,
-                        ActualOpCount,
-                        History,
-                        ResData
-                    ]
-                ),
-                aggregate(
-                    [ConnStatus],
-                    aggregate(
-                        Commands,
-                        HasExpectedConfigs andalso
-                            IsInExpectedResState andalso
-                            IsCompressedAsExpected
-                    )
-                )
-            )
-        end
-    ).
-
-process_commands_expectation(Commands) ->
-    lists:foldl(
-        fun
-            ({N, {add, ChannelConf}}, ModelState) ->
-                ChannelId = channel_num_to_id(N),
-                ModelState#{ChannelId => ChannelConf};
-            ({N, del}, ModelState) ->
-                ChannelId = channel_num_to_id(N),
-                maps:remove(ChannelId, ModelState)
-        end,
-        #{},
-        Commands
-    ).
-
-channel_num_to_id(N) ->
-    <<"action:atype:", (integer_to_binary(N))/binary, ":connector:ctype:c">>.
-
-exec_channel_operation({N, {add, ChannelConf}}, ConnResId) ->
-    ChannelId = channel_num_to_id(N),
-    ok = add_channel_async(ConnResId, ChannelId, ChannelConf);
-exec_channel_operation({N, del}, ConnResId) ->
-    ChannelId = channel_num_to_id(N),
-    ok = remove_channel_async(ConnResId, ChannelId).
-
-channel_op_gen() ->
-    frequency([{2, add_channel_gen()}, {1, del}]).
-
-add_channel_gen() ->
-    ?LET(
-        HealthCheckInterval,
-        range(1, 10),
-        {add, #{resource_opts => #{health_check_interval => HealthCheckInterval}}}
-    ).
-
-resource_status_gen() ->
-    %% Stopped is a more special state, which is not entered automatically
-    oneof([
-        ?status_connected,
-        ?status_connecting,
-        ?status_disconnected
-    ]).
-
-%%------------------------------------------------------------------------------
-%% Helpers
-%%------------------------------------------------------------------------------
-
-inc_counter_in_parallel(N) ->
-    inc_counter_in_parallel(N, {inc_counter, 1}, #{}).
-
-inc_counter_in_parallel(N, Opts0) ->
-    inc_counter_in_parallel(N, {inc_counter, 1}, Opts0).
-
-inc_counter_in_parallel(N, Query, Opts) ->
-    Parent = self(),
-    Pids = [
-        erlang:spawn(fun() ->
-            emqx_resource:query(?ID, maybe_apply(Query), maybe_apply(Opts)),
-            Parent ! {complete, self()}
-        end)
-     || _ <- lists:seq(1, N)
-    ],
-    [
-        receive
-            {complete, Pid} -> ok
-        after 1000 ->
-            ct:fail({wait_for_query_timeout, Pid})
-        end
-     || Pid <- Pids
-    ],
-    ok.
-
-inc_counter_in_parallel_increasing(N, StartN, Opts) ->
-    Parent = self(),
-    Pids = [
-        erlang:spawn(fun() ->
-            emqx_resource:query(?ID, {inc_counter, M}, maybe_apply(Opts)),
-            Parent ! {complete, self()}
-        end)
-     || M <- lists:seq(StartN, StartN + N - 1)
-    ],
-    [
-        receive
-            {complete, Pid} -> ok
-        after 1000 ->
-            ct:fail({wait_for_query_timeout, Pid})
-        end
-     || Pid <- Pids
-    ].
-
-maybe_apply(FunOrTerm) ->
-    maybe_apply(FunOrTerm, []).
-
-maybe_apply(Fun, Args) when is_function(Fun) ->
-    erlang:apply(Fun, Args);
-maybe_apply(Term, _Args) ->
-    Term.
-
-bin_config() ->
-    <<"\"name\": \"test_resource\"">>.
-
-config() ->
-    {ok, Config} = hocon:binary(bin_config()),
-    Config.
-
-tap_metrics(Line) ->
-    #{counters := C, gauges := G} = emqx_resource:get_metrics(?ID),
-    ct:pal("metrics (l. ~b): ~p", [Line, #{counters => C, gauges => G}]),
-    #{counters => C, gauges => G}.
-
-install_telemetry_handler(TestCase) ->
-    Tid = ets:new(TestCase, [ordered_set, public]),
-    HandlerId = TestCase,
-    TestPid = self(),
-    _ = telemetry:attach_many(
-        HandlerId,
-        emqx_resource_metrics:events(),
-        fun(EventName, Measurements, Metadata, _Config) ->
-            Data = #{
-                name => EventName,
-                measurements => Measurements,
-                metadata => Metadata
-            },
-            ets:insert(Tid, {erlang:monotonic_time(), Data}),
-            TestPid ! {telemetry, Data},
-            ok
-        end,
-        unused_config
-    ),
-    on_exit(fun() ->
-        telemetry:detach(HandlerId),
-        ets:delete(Tid)
-    end),
-    put({?MODULE, telemetry_table}, Tid),
-    Tid.
-
-wait_until_gauge_is(
-    GaugeName,
-    #{
-        expected_value := ExpectedValue,
-        timeout := Timeout,
-        max_events := MaxEvents
-    }
-) ->
-    Events = receive_all_events(GaugeName, Timeout, MaxEvents),
-    case length(Events) > 0 andalso lists:last(Events) of
-        #{measurements := #{gauge_set := ExpectedValue}} ->
-            ok;
-        #{measurements := #{gauge_set := Value}} ->
-            ct:fail(
-                "gauge ~p didn't reach expected value ~p; last value: ~p",
-                [GaugeName, ExpectedValue, Value]
-            );
-        false ->
-            ct:pal("no ~p gauge events received!", [GaugeName])
-    end.
-
-receive_all_events(EventName, Timeout) ->
-    receive_all_events(EventName, Timeout, _MaxEvents = 50, _Count = 0, _Acc = []).
-
-receive_all_events(EventName, Timeout, MaxEvents) ->
-    receive_all_events(EventName, Timeout, MaxEvents, _Count = 0, _Acc = []).
-
-receive_all_events(_EventName, _Timeout, MaxEvents, Count, Acc) when Count >= MaxEvents ->
-    lists:reverse(Acc);
-receive_all_events(EventName, Timeout, MaxEvents, Count, Acc) ->
-    receive
-        {telemetry, #{name := [_, _, EventName]} = Event} ->
-            ct:pal("telemetry event: ~p", [Event]),
-            receive_all_events(EventName, Timeout, MaxEvents, Count + 1, [Event | Acc])
-    after Timeout ->
-        lists:reverse(Acc)
-    end.
-
-wait_telemetry_event(EventName) ->
-    wait_telemetry_event(EventName, #{timeout => 5_000, n_events => 1}).
-
-wait_telemetry_event(
-    EventName,
-    Opts0
-) ->
-    DefaultOpts = #{timeout => 5_000, n_events => 1},
-    #{timeout := Timeout, n_events := NEvents} = maps:merge(DefaultOpts, Opts0),
-    wait_n_events(NEvents, Timeout, EventName).
-
-wait_n_events(NEvents, _Timeout, _EventName) when NEvents =< 0 ->
-    ok;
-wait_n_events(NEvents, Timeout, EventName) ->
-    TelemetryTable = get({?MODULE, telemetry_table}),
-    receive
-        {telemetry, #{name := [_, _, EventName]}} ->
-            wait_n_events(NEvents - 1, Timeout, EventName)
-    after Timeout ->
-        RecordedEvents = ets:tab2list(TelemetryTable),
-        ct:pal("recorded events: ~p", [RecordedEvents]),
-        error({timeout_waiting_for_telemetry, EventName})
-    end.
-
-assert_sync_retry_fail_then_succeed_inflight(Trace) ->
-    ?assert(
-        ?strict_causality(
-            #{?snk_kind := buffer_worker_flush_nack, ref := _Ref},
-            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
-            Trace
-        )
-    ),
-    %% not strict causality because it might retry more than once
-    %% before restoring the resource health.
-    ?assert(
-        ?causality(
-            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
-            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
-            Trace
-        )
-    ),
-    ok.
-
-assert_async_retry_fail_then_succeed_inflight(Trace) ->
-    ?assert(
-        ?strict_causality(
-            #{?snk_kind := handle_async_reply, action := nack},
-            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
-            Trace
-        )
-    ),
-    %% not strict causality because it might retry more than once
-    %% before restoring the resource health.
-    ?assert(
-        ?causality(
-            #{?snk_kind := buffer_worker_retry_inflight_failed, ref := _Ref},
-            #{?snk_kind := buffer_worker_retry_inflight_succeeded, ref := _Ref},
-            Trace
-        )
-    ),
-    ok.
-
-trace_between_span(Trace0, Marker) ->
-    {Trace1, [_ | _]} = ?split_trace_at(#{?snk_kind := Marker, ?snk_span := {complete, _}}, Trace0),
-    {[_ | _], [_ | Trace2]} = ?split_trace_at(#{?snk_kind := Marker, ?snk_span := start}, Trace1),
-    Trace2.
-
-wait_until_all_marked_as_retriable(NumExpected) when NumExpected =< 0 ->
-    ok;
-wait_until_all_marked_as_retriable(NumExpected) ->
-    Seen = #{},
-    do_wait_until_all_marked_as_retriable(NumExpected, Seen).
-
-do_wait_until_all_marked_as_retriable(NumExpected, _Seen) when NumExpected =< 0 ->
-    ok;
-do_wait_until_all_marked_as_retriable(NumExpected, Seen) ->
-    Res = ?block_until(
-        #{?snk_kind := buffer_worker_async_agent_down, ?snk_meta := #{pid := P}} when
-            not is_map_key(P, Seen),
-        10_000
-    ),
-    case Res of
-        {timeout, Evts} ->
-            ct:pal("events so far:\n  ~p", [Evts]),
-            ct:fail("timeout waiting for events");
-        {ok, #{num_affected := NumAffected, ?snk_meta := #{pid := Pid}}} ->
-            ct:pal("affected: ~p; pid: ~p", [NumAffected, Pid]),
-            case NumAffected >= NumExpected of
-                true ->
-                    ok;
-                false ->
-                    do_wait_until_all_marked_as_retriable(NumExpected - NumAffected, Seen#{
-                        Pid => true
-                    })
-            end
-    end.
-
-counter_metric_inc_fns() ->
-    Mod = emqx_resource_metrics,
-    [
-        fun Mod:Fn/1
-     || {Fn, 1} <- Mod:module_info(functions),
-        case string:find(atom_to_list(Fn), "_inc", trailing) of
-            "_inc" -> true;
-            _ -> false
-        end
-    ].
-
-gauge_metric_set_fns() ->
-    Mod = emqx_resource_metrics,
-    [
-        fun Mod:Fn/3
-     || {Fn, 3} <- Mod:module_info(functions),
-        case string:find(atom_to_list(Fn), "_set", trailing) of
-            "_set" -> true;
-            _ -> false
-        end
-    ].
-
-create(Id, Group, Type, Config) ->
-    create(Id, Group, Type, Config, #{}).
-
-create(Id, Group, Type, Config, Opts) ->
-    Res = emqx_resource:create_local(Id, Group, Type, Config, Opts),
-    on_exit(fun() -> emqx_resource:remove_local(Id) end),
-    case Type of
-        ?TEST_RESOURCE ->
-            on_exit(fun() -> emqx_connector_demo:clear_emulated_config(Id) end);
-        _ ->
-            ok
-    end,
-    Res.
-
-add_channel_emualte_config(ConnResId, ChanId, ChanConfig, Mode) ->
-    emqx_connector_demo:add_channel_emualte_config(ConnResId, ChanId, ChanConfig, Mode).
-
-remove_channel_emualte_config(ConnResId, ChanId, Mode) ->
-    emqx_connector_demo:remove_channel_emualte_config(ConnResId, ChanId, Mode).
-
-dryrun(Id, Type, Config) ->
-    TestPid = self(),
-    OnReady = fun(ResId) -> TestPid ! {resource_ready, ResId} end,
-    emqx_resource:create_dry_run_local(Id, Type, Config, OnReady).
-
-log_consistency_prop() ->
-    {"check state and cache consistency", fun ?MODULE:log_consistency_prop/1}.
-log_consistency_prop(Trace) ->
-    ?assertEqual([], ?of_kind("inconsistent_status", Trace)),
-    ?assertEqual([], ?of_kind("inconsistent_cache", Trace)),
-    ok.
-
-connector_res_id(Name) ->
-    %% Needs to have this form to satifisfy internal, implicit requirements of
-    %% `emqx_resource_cache'.
-    <<"connector:ctype:", Name/binary>>.
-
-action_res_id(ConnResId) ->
-    %% Needs to have this form to satifisfy internal, implicit requirements of
-    %% `emqx_resource_cache'.
-    <<"action:atype:aname:", ConnResId/binary>>.
-
-add_channel(ConnResId, ChanId, Config) ->
-    do_add_channel(ConnResId, ChanId, Config, sync).
-
-add_channel_async(ConnResId, ChanId, Config) ->
-    do_add_channel(ConnResId, ChanId, Config, async).
-
-do_add_channel(ConnResId, ChanId, Config, Mode) ->
-    ok = emqx_resource:create_metrics(ChanId),
-    on_exit(fun() -> emqx_resource:clear_metrics(ChanId) end),
-    ResourceOpts = emqx_resource:fetch_creation_opts(Config),
-    on_exit(fun() -> emqx_resource_buffer_worker_sup:stop_workers(ChanId, ResourceOpts) end),
-    ok = emqx_resource_buffer_worker_sup:start_workers(ChanId, ResourceOpts),
-    emqx_connector_demo:add_channel_emulate_config(ConnResId, ChanId, Config, Mode).
-
-remove_channel(ConnResId, ChanId) ->
-    do_remove_channel(ConnResId, ChanId, sync).
-
-remove_channel_async(ConnResId, ChanId) ->
-    do_remove_channel(ConnResId, ChanId, async).
-
-do_remove_channel(ConnResId, ChanId, Mode) ->
-    emqx_connector_demo:remove_channel_emulate_config(ConnResId, ChanId, Mode).
-
-group_path(Config, Default) ->
-    case emqx_common_test_helpers:group_path(Config) of
-        [] -> Default;
-        Path -> Path
-    end.
-
-fallback_actions_batch_opts(no_batch) ->
-    #{
-        resource_opts => #{batch_time => 0, batch_size => 1},
-        n_reqs => 1
-    };
-fallback_actions_batch_opts(batch) ->
-    #{
-        resource_opts => #{batch_time => 100, batch_size => 100},
-        n_reqs => 10
-    }.
-
-fallback_action_query(ConnResId, ChanId, FallbackFn, Ctx, #{query_mode := async} = QueryOpts0) ->
-    AdjustQueryOptsFn = maps:get(adjust_query_opts, Ctx, fun(_Ctx, QO) -> QO end),
-    Alias = alias([reply]),
-    ReplyTo = {
-        fun(ReplyCallerContext) ->
-            Alias ! {Alias, ReplyCallerContext}
-        end,
-        [],
-        #{reply_dropped => true}
-    },
-    QueryOpts1 = maps:merge(
-        #{connector_resource_id => ConnResId},
-        QueryOpts0#{reply_to => ReplyTo}
-    ),
-    QueryOpts = AdjustQueryOptsFn(Ctx, QueryOpts1),
-    Req = #{q => ask, fn => FallbackFn, ctx => Ctx},
-    ct:pal("~p sending query\n  ~p", [self(), #{query_opts => QueryOpts, ctx => Ctx}]),
-    Res = emqx_resource:query(
-        ChanId,
-        {ChanId, Req},
-        QueryOpts
-    ),
-    case Res of
-        ok ->
-            ok;
-        {async_return, {ok, _Pid}} ->
-            %% Simple async queries do not massage the returned value to stip the
-            %% `{async_return, _}' tag.
-            ok
-    end,
-    ct:pal("~p waiting for reply", [self()]),
-    receive
-        {Alias, ReplyCallerContext} ->
-            ct:pal("~p received async reply:\n  ~p", [self(), ReplyCallerContext]),
-            case ReplyCallerContext of
-                #{result := Result} ->
-                    Result;
-                Result ->
-                    %% If expired, it's a simple tuple
-                    Result
-            end
-    after 1_000 -> ct:fail("~p timed out waiting for reply", [self()])
-    end;
-fallback_action_query(ConnResId, ChanId, FallbackFn, Ctx, #{query_mode := sync} = QueryOpts0) ->
-    AdjustQueryOptsFn = maps:get(adjust_query_opts, Ctx, fun(QO) -> QO end),
-    QueryOpts1 = maps:merge(
-        #{connector_resource_id => ConnResId},
-        QueryOpts0
-    ),
-    QueryOpts = AdjustQueryOptsFn(QueryOpts1),
-    Req = #{q => ask, fn => FallbackFn, ctx => Ctx},
-    ct:pal("~p sending query\n  ~p", [self(), #{query_opts => QueryOpts, ctx => Ctx}]),
-    emqx_resource:query(
-        ChanId,
-        {ChanId, Req},
-        QueryOpts
-    ).
-
-fallback_query_wait_async(N, RequestQueryKind, QueryOpts, Ctx) ->
-    #{
-        conn_res_id := ConnResId,
-        chan_id := ChanId,
-        mk_event_matcher := MkEventMatcher,
-        fallback_fn := FallbackFn
-    } = Ctx,
-    AssertExpectedCallMode = maps:get(assert_expected_callmode, Ctx, true),
-    ReqCtx = Ctx#{req_n => N},
-    case AssertExpectedCallMode of
-        true ->
-            ct:pal("~p sending request ~b", [self(), N]),
-            EventMatcher = MkEventMatcher(RequestQueryKind),
-            {Result, {ok, _}} =
-                snabbkaffe:wait_async_action(
-                    fun() ->
-                        fallback_action_query(
-                            ConnResId, ChanId, FallbackFn, ReqCtx, QueryOpts#{
-                                query_mode => RequestQueryKind
-                            }
-                        )
-                    end,
-                    EventMatcher,
-                    infinity
-                );
-        false ->
-            Result = fallback_action_query(
-                ConnResId, ChanId, FallbackFn, ReqCtx, QueryOpts#{
-                    query_mode => RequestQueryKind
-                }
-            )
-    end,
-    ct:pal("~p received reply ~b:\n  ~p", [self(), N, Result]),
-    Result.
-
-fallback_send_many(RequestQueryKind, Ctx) ->
-    #{n_reqs := NReqs} = Ctx,
-    BaseQueryOpts = maps:get(base_query_opts, Ctx),
-    QueryOpts0 = maps:get(query_opts, Ctx, #{}),
-    QueryOpts = emqx_utils_maps:deep_merge(BaseQueryOpts, QueryOpts0),
-    Results = emqx_utils:pmap(
-        fun(N) ->
-            fallback_query_wait_async(N, RequestQueryKind, QueryOpts, Ctx)
-        end,
-        lists:seq(1, NReqs)
-    ),
-    Results.
-
-assert_all_queries_triggered_fallbacks(Ctx) ->
-    #{n_reqs := NReqs} = Ctx,
-    lists:foreach(
-        fun(N) ->
-            ?assertReceive(
-                {fallback_called, #{n := 1, request := #{ctx := #{req_n := N}}}}
-            ),
-            ?assertReceive({fallback_called, #{n := 2, request := #{ctx := #{req_n := N}}}})
-        end,
-        lists:seq(1, NReqs)
-    ),
-    ?assertNotReceive({fallback_called, _}),
-    ok.
-
-merge_maps(Maps) ->
-    lists:foldl(fun emqx_utils_maps:deep_merge/2, #{}, Maps).
-
-%% Poor man's `timer:apply_after', prior to OTP 27.
-apply_after(Time, Fn) ->
-    spawn(fun() ->
-        timer:sleep(Time),
-        Fn()
-    end).
-
-fallback_actions_basic_setup(ConnName, ChanQueryMode, CallbackMode, ShouldBatch) ->
-    fallback_actions_basic_setup(ConnName, ChanQueryMode, CallbackMode, ShouldBatch, _Opts = #{}).
-
-fallback_actions_basic_setup(ConnName, ChanQueryMode, CallbackMode, ShouldBatch, Opts) ->
-    ChanResourceOptsOverride = maps:get(chan_resource_opts_override, Opts, #{}),
-    emqx_connector_demo:set_callback_mode(CallbackMode),
-    #{
-        resource_opts := ResourceOpts0,
-        n_reqs := NReqs
-    } = fallback_actions_batch_opts(ShouldBatch),
-    MkEventMatcher = fun(RequestQueryKind) ->
-        QMSummary = emqx_resource_manager:summarize_query_mode(ChanQueryMode, RequestQueryKind),
-        case {ShouldBatch, CallbackMode, QMSummary} of
-            {no_batch, always_sync, _} ->
-                ?match_event(#{?snk_kind := call_query});
-            {batch, always_sync, _} ->
-                ?match_event(#{?snk_kind := call_batch_query});
-            {no_batch, async_if_possible, #{is_simple := false, has_internal_buffer := false}} ->
-                ?match_event(#{?snk_kind := call_query_async});
-            {batch, async_if_possible, #{is_simple := false, has_internal_buffer := false}} ->
-                ?match_event(#{?snk_kind := call_batch_query_async});
-            {no_batch, async_if_possible, #{has_internal_buffer := true}} ->
-                ?match_event(#{?snk_kind := call_query_async});
-            {no_batch, async_if_possible, #{is_simple := true, requested_query_kind := sync}} ->
-                ?match_event(#{?snk_kind := call_query});
-            {no_batch, async_if_possible, #{is_simple := true, requested_query_kind := async}} ->
-                ?match_event(#{?snk_kind := call_query_async})
-        end
-    end,
-    ConnResId = connector_res_id(ConnName),
-    {ok, _} =
-        create(
-            ConnResId,
-            ?DEFAULT_RESOURCE_GROUP,
-            ?TEST_RESOURCE,
-            #{name => test_resource},
-            #{
-                health_check_interval => 100,
-                start_timeout => 100
-            }
-        ),
-    ChanId = action_res_id(ConnResId),
-    ChanResourceOpts = merge_maps([
-        #{
-            health_check_interval => 100,
-            worker_pool_size => 1
-        },
-        ResourceOpts0,
-        ChanResourceOptsOverride
-    ]),
-    ok =
-        add_channel(
-            ConnResId,
-            ChanId,
-            #{
-                force_query_mode => ChanQueryMode,
-                resource_opts => ChanResourceOpts
-            }
-        ),
-    FallbackFn = maps:get(
-        fallback_fn,
-        Opts,
-        fun(_Ctx) ->
-            {error, {unrecoverable_error, fallback_time}}
-        end
-    ),
-    TestPid = self(),
-    FallbackAction = fun(Ctx) ->
-        ct:pal("fallback triggered:\n  ~p", [Ctx]),
-        TestPid ! {fallback_called, Ctx},
-        ok
-    end,
-    MkFallback = fun(N) -> fun(Ctx) -> FallbackAction(Ctx#{n => N}) end end,
-    QueryOpts = #{
-        ?fallback_actions => [
-            MkFallback(1),
-            MkFallback(2)
-        ]
-    },
-    #{
-        base_query_opts => QueryOpts,
-        mk_fallback => MkFallback,
-        fallback_action => FallbackAction,
-        conn_res_id => ConnResId,
-        chan_id => ChanId,
-        mk_event_matcher => MkEventMatcher,
-        chan_resource_opts => ChanResourceOpts,
-        n_reqs => NReqs,
-        fallback_fn => FallbackFn
-    }.


### PR DESCRIPTION
Release version: 5.9.0

## Summary

Incited by investigating https://emqx.atlassian.net/browse/EMQX-14045

The original issue was already fixed by:
- https://github.com/emqx/emqx/pull/14740
- https://github.com/emqx/emqx/pull/14867

This patch improves the logic by preventing such cases from occurring even if manually (in
console) trying to provoke resource health checks.

Also fixes minor issue: https://emqx.atlassian.net/browse/EMQX-14047

See individual commits for clearer changes.

## PR Checklist

- [x] Added tests for the changes
- [na] ~~Change log has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~ already fixed elsewhere; this only makes things more robust.
- [x] For internal contributor: there is a jira ticket to track this change
