### PR TITLE
fix(external schema registry): deobfuscate passwords when updating

### DIFF
--- a/apps/emqx_schema_registry/src/emqx_schema_registry_http_api.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_http_api.erl
@@ -445,11 +445,12 @@ validate_protobuf_bundle_request(_Params, _Meta) ->
         end,
         not_found()
     );
-'/schema_registry_external/registry/:name'(put, #{bindings := #{name := Name}, body := Params}) ->
+'/schema_registry_external/registry/:name'(put, #{bindings := #{name := Name}, body := NewParams0}) ->
     with_external_registry(
         Name,
-        fun() ->
-            case emqx_schema_registry_config:upsert_external_registry(Name, Params) of
+        fun(CurrentParams) ->
+            NewParams = emqx_utils:deobfuscate(NewParams0, CurrentParams),
+            case emqx_schema_registry_config:upsert_external_registry(Name, NewParams) of
                 {ok, Registry} ->
                     ?OK(external_registry_out(Registry));
                 {error, Reason} ->

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -885,6 +885,22 @@ t_smoke_test_external_registry_confluent(_Config) ->
         #{expected => Expected4}
     ),
 
+    %% Update external schema config with obfuscated password to simulate frontend.
+    %% Should not clobber password.
+    UpdateParams1 = emqx_utils_maps:deep_merge(
+        Params1,
+        #{<<"auth">> => #{<<"password">> => ?REDACTED}}
+    ),
+    ?assertMatch({200, _}, update_external_registry(Name1, UpdateParams1)),
+    PassFn = emqx_config:get([
+        schema_registry,
+        external,
+        binary_to_atom(Name1),
+        auth,
+        password
+    ]),
+    ?assertEqual(<<"mypass">>, PassFn()),
+
     ok.
 
 %% Smoke test for registering and using an external HTTP serde.

--- a/changes/ee/fix-15224.en.md
+++ b/changes/ee/fix-15224.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where updating an External Schema Registry via the dashboard would inadvertently change the password to `******`.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14280

Release version: 5.10.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
