### PR TITLE
test(iceberg): attempt to fix flaky container

### DIFF
--- a/.ci/docker-compose-file/docker-compose-iceberg.yaml
+++ b/.ci/docker-compose-file/docker-compose-iceberg.yaml
@@ -88,6 +88,9 @@ services:
       retries: 5
     # ports:
     #   - 8181:8181
+    command: ["java",
+              "-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG",
+              "-jar", "iceberg-rest-adapter.jar"]
     environment:
       - AWS_ACCESS_KEY_ID=admin
       - AWS_SECRET_ACCESS_KEY=password

--- a/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
+++ b/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
@@ -234,6 +234,8 @@ ensure_namespace_deleted(Client, Namespace) ->
     case delete_namespace(Client, Namespace) of
         {ok, _} ->
             ct:pal("namespace ~p deleted", [Namespace]),
+            %% See Note [Flaky iceberg-rest-fixtures]
+            ct:sleep(200),
             ok;
         {error, {http_error, 404, _, _, _}} ->
             ct:pal("namespace ~p already gone", [Namespace]),
@@ -276,6 +278,11 @@ ensure_table_created(Client, Namespace, Table, Schema, Opts) ->
     case create_table(Client, Namespace, Table, Schema, Opts) of
         {ok, _} ->
             ct:pal("table ~p.~p created", [Namespace, Table]),
+            %% Note [Flaky iceberg-rest-fixtures]
+            %% This is an attempt to circumvent buggy iceberg-rest container, which
+            %% frequently breaks and starts returning 500 responses, internally due to `no
+            %% such table: iceberg_tables`.
+            ct:sleep(200),
             ok;
         {error, {http_error, 409, _, _, _}} ->
             ct:pal("table ~p.~p already exists", [Namespace, Table]),


### PR DESCRIPTION
I don't know the reason yet, but seems somewhat related to 2 threads that interact with the in-memory SQLite3 catalog concurrently.  🤔

```
iceberg-rest          | 2025-05-21T15:35:15.281733085Z Caused by: org.sqlite.SQLiteException: [SQLITE_ERROR] SQL error or missing database (no such table: iceberg_tables)
```