### PR TITLE
fix(ctl): avoid crash 'emqx ctl cluster join' when node is unknown

### DIFF
--- a/apps/emqx/src/emqx_cluster.erl
+++ b/apps/emqx/src/emqx_cluster.erl
@@ -50,6 +50,8 @@ check_permission(PeerNode) ->
     try
         emqx_cluster_proto_v1:can_i_join(node(), PeerNode)
     catch
+        error:{erpc, noconnection} ->
+            {error, {node_down, PeerNode}};
         error:{exception, undef, [{emqx_cluster, can_i_join, _, _}]} ->
             %% The peer node is older than 5.9.0
             %% This can happen during rolling upgrade.

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -94,6 +94,11 @@ t_cluster(_Config) ->
     %% cluster status             # Cluster status
     emqx_ctl:run_command(["cluster", "status"]),
 
+    ?assertEqual(
+        {error, {node_down, 'nosuchnode@127.0.0.1'}},
+        emqx_ctl:run_command(["cluster", "join", "nosuchnode@127.0.0.1"])
+    ),
+
     emqx_ctl:run_command(["cluster", "force-leave", atom_to_list(FakeNode)]),
     ?assertMatch(
         {atomic, [


### PR DESCRIPTION
Fixes [EMQX-14122](https://emqx.atlassian.net/browse/EMQX-14122)

Release version: 5.9.0

## Summary

When connecting an unreachable node, avoid crash logs, also keep the error backward compatible.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [~] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)



[EMQX-14122]: https://emqx.atlassian.net/browse/EMQX-14122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ