### PR TITLE
fix(conn): ensure events do not accidentally resurrect chaninfo

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -590,8 +590,11 @@ handle_msg({event, disconnected}, State = #state{channel = Channel}) ->
 handle_msg({event, _Other}, State = #state{channel = Channel}) ->
     case emqx_channel:info(clientid, Channel) of
         %% ClientId is yet unknown (i.e. connect packet is not received yet)
-        undefined -> ok;
-        ClientId -> emqx_cm:insert_channel_info(ClientId, info(State), stats(State))
+        undefined ->
+            ok;
+        ClientId ->
+            emqx_cm:set_chan_info(ClientId, info(State)),
+            emqx_cm:set_chan_stats(ClientId, stats(State))
     end,
     {ok, State};
 handle_msg({timeout, TRef, TMsg}, State) ->

--- a/changes/ce/fix-15106.en.md
+++ b/changes/ce/fix-15106.en.md
@@ -1,0 +1,1 @@
+Prevent connection events from inadvertently publishing channel information for already unregistered channels.


### PR DESCRIPTION
Fixes [EMQX-14170](https://emqx.atlassian.net/browse/EMQX-14170).

Release version: 5.9.0

## Summary

In effect, this piece of code is now equivalent to `emqx_ws_connection`.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14170]: https://emqx.atlassian.net/browse/EMQX-14170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ