### PR TITLE
fix: correct monitor rate documentation from per 10 seconds to per second

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -203,25 +203,25 @@ current_rate(Node) ->
 -define(APPROXIMATE_DESC, " Can only represent an approximate state.").
 
 swagger_desc(received) ->
-    swagger_desc_format("Received messages ");
+    swagger_desc_format("Received messages");
 swagger_desc(received_bytes) ->
-    swagger_desc_format("Received bytes ");
+    swagger_desc_format("Received bytes");
 swagger_desc(sent) ->
-    swagger_desc_format("Sent messages ");
+    swagger_desc_format("Sent messages");
 swagger_desc(sent_bytes) ->
-    swagger_desc_format("Sent bytes ");
+    swagger_desc_format("Sent bytes");
 swagger_desc(dropped) ->
-    swagger_desc_format("Dropped messages ");
+    swagger_desc_format("Dropped messages");
 swagger_desc(validation_succeeded) ->
-    swagger_desc_format("Schema validations succeeded ");
+    swagger_desc_format("Schema validations succeeded");
 swagger_desc(validation_failed) ->
-    swagger_desc_format("Schema validations failed ");
+    swagger_desc_format("Schema validations failed");
 swagger_desc(transformation_succeeded) ->
-    swagger_desc_format("Message transformations succeeded ");
+    swagger_desc_format("Message transformations succeeded");
 swagger_desc(transformation_failed) ->
-    swagger_desc_format("Message transformations failed ");
+    swagger_desc_format("Message transformations failed");
 swagger_desc(persisted) ->
-    swagger_desc_format("Messages saved to the durable storage ");
+    swagger_desc_format("Messages saved to the durable storage");
 swagger_desc(disconnected_durable_sessions) ->
     <<"Disconnected durable sessions at the time of sampling.", ?APPROXIMATE_DESC>>;
 swagger_desc(subscriptions_durable) ->
@@ -241,23 +241,21 @@ swagger_desc(cluster_sessions) ->
         ?APPROXIMATE_DESC
     >>;
 swagger_desc(received_msg_rate) ->
-    swagger_desc_format("Dropped messages ", per);
-%swagger_desc(received_bytes_rate) -> swagger_desc_format("Received bytes ", per);
+    <<"Dropped messages per second">>;
 swagger_desc(sent_msg_rate) ->
-    swagger_desc_format("Sent messages ", per);
-%swagger_desc(sent_bytes_rate)     -> swagger_desc_format("Sent bytes ", per);
+    <<"Sent messages per second">>;
 swagger_desc(dropped_msg_rate) ->
-    swagger_desc_format("Dropped messages ", per);
+    <<"Dropped messages per second">>;
 swagger_desc(validation_succeeded_rate) ->
-    swagger_desc_format("Schema validations succeeded ", per);
+    <<"Schema validations succeeded per second">>;
 swagger_desc(validation_failed_rate) ->
-    swagger_desc_format("Schema validations failed ", per);
+    <<"Schema validations failed per second">>;
 swagger_desc(transformation_succeeded_rate) ->
-    swagger_desc_format("Message transformations succeeded ", per);
+    <<"Message transformations succeeded per second">>;
 swagger_desc(transformation_failed_rate) ->
-    swagger_desc_format("Message transformations failed ", per);
+    <<"Message transformations failed per second">>;
 swagger_desc(persisted_rate) ->
-    swagger_desc_format("Messages saved to the durable storage ", per);
+    <<"Messages saved to the durable storage per second">>;
 swagger_desc(retained_msg_count) ->
     <<"Retained messages count at the time of sampling.", ?APPROXIMATE_DESC>>;
 swagger_desc(shared_subscriptions) ->
@@ -270,11 +268,8 @@ swagger_desc(Name) ->
     ?DESC(Name).
 
 swagger_desc_format(Format) ->
-    swagger_desc_format(Format, last).
-
-swagger_desc_format(Format, Type) ->
     Interval = emqx_conf:get([dashboard, monitor, interval], ?DEFAULT_SAMPLE_INTERVAL),
-    list_to_binary(io_lib:format(Format ++ "~p ~p seconds", [Type, Interval])).
+    list_to_binary(io_lib:format(Format ++ " last ~p seconds", [Interval])).
 
 maybe_reject_cluster_only_metrics(<<"all">>, Rates) ->
     Rates;


### PR DESCRIPTION
Updated the documentation to clarify that the monitor rate is measured 
per second rather than per 10 seconds as previously stated.

<img width="730" alt="image" src="https://github.com/user-attachments/assets/56498206-170a-4d7b-b73d-8750d9231a18" />

<img width="628" alt="image" src="https://github.com/user-attachments/assets/4a26bad5-ace7-43c8-b695-e66b44a1093f" />


Fixes <issue-or-jira-number>

Release version: 5.9.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
