### PR TITLE
refactor: refine cinfo expression evaluation failure warning message

### DIFF
--- a/apps/emqx_auth_cinfo/src/emqx_auth_cinfo.app.src
+++ b/apps/emqx_auth_cinfo/src/emqx_auth_cinfo.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_cinfo, [
     {description, "EMQX Client Information Authorization"},
-    {vsn, "0.1.0"},
+    {vsn, "0.1.1"},
     {registered, []},
     {mod, {emqx_auth_cinfo_app, []}},
     {applications, [

--- a/apps/emqx_auth_cinfo/src/emqx_authn_cinfo.erl
+++ b/apps/emqx_auth_cinfo/src/emqx_authn_cinfo.erl
@@ -107,16 +107,18 @@ is_match([CompiledExpr | CompiledExprs], Credential) ->
         {ok, <<"false">>} ->
             false;
         {ok, Other} ->
-            ?SLOG(debug, "clientinfo_auth_expression_yield_non_boolean", #{
+            ?SLOG(debug, #{
+                msg => "clientinfo_auth_expression_yield_non_boolean",
                 expr => emqx_variform:decompile(CompiledExpr),
                 yield => Other
             }),
             false;
         {error, Reason} ->
-            {error, #{
-                cause => "clientinfo_auth_expression_evaluation_error",
-                error => Reason
-            }}
+            ?SLOG(warning, #{
+                msg => "clientinfo_auth_expression_evaluation_error",
+                reason => Reason
+            }),
+            false
     end.
 
 destroy(_) ->

--- a/changes/ee/fix-15117.en.md
+++ b/changes/ee/fix-15117.en.md
@@ -1,0 +1,1 @@
+Fix a warning message when Client-Info authentication expression evaluation failed.


### PR DESCRIPTION
Release version: 5.9.0

## Summary

This PR fixes a `case_clause` warning level log in case cinfo auth expression failed to evaluate.
There will still be a warning level log, but will not appear like a crash.

```
2025-04-25T13:15:59.993395+00:00 [warning] tag: AUTHN, clientid: mqttx_a50058aa, msg: authenticator_error, peername: 127.0.0.1:60842, 
reason: {case_clause,{error,#{error => #{reason => var_unbound,var_name => <<"cert_common_name">>},
cause => "clientinfo_auth_expression_evaluation_error"}}}, 
stacktrace: [{emqx_authn_cinfo,do_check,2,[{file,"emqx_authn_cinfo.erl"},{line,94}]},{emqx_authn_cinfo,check,2,[{file,"emqx_authn_cinfo.erl"},{line,82}]},{emqx_authn_chains,authenticate_with_provider,2,...
```

New log looks like this

```
2025-04-25T15:46:50.748732+02:00 [warning] clientid: client1, 
msg: clientinfo_auth_expression_evaluation_error, 
peername: 127.0.0.1:53919, 
reason: #{reason => var_unbound,var_name => <<"cert_common_name">>}
```

## PR Checklist

- [~] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

