### PR TITLE
docs(limiter): describe `max_conn_rate` semantics correctly

### DIFF
--- a/rel/i18n/emqx_limiter_schema.hocon
+++ b/rel/i18n/emqx_limiter_schema.hocon
@@ -3,7 +3,7 @@ emqx_limiter_schema {
 max_conn_rate.desc:
 """Limits how quickly this listener accepts connections, per each node.
 
-Once the limit is reached, EMQX will pause serving connections from the Accept queue, thereby delaying or rejecting new connections.
+Once the limit is reached, EMQX will automatically close any new connections right after they’re accepted, effectively draining the queue of connections waiting to be accepted.
 
 For example:
 


### PR DESCRIPTION
Followup to #15082.

Release version: 5.9.x
