### PR TITLE
feat(limiter): handle dynamic zone update for limiters

### DIFF
--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -559,7 +559,6 @@ t_quic_update_opts(Config) ->
     Host = "127.0.0.1",
     Port = emqx_common_test_helpers:select_free_port(ListenerType),
     ok = emqx_config:put_zone_conf(?FUNCTION_NAME, [mqtt, max_topic_levels], 2),
-    ok = emqx_limiter:create_zone_limiters(?FUNCTION_NAME),
 
     Conf = #{
         <<"enable">> => true,

--- a/apps/emqx_management/src/emqx_mgmt_api_configs.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_configs.erl
@@ -301,8 +301,6 @@ global_zone_configs(put, #{body := Body}, _Req) ->
             {#{}, #{}},
             Body
         ),
-    %% TODO: introduce a hook?
-    ok = emqx_limiter:update_zone_limiters(),
     case maps:size(Res) =:= maps:size(Body) of
         true -> {200, Res};
         false -> {400, #{code => 'UPDATE_FAILED', message => ?ERR_MSG(Error)}}

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -283,8 +283,7 @@ set_limiter_for_zone(Key, Value) ->
     KeyBin = atom_to_binary(Key, utf8),
     MqttConf0 = emqx_config:fill_defaults(#{<<"mqtt">> => emqx:get_raw_config([<<"mqtt">>])}),
     MqttConf1 = emqx_utils_maps:deep_put([<<"mqtt">>, <<"limiter">>, KeyBin], MqttConf0, Value),
-    {ok, _} = emqx:update_config([mqtt], maps:get(<<"mqtt">>, MqttConf1)),
-    ok = emqx_limiter:update_zone_limiters().
+    {ok, _} = emqx:update_config([mqtt], maps:get(<<"mqtt">>, MqttConf1)).
 
 set_limiter_for_listener(Key, Value) ->
     KeyBin = atom_to_binary(Key, utf8),

--- a/changes/ce/fix-15037.en.md
+++ b/changes/ce/fix-15037.en.md
@@ -1,0 +1,1 @@
+Fix rate limiting for dynamically created zones. Previously, the rate-limiting was not applied if a zone was created after the EMQX node was started.


### PR DESCRIPTION
Fixes [EMQX-14105](https://emqx.atlassian.net/browse/EMQX-14105)

Release version: 5.9

Although this goes as a fix, it seems we never supported dynamic zone update for rate limiting. 
This was just revealed by more strict listener creation.


## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14105]: https://emqx.atlassian.net/browse/EMQX-14105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ