### PR TITLE
250430 fix cm retained info cleanup

### DIFF
--- a/apps/emqx/src/emqx_cm_registry_keeper.erl
+++ b/apps/emqx/src/emqx_cm_registry_keeper.erl
@@ -28,6 +28,7 @@
 -define(CACHE_COUNT_THRESHOLD, 1000).
 -define(MIN_COUNT_INTERVAL_SECONDS, 5).
 -define(CLEANUP_CHUNK_SIZE, 10000).
+-define(CLEANUP_CHUNK_INTERVAL, 5000).
 
 -define(IS_HIST_ENABLED(RETAIN), (RETAIN > 0)).
 
@@ -114,6 +115,7 @@ handle_info(start, #{next_clientid := NextClientId} = State) ->
                         undefined;
                     Id ->
                         _ = erlang:garbage_collect(),
+                        send_delay_start(?CLEANUP_CHUNK_INTERVAL),
                         Id
                 end,
             {noreply, State#{next_clientid := NewNext}};
@@ -189,8 +191,7 @@ send_delay_start() ->
     ok = send_delay_start(Delay).
 
 send_delay_start(Delay) ->
-    _ = erlang:send_after(Delay, self(), start),
-    ok.
+    erlang:send_after(Delay, self(), start).
 
 now_ts() ->
     erlang:system_time(seconds).

--- a/apps/emqx/src/emqx_cm_registry_keeper.erl
+++ b/apps/emqx/src/emqx_cm_registry_keeper.erl
@@ -75,10 +75,11 @@ purge() ->
     purge_loop(undefined).
 
 purge_loop(StartId) ->
-    case cleanup_one_chunk(StartId, _IsPurge = true) of
-        '$end_of_table' ->
+    NextId = cleanup_one_chunk(StartId, _IsPurge = true),
+    case NextId =:= '$end_of_table' of
+        true ->
             ok;
-        NextId ->
+        false ->
             purge_loop(NextId)
     end.
 

--- a/changes/ee/fix-15143.en.md
+++ b/changes/ee/fix-15143.en.md
@@ -1,0 +1,3 @@
+Resolved a bug affecting session history cleanup when `broker.session_history_retain` is set to a value greater than the default `0s`.
+
+Previously, if more than 10,000 sessions existed in the session registry table, old records could be retained indefinitely instead of being cleaned up as expected.


### PR DESCRIPTION
Release version: 5.9.0

## Summary

Introduced in 5.8, the chunked cleanup of retained session history missed a timer restart, slipped due to lack of test coverage.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [~] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

