### PR TITLE
test(dashboard https): fix flaky test

### DIFF
--- a/apps/emqx/src/emqx_config_handler.erl
+++ b/apps/emqx/src/emqx_config_handler.erl
@@ -162,7 +162,7 @@ get_raw_cluster_override_conf() ->
     gen_server:call(?MODULE, get_raw_cluster_override_conf).
 
 info() ->
-    gen_server:call(?MODULE, info).
+    gen_server:call(?MODULE, info, infinity).
 
 %%============================================================================
 

--- a/apps/emqx_dashboard/src/emqx_dashboard_dispatch.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_dispatch.erl
@@ -59,7 +59,7 @@ Regenerate the dispatch for the given listeners immediately and synchronously.
 """.
 -spec regenerate_dispatch([emqx_dashboard:listener_name()]) -> ok.
 regenerate_dispatch(Listeners) ->
-    gen_server:call(?SERVER, #regenerate_dispatch{listeners = Listeners}).
+    gen_server:call(?SERVER, #regenerate_dispatch{listeners = Listeners}, infinity).
 
 -doc """
 Regenerate the dispatch for the given listeners asynchronously after the current

--- a/apps/emqx_dashboard/src/emqx_dashboard_listener_config.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_listener_config.erl
@@ -12,6 +12,9 @@
 %% API
 -export([start_link/0]).
 
+%% For tests
+-export([info/0]).
+
 %% emqx_config_handler API
 -export([add_handler/0, remove_handler/0]).
 -export([pre_config_update/3, post_config_update/5]).
@@ -33,6 +36,7 @@
     old_listeners :: emqx_dashboard:listener_configs(),
     new_listeners :: emqx_dashboard:listener_configs()
 }).
+-record(info, {}).
 
 %%--------------------------------------------------------------------
 %% API
@@ -40,6 +44,9 @@
 
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+info() ->
+    gen_server:call(?MODULE, #info{}, infinity).
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks
@@ -50,6 +57,8 @@ init([]) ->
     ok = add_handler(),
     {ok, #{}}.
 
+handle_call(#info{}, _From, State) ->
+    {reply, {ok, State}, State};
 handle_call(_Request, _From, State) ->
     {reply, {error, not_implemented}, State, hibernate}.
 


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/15684118558/job/44183628310?pr=15382#step:5:465

```
%%% emqx_dashboard_https_SUITE ==> t_verify_cacertfile: FAILED
%%% emqx_dashboard_https_SUITE ==> {{badmatch,{error,['https:dashboard']}},
 [{emqx_dashboard_https_SUITE,t_verify_cacertfile,1,
                              [{file,"/__w/emqx/emqx/apps/emqx_dashboard/test/emqx_dashboard_https_SUITE.erl"},
                               {line,242}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```
