### PR TITLE
feat(emqx_plugins): respect plugin's `on_config_changed` callback response

### DIFF
--- a/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_SUITE.erl
@@ -28,8 +28,8 @@
 -define(EMQX_PLUGIN_TEMPLATE_URL,
     "https://github.com/emqx/emqx-plugin-template/releases/download/"
 ).
--define(EMQX_PLUGIN_TEMPLATE_VSN, "5.1.0").
--define(EMQX_PLUGIN_TEMPLATE_TAG, "5.1.0").
+-define(EMQX_PLUGIN_TEMPLATE_VSN, "5.9.0-beta.2").
+-define(EMQX_PLUGIN_TEMPLATE_TAG, "5.9.0-beta.2").
 
 -define(EMQX_PLUGIN_TEMPLATES_LEGACY, [
     #{

--- a/apps/emqx_plugins/test/emqx_plugins_config_SUITE.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_config_SUITE.erl
@@ -7,6 +7,8 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include_lib("emqx_plugins/include/emqx_plugins.hrl").
+
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -17,8 +19,8 @@
 -define(EMQX_PLUGIN_TEMPLATE_URL,
     "https://github.com/emqx/emqx-plugin-template/releases/download/"
 ).
--define(EMQX_PLUGIN_TEMPLATE_VSN, "5.9.0-beta.1").
--define(EMQX_PLUGIN_TEMPLATE_TAG, "5.9.0-beta.1").
+-define(EMQX_PLUGIN_TEMPLATE_VSN, "5.9.0-beta.2").
+-define(EMQX_PLUGIN_TEMPLATE_TAG, "5.9.0-beta.2").
 
 -define(EMQX_PLUGIN_NO_AVSC, #{
     vsn => ?EMQX_PLUGIN_TEMPLATE_VSN,
@@ -43,7 +45,11 @@
 %%--------------------------------------------------------------------
 
 all() ->
-    emqx_common_test_helpers:all(?MODULE).
+    [{group, avsc}, {group, no_avsc}].
+
+groups() ->
+    All = emqx_common_test_helpers:all(?MODULE),
+    [{avsc, All}, {no_avsc, All}].
 
 init_per_suite(Config) ->
     WorkDir = emqx_cth_suite:work_dir(Config),
@@ -62,9 +68,21 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
+init_per_group(avsc, Config) ->
+    [{plugin_download_options, ?EMQX_PLUGIN_AVSC} | Config];
+init_per_group(no_avsc, Config) ->
+    [{plugin_download_options, ?EMQX_PLUGIN_NO_AVSC} | Config].
+
+end_per_group(_Group, _Config) ->
+    ok.
+
 init_per_testcase(_TestCase, Config) ->
     emqx_plugins_test_helpers:purge_plugins(),
-    Config.
+    PluginDownloadOptions = ?config(plugin_download_options, Config),
+    #{name_vsn := NameVsn} = emqx_plugins_test_helpers:get_demo_plugin_package(
+        PluginDownloadOptions
+    ),
+    [{name_vsn, NameVsn} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
     emqx_plugins_test_helpers:purge_plugins().
@@ -73,26 +91,45 @@ end_per_testcase(_TestCase, _Config) ->
 %% Test cases
 %%--------------------------------------------------------------------
 
-t_plugin_with_avsc_config(_Config) ->
-    #{name_vsn := NameVsn} = emqx_plugins_test_helpers:get_demo_plugin_package(?EMQX_PLUGIN_AVSC),
-    ok = emqx_plugins:ensure_installed(NameVsn),
+t_update_config(Config) ->
+    NameVsn = ?config(name_vsn, Config),
 
+    %% Plugin is not installed, so we cannot update the config
+    ?assertMatch(
+        {error, _},
+        emqx_plugins:update_config(NameVsn, #{<<"foo">> => <<"bar">>})
+    ),
+
+    %% Install the plugin, verify that we have a config
+    ok = emqx_plugins:ensure_installed(NameVsn, ?fresh_install),
     ?assertMatch(
         #{<<"hostname">> := <<"localhost">>},
         emqx_plugins:get_config(NameVsn)
     ),
 
-    ok = emqx_plugins:ensure_uninstalled(NameVsn).
-
-t_plugin_with_no_avsc_config(_Config) ->
-    #{name_vsn := NameVsn} = emqx_plugins_test_helpers:get_demo_plugin_package(
-        ?EMQX_PLUGIN_NO_AVSC
-    ),
-    ok = emqx_plugins:ensure_installed(NameVsn),
-
+    %% Verify that callbacks are called even if the plugin is not running
+    OldConfig = emqx_plugins:get_config(NameVsn),
+    BadConfig = OldConfig#{<<"hostname">> => <<"bad.host">>},
+    %% The error for non-localhost is baked into the plugin
     ?assertMatch(
-        #{<<"hostname">> := <<"localhost">>},
-        emqx_plugins:get_config(NameVsn)
+        {error, <<"Invalid host: bad.host">>}, emqx_plugins:update_config(NameVsn, BadConfig)
     ),
+    ?assertMatch(ok, emqx_plugins:update_config(NameVsn, OldConfig)),
 
-    ok = emqx_plugins:ensure_uninstalled(NameVsn).
+    %% Verify that callbacks are called if the plugin is running
+    ok = emqx_plugins:ensure_started(NameVsn),
+    ?assertMatch(
+        {error, <<"Invalid host: bad.host">>}, emqx_plugins:update_config(NameVsn, BadConfig)
+    ),
+    ?assertMatch(ok, emqx_plugins:update_config(NameVsn, OldConfig)),
+
+    %% Verify that callbacks are called if the plugin is stopped
+    ok = emqx_plugins:ensure_stopped(NameVsn),
+    ?assertMatch(
+        {error, <<"Invalid host: bad.host">>}, emqx_plugins:update_config(NameVsn, BadConfig)
+    ),
+    ?assertMatch(ok, emqx_plugins:update_config(NameVsn, OldConfig)),
+
+    %% Verify that config cannot be updated if the plugin is uninstalled
+    ok = emqx_plugins:ensure_uninstalled(NameVsn),
+    ?assertMatch({error, _}, emqx_plugins:update_config(NameVsn, OldConfig)).

--- a/apps/emqx_plugins/test/emqx_plugins_test_helpers.erl
+++ b/apps/emqx_plugins/test/emqx_plugins_test_helpers.erl
@@ -24,7 +24,7 @@ get_demo_plugin_package(
 ) ->
     TargetName = lists:flatten([ReleaseName, "-", PluginVsn, ?PACKAGE_SUFFIX]),
     FileURI = lists:flatten(lists:join("/", [GitUrl, ReleaseTag, TargetName])),
-    {ok, {_, _, PluginBin}} = httpc:request(FileURI),
+    {ok, {_Status, _Headers, PluginBin}} = httpc:request(FileURI),
     Pkg = filename:join([
         WorkDir,
         TargetName

--- a/changes/ce/breaking-14957.en.md
+++ b/changes/ce/breaking-14957.en.md
@@ -1,0 +1,3 @@
+Plugin subsystem now respects the result of the plugin's `on_config_changed` callback.
+
+The callback is called before updating the config. If the callback does not return `ok`, the config is not updated and a error is returned to the dasboard.


### PR DESCRIPTION
Fixes [EMQX-14039](http://emqx.atlassian.net/browse/EMQX-14039)

Release version: 5.9

## Summary

The major changes are:
* We load plugin apps during the _installation_ of a plugin. We need this to call the `on_config_change` callback for stopped plugins.
* We introduce a new method for updating plugins' config and respect `on_config_change` result in it. 

**NOTE** This is obviously a breaking change, but only for new config updates coming from the dashboard. The callback result is still ignored for the configs already stored in the cluster. 

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14039]: https://emqx.atlassian.net/browse/EMQX-14039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ