### PR TITLE
fix(router): purge orphaned routing nodes during reconcile

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.1"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.1"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.6"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.1"}}},

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -146,7 +146,7 @@ t_membership_node_leaving(_Config) ->
     {_, {ok, _}} = ?wait_async_action(
         ?ROUTER_HELPER ! {membership, {node, leaving, AnotherNode}},
         #{?snk_kind := router_node_routing_table_purged, node := AnotherNode},
-        1_000
+        5_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
 

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_replication_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_replication_SUITE.erl
@@ -132,7 +132,9 @@ t_shards_allocation(Config) ->
     %% Make the cluster consider `Node1` as lost.
     ok = emqx_cth_peer:kill(NodeLost),
     _ = ?retry(200, 5, [NodeLost] = [NodeLost] -- ?ON(Node, mria:cluster_nodes(running))),
-    ok = ?ON(Node, emqx_cluster:force_leave(NodeLost)),
+    %% Simulate node loss that went unnoticed, taken from `mria:force_leave/1`.
+    true = ?ON(Node, mnesia_lib:del(extra_db_nodes, Node)),
+    ok = ?ON(Node, mria_mnesia:del_schema_copy(NodeLost)),
     ?assertEqual(
         [SiteLost],
         ?ON(Node, emqx_ds_replication_layer_meta:sites(lost))

--- a/changes/ce/fix-14936.en.md
+++ b/changes/ce/fix-14936.en.md
@@ -1,0 +1,1 @@
+Resolved an issue where, in rare cases, the global routing table could indefinitely retain routing information for nodes that had long left the cluster.

--- a/mix.exs
+++ b/mix.exs
@@ -183,7 +183,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.21.1", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.21.2", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.1", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.1", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -85,7 +85,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.1"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-8"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.1"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.1"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},


### PR DESCRIPTION
Release version: 5.9.0

Fixes https://emqx.atlassian.net/browse/EMQX-14055.

## Summary

_Orphaned_ node here means a node that is marked as "routing node" in the respective table but cluster membership does not know about it.

See individual commits for details.

Behavior is slightly changed, most notably:
* Nodes which are leaving / have left the cluster will be purged after 10 second delay, after cluster membership changes are completed.
* Nodes which have been "force-left" right after going down will be purged after 10 second delay, after cluster membership changes are completed; in other cases in ~1 minute during the next reconcile (same as before).

This also means that flapping cluster nodes may delay purges for considerable amount of time.

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [x] Added tests for the changes
- [ ] ~~Added property-based tests for code which performs user input validation~~
- [ ] Changed lines covered by tests
- [x] Change log has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket~~
- [x] Schema changes are backward compatible
