### PR TITLE
chore: Bump ekka to 0.23.0 and mria to 0.8.17

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-1"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.14.0"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.22.1"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.3"}}},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.6"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.3"}}},

--- a/changes/ee/fix-15304.en.md
+++ b/changes/ee/fix-15304.en.md
@@ -1,0 +1,4 @@
+Fixed the problem related to core node discovery by replicant nodes when using `static` discovery strategy.
+
+Previously, the replicants could ignore core nodes not explicitly listed in the `static_seeds` list.
+This could lead to an inconsistent cluster view and load imbalance.

--- a/mix.exs
+++ b/mix.exs
@@ -186,7 +186,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.22.1", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.0", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.14.0", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.3", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -91,7 +91,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-1"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.14.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-8"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.22.1"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.3"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.2"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.7"}}},


### PR DESCRIPTION
Fixes [EMQX-14135](https://emqx.atlassian.net/browse/EMQX-14135)

Release version: 5.10

## Summary

Improved node discovery by the replicants' load-balancer module. Previously, it only considered nodes listed in the output of the discovery callback. In some cases, for example when `static` discovery strategy is used, it could lead to missed discovery of core nodes.   

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14135]: https://emqx.atlassian.net/browse/EMQX-14135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ