### PR TITLE
feat: rabbitmq exchange as non-required to support default exchange

### DIFF
--- a/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_pubsub_schema.erl
+++ b/apps/emqx_bridge_rabbitmq/src/emqx_bridge_rabbitmq_pubsub_schema.erl
@@ -77,7 +77,7 @@ fields(action_parameters) ->
             hoconsc:mk(
                 emqx_schema:template(),
                 #{
-                    required => true,
+                    default => <<>>,
                     desc => ?DESC(?CONNECTOR_SCHEMA, "exchange")
                 }
             )},

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_connector_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_connector_SUITE.erl
@@ -52,9 +52,9 @@ init_per_group(Group, Config) ->
 end_per_group(Group, Config) ->
     emqx_bridge_rabbitmq_test_utils:end_per_group(Group, Config).
 
-% %%------------------------------------------------------------------------------
-% %% Testcases
-% %%------------------------------------------------------------------------------
+%%------------------------------------------------------------------------------
+%% Testcases
+%%------------------------------------------------------------------------------
 
 t_lifecycle(Config) ->
     perform_lifecycle_check(
@@ -124,9 +124,9 @@ perform_lifecycle_check(ResourceID, InitialConfig, TestConfig) ->
     % Should not even be able to get the resource data out of ets now unlike just stopping.
     ?assertEqual({error, not_found}, emqx_resource:get_instance(ResourceID)).
 
-% %%------------------------------------------------------------------------------
-% %% Helpers
-% %%------------------------------------------------------------------------------
+%%------------------------------------------------------------------------------
+%% Helpers
+%%------------------------------------------------------------------------------
 
 check_config(Config) ->
     {ok, #{config := CheckedConfig}} =

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_test_utils.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_test_utils.erl
@@ -140,6 +140,9 @@ rabbit_mq_port() ->
 rabbit_mq_exchange() ->
     <<"messages">>.
 
+rabbit_mq_default_exchange() ->
+    <<>>.
+
 rabbit_mq_queue() ->
     <<"test_queue">>.
 

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
@@ -545,18 +545,30 @@ t_action_use_default_exchange(Config) ->
 
 waiting_for_disconnected_alarms(InstanceId) ->
     ?retry(
-        100,
-        20,
-        ?assertMatch(
-            [
-                #{
-                    message :=
-                        <<"resource down: #{error => not_connected,status => disconnected}">>,
-                    name := InstanceId
-                }
-            ],
-            emqx_alarm:get_alarms(activated)
-        )
+        _TimeOut = 100,
+        _Times = 20,
+        case
+            lists:any(
+                fun
+                    (
+                        #{
+                            message :=
+                                <<"resource down: #{error => not_connected,status => disconnected}">>,
+                            name := InstanceId0
+                        }
+                    ) ->
+                        InstanceId0 =:= InstanceId;
+                    (_) ->
+                        false
+                end,
+                emqx_alarm:get_alarms(activated)
+            )
+        of
+            true ->
+                ok;
+            false ->
+                throw(not_receive_disconnect_alarm)
+        end
     ).
 
 waiting_for_dropped_count(InstanceId) ->

--- a/changes/ee/feat-14996.en.md
+++ b/changes/ee/feat-14996.en.md
@@ -1,0 +1,1 @@
+RabbitMQ action supports using the default exchange.

--- a/rel/i18n/emqx_bridge_rabbitmq_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_rabbitmq_connector_schema.hocon
@@ -56,7 +56,7 @@ auto_reconnect.label:
 """Auto Reconnect"""
 
 exchange.desc:
-"""The name of the RabbitMQ exchange where the messages will be sent. Supports templates (e.g.: `e-${payload.e}`)."""
+"""The name of the RabbitMQ exchange where the messages will be sent. Supports templates (e.g.: `e-${payload.e}`). Leave blank and configure `routing_key` to the specified Queue to use RabbitMQ's default Exchange."""
 
 exchange.label:
 """Exchange"""


### PR DESCRIPTION
Fixes [EMQX-14082](https://emqx.atlassian.net/browse/EMQX-14082)

Release version: 5.9.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

Mark `exchange` field as non-required and default to `<<>>` to use default exchange
see also https://www.rabbitmq.com/docs/exchanges#default-exchange

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14082]: https://emqx.atlassian.net/browse/EMQX-14082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ