### PR TITLE
feat(dashboard api): allow deleting default admin when others exist

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -28,7 +28,7 @@
 %% Authorization
 -export([authorize/1]).
 
--export([save_dispatch_eterm/1]).
+-export([save_dispatch_eterm/1, save_dispatch_eterm/2]).
 
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/http_api.hrl").
@@ -124,8 +124,12 @@ minirest_option(Options) ->
 
 %% save dispatch to priv dir.
 save_dispatch_eterm(SchemaMod) ->
+    save_dispatch_eterm(SchemaMod, _ConfigToMerge = #{}).
+
+save_dispatch_eterm(SchemaMod, ConfigToMerge) ->
     Dir = code:priv_dir(emqx_dashboard),
-    emqx_config:put([dashboard], #{i18n_lang => en, swagger_support => false}),
+    Config = maps:merge(ConfigToMerge, #{i18n_lang => en, swagger_support => false}),
+    emqx_config:put([dashboard], Config),
     os:putenv("SCHEMA_MOD", atom_to_list(SchemaMod)),
     DispatchFile = filename:join([Dir, ?DISPATCH_FILE]),
     io:format(user, "===< Generating: ~s~n", [DispatchFile]),

--- a/apps/emqx_dashboard/src/emqx_dashboard_app.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_app.erl
@@ -38,7 +38,6 @@ start(_StartType, _StartArgs) ->
     case emqx_dashboard:start_listeners() of
         ok ->
             emqx_dashboard_cli:load(),
-            %emqx_dashboard_log:setup(),
             {ok, _} = emqx_dashboard_admin:add_default_user(),
             {ok, Sup};
         {error, Reason} ->

--- a/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_SUITE.erl
@@ -63,18 +63,19 @@ init_per_suite(Config) ->
         [
             emqx_conf,
             emqx_management,
-            {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"}
+            emqx_mgmt_api_test_util:emqx_dashboard()
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     _ = emqx_conf_schema:roots(),
     ok = emqx_dashboard_desc_cache:init(),
-    emqx_dashboard:save_dispatch_eterm(emqx_conf:schema_module()),
-    emqx_common_test_http:create_default_app(),
+    %% We must pass on the current config here, otherwise it would clobber normal
+    %% configuration keys such as default_password and default_username...
+    DashboardConfig = emqx_conf:get([dashboard]),
+    emqx_dashboard:save_dispatch_eterm(emqx_conf:schema_module(), DashboardConfig),
     [{suite_apps, SuiteApps} | Config].
 
 end_per_suite(Config) ->
-    emqx_common_test_http:delete_default_app(),
     emqx_cth_suite:stop(?config(suite_apps, Config)).
 
 t_overview(_) ->
@@ -195,6 +196,48 @@ t_admin_delete_self_failed(_) ->
     Header2 = {"Authorization", Token},
     {error, {_, 401, _}} = request_dashboard(delete, api_path(["users", "username1"]), Header2),
     mnesia:clear_table(?ADMIN).
+
+%% This verifies that we can delete the default admin only if there is at least another
+%% admin username in the database.
+t_admin_delete_default_username(_TCConfig) ->
+    mnesia:clear_table(?ADMIN),
+    DefaultUsername = emqx_dashboard_admin:default_username(),
+    DefaultPassword = emqx_dashboard_admin:default_password(),
+    %% Sanity checks
+    ?assertNotEqual(<<"">>, DefaultUsername),
+    ?assertNotEqual(<<"">>, DefaultPassword),
+    {ok, #{}} = emqx_dashboard_admin:add_default_user(),
+    HeaderDefault = auth_header_(DefaultUsername, DefaultPassword),
+    ?assertMatch(
+        {error, {_, 400, _}},
+        request_dashboard(delete, api_path(["users", DefaultUsername]), HeaderDefault)
+    ),
+    NewAdmin = <<"newadmin">>,
+    NewPassword = <<"newadminpassword_123">>,
+    {ok, #{}} = emqx_dashboard_admin:add_user(
+        NewAdmin, NewPassword, ?ROLE_SUPERUSER, <<"description">>
+    ),
+    NewHeader = auth_header_(NewAdmin, NewPassword),
+    %% Now we can delete the default admin user
+    ?assertMatch(
+        {ok, _},
+        request_dashboard(delete, api_path(["users", DefaultUsername]), NewHeader)
+    ),
+    ?assertMatch(
+        {error, {_, 404, _}},
+        request_dashboard(delete, api_path(["users", DefaultUsername]), NewHeader)
+    ),
+    %% Cannot delete self
+    ?assertMatch(
+        {error, {_, 400, _}},
+        request_dashboard(delete, api_path(["users", NewAdmin]), NewHeader)
+    ),
+    %% Restarting the application should not restore the default admin user
+    ?assertMatch([_], emqx_dashboard_admin:admin_users()),
+    ok = application:stop(emqx_dashboard),
+    ok = application:start(emqx_dashboard),
+    ?assertMatch([_], emqx_dashboard_admin:admin_users()),
+    ok.
 
 t_rest_api(_Config) ->
     mnesia:clear_table(?ADMIN),

--- a/changes/ee/feat-14966.en.md
+++ b/changes/ee/feat-14966.en.md
@@ -1,0 +1,1 @@
+Added the possibility of deleting the default dashboard admin user.  For that, at least one other admin user must exist.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14053

Release version: 5.9.0

## Summary

This essentially allows one to rename the default admin user after a cluster is already started by creating a new admin and deleting the default one.

If there is at least one admin user other than the default one, we may delete the latter.

Also, since the `emqx_dashboard` application attempts to create the default user every time it starts, we use the same logic to avoid creating it.  

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
