### PR TITLE
test(aggregator): attempt to fix flaky test

### DIFF
--- a/apps/emqx_connector_aggregator/test/emqx_connector_aggregator_SUITE.erl
+++ b/apps/emqx_connector_aggregator/test/emqx_connector_aggregator_SUITE.erl
@@ -93,7 +93,7 @@ t_trigger_max_records(Config) ->
                 container => ContainerOpts,
                 upload_options => #{}
             },
-            {ok, _Sup} = emqx_connector_aggreg_upload_sup:start_link(
+            {ok, Sup} = emqx_connector_aggreg_upload_sup:start_link(
                 AggregId, AggregOpts, DeliveryOpts
             ),
             Timestamp = now_ms(),
@@ -106,6 +106,7 @@ t_trigger_max_records(Config) ->
                     #{?snk_kind := connector_aggreg_delivery_completed}
                 )
             ),
+            gen_server:stop(Sup),
             ok
         end,
         []


### PR DESCRIPTION
```
%%% emqx_connector_aggregator_SUITE ==> t_trigger_max_records: FAILED
%%% emqx_connector_aggregator_SUITE ==> {noproc,{gen_server,call,[snabbkaffe_collector,flush_trace,infinity]}}
```

https://github.com/emqx/emqx/actions/runs/14883981230/job/41799294818?pr=15159#step:5:351
