### PR TITLE
fix: handle single dots when exporting protobuf bundles in config backup

### DIFF
--- a/apps/emqx_schema_registry/src/emqx_schema_registry_config.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_config.erl
@@ -552,7 +552,16 @@ str(X) -> emqx_utils_conv:str(X).
 strip_leading_dir(Path0, Dir0) ->
     Path = str(Path0),
     Dir = str(Dir0),
-    lists:flatten(string:replace(Path, Dir ++ "/", "", leading)).
+    do_strip_leading_dir(filename:split(Path), filename:split(Dir)).
+
+do_strip_leading_dir(["." | PathSegs], PrefixSegs) ->
+    do_strip_leading_dir(PathSegs, PrefixSegs);
+do_strip_leading_dir(PathSegs, ["." | PrefixSegs]) ->
+    do_strip_leading_dir(PathSegs, PrefixSegs);
+do_strip_leading_dir([X | PathSegs], [X | PrefixSegs]) ->
+    do_strip_leading_dir(PathSegs, PrefixSegs);
+do_strip_leading_dir(PathSegs, _PrefixSegs) ->
+    filename:join(PathSegs).
 
 prepare_protobuf_files_for_export2(#{<<"type">> := <<"bundle">>} = Source0, Name) ->
     #{<<"root_proto_path">> := RootPath} = Source0,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14372

Release version: 5.10.0

## Summary


https://github.com/user-attachments/assets/9e8ce66f-47ea-470f-9b5d-d4eb375650a9



<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests (tested manually)
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (unreleased feature)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
