### PR TITLE
fix(authn): fix redis config update

### DIFF
--- a/changes/ce/fix-15059.en.md
+++ b/changes/ce/fix-15059.en.md
@@ -1,0 +1,4 @@
+Fix the reaction to updating the Redis authentication config with invalid values.
+
+Previously, the authenticator could crash and stop being applied during authentication.
+Now, proper errors are provided to the user and the update is denied.


### PR DESCRIPTION
Fixes [EMQX-14137](https://emqx.atlassian.net/browse/EMQX-14137)

Release version: 5.9

## Summary

Legacy bug. The Redis resource crashed in the case of an update to the Redis authn config with values that did not pass validation.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14137]: https://emqx.atlassian.net/browse/EMQX-14137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ