### PR TITLE
fix(connectors api): focus on value when there's an update error

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -823,7 +823,9 @@ maybe_unwrap(RpcMulticallResult) ->
 redact(Term) ->
     emqx_utils:redact(Term).
 
-maybe_focus_on_request_connector(Reason0, Type, Name) ->
+maybe_focus_on_request_connector(Reason0, Type0, Name0) ->
+    Type = bin(Type0),
+    Name = bin(Name0),
     case Reason0 of
         #{value := #{Type := #{Name := Val}}} ->
             Reason0#{value := Val};


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14292

Release version: 5.10.0

## Summary

The problem was that, during an update, the type is an atom instead of a binary.

![image](https://github.com/user-attachments/assets/45df6524-1bb4-424d-a26f-6e841e40f05f)


<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [na] The changes are covered with new or existing tests (tested manually)
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (unreleased feature)


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
