### PR TITLE
fix(dsraft): avoid allocating shards on lost sites

### DIFF
--- a/changes/ee/fix-14933.en.md
+++ b/changes/ee/fix-14933.en.md
@@ -1,0 +1,1 @@
+Resolved a rare edge case where a Durable Storage backed by DS Raft could be assigned to storage sites that had left the cluster long ago.


### PR DESCRIPTION
Part of [EMQX-13864](https://emqx.atlassian.net/browse/EMQX-13864).

Release version: 5.9

## Summary

Address an edge case in shard allocation: avoid allocating shards to lost sites. This is extremely unlikely to happen in practice, but occasionally manifests in emqx/emqx-operator#1123 test runs.

See individual commits for details.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered by tests
- [x] Change log has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible


[EMQX-13864]: https://emqx.atlassian.net/browse/EMQX-13864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ