### PR TITLE
test(redis): attempt to fix flaky test

### DIFF
--- a/apps/emqx_bridge_redis/test/emqx_bridge_redis_SUITE.erl
+++ b/apps/emqx_bridge_redis/test/emqx_bridge_redis_SUITE.erl
@@ -291,9 +291,12 @@ t_check_replay(Config) ->
         5
     ),
 
+    ct:timetrap({seconds, 15}),
     ?check_trace(
+        emqx_bridge_v2_testlib:snk_timetrap(),
         ?wait_async_action(
             with_down_failure(Config, ProxyName, fun() ->
+                ct:sleep(500),
                 {_, {ok, _}} =
                     ?wait_async_action(
                         lists:foreach(
@@ -306,12 +309,10 @@ t_check_replay(Config) ->
                             ?snk_kind := redis_bridge_connector_send_done,
                             batch := true,
                             result := {error, _}
-                        },
-                        10_000
+                        }
                     )
             end),
-            #{?snk_kind := redis_bridge_connector_send_done, batch := true, result := {ok, _}},
-            10_000
+            #{?snk_kind := redis_bridge_connector_send_done, batch := true, result := {ok, _}}
         ),
         fun(Trace) ->
             ?assert(
@@ -323,7 +324,7 @@ t_check_replay(Config) ->
             )
         end
     ),
-    ok = emqx_bridge:remove(Type, Name).
+    ok.
 
 t_permanent_error(_Config) ->
     Name = <<"invalid_command_bridge">>,


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/15684118558/job/44183627993?pr=15382#step:4:642

```
2025-06-16T15:02:32.343267+00:00 [critical] "check stage" failed: error, {panic,#{msg => "Causality violation",causes_without_effect => [],effects_without_cause => [#{mode => sync,msg => redis_bridge_connector_send_done,result => {ok,[{ok,<<"2">>},{ok,<<"3">>},{ok,<<"4">>},{ok,<<"5">>}]}, .....
```
