### PR TITLE
feat: add a hook to change the channel data in plugins

### DIFF
--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -8,6 +8,11 @@
 
 -type callback_result() :: stop | any().
 -type fold_callback_result(Acc) :: {stop, Acc} | {ok, Acc} | stop | any().
+-type channel_data() :: #{
+    clientinfo := emqx_types:clientinfo(),
+    conninfo := emqx_types:conninfo(),
+    will_msg := emqx_types:message()
+}.
 
 -export_type([
     fold_callback_result/1,
@@ -42,6 +47,7 @@
     'client.unsubscribe',
     'client.timeout',
     'client.monitored_process_down',
+    'session.creating',
     'session.created',
     'session.subscribed',
     'session.unsubscribed',
@@ -162,6 +168,8 @@ when
     fold_callback_result(Replies)
 when
     Replies :: emqx_channel:replies().
+
+-callback 'session.creating'(channel_data()) -> fold_callback_result(channel_data()).
 
 -callback 'session.created'(emqx_types:clientinfo(), _SessionInfo :: emqx_types:infos()) ->
     callback_result().

--- a/changes/ce/feat-15229.en.md
+++ b/changes/ce/feat-15229.en.md
@@ -1,0 +1,2 @@
+Add a new hook 'session.creating' to allow plugins to fully control the channel data before creating the session.
+


### PR DESCRIPTION
Part of https://emqx.atlassian.net/browse/EMQX-14008

Release version: 5.10

## Summary

Add a new hook to allow plugins to fully control the channel data before creating the session.

This will be used by the [MCP Server Gateway](https://github.com/emqx/emqx-plugin-mcp-gateway) to change the will topic when `broker_suggested_server_name` is enabled.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
