### PR TITLE
feat: add TTL support to GreptimeDB connector

### DIFF
--- a/.ci/docker-compose-file/docker-compose-greptimedb.yaml
+++ b/.ci/docker-compose-file/docker-compose-greptimedb.yaml
@@ -2,7 +2,7 @@ services:
   greptimedb:
     container_name: greptimedb
     hostname: greptimedb
-    image: greptime/greptimedb:v0.7.1
+    image: greptime/greptimedb:v0.14.2
     expose:
       - "4000"
       - "4001"

--- a/apps/emqx_bridge_greptimedb/README.md
+++ b/apps/emqx_bridge_greptimedb/README.md
@@ -17,7 +17,7 @@ Just like the InfluxDB data bridge but have some different parameters. Below are
   - `server`: The IPv4 or IPv6 address or the hostname to connect to.
   - `dbname`: The GreptimeDB database name.
   - `write_syntax`: Like the `write_syntax` in `InfluxDB` conf, it's the conf of InfluxDB line protocol to write data points. It is a text-based format that provides the measurement, tag set, field set, and timestamp of a data point, and placeholder supported.
-
+  - `ttl`: The time-to-live setting for automatically created tables. For more information about TTL, please read [the documentation](https://docs.greptime.com/reference/sql/create#create-a-table-with-ttl).
 
 # Contributing - [Mandatory]
 Please see our [contributing.md](../../CONTRIBUTING.md).

--- a/apps/emqx_bridge_greptimedb/rebar.config
+++ b/apps/emqx_bridge_greptimedb/rebar.config
@@ -6,7 +6,7 @@
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}},
-    {greptimedb, {git, "https://github.com/GreptimeTeam/greptimedb-ingester-erl", {tag, "v0.1.8"}}}
+    {greptimedb, {git, "https://github.com/GreptimeTeam/greptimedb-ingester-erl", {tag, "v0.2.0"}}}
 ]}.
 {plugins, [rebar3_path_deps]}.
 {project_plugins, [erlfmt]}.

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb.erl
@@ -86,6 +86,7 @@ bridge_v1_values(_Method) ->
         username => <<"example_username">>,
         password => <<"******">>,
         dbname => <<"example_db">>,
+        ttl => <<"3 years">>,
         server => <<"127.0.0.1:4001">>,
         ssl => #{enable => false}
     }.

--- a/changes/ee/feat-15176.en.md
+++ b/changes/ee/feat-15176.en.md
@@ -1,0 +1,1 @@
+Upgrade the GreptimeDB connector client and support an optional new parameter `ttl` to set the default time-to-live for automatically created tables.

--- a/mix.exs
+++ b/mix.exs
@@ -421,7 +421,7 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:crc32cer),
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1", override: true},
       {:greptimedb,
-       github: "GreptimeTeam/greptimedb-ingester-erl", tag: "v0.1.8", override: true},
+       github: "GreptimeTeam/greptimedb-ingester-erl", tag: "v0.2.0", override: true},
       {:amqp_client, "4.0.3", override: true}
     ]
   end

--- a/rel/i18n/emqx_bridge_greptimedb_connector.hocon
+++ b/rel/i18n/emqx_bridge_greptimedb_connector.hocon
@@ -18,6 +18,12 @@ password.desc:
 password.label:
 """Password"""
 
+ttl.desc:
+"""The time-to-live setting for automatically created tables in GreptimeDB."""
+
+ttl.label:
+"""Table data TTL"""
+
 precision.desc:
 """GreptimeDB time precision."""
 


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 5.?

## Summary

This PR enhances the GreptimeDB connector by adding support for the TTL (Time-To-Live) parameter, allowing users to configure default expiration times for automatically created tables. This improvement enables better data lifecycle management in time-series storage scenarios.

Changes:
* Added a new optional `ttl` parameter to the GreptimeDB connector configuration, and set default TTL value to "3 years" in the example configuration
* Bump greptimedb ingester to [v0.2.0](https://github.com/GreptimeTeam/greptimedb-ingester-erl/releases/tag/v0.2.0)
* Bump GreptimeDB image for CI to v0.14.2

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
