### PR TITLE
fix(prometheus): anticipate empty DS Raft metric families

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -305,7 +305,9 @@ prefix_collect_helpful_family(Callback, Prefix, MetricsTypeAndHelp, Metrics) ->
         fun({Name, Type, Help}) ->
             %% Using `create_mf/4` that doesn't call back into `collect_metrics/2.`
             PromName = [Prefix, atom_to_binary(Name)],
-            Callback(prometheus_model_helpers:create_mf(PromName, Help, Type, ?MG(Name, Metrics)))
+            Callback(
+                prometheus_model_helpers:create_mf(PromName, Help, Type, ?MG(Name, Metrics, []))
+            )
         end,
         MetricsTypeAndHelp
     ).


### PR DESCRIPTION
Release version: 5.10?

## Summary

Metrics are expected to be missing in some circumstances, which essentially means that respective metric families are empty.

For example:
* There's no DS Raft databases.
* Local node is not responsible for any DB shards.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
