### PR TITLE
test: fix flaky emqx_cm_SUITE:t_open_session_race_condition

### DIFF
--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -219,7 +219,14 @@ t_open_session_race_condition(_) ->
         bug_triggered ->
             ok;
         Winner when is_pid(Winner) ->
-            ?assertMatch([_], ets:lookup(?CHAN_TAB, ClientId)),
+            ?assertMatch(
+                [_],
+                ?retry(
+                    _Interval = 100,
+                    _NTimes = 10,
+                    [_] = ets:lookup(?CHAN_TAB, ClientId)
+                )
+            ),
             ?assertEqual([Winner], emqx_cm:lookup_channels(ClientId)),
             ?assertMatch([_], ets:lookup(?CHAN_CONN_TAB, Winner)),
             ?assertMatch([_], ets:lookup(?CHAN_REG_TAB, ClientId)),


### PR DESCRIPTION
fix flaky emqx_cm_SUITE:t_open_session_race_condition

Release version: 5.?

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
