### PR TITLE
feat: exhook health checker

### DIFF
--- a/apps/emqx_exhook/src/emqx_exhook.erl
+++ b/apps/emqx_exhook/src/emqx_exhook.erl
@@ -30,7 +30,7 @@ cast(Hookpoint, Req, [ServerName | More]) ->
     _ = emqx_exhook_server:call(
         Hookpoint,
         Req,
-        emqx_exhook_mgr:server(ServerName)
+        emqx_exhook_mgr:service(ServerName)
     ),
     cast(Hookpoint, Req, More).
 
@@ -51,7 +51,7 @@ call_fold(true, _, _Req, _, []) ->
 call_fold(false, _, Req, _, []) ->
     {ok, Req};
 call_fold(IsIgnore, Hookpoint, Req, AccFun, [ServerName | More]) ->
-    Server = emqx_exhook_mgr:server(ServerName),
+    Server = emqx_exhook_mgr:service(ServerName),
     case emqx_exhook_server:call(Hookpoint, Req, Server) of
         {ok, Resp} ->
             case AccFun(Req, Resp) of

--- a/apps/emqx_exhook/src/emqx_exhook_mgr.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_mgr.erl
@@ -79,9 +79,9 @@
     | disabled.
 
 -type server() :: #{
-    status := status(),
-    timer := reference(),
-    order := integer(),
+    status => status(),
+    timer => undefined | reference(),
+    order => integer(),
     %% include the content of server_options
     atom() => any()
 }.
@@ -392,7 +392,7 @@ do_load_server(#{name := Name} = Server) ->
             {ok, Server#{status => connected}};
         disable ->
             {ok, set_disable(Server)};
-        {ErrorType, Reason} = Error ->
+        {ErrorType, Reason} ->
             ?SLOG(
                 error,
                 #{
@@ -405,7 +405,7 @@ do_load_server(#{name := Name} = Server) ->
                 load_error ->
                     {ok, ensure_reload_timer(Server)};
                 _ ->
-                    {Error, Server#{status => disconnected}}
+                    {ErrorType, Server#{status => disconnected}}
             end
     end.
 

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -317,9 +317,7 @@ health_check(#{name := Name, request_timeout := Timeout, failed_action := Failed
                     case
                         grpc_client:health_check(
                             WorkerPid,
-                            _ReqOpts = #{
-                                timeout => Timeout, failed_action => FailedAction, channel => Name
-                            }
+                            #{timeout => Timeout, failed_action => FailedAction, channel => Name}
                         )
                     of
                         ok -> true;

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -71,7 +71,10 @@
 
 -dialyzer({nowarn_function, [inc_metrics/2]}).
 
--elvis([{elvis_style, dont_repeat_yourself, disable}, {elvis_style, no_catch_expressions, disable}]).
+-elvis([
+    {elvis_style, dont_repeat_yourself, disable},
+    {elvis_style, no_catch_expressions, disable}
+]).
 
 %%--------------------------------------------------------------------
 %% Load/Unload APIs
@@ -107,7 +110,7 @@ load(Name, #{request_timeout := Timeout, failed_action := FailedAction} = Opts) 
                                 prefix => Prefix
                             }};
                         {error, Reason} ->
-                            emqx_exhook_sup:stop_grpc_client_channel(Name),
+                            _ = emqx_exhook_sup:stop_grpc_client_channel(Name),
                             {load_error, Reason}
                     end;
                 {error, _} = E ->

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -84,9 +84,6 @@
 -spec load(binary(), map()) -> {ok, service()} | {error, term()} | {load_error, term()} | disable.
 load(_Name, #{enable := false}) ->
     disable;
-%% load(_Name, #{status := disconnected}) ->
-%%     %% for disconnected Service, skip load to follow auto_reconnect timer
-%%     {load_error, disconnected};
 load(Name, #{request_timeout := Timeout, failed_action := FailedAction} = Opts) ->
     ReqOpts = #{timeout => Timeout, failed_action => FailedAction},
     case channel_opts(Opts) of
@@ -306,7 +303,7 @@ health_check(#{enable := false}) ->
 health_check(#{status := disconnected}) ->
     %% for disconnected Service, skip health check to follow auto_reconnect timer
     skip;
-health_check(#{name := Name, request_timeout := Timeout, failed_action := FailedAction} = _Opts) ->
+health_check(#{name := Name, request_timeout := Timeout} = _Opts) ->
     %% check all workers
     case grpc_client_sup:workers(Name) of
         [] ->
@@ -317,7 +314,7 @@ health_check(#{name := Name, request_timeout := Timeout, failed_action := Failed
                     case
                         grpc_client:health_check(
                             WorkerPid,
-                            #{timeout => Timeout, failed_action => FailedAction, channel => Name}
+                            #{timeout => Timeout, channel => Name}
                         )
                     of
                         ok -> true;

--- a/apps/emqx_exhook/src/emqx_exhook_sup.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_sup.erl
@@ -56,7 +56,7 @@ init([]) ->
 start_grpc_client_channel(Name, SvrAddr, Options) ->
     grpc_client_sup:create_channel_pool(Name, SvrAddr, Options).
 
--spec stop_grpc_client_channel(binary()) -> ok.
+-spec stop_grpc_client_channel(binary()) -> ok | {error, term()}.
 stop_grpc_client_channel(Name) ->
     %% Avoid crash due to hot-upgrade had unloaded
     %% grpc application

--- a/apps/emqx_exhook/src/emqx_exhook_sup.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_sup.erl
@@ -15,7 +15,8 @@
 
 -export([
     start_grpc_client_channel/3,
-    stop_grpc_client_channel/1
+    stop_grpc_client_channel/1,
+    grpc_client_channel_workers/1
 ]).
 
 -define(DEFAULT_TIMEOUT, 5000).
@@ -66,6 +67,10 @@ stop_grpc_client_channel(Name) ->
         _:_:_ ->
             ok
     end.
+
+-spec grpc_client_channel_workers(binary()) -> list().
+grpc_client_channel_workers(Name) ->
+    grpc_client_sup:workers(Name).
 
 %% Calculate the maximum timeout, which will help to shutdown the
 %% emqx_exhook_mgr process correctly.

--- a/changes/ee/fix-15108.en.md
+++ b/changes/ee/fix-15108.en.md
@@ -1,0 +1,1 @@
+Add health check mechanism for ExHook and work with existing auto_reconnect configuration.

--- a/mix.exs
+++ b/mix.exs
@@ -201,7 +201,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:grpc),
     do:
       {:grpc,
-       github: "emqx/grpc-erl", tag: "0.7.1", override: true, system_env: emqx_app_system_env()}
+       github: "emqx/grpc-erl", tag: "0.7.2", override: true, system_env: emqx_app_system_env()}
 
   def common_dep(:cowboy), do: {:cowboy, github: "emqx/cowboy", tag: "2.9.2", override: true}
 

--- a/rebar.config
+++ b/rebar.config
@@ -87,7 +87,7 @@
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-8"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
-    {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.1"}}},
+    {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.2"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.4"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.1"}}},


### PR DESCRIPTION
Fixes: [EMQX-14048](https://emqx.atlassian.net/browse/EMQX-14048)

Release version: 5.9.0

## Summary

Bump `grpc-erl` vsn to `0.7.2` to add health check feature for ExHook.

The logic of health check and automatic reconnection working together:
- Server running and everything working.
- Do health check (C1), found it health, nothing happened.
  - Stop server.
- Do health check (C2), found it unhealthy.
  - Start a reload timer if the server configured `auto_reconnect`.
  - Mark server `connecting` Aka status `R` here.
- Do health check (C3), found it still unhealthy.
  - Ensure the reload timer. if was a timer here, do nothing.
  - Mark server `disconnected`
- Do reload, (between C3 and C4)
  - Still cann't connected to server.
  - Ensure a reolad timer, old timer stopped here, start a new one.
  - Mark `disconnected`
- Do health check (C4)
  - Still unhealthy.
  - Ensure a reload timer, it was a timer here, do nothing.
  - Mark `disconnected`
- Do health check (C5)
  - Server started
  - Cancal reload timer
  - Do hooks loading.
  - Mark `connected`
```
Status:
C: Connected
R: (re)Connecting
D: Disconnected
Time (s) 0.0   2.5   5.0   7.5  10.0  12.5  15.0  17.5  20.0  22.5  25.0
          |-----|-----|-----|-----|-----|-----|-----|-----|-----|-----|
      Stop Server  ^                      Start Server ^
Health Check timer:
          |           |           |           |           |           |
          C1          C2         C3          C4          C5          C6
          |---------->|---------->|---------->|---------->|---------->|
          |           |           |           |           |           |
 Status:  |---- C ----|---- R ----|- D -|- R -|---- D ----|---- C ----|
          |           |           |           |           |           |
 Reconnect Interval:  |           |           |           |           |
                      |---- 7.5s ------>|---- 7.5s ------>| Cancaled
```


<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- ~[ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)~

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
-->


[EMQX-14048]: https://emqx.atlassian.net/browse/EMQX-14048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ