### PR TITLE
feat(kinesis producer): add rate limiter to reduce quota limit probability

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -11,6 +11,7 @@
 {emqx_bridge,5}.
 {emqx_bridge,6}.
 {emqx_bridge,7}.
+{emqx_bridge_kinesis,1}.
 {emqx_broker,1}.
 {emqx_cluster,1}.
 {emqx_cluster_link,1}.

--- a/apps/emqx/src/bpapi/emqx_bpapi.erl
+++ b/apps/emqx/src/bpapi/emqx_bpapi.erl
@@ -7,6 +7,7 @@
 -export([
     start/0,
     announce/2,
+    nodes_supporting_bpapi_version/2,
     supported_version/1, supported_version/2,
     supported_apis/1,
     versions_file/1
@@ -117,6 +118,17 @@ announce(Node, App) ->
 -spec versions_file(atom()) -> file:filename_all().
 versions_file(App) ->
     filename:join(code:priv_dir(App), "bpapi.versions").
+
+-spec nodes_supporting_bpapi_version(api(), api_version()) -> [node()].
+nodes_supporting_bpapi_version(BPAPIName, Vsn) ->
+    [
+        N
+     || N <- emqx:running_nodes(),
+        case emqx_bpapi:supported_version(N, BPAPIName) of
+            undefined -> false;
+            NVsn when is_number(NVsn) -> NVsn >= Vsn
+        end
+    ].
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -1216,14 +1216,7 @@ bpapi_version_range(From, To) ->
     lists:seq(From, To).
 
 nodes_supporting_bpapi_version(Vsn) ->
-    [
-        N
-     || N <- emqx:running_nodes(),
-        case emqx_bpapi:supported_version(N, ?BPAPI_NAME) of
-            undefined -> false;
-            NVsn when is_number(NVsn) -> NVsn >= Vsn
-        end
-    ].
+    emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, Vsn).
 
 maybe_unwrap({error, not_implemented}) ->
     {error, not_implemented};

--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -466,6 +466,7 @@ common_action_resource_opts_subfields() ->
         buffer_mode,
         buffer_seg_bytes,
         health_check_interval,
+        health_check_interval_jitter,
         health_check_timeout,
         inflight_window,
         max_buffer_bytes,
@@ -479,6 +480,7 @@ common_action_resource_opts_subfields() ->
 common_source_resource_opts_subfields() ->
     [
         health_check_interval,
+        health_check_interval_jitter,
         health_check_timeout,
         resume_interval
     ].

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -1922,6 +1922,7 @@ common_action_resource_opts() ->
         <<"buffer_mode">> => <<"memory_only">>,
         <<"buffer_seg_bytes">> => <<"10MB">>,
         <<"health_check_interval">> => <<"1s">>,
+        <<"health_check_interval_jitter">> => <<"0s">>,
         <<"health_check_timeout">> => <<"30s">>,
         <<"inflight_window">> => 100,
         <<"max_buffer_bytes">> => <<"256MB">>,
@@ -1935,6 +1936,7 @@ common_action_resource_opts() ->
 common_source_resource_opts() ->
     #{
         <<"health_check_interval">> => <<"1s">>,
+        <<"health_check_interval_jitter">> => <<"0s">>,
         <<"health_check_timeout">> => <<"30s">>,
         <<"resume_interval">> => <<"1s">>
     }.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_gcp_pubsub, [
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
-    {vsn, "0.3.7"},
+    {vsn, "0.3.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_schema.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_schema.erl
@@ -95,6 +95,7 @@ fields(source_parameters) ->
 fields(source_resource_opts) ->
     Fields = [
         health_check_interval,
+        health_check_interval_jitter,
         health_check_timeout,
         %% the workers pull the messages
         request_ttl,

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_v2_gcp_pubsub_consumer_SUITE.erl
@@ -85,11 +85,7 @@ connector_config(Name, ServiceAccountJSON) ->
             <<"max_inactive">> => <<"10s">>,
             <<"service_account_json">> => ServiceAccountJSON,
             <<"resource_opts">> =>
-                #{
-                    <<"health_check_interval">> => <<"1s">>,
-                    <<"start_after_created">> => true,
-                    <<"start_timeout">> => <<"5s">>
-                }
+                emqx_bridge_v2_testlib:common_connector_resource_opts()
         },
     emqx_bridge_v2_testlib:parse_and_check_connector(?SOURCE_TYPE_BIN, Name, InnerConfigMap0).
 

--- a/apps/emqx_bridge_kinesis/mix.exs
+++ b/apps/emqx_bridge_kinesis/mix.exs
@@ -24,6 +24,7 @@ defmodule EMQXBridgeKinesis.MixProject do
   def deps() do
     [
       UMP.common_dep(:erlcloud),
+      {:emqx, in_umbrella: true, runtime: false},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/apps/emqx_bridge_kinesis/rebar.config
+++ b/apps/emqx_bridge_kinesis/rebar.config
@@ -3,6 +3,7 @@
 {erl_opts, [debug_info]}.
 {deps, [
     {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.7.0.4"}}},
+    {emqx, {path, "../../apps/emqx"}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_kinesis, [
     {description, "EMQX Enterprise Amazon Kinesis Bridge"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis.erl
@@ -75,6 +75,9 @@ fields(action_resource_opts) ->
             {batch_size, #{
                 type => range(1, 500),
                 validator => emqx_resource_validator:max(int, 500)
+            }},
+            {health_check_interval_jitter, #{
+                default => <<"15s">>
             }}
         ]
     );

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_connector_client.erl
@@ -138,7 +138,7 @@ handle_call(connection_status, _From, State) ->
         case erlcloud_kinesis:list_streams() of
             {ok, _ListStreamsResult} ->
                 {ok, ?status_connected};
-            Error ->
+            {error, Error} ->
                 {error, Error}
         end,
     {reply, Status, State};
@@ -171,7 +171,7 @@ get_status(StreamName) ->
             {ok, ?status_connected};
         {error, {<<"ResourceNotFoundException">>, _}} ->
             {error, unhealthy_target};
-        Error ->
+        {error, Error} ->
             {error, Error}
     end.
 

--- a/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
+++ b/apps/emqx_bridge_kinesis/src/emqx_bridge_kinesis_impl_producer.erl
@@ -8,27 +8,8 @@
 
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
+-include_lib("emqx_resource/include/emqx_resource_runtime.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
-
--define(HEALTH_CHECK_TIMEOUT, 15000).
--define(TOPIC_MESSAGE,
-    "Kinesis stream is invalid. Please check if the stream exist in Kinesis account."
-).
-
--type config_connector() :: #{
-    aws_access_key_id := binary(),
-    aws_secret_access_key := emqx_secret:t(binary()),
-    endpoint := binary(),
-    max_retries := non_neg_integer(),
-    pool_size := non_neg_integer(),
-    instance_id => resource_id(),
-    any() => term()
-}.
--type state() :: #{
-    pool_name := resource_id(),
-    installed_channels := map()
-}.
--export_type([config_connector/0]).
 
 %% `emqx_resource' API
 -export([
@@ -48,13 +29,51 @@
 
 -export([
     connect/1,
-    do_connector_health_check/1,
-    do_channel_health_check/2
+    do_connector_health_check/3,
+    do_channel_health_check/4
 ]).
+
+%% BPAPI RPC Targets
+-export([
+    try_consume_connector_limiter_v1/3,
+    try_consume_action_limiter_v1/4
+]).
+
+%%-------------------------------------------------------------------------------------------------
+%% Type declarations
+%%-------------------------------------------------------------------------------------------------
+
+-define(BPAPI_NAME, emqx_bridge_kinesis).
+-define(HEALTH_CHECK_TIMEOUT, 15000).
+-define(TOPIC_MESSAGE,
+    "Kinesis stream is invalid. Please check if the stream exist in Kinesis account."
+).
+
+-define(connector_hc, connector_hc).
+-define(action_hc, action_hc).
+-define(connector_account, connector_account).
+-define(action_account, action_account).
+
+-type config_connector() :: #{
+    aws_access_key_id := binary(),
+    aws_secret_access_key := emqx_secret:t(binary()),
+    endpoint := binary(),
+    max_retries := non_neg_integer(),
+    pool_size := non_neg_integer(),
+    instance_id => resource_id(),
+    any() => term()
+}.
+-type state() :: #{
+    pool_name := resource_id(),
+    health_check_timeout := timeout(),
+    installed_channels := map()
+}.
+-export_type([config_connector/0]).
 
 %%-------------------------------------------------------------------------------------------------
 %% `emqx_resource' API
 %%-------------------------------------------------------------------------------------------------
+
 resource_type() -> kinesis_producer.
 
 callback_mode() -> always_sync.
@@ -76,11 +95,16 @@ on_start(
         {config, Config},
         {pool_size, PoolSize}
     ],
+    HealthCheckTimeout = emqx_utils_maps:deep_get(
+        [resource_opts, health_check_timeout],
+        Config0,
+        60_000
+    ),
     State = #{
         pool_name => InstanceId,
+        health_check_timeout => HealthCheckTimeout,
         installed_channels => #{}
     },
-
     case emqx_resource_pool:start(InstanceId, ?MODULE, Options) of
         ok ->
             ?tp(emqx_bridge_kinesis_impl_producer_start_ok, #{config => Config}),
@@ -92,22 +116,25 @@ on_start(
 
 -spec on_stop(resource_id(), state()) -> ok | {error, term()}.
 on_stop(InstanceId, _State) ->
-    emqx_resource_pool:stop(InstanceId).
+    Res = emqx_resource_pool:stop(InstanceId),
+    ensure_limiter_group_deleted(InstanceId),
+    Res.
 
 -spec on_get_status(resource_id(), state()) ->
     ?status_connected
     | ?status_disconnected
     | {?status_disconnected, state(), {unhealthy_target, string()}}.
-on_get_status(_InstanceId, #{pool_name := Pool} = _State) ->
+on_get_status(ConnResId, ConnState) ->
+    #{pool_name := Pool} = ConnState,
     case
         emqx_resource_pool:health_check_workers_optimistic(
             Pool,
-            {?MODULE, do_connector_health_check, []},
+            {?MODULE, do_connector_health_check, [ConnResId, ConnState]},
             ?HEALTH_CHECK_TIMEOUT
         )
     of
-        ok ->
-            ?status_connected;
+        {ok, Status} ->
+            Status;
         {error, {error, {nxdomain = Posix, _}}} ->
             {error, emqx_utils:explain_posix(Posix)};
         {error, {error, {econnrefused = Posix, _}}} ->
@@ -120,16 +147,84 @@ on_get_status(_InstanceId, #{pool_name := Pool} = _State) ->
             {?status_disconnected, Reason}
     end.
 
-do_connector_health_check(WorkerPid) ->
+do_connector_health_check(WorkerPid, ConnResId, ConnState) ->
+    ?tp("kinesis_producer_connector_hc_enter", #{}),
+    #{
+        status := StatusBefore,
+        error := ErrorBefore
+    } = emqx_resource_cache:read_status(ConnResId),
+    %% Guard against race conditions
+    true = StatusBefore /= ?rm_status_stopped,
     maybe
-        {ok, connected} ?=
+        ok ?= try_consume_connector_limiter(ConnResId, ConnState),
+        {ok, ?status_connected} ?=
             emqx_bridge_kinesis_connector_client:connection_status(WorkerPid),
-        ok
+        {halt, {ok, ?status_connected}}
+    else
+        timeout ->
+            %% Timeout in erpc while attempting to acquire limiter tokens.
+            ?tp(info, "kinesis_producer_connector_hc_timeout", #{
+                hint => "repeating last status",
+                connector => ConnResId,
+                status => StatusBefore,
+                error => ErrorBefore
+            }),
+            {halt, {ok, {StatusBefore, ErrorBefore}}};
+        {error, timeout} ->
+            %% Timeout in client `gen_server:call`.
+            ?tp(info, "kinesis_producer_connector_hc_client_call_timeout", #{
+                hint => "repeating last status",
+                connector => ConnResId,
+                status => StatusBefore,
+                error => ErrorBefore
+            }),
+            {halt, {ok, {StatusBefore, ErrorBefore}}};
+        {error, Reason} ->
+            {error, Reason}
     end.
 
-do_channel_health_check(WorkerPid, StreamName) ->
+do_channel_health_check(WorkerPid, ChanResId, ChanState, ConnResId) ->
+    #{stream_name := StreamName} = ChanState,
+    StatusBefore =
+        case emqx_resource_cache:get_runtime(ChanResId) of
+            {ok, #rt{channel_status = StatusBefore0}} ->
+                StatusBefore0;
+            {error, not_found} ->
+                %% Starting this channel just now
+                ?status_connecting
+        end,
+    %% Guard against race conditions
+    true = StatusBefore /= no_channel,
+    maybe
+        ok ?= try_consume_action_limiter(ConnResId, ChanResId, ChanState),
+        ok ?= do_channel_health_check1(WorkerPid, StreamName),
+        {halt, {ok, ?status_connected}}
+    else
+        timeout ->
+            %% Timeout in erpc while attempting to acquire limiter tokens.
+            ?tp(info, "kinesis_producer_action_hc_timeout", #{
+                hint => "repeating last status",
+                action => ChanResId,
+                status => StatusBefore
+            }),
+            {halt, {ok, StatusBefore}};
+        {error, timeout} ->
+            %% Timeout in client `gen_server:call`.
+            ?tp(info, "kinesis_producer_action_hc_client_call_timeout", #{
+                hint => "repeating last status",
+                action => ChanResId,
+                status => StatusBefore
+            }),
+            {halt, {ok, StatusBefore}};
+        {halt, Res} ->
+            Res;
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+do_channel_health_check1(WorkerPid, StreamName) ->
     case emqx_bridge_kinesis_connector_client:connection_status(WorkerPid, StreamName) of
-        {ok, connected} ->
+        {ok, ?status_connected} ->
             ok;
         {error, unhealthy_target} ->
             {halt, {error, unhealthy_target}};
@@ -152,13 +247,19 @@ on_add_channel(
     {ok, NewState}.
 
 create_channel_state(
-    #{parameters := Parameters} = _ChannelConfig
+    #{parameters := Parameters} = ChannelConfig
 ) ->
     #{
         stream_name := StreamName,
         partition_key := PartitionKey
     } = Parameters,
+    HealthCheckTimeout = emqx_utils_maps:deep_get(
+        [resource_opts, health_check_timeout],
+        ChannelConfig,
+        60_000
+    ),
     {ok, #{
+        health_check_timeout => HealthCheckTimeout,
         templates => parse_template(Parameters),
         stream_name => StreamName,
         partition_key => PartitionKey
@@ -177,23 +278,24 @@ on_remove_channel(
     {ok, NewState}.
 
 on_get_channel_status(
-    _ResId,
-    ChannelId,
+    ConnResId,
+    ChanResId,
     #{
         pool_name := Pool,
         installed_channels := Channels
-    } = _State
+    } = _ConnState
 ) ->
-    #{stream_name := StreamName} = maps:get(ChannelId, Channels),
+    ChanState = maps:get(ChanResId, Channels),
     case
         emqx_resource_pool:health_check_workers_optimistic(
             Pool,
-            {?MODULE, do_channel_health_check, [StreamName]},
+            {?MODULE, do_channel_health_check, [ChanResId, ChanState, ConnResId]},
             ?HEALTH_CHECK_TIMEOUT
         )
     of
-        ok ->
-            ?status_connected;
+        {ok, Status} ->
+            %% Note: may actually be status and reason tuple.
+            Status;
         {error, unhealthy_target} ->
             {?status_disconnected, {unhealthy_target, ?TOPIC_MESSAGE}};
         {error, Reason} ->
@@ -236,6 +338,45 @@ on_batch_query(ResourceId, [{ChannelId, _} | _] = Requests, State) ->
 connect(Opts) ->
     Options = proplists:get_value(config, Opts),
     emqx_bridge_kinesis_connector_client:start_link(Options).
+
+%%-------------------------------------------------------------------------------------------------
+%% BPAPI RPC Targets
+%%-------------------------------------------------------------------------------------------------
+
+-spec try_consume_connector_limiter_v1(
+    connector_resource_id(), [{emqx_limiter:name(), emqx_limiter:options()}], timeout()
+) ->
+    ok | timeout.
+try_consume_connector_limiter_v1(ConnResId, LimiterConfig, Timeout) ->
+    Deadline =
+        case Timeout of
+            infinity -> infinity;
+            _ -> max(0, now_ms() + Timeout - 100)
+        end,
+    do_ensure_limiter_group_created(ConnResId, LimiterConfig),
+    Limiter = connect_limiter(?connector_hc, ConnResId),
+    LogMsg = "kinesis_connector_hc_rate_limited",
+    LogMeta = #{conn_res_id => ConnResId},
+    do_try_consume_limiter_v1(Limiter, Deadline, ConnResId, LogMsg, LogMeta).
+
+-spec try_consume_action_limiter_v1(
+    connector_resource_id(),
+    action_resource_id(),
+    [{emqx_limiter:name(), emqx_limiter:options()}],
+    timeout()
+) ->
+    ok | timeout.
+try_consume_action_limiter_v1(ConnResId, ChanResId, LimiterConfig, Timeout) ->
+    Deadline =
+        case Timeout of
+            infinity -> infinity;
+            _ -> max(0, now_ms() + Timeout - 100)
+        end,
+    do_ensure_limiter_group_created(ConnResId, LimiterConfig),
+    Limiter = connect_limiter(?action_hc, ConnResId),
+    LogMsg = "kinesis_action_hc_rate_limited",
+    LogMeta = #{action_res_id => ChanResId},
+    do_try_consume_limiter_v1(Limiter, Deadline, ConnResId, LogMsg, LogMeta).
 
 %%-------------------------------------------------------------------------------------------------
 %% Helper fns
@@ -353,3 +494,110 @@ render_messages(
 
 redact(Config) ->
     emqx_utils:redact(Config, fun(Any) -> Any =:= aws_secret_access_key end).
+
+limiter_group(ConnResId) ->
+    {connector, kinesis_producer, ConnResId}.
+
+limiter_group_config() ->
+    Types = [?action_hc, ?connector_hc],
+    LimiterConfigs0 = lists:flatmap(fun limiter_config/1, Types),
+    lists:sort(LimiterConfigs0).
+
+do_ensure_limiter_group_created(ConnResId, LimiterConfigs) ->
+    case find_limiter_group(ConnResId) of
+        {ok, LimiterConfigs} ->
+            %% No changes in config
+            ok;
+        {ok, _OtherConfigs} ->
+            %% Needs update
+            emqx_limiter:update_group(limiter_group(ConnResId), LimiterConfigs);
+        undefined ->
+            emqx_limiter:create_group(shared, limiter_group(ConnResId), LimiterConfigs)
+    end.
+
+try_consume_connector_limiter(ConnResId, ConnState) ->
+    LimiterConfig = limiter_group_config(),
+    CompatibleNodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, 1),
+    Coordinator = mria_membership:coordinator(CompatibleNodes),
+    HealthCheckTimeout = maps:get(health_check_timeout, ConnState, 60_000),
+    try
+        emqx_bridge_kinesis_proto_v1:try_consume_connector_limiter(
+            Coordinator, ConnResId, LimiterConfig, HealthCheckTimeout, HealthCheckTimeout
+        )
+    catch
+        error:{erpc, _} ->
+            %% Treating erpc errors as a timeout
+            timeout
+    end.
+
+try_consume_action_limiter(ConnResId, ChanResId, ChanState) ->
+    LimiterConfig = limiter_group_config(),
+    CompatibleNodes = emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, 1),
+    Coordinator = mria_membership:coordinator(CompatibleNodes),
+    HealthCheckTimeout = maps:get(health_check_timeout, ChanState, 60_000),
+    try
+        emqx_bridge_kinesis_proto_v1:try_consume_action_limiter(
+            Coordinator, ConnResId, ChanResId, LimiterConfig, HealthCheckTimeout, HealthCheckTimeout
+        )
+    catch
+        error:{erpc, _} ->
+            %% Treating erpc errors as a timeout
+            timeout
+    end.
+
+connect_limiter(Kind, ConnResId) ->
+    Clients =
+        lists:map(
+            fun(Name) ->
+                emqx_limiter:connect({limiter_group(ConnResId), Name})
+            end,
+            limiter_names(Kind)
+        ),
+    emqx_limiter_composite:new(Clients).
+
+limiter_names(?connector_hc) ->
+    [?connector_account];
+limiter_names(?action_hc) ->
+    [?action_account].
+
+find_limiter_group(ConnResId) ->
+    maybe
+        {_, Options} ?= emqx_limiter_registry:find_group(limiter_group(ConnResId)),
+        {ok, lists:sort(Options)}
+    end.
+
+%% https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html
+limiter_config(?connector_hc) ->
+    %% AWS quota: 5 TPS per account
+    Capacity = 5,
+    [{?connector_account, emqx_limiter:config_from_rate({Capacity, 1_000})}];
+limiter_config(?action_hc) ->
+    %% AWS quota: 10 TPS per account
+    Capacity = 10,
+    [{?action_account, emqx_limiter:config_from_rate({Capacity, 1_000})}].
+
+ensure_limiter_group_deleted(ConnResId) ->
+    try
+        emqx_limiter:delete_group(limiter_group(ConnResId))
+    catch
+        error:{limiter_group_not_found, _} ->
+            ok
+    end.
+
+now_ms() ->
+    erlang:system_time(millisecond).
+
+do_try_consume_limiter_v1(Limiter0, Deadline, ConnResId, LogMsg, LogMeta) ->
+    maybe
+        {false, Limiter1, _Reason} ?=
+            emqx_limiter_client:try_consume(Limiter0, 1),
+        ?tp(debug, LogMsg, LogMeta),
+        true ?= now_ms() < Deadline orelse timeout,
+        timer:sleep(100),
+        do_try_consume_limiter_v1(Limiter1, Deadline, ConnResId, LogMsg, LogMeta)
+    else
+        timeout ->
+            timeout;
+        {true, _Limiter} ->
+            ok
+    end.

--- a/apps/emqx_bridge_kinesis/src/proto/emqx_bridge_kinesis_proto_v1.erl
+++ b/apps/emqx_bridge_kinesis/src/proto/emqx_bridge_kinesis_proto_v1.erl
@@ -1,0 +1,49 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_kinesis_proto_v1).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    try_consume_connector_limiter/5,
+    try_consume_action_limiter/6
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+introduced_in() ->
+    "5.10.1".
+
+-spec try_consume_connector_limiter(
+    node(), binary(), [{emqx_limiter:name(), emqx_limiter:options()}], timeout(), timeout()
+) ->
+    ok | timeout.
+try_consume_connector_limiter(Node, ConnResId, LimiterConfig, Timeout, RPCTimeout) ->
+    erpc:call(
+        Node,
+        emqx_bridge_kinesis_impl_producer,
+        try_consume_connector_limiter_v1,
+        [ConnResId, LimiterConfig, Timeout],
+        RPCTimeout
+    ).
+
+-spec try_consume_action_limiter(
+    node(),
+    binary(),
+    binary(),
+    [{emqx_limiter:name(), emqx_limiter:options()}],
+    timeout(),
+    timeout()
+) ->
+    ok | timeout.
+try_consume_action_limiter(Node, ConnResId, ChanResId, LimiterConfig, Timeout, RPCTimeout) ->
+    erpc:call(
+        Node,
+        emqx_bridge_kinesis_impl_producer,
+        try_consume_action_limiter_v1,
+        [ConnResId, ChanResId, LimiterConfig, Timeout],
+        RPCTimeout
+    ).

--- a/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_v2_SUITE.erl
+++ b/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_v2_SUITE.erl
@@ -1,0 +1,677 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_kinesis_v2_SUITE).
+
+-feature(maybe_expr, enable).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
+
+-define(CONNECTOR_TYPE_BIN, <<"kinesis">>).
+-define(ACTION_TYPE_BIN, <<"kinesis">>).
+
+-define(ACCESS_KEY_ID, <<"aws_access_key_id">>).
+-define(SECRET_ACCESS_KEY, <<"aws_secret_access_key">>).
+
+-define(STREAM_NAME, <<"stream0">>).
+
+-define(PROXY_NAME, "kinesis").
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    [
+        {group, local},
+        {group, cluster}
+    ].
+
+matrix_cases() ->
+    lists:filter(
+        fun
+            ({testcase, TestCase, _Opts}) ->
+                get_tc_prop(TestCase, matrix, false);
+            (TestCase) ->
+                get_tc_prop(TestCase, matrix, false)
+        end,
+        emqx_common_test_helpers:all(?MODULE)
+    ).
+
+groups() ->
+    All0 = emqx_common_test_helpers:all(?MODULE),
+    ClusterCases = cluster_cases(),
+    All = All0 -- (matrix_cases() ++ ClusterCases),
+    MatrixGroups = emqx_common_test_helpers:matrix_to_groups(?MODULE, matrix_cases()),
+    Groups = lists:map(fun({G, _, _}) -> {group, G} end, MatrixGroups),
+    [
+        {cluster, ClusterCases},
+        {local, Groups ++ All}
+        | MatrixGroups
+    ].
+
+cluster_cases() ->
+    lists:filter(
+        fun(TestCase) ->
+            maybe
+                true ?= erlang:function_exported(?MODULE, TestCase, 0),
+                {cluster, true} ?= proplists:lookup(cluster, ?MODULE:TestCase()),
+                true
+            else
+                _ -> false
+            end
+        end,
+        emqx_common_test_helpers:all(?MODULE)
+    ).
+
+get_tc_prop(TestCase, Key, Default) ->
+    maybe
+        true ?= erlang:function_exported(?MODULE, TestCase, 0),
+        {Key, Val} ?= proplists:lookup(Key, ?MODULE:TestCase()),
+        Val
+    else
+        _ -> Default
+    end.
+
+init_per_suite(TCConfig) ->
+    TCConfig.
+
+end_per_suite(_TCConfig) ->
+    ok.
+
+init_per_group(local, TCConfig) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_bridge_kinesis,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(TCConfig)}
+    ),
+    [
+        {apps, Apps}
+        | TCConfig
+    ];
+init_per_group(_Group, TCConfig) ->
+    TCConfig.
+
+end_per_group(local, TCConfig) ->
+    Apps = ?config(apps, TCConfig),
+    emqx_cth_suite:stop(Apps),
+    reset_proxy(),
+    ok;
+end_per_group(_Group, _TCConfig) ->
+    ok.
+
+init_per_testcase(TestCase, TCConfig0) ->
+    reset_proxy(),
+    Path = group_path(TCConfig0, no_groups),
+    ct:print(asciiart:visible($%, "~p - ~s", [Path, TestCase])),
+    TCConfig =
+        case erlang:function_exported(?MODULE, TestCase, 2) of
+            true ->
+                ?MODULE:TestCase(init, TCConfig0);
+            false ->
+                TCConfig0
+        end,
+    ConnectorName = atom_to_binary(TestCase),
+    ConnectorConfig = connector_config(),
+    ActionName = ConnectorName,
+    ActionConfig = action_config(#{<<"connector">> => ConnectorName}),
+    create_stream(?STREAM_NAME),
+    snabbkaffe:start_trace(),
+    [
+        {bridge_kind, action},
+        {connector_type, ?CONNECTOR_TYPE_BIN},
+        {connector_name, ConnectorName},
+        {connector_config, ConnectorConfig},
+        {action_type, ?ACTION_TYPE_BIN},
+        {action_name, ActionName},
+        {action_config, ActionConfig}
+        | TCConfig
+    ].
+
+end_per_testcase(TestCase, TCConfig) ->
+    case erlang:function_exported(?MODULE, TestCase, 2) of
+        true ->
+            ?MODULE:TestCase('end', TCConfig);
+        false ->
+            ok
+    end,
+    snabbkaffe:stop(),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    emqx_common_test_helpers:call_janitor(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+reset_proxy() ->
+    emqx_common_test_helpers:reset_proxy(?PROXY_HOST, ?PROXY_PORT).
+
+group_path(Config, Default) ->
+    case emqx_common_test_helpers:group_path(Config) of
+        [] -> Default;
+        Path -> Path
+    end.
+
+connector_config() ->
+    connector_config(_Overrides = #{}).
+
+connector_config(Overrides) ->
+    Defaults = #{
+        <<"aws_access_key_id">> => ?ACCESS_KEY_ID,
+        <<"aws_secret_access_key">> => ?SECRET_ACCESS_KEY,
+        <<"endpoint">> => <<"http://toxiproxy:4566">>,
+        <<"max_retries">> => 3,
+        <<"pool_size">> => 2,
+        <<"resource_opts">> =>
+            emqx_bridge_v2_testlib:common_connector_resource_opts()
+    },
+    InnerConfigMap = emqx_utils_maps:deep_merge(Defaults, Overrides),
+    emqx_bridge_v2_testlib:parse_and_check_connector(?CONNECTOR_TYPE_BIN, <<"x">>, InnerConfigMap).
+
+action_config(Overrides) ->
+    Defaults = #{
+        <<"connector">> => <<"please override">>,
+        <<"parameters">> => #{
+            <<"payload_template">> => <<"${.}">>,
+            <<"partition_key">> => <<"key">>,
+            <<"stream_name">> => ?STREAM_NAME
+        },
+        <<"resource_opts">> =>
+            maps:merge(
+                emqx_bridge_v2_testlib:common_action_resource_opts(),
+                #{
+                    <<"batch_size">> => 10,
+                    <<"batch_time">> => <<"100ms">>
+                }
+            )
+    },
+    InnerConfigMap = emqx_utils_maps:deep_merge(Defaults, Overrides),
+    emqx_bridge_v2_testlib:parse_and_check(action, ?ACTION_TYPE_BIN, <<"x">>, InnerConfigMap).
+
+create_connector_api(Config) ->
+    create_connector_api(Config, _Overrides = #{}).
+create_connector_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_connector_api(Config, Overrides)
+    ).
+
+update_connector_api(Config) ->
+    update_connector_api(Config, _Overrides = #{}).
+update_connector_api(Config, Overrides) ->
+    Type = emqx_bridge_v2_testlib:get_value(connector_type, Config),
+    Name = emqx_bridge_v2_testlib:get_value(connector_name, Config),
+    Cfg0 = emqx_bridge_v2_testlib:get_value(connector_config, Config),
+    Cfg = emqx_utils_maps:deep_merge(Cfg0, Overrides),
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:update_connector_api(Name, Type, Cfg)
+    ).
+
+create_action_api(Config) ->
+    create_action_api(Config, _Overrides = #{}).
+create_action_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_action_api(Config, Overrides)
+    ).
+
+update_action_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:update_bridge_api(Config, Overrides)
+    ).
+
+fmt_atom(Fmt, Args) ->
+    binary_to_atom(
+        iolist_to_binary(
+            io_lib:format(Fmt, Args)
+        )
+    ).
+
+peer_name(TestName, N) ->
+    fmt_atom("~s_~b", [TestName, N]).
+
+next_cluster_n() ->
+    case get(cluster_n) of
+        undefined ->
+            put(cluster_n, 2),
+            1;
+        N ->
+            put(cluster_n, N + 1),
+            N
+    end.
+
+start_cluster(TestCase, Specs, TCConfig) ->
+    AppsSpecs = [
+        emqx,
+        emqx_conf,
+        emqx_bridge_kinesis,
+        emqx_bridge,
+        emqx_rule_engine,
+        emqx_management
+    ],
+    NodeSpecs =
+        lists:map(
+            fun({N, Opts0}) ->
+                Opts =
+                    case N == 1 of
+                        true ->
+                            Opts0#{
+                                apps => AppsSpecs ++
+                                    [emqx_mgmt_api_test_util:emqx_dashboard()]
+                            };
+                        false ->
+                            Opts0#{apps => AppsSpecs}
+                    end,
+                {peer_name(TestCase, N), Opts}
+            end,
+            lists:enumerate(Specs)
+        ),
+    Name = fmt_atom("~s_~b", [TestCase, next_cluster_n()]),
+    Nodes =
+        [N1 | _] = emqx_cth_cluster:start(
+            NodeSpecs,
+            #{work_dir => emqx_cth_suite:work_dir(Name, TCConfig)}
+        ),
+    on_exit(fun() -> emqx_cth_cluster:stop(Nodes) end),
+    Fun = fun() -> ?ON(N1, emqx_mgmt_api_test_util:auth_header_()) end,
+    emqx_bridge_v2_testlib:set_auth_header_getter(Fun),
+    Nodes.
+
+delete_stream(StreamName, ErlcloudConfig) ->
+    case erlcloud_kinesis:delete_stream(StreamName, ErlcloudConfig) of
+        {ok, _} ->
+            ?retry(
+                _Sleep = 100,
+                _Attempts = 10,
+                ?assertMatch(
+                    {error, {<<"ResourceNotFoundException">>, _}},
+                    erlcloud_kinesis:describe_stream(StreamName, ErlcloudConfig)
+                )
+            );
+        _ ->
+            ok
+    end,
+    ok.
+
+create_stream(StreamName) ->
+    Host = "toxiproxy.emqx.net",
+    Port = 4566,
+    ErlcloudConfig = erlcloud_kinesis:new("access_key", "secret", Host, Port, "http://"),
+    {ok, _} = application:ensure_all_started(erlcloud),
+    delete_stream(StreamName, ErlcloudConfig),
+    {ok, _} = erlcloud_kinesis:create_stream(StreamName, 1, ErlcloudConfig),
+    ?retry(
+        _Sleep = 100,
+        _Attempts = 10,
+        begin
+            {ok, [{<<"StreamDescription">>, StreamInfo}]} =
+                erlcloud_kinesis:describe_stream(StreamName, ErlcloudConfig),
+            ?assertEqual(
+                <<"ACTIVE">>,
+                proplists:get_value(<<"StreamStatus">>, StreamInfo)
+            )
+        end
+    ),
+    on_exit(fun() -> delete_stream(StreamName, ErlcloudConfig) end),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+%% Checks that we throttle control plance APIs when doing connector health checks.
+%% For connector HCs, AWS quota is 5 TPS.
+t_connector_health_check_rate_limit() ->
+    [{cluster, true}].
+t_connector_health_check_rate_limit(TCConfig) when is_list(TCConfig) ->
+    %% Using long enough interval with few nodes, should not hit limit
+    ct:pal("Testing with 1 node, no rate limit"),
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig, #{
+                <<"resource_opts">> => #{<<"health_check_interval">> => <<"500ms">>}
+            }),
+            ct:sleep(2_000),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+    snabbkaffe:stop(),
+
+    ct:pal("Testing with 1 node"),
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig, #{
+                <<"resource_opts">> => #{<<"health_check_interval">> => <<"100ms">>}
+            }),
+            ?block_until(#{?snk_kind := "kinesis_connector_hc_rate_limited"}),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([_ | _], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+    snabbkaffe:stop(),
+
+    ct:pal("Testing with 3 nodes"),
+    ct:timetrap({seconds, 15}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}, #{role => core}, #{role => replicant}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig, #{
+                <<"resource_opts">> => #{
+                    %% With more nodes, we trigger quota limit earlier
+                    <<"health_check_interval">> => <<"400ms">>
+                }
+            }),
+            ?block_until(#{?snk_kind := "kinesis_connector_hc_rate_limited"}),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([_ | _], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+    ok.
+
+%% Checks that we handle timeouts while waiting to consume limiter tokens (connector).
+t_connector_health_check_rate_limit_timeout(TCConfig) when is_list(TCConfig) ->
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            {201, _} = create_connector_api(TCConfig, #{
+                <<"resource_opts">> => #{
+                    <<"health_check_timeout">> => <<"400ms">>,
+                    <<"health_check_interval">> => <<"50ms">>
+                }
+            }),
+            ?inject_crash(
+                #{?snk_kind := "kinesis_connector_hc_rate_limited"},
+                fun(_) ->
+                    timer:sleep(400),
+                    false
+                end
+            ),
+            ?block_until(#{?snk_kind := "kinesis_producer_connector_hc_timeout"}),
+
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([_ | _], ?of_kind("kinesis_producer_connector_hc_timeout", Trace)),
+            ok
+        end
+    ),
+    ok.
+
+%% Checks that we handle timeouts while waiting for client gen_server call (connector).
+t_connector_health_check_rate_limit_call_timeout(TCConfig) when is_list(TCConfig) ->
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            meck:unload(),
+            emqx_common_test_helpers:with_mock(
+                erlcloud_kinesis,
+                list_streams,
+                fun() ->
+                    timer:sleep(1_500),
+                    meck:passthrough([])
+                end,
+                fun() ->
+                    {201, _} = create_connector_api(TCConfig, #{
+                        <<"resource_opts">> => #{
+                            <<"health_check_interval">> => <<"50ms">>
+                        }
+                    }),
+                    ?block_until(#{?snk_kind := "kinesis_producer_connector_hc_client_call_timeout"})
+                end
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [_ | _], ?of_kind("kinesis_producer_connector_hc_client_call_timeout", Trace)
+            ),
+            ok
+        end
+    ),
+    ok.
+
+%% Checks that we throttle control plance APIs when doing action health checks.
+%% For action HCs, AWS quota is 10 TPS.
+t_action_health_check_rate_limit() ->
+    [{cluster, true}].
+t_action_health_check_rate_limit(TCConfig) when is_list(TCConfig) ->
+    %% Using long enough interval with few nodes, should not hit limit
+    ct:pal("Testing with 1 node, no rate limit"),
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig),
+            {201, _} = create_action_api(TCConfig, #{
+                <<"resource_opts">> => #{<<"health_check_interval">> => <<"200ms">>}
+            }),
+            ct:sleep(2_000),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ?assertMatch([], ?of_kind("kinesis_action_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+    snabbkaffe:stop(),
+
+    ct:pal("Testing with 1 node"),
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig),
+            {201, _} = create_action_api(TCConfig, #{
+                <<"resource_opts">> => #{<<"health_check_interval">> => <<"50ms">>}
+            }),
+            ?block_until(#{?snk_kind := "kinesis_action_hc_rate_limited"}),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ?assertMatch([_ | _], ?of_kind("kinesis_action_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+    snabbkaffe:stop(),
+
+    ct:pal("Testing with 3 nodes"),
+    ct:timetrap({seconds, 15}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}, #{role => core}, #{role => replicant}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig),
+            {201, _} = create_action_api(TCConfig, #{
+                %% With more nodes, we trigger quota limit earlier
+                <<"resource_opts">> => #{<<"health_check_interval">> => <<"200ms">>}
+            }),
+            ?block_until(#{?snk_kind := "kinesis_action_hc_rate_limited"}),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ?assertMatch([_ | _], ?of_kind("kinesis_action_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+
+    CreateNamedAction = fun(Name) ->
+        {201, _} = create_action_api([{action_name, Name} | TCConfig], #{
+            %% With more action, we trigger quota limit earlier
+            <<"resource_opts">> => #{<<"health_check_interval">> => <<"200ms">>}
+        })
+    end,
+    ct:pal("Testing with 3 actions"),
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            Specs = [#{role => core}],
+            Nodes = start_cluster(?FUNCTION_NAME, Specs, TCConfig),
+            {201, _} = create_connector_api(TCConfig),
+            {201, _} = CreateNamedAction(<<"a">>),
+            {201, _} = CreateNamedAction(<<"b">>),
+            {201, _} = CreateNamedAction(<<"c">>),
+            ?block_until(#{?snk_kind := "kinesis_action_hc_rate_limited"}),
+            emqx_cth_cluster:stop(Nodes),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind("kinesis_connector_hc_rate_limited", Trace)),
+            ?assertMatch([_ | _], ?of_kind("kinesis_action_hc_rate_limited", Trace)),
+            ok
+        end
+    ),
+    ok.
+
+%% Checks that we handle timeouts while waiting to consume limiter tokens (action).
+t_action_health_check_rate_limit_timeout(TCConfig) when is_list(TCConfig) ->
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            {201, _} = create_connector_api(TCConfig),
+            {201, _} = create_action_api(TCConfig, #{
+                <<"resource_opts">> => #{
+                    <<"health_check_timeout">> => <<"400ms">>,
+                    <<"health_check_interval">> => <<"50ms">>
+                }
+            }),
+            ?inject_crash(
+                #{?snk_kind := "kinesis_action_hc_rate_limited"},
+                fun(_) ->
+                    timer:sleep(400),
+                    false
+                end
+            ),
+            ?block_until(#{?snk_kind := "kinesis_producer_action_hc_timeout"}),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch([], ?of_kind("kinesis_producer_connector_hc_timeout", Trace)),
+            ?assertMatch([_ | _], ?of_kind("kinesis_producer_action_hc_timeout", Trace)),
+            ok
+        end
+    ),
+    ok.
+
+%% Checks that we handle timeouts while waiting for client gen_server call (action).
+t_action_health_check_rate_limit_call_timeout(TCConfig) when is_list(TCConfig) ->
+    ct:timetrap({seconds, 10}),
+    ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
+        begin
+            meck:unload(),
+            emqx_common_test_helpers:with_mock(
+                erlcloud_kinesis,
+                describe_stream,
+                fun(StreamName) ->
+                    timer:sleep(1_500),
+                    meck:passthrough([StreamName])
+                end,
+                fun() ->
+                    {201, _} = create_connector_api(TCConfig),
+                    {201, _} = create_action_api(TCConfig, #{
+                        <<"resource_opts">> => #{
+                            <<"health_check_interval">> => <<"100ms">>
+                        }
+                    }),
+                    ?block_until(#{?snk_kind := "kinesis_producer_action_hc_client_call_timeout"})
+                end
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            ?assertMatch(
+                [_ | _], ?of_kind("kinesis_producer_action_hc_client_call_timeout", Trace)
+            ),
+            ok
+        end
+    ),
+    ok.
+
+%% Checks that we handle limiter config updates accordingly.
+t_limiter_config_updates(TCConfig) when is_list(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig),
+    {201, _} = create_action_api(TCConfig),
+    {200, _} = update_connector_api(TCConfig),
+    {200, _} = update_action_api(TCConfig, #{}),
+    ok.
+
+%% Checks that we handle `resource_opts.health_check_timeout = infinity`.
+t_limiter_config_infinity_timeout(TCConfig) when is_list(TCConfig) ->
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_connector_api(TCConfig, #{
+            <<"resource_opts">> => #{
+                <<"health_check_timeout">> => <<"infinity">>
+            }
+        })
+    ),
+    ?assertMatch(
+        {201, #{<<"status">> := <<"connected">>}},
+        create_action_api(TCConfig, #{
+            <<"resource_opts">> => #{
+                <<"health_check_timeout">> => <<"infinity">>
+            }
+        })
+    ),
+    ok.

--- a/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_v2_SUITE.erl
+++ b/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_v2_SUITE.erl
@@ -202,13 +202,7 @@ action_config(Overrides) ->
             <<"stream_name">> => ?STREAM_NAME
         },
         <<"resource_opts">> =>
-            maps:merge(
-                emqx_bridge_v2_testlib:common_action_resource_opts(),
-                #{
-                    <<"batch_size">> => 10,
-                    <<"batch_time">> => <<"100ms">>
-                }
-            )
+            emqx_bridge_v2_testlib:common_action_resource_opts()
     },
     InnerConfigMap = emqx_utils_maps:deep_merge(Defaults, Overrides),
     emqx_bridge_v2_testlib:parse_and_check(action, ?ACTION_TYPE_BIN, <<"x">>, InnerConfigMap).
@@ -391,7 +385,7 @@ t_connector_health_check_rate_limit(TCConfig) when is_list(TCConfig) ->
     snabbkaffe:stop(),
 
     ct:pal("Testing with 3 nodes"),
-    ct:timetrap({seconds, 15}),
+    ct:timetrap({seconds, 30}),
     ?check_trace(
         emqx_bridge_v2_testlib:snk_timetrap(),
         begin
@@ -531,7 +525,7 @@ t_action_health_check_rate_limit(TCConfig) when is_list(TCConfig) ->
     snabbkaffe:stop(),
 
     ct:pal("Testing with 3 nodes"),
-    ct:timetrap({seconds, 15}),
+    ct:timetrap({seconds, 30}),
     ?check_trace(
         emqx_bridge_v2_testlib:snk_timetrap(),
         begin

--- a/apps/emqx_resource/include/emqx_resource.hrl
+++ b/apps/emqx_resource/include/emqx_resource.hrl
@@ -151,6 +151,10 @@
 -define(HEALTHCHECK_INTERVAL_RAW, <<"15s">>).
 
 %% milliseconds
+-define(HEALTHCHECK_INTERVAL_JITTER, 0).
+-define(HEALTHCHECK_INTERVAL_JITTER_RAW, <<"0ms">>).
+
+%% milliseconds
 -define(HEALTHCHECK_TIMEOUT, 60_000).
 -define(HEALTHCHECK_TIMEOUT_RAW, <<"60s">>).
 

--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.2.0"},
+    {vsn, "0.2.1"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -1774,7 +1774,9 @@ start_channel_health_check_action(ChannelId, NewChanStatus, PreviousChanStatus, 
             end,
             [NewChanStatus, PreviousChanStatus]
         ),
-    Timeout = get_channel_health_check_interval(ChannelId, ConfigSources, Data),
+    Timeout0 = get_channel_health_check_interval(ChannelId, ConfigSources, Data),
+    MaxJitter = get_channel_health_check_interval_jitter(ChannelId, ConfigSources, Data),
+    Timeout = Timeout0 + rand:uniform(MaxJitter + 1) - 1,
     Event = #start_channel_health_check{channel_id = ChannelId},
     [generic_timeout_action(Event, Timeout, Event)].
 
@@ -1826,6 +1828,11 @@ get_channel_health_check_timeout(ChannelId, ConfigSources, Data) ->
 get_channel_health_check_interval(ChannelId, ConfigSources, Data) ->
     Field = health_check_interval,
     Default = ?HEALTHCHECK_INTERVAL,
+    get_resource_opts_field_with_fallback(Field, Default, ChannelId, ConfigSources, Data).
+
+get_channel_health_check_interval_jitter(ChannelId, ConfigSources, Data) ->
+    Field = health_check_interval_jitter,
+    Default = ?HEALTHCHECK_INTERVAL_JITTER,
     get_resource_opts_field_with_fallback(Field, Default, ChannelId, ConfigSources, Data).
 
 get_resource_opts_field_with_fallback(Field, Default, ChannelId, ConfigSources, Data) ->

--- a/apps/emqx_resource/src/schema/emqx_resource_schema.erl
+++ b/apps/emqx_resource/src/schema/emqx_resource_schema.erl
@@ -43,6 +43,7 @@ create_opts(Overrides) ->
             {buffer_mode, fun buffer_mode/1},
             {worker_pool_size, fun worker_pool_size/1},
             {health_check_interval, fun health_check_interval/1},
+            {health_check_interval_jitter, fun health_check_interval_jitter/1},
             {health_check_timeout, fun health_check_timeout/1},
             {resume_interval, fun resume_interval/1},
             {metrics_flush_interval, fun metrics_flush_interval/1},
@@ -102,6 +103,12 @@ health_check_interval(default) -> ?HEALTHCHECK_INTERVAL_RAW;
 health_check_interval(required) -> false;
 health_check_interval(validator) -> fun health_check_interval_range/1;
 health_check_interval(_) -> undefined.
+
+health_check_interval_jitter(type) -> emqx_schema:timeout_duration_ms();
+health_check_interval_jitter(desc) -> ?DESC("health_check_interval_jitter");
+health_check_interval_jitter(default) -> ?HEALTHCHECK_INTERVAL_JITTER_RAW;
+health_check_interval_jitter(required) -> false;
+health_check_interval_jitter(_) -> undefined.
 
 health_check_timeout(type) -> hoconsc:union([emqx_schema:timeout_duration_ms(), infinity]);
 health_check_timeout(desc) -> ?DESC("health_check_timeout");

--- a/changes/ee/feat-15387.en.md
+++ b/changes/ee/feat-15387.en.md
@@ -1,0 +1,3 @@
+Improved Kinesis Producer Connector and Action health checks to mitigate the occurrence of rate limiting when calling `ListStreams` and `DescribeStream` APIs.  Now, we limit the the calls per Connector to such APIs to 5/s and 10/s, respectively.  If a Connector or Action cannot call their health check API before timing out, they will simply maintain their current status.  If they receive a throttling response (e.g.: `LimitExceededException`), they will also maintain their current status.
+
+Introduced a new `resource_opts.health_check_interval_jitter` configuration to add an uniform random delay to `resource_opts.health_check_interval`, so that multiple Actions under the same Connector will seldom run their health checks simultaneously.

--- a/rel/i18n/emqx_resource_schema.hocon
+++ b/rel/i18n/emqx_resource_schema.hocon
@@ -45,6 +45,12 @@ health_check_interval.desc:
 health_check_interval.label:
 """Health Check Interval"""
 
+health_check_interval_jitter.desc:
+"""A uniform random delay to be added to health check interval, so that Actions and Sources from the same Connector start their health checks at different instants."""
+
+health_check_interval_jitter.label:
+"""Health Check Interval Jitter"""
+
 health_check_timeout.desc:
 """Health check timeout.  If a health check call takes more than this time to return a result, the resource is deemed disconnected."""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14359

Release version: 5.10.1

## Summary

AWS Kinesis APIs that are used for health checks in Kinesis producer are very rate limited: 5 TPS for connector HCs and 10 TPS for action HCs, per region per account, respectively.

To reduce the probability of triggering alerts and hitting such quotas, we introduce here limiters to adhere to such limits.  To make it work in a cluster, one core node is considered the coordinator, and holds the actual limiter that is consumed during HCs.  If a HC is rate limited, we wait for a bit and try again until either it succeeds or times out.  In the latter case, we repeat the last status of the connector/action instead of marking it as disconnected straight away.  

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
