### PR TITLE
fix(rule api): make `/rules/:id/test` respond to legacy event topics in rule

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_sqltester.erl
@@ -34,7 +34,11 @@ do_apply_rule(
     }
 ) ->
     InTopic = get_in_topic(Context),
-    Topics = maps:get(from, Rule, []),
+    Topics0 = maps:get(from, Rule, []),
+    Topics = lists:flatmap(
+        fun emqx_rule_events:expand_legacy_event_topics/1,
+        Topics0
+    ),
     case match_any(InTopic, Topics) of
         {ok, Filter} ->
             do_apply_matched_rule(

--- a/changes/ee/fix-15334.en.md
+++ b/changes/ee/fix-15334.en.md
@@ -1,1 +1,0 @@
-Made the `POST /rules/:id/test` API respond to simulated tests when the rule contains legacy (non-namespaced) event topics (e.g.: `$events/client_connected` instead of `$events/client/connected`).

--- a/changes/ee/fix-15334.en.md
+++ b/changes/ee/fix-15334.en.md
@@ -1,0 +1,1 @@
+Made the `POST /rules/:id/test` API respond to simulated tests when the rule contains legacy (non-namespaced) event topics (e.g.: `$events/client_connected` instead of `$events/client/connected`).


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14363

Release version: 5.10.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
