### PR TITLE
ci: delete schema-dump from push workflow

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -158,14 +158,6 @@ jobs:
           name: ${{ matrix.profile }}
           path: ${{ matrix.profile }}.zip
           retention-days: 7
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: "${{ matrix.profile }}-schema-dump"
-          path: |
-            env.sh
-            _build/docgen/${{ matrix.profile }}/*.json
-            _build/docgen/${{ matrix.profile }}/*.hocon
-          retention-days: 7
 
   performance_test:
     if: needs.prepare.outputs.release == 'true'


### PR DESCRIPTION
schema-dump is now only required in pr work flow (spellcheck)