### PR TITLE
fix(telemetry): fix double timer scheduling

### DIFF
--- a/apps/emqx_telemetry/src/emqx_telemetry.erl
+++ b/apps/emqx_telemetry/src/emqx_telemetry.erl
@@ -211,8 +211,10 @@ is_enabled() ->
 ensure_report_timer(State = #state{report_interval = ReportInterval}) ->
     ensure_report_timer(ReportInterval, State).
 
-ensure_report_timer(ReportInterval, State) ->
-    State#state{timer = emqx_utils:start_timer(ReportInterval, time_to_report_telemetry_data)}.
+ensure_report_timer(ReportInterval, #state{timer = undefined} = State) ->
+    State#state{timer = emqx_utils:start_timer(ReportInterval, time_to_report_telemetry_data)};
+ensure_report_timer(_ReportInterval, State) ->
+    State.
 
 os_info() ->
     case erlang:system_info(os_type) of


### PR DESCRIPTION
Tiny fix to avoid log pollution with info messages:
```
2025-04-11T19:12:12.834731+03:00 [error]     msg: unexpected_info
    info: {timeout,#Ref<0.1456251408.65536002.65347>,
                   time_to_report_telemetry_data}
2025-04-11T19:12:17.458594+03:00 [error]     msg: unexpected_info
    info: {timeout,#Ref<0.1456251408.65536001.70515>,
                   time_to_report_telemetry_data}
...
```

