### PR TITLE
fix(postgres): reconnect after health check failures, return more info

### DIFF
--- a/apps/emqx_bridge_pgsql/test/emqx_bridge_v2_pgsql_SUITE.erl
+++ b/apps/emqx_bridge_pgsql/test/emqx_bridge_v2_pgsql_SUITE.erl
@@ -15,6 +15,10 @@
 -define(CONNECTOR_TYPE, pgsql).
 -define(CONNECTOR_TYPE_BIN, <<"pgsql">>).
 
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+-define(PROXY_NAME, "pgsql_tcp").
+
 -import(emqx_common_test_helpers, [on_exit/1]).
 -import(emqx_utils_conv, [bin/1]).
 
@@ -39,6 +43,7 @@ groups() ->
 init_per_suite(Config) ->
     PostgresHost = os:getenv("PGSQL_TCP_HOST", "toxiproxy"),
     PostgresPort = list_to_integer(os:getenv("PGSQL_TCP_PORT", "5432")),
+    emqx_common_test_helpers:reset_proxy(?PROXY_HOST, ?PROXY_PORT),
     case emqx_common_test_helpers:is_tcp_server_available(PostgresHost, PostgresPort) of
         true ->
             Apps = emqx_cth_suite:start(
@@ -144,6 +149,7 @@ init_per_testcase(TestCase, Config) ->
     ].
 
 end_per_testcase(_Testcase, Config) ->
+    emqx_common_test_helpers:reset_proxy(?PROXY_HOST, ?PROXY_PORT),
     case proplists:get_bool(skip_does_not_apply, Config) of
         true ->
             ok;
@@ -226,8 +232,11 @@ make_message() ->
     }.
 
 create_connector_api(Config) ->
+    create_connector_api(Config, _Overrides = #{}).
+
+create_connector_api(Config, Overrides) ->
     emqx_bridge_v2_testlib:simplify_result(
-        emqx_bridge_v2_testlib:create_connector_api(Config)
+        emqx_bridge_v2_testlib:create_connector_api(Config, Overrides)
     ).
 
 create_action_api(Config, Overrides) ->
@@ -235,8 +244,20 @@ create_action_api(Config, Overrides) ->
         emqx_bridge_v2_testlib:create_action_api(Config, Overrides)
     ).
 
+get_connector_api(Config) ->
+    Type = emqx_bridge_v2_testlib:get_value(connector_type, Config),
+    Name = emqx_bridge_v2_testlib:get_value(connector_name, Config),
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:get_connector_api(Type, Name)
+    ).
+
+with_failure(FailureType, Fn) ->
+    emqx_common_test_helpers:with_failure(
+        FailureType, ?PROXY_NAME, ?PROXY_HOST, ?PROXY_PORT, Fn
+    ).
+
 %%------------------------------------------------------------------------------
-%% Testcases
+%% Test cases
 %%------------------------------------------------------------------------------
 
 t_start_stop(Config) ->
@@ -413,5 +434,50 @@ t_bad_datetime_param(Config) ->
             emqx:publish(emqx_message:make(RuleTopic, Payload)),
             #{?snk_kind := "postgres_bad_param_error"}
         )
+    ),
+    ok.
+
+%% Checks that we trigger a full reconnection if the health check times out, by declaring
+%% the connector `?status_disconnected`.  We choose to do this because there have been
+%% issues where the connection process does not die and the connection itself unusable.
+t_reconnect_on_connector_health_check_timeout(Config) ->
+    {201, _} = create_connector_api(
+        Config,
+        #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"750ms">>}}
+    ),
+    ?assertMatch(
+        {200, #{<<"status">> := <<"connected">>}},
+        get_connector_api(Config)
+    ),
+    meck:new(epgsql, [passthrough]),
+    with_failure(timeout, fun() ->
+        ?retry(
+            750,
+            5,
+            ?assertMatch(
+                {200, #{
+                    <<"status">> := <<"disconnected">>,
+                    <<"status_reason">> := <<"health_check_timeout">>
+                }},
+                get_connector_api(Config)
+            )
+        )
+    end),
+    %% Recovery
+    ?retry(
+        750,
+        5,
+        ?assertMatch(
+            {200, #{<<"status">> := <<"connected">>}},
+            get_connector_api(Config)
+        )
+    ),
+    %% Should have triggered a reconnection
+    ?assertMatch(
+        [_ | _],
+        [
+            1
+         || {_, {_, connect, _}, _} <- meck:history(epgsql)
+        ]
     ),
     ok.

--- a/apps/emqx_postgresql/src/emqx_postgresql.app.src
+++ b/apps/emqx_postgresql/src/emqx_postgresql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_postgresql, [
     {description, "EMQX PostgreSQL Database Connector"},
-    {vsn, "0.2.7"},
+    {vsn, "0.2.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -507,23 +507,52 @@ on_sql_query(InstId, PoolName, Type, NameOrSQL, Data) ->
             {error, {unrecoverable_error, invalid_request}}
     end.
 
-on_get_status(_InstId, #{pool_name := PoolName} = State) ->
-    case emqx_resource_pool:health_check_workers(PoolName, fun ?MODULE:do_get_status/1) of
-        true ->
-            case do_check_prepares(State) of
-                ok ->
-                    ?status_connected;
-                {error, undefined_table} ->
-                    %% return error indicating that we are connected but the target table
-                    %% is not created
-                    {?status_disconnected, unhealthy_target}
+on_get_status(_InstId, #{pool_name := PoolName} = ConnState) ->
+    Res = emqx_resource_pool:health_check_workers(
+        PoolName,
+        fun ?MODULE:do_get_status/1,
+        emqx_resource_pool:health_check_timeout(),
+        #{return_values => true}
+    ),
+    case Res of
+        {ok, []} ->
+            {?status_connecting, <<"connection_pool_not_initialized">>};
+        {ok, Results} ->
+            Errors =
+                lists:filter(
+                    fun
+                        ({ok, _, _}) ->
+                            false;
+                        (_) ->
+                            true
+                    end,
+                    Results
+                ),
+            case Errors of
+                [] -> on_get_status_prepares(ConnState);
+                [{error, Reason} | _] -> {?status_disconnected, Reason};
+                [Reason | _] -> {?status_disconnected, Reason}
             end;
-        false ->
-            ?status_connecting
+        {error, timeout} ->
+            %% We trigger a full reconnection if the health check times out, by declaring
+            %% the connector `?status_disconnected`.  We choose to do this because there
+            %% have been issues where the connection process does not die and the
+            %% connection itself unusable.
+            {?status_disconnected, <<"health_check_timeout">>}
+    end.
+
+on_get_status_prepares(ConnState) ->
+    case do_check_prepares(ConnState) of
+        ok ->
+            ?status_connected;
+        {error, undefined_table} ->
+            %% return error indicating that we are connected but the target table
+            %% is not created
+            {?status_disconnected, {unhealthy_target, undefined_table}}
     end.
 
 do_get_status(Conn) ->
-    ok == element(1, epgsql:squery(Conn, "SELECT count(1) AS T")).
+    epgsql:squery(Conn, "SELECT count(1) AS T").
 
 do_check_prepares(
     #{

--- a/changes/ee/fix-15274.en.md
+++ b/changes/ee/fix-15274.en.md
@@ -1,0 +1,1 @@
+Now, any health check failure for Postgres, Matrix and TimescaleDB Connectors will trigger a full reconnection.  Prior to this change, there were situations where the connection would become unusable and attempts to use it would hang, potentially leading to out of memory issues.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14321

Release version: 5.10.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
