### PR TITLE
fix(new mix build): add missing `mix.exs` for `emqx_gateway_nats`

### DIFF
--- a/apps/emqx_gateway_nats/mix.exs
+++ b/apps/emqx_gateway_nats/mix.exs
@@ -1,0 +1,31 @@
+defmodule EMQXGatewayNats.MixProject do
+  use Mix.Project
+  alias EMQXUmbrella.MixProject, as: UMP
+
+  def project do
+    [
+      app: :emqx_gateway_nats,
+      version: "0.1.0",
+      build_path: "../../_build",
+      erlc_options: UMP.erlc_options(),
+      erlc_paths: UMP.erlc_paths(),
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: UMP.extra_applications()]
+  end
+
+  def deps() do
+    [
+      {:emqx, in_umbrella: true},
+      {:emqx_utils, in_umbrella: true},
+      {:emqx_gateway, in_umbrella: true}
+    ]
+  end
+end


### PR DESCRIPTION
Only affects new mix build.