### PR TITLE
fix(resource manager): don't kick off channel health check unconditionally when resource HC returns

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -56,8 +56,6 @@
 -export([
     disable_enable/3,
     disable_enable/4,
-    health_check/2,
-    health_check/3,
     send_message/4,
     query/4,
     start/2,
@@ -88,6 +86,8 @@
 -export([
     id/2,
     id/3,
+    health_check/2,
+    health_check/3,
     source_id/3,
     source_hookpoint/1,
     bridge_v1_is_valid/2,
@@ -771,11 +771,15 @@ query_opts(ActionOrSourceType, Config) ->
     Mod = emqx_connector_resource:connector_to_resource_type(ConnectorType),
     emqx_resource:get_query_opts(Mod, Config).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 -spec health_check(BridgeType :: term(), BridgeName :: term()) ->
     #{status := emqx_resource:resource_status(), error := term()} | {error, Reason :: term()}.
 health_check(BridgeType, BridgeName) ->
     health_check(?ROOT_KEY_ACTIONS, BridgeType, BridgeName).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 health_check(ConfRootKey, BridgeType, BridgeName) ->
     case lookup_conf(ConfRootKey, BridgeType, BridgeName) of
         #{

--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -52,9 +52,6 @@
     start/2,
     restart/1,
     restart/2,
-    %% verify if the resource is working normally
-    health_check/1,
-    channel_health_check/2,
     get_channels/1,
     %% set resource status to disconnected
     set_resource_status_connecting/1,
@@ -134,6 +131,10 @@
 ]).
 
 -export([is_dry_run/1]).
+
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
+-export([health_check/1, channel_health_check/2]).
 
 -export_type([
     query_mode/0,
@@ -450,10 +451,14 @@ restart(ResId, Opts) ->
 stop(ResId) ->
     emqx_resource_manager:stop(ResId).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 -spec health_check(resource_id()) -> {ok, resource_status()} | {error, term()}.
 health_check(ResId) ->
     emqx_resource_manager:health_check(ResId).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 -spec channel_health_check(resource_id(), channel_id()) ->
     #{status := resource_status(), error := term()}.
 channel_health_check(ResId, ChannelId) ->

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -23,8 +23,6 @@
     restart/2,
     start/2,
     stop/1,
-    health_check/1,
-    channel_health_check/2,
     add_channel/3,
     add_channel/4,
     add_channel_async/3,
@@ -63,6 +61,10 @@
 -export([do_worker_channel_health_check/3, do_worker_resource_health_check/1]).
 -export([wait_for_ready/2]).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
+-export([health_check/1, channel_health_check/2]).
+
 -ifdef(TEST).
 -export([stop/2, summarize_query_mode/2]).
 -endif.
@@ -93,13 +95,17 @@
     hc_workers = #{
         resource => #{},
         channel => #{
-            ongoing => #{}
+            ongoing => #{},
+            kicked_off => #{}
         }
     } :: #{
         resource := #{pid() => true},
         channel := #{
             pid() => channel_id(),
-            ongoing := #{channel_id() => channel_status_map()}
+            ongoing := #{channel_id() => channel_status_map()},
+            %% Tracks periodic timers already set, so that when connector health check
+            %% returns it doesn't need to kick these off.
+            kicked_off := #{channel_id() => true}
         }
     },
     %% Callers waiting on health check
@@ -475,10 +481,14 @@ list_all() ->
 list_group(Group) ->
     emqx_resource_cache:group_ids(Group).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 -spec health_check(resource_id()) -> {ok, resource_status()} | {error, term()}.
 health_check(ResId) ->
     safe_call(ResId, #manual_resource_health_check{}, ?T_OPERATION).
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 -spec channel_health_check(resource_id(), channel_id()) ->
     #{status := resource_status(), error := term()}.
 channel_health_check(ResId, ChannelId) ->
@@ -1388,6 +1398,8 @@ handle_update_channel(From, ChannelId, ChannelConfig, Data0) ->
             handle_add_channel(From, Data1, ChannelId, ChannelConfig)
     end.
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 handle_manual_resource_health_check(From, Data0 = #data{hc_workers = #{resource := HCWorkers}}) when
     map_size(HCWorkers) > 0
 ->
@@ -1539,6 +1551,8 @@ continue_resource_health_check_not_connected(NewStatus, Data0) ->
             {next_state, ?state_disconnected, Data, Actions}
     end.
 
+%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
+%% process.  Avoid doing manual health checks outside tests.
 handle_manual_channel_health_check(From, #data{state = undefined}, _ChannelId) ->
     {keep_state_and_data, [
         {reply, From, channel_error_status(resource_disconnected)}
@@ -1569,16 +1583,27 @@ handle_manual_channel_health_check(
     {keep_state, Data};
 handle_manual_channel_health_check(
     From,
-    #data{added_channels = Channels} = _Data,
+    #data{
+        added_channels = Channels,
+        hc_pending_callers = #{channel := CPending0} = Pending0
+    } = Data0,
     ChannelId
 ) when
     is_map_key(ChannelId, Channels)
 ->
-    %% No ongoing health check: reply with current status.
-    StatusMap = maps:get(ChannelId, Channels),
-    {keep_state_and_data, [
-        {reply, From, to_external_channel_status(StatusMap)}
-    ]};
+    %% No ongoing health check
+    CPending = maps:update_with(
+        ChannelId,
+        fun(OtherCallers) ->
+            [From | OtherCallers]
+        end,
+        [From],
+        CPending0
+    ),
+    Pending = Pending0#{channel := CPending},
+    Data1 = Data0#data{hc_pending_callers = Pending},
+    Data = start_channel_health_check(Data1, ChannelId),
+    {keep_state, Data};
 handle_manual_channel_health_check(
     From,
     _Data,
@@ -1795,11 +1820,12 @@ get_resource_opts_field_with_fallback(Field, Default, ChannelId, ConfigSources, 
 -spec trigger_health_check_for_added_channels(data()) -> data().
 trigger_health_check_for_added_channels(Data0 = #data{hc_workers = HCWorkers0}) ->
     #{
-        channel := #{ongoing := Ongoing0}
+        channel := #{ongoing := Ongoing0, kicked_off := KickedOff0}
     } = HCWorkers0,
     NewOngoing = maps:filter(
         fun(ChannelId, OldStatus) ->
             (not is_map_key(ChannelId, Ongoing0)) andalso
+                (not is_map_key(ChannelId, KickedOff0)) andalso
                 is_channel_apt_for_health_check(OldStatus)
         end,
         Data0#data.added_channels
@@ -1865,7 +1891,15 @@ handle_start_channel_health_check(Data0, ChannelId) ->
 
 -spec start_channel_health_check(data(), channel_id()) -> data().
 start_channel_health_check(
-    #data{added_channels = AddedChannels, hc_workers = #{channel := #{ongoing := CHCOngoing0}}} =
+    #data{
+        added_channels = AddedChannels,
+        hc_workers = #{
+            channel := #{
+                ongoing := CHCOngoing0,
+                kicked_off := CHCKickedOff0
+            }
+        }
+    } =
         Data0,
     ChannelId
 ) when
@@ -1875,7 +1909,12 @@ start_channel_health_check(
     WorkerPid = spawn_channel_health_check_worker(Data0, ChannelId),
     ChannelStatus = maps:get(ChannelId, AddedChannels),
     CHCOngoing = CHCOngoing0#{ChannelId => ChannelStatus},
-    CHCWorkers = CHCWorkers0#{WorkerPid => ChannelId, ongoing := CHCOngoing},
+    CHCKickedOff = CHCKickedOff0#{ChannelId => true},
+    CHCWorkers = CHCWorkers0#{
+        WorkerPid => ChannelId,
+        ongoing := CHCOngoing,
+        kicked_off := CHCKickedOff
+    },
     HCWorkers = HCWorkers0#{channel := CHCWorkers},
     Data0#data{hc_workers = HCWorkers};
 start_channel_health_check(Data, _ChannelId) ->
@@ -2357,7 +2396,7 @@ abort_all_channel_health_checks(Data0) ->
         end,
         CHCWorkers
     ),
-    HCWorkers = HCWorkers0#{channel := #{ongoing => #{}}},
+    HCWorkers = HCWorkers0#{channel := #{ongoing => #{}, kicked_off => #{}}},
     Pending = Pending0#{channel := #{}},
     Data0#data{
         hc_workers = HCWorkers,
@@ -2387,10 +2426,17 @@ map_take_or(Map, Key, Default) ->
 
 abort_health_checks_for_channel(Data0, ChannelId) ->
     #data{
-        hc_workers = #{channel := #{ongoing := Ongoing0} = CHCWorkers0} = HCWorkers0,
+        hc_workers =
+            #{
+                channel := #{
+                    ongoing := Ongoing0,
+                    kicked_off := KickedOff0
+                } = CHCWorkers0
+            } = HCWorkers0,
         hc_pending_callers = #{channel := CPending0} = Pending0
     } = Data0,
     Ongoing = maps:remove(ChannelId, Ongoing0),
+    KickedOff = maps:remove(ChannelId, KickedOff0),
     {Callers, CPending} = map_take_or(CPending0, ChannelId, []),
     lists:foreach(
         fun(From) ->
@@ -2412,7 +2458,12 @@ abort_health_checks_for_channel(Data0, ChannelId) ->
         CHCWorkers0,
         CHCWorkers0
     ),
-    HCWorkers = HCWorkers0#{channel := CHCWorkers#{ongoing := Ongoing}},
+    HCWorkers = HCWorkers0#{
+        channel := CHCWorkers#{
+            ongoing := Ongoing,
+            kicked_off := KickedOff
+        }
+    },
     Pending = Pending0#{channel := CPending},
     Data0#data{
         hc_workers = HCWorkers,

--- a/apps/emqx_resource/test/emqx_connector_demo.erl
+++ b/apps/emqx_resource/test/emqx_connector_demo.erl
@@ -491,6 +491,9 @@ on_get_channel_status(ConnResId, ChanId, #{health_check_agent := Agent}) ->
                 {Alias, Result} ->
                     Result
             end;
+        {notify, Pid, Status} when ?IS_STATUS(Status) ->
+            Pid ! {returning_channel_health_check_result, ConnResId, ChanId, Status},
+            Status;
         Result ->
             Result
     end;

--- a/apps/emqx_resource/test/emqx_resource_SUITE.erl
+++ b/apps/emqx_resource/test/emqx_resource_SUITE.erl
@@ -5258,3 +5258,67 @@ t_channel_health_check_timeout(_Config) ->
         [log_consistency_prop()]
     ),
     ok.
+
+%% Context: https://emqx.atlassian.net/browse/EMQX-14337
+%% Original bug: upon returning, the resource/connector health check would unconditionally
+%% trigger health checks for channels, even if they had already established their own
+%% periodic timers after their first trigger.
+t_independent_channel_health_check_interval(_Config) ->
+    ?check_trace(
+        begin
+            TestPid = self(),
+            AgentState0 = #{
+                resource_health_check => {notify, TestPid, ?status_connected},
+                channel_health_check => {notify, TestPid, ?status_connected}
+            },
+            {ok, Agent} = emqx_utils_agent:start_link(AgentState0),
+            ConnName = <<"cname">>,
+            %% Needs to have this form to satifisfy internal, implicit requirements of
+            %% `emqx_resource_cache'.
+            ConnResId = <<"connector:ctype:", ConnName/binary>>,
+            {ok, _} =
+                create(
+                    ConnResId,
+                    ?DEFAULT_RESOURCE_GROUP,
+                    ?TEST_RESOURCE,
+                    #{
+                        name => test_resource,
+                        health_check_agent => Agent
+                    },
+                    #{
+                        health_check_interval => 100,
+                        start_timeout => 100
+                    }
+                ),
+            %% Needs to have this form to satifisfy internal, implicit requirements of
+            %% `emqx_resource_cache'.
+            ChanId = <<"action:atype:aname:", ConnResId/binary>>,
+            ok =
+                emqx_resource_manager:add_channel(
+                    ConnResId,
+                    ChanId,
+                    #{
+                        resource_opts => #{
+                            %% Using a huge interval so that it does not
+                            %% repeat during the test
+                            health_check_interval => 1_000_000
+                        }
+                    }
+                ),
+            ?assertMatch({ok, connected}, emqx_resource:health_check(ConnResId)),
+            ?assertMatch(
+                #{status := connected}, emqx_resource:channel_health_check(ConnResId, ChanId)
+            ),
+            %% Upon entering `?status_connected` for the first time, the connector/resource
+            %% will kick off the channel health check.  After that, the channel manages its
+            %% own interval with generic statem timers, and should not be triggered again
+            %% by the more frequent connector health checks.
+            ?assertReceive({returning_resource_health_check_result, _, _}),
+            ?assertReceive({returning_channel_health_check_result, _, _, _}),
+            ?assertNotReceive({returning_channel_health_check_result, _, _, _}),
+            ?assertReceive({returning_resource_health_check_result, _, _}),
+            ok
+        end,
+        [log_consistency_prop()]
+    ),
+    ok.

--- a/changes/ee/fix-15307.en.md
+++ b/changes/ee/fix-15307.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where health checks for Actions/Sources were triggered at the same interval as the Connector's health check interval, if the latter was shorter than the Action/Source's interval.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14337

Release version: 5.10.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
