### PR TITLE
chore: bump minirest to 1.4.8 to fix swagger css

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -239,7 +239,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.2", override: true}
 
   def common_dep(:minirest),
-    do: {:minirest, github: "emqx/minirest", tag: "1.4.7", override: true}
+    do: {:minirest, github: "emqx/minirest", tag: "1.4.8", override: true}
 
   # maybe forbid to fetch quicer
   def common_dep(:emqtt),

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,7 @@
     {mria, {git, "https://github.com/emqx/mria", {tag, "0.8.12.1"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.6.12"}}},
-    {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.7"}}},
+    {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.8"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.1"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}},


### PR DESCRIPTION
backport of #15332

Fixes [EMQX-14397](https://emqx.atlassian.net/browse/EMQX-14397)

Release version: 5.8.7, 5.9.1

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14397]: https://emqx.atlassian.net/browse/EMQX-14397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ