### PR TITLE
ci: manually install cmake v3.x in macos action for RocksDB build

### DIFF
--- a/.github/actions/package-macos/action.yaml
+++ b/.github/actions/package-macos/action.yaml
@@ -31,13 +31,26 @@ runs:
       shell: bash
       run: |
         brew update
-        brew install curl zip unzip unixodbc coreutils freetds autoconf automake cmake openssl kerl
-        brew upgrade curl zip unzip unixodbc coreutils freetds autoconf automake cmake openssl kerl
+        brew install curl zip unzip unixodbc coreutils freetds autoconf automake openssl kerl
+        brew upgrade curl zip unzip unixodbc coreutils freetds autoconf automake openssl kerl
+    # Homebrew installs CMake v4, while RocksDB requires CMake 3.x
+    - name: Install cmake 3.x
+      shell: bash
+      run: |
+        curl -LO https://cmake.org/files/v3.31/cmake-3.31.7-macos-universal.tar.gz
+        tar -xzf cmake-3.31.7-macos-universal.tar.gz
+        sudo mv cmake-3.31.7-macos-universal/CMake.app/Contents/bin/cmake /usr/local/bin/
+        sudo mv cmake-3.31.7-macos-universal/CMake.app/Contents/share/cmake-3.31 /usr/local/share/
+        sudo rm -rf cmake-3.31.7-macos-universal
+        export CMAKE_ROOT=/usr/local/share/cmake-3.31
+        echo "CMAKE_ROOT=/usr/local/share/cmake-3.31" >> $GITHUB_ENV
+        hash -r
+        cmake --version
     - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       id: cache
       with:
         path: ~/.kerl/installations/${{ inputs.otp }}
-        key: otp-install-${{ inputs.otp }}-${{ inputs.os }}-disable-jit-20250325
+        key: otp-install-${{ inputs.otp }}-${{ inputs.os }}-static-ssl-disable-jit-20250325
     - name: build erlang
       if: steps.cache.outputs.cache-hit != 'true'
       shell: bash
@@ -46,7 +59,7 @@ runs:
       run: |
         export LDFLAGS="-L$(brew --prefix unixodbc)/lib"
         export CC="/usr/bin/gcc -I$(brew --prefix unixodbc)/include"
-        export KERL_CONFIGURE_OPTIONS="--disable-jit --with-ssl=$(brew --prefix openssl) --with-odbc=$(brew --prefix unixodbc)"
+        export KERL_CONFIGURE_OPTIONS="--disable-jit --disable-dynamic-ssl-lib --with-ssl=$(brew --prefix openssl) --with-odbc=$(brew --prefix unixodbc)"
         export MAKEFLAGS=-j$(nproc)
         kerl build git https://github.com/emqx/otp.git OTP-$OTP_VERSION $OTP_VERSION
         kerl install $OTP_VERSION ~/.kerl/installations/$OTP_VERSION


### PR DESCRIPTION
Also restore linking with static ssl lib when building Erlang/OTP.

See also https://github.com/emqx/emqx/pull/15005.

Build packages run: https://github.com/emqx/emqx/actions/runs/14445913465

Release version: 5.9.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

## Checklist for CI (.github/workflows) changes
- [x] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update