### PR TITLE
ci: fix azurite container health check

### DIFF
--- a/.ci/docker-compose-file/docker-compose-azurite.yaml
+++ b/.ci/docker-compose-file/docker-compose-azurite.yaml
@@ -10,7 +10,7 @@ services:
     networks:
       - emqx_bridge
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:10000"]
+      test: ["CMD", "nc", "-zv", "127.0.0.1", "10000"]
       interval: 30s
       timeout: 5s
       retries: 4


### PR DESCRIPTION
Apparently, microsoft decided to change some things in the already tagged image.... 🫠

- `curl` no longer exists in the image.
- `GET /` now seems to return a 400 error, which would make `curl -f` fail anyway.
