### PR TITLE
ci: run push workflow for `release-510`

### DIFF
--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -11,6 +11,7 @@ on:
     branches:
       - 'master'
       - 'release-5[0-9]'
+      - 'release-5[1-9][0-9]'
       - 'ci/**'
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Otherwise, codecov won't have a base to compare against.