### PR TITLE
ci: fix docker smoke test

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -182,13 +182,11 @@ jobs:
       - name: smoke test
         timeout-minutes: 5
         run: |
-          for tag in $(cat .emqx_docker_image_tags); do
-            CID=$(docker run -d -p 18083:18083 $tag)
-            HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' $CID)
-            ./scripts/test/emqx-smoke-test.sh localhost $HTTP_PORT
-            docker rm -f $CID
-            ./scripts/test/cluster-smoke-test.sh $tag
-          done
+          CID=$(docker run -d -p 18083:18083 $_EMQX_DOCKER_IMAGE_TAG)
+          HTTP_PORT=$(docker inspect --format='{{(index (index .NetworkSettings.Ports "18083/tcp") 0).HostPort}}' $CID)
+          ./scripts/test/emqx-smoke-test.sh localhost $HTTP_PORT
+          docker rm -f $CID
+          ./scripts/test/cluster-smoke-test.sh $_EMQX_DOCKER_IMAGE_TAG
 
       - name: dashboard tests
         working-directory: ./scripts/ui-tests


### PR DESCRIPTION
The [job for e5.9.0 tag push](https://github.com/emqx/emqx/actions/runs/14792592623) failed because docker smoke test has become more advanced, and 5 minutes for all tags is not enough anymore.
But we don't actually need to test each and every tag, since all of them point to the same image.

No need to retag, manually triggered docker build here: https://github.com/emqx/emqx/actions/runs/14792592623

Release version: 5.9.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
