### PR TITLE
Transactional key-value API for DS

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -33,6 +33,7 @@
 {emqx_ds_beamsplitter,1}.
 {emqx_ds_beamsplitter,2}.
 {emqx_ds_new_streams,1}.
+{emqx_ds_otx,1}.
 {emqx_ds_shared_sub,3}.
 {emqx_eviction_agent,1}.
 {emqx_eviction_agent,2}.

--- a/apps/emqx/src/emqx_ds_schema.erl
+++ b/apps/emqx/src/emqx_ds_schema.erl
@@ -321,6 +321,36 @@ fields(layout_builtin_reference) ->
                     desc => ?DESC(layout_builtin_reference_type)
                 }
             )}
+    ];
+fields(optimistic_transaction) ->
+    [
+        {flush_interval,
+            sc(
+                emqx_schema:duration_ms(),
+                #{
+                    default => "5s",
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(ds_otx_flush_interval)
+                }
+            )},
+        {idle_flush_interval,
+            sc(
+                emqx_schema:duration_ms(),
+                #{
+                    default => "1ms",
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(ds_otx_flush_interval)
+                }
+            )},
+        {conflict_window,
+            sc(
+                emqx_schema:duration_ms(),
+                #{
+                    default => "5s",
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(ds_otx_flush_interval)
+                }
+            )}
     ].
 
 common_builtin_fields(basic) ->

--- a/apps/emqx/src/emqx_ds_schema.erl
+++ b/apps/emqx/src/emqx_ds_schema.erl
@@ -334,7 +334,7 @@ fields(optimistic_transaction) ->
                 #{
                     default => "5s",
                     importance => ?IMPORTANCE_LOW,
-                    desc => ?DESC(ds_otx_flush_interval)
+                    desc => ?DESC(otx_flush_interval)
                 }
             )},
         {idle_flush_interval,
@@ -343,7 +343,7 @@ fields(optimistic_transaction) ->
                 #{
                     default => "1ms",
                     importance => ?IMPORTANCE_LOW,
-                    desc => ?DESC(ds_otx_flush_interval)
+                    desc => ?DESC(otx_idle_flush_interval)
                 }
             )},
         {conflict_window,
@@ -352,7 +352,7 @@ fields(optimistic_transaction) ->
                 #{
                     default => "5s",
                     importance => ?IMPORTANCE_LOW,
-                    desc => ?DESC(ds_otx_flush_interval)
+                    desc => ?DESC(otx_conflict_window)
                 }
             )}
     ].
@@ -391,7 +391,7 @@ common_builtin_fields(basic) ->
                 ref(optimistic_transaction),
                 #{
                     importance => ?IMPORTANCE_LOW,
-                    desc => ?DESC(ds_optimistic_transaction)
+                    desc => ?DESC(builtin_optimistic_transaction)
                 }
             )}
     ];
@@ -447,6 +447,8 @@ desc(layout_builtin_wildcard_optimized_v2) ->
     ?DESC(layout_builtin_wildcard_optimized);
 desc(layout_builtin_reference) ->
     ?DESC(layout_builtin_reference);
+desc(optimistic_transaction) ->
+    ?DESC(optimistic_transaction);
 desc(_) ->
     undefined.
 

--- a/apps/emqx/src/emqx_ds_schema.erl
+++ b/apps/emqx/src/emqx_ds_schema.erl
@@ -49,7 +49,8 @@ translate_builtin_raft(
         backend := builtin_raft,
         n_shards := NShards,
         n_sites := NSites,
-        replication_factor := ReplFactor
+        replication_factor := ReplFactor,
+        transaction := Transaction
     }
 ) ->
     %% NOTE: Undefined if `basic` schema is in use.
@@ -60,13 +61,15 @@ translate_builtin_raft(
         n_sites => NSites,
         replication_factor => ReplFactor,
         replication_options => maps:get(replication_options, Backend, #{}),
-        storage => emqx_maybe:apply(fun translate_layout/1, Layout)
+        storage => emqx_maybe:apply(fun translate_layout/1, Layout),
+        transaction => Transaction
     }.
 
 translate_builtin_local(
     Backend = #{
         backend := builtin_local,
-        n_shards := NShards
+        n_shards := NShards,
+        transaction := Transaction
     }
 ) ->
     %% NOTE: Undefined if `basic` schema is in use.
@@ -78,7 +81,8 @@ translate_builtin_local(
         n_shards => NShards,
         storage => emqx_maybe:apply(fun translate_layout/1, Layout),
         poll_workers_per_shard => NPollers,
-        poll_batch_size => BatchSize
+        poll_batch_size => BatchSize,
+        transaction => Transaction
     }.
 
 %%================================================================================
@@ -380,6 +384,14 @@ common_builtin_fields(basic) ->
                 #{
                     importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(builtin_write_buffer)
+                }
+            )},
+        {transaction,
+            sc(
+                ref(optimistic_transaction),
+                #{
+                    importance => ?IMPORTANCE_LOW,
+                    desc => ?DESC(ds_optimistic_transaction)
                 }
             )}
     ];

--- a/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_swagger.erl
@@ -30,8 +30,7 @@
 
 -ifdef(TEST).
 -export([
-    parse_spec_ref/3,
-    components/2
+    parse_spec_ref/3
 ]).
 -endif.
 

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -993,6 +993,7 @@ t_13_smoke_kv_tx(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
+            timer:sleep(100),
             %% 1. Start a write-only transaction to create some data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, #{
                 generation => 1,
@@ -1072,6 +1073,7 @@ t_14_kv_wildcard_deletes(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
+            timer:sleep(100),
             %% 1. Insert test data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
             Msgs0 =
@@ -1134,6 +1136,7 @@ t_15_kv_write_serial(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
+            timer:sleep(100),
             %% 1. Insert test data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
             Ops = #{
@@ -1173,6 +1176,7 @@ t_16_kv_preconditions(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
+            timer:sleep(100),
             %% 1. Insert test data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
             Ops1 = #{

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -1456,24 +1456,9 @@ all() ->
     [{group, Backend} || Backend <- backends()].
 
 groups() ->
-    AllTCs = emqx_common_test_helpers:all(?MODULE),
+    TCs = emqx_common_test_helpers:all(?MODULE),
     lists:map(
         fun(Backend) ->
-            TCs =
-                case Backend of
-                    emqx_ds_builtin_local ->
-                        AllTCs;
-                    _ ->
-                        AllTCs --
-                            [
-                                t_13_smoke_kv_tx,
-                                t_14_kv_wildcard_deletes,
-                                t_15_kv_write_serial,
-                                t_16_kv_preconditions,
-                                t_17_tx_wrapper,
-                                t_18_async_trans
-                            ]
-                end,
             {Backend, TCs}
         end,
         backends()

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -993,7 +993,6 @@ t_13_smoke_kv_tx(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
-            timer:sleep(100),
             %% 1. Start a write-only transaction to create some data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, #{
                 generation => 1,
@@ -1073,7 +1072,6 @@ t_14_kv_wildcard_deletes(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
-            timer:sleep(100),
             %% 1. Insert test data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
             Msgs0 =
@@ -1136,7 +1134,6 @@ t_15_kv_write_serial(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
-            timer:sleep(100),
             %% 1. Insert test data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
             Ops = #{
@@ -1176,7 +1173,6 @@ t_16_kv_preconditions(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
-            timer:sleep(100),
             %% 1. Insert test data:
             {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
             Ops1 = #{

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -1057,7 +1057,7 @@ t_13_smoke_kv_tx(Config) ->
 %% API
 t_14_kv_wildcard_deletes(Config) ->
     DB = ?FUNCTION_NAME,
-    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity},
+    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity, generation => 1},
     ?check_trace(
         begin
             %% Open the database
@@ -1121,7 +1121,7 @@ t_14_kv_wildcard_deletes(Config) ->
 %% transaction serial.
 t_15_kv_write_serial(Config) ->
     DB = ?FUNCTION_NAME,
-    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity},
+    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity, generation => 1},
     Topic = [<<"foo">>],
     ?check_trace(
         begin
@@ -1159,7 +1159,7 @@ t_15_kv_write_serial(Config) ->
 
 t_16_kv_preconditions(Config) ->
     DB = ?FUNCTION_NAME,
-    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity},
+    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity, generation => 1},
     Topic1 = [<<"foo">>],
     Topic2 = [<<"bar">>],
     ?check_trace(
@@ -1337,6 +1337,7 @@ t_18_async_trans(Config) ->
                 ok,
                 emqx_ds_open_db(DB, Opts)
             ),
+            timer:sleep(100),
             %% 1. Successful async write transaction:
             {async, Ref1, hello} =
                 emqx_ds:trans(

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -978,6 +978,431 @@ t_sub_catchup_unrecoverable(Config) ->
         []
     ).
 
+%% Verify functionality of the low-level transaction API.
+t_13_smoke_kv_tx(Config) ->
+    DB = ?FUNCTION_NAME,
+    Owner = <<"test_clientid">>,
+    ?check_trace(
+        begin
+            %% Open the database
+            Opts = maps:merge(opts(Config), #{
+                store_kv => true,
+                storage => {emqx_ds_storage_kv_skipstream_lts, #{}}
+            }),
+            ?assertMatch(
+                ok,
+                emqx_ds_open_db(DB, Opts)
+            ),
+            %% 1. Start a write-only transaction to create some data:
+            {ok, Tx1} = emqx_ds:new_kv_tx(DB, #{
+                generation => 1,
+                shard => emqx_ds:shard_of(DB, Owner),
+                timeout => infinity
+            }),
+            Ops1 = #{
+                ?ds_tx_write => [
+                    {[<<"foo">>], <<"payload0">>},
+                    {[<<"t">>, <<"1">>], <<"payload1">>},
+                    {[<<"t">>, <<"2">>], <<"payload2">>}
+                ]
+            },
+            %% Commit:
+            ?assertMatch(
+                {ok, _Serial},
+                do_commit_tx(DB, Tx1, Ops1)
+            ),
+
+            %% Verify side effects of the transaction:
+            ?assertEqual(
+                [{[<<"t">>, <<"1">>], <<"payload1">>}],
+                emqx_ds:dirty_read(DB, [<<"t">>, <<"1">>])
+            ),
+            ?assertEqual(
+                [{[<<"t">>, <<"2">>], <<"payload2">>}],
+                emqx_ds:dirty_read(DB, [<<"t">>, <<"2">>])
+            ),
+            %%   All topics together:
+            ?assertEqual(
+                [
+                    {[<<"foo">>], <<"payload0">>},
+                    {[<<"t">>, <<"1">>], <<"payload1">>},
+                    {[<<"t">>, <<"2">>], <<"payload2">>}
+                ],
+                lists:sort(emqx_ds:dirty_read(DB, ['#']))
+            ),
+
+            %% 2. Create a transaction that deletes one of the topics:
+            {ok, Tx2} = emqx_ds:new_kv_tx(DB, #{
+                generation => 1,
+                shard => {auto, Owner},
+                timeout => infinity
+            }),
+            Ops2 = #{
+                ?ds_tx_delete_topic => [[<<"t">>, <<"2">>]]
+            },
+            ?assertMatch({ok, _Serial}, do_commit_tx(DB, Tx2, Ops2)),
+            %% Verify that data in t/2 is gone:
+            ?assertMatch(
+                [
+                    {[<<"foo">>], <<"payload0">>},
+                    {[<<"t">>, <<"1">>], <<"payload1">>}
+                ],
+                lists:sort(emqx_ds:dirty_read(DB, ['#']))
+            )
+        end,
+        []
+    ).
+
+%% Verify correctness of wildcard topic deletions in the transactional
+%% API
+t_14_kv_wildcard_deletes(Config) ->
+    DB = ?FUNCTION_NAME,
+    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity},
+    ?check_trace(
+        begin
+            %% Open the database
+            Opts = maps:merge(opts(Config), #{
+                store_kv => true,
+                storage => {emqx_ds_storage_kv_skipstream_lts, #{}}
+            }),
+            ?assertMatch(
+                ok,
+                emqx_ds_open_db(DB, Opts)
+            ),
+            %% 1. Insert test data:
+            {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Msgs0 =
+                [{[<<"foo">>], <<"payload">>}] ++
+                    [
+                        {[<<"t">>, <<I:16>>, <<J:16>>], <<I:16, J:16>>}
+                     || I <- lists:seq(1, 10),
+                        J <- lists:seq(1, 10)
+                    ],
+            Ops1 = #{?ds_tx_write => Msgs0},
+            ?assertMatch({ok, _}, do_commit_tx(DB, Tx1, Ops1)),
+            %% Verify that all data has been inserted:
+            ?assertEqual(
+                100,
+                emqx_ds:fold_topic(
+                    fun(_, _, _, _, Acc) -> Acc + 1 end,
+                    0,
+                    [<<"t">>, '+', '+'],
+                    #{db => DB}
+                )
+            ),
+            %% 2. Issue a new transaction that deletes t/10/+:
+            {ok, Tx2} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops2 = #{
+                ?ds_tx_delete_topic => [[<<"t">>, <<10:16>>, '+']]
+            },
+            ?assertMatch({ok, _}, do_commit_tx(DB, Tx2, Ops2)),
+            Msgs1 = lists:filter(
+                fun
+                    ({[<<"t">>, <<10:16>>, _], _}) ->
+                        false;
+                    (_) ->
+                        true
+                end,
+                Msgs0
+            ),
+            %% Verify side effects, t/100/+ is gone:
+            ?assertEqual(
+                lists:sort(Msgs1),
+                lists:sort(emqx_ds:dirty_read(DB, ['#']))
+            )
+        end,
+        []
+    ).
+
+%% Verify that `?ds_tx_serial' is properly substituted with the
+%% transaction serial.
+t_15_kv_write_serial(Config) ->
+    DB = ?FUNCTION_NAME,
+    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity},
+    Topic = [<<"foo">>],
+    ?check_trace(
+        begin
+            %% Open the database
+            Opts = maps:merge(opts(Config), #{
+                store_kv => true,
+                storage => {emqx_ds_storage_kv_skipstream_lts, #{}}
+            }),
+            ?assertMatch(
+                ok,
+                emqx_ds_open_db(DB, Opts)
+            ),
+            %% 1. Insert test data:
+            {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops = #{
+                ?ds_tx_write => [{Topic, ?ds_tx_serial}]
+            },
+            {ok, Serial1} = do_commit_tx(DB, Tx1, Ops),
+            %% Verify that foo is set to Serial:
+            ?assertEqual(
+                [{Topic, Serial1}],
+                emqx_ds:dirty_read(DB, Topic)
+            ),
+            %% Repeat the procedure and make sure serial increases
+            {ok, Tx2} = emqx_ds:new_kv_tx(DB, TXOpts),
+            {ok, Serial2} = do_commit_tx(DB, Tx2, Ops),
+            ?assertEqual(
+                [{Topic, Serial2}],
+                emqx_ds:dirty_read(DB, Topic)
+            ),
+            ?assert(Serial2 > Serial1, [Serial2, Serial1])
+        end,
+        []
+    ).
+
+t_16_kv_preconditions(Config) ->
+    DB = ?FUNCTION_NAME,
+    TXOpts = #{shard => {auto, <<"me">>}, timeout => infinity},
+    Topic1 = [<<"foo">>],
+    Topic2 = [<<"bar">>],
+    ?check_trace(
+        begin
+            %% Open the database
+            Opts = maps:merge(opts(Config), #{
+                store_kv => true,
+                storage => {emqx_ds_storage_kv_skipstream_lts, #{}}
+            }),
+            ?assertMatch(
+                ok,
+                emqx_ds_open_db(DB, Opts)
+            ),
+            %% 1. Insert test data:
+            {ok, Tx1} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops1 = #{
+                ?ds_tx_write => [{Topic1, <<"payload0">>}]
+            },
+            ?assertMatch({ok, _}, do_commit_tx(DB, Tx1, Ops1)),
+
+            %% 2. Preconditions, successful.
+            {ok, Tx2} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops2 = #{
+                ?ds_tx_expected => [
+                    {Topic1, '_'},
+                    {Topic1, <<"payload0">>}
+                ],
+                ?ds_tx_unexpected => [Topic2],
+                ?ds_tx_write => [{Topic1, <<"payload1">>}]
+            },
+            ?assertMatch(
+                {ok, _},
+                do_commit_tx(DB, Tx2, Ops2)
+            ),
+            ?assertEqual(
+                [{Topic1, <<"payload1">>}],
+                emqx_ds:dirty_read(DB, ['#'])
+            ),
+
+            %% 3. Precondiction fail, unexpected message:
+            {ok, Tx3} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops3 = #{
+                ?ds_tx_unexpected => [Topic1],
+                ?ds_tx_write => [{Topic1, <<"fail">>}]
+            },
+            ?assertMatch(
+                ?err_unrec({precondition_failed, _}),
+                do_commit_tx(DB, Tx3, Ops3)
+            ),
+
+            %% 4 Preconditions, fail, expected message not found:
+            {ok, Tx4} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops4 = #{
+                ?ds_tx_expected => [{Topic2, '_'}],
+                ?ds_tx_write => [{Topic2, <<"fail">>}]
+            },
+            ?assertMatch(
+                ?err_unrec({precondition_failed, _}),
+                do_commit_tx(DB, Tx4, Ops4)
+            ),
+
+            %% 5 Preconditions, fail, value is different:
+            {ok, Tx5} = emqx_ds:new_kv_tx(DB, TXOpts),
+            Ops5 = #{
+                ?ds_tx_expected => [{Topic1, <<"payload0">>}],
+                ?ds_tx_write => [{Topic1, <<"fail">>}]
+            },
+            ?assertMatch(
+                ?err_unrec(
+                    {precondition_failed, [
+                        #{expected := <<"payload0">>, got := <<"payload1">>, topic := Topic1}
+                    ]}
+                ),
+                do_commit_tx(DB, Tx5, Ops5)
+            ),
+
+            %% Verify that side effects of failed transactions weren't
+            %% applied:
+            ?assertEqual(
+                [{Topic1, <<"payload1">>}],
+                emqx_ds:dirty_read(DB, ['#'])
+            )
+        end,
+        []
+    ).
+
+%% Verify basic functions of the high-level transaction wrapper:
+t_17_tx_wrapper(Config) ->
+    DB = ?FUNCTION_NAME,
+    TXOpts = #{db => DB, shard => {auto, <<"me">>}, generation => 1},
+    ?check_trace(
+        begin
+            %% Open the database
+            Opts = maps:merge(opts(Config), #{
+                store_kv => true,
+                storage => {emqx_ds_storage_kv_skipstream_lts, #{}}
+            }),
+            ?assertMatch(
+                ok,
+                emqx_ds_open_db(DB, Opts)
+            ),
+            %% Transaction wrapper uses process dictionary to store
+            %% pending ops. Make the snapshot of the PD to make sure
+            %% no garbage is left behind:
+            PD = lists:sort(get()),
+            %% 1. Empty transaction:
+            ?assertEqual(
+                {nop, hello},
+                emqx_ds:trans(
+                    TXOpts,
+                    fun() ->
+                        hello
+                    end
+                )
+            ),
+            ?assertEqual(PD, lists:sort(get())),
+            %% 2. Write transaction:
+            ?assertMatch(
+                {atomic, Serial, ok} when is_binary(Serial),
+                emqx_ds:trans(
+                    TXOpts,
+                    fun() ->
+                        emqx_ds:tx_kv_write([<<"foo">>], <<"1">>),
+                        emqx_ds:tx_kv_write([<<"t">>, <<"1">>], <<"2">>)
+                    end
+                )
+            ),
+            ?assertEqual(PD, lists:sort(get())),
+            ?assertEqual(
+                [
+                    {[<<"foo">>], <<"1">>},
+                    {[<<"t">>, <<"1">>], <<"2">>}
+                ],
+                lists:sort(emqx_ds:dirty_read(DB, ['#']))
+            ),
+            %% 3. Delete transaction:
+            ?assertMatch(
+                {atomic, _Serial, ok},
+                emqx_ds:trans(
+                    TXOpts,
+                    fun() ->
+                        emqx_ds:tx_del_topic([<<"foo">>])
+                    end
+                )
+            ),
+            ?assertEqual(PD, lists:sort(get())),
+            ?assertEqual(
+                [
+                    {[<<"t">>, <<"1">>], <<"2">>}
+                ],
+                lists:sort(emqx_ds:dirty_read(DB, ['#']))
+            )
+        end,
+        []
+    ).
+
+%% Verify properties of asynchronous transaction commit
+t_18_async_trans(Config) ->
+    DB = ?FUNCTION_NAME,
+    Timeout = 1_000,
+    TXOpts = #{
+        db => DB, shard => {auto, <<"me">>}, sync => false, timeout => Timeout, generation => 1
+    },
+    ?check_trace(
+        begin
+            %% Open the database
+            Opts = maps:merge(opts(Config), #{
+                store_kv => true,
+                storage => {emqx_ds_storage_kv_skipstream_lts, #{}}
+            }),
+            ?assertMatch(
+                ok,
+                emqx_ds_open_db(DB, Opts)
+            ),
+            %% 1. Successful async write transaction:
+            {async, Ref1, hello} =
+                emqx_ds:trans(
+                    TXOpts,
+                    fun() ->
+                        emqx_ds:tx_kv_write([<<"foo">>], ?ds_tx_serial),
+                        hello
+                    end
+                ),
+            %% Wait for commit and verify side effects:
+            receive
+                ?ds_tx_commit_reply(Ref1, Reply1) ->
+                    {ok, Serial1} = emqx_ds:tx_commit_outcome(DB, Ref1, Reply1)
+            end,
+            ?assertEqual(
+                [
+                    {[<<"foo">>], Serial1}
+                ],
+                lists:sort(emqx_ds:dirty_read(DB, ['#']))
+            ),
+            %% 2. Verify error handling (preconditions)
+            {async, Ref2, there} =
+                emqx_ds:trans(
+                    TXOpts,
+                    fun() ->
+                        emqx_ds:tx_kv_write([<<"foo">>], ?ds_tx_serial),
+                        emqx_ds:tx_kv_assert_present([<<"bar">>], '_'),
+                        there
+                    end
+                ),
+            %% Wait for the commit outcome:
+            receive
+                ?ds_tx_commit_reply(Ref2, Reply2) ->
+                    ?assertMatch(
+                        {error, unrecoverable,
+                            {precondition_failed, [
+                                #{
+                                    expected := '_',
+                                    got := undefined,
+                                    topic := [<<"bar">>]
+                                }
+                            ]}},
+                        emqx_ds:tx_commit_outcome(DB, Ref2, Reply2)
+                    )
+            end,
+            %% 3. Verify absence of stray unexpected messages, such as
+            %% timeouts.
+            timer:sleep(Timeout * 2),
+            ?assertMatch([], mailbox()),
+
+            %% 4. Timeout (there's a miniscule chance of committing
+            %% before the timeout of 0 which might make this case
+            %% unstable)
+            {async, Ref3, ok} =
+                emqx_ds:trans(
+                    TXOpts#{timeout => 0},
+                    fun() ->
+                        emqx_ds:tx_kv_write([<<"foo">>], ?ds_tx_serial)
+                    end
+                ),
+            %% Wait for timeout
+            receive
+                ?ds_tx_commit_reply(Ref3, Reply3) ->
+                    ?assertMatch(
+                        {error, unrecoverable, timeout},
+                        emqx_ds:tx_commit_outcome(DB, Ref3, Reply3)
+                    )
+            end
+        end,
+        []
+    ).
+
 message(ClientId, Topic, Payload, PublishedAt) ->
     Msg = message(Topic, Payload, PublishedAt),
     Msg#message{from = ClientId}.
@@ -1024,8 +1449,28 @@ all() ->
     [{group, Backend} || Backend <- backends()].
 
 groups() ->
-    TCs = emqx_common_test_helpers:all(?MODULE),
-    [{Backend, TCs} || Backend <- backends()].
+    AllTCs = emqx_common_test_helpers:all(?MODULE),
+    lists:map(
+        fun(Backend) ->
+            TCs =
+                case Backend of
+                    emqx_ds_builtin_local ->
+                        AllTCs;
+                    _ ->
+                        AllTCs --
+                            [
+                                t_13_smoke_kv_tx,
+                                t_14_kv_wildcard_deletes,
+                                t_15_kv_write_serial,
+                                t_16_kv_preconditions,
+                                t_17_tx_wrapper,
+                                t_18_async_trans
+                            ]
+                end,
+            {Backend, TCs}
+        end,
+        backends()
+    ).
 
 init_per_group(emqx_ds_builtin_raft, Config) ->
     %% Raft backend is an odd one, as its main module is named
@@ -1160,3 +1605,21 @@ create_wildcard(DB, Prefix) ->
         is_integer(Until)
     ],
     ?assertMatch(ok, emqx_ds:drop_generation(DB, GenToDel)).
+
+%% Manual sync wrapper for the low-level DS transaction API.
+do_commit_tx(DB, Ctx, Ops) ->
+    Ref = emqx_ds:commit_tx(DB, Ctx, Ops),
+    ?assert(is_reference(Ref)),
+    receive
+        ?ds_tx_commit_reply(Ref, Reply) ->
+            emqx_ds:tx_commit_outcome(DB, Ref, Reply)
+    after 5_000 ->
+        error({timeout, mailbox()})
+    end.
+
+mailbox() ->
+    receive
+        A -> [A | mailbox()]
+    after 0 ->
+        []
+    end.

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -1285,8 +1285,8 @@ t_17_tx_wrapper(Config) ->
                 emqx_ds:trans(
                     TXOpts,
                     fun() ->
-                        emqx_ds:tx_ttv_write([<<"foo">>], 0, <<"1">>),
-                        emqx_ds:tx_ttv_write([<<"t">>, <<"1">>], 0, <<"2">>)
+                        emqx_ds:tx_write({[<<"foo">>], 0, <<"1">>}),
+                        emqx_ds:tx_write({[<<"t">>, <<"1">>], 0, <<"2">>})
                     end
                 )
             ),
@@ -1343,7 +1343,7 @@ t_18_async_trans(Config) ->
                 emqx_ds:trans(
                     TXOpts,
                     fun() ->
-                        emqx_ds:tx_ttv_write([<<"foo">>], 0, ?ds_tx_serial),
+                        emqx_ds:tx_write({[<<"foo">>], 0, ?ds_tx_serial}),
                         hello
                     end
                 ),
@@ -1363,7 +1363,7 @@ t_18_async_trans(Config) ->
                 emqx_ds:trans(
                     TXOpts,
                     fun() ->
-                        emqx_ds:tx_ttv_write([<<"foo">>], 0, ?ds_tx_serial),
+                        emqx_ds:tx_write({[<<"foo">>], 0, ?ds_tx_serial}),
                         emqx_ds:tx_ttv_assert_present([<<"bar">>], 0, '_'),
                         there
                     end
@@ -1395,7 +1395,7 @@ t_18_async_trans(Config) ->
                 emqx_ds:trans(
                     TXOpts#{timeout => 0},
                     fun() ->
-                        emqx_ds:tx_ttv_write([<<"foo">>], 0, ?ds_tx_serial)
+                        emqx_ds:tx_write({[<<"foo">>], 0, ?ds_tx_serial})
                     end
                 ),
             %% Wait for timeout

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -1087,7 +1087,7 @@ t_14_kv_wildcard_deletes(Config) ->
             ?assertEqual(
                 100,
                 emqx_ds:fold_topic(
-                    fun(_, _, _, _, Acc) -> Acc + 1 end,
+                    fun(_Slab, _Stream, _Obj, Acc) -> Acc + 1 end,
                     0,
                     [<<"t">>, '+', '+'],
                     #{db => DB}

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -986,7 +986,7 @@ t_13_smoke_kv_tx(Config) ->
         begin
             %% Open the database
             Opts = maps:merge(opts(Config), #{
-                store_kv => true,
+                store_ttv => true,
                 storage => {emqx_ds_storage_skipstream_lts_v2, #{}}
             }),
             ?assertMatch(
@@ -1062,7 +1062,7 @@ t_14_kv_wildcard_deletes(Config) ->
         begin
             %% Open the database
             Opts = maps:merge(opts(Config), #{
-                store_kv => true,
+                store_ttv => true,
                 storage =>
                     {emqx_ds_storage_skipstream_lts_v2, #{
                         timestamp_bytes => 0
@@ -1127,7 +1127,7 @@ t_15_kv_write_serial(Config) ->
         begin
             %% Open the database
             Opts = maps:merge(opts(Config), #{
-                store_kv => true,
+                store_ttv => true,
                 storage => {emqx_ds_storage_skipstream_lts_v2, #{}}
             }),
             ?assertMatch(
@@ -1166,7 +1166,7 @@ t_16_kv_preconditions(Config) ->
         begin
             %% Open the database
             Opts = maps:merge(opts(Config), #{
-                store_kv => true,
+                store_ttv => true,
                 storage => {emqx_ds_storage_skipstream_lts_v2, #{}}
             }),
             ?assertMatch(
@@ -1254,7 +1254,7 @@ t_17_tx_wrapper(Config) ->
         begin
             %% Open the database
             Opts = maps:merge(opts(Config), #{
-                store_kv => true,
+                store_ttv => true,
                 storage =>
                     {emqx_ds_storage_skipstream_lts_v2, #{
                         timestamp_bytes => 0
@@ -1330,7 +1330,7 @@ t_18_async_trans(Config) ->
         begin
             %% Open the database
             Opts = maps:merge(opts(Config), #{
-                store_kv => true,
+                store_ttv => true,
                 storage => {emqx_ds_storage_skipstream_lts_v2, #{}}
             }),
             ?assertMatch(

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.app.src
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.app.src
@@ -2,7 +2,7 @@
 {application, emqx_ds_builtin_local, [
     {description, "A DS backend that stores all data locally and thus doesn't support clustering."},
     % strict semver, bump manually!
-    {vsn, "0.2.3"},
+    {vsn, "0.3.0"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, gproc, mria, rocksdb, emqx_durable_storage, emqx_utils]},

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -58,9 +58,7 @@
     otx_prepare_tx/5,
     otx_commit_tx_batch/4,
     otx_lookup_ttv/4,
-    otx_cfg_flush_interval/1,
-    otx_cfg_idle_flush_interval/1,
-    otx_cfg_conflict_tracking_interval/1
+    otx_get_runtime_config/1
 ]).
 
 %% Internal exports:
@@ -111,13 +109,16 @@
 -type db_opts() ::
     #{
         backend := builtin_local,
+        store_ttv := boolean(),
         storage := emqx_ds_storage_layer:prototype(),
+
         n_shards := pos_integer(),
         poll_workers_per_shard => pos_integer(),
         %% Equivalent to `append_only' from `emqx_ds:create_db_opts':
         force_monotonic_timestamps := boolean(),
         atomic_batches := boolean(),
-        store_ttv := boolean()
+        %% Optimistic transaction:
+        transaction => emqx_ds_optimistic_tx:runtime_config()
     }.
 
 -type slab() :: {shard(), emqx_ds_storage_layer:gen_id()}.
@@ -139,7 +140,17 @@
 open_db(DB, CreateOpts0) ->
     %% Rename `append_only' flag to `force_monotonic_timestamps':
     AppendOnly = maps:get(append_only, CreateOpts0),
-    CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts0),
+    CreateOpts1 = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts0),
+    CreateOpts = emqx_utils_maps:deep_merge(
+        #{
+            transaction => #{
+                flush_interval => 1_000,
+                idle_flush_interval => 1,
+                conflict_window => 5_000
+            }
+        },
+        CreateOpts1
+    ),
     case emqx_ds_builtin_local_sup:start_db(DB, CreateOpts) of
         {ok, _} ->
             ok;
@@ -629,17 +640,9 @@ otx_commit_tx_batch(DBShard = {DB, Shard}, SerCtl, Serial, Batches) ->
 otx_lookup_ttv(DBShard, GenId, Topic, Timestamp) ->
     emqx_ds_storage_layer_ttv:lookup(DBShard, GenId, Topic, Timestamp).
 
-otx_cfg_flush_interval(_DB) ->
-    %% FIXME:
-    1_000.
-
-otx_cfg_idle_flush_interval(_DB) ->
-    %% FIXME:
-    1.
-
-otx_cfg_conflict_tracking_interval(_DB) ->
-    %% FIXME:
-    5_000.
+otx_get_runtime_config(DB) ->
+    #{transaction := Val} = emqx_ds_builtin_local_meta:db_config(DB),
+    Val.
 
 %%================================================================================
 %% Internal functions

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -153,7 +153,6 @@ close_db(DB) ->
 
 -spec add_generation(emqx_ds:db()) -> ok | {error, _}.
 add_generation(DB) ->
-    %% FIXME: execute this in the serializer's context
     Shards = emqx_ds_builtin_local_meta:shards(DB),
     Errors = lists:filtermap(
         fun(Shard) ->

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -115,7 +115,7 @@
         %% Equivalent to `append_only' from `emqx_ds:create_db_opts':
         force_monotonic_timestamps := boolean(),
         atomic_batches := boolean(),
-        store_kv := boolean()
+        store_ttv := boolean()
     }.
 
 -type slab() :: {shard(), emqx_ds_storage_layer:gen_id()}.
@@ -240,7 +240,7 @@ store_batch(DB, Batch, Opts) ->
     {ok, tx_context()} | emqx_ds:error(_).
 new_kv_tx(DB, Options = #{shard := ShardOpt}) ->
     case emqx_ds_builtin_local_meta:db_config(DB) of
-        #{atomic_batches := true, store_kv := true} ->
+        #{atomic_batches := true, store_ttv := true} ->
             case ShardOpt of
                 {auto, Owner} ->
                     Shard = shard_of(DB, Owner);

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -57,6 +57,7 @@
     otx_get_tx_serial/1,
     otx_prepare_tx/5,
     otx_commit_tx_batch/4,
+    otx_lookup_ttv/4,
     otx_cfg_flush_interval/1,
     otx_cfg_idle_flush_interval/1,
     otx_cfg_conflict_tracking_interval/1
@@ -638,6 +639,9 @@ otx_commit_tx_batch(DBShard, SerCtl, Serial, Batches) ->
         Val ->
             ?err_unrec({serial_mismatch, SerCtl, Val})
     end.
+
+otx_lookup_ttv(DBShard, GenId, Topic, Timestamp) ->
+    emqx_ds_storage_layer_ttv:lookup(DBShard, GenId, Topic, Timestamp).
 
 otx_cfg_flush_interval(_DB) ->
     %% FIXME:

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local.erl
@@ -267,7 +267,7 @@ new_kv_tx(DB, Options = #{shard := ShardOpt}) ->
             ?err_unrec(database_does_not_support_transactions)
     end.
 
--spec commit_tx(emqx_ds:db(), tx_context(), emqx_ds:kv_tx_ops()) -> reference().
+-spec commit_tx(emqx_ds:db(), tx_context(), emqx_ds:tx_ops()) -> reference().
 commit_tx(DB, Ctx, Ops) ->
     emqx_ds_optimistic_tx:commit_kv_tx(DB, Ctx, Ops).
 
@@ -636,12 +636,12 @@ update_tx_serial(DBShard, SerCtl, Serial) ->
     end.
 
 prepare_kv_tx(DBShard, Generation, SerialBin, Ops, Opts) ->
-    emqx_ds_storage_layer_kv:prepare_kv_tx(DBShard, Generation, SerialBin, Ops, Opts).
+    emqx_ds_storage_layer_ttv:prepare_tx(DBShard, Generation, SerialBin, Ops, Opts).
 
 commit_kv_tx_batch(DBShard, Generation, SerCtl, CookedBatch) ->
     case get_tx_serial(DBShard) of
         SerCtl ->
-            emqx_ds_storage_layer_kv:commit_batch(DBShard, Generation, CookedBatch, #{});
+            emqx_ds_storage_layer_ttv:commit_batch(DBShard, Generation, CookedBatch, #{});
         Val ->
             ?err_unrec({serial_mismatch, SerCtl, Val})
     end.

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_batch_serializer.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_batch_serializer.erl
@@ -72,7 +72,7 @@ db_config(#{db := DB}) ->
     emqx_ds_builtin_local_meta:db_config(DB).
 
 -spec do_store_batch_atomic(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     emqx_ds:dsbatch(),
     emqx_ds_builtin_local:db_opts(),
     emqx_ds:message_store_opts()

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_db_sup.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_db_sup.erl
@@ -208,7 +208,7 @@ shard_buffer_spec(DB, Shard, Options) ->
         type => worker
     }.
 
-shard_batch_serializer_spec(DB, Shard, #{store_kv := true}) ->
+shard_batch_serializer_spec(DB, Shard, #{store_ttv := true}) ->
     #{
         id => {Shard, batch_serializer},
         start => {emqx_ds_optimistic_tx, start_link, [DB, Shard, emqx_ds_builtin_local]},
@@ -216,7 +216,7 @@ shard_batch_serializer_spec(DB, Shard, #{store_kv := true}) ->
         restart => permanent,
         type => worker
     };
-shard_batch_serializer_spec(DB, Shard, Opts = #{store_kv := false}) ->
+shard_batch_serializer_spec(DB, Shard, Opts = #{store_ttv := false}) ->
     #{
         id => {Shard, batch_serializer},
         start => {emqx_ds_builtin_local_batch_serializer, start_link, [DB, Shard, Opts]},
@@ -225,7 +225,7 @@ shard_batch_serializer_spec(DB, Shard, Opts = #{store_kv := false}) ->
         type => worker
     }.
 
-shard_beamformers_spec(_DB, _Shard, #{store_kv := true}) ->
+shard_beamformers_spec(_DB, _Shard, #{store_ttv := true}) ->
     %% Currently subscribe API is not supported for KV
     [];
 shard_beamformers_spec(DB, Shard, _Opts) ->

--- a/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta.erl
+++ b/apps/emqx_ds_builtin_local/src/emqx_ds_builtin_local_meta.erl
@@ -46,7 +46,7 @@
 %% node restarts.
 -define(TS_TAB, emqx_ds_builtin_local_timestamp_tab).
 -record(?TS_TAB, {
-    id :: emqx_ds_storage_layer:shard_id(),
+    id :: emqx_ds_storage_layer:dbshard(),
     latest :: integer()
 }).
 
@@ -117,11 +117,11 @@ db_config(DB) ->
             error({no_such_db, DB})
     end.
 
--spec set_current_timestamp(emqx_ds_storage_layer:shard_id(), emqx_ds:time()) -> ok.
+-spec set_current_timestamp(emqx_ds_storage_layer:dbshard(), emqx_ds:time()) -> ok.
 set_current_timestamp(ShardId, Time) ->
     mria:dirty_write(?TS_TAB, #?TS_TAB{id = ShardId, latest = Time}).
 
--spec current_timestamp(emqx_ds_storage_layer:shard_id()) -> emqx_ds:time() | undefined.
+-spec current_timestamp(emqx_ds_storage_layer:dbshard()) -> emqx_ds:time() | undefined.
 current_timestamp(ShardId) ->
     case mnesia:dirty_read(?TS_TAB, ShardId) of
         [#?TS_TAB{latest = Latest}] ->
@@ -130,7 +130,7 @@ current_timestamp(ShardId) ->
             undefined
     end.
 
--spec ensure_monotonic_timestamp(emqx_ds_storage_layer:shard_id()) -> emqx_ds:time().
+-spec ensure_monotonic_timestamp(emqx_ds_storage_layer:dbshard()) -> emqx_ds:time().
 ensure_monotonic_timestamp(ShardId) ->
     mria:dirty_update_counter({?TS_TAB, ShardId}, 1).
 

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
@@ -148,16 +148,7 @@ get_shard_workers(DB) ->
 -spec start_optimistic_tx_leader(emqx_ds:db(), emqx_ds:shard()) -> ok | {error, _}.
 start_optimistic_tx_leader(DB, Shard) ->
     Sup = ?via(#?shard_sup{db = DB, shard = Shard}),
-    case supervisor:start_child(Sup, shard_optimistic_tx_spec(DB, Shard)) of
-        {ok, _} ->
-            ok;
-        {ok, _, _} ->
-            ok;
-        {error, {already_started, _}} ->
-            ok;
-        Err ->
-            Err
-    end.
+    ensure_started(supervisor:start_child(Sup, shard_optimistic_tx_spec(DB, Shard))).
 
 -spec stop_optimistic_tx_leader(emqx_ds:db(), emqx_ds:shard()) -> ok.
 stop_optimistic_tx_leader(DB, Shard) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -231,6 +231,8 @@ open_db(DB, CreateOpts0) ->
     %% Rename `append_only' flag to `force_monotonic_timestamps':
     AppendOnly = maps:get(append_only, CreateOpts0),
     CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts0),
+    maps:get(store_kv, CreateOpts0) andalso
+        error(store_kv_is_not_supported_by_this_backend),
     case emqx_ds_builtin_raft_sup:start_db(DB, CreateOpts) of
         {ok, _} ->
             ok;
@@ -1283,7 +1285,7 @@ scan_stream(DBShard = {DB, Shard}, Stream, TopicFilter, StartMsg, BatchSize) ->
         end
     ).
 
--spec update_iterator(emqx_ds_storage_layer:shard_id(), iterator(), emqx_ds:message_key()) ->
+-spec update_iterator(emqx_ds_storage_layer:dbshard(), iterator(), emqx_ds:message_key()) ->
     emqx_ds:make_iterator_result(iterator()).
 update_iterator(ShardId, OldIter, DSKey) ->
     #{?tag := ?IT, ?enc := Inner0} = OldIter,

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -231,8 +231,8 @@ open_db(DB, CreateOpts0) ->
     %% Rename `append_only' flag to `force_monotonic_timestamps':
     AppendOnly = maps:get(append_only, CreateOpts0),
     CreateOpts = maps:put(force_monotonic_timestamps, AppendOnly, CreateOpts0),
-    maps:get(store_kv, CreateOpts0) andalso
-        error(store_kv_is_not_supported_by_this_backend),
+    maps:get(store_ttv, CreateOpts0) andalso
+        error(store_ttv_is_not_supported_by_this_backend),
     case emqx_ds_builtin_raft_sup:start_db(DB, CreateOpts) of
         {ok, _} ->
             ok;

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -1268,7 +1268,7 @@ apply(
 
 start_otx_leader(DB, Shard) ->
     ?tp_span(
-        warning,
+        debug,
         dsrepl_start_otx_leader,
         #{db => DB, shard => Shard},
         emqx_ds_builtin_raft_db_sup:start_shard_leader_sup(DB, Shard)
@@ -1495,7 +1495,7 @@ set_otx_leader({DB, Shard}, Pid) ->
 -spec state_enter(ra_server:ra_state() | eol, ra_state()) -> ra_machine:effects().
 state_enter(MemberState, State = #{db_shard := {DB, Shard}}) ->
     ?tp(
-        warning,
+        debug,
         ds_ra_state_enter,
         State#{state => MemberState}
     ),

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.erl
@@ -1249,8 +1249,7 @@ apply(
 ) ->
     case SerCtl =:= ExpectedSerial of
         true ->
-            %% FIXME: better error handling? durable => false?
-            ok = emqx_ds_storage_layer_ttv:commit_batch(DBShard, Batches, #{}),
+            ok = emqx_ds_storage_layer_ttv:commit_batch(DBShard, Batches, #{durable => false}),
             emqx_ds_storage_layer_ttv:set_read_tx_serial(DBShard, Serial),
             {State#{tx_serial := Serial}, ok};
         false ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.hrl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.hrl
@@ -38,4 +38,9 @@
     shard, server, ref
 }).
 
+%% Tx
+-define(prev_serial, 2).
+-define(serial, 3).
+-define(batches, 4).
+
 -endif.

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.hrl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_replication_layer.hrl
@@ -42,5 +42,6 @@
 -define(prev_serial, 2).
 -define(serial, 3).
 -define(batches, 4).
+-define(otx_leader_pid, 5).
 
 -endif.

--- a/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_otx_proto_v1.erl
+++ b/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_otx_proto_v1.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 -module(emqx_ds_otx_proto_v1).
 

--- a/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_otx_proto_v1.erl
+++ b/apps/emqx_ds_builtin_raft/src/proto/emqx_ds_otx_proto_v1.erl
@@ -1,0 +1,35 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_ds_otx_proto_v1).
+
+-behavior(emqx_bpapi).
+
+-include_lib("emqx_utils/include/bpapi.hrl").
+%% API:
+-export([
+    new_kv_tx_ctx/5
+]).
+
+%% behavior callbacks:
+-export([introduced_in/0]).
+
+%%================================================================================
+%% API functions
+%%================================================================================
+
+-spec new_kv_tx_ctx(
+    node(), emqx_ds:db(), emqx_ds:shard(), emqx_ds:generation(), emqx_ds:transaction_opts()
+) ->
+    {ok, emqx_ds_replication_layer:tx_context()} | emqx_ds:error(_).
+new_kv_tx_ctx(Node, DB, Shard, Generation, Options) ->
+    erpc:call(Node, emqx_ds_replication_layer, do_new_kv_tx_ctx_v1, [
+        DB, Shard, Generation, Options
+    ]).
+
+%%================================================================================
+%% behavior callbacks
+%%================================================================================
+
+introduced_in() ->
+    "5.10.0".

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -143,7 +143,7 @@ t_shards_allocation(Config) ->
     [_SpecLost, Spec | _] = ?config(specs, Config),
     [Node] = emqx_cth_cluster:restart(Spec),
     emqx_ds_raft_test_helpers:assert_db_open([Node], DB, Opts),
-    %% FIXME: Manually forget the lost node.
+    %% Forget the lost node.
     ?ON(Node, emqx_ds_builtin_raft_meta:forget_node(NodeLost)),
     ?retry(
         5_000,

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinMetadata.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinMetadata.asn
@@ -1,0 +1,60 @@
+--------------------------------------------------------------------------
+-- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+--------------------------------------------------------------------------
+
+-- A collection of ASN.1 definitions encoding various types related to
+-- the builtin backends that may at some point end up stored
+-- persistently on disk.
+DSBuiltinMetadata DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+  -- Common definitions
+  TopicWords ::= SEQUENCE OF OCTET STRING
+
+  -- Layout-specific storage layer definitions
+  --   emqx_ds_storage_reference
+  SLReferenceStream ::= NULL
+  --   We encode iterator as term_to_binary. Reference layout is not
+  --   built for efficiency anyways
+  SLReferenceIt ::= OCTET STRING
+
+  --   emqx_ds_storage_skipstream_lts
+  SLSkipstreamLtsV1Stream ::= OCTET STRING
+
+  SLSkipstreamV1It ::= SEQUENCE {
+    static OCTET STRING,
+    lastKey INTEGER,
+    compressedTf OCTET STRING
+  }
+
+  -- Common storage layer definitions
+  SLStream ::= CHOICE {
+    reference SLReferenceStream,
+    skipstreamLtsV1 SLSkipstreamLtsV1Stream,
+    ...
+  }
+
+  --   Iterator:
+  SLIterator ::= CHOICE {
+    reference SLReferenceIt,
+    skipstreamLtsV1 SLSkipstreamV1It,
+    ...
+  }
+
+  -- Top level (local and Raft)
+  Stream ::= SEQUENCE {
+    shard OCTET STRING,
+    generation INTEGER,
+    inner SLStream
+  }
+
+  Iterator ::= SEQUENCE {
+    shard OCTET STRING,
+    generation INTEGER,
+    inner SLIterator
+  }
+
+  It ::= CHOICE {
+    endOfStream NULL,
+    value Iterator
+  }
+END

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinMetadata.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinMetadata.asn
@@ -7,53 +7,21 @@
 -- persistently on disk.
 DSBuiltinMetadata DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
-  -- Common definitions
-  TopicWords ::= SEQUENCE OF OCTET STRING
-
-  -- Layout-specific storage layer definitions
-  --   emqx_ds_storage_reference
-  SLReferenceStream ::= NULL
-  --   We encode iterator as term_to_binary. Reference layout is not
-  --   built for efficiency anyways
-  SLReferenceIt ::= OCTET STRING
-
-  --   emqx_ds_storage_skipstream_lts
-  SLSkipstreamLtsV1Stream ::= OCTET STRING
-
-  SLSkipstreamV1It ::= SEQUENCE {
-    static OCTET STRING,
-    lastKey INTEGER,
-    compressedTf OCTET STRING
-  }
-
-  -- Common storage layer definitions
-  SLStream ::= CHOICE {
-    reference SLReferenceStream,
-    skipstreamLtsV1 SLSkipstreamLtsV1Stream,
-    ...
-  }
-
-  --   Iterator:
-  SLIterator ::= CHOICE {
-    reference SLReferenceIt,
-    skipstreamLtsV1 SLSkipstreamV1It,
-    ...
-  }
-
-  -- Top level (local and Raft)
+  -- Top level (Local and Raft)
   Stream ::= SEQUENCE {
     shard OCTET STRING,
     generation INTEGER,
-    inner SLStream
+    inner DSBuiltinStorageLayer.Stream
   }
 
   Iterator ::= SEQUENCE {
     shard OCTET STRING,
     generation INTEGER,
-    inner SLIterator
+    inner DSBuiltinStorageLayer.Iterator
   }
 
-  It ::= CHOICE {
+  -- Encoding of iterator or end_of_stream
+  ReplayPosition ::= CHOICE {
     endOfStream NULL,
     value Iterator
   }

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinSLReference.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinSLReference.asn
@@ -1,0 +1,13 @@
+--------------------------------------------------------------------------
+-- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+--------------------------------------------------------------------------
+
+-- Metadata definitions for emqx_ds_storage_reference module
+DSBuiltinSLReference DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+  EXPORTS ALL;
+
+  Stream ::= NULL
+
+  Iterator ::= OCTET STRING
+END

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinSLSkipstreamKV.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinSLSkipstreamKV.asn
@@ -1,0 +1,17 @@
+--------------------------------------------------------------------------
+-- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+--------------------------------------------------------------------------
+
+DSBuiltinSLSkipstreamKV DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+  EXPORTS ALL;
+  IMPORTS TopicFilter FROM DSMetadataCommon;
+
+  Stream ::= OCTET STRING
+
+  Iterator ::= SEQUENCE {
+    static OCTET STRING,
+    lastKey OCTET STRING,
+    topicFilter TopicFilter
+  }
+END

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinSLSkipstreamV1.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinSLSkipstreamV1.asn
@@ -1,0 +1,17 @@
+--------------------------------------------------------------------------
+-- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+--------------------------------------------------------------------------
+
+DSBuiltinSLSkipstreamV1 DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+  EXPORTS ALL;
+
+    --   emqx_ds_storage_skipstream_lts
+  Stream ::= OCTET STRING
+
+  Iterator ::= SEQUENCE {
+    static OCTET STRING,
+    lastKey INTEGER,
+    compressedTf OCTET STRING
+  }
+END

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinSLSkipstreamV2.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinSLSkipstreamV2.asn
@@ -2,7 +2,7 @@
 -- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 --------------------------------------------------------------------------
 
-DSBuiltinSLSkipstreamKV DEFINITIONS AUTOMATIC TAGS ::=
+DSBuiltinSLSkipstreamV2 DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
   EXPORTS ALL;
   IMPORTS TopicFilter FROM DSMetadataCommon;

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinStorageLayer.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinStorageLayer.asn
@@ -9,14 +9,14 @@ BEGIN
   Stream ::= CHOICE {
     reference DSBuiltinSLReference.Stream,
     skipstreamV1 DSBuiltinSLSkipstreamV1.Stream,
-    skipstreamKV DSBuiltinSLSkipstreamKV.Stream,
+    skipstreamV2 DSBuiltinSLSkipstreamV2.Stream,
     ...
   }
 
   Iterator ::= CHOICE {
     reference DSBuiltinSLReference.Iterator,
     skipstreamV1 DSBuiltinSLSkipstreamV1.Iterator,
-    skipstreamKV DSBuiltinSLSkipstreamKV.Iterator,
+    skipstreamV2 DSBuiltinSLSkipstreamV2.Iterator,
     ...
   }
 END

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinStorageLayer.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinStorageLayer.asn
@@ -1,0 +1,20 @@
+--------------------------------------------------------------------------
+-- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+--------------------------------------------------------------------------
+
+DSBuiltinStorageLayer DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+  EXPORTS ALL;
+
+  Stream ::= CHOICE {
+    reference DSBuiltinSLReference.Stream,
+    skipstreamV1 DSBuiltinSLSkipstreamV1.Stream,
+    ...
+  }
+
+  Iterator ::= CHOICE {
+    reference DSBuiltinSLReference.Iterator,
+    skipstreamV1 DSBuiltinSLSkipstreamV1.Iterator,
+    ...
+  }
+END

--- a/apps/emqx_durable_storage/asn.1/DSBuiltinStorageLayer.asn
+++ b/apps/emqx_durable_storage/asn.1/DSBuiltinStorageLayer.asn
@@ -9,12 +9,14 @@ BEGIN
   Stream ::= CHOICE {
     reference DSBuiltinSLReference.Stream,
     skipstreamV1 DSBuiltinSLSkipstreamV1.Stream,
+    skipstreamKV DSBuiltinSLSkipstreamKV.Stream,
     ...
   }
 
   Iterator ::= CHOICE {
     reference DSBuiltinSLReference.Iterator,
     skipstreamV1 DSBuiltinSLSkipstreamV1.Iterator,
+    skipstreamKV DSBuiltinSLSkipstreamKV.Iterator,
     ...
   }
 END

--- a/apps/emqx_durable_storage/asn.1/DSMetadataCommon.asn
+++ b/apps/emqx_durable_storage/asn.1/DSMetadataCommon.asn
@@ -1,0 +1,10 @@
+--------------------------------------------------------------------------
+-- Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+--------------------------------------------------------------------------
+
+-- A collection of ASN.1 definitions encoding common types
+DSMetadataCommon DEFINITIONS AUTOMATIC TAGS ::=
+BEGIN
+  EXPORTS ALL;
+  TopicWords ::= SEQUENCE OF OCTET STRING
+END

--- a/apps/emqx_durable_storage/asn.1/DSMetadataCommon.asn
+++ b/apps/emqx_durable_storage/asn.1/DSMetadataCommon.asn
@@ -7,4 +7,12 @@ DSMetadataCommon DEFINITIONS AUTOMATIC TAGS ::=
 BEGIN
   EXPORTS ALL;
   TopicWords ::= SEQUENCE OF OCTET STRING
+
+  TopicFilterWord ::= CHOICE {
+    const OCTET STRING,
+    plus NULL,
+    hash NULL
+  }
+
+  TopicFilter ::= SEQUENCE OF TopicFilterWord
 END

--- a/apps/emqx_durable_storage/include/emqx_ds.hrl
+++ b/apps/emqx_durable_storage/include/emqx_ds.hrl
@@ -42,11 +42,30 @@
     lagging :: boolean() | undefined
 }).
 
+-define(ds_tx_commit_reply(REF, REPLY), REPLY = {'DOWN', REF, _, _, _}).
+
+%% Helper macros for generating transaction commit messages (internal
+%% macros, for use in the backends). `META' argument can be used by
+%% the backend to store arbitrary data.
+-define(ds_tx_commit_ok(REF, META, SERIAL), {'DOWN', REF, ok, META, SERIAL}).
+-define(ds_tx_commit_error(REF, META, ERROR_CLASS, INFO),
+    {'DOWN', REF, {error, ERROR_CLASS}, META, INFO}
+).
+
 -record(new_stream_event, {
     subref :: emqx_ds_new_streams:watch()
 }).
 
 -define(err_rec(E), {error, recoverable, E}).
 -define(err_unrec(E), {error, unrecoverable, E}).
+
+%% Transaction
+-define(ds_tx_serial, tx_serial).
+
+-define(ds_tx_write, w).
+-define(ds_tx_delete_topic, dt).
+-define(ds_tx_read, r).
+-define(ds_tx_expected, e).
+-define(ds_tx_unexpected, u).
 
 -endif.

--- a/apps/emqx_durable_storage/include/emqx_ds_builtin_tx.hrl
+++ b/apps/emqx_durable_storage/include/emqx_ds_builtin_tx.hrl
@@ -8,8 +8,6 @@
     shard :: emqx_ds:shard(),
     leader :: pid(),
     serial :: term(),
-    %% Current generation. Used to guard against committing
-    %% transactions that span multiple generations
     generation :: emqx_ds:generation(),
     opts :: emqx_ds:transaction_opts()
 }).
@@ -17,7 +15,7 @@
 -record(ds_tx, {
     ctx :: emqx_ds_optimistic_tx:ctx(),
     ops :: emqx_ds:tx_ops() | emqx_ds:tx_ops(),
-    from :: pid() | reference(),
+    from :: pid(),
     ref :: reference(),
     meta :: term()
 }).

--- a/apps/emqx_durable_storage/include/emqx_ds_builtin_tx.hrl
+++ b/apps/emqx_durable_storage/include/emqx_ds_builtin_tx.hrl
@@ -1,0 +1,25 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-ifndef(EMQX_DS_BUILTIN_TX_HRL).
+-define(EMQX_DS_BUILTIN_TX_HRL, true).
+
+-record(kv_tx_ctx, {
+    shard :: emqx_ds:shard(),
+    leader :: pid(),
+    serial :: term(),
+    %% Current generation. Used to guard against committing
+    %% transactions that span multiple generations
+    generation :: emqx_ds:generation(),
+    opts :: emqx_ds:transaction_opts()
+}).
+
+-record(ds_tx, {
+    ctx :: emqx_ds_optimistic_tx:ctx(),
+    ops :: emqx_ds:kv_tx_ops() | emqx_ds:tx_ops(),
+    from :: pid() | reference(),
+    ref :: reference(),
+    meta :: term()
+}).
+
+-endif.

--- a/apps/emqx_durable_storage/include/emqx_ds_builtin_tx.hrl
+++ b/apps/emqx_durable_storage/include/emqx_ds_builtin_tx.hrl
@@ -16,7 +16,7 @@
 
 -record(ds_tx, {
     ctx :: emqx_ds_optimistic_tx:ctx(),
-    ops :: emqx_ds:kv_tx_ops() | emqx_ds:tx_ops(),
+    ops :: emqx_ds:tx_ops() | emqx_ds:tx_ops(),
     from :: pid() | reference(),
     ref :: reference(),
     meta :: term()

--- a/apps/emqx_durable_storage/mix.exs
+++ b/apps/emqx_durable_storage/mix.exs
@@ -13,6 +13,8 @@ defmodule EMQXDurableStorage.MixProject do
       # used by our `compile.asn1` compiler
       asn1_srcs: [
         %{src: "./asn.1/DurableMessage.asn",
+          compile_opts: [:per, :noobj, outdir: ~c"gen_src"]},
+        %{src: "./asn.1/DSBuiltinMetadata.asn",
           compile_opts: [:per, :noobj, outdir: ~c"gen_src"]}
       ],
       deps_path: "../../deps",

--- a/apps/emqx_durable_storage/mix.exs
+++ b/apps/emqx_durable_storage/mix.exs
@@ -11,12 +11,16 @@ defmodule EMQXDurableStorage.MixProject do
       erlc_options: UMP.erlc_options(),
       erlc_paths: ["gen_src" | UMP.erlc_paths()],
       # used by our `compile.asn1` compiler
-      asn1_srcs: [
-        %{src: "./asn.1/DurableMessage.asn",
-          compile_opts: [:per, :noobj, outdir: ~c"gen_src"]},
-        %{src: "./asn.1/DSBuiltinMetadata.asn",
-          compile_opts: [:per, :noobj, outdir: ~c"gen_src"]}
-      ],
+      asn1_srcs: for i <- ["DurableMessage",
+                           "DSBuiltinMetadata",
+                           "DSBuiltinSLReference",
+                           "DSBuiltinSLSkipstreamV1",
+                           "DSBuiltinSLSkipstreamKV",
+                           "DSBuiltinStorageLayer"
+                          ],
+               do: %{src: "./asn.1/" ++ i ++ ".asn",
+                     compile_opts: [:per, :noobj, outdir: ~c"gen_src"]
+                    },
       deps_path: "../../deps",
       lockfile: "../../mix.lock",
       elixir: "~> 1.14",

--- a/apps/emqx_durable_storage/mix.exs
+++ b/apps/emqx_durable_storage/mix.exs
@@ -18,7 +18,7 @@ defmodule EMQXDurableStorage.MixProject do
                            "DSBuiltinSLSkipstreamKV",
                            "DSBuiltinStorageLayer"
                           ],
-               do: %{src: "./asn.1/" ++ i ++ ".asn",
+               do: %{src: "./asn.1/#{i}.asn",
                      compile_opts: [:per, :noobj, outdir: ~c"gen_src"]
                     },
       deps_path: "../../deps",

--- a/apps/emqx_durable_storage/rebar.config
+++ b/apps/emqx_durable_storage/rebar.config
@@ -4,5 +4,6 @@
 {erl_opts, [{src_dirs, ["src", "gen_src"]}]}.
 
 {pre_hooks, [
-    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DurableMessage.asn"}
+    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DurableMessage.asn"},
+    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DSBuiltinMetadata.asn"}
 ]}.

--- a/apps/emqx_durable_storage/rebar.config
+++ b/apps/emqx_durable_storage/rebar.config
@@ -5,5 +5,13 @@
 
 {pre_hooks, [
     {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DurableMessage.asn"},
+
+    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DSMetadataCommon.asn"},
+    {"(linux|darwin|solaris)", compile,
+        "erlc -bper +noobj -o gen_src asn.1/DSBuiltinSLReference.asn"},
+    {"(linux|darwin|solaris)", compile,
+        "erlc -bper +noobj -o gen_src asn.1/DSBuiltinSLSkipstreamV1.asn"},
+    {"(linux|darwin|solaris)", compile,
+        "erlc -bper +noobj -o gen_src asn.1/DSBuiltinStorageLayer.asn"},
     {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DSBuiltinMetadata.asn"}
 ]}.

--- a/apps/emqx_durable_storage/rebar.config
+++ b/apps/emqx_durable_storage/rebar.config
@@ -6,12 +6,5 @@
 {pre_hooks, [
     {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DurableMessage.asn"},
 
-    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DSMetadataCommon.asn"},
-    {"(linux|darwin|solaris)", compile,
-        "erlc -bper +noobj -o gen_src asn.1/DSBuiltinSLReference.asn"},
-    {"(linux|darwin|solaris)", compile,
-        "erlc -bper +noobj -o gen_src asn.1/DSBuiltinSLSkipstreamV1.asn"},
-    {"(linux|darwin|solaris)", compile,
-        "erlc -bper +noobj -o gen_src asn.1/DSBuiltinStorageLayer.asn"},
-    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DSBuiltinMetadata.asn"}
+    {"(linux|darwin|solaris)", compile, "erlc -bper +noobj -o gen_src asn.1/DS*.asn"}
 ]}.

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -302,8 +302,8 @@
         %% The whole batch must be crafted so that it belongs to a single shard (if
         %% applicable to the backend).
         atomic_batches => boolean(),
-        %% Whether the DB stores values of type `#message{}' or raw
-        %% binaries.
+        %% Whether the DB stores values of type `#message{}' or
+        %% key-value pairs of raw binaries.
         store_kv => boolean(),
         %% Backend-specific options:
         _ => _

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -115,6 +115,7 @@
     sub_info/0,
     sub_seqno/0,
 
+    value/0,
     ttv/0,
 
     tx_serial/0,

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -1228,7 +1228,7 @@ trans_maybe_retry(DB, Fun, Opts = #{retry_interval := RetryInterval}, Retries) -
                     db => DB,
                     tx_fun => Fun,
                     opts => Opts,
-                    retries => Retries,
+                    attempts_left => Retries,
                     reason => Reason
                 }
             ),

--- a/apps/emqx_durable_storage/src/emqx_ds.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds.erl
@@ -58,7 +58,7 @@
     tx_read/2,
 
     %% Key-value functions:
-    tx_ttv_write/3,
+    tx_write/1,
     tx_del_topic/1,
     tx_ttv_assert_present/3,
     tx_ttv_assert_absent/2
@@ -929,8 +929,8 @@ trans(UserOpts = #{db := DB, shard := _, generation := _}, Fun) ->
 %%
 %% NOTE: topics used in TTV interface are not MQTT topics: they don't
 %% have to be proper unicode and levels can contain slashes.
--spec tx_ttv_write(topic(), time(), binary() | ?ds_tx_serial) -> ok.
-tx_ttv_write(Topic, Time, Value) ->
+-spec tx_write({topic(), time(), binary() | ?ds_tx_serial}) -> ok.
+tx_write({Topic, Time, Value}) ->
     case
         is_topic(Topic) andalso is_integer(Time) andalso
             (is_binary(Value) orelse Value =:= ?ds_tx_serial)

--- a/apps/emqx_durable_storage/src/emqx_ds_beamformer_catchup.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_beamformer_catchup.erl
@@ -307,6 +307,11 @@ handover_complete(
             %% Race condition: new data has been added. Add the
             %% request back to the active queue, so it can be
             %% retried:
+            ?tp(
+                notice,
+                failed_to_promote_iterator_to_rt,
+                #{dbshard => DBShard}
+            ),
             queue_push(Queue, SubState);
         ?err_rec(Reason) ->
             ?tp(

--- a/apps/emqx_durable_storage/src/emqx_ds_gen_skipstream_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_gen_skipstream_lts.erl
@@ -1,0 +1,806 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Common routines for implementing storage layouts based on
+%% "skip-stream" indexing.
+-module(emqx_ds_gen_skipstream_lts).
+
+%% API:
+-export([
+    open/1,
+    drop/1,
+    %% Trie management:
+    restore_trie/4,
+    pop_lts_persist_ops/0,
+    notify_new_streams/3,
+    copy_previous_trie/3,
+    %% DB key management:
+    mk_key/4,
+    stream_key/2,
+    match_key/4,
+    %% Update the table:
+    batch_put/6,
+    batch_delete/5,
+
+    %% Reading:
+    lookup_message/3,
+    fold/7
+]).
+
+-export_type([
+    fold_fun/1,
+    s/0,
+    stream_key/0
+]).
+
+%% inline small functions:
+-compile(inline).
+
+-include("emqx_ds.hrl").
+-include("emqx_ds_metrics.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%%================================================================================
+%% Type declarations
+%%================================================================================
+
+%% Width of the wildcard layer, in bits:
+-define(wcb, 16).
+
+-type wildcard_idx() :: 0..16#ffff.
+-type wildcard_hash() :: binary().
+
+%% Deserialized value:
+-type deser_value() :: term().
+
+%% Key that identifies a message in the stream. It's the suffix of
+%% `emqx_ds:message_key'.
+-type stream_key() :: binary().
+
+%% Runtime state:
+-record(s, {
+    dbshard :: {emqx_ds:db(), emqx_ds:shard()},
+    db :: rocksdb:db_handle(),
+    data_cf :: rocksdb:cf_handle(),
+    trie_cf :: rocksdb:cf_handle(),
+    trie :: emqx_ds_lts:trie(),
+    serialization_schema :: emqx_ds_msg_serializer:schema(),
+    %% A callback that returns varying parts of the topic from stream
+    %% key or deserialized message. It's used to check for hash
+    %% collisions.
+    get_topic :: fun((stream_key(), _) -> emqx_ds:topic()),
+    %% Number of bytes per wildcard topic level:
+    hash_bytes :: pos_integer()
+}).
+
+-opaque s() :: #s{}.
+
+-define(COUNTERS, [
+    ?DS_SKIPSTREAM_LTS_SEEK,
+    ?DS_SKIPSTREAM_LTS_NEXT,
+    ?DS_SKIPSTREAM_LTS_HASH_COLLISION,
+    ?DS_SKIPSTREAM_LTS_HIT,
+    ?DS_SKIPSTREAM_LTS_MISS,
+    ?DS_SKIPSTREAM_LTS_FUTURE,
+    ?DS_SKIPSTREAM_LTS_EOS
+]).
+
+%% Interval that constrains stream keys visited by the fold. The
+%% interval is always open on the upper endpoint, but it can be open
+%% (if the first element of tuple is atom '(') or half-closed '[' on
+%% the lower endpoint.
+-type fold_interval() :: {
+    '[' | '(',
+    stream_key() | '-infinity',
+    stream_key() | 'infinity'
+}.
+
+-type fold_fun(Acc) :: fun(
+    (emqx_ds_lts:learned_structure(), emqx_ds:message_key(), emqx_ds:topic(), _Value, Acc) -> Acc
+).
+
+%% Fold loop context:
+-record(fold_ctx, {
+    %% Generation runtime state:
+    s,
+    %% Fold function:
+    f,
+    %% RocksDB iterators:
+    iters,
+    %% Topic filter:
+    %%   Cached topic structure for the static index:
+    topic_structure,
+    %%   Compressed topic filter, split into words:
+    filter,
+    %%   Static index:
+    static :: emqx_ds_lts:static_key(),
+    %% Lower and upper endpoint of the stream key _open_ interval:
+    lower_endpoint :: stream_key() | '-infinity',
+    upper_endpoint :: stream_key() | infinity
+}).
+
+%% Level iterator:
+-record(l, {
+    n :: wildcard_idx(),
+    handle :: rocksdb:itr_handle(),
+    hash :: wildcard_hash()
+}).
+
+-type l() :: #l{}.
+
+-ifdef(DEBUG2).
+-include_lib("snabbkaffe/include/trace.hrl").
+-define(dbg(K, A), ?tp(K, A)).
+-else.
+-define(dbg(K, A), ok).
+-endif.
+
+-define(lts_persist_ops, emqx_ds_storage_gen_skipstream_lts_ops).
+
+%%================================================================================
+%% API functions
+%%================================================================================
+
+%%%% Trie
+
+-spec restore_trie(
+    emqx_ds_storage_layer:dbshard(), pos_integer(), rocksdb:db_handle(), rocksdb:cf_handle()
+) -> emqx_ds_lts:trie().
+restore_trie(Shard, StaticIdxBytes, DB, CF) ->
+    PersistCallback = fun(Key, Val) ->
+        push_lts_persist_op(Key, Val),
+        ok
+    end,
+    {ok, It} = rocksdb:iterator(DB, CF, []),
+    try
+        Dump = read_persisted_trie(It, rocksdb:iterator_move(It, first)),
+        TrieOpts = #{
+            persist_callback => PersistCallback,
+            static_key_bytes => StaticIdxBytes,
+            reverse_lookups => true
+        },
+        Trie = emqx_ds_lts:trie_restore(TrieOpts, Dump),
+        notify_new_streams(Shard, Trie, Dump),
+        Trie
+    after
+        rocksdb:iterator_close(It)
+    end.
+
+%% Send notifications about new streams:
+notify_new_streams({DB, _Shard}, Trie, Dump) ->
+    [
+        emqx_ds_new_streams:notify_new_stream(DB, TopicFilter)
+     || TopicFilter <- emqx_ds_lts:updated_topics(Trie, Dump)
+    ],
+    ok.
+
+-spec pop_lts_persist_ops() -> emqx_ds_lts:dump().
+pop_lts_persist_ops() ->
+    case erlang:erase(?lts_persist_ops) of
+        undefined ->
+            [];
+        L when is_list(L) ->
+            L
+    end.
+
+-spec copy_previous_trie(rocksdb:db_handle(), rocksdb:cf_handle(), emqx_ds_lts:trie()) ->
+    ok.
+copy_previous_trie(RocksDB, TrieCF, TriePrev) ->
+    {ok, Batch} = rocksdb:batch(),
+    lists:foreach(
+        fun({Key, Val}) ->
+            ok = rocksdb:batch_put(Batch, TrieCF, term_to_binary(Key), term_to_binary(Val))
+        end,
+        emqx_ds_lts:trie_dump(TriePrev, wildcard)
+    ),
+    Result = rocksdb:write_batch(RocksDB, Batch, []),
+    rocksdb:release_batch(Batch),
+    Result.
+
+%%%% Data
+
+%% @doc Initialize the module.
+-spec open(#{
+    db_shard := {emqx_ds:db(), emqx_ds:shard()},
+    db_handle := rocksdb:db_handle(),
+    data_cf := rocksdb:cf_handle(),
+    trie_cf := rocksdb:cf_handle(),
+    trie := emqx_ds_lts:trie(),
+    serialization_schema := emqx_ds_msg_serializer:schema(),
+    get_topic := fun((stream_key(), deser_value()) -> emqx_ds:topic()),
+    wildcard_hash_bytes := pos_integer()
+}) ->
+    s().
+open(
+    #{
+        db_shard := DBShard,
+        db_handle := DBHandle,
+        data_cf := DataCF,
+        trie_cf := TrieCF,
+        trie := Trie,
+        serialization_schema := SerSchema,
+        get_topic := GetTopic,
+        wildcard_hash_bytes := HashBytes
+    }
+) ->
+    #s{
+        dbshard = DBShard,
+        db = DBHandle,
+        data_cf = DataCF,
+        trie_cf = TrieCF,
+        trie = Trie,
+        serialization_schema = SerSchema,
+        get_topic = GetTopic,
+        hash_bytes = HashBytes
+    }.
+
+-spec drop(s()) -> ok.
+drop(#s{trie = Trie, db = DBHandle, data_cf = DataCF, trie_cf = TrieCF}) ->
+    emqx_ds_lts:destroy(Trie),
+    ok = rocksdb:drop_column_family(DBHandle, DataCF),
+    ok = rocksdb:drop_column_family(DBHandle, TrieCF),
+    ok.
+
+%% @doc Low-level API for writing data and indexes to the column
+%% family via RocksDB batch.
+%%
+%% It's assumed that the caller already made an LTS trie lookup for
+%% the topic, and got static and varying parts of the key.
+-spec batch_put(
+    s(),
+    rocksdb:batch_handle(),
+    emqx_ds_lts:static_key(),
+    emqx_ds_lts:varying(),
+    stream_key(),
+    binary()
+) -> ok.
+batch_put(
+    #s{data_cf = DataCF, hash_bytes = HashBytes}, Batch, Static, Varying, StreamKey, SerializedValue
+) ->
+    MasterKey = mk_master_key(Static, StreamKey),
+    ok = rocksdb:batch_put(Batch, DataCF, MasterKey, SerializedValue),
+    mk_index(Batch, DataCF, HashBytes, Static, Varying, StreamKey).
+
+%% @doc Low-level API for deleting data and indexes. Similar to
+%% `batch_put'.
+-spec batch_delete(
+    s(), rocksdb:batch_handle(), emqx_ds_lts:static_key(), emqx_ds_lts:varying(), stream_key()
+) -> ok.
+batch_delete(#s{data_cf = DataCF, hash_bytes = HashBytes}, Batch, Static, Varying, StreamKey) ->
+    delete_index(Batch, DataCF, HashBytes, Static, Varying, StreamKey),
+    MasterKey = mk_master_key(Static, StreamKey),
+    ok = rocksdb:batch_delete(Batch, DataCF, MasterKey).
+
+%% @doc Compose a RocksDB key for data or index from the parts.
+-spec mk_key(emqx_ds_lts:static_key(), wildcard_idx(), wildcard_hash(), stream_key()) ->
+    binary().
+mk_key(StaticIdx, 0, <<>>, StreamKey) ->
+    mk_master_key(StaticIdx, StreamKey);
+mk_key(StaticIdx, N, WildcardHash, StreamKey) when N > 0 ->
+    mk_index_key(StaticIdx, N, WildcardHash, StreamKey).
+
+%% @doc Extract stream key from the DSKey. Crashes on mismatch.
+-spec stream_key(emqx_ds_lts:static_key(), emqx_ds:message_key()) ->
+    stream_key().
+stream_key(Static, DSKey) ->
+    TSz = byte_size(Static),
+    <<Static:TSz/binary, 0:?wcb, StreamKey/binary>> = DSKey,
+    StreamKey.
+
+%% @doc Extract a stream key from RocksDB key
+-spec match_key(emqx_ds_lts:static_key(), wildcard_idx(), wildcard_hash(), emqx_ds:message_key()) ->
+    stream_key() | false.
+match_key(StaticIdx, 0, <<>>, Key) ->
+    TSz = byte_size(StaticIdx),
+    case Key of
+        <<StaticIdx:TSz/binary, 0:?wcb, StreamKey/binary>> ->
+            StreamKey;
+        _ ->
+            false
+    end;
+match_key(StaticIdx, Idx, Hash, Key) when Idx > 0 ->
+    TSz = byte_size(StaticIdx),
+    Hsz = byte_size(Hash),
+    case Key of
+        <<StaticIdx:TSz/binary, Idx:?wcb, Hash:Hsz/binary, StreamKey/binary>> ->
+            StreamKey;
+        _ ->
+            false
+    end.
+
+%% @doc Lookup a message by LTS static index and stream key.
+%%
+%% Note: the returned message is *deserialized*, but no further
+%% transformation or enrichment is performed.
+-spec lookup_message(s(), emqx_ds_lts:static_key(), stream_key()) ->
+    {ok, emqx_ds:message_key(), deser_value()}
+    | undefined
+    | emqx_ds:error(_).
+lookup_message(
+    S = #s{db = DB, data_cf = CF},
+    Static,
+    StreamKey
+) ->
+    DSKey = mk_master_key(Static, StreamKey),
+    case rocksdb:get(DB, CF, DSKey, []) of
+        {ok, Bin} ->
+            {ok, DSKey, deserialize(S, Bin)};
+        not_found ->
+            undefined;
+        {error, Reason} ->
+            ?err_unrec({rocksdb, Reason})
+    end.
+
+%% @doc Iterate over messages with a given topic filter.
+%%
+%% @param S State
+%%
+%% @param Static Static topic index, as returned by the LTS trie
+%% lookup for the topic-filter
+%%
+%% @param Varying Varying topic parts, as returned by the LTS trie
+%% lookup for the topic-filter
+%%
+%% @param Interval Interval that restricts the range of stream keys in
+%% the topic filter. It's a 3-tuple
+%%
+%% - Second element of the tuple is the lower endpoint of the stream
+%% key interval
+%%
+%% - Third element of the tuple is the upper endpoint of the stream
+%% key interval. Note: interval is always open on the upper endpoint,
+%% i.e. upper endpoint is *excluded* from the iteration.
+%%
+%% - First element of the tuple is an atom '[' or '('. '[' signifies
+%% half-closed interval (i.e. lower endpoint is included in the scan),
+%% and '(' signifies open interval.
+%%
+%% @param BatchSize Stop iteration after visiting so many elements
+%%
+%% @param Acc0 Initial value of the accumulator
+%%
+%% @param Fun Fold function
+-spec fold(
+    s(),
+    emqx_ds_lts:static_key(),
+    emqx_ds_lts:varying(),
+    fold_interval(),
+    _BatchSize :: pos_integer(),
+    Acc,
+    fold_fun(Acc)
+) -> {ok, stream_key(), Acc} | emqx_ds:error(_).
+fold(
+    S = #s{trie = Trie, dbshard = DBShard},
+    Static,
+    Varying,
+    Interval = {LEType, LowerEndpoint, UpperEndpoint},
+    BatchSize,
+    Acc0,
+    Fun
+) ->
+    init_counters(),
+    {Snapshot, PerLevelIterators} = init_iterators(S, Static, Varying, Interval),
+    %% ?tp(notice, skipstream_init_iters, #{it => It, its => Iterators}),
+    try
+        TopicStructure = get_topic_structure(Trie, Static),
+        Ctx = #fold_ctx{
+            s = S,
+            f = Fun,
+            iters = PerLevelIterators,
+            topic_structure = TopicStructure,
+            filter = Varying,
+            static = Static,
+            %% Note on half-closed intervals: lower_endpoint field is
+            %% compared < against visited stream keys. Since every
+            %% stream key is a binary, using an atom shunts this
+            %% comparison: according to Erlang term order binary is
+            %% greater than atom, so every key is accepted.
+            lower_endpoint =
+                case LEType of
+                    '(' ->
+                        LowerEndpoint;
+                    '[' ->
+                        '-infinity'
+                end,
+            upper_endpoint = UpperEndpoint
+        },
+        StartPoint =
+            case LowerEndpoint of
+                '-infinity' ->
+                    <<>>;
+                _ when is_binary(LowerEndpoint) ->
+                    LowerEndpoint
+            end,
+        fold_loop(Ctx, StartPoint, BatchSize, {seek, StartPoint}, Acc0)
+    catch
+        EC:Err:Stack ->
+            %% FIXME:
+            ?err_unrec({EC, Err, Stack})
+    after
+        free_iterators(PerLevelIterators),
+        _ = rocksdb:release_snapshot(Snapshot),
+        collect_counters(DBShard)
+    end.
+
+%%================================================================================
+%% Internal exports
+%%================================================================================
+
+%%================================================================================
+%% Internal functions
+%%===============================================================================
+
+%%%% Trie
+
+push_lts_persist_op(Key, Val) ->
+    case erlang:get(?lts_persist_ops) of
+        undefined ->
+            erlang:put(?lts_persist_ops, [{Key, Val}]);
+        L when is_list(L) ->
+            erlang:put(?lts_persist_ops, [{Key, Val} | L])
+    end.
+
+read_persisted_trie(It, {ok, KeyB, ValB}) ->
+    [
+        {binary_to_term(KeyB), binary_to_term(ValB)}
+        | read_persisted_trie(It, rocksdb:iterator_move(It, next))
+    ];
+read_persisted_trie(_It, {error, invalid_iterator}) ->
+    [].
+
+%%%% Fold %%%%
+
+%% @doc Init RockDB iterators for each non-wildcard level of indices,
+%% order is important: e.g. [L1, L2, L3, L0].
+-spec init_iterators(s(), emqx_ds_lts:static_key(), emqx_ds:topic_filter(), fold_interval()) ->
+    {rocksdb:snapshot_handle(), [l()]}.
+init_iterators(S, Static, CompressedTF, Interval) ->
+    {ok, Snapshot} = rocksdb:snapshot(S#s.db),
+    {Snapshot, do_init_iterators(S, Snapshot, Static, CompressedTF, Interval, 1)}.
+
+do_init_iterators(S, Snapshot, Static, ['#'], Interval, WildcardLevel) ->
+    do_init_iterators(S, Snapshot, Static, [], Interval, WildcardLevel);
+do_init_iterators(S, Snapshot, Static, ['+' | TopicFilter], Interval, WildcardLevel) ->
+    %% Ignore wildcard levels in the topic filter because it has no value to index '+'
+    do_init_iterators(S, Snapshot, Static, TopicFilter, Interval, WildcardLevel + 1);
+do_init_iterators(S, Snapshot, Static, [Constraint | TopicFilter], Interval, WildcardLevel) ->
+    %% Create iterator for the index stream:
+    #s{db = DB, data_cf = DataCF, hash_bytes = HashBytes} = S,
+    Hash = hash_topic_level(HashBytes, Constraint),
+    {ok, ItHandle} = rocksdb:iterator(
+        DB, DataCF, get_key_range(S, Snapshot, Static, Interval, WildcardLevel, Hash)
+    ),
+    It = #l{
+        n = WildcardLevel,
+        handle = ItHandle,
+        hash = Hash
+    },
+    [It | do_init_iterators(S, Snapshot, Static, TopicFilter, Interval, WildcardLevel + 1)];
+do_init_iterators(S, Snapshot, Static, [], Interval, _WildcardLevel) ->
+    %% Create an iterator for the data stream:
+    #s{db = DB, data_cf = DataCF} = S,
+    {ok, ItHandle} = rocksdb:iterator(
+        DB, DataCF, get_key_range(S, Snapshot, Static, Interval, 0, <<>>)
+    ),
+    [
+        #l{
+            n = 0,
+            handle = ItHandle,
+            hash = <<>>
+        }
+    ].
+
+get_key_range(_S, Snapshot, Static, {_, Lower, Upper}, WildcardLevel, Hash) ->
+    %% Note: rocksdb treats lower bound as inclusive
+    L =
+        case Lower of
+            '-infinity' -> <<>>;
+            _ -> Lower
+        end,
+    %% Note: rocksdb treats upper bound as non-inclusive
+    U =
+        case Upper of
+            'infinity' ->
+                stream_limit(Static, WildcardLevel, Hash);
+            _ ->
+                mk_key(Static, WildcardLevel, Hash, Upper)
+        end,
+    [
+        {iterate_lower_bound, mk_key(Static, WildcardLevel, Hash, L)},
+        {iterate_upper_bound, U},
+        {snapshot, Snapshot}
+    ].
+
+%% @doc Calculate `iterate_upper_bound' of the rocksdb iterator that
+%% covers _all_ values in the stream.
+-spec stream_limit(emqx_ds_lts:static_key(), wildcard_idx(), wildcard_hash()) -> binary().
+stream_limit(Static, 0, _) ->
+    %% Data stream:
+    mk_key(Static, 1, <<>>, <<>>);
+stream_limit(_, WcLevel, _) when WcLevel >= 16#ffff ->
+    error(too_many_wildcard_levels);
+stream_limit(Static, WcLevel, Hash) ->
+    Sz = bit_size(Hash),
+    <<HashInt:Sz>> = Hash,
+    case 1 bsl Sz - 1 of
+        HashInt ->
+            %% This happens to be the maximum hash of the given size.
+            %% We increase the wildcard index instead:
+            mk_key(Static, WcLevel + 1, <<>>, <<>>);
+        _ ->
+            mk_key(Static, WcLevel, <<(HashInt + 1):Sz>>, <<>>)
+    end.
+
+free_iterators(Its) ->
+    lists:foreach(
+        fun(#l{handle = IH}) ->
+            ok = rocksdb:iterator_close(IH)
+        end,
+        Its
+    ).
+
+fold_loop(_Ctx, LastKey, 0, _Op, Acc) ->
+    {ok, LastKey, Acc};
+fold_loop(Ctx, SK0, BatchSize, Op, Acc0) ->
+    ?dbg(skipstream_loop, #{
+        sk => SK0, tf => Ctx#fold_ctx.filter, bs => BatchSize, op => Op
+    }),
+    #fold_ctx{
+        s = S,
+        f = Fun,
+        iters = Iterators,
+        static = StaticIdx,
+        filter = CompressedTF,
+        upper_endpoint = UpperEndpoint
+    } = Ctx,
+    %% Note: `next_step' function destructively updates RocksDB
+    %% iterators in `ctx.iters' (they are handles, not values!),
+    %% therefore a recursive call with the same arguments is not a
+    %% bug.
+    case fold_step(S, StaticIdx, CompressedTF, Iterators, any, Op) of
+        none ->
+            ?dbg(skipstream_loop_result, #{r => none}),
+            inc_counter(?DS_SKIPSTREAM_LTS_EOS),
+            {ok, SK0, Acc0};
+        {seek, SK} when is_binary(UpperEndpoint), SK >= UpperEndpoint ->
+            %% Iteration reached the upper endpoint:
+            ?dbg(skipstream_loop_seek_upper, #{to => SK, upper => UpperEndpoint}),
+            {ok, SK0, Acc0};
+        {seek, SK} ->
+            ?dbg(skipstream_loop_seek, #{r => seek, sk => SK}),
+            fold_loop(Ctx, SK, BatchSize, {seek, SK}, Acc0);
+        {ok, SK, CompressedTopic, DSKey, Val} ->
+            ?dbg(skipstream_loop_result, #{r => ok, sk => SK, key => DSKey}),
+            case Ctx#fold_ctx.lower_endpoint < SK of
+                true ->
+                    Acc = Fun(Ctx#fold_ctx.topic_structure, DSKey, CompressedTopic, Val, Acc0),
+                    fold_loop(Ctx, SK, BatchSize - 1, next, Acc);
+                false ->
+                    fold_loop(Ctx, SK, BatchSize, next, Acc0)
+            end
+    end.
+
+fold_step(
+    S = #s{get_topic = GetTopic},
+    StaticIdx,
+    CompressedTF,
+    [#l{hash = Hash, handle = IH, n = Level} | Iterators],
+    ExpectedSK,
+    Op
+) ->
+    Result =
+        case Op of
+            next ->
+                inc_counter(?DS_SKIPSTREAM_LTS_NEXT),
+                rocksdb:iterator_move(IH, next);
+            {seek, SK} ->
+                inc_counter(?DS_SKIPSTREAM_LTS_SEEK),
+                rocksdb:iterator_move(IH, {seek, mk_key(StaticIdx, Level, Hash, SK)})
+        end,
+    case Result of
+        {error, invalid_iterator} ->
+            ?dbg(?MODULE_STRING "_step_limit", #{
+                level => Level
+            }),
+            none;
+        {ok, Key, Blob} ->
+            case match_key(StaticIdx, Level, Hash, Key) of
+                false ->
+                    %% This should not happen, since we set boundaries
+                    %% to the iterators, and overflow to a different
+                    %% key prefix should be caught by the previous
+                    %% clause:
+                    none;
+                NextSK when ExpectedSK =:= any; NextSK =:= ExpectedSK ->
+                    %% We found a key that corresponds to the stream key
+                    %% (timestamp) we expect.
+                    ?dbg(?MODULE_STRING "_step_hit", #{
+                        next => NextSK, expected => ExpectedSK, level => Level
+                    }),
+                    case Iterators of
+                        [] ->
+                            %% Last one in PerLevelIterators is the one and the only one data stream.
+                            0 = Level,
+                            %% This is data stream as well. Check
+                            %% message for hash collisions and return
+                            %% value:
+                            Val = deserialize(S, Blob),
+                            CompressedTopic = GetTopic(NextSK, Val),
+                            case emqx_topic:match(CompressedTopic, CompressedTF) of
+                                true ->
+                                    inc_counter(?DS_SKIPSTREAM_LTS_HIT),
+                                    {ok, NextSK, CompressedTopic, Key, Val};
+                                false ->
+                                    %% Hash collision. Advance to the
+                                    %% next key:
+                                    inc_counter(?DS_SKIPSTREAM_LTS_HASH_COLLISION),
+                                    %% FIXME: this part is different
+                                    %% than in the original file, make
+                                    %% sure this path is covered by
+                                    %% tests.
+                                    next
+                            end;
+                        _ ->
+                            %% This is index stream. Keep matching NextSK in other levels.
+                            fold_step(
+                                S, StaticIdx, CompressedTF, Iterators, NextSK, {seek, NextSK}
+                            )
+                    end;
+                NextSK when NextSK > ExpectedSK, Level > 0 ->
+                    %% Next index level is not what we expect. Reset
+                    %% search to the first wildcard index, but
+                    %% continue from `NextSK'.
+                    %%
+                    %% Note: if `NextSK > ExpectedSK' and `N =:= 0',
+                    %% it means the upper (replication) level is
+                    %% broken and supplied us NextSK that advenced
+                    %% past the point of time that can be safely read.
+                    %% We don't handle it here.
+                    inc_counter(?DS_SKIPSTREAM_LTS_MISS),
+                    {seek, NextSK};
+                NextSK ->
+                    error(#{
+                        reason => internal_error,
+                        move => Op,
+                        static => StaticIdx,
+                        next_sk => NextSK,
+                        expected_sk => ExpectedSK,
+                        n => Level
+                    })
+            end
+    end.
+
+%% Misc.
+
+get_topic_structure(Trie, StaticIdx) ->
+    case emqx_ds_lts:reverse_lookup(Trie, StaticIdx) of
+        {ok, Rev} ->
+            Rev;
+        undefined ->
+            throw(#{
+                msg => "LTS trie missing key",
+                key => StaticIdx
+            })
+    end.
+
+%% Counters
+
+inc_counter(Counter) ->
+    N = get(Counter),
+    put(Counter, N + 1).
+
+init_counters() ->
+    _ = [put(I, 0) || I <- ?COUNTERS],
+    ok.
+
+collect_counters(Shard) ->
+    lists:foreach(
+        fun(Key) ->
+            emqx_ds_builtin_metrics:collect_shard_counter(Shard, Key, get(Key))
+        end,
+        ?COUNTERS
+    ).
+
+%%%%%%%% Indexes %%%%%%%%%%
+
+mk_index(Batch, CF, HashBytes, Static, Varying, StreamKey) ->
+    do_mk_index(Batch, CF, HashBytes, Static, 1, Varying, StreamKey).
+
+do_mk_index(Batch, CF, HashBytes, Static, N, [TopicLevel | Varying], StreamKey) ->
+    Key = mk_key(Static, N, hash_topic_level(HashBytes, TopicLevel), StreamKey),
+    ok = rocksdb:batch_put(Batch, CF, Key, <<>>),
+    do_mk_index(Batch, CF, HashBytes, Static, N + 1, Varying, StreamKey);
+do_mk_index(_Batch, _CF, _HashBytes, _Static, _N, [], _StreamKey) ->
+    ok.
+
+delete_index(Batch, CF, HashBytes, Static, Varying, StreamKey) ->
+    do_delete_index(Batch, CF, HashBytes, Static, 1, Varying, StreamKey).
+
+do_delete_index(Batch, CF, HashBytes, Static, N, [TopicLevel | Varying], StreamKey) ->
+    Key = mk_key(Static, N, hash_topic_level(HashBytes, TopicLevel), StreamKey),
+    ok = rocksdb:batch_delete(Batch, CF, Key),
+    do_delete_index(Batch, CF, HashBytes, Static, N + 1, Varying, StreamKey);
+do_delete_index(_Batch, _CF, _HashBytes, _Static, _N, [], _StreamKey) ->
+    ok.
+
+%% Key
+
+mk_master_key(StaticIdx, StreamKey) ->
+    %% Data stream is identified by wildcard level = 0
+    <<StaticIdx/binary, 0:?wcb, StreamKey/binary>>.
+
+mk_index_key(StaticIdx, WildcardLevel, Hash, StreamKey) ->
+    <<StaticIdx/binary, WildcardLevel:?wcb/big, Hash/binary, StreamKey/binary>>.
+
+%% Hashing
+
+hash_topic_level(HashBytes, TopicLevel) ->
+    <<Ret:HashBytes/binary, _/binary>> = hash_topic_level(TopicLevel),
+    Ret.
+
+hash_topic_level(TopicLevel) ->
+    erlang:md5(TopicLevel).
+
+%% Serialization
+
+deserialize(
+    #s{serialization_schema = SSchema},
+    Blob
+) ->
+    emqx_ds_msg_serializer:deserialize(SSchema, Blob).
+
+-ifdef(TEST).
+
+%% Verify calculation of the upper bound for rocksdb iterators
+rocksdb_upper_limit_test() ->
+    %% End of the data stream is always calculated as the beginning of
+    %% the index stream:
+    ?assertMatch(
+        <<"static", 1:?wcb>>,
+        stream_limit(<<"static">>, 0, <<>>)
+    ),
+    %% Index streams:
+    %% 1. 1st level, 8-bit hash, no overflow:
+    ?assertMatch(
+        <<"static", 1:?wcb, 2:8>>,
+        stream_limit(<<"static">>, 1, <<1:8>>)
+    ),
+    ?assertMatch(
+        <<"static", 1:?wcb, 255:8>>,
+        stream_limit(<<"static">>, 1, <<254:8>>)
+    ),
+    %% 2. 1st level, 8-bit hash, overflow:
+    ?assertMatch(
+        <<"static", 2:?wcb>>,
+        stream_limit(<<"static">>, 1, <<16#ff:8>>)
+    ),
+    %% 3. 10th level, 128-bit hash, no overflow:
+    ?assertMatch(
+        <<"hello", 10:?wcb, "0123456789ABCDEG">>,
+        stream_limit(<<"hello">>, 10, <<"0123456789ABCDEF">>)
+    ),
+    %% 3. 10th level, 128-bit hash, overflow:
+    ?assertMatch(
+        <<"hello", 11:?wcb>>,
+        stream_limit(<<"hello">>, 10, <<(1 bsl 128 - 1):128>>)
+    ),
+    %% 4. Last valid wildcard hash level, 16-bit hash, overflow:
+    ?assertMatch(
+        <<"hello", 16#ffff:?wcb>>,
+        stream_limit(<<"hello">>, 16#ffff - 1, <<16#ffff:16>>)
+    ),
+    %% 5. Too many wildcard levels:
+    ?assertError(
+        too_many_wildcard_levels,
+        stream_limit(<<"hello">>, 16#ffff, <<"hash">>)
+    ),
+    ?assertError(
+        too_many_wildcard_levels,
+        stream_limit(<<"hello">>, 16#100000, <<"hash">>)
+    ).
+
+-endif.

--- a/apps/emqx_durable_storage/src/emqx_ds_lib.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_lib.erl
@@ -77,7 +77,7 @@ cancel_timer(TRef, TimeoutMsg) ->
         ok
     end.
 
-%% @doc A non-throwing version of ets:delete
+%% @doc A non-throwing version of `ets:delete/1'
 ets_delete(Tid) ->
     try
         ets:delete(Tid)

--- a/apps/emqx_durable_storage/src/emqx_ds_lib.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_lib.erl
@@ -7,7 +7,15 @@
 -include_lib("snabbkaffe/include/trace.hrl").
 
 %% API:
--export([with_worker/3, terminate/3, send_after/3, cancel_timer/2, ets_delete/1]).
+-export([
+    with_worker/3,
+    terminate/3,
+    send_after/3,
+    cancel_timer/2,
+    ets_delete/1,
+    tf_to_asn1/1,
+    asn1_to_tf/1
+]).
 
 %% internal exports:
 -export([]).
@@ -77,6 +85,42 @@ ets_delete(Tid) ->
         _:_ ->
             ok
     end.
+
+%% @doc Transform normal representation of the topic filter to
+%% serializable representation defined in DSMetadataCommon ASN.1
+%% schema
+tf_to_asn1(TF) ->
+    lists:map(
+        fun(Level) ->
+            case Level of
+                '+' ->
+                    {plus, 'NULL'};
+                '#' ->
+                    {hash, 'NULL'};
+                B when is_binary(B) ->
+                    {const, B};
+                '' ->
+                    {const, <<>>}
+            end
+        end,
+        TF
+    ).
+
+%% @doc Opposite to tf_to_asn1 modulo empty topic level
+asn1_to_tf(ASN1) ->
+    lists:map(
+        fun(Level) ->
+            case Level of
+                {plus, 'NULL'} ->
+                    '+';
+                {hash, 'NULL'} ->
+                    '#';
+                {const, Const} ->
+                    Const
+            end
+        end,
+        ASN1
+    ).
 
 %%================================================================================
 %% Internal exports

--- a/apps/emqx_durable_storage/src/emqx_ds_lib.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_lib.erl
@@ -7,7 +7,7 @@
 -include_lib("snabbkaffe/include/trace.hrl").
 
 %% API:
--export([with_worker/3, terminate/3, send_after/3, cancel_timer/2]).
+-export([with_worker/3, terminate/3, send_after/3, cancel_timer/2, ets_delete/1]).
 
 %% internal exports:
 -export([]).
@@ -67,6 +67,15 @@ cancel_timer(TRef, TimeoutMsg) ->
             ok
     after 0 ->
         ok
+    end.
+
+%% @doc A non-throwing version of ets:delete
+ets_delete(Tid) ->
+    try
+        ets:delete(Tid)
+    catch
+        _:_ ->
+            ok
     end.
 
 %%================================================================================

--- a/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl
@@ -52,7 +52,7 @@ check_schema(verbatim) ->
 check_schema(_) ->
     {error, "Unknown schema type"}.
 
--spec serialize(schema(), tuple()) -> binary().
+-spec serialize(schema(), emqx_types:message() | binary()) -> binary().
 serialize(v1, Msg) ->
     serialize_v1(Msg);
 serialize(asn1, Msg) ->
@@ -60,7 +60,7 @@ serialize(asn1, Msg) ->
 serialize(verbatim, Blob) ->
     Blob.
 
--spec deserialize(schema(), binary()) -> tuple().
+-spec deserialize(schema(), binary()) -> emqx_types:message() | binary().
 deserialize(v1, Blob) ->
     deserialize_v1(Blob);
 deserialize(asn1, Blob) ->

--- a/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_msg_serializer.erl
@@ -47,26 +47,20 @@ check_schema(v1) ->
     ok;
 check_schema(asn1) ->
     ok;
-check_schema(verbatim) ->
-    ok;
 check_schema(_) ->
     {error, "Unknown schema type"}.
 
--spec serialize(schema(), emqx_types:message() | binary()) -> binary().
+-spec serialize(schema(), emqx_types:message()) -> binary().
 serialize(v1, Msg) ->
     serialize_v1(Msg);
 serialize(asn1, Msg) ->
-    serialize_asn1(Msg);
-serialize(verbatim, Blob) ->
-    Blob.
+    serialize_asn1(Msg).
 
--spec deserialize(schema(), binary()) -> emqx_types:message() | binary().
+-spec deserialize(schema(), binary()) -> emqx_types:message().
 deserialize(v1, Blob) ->
     deserialize_v1(Blob);
 deserialize(asn1, Blob) ->
-    deserialize_asn1(Blob);
-deserialize(verbatim, Blob) ->
-    Blob.
+    deserialize_asn1(Blob).
 
 %%================================================================================
 %% Internal functions

--- a/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
@@ -96,7 +96,7 @@
     emqx_ds:topic(),
     emqx_ds:time()
 ) ->
-    {ok, emqx_ds:value()} | undefined | emqx_ds:error(_).
+    {ok, binary()} | undefined | emqx_ds:error(_).
 
 %% Configuration that can be changed in the runtime.
 -type runtime_config() :: #{

--- a/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
@@ -1,0 +1,472 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc This module serves the same role as `emqx_ds_buffer', but it's
+%% suited for transactions. Also, it runs on the leader node as
+%% opposed to the buffer.
+-module(emqx_ds_optimistic_tx).
+
+-behaviour(gen_statem).
+
+%% API:
+-export([
+    start_link/3,
+
+    where/2,
+
+    new_kv_tx_ctx/6,
+    commit_kv_tx/3
+]).
+
+%% Behaviour callbacks
+-export([
+    init/1,
+    handle_event/4,
+    callback_mode/0
+]).
+
+-export_type([
+    ctx/0,
+    serial/0
+]).
+
+-include("emqx_ds.hrl").
+-include("emqx_ds_builtin_tx.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%%================================================================================
+%% Type declarations
+%%================================================================================
+
+-type serial() :: integer().
+
+-callback get_tx_serial({emqx_ds:db(), emqx_ds:shard()}) -> serial().
+
+-callback prepare_kv_tx(
+    {emqx_ds:db(), emqx_ds:shard()}, emqx_ds:generation(), binary(), emqx_ds:kv_tx_ops(), _
+) ->
+    {ok, _CookedTx}
+    | emqx_ds:error(_).
+
+-callback commit_kv_tx_batch({emqx_ds:db(), emqx_ds:shard()}, emqx_ds:generation(), serial(), [
+    _CookedTx
+]) ->
+    ok
+    | emqx_ds:error(_).
+
+-callback update_tx_serial({emqx_ds:db(), emqx_ds:shard()}, serial(), serial()) ->
+    ok
+    | emqx_ds:error(_).
+
+-type ctx() :: #kv_tx_ctx{}.
+
+-define(name(DB, SHARD), {n, l, {?MODULE, DB, SHARD}}).
+-define(via(DB, SHARD), {via, gproc, ?name(DB, SHARD)}).
+
+%% States
+-define(leader(SUBSTATE), {leader, SUBSTATE}).
+-define(idle, idle).
+-define(pending, pending).
+
+%% Timeouts
+%%   Flush pending transactions to the storage:
+-define(timeout_flush, timout_flush).
+
+-record(gen_data, {
+    dirty :: emqx_ds_tx_conflict_trie:t(),
+    buffer = [],
+    pending_replies = []
+}).
+
+-type gen_data() :: #gen_data{}.
+
+-record(d, {
+    dbshard,
+    cbm,
+    flush_interval,
+    rotate_interval,
+    last_rotate_ts,
+    serial,
+    committed_serial,
+    gens = #{} :: #{emqx_ds:generation() => gen_data()}
+}).
+
+%%================================================================================
+%% API functions
+%%================================================================================
+
+-spec where(emqx_ds:db(), emqx_ds:shard()) -> pid() | undefined.
+where(DB, Shard) ->
+    gproc:whereis_name(?name(DB, Shard)).
+
+-spec start_link(emqx_ds:db(), emqx_ds:shard(), module()) -> {ok, pid()}.
+start_link(DB, Shard, CBM) ->
+    gen_statem:start_link(?via(DB, Shard), ?MODULE, [DB, Shard, CBM], []).
+
+-spec new_kv_tx_ctx(
+    emqx_ds:db(), emqx_ds:shard(), emqx_ds:generation(), pid(), emqx_ds:transaction_opts(), serial()
+) ->
+    ctx().
+new_kv_tx_ctx(_DB, Shard, Generation, Leader, Options, Serial) ->
+    #kv_tx_ctx{
+        shard = Shard,
+        leader = Leader,
+        serial = Serial,
+        generation = Generation,
+        opts = Options
+    }.
+
+commit_kv_tx(DB, Ctx = #kv_tx_ctx{opts = #{timeout := Timeout}}, Ops) ->
+    ?tp(emqx_ds_optimistic_tx_commit_begin, #{db => DB, ctx => Ctx, ops => Ops}),
+    #kv_tx_ctx{leader = Leader} = Ctx,
+    Ref = monitor(process, Leader),
+    %% Note: currently timer is not canceled when commit abort is
+    %% signalled via the monitor message (i.e. when the leader process
+    %% is down). In this case the caller _will_ receive double `DOWN'.
+    %% There's no trivial way to fix it. It's up to the client to
+    %% track the pending transactions and ignore unexpected commit
+    %% notifications.
+    TRef = emqx_ds_lib:send_after(Timeout, self(), tx_timeout_msg(Ref)),
+    gen_statem:cast(Leader, #ds_tx{
+        ctx = Ctx, ops = Ops, from = self(), ref = Ref, meta = TRef
+    }),
+    Ref.
+
+%%================================================================================
+%% Behavior callbacks
+%%================================================================================
+
+callback_mode() ->
+    [handle_event_function, state_enter].
+
+init([DB, Shard, CBM]) ->
+    RI = 5_000,
+    Serial = CBM:get_tx_serial({DB, Shard}),
+    {ok, ?leader(?idle), #d{
+        dbshard = {DB, Shard},
+        cbm = CBM,
+        rotate_interval = RI,
+        last_rotate_ts = erlang:monotonic_time(millisecond),
+        %% FIXME: hardcode
+        flush_interval = 10,
+        serial = Serial,
+        committed_serial = Serial
+    }}.
+
+handle_event(enter, _OldState, ?leader(?pending), #d{flush_interval = T}) ->
+    %% Schedule unconditional flush after the given interval:
+    {keep_state_and_data, {state_timeout, T, ?timeout_flush}};
+handle_event(enter, _, _, _) ->
+    keep_state_and_data;
+handle_event(cast, Tx = #ds_tx{}, ?leader(State), D0) ->
+    %% Enqueue transaction commit:
+    case handle_tx(D0, Tx) of
+        {ok, D} ->
+            %% Schedule early flush if the shard is idle:
+            IdleInterval = 1,
+            Timeout = {timeout, IdleInterval, ?timeout_flush},
+            case State of
+                ?idle ->
+                    {next_state, ?leader(?pending), D, Timeout};
+                _ ->
+                    {keep_state, D, Timeout}
+            end;
+        aborted ->
+            keep_state_and_data
+    end;
+handle_event(cast, #ds_tx{from = From, ref = Ref, meta = Meta}, _Other, _) ->
+    reply_error(From, Ref, Meta, recoverable, not_the_leader),
+    keep_state_and_data;
+handle_event(ET, ?timeout_flush, ?leader(_State), D0) when ET =:= state_timeout; ET =:= timeout ->
+    %% Execute flush. After flushing the buffer it's safe to rotate
+    %% the conflict tree.
+    D = maybe_rotate(flush(D0)),
+    {next_state, ?leader(?idle), D};
+handle_event(ET, Event, State, _D) ->
+    ?tp(
+        error,
+        emqx_ds_tx_serializer_unknown_event,
+        #{ET => Event, state => State}
+    ),
+    keep_state_and_data.
+
+%%================================================================================
+%% Internal functions
+%%================================================================================
+
+handle_tx(
+    D = #d{
+        dbshard = DBShard,
+        cbm = CBM,
+        serial = Serial,
+        committed_serial = SafeToReadSerial,
+        gens = Gens
+    },
+    Tx
+) ->
+    #ds_tx{ref = TxRef, ctx = #kv_tx_ctx{generation = Gen}} = Tx,
+    ?tp(
+        emqx_ds_optimistic_tx_commit_received,
+        #{
+            shard => DBShard,
+            serial => Serial,
+            committed_serial => SafeToReadSerial,
+            ref => TxRef,
+            tx => Tx
+        }
+    ),
+    case Gens of
+        #{Gen := GS0} ->
+            ok;
+        #{} ->
+            GS0 = #gen_data{dirty = emqx_ds_tx_conflict_trie:new(Serial, infinity)}
+    end,
+    PresumedCommitSerial = Serial + 1,
+    case try_commit(DBShard, Gen, CBM, SafeToReadSerial, PresumedCommitSerial, Tx, GS0) of
+        {ok, GS} ->
+            ?tp(emqx_ds_optimistic_tx_commit_pending, #{ref => TxRef}),
+            {ok, D#d{
+                serial = PresumedCommitSerial,
+                gens = Gens#{Gen => GS}
+            }};
+        aborted ->
+            aborted
+    end.
+
+try_commit(
+    DBShard,
+    Gen,
+    CBM,
+    SafeToReadSerial,
+    PresumedCommitSerial,
+    Tx,
+    GS = #gen_data{dirty = Dirty0, buffer = Buff, pending_replies = Pending}
+) ->
+    #ds_tx{
+        ctx = Ctx,
+        ops = Ops,
+        from = From,
+        ref = Ref,
+        meta = Meta
+    } = Tx,
+    #kv_tx_ctx{serial = TxStartSerial} = Ctx,
+    maybe
+        ok ?= check_conflicts(Dirty0, TxStartSerial, SafeToReadSerial, Ops),
+        ok ?= verify_preconditions(DBShard, Gen, Ops),
+        {ok, CookedTx} ?=
+            CBM:prepare_kv_tx(
+                DBShard, Gen, serial_bin(PresumedCommitSerial), Ops, #{}
+            ),
+        Dirty = update_dirty(PresumedCommitSerial, Ops, Dirty0),
+        {ok, GS#gen_data{
+            dirty = Dirty,
+            buffer = [CookedTx | Buff],
+            pending_replies = [{From, Ref, Meta, PresumedCommitSerial} | Pending]
+        }}
+    else
+        {error, Class, Error} ->
+            ?tp(
+                debug,
+                emqx_ds_optimistic_tx_commit_abort,
+                #{
+                    ref => Ref, ec => Class, reason => Error, stage => prepare
+                }
+            ),
+            reply_error(From, Ref, Meta, Class, Error),
+            aborted
+    end.
+
+update_dirty(Serial, Ops, Dirty0) ->
+    %% Mark all deleted topics as dirty:
+    Dirty1 = lists:foldl(
+        fun(TF, Acc) ->
+            emqx_ds_tx_conflict_trie:push(
+                emqx_ds_tx_conflict_trie:topic_filter_to_conflict_domain(TF),
+                Serial,
+                Acc
+            )
+        end,
+        Dirty0,
+        maps:get(?ds_tx_delete_topic, Ops, [])
+    ),
+    %% Mark written topics as dirty:
+    lists:foldl(
+        fun({TF, _Val}, Acc) ->
+            emqx_ds_tx_conflict_trie:push(TF, Serial, Acc)
+        end,
+        Dirty1,
+        maps:get(?ds_tx_write, Ops, [])
+    ).
+
+flush(
+    D = #d{dbshard = DBShard, cbm = CBM, committed_serial = SerCtl, serial = Serial, gens = Gens0}
+) ->
+    Gens = maps:map(
+        fun(Gen, GS = #gen_data{buffer = Buf, pending_replies = Replies, dirty = Dirty}) ->
+            ?tp(emqx_ds_optimistic_tx_flush, #{
+                shard => DBShard,
+                generation => Gen,
+                buffer => Buf,
+                conflict_tree => emqx_ds_tx_conflict_trie:print(Dirty)
+            }),
+            _ =
+                case CBM:commit_kv_tx_batch(DBShard, Gen, SerCtl, Buf) of
+                    ok ->
+                        [
+                            reply_success(From, Ref, Meta, CommitSerial)
+                         || {From, Ref, Meta, CommitSerial} <- Replies
+                        ];
+                    {error, Class, Err} ->
+                        [
+                            reply_error(From, Ref, Meta, Class, Err)
+                         || {From, Ref, Meta, _CommitSerial} <- Replies
+                        ]
+                end,
+            GS#gen_data{
+                dirty = Dirty,
+                buffer = [],
+                pending_replies = []
+            }
+        end,
+        Gens0
+    ),
+    ok = CBM:update_tx_serial(DBShard, SerCtl, Serial),
+    D#d{
+        committed_serial = Serial,
+        gens = Gens
+    }.
+
+serial_bin(A) ->
+    <<A:128>>.
+
+maybe_rotate(D = #d{rotate_interval = RI, last_rotate_ts = LastRotTS}) ->
+    case erlang:monotonic_time(millisecond) - LastRotTS > RI of
+        true ->
+            rotate(D);
+        false ->
+            D
+    end.
+
+rotate(D = #d{gens = Gens0}) ->
+    Gens = maps:map(
+        fun(_, GS = #gen_data{dirty = Dirty}) ->
+            GS#gen_data{
+                dirty = emqx_ds_tx_conflict_trie:rotate(Dirty)
+            }
+        end,
+        Gens0
+    ),
+    D#d{
+        gens = Gens,
+        last_rotate_ts = erlang:monotonic_time(millisecond)
+    }.
+
+check_conflicts(Dirty, TxStartSerial, SafeToReadSerial, Ops) ->
+    maybe
+        ok ?= do_check_conflicts(Dirty, TxStartSerial, maps:get(?ds_tx_read, Ops, [])),
+        %% Deletion of topics involves scanning of the storage. We
+        %% can't do it when there is potentially buffered data:
+        ok ?= do_check_conflicts(Dirty, SafeToReadSerial, maps:get(?ds_tx_delete_topic, Ops, [])),
+        %% Verifying precondition requires reading from the storage
+        %% too. Make sure we don't ignore the cache:
+        ok ?= do_check_conflicts(Dirty, SafeToReadSerial, maps:get(?ds_tx_unexpected, Ops, [])),
+        ExpectedTopics = [Topic || {Topic, _} <- maps:get(?ds_tx_expected, Ops, [])],
+        ok ?= do_check_conflicts(Dirty, SafeToReadSerial, ExpectedTopics)
+    end.
+
+do_check_conflicts(Dirty, Serial, Topics) ->
+    Errors = lists:foldl(
+        fun(ReadTF, Acc) ->
+            case
+                emqx_ds_tx_conflict_trie:is_dirty(
+                    emqx_ds_tx_conflict_trie:topic_filter_to_conflict_domain(ReadTF),
+                    Serial,
+                    Dirty
+                )
+            of
+                false ->
+                    Acc;
+                true ->
+                    [{ReadTF, Serial} | Acc]
+            end
+        end,
+        [],
+        Topics
+    ),
+    case Errors of
+        [] ->
+            ok;
+        _ ->
+            ?err_rec({read_conflict, Errors})
+    end.
+
+verify_preconditions(DBShard, GenId, Ops) ->
+    %% Verify expected values:
+    Unrecoverable0 = lists:foldl(
+        fun({Topic, ValueMatcher}, Acc) ->
+            case lookup_kv(DBShard, GenId, Topic) of
+                {ok, {_, Value}} when
+                    ValueMatcher =:= '_';
+                    ValueMatcher =:= Value
+                ->
+                    Acc;
+                {ok, {_, Value}} ->
+                    [#{topic => Topic, expected => ValueMatcher, got => Value} | Acc];
+                undefined ->
+                    [#{topic => Topic, expected => ValueMatcher, got => undefined} | Acc]
+            end
+        end,
+        [],
+        maps:get(?ds_tx_expected, Ops, [])
+    ),
+    %% Verify unexpected values:
+    Unrecoverable = lists:foldl(
+        fun(Topic, Acc) ->
+            case lookup_kv(DBShard, GenId, Topic) of
+                undefined ->
+                    Acc;
+                {ok, Value} ->
+                    [#{topic => Topic, unexpected => Value} | Acc]
+            end
+        end,
+        Unrecoverable0,
+        maps:get(?ds_tx_unexpected, Ops, [])
+    ),
+    case Unrecoverable of
+        [] ->
+            ok;
+        _ ->
+            ?err_unrec({precondition_failed, Unrecoverable})
+    end.
+
+lookup_kv(DBShard, GenId, Topic) ->
+    emqx_ds_storage_layer_kv:lookup_kv(DBShard, GenId, Topic).
+
+tx_timeout_msg(Ref) ->
+    ?ds_tx_commit_error(Ref, undefined, unrecoverable, timeout).
+
+reply_success(From, Ref, Meta, Serial) ->
+    ?tp(
+        emqx_ds_optimistic_tx_commit_success,
+        #{client => From, ref => Ref, meta => Meta, serial => Serial}
+    ),
+    From ! ?ds_tx_commit_ok(Ref, Meta, serial_bin(Serial)),
+    ok.
+
+reply_error(From, Ref, Meta, Class, Error) ->
+    ?tp(
+        debug,
+        emqx_ds_optimistic_tx_commit_abort,
+        #{client => From, ref => Ref, meta => Meta, ec => Class, reason => Error, stage => final}
+    ),
+    From ! ?ds_tx_commit_error(Ref, Meta, Class, Error),
+    ok.
+
+%%================================================================================
+%% Tests
+%%================================================================================

--- a/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
@@ -13,7 +13,9 @@
 %%
 %% Buffer is periodically flushed in a single call the backend.
 %%
-%% Leader also keeps the transaction serial.
+%% Leader is also tasked with keeping and incrementing the transaction
+%% serial for the pending transactions. The latest serial is committed
+%% to the storage together with the batches.
 %%
 %% Potential split brain situations are handled optimistically: the
 %% backend can reject flush request.

--- a/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
@@ -595,7 +595,7 @@ verify_preconditions(DBShard, CBM, GenId, Ops) ->
     end.
 
 tx_timeout_msg(Ref) ->
-    ?ds_tx_commit_error(Ref, undefined, unrecoverable, timeout).
+    ?ds_tx_commit_error(Ref, undefined, unrecoverable, commit_timeout).
 
 reply_success(From, Ref, Meta, Serial) ->
     ?tp(

--- a/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_optimistic_tx.erl
@@ -408,17 +408,17 @@ do_check_conflicts(Dirty, Serial, Topics) ->
 verify_preconditions(DBShard, GenId, Ops) ->
     %% Verify expected values:
     Unrecoverable0 = lists:foldl(
-        fun({Topic, ValueMatcher}, Acc) ->
+        fun({Topic, ExpectedValue}, Acc) ->
             case lookup_kv(DBShard, GenId, Topic) of
-                {ok, {_, Value}} when
-                    ValueMatcher =:= '_';
-                    ValueMatcher =:= Value
+                {ok, Value} when
+                    ExpectedValue =:= '_';
+                    ExpectedValue =:= Value
                 ->
                     Acc;
-                {ok, {_, Value}} ->
-                    [#{topic => Topic, expected => ValueMatcher, got => Value} | Acc];
+                {ok, Value} ->
+                    [#{topic => Topic, expected => ExpectedValue, got => Value} | Acc];
                 undefined ->
-                    [#{topic => Topic, expected => ValueMatcher, got => undefined} | Acc]
+                    [#{topic => Topic, expected => ExpectedValue, got => undefined} | Acc]
             end
         end,
         [],

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_bitfield_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_bitfield_lts.erl
@@ -186,7 +186,7 @@
 %%================================================================================
 
 -spec create(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     rocksdb:db_handle(),
     emqx_ds_storage_layer:gen_id(),
     options(),
@@ -233,7 +233,7 @@ create(_ShardId, DBHandle, GenId, Options, SPrev, _DBOpts) ->
     {Schema, [{DataCFName, DataCFHandle}, {TrieCFName, TrieCFHandle}]}.
 
 -spec open(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     rocksdb:db_handle(),
     emqx_ds_storage_layer:gen_id(),
     emqx_ds_storage_layer:cf_refs(),
@@ -275,7 +275,7 @@ open(_Shard, DBHandle, GenId, CFRefs, Schema) ->
     }.
 
 -spec drop(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     rocksdb:db_handle(),
     emqx_ds_storage_layer:gen_id(),
     emqx_ds_storage_layer:cf_refs(),
@@ -292,7 +292,7 @@ drop(_Shard, DBHandle, GenId, CFRefs, #s{trie = Trie, gvars = GVars}) ->
     ok.
 
 -spec prepare_batch(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     emqx_ds_storage_layer:batch(),
     emqx_ds_storage_layer:batch_store_opts()
@@ -321,7 +321,7 @@ prepare_batch(_ShardId, S, Batch, _Options) ->
     }}.
 
 -spec commit_batch(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     cooked_batch(),
     emqx_ds_storage_layer:batch_store_opts()
@@ -375,7 +375,7 @@ commit_batch(
     end.
 
 -spec get_streams(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     emqx_ds:topic_filter(),
     emqx_ds:time()
@@ -384,7 +384,7 @@ get_streams(_Shard, #s{trie = Trie}, TopicFilter, _StartTime) ->
     emqx_ds_lts:match_topics(Trie, TopicFilter).
 
 -spec get_delete_streams(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     emqx_ds:topic_filter(),
     emqx_ds:time()
@@ -393,7 +393,7 @@ get_delete_streams(Shard, State, TopicFilter, StartTime) ->
     get_streams(Shard, State, TopicFilter, StartTime).
 
 -spec make_iterator(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     stream(),
     emqx_ds:topic_filter(),
@@ -414,7 +414,7 @@ make_iterator(
     }}.
 
 -spec make_delete_iterator(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     delete_stream(),
     emqx_ds:topic_filter(),
@@ -435,7 +435,7 @@ make_delete_iterator(
     }}.
 
 -spec update_iterator(
-    emqx_ds_storage_layer:shard_id(),
+    emqx_ds_storage_layer:dbshard(),
     s(),
     iterator(),
     emqx_ds:message_key()
@@ -589,7 +589,7 @@ delete_next_until(
         rocksdb:iterator_close(ITHandle)
     end.
 
--spec lookup_message(emqx_ds_storage_layer:shard_id(), s(), emqx_ds_precondition:matcher()) ->
+-spec lookup_message(emqx_ds_storage_layer:dbshard(), s(), emqx_ds_precondition:matcher()) ->
     emqx_types:message() | not_found | emqx_ds:error(_).
 lookup_message(
     _ShardId,

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_kv_skipstream_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_kv_skipstream_lts.erl
@@ -156,7 +156,7 @@ open(
             trie => Trie,
             serialization_schema => SSchema,
             get_topic => fun(StreamKey, _Val) ->
-                {ok, Varying} = 'DSBuiltinMetadata':decode('TopicWords', StreamKey),
+                {ok, Varying} = decode_stream_key(StreamKey),
                 Varying
             end,
             wildcard_hash_bytes => WCBytes
@@ -404,9 +404,14 @@ get_streams(Trie, TopicFilter) ->
 
 %%%%%%%% Keys %%%%%%%%%%
 
+%% TODO: https://github.com/erlang/otp/issues/9841
+-dialyzer({nowarn_function, [stream_key/1, decode_stream_key/1]}).
 stream_key(Varying) ->
-    {ok, StreamKey} = 'DSBuiltinMetadata':encode('TopicWords', Varying),
+    {ok, StreamKey} = 'DSMetadataCommon':encode('TopicWords', Varying),
     StreamKey.
+
+decode_stream_key(StreamKey) ->
+    'DSMetadataCommon':decode('TopicWords', StreamKey).
 
 %%%%%%%% Column families %%%%%%%%%%
 

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_kv_skipstream_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_kv_skipstream_lts.erl
@@ -1,0 +1,425 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc This module implements a key-value storage layout based on the
+%% "skipstream" indexing + LTS.
+%%
+%% NOTE: Varying topic levels are used as the stream key.
+-module(emqx_ds_storage_kv_skipstream_lts).
+
+-behaviour(emqx_ds_storage_layer_kv).
+
+%% API:
+-export([]).
+
+%% behavior callbacks:
+-export([
+    create/6,
+    open/5,
+    drop/5,
+    prepare_kv_tx/5,
+    commit_batch/4,
+    get_streams/4,
+    make_iterator/5,
+    next/6,
+    lookup_message/4,
+
+    batch_events/3
+]).
+
+%% internal exports:
+-export([]).
+
+%% inline small functions:
+-compile(inline).
+
+-export_type([schema/0, s/0]).
+
+-include_lib("snabbkaffe/include/trace.hrl").
+-include("emqx_ds.hrl").
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+-elvis([{elvis_style, nesting_level, disable}]).
+-elvis([{elvis_style, no_if_expression, disable}]).
+
+%%================================================================================
+%% Type declarations
+%%================================================================================
+
+%% TLOG entry
+%%   Keys:
+-define(cooked_msg_ops, 6).
+-define(cooked_lts_ops, 7).
+%%   Payload:
+-define(cooked_delete, 100).
+-define(cooked_msg_op(STATIC, VARYING, VALUE),
+    {STATIC, VARYING, VALUE}
+).
+
+%% Permanent state:
+-type schema() ::
+    #{
+        %% Number of index key bytes allocated for the hash of topic level.
+        wildcard_hash_bytes := pos_integer(),
+        serialization_schema := emqx_ds_msg_serializer:schema(),
+        with_guid := boolean(),
+        lts_threshold_spec => emqx_ds_lts:threshold_spec()
+    }.
+
+%% Default LTS thresholds: 0th level = 100 entries max, other levels = 10 entries.
+-define(DEFAULT_LTS_THRESHOLD, {simple, {100, 10}}).
+
+%% Runtime state:
+-record(s, {
+    db :: rocksdb:db_handle(),
+    trie :: emqx_ds_lts:trie(),
+    trie_cf :: rocksdb:cf_handle(),
+    serialization_schema :: emqx_ds_msg_serializer:schema(),
+    gs :: emqx_ds_gen_skipstream_lts:s(),
+    threshold_fun :: emqx_ds_lts:threshold_fun()
+}).
+
+-type s() :: #s{}.
+
+-record(kv_stream, {
+    static_index :: emqx_ds_lts:static_key()
+}).
+
+-record(it, {
+    static_index :: emqx_ds_lts:static_key(),
+    %% Key of the last visited message:
+    last_key :: emqx_ds_gen_skipstream_lts:stream_key(),
+    %% Compressed topic filter:
+    compressed_tf :: [emqx_ds_lts:level() | '+']
+}).
+
+%% Last Seen Key placeholder that is used to indicate that the
+%% iterator points at the beginning of the topic.
+-define(lsk_begin, <<>>).
+
+%%================================================================================
+%% API functions
+%%================================================================================
+
+%%================================================================================
+%% behavior callbacks
+%%================================================================================
+
+create(_ShardId, DBHandle, GenId, Schema0, SPrev, _DBOpts) ->
+    Defaults = #{
+        wildcard_hash_bytes => 8,
+        topic_index_bytes => 8,
+        serialization_schema => verbatim,
+        lts_threshold_spec => ?DEFAULT_LTS_THRESHOLD
+    },
+    Schema = maps:merge(Defaults, Schema0),
+    ok = emqx_ds_msg_serializer:check_schema(maps:get(serialization_schema, Schema)),
+    DataCFName = data_cf(GenId),
+    TrieCFName = trie_cf(GenId),
+    {ok, DataCFHandle} = rocksdb:create_column_family(DBHandle, DataCFName, []),
+    {ok, TrieCFHandle} = rocksdb:create_column_family(DBHandle, TrieCFName, []),
+    case SPrev of
+        #s{trie = TriePrev} ->
+            ok = emqx_ds_gen_skipstream_lts:copy_previous_trie(DBHandle, TrieCFHandle, TriePrev),
+            ?tp(layout_inherited_lts_trie, #{}),
+            ok;
+        undefined ->
+            ok
+    end,
+    {Schema, [{DataCFName, DataCFHandle}, {TrieCFName, TrieCFHandle}]}.
+
+open(
+    ShardId,
+    DBHandle,
+    GenId,
+    CFRefs,
+    Schema = #{
+        topic_index_bytes := TIBytes,
+        wildcard_hash_bytes := WCBytes,
+        serialization_schema := SSchema
+    }
+) ->
+    {_, DataCF} = lists:keyfind(data_cf(GenId), 1, CFRefs),
+    {_, TrieCF} = lists:keyfind(trie_cf(GenId), 1, CFRefs),
+    Trie = emqx_ds_gen_skipstream_lts:restore_trie(ShardId, TIBytes, DBHandle, TrieCF),
+    ThresholdSpec = maps:get(lts_threshold_spec, Schema, ?DEFAULT_LTS_THRESHOLD),
+    GS = emqx_ds_gen_skipstream_lts:open(
+        #{
+            db_shard => ShardId,
+            db_handle => DBHandle,
+            data_cf => DataCF,
+            trie_cf => TrieCF,
+            trie => Trie,
+            serialization_schema => SSchema,
+            get_topic => fun(StreamKey, _Val) ->
+                {ok, Varying} = 'DSBuiltinMetadata':decode('TopicWords', StreamKey),
+                Varying
+            end,
+            wildcard_hash_bytes => WCBytes
+        }
+    ),
+    #s{
+        db = DBHandle,
+        trie_cf = TrieCF,
+        trie = Trie,
+        gs = GS,
+        serialization_schema = SSchema,
+        threshold_fun = emqx_ds_lts:threshold_fun(ThresholdSpec)
+    }.
+
+drop(_ShardId, _DBHandle, _GenId, _CFRefs, #s{gs = GS}) ->
+    emqx_ds_gen_skipstream_lts:drop(GS).
+
+prepare_kv_tx(DBShard, S, TXID, Ops, _Options) ->
+    _ = emqx_ds_gen_skipstream_lts:pop_lts_persist_ops(),
+    W = maps:get(?ds_tx_write, Ops, []),
+    DT = maps:get(?ds_tx_delete_topic, Ops, []),
+    try
+        OperationsCooked = cook_blob_deletes(DBShard, S, DT, cook_blob_writes(S, TXID, W, [])),
+        {ok, #{
+            ?cooked_msg_ops => OperationsCooked,
+            ?cooked_lts_ops => emqx_ds_gen_skipstream_lts:pop_lts_persist_ops()
+        }}
+    catch
+        {Type, Err} ->
+            {error, Type, Err}
+    end.
+
+cook_blob_writes(_, _TXID, [], Acc) ->
+    lists:reverse(Acc);
+cook_blob_writes(S = #s{serialization_schema = SSchema}, TXID, [{Topic, Value0} | Rest], Acc) ->
+    #s{trie = Trie, threshold_fun = TFun} = S,
+    {Static, Varying} = emqx_ds_lts:topic_key(Trie, TFun, Topic),
+    Value =
+        case Value0 of
+            ?ds_tx_serial ->
+                TXID;
+            _ when is_binary(Value0) ->
+                Value0
+        end,
+    Bin = emqx_ds_msg_serializer:serialize(SSchema, Value),
+    cook_blob_writes(S, TXID, Rest, [?cooked_msg_op(Static, Varying, Bin) | Acc]).
+
+cook_blob_deletes(DBShard, S, Topics, Acc0) ->
+    lists:foldl(
+        fun(TopicFilter, Acc) ->
+            cook_blob_deletes1(DBShard, S, TopicFilter, Acc)
+        end,
+        Acc0,
+        Topics
+    ).
+
+cook_blob_deletes1(DBShard, S, TopicFilter, Acc0) ->
+    lists:foldl(
+        fun(Stream, Acc) ->
+            {ok, #it{static_index = Static, compressed_tf = Varying, last_key = LK}} = make_iterator(
+                DBShard, S, Stream, TopicFilter, 0
+            ),
+            cook_blob_deletes2(S#s.gs, Static, Varying, LK, Acc)
+        end,
+        Acc0,
+        get_streams(S#s.trie, TopicFilter)
+    ).
+
+cook_blob_deletes2(GS, Static, Varying, LSK, Acc0) ->
+    Fun = fun(_TopicStructure, _DSKey, Var, _Val, Acc) ->
+        [?cooked_msg_op(Static, Var, ?cooked_delete) | Acc]
+    end,
+    Interval = {'[', LSK, infinity},
+    %% Note: we don't reverse the batch here.
+    case emqx_ds_gen_skipstream_lts:fold(GS, Static, Varying, Interval, 100, Acc0, Fun) of
+        {ok, SK, Acc} when SK =:= LSK ->
+            %% TODO: is this a reliable stopping condition?
+            Acc;
+        {ok, SK, Acc} ->
+            cook_blob_deletes2(GS, Static, Varying, SK, Acc);
+        {error, _, _} = Err ->
+            error(Err)
+    end.
+
+commit_batch(
+    ShardId,
+    #s{db = DB, trie_cf = TrieCF, trie = Trie, gs = GS},
+    Input,
+    Options
+) ->
+    {ok, Batch} = rocksdb:batch(),
+    try
+        %% Handle LTS updates:
+        lists:foreach(
+            fun(#{?cooked_lts_ops := LtsOps}) ->
+                %% Commit LTS trie to the storage:
+                lists:foreach(
+                    fun({Key, Val}) ->
+                        ok = rocksdb:batch_put(
+                            Batch, TrieCF, term_to_binary(Key), term_to_binary(Val)
+                        )
+                    end,
+                    LtsOps
+                ),
+                %% Apply LTS ops to the memory cache and notify about the new
+                %% streams. Note: in case of `builtin_raft' backend
+                %% notification is sent _for every replica_ of the database, to
+                %% account for possible delays in the replication. Event
+                %% deduplication logic of `emqx_ds_new_streams' module should
+                %% mitigate the performance impact of repeated events.
+                _ = emqx_ds_lts:trie_update(Trie, LtsOps),
+                emqx_ds_gen_skipstream_lts:notify_new_streams(ShardId, Trie, LtsOps)
+            end,
+            Input
+        ),
+        %% Commit payloads:
+        lists:foreach(
+            fun(#{?cooked_msg_ops := Operations}) ->
+                lists:foreach(
+                    fun(?cooked_msg_op(Static, Varying, Op)) ->
+                        StreamKey = stream_key(Varying),
+                        case Op of
+                            Payload when is_binary(Payload) ->
+                                emqx_ds_gen_skipstream_lts:batch_put(
+                                    GS, Batch, Static, Varying, StreamKey, Payload
+                                );
+                            ?cooked_delete ->
+                                emqx_ds_gen_skipstream_lts:batch_delete(
+                                    GS, Batch, Static, Varying, StreamKey
+                                )
+                        end
+                    end,
+                    Operations
+                )
+            end,
+            Input
+        ),
+        Result = rocksdb:write_batch(DB, Batch, [
+            {disable_wal, not maps:get(durable, Options, true)}
+        ]),
+        %% NOTE
+        %% Strictly speaking, `{error, incomplete}` is a valid result but should be impossible to
+        %% observe until there's `{no_slowdown, true}` in write options.
+        case Result of
+            ok ->
+                ok;
+            {error, {error, Reason}} ->
+                ?err_unrec({rocksdb, Reason})
+        end
+    after
+        rocksdb:release_batch(Batch)
+    end.
+
+batch_events(
+    _Shard,
+    #s{},
+    #{?cooked_msg_ops := Payloads}
+) ->
+    EventMap = lists:foldl(
+        fun
+            (?cooked_msg_op(_Static, _Varying, ?cooked_delete), Acc) ->
+                Acc;
+            (?cooked_msg_op(Static, _Varying, _ValBlob), Acc) ->
+                maps:put(#kv_stream{static_index = Static}, 1, Acc)
+        end,
+        #{},
+        Payloads
+    ),
+    maps:keys(EventMap).
+
+get_streams(_Shard, #s{trie = Trie}, TopicFilter, _) ->
+    get_streams(Trie, TopicFilter).
+
+make_iterator(
+    _Shard,
+    #s{trie = Trie},
+    #kv_stream{static_index = StaticIdx},
+    TopicFilter,
+    StartPos
+) ->
+    ?tp_ignore_side_effects_in_prod(emqx_ds_storage_skipstream_lts_make_blob_iterator, #{
+        static_index => StaticIdx, topic_filter => TopicFilter
+    }),
+    {ok, TopicStructure} = emqx_ds_lts:reverse_lookup(Trie, StaticIdx),
+    CompressedTF = emqx_ds_lts:compress_topic(StaticIdx, TopicStructure, TopicFilter),
+    case StartPos of
+        beginning ->
+            LastSK = ?lsk_begin;
+        0 ->
+            %% FIXME, don't translate it here.
+            LastSK = ?lsk_begin;
+        LastSK when is_binary(LastSK) ->
+            ok
+    end,
+    {ok, #it{
+        static_index = StaticIdx,
+        last_key = LastSK,
+        compressed_tf = CompressedTF
+    }}.
+
+next(_DBShard, #s{gs = GS}, ItSeed, BatchSize, _, _) ->
+    Fun = fun(TopicStructure, DSKey, Varying, Val, Acc) ->
+        Topic = emqx_ds_lts:decompress_topic(TopicStructure, Varying),
+        [{DSKey, {Topic, Val}} | Acc]
+    end,
+    #it{static_index = Static, compressed_tf = Varying, last_key = LSK} = ItSeed,
+    Interval = {'(', LSK, infinity},
+    %% Note: we don't reverse the batch here.
+    case emqx_ds_gen_skipstream_lts:fold(GS, Static, Varying, Interval, BatchSize, [], Fun) of
+        {ok, SK, Batch} ->
+            {ok, ItSeed#it{last_key = SK}, Batch};
+        {error, _, _} = Err ->
+            Err
+    end.
+
+lookup_message(
+    _Shard,
+    #s{trie = Trie, gs = GS},
+    Topic,
+    _Timestamp
+) ->
+    maybe
+        {ok, {Static, Varying}} ?= emqx_ds_lts:lookup_topic_key(Trie, Topic),
+        StreamKey = stream_key(Varying),
+        {ok, _DSKey, Value} ?=
+            emqx_ds_gen_skipstream_lts:lookup_message(GS, Static, StreamKey),
+        {ok, {Topic, Value}}
+    end.
+
+%%================================================================================
+%% Internal exports
+%%================================================================================
+
+%%================================================================================
+%% Internal functions
+%%================================================================================
+
+get_streams(Trie, TopicFilter) ->
+    lists:map(
+        fun({Static, _Varying}) ->
+            #kv_stream{static_index = Static}
+        end,
+        emqx_ds_lts:match_topics(Trie, TopicFilter)
+    ).
+
+%%%%%%%% Keys %%%%%%%%%%
+
+stream_key(Varying) ->
+    {ok, StreamKey} = 'DSBuiltinMetadata':encode('TopicWords', Varying),
+    StreamKey.
+
+%%%%%%%% Column families %%%%%%%%%%
+
+%% @doc Generate a column family ID for the MQTT messages
+-spec data_cf(emqx_ds_storage_layer:gen_id()) -> [char()].
+data_cf(GenId) ->
+    "emqx_ds_storage_kv_skipstream_lts_data" ++ integer_to_list(GenId).
+
+%% @doc Generate a column family ID for the trie
+-spec trie_cf(emqx_ds_storage_layer:gen_id()) -> [char()].
+trie_cf(GenId) ->
+    "emqx_ds_storage_kv_skipstream_lts_trie" ++ integer_to_list(GenId).
+
+%%================================================================================
+%% Tests
+%%================================================================================

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -160,10 +160,7 @@
         %% writes are in general unsafe but require much less resources, i.e. with RocksDB
         %% non-durable (WAL-less) writes do not usually involve _any_ disk I/O.
         %% Default: `true'.
-        durable => boolean(),
-        %% Whether the argument is a list of cooked batches instead of
-        %% a single batch. Default: `false'.
-        list => boolean()
+        durable => boolean()
     }.
 
 %% Options affecting how batches should be prepared.

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -262,7 +262,7 @@
 -define(STORAGE_LAYOUT_DB_OPTS, [
     append_only,
     atomic_batches,
-    store_kv
+    store_ttv
 ]).
 
 -define(GLOBAL(K), <<"G/", K/binary>>).

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_kv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_kv.erl
@@ -1,0 +1,173 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_ds_storage_layer_kv).
+
+%% API:
+-export([prepare_kv_tx/5, commit_batch/4, lookup_kv/3]).
+
+%% internal exports:
+-export([]).
+
+-export_type([]).
+
+-include_lib("snabbkaffe/include/trace.hrl").
+-include("emqx_ds.hrl").
+
+%%================================================================================
+%% Type declarations
+%%================================================================================
+
+-type cooked_tx() :: term().
+
+-callback create(
+    emqx_ds_storage_layer:dbshard(),
+    rocksdb:db_handle(),
+    emqx_ds:generation(),
+    Options :: map(),
+    emqx_ds_storage_layer:generation_data() | undefined,
+    emqx_ds:db_opts()
+) ->
+    {_Schema, emqx_ds_storage_layer:cf_refs()}.
+
+%% Open the existing schema
+-callback open(
+    emqx_ds_storage_layer:dbshard(),
+    rocksdb:db_handle(),
+    emqx_ds:generation(),
+    emqx_ds_storage_layer:cf_refs(),
+    _Schema
+) ->
+    emqx_ds_storage_layer:generation_data().
+
+%% Delete the schema and data
+-callback drop(
+    emqx_ds_storage_layer:dbshard(),
+    rocksdb:db_handle(),
+    emqx_ds:generation(),
+    emqx_ds_storage_layer:cf_refs(),
+    emqx_ds_storage_layer:generation_data()
+) ->
+    ok | {error, _Reason}.
+
+-callback prepare_kv_tx(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    emqx_ds:tx_serial(),
+    emqx_ds:kv_tx_ops(),
+    emqx_ds_storage_layer:batch_prepare_opts()
+) ->
+    {ok, cooked_tx()} | emqx_ds:error(_).
+
+-callback commit_batch(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    [cooked_tx()],
+    emqx_ds_storage_layer:batch_store_opts()
+) -> ok | emqx_ds:error(_).
+
+-callback get_streams(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    emqx_ds:topic_filter(),
+    _Time
+) ->
+    [_Stream].
+
+-callback make_iterator(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    _Stream,
+    emqx_ds:topic_filter(),
+    beginning | emqx_ds:message_key()
+) ->
+    emqx_ds:make_iterator_result(_Iterator).
+
+-callback next(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    Iter,
+    pos_integer(),
+    %% FIXME: remove
+    _,
+    _
+) ->
+    {ok, Iter, [emqx_ds:kv_pair()]} | emqx_ds:error(_).
+
+-callback batch_events(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    _CookedBatch
+) -> [_Stream].
+
+%%================================================================================
+%% API functions
+%%================================================================================
+
+%% @doc Transform write and delete operations of a transaction into a
+%% "cooked batch" that can be stored in the transaction log or
+%% transfered over the network.
+-spec prepare_kv_tx(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:gen_id(),
+    emqx_ds:tx_serial(),
+    emqx_ds:kv_tx_ops(),
+    emqx_ds_storage_layer:batch_prepare_opts()
+) ->
+    {ok, cooked_tx()} | emqx_ds:error(_).
+prepare_kv_tx(DBShard, GenId, TXSerial, Tx, Options) ->
+    ?tp(emqx_ds_storage_layer_prepare_kv_tx, #{
+        shard => DBShard, generation => GenId, batch => Tx, options => Options
+    }),
+    case emqx_ds_storage_layer:generation_get(DBShard, GenId) of
+        #{module := Mod, data := GenData} ->
+            T0 = erlang:monotonic_time(microsecond),
+            Result = Mod:prepare_kv_tx(DBShard, GenData, TXSerial, Tx, Options),
+            T1 = erlang:monotonic_time(microsecond),
+            %% TODO store->prepare
+            emqx_ds_builtin_metrics:observe_store_batch_time(DBShard, T1 - T0),
+            Result;
+        not_found ->
+            ?err_unrec({storage_not_found, GenId})
+    end.
+
+%% @doc Commit a collection of cooked KV transactions to the storage
+-spec commit_batch(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds:generation(),
+    [cooked_tx()],
+    emqx_ds_storage_layer:batch_store_opts()
+) -> emqx_ds:store_batch_result().
+commit_batch(DBShard, GenId, CookedTransactions, Options) ->
+    case emqx_ds_storage_layer:generation_get(DBShard, GenId) of
+        #{module := Mod, data := GenData} ->
+            T0 = erlang:monotonic_time(microsecond),
+            Result = Mod:commit_batch(DBShard, GenData, CookedTransactions, Options),
+            T1 = erlang:monotonic_time(microsecond),
+            emqx_ds_builtin_metrics:observe_store_batch_time(DBShard, T1 - T0),
+            Result;
+        not_found ->
+            ?err_unrec({storage_not_found, GenId})
+    end.
+
+-spec lookup_kv(emqx_ds_storage_layer:dbshard(), emqx_ds:generation(), emqx_ds:topic()) ->
+    {ok, emqx_ds:kv_pair()} | undefined | emqx_ds:error(_).
+lookup_kv(DBShard, Generation, Topic) ->
+    case emqx_ds_storage_layer:generation_get(DBShard, Generation) of
+        not_found ->
+            ?err_unrec(generation_not_found);
+        #{module := Mod, data := GenData} ->
+            Mod:lookup_message(DBShard, GenData, Topic, 0)
+    end.
+
+%%================================================================================
+%% behavior callbacks
+%%================================================================================
+
+%%================================================================================
+%% Internal exports
+%%================================================================================
+
+%%================================================================================
+%% Internal functions
+%%================================================================================

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_kv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_kv.erl
@@ -95,7 +95,11 @@
     emqx_ds_storage_layer:generation_data(),
     Iter,
     pos_integer(),
-    %% FIXME: remove
+    %% TODO: Currently calls to kv layouts are still dispatched
+    %% through `emqx_ds_storage_layer' and carry some extra
+    %% parameters. Fixing it is not super trivial and not very useful,
+    %% except from aesthetics perspective, so there are some useless
+    %% parameters.
     _,
     _
 ) ->

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_kv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_kv.erl
@@ -83,6 +83,13 @@
 ) ->
     emqx_ds:make_iterator_result(_Iterator).
 
+-callback lookup(
+    emqx_ds_storage_layer:dbshard(),
+    emqx_ds_storage_layer:generation_data(),
+    emqx_ds:topic()
+) ->
+    {ok, binary()} | undefined.
+
 -callback next(
     emqx_ds_storage_layer:dbshard(),
     emqx_ds_storage_layer:generation_data(),
@@ -157,7 +164,7 @@ lookup_kv(DBShard, Generation, Topic) ->
         not_found ->
             ?err_unrec(generation_not_found);
         #{module := Mod, data := GenData} ->
-            Mod:lookup_message(DBShard, GenData, Topic, 0)
+            Mod:lookup(DBShard, GenData, Topic)
     end.
 
 %%================================================================================

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
@@ -165,6 +165,7 @@ commit_batch(DBShard, GenId, CookedTransactions, Options) ->
             ?err_unrec({storage_not_found, GenId})
     end.
 
+%% @doc Lookup a single value matching a concrete topic and timestamp
 -spec lookup(
     emqx_ds_storage_layer:dbshard(), emqx_ds:generation(), emqx_ds:topic(), emqx_ds:time()
 ) ->

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
@@ -98,7 +98,7 @@
     emqx_ds:topic(),
     emqx_ds:time()
 ) ->
-    {ok, emqx_ds:value()} | undefined | emqx_ds:error(_).
+    {ok, binary()} | undefined | emqx_ds:error(_).
 
 -callback next(
     emqx_ds_storage_layer:dbshard(),
@@ -158,7 +158,7 @@ prepare_tx(DBShard, GenId, TXSerial, Tx, Options) ->
 -spec lookup(
     emqx_ds_storage_layer:dbshard(), emqx_ds:generation(), emqx_ds:topic(), emqx_ds:time()
 ) ->
-    {ok, emqx_ds:value()} | undefined | emqx_ds:error(_).
+    {ok, binary()} | undefined | emqx_ds:error(_).
 lookup(DBShard, Generation, Topic, Time) ->
     case emqx_ds_storage_layer:generation_get(DBShard, Generation) of
         not_found ->

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
@@ -92,7 +92,7 @@
     emqx_ds:topic(),
     emqx_ds:time()
 ) ->
-    {ok, binary()} | undefined.
+    {ok, emqx_ds:value()} | undefined | emqx_ds:error(_).
 
 -callback next(
     emqx_ds_storage_layer:dbshard(),
@@ -169,7 +169,7 @@ commit_batch(DBShard, GenId, CookedTransactions, Options) ->
 -spec lookup(
     emqx_ds_storage_layer:dbshard(), emqx_ds:generation(), emqx_ds:topic(), emqx_ds:time()
 ) ->
-    {ok, emqx_ds:ttv()} | undefined | emqx_ds:error(_).
+    {ok, emqx_ds:value()} | undefined | emqx_ds:error(_).
 lookup(DBShard, Generation, Topic, Time) ->
     case emqx_ds_storage_layer:generation_get(DBShard, Generation) of
         not_found ->

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer_ttv.erl
@@ -1,6 +1,9 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
+
+%% @doc An alternative storage layer interface that works with
+%% Topic-Time-Value triples instead of `#message' records.
 -module(emqx_ds_storage_layer_ttv).
 
 %% API:

--- a/apps/emqx_durable_storage/src/emqx_ds_storage_skipstream_lts.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_skipstream_lts.erl
@@ -1005,7 +1005,7 @@ topic_level_bin(TL) -> TL.
 %%%%%%%% LTS %%%%%%%%%%
 
 -spec restore_trie(
-    emqx_ds_storage_layer:shard_id(), pos_integer(), rocksdb:db_handle(), rocksdb:cf_handle()
+    emqx_ds_storage_layer:dbshard(), pos_integer(), rocksdb:db_handle(), rocksdb:cf_handle()
 ) -> emqx_ds_lts:trie().
 restore_trie(Shard, StaticIdxBytes, DB, CF) ->
     PersistCallback = fun(Key, Val) ->

--- a/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
@@ -58,7 +58,7 @@ topic_filter_to_conflict_domain(TF) ->
 %% @param MinSerial Transaction serial at the time of creation.
 %%
 %% @param RotateEvery Automatically rotate the trie when the tracked
-%% serial interval reaches this value. Atom `infinity' disable
+%% serial interval reaches this value. Atom `infinity' disables
 %% automatic rotation.
 -spec new(emqx_ds_optimistic_tx:serial(), pos_integer() | infinity) -> t().
 new(MinSerial, RotateEvery) when

--- a/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
@@ -117,6 +117,10 @@ is_dirty(
 %%
 %% It moves `current' trie to `old', empties the current trie, and
 %% shrinks the tracked interval.
+%%
+%% From practical standpoint it means that any transaction that
+%% started earlier than the beginning of the conflict window is
+%% unconditionally considered conflicting and is rejected.
 -spec rotate(t()) -> t().
 rotate(S = #conflict_tree{old_max_serial = OldMax, max_serial = Max, trie = Trie}) ->
     S#conflict_tree{

--- a/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
@@ -1,0 +1,499 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc This module implements a data structure for storing
+%% information about recent updates. It is used to reject transactions
+%% that may potentially read dirty data.
+-module(emqx_ds_tx_conflict_trie).
+
+%% API:
+-export([topic_filter_to_conflict_domain/1, new/2, push/3, rotate/1, is_dirty/3, print/1]).
+
+-export_type([t/0, conflict_domain/0]).
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+-endif.
+
+%%================================================================================
+%% Type declarations
+%%================================================================================
+
+-record(conflict_tree, {
+    rotate_every :: pos_integer() | infinity,
+    min_serial,
+    old_max_serial,
+    max_serial,
+    old_trie = gb_trees:empty(),
+    trie = gb_trees:empty()
+}).
+
+-opaque t() :: #conflict_tree{}.
+
+-type conflict_domain() :: [binary() | '#'].
+
+%%================================================================================
+%% API functions
+%%================================================================================
+
+-spec print(t()) -> map().
+print(#conflict_tree{min_serial = Min, max_serial = Max, old_trie = Old, trie = Current}) ->
+    #{
+        range => {Min, Max},
+        old => gb_trees:to_list(Old),
+        current => gb_trees:to_list(Current)
+    }.
+
+%% @doc Translate topic filter to conflict domain. This function
+%% replaces all topic levels following a wildcard (+ or #) with #
+-spec topic_filter_to_conflict_domain(emqx_ds:topic_filter()) -> conflict_domain().
+topic_filter_to_conflict_domain(TF) ->
+    tf2cd(TF, []).
+
+%% @doc Create a new conflict tracking trie.
+%%
+%% @param MinSerial Transaction serial at the time of creation.
+%%
+%% @param RotateEvery Automatically rotate the trie when the tracked
+%% serial interval reaches this value. Atom `infinity' disable
+%% automatic rotation.
+-spec new(emqx_ds_optimistic_tx:serial(), pos_integer() | infinity) -> t().
+new(MinSerial, RotateEvery) when
+    RotateEvery > 0;
+    RotateEvery =:= infinity
+->
+    #conflict_tree{
+        rotate_every = RotateEvery,
+        min_serial = MinSerial,
+        max_serial = MinSerial,
+        old_max_serial = MinSerial
+    }.
+
+%% @doc Add a new conflict domain to the trie.
+-spec push(conflict_domain(), emqx_ds_optimistic_tx:serial(), t()) -> t().
+push(
+    CD,
+    Serial,
+    S = #conflict_tree{min_serial = MinS, max_serial = MaxS}
+) when Serial > MinS, Serial >= MaxS ->
+    #conflict_tree{rotate_every = RotateEvery, old_max_serial = OldMax, trie = Trie} = S,
+    case Serial - OldMax >= RotateEvery of
+        true ->
+            push(CD, Serial, rotate(S));
+        false ->
+            WildcardPrefix = wildcard_prefix(CD),
+            S#conflict_tree{
+                max_serial = Serial,
+                trie = do_push(WildcardPrefix, CD, Serial, Trie)
+            }
+    end.
+
+%% @doc Return `false' if there are no entries with serial **greater**
+%% than `Serial' in the tracked conflict range. Otherwise, return
+%% `true'.
+-spec is_dirty(conflict_domain(), emqx_ds_optimistic_tx:serial(), t()) -> boolean().
+is_dirty(
+    _CD,
+    Serial,
+    #conflict_tree{min_serial = MinS}
+) when Serial < MinS ->
+    %% Serial is out of the tracked conflict range:
+    true;
+is_dirty(
+    CD,
+    Serial,
+    #conflict_tree{trie = Trie, old_trie = OldTrie}
+) ->
+    check_dirty(CD, Serial, Trie) orelse
+        check_dirty(CD, Serial, OldTrie).
+
+%% @doc This function is used to reduce size of the trie by removing old
+%% conflicts.
+%%
+%% It moves `current' trie to `old', empties the current trie, and
+%% shrinks the tracked interval.
+-spec rotate(t()) -> t().
+rotate(S = #conflict_tree{old_max_serial = OldMax, max_serial = Max, trie = Trie}) ->
+    S#conflict_tree{
+        min_serial = OldMax,
+        old_max_serial = Max,
+        max_serial = Max,
+        old_trie = Trie,
+        trie = gb_trees:empty()
+    }.
+
+%%================================================================================
+%% Internal functions
+%%================================================================================
+
+tf2cd([], Acc) ->
+    lists:reverse(Acc);
+tf2cd(['#' | _], Acc) ->
+    lists:reverse(['#' | Acc]);
+tf2cd(['+' | _], Acc) ->
+    lists:reverse(['#' | Acc]);
+tf2cd([Const | Rest], Acc) ->
+    tf2cd(Rest, [Const | Acc]).
+
+do_push(false, CD, Serial, Trie) ->
+    gb_trees:enter(CD, Serial, Trie);
+do_push(WildcardPrefix, CD, Serial, Trie) ->
+    gb_trees:enter(CD, Serial, remove_keys_with_prefix(WildcardPrefix, Trie)).
+
+check_dirty(CD, Serial, Trie) ->
+    WCPrefixes = wc_prefixes(CD),
+    maybe
+        %% 1. Verify the exact domain:
+        false ?= compare_domain_serial(CD, Serial, Trie),
+        %% 2. Verify its wildcard prefixes:
+        false ?=
+            lists:search(
+                fun(WCPrefix) ->
+                    compare_domain_serial(WCPrefix, Serial, Trie)
+                end,
+                WCPrefixes
+            ),
+        %% 3. If CD is itself a wildcard we need to check all
+        %% subdomains in the trie:
+        case wildcard_prefix(CD) of
+            false ->
+                false;
+            Prefix ->
+                Fun = fun(_Key, KeySerial, Acc) ->
+                    Acc orelse (KeySerial > Serial)
+                end,
+                fold_keys_with_prefix(Fun, Prefix, Trie, false)
+        end
+    else
+        _ -> true
+    end.
+
+compare_domain_serial(CD, Serial, Trie) ->
+    case gb_trees:lookup(CD, Trie) of
+        {value, Val} when Val > Serial ->
+            true;
+        _ ->
+            false
+    end.
+
+remove_keys_with_prefix(Prefix, Trie) ->
+    Fun = fun(Key, _Val, Acc) ->
+        gb_trees:delete(Key, Acc)
+    end,
+    fold_keys_with_prefix(Fun, Prefix, Trie, Trie).
+
+fold_keys_with_prefix(Fun, Prefix, Trie, Acc) ->
+    It = gb_trees:iterator_from(Prefix, Trie),
+    do_fold_keys_with_prefix(Fun, Prefix, It, Acc).
+
+do_fold_keys_with_prefix(Fun, Prefix, It0, Acc0) ->
+    case gb_trees:next(It0) of
+        none ->
+            Acc0;
+        {Key, Val, It} ->
+            case lists:prefix(Prefix, Key) of
+                true ->
+                    Acc = Fun(Key, Val, Acc0),
+                    do_fold_keys_with_prefix(Fun, Prefix, It, Acc);
+                false ->
+                    Acc0
+            end
+    end.
+
+wildcard_prefix(L) ->
+    wc_prefix(L, []).
+
+wc_prefix([], _Acc) ->
+    false;
+wc_prefix(['#'], Acc) ->
+    lists:reverse(Acc);
+wc_prefix([A | L], Acc) ->
+    wc_prefix(L, [A | Acc]).
+
+wc_prefixes(CD) ->
+    wc_prefixes(CD, [], []).
+
+wc_prefixes(Suffix, PrefixAcc, Acc) ->
+    Prefix = lists:reverse(['#' | PrefixAcc]),
+    case Suffix of
+        ['#'] ->
+            Acc;
+        [] ->
+            [Prefix | Acc];
+        [Token | Rest] ->
+            wc_prefixes(Rest, [Token | PrefixAcc], [Prefix | Acc])
+    end.
+
+%%================================================================================
+%% Tests
+%%================================================================================
+
+-ifdef(TEST).
+
+tf2cd_test() ->
+    ?assertEqual([], topic_filter_to_conflict_domain([])),
+    ?assertEqual(
+        [<<1>>, <<2>>],
+        topic_filter_to_conflict_domain([<<1>>, <<2>>])
+    ),
+    ?assertEqual(
+        [<<1>>, <<2>>, '#'],
+        topic_filter_to_conflict_domain([<<1>>, <<2>>, '+', <<3>>])
+    ),
+    ?assertEqual(
+        [<<1>>, <<2>>, '#'],
+        topic_filter_to_conflict_domain([<<1>>, <<2>>, '#'])
+    ).
+
+-define(dirty(CD, SERIAL, TRIE),
+    ?assertMatch(
+        true,
+        is_dirty(CD, SERIAL, TRIE)
+    )
+).
+
+-define(clean(CD, SERIAL, TRIE),
+    ?assertMatch(
+        false,
+        is_dirty(CD, SERIAL, TRIE)
+    )
+).
+
+%% Test is_dirty on an empty trie:
+is_dirty0_test() ->
+    Trie = mk_test_trie(0, []),
+    ?clean([], 1, Trie),
+    ?clean([], 1, rotate(Trie)),
+
+    ?clean(['#'], 1, Trie),
+    ?clean(['#'], 1, rotate(Trie)),
+
+    ?clean([<<1>>, <<2>>, '#'], 1, Trie),
+    ?clean([<<1>>, <<2>>, '#'], 1, rotate(Trie)).
+
+%% Test is_dirty on a trie without wildcards:
+is_dirty1_test() ->
+    D1 = {[<<1>>], 2},
+    D2 = {[<<1>>, <<2>>], 3},
+    D3 = {[<<2>>], 4},
+    D4 = {[], 5},
+    Trie = mk_test_trie(0, [D1, D2, D3, D4]),
+    %% Non-existent domains:
+    ?clean([<<3>>], 1, Trie),
+    ?clean([<<3>>], 1, rotate(Trie)),
+    %% Existing domains:
+    ?clean([<<1>>], 2, Trie),
+    ?dirty([<<1>>], 1, Trie),
+    ?dirty([<<1>>], 1, rotate(Trie)),
+
+    ?dirty([], 1, Trie),
+    ?dirty([], 4, rotate(Trie)),
+    ?clean([], 5, Trie),
+    ?clean([], 5, rotate(Trie)),
+    %% Existing wildcard domains:
+    ?dirty([<<1>>, '#'], 1, Trie),
+    ?dirty([<<1>>, '#'], 1, rotate(Trie)),
+    ?dirty([<<1>>, '#'], 2, Trie),
+    ?dirty([<<1>>, '#'], 2, rotate(Trie)),
+
+    ?clean([<<1>>, '#'], 3, Trie),
+    ?clean([<<1>>, '#'], 3, rotate(Trie)),
+    %% All domains:
+    ?dirty(['#'], 1, Trie),
+    ?dirty(['#'], 1, rotate(Trie)),
+    ?dirty(['#'], 4, Trie),
+    ?dirty(['#'], 4, rotate(Trie)),
+    ?clean(['#'], 5, Trie),
+    ?clean(['#'], 5, rotate(Trie)).
+
+%% Test is_dirty on a trie with wildcards:
+is_dirty2_test() ->
+    D1 = {[<<1>>], 2},
+    D2 = {[<<1>>, <<2>>, '#'], 3},
+    D3 = {[<<2>>, '#'], 4},
+    Trie = mk_test_trie(0, [D1, D2, D3]),
+    %% Non-existent domains:
+    ?clean([<<3>>], 1, Trie),
+    ?clean([<<3>>], 1, rotate(Trie)),
+    %% Existing domains:
+    ?clean([<<1>>], 2, Trie),
+    ?clean([<<1>>], 2, rotate(Trie)),
+    ?dirty([<<1>>, <<2>>], 2, Trie),
+    ?dirty([<<1>>, <<2>>], 2, rotate(Trie)),
+
+    ?clean([<<1>>, <<2>>], 3, Trie),
+    ?dirty([<<1>>, <<2>>, <<3>>], 2, Trie),
+    ?clean([<<1>>, <<2>>, <<3>>], 3, Trie),
+    %% Existing wildcard domains:
+    ?dirty([<<1>>, <<2>>, '#'], 1, Trie),
+    ?dirty([<<1>>, <<2>>, '#'], 1, rotate(Trie)),
+
+    ?dirty([<<1>>, <<2>>, '#'], 2, Trie),
+    ?clean([<<1>>, <<2>>, '#'], 3, Trie),
+    ?clean([<<1>>, <<2>>, '#'], 3, rotate(Trie)),
+
+    ?dirty([<<1>>, <<2>>, <<3>>, '#'], 2, Trie),
+    ?clean([<<1>>, <<2>>, <<3>>, '#'], 3, Trie),
+
+    %% All domains:
+    ?dirty(['#'], 1, Trie),
+    ?dirty(['#'], 1, rotate(Trie)),
+    ?dirty(['#'], 3, Trie),
+    ?dirty(['#'], 3, rotate(Trie)),
+    ?clean(['#'], 4, Trie),
+    ?clean(['#'], 4, rotate(Trie)).
+
+mk_test_trie(Min, L) ->
+    lists:foldl(
+        fun({Dom, Serial}, Acc) ->
+            push(Dom, Serial, Acc)
+        end,
+        new(Min, infinity),
+        L
+    ).
+
+wc_prefixes_test() ->
+    ?assertEqual(
+        [['#']],
+        wc_prefixes([])
+    ),
+    ?assertEqual(
+        [],
+        wc_prefixes(['#'])
+    ),
+    ?assertEqual(
+        [
+            [<<>>, '#'],
+            ['#']
+        ],
+        wc_prefixes([<<>>])
+    ),
+    ?assertEqual(
+        [
+            ['#']
+        ],
+        wc_prefixes([<<>>, '#'])
+    ),
+    ?assertEqual(
+        [
+            [<<1>>, <<2>>, <<3>>, '#'],
+            [<<1>>, <<2>>, '#'],
+            [<<1>>, '#'],
+            ['#']
+        ],
+        wc_prefixes([<<1>>, <<2>>, <<3>>])
+    ),
+    ?assertEqual(
+        [
+            [<<1>>, <<2>>, '#'],
+            [<<1>>, '#'],
+            ['#']
+        ],
+        wc_prefixes([<<1>>, <<2>>, <<3>>, '#'])
+    ).
+
+push_test() ->
+    T0 = new(0, infinity),
+    T1 = push([<<1>>], 1, T0),
+    T2 = push([<<1>>, <<1>>], 1, T1),
+    T3 = push([<<1>>, <<2>>], 1, T2),
+    T4 = push([<<1>>, <<3>>, '#'], 1, T3),
+    T5 = push([<<2>>], 2, T4),
+    T6 = push([<<2>>, <<1>>], 2, T5),
+    T7 = push([<<2>>, <<2>>], 2, T6),
+    T8 = push([<<2>>, <<3>>], 2, T7),
+    ?assertEqual(
+        [
+            {[<<1>>], 1},
+            {[<<1>>, <<1>>], 1},
+            {[<<1>>, <<2>>], 1},
+            {[<<1>>, <<3>>, '#'], 1},
+            {[<<2>>], 2},
+            {[<<2>>, <<1>>], 2},
+            {[<<2>>, <<2>>], 2},
+            {[<<2>>, <<3>>], 2}
+        ],
+        gb_trees:to_list(T8#conflict_tree.trie)
+    ),
+    %% Overwrite some key:
+    T9 = push([<<1>>, <<3>>, '#'], 3, T8),
+    T10 = push([<<1>>, <<2>>], 3, T9),
+    ?assertEqual(
+        [
+            {[<<1>>], 1},
+            {[<<1>>, <<1>>], 1},
+            {[<<1>>, <<2>>], 3},
+            {[<<1>>, <<3>>, '#'], 3},
+            {[<<2>>], 2},
+            {[<<2>>, <<1>>], 2},
+            {[<<2>>, <<2>>], 2},
+            {[<<2>>, <<3>>], 2}
+        ],
+        gb_trees:to_list(T10#conflict_tree.trie)
+    ),
+    %% Insert wildcard:
+    T11 = push([<<1>>, '#'], 4, T10),
+    ?assertEqual(
+        [
+            {[<<1>>, '#'], 4},
+            {[<<2>>], 2},
+            {[<<2>>, <<1>>], 2},
+            {[<<2>>, <<2>>], 2},
+            {[<<2>>, <<3>>], 2}
+        ],
+        gb_trees:to_list(T11#conflict_tree.trie)
+    ),
+    ok.
+
+rotate_test() ->
+    T0 = new(0, 3),
+    T1 = push([<<1>>], 1, T0),
+    T2 = push([<<2>>], 2, T1),
+    ?assertEqual(
+        [],
+        gb_trees:to_list(T2#conflict_tree.old_trie)
+    ),
+    %% Push an item with serial that should rotate the tree:
+    T3 = push([<<3>>], 3, T2),
+    %% Old items were moved to the old trie:
+    ?assertEqual(
+        [
+            {[<<1>>], 1},
+            {[<<2>>], 2}
+        ],
+        gb_trees:to_list(T3#conflict_tree.old_trie)
+    ),
+    %% New item has been added to the current trie:
+    ?assertEqual(
+        [
+            {[<<3>>], 3}
+        ],
+        gb_trees:to_list(T3#conflict_tree.trie)
+    ),
+    ?assertEqual(0, T3#conflict_tree.min_serial),
+    ?assertEqual(2, T3#conflict_tree.old_max_serial),
+    ?assertEqual(3, T3#conflict_tree.max_serial),
+    %% Push an item to the same "generation":
+    T4 = push([<<4>>], 4, T3),
+    %% Push an item that will rotate the tree again:
+    T5 = push([<<5>>], 6, T4),
+    ?assertEqual(
+        [
+            {[<<3>>], 3},
+            {[<<4>>], 4}
+        ],
+        gb_trees:to_list(T5#conflict_tree.old_trie)
+    ),
+    ?assertEqual(
+        [
+            {[<<5>>], 6}
+        ],
+        gb_trees:to_list(T5#conflict_tree.trie)
+    ),
+    ?assertEqual(2, T5#conflict_tree.min_serial),
+    ?assertEqual(4, T5#conflict_tree.old_max_serial),
+    ?assertEqual(6, T5#conflict_tree.max_serial),
+    ok.
+
+-endif.

--- a/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_tx_conflict_trie.erl
@@ -16,6 +16,8 @@
 -include_lib("eunit/include/eunit.hrl").
 -endif.
 
+-elvis([{elvis_style, dont_repeat_yourself, disable}]).
+
 %%================================================================================
 %% Type declarations
 %%================================================================================

--- a/apps/emqx_durable_storage/src/emqx_durable_storage.app.src
+++ b/apps/emqx_durable_storage/src/emqx_durable_storage.app.src
@@ -2,7 +2,7 @@
 {application, emqx_durable_storage, [
     {description, "Message persistence and subscription replays for EMQX"},
     % strict semver, bump manually!
-    {vsn, "0.4.6"},
+    {vsn, "0.5.0"},
     {modules, []},
     {registered, []},
     {applications, [kernel, stdlib, rocksdb, gproc, mria, emqx_utils, gen_rpc]},

--- a/apps/emqx_durable_storage/test/perf_testing.org
+++ b/apps/emqx_durable_storage/test/perf_testing.org
@@ -1,0 +1,811 @@
+#+TITLE: Performance testing of DS optimistic transactions
+#+PROPERTY: header-args :eval no-export :exports both
+#+PROPERTY: header-args:sh :results output drawer :dir /docker:root@dev-cluster-emqx1-1:/opt/emqx
+#+PROPERTY: header-args:erlang :tangle ../src/emqx_ds_otx_test.erl
+#+PROPERTY: header-args:python :session *python*
+#+PROPERTY: header-args:elisp :exports none
+#+STARTUP: hideblocks
+#+LATEX_HEADER: \usepackage{graphicx}
+#+LATEX_HEADER: \lstset{basicstyle=\fontsize{8}{8}}
+
+
+* Traffic generator
+
+This file contains an embedded traffic generator that starts an ensemble of processes on different nodes that run a specified function.
+
+Scenarios implemented with this generator have two general variables: =N= and =Nnodes=.
+
+#+begin_src erlang :exports none
+%% Generated file, do not edit
+-module(emqx_ds_otx_test).
+
+-behavior(supervisor).
+
+%% API:
+-export([l/0, create_db/1, test_dbs/0, create_dbs/0, counter_test/1, owned_counter_test/1]).
+
+%% Test setup and supervisor callbacks:
+-export([init/1, start_worker/6, worker_entrypoint/5]).
+
+-include_lib("emqx_durable_storage/include/emqx_ds.hrl").
+
+-define(MRIA_SHARD, otx_test_shard).
+
+-define(with_metric(METRIC, BODY), with_metric(METRIC, fun() -> BODY end)).
+
+%% Reload code
+l() ->
+    erpc:multicall(
+        [node() | nodes()],
+        fun() ->
+            ok = code:atomic_load([?MODULE]),
+            code:purge(?MODULE)
+        end
+    ).
+#+end_src
+
+* Test setup
+
+#+begin_src elisp :exports none
+;; Run something in a docker container, async
+(defun my-run-in-docker (erl)
+  (async-shell-command (concat
+                        "docker exec dev-cluster-emqx1-1 bin/emqx eval "
+                        (prin1-to-string erl))))
+#+end_src
+
+#+RESULTS:
+: my-run-in-docker
+
+
+#+begin_src erlang :export no
+create_db(UserOpts = #{db := DB, type := ds}) ->
+    DB = maps:get(db, UserOpts, t),
+    Defaults = #{
+        backend => builtin_raft,
+        store_ttv => true,
+        n_shards => 16,
+        replication_options => #{},
+        n_sites => 5,
+        replication_factor => 5,
+        storage => {emqx_ds_storage_skipstream_lts_v2, #{}},
+        transaction => #{flush_interval => 10, idle_flush_interval => 1, conflict_window => 10_000},
+        reads => local_preferred
+    },
+    Opts = emqx_utils_maps:deep_merge(Defaults, maps:remove(db, UserOpts)),
+    multicall(fun() -> emqx_ds:open_db(DB, Opts) end);
+create_db(UserOpts = #{db := DB, type := mria}) ->
+    Opts = maps:merge(
+        #{type => ordered_set, storage => rocksdb_copies, rlog_shard => ?MRIA_SHARD},
+        maps:without([db, rlog_shard, type], UserOpts)
+    ),
+    multicall(
+        fun() ->
+            ok = mria:create_table(DB, maps:to_list(Opts)),
+            ok = mria:wait_for_tables([DB])
+        end
+    ).
+#+end_src
+
+Create a standard set of test databases with different parameters:
+
+#+begin_src erlang
+test_dbs() ->
+  [ #{type => mria, db => md, storage => disc_copies}
+  , #{type => mria, db => mr, storage => rocksdb_copies}
+  , #{type => ds, db => d3l, replication_factor => 3, reads => local_preferred}
+  %% TODO: Excluded due to some weird outliers
+  %% , #{type => ds, db => d3L, replication_factor => 3, reads => leader_preferred}
+  , #{type => ds, db => d5l, replication_factor => 5, reads => local_preferred}
+  , #{type => ds, db => d5L, replication_factor => 5, reads => leader_preferred}
+  ].
+
+create_dbs() ->
+  [create_db(I) || I <- test_dbs()].
+#+end_src
+
+#+begin_src elisp :exports none
+(my-run-in-docker "emqx_ds_otx_test:create_dbs()")
+#+end_src
+
+
+#+RESULTS:
+: #<window 17 on *Async Shell Command*>
+
+* Data processing
+** Histogram
+
+Subroutines to create histograms:
+
+#+begin_src python :exports none
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+import os
+import math
+
+def mgroups(df):
+    """Group data by measurement type"""
+    # Measurement types:
+    mtypes = df.columns.to_list()
+    mtypes.pop()
+    # Group data by measurement type:
+    return df.groupby(mtypes, sort=False)
+
+# Style of hisogram where plots are overlayed
+def histogram_vs_overlayed(df, title):
+    """Calculate a histogram for each measurement type, then plot them all overlayed"""
+    plt.figure(dpi=200)
+    plt.title(title)
+    bins = np.linspace(df['Val'].min(), df['Val'].max(), 100)
+    plt.xlabel('Transaction Time, μS')
+    plt.ylabel('Frequency')
+    grps = mgroups(df),
+    for i in mgroups(df):
+        counts, bin_edges = np.histogram(i[1]['Val'], bins=50)
+        label=','.join(map(str, i[0]))
+        plt.hist(bin_edges[:-1], bins=bins, weights=counts, alpha=1, label=label, linewidth=1, histtype='step')
+    plt.grid(True)
+    plt.tight_layout()
+    plt.legend()
+    fn = title + ".png"
+    plt.savefig(fn)
+    return fn
+
+# Style of histogram with subplots
+def histogram_vs_separate(df, title):
+    # Measurement types:
+    mtypes = df.columns.to_list()
+    mtypes.pop()
+    # Use the same bins for everything:
+    bins = np.linspace(df['Val'].min(), df['Val'].max(), 100)
+    # Plot it
+    df.hist(column='Val', grid=True, by=mtypes, sharex=True, sharey=True, bins=bins, histtype='stepfilled')
+    plt.tight_layout()
+    fn = title + ".hist.png"
+    plt.savefig(fn)
+    return fn
+
+def histogram_vs(df, title):
+    plt.close()
+    #return histogram_vs_overlayed(df, title)
+    return histogram_vs_separate(df, title)
+
+def boxplot_vs(df, title):
+    plt.close()
+    fn = title + ".bp.png"
+    df.boxplot(column='Val', by='DB', flierprops=dict(marker='.', markersize=2), whis=(0, 100))
+    plt.savefig(fn)
+    return fn
+#+end_src
+
+#+RESULTS:
+: None
+
+** Load data
+CSV file generation by the loadgen:
+
+#+begin_src erlang
+open_csv(Experiment, ColumnNames) ->
+    Filename = filename:join(emqx:data_dir(), Experiment ++ ".csv"),
+    IsNew = not filelib:is_file(Filename),
+    {ok, FD} = file:open(Filename, [append]),
+    %% Insert CSV header:
+    IsNew andalso
+        io:format(FD, "~s;Metric;Val~n", [lists:join(";", ColumnNames)]),
+    FD.
+#+end_src
+
+Delete old data:
+
+#+begin_src sh :results ignore
+rm /opt/emqx/data/*.csv
+#+end_src
+
+#+RESULTS:
+:results:
+:end:
+
+Copy CSVs from docker and parse it:
+
+#+begin_src python :results discard
+import pandas as pd
+import os
+
+os.system("docker cp dev-cluster-emqx1-1:/opt/emqx/data/counter.csv .")
+df_cntr = pd.read_csv('counter.csv', sep=';')
+
+os.system("docker cp dev-cluster-emqx1-1:/opt/emqx/data/owned_counter.csv .")
+df_ocntr = pd.read_csv('owned_counter.csv', sep=';')
+#+end_src
+
+#+RESULTS:
+
+* Test scenarios
+
+** Naive counter increment
+
+A naive and inefficient implementation of counter increment by reading data from the DB, incrementing it and writing it back.
+
+Below is implementation for DS:
+
+#+begin_src erlang
+do_inc_counter(MyId, Opts = #{type := ds}) ->
+  TxOpts = maps:with([db, timeout, retries, retry_interval], Opts),
+  Result = emqx_ds:trans(
+             TxOpts#{shard => {auto, MyId}, generation => 1},
+             fun() ->
+                 Key = [<<"cnt">>, <<MyId:64>>],
+                 case emqx_ds:tx_read(Key) of
+                   [{_, _, <<Val:64>>}] ->
+                     ok;
+                   [] ->
+                     Val = 0
+                 end,
+                 emqx_ds:tx_write({Key, 0, <<(Val + 1):64>>})
+             end
+            ),
+  case Result of
+    {atomic, _, _} ->
+      ok;
+    _ ->
+      Result
+  end;
+#+end_src
+
+And for Mria:
+
+#+begin_src erlang
+do_inc_counter(MyId, #{type := mria, db := DB}) ->
+    Result = mria:transaction(
+        ?MRIA_SHARD,
+        fun() ->
+            Key = {<<"cnt">>, MyId},
+            case mnesia:read(DB, Key) of
+                [{DB, _, <<Val:64>>}] ->
+                    ok;
+                [] ->
+                    Val = 0
+            end,
+            mnesia:write({DB, Key, <<(Val + 1):64>>})
+        end
+    ),
+    case Result of
+        {atomic, _} ->
+            ok;
+        _ ->
+            Result
+    end.
+#+end_src
+
+Test itself:
+
+#+begin_src erlang
+inc_counter_loop(MyId, Opts = #{sleep := Sleep}, State) ->
+  ok = ?with_metric(t, do_inc_counter(MyId, Opts)),
+  (Sleep > 0) andalso timer:sleep(Sleep),
+  State.
+
+counter_test(UserOpts = #{db := DB, type := _}) ->
+  Defaults = #{ repeats => 1
+              , n => 1
+              , sleep => 0
+              , n_nodes => 1
+              , retries => 10
+              , retry_interval => 10
+              },
+  #{ sleep := Sleep
+   , n := N
+   , n_nodes := NNodes
+   , repeats := Repeats
+   , retries := TxRetries
+   } = Opts = maps:merge(Defaults, UserOpts),
+  io:format("Cleanup..."),
+  clear_table(Opts),
+  timer:sleep(1000),
+  Success = exec_test(Opts,
+                      fun inc_counter_loop/3,
+                      "counter",
+                      ["DB", "N", "Nnodes", "Sleep", "Retries"],
+                      [DB, N, NNodes, Sleep, TxRetries]
+                     ),
+  case Success of
+    true ->
+      io:format("Verifying results...~n"),
+      ExpectedValue = <<(NNodes * Repeats):64>>,
+      verify_counters(Opts, ExpectedValue);
+    false ->
+      io:format("Run wasn't successful...~n"),
+      false
+  end;
+counter_test(UserOpts) ->
+  [?FUNCTION_NAME(maps:merge(UserOpts, maps:with([db, type], I))) || I <- test_dbs()].
+#+end_src
+
+Verification of counter values:
+
+#+begin_src erlang
+
+verify_counters(#{db := _DB, n := _N, type := mria}, _ExpectedVal) ->
+    io:format("Ignored~n"),
+    ok;
+verify_counters(#{db := DB, n := N, type := ds}, ExpectedVal) ->
+    timer:sleep(2000),
+    NVerified = emqx_ds:fold_topic(
+        fun(_Slab, _Stream, {Topic, _, Bin}, Acc) ->
+            case Bin of
+                ExpectedVal ->
+                    Acc + 1;
+                Other ->
+                    io:format("Mismatch for topic ~p, got ~p expected ~p~n", [
+                        Topic, Other, ExpectedVal
+                    ]),
+                    Acc + 1
+            end
+        end,
+        0,
+        [<<"cnt">>, '+'],
+        #{db => DB}
+    ),
+    case NVerified of
+        N ->
+            ok;
+        _ ->
+            io:format("Number of counters is ~p, expected ~p~n", [NVerified, N])
+    end.
+#+end_src
+
+
+#+RESULTS:
+: #<buffer *perf-test*>
+
+*** 1k parallel workers, no sleep, no conflicts
+
+#+begin_src elisp :exports none
+(my-run-in-docker "emqx_ds_otx_test:l(), emqx_ds_otx_test:counter_test(#{n => 1000, repeats => 100, test_timeout => 60_000}), all_done.")
+#+end_src
+
+#+RESULTS:
+: #<window 54 on *Async Shell Command*>
+
+
+#+begin_src python :results file
+c1ks0 = df_cntr[(df_cntr['Nnodes'] == 1) & (df_cntr['N'] == 1000) & (df_cntr['Sleep'] == 0)]
+histogram_vs(c1ks0, "1k naive counters, no sleep")
+#+end_src
+
+#+RESULTS:
+[[file:1k naive counters, no sleep.hist.png]]
+
+#+begin_src python :results file
+boxplot_vs(c1ks0, "1k naive counters, no sleep")
+#+end_src
+
+#+RESULTS:
+[[file:1k naive counters, no sleep.bp.png]]
+
+#+begin_src python :results value table
+mgroups(fdf).count()
+#+end_src
+
+#+RESULTS:
+|   |
+
+*** 10k parallel workers, no sleep, no conflicts
+
+#+begin_src elisp :exports none
+(my-run-in-docker "emqx_ds_otx_test:l(), emqx_ds_otx_test:counter_test(#{n => 10000, repeats => 100, test_timeout => 300_000}), all_done.")
+#+end_src
+
+#+RESULTS:
+: #<window 54 on *Async Shell Command*>
+
+
+#+begin_src python :results file
+c10ks0 = df_cntr[(df_cntr['Nnodes'] == 1) & (df_cntr['N'] == 10000) & (df_cntr['Sleep'] == 0)]
+histogram_vs(c10ks0, "10k naive counters, no sleep")
+#+end_src
+
+#+RESULTS:
+[[file:10k naive counters, no sleep.hist.png]]
+
+
+#+begin_src python :results file
+boxplot_vs(c10ks0, "10k naive counters, no sleep")
+#+end_src
+
+#+RESULTS:
+[[file:10k naive counters, no sleep.bp.png]]
+
+
+*** 10k parallel workers, sleep 30ms, no conflicts
+
+#+begin_src elisp :exports none
+(my-run-in-docker "emqx_ds_otx_test:l(), emqx_ds_otx_test:counter_test(#{n => 10000, repeats => 30, sleep => 30, test_timeout => 300_000}), all_done.")
+#+end_src
+
+#+RESULTS:
+: #<window 54 on *Async Shell Command*>
+
+
+#+begin_src python :results file
+c10ks30 = df_cntr[(df_cntr['Nnodes'] == 1) & (df_cntr['N'] == 10000) & (df_cntr['Sleep'] == 30)]
+histogram_vs(c10ks30, "10k naive counters, 30ms sleep")
+#+end_src
+
+#+RESULTS:
+[[file:10k naive counters, 30ms sleep.hist.png]]
+
+
+#+begin_src python :results file
+boxplot_vs(c10ks30, "10k naive counters, 30ms sleep")
+#+end_src
+
+#+RESULTS:
+[[file:10k naive counters, 30ms sleep.bp.png]]
+
+
+** Owned counter increment
+
+Reading data from DB, processing it and writing it back is not the best approach.
+
+Take ownership over counter:
+
+#+begin_src erlang
+do_own_counter(MyId, Opts = #{type := ds}) ->
+  TxOpts = maps:with([db, timeout, retries, retry_interval], Opts),
+  Result = emqx_ds:trans(
+             TxOpts#{shard => {auto, MyId}, generation => 1},
+             fun() ->
+                 emqx_ds:tx_write({[<<"g">>, <<MyId:64>>], 0, ?ds_tx_serial}),
+                 case emqx_ds:tx_read([<<"d">>, <<MyId:64>>]) of
+                   [{_, _, <<Val:64>>}] ->
+                     Val;
+                   [] ->
+                     0
+                 end
+             end),
+    case Result of
+      {atomic, Guard, Val} ->
+        {ok, Guard, Val};
+      _ ->
+        Result
+    end;
+do_own_counter(MyId, Opts = #{type := mria}) ->
+    #{db := DB} = Opts,
+    Guard = make_ref(),
+    Result = mria:transaction(
+        ?MRIA_SHARD,
+        fun() ->
+            mnesia:write({DB, {g, MyId}, Guard}),
+            case mnesia:read(DB, {d, MyId}) of
+                [{DB, _, <<Val:64>>}] ->
+                    Val;
+                _ ->
+                    0
+            end
+        end
+    ),
+    case Result of
+        {atomic, Val} ->
+            {ok, Guard, Val};
+        _ ->
+            Result
+    end.
+#+end_src
+
+Increment owned counter:
+
+#+begin_src erlang
+do_inc_owned_counter(MyId, Val0, Guard, Opts = #{type := ds}) ->
+  TxOpts = maps:with([db, timeout, retries, retry_interval], Opts),
+  Result = emqx_ds:trans(
+             TxOpts#{shard => {auto, MyId}, generation => 1},
+             fun() ->
+                 Val = Val0 + 1,
+                 emqx_ds:tx_ttv_assert_present([<<"g">>, <<MyId:64>>], 0, Guard),
+                 emqx_ds:tx_write({[<<"cnt">>, <<MyId:64>>], 0, <<Val:64>>}),
+                 {ok, Val}
+             end),
+  case Result of
+    {atomic, _, Ret} ->
+      Ret;
+    ?err_unrec({precondition_failed, _}) ->
+      lost_ownership;
+    _ ->
+      Result
+  end;
+do_inc_owned_counter(MyId, Val0, Guard, Opts = #{type := mria}) ->
+  Val = Val0 + 1,
+  #{db := DB} = Opts,
+  Result = mria:transaction(
+             ?MRIA_SHARD,
+             fun() ->
+                 case mnesia:read(DB, {g, MyId}) of
+                   [{DB, _, Guard}] ->
+                     mnesia:write({DB, {cnt, MyId}, <<Val:64>>}),
+                     {ok, Val};
+                   _ ->
+                     lost_ownership
+                 end
+             end),
+    case Result of
+        {atomic, R} ->
+            R;
+        _ ->
+            Result
+    end.
+#+end_src
+
+Test itself:
+
+#+begin_src erlang
+inc_owned_counter_loop(MyId, Opts, S0) ->
+  case S0 of
+    undefined ->
+      {ok, Guard, Val0} = ?with_metric(o, do_own_counter(MyId, Opts));
+    {Guard, Val0} ->
+      ok
+  end,
+  {ok, Val} = ?with_metric(i, do_inc_owned_counter(MyId, Val0, Guard, Opts)),
+  {Guard, Val}.
+
+owned_counter_test(UserOpts = #{db := DB, type := _}) ->
+  Defaults = #{ repeats => 1
+              , n => 1
+              , n_nodes => 1
+              , timeout => 10_000
+              , retries => 10
+              },
+  Opts = #{n := N, n_nodes := NNodes, repeats := Repeats, retries := TxRetries} = maps:merge(Defaults, UserOpts),
+  io:format("Cleanup..."),
+  clear_table(Opts),
+  timer:sleep(1000),
+  Success = exec_test(Opts,
+                      fun inc_owned_counter_loop/3,
+                      "owned_counter",
+                      ["DB", "N", "Nnodes", "Retries"],
+                      [DB, N, NNodes, TxRetries]
+                     ),
+  case Success of
+    true ->
+      io:format("Verifying results...~n"),
+      ExpectedValue = <<(NNodes * Repeats):64>>,
+      verify_counters(Opts, ExpectedValue);
+    false ->
+      io:format("Run wasn't successful...~n"),
+      false
+  end;
+owned_counter_test(UserOpts) ->
+  [?FUNCTION_NAME(maps:merge(UserOpts, maps:with([db, type], I))) || I <- test_dbs()].
+#+end_src
+
+*** 10k parallel workers, no conflicts
+
+#+begin_src elisp :exports none
+(my-run-in-docker "emqx_ds_otx_test:l(), emqx_ds_otx_test:owned_counter_test(#{n => 10000, repeats => 100, test_timeout => 300_000}), all_done.")
+#+end_src
+
+#+RESULTS:
+: #<window 54 on *Async Shell Command*>
+
+Increment:
+#+begin_src python :results file
+owc10ki = df_ocntr[(df_ocntr['Nnodes'] == 1) & (df_ocntr['N'] == 10000) & (df_ocntr['Metric'] == 'i')]
+histogram_vs(owc10ki, "10k owned counters, no conflicts, increment")
+#+end_src
+
+#+RESULTS:
+[[file:10k owned counters, no conflicts, increment.hist.png]]
+
+#+begin_src python :results file :exports result
+boxplot_vs(owc10ki, "10k owned counters, no conflicts, increment")
+#+end_src
+
+#+RESULTS:
+[[file:10k owned counters, no conflicts, increment.bp.png]]
+
+
+#+begin_src python :results file
+owc10ko = df_ocntr[(df_ocntr['Nnodes'] == 1) & (df_ocntr['N'] == 10000) & (df_ocntr['Metric'] == 'o')]
+histogram_vs(owc10ko, "10k owned counters, no conflicts, own")
+#+end_src
+
+#+RESULTS:
+[[file:10k owned counters, no conflicts, own.hist.png]]
+
+* Appendix A: Test harness
+
+#+begin_src erlang :exports none
+
+%%-----------------------------------------------------------------------------------------------------------
+%% Test harness
+%%-----------------------------------------------------------------------------------------------------------
+
+-record(s,
+        { success = true :: boolean(),
+          csv_fd :: file:iodevice(),
+          csv_prefix :: binary(),
+          t0 :: integer(),
+          mref :: reference() | undefined,
+          timeout :: timeout()
+        }).
+
+%% 1. Start a supervision tree with `n_nodes' copies on random nodes
+%% in the cluster for each integer between 1 and 'n'.
+%%
+%% 2. Once all processes are ready, execute `Fun' in each of them
+%%
+%% 3. Wait until all processes are done.
+-spec exec_test(
+    #{
+        n := pos_integer(),
+        n_nodes => pos_integer(),
+        available_nodes => [node()],
+        test_timeout => timeout(),
+        repeats => pos_integer()
+    },
+    fun((_MyId :: pos_integer(), _Opts :: map(), Acc | undefined) -> Acc),
+    string(),
+    list(),
+    list()
+) ->
+    boolean().
+exec_test(UserOpts, Fun, ExperimentName, ColumNames, MeasurementFields) ->
+    CSV = open_csv(ExperimentName, ColumNames),
+    Defaults = #{
+        available_nodes => [node() | nodes()],
+        n_nodes => 1,
+        test_timeout => infinity
+    },
+    #{test_timeout := TestTimeout} = Opts = maps:merge(Defaults, UserOpts),
+    DatapointPrefix = lists:join(";", [io_lib:format("~p", [I]) || I <- MeasurementFields]),
+    %% Spawn a temporary process that will be monitored by all worker
+    %% processes. Its termination signals start of the test:
+    Trigger = spawn_link(fun() ->
+        receive
+            pull -> ok
+        end
+    end),
+    %% Start the workers:
+    {ok, Top} = supervisor:start_link(?MODULE, {top, Fun, Opts, self(), Trigger}),
+    io:format("Ensemble is ready: ~p~n", [Top]),
+    MRef = monitor(process, Top),
+    unlink(Top),
+    %% Now when the setup is complete, let's broadcast that it's time
+    %% to start the test:
+    Trigger ! pull,
+    %% Start collecting messages until supervisor terminates:
+    Success = collect_replies(#s{ csv_fd = CSV
+                                , csv_prefix = iolist_to_binary(DatapointPrefix)
+                                , t0 = erlang:system_time(microsecond)
+                                , mref = MRef
+                                , timeout = TestTimeout
+                                }),
+    %% Shutdown the sup in case of timeout:
+    exit(Top, shutdown),
+    file:close(CSV),
+    Success.
+
+collect_replies(S = #s{timeout = Timeout, mref = MRef, t0 = T0, csv_fd = FD, csv_prefix = Prefix}) ->
+  receive
+    {'DOWN', MRef, process, _, _} ->
+      %% Supervisor has stopped, everything's done:
+      T1 = erlang:system_time(microsecond),
+      io:format("Complete in ~p s~n", [(T1 - T0) / 1_000_000]),
+      %% Wait a little more to collect the rest of the messages:
+      collect_replies(S#s{timeout = 100});
+    {metric, M, Val} ->
+      io:format(FD, "~s;~p;~p~n", [Prefix, M, Val]),
+      collect_replies(S);
+    {fail, _} ->
+      collect_replies(S#s{success = false})
+  after Timeout ->
+      S#s.success
+  end.
+
+report_metric(Metric, Val) ->
+  get(parent) ! {metric, Metric, Val}.
+
+report_fail(Reason) ->
+  get(parent) ! {fail, Reason}.
+
+%%-----------------------------------------------------------------------------------------------------------
+%% Supervisor
+%%-----------------------------------------------------------------------------------------------------------
+
+init({top, Fun, Opts = #{n := N}, Parent, Trigger}) ->
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 1,
+        auto_shutdown => all_significant
+    },
+    Children = [
+        #{
+            id => I,
+            type => supervisor,
+            shutdown => infinity,
+            restart => temporary,
+            start => {supervisor, start_link, [?MODULE, {worker, Fun, Opts, Parent, Trigger, I}]},
+            significant => true
+        }
+     || I <- lists:seq(1, N)
+    ],
+    {ok, {SupFlags, Children}};
+init({worker, Fun, Opts, Parent, Trigger, MyId}) ->
+    #{n_nodes := NNodes, available_nodes := NodeAvail} = Opts,
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 1,
+        auto_shutdown => all_significant
+    },
+    {Nodes, _} = lists:split(NNodes, shuffle(NodeAvail)),
+    Children = [
+        #{
+            id => Node,
+            type => worker,
+            restart => temporary,
+            start => {?MODULE, start_worker, [Node, Fun, Opts, MyId, Parent, Trigger]},
+            shutdown => 100,
+            significant => true
+        }
+     || Node <- Nodes
+    ],
+    {ok, {SupFlags, Children}}.
+
+start_worker(Node, Fun, Opts, N, Parent, Trigger) ->
+    Pid = proc_lib:spawn_link(Node, ?MODULE, worker_entrypoint, [Fun, Opts, N, Parent, Trigger]),
+    {ok, Pid}.
+
+worker_entrypoint(Fun, Opts = #{repeats := Repeats}, MyId, Parent, Trigger) ->
+    MRef = monitor(process, Trigger),
+    put(parent, Parent),
+    receive
+        {'DOWN', MRef, process, Trigger, _} ->
+            try
+              lists:foldl(
+                fun(_, Acc) -> Fun(MyId, Opts, Acc) end,
+                undefined,
+                lists:seq(1, Repeats)
+               )
+            catch EC:Err:Stack ->
+                logger:error("Test worker ~p failed with reason ~p:~p~nStack: ~p", [MyId, EC, Err, Stack]),
+                report_fail({EC, Err})
+            end
+    end.
+
+shuffle(L) ->
+    {_, Ret} = lists:unzip(lists:sort([{rand:uniform(), I} || I <- L])),
+    Ret.
+
+clear_table(#{type := mria, db := DB}) ->
+    mria:clear_table(DB);
+clear_table(#{type := ds, db := DB}) ->
+    maps:foreach(
+        fun({Shard, Gen}, _Val) ->
+            {atomic, _, _} = emqx_ds:trans(
+                #{db => DB, generation => Gen, shard => Shard},
+                fun() ->
+                    emqx_ds:tx_del_topic(['#'])
+                end
+            )
+        end,
+        emqx_ds:list_generations_with_lifetimes(DB)
+    ).
+
+multicall(Fun) ->
+  Nodes = [node() | nodes()],
+  {_, []} = rpc:multicall(Nodes, erlang, apply, [Fun, []]),
+  ok.
+
+with_metric(Metric, Fun) ->
+  T0 = erlang:system_time(microsecond),
+  try
+    Fun()
+  after
+    T1 = erlang:system_time(microsecond),
+    report_metric(Metric, T1 - T0)
+  end.
+#+end_src

--- a/rebar.config
+++ b/rebar.config
@@ -53,7 +53,7 @@
         'DSMetadataCommon',
         'DSBuiltinSLReference',
         'DSBuiltinSLSkipstreamV1',
-        'DSBuiltinSLSkipstreamKV',
+        'DSBuiltinSLSkipstreamV2',
         'DSBuiltinStorageLayer'
     ]},
     {plt_location, "."},

--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,12 @@
         emqx_exproto_v_1_connection_unary_handler_client,
         emqx_exhook_v_2_hook_provider_client,
         emqx_exhook_v_2_hook_provider_bhvr,
-        'DurableMessage'
+        'DurableMessage',
+        'DSBuiltinMetadata',
+        'DSMetadataCommon',
+        'DSBuiltinSLReference',
+        'DSBuiltinSLSkipstreamV1',
+        'DSBuiltinStorageLayer'
     ]},
     {plt_location, "."},
     {plt_prefix, "emqx_dialyzer"},

--- a/rebar.config
+++ b/rebar.config
@@ -53,6 +53,7 @@
         'DSMetadataCommon',
         'DSBuiltinSLReference',
         'DSBuiltinSLSkipstreamV1',
+        'DSBuiltinSLSkipstreamKV',
         'DSBuiltinStorageLayer'
     ]},
     {plt_location, "."},

--- a/rel/i18n/emqx_ds_schema.hocon
+++ b/rel/i18n/emqx_ds_schema.hocon
@@ -121,4 +121,34 @@ layout_builtin_reference.desc:
 layout_builtin_reference_type.label: "Layout type"
 layout_builtin_reference_type.desc: "Reference layout type."
 
+optimistic_transaction.label: "Transaction"
+optimistic_transaction.desc:
+  """~
+  Transaction settings for built-in durable storage backends.~"""
+
+builtin_optimistic_transaction.label: "Transaction settings"
+builtin_optimistic_transaction.desc: "Transaction settings."
+
+otx_flush_interval.label: "Transaction flush interval"
+otx_flush_interval.desc:
+  """~
+  Specifies the maximum time operations may linger in the buffer before they are committed to the storage.~"""
+
+otx_idle_flush_interval.label: "Idle transaction flush interval"
+otx_idle_flush_interval.desc:
+  """~
+  If shard doesn't receive new transactions within this period, the buffer is flushed early.~"""
+
+otx_conflict_window.label: "Conflict tracking window"
+otx_conflict_window.desc:
+  """~
+  Builtin durable storage backends track recent updates over a period of time known as the conflict tracking window.
+
+  Transactions that started earlier than the beginning of the window are automatically rejected.
+  So, effectively, this parameter limits the time the transactions can run.
+
+  Higher values reduce the risk of rejecting transactions due to long run time, but may increase RAM demands.
+
+  This value should be greater than the flush interval.~"""
+
 }


### PR DESCRIPTION
Fixes [EMQX-14049](https://emqx.atlassian.net/browse/EMQX-14049)

Release version: 5.10.0

## Summary

The best time to drop mnesia was 4 years ago when we started mria project, the next best time is now. This PR introduces a key-value transactional API for the durable storage with optimistic concurrency control.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14049]: https://emqx.atlassian.net/browse/EMQX-14049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ