### PR TITLE
feat(new mix build): add cover analysis support

### DIFF
--- a/apps/emqx_mix_utils/lib/emqx/mix/utils.ex
+++ b/apps/emqx_mix_utils/lib/emqx/mix/utils.ex
@@ -1,0 +1,16 @@
+defmodule EMQX.Mix.Utils do
+  def clear_screen() do
+    k = {__MODULE__, :clear_screen}
+    case {System.get_env("CLEAR_SCREEN"), :persistent_term.get(k, false)} do
+      {"true", false} ->
+        IO.write(:stdio, "\x1b[H\x1b[2J")
+        IO.write(:stderr, "\x1b[H\x1b[2J")
+        IO.write(:stdio, "\x1b[H\x1b[3J")
+        IO.write(:stderr, "\x1b[H\x1b[3J")
+        :persistent_term.put(k, true)
+
+      _ ->
+        :ok
+    end
+  end
+end

--- a/apps/emqx_mix_utils/lib/mix/tasks/cover_index.html.eex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/cover_index.html.eex
@@ -1,0 +1,17 @@
+<!DOCTYPE HTML>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Coverage Summary</title>
+  </head>
+  <body>
+    <h1>Summary</h1>
+    <table>
+      <tr><th>module</th><th>coverage %</th></tr>
+
+      <%= for line <- lines do %>
+      <tr><td><a href="<%= line.mod_report_path %>"><%= line.mod %></td><td><%= line.cover_percentage %>%</td></tr>
+      <% end %>
+    </table>
+  </body>
+</html>

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.cover.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.cover.ex
@@ -1,0 +1,95 @@
+defmodule Mix.Tasks.Emqx.Cover do
+  use Mix.Task
+
+  alias Mix.Tasks.Emqx.Ct, as: ECt
+
+  @requirements ["compile", "loadpaths"]
+
+  @impl true
+  def run(args) do
+    cover_dir = Path.join([Mix.Project.build_path(), "cover"])
+    File.mkdir_p!(cover_dir)
+
+    Enum.each([:common_test, :eunit, :mnesia, :tools], &ECt.add_to_path_and_cache/1)
+    {:ok, cover_pid} = ECt.start_cover()
+    redirect_cover_output(cover_pid, cover_dir)
+
+    coverdata_files =
+      cover_dir
+      |> List.wrap()
+      |> Mix.Utils.extract_files("*.coverdata")
+
+    :ok = :cover.reset()
+
+    ECt.info("Loading coverdata...")
+    Enum.each(coverdata_files, fn coverdata_file ->
+      case :cover.import(to_charlist(coverdata_file)) do
+        :ok ->
+          :ok
+
+        {:error, {:cant_open_file, f, _reason}} ->
+          ECt.warn("Can't import cover data from #{f}")
+      end
+    end)
+
+    outdir = Path.join([cover_dir, "aggregate"])
+    File.mkdir_p!(outdir)
+
+    ECt.info("Analyzing coverdata...")
+    results =
+      :cover.imported_modules()
+      |> Enum.flat_map(fn mod ->
+        # {:ok, answer} = :cover.analyze(mod, :coverage, :line)
+        outfile = Path.join([outdir, "#{mod}.html"]) |> to_charlist()
+        coverage = compute_coverage(mod)
+        ECt.debug("Analyzing coverage of #{mod}")
+        case :cover.analyze_to_file(mod, outfile, [:html]) do
+          {:ok, file} ->
+            mod_report_path = Path.relative_to(outfile, cover_dir)
+            [%{mod: mod, mod_report_path: mod_report_path, cover_percentage: coverage}]
+
+          {:error, reason} ->
+            ECt.warn("Couldn't write annotated file for module #{mod}: #{inspect(reason, pretty: true)}")
+        end
+      end)
+      |> Enum.sort_by(& &1.mod)
+
+    # require IEx; IEx.pry()
+
+    aggregate_outfile = Path.join(cover_dir, "index.html")
+    ECt.info("Saving analysis index to #{aggregate_outfile}")
+    __DIR__
+    |> Path.join("cover_index.html.eex")
+    |> EEx.eval_file([lines: results], [])
+    |> then(& File.write!(aggregate_outfile, &1))
+
+    ECt.info("Cover analysis done")
+
+    :ok
+  end
+
+  defp compute_coverage(mod) do
+    {:ok, result} = :cover.analyse(mod, :coverage, :line)
+    coverage = Enum.reduce(result, {0, 0}, fn
+      {{_, 0}, _}, acc ->
+        # line 0 is a line added by eunit and never executed so ignore it
+        acc
+
+      {_, {covered, not_covered}}, {acc_cov, acc_not_cov} ->
+        {acc_cov + covered, acc_not_cov + not_covered}
+    end)
+
+    case coverage do
+      {_, 0} -> 100
+      {cov, not_cov} -> trunc(cov / (cov + not_cov) * 100)
+    end
+  end
+
+  defp redirect_cover_output(cover_pid, cover_dir) do
+    log_out = Path.join(cover_dir, "cover.log")
+    ECt.debug("Writing :cover log output to #{log_out}")
+    File.rm(log_out)
+    fd = File.open!(log_out, [:append])
+    Process.group_leader(cover_pid, fd)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1277,6 +1277,7 @@ defmodule EMQXUmbrella.MixProject do
   defp aliases() do
     [
       ct: &do_ct/1,
+      cover: &do_cover/1,
       eunit: &do_eunit/1,
       proper: &do_proper/1,
       dialyzer: &do_dialyzer/1
@@ -1291,6 +1292,12 @@ defmodule EMQXUmbrella.MixProject do
     set_test_env!(true)
 
     Mix.Task.run("emqx.ct", args)
+  end
+
+  defp do_cover(args) do
+    ensure_test_mix_env!()
+    set_test_env!(true)
+    Mix.Task.run("emqx.cover", args)
   end
 
   defp do_eunit(args) do


### PR DESCRIPTION
This only affects the new mix build.

Running multiple tests in the same mix invocation is much faster, as cover compilations happens only once.

Only outputs HTML report at the moment.

Ex:

```sh
env NEW_MIX_BUILD=1 ENABLE_COVER_COMPILE=1 CLEAR_SCREEN=true PROFILE=emqx-enterprise-test mix do ct --suites apps/emqx_message_transformation/test/emqx_message_transformation_http_api_SUITE.erl --cases t_smoke_test, eunit --cases emqx_schema_validation_tests:duplicated_check_test_ , cover 

# ......

Saving analysis index to /emqx/_build/emqx-enterprise-test/cover/index.html
Cover analysis done
```