### PR TITLE
fix(frame): handle malformed v5 user-property length for pair

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.5.4"},
+    {vsn, "5.5.5"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -692,13 +692,6 @@ parse_utf8_pair(<<LenK:16/big, Key:LenK/binary, Rest/binary>>, _StrictMode) ->
         parsed_key => Key,
         remaining_bytes_length => byte_size(Rest)
     });
-parse_utf8_pair(Bin, _StrictMode) when
-    4 > byte_size(Bin)
-->
-    ?PARSE_ERR(#{
-        cause => user_property_not_enough_bytes,
-        total_bytes => byte_size(Bin)
-    });
 parse_utf8_pair(Bin, _StrictMode) ->
     ?PARSE_ERR(#{
         cause => malformated_user_property,

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -685,11 +685,23 @@ parse_utf8_pair(<<LenK:16/big, _Key:LenK/binary, LenV:16/big, Rest/binary>>, _St
         parsed_value_length => LenV,
         remaining_bytes_length => byte_size(Rest)
     });
+parse_utf8_pair(<<LenK:16/big, Key:LenK/binary, Rest/binary>>, _StrictMode) ->
+    ?PARSE_ERR(#{
+        cause => malformed_user_property_missing_value,
+        parsed_key_length => LenK,
+        parsed_key => Key,
+        remaining_bytes_length => byte_size(Rest)
+    });
 parse_utf8_pair(Bin, _StrictMode) when
     4 > byte_size(Bin)
 ->
     ?PARSE_ERR(#{
         cause => user_property_not_enough_bytes,
+        total_bytes => byte_size(Bin)
+    });
+parse_utf8_pair(Bin, _StrictMode) ->
+    ?PARSE_ERR(#{
+        cause => malformated_user_property,
         total_bytes => byte_size(Bin)
     }).
 

--- a/changes/ee/fix-15361.en.md
+++ b/changes/ee/fix-15361.en.md
@@ -1,0 +1,1 @@
+Fixed a function clause error when parsing a malformed `User-Property` pair where the pair length is wrong (too short).


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14323

Release version: 5.10.1

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
