### PR TITLE
fix(dashboard): compare with hwmark peak_value instead of current_value

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -701,10 +701,10 @@ current_wmark(sessions_hist_hwmark) ->
 
 do_refresh_hwmark(
     Key,
-    ?HWMARK(TPast, PPast, VPast),
+    ?HWMARK(TPast, PPast, _VPast),
     ?HWMARK(TNow, _PNow, VNow)
-) when VNow < VPast ->
-    %% Check if the last high watermark is expired.
+) when VNow < PPast ->
+    %% Lower than peak, check if the peak is expired.
     RetentionTime = emqx_conf:get([dashboard, hwmark_expire_time]),
     ExpireAt = TNow - RetentionTime,
     case TPast =< ExpireAt of

--- a/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_monitor_SUITE.erl
@@ -603,6 +603,32 @@ t_monitor_sessions_hist_hwmark(Config) when is_list(Config) ->
     } = maps:get(<<"sessions_hist_hwmark">>, Res4),
     ?assertEqual(Count, Count3),
     ?assertEqual(Peak2, Peak3),
+    %% delete all clients
+    ok = lists:foreach(
+        fun(Id) ->
+            ok = emqx_cm_registry:force_delete(Id)
+        end,
+        ClientIds
+    ),
+    ok = Wait(),
+    {ok, Res5} = request(["monitor_current"]),
+    ?assertMatch(
+        #{
+            <<"peak_value">> := Peak3,
+            <<"current_value">> := 0
+        },
+        maps:get(<<"sessions_hist_hwmark">>, Res5)
+    ),
+    %% wait for another flush
+    ok = Wait(),
+    {ok, Res6} = request(["monitor_current"]),
+    ?assertMatch(
+        #{
+            <<"peak_value">> := Peak3,
+            <<"current_value">> := 0
+        },
+        maps:get(<<"sessions_hist_hwmark">>, Res6)
+    ),
     ok.
 
 t_merge_hwmark(Config) when is_list(Config) ->


### PR DESCRIPTION
Release 5.9.0

Bug not released yet.

This was a bug introduced during some refactoring after manual tests.
And the CT case only tested one flush cycle, it take two to trigger the bug.