### PR TITLE
test: fix broken test

### DIFF
--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -97,6 +97,7 @@ t_base_create_delete(_Config) ->
             start_at => Now,
             end_at => Now + 30 * 60,
             payload_encode => text,
+            payload_limit => 1024,
             formatter => text
         }
     ],


### PR DESCRIPTION
https://github.com/emqx/emqx/pull/14935 was merged with this test broken.

```
%%% emqx_trace_SUITE ==> t_base_create_delete: FAILED
%%% emqx_trace_SUITE ==> 
Failure/Error: ?assertEqual([#{name => <<110,97,109,101,49>>,type => clientid,filter => <<116,101,115,116,45,100,101,118,105,99,101>>,formatter => text,enable => true,payload_encode => text,start_at => 1743045398,end_at => 1743047198}], emqx_trace : format ( [ TraceRec ] ))
  expected: [#{name => <<"name1">>,type => clientid,
               filter => <<"test-device">>,formatter => text,enable => true,
               payload_encode => text,start_at => 1743045398,
               end_at => 1743047198}]
       got: [#{name => <<"name1">>,type => clientid,
               filter => <<"test-device">>,formatter => text,enable => true,
               payload_limit => 1024,payload_encode => text,
               start_at => 1743045398,end_at => 1743047198}]
      line: 103
```
