### PR TITLE
refactor(ctl): improve usage info for rebalance ctl command

### DIFF
--- a/apps/emqx_ctl/src/emqx_ctl.erl
+++ b/apps/emqx_ctl/src/emqx_ctl.erl
@@ -231,7 +231,7 @@ format(Format, Args) ->
 format_usage(UsageList) ->
     Width = lists:foldl(
         fun({CmdStr, _}, W) ->
-            max(iolist_size(CmdStr), W)
+            max(cmd_str_width(CmdStr), W)
         end,
         0,
         UsageList
@@ -241,6 +241,16 @@ format_usage(UsageList) ->
             format_usage(CmdParams, Desc, Width)
         end,
         UsageList
+    ).
+
+-spec cmd_str_width(string()) -> integer().
+cmd_str_width(CmdStr) ->
+    lists:foldl(
+        fun(Line, W) ->
+            max(iolist_size(Line), W)
+        end,
+        0,
+        split_cmd(CmdStr)
     ).
 
 -spec format_usage(cmd_params(), cmd_descr()) -> string().

--- a/apps/emqx_node_rebalance/src/emqx_node_rebalance_cli.erl
+++ b/apps/emqx_node_rebalance/src/emqx_node_rebalance_cli.erl
@@ -129,13 +129,14 @@ cli(_) ->
         [
             {
                 "rebalance start --evacuation \\\n"
-                "    [--wait-health-check Secs] \\\n"
-                "    [--redirect-to \"Host1:Port1 Host2:Port2 ...\"] \\\n"
-                "    [--conn-evict-rate CountPerSec] \\\n"
-                "    [--migrate-to \"node1@host1 node2@host2 ...\"] \\\n"
-                "    [--wait-takeover Secs] \\\n"
-                "    [--sess-evict-rate CountPerSec]",
-                "Start current node evacuation with optional server redirect to the specified servers"
+                "  [--wait-health-check Secs] \\\n"
+                "  [--redirect-to \"Host1 Host2 ..\"] \\\n"
+                "  [--conn-evict-rate CountPerSec] \\\n"
+                "  [--migrate-to \"emqx@h.1 emqx@h.2 ..\"] \\\n"
+                "  [--wait-takeover Secs] \\\n"
+                "  [--sess-evict-rate CountPerSec]",
+                "Start current node evacuation with optional\n"
+                "server redirect to the specified servers"
             },
 
             %% TODO: uncomment after we officially release the feature.
@@ -147,27 +148,28 @@ cli(_) ->
 
             {
                 "rebalance start \\\n"
-                "    [--nodes \"node1@host1 node2@host2\"] \\\n"
-                "    [--wait-health-check Secs] \\\n"
-                "    [--conn-evict-rate ConnPerSec] \\\n"
-                "    [--conn-evict-rpc-timeout Secs] \\\n"
-                "    [--abs-conn-threshold Count] \\\n"
-                "    [--rel-conn-threshold Fraction] \\\n"
-                "    [--wait-takeover Secs] \\\n"
-                "    [--sess-evict-rate CountPerSec] \\\n"
-                "    [--sess-evict-rpc-timeout Secs] \\\n"
-                "    [--abs-sess-threshold Count] \\\n"
-                "    [--rel-sess-threshold Fraction]",
-                "Start rebalance on the specified nodes using the current node as the coordinator"
+                "  [--nodes \"eqmx@h.1 emqx@h.2 ..\"] \\\n"
+                "  [--wait-health-check Secs] \\\n"
+                "  [--conn-evict-rate ConnPerSec] \\\n"
+                "  [--conn-evict-rpc-timeout Secs] \\\n"
+                "  [--abs-conn-threshold Count] \\\n"
+                "  [--rel-conn-threshold Fraction] \\\n"
+                "  [--wait-takeover Secs] \\\n"
+                "  [--sess-evict-rate CountPerSec] \\\n"
+                "  [--sess-evict-rpc-timeout Secs] \\\n"
+                "  [--abs-sess-threshold Count] \\\n"
+                "  [--rel-sess-threshold Fraction]",
+                "Start rebalance on the specified nodes\n"
+                "using the current node as the coordinator"
             },
 
             {"rebalance node-status", "Get current node rebalance status"},
 
-            {"rebalance node-status \"node1@host1\"", "Get remote node rebalance status"},
+            {"rebalance node-status \"emqx@h.1\"", "Get remote node rebalance status"},
 
             {"rebalance status",
-                "Get statuses of all current rebalance/evacuation processes across the cluster"},
-
+                "Get statuses of all current rebalance/evacuation\n"
+                "processes across the cluster"},
             {"rebalance stop", "Stop node rebalance"}
         ]
     ).


### PR DESCRIPTION
Fixes: [EMQX-14203](https://emqx.atlassian.net/browse/EMQX-14203)
Release version: 5.9.0

## Summary

Only cosmetic. After fix:

```
rebalance start --evacuation \            # Start current node evacuation with optional
  [--wait-health-check Secs] \            # server redirect to the specified servers
  [--redirect-to "Host1 Host2 .."] \      #
  [--conn-evict-rate CountPerSec] \       #
  [--migrate-to "emqx@h.1 emqx@h.2 .."] \ #
  [--wait-takeover Secs] \                #
  [--sess-evict-rate CountPerSec]         #
rebalance start \                         # Start rebalance on the specified nodes
  [--nodes "eqmx@h.1 emqx@h.2 .."] \      # using the current node as the coordinator
  [--wait-health-check Secs] \            #
  [--conn-evict-rate ConnPerSec] \        #
  [--conn-evict-rpc-timeout Secs] \       #
  [--abs-conn-threshold Count] \          #
  [--rel-conn-threshold Fraction] \       #
  [--wait-takeover Secs] \                #
  [--sess-evict-rate CountPerSec] \       #
  [--sess-evict-rpc-timeout Secs] \       #
  [--abs-sess-threshold Count] \          #
  [--rel-sess-threshold Fraction]         #
rebalance node-status                     # Get current node rebalance status
rebalance node-status "emqx@h.1"          # Get remote node rebalance status
rebalance status                          # Get statuses of all current rebalance/evacuation
                                          # processes across the cluster
rebalance stop                            # Stop node rebalance
```

[EMQX-14203]: https://emqx.atlassian.net/browse/EMQX-14203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ