### PR TITLE
feat(config handler): allow saving namespaced configs in mnesia

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -99,15 +99,6 @@
 -define(KIND_REPLICATE, replicate).
 -define(KIND_INITIATE, initiate).
 
--define(CONFIG_TAB, emqx_config).
-
--record(?CONFIG_TAB, {
-    %% {Namespace, RootKey}
-    root_key,
-    raw_value,
-    extra = #{}
-}).
-
 %%--------------------------------------------------------------------
 %% Client Attributes
 %%--------------------------------------------------------------------

--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -99,6 +99,16 @@
 -define(KIND_REPLICATE, replicate).
 -define(KIND_INITIATE, initiate).
 
+-define(CONFIG_TAB, emqx_config).
+
+-record(?CONFIG_TAB, {
+    %% {Namespace, RootKey}
+    root_key,
+    raw_value,
+    checked_value,
+    extra = #{}
+}).
+
 %%--------------------------------------------------------------------
 %% Client Attributes
 %%--------------------------------------------------------------------

--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -105,7 +105,6 @@
     %% {Namespace, RootKey}
     root_key,
     raw_value,
-    checked_value,
     extra = #{}
 }).
 

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -33,6 +33,7 @@ start(_Type, _Args) ->
     {ok, Sup} = emqx_sup:start_link(),
     ok = emqx_limiter:init(),
     ok = maybe_start_listeners(),
+    _ = emqx_config:create_tables(),
     emqx_config:add_handlers(),
     register(emqx, self()),
     {ok, Sup}.

--- a/apps/emqx/src/emqx_app.erl
+++ b/apps/emqx/src/emqx_app.erl
@@ -25,6 +25,7 @@
 %%--------------------------------------------------------------------
 
 start(_Type, _Args) ->
+    _ = emqx_config:create_tables(),
     ok = maybe_load_config(),
     _ = emqx_persistent_message:init(),
     ok = maybe_start_quicer(),
@@ -33,7 +34,6 @@ start(_Type, _Args) ->
     {ok, Sup} = emqx_sup:start_link(),
     ok = emqx_limiter:init(),
     ok = maybe_start_listeners(),
-    _ = emqx_config:create_tables(),
     emqx_config:add_handlers(),
     register(emqx, self()),
     {ok, Sup}.

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -593,9 +593,10 @@ clear_invalid_namespaced_config(Namespace, RootKeyBin) when is_binary(Namespace)
             case map_size(Errors) == 0 of
                 true ->
                     persistent_term:erase(?INVALID_NS_CONF_PT_KEY(Namespace)),
-                    emqx_corrupt_namespace_config_checker:check(Namespace);
+                    emqx_corrupt_namespace_config_checker:clear(Namespace);
                 false ->
-                    persistent_term:put(?INVALID_NS_CONF_PT_KEY(Namespace), Errors)
+                    persistent_term:put(?INVALID_NS_CONF_PT_KEY(Namespace), Errors),
+                    emqx_corrupt_namespace_config_checker:check(Namespace)
             end
     end.
 

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -128,6 +128,14 @@
     runtime_config_key_path/0
 ]).
 
+-define(CONFIG_TAB, emqx_config).
+-record(?CONFIG_TAB, {
+    %% {Namespace, RootKey}
+    root_key,
+    raw_value,
+    extra = #{}
+}).
+
 -type update_request() :: term().
 -type update_cmd() :: {update, update_request()} | remove.
 -type update_opts() :: #{

--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -22,6 +22,7 @@
     fill_defaults/2,
     fill_defaults/3,
     save_configs/5,
+    save_configs_mnesia/5,
     save_to_app_env/1,
     save_to_config_map/2,
     save_to_override_conf/3,
@@ -32,7 +33,9 @@
 
 -export([
     get_root/1,
-    get_root_raw/1
+    get_root_raw/1,
+    get_root_mnesia/2,
+    get_root_raw_mnesia/2
 ]).
 
 -export([get_default_value/1]).
@@ -40,6 +43,8 @@
 -export([
     get/1,
     get/2,
+    get_mnesia/2,
+    get_mnesia/3,
     find/1,
     find_raw/1,
     put/1,
@@ -52,6 +57,8 @@
 -export([
     get_raw/1,
     get_raw/2,
+    get_raw_mnesia/2,
+    get_raw_mnesia/3,
     put_raw/1,
     put_raw/2
 ]).
@@ -81,9 +88,11 @@
     remove_handlers/0
 ]).
 
+-export([create_tables/0]).
 -export([ensure_atom_conf_path/2]).
 -export([load_config_files/2]).
 -export([upgrade_raw_conf/2]).
+-export([seed_defaults_for_all_roots_mnesia/2, erase_namespace_configs_mnesia/1]).
 
 -ifdef(TEST).
 -export([erase_all/0, backup_and_write/2, cluster_hocon_file/0, base_hocon_file/0]).
@@ -95,6 +104,7 @@
 -define(CONF, conf).
 -define(RAW_CONF, raw_conf).
 -define(PERSIS_SCHEMA_MODS, {?MODULE, schema_mods}).
+-define(PERSIS_SCHEMA_MODS_MNESIA, {?MODULE, schema_mods, mnesia}).
 -define(PERSIS_KEY(TYPE, ROOT), {?MODULE, TYPE, ROOT}).
 -define(ZONE_CONF_PATH(ZONE, PATH), [zones, ZONE | PATH]).
 -define(LISTENER_CONF_PATH(TYPE, LISTENER, PATH), [listeners, TYPE, LISTENER | PATH]).
@@ -125,7 +135,8 @@
     %%   defaults to `true`
     persistent => boolean(),
     override_to => local | cluster,
-    lazy_evaluator => fun((function()) -> term())
+    lazy_evaluator => fun((function()) -> term()),
+    namespace => binary()
 }.
 -type update_args() :: {update_cmd(), Opts :: update_opts()}.
 -type update_stage() :: pre_config_update | post_config_update.
@@ -145,15 +156,76 @@
 
 -type runtime_config_key_path() :: [atom()].
 
+-spec create_tables() -> [atom()].
+create_tables() ->
+    ok = mria:create_table(?CONFIG_TAB, [
+        {type, ordered_set},
+        {rlog_shard, ?COMMON_SHARD},
+        {storage, disc_copies},
+        {record_name, ?CONFIG_TAB},
+        {attributes, record_info(fields, ?CONFIG_TAB)}
+    ]),
+    Tables = [?CONFIG_TAB],
+    ok = mria:wait_for_tables(Tables),
+    Tables.
+
 %% @doc For the given path, get root value enclosed in a single-key map.
 -spec get_root(emqx_utils_maps:config_key_path()) -> map().
 get_root([RootName | _]) ->
     #{RootName => do_get(?CONF, [RootName], #{})}.
 
+get_root_mnesia([RootName | _], Namespace) ->
+    #{bin(RootName) => do_get_mnesia([RootName], Namespace, {value, #{}})}.
+
 %% @doc For the given path, get raw root value enclosed in a single-key map.
 %% key is ensured to be binary.
 get_root_raw([RootName | _]) ->
     #{bin(RootName) => get_raw([RootName], #{})}.
+
+get_root_raw_mnesia([RootName | _], Namespace) ->
+    #{bin(RootName) => do_get_raw_mnesia([RootName], Namespace, {value, #{}})}.
+
+do_get_mnesia([Root | KeyRest] = KeyPath, Namespace, DefaultAction) ->
+    RootBin = bin(Root),
+    case mnesia:dirty_read(?CONFIG_TAB, {Namespace, RootBin}) of
+        [#?CONFIG_TAB{checked_value = #{} = RawConfig}] when DefaultAction == error ->
+            deep_get_mnesia(Root, KeyRest, RawConfig);
+        [#?CONFIG_TAB{checked_value = #{} = RawConfig}] ->
+            {value, Default} = DefaultAction,
+            emqx_utils_maps:deep_get(KeyRest, RawConfig, Default);
+        _ ->
+            case DefaultAction of
+                error ->
+                    error({config_not_found, KeyPath});
+                {value, Default} ->
+                    Default
+            end
+    end.
+
+do_get_raw_mnesia([Root | KeyRest] = KeyPath, Namespace, DefaultAction) ->
+    RootBin = bin(Root),
+    case mnesia:dirty_read(?CONFIG_TAB, {Namespace, RootBin}) of
+        [#?CONFIG_TAB{raw_value = #{} = RawConfig}] when DefaultAction == error ->
+            deep_get_mnesia(RootBin, KeyRest, RawConfig);
+        [#?CONFIG_TAB{raw_value = #{} = RawConfig}] ->
+            {value, Default} = DefaultAction,
+            emqx_utils_maps:deep_get(KeyRest, RawConfig, Default);
+        _ ->
+            case DefaultAction of
+                error ->
+                    error({config_not_found, KeyPath});
+                {value, Default} ->
+                    Default
+            end
+    end.
+
+deep_get_mnesia(Root, KeyPath, Config) ->
+    try
+        emqx_utils_maps:deep_get(KeyPath, Config)
+    catch
+        error:{config_not_found, _} ->
+            error({config_not_found, [Root | KeyPath]})
+    end.
 
 %% @doc Get a config value for the given path.
 %% The path should at least include root config name.
@@ -162,6 +234,14 @@ get(KeyPath) -> do_get(?CONF, KeyPath).
 
 -spec get(runtime_config_key_path(), term()) -> term().
 get(KeyPath, Default) -> do_get(?CONF, KeyPath, Default).
+
+get_mnesia(KeyPath0, Namespace) when is_binary(Namespace) ->
+    KeyPath = emqx_config:ensure_atom_conf_path(KeyPath0, {raise_error, config_not_found}),
+    do_get_mnesia(KeyPath, Namespace, error).
+
+get_mnesia(KeyPath0, Namespace, Default) when is_binary(Namespace) ->
+    KeyPath = emqx_config:ensure_atom_conf_path(KeyPath0, {raise_error, config_not_found}),
+    do_get_mnesia(KeyPath, Namespace, {value, Default}).
 
 -spec find(runtime_config_key_path()) ->
     {ok, term()} | {not_found, emqx_utils_maps:config_key_path(), term()}.
@@ -284,6 +364,14 @@ get_raw([Root | _] = KeyPath, Default) when is_binary(Root) -> do_get_raw(KeyPat
 get_raw([Root | T], Default) -> get_raw([bin(Root) | T], Default);
 get_raw([], Default) -> do_get_raw([], Default).
 
+get_raw_mnesia([_Root | _] = KeyPath0, Namespace) ->
+    KeyPath = lists:map(fun bin/1, KeyPath0),
+    do_get_raw_mnesia(KeyPath, Namespace, error).
+
+get_raw_mnesia([_Root | _] = KeyPath0, Namespace, Default) ->
+    KeyPath = lists:map(fun bin/1, KeyPath0),
+    do_get_raw_mnesia(KeyPath, Namespace, {value, Default}).
+
 -spec put_raw(map()) -> ok.
 put_raw(Config) ->
     maps:fold(
@@ -379,6 +467,49 @@ fill_defaults_for_all_roots(SchemaMod, RawConf0) ->
         MissingRoots
     ),
     fill_defaults(RawConf).
+
+seed_defaults_for_all_roots_mnesia(SchemaMod, Namespace) when is_binary(Namespace) ->
+    RootSchemas = hocon_schema:roots(SchemaMod),
+    AllowedMnesiaRoots = mnesia_config_allowed_roots(),
+    RawConf0 = lists:foldl(
+        fun({BinRootName, {_RootName, Schema}}, Acc) ->
+            case maps:get(BinRootName, AllowedMnesiaRoots, false) of
+                true ->
+                    Acc#{BinRootName => seed_default(Schema)};
+                false ->
+                    Acc
+            end
+        end,
+        #{},
+        RootSchemas
+    ),
+    RawConf = fill_defaults(RawConf0),
+    {_AppEnvs, CheckedConf} = check_config(SchemaMod, RawConf, #{}),
+    Opts = #{},
+    {atomic, ok} = mria:transaction(?COMMON_SHARD, fun() ->
+        lists:foreach(
+            fun(RootKeyAtom) ->
+                RootKeyBin = atom_to_binary(RootKeyAtom, utf8),
+                %% Checked conf may contain root keys that are not allowed.
+                maybe
+                    {ok, OneRawConf} ?= maps:find(RootKeyBin, RawConf),
+                    OneCheckedConf = maps:get(RootKeyAtom, CheckedConf),
+                    save_configs_mnesia_tx(Namespace, RootKeyBin, OneCheckedConf, OneRawConf, Opts)
+                end
+            end,
+            maps:keys(CheckedConf)
+        )
+    end),
+    ok.
+
+erase_namespace_configs_mnesia(Namespace) when is_binary(Namespace) ->
+    MS = erlang:make_tuple(
+        record_info(size, ?CONFIG_TAB),
+        '_',
+        [{#?CONFIG_TAB.root_key, {Namespace, '_'}}]
+    ),
+    _ = mria:match_delete(?CONFIG_TAB, MS),
+    ok.
 
 %% So far, this can only return true when testing.
 %% e.g. when testing an app, we need to load its config first
@@ -571,11 +702,16 @@ save_schema_mod_and_names(SchemaMod) ->
         names => lists:usort(OldNames ++ RootNames)
     }).
 
+mnesia_config_allowed_roots() ->
+    Roots = emqx_schema_hooks:list_injection_point('config.allowed_mnesia_roots', []),
+    maps:from_keys(Roots, true).
+
 -ifdef(TEST).
 erase_all() ->
     Names = get_root_names(),
     lists:foreach(fun erase/1, Names),
-    persistent_term:erase(?PERSIS_SCHEMA_MODS).
+    persistent_term:erase(?PERSIS_SCHEMA_MODS),
+    persistent_term:erase(?PERSIS_SCHEMA_MODS_MNESIA).
 -endif.
 
 -spec get_schema_mod() -> #{binary() => atom()}.
@@ -601,6 +737,34 @@ save_configs(AppEnvs, Conf, RawConf, OverrideConf, Opts) ->
     ok = save_to_override_conf(HasDeprecatedFile, OverrideConf, Opts),
     save_to_app_env(AppEnvs),
     save_to_config_map(Conf, RawConf).
+
+save_configs_mnesia(Namespace, RootKey, Conf, RawConf, Opts) when is_binary(Namespace) ->
+    RootKeyBin = bin(RootKey),
+    {atomic, ok} = mria:transaction(?COMMON_SHARD, fun() ->
+        save_configs_mnesia_tx(Namespace, RootKeyBin, Conf, RawConf, Opts)
+    end),
+    ok.
+
+save_configs_mnesia_tx(Namespace, RootKeyBin, Conf, RawConf, _Opts) when
+    is_binary(Namespace),
+    is_binary(RootKeyBin)
+->
+    Key = {Namespace, RootKeyBin},
+    Rec =
+        case mnesia:read(?CONFIG_TAB, Key, write) of
+            [] ->
+                #?CONFIG_TAB{
+                    root_key = Key,
+                    raw_value = RawConf,
+                    checked_value = Conf
+                };
+            [Rec0] ->
+                Rec0#?CONFIG_TAB{
+                    raw_value = RawConf,
+                    checked_value = Conf
+                }
+        end,
+    ok = mnesia:write(?CONFIG_TAB, Rec, write).
 
 %% we ignore kernel app env,
 %% because the old app env will be used in emqx_config_logger:post_config_update/5

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -372,7 +372,7 @@ post_update_ok(
     #conf_info{conf_key_path = [RootKeyAtom | _]} = ConfInfo,
     NewConf = maps:get(RootKeyAtom, NewConf0),
     NewRawConf = maps:get(bin(RootKeyAtom), NewRawConf0),
-    ok = emqx_config:save_configs_mnesia(Namespace, RootKeyAtom, NewConf, NewRawConf, Opts),
+    ok = emqx_config:save_configs_namespaced(Namespace, RootKeyAtom, NewConf, NewRawConf, Opts),
     Result1 = return_change_result(ConfInfo),
     {ok, Result1#{post_config_update => Result0}}.
 
@@ -857,9 +857,9 @@ get_root(ConfKeyPath, Namespace) when is_binary(Namespace) ->
 config_get(ConfKeyPath, undefined = _Namespace, Default) ->
     emqx_config:get(ConfKeyPath, Default);
 config_get(ConfKeyPath, Namespace, Default) when is_binary(Namespace) ->
-    emqx_config:get_mnesia(ConfKeyPath, Namespace, Default).
+    emqx_config:get_namespaced(ConfKeyPath, Namespace, Default).
 
 config_get_raw(ConfKeyPath, undefined = _Namespace) ->
     emqx_config:get_raw(ConfKeyPath);
 config_get_raw(ConfKeyPath, Namespace) when is_binary(Namespace) ->
-    emqx_config:get_raw_mnesia(ConfKeyPath, Namespace).
+    emqx_config:get_raw_namespaced(ConfKeyPath, Namespace).

--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -139,7 +139,7 @@ update_config(SchemaModule, ConfKeyPath, UpdateArgs) ->
 
 -spec update_config(module(), conf_key_path(), emqx_config:update_args(), map()) ->
     {ok, emqx_config:update_result()} | {error, emqx_config:update_error()}.
-update_config(SchemaModule, ConfKeyPath, UpdateArgs, ClusterRpcOpts) ->
+update_config(SchemaModule, ConfKeyPath, UpdateArgs, ClusterRPCOpts) ->
     %% force convert the path to a list of atoms, as there maybe some wildcard names/ids in the path
     AtomKeyPath = [atom(Key) || Key <- ConfKeyPath],
     Namespace =
@@ -156,7 +156,7 @@ update_config(SchemaModule, ConfKeyPath, UpdateArgs, ClusterRpcOpts) ->
         conf_key_path = AtomKeyPath,
         update_args = UpdateArgs,
         namespace = Namespace,
-        cluster_rpc_opts = ClusterRpcOpts
+        cluster_rpc_opts = ClusterRPCOpts
     },
     gen_server:call(?MODULE, ConfInfo, infinity).
 
@@ -330,10 +330,10 @@ check_and_save_configs(ConfInfo, NewRawConf, OverrideConf, Opts) ->
     #conf_info{
         schema_mod = SchemaModule,
         conf_key_path = ConfKeyPath,
-        cluster_rpc_opts = ClusterRpcOpts
+        cluster_rpc_opts = ClusterRPCOpts
     } = ConfInfo,
     Schema = schema(SchemaModule, ConfKeyPath),
-    Kind = maps:get(kind, ClusterRpcOpts, ?KIND_INITIATE),
+    Kind = maps:get(kind, ClusterRPCOpts, ?KIND_INITIATE),
     {AppEnvs, NewConf} = emqx_config:check_config(Schema, NewRawConf),
     OldConf = get_root(ConfKeyPath, ConfInfo#conf_info.namespace),
     PostUpCtx = #{old_conf => OldConf, new_conf => NewConf, app_envs => AppEnvs},
@@ -450,18 +450,18 @@ apply_pre_config_update(Module, Callback, 4, #{
     conf_key_path := ConfKeyPath,
     update_req := UpdateReq,
     old_raw_conf := OldRawConf,
-    cluster_rpc_opts := ClusterRpcOpts
+    cluster_rpc_opts := ClusterRPCOpts
 }) ->
-    Module:Callback(ConfKeyPath, UpdateReq, OldRawConf, ClusterRpcOpts);
+    Module:Callback(ConfKeyPath, UpdateReq, OldRawConf, ClusterRPCOpts);
 apply_pre_config_update(Module, Callback, 5, #{
     conf_key_path := ConfKeyPath,
     update_req := UpdateReq,
     namespace := Namespace,
     old_raw_conf := OldRawConf,
-    cluster_rpc_opts := ClusterRpcOpts
+    cluster_rpc_opts := ClusterRPCOpts
 }) ->
     ExtraContext = #{namespace => Namespace},
-    Module:Callback(ConfKeyPath, UpdateReq, OldRawConf, ClusterRpcOpts, ExtraContext);
+    Module:Callback(ConfKeyPath, UpdateReq, OldRawConf, ClusterRPCOpts, ExtraContext);
 apply_pre_config_update(_Module, _Callback, false, #{
     update_req := UpdateReq,
     old_raw_conf := OldRawConf
@@ -575,24 +575,24 @@ apply_post_config_update(Module, Callback, 5, #{
 apply_post_config_update(Module, Callback, 6, #{
     conf_key_path := ConfKeyPath,
     update_req := UpdateReq,
-    cluster_rpc_opts := ClusterRpcOpts,
+    cluster_rpc_opts := ClusterRPCOpts,
     new_conf := NewConf,
     old_conf := OldConf,
     app_envs := AppEnvs
 }) ->
-    Module:Callback(ConfKeyPath, UpdateReq, NewConf, OldConf, AppEnvs, ClusterRpcOpts);
+    Module:Callback(ConfKeyPath, UpdateReq, NewConf, OldConf, AppEnvs, ClusterRPCOpts);
 apply_post_config_update(Module, Callback, 7, #{
     conf_key_path := ConfKeyPath,
     update_req := UpdateReq,
     namespace := Namespace,
-    cluster_rpc_opts := ClusterRpcOpts,
+    cluster_rpc_opts := ClusterRPCOpts,
     new_conf := NewConf,
     old_conf := OldConf,
     app_envs := AppEnvs
 }) ->
     ExtraContext = #{namespace => Namespace},
     Module:Callback(
-        ConfKeyPath, UpdateReq, NewConf, OldConf, AppEnvs, ClusterRpcOpts, ExtraContext
+        ConfKeyPath, UpdateReq, NewConf, OldConf, AppEnvs, ClusterRPCOpts, ExtraContext
     );
 apply_post_config_update(_Module, _Callback, false, _Ctx) ->
     ok.
@@ -836,7 +836,7 @@ conf_info_to_map(#conf_info{
     conf_key_path = ConfKeyPath,
     update_args = UpdateArgs,
     namespace = Namespace,
-    cluster_rpc_opts = ClusterRpcOpts,
+    cluster_rpc_opts = ClusterRPCOpts,
     handlers = Handlers
 }) ->
     #{
@@ -845,7 +845,7 @@ conf_info_to_map(#conf_info{
         update_args => UpdateArgs,
         namespace => Namespace,
         update_req => up_req(UpdateArgs),
-        cluster_rpc_opts => ClusterRpcOpts,
+        cluster_rpc_opts => ClusterRPCOpts,
         handlers => Handlers
     }.
 

--- a/apps/emqx/src/emqx_corrupt_namespace_config_checker.erl
+++ b/apps/emqx/src/emqx_corrupt_namespace_config_checker.erl
@@ -1,0 +1,118 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_corrupt_namespace_config_checker).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
+%% API
+-export([
+    start_link/0,
+
+    check/1
+]).
+
+%% `gen_server' API
+-export([
+    init/1,
+    handle_continue/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%% Calls/casts/infos
+-record(check_all, {}).
+-record(check, {ns}).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+check(Namespace) ->
+    gen_server:cast(?MODULE, #check{ns = Namespace}).
+
+%%------------------------------------------------------------------------------
+%% `gen_server' API
+%%------------------------------------------------------------------------------
+
+init(_) ->
+    case mria_config:whoami() of
+        replicant ->
+            ignore;
+        _ ->
+            State = #{},
+            {ok, State, {continue, #check_all{}}}
+    end.
+
+handle_continue(#check_all{}, State) ->
+    NamespaceErrors = emqx_config:get_all_namespace_config_errors(),
+    raise_alarms(NamespaceErrors),
+    ?tp("corrupt_ns_checker_started", #{}),
+    {noreply, State}.
+
+handle_call(Call, _From, State) ->
+    {reply, {error, {unknown_call, Call}}, State}.
+
+handle_cast(#check{ns = Namespace}, State) ->
+    do_check(Namespace),
+    ?tp("corrupt_ns_checker_checked", #{ns => Namespace}),
+    {noreply, State};
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+raise_alarms(NamespaceErrors) when is_list(NamespaceErrors) ->
+    lists:foreach(fun raise_alarms/1, NamespaceErrors);
+raise_alarms({Namespace, HoconErrorsPerRoot0}) ->
+    HoconErrorsPerRoot = format_errors(HoconErrorsPerRoot0),
+    emqx_alarm:safe_activate(
+        Namespace,
+        #{namespace => Namespace, errors => HoconErrorsPerRoot},
+        <<"Namespace contains invalid configuration">>
+    ),
+    ok.
+
+format_errors(HoconErrorsPerRoot0) ->
+    SchemaMod = emqx_config:get_schema_mod(),
+    maps:map(
+        fun(_Root, HoconErrors) ->
+            case emqx_hocon:format_error({SchemaMod, HoconErrors}) of
+                false ->
+                    %% Should be impossible
+                    HoconErrors;
+                {ok, Formatted} ->
+                    emqx_utils_json:decode(Formatted)
+            end
+        end,
+        HoconErrorsPerRoot0
+    ).
+
+do_check(Namespace) ->
+    case emqx_config:get_namespace_config_errors(Namespace) of
+        undefined ->
+            emqx_alarm:ensure_deactivated(Namespace),
+            ok;
+        #{} = HoconErrorsPerRoot0 ->
+            HoconErrorsPerRoot = format_errors(HoconErrorsPerRoot0),
+            emqx_alarm:safe_activate(
+                Namespace,
+                #{namespace => Namespace, errors => HoconErrorsPerRoot},
+                <<"Namespace contains invalid configuration">>
+            ),
+            ok
+    end.

--- a/apps/emqx/src/emqx_sys_sup.erl
+++ b/apps/emqx/src/emqx_sys_sup.erl
@@ -26,7 +26,7 @@ init([]) ->
             child_spec(emqx_sys_mon),
             child_spec(emqx_vm_mon),
             child_spec(emqx_broker_mon)
-        ] ++ OsMon,
+        ] ++ OsMon ++ [child_spec(emqx_corrupt_namespace_config_checker)],
     {ok, {{one_for_one, 10, 100}, Children}}.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -109,6 +109,8 @@
 
 -export([capture_io_format/1]).
 
+-export([seed_defaults_for_all_roots_namespaced_cluster/2]).
+
 -define(CERTS_PATH(CertName), filename:join(["etc", "certs", CertName])).
 
 -define(MQTT_SSL_CLIENT_CERTS, [
@@ -1608,3 +1610,10 @@ format_io_requests(IoRequests) ->
 %% In standalone tests, other applications such as `emqx_conf` are not available.
 is_standalone_test() ->
     not emqx_common_test_helpers:ensure_loaded(emqx_conf).
+
+seed_defaults_for_all_roots_namespaced_cluster(SchemaMod, Namespace) ->
+    emqx_cluster_rpc:multicall(
+        emqx_config,
+        seed_defaults_for_all_roots_namespaced,
+        [SchemaMod, Namespace]
+    ).

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -330,11 +330,11 @@ t_root_key_update(TCConfig) when is_list(TCConfig) ->
 
     %% update sub key
     SubKey = KeyPath ++ [os, cpu_high_watermark],
-    ?assertEqual(
+    ?assertMatch(
         {ok, #{
-            config => 0.81,
-            post_config_update => #{},
-            raw_config => <<"81%">>
+            config := 0.81,
+            post_config_update := #{},
+            raw_config := <<"81%">>
         }},
         emqx:update_config(SubKey, "81%", Opts)
     ),
@@ -381,8 +381,8 @@ t_sub_key_update_remove(TCConfig) when is_list(TCConfig) ->
 
     %% remove
     on_exit(fun() -> emqx:update_config(KeyPath, OriginalVal, Opts) end),
-    ?assertEqual(
-        {ok, #{post_config_update => #{?MODULE => ok}}},
+    ?assertMatch(
+        {ok, #{post_config_update := #{?MODULE := ok}}},
         remove_config(TCConfig, KeyPath)
     ),
     try

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -7,18 +7,47 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
+
 -define(MOD, '$mod').
 -define(WKEY, '?').
 -define(CLUSTER_CONF, "/tmp/cluster.conf").
 
--include_lib("eunit/include/eunit.hrl").
--include_lib("common_test/include/ct.hrl").
+-define(NS, <<"testns">>).
+-define(global, global).
+-define(namespace, namespace).
+
+-define(pre_post_table, pre_post_table).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
 
 all() ->
-    emqx_common_test_helpers:all(?MODULE).
+    emqx_common_test_helpers:all_with_matrix(?MODULE).
+
+groups() ->
+    emqx_common_test_helpers:groups_with_matrix(?MODULE).
 
 init_per_suite(Config) ->
-    Apps = emqx_cth_suite:start([emqx], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx, #{
+                after_start =>
+                    fun() ->
+                        ok = emqx_schema_hooks:inject_from_modules([?MODULE])
+                    end
+            }}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
@@ -26,10 +55,193 @@ end_per_suite(Config) ->
 
 init_per_testcase(_Case, Config) ->
     _ = file:delete(?CLUSTER_CONF),
+    _ = ets:new(?pre_post_table, [named_table, bag, public]),
+    maybe
+        true ?= is_namespaced(Config),
+        emqx_config:seed_defaults_for_all_roots_mnesia(emqx_schema, ?NS),
+        on_exit(fun() -> ok = emqx_config:erase_namespace_configs_mnesia(?NS) end)
+    end,
     Config.
 
 end_per_testcase(_Case, _Config) ->
+    emqx_common_test_helpers:call_janitor(),
     ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+injected_fields() ->
+    #{
+        'config.allowed_mnesia_roots' => [<<"sysmon">>]
+    }.
+
+update_config_opts(TCConfig) ->
+    update_config_opts(TCConfig, _Overrides = #{}).
+update_config_opts(TCConfig, Overrides) ->
+    Opts = lists:foldl(
+        fun
+            (?namespace, Acc) ->
+                Acc#{namespace => ?NS};
+            (_Group, Acc) ->
+                Acc
+        end,
+        #{},
+        emqx_common_test_helpers:group_path(TCConfig)
+    ),
+    maps:merge(Opts, Overrides).
+
+is_namespaced(TCConfig) ->
+    case [true || ?namespace <- emqx_common_test_helpers:group_path(TCConfig)] of
+        [] ->
+            false;
+        _ ->
+            true
+    end.
+
+get_raw_config(TCConfig, KeyPath) when is_list(TCConfig) ->
+    case is_namespaced(TCConfig) of
+        true ->
+            emqx_config:get_raw_mnesia(KeyPath, ?NS);
+        false ->
+            emqx:get_raw_config(KeyPath)
+    end.
+
+get_raw_config(TCConfig, KeyPath, Default) when is_list(TCConfig) ->
+    case is_namespaced(TCConfig) of
+        true ->
+            emqx_config:get_raw_mnesia(KeyPath, ?NS, Default);
+        false ->
+            emqx:get_raw_config(KeyPath, Default)
+    end.
+
+get_config(TCConfig, KeyPath) when is_list(TCConfig) ->
+    case is_namespaced(TCConfig) of
+        true ->
+            emqx_config:get_mnesia(KeyPath, ?NS);
+        false ->
+            emqx:get_config(KeyPath)
+    end.
+
+remove_config(TCConfig, KeyPath) ->
+    emqx:remove_config(KeyPath, update_config_opts(TCConfig)).
+
+pre_config_update([sysmon], UpdateReq, _RawConf, _ClusterRPCOpts, ExtraContext) ->
+    ets:insert(?pre_post_table, {pre, #{extra_context => ExtraContext}}),
+    {ok, UpdateReq};
+pre_config_update([sysmon, os], UpdateReq, _RawConf, _, _) ->
+    {ok, UpdateReq};
+pre_config_update([sysmon, os, cpu_check_interval], UpdateReq, _RawConf, _, _) ->
+    {ok, UpdateReq};
+pre_config_update([sysmon, os, cpu_low_watermark], UpdateReq, _RawConf, _, _) ->
+    {ok, UpdateReq};
+pre_config_update([sysmon, os, cpu_high_watermark], UpdateReq, _RawConf, _, _) ->
+    {ok, UpdateReq};
+pre_config_update([sysmon, os, sysmem_high_watermark], UpdateReq, _RawConf, _, _) ->
+    {ok, UpdateReq};
+pre_config_update([sysmon, os, mem_check_interval], _UpdateReq, _RawConf, _, _) ->
+    {error, pre_config_update_error}.
+
+propagated_pre_config_update(
+    [<<"sysmon">>, <<"os">>, <<"cpu_check_interval">>],
+    <<"333s">>,
+    _RawConf,
+    _ClusterRPCOpts,
+    _ExtraContext
+) ->
+    {ok, <<"444s">>};
+propagated_pre_config_update(
+    [<<"sysmon">>, <<"os">>, <<"mem_check_interval">>],
+    _UpdateReq,
+    _RawConf,
+    _ClusterRPCOpts,
+    _ExtraContext
+) ->
+    {error, pre_config_update_error};
+propagated_pre_config_update(_ConfKeyPath, _UpdateReq, _RawConf, _ClusterRPCOpts, ExtraContext) ->
+    ets:insert(?pre_post_table, {propagated_pre, #{extra_context => ExtraContext}}),
+    ok.
+
+post_config_update(
+    [sysmon], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _ClusterRPCOpts, ExtraContext
+) ->
+    ets:insert(?pre_post_table, {post, #{extra_context => ExtraContext}}),
+    {ok, ok};
+post_config_update([sysmon, os], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _) ->
+    {ok, ok};
+post_config_update(
+    [sysmon, os, cpu_check_interval], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _
+) ->
+    {ok, ok};
+post_config_update([sysmon, os, cpu_low_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _) ->
+    ok;
+post_config_update(
+    [sysmon, os, cpu_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _
+) ->
+    ok;
+post_config_update(
+    [sysmon, os, sysmem_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _
+) ->
+    {error, post_config_update_error}.
+
+propagated_post_config_update(
+    [sysmon, os, sysmem_high_watermark],
+    _UpdateReq,
+    _NewConf,
+    _OldConf,
+    _AppEnvs,
+    _ClusterRPCOpts,
+    _ExtraContext
+) ->
+    {error, post_config_update_error};
+propagated_post_config_update(
+    _ConfKeyPath, _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, ExtraContext
+) ->
+    ets:insert(?pre_post_table, {propagated_post, #{extra_context => ExtraContext}}),
+    ok.
+
+wait_for_new_pid() ->
+    case erlang:whereis(emqx_config_handler) of
+        undefined ->
+            ct:sleep(10),
+            wait_for_new_pid();
+        Pid ->
+            Pid
+    end.
+
+assert_update_result(TCConfig, FailedPath, Update, Expect) ->
+    assert_update_result(TCConfig, [FailedPath], FailedPath, Update, Expect).
+
+assert_update_result(TCConfig, Paths, UpdatePath, Update, Expect) ->
+    with_update_result(TCConfig, Paths, UpdatePath, Update, fun(Old, Result) ->
+        ?assertEqual(Expect, Result),
+        New = get_raw_config(TCConfig, UpdatePath, undefined),
+        ?assertEqual(Old, New)
+    end).
+
+with_update_result(TCConfig, Paths, UpdatePath, Update, Fun) ->
+    ok = lists:foreach(
+        fun(Path) -> emqx_config_handler:add_handler(Path, ?MODULE) end,
+        Paths
+    ),
+    Opts = update_config_opts(TCConfig, #{rawconf_with_defaults => true}),
+    Old = get_raw_config(TCConfig, UpdatePath, undefined),
+    Result = emqx:update_config(UpdatePath, Update, Opts),
+    _ = Fun(Old, Result),
+    ok = lists:foreach(
+        fun(Path) -> emqx_config_handler:remove_handler(Path) end,
+        Paths
+    ),
+    ok.
+
+add_handler(KeyPath, Module) ->
+    Res = emqx_config_handler:add_handler(KeyPath, Module),
+    on_exit(fun() -> emqx_config_handler:remove_handler(KeyPath) end),
+    Res.
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
 
 t_handler(_Config) ->
     BadCallBackMod = emqx,
@@ -54,7 +266,7 @@ t_handler(_Config) ->
     ?assertMatch(#{RootKey := #{?WKEY := #{cpu_check_interval := #{?MOD := ?MODULE}}}}, Handlers2),
     ok = emqx_config_handler:remove_handler(Wildcard1),
     #{handlers := Handlers3} = emqx_config_handler:info(),
-    ct:pal("Key:~p wildcard1: ~p~n", [Wildcard1, Handlers3]),
+    ct:pal("Key:~p wildcard1:\n ~p~n", [Wildcard1, Handlers3]),
     ?assertEqual(false, maps:is_key(RootKey, Handlers3)),
 
     %% can_override_a_wildcard_path
@@ -92,29 +304,33 @@ t_conflict_handler(_Config) ->
     ),
     ok.
 
-t_root_key_update(_Config) ->
-    PathKey = [sysmon],
-    Opts = #{rawconf_with_defaults => true},
-    ok = emqx_config_handler:add_handler(PathKey, ?MODULE),
+t_root_key_update() ->
+    [{matrix, true}].
+t_root_key_update(matrix) ->
+    [[?global], [?namespace]];
+t_root_key_update(TCConfig) when is_list(TCConfig) ->
+    KeyPath = [sysmon],
+    Opts = update_config_opts(TCConfig, #{rawconf_with_defaults => true}),
+    ok = add_handler(KeyPath, ?MODULE),
     %% update
-    Old = #{<<"os">> := OS} = emqx:get_raw_config(PathKey),
+    Old = #{<<"os">> := OS} = get_raw_config(TCConfig, KeyPath),
     {ok, Res} = emqx:update_config(
-        PathKey,
+        KeyPath,
         Old#{<<"os">> => OS#{<<"cpu_check_interval">> => <<"12s">>}},
         Opts
     ),
     ?assertMatch(
         #{
-            config := #{os := #{cpu_check_interval := 12000}},
+            config := #{os := #{cpu_check_interval := 12_000}},
             post_config_update := #{?MODULE := ok},
             raw_config := #{<<"os">> := #{<<"cpu_check_interval">> := <<"12s">>}}
         },
         Res
     ),
-    ?assertMatch(#{os := #{cpu_check_interval := 12000}}, emqx:get_config(PathKey)),
+    ?assertMatch(#{os := #{cpu_check_interval := 12000}}, get_config(TCConfig, KeyPath)),
 
     %% update sub key
-    SubKey = PathKey ++ [os, cpu_high_watermark],
+    SubKey = KeyPath ++ [os, cpu_high_watermark],
     ?assertEqual(
         {ok, #{
             config => 0.81,
@@ -123,32 +339,36 @@ t_root_key_update(_Config) ->
         }},
         emqx:update_config(SubKey, "81%", Opts)
     ),
-    ?assertEqual(0.81, emqx:get_config(SubKey)),
-    ?assertEqual("81%", emqx:get_raw_config(SubKey)),
+    ?assertEqual(0.81, get_config(TCConfig, SubKey)),
+    ?assertEqual("81%", get_raw_config(TCConfig, SubKey)),
     %% remove
-    ?assertEqual({error, "remove_root_is_forbidden"}, emqx:remove_config(PathKey)),
-    ?assertMatch(true, is_map(emqx:get_raw_config(PathKey))),
+    ?assertEqual({error, "remove_root_is_forbidden"}, remove_config(TCConfig, KeyPath)),
+    ?assertMatch(true, is_map(get_raw_config(TCConfig, KeyPath))),
 
-    ok = emqx_config_handler:remove_handler(PathKey),
     ok.
 
-t_sub_key_update_remove(_Config) ->
+t_sub_key_update_remove() ->
+    [{matrix, true}].
+t_sub_key_update_remove(matrix) ->
+    [[?global], [?namespace]];
+t_sub_key_update_remove(TCConfig) when is_list(TCConfig) ->
     KeyPath = [sysmon, os, cpu_check_interval],
-    Opts = #{},
-    ok = emqx_config_handler:add_handler(KeyPath, ?MODULE),
+    Opts = update_config_opts(TCConfig),
+    ok = add_handler(KeyPath, ?MODULE),
     {ok, Res} = emqx:update_config(KeyPath, <<"60s">>, Opts),
     ?assertMatch(
         #{
-            config := 60000,
+            config := 60_000,
             post_config_update := #{?MODULE := ok},
             raw_config := <<"60s">>
         },
         Res
     ),
-    ?assertMatch(60000, emqx:get_config(KeyPath)),
+    ?assertMatch(60_000, get_config(TCConfig, KeyPath)),
+    OriginalVal = get_raw_config(TCConfig, KeyPath),
 
     KeyPath2 = [sysmon, os, cpu_low_watermark],
-    ok = emqx_config_handler:add_handler(KeyPath2, ?MODULE),
+    ok = add_handler(KeyPath2, ?MODULE),
     {ok, Res1} = emqx:update_config(KeyPath2, <<"40%">>, Opts),
     ?assertMatch(
         #{
@@ -158,34 +378,46 @@ t_sub_key_update_remove(_Config) ->
         },
         Res1
     ),
-    ?assertMatch(0.4, emqx:get_config(KeyPath2)),
+    ?assertMatch(0.4, get_config(TCConfig, KeyPath2)),
 
     %% remove
+    on_exit(fun() -> emqx:update_config(KeyPath, OriginalVal, Opts) end),
     ?assertEqual(
         {ok, #{post_config_update => #{?MODULE => ok}}},
-        emqx:remove_config(KeyPath)
+        remove_config(TCConfig, KeyPath)
     ),
-    ?assertError(
-        {config_not_found, [<<"sysmon">>, os, cpu_check_interval]}, emqx:get_raw_config(KeyPath)
-    ),
-    OSKey = maps:keys(emqx:get_raw_config([sysmon, os])),
+    try
+        get_raw_config(TCConfig, KeyPath),
+        ct:fail("should have raised a config_not_found error")
+    catch
+        error:{config_not_found, [<<"sysmon">>, os, cpu_check_interval]} ->
+            %% Global config
+            ok;
+        error:{config_not_found, [<<"sysmon">>, <<"os">>, <<"cpu_check_interval">>]} ->
+            %% Namespace config
+            ok;
+        K:E:S ->
+            ct:fail("unexpected error:\n  ~p", [{K, E, S}])
+    end,
+    OSKey = maps:keys(get_raw_config(TCConfig, [sysmon, os])),
     ?assertEqual(false, lists:member(<<"cpu_check_interval">>, OSKey)),
     ?assert(length(OSKey) > 0),
 
-    ok = emqx_config_handler:remove_handler(KeyPath),
-    ok = emqx_config_handler:remove_handler(KeyPath2),
     ok.
 
-t_check_failed(_Config) ->
+t_check_failed() ->
+    [{matrix, true}].
+t_check_failed(matrix) ->
+    [[?global], [?namespace]];
+t_check_failed(TCConfig) when is_list(TCConfig) ->
     KeyPath = [sysmon, os, cpu_check_interval],
-    Opts = #{rawconf_with_defaults => true},
-    Origin = emqx:get_raw_config(KeyPath),
-    ok = emqx_config_handler:add_handler(KeyPath, ?MODULE),
+    Opts = update_config_opts(TCConfig, #{rawconf_with_defaults => true}),
+    Origin = get_raw_config(TCConfig, KeyPath),
+    ok = add_handler(KeyPath, ?MODULE),
     %% It should be a duration("1h"), but we set it as a percent.
     ?assertMatch({error, _Res}, emqx:update_config(KeyPath, <<"80%">>, Opts)),
-    New = emqx:get_raw_config(KeyPath),
+    New = get_raw_config(TCConfig, KeyPath),
     ?assertEqual(Origin, New),
-    ok = emqx_config_handler:remove_handler(KeyPath),
     ok.
 
 t_stop(_Config) ->
@@ -198,39 +430,57 @@ t_stop(_Config) ->
     ?assertEqual(OldInfo, NewInfo),
     ok.
 
-t_callback_crash(_Config) ->
+t_callback_crash() ->
+    [{matrix, true}].
+t_callback_crash(matrix) ->
+    [[?global], [?namespace]];
+t_callback_crash(TCConfig) when is_list(TCConfig) ->
     CrashPath = [sysmon, os, procmem_high_watermark],
-    Opts = #{rawconf_with_defaults => true},
-    ok = emqx_config_handler:add_handler(CrashPath, ?MODULE),
-    Old = emqx:get_raw_config(CrashPath),
+    Opts = update_config_opts(TCConfig, #{rawconf_with_defaults => true}),
+    ok = add_handler(CrashPath, ?MODULE),
+    Old = get_raw_config(TCConfig, CrashPath),
     ?assertMatch(
         {error, {config_update_crashed, _}}, emqx:update_config(CrashPath, <<"89%">>, Opts)
     ),
-    New = emqx:get_raw_config(CrashPath),
+    New = get_raw_config(TCConfig, CrashPath),
     ?assertEqual(Old, New),
-    ok = emqx_config_handler:remove_handler(CrashPath),
     ok.
 
-t_pre_assert_update_result(_Config) ->
+t_pre_assert_update_result() ->
+    [{matrix, true}].
+t_pre_assert_update_result(matrix) ->
+    [[?global], [?namespace]];
+t_pre_assert_update_result(TCConfig) when is_list(TCConfig) ->
     assert_update_result(
+        TCConfig,
         [sysmon, os, mem_check_interval],
         <<"100s">>,
         {error, {pre_config_update, ?MODULE, pre_config_update_error}}
     ),
     ok.
 
-t_post_update_error(_Config) ->
+t_post_update_error() ->
+    [{matrix, true}].
+t_post_update_error(matrix) ->
+    [[?global], [?namespace]];
+t_post_update_error(TCConfig) when is_list(TCConfig) ->
     assert_update_result(
+        TCConfig,
         [sysmon, os, sysmem_high_watermark],
         <<"60%">>,
         {error, {post_config_update, ?MODULE, post_config_update_error}}
     ),
     ok.
 
-t_post_update_propagate_error_wkey(_Config) ->
+t_post_update_propagate_error_wkey() ->
+    [{matrix, true}].
+t_post_update_propagate_error_wkey(matrix) ->
+    [[?global], [?namespace]];
+t_post_update_propagate_error_wkey(TCConfig) when is_list(TCConfig) ->
     Conf0 = emqx_config:get_raw([sysmon]),
     Conf1 = emqx_utils_maps:deep_put([<<"os">>, <<"sysmem_high_watermark">>], Conf0, <<"60%">>),
     assert_update_result(
+        TCConfig,
         [
             [sysmon, '?', sysmem_high_watermark],
             [sysmon]
@@ -241,10 +491,15 @@ t_post_update_propagate_error_wkey(_Config) ->
     ),
     ok.
 
-t_post_update_propagate_error_key(_Config) ->
+t_post_update_propagate_error_key() ->
+    [{matrix, true}].
+t_post_update_propagate_error_key(matrix) ->
+    [[?global], [?namespace]];
+t_post_update_propagate_error_key(TCConfig) when is_list(TCConfig) ->
     Conf0 = emqx_config:get_raw([sysmon]),
     Conf1 = emqx_utils_maps:deep_put([<<"os">>, <<"sysmem_high_watermark">>], Conf0, <<"60%">>),
     assert_update_result(
+        TCConfig,
         [
             [sysmon, os, sysmem_high_watermark],
             [sysmon]
@@ -255,10 +510,15 @@ t_post_update_propagate_error_key(_Config) ->
     ),
     ok.
 
-t_pre_update_propagate_error_wkey(_Config) ->
+t_pre_update_propagate_error_wkey() ->
+    [{matrix, true}].
+t_pre_update_propagate_error_wkey(matrix) ->
+    [[?global], [?namespace]];
+t_pre_update_propagate_error_wkey(TCConfig) when is_list(TCConfig) ->
     Conf0 = emqx_config:get_raw([sysmon]),
     Conf1 = emqx_utils_maps:deep_put([<<"os">>, <<"mem_check_interval">>], Conf0, <<"70s">>),
     assert_update_result(
+        TCConfig,
         [
             [sysmon, '?', mem_check_interval],
             [sysmon]
@@ -269,10 +529,15 @@ t_pre_update_propagate_error_wkey(_Config) ->
     ),
     ok.
 
-t_pre_update_propagate_error_key(_Config) ->
+t_pre_update_propagate_error_key() ->
+    [{matrix, true}].
+t_pre_update_propagate_error_key(matrix) ->
+    [[?global], [?namespace]];
+t_pre_update_propagate_error_key(TCConfig) when is_list(TCConfig) ->
     Conf0 = emqx_config:get_raw([sysmon]),
     Conf1 = emqx_utils_maps:deep_put([<<"os">>, <<"mem_check_interval">>], Conf0, <<"70s">>),
     assert_update_result(
+        TCConfig,
         [
             [sysmon, os, mem_check_interval],
             [sysmon]
@@ -283,10 +548,15 @@ t_pre_update_propagate_error_key(_Config) ->
     ),
     ok.
 
-t_pre_update_propagate_key_rewrite(_Config) ->
+t_pre_update_propagate_key_rewrite() ->
+    [{matrix, true}].
+t_pre_update_propagate_key_rewrite(matrix) ->
+    [[?global], [?namespace]];
+t_pre_update_propagate_key_rewrite(TCConfig) when is_list(TCConfig) ->
     Conf0 = emqx_config:get_raw([sysmon]),
     Conf1 = emqx_utils_maps:deep_put([<<"os">>, <<"cpu_check_interval">>], Conf0, <<"333s">>),
     with_update_result(
+        TCConfig,
         [
             [sysmon, '?', cpu_check_interval],
             [sysmon]
@@ -300,30 +570,6 @@ t_pre_update_propagate_key_rewrite(_Config) ->
             )
         end
     ),
-    ok.
-
-t_handler_root() ->
-    %% Don't rely on default emqx_config_handler's merge behaviour.
-    RootKey = [],
-    Opts = #{rawconf_with_defaults => true},
-    ok = emqx_config_handler:add_handler(RootKey, ?MODULE),
-    %% update
-    Old = #{<<"sysmon">> := #{<<"os">> := OS}} = emqx:get_raw_config(RootKey),
-    {ok, Res} = emqx:update_config(
-        RootKey,
-        Old#{<<"sysmon">> => #{<<"os">> => OS#{<<"cpu_check_interval">> => <<"12s">>}}},
-        Opts
-    ),
-    ?assertMatch(
-        #{
-            config := #{os := #{cpu_check_interval := 12000}},
-            post_config_update := #{?MODULE := ok},
-            raw_config := #{<<"os">> := #{<<"cpu_check_interval">> := <<"12s">>}}
-        },
-        Res
-    ),
-    ?assertMatch(#{sysmon := #{os := #{cpu_check_interval := 12000}}}, emqx:get_config(RootKey)),
-    ok = emqx_config_handler:remove_handler(RootKey),
     ok.
 
 t_get_raw_cluster_override_conf(_Config) ->
@@ -343,82 +589,79 @@ t_get_raw_cluster_override_conf(_Config) ->
     ?assertEqual(OldInfo, NewInfo),
     ok.
 
-pre_config_update([sysmon], UpdateReq, _RawConf) ->
-    {ok, UpdateReq};
-pre_config_update([sysmon, os], UpdateReq, _RawConf) ->
-    {ok, UpdateReq};
-pre_config_update([sysmon, os, cpu_check_interval], UpdateReq, _RawConf) ->
-    {ok, UpdateReq};
-pre_config_update([sysmon, os, cpu_low_watermark], UpdateReq, _RawConf) ->
-    {ok, UpdateReq};
-pre_config_update([sysmon, os, cpu_high_watermark], UpdateReq, _RawConf) ->
-    {ok, UpdateReq};
-pre_config_update([sysmon, os, sysmem_high_watermark], UpdateReq, _RawConf) ->
-    {ok, UpdateReq};
-pre_config_update([sysmon, os, mem_check_interval], _UpdateReq, _RawConf) ->
-    {error, pre_config_update_error}.
-
-propagated_pre_config_update(
-    [<<"sysmon">>, <<"os">>, <<"cpu_check_interval">>], <<"333s">>, _RawConf
-) ->
-    {ok, <<"444s">>};
-propagated_pre_config_update(
-    [<<"sysmon">>, <<"os">>, <<"mem_check_interval">>], _UpdateReq, _RawConf
-) ->
-    {error, pre_config_update_error};
-propagated_pre_config_update(_ConfKeyPath, _UpdateReq, _RawConf) ->
-    ok.
-
-post_config_update([sysmon], _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    {ok, ok};
-post_config_update([sysmon, os], _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    {ok, ok};
-post_config_update([sysmon, os, cpu_check_interval], _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    {ok, ok};
-post_config_update([sysmon, os, cpu_low_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    ok;
-post_config_update([sysmon, os, cpu_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    ok;
-post_config_update([sysmon, os, sysmem_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    {error, post_config_update_error}.
-
-propagated_post_config_update(
-    [sysmon, os, sysmem_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs
-) ->
-    {error, post_config_update_error};
-propagated_post_config_update(_ConfKeyPath, _UpdateReq, _NewConf, _OldConf, _AppEnvs) ->
-    ok.
-
-wait_for_new_pid() ->
-    case erlang:whereis(emqx_config_handler) of
-        undefined ->
-            ct:sleep(10),
-            wait_for_new_pid();
-        Pid ->
-            Pid
-    end.
-
-assert_update_result(FailedPath, Update, Expect) ->
-    assert_update_result([FailedPath], FailedPath, Update, Expect).
-
-assert_update_result(Paths, UpdatePath, Update, Expect) ->
-    with_update_result(Paths, UpdatePath, Update, fun(Old, Result) ->
-        ?assertEqual(Expect, Result),
-        New = emqx:get_raw_config(UpdatePath, undefined),
-        ?assertEqual(Old, New)
-    end).
-
-with_update_result(Paths, UpdatePath, Update, Fun) ->
-    ok = lists:foreach(
-        fun(Path) -> emqx_config_handler:add_handler(Path, ?MODULE) end,
-        Paths
+t_independent_namespace_configs() ->
+    [{matrix, true}].
+t_independent_namespace_configs(matrix) ->
+    [[?namespace]];
+t_independent_namespace_configs(TCConfig) when is_list(TCConfig) ->
+    OtherNS = <<"other_ns">>,
+    on_exit(fun() -> ok = emqx_config:erase_namespace_configs_mnesia(OtherNS) end),
+    emqx_config:seed_defaults_for_all_roots_mnesia(emqx_schema, OtherNS),
+    KeyPath = [sysmon],
+    ok = add_handler(KeyPath, ?MODULE),
+    Wildcard = KeyPath ++ ['?', cpu_check_interval],
+    ok = add_handler(Wildcard, ?MODULE),
+    %% Initially, both are seeded with same defaults.
+    ?assertEqual(emqx_config:get_mnesia(KeyPath, ?NS), emqx_config:get_mnesia(KeyPath, OtherNS)),
+    ?assertEqual(
+        emqx_config:get_raw_mnesia(KeyPath, ?NS), emqx_config:get_raw_mnesia(KeyPath, OtherNS)
     ),
-    Opts = #{rawconf_with_defaults => true},
-    Old = emqx:get_raw_config(UpdatePath, undefined),
-    Result = emqx:update_config(UpdatePath, Update, Opts),
-    _ = Fun(Old, Result),
-    ok = lists:foreach(
-        fun(Path) -> emqx_config_handler:remove_handler(Path) end,
-        Paths
+    %% They should update independently, and not affect globals as well.
+    OriginalValGlobal = emqx_config:get(KeyPath),
+    OriginalValRawGlobal = emqx_config:get_raw(KeyPath),
+    OriginalVal = emqx_config:get_mnesia(KeyPath, ?NS),
+    OriginalValRaw = emqx_config:get_raw_mnesia(KeyPath, ?NS),
+    Val1 = emqx_utils_maps:deep_put(
+        [<<"os">>, <<"cpu_check_interval">>], OriginalValRaw, <<"666s">>
+    ),
+    Opts = #{namespace => OtherNS},
+    ?assertMatch(
+        {ok, #{
+            config := #{os := #{cpu_check_interval := 666_000}},
+            raw_config := #{<<"os">> := #{<<"cpu_check_interval">> := <<"666s">>}}
+        }},
+        emqx:update_config(KeyPath, Val1, Opts)
+    ),
+    %% Global and other namespaces are untouched.
+    ?assertEqual(OriginalValGlobal, emqx_config:get(KeyPath)),
+    ?assertEqual(OriginalValRawGlobal, emqx_config:get_raw(KeyPath)),
+    ?assertEqual(OriginalVal, emqx_config:get_mnesia(KeyPath, ?NS)),
+    ?assertEqual(OriginalValRaw, emqx_config:get_raw_mnesia(KeyPath, ?NS)),
+    %% Only target namespace is affected
+    ?assertEqual(Val1, emqx_config:get_raw_mnesia(KeyPath, OtherNS)),
+    ?assertEqual(666_000, emqx_config:get_mnesia(KeyPath ++ [os, cpu_check_interval], OtherNS)),
+    KeyPathSpecific = KeyPath ++ [os, cpu_check_interval],
+    KeyPathSpecificBin = lists:map(fun emqx_utils_conv:bin/1, KeyPathSpecific),
+    %% Trigger propagated pre/post config update callbacks
+    ?assertMatch(
+        {ok, #{
+            config := 432_000_000,
+            raw_config := <<"5d">>
+        }},
+        emqx:update_config(KeyPathSpecific, <<"5d">>, Opts)
+    ),
+    %% Removing is also independent
+    ?assertMatch({ok, _}, emqx:remove_config(KeyPathSpecific, Opts)),
+    %% Global and other namespaces are untouched.
+    ?assertEqual(OriginalValGlobal, emqx_config:get(KeyPath)),
+    ?assertEqual(OriginalValRawGlobal, emqx_config:get_raw(KeyPath)),
+    ?assertEqual(OriginalVal, emqx_config:get_mnesia(KeyPath, ?NS)),
+    ?assertEqual(OriginalValRaw, emqx_config:get_raw_mnesia(KeyPath, ?NS)),
+    %% Removed
+    ?assertError(
+        {config_not_found, KeyPathSpecificBin},
+        emqx_config:get_raw_mnesia(KeyPathSpecific, OtherNS)
+    ),
+    %% Returns default again
+    ?assertEqual(60_000, emqx_config:get_mnesia(KeyPathSpecific, OtherNS)),
+    %% Pre/Post callbacks receive the namespace in extra context.
+    ?assertMatch(
+        [
+            {post, #{extra_context := #{namespace := OtherNS}}},
+            {pre, #{extra_context := #{namespace := OtherNS}}},
+            {propagated_post, #{extra_context := #{namespace := OtherNS}}},
+            {propagated_pre, #{extra_context := #{namespace := OtherNS}}}
+        ],
+        lists:sort(ets:tab2list(?pre_post_table))
     ),
     ok.

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -128,27 +128,26 @@ get_config(TCConfig, KeyPath) when is_list(TCConfig) ->
 remove_config(TCConfig, KeyPath) ->
     emqx:remove_config(KeyPath, update_config_opts(TCConfig)).
 
-pre_config_update([sysmon], UpdateReq, _RawConf, _ClusterRPCOpts, ExtraContext) ->
+pre_config_update([sysmon], UpdateReq, _RawConf, ExtraContext) ->
     ets:insert(?pre_post_table, {pre, #{extra_context => ExtraContext}}),
     {ok, UpdateReq};
-pre_config_update([sysmon, os], UpdateReq, _RawConf, _, _) ->
+pre_config_update([sysmon, os], UpdateReq, _RawConf, _) ->
     {ok, UpdateReq};
-pre_config_update([sysmon, os, cpu_check_interval], UpdateReq, _RawConf, _, _) ->
+pre_config_update([sysmon, os, cpu_check_interval], UpdateReq, _RawConf, _) ->
     {ok, UpdateReq};
-pre_config_update([sysmon, os, cpu_low_watermark], UpdateReq, _RawConf, _, _) ->
+pre_config_update([sysmon, os, cpu_low_watermark], UpdateReq, _RawConf, _) ->
     {ok, UpdateReq};
-pre_config_update([sysmon, os, cpu_high_watermark], UpdateReq, _RawConf, _, _) ->
+pre_config_update([sysmon, os, cpu_high_watermark], UpdateReq, _RawConf, _) ->
     {ok, UpdateReq};
-pre_config_update([sysmon, os, sysmem_high_watermark], UpdateReq, _RawConf, _, _) ->
+pre_config_update([sysmon, os, sysmem_high_watermark], UpdateReq, _RawConf, _) ->
     {ok, UpdateReq};
-pre_config_update([sysmon, os, mem_check_interval], _UpdateReq, _RawConf, _, _) ->
+pre_config_update([sysmon, os, mem_check_interval], _UpdateReq, _RawConf, _) ->
     {error, pre_config_update_error}.
 
 propagated_pre_config_update(
     [<<"sysmon">>, <<"os">>, <<"cpu_check_interval">>],
     <<"333s">>,
     _RawConf,
-    _ClusterRPCOpts,
     _ExtraContext
 ) ->
     {ok, <<"444s">>};
@@ -156,33 +155,32 @@ propagated_pre_config_update(
     [<<"sysmon">>, <<"os">>, <<"mem_check_interval">>],
     _UpdateReq,
     _RawConf,
-    _ClusterRPCOpts,
     _ExtraContext
 ) ->
     {error, pre_config_update_error};
-propagated_pre_config_update(_ConfKeyPath, _UpdateReq, _RawConf, _ClusterRPCOpts, ExtraContext) ->
+propagated_pre_config_update(_ConfKeyPath, _UpdateReq, _RawConf, ExtraContext) ->
     ets:insert(?pre_post_table, {propagated_pre, #{extra_context => ExtraContext}}),
     ok.
 
 post_config_update(
-    [sysmon], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _ClusterRPCOpts, ExtraContext
+    [sysmon], _UpdateReq, _NewConf, _OldConf, _AppEnvs, ExtraContext
 ) ->
     ets:insert(?pre_post_table, {post, #{extra_context => ExtraContext}}),
     {ok, ok};
-post_config_update([sysmon, os], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _) ->
+post_config_update([sysmon, os], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _) ->
     {ok, ok};
 post_config_update(
-    [sysmon, os, cpu_check_interval], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _
+    [sysmon, os, cpu_check_interval], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _
 ) ->
     {ok, ok};
-post_config_update([sysmon, os, cpu_low_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _) ->
+post_config_update([sysmon, os, cpu_low_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _) ->
     ok;
 post_config_update(
-    [sysmon, os, cpu_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _
+    [sysmon, os, cpu_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _
 ) ->
     ok;
 post_config_update(
-    [sysmon, os, sysmem_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, _
+    [sysmon, os, sysmem_high_watermark], _UpdateReq, _NewConf, _OldConf, _AppEnvs, _
 ) ->
     {error, post_config_update_error}.
 
@@ -192,12 +190,11 @@ propagated_post_config_update(
     _NewConf,
     _OldConf,
     _AppEnvs,
-    _ClusterRPCOpts,
     _ExtraContext
 ) ->
     {error, post_config_update_error};
 propagated_post_config_update(
-    _ConfKeyPath, _UpdateReq, _NewConf, _OldConf, _AppEnvs, _, ExtraContext
+    _ConfKeyPath, _UpdateReq, _NewConf, _OldConf, _AppEnvs, ExtraContext
 ) ->
     ets:insert(?pre_post_table, {propagated_post, #{extra_context => ExtraContext}}),
     ok.

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -104,7 +104,7 @@ is_namespaced(TCConfig) ->
 get_raw_config(TCConfig, KeyPath) when is_list(TCConfig) ->
     case is_namespaced(TCConfig) of
         true ->
-            emqx_config:get_raw_namespaced(KeyPath, ?NS);
+            emqx:get_raw_config({?NS, KeyPath});
         false ->
             emqx:get_raw_config(KeyPath)
     end.
@@ -112,7 +112,7 @@ get_raw_config(TCConfig, KeyPath) when is_list(TCConfig) ->
 get_raw_config(TCConfig, KeyPath, Default) when is_list(TCConfig) ->
     case is_namespaced(TCConfig) of
         true ->
-            emqx_config:get_raw_namespaced(KeyPath, ?NS, Default);
+            emqx:get_raw_config({?NS, KeyPath}, Default);
         false ->
             emqx:get_raw_config(KeyPath, Default)
     end.
@@ -120,7 +120,7 @@ get_raw_config(TCConfig, KeyPath, Default) when is_list(TCConfig) ->
 get_config(TCConfig, KeyPath) when is_list(TCConfig) ->
     case is_namespaced(TCConfig) of
         true ->
-            emqx_config:get_namespaced(KeyPath, ?NS);
+            emqx:get_config({?NS, KeyPath});
         false ->
             emqx:get_config(KeyPath)
     end.

--- a/apps/emqx/test/emqx_config_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_config_handler_SUITE.erl
@@ -26,6 +26,8 @@
 
 -define(pre_post_table, pre_post_table).
 
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
 %%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
@@ -73,7 +75,7 @@ end_per_testcase(_Case, _Config) ->
 
 injected_fields() ->
     #{
-        'config.allowed_mnesia_roots' => [<<"sysmon">>]
+        'config.allowed_namespaced_roots' => [<<"sysmon">>]
     }.
 
 update_config_opts(TCConfig) ->

--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -434,7 +434,7 @@ start_apps(Node, #{apps := Apps} = Spec) ->
         _Started = erpc:call(Node, emqx_cth_suite, start_apps, [AppsRest, SuiteOpts])
     catch
         K:E:S ->
-            ct:pal("failure while starting apps on node ~s: ~p:~p\n  ~p", [Node, K, E, S]),
+            ct:pal("failure while starting apps on node ~s:\n  ~p:~p\n  ~p", [Node, K, E, S]),
             erlang:raise(K, E, S)
     end,
     ok.

--- a/apps/emqx/test/emqx_cth_cluster.erl
+++ b/apps/emqx/test/emqx_cth_cluster.erl
@@ -167,6 +167,23 @@ wait_clustered([Node | Nodes] = All, Check, Deadline) ->
 -spec restart(Complete :: [bakedspec()] | bakedspec()) -> [node()].
 restart(NodeSpecs = [_ | _]) ->
     Nodes = [maps:get(name, Spec) || Spec <- NodeSpecs],
+    Cores = [maps:get(name, Spec) || Spec = #{role := core} <- NodeSpecs],
+    %% The default `shutdown` option that we currently pass to `peer` does not allow
+    %% `mnesia` to correctly sync its log and shutdown properly, even when using `shutdown
+    %% => 5_000` in some situations.  Since we are restarting the cluster in our test
+    %% here, it's expected that we don't lose the data in mnesia.  So we explicitly flush
+    %% it here.
+    ct:pal("Flushing mnesia in cores: ~p", [Cores]),
+    emqx_utils:pforeach(
+        fun(N) ->
+            maybe
+                Pid = whereis(N),
+                true ?= is_pid(Pid),
+                erpc:call(N, fun mnesia:sync_log/0)
+            end
+        end,
+        Cores
+    ),
     ct:pal("Stopping peer nodes: ~p", [Nodes]),
     ok = stop(Nodes),
     perform(restart, NodeSpecs, _Opts = #{});

--- a/apps/emqx/test/emqx_cth_suite.erl
+++ b/apps/emqx/test/emqx_cth_suite.erl
@@ -256,6 +256,7 @@ maybe_configure_app(_App, #{}) ->
     ok.
 
 configure_app(SchemaModule, Config) ->
+    _ = emqx_config:create_tables(),
     ok = emqx_config:init_load(SchemaModule, render_config(Config)),
     ok.
 

--- a/apps/emqx_bridge_s3/src/emqx_bridge_s3.erl
+++ b/apps/emqx_bridge_s3/src/emqx_bridge_s3.erl
@@ -112,6 +112,7 @@ connector_example(put) ->
     }.
 
 %% Config update
+%% `emqx_connector' API
 
 pre_config_update(Path, _Name, Conf = #{<<"transport_options">> := TransportOpts}, _ConfOld) ->
     case emqx_connector_ssl:convert_certs(filename:join(Path), TransportOpts) of

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -33,6 +33,7 @@ start(_StartType, _StartArgs) ->
     emqx_conf_sup:start_link().
 
 stop(_State) ->
+    emqx_config:clear_all_invalid_namespaced_configs(),
     ok.
 
 %% @doc emqx_conf relies on this flag to synchronize configuration between nodes.

--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -20,6 +20,7 @@
 
 start(_StartType, _StartArgs) ->
     ok = mria:wait_for_tables(emqx_cluster_rpc:create_tables()),
+    _ = emqx_config:create_tables(),
     try
         ok = init_conf()
     catch

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
@@ -9,24 +9,90 @@
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include("emqx_conf.hrl").
 
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
+
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
 
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    WorkDir = ?config(priv_dir, Config),
-    Cluster = mk_cluster_spec(#{}),
-    Nodes = emqx_cth_cluster:start(Cluster, #{work_dir => WorkDir}),
-    [{cluster_nodes, Nodes} | Config].
+    Config.
 
-end_per_suite(Config) ->
-    ok = emqx_cth_cluster:stop(?config(cluster_nodes, Config)).
+end_per_suite(_Config) ->
+    ok.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    emqx_common_test_helpers:call_janitor(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+injected_fields() ->
+    #{
+        'config.allowed_namespaced_roots' => [<<"sysmon">>]
+    }.
+
+fake_mfa(TnxId, Node, MFA) ->
+    Func = fun() ->
+        MFARec = #cluster_rpc_mfa{
+            tnx_id = TnxId,
+            mfa = MFA,
+            initiator = Node,
+            created_at = erlang:localtime()
+        },
+        ok = mnesia:write(?CLUSTER_MFA, MFARec, write),
+        ok = emqx_cluster_rpc:commit(Node, TnxId)
+    end,
+    {atomic, ok} = mria:transaction(?CLUSTER_RPC_SHARD, Func, []),
+    ok.
+
+mk_cluster_spec(Opts) ->
+    Conf = #{
+        listeners => #{
+            tcp => #{default => <<"marked_for_deletion">>},
+            ssl => #{default => <<"marked_for_deletion">>},
+            ws => #{default => <<"marked_for_deletion">>},
+            wss => #{default => <<"marked_for_deletion">>}
+        }
+    },
+    Apps = [
+        {emqx, #{config => Conf}},
+        {emqx_conf, #{config => Conf}}
+    ],
+    [
+        {emqx_conf_cluster_sync_SUITE1, Opts#{role => core, apps => Apps}},
+        {emqx_conf_cluster_sync_SUITE2, Opts#{role => core, apps => Apps}}
+    ].
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
 
 t_fix(Config) ->
-    [Node1, Node2] = ?config(cluster_nodes, Config),
+    Cluster = mk_cluster_spec(#{}),
+    Nodes =
+        [Node1, Node2] = emqx_cth_cluster:start(
+            Cluster, #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+        ),
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+
     ?ON(Node1, ?assertMatch({atomic, []}, emqx_cluster_rpc:status())),
     ?ON(Node2, ?assertMatch({atomic, []}, emqx_cluster_rpc:status())),
     ?ON(Node1, emqx_conf_proto_v4:update([<<"mqtt">>], #{<<"max_topic_levels">> => 100}, #{})),
@@ -114,34 +180,97 @@ t_fix(Config) ->
     end),
     ok.
 
-fake_mfa(TnxId, Node, MFA) ->
-    Func = fun() ->
-        MFARec = #cluster_rpc_mfa{
-            tnx_id = TnxId,
-            mfa = MFA,
-            initiator = Node,
-            created_at = erlang:localtime()
-        },
-        ok = mnesia:write(?CLUSTER_MFA, MFARec, write),
-        ok = emqx_cluster_rpc:commit(Node, TnxId)
-    end,
-    {atomic, ok} = mria:transaction(?CLUSTER_RPC_SHARD, Func, []),
-    ok.
-
-mk_cluster_spec(Opts) ->
-    Conf = #{
-        listeners => #{
-            tcp => #{default => <<"marked_for_deletion">>},
-            ssl => #{default => <<"marked_for_deletion">>},
-            ws => #{default => <<"marked_for_deletion">>},
-            wss => #{default => <<"marked_for_deletion">>}
-        }
-    },
-    Apps = [
-        {emqx, #{config => Conf}},
-        {emqx_conf, #{config => Conf}}
+%% Checks that (checked) namespaced config is loaded when a node (re)starts.  Also, checks
+%% that we don't execute mnesia transactions to re-insert the same config when replicating
+%% cluster RPC entries.
+t_namespaced_config_restart(Config) ->
+    Ns = <<"some_namespace">>,
+    AppSpecs = [
+        {emqx, #{
+            before_start =>
+                fun(App, AppOpts) ->
+                    ok = emqx_schema_hooks:inject_from_modules([?MODULE]),
+                    emqx_cth_suite:inhibit_config_loader(App, AppOpts)
+                end
+        }},
+        emqx_conf
     ],
-    [
-        {emqx_authz_api_cluster_SUITE1, Opts#{role => core, apps => Apps}},
-        {emqx_authz_api_cluster_SUITE2, Opts#{role => core, apps => Apps}}
-    ].
+    NodeSpecs =
+        [_NSpec1, NSpec2] = emqx_cth_cluster:mk_nodespecs(
+            [
+                {namespace_cfg_restart1, #{apps => AppSpecs}},
+                {namespace_cfg_restart2, #{apps => AppSpecs}}
+            ],
+            #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+        ),
+    ct:pal("starting cluster"),
+    Nodes = [N1, N2] = emqx_cth_cluster:start(NodeSpecs),
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+    ct:pal("cluster started"),
+    ct:pal("seeding namespace"),
+    ?ON(
+        N1,
+        ok = emqx_common_test_helpers:seed_defaults_for_all_roots_namespaced_cluster(
+            emqx_schema, Ns
+        )
+    ),
+    ct:pal("seeded namespace"),
+    ?check_trace(
+        #{timetrap => 15_000},
+        begin
+            KeyPath = [sysmon],
+            %% Checked configs must exist on both nodes
+            ?assertMatch(#{}, ?ON(N1, emqx_config:get_namespaced(KeyPath, Ns))),
+            ?assertMatch(#{os := #{}}, ?ON(N2, emqx_config:get_namespaced(KeyPath, Ns))),
+            ?ON(N1, begin
+                OriginalValRaw = emqx_config:get_raw_namespaced(KeyPath, Ns),
+                Val1 = emqx_utils_maps:deep_put(
+                    [<<"os">>, <<"cpu_check_interval">>], OriginalValRaw, <<"666s">>
+                ),
+                Opts = #{namespace => Ns},
+                ct:pal("will update config"),
+                ?assertMatch(
+                    {ok, #{
+                        config := #{os := #{cpu_check_interval := 666_000}},
+                        raw_config := #{<<"os">> := #{<<"cpu_check_interval">> := <<"666s">>}}
+                    }},
+                    emqx_conf:update(KeyPath, Val1, Opts)
+                ),
+                ct:pal("config updated"),
+                ok
+            end),
+            %% Same raw config seen from all nodes.
+            ?assertMatch(
+                #{<<"os">> := #{<<"cpu_check_interval">> := <<"666s">>}},
+                ?ON(N1, emqx_config:get_raw_namespaced(KeyPath, Ns))
+            ),
+            ?assertMatch(
+                #{<<"os">> := #{<<"cpu_check_interval">> := <<"666s">>}},
+                ?ON(N2, emqx_config:get_raw_namespaced(KeyPath, Ns))
+            ),
+            ?assertMatch(
+                #{os := #{cpu_check_interval := 666_000}},
+                ?ON(N1, emqx_config:get_namespaced(KeyPath, Ns))
+            ),
+            ?assertMatch(
+                #{os := #{cpu_check_interval := 666_000}},
+                ?ON(N2, emqx_config:get_namespaced(KeyPath, Ns))
+            ),
+            %% Now we restart `N2`.  It should reconstruct the persistent term
+            %% configuration for the namespace.
+            ct:pal("restarting node 2"),
+            [N2] = emqx_cth_cluster:restart([NSpec2]),
+            ct:pal("restarted node 2"),
+            ?assertMatch(
+                #{os := #{cpu_check_interval := 666_000}},
+                ?ON(N2, emqx_config:get_namespaced(KeyPath, Ns))
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            %% Should not trigger transactions when replicating RPC entries.
+            ?assertMatch([_], ?of_kind("emqx_config_save_configs_namespaced_transaction", Trace)),
+            ok
+        end
+    ),
+    ok.

--- a/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_cluster_sync_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("typerefl/include/types.hrl").
 -include("emqx_conf.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).

--- a/apps/emqx_conf/test/emqx_global_gc_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_global_gc_SUITE.erl
@@ -8,14 +8,17 @@
 -compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
-    Config.
+    Apps = emqx_cth_suite:start([], #{work_dir => emqx_cth_suite:work_dir(Config)}),
+    _ = emqx_config:create_tables(),
+    [{apps, Apps} | Config].
 
-end_per_suite(_Config) ->
-    emqx_config:erase_all(),
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(apps, Config)),
     ok.
 
 t_run_gc(_) ->

--- a/apps/emqx_gateway/test/emqx_gateway_cm_registry_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cm_registry_SUITE.erl
@@ -5,6 +5,7 @@
 -module(emqx_gateway_cm_registry_SUITE).
 
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
 
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -21,15 +22,19 @@
 all() -> emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Conf) ->
-    emqx_config:erase(gateway),
-    emqx_gateway_test_utils:load_all_gateway_apps(),
-    emqx_common_test_helpers:load_config(emqx_gateway_schema, ?CONF_DEFAULT),
-    emqx_common_test_helpers:start_apps([]),
-    Conf.
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            {emqx_gateway, ?CONF_DEFAULT}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Conf)}
+    ),
+    [{apps, Apps} | Conf].
 
-end_per_suite(_Conf) ->
-    emqx_common_test_helpers:stop_apps([]),
-    emqx_config:delete_override_conf_files().
+end_per_suite(Conf) ->
+    ok = emqx_cth_suite:stop(?config(apps, Conf)),
+    ok.
 
 init_per_testcase(_TestCase, Conf) ->
     {ok, Pid} = emqx_gateway_cm_registry:start_link(?GWNAME),

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -11,6 +11,13 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("typerefl/include/types.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
 
 -define(NEW_CLIENTID(),
     iolist_to_binary("c-" ++ atom_to_list(?FUNCTION_NAME) ++ "-" ++ integer_to_list(?LINE))
@@ -30,6 +37,10 @@
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
@@ -46,6 +57,7 @@ init_per_testcase(Case, Config) ->
 
 end_per_testcase(Case, Config) ->
     snabbkaffe:stop(),
+    emqx_common_test_helpers:call_janitor(),
     ?MODULE:Case({'end', Config}),
     ok.
 
@@ -56,6 +68,45 @@ app_specs() ->
         emqx_mt,
         emqx_management
     ].
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+injected_fields() ->
+    #{
+        'config.allowed_namespaced_roots' => [<<"sysmon">>, <<"foo">>],
+        'roots.high' => [{foo, hoconsc:mk(hoconsc:ref(?MODULE, foo), #{})}]
+    }.
+
+fields(foo) ->
+    [{bar, hoconsc:mk(persistent_term:get({?MODULE, bar_type}, binary()), #{})}].
+
+connect(ClientId, Username) ->
+    connect(#{clientid => ClientId, username => Username}).
+
+connect(Opts0) ->
+    DefaultOpts = #{proto_ver => v5},
+    Opts = maps:merge(DefaultOpts, Opts0),
+    {ok, Pid} = emqtt:start_link(Opts),
+    monitor(process, Pid),
+    unlink(Pid),
+    case emqtt:connect(Pid) of
+        {ok, _} ->
+            Pid;
+        {error, _Reason} = E ->
+            catch emqtt:stop(Pid),
+            receive
+                {'DOWN', _, process, Pid, _, _} -> ok
+            after 3000 ->
+                exit(Pid, kill)
+            end,
+            erlang:error(E)
+    end.
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
 
 t_connect_disconnect({init, Config}) ->
     Config;
@@ -86,28 +137,6 @@ t_connect_disconnect(_Config) ->
         )
     ),
     ok.
-
-connect(ClientId, Username) ->
-    Opts = [
-        {clientid, ClientId},
-        {username, Username},
-        {proto_ver, v5}
-    ],
-    {ok, Pid} = emqtt:start_link(Opts),
-    monitor(process, Pid),
-    unlink(Pid),
-    case emqtt:connect(Pid) of
-        {ok, _} ->
-            Pid;
-        {error, _Reason} = E ->
-            catch emqtt:stop(Pid),
-            receive
-                {'DOWN', _, process, Pid, _, _} -> ok
-            after 3000 ->
-                exit(Pid, kill)
-            end,
-            erlang:error(E)
-    end.
 
 t_session_limit_exceeded({init, Config}) ->
     emqx_mt_config:tmp_set_default_max_sessions(1),
@@ -227,4 +256,113 @@ t_initialize_limiter_groups(Config) when is_list(Config) ->
             ok
         end
     ),
+    ok.
+
+-doc """
+When (re)starting a node, it's possible that due to a bug or to intentionally
+non-backwards compatible schema changes, we have persisted namespaced configs that are
+invalid in mnesia.
+
+This test attempts to emulate that situation, and verify that we _can_ start the node
+normally, but such namespace will be "unavailable" in the sense that some operations such
+as MQTT clients attempting to connect or data integrations will not work until the
+configuration is manually fixed.
+
+Note that this is just an emulation of such situation, because here in tests we don't
+start the peer node exactly how it happens in a release.  For a real test, see the boot
+tests that exist outside CT in this repo.
+""".
+t_namespaced_bad_config_during_start({init, Config}) ->
+    Config;
+t_namespaced_bad_config_during_start({'end', _Config}) ->
+    ok;
+t_namespaced_bad_config_during_start(Config) when is_list(Config) ->
+    Ns = <<"some_namespace">>,
+    {ok, Agent} = emqx_utils_agent:start_link(_BarType0 = binary()),
+    SetType = fun() ->
+        BarType = emqx_utils_agent:get(Agent),
+        persistent_term:put({?MODULE, bar_type}, BarType)
+    end,
+    AppSpecs = [
+        {emqx_conf, #{
+            before_start =>
+                fun(App, AppCfg) ->
+                    SetType(),
+                    ok = emqx_schema_hooks:inject_from_modules([?MODULE]),
+                    emqx_cth_suite:inhibit_config_loader(App, AppCfg)
+                end
+        }},
+        emqx,
+        {emqx_mt, #{
+            after_start =>
+                fun() ->
+                    {ok, _} = emqx:update_config(
+                        [mqtt, client_attrs_init],
+                        [
+                            #{
+                                <<"expression">> => <<"username">>,
+                                <<"set_as_attr">> => <<"tns">>
+                            }
+                        ]
+                    )
+                end
+        }}
+    ],
+    NodeSpecs =
+        [N1Spec] = emqx_cth_cluster:mk_nodespecs(
+            [
+                {corrupt_namespace_cfg1, #{apps => AppSpecs}}
+            ],
+            #{work_dir => emqx_cth_suite:work_dir(?FUNCTION_NAME, Config)}
+        ),
+    ct:pal("starting cluster"),
+    Nodes = [N1] = emqx_cth_cluster:start(NodeSpecs),
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+    ct:pal("cluster started"),
+    ?assertMatch([_], ?ON(N1, emqx:get_config([mqtt, client_attrs_init]))),
+    ct:pal("seeding namespace"),
+    ?ON(
+        N1,
+        ok = emqx_common_test_helpers:seed_defaults_for_all_roots_namespaced_cluster(
+            emqx_schema, Ns
+        )
+    ),
+    ct:pal("seeded namespace"),
+    ct:pal("updating config that will become \"corrupt\" later on"),
+    {ok, #{
+        config := #{bar := <<"hello">>},
+        namespace := Ns,
+        raw_config := #{<<"bar">> := <<"hello">>}
+    }} =
+        ?ON(N1, emqx_conf:update([foo], #{<<"bar">> => <<"hello">>}, #{namespace => Ns})),
+    ct:pal("injecting failure"),
+    _ = emqx_utils_agent:get_and_update(Agent, fun(_Old) -> {unused, _BarType1 = integer()} end),
+    ct:pal("restarting node; should not fail to start"),
+    [N1] = emqx_cth_cluster:restart([N1Spec]),
+    ?assertMatch(#{<<"foo">> := _}, ?ON(N1, emqx_config:get_namespace_config_errors(Ns))),
+    %% Using the same value (now invalid)
+    ?assertMatch(
+        {error, #{reason := "Unable to parse integer value"}},
+        ?ON(N1, emqx_conf:update([foo], #{<<"bar">> => <<"hello">>}, #{namespace => Ns}))
+    ),
+    ?assertMatch([_], ?ON(N1, emqx:get_config([mqtt, client_attrs_init]))),
+    ClientId = ?NEW_CLIENTID(),
+    Port1 = emqx_mt_api_SUITE:get_mqtt_tcp_port(N1),
+    ?assertError(
+        {error, {server_unavailable, _}},
+        connect(#{
+            clientid => ClientId,
+            username => Ns,
+            port => Port1
+        })
+    ),
+    %% With valid values of new type; should succeed and heal the node
+    ?assertMatch(
+        {ok, #{namespace := Ns, config := #{bar := 1}, raw_config := #{<<"bar">> := 1}}},
+        ?ON(N1, emqx_conf:update([foo], #{<<"bar">> => 1}, #{namespace => Ns}))
+    ),
+    ?assertMatch(undefined, ?ON(N1, emqx_config:get_namespace_config_errors(Ns))),
+    KeyPath = [foo, bar],
+    ?assertMatch(1, ?ON(N1, emqx:get_config({Ns, KeyPath}))),
+    ?assertMatch(1, ?ON(N1, emqx:get_raw_config({Ns, KeyPath}))),
     ok.

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -377,7 +377,7 @@ t_namespaced_bad_config_during_start(Config) when is_list(Config) ->
         {{ok, #{namespace := Ns, config := #{bar := 1}, raw_config := #{<<"bar">> := 1}}}, {ok, _}},
         ?wait_async_action(
             ?ON(N1, emqx_conf:update([foo], #{<<"bar">> => 1}, #{namespace => Ns})),
-            #{?snk_kind := "corrupt_ns_checker_checked", ns := Ns}
+            #{?snk_kind := "corrupt_ns_checker_cleared", ns := Ns}
         )
     ),
     ?assertMatch(undefined, ?ON(N1, emqx_config:get_namespace_config_errors(Ns))),


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14389

Release version: 6.0.0

## Summary

In order to support per-namespace user roles with scoped resources and permissions, we'll need to store namespaced configurations in mnesia.  Mnesia was chosen because we want to avoid generating large or multiple `cluster.hocon` files as the number of namespaces and their configs might be large.

Here, in order to persist the config changes in mnesia, one calls `emqx:update_config(KeyPath, Req, #{namespace => Namespace, ...}).`, where `Namespace` is the binary name for the namespace.  This config will use the existing `emqx_config_handler` machinery (i.e., type check, call pre/post config update hooks), but read and write configs to mnesia instead of persistent term and/or `cluster.hocon`.

Later, for this milestone, we'll want tenant admin users to have their independent, namespaced configurations with resouces that are independent (i.e., they may have connectors/actions/sources/rules with the same names without clashes).  The `{pre,post}_config_update` hooks for such config root keys will use the newly introduced arity that passes down the extra context (namespace) so they may act in the appropriate configuration.


## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [na] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~ (this is an internal change that should not be externally visible right now) 
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
