### PR TITLE
250425 expose session hist count metric

### DIFF
--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -11,7 +11,7 @@
 
 -export([start_link/0]).
 
--export([is_enabled/0, is_hist_enabled/0]).
+-export([is_enabled/0, is_hist_enabled/0, table_size/0]).
 
 -export([
     register_channel/1,
@@ -63,6 +63,11 @@ is_enabled() ->
 -spec is_hist_enabled() -> boolean().
 is_hist_enabled() ->
     retain_duration() > 0.
+
+%% @doc Get the size of the global channel registry table.
+-spec table_size() -> non_neg_integer().
+table_size() ->
+    ets:info(?CHAN_REG_TAB, size).
 
 %% @doc Register a global channel.
 -spec register_channel(
@@ -120,6 +125,9 @@ lookup_channels(ClientId) ->
 
 %% Return 'true' or 'false' if it's a local pid.
 %% Otherwise return 'unknown'.
+is_pid_alive(Pid) when is_integer(Pid) ->
+    %% broker.session_history_retain > 0
+    false;
 is_pid_alive(Pid) when is_pid(Pid) andalso node(Pid) =:= node() ->
     erlang:is_process_alive(Pid);
 is_pid_alive(_) ->

--- a/apps/emqx/src/emqx_cm_registry.erl
+++ b/apps/emqx/src/emqx_cm_registry.erl
@@ -37,6 +37,14 @@
     do_cleanup_channels/1
 ]).
 
+-ifdef(TEST).
+%% For testing only
+-export([
+    force_delete/1,
+    purge/0
+]).
+-endif.
+
 -include("emqx.hrl").
 -include("emqx_cm.hrl").
 -include("logger.hrl").
@@ -111,6 +119,20 @@ unregister_channel({ClientId, ChanPid}) when is_binary(ClientId), is_pid(ChanPid
         false ->
             ok
     end.
+
+-ifdef(TEST).
+%% @hidden Force delete a global channel.
+%% For testing only.
+-spec force_delete(emqx_types:clientid()) -> ok.
+force_delete(ClientId) ->
+    mria:dirty_delete(?CHAN_REG_TAB, ClientId).
+
+%% @hidden Purge the global channel registry.
+%% For testing only.
+-spec purge() -> ok.
+purge() ->
+    ets:delete_all_objects(?CHAN_REG_TAB).
+-endif.
 
 %% @private
 unregister_channel2(#channel{chid = ClientId} = Record) ->

--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -100,6 +100,17 @@
 -define(LICENSE_QUOTA, []).
 -endif.
 
+%% record the max value over the history
+-define(WATERMARK_SAMPLER_LIST, [
+    %% sessions history high water mark is only recorded when
+    %% the config broker.s
+    sessions_hist_hwmark
+]).
+
+-define(NEWER_WINS_KEYS, maps:from_keys(?WATERMARK_SAMPLER_LIST ++ ?GAUGE_SAMPLER_LIST, true)).
+
+-define(PICK_NEWER(Key), is_map_key(Key, ?NEWER_WINS_KEYS)).
+
 %% use this atom to indicate no value provided from http request
 -define(NO_MFA_TOKEN, no_mfa_token).
 %% use this atom for internal calls where token validation is not required

--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -107,9 +107,18 @@
     sessions_hist_hwmark
 ]).
 
--define(NEWER_WINS_KEYS, maps:from_keys(?WATERMARK_SAMPLER_LIST ++ ?GAUGE_SAMPLER_LIST, true)).
-
--define(PICK_NEWER(Key), is_map_key(Key, ?NEWER_WINS_KEYS)).
+%% Pick the newer value from the two maps when merging
+%% Keys are from ?WATERMARK_SAMPLER_LIST and ?GAUGE_SAMPLER_LIST
+%% test case is added to ensure no missing key in this macro
+-define(IS_PICK_NEWER(Key),
+    (Key =:= sessions_hist_hwmark orelse
+        Key =:= disconnected_durable_sessions orelse
+        Key =:= subscriptions_durable orelse
+        Key =:= subscriptions orelse
+        Key =:= topics orelse
+        Key =:= connections orelse
+        Key =:= live_connections)
+).
 
 %% use this atom to indicate no value provided from http request
 -define(NO_MFA_TOKEN, no_mfa_token).

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -656,7 +656,8 @@ current_wmark(sessions_hist_hwmark) ->
 hwmark(?HWMARK(TPast, PPast, _VPast), ?HWMARK(TNow, PNow, VNow) = Now) ->
     %% The old high watermark is expired,
     %% or the current watermark is higher than the old one.
-    IsNewPeak = (TPast + ?RETENTION_TIME < TNow) orelse (PPast < PNow),
+    RetentionTime = emqx_conf:get([dashboard, hwmark_expire_time]),
+    IsNewPeak = (TPast + RetentionTime < TNow) orelse (PPast < PNow),
     case IsNewPeak of
         true -> Now;
         false -> ?HWMARK(TPast, PPast, VNow)

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -128,7 +128,8 @@ fields(sampler_current) ->
     fields_current(sample_names(sampler_current)).
 
 sample_names(sampler_current_node) ->
-    maps:values(?DELTA_SAMPLER_RATE_MAP) ++ ?GAUGE_SAMPLER_LIST ++ ?CURRENT_SAMPLE_NON_RATE;
+    maps:values(?DELTA_SAMPLER_RATE_MAP) ++ ?GAUGE_SAMPLER_LIST ++ ?CURRENT_SAMPLE_NON_RATE ++
+        ?WATERMARK_SAMPLER_LIST;
 sample_names(sampler_current) ->
     sample_names(sampler_current_node) -- [node_uptime].
 
@@ -254,7 +255,9 @@ swagger_desc(shared_subscriptions) ->
 swagger_desc(node_uptime) ->
     <<"Node up time in seconds. Only presented in endpoint: `/monitor_current/nodes/:node`.">>;
 swagger_desc(license_quota) ->
-    <<"License quota. AKA: limited max_connections for cluster">>.
+    <<"License quota. AKA: limited max_connections for cluster">>;
+swagger_desc(Name) ->
+    ?DESC(Name).
 
 swagger_desc_format(Format) ->
     swagger_desc_format(Format, last).

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -125,19 +125,29 @@ fields(sampler) ->
 fields(sampler_current_node) ->
     fields_current(sample_names(sampler_current_node));
 fields(sampler_current) ->
-    fields_current(sample_names(sampler_current)).
+    fields_current(sample_names(sampler_current));
+fields(session_hist_hwmark) ->
+    [
+        {peak_time, hoconsc:mk(non_neg_integer(), #{desc => ?DESC(hwmark_kpeak_time)})},
+        {peak_value, hoconsc:mk(non_neg_integer(), #{desc => ?DESC(hwmark_peak_value)})},
+        {current_value, hoconsc:mk(non_neg_integer(), #{desc => ?DESC(hwmark_current_value)})}
+    ].
 
 sample_names(sampler_current_node) ->
-    maps:values(?DELTA_SAMPLER_RATE_MAP) ++ ?GAUGE_SAMPLER_LIST ++ ?CURRENT_SAMPLE_NON_RATE ++
-        ?WATERMARK_SAMPLER_LIST;
+    maps:values(?DELTA_SAMPLER_RATE_MAP) ++ ?GAUGE_SAMPLER_LIST ++ ?CURRENT_SAMPLE_NON_RATE;
 sample_names(sampler_current) ->
     sample_names(sampler_current_node) -- [node_uptime].
 
 fields_current(Names) ->
-    [
+    IntegerSamplers = [
         {SamplerName, hoconsc:mk(integer(), #{desc => swagger_desc(SamplerName)})}
      || SamplerName <- Names
-    ].
+    ],
+    HwmarkSamplers = [
+        {sessions_hist_hwmark,
+            hoconsc:mk(hoconsc:ref(session_hist_hwmark), #{desc => ?DESC(sessions_hist_hwmark)})}
+    ],
+    IntegerSamplers ++ HwmarkSamplers.
 
 %% -------------------------------------------------------------------------------------------------
 %% API

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema.erl
@@ -39,6 +39,15 @@ fields("dashboard") ->
                     validator => fun validate_sample_interval/1
                 }
             )},
+        {hwmark_expire_time,
+            ?HOCON(
+                emqx_schema:duration(),
+                #{
+                    default => <<"7d">>,
+                    desc => ?DESC(hwmark_expire_time),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
         {token_expired_time,
             ?HOCON(
                 emqx_schema:duration(),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -107,40 +107,31 @@ end_per_group(common, Config) ->
     emqx_common_test_helpers:stop_apps_ds(Config),
     ok.
 
-init_per_testcase(t_smoke_test_monitor_multiple_windows = TestCase, Config0) ->
-    Port = 28083,
-    NodeSpecs = [
-        {smoke_multiple_windows1, #{apps => cluster_node_appspec(true, Port)}},
-        {smoke_multiple_windows2, #{apps => cluster_node_appspec(false, Port)}}
-    ],
-    Config = emqx_common_test_helpers:start_cluster_ds(
-        Config0,
-        NodeSpecs,
-        #{work_dir => emqx_cth_suite:work_dir(TestCase, Config0)}
-    ),
-    ok = snabbkaffe:start_trace(),
-    Config;
-init_per_testcase(t_monitor_current_shared_subscription, Config) ->
-    init_per_testcase(common, Config);
-init_per_testcase(_TestCase, Config) ->
-    ok = snabbkaffe:start_trace(),
-    ct:timetrap({seconds, 30}),
-    Config.
+init_per_testcase(TestCase, Config) ->
+    try
+        ?MODULE:TestCase({init, Config})
+    catch
+        error:function_clause ->
+            ok = snabbkaffe:start_trace(),
+            ct:timetrap({seconds, 30}),
+            Config
+    end.
 
-end_per_testcase(t_smoke_test_monitor_multiple_windows, Config) ->
-    ok = snabbkaffe:stop(),
-    ok = emqx_common_test_helpers:stop_cluster_ds(Config),
-    ok;
-end_per_testcase(_TestCase, _Config) ->
-    ok = snabbkaffe:stop(),
-    emqx_common_test_helpers:call_janitor(),
-    ok.
+end_per_testcase(TestCase, Config) ->
+    try
+        ?MODULE:TestCase({'end', Config})
+    catch
+        error:function_clause ->
+            ok = snabbkaffe:stop(),
+            emqx_common_test_helpers:call_janitor(),
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Test Cases
 %%--------------------------------------------------------------------
 
-t_assert_no_missing_key_in_IS_PICK_NEWER(_Config) ->
+t_assert_no_missing_key_in_IS_PICK_NEWER(Config) when is_list(Config) ->
     Missing = lists:filter(
         fun(Key) ->
             not ?IS_PICK_NEWER(Key)
@@ -149,12 +140,12 @@ t_assert_no_missing_key_in_IS_PICK_NEWER(_Config) ->
     ),
     ?assertEqual([], Missing).
 
-t_empty_table(_Config) ->
+t_empty_table(Config) when is_list(Config) ->
     pause_monitor_process(),
     clean_data(),
     ?assertEqual({ok, []}, request(["monitor"], "latest=20000")).
 
-t_pmap_nodes(_Config) ->
+t_pmap_nodes(Config) when is_list(Config) ->
     MaxAge = timer:hours(1),
     Now = erlang:system_time(millisecond) - 1,
     Interval = emqx_dashboard_monitor:sample_interval(MaxAge),
@@ -170,7 +161,7 @@ t_pmap_nodes(_Config) ->
     ok = check_sample_intervals(Interval, hd(Data), tl(Data)),
     ?assertEqual(LastVal * length(Nodes), maps:get(sent, lists:last(Data))).
 
-t_inplace_downsample(_Config) ->
+t_inplace_downsample(Config) when is_list(Config) ->
     clean_data(),
     %% -20s to ensure the oldest data point will not expire during the test
     SinceT = 7 * timer:hours(24) - timer:seconds(20),
@@ -215,7 +206,7 @@ check_intervals([Interval | Rest], [{Ts, _} | RestData] = All) ->
             check_intervals(Rest, All)
     end.
 
-t_randomize(_Config) ->
+t_randomize(Config) when is_list(Config) ->
     clean_data(),
     emqx_dashboard_monitor:randomize(1, #{sent => 100}),
     Since = integer_to_list(7 * timer:hours(24)),
@@ -223,19 +214,19 @@ t_randomize(_Config) ->
     Count = lists:sum(lists:map(fun(#{<<"sent">> := S}) -> S end, Samplers)),
     ?assertEqual(100, Count).
 
-t_downsample_7d(_Config) ->
+t_downsample_7d(Config) when is_list(Config) ->
     MaxAge = 7 * timer:hours(24),
     test_downsample(MaxAge, 10).
 
-t_downsample_3d(_Config) ->
+t_downsample_3d(Config) when is_list(Config) ->
     MaxAge = 3 * timer:hours(24),
     test_downsample(MaxAge, 10).
 
-t_downsample_1d(_Config) ->
+t_downsample_1d(Config) when is_list(Config) ->
     MaxAge = timer:hours(24),
     test_downsample(MaxAge, 10).
 
-t_downsample_1h(_Config) ->
+t_downsample_1h(Config) when is_list(Config) ->
     MaxAge = timer:hours(1),
     test_downsample(MaxAge, 10).
 
@@ -353,7 +344,7 @@ write(Time, Data) ->
     {atomic, ok} = emqx_dashboard_monitor:store({emqx_monit, Time, Data}),
     ok.
 
-t_monitor_sampler_format(_Config) ->
+t_monitor_sampler_format(Config) when is_list(Config) ->
     {ok, _} =
         snabbkaffe:block_until(
             ?match_event(#{?snk_kind := dashboard_monitor_flushed}),
@@ -364,7 +355,7 @@ t_monitor_sampler_format(_Config) ->
     [?assert(lists:member(SamplerName, SamplerKeys)) || SamplerName <- ?SAMPLER_LIST],
     ok.
 
-t_sample_specific_node_but_badrpc(_Config) ->
+t_sample_specific_node_but_badrpc(Config) when is_list(Config) ->
     meck:new(emqx_dashboard_monitor, [non_strict, passthrough, no_history, no_link]),
     meck:expect(
         emqx_dashboard_monitor,
@@ -383,7 +374,7 @@ t_sample_specific_node_but_badrpc(_Config) ->
     meck:unload(emqx_dashboard_monitor),
     ok.
 
-t_handle_old_monitor_data(_Config) ->
+t_handle_old_monitor_data(Config) when is_list(Config) ->
     Now = erlang:system_time(second),
     FakeOldData = maps:from_list(
         lists:map(
@@ -418,7 +409,7 @@ t_handle_old_monitor_data(_Config) ->
     ok = meck:unload([emqx, emqx_dashboard_proto_v2]),
     ok.
 
-t_monitor_api(_) ->
+t_monitor_api(Config) when is_list(Config) ->
     clean_data(),
     {ok, _} =
         snabbkaffe:block_until(
@@ -450,7 +441,7 @@ t_monitor_api(_) ->
     [Fun(NodeSampler) || NodeSampler <- NodeSamplers],
     ok.
 
-t_monitor_current_api(_) ->
+t_monitor_current_api(Config) when is_list(Config) ->
     {ok, _} =
         snabbkaffe:block_until(
             ?match_n_events(2, #{?snk_kind := dashboard_monitor_flushed}),
@@ -480,7 +471,7 @@ t_monitor_current_api(_) ->
     ?assertNot(maps:is_key(<<"disconnected_durable_sessions">>, NodeRate)),
     ok.
 
-t_monitor_current_api_live_connections(_) ->
+t_monitor_current_api_live_connections(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     ClientId = <<"live_conn_tests">>,
     ClientId1 = <<"live_conn_tests1">>,
@@ -501,7 +492,7 @@ t_monitor_current_api_live_connections(_) ->
     {ok, _} = emqtt:connect(C2),
     ok = emqtt:disconnect(C2).
 
-t_monitor_current_retained_count(_) ->
+t_monitor_current_retained_count(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     ClientId = <<"live_conn_tests">>,
     {ok, C} = emqtt:start_link([{clean_start, false}, {clientid, ClientId}]),
@@ -517,7 +508,104 @@ t_monitor_current_retained_count(_) ->
     ok = emqtt:disconnect(C),
     ok.
 
-t_monitor_current_shared_subscription(_) ->
+t_monitor_sessions_hist_hwmark({init, Config}) ->
+    %% some stale channels might exist, purge them
+    emqx_cm_registry:purge(),
+    meck:new(emqx_config, [passthrough, no_history]),
+    meck:expect(
+        emqx_config,
+        get,
+        fun
+            ([broker, session_history_retain]) ->
+                timer:seconds(60);
+            (Path) ->
+                meck:passthrough([Path])
+        end
+    ),
+    ok = snabbkaffe:start_trace(),
+    ct:timetrap({seconds, 30}),
+    Config;
+t_monitor_sessions_hist_hwmark({'end', _Config}) ->
+    emqx_cm_registry:purge(),
+    meck:unload(emqx_config),
+    ok = snabbkaffe:stop(),
+    emqx_common_test_helpers:call_janitor();
+t_monitor_sessions_hist_hwmark(Config) when is_list(Config) ->
+    ?assertEqual(0, emqx_cm_registry:table_size()),
+    Wait = fun() ->
+        {ok, _} =
+            snabbkaffe:block_until(
+                ?match_n_events(1, #{?snk_kind := dashboard_monitor_flushed}),
+                infinity,
+                0
+            ),
+        ok
+    end,
+
+    ClientId = fun(I) -> list_to_binary(["sessions_hist_hwmark_", integer_to_list(I)]) end,
+    Connect = fun(Id) ->
+        {ok, C} = emqtt:start_link([{clean_start, false}, {clientid, Id}]),
+        unlink(C),
+        {ok, _} = emqtt:connect(C),
+        ok = emqtt:disconnect(C)
+    end,
+    %% Connect 10 clients
+    Count = 10,
+    ClientIds = lists:map(ClientId, lists:seq(1, Count)),
+    ok = lists:foreach(Connect, ClientIds),
+    ?assertEqual(Count, emqx_cm_registry:table_size()),
+    {ok, Res1} = request(["monitor_current"]),
+    #{
+        <<"peak_value">> := Peak1,
+        <<"peak_time">> := T1,
+        <<"current_value">> := Count1
+    } = maps:get(<<"sessions_hist_hwmark">>, Res1),
+    ?assertEqual(Count, Count1),
+    ?assertEqual(Count, Peak1),
+    ok = Wait(),
+    %% request again after flushed
+    {ok, Res2} = request(["monitor_current"]),
+    %% expect the same values
+    ?assertMatch(
+        #{
+            <<"peak_value">> := Peak1,
+            <<"current_value">> := Count1
+        },
+        maps:get(<<"sessions_hist_hwmark">>, Res2)
+    ),
+    %% connect another client
+    ClientId11 = ClientId(11),
+    ok = Connect(ClientId11),
+    ok = Wait(),
+    {ok, Res3} = request(["monitor_current"]),
+    %% expect new peak value
+    #{
+        <<"peak_value">> := Peak2,
+        <<"peak_time">> := T2,
+        <<"current_value">> := Count2
+    } = maps:get(<<"sessions_hist_hwmark">>, Res3),
+    ?assert(T2 > T1),
+    ?assertEqual(Count + 1, Count2),
+    ?assertEqual(Count + 1, Peak2),
+    %% wait for the new peak to be flushed
+    ok = Wait(),
+    %% delete the client
+    ok = emqx_cm_registry:force_delete(ClientId11),
+    %% wait for the new current value to be flushed
+    ok = Wait(),
+    {ok, Res4} = request(["monitor_current"]),
+    %% expect the old peak value and new current value
+    #{
+        <<"peak_value">> := Peak3,
+        <<"peak_time">> := T3,
+        <<"current_value">> := Count3
+    } = maps:get(<<"sessions_hist_hwmark">>, Res4),
+    ?assertEqual(Count, Count3),
+    ?assertEqual(Peak2, Peak3),
+    ?assertEqual(T2, T3),
+    ok.
+
+t_monitor_current_shared_subscription(Config) when is_list(Config) ->
     process_flag(trap_exit, true),
     ShareT = <<"$share/group1/t/1">>,
     AssertFun = fun(Num, Line) ->
@@ -560,7 +648,7 @@ t_monitor_current_shared_subscription(_) ->
     ok = ?retry(100, 10, AssertFun(0, ?LINE)),
     ok.
 
-t_monitor_reset(_) ->
+t_monitor_reset(Config) when is_list(Config) ->
     restart_monitor(),
     {ok, Rate} = request(["monitor_current"]),
     [
@@ -581,7 +669,7 @@ t_monitor_reset(_) ->
     ?assertMatch({ok, []}, request(["monitor"], "latest=1")),
     ok.
 
-t_monitor_api_error(_) ->
+t_monitor_api_error(Config) when is_list(Config) ->
     {error, {404, #{<<"code">> := <<"NOT_FOUND">>}}} =
         request(["monitor", "nodes", 'emqx@127.0.0.2']),
     {error, {404, #{<<"code">> := <<"NOT_FOUND">>}}} =
@@ -593,7 +681,7 @@ t_monitor_api_error(_) ->
     ok.
 
 %% Verifies that subscriptions from persistent sessions are correctly accounted for.
-t_persistent_session_stats(Config) ->
+t_persistent_session_stats(Config) when is_list(Config) ->
     [N1, N2 | _] = ?config(cluster_nodes, Config),
     %% pre-condition
     true = ?ON(N1, emqx_persistent_message:is_persistence_enabled()),
@@ -672,6 +760,12 @@ t_persistent_session_stats(Config) ->
             ?ON(N1, request(["monitor_current"]))
         )
     end),
+    {ok, _} =
+        snabbkaffe:block_until(
+            ?match_n_events(1, #{?snk_kind := dashboard_monitor_flushed}),
+            infinity,
+            0
+        ),
     %% Verify that historical metrics are in line with the current ones.
     ?assertMatch(
         {ok, [
@@ -715,7 +809,23 @@ t_persistent_session_stats(Config) ->
 
 %% Checks that we get consistent data when changing the requested time window for
 %% `/monitor'.
-t_smoke_test_monitor_multiple_windows(Config) ->
+t_smoke_test_monitor_multiple_windows({init, Config0}) ->
+    Port = 28083,
+    NodeSpecs = [
+        {smoke_multiple_windows1, #{apps => cluster_node_appspec(true, Port)}},
+        {smoke_multiple_windows2, #{apps => cluster_node_appspec(false, Port)}}
+    ],
+    Config = emqx_common_test_helpers:start_cluster_ds(
+        Config0,
+        NodeSpecs,
+        #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config0)}
+    ),
+    ok = snabbkaffe:start_trace(),
+    Config;
+t_smoke_test_monitor_multiple_windows({'end', Config}) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_common_test_helpers:stop_cluster_ds(Config);
+t_smoke_test_monitor_multiple_windows(Config) when is_list(Config) ->
     [N1, N2 | _] = ?config(cluster_nodes, Config),
     %% pre-condition
     true = ?ON(N1, emqx_persistent_message:is_persistence_enabled()),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -140,6 +140,15 @@ end_per_testcase(_TestCase, _Config) ->
 %% Test Cases
 %%--------------------------------------------------------------------
 
+t_assert_no_missing_key_in_IS_PICK_NEWER(_Config) ->
+    Missing = lists:filter(
+        fun(Key) ->
+            not ?IS_PICK_NEWER(Key)
+        end,
+        ?GAUGE_SAMPLER_LIST ++ ?WATERMARK_SAMPLER_LIST
+    ),
+    ?assertEqual([], Missing).
+
 t_empty_table(_Config) ->
     pause_monitor_process(),
     clean_data(),

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -554,6 +554,8 @@ t_monitor_sessions_hist_hwmark(Config) when is_list(Config) ->
     ClientIds = lists:map(ClientId, lists:seq(1, Count)),
     ok = lists:foreach(Connect, ClientIds),
     ?assertEqual(Count, emqx_cm_registry:table_size()),
+    %% wait for the first flush
+    ok = Wait(),
     {ok, Res1} = request(["monitor_current"]),
     #{
         <<"peak_value">> := Peak1,
@@ -563,7 +565,7 @@ t_monitor_sessions_hist_hwmark(Config) when is_list(Config) ->
     ?assertEqual(Count, Count1),
     ?assertEqual(Count, Peak1),
     ok = Wait(),
-    %% request again after flushed
+    %% request again after flushed again
     {ok, Res2} = request(["monitor_current"]),
     %% expect the same values
     ?assertMatch(
@@ -597,12 +599,10 @@ t_monitor_sessions_hist_hwmark(Config) when is_list(Config) ->
     %% expect the old peak value and new current value
     #{
         <<"peak_value">> := Peak3,
-        <<"peak_time">> := T3,
         <<"current_value">> := Count3
     } = maps:get(<<"sessions_hist_hwmark">>, Res4),
     ?assertEqual(Count, Count3),
     ?assertEqual(Peak2, Peak3),
-    ?assertEqual(T2, T3),
     ok.
 
 t_monitor_current_shared_subscription(Config) when is_list(Config) ->

--- a/changes/ee/feat-15119.en.md
+++ b/changes/ee/feat-15119.en.md
@@ -1,0 +1,7 @@
+Added a new field `sessions_hist_hwmark` to the `GET /api/v5/monitor_current response`.
+
+This metric represents the high watermark of session history count.
+- It is recorded only when the `broker.session_history_retain` configuration is set to a duration greater than `0s`.
+- The highest watermark value may persist for up to 7 days before expiring.
+- After expiration, the system resets, using the current session history count as the starting point, and begins recording a new high watermark and its associated timestamp.
+- The expiration interval can be configured via the `dashboard.hwmark_expire_time` setting.

--- a/rel/i18n/emqx_dashboard_monitor_api.hocon
+++ b/rel/i18n/emqx_dashboard_monitor_api.hocon
@@ -26,11 +26,21 @@ current_stats_node.label:
 """Node runtime stats"""
 
 sessions_hist_hwmark.desc:
-"""Sessions count high watermark is tracked when `broker.session_history_retain` is configured with a non-zero duration.
-
-Note: After a full cluster restart, the previously recorded high watermark will continue to be reported until either its retention period expires or a new higher value is recorded."""
+"""Sessions count high watermark is tracked when `broker.session_history_retain` is configured with a non-zero duration."""
 
 sessions_hist_hwmark.label:
 """Sessions Count High Watermark"""
+
+hwmark_peak_time.desc:
+"""Timestamp for when the peak value was recorded. Unix epoch in milliseconds."""
+hwmark_peak_time.label: "Peak Time"
+
+hwmark_peak_value.desc:
+"""The peak value of the high watermark."""
+hwmark_peak_value.label: "Peak Value"
+
+hwmark_current_value.desc:
+"""The current hight of the watermark."""
+hwmark_current_value.label: "Current Hight"
 
 }

--- a/rel/i18n/emqx_dashboard_monitor_api.hocon
+++ b/rel/i18n/emqx_dashboard_monitor_api.hocon
@@ -25,4 +25,12 @@ current_stats_node.desc:
 current_stats_node.label:
 """Node runtime stats"""
 
+sessions_hist_hwmark.desc:
+"""Sessions count high watermark is tracked when `broker.session_history_retain` is configured with a non-zero duration.
+
+Note: After a full cluster restart, the previously recorded high watermark will continue to be reported until either its retention period expires or a new higher value is recorded."""
+
+sessions_hist_hwmark.label:
+"""Sessions Count High Watermark"""
+
 }

--- a/rel/i18n/emqx_dashboard_schema.hocon
+++ b/rel/i18n/emqx_dashboard_schema.hocon
@@ -125,6 +125,11 @@ sample_interval.desc:
 """How often to update metrics displayed in the dashboard.
 Note: `sample_interval` should be a divisor of 60, default is 10s."""
 
+hwmark_expire_time.desc: """~
+   Specifies the expiration interval for high watermark metrics such as the session history high watermark (`sessions_hist_hwmark`).
+   When the high watermark is recorded, it remains valid for this configured duration. After the interval expires, the system resets the high watermark, using the current value as the new baseline and starts recording the next high value along with its timestamp.~"""
+hwmark_expire_time.label: "High Watermark Expire Time"
+
 send_timeout.desc:
 """Send timeout for the socket."""
 

--- a/rel/i18n/emqx_dashboard_schema.hocon
+++ b/rel/i18n/emqx_dashboard_schema.hocon
@@ -126,8 +126,10 @@ sample_interval.desc:
 Note: `sample_interval` should be a divisor of 60, default is 10s."""
 
 hwmark_expire_time.desc: """~
-   Specifies the expiration interval for high watermark metrics such as the session history high watermark (`sessions_hist_hwmark`).
-   When the high watermark is recorded, it remains valid for this configured duration. After the interval expires, the system resets the high watermark, using the current value as the new baseline and starts recording the next high value along with its timestamp.~"""
+   Specifies the expiration interval for high watermark metrics, such as the session history high watermark (`sessions_hist_hwmark`).
+   A high watermark remains valid for the configured duration.
+   When it expires, the system scans the recorded values up to now and updates the high watermark to the highest observed value.~"""
+
 hwmark_expire_time.label: "High Watermark Expire Time"
 
 send_timeout.desc:


### PR DESCRIPTION
Fixes [EEC-1117](https://emqx.atlassian.net/browse/EEC-1117)

Release version: 5.9.0

## Summary

Expose session registry table size as a high-watermark metric and expose it to dashboard.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)



[EEC-1117]: https://emqx.atlassian.net/browse/EEC-1117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ