### PR TITLE
test(gcp pubsub producer): fix flaky test

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -1225,7 +1225,7 @@ do_econnrefused_or_timeout_test(Config, Error) ->
                         [#{reason := Reason, connector := ConnectorResourceId} | _] when
                             Reason == Error;
                             Reason == closed;
-                            element(1, Reason) == closed
+                            element(2, Reason) == closed
                         ->
                             ok;
                         Trace0 ->


### PR DESCRIPTION
```
2025-04-22T21:13:37.514438+00:00 [critical] "check stage" failed: error, {unexpected_trace,[#{reason => {error,closed},msg => gcp_pubsub_request_failed,connector => ...
```

https://github.com/emqx/emqx/actions/runs/14604493674/job/40970793439#step:4:615
