### PR TITLE
fix(raft): local node should not remove other node's presence.

### DIFF
--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -612,7 +612,7 @@ t_sub_shard_down_notify(Config) ->
             {ok, It} = emqx_ds:make_iterator(DB, Stream, [<<"t">>], 0),
             {ok, _Handle, MRef} = emqx_ds:subscribe(DB, It, #{max_unacked => 100}),
             ?assertEqual(ok, emqx_ds:close_db(DB)),
-            ?assertEqual([MRef], collect_down_msgs())
+            ?assertEqual([MRef], lists:usort(collect_down_msgs()))
         end,
         []
     ).

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -143,11 +143,15 @@ t_shards_allocation(Config) ->
     [_SpecLost, Spec | _] = ?config(specs, Config),
     [Node] = emqx_cth_cluster:restart(Spec),
     emqx_ds_raft_test_helpers:assert_db_open([Node], DB, Opts),
-
-    %% It shuould cleanup metadata upon restart.
-    ?assertEqual(
-        [],
-        ?ON(Node, emqx_ds_builtin_raft_meta:sites(lost))
+    %% FIXME: Manually forget the lost node.
+    ?ON(Node, emqx_ds_builtin_raft_meta:forget_node(NodeLost)),
+    ?retry(
+        5_000,
+        5,
+        ?assertEqual(
+            [],
+            ?ON(Node, emqx_ds_builtin_raft_meta:sites(lost))
+        )
     ).
 
 t_replication_transfers_snapshots(init, Config) ->

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -401,8 +401,11 @@ t_leave_rejected_ds_nonempty(Config) ->
     ?assertEqual(ok, ?ON(N1, emqx_mgmt_cli:ds(["leave", DBArg, S2Arg]))),
     ?ON(N1, emqx_ds_raft_test_helpers:wait_db_transitions_done(DB)),
 
-    %% Now leave the cluster again, wait until N1 forgets about S2.
+    %% Now leave the cluster again.
     ?assertEqual(ok, ?ON(N2, emqx_mgmt_cli:cluster(["leave"]))),
+    %% Make N1 forget about S2
+    LostSite = binary_to_list(?ON(N2, emqx_ds_builtin_raft_meta:this_site())),
+    ?assertEqual(ok, ?ON(N1, emqx_mgmt_cli:ds(["forget", LostSite]))),
     ?retry(500, 10, undefined = ?ON(N1, emqx_ds_builtin_raft_meta:node(S2))),
     ?ON(N1, emqx_mgmt_cli:ds(["info"])),
 


### PR DESCRIPTION
Fixes  EMQX-14193
Release version: 5.9

## Summary

Old behaviour casues race cond that, if other node just rejoin the cluster but get removed by this node, both are run in mria transaction but in different order.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
