### PR TITLE
fix(license): do not allow single node license when already clustered

### DIFF
--- a/.ci/docker-compose-file/docker-compose-elastic-search-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-elastic-search-tls.yaml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 # hint: run the following if the container fails to start locally
 # sysctl -w vm.max_map_count=262144
 services:

--- a/.ci/docker-compose-file/docker-compose-emqx-cluster-mnesia.override.yaml
+++ b/.ci/docker-compose-file/docker-compose-emqx-cluster-mnesia.override.yaml
@@ -16,6 +16,7 @@ services:
       - "EMQX_HOST=node1.emqx.io"
       - "EMQX_NODE__DB_BACKEND=mnesia"
       - "EMQX_NODE__DB_ROLE=core"
+      - "EMQX_LICENSE__KEY=evaluation"
 
   emqx2:
     <<: *default-emqx
@@ -27,3 +28,4 @@ services:
       - "EMQX_HOST=node2.emqx.io"
       - "EMQX_NODE__DB_BACKEND=mnesia"
       - "EMQX_NODE__DB_ROLE=core"
+      - "EMQX_LICENSE__KEY=evaluation"

--- a/.ci/docker-compose-file/docker-compose-emqx-cluster-rlog.override.yaml
+++ b/.ci/docker-compose-file/docker-compose-emqx-cluster-rlog.override.yaml
@@ -19,6 +19,7 @@ services:
       - "EMQX_CLUSTER__STATIC__SEEDS=[emqx@node1.emqx.io]"
       - "EMQX_LISTENERS__TCP__DEFAULT__PROXY_PROTOCOL=false"
       - "EMQX_LISTENERS__WS__DEFAULT__PROXY_PROTOCOL=false"
+      - "EMQX_LICENSE__KEY=evaluation"
 
   emqx2:
     <<: *default-emqx
@@ -34,3 +35,4 @@ services:
       - "EMQX_CLUSTER__STATIC__SEEDS=[emqx@node1.emqx.io]"
       - "EMQX_LISTENERS__TCP__DEFAULT__PROXY_PROTOCOL=false"
       - "EMQX_LISTENERS__WS__DEFAULT__PROXY_PROTOCOL=false"
+      - "EMQX_LICENSE__KEY=evaluation"

--- a/.ci/docker-compose-file/docker-compose-emqx-cluster.yaml
+++ b/.ci/docker-compose-file/docker-compose-emqx-cluster.yaml
@@ -42,6 +42,7 @@ services:
     container_name: node1.emqx.io
     environment:
       - "EMQX_HOST=node1.emqx.io"
+      - "EMQX_LICENSE__KEY=evaluation"
     networks:
       emqx_bridge:
         aliases:
@@ -52,6 +53,7 @@ services:
     container_name: node2.emqx.io
     environment:
       - "EMQX_HOST=node2.emqx.io"
+      - "EMQX_LICENSE__KEY=evaluation"
     networks:
       emqx_bridge:
         aliases:

--- a/.ci/docker-compose-file/docker-compose-hstreamdb.yaml
+++ b/.ci/docker-compose-file/docker-compose-hstreamdb.yaml
@@ -1,5 +1,3 @@
-version: "3.5"
-
 services:
   hserver:
     image: hstreamdb/hstream:${HSTREAMDB_TAG}

--- a/.ci/docker-compose-file/docker-compose-mongo-replicaset-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-replicaset-tcp.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mongo1:
     hostname: mongo1

--- a/.ci/docker-compose-file/docker-compose-mongo-replicaset-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-replicaset-tls.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mongo1:
     hostname: mongo1

--- a/.ci/docker-compose-file/docker-compose-mongo-sharded-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-mongo-sharded-tcp.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   mongosharded1:
     hostname: mongosharded1

--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tcp.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   redis-sentinel-master:

--- a/.ci/docker-compose-file/docker-compose-redis-sentinel-tls.yaml
+++ b/.ci/docker-compose-file/docker-compose-redis-sentinel-tls.yaml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   redis-sentinel-tls-master:

--- a/.ci/docker-compose-file/scripts/run-emqx.sh
+++ b/.ci/docker-compose-file/scripts/run-emqx.sh
@@ -24,6 +24,7 @@ esac
   echo "EMQX_MQTT__MAX_TOPIC_ALIAS=10"
   echo "EMQX_AUTHORIZATION__SOURCES=[]"
   echo "EMQX_AUTHORIZATION__NO_MATCH=allow"
+  echo "EMQX_LICENSE__KEY=evaluation"
 } >> .ci/docker-compose-file/conf.cluster.env
 
 is_node_up() {

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -68,6 +68,7 @@ jobs:
           EMQX_RPC__CACERTFILE: /opt/emqx/etc/certs/cacert.pem
           EMQX_RPC__CIPHERS: TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256
           EMQX_RPC__TLS_VERSIONS: "[tlsv1.3]"
+          EMQX_LICENSE__KEY: evaluation
         EOL
     - name: Prepare emqxConfig.EMQX_RPC using ssl1.2
       working-directory: source
@@ -81,6 +82,7 @@ jobs:
           EMQX_RPC__CACERTFILE: /opt/emqx/etc/certs/cacert.pem
           EMQX_RPC__CIPHERS: TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256
           EMQX_RPC__TLS_VERSIONS: "[tlsv1.2]"
+          EMQX_LICENSE__KEY: evaluation
         EOL
     - name: run emqx on chart (k8s)
       if: matrix.discovery == 'k8s'
@@ -100,6 +102,7 @@ jobs:
             --set emqxConfig.EMQX_AUTHORIZATION__SOURCES=[] \
             --set emqxConfig.EMQX_LOG__CONSOLE__LEVEL=debug \
             --set emqxConfig.EMQX_AUTHORIZATION__NO_MATCH=allow \
+            --set emqxConfig.EMQX_LICENSE__KEY=evaluation \
             --values rpc-overrides.yaml \
             deploy/charts/${EMQX_NAME} \
             --debug
@@ -120,6 +123,7 @@ jobs:
             --set emqxConfig.EMQX_AUTHORIZATION__SOURCES=[] \
             --set emqxConfig.EMQX_LOG__CONSOLE__LEVEL=debug \
             --set emqxConfig.EMQX_AUTHORIZATION__NO_MATCH=allow \
+            --set emqxConfig.EMQX_LICENSE__KEY=evaluation \
             --values rpc-overrides.yaml \
             deploy/charts/${EMQX_NAME} \
             --wait \

--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -20,7 +20,12 @@
 -define(CLUSTER_MODE_NORMAL, normal).
 -define(CLUSTER_MODE_SINGLE, singleton).
 
+-ifdef(TEST).
+%% Some tests run cluster without emqx_license app
+-define(DEFAULT_MODE, ?CLUSTER_MODE_NORMAL).
+-else.
 -define(DEFAULT_MODE, ?CLUSTER_MODE_SINGLE).
+-endif.
 
 join(PeerNode) ->
     %% Local node starts with default license (singleton mode),

--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -20,12 +20,7 @@
 -define(CLUSTER_MODE_NORMAL, normal).
 -define(CLUSTER_MODE_SINGLE, singleton).
 
-%% Allow cluster when running tests
--ifdef(TEST).
--define(DEFAULT_MODE, ?CLUSTER_MODE_NORMAL).
--else.
 -define(DEFAULT_MODE, ?CLUSTER_MODE_SINGLE).
--endif.
 
 join(PeerNode) ->
     %% Local node starts with default license (singleton mode),

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -738,7 +738,8 @@ start_peer(Name, Opts) when is_map(Opts) ->
             Envs = [
                 {"HOCON_ENV_OVERRIDE_PREFIX", "EMQX_"},
                 {"EMQX_NODE__COOKIE", Cookie},
-                {"EMQX_NODE__DATA_DIR", NodeDataDir}
+                {"EMQX_NODE__DATA_DIR", NodeDataDir},
+                {"EMQX_LICENSE__KEY", "evaluation"}
             ],
             emqx_cth_peer:start(Node, erl_flags(), Envs)
         end,

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -104,6 +104,8 @@
     restart_node_ds/2
 ]).
 
+-export([capture_io_format/1]).
+
 -define(CERTS_PATH(CertName), filename:join(["etc", "certs", CertName])).
 
 -define(MQTT_SSL_CLIENT_CERTS, [
@@ -1510,4 +1512,55 @@ wait_nodeup(Node) ->
         _Sleep0 = 500,
         _Attempts0 = 50,
         pong = net_adm:ping(Node)
+    ).
+
+capture_io_format(Fn) ->
+    Owner = self(),
+    {GL, _} = spawn_monitor(fun() -> gl_sink(Owner, []) end),
+    {Runner, _} = spawn_monitor(fun() ->
+        group_leader(GL, self()),
+        exit({self(), result, Fn()})
+    end),
+    Result =
+        receive
+            {'DOWN', _, process, Runner, {_, result, Res}} ->
+                Res
+        after 1000 ->
+            exit(Runner, kill),
+            error(timeout)
+        end,
+    GL ! stop,
+    Prints =
+        receive
+            {'DOWN', _, process, GL, {_, prints, IoRequests}} ->
+                IoRequests
+        after 1000 ->
+            exit(GL, kill),
+            error(timeout)
+        end,
+    {Result, format_io_requests(Prints)}.
+
+gl_sink(Owner, Acc) ->
+    receive
+        {io_request, From, ReplyAs, Request} ->
+            From ! {io_reply, ReplyAs, ok},
+            gl_sink(Owner, [Request | Acc]);
+        stop ->
+            exit({self(), prints, lists:reverse(Acc)});
+        _ ->
+            gl_sink(Owner, Acc)
+    end.
+
+format_io_requests(IoRequests) ->
+    lists:map(
+        fun(Request) ->
+            case Request of
+                {put_chars, unicode, M, F, A} ->
+                    IoDat = apply(M, F, A),
+                    unicode:characters_to_binary(IoDat);
+                _ ->
+                    error({unknown_io_request, Request})
+            end
+        end,
+        IoRequests
     ).

--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -74,7 +74,7 @@
     cannot_publish_to_topic_due_to_quota_exceeded,
     connection_rejected_due_to_license_limit_reached,
     connection_rejected_due_to_trial_license_uptime_limit,
-    connection_rejected_due_to_max_uptime_reached,
+    connection_rejected_due_to_license_expired,
     listener_accept_throttled_due_to_quota_exceeded,
     failed_to_consume_from_limiter,
     failed_to_put_back_to_limiter,

--- a/apps/emqx_license/src/emqx_license_app.erl
+++ b/apps/emqx_license/src/emqx_license_app.erl
@@ -3,16 +3,32 @@
 %%--------------------------------------------------------------------
 
 -module(emqx_license_app).
+-feature(maybe_expr, enable).
 
 -behaviour(application).
 
 -export([start/2, stop/1]).
 
 start(_Type, _Args) ->
-    ok = emqx_license:load(),
-    {ok, Sup} = emqx_license_sup:start_link(),
-    {ok, Sup}.
+    Reader = fun emqx_license:read_license/0,
+    case validate_license(Reader) of
+        ok ->
+            ok = emqx_license:load(),
+            emqx_license_sup:start_link(Reader);
+        {error, 'SINGLE_NODE_LICENSE'} ->
+            {error,
+                "SINGLE_NODE_LICENSE, make sure this node and peer nodes are configured with a valid license"}
+    end.
 
 stop(_State) ->
     ok = emqx_license:unload(),
     ok.
+
+%% License violation check is done here (but not before boot)
+%% because we must allow default single-node license to join cluster,
+%% then check if the **fetched** license from peer node allows clustering.
+validate_license(Reader) ->
+    maybe
+        {ok, License} ?= Reader(),
+        ok ?= emqx_license_checker:no_violation(License)
+    end.

--- a/apps/emqx_license/src/emqx_license_checker.erl
+++ b/apps/emqx_license/src/emqx_license_checker.erl
@@ -237,10 +237,10 @@ check_license(#{license := License, start_time := StartTime} = _State) ->
     }.
 
 ensure_cluster_mode(License) ->
-    case emqx_license_parser:license_type(License) of
-        ?COMMUNITY ->
+    case emqx_license_parser:is_single_node(License) of
+        true ->
             ok = emqx_cluster:ensure_singleton_mode();
-        _ ->
+        false ->
             ok = emqx_cluster:ensure_normal_mode()
     end.
 

--- a/apps/emqx_license/src/emqx_license_checker.erl
+++ b/apps/emqx_license/src/emqx_license_checker.erl
@@ -217,10 +217,10 @@ cancel_timer(State, Key) ->
 
 -spec no_violation(license()) -> ok | {error, atom()}.
 no_violation(License) ->
+    IsSingleNodeLicense = emqx_license_parser:is_single_node(License),
     %% check only running nodes to allow once misconfigured cluster recover
-    case
-        emqx_license_parser:is_single_node(License) andalso length(emqx:cluster_nodes(running)) > 1
-    of
+    IsClustered = length(emqx:cluster_nodes(running)) > 1,
+    case IsSingleNodeLicense andalso IsClustered of
         true -> {error, 'SINGLE_NODE_LICENSE'};
         false -> ok
     end.

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -24,6 +24,8 @@ license(["update", EncodedLicense]) ->
         {ok, Warnings} ->
             ok = print_warnings(Warnings),
             ok = ?PRINT_MSG("ok~n");
+        {error, Reason} when is_atom(Reason) ->
+            ?PRINT("Error: ~s~n", [Reason]);
         {error, Reason} ->
             ?PRINT("Error: ~p~n", [Reason])
     end;

--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -138,7 +138,12 @@ error_msg(Code, Msg) ->
                 },
                 #{tag => "LICENSE"}
             ),
-            {400, error_msg(?BAD_REQUEST, <<"Bad license key">>)};
+            Msg =
+                case is_atom(Error) orelse is_binary(Error) of
+                    true -> Error;
+                    false -> <<"Bad license key, see logs for more details">>
+                end,
+            {400, error_msg(?BAD_REQUEST, Msg)};
         {ok, _} ->
             ?SLOG(info, #{msg => "updated_license_key"}, #{tag => "LICENSE"}),
             {200, license_info()}

--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -139,8 +139,8 @@ error_msg(Code, Msg) ->
                 #{tag => "LICENSE"}
             ),
             Msg =
-                case is_atom(Error) orelse is_binary(Error) of
-                    true -> Error;
+                case is_atom(Error) of
+                    true -> atom_to_binary(Error);
                     false -> <<"Bad license key, see logs for more details">>
                 end,
             {400, error_msg(?BAD_REQUEST, Msg)};

--- a/apps/emqx_license/src/emqx_license_parser.erl
+++ b/apps/emqx_license/src/emqx_license_parser.erl
@@ -99,8 +99,13 @@
 %%--------------------------------------------------------------------
 
 pubkey() -> ?PUBKEY.
-default() -> ?DEFAULT_COMMUNITY_LICENSE_KEY.
 evaluation() -> ?DEFAULT_EVALUATION_LICENSE_KEY.
+-ifdef(TEST).
+%% Allow common tests to run without setting license key.
+default() -> evaluation().
+-else.
+default() -> ?DEFAULT_COMMUNITY_LICENSE_KEY.
+-endif.
 
 %% @doc Parse license key.
 %% If the license key is prefixed with "file://path/to/license/file",

--- a/apps/emqx_license/src/emqx_license_parser.erl
+++ b/apps/emqx_license/src/emqx_license_parser.erl
@@ -69,6 +69,7 @@
 %% for testing purpose
 -export([
     default/0,
+    community/0,
     evaluation/0,
     pubkey/0
 ]).
@@ -100,11 +101,12 @@
 
 pubkey() -> ?PUBKEY.
 evaluation() -> ?DEFAULT_EVALUATION_LICENSE_KEY.
+community() -> ?DEFAULT_COMMUNITY_LICENSE_KEY.
 -ifdef(TEST).
 %% Allow common tests to run without setting license key.
 default() -> evaluation().
 -else.
-default() -> ?DEFAULT_COMMUNITY_LICENSE_KEY.
+default() -> community().
 -endif.
 
 %% @doc Parse license key.

--- a/apps/emqx_license/src/emqx_license_parser.erl
+++ b/apps/emqx_license/src/emqx_license_parser.erl
@@ -62,7 +62,8 @@
     expiry_date/1,
     max_sessions/1,
     max_uptime_seconds/1,
-    is_business_critical/1
+    is_business_critical/1,
+    is_single_node/1
 ]).
 
 %% for testing purpose
@@ -168,6 +169,12 @@ is_business_critical(#{module := Module, data := LicenseData}) ->
 is_business_critical(Key) when is_binary(Key) ->
     {ok, License} = parse(Key),
     is_business_critical(License).
+
+%% @doc Check if the license is a single node license.
+%% currently, community license = single node license.
+-spec is_single_node(license()) -> boolean().
+is_single_node(License) ->
+    license_type(License) =:= ?COMMUNITY.
 
 %%--------------------------------------------------------------------
 %% Private functions

--- a/apps/emqx_license/src/emqx_license_sup.erl
+++ b/apps/emqx_license/src/emqx_license_sup.erl
@@ -3,55 +3,41 @@
 %%--------------------------------------------------------------------
 
 -module(emqx_license_sup).
--feature(maybe_expr, enable).
 
 -behaviour(supervisor).
 
--export([start_link/0]).
+-export([start_link/1]).
 
 -export([init/1]).
 
-start_link() ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, []).
+start_link(Reader) ->
+    supervisor:start_link({local, ?MODULE}, ?MODULE, [Reader]).
 
-init([]) ->
-    Loader = fun emqx_license:read_license/0,
-    maybe
-        ok ?= validate_license(Loader),
-        {ok,
-            {
-                #{
-                    strategy => one_for_one,
-                    intensity => 2,
-                    period => 10
-                },
-                [
-                    #{
-                        id => license_checker,
-                        start => {emqx_license_checker, start_link, [Loader]},
-                        restart => permanent,
-                        shutdown => 5000,
-                        type => worker,
-                        modules => [emqx_license_checker]
-                    },
+init([Reader]) ->
+    Strategy =
+        #{
+            strategy => one_for_one,
+            intensity => 2,
+            period => 10
+        },
+    Children =
+        [
+            #{
+                id => license_checker,
+                start => {emqx_license_checker, start_link, [Reader]},
+                restart => permanent,
+                shutdown => 5000,
+                type => worker,
+                modules => [emqx_license_checker]
+            },
 
-                    #{
-                        id => license_resources,
-                        start => {emqx_license_resources, start_link, []},
-                        restart => permanent,
-                        shutdown => 5000,
-                        type => worker,
-                        modules => [emqx_license_resources]
-                    }
-                ]
-            }}
-    end.
-
-%% License violation check is done here (but not before boot)
-%% because we must allow default single-node license to join cluster,
-%% then check if the **fetched** license from peer node allows clustering.
-validate_license(Loader) ->
-    maybe
-        {ok, License} ?= Loader(),
-        ok ?= emqx_license_checker:no_violation(License)
-    end.
+            #{
+                id => license_resources,
+                start => {emqx_license_resources, start_link, []},
+                restart => permanent,
+                shutdown => 5000,
+                type => worker,
+                modules => [emqx_license_resources]
+            }
+        ],
+    {ok, {Strategy, Children}}.

--- a/apps/emqx_license/test/emqx_license_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_SUITE.erl
@@ -225,6 +225,17 @@ t_import_config(_Config) ->
         emqx:get_config([license])
     ).
 
+t_app_cannot_start_with_inalid_license(_Config) ->
+    meck:new(emqx_license, [passthrough, no_history]),
+    meck:expect(emqx_license, read_license, fun() -> {error, 'SINGLE_NODE_LICENSE'} end),
+    try
+        ?assertMatch(
+            {error, "SINGLE_NODE_LICENSE," ++ _}, emqx_license_app:start(normal, permanent)
+        )
+    after
+        meck:unload(emqx_license)
+    end.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -84,7 +84,7 @@ t_update_with_invalid_license_value(_Config) ->
     T = integer_to_list(?TRIAL),
     Key2 = emqx_license_test_lib:make_license(#{max_sessions => "100", license_type => C}),
     Key3 = emqx_license_test_lib:make_license(#{max_sessions => "100", license_type => T}),
-    Err = <<"Error: single_node_license_not_allowed_when_clusterd\n">>,
+    Err = <<"Error: SINGLE_NODE_LICENSE\n">>,
     ?assertEqual({ok, [Err]}, ?CAPTURE(emqx_license_cli:license(["update", binary_to_list(Key1)]))),
     ?assertEqual({ok, [Err]}, ?CAPTURE(emqx_license_cli:license(["update", binary_to_list(Key2)]))),
     ?assertEqual(

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -10,6 +10,9 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx_license.hrl").
+
+-define(CAPTURE(Expr), emqx_common_test_helpers:capture_io_format(fun() -> Expr end)).
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -29,11 +32,12 @@ init_per_suite(Config) ->
 end_per_suite(Config) ->
     ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
 
-init_per_testcase(_Case, Config) ->
+init_per_testcase(Case, Config) ->
     emqx_license_test_lib:mock_parser(),
-    Config.
+    ?MODULE:Case({init, Config}).
 
-end_per_testcase(_Case, _Config) ->
+end_per_testcase(Case, Config) ->
+    ?MODULE:Case({'end', Config}),
     emqx_license_test_lib:unmock_parser(),
     ok.
 
@@ -41,18 +45,57 @@ end_per_testcase(_Case, _Config) ->
 %% Tests
 %%------------------------------------------------------------------------------
 
+t_help({init, Config}) ->
+    Config;
+t_help({'end', _Config}) ->
+    ok;
 t_help(_Config) ->
     _ = emqx_license_cli:license([]).
 
+t_info({init, Config}) ->
+    Config;
+t_info({'end', _Config}) ->
+    ok;
 t_info(_Config) ->
     _ = emqx_license_cli:license(["info"]).
 
+t_update({init, Config}) ->
+    Config;
+t_update({'end', _Config}) ->
+    ok;
 t_update(_Config) ->
     LicenseValue = emqx_license_test_lib:default_license(),
     _ = emqx_license_cli:license(["update", LicenseValue]),
     _ = emqx_license_cli:license(["reload"]),
     _ = emqx_license_cli:license(["update", "Invalid License Value"]).
 
+t_update_with_invalid_license_value({init, Config}) ->
+    _ = emqx_license_cli:license(["update", "evaluation"]),
+    meck:new(emqx, [passthrough, no_history]),
+    meck:expect(emqx, cluster_nodes, fun(all) -> [node(), node()] end),
+    Config;
+t_update_with_invalid_license_value({'end', _Config}) ->
+    meck:unload(emqx),
+    ok;
+t_update_with_invalid_license_value(_Config) ->
+    %% do not allow setting to "default" license key or any community license key
+    Key1 = <<"default">>,
+    C = integer_to_list(?COMMUNITY),
+    T = integer_to_list(?TRIAL),
+    Key2 = emqx_license_test_lib:make_license(#{max_sessions => "100", license_type => C}),
+    Key3 = emqx_license_test_lib:make_license(#{max_sessions => "100", license_type => T}),
+    Err = <<"Error: single_node_license_not_allowed_when_clusterd\n">>,
+    ?assertEqual({ok, [Err]}, ?CAPTURE(emqx_license_cli:license(["update", binary_to_list(Key1)]))),
+    ?assertEqual({ok, [Err]}, ?CAPTURE(emqx_license_cli:license(["update", binary_to_list(Key2)]))),
+    ?assertEqual(
+        {ok, [<<"ok\n">>]}, ?CAPTURE(emqx_license_cli:license(["update", binary_to_list(Key3)]))
+    ),
+    ok.
+
+t_conf_update({init, Config}) ->
+    Config;
+t_conf_update({'end', _Config}) ->
+    ok;
 t_conf_update(_Config) ->
     LicenseKey = emqx_license_test_lib:make_license(#{max_sessions => "123"}),
     Conf = #{

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -72,7 +72,7 @@ t_update(_Config) ->
 t_update_with_invalid_license_value({init, Config}) ->
     _ = emqx_license_cli:license(["update", "evaluation"]),
     meck:new(emqx, [passthrough, no_history]),
-    meck:expect(emqx, cluster_nodes, fun(all) -> [node(), node()] end),
+    meck:expect(emqx, cluster_nodes, fun(running) -> [node(), node()] end),
     Config;
 t_update_with_invalid_license_value({'end', _Config}) ->
     meck:unload(emqx),

--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -140,7 +140,7 @@ t_set_evaluation_license({init, Config}) ->
     ?assertMatch(#{<<"customer">> := _}, emqx_utils_json:decode(Payload)),
     %% mock emqx:cluster_nodes/1 to return 2 nodes to test cluster mode
     meck:new(emqx, [passthrough, no_history]),
-    meck:expect(emqx, cluster_nodes, fun(all) -> [node(), node()] end),
+    meck:expect(emqx, cluster_nodes, fun(running) -> [node(), node()] end),
     Config;
 t_set_evaluation_license({'end', _Config}) ->
     meck:unload(emqx),

--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -156,7 +156,7 @@ t_set_evaluation_license(_Config) ->
     ?assertEqual(
         #{
             <<"code">> => <<"BAD_REQUEST">>,
-            <<"message">> => <<"single_node_license_not_allowed_when_clusterd">>
+            <<"message">> => <<"SINGLE_NODE_LICENSE">>
         },
         emqx_utils_json:decode(Message1)
     ),

--- a/apps/emqx_license/test/emqx_license_parser_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_parser_SUITE.erl
@@ -272,6 +272,13 @@ t_empty_string(_Config) ->
         emqx_license_parser:parse(<<>>)
     ).
 
+t_default_is_not_community_in_ct(_Config) ->
+    Default = emqx_license_parser:default(),
+    Community = emqx_license_parser:community(),
+    Evaluation = emqx_license_parser:evaluation(),
+    ?assertEqual(Evaluation, Default),
+    ?assertNotEqual(Community, Default).
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_machine/priv/reboot_lists.eterm
+++ b/apps/emqx_machine/priv/reboot_lists.eterm
@@ -39,6 +39,7 @@
             emqx,
             emqx_conf,
             emqx_utils,
+            emqx_license,
             emqx_durable_storage,
             emqx_ds_backends,
             emqx_http_lib,
@@ -86,7 +87,6 @@
     %% must always be of type `load'
     ee_business_apps =>
         [
-            emqx_license,
             emqx_enterprise,
             emqx_opentelemetry,
             emqx_mt,

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -93,10 +93,15 @@ ensure_apps_started() ->
 
 start_one_app(App) ->
     ?SLOG(debug, #{msg => "starting_app", app => App}),
-    case application:ensure_all_started(App, restart_type(App)) of
+    Type = restart_type(App),
+    case application:ensure_all_started(App, Type) of
         {ok, Apps} ->
             ?SLOG(debug, #{msg => "started_apps", apps => Apps});
+        {error, Reason} when Type =:= permanent ->
+            %% log debug and wait for application_master to terminate the node
+            ?SLOG(debug, #{msg => "failed_to_start_app", app => App, reason => Reason});
         {error, Reason} ->
+            %% this is unexpected, fail loudly (this also results in a crash dump)
             ?SLOG(critical, #{msg => "failed_to_start_app", app => App, reason => Reason}),
             error({failed_to_start_app, App, Reason})
     end.

--- a/apps/emqx_machine/src/emqx_machine_boot.erl
+++ b/apps/emqx_machine/src/emqx_machine_boot.erl
@@ -23,7 +23,7 @@
 -define(BASIC_REBOOT_APPS, [gproc, esockd, ranch, cowboy, emqx_durable_storage, emqx]).
 
 %% If any of these applications crash, the entire EMQX node shuts down:
--define(BASIC_PERMANENT_APPS, [mria, ekka, esockd, emqx]).
+-define(BASIC_PERMANENT_APPS, [mria, ekka, esockd, emqx, emqx_license]).
 
 %% These apps are optional, they may or may not be present in the
 %% release, depending on the build flags:


### PR DESCRIPTION
Fixes [EMQX-14092](https://emqx.atlassian.net/browse/EMQX-14092)

Release version: 5.9.0

## Summary

- Do not allow setting license key back to 'default' (or single-node license) if the node is already clustered.
- If auto cluster is configured (e.g. `static`, `dns` or `k8s` strategy), the `emqx_cluster:join/1` API is not called, clustering is completed by `ekka` -- for this case, `emqx_license` app would not boot if 1) it's currently clustered, 2) the taking-effect license is single-node.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [~] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)



[EMQX-14092]: https://emqx.atlassian.net/browse/EMQX-14092?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ