### PR TITLE
test(mgmt cli): attempt to fix flaky test

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -247,6 +247,9 @@ t_listeners(_Config) ->
 t_authz(_Config) ->
     %% authz cache-clean all         # Clears authorization cache on all nodes
     ?assertMatch(ok, emqx_ctl:run_command(["authz", "cache-clean", "all"])),
+    %% "cache-clean all" relies on an inserted timestamp in persistent term; we need to
+    %% sleep to avoid considering a freshly inserted cache entry as stale.
+    ct:sleep(1),
     ClientId = "authz_clean_test",
     ClientIdBin = list_to_binary(ClientId),
     %% authz cache-clean <ClientId>  # Clears authorization cache for given client


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/15684118558/job/44183628374?pr=15382#step:5:590

```
%%% emqx_mgmt_cli_SUITE ==> t_authz: FAILED
%%% emqx_mgmt_cli_SUITE ==>
Failure/Error: ?assertMatch([ _ ], gen_server : call ( Pid , list_authz_cache ))
  expected: = [ _ ]
       got: []
      line: 258
```
