### PR TITLE
ci: pin codecov action

### DIFF
--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -236,6 +236,6 @@ jobs:
         run: |
           ./scripts/covertool-2.1.0-emqx-1 -cover _build/test/cover -appname emqx -lookup apps
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/scripts/bump-actions-versions.sh
+++ b/scripts/bump-actions-versions.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-actions=( 'actions/checkout' 'actions/cache' 'actions/stale' 'actions/upload-artifact' 'actions/download-artifact' 'aws-actions/configure-aws-credentials' 'ossf/scorecard-action' 'erlef/setup-beam' 'slackapi/slack-github-action' 'hashicorp/setup-terraform' 'docker/login-action' 'docker/setup-buildx-action' 'docker/setup-qemu-action' 'actions/setup-java' 'peter-evans/repository-dispatch' 'rtCamp/action-slack-notify' )
+actions=( 'actions/checkout' 'actions/cache' 'actions/stale' 'actions/upload-artifact' 'actions/download-artifact' 'aws-actions/configure-aws-credentials' 'ossf/scorecard-action' 'erlef/setup-beam' 'slackapi/slack-github-action' 'hashicorp/setup-terraform' 'docker/login-action' 'docker/setup-buildx-action' 'docker/setup-qemu-action' 'actions/setup-java' 'peter-evans/repository-dispatch' 'rtCamp/action-slack-notify' 'codecov/codecov-action')
 for a in "${actions[@]}"; do
     # shellcheck disable=SC2086
     TAG=$(curl -sSfL -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/$a/releases/latest | jq -r '.tag_name')


### PR DESCRIPTION
Apparently, 5.4.1, which was released 1 h ago, broke our workflow.

5.4.1 (broken):

https://github.com/emqx/emqx/actions/runs/14452888764/job/40531624477?pr=15036#step:8:71

5.4.0 (ok):
https://github.com/emqx/emqx/actions/runs/14446086477/job/40509966882?pr=15035#step:8:30
