### PR TITLE
fix(connector): correctly detect toggle operation

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -155,7 +155,7 @@ update(Type, Name, {OldConf, Conf0}, Opts) ->
     %% without restarting the connector.
     %%
     Conf = Conf0#{connector_type => bin(Type), connector_name => bin(Name)},
-    case emqx_utils_maps:if_only_to_toggle_enable(OldConf, Conf) of
+    case emqx_utils_maps:if_only_to_toggle_enable(OldConf, Conf0) of
         false ->
             ?SLOG(info, #{
                 msg => "update connector",
@@ -179,7 +179,7 @@ update(Type, Name, {OldConf, Conf0}, Opts) ->
             end;
         true ->
             %% we don't need to recreate the connector if this config change is only to
-            %% toggole the config 'connector.{type}.{name}.enable'
+            %% toggle the config 'connector.{type}.{name}.enable'
             _ =
                 case maps:get(enable, Conf, true) of
                     true ->

--- a/apps/emqx_connector/test/emqx_connector_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_SUITE.erl
@@ -184,14 +184,20 @@ t_connector_lifecycle(_Config) ->
     ?assert(meck:validate(?CONNECTOR)),
     ?assertMatch(
         [
+            %% Creation
             {_, {?CONNECTOR, on_start, [_, _]}, {ok, connector_state}},
             {_, {?CONNECTOR, on_get_status, [_, connector_state]}, connected},
+            %% Disable
+            {_, {?CONNECTOR, on_stop, [_, connector_state]}, ok},
+            %% Enable (restart); it attempts to stop again
             {_, {?CONNECTOR, on_stop, [_, connector_state]}, ok},
             {_, {?CONNECTOR, on_start, [_, _]}, {ok, connector_state}},
             {_, {?CONNECTOR, on_get_status, [_, connector_state]}, connected},
+            %% Update
             {_, {?CONNECTOR, on_stop, [_, connector_state]}, ok},
             {_, {?CONNECTOR, on_start, [_, _]}, {ok, connector_state}},
             {_, {?CONNECTOR, on_get_status, [_, connector_state]}, connected},
+            %% Remove
             {_, {?CONNECTOR, on_stop, [_, connector_state]}, ok}
         ],
         lists:filter(

--- a/changes/ce/fix-15010.en.md
+++ b/changes/ce/fix-15010.en.md
@@ -1,0 +1,1 @@
+Previously, disabling any Connector could take about 5 to 10 s, even when it was healthy.  This has been fixed.  Note that some Connectors still naturally require time to disable, especially when they have Actions and when they are unhealthy.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14090

Previously, the toggle check always failed because extra keys were being injected into the new configuration being compared to the old one.

Release version: 5.9.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests (checked manually)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
