### PR TITLE
test(s3tables): attempt to stabilize flaky test

### DIFF
--- a/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
+++ b/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
@@ -691,6 +691,8 @@ restart_server() ->
             [{body_format, binary}]
         ),
     ct:pal("restarted iceberg server."),
+    %% Wait for a bit to ensure server is stable...
+    ct:sleep(1_000),
     ok.
 
 %%------------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/15688240390/job/44197310871?pr=15391#step:4:763

```
Testing lib.emqx_bridge_s3tables.emqx_bridge_s3tables_SUITE: *** SKIPPED test case 11 ***
%%% emqx_bridge_s3tables_SUITE ==> not_partitioned.t_multipart_upload: SKIPPED
%%% emqx_bridge_s3tables_SUITE ==> {tc_auto_skip,
    {failed,
        {emqx_bridge_s3tables_SUITE,init_per_testcase,
            {{http_error,502,"Bad Gateway",
                 <<"<html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx/1.27.5</center>\r\n</body>\r\n</html>\r\n">>,
                 [{"connection","keep-alive"},
                  {"content-length","157"},
                  {"content-type","text/html"},
                  {"date","Mon, 16 Jun 2025 18:10:36 GMT"},
                  {"server","nginx/1.27.5"}]},
             [{emqx_bridge_s3tables_SUITE,ensure_namespace_created,2,
                  [{file,
                       "/emqx/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl"},
                   {line,285}]},
```
