### PR TITLE
feat: Linearizable session registry

### DIFF
--- a/apps/emqx/include/emqx_cm.hrl
+++ b/apps/emqx/include/emqx_cm.hrl
@@ -36,7 +36,8 @@
 -record(channel, {
     chid :: emqx_types:clientid() | '_',
     %% pid field is extended in 5.6.0 to support recording unregistration timestamp.
-    pid :: pid() | non_neg_integer() | '$1'
+    pid :: pid() | non_neg_integer() | '$1',
+    vsn :: integer() | undefined | '_'
 }).
 
 %% Map from channel pid to connection module and client ID.

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -114,6 +114,7 @@
 -export_type([
     channel_info/0,
     chan_pid/0,
+    channel/0,
     takeover_state/0
 ]).
 
@@ -129,7 +130,8 @@
     {_ConnMod :: module(), chan_pid()}
     | {_ConnMod :: module(), #channel{}}.
 
--type max_channel() :: option(#channel{}).
+-type channel() :: #channel{}.
+-type max_channel() :: option(channel()).
 
 -define(BPAPI_NAME, emqx_cm).
 
@@ -332,7 +334,7 @@ open_session(
 %%      return {error, Err, Channel} if takeover is unsuccessful.
 -spec takeover_session_begin(emqx_types:clientid()) ->
     {ok, emqx_session_mem:session(), takeover_state()}
-    | {error, _Err, #channel{}}
+    | {error, _Err, channel()}
     | none.
 takeover_session_begin(ClientId) ->
     Channel = pick_channel_max(ClientId),
@@ -386,7 +388,7 @@ pick_channel(ClientId) ->
     end.
 
 -spec pick_channel_max(emqx_types:clientid()) ->
-    option(#channel{}).
+    option(channel()).
 pick_channel_max(ClientId) ->
     emqx_cm_registry:max_channel(read_channels(ClientId)).
 

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -64,6 +64,8 @@
 -define(REGISTRY, ?MODULE).
 -define(NODE_DOWN_CLEANUP_LOCK, {?MODULE, cleanup_down}).
 
+-type channel() :: emqx_cm:channel().
+
 %% @doc Start the global channel registry.
 -spec start_link() -> startlink_ret().
 start_link() ->
@@ -144,7 +146,7 @@ register_channel({ClientId, ChanPid}, MyVsn, CachedMax) when
     end.
 
 %% @doc find last channel with the highest version
--spec max_channel([#channel{}]) -> option(#channel{}).
+-spec max_channel([channel()]) -> option(channel()).
 max_channel([]) ->
     undefined;
 max_channel(Channels) ->
@@ -204,12 +206,12 @@ is_pid_alive(Pid) when is_pid(Pid) andalso node(Pid) =:= node() ->
 is_pid_alive(_) ->
     unknown.
 
--spec read_channels(emqx_types:clientid()) -> list(#channel{}).
+-spec read_channels(emqx_types:clientid()) -> list(channel()).
 read_channels(ClientId) ->
     mnesia:dirty_read(?CHAN_REG_TAB, ClientId).
 
 %% @doc Lookup max vsn of a channel locally
--spec local_lookup_channel_max(emqx_types:clientid()) -> #channel{} | undefined.
+-spec local_lookup_channel_max(emqx_types:clientid()) -> channel() | undefined.
 local_lookup_channel_max(ClientId) ->
     max_channel(read_channels(ClientId)).
 

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -304,6 +304,7 @@ init_state(
         peercert => Peercert,
         peersni => PeerSNI,
         conn_mod => ?MODULE,
+        trpt_started_at => erlang:system_time(millisecond),
         sock => Socket
     },
 

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -265,7 +265,7 @@ create(Mod, ClientInfo, ConnInfo, MaybeWillMsg, Conf) ->
     Session.
 
 -spec open(clientinfo(), conninfo(), emqx_maybe:t(message())) ->
-    {_IsPresent :: true, t(), _ReplayContext} | {_IsPresent :: false, t()}.
+    {_IsPresent :: boolean(), t(), _ReplayContext} | {_IsPresent :: false, t()}.
 open(ClientInfo, ConnInfo, MaybeWillMsg) ->
     Conf = get_session_conf(ClientInfo),
     Mods = [Default | _] = choose_impl_candidates(ClientInfo, ConnInfo),
@@ -275,6 +275,9 @@ open(ClientInfo, ConnInfo, MaybeWillMsg) ->
     case try_open(Mods, ClientInfo, ConnInfo, MaybeWillMsg, Conf) of
         {_IsPresent = true, _, _} = Present ->
             Present;
+        {false, TakeoverState} ->
+            %% We found session but failed to open it due to reasons.
+            {false, create(Default, ClientInfo, ConnInfo, MaybeWillMsg, Conf), TakeoverState};
         false ->
             %% NOTE
             %% Nothing was found, create a new session with the `Default` implementation.

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -217,7 +217,9 @@ destroy(_Session) ->
 %%--------------------------------------------------------------------
 
 -spec open(clientinfo(), conninfo(), emqx_maybe:t(message()), emqx_session:conf()) ->
-    {_IsPresent :: true, session(), replayctx()} | _IsPresent :: false.
+    {_IsPresent :: true, session(), replayctx()}
+    | {false, replayctx()}
+    | false.
 open(ClientInfo = #{clientid := ClientId}, ConnInfo, _MaybeWillMsg, Conf) ->
     case emqx_cm:takeover_session_begin(ClientId) of
         {ok, SessionRemote, TakeoverState} ->
@@ -226,6 +228,9 @@ open(ClientInfo = #{clientid := ClientId}, ConnInfo, _MaybeWillMsg, Conf) ->
             Session2 = apply_conf(Conf, Session1),
             Session = fliter_remote_session(Session2),
             {true, Session, TakeoverState};
+        {error, _Err, OldChannel} ->
+            %% @TODO we could cust the error handling here
+            {false, {?MODULE, OldChannel}};
         none ->
             false
     end.

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -1001,7 +1001,7 @@ do_wait_subscription([CPid | Rest]) ->
     end.
 
 kick_client(Ctx, ClientId) ->
-    ok = emqx_cm:kick_session(ClientId),
+    _ = emqx_cm:kick_session(ClientId),
     Ctx.
 
 publish_msg(Ctx, Msg) ->

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -240,8 +240,12 @@ clients(["list"]) ->
 clients(["show", ClientId]) ->
     if_client(ClientId, fun print/1);
 clients(["kick", ClientId]) ->
-    ok = emqx_cm:kick_session(bin(ClientId)),
-    emqx_ctl:print("ok~n");
+    case emqx_cm:kick_session(bin(ClientId)) of
+        undefined ->
+            emqx_ctl:print("Not Found.~n");
+        _ ->
+            emqx_ctl:print("ok~n")
+    end;
 clients(_) ->
     emqx_ctl:usage([
         {"clients list", "List all clients"},


### PR DESCRIPTION
Allow latest connected channel to take ownership of the session immediately, a session might be 'started' multiple times but only 'ended' once.

Sessions that fail to be taken over (due to timeout, RPC failure, or noproc) are no longer treated as new sessions. The linearizable session registry ensures correct session takeover behavior.

- remove the usage of emqx_cm_locker:trans/2
- add trpt_started_at in connection info
- use trpt_started_at as version field in emqx_cm #channel{}
- ensures the correct channel are takenover/discarded/kicked

Fixes <issue-or-jira-number>

Release version: 5.?

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
