### PR TITLE
chore(dsraft): rename modules for consistency

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -7,7 +7,7 @@
 %% Currently metadata is stored in mria; that's not ideal, but
 %% eventually we'll replace it, so it's important not to leak
 %% implementation details from this module.
--module(emqx_ds_replication_layer_meta).
+-module(emqx_ds_builtin_raft_meta).
 
 -feature(maybe_expr, enable).
 -compile(inline).

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_server_snapshot.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_server_snapshot.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_ds_replication_snapshot).
+-module(emqx_ds_builtin_raft_server_snapshot).
 
 -include_lib("snabbkaffe/include/trace.hrl").
 

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_sup.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_sup.erl
@@ -110,7 +110,7 @@ init(?top) ->
     %% Children:
     MetadataServer = #{
         id => metadata_server,
-        start => {emqx_ds_replication_layer_meta, start_link, []},
+        start => {emqx_ds_builtin_raft_meta, start_link, []},
         restart => permanent,
         type => worker,
         shutdown => 5000

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_raft_test_helpers.erl
@@ -3,6 +3,8 @@
 %%--------------------------------------------------------------------
 -module(emqx_ds_raft_test_helpers).
 
+-include_lib("emqx_utils/include/emqx_message.hrl").
+
 -compile(export_all).
 -compile(nowarn_export_all).
 
@@ -40,7 +42,7 @@ wait_db_bootstrapped(Nodes, DB, Timeout, BackInTime) ->
             BackInTime
         )
      || Node <- Nodes,
-        Shard <- ?ON(Node, emqx_ds_replication_layer_meta:my_shards(DB))
+        Shard <- ?ON(Node, emqx_ds_builtin_raft_meta:my_shards(DB))
     ],
     lists:foreach(
         fun({ok, SRef}) ->
@@ -51,7 +53,7 @@ wait_db_bootstrapped(Nodes, DB, Timeout, BackInTime) ->
 
 -spec assert_db_stable([node()], emqx_ds:db()) -> _Ok.
 assert_db_stable([Node | _], DB) ->
-    Shards = ?ON(Node, emqx_ds_replication_layer_meta:shards(DB)),
+    Shards = ?ON(Node, emqx_ds_builtin_raft_meta:shards(DB)),
     ?assertMatch(
         _Leadership = [_ | _],
         ?ON(Node, db_leadership(DB, Shards))
@@ -68,8 +70,8 @@ db_leadership(DB, Shards) ->
     end.
 
 shard_leadership(DB, Shard) ->
-    ReplicaSet = emqx_ds_replication_layer_meta:replica_set(DB, Shard),
-    Nodes = [emqx_ds_replication_layer_meta:node(Site) || Site <- ReplicaSet],
+    ReplicaSet = emqx_ds_builtin_raft_meta:replica_set(DB, Shard),
+    Nodes = [emqx_ds_builtin_raft_meta:node(Site) || Site <- ReplicaSet],
     lists:foldl(
         fun({Site, SN}, Acc) -> Acc#{shard_leader(SN, DB, Shard, Site) => SN} end,
         #{},
@@ -85,20 +87,187 @@ shard_readiness(Node, DB, Shard, Site) ->
 shard_server_info(Node, DB, Shard, Site, Info) ->
     ?ON(
         Node,
-        emqx_ds_replication_layer_shard:server_info(
+        emqx_ds_builtin_raft_shard:server_info(
             Info,
-            emqx_ds_replication_layer_shard:shard_server(DB, Shard, Site)
+            emqx_ds_builtin_raft_shard:shard_server(DB, Shard, Site)
         )
     ).
 
 -spec db_transitions(emqx_ds:db()) ->
-    [{emqx_ds_replication_layer:shard_id(), emqx_ds_replication_layer_meta:transition()}].
+    [{emqx_ds_replication_layer:shard_id(), emqx_ds_builtin_raft_meta:transition()}].
 db_transitions(DB) ->
-    Shards = emqx_ds_replication_layer_meta:shards(DB),
+    Shards = emqx_ds_builtin_raft_meta:shards(DB),
     [
         {S, T}
-     || S <- Shards, T <- emqx_ds_replication_layer_meta:replica_set_transitions(DB, S)
+     || S <- Shards, T <- emqx_ds_builtin_raft_meta:replica_set_transitions(DB, S)
     ].
 
 wait_db_transitions_done(DB) ->
     ?retry(1000, 20, ?assertEqual([], db_transitions(DB))).
+
+%% Payload generation:
+
+apply_stream(DB, Nodes, Stream) ->
+    apply_stream(
+        DB,
+        emqx_utils_stream:repeat(emqx_utils_stream:list(Nodes)),
+        Stream,
+        0
+    ).
+
+apply_stream(DB, NodeStream0, Stream0, N) ->
+    case emqx_utils_stream:next(Stream0) of
+        [] ->
+            ?tp(all_done, #{});
+        [Msg = #message{} | Stream] ->
+            [Node | NodeStream] = emqx_utils_stream:next(NodeStream0),
+            ?tp(
+                test_push_message,
+                maps:merge(
+                    emqx_message:to_map(Msg),
+                    #{n => N}
+                )
+            ),
+            ?ON(Node, emqx_ds:store_batch(DB, [Msg], #{sync => true})),
+            apply_stream(DB, NodeStream, Stream, N + 1);
+        [add_generation | Stream] ->
+            ?tp(notice, test_add_generation, #{}),
+            [Node | NodeStream] = emqx_utils_stream:next(NodeStream0),
+            ?ON(Node, emqx_ds:add_generation(DB)),
+            apply_stream(DB, NodeStream, Stream, N);
+        [{Node, Operation, Arg} | Stream] when
+            Operation =:= join_db_site;
+            Operation =:= leave_db_site;
+            Operation =:= assign_db_sites
+        ->
+            ?tp(notice, test_apply_operation, #{node => Node, operation => Operation, arg => Arg}),
+            %% Apply the transition.
+            ?assertMatch(
+                {ok, _},
+                ?ON(
+                    Node,
+                    emqx_ds_builtin_raft_meta:Operation(DB, Arg)
+                )
+            ),
+            %% Give some time for at least one transition to complete.
+            Transitions = ?ON(Node, db_transitions(DB)),
+            ct:pal("Transitions after ~p: ~p", [Operation, Transitions]),
+            case Transitions of
+                [_ | _] ->
+                    ?retry(200, 10, ?assertNotEqual(Transitions, ?ON(Node, db_transitions(DB))));
+                [] ->
+                    ok
+            end,
+            apply_stream(DB, NodeStream0, Stream, N);
+        [Fun | Stream] when is_function(Fun) ->
+            Fun(),
+            apply_stream(DB, NodeStream0, Stream, N)
+    end.
+
+%% Consuming streams and iterators
+
+%% Consume data from the DS storage on a given node as a stream:
+-type ds_stream() :: emqx_utils_stream:stream({emqx_ds:message_key(), emqx_types:message()}).
+
+%% Create a stream from the topic (wildcards are NOT supported for a
+%% good reason: order of messages is implementation-dependent!).
+%%
+%% Note: stream produces messages with keys
+-spec ds_topic_stream(atom(), binary(), binary(), node()) -> ds_stream().
+ds_topic_stream(DB, ClientId, TopicBin, Node) ->
+    Topic = emqx_topic:words(TopicBin),
+    Shard = shard_of_clientid(DB, Node, ClientId),
+    {ShardId, DSStreams} =
+        ?ON(
+            Node,
+            begin
+                DBShard = {DB, Shard},
+                {DBShard, emqx_ds_storage_layer:get_streams(DBShard, Topic, 0)}
+            end
+        ),
+    ct:pal("Streams for ~p, ~p @ ~p:~n    ~p", [ClientId, TopicBin, Node, DSStreams]),
+    %% Sort streams by their rank Y, and chain them together:
+    emqx_utils_stream:chain([
+        ds_topic_generation_stream(DB, Node, ShardId, Topic, S)
+     || {_RankY, S} <- lists:sort(DSStreams)
+    ]).
+
+ds_topic_generation_stream(DB, Node, Shard, Topic, Stream) ->
+    {ok, Iterator} = ?ON(
+        Node,
+        emqx_ds_storage_layer:make_iterator(Shard, Stream, Topic, 0)
+    ),
+    do_ds_topic_generation_stream(DB, Node, Shard, Iterator).
+
+do_ds_topic_generation_stream(DB, Node, Shard, It0) ->
+    fun() ->
+        case
+            ?ON(
+                Node,
+                begin
+                    emqx_ds_storage_layer:next(Shard, It0, 1, _Now = 1 bsl 63)
+                end
+            )
+        of
+            {ok, _It, []} ->
+                [];
+            {ok, end_of_stream} ->
+                [];
+            {ok, It, [KeyMsg]} ->
+                [KeyMsg | do_ds_topic_generation_stream(DB, Node, Shard, It)]
+        end
+    end.
+
+-spec verify_stream_effects(atom(), binary(), [node()], [{emqx_types:clientid(), ds_stream()}]) ->
+    ok.
+verify_stream_effects(DB, TestCase, Nodes0, L) ->
+    Checked = lists:flatmap(
+        fun({ClientId, Stream}) ->
+            Nodes = nodes_of_clientid(DB, ClientId, Nodes0),
+            ct:pal("Nodes allocated for client ~p: ~p", [ClientId, Nodes]),
+            ?defer_assert(
+                ?assertMatch([_ | _], Nodes, ["No nodes have been allocated for ", ClientId])
+            ),
+            [verify_stream_effects(DB, TestCase, Node, ClientId, Stream) || Node <- Nodes]
+        end,
+        L
+    ),
+    ?defer_assert(?assertMatch([_ | _], Checked, "Some messages have been verified")).
+
+-spec verify_stream_effects(atom(), binary(), node(), emqx_types:clientid(), ds_stream()) -> ok.
+verify_stream_effects(DB, TestCase, Node, ClientId, ExpectedStream) ->
+    ct:pal("Checking consistency of effects for ~p on ~p", [ClientId, Node]),
+    ?defer_assert(
+        begin
+            Topic = emqx_ds_test_helpers:client_topic(TestCase, ClientId),
+            emqx_ds_test_helpers:diff_messages(
+                ExpectedStream,
+                ds_topic_stream(DB, ClientId, Topic, Node)
+            ),
+            ct:pal("Data for client ~p on ~p is consistent.", [ClientId, Node])
+        end
+    ).
+
+%% Find which nodes from the list contain the shards for the given
+%% client ID:
+nodes_of_clientid(DB, ClientId, Nodes = [N0 | _]) ->
+    Shard = shard_of_clientid(DB, N0, ClientId),
+    SiteNodes = ?ON(
+        N0,
+        begin
+            Sites = emqx_ds_builtin_raft_meta:replica_set(DB, Shard),
+            lists:map(fun emqx_ds_builtin_raft_meta:node/1, Sites)
+        end
+    ),
+    lists:filter(
+        fun(N) ->
+            lists:member(N, SiteNodes)
+        end,
+        Nodes
+    ).
+
+shard_of_clientid(DB, Node, ClientId) ->
+    ?ON(
+        Node,
+        emqx_ds_buffer:shard_of_operation(DB, #message{from = ClientId}, clientid)
+    ).

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -986,7 +986,7 @@ ds(Cmd) ->
     end.
 
 do_ds(["info"]) ->
-    emqx_ds_replication_layer_meta:print_status(),
+    emqx_ds_builtin_raft_meta:print_status(),
     ok;
 do_ds(["set-replicas", DBStr | SitesStr]) ->
     case emqx_utils:safe_to_existing_atom(DBStr) of

--- a/apps/emqx_management/test/emqx_mgmt_api_ds_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_ds_SUITE.erl
@@ -34,7 +34,7 @@ init_per_suite(Config) ->
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
     [N1 | _] = Cluster,
-    Sites = [?ON(N, emqx_ds_replication_layer_meta:this_site()) || N <- Cluster],
+    Sites = [?ON(N, emqx_ds_builtin_raft_meta:this_site()) || N <- Cluster],
     ApiAuth = ?ON(N1, emqx_common_test_http:default_auth_header()),
     [{cluster, Cluster}, {sites, Sites}, {api_auth, ApiAuth} | Config].
 

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -377,7 +377,7 @@ t_leave_rejected_ds_nonempty('end', Config) ->
 t_leave_rejected_ds_nonempty(Config) ->
     _Specs = [_, NS2] = ?config(nodespecs, Config),
     Nodes = [N1, N2] = ?config(cluster, Config),
-    S2 = ?ON(N2, emqx_ds_replication_layer_meta:this_site()),
+    S2 = ?ON(N2, emqx_ds_builtin_raft_meta:this_site()),
     DB = messages,
     DBArg = "messages",
     S2Arg = binary_to_list(S2),
@@ -398,13 +398,12 @@ t_leave_rejected_ds_nonempty(Config) ->
 
     %% Now leave the cluster again, wait until N1 forgets about S2.
     ?assertEqual(ok, ?ON(N2, emqx_mgmt_cli:cluster(["leave"]))),
-    ?retry(500, 10, undefined = ?ON(N1, emqx_ds_replication_layer_meta:node(S2))),
+    ?retry(500, 10, undefined = ?ON(N1, emqx_ds_builtin_raft_meta:node(S2))),
     ?ON(N1, emqx_mgmt_cli:ds(["info"])),
 
     %% Join the cluster again.
     ?assertEqual(ok, ?ON(N2, emqx_mgmt_cli:cluster(["join", atom_to_list(N1)]))),
     [N2] = emqx_cth_cluster:restart(NS2),
-    % ?retry(500, 10, N2 = ?ON(N1, emqx_ds_replication_layer_meta:node(S2))),
     ?ON(N1, emqx_mgmt_cli:ds(["info"])),
 
     %% Ask to be DS DB replication site again.


### PR DESCRIPTION
Release version: 5.9

## Summary

* Most of the `emqx_ds_builtin_raft` modules renamed to be consistent with the application name.
* Module `emqx_ds_replication_layer` will have to stay as is for now, since few things rely on this name.
* Move some test helpers to where they actually belong, and reuse them in other testsuites.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible
