### PR TITLE
fix(resource): trigger fallback actions when action is an "unhealthy target"

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -2549,8 +2549,8 @@ result_context(Queries) ->
     #{?queries => Queries}.
 
 -doc """
-This an internal export to be used only in `emqx_resourcee` application in places where
-the request is fropped/fails before it even reaches the buffering layer (here).  An
+This an internal export to be used only in `emqx_resource` application in places where
+the request is dropped/fails before it even reaches the buffering layer (here).  An
 example of such situation is when the resource is deemed an "unhealthy target".
 """.
 -spec unhealthy_target_maybe_trigger_fallback_actions(

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -422,6 +422,8 @@ on_get_status(ConnResId, #{health_check_agent := Agent}) ->
         {notify, Pid, Status} when ?IS_STATUS(Status) ->
             Pid ! {returning_resource_health_check_result, ConnResId, Status},
             Status;
+        {Status, Msg} when ?IS_STATUS(Status) ->
+            {Status, Msg};
         Status when ?IS_STATUS(Status) ->
             Status
     end;


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14109

Release version: 5.9.0

## Summary

Previously, when the Action was marked as an "unhealthy target", the request would not even reach the buffering layer, where the fallback action triggering logic lives.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [na] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~ unreleased feature

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
