### PR TITLE
test(mqtt connector): fix flaky test

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.2.10"},
+    {vsn, "0.2.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -657,14 +657,19 @@ explain_error(econnrefused) ->
         "or port number for the server."
     >>;
 explain_error({tcp_closed, _}) ->
+    listener_max_limit_explanation();
+explain_error(closed) ->
+    listener_max_limit_explanation();
+explain_error(_Reason) ->
+    undefined.
+
+listener_max_limit_explanation() ->
     <<
         "Your MQTT connection attempt was unsuccessful. "
         "It might be at its maximum capacity for handling new connections. "
         "To diagnose the issue further, you can check the server logs for "
         "any specific messages related to the unavailability or connection limits."
-    >>;
-explain_error(_Reason) ->
-    undefined.
+    >>.
 
 handle_disconnect(_Reason) ->
     ok.


### PR DESCRIPTION
Apparently, the reason might alternate between `closed` and `{tcp_closed, _}`.

```
Error: -12T13:33:40.119395+00:00 [error] msg: failed_to_start_connection_process, cause: maxlimit, listener: 0.0.0.0:1883
Warning: 2T13:33:40.119704+00:00 [warning] msg: ingress_client_connect_failed, name: <<"connector:mqtt:t_connect_with_more_clients_than_the_broker_accepts-576460752303419311">>, reason: {tcp_closed,#Port<0.1035>}, explain: <<"Your MQTT connection attempt was unsuccessful. It might be at its maximum capacity for handling new connections. To diagnose the issue further, you can check the server logs for any specific messages related to the unavailability or connection limits.">>
Warning: 2T13:33:40.119764+00:00 [warning] msg: ingress_client_connect_failed, name: <<"connector:mqtt:t_connect_with_more_clients_than_the_broker_accepts-576460752303419311">>, reason: {tcp_closed,#Port<0.1037>}, explain: <<"Your MQTT connection attempt was unsuccessful. It might be at its maximum capacity for handling new connections. To diagnose the issue further, you can check the server logs for any specific messages related to the unavailability or connection limits.">>
Warning: 2T13:33:40.120037+00:00 [warning] msg: ingress_client_connect_failed, name: <<"connector:mqtt:t_connect_with_more_clients_than_the_broker_accepts-576460752303419311">>, reason: closed
```

https://github.com/emqx/emqx/actions/runs/15611644433/job/43974468897?pr=15372#step:5:521
