### PR TITLE
test: attempt to fix flaky test, improve returned error during HC call timeout

### DIFF
--- a/apps/emqx_bridge_mysql/test/emqx_bridge_v2_mysql_SUITE.erl
+++ b/apps/emqx_bridge_mysql/test/emqx_bridge_v2_mysql_SUITE.erl
@@ -335,7 +335,8 @@ t_timeout_disconnected_then_recover(Config) ->
                 500,
                 10,
                 ?assertMatch(
-                    {200, #{<<"status">> := <<"connecting">>}},
+                    {200, #{<<"status">> := Status}} when
+                        Status == <<"connecting">> orelse Status == <<"disconnected">>,
                     get_connector_api(Config)
                 )
             ),
@@ -346,7 +347,8 @@ t_timeout_disconnected_then_recover(Config) ->
                 500,
                 10,
                 ?assertMatch(
-                    {200, #{<<"status">> := <<"connecting">>}},
+                    {200, #{<<"status">> := Status}} when
+                        Status == <<"connecting">> orelse Status == <<"disconnected">>,
                     get_connector_api(Config)
                 )
             ),

--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [


### PR DESCRIPTION
Fixes <issue-or-jira-number>

https://github.com/emqx/emqx/actions/runs/15634307273/job/44046132167?pr=15377#step:4:1326

```
%%% emqx_bridge_v2_mysql_SUITE ==> t_timeout_disconnected_then_recover: FAILED
%%% emqx_bridge_v2_mysql_SUITE ==> {{panic,
     #{msg => "Unexpected result",
       result =>
           {run_stage_failed,error,
               {assertMatch,
                   [{module,emqx_bridge_v2_mysql_SUITE},
                    {line,338},
                    {expression,"get_connector_api ( Config )"},
                    {pattern,
                        "{ 200 , # { << \"status\" >> := << \"connecting\" >> } }"},
                    {value,
                        {200,
                         #{<<"actions">> =>
                               [<<"t_timeout_disconnected_then_recover-576460752303399231">>],
                           <<"database">> => <<"mqtt">>,
                           <<"description">> => <<>>,<<"enable">> => true,
                           <<"name">> =>
                               <<"t_timeout_disconnected_then_recover-576460752303399231">>,
                           <<"node_status">> =>
                               [#{<<"node">> => <<"test@127.0.0.1">>,
                                  <<"status">> => <<"disconnected">>,
                                  <<"status_reason">> =>
                                      <<"#{reason => {timeout,{gen_server,call,[<0.493891.0>,{exec,fun emqx_mysql:do_get_status/1},1000]}},stacktrace => [{gen_server,call,3,[{file,\"gen_server.erl\"},{line,1222}]},{emqx_utils,'-do_parallel_map/2-anonymous-0-',3,[{file,\"/emqx/apps/emqx_utils/src/emqx_utils.erl\"},{line,601}]}],exception => exit}">>}],
     ......
```
