### PR TITLE
feat(sessds): turn QoS0 subscriptions into direct broker subscriptions

### DIFF
--- a/apps/emqx/test/emqx_persistent_messages_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_messages_SUITE.erl
@@ -18,6 +18,8 @@
 
 -include("emqx_persistent_message.hrl").
 
+-define(PROP_SUBID, 'Subscription-Identifier').
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -263,8 +265,152 @@ t_qos0_only_many_streams(_Config) ->
         emqtt:stop(Pub)
     end.
 
-get_session_inflight(ConnPid) ->
-    emqx_connection:info({channel, {session, inflight}}, sys:get_state(ConnPid)).
+t_mixed_qos_subscriptions(_Config) ->
+    CPub = connect(<<"mixed_qos_subscriptions:pub">>, true, 0),
+    CSub = connect(<<"mixed_qos_subscriptions:sub">>, true, 30),
+    try
+        %% Subscribe to overlapping topics using different QoS levels:
+        SIDQ1 = 32#Q1,
+        SIDQ0 = 32#Q0,
+        %% This should turn into durable mode subscription.
+        {ok, _, [?RC_GRANTED_QOS_1]} =
+            emqtt:subscribe(CSub, #{?PROP_SUBID => SIDQ1}, <<"t/+/#">>, qos1),
+        %% This should turn into simpler, direct mode subscription.
+        {ok, _, [?RC_GRANTED_QOS_0]} =
+            emqtt:subscribe(CSub, #{?PROP_SUBID => SIDQ0}, <<"t/+/+">>, qos0),
+        %% Verify that respective routes end up in different tables:
+        ?assertEqual([<<"t/+/+">>], emqx_router:topics()),
+        ?assertEqual([<<"t/+/#">>], emqx_persistent_session_ds_router:topics()),
+        %% Publish a bunch of messages:
+        Messages = [
+            {<<"t/level/1">>, <<"0">>, 2},
+            {<<"t/1">>, <<"1">>, 2},
+            {<<"t/level/2">>, <<"2">>, 1},
+            {<<"t">>, <<"XXX">>, 0},
+            {<<"t/1">>, <<"3">>, 0},
+            {<<"t/level/1">>, <<"4">>, 0},
+            {<<"t/1">>, <<"5">>, 0}
+        ],
+        [emqtt:publish(CPub, Topic, Payload, Qos) || {Topic, Payload, Qos} <- Messages],
+        Received = receive_messages(9),
+        %% QoS 0 messages preserve relative publishing order.
+        ?assertMatch(
+            [
+                #{topic := <<"t/level/1">>, payload := <<"0">>},
+                #{topic := <<"t/level/2">>, payload := <<"2">>},
+                #{topic := <<"t/level/1">>, payload := <<"4">>}
+            ],
+            [M || M = #{properties := #{?PROP_SUBID := SID}} <- Received, SID == SIDQ0],
+            Received
+        ),
+        %% QoS 1/2 messages preserve only per-topic publishing order.
+        ?assertMatch(
+            [
+                #{qos := 1, topic := <<"t/1">>, payload := <<"1">>},
+                #{qos := 0, topic := <<"t/1">>, payload := <<"3">>},
+                #{qos := 0, topic := <<"t/1">>, payload := <<"5">>},
+                #{qos := 1, topic := <<"t/level/1">>, payload := <<"0">>},
+                #{qos := 0, topic := <<"t/level/1">>, payload := <<"4">>},
+                #{qos := 1, topic := <<"t/level/2">>, payload := <<"2">>}
+            ],
+            group_by(
+                topic,
+                [M || M = #{properties := #{?PROP_SUBID := SID}} <- Received, SID == SIDQ1]
+            ),
+            Received
+        ),
+        ?assertNotReceive(_)
+    after
+        lists:foreach(fun emqtt:stop/1, [CPub, CSub])
+    end.
+
+t_qos0_subscription_upgrade_downgrade(_Config) ->
+    CIDSub = <<"qos0_subscription_upgrade_downgrade:sub">>,
+    CPub = connect(<<"mixed_qos_subscriptions:pub">>, true, 0),
+    CSub1 = connect(CIDSub, true, 30),
+    try
+        %% This should turn into durable mode subscription.
+        {ok, _, [?RC_GRANTED_QOS_1]} =
+            emqtt:subscribe(CSub1, #{?PROP_SUBID => 1}, <<"t/+">>, qos1),
+        %% This should turn into direct mode subscription.
+        {ok, _, [?RC_GRANTED_QOS_0]} =
+            emqtt:subscribe(CSub1, #{?PROP_SUBID => 2}, <<"t/#">>, qos0),
+        %% Publish a bunch of messages:
+        [
+            emqtt:publish(CPub, Topic, Payload, Qos)
+         || {Topic, Payload, Qos} <- [
+                {<<"t/level/1">>, <<"0">>, 2},
+                {<<"t/1">>, <<"1">>, 2},
+                {<<"t/level/1">>, <<"2">>, 1},
+                {<<"t/1">>, <<"3">>, 0}
+            ]
+        ],
+        %% Receive them back:
+        Received0 = receive_messages(2 + 4),
+        %% Downgrade QoS1 subscription:
+        {ok, _, [?RC_GRANTED_QOS_0]} =
+            emqtt:subscribe(CSub1, #{?PROP_SUBID => 1}, <<"t/+">>, qos0),
+        %% Upgrade QoS0 subscription:
+        {ok, _, [?RC_GRANTED_QOS_1]} =
+            emqtt:subscribe(CSub1, #{?PROP_SUBID => 2}, <<"t/#">>, qos1),
+        %% Verify that respective routes switched places:
+        ?assertEqual([<<"t/+">>], emqx_router:topics()),
+        ?assertEqual([<<"t/#">>], emqx_persistent_session_ds_router:topics()),
+        %% Simulate subscriber going offline for some time:
+        ok = emqtt:disconnect(CSub1),
+        %% Publish a bunch of messages:
+        [
+            emqtt:publish(CPub, Topic, Payload, Qos)
+         || {Topic, Payload, Qos} <- [
+                {<<"t/level/1">>, <<"4">>, 2},
+                {<<"t/1">>, <<"5">>, 1},
+                {<<"t/level/1">>, <<"6">>, 0},
+                {<<"t/1">>, <<"7">>, 0}
+            ]
+        ],
+        %% Reconnect and see what we got:
+        CSub2 = connect(CIDSub, false, 30),
+        Received1 = receive_messages(4),
+        Received = Received0 ++ Received1,
+        ?assertNotReceive(_),
+        ReceivedS1 = [M || M = #{properties := #{?PROP_SUBID := 1}} <- Received],
+        ReceivedS2 = [M || M = #{properties := #{?PROP_SUBID := 2}} <- Received],
+        %% Subscription 1 messages preserve per-topic publishing order.
+        %% We expect not to receive any messages after downgrade.
+        ?assertMatch(
+            [
+                #{client_pid := CSub1, qos := 1, topic := <<"t/1">>, payload := <<"1">>},
+                #{client_pid := CSub1, qos := 0, topic := <<"t/1">>, payload := <<"3">>}
+            ],
+            ReceivedS1,
+            Received
+        ),
+        %% Subscription 2 messages preserve publishing order before upgrade,
+        %% per-topic publishing order after upgrade.
+        ?assertMatch(
+            [
+                #{qos := 0, topic := <<"t/level/1">>, payload := <<"0">>},
+                #{qos := 0, topic := <<"t/1">>, payload := <<"1">>},
+                #{qos := 0, topic := <<"t/level/1">>, payload := <<"2">>},
+                #{qos := 0, topic := <<"t/1">>, payload := <<"3">>}
+            ],
+            [M || M = #{client_pid := C} <- ReceivedS2, C == CSub1],
+            Received
+        ),
+        ?assertMatch(
+            [
+                #{topic := <<"t/1">>, payload := <<"5">>},
+                #{topic := <<"t/1">>, payload := <<"7">>},
+                #{topic := <<"t/level/1">>, payload := <<"4">>},
+                #{topic := <<"t/level/1">>, payload := <<"6">>}
+            ],
+            group_by(topic, [M || M = #{client_pid := C} <- ReceivedS2, C == CSub2]),
+            Received
+        ),
+        ok = emqtt:disconnect(CSub2)
+    after
+        emqtt:stop(CPub)
+    end.
 
 t_publish_as_persistent(_Config) ->
     Sub = connect(<<?MODULE_STRING "1">>, true, 30),

--- a/apps/emqx/test/emqx_persistent_messages_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_messages_SUITE.erl
@@ -265,6 +265,11 @@ t_qos0_only_many_streams(_Config) ->
         emqtt:stop(Pub)
     end.
 
+%% Smoke test QoS0 and QoS1/2 subscriptions coexisting in a durable session.
+%% Verifies that such subscriptions follow relevant MQTT Spec requirements and provide
+%% message ordering guarantees corresponding to the mechanism they operate through:
+%% publishing order for "direct" QoS0 subsctipions and per-topic publishing order for
+%% DS-based QoS1/2 subscriptions.
 t_mixed_qos_subscriptions(_Config) ->
     CPub = connect(<<"mixed_qos_subscriptions:pub">>, true, 0),
     CSub = connect(<<"mixed_qos_subscriptions:sub">>, true, 30),
@@ -324,9 +329,12 @@ t_mixed_qos_subscriptions(_Config) ->
         lists:foreach(fun emqtt:stop/1, [CPub, CSub])
     end.
 
-t_qos0_subscription_upgrade_downgrade(_Config) ->
-    CIDSub = <<"qos0_subscription_upgrade_downgrade:sub">>,
-    CPub = connect(<<"mixed_qos_subscriptions:pub">>, true, 0),
+%% Verify that QoS0 "direct" subcsriptions can be turned into QoS1/2 DS-based
+%% subscriptions in a durable session and vice versa, and subscriptions survive
+%% client reconnects regardless of the mechanism.
+t_mixed_qos_subscription_upgrade_downgrade(_Config) ->
+    CIDSub = <<"mixed_qos_subscription_upgrade_downgrade:sub">>,
+    CPub = connect(<<"mixed_qos_subscription_upgrade_downgrade:pub">>, true, 0),
     CSub1 = connect(CIDSub, true, 30),
     try
         %% This should turn into durable mode subscription.

--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -318,12 +318,6 @@ t_session_subscription_idempotency(Config) ->
                 #{?snk_kind := will_restart_node},
                 _Guard0 = true
             ),
-            ?force_ordering(
-                #{?snk_kind := restarted_node},
-                _NEvents1 = 1,
-                #{?snk_kind := persistent_session_ds_open_iterators, ?snk_span := start},
-                _Guard1 = true
-            ),
 
             spawn_link(fun() -> restart_node(Node1, Node1Spec) end),
 
@@ -346,10 +340,7 @@ t_session_subscription_idempotency(Config) ->
             {ok, _} = emqtt:connect(Client1),
             ?tp(notice, "subscribing 2", #{}),
             {ok, _, [2]} = emqtt:subscribe(Client1, SubTopicFilter, qos2),
-
-            ok = emqtt:stop(Client1),
-
-            ok
+            ok = stop_and_commit(Client1)
         end,
         [
             fun(_Trace) ->
@@ -384,12 +375,6 @@ t_session_unsubscription_idempotency(Config) ->
                 #{?snk_kind := will_restart_node},
                 _Guard0 = true
             ),
-            ?force_ordering(
-                #{?snk_kind := restarted_node},
-                _NEvents1 = 1,
-                #{?snk_kind := persistent_session_ds_subscription_route_delete, ?snk_span := start},
-                _Guard1 = true
-            ),
 
             spawn_link(fun() -> restart_node(Node1, Node1Spec) end),
 
@@ -415,16 +400,7 @@ t_session_unsubscription_idempotency(Config) ->
             ?tp(notice, "subscribing 2", #{}),
             {ok, _, [?RC_GRANTED_QOS_2]} = emqtt:subscribe(Client1, SubTopicFilter, qos2),
             ?tp(notice, "unsubscribing 2", #{}),
-            {{ok, _, [?RC_SUCCESS]}, {ok, _}} =
-                ?wait_async_action(
-                    emqtt:unsubscribe(Client1, SubTopicFilter),
-                    #{
-                        ?snk_kind := persistent_session_ds_subscription_route_delete,
-                        ?snk_span := {complete, _}
-                    },
-                    15_000
-                ),
-
+            {ok, _, [?RC_SUCCESS]} = emqtt:unsubscribe(Client1, SubTopicFilter),
             ok = stop_and_commit(Client1)
         end,
         [

--- a/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_subscriptions.erl
@@ -237,7 +237,7 @@ do_subscriptions_query_persistent(#{<<"page">> := Page, <<"limit">> := Limit} = 
     ),
     SubMap = fun enrich_dssub/1,
     SubPred = fun(Sub) ->
-        Sub =/= undefined andalso
+        Sub =/= undefined andalso dssub_mode(Sub) =:= durable andalso
             compare_optional(<<"topic">>, QString, fun dssub_topic/1, Sub) andalso
             compare_optional(<<"clientid">>, QString, fun dssub_session_id/1, Sub) andalso
             compare_optional(<<"qos">>, QString, fun dssub_qos/1, Sub) andalso
@@ -278,6 +278,9 @@ dssub_group({_SessionID, #share{group = Group}, _Sub}) ->
 dssub_group({_SessionID, _Topic, _Sub}) ->
     undefined.
 
+dssub_mode({_SessionID, _Topic, Sub}) ->
+    maps:get(mode, Sub, durable).
+
 dssub_subopts({_SessionID, _Topic, Sub}) ->
     maps:get(subopts, Sub, #{}).
 
@@ -303,11 +306,11 @@ dssub_to_subscription(DSSub = {SessionID, Topic, _}) ->
             Sub
     end.
 
-enrich_dssub({SessionId, Topic}) ->
+enrich_dssub({SessionID, Topic}) ->
     %% TODO: Suboptimal, especially with DS-backed session storage.
-    case emqx_persistent_session_ds:get_client_subscription(SessionId, Topic) of
+    case emqx_persistent_session_ds:get_client_subscription(SessionID, Topic) of
         Subscription = #{} ->
-            {SessionId, Topic, Subscription};
+            {SessionID, Topic, Subscription};
         undefined ->
             undefined
     end.

--- a/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_publish_SUITE.erl
@@ -69,8 +69,8 @@ t_publish_api({init, Config}) ->
         }
     ),
     {ok, _} = emqtt:connect(Client),
-    {ok, _, [0]} = emqtt:subscribe(Client, ?TOPIC1),
-    {ok, _, [0]} = emqtt:subscribe(Client, ?TOPIC2),
+    {ok, _, [?RC_GRANTED_QOS_1]} = emqtt:subscribe(Client, ?TOPIC1, ?QOS_1),
+    {ok, _, [?RC_GRANTED_QOS_1]} = emqtt:subscribe(Client, ?TOPIC2, ?QOS_1),
     [{client, Client} | Config];
 t_publish_api({'end', Config}) ->
     Client = ?config(client, Config),
@@ -367,7 +367,7 @@ t_publish_offline_api({init, Config}) ->
         }
     ),
     {ok, _} = emqtt:connect(Client),
-    {ok, _, [0]} = emqtt:subscribe(Client, ?OFFLINE_TOPIC),
+    {ok, _, [?RC_GRANTED_QOS_1]} = emqtt:subscribe(Client, ?OFFLINE_TOPIC, ?QOS_1),
     _ = emqtt:stop(Client),
     Config;
 t_publish_offline_api({'end', _Config}) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_subscription_SUITE.erl
@@ -242,7 +242,7 @@ t_subscription_fuzzy_search(Config) ->
         <<"topic/foo/bar">>,
         <<"topic/foo/baz">>
     ],
-    _ = [{ok, _, _} = emqtt:subscribe(Client, T) || T <- Topics],
+    [{ok, _, _} = emqtt:subscribe(Client, T, ?QOS_1) || T <- Topics],
 
     Headers = emqx_mgmt_api_test_util:auth_header_(),
     MatchQs = [

--- a/apps/emqx_management/test/emqx_mgmt_api_topics_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_topics_SUITE.erl
@@ -228,7 +228,7 @@ t_persistent_topics(_Config) ->
     ClientPersistent1 = client(SessionId1, PersistentOpts),
     ClientPersistent2 = client(SessionId2, PersistentOpts),
     _ = [
-        ?assertMatch({ok, _, _}, emqtt:subscribe(Client, Topic))
+        ?assertMatch({ok, _, [1]}, emqtt:subscribe(Client, Topic, _QoS = 1))
      || {Client, Topics} <- [
             {Client1, [<<"t/client/mem">>, <<"t/+">>]},
             {Client2, [<<"t/client/mem">>, <<"t/+">>]},


### PR DESCRIPTION
Fixes [EMQX-9746](https://emqx.atlassian.net/browse/EMQX-9746).

Release version: 5.10.0

## Summary

1. Introduce concept of _direct_ subscriptions for DS-based persistent sessions.
2. Use `emqx_broker` mechanics for _direct_ subscriptions, similar to in-memory sessions.
3. Avoid setting persistent routes for direct subscriptions.
4. Turn QoS0 subscriptions into direct subscriptions.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-9746]: https://emqx.atlassian.net/browse/EMQX-9746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ