### PR TITLE
Expose concepts of shard and generation directly

### DIFF
--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_state.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_state.erl
@@ -1034,7 +1034,7 @@ put_seqno(Key, Val, Rec) ->
 
 %%
 
--type rank_key() :: {emqx_persistent_session_ds:subscription_id(), emqx_ds:rank_x()}.
+-type rank_key() :: {emqx_persistent_session_ds:subscription_id(), emqx_ds:shard()}.
 
 -spec get_rank(rank_key(), t()) -> integer() | undefined.
 get_rank(Key, Rec) ->
@@ -1055,7 +1055,7 @@ fold_ranks(Fun, Acc, Rec) ->
 %% @doc Fold ranks for a specific subscription ID
 -spec fold_ranks(
     emqx_persistent_session_ds:subscription_id(),
-    fun((emqx_ds:rank_x(), emqx_ds:rank_y(), Acc) -> Acc),
+    fun((emqx_ds:shard(), emqx_ds:generation(), Acc) -> Acc),
     Acc,
     t()
 ) -> Acc.

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_stream_scheduler.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_stream_scheduler.erl
@@ -176,7 +176,7 @@
     emqx_ds_new_streams:watch() => emqx_persistent_session_ds:topic_filter()
 }.
 
--type stream_map() :: #{emqx_ds:rank_x() => [{emqx_ds:rank_y(), emqx_ds:stream()}]}.
+-type stream_map() :: #{emqx_ds:shard() => [{emqx_ds:generation(), emqx_ds:stream()}]}.
 
 %% Subscription-specific state:
 -record(sub_metadata, {
@@ -770,7 +770,7 @@ renew_streams(S0, TopicFilter, Subscription, StreamMap, SubState0) ->
 -spec renew_streams_for_x(
     emqx_persistent_session_ds_state:t(),
     emqx_persistent_session_ds:subscription_id(),
-    emqx_ds:rank_x(),
+    emqx_ds:shard(),
     t()
 ) ->
     ret().
@@ -801,10 +801,12 @@ renew_streams_for_x(S0, SubId, RankX, SchedS0 = #s{sub_metadata = SubMeta0}) ->
     emqx_persistent_session_ds_state:t(),
     emqx_ds:topic_filter(),
     emqx_persistent_session_ds_subs:subscription(),
-    emqx_ds:rank_x(),
-    [{emqx_ds:rank_y(), emqx_ds:stream()}]
+    emqx_ds:shard(),
+    [{emqx_ds:generation(), emqx_ds:stream()}]
 ) ->
-    {[stream_key()], emqx_persistent_session_ds_state:t(), [{emqx_ds:rank_y(), emqx_ds:stream()}]}.
+    {[stream_key()], emqx_persistent_session_ds_state:t(), [
+        {emqx_ds:generation(), emqx_ds:stream()}
+    ]}.
 do_renew_streams_for_x(S0, TopicFilter, Subscription = #{id := SubId}, RankX, YStreamL) ->
     CommQos1 = emqx_persistent_session_ds_state:get_seqno(?committed(?QOS_1), S0),
     CommQos2 = emqx_persistent_session_ds_state:get_seqno(?committed(?QOS_2), S0),
@@ -1073,8 +1075,8 @@ to_BQ12(Key, SRS, S = #s{bq1 = BQ1, bq2 = BQ2}) ->
 -spec make_iterator(
     emqx_ds:topic_filter(),
     emqx_persistent_session_ds_subs:subscription(),
-    emqx_ds:rank_x(),
-    emqx_ds:rank_y(),
+    emqx_ds:shard(),
+    emqx_ds:generation(),
     emqx_ds:stream(),
     emqx_persistent_session_ds_state:t()
 ) ->

--- a/apps/emqx/src/emqx_persistent_session_ds/session_internals.hrl
+++ b/apps/emqx/src/emqx_persistent_session_ds/session_internals.hrl
@@ -53,8 +53,8 @@
 
 %%%%% Stream Replay State:
 -record(srs, {
-    rank_x :: emqx_ds:rank_x(),
-    rank_y :: emqx_ds:rank_y(),
+    rank_x :: emqx_ds:shard(),
+    rank_y :: emqx_ds:generation(),
     %% Iterators at the beginning and the end of the last batch:
     it_begin :: emqx_ds:iterator() | undefined,
     it_end :: emqx_ds:iterator() | end_of_stream,

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -116,7 +116,7 @@
         atomic_batches := boolean()
     }.
 
--type generation_rank() :: {shard(), emqx_ds_storage_layer:gen_id()}.
+-type slab() :: {shard(), emqx_ds_storage_layer:gen_id()}.
 
 -define(stream(SHARD, INNER), [2, SHARD | INNER]).
 -define(delete_stream(SHARD, INNER), [3, SHARD | INNER]).
@@ -186,7 +186,7 @@ update_db_config(DB, CreateOpts) ->
     ).
 
 -spec list_generations_with_lifetimes(emqx_ds:db()) ->
-    #{emqx_ds:generation_rank() => emqx_ds:generation_info()}.
+    #{emqx_ds:slab() => emqx_ds:slab_info()}.
 list_generations_with_lifetimes(DB) ->
     lists:foldl(
         fun(Shard, Acc) ->
@@ -207,7 +207,7 @@ list_generations_with_lifetimes(DB) ->
         emqx_ds_builtin_local_meta:shards(DB)
     ).
 
--spec drop_generation(emqx_ds:db(), generation_rank()) -> ok | {error, _}.
+-spec drop_generation(emqx_ds:db(), slab()) -> ok | {error, _}.
 drop_generation(DB, {Shard, GenId}) ->
     emqx_ds_storage_layer:drop_generation({DB, Shard}, GenId).
 
@@ -350,7 +350,7 @@ shard_of_key(DB, Key) ->
     integer_to_binary(Hash).
 
 -spec get_streams(emqx_ds:db(), emqx_ds:topic_filter(), emqx_ds:time()) ->
-    [{emqx_ds:stream_rank(), emqx_ds:ds_specific_stream()}].
+    [{emqx_ds:slab(), emqx_ds:ds_specific_stream()}].
 get_streams(DB, TopicFilter, StartTime) ->
     Shards = emqx_ds_builtin_local_meta:shards(DB),
     lists:flatmap(

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -20,7 +20,7 @@
     drop_generation/2,
     drop_db/1,
     store_batch/3,
-    get_streams/3,
+    get_streams/4,
     get_delete_streams/3,
     make_iterator/4,
     make_delete_iterator/4,
@@ -34,6 +34,7 @@
 
     current_timestamp/2,
 
+    shard_of/2,
     shard_of_operation/4,
     flush_buffer/4,
     init_buffer/3
@@ -341,42 +342,38 @@ store_batch_atomic(DB, Batch, _Opts) ->
             {error, unrecoverable, atomic_batch_spans_multiple_shards}
     end.
 
--spec get_streams(emqx_ds:db(), emqx_ds:topic_filter(), emqx_ds:time()) ->
-    [{emqx_ds:slab(), stream()}].
-get_streams(DB, TopicFilter, StartTime) ->
-    Shards = list_shards(DB),
-    lists:flatmap(
-        fun(Shard) ->
+-spec get_streams(emqx_ds:db(), emqx_ds:topic_filter(), emqx_ds:time(), emqx_ds:get_streams_opts()) ->
+    emqx_ds:get_streams_result().
+get_streams(DB, TopicFilter, StartTime, Opts) ->
+    Shards =
+        case Opts of
+            #{shard := ReqShard} ->
+                [ReqShard];
+            _ ->
+                list_shards(DB)
+        end,
+    lists:foldl(
+        fun(Shard, {Acc, AccErr}) ->
             try ra_get_streams(DB, Shard, TopicFilter, StartTime) of
                 Streams when is_list(Streams) ->
-                    lists:map(
-                        fun({RankY, StorageLayerStream}) ->
-                            RankX = Shard,
-                            Rank = {RankX, RankY},
-                            {Rank, ?stream_v2(Shard, StorageLayerStream)}
+                    L = lists:map(
+                        fun({Generation, StorageLayerStream}) ->
+                            Slab = {Shard, Generation},
+                            {Slab, ?stream_v2(Shard, StorageLayerStream)}
                         end,
                         Streams
-                    );
-                {error, Class, Reason} ->
-                    ?tp(debug, ds_repl_get_streams_failed, #{
-                        db => DB,
-                        shard => Shard,
-                        class => Class,
-                        reason => Reason
-                    }),
-                    []
+                    ),
+                    {L ++ Acc, AccErr};
+                {error, _, _} = Err ->
+                    E = {Shard, Err},
+                    {Acc, [E | AccErr]}
             catch
                 EC:Err:Stack ->
-                    ?tp(debug, ds_repl_get_streams_failed, #{
-                        db => DB,
-                        shard => Shard,
-                        class => EC,
-                        reason => Err,
-                        stack => Stack
-                    }),
-                    []
+                    E = {Shard, ?err_rec({EC, Err, Stack})},
+                    {Acc, [E | AccErr]}
             end
         end,
+        {[], []},
         Shards
     ).
 
@@ -549,16 +546,16 @@ shard_of_operation(DB, #message{from = From, topic = Topic}, SerializeBy, _Optio
         clientid -> Key = From;
         topic -> Key = Topic
     end,
-    shard_of_key(DB, Key);
+    shard_of(DB, Key);
 shard_of_operation(DB, {_OpName, Matcher}, SerializeBy, _Options) ->
     #message_matcher{from = From, topic = Topic} = Matcher,
     case SerializeBy of
         clientid -> Key = From;
         topic -> Key = Topic
     end,
-    shard_of_key(DB, Key).
+    shard_of(DB, Key).
 
-shard_of_key(DB, Key) ->
+shard_of(DB, Key) ->
     N = emqx_ds_replication_shard_allocator:n_shards(DB),
     Hash = erlang:phash2(Key, N),
     integer_to_binary(Hash).

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -196,7 +196,7 @@
     ?batch_preconditions => [emqx_ds:precondition()]
 }.
 
--type generation_rank() :: {shard_id(), term()}.
+-type slab() :: {shard_id(), term()}.
 
 %% Core state of the replication, i.e. the state of ra machine.
 -type ra_state() :: #{
@@ -266,7 +266,7 @@ update_db_config(DB, CreateOpts) ->
     ).
 
 -spec list_generations_with_lifetimes(emqx_ds:db()) ->
-    #{generation_rank() => emqx_ds:generation_info()}.
+    #{slab() => emqx_ds:slab_info()}.
 list_generations_with_lifetimes(DB) ->
     Shards = list_shards(DB),
     lists:foldl(
@@ -290,7 +290,7 @@ list_generations_with_lifetimes(DB) ->
         Shards
     ).
 
--spec drop_generation(emqx_ds:db(), generation_rank()) -> ok | {error, _}.
+-spec drop_generation(emqx_ds:db(), slab()) -> ok | {error, _}.
 drop_generation(DB, {Shard, GenId}) ->
     ra_drop_generation(DB, Shard, GenId).
 
@@ -342,7 +342,7 @@ store_batch_atomic(DB, Batch, _Opts) ->
     end.
 
 -spec get_streams(emqx_ds:db(), emqx_ds:topic_filter(), emqx_ds:time()) ->
-    [{emqx_ds:stream_rank(), stream()}].
+    [{emqx_ds:slab(), stream()}].
 get_streams(DB, TopicFilter, StartTime) ->
     Shards = list_shards(DB),
     lists:flatmap(
@@ -727,7 +727,7 @@ do_add_generation_v2(_DB) ->
     error(obsolete_api).
 
 -spec do_list_generations_with_lifetimes_v3(emqx_ds:db(), shard_id()) ->
-    #{emqx_ds:ds_specific_generation_rank() => emqx_ds:generation_info()}
+    #{emqx_ds:generation() => emqx_ds:slab_info()}
     | emqx_ds:error(storage_down).
 do_list_generations_with_lifetimes_v3(DB, Shard) ->
     ShardId = {DB, Shard},

--- a/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_proto_v4.erl
+++ b/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_proto_v4.erl
@@ -108,9 +108,7 @@ add_generation(Node, DB) ->
     emqx_ds:db(),
     emqx_ds_replication_layer:shard_id()
 ) ->
-    #{
-        emqx_ds:ds_specific_generation_rank() => emqx_ds:generation_info()
-    }.
+    #{emqx_ds:slab() => emqx_ds:slab_info()}.
 list_generations_with_lifetimes(Node, DB, Shard) ->
     erpc:call(Node, emqx_ds_replication_layer, do_list_generations_with_lifetimes_v3, [DB, Shard]).
 

--- a/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_proto_v5.erl
+++ b/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_proto_v5.erl
@@ -125,7 +125,7 @@ add_generation(Node, DB) ->
     emqx_ds_replication_layer:shard_id()
 ) ->
     #{
-        emqx_ds:ds_specific_generation_rank() => emqx_ds:generation_info()
+        emqx_ds:generation() => emqx_ds:slab_info()
     }.
 list_generations_with_lifetimes(Node, DB, Shard) ->
     erpc:call(Node, emqx_ds_replication_layer, do_list_generations_with_lifetimes_v3, [DB, Shard]).

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_leader_rank_progress.erl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_leader_rank_progress.erl
@@ -14,10 +14,10 @@
 ]).
 
 %% "shard"
--type rank_x() :: emqx_ds:rank_x().
+-type rank_x() :: emqx_ds:shard().
 
 %% "generation"
--type rank_y() :: emqx_ds:rank_y().
+-type rank_y() :: emqx_ds:generation().
 
 %% shard progress
 -type x_progress() :: #{
@@ -46,7 +46,7 @@
 -spec init() -> t().
 init() -> #{}.
 
--spec set_replayed(emqx_ds:stream_rank(), t()) -> t().
+-spec set_replayed(emqx_ds:slab(), t()) -> t().
 set_replayed({{RankX, RankY}, Stream}, State) ->
     case State of
         #{RankX := #{ys := #{RankY := #{Stream := false} = RankYStreams} = Ys0}} ->
@@ -66,8 +66,8 @@ set_replayed({{RankX, RankY}, Stream}, State) ->
             State
     end.
 
--spec add_streams([{emqx_ds:stream_rank(), emqx_ds:stream()}], t()) ->
-    {[{emqx_ds:stream_rank(), emqx_ds:stream()}], t()}.
+-spec add_streams([{emqx_ds:slab(), emqx_ds:stream()}], t()) ->
+    {[{emqx_ds:slab(), emqx_ds:stream()}], t()}.
 add_streams(StreamsWithRanks, State) ->
     SortedStreamsWithRanks = lists:sort(
         fun({{_RankX1, RankY1}, _Stream1}, {{_RankX2, RankY2}, _Stream2}) ->
@@ -88,7 +88,7 @@ add_streams(StreamsWithRanks, State) ->
         SortedStreamsWithRanks
     ).
 
--spec replayed_up_to(emqx_ds:rank_x(), t()) -> emqx_ds:rank_y().
+-spec replayed_up_to(emqx_ds:shard(), t()) -> emqx_ds:generation().
 replayed_up_to(RankX, State) ->
     case State of
         #{RankX := #{min_y := MinY}} ->

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_store.erl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_store.erl
@@ -311,7 +311,7 @@ mk_leader_topic(ID) ->
 
 -type stream_state() :: #{
     progress => emqx_persistent_session_ds_shared_subs:progress(),
-    rank => emqx_ds:stream_rank()
+    rank => emqx_ds:slab()
 }.
 
 -spec init(id()) -> t().

--- a/apps/emqx_durable_storage/src/emqx_ds_beamformer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_beamformer.erl
@@ -195,7 +195,7 @@
         %% Flow control:
         flowcontrol :: flowcontrol(),
         %%
-        rank :: emqx_ds:stream_rank(),
+        rank :: emqx_ds:slab(),
         stream :: _Stream,
         topic_filter :: emqx_ds:topic_filter(),
         start_key :: emqx_ds:message_key(),
@@ -306,7 +306,7 @@
     stream := Stream,
     topic_filter := event_topic_filter(),
     last_seen_key := emqx_ds:message_key(),
-    rank := emqx_ds:stream_rank()
+    rank := emqx_ds:slab()
 }.
 
 -callback unpack_iterator(dbshard(), _Iterator) ->
@@ -756,7 +756,7 @@ generation_event(DBShard) ->
     %% worker:
     pending = [] :: [sub_state()],
     %% Generation cache:
-    generations :: #{emqx_ds:generation_rank() => emqx_ds:generation_info()}
+    generations :: #{emqx_ds:slab() => emqx_ds:slab_info()}
 }).
 
 -type d() :: #d{}.


### PR DESCRIPTION
Fixes [EMQX-14054](https://emqx.atlassian.net/browse/EMQX-14054)

Release version: 5.9

## Summary

The abstraction of "rank" was a leaky one. This PR removes it and replaces it with concepts of shard and generation.

- First of all, there wasn't any real reason to hide the existence of shards from the user.
- When we want to use DS as a serializable storage for session data, this obscurity becomes a major obstacle: user code has no reliable way to handle errors
- It also leads to inefficiencies: when the user code has to iterate over data that belongs to a certain client ID, it should be able to do so over streams that belong to the specific shard instead of sending `get_streams` request to _all_ shards.   

## PR Checklist
Please convert it to a draft if any of the following conditions are not met. Reviewers may skip over until all the items are checked:

- [ ] Added tests for the changes
- [x] Added property-based tests for code which performs user input validation
- [x] Changed lines covered by tests
- [x] Change log has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] For internal contributor: there is a jira ticket to track this change
- [x] Created PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or link to a follow-up jira ticket
- [x] Schema changes are backward compatible

## Checklist for CI (.github/workflows) changes

- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update


[EMQX-14054]: https://emqx.atlassian.net/browse/EMQX-14054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ