### PR TITLE
250423 zone and listener for all backends

### DIFF
--- a/apps/emqx_auth_http/src/emqx_authz_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authz_http.erl
@@ -43,6 +43,7 @@
     ?VAR_CERT_PEM,
     ?VAR_ACCESS,
     ?VAR_NS_CLIENT_ATTRS,
+    ?VAR_ZONE,
     ?VAR_LISTENER
 ]).
 

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap_bind.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap_bind.erl
@@ -41,6 +41,7 @@ authenticate(
                 )
             of
                 {ok, #{result := ok}} ->
+                    %% TODO: take is_superuser_attribute from Entry
                     {ok, #{is_superuser => false}};
                 {ok, #{result := 'invalidCredentials'}} ->
                     ?TRACE_AUTHN_PROVIDER(info, "ldap_bind_failed", #{

--- a/apps/emqx_ldap/src/emqx_ldap.erl
+++ b/apps/emqx_ldap/src/emqx_ldap.erl
@@ -359,6 +359,8 @@ prepare_template(filter, V, State) ->
 prepare_template(_Entry, _, State) ->
     State.
 
+filter_escape(Atom) when is_atom(Atom) ->
+    filter_escape(atom_to_list(Atom));
 filter_escape(Binary) when is_binary(Binary) ->
     filter_escape(erlang:binary_to_list(Binary));
 filter_escape([Char | T]) ->


### PR DESCRIPTION
Fixes [EMQX-14161](https://emqx.atlassian.net/browse/EMQX-14161)

Release version: 5.9.0

## Summary

this is a follow-up fix for https://github.com/emqx/emqx/pull/14979 (5.9.0, not released yet)

1. Missed `zone` for allowed vars in HTTP authz
2. Ensure ldap filter var allows atom values to render template

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [~] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)



[EMQX-14161]: https://emqx.atlassian.net/browse/EMQX-14161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ