### PR TITLE
fix(kafka): allow `topic_authorization_failed` for probing topic

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -737,7 +737,10 @@ check_topic_status(ClientId, WolffClientPid, KafkaTopic) ->
     case wolff_client:check_topic_exists_with_client_pid(WolffClientPid, KafkaTopic) of
         ok ->
             ok;
-        {error, unknown_topic_or_partition} when KafkaTopic =:= ?PROBE_TOPIC_NAME ->
+        {error, R} when
+            KafkaTopic =:= ?PROBE_TOPIC_NAME andalso
+                (R =:= unknown_topic_or_partition orelse R =:= topic_authorization_failed)
+        ->
             %% The probing topic is only used to check if metadata request can be sent
             ok;
         {error, unknown_topic_or_partition} ->

--- a/changes/ee/fix-15116.en.md
+++ b/changes/ee/fix-15116.en.md
@@ -1,0 +1,1 @@
+Consider Kafka healthy if `topic_authorization_failed` is received for the default probing topic.


### PR DESCRIPTION

Release version: 5.9.0

## Summary

If Kafka has ACL control for clients, it may return topic_authorization_failed for the default health-check probing topic.
Allow this reason code.

## PR Checklist

- [~] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
