### PR TITLE
test(rule engine api): fix flaky test

### DIFF
--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -929,7 +929,7 @@ t_remove_rule_with_wildcard(_Config) ->
     ?assertEqual(lists:sort(Events), lists:sort(ListRuleHooks())),
     {204, _} = delete_rule(RuleId2),
     %% Should have cleared up all hooks but `'message.publish'``.
-    ?assertMatch(['message.publish'], ListRuleHooks()),
+    ?retry(100, 10, ?assertMatch(['message.publish'], ListRuleHooks())),
     {204, _} = delete_rule(RuleId1),
     ?assertMatch([], ListRuleHooks()),
     ok.


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/15686789552/job/44192452191?pr=15390#step:5:431

```
%%% emqx_rule_engine_api_2_SUITE ==> t_remove_rule_with_wildcard: FAILED
%%% emqx_rule_engine_api_2_SUITE ==>
Failure/Error: ?assertMatch([ 'message.publish' ], ListRuleHooks ( ))
  expected: = [ 'message.publish' ]
       got: ['message.publish','session.unsubscribed','session.unsubscribed']
      line: 932
```
