### PR TITLE
250404 refactor license take2

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -180,13 +180,14 @@ jobs:
           docker image inspect $_EMQX_DOCKER_IMAGE_TAG --format='{{.Size}}' | xargs -I {} test {} -lt 300000000
 
       - name: smoke test
-        timeout-minutes: 1
+        timeout-minutes: 5
         run: |
           for tag in $(cat .emqx_docker_image_tags); do
             CID=$(docker run -d -p 18083:18083 $tag)
             HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' $CID)
             ./scripts/test/emqx-smoke-test.sh localhost $HTTP_PORT
             docker rm -f $CID
+            ./scripts/test/cluster-smoke-test.sh $tag
           done
 
       - name: dashboard tests

--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -12,6 +12,7 @@
 {emqx_bridge,6}.
 {emqx_bridge,7}.
 {emqx_broker,1}.
+{emqx_cluster,1}.
 {emqx_cluster_link,1}.
 {emqx_cm,1}.
 {emqx_cm,2}.

--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -24,6 +24,11 @@
     ensure_singleton_mode/0
 ]).
 
+%% RPC callback functions
+-export([
+    can_i_join/1
+]).
+
 -define(CLUSTER_MODE_NORMAL, normal).
 -define(CLUSTER_MODE_SINGLE, singleton).
 
@@ -34,12 +39,15 @@
 -define(DEFAULT_MODE, ?CLUSTER_MODE_SINGLE).
 -endif.
 
-join(Node) ->
-    case is_single_node_mode() of
-        true ->
-            {error, single_node_mode};
-        false ->
-            ekka:join(Node)
+join(PeerNode) ->
+    %% Local node starts with default license (singleton mode),
+    %% But the peer node(s) may have a license which allows local node to join.
+    %% So we do not check the license locally.
+    case check_permission(PeerNode) of
+        ok ->
+            ekka:join(PeerNode);
+        {error, Message} ->
+            {error, Message}
     end.
 
 leave() ->
@@ -47,6 +55,30 @@ leave() ->
 
 force_leave(Node) ->
     ekka:force_leave(Node).
+
+check_permission(PeerNode) ->
+    %% This call happens before clustered, so it's not possible to
+    %% check peer node's bpapi versions.
+    try
+        emqx_cluster_proto_v1:can_i_join(node(), PeerNode)
+    catch
+        error:{exception, undef, [{emqx_cluster, can_i_join, _, _}]} ->
+            %% The peer node is older than 5.9.0
+            %% This can happen during rolling upgrade.
+            ok
+    end.
+
+%% @doc Check if the requesting node is allowed to join the cluster.
+%% Called by license checker for community license.
+-spec can_i_join(node()) -> ok | {error, string()}.
+can_i_join(_RequestingNode) ->
+    case is_single_node_mode() of
+        true ->
+            Msg = lists:flatten(io_lib:format("Node ~s has a single node license", [node()])),
+            {error, Msg};
+        false ->
+            ok
+    end.
 
 is_single_node_mode() ->
     case application:get_env(emqx, cluster_mode, ?DEFAULT_MODE) of

--- a/apps/emqx/src/proto/emqx_cluster_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_cluster_proto_v1.erl
@@ -16,6 +16,6 @@
 introduced_in() ->
     "5.9.0".
 
--spec can_i_join(node(), node()) -> ok | {error, string()} | {badrpc, term()}.
+-spec can_i_join(node(), node()) -> ok | {error, string()}.
 can_i_join(SelfNode, PeerNode) ->
     erpc:call(PeerNode, emqx_cluster, can_i_join, [SelfNode]).

--- a/apps/emqx/src/proto/emqx_cluster_proto_v1.erl
+++ b/apps/emqx/src/proto/emqx_cluster_proto_v1.erl
@@ -1,0 +1,21 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_cluster_proto_v1).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+    can_i_join/2
+]).
+
+-include("bpapi.hrl").
+
+introduced_in() ->
+    "5.9.0".
+
+-spec can_i_join(node(), node()) -> ok | {error, string()} | {badrpc, term()}.
+can_i_join(SelfNode, PeerNode) ->
+    erpc:call(PeerNode, emqx_cluster, can_i_join, [SelfNode]).

--- a/apps/emqx_license/include/emqx_license.hrl
+++ b/apps/emqx_license/include/emqx_license.hrl
@@ -12,13 +12,12 @@
 %% resolved to DEFAULT_MAX_SESSIONS_LTYPE2 at runtime.
 -define(COMMUNITY_LICENSE_LOG,
     "\n"
-    "==============================================================================\n"
-    "Using a single-node community license!\n"
-    "This license is not permitted for commercial use.\n"
-    "Visit https://emqx.com/apply-licenses/emqx?version=5 to apply a license for:\n"
-    " - Commercial use\n"
+    "=====================================================================\n"
+    "You are using a single-node license!\n"
+    "Visit https://emqx.com/apply-licenses/emqx to apply a license for:\n"
+    " - Clustered deployment\n"
     " - Education or Non-profit use (clustered deployment, free of charge)\n"
-    "==============================================================================\n"
+    "=====================================================================\n"
 ).
 
 %% Similar to the ltype=trial&ctype=evaluation license from before 5.9
@@ -32,7 +31,7 @@
     "Limitations:\n"
     " - At most ~p concurrent sessions.\n"
     " - A 30-day uptime limit, must restart the node to regain the sessions quota.\n"
-    "Visit https://emqx.com/apply-licenses/emqx?version=5 to apply a license for:\n"
+    "Visit https://emqx.com/apply-licenses/emqx to apply a license for:\n"
     " - Commercial use\n"
     " - Education or Non-profit use (clustered deployment, free of charge)\n"
     "=============================================================================\n"

--- a/mix.exs
+++ b/mix.exs
@@ -851,6 +851,12 @@ defmodule EMQXUmbrella.MixProject do
     # So, this should be run before the release.
     # TODO: run as a "compiler" step???
     render_template(
+      "apps/emqx/etc/ssl_dist.conf",
+      assigns,
+      Path.join(etc, "ssl_dist.conf")
+    )
+
+    render_template(
       "apps/emqx_conf/etc/emqx.conf.all",
       assigns,
       Path.join(etc, "emqx.conf")

--- a/scripts/test/cluster-smoke-test.sh
+++ b/scripts/test/cluster-smoke-test.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+[ $# -ne 1 ] && { echo "Usage: $0 DOCKER_IMAGE_TAG"; exit 1; }
+
+DOCKER_IMAGE_TAG="$1"
+
+check_cluster_status () {
+    docker exec -it 'node1.emqx.io' emqx ctl cluster status --json
+}
+
+cd -P -- "$(dirname -- "$0")"
+
+## can join cluster by default
+echo '======== Allow clustering with "evaluation" license'
+env EMQX_LICENSE__KEY1='evaluation' \
+    EMQX_LICENSE__KEY2='default' \
+./start-two-nodes-in-docker.sh "${DOCKER_IMAGE_TAG}"
+
+## cannot join cluster if node1 does not have a license
+echo '======== Do not allow clustering with "default" license'
+! env EMQX_LICENSE__KEY1='default' \
+      EMQX_LICENSE__KEY2='default' \
+  ./start-two-nodes-in-docker.sh "${DOCKER_IMAGE_TAG}" || {
+    echo "ERROR: 'default' license allowed cluster join, but expected to fail"
+    exit 1
+}
+
+echo '======== Allow clustering with "default" license if peer node is before 5.9'
+## new (>= 5.9.0) can join cluster with old (< 5.9.0)
+IMAGE1='emqx/emqx-enterprise:5.8.6'
+env EMQX_LICENSE__KEY1='default' \
+    EMQX_LICENSE__KEY2='default' \
+./start-two-nodes-in-docker.sh "${IMAGE1}" "${DOCKER_IMAGE_TAG}"
+
+## Clenaup
+./start-two-nodes-in-docker.sh -c

--- a/scripts/test/start-two-nodes-in-docker.sh
+++ b/scripts/test/start-two-nodes-in-docker.sh
@@ -10,7 +10,7 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "$0")/../../"
 
-HAPROXY_PORTS=(-p 18083:18083 -p 1883:1883 -p 8883:8883 -p 8084:8084)
+HAPROXY_PORTS=(-p 18083:18083 -p 1883:1883 -p 8883:8883 -p 8884:8884)
 
 NET='emqx.io'
 NODE1="node1.$NET"
@@ -50,7 +50,7 @@ do
     case $opt in
         # -P option is treated similarly to docker run -P:
         # publish ports to random available host ports
-        P) HAPROXY_PORTS=(-p 18083 -p 1883 -p 8883 -p 8084);;
+        P) HAPROXY_PORTS=(-p 18083 -p 1883 -p 8883 -p 8884);;
         c) cleanup; exit 0;;
         h) show_help; exit 0;;
         6) IPV6=1;;
@@ -105,7 +105,7 @@ docker run -d -t --restart=always --name "$NODE1" \
   -e EMQX_listeners__wss__default__enable=false \
   -e EMQX_listeners__tcp__default__proxy_protocol=true \
   -e EMQX_listeners__ws__default__proxy_protocol=true \
-  -e EMQX_LICENSE__KEY=evaluation \
+  -e EMQX_LICENSE__KEY="${EMQX_LICENSE__KEY1:-evaluation}" \
   "$IMAGE1"
 
 docker run -d -t --restart=always --name "$NODE2" \
@@ -120,7 +120,7 @@ docker run -d -t --restart=always --name "$NODE2" \
   -e EMQX_listeners__wss__default__enable=false \
   -e EMQX_listeners__tcp__default__proxy_protocol=true \
   -e EMQX_listeners__ws__default__proxy_protocol=true \
-  -e EMQX_LICENSE__KEY=evaluation \
+  -e EMQX_LICENSE__KEY="${EMQX_LICENSE__KEY2:-evaluation}" \
   "$IMAGE2"
 
 mkdir -p tmp
@@ -190,7 +190,7 @@ frontend emqx_ssl
 frontend emqx_wss
     mode tcp
     option tcplog
-    bind *:8084 ssl crt /tmp/emqx.pem ca-file /usr/local/etc/haproxy/certs/cacert.pem verify required no-sslv3
+    bind *:8884 ssl crt /tmp/emqx.pem ca-file /usr/local/etc/haproxy/certs/cacert.pem verify required no-sslv3
     default_backend emqx_backend_ws
 
 backend emqx_backend_tcp
@@ -219,17 +219,17 @@ haproxy_cid=$(docker run -d --name haproxy \
                               cat certs/cert.pem certs/key.pem > /tmp/emqx.pem;
                               haproxy -f haproxy.cfg')
 
-haproxy_ssl_port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8084/tcp") 0).HostPort}}' "$haproxy_cid")
+haproxy_ssl_port=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "8884/tcp") 0).HostPort}}' "$haproxy_cid")
 
-wait_limit=60
 wait_for_emqx() {
     container="$1"
     wait_limit="$2"
     wait_sec=0
-    while ! docker exec "$container" emqx ctl status; do
+    while ! docker exec "$container" emqx ctl status >/dev/null 2>&1; do
         wait_sec=$(( wait_sec + 1 ))
         if [ $wait_sec -gt "$wait_limit" ]; then
             echo "timeout wait for EMQX"
+            docker logs "$container"
             exit 1
         fi
         echo -n '.'
@@ -237,15 +237,20 @@ wait_for_emqx() {
     done
 }
 
+## Probe wss listener by haproxy.
+probe_wss_listener() {
+    openssl s_client \
+        -CAfile apps/emqx/etc/certs/cacert.pem \
+        -cert apps/emqx/etc/certs/client-cert.pem \
+        -key apps/emqx/etc/certs/client-key.pem \
+        -connect localhost:"$haproxy_ssl_port" </dev/null >/dev/null 2>&1
+}
+
 wait_for_haproxy() {
     wait_sec=0
     wait_limit="$1"
     set +x
-    while ! openssl s_client \
-                -CAfile apps/emqx/etc/certs/cacert.pem \
-                -cert apps/emqx/etc/certs/cert.pem \
-                -key apps/emqx/etc/certs/key.pem \
-                localhost:"$haproxy_ssl_port" </dev/null; do
+    while ! probe_wss_listener; do
         wait_sec=$(( wait_sec + 1 ))
         if [ $wait_sec -gt "$wait_limit" ]; then
             echo "timeout wait for haproxy"
@@ -256,10 +261,16 @@ wait_for_haproxy() {
     done
 }
 
-wait_for_emqx "$NODE1" 30
+wait_for_emqx "$NODE1" 60
 wait_for_emqx "$NODE2" 30
-wait_for_haproxy 10
+wait_for_haproxy 30
 
 echo
 
-docker exec $NODE1 emqx ctl cluster join "emqx@$NODE2"
+docker exec "${NODE2}" emqx ctl cluster join "emqx@$NODE1"
+
+RUNNING_NODES="$(docker exec -t "$NODE1" emqx ctl cluster status --json | jq '.running_nodes | length')"
+if ! [ "${RUNNING_NODES}" -eq "${EXPECTED_RUNNING_NODES:-2}" ]; then
+    echo "Expected running nodes is ${EXPECTED_RUNNING_NODES}, but got ${RUNNING_NODES}"
+    exit 1
+fi


### PR DESCRIPTION
Release version: 5.9.0

## Summary

Added a RPC call `emqx_cluster:can_i_join/1` to if peer node allows the requesting node to join cluster.
Previously (5.9, but not released yet), the check is done locally, as a result it was not possible to join cluster without adding a license first --- this was considered a bad user experience.
Now the new node can join cluster without a license added, then license will be fetched from peer node after joined.

## PR Checklist

- [~] For internal contributor: there is a jira ticket to track this change (this is a follow-up fix for https://github.com/emqx/emqx/pull/14803
- [x] The changes are covered with new or existing tests
- [~] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

