### PR TITLE
fix(new mix build): add missing dependency to `emqx_opentelemetry`

### DIFF
--- a/apps/emqx_opentelemetry/mix.exs
+++ b/apps/emqx_opentelemetry/mix.exs
@@ -24,6 +24,7 @@ defmodule EMQXOpentelemetry.MixProject do
   def deps() do
     [
       {:emqx, in_umbrella: true},
+      {:emqx_resource, in_umbrella: true},
       {:opentelemetry_api,
        github: "emqx/opentelemetry-erlang",
        tag: "v1.4.9-emqx",


### PR DESCRIPTION
This only affects the new mix build.