### PR TITLE
[6.0.0] support new releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,13 @@
 Fixes <issue-or-jira-number>
 
-Release version: 5.?
+<!--
+5.8.7
+5.9.1
+6.0.0-M1.202507
+6.0.0-M2.202508
+6.0.0
+-->
+Release version:
 
 ## Summary
 

--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -23,6 +23,7 @@ jobs:
         profile:
           - ['emqx-enterprise', 'master']
           - ['emqx-enterprise', 'release-510']
+          - ['emqx-enterprise', 'release-60']
         os:
           - ubuntu22.04
           - amzn2023
@@ -80,6 +81,7 @@ jobs:
         branch:
           - master
           - release-510
+          - release-60
         os:
           - macos-15
 

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,16 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       BUILDER_master: ${{ steps.env.outputs.BUILDER_master }}
+      BUILDER_release-58: ${{ steps.env.outputs.BUILDER_release-58 }}
       BUILDER_release-59: ${{ steps.env.outputs.BUILDER_release-59 }}
       BUILDER_release-510: ${{ steps.env.outputs.BUILDER_release-510 }}
+      BUILDER_release-60: ${{ steps.env.outputs.BUILDER_release-60 }}
 
     strategy:
       fail-fast: false
       matrix:
         branch:
           - master
+          - release-58
           - release-59
           - release-510
+          - release-60
 
     steps:
       - name: Checkout repository
@@ -53,8 +57,10 @@ jobs:
       matrix:
         branch:
           - master
+          - release-58
           - release-59
           - release-510
+          - release-60
         language:
           - cpp
           - python

--- a/.github/workflows/green_master.yaml
+++ b/.github/workflows/green_master.yaml
@@ -23,8 +23,10 @@ jobs:
       matrix:
         ref:
           - master
+          - release-58
           - release-59
           - release-510
+          - release-60
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include env.sh
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= v1.10.6
-export EMQX_EE_DASHBOARD_VERSION ?= e1.10.0-2
+export EMQX_EE_DASHBOARD_VERSION ?= 2.0.0-M1.202507-beta.1
 
 export EMQX_RELUP ?= true
 export EMQX_REL_FORM ?= tgz

--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "5.10.0").
+-define(EMQX_RELEASE_EE, "6.0.0-M1.202507-alpha.1").

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -934,7 +934,9 @@ run_migrations(_Version = "5.8." ++ _) ->
 run_migrations(_Version = "5.9." ++ _) ->
     run_migrations_e58();
 run_migrations(_Version = "5.10." ++ _) ->
-    run_migrations_e58().
+    run_migrations_e58();
+run_migrations(_Version = "6." ++ _) ->
+    ok.
 
 ensure_site() ->
     Filename = filename:join(emqx_ds_storage_layer:base_dir(), "emqx_ds_builtin_site.eterm"),

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 5.10.0
+version: 6.0.0-M1.202507-alpha.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 5.10.0
+appVersion: 6.0.0-M1.202507-alpha.1

--- a/scripts/get-dashboard.sh
+++ b/scripts/get-dashboard.sh
@@ -13,6 +13,9 @@ case "$VERSION" in
     e*)
         RELEASE_ASSET_FILE="emqx-enterprise-dashboard-$VERSION.zip"
         ;;
+    2*)
+        RELEASE_ASSET_FILE="emqx-enterprise-dashboard-$VERSION.zip"
+        ;;
     *)
         echo "Unknown version $VERSION"
         exit 1

--- a/scripts/parse-git-ref.sh
+++ b/scripts/parse-git-ref.sh
@@ -40,6 +40,14 @@ elif [[ $1 =~ ^refs/tags/e[5-9]+\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; th
     PROFILE=emqx-enterprise
     RELEASE=true
     LATEST=false
+elif [[ $1 =~ ^refs/tags/e[6-9]+\.[0-9]+\.[0-9]+-M[0-9]+\.[0-9]+$ ]]; then
+    PROFILE=emqx-enterprise
+    RELEASE=true
+    LATEST=false
+elif [[ $1 =~ ^refs/tags/e[6-9]+\.[0-9]+\.[0-9]+-M[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
+    PROFILE=emqx-enterprise
+    RELEASE=true
+    LATEST=false
 elif [[ $1 =~ ^refs/tags/.+ ]]; then
     echo "Unrecognized tag: $1" 1>&2
     exit 1

--- a/scripts/rel/cut.sh
+++ b/scripts/rel/cut.sh
@@ -13,14 +13,19 @@ usage() {
     cat <<EOF
 $0 RELEASE_GIT_TAG [option]
 RELEASE_GIT_TAG is a 'e*' tag, for example:
-  e5.9.0-beta.6
+  e5.8.7-alpha.1
+  e5.9.1-beta.6
+  e6.0.0-M1.202507-rc.1
+  e6.0.0
 
 options:
   -h|--help:         Print this usage.
 
   -b|--base:         Specify the current release base branch, can be one of
+                     release-58
                      release-59
                      release-510
+                     release-60
                      NOTE: this option should be used when --dryrun.
 
   --dryrun:          Do not actually create the git tag.
@@ -35,7 +40,12 @@ options:
 For 5.X series the current working branch must be 'release-5X'
       --.--[  master  ]---------------------------.-----------.---
          \\                                      /
-          \`---[release-5X]----------------e5.9.0
+          \`---[release-5X]----------------e5.10.0
+
+For 6.X series the current working branch must be 'release-6X'
+      --.--[  master  ]---------------------------.-----------.---
+         \\                                      /
+          \`---[release-6X]----------------e6.0.0
 EOF
 }
 
@@ -111,8 +121,17 @@ done
 rel_branch() {
     local tag="$1"
     case "$tag" in
+        e5.8.*)
+            echo 'release-58'
+            ;;
+        e5.9.*)
+            echo 'release-59'
+            ;;
         e5.10.*)
             echo 'release-510'
+            ;;
+        e6.0.*)
+            echo 'release-60'
             ;;
         *)
             logerr "Unsupported version tag $TAG"

--- a/scripts/rel/sync-remotes.sh
+++ b/scripts/rel/sync-remotes.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/../.."
 
-BASE_BRANCHES=( 'release-510' 'release-59' 'release-58' 'release-57' 'release-56' 'release-55' 'master' )
+BASE_BRANCHES=( 'release-60' 'release-510' 'release-59' 'release-58' 'release-57' 'release-56' 'release-55' 'master' )
 
 usage() {
     cat <<EOF
@@ -18,13 +18,14 @@ options:
     It tries to merge (by default with --ff-only option)
     upstreams branches for the current working branch.
     The uppstream branch of the current branch are as below:
-    * release-55: []        # no upstream for 5.5 opensource edition
-    * release-56: []        # no upstream for 5.6 opensource edition
-    * release-57: []        # no upstream for 5.7 opensource edition
-    * release-58: []        # no upstream for 5.8 opensource edition
-    * release-59: []        # no upstream for 5.9
-    * release-510: []       # no upstream for 5.10
-    * master: [release-5x]  # sync release-5x to master
+    * release-55:  []                   # no upstream for 5.5 opensource edition
+    * release-56:  []                   # no upstream for 5.6 opensource edition
+    * release-57:  []                   # no upstream for 5.7 opensource edition
+    * release-58:  []                   # no upstream for 5.8 opensource edition
+    * release-59:  []                   # no upstream for 5.9
+    * release-510: []                   # no upstream for 5.10
+    * release-60:  []                   # no upstream for 6.0
+    * master: [release-5x, release-6x]  # sync release-5x and release-6x to master
 
   -b|--base:
     The base branch of current working branch if currently is not
@@ -168,8 +169,11 @@ upstream_branches() {
         release-510)
             remote_ref "$base"
             ;;
+        release-60)
+            remote_ref "$base"
+            ;;
         master)
-            remote_refs "$base" 'release-55' 'release-56' 'release-57' 'release-58' 'release-59' 'release-510'
+            remote_refs "$base" 'release-55' 'release-56' 'release-57' 'release-58' 'release-59' 'release-510' 'release-60'
             ;;
     esac
 }

--- a/scripts/semver.sh
+++ b/scripts/semver.sh
@@ -3,7 +3,7 @@
 set -e
 
 function parseSemver() {
-    local RE='^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+\.[0-9]+))?(-g[0-9a-f]+)?$'
+    local RE='^([0-9]+)\.([0-9]+)\.([0-9]+)(-([a-z]+\.[0-9]+|M[0-9]+\.[0-9]+|M[0-9]+\.[0-9]+-[a-z]+\.[0-9]+))?(-g[0-9a-f]+)?$'
     echo "$1" | grep -qE "$RE" || exit 1
     #shellcheck disable=SC2155
     local MAJOR=$(echo "$1" | sed -r "s#$RE#\1#")

--- a/scripts/shelltest/parse-git-ref.test
+++ b/scripts/shelltest/parse-git-ref.test
@@ -118,6 +118,36 @@ Unrecognized tag: refs/tags/v5.2.0-alpha-1
 {"profile": "emqx-enterprise", "release": true, "latest": false}
 >>>= 0
 
+./parse-git-ref.sh refs/tags/e6.0.0-M1.202507
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/e6.0.0-M1.202507-alpha.1
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/e6.0.0-M1.202507-beta.1
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/e6.0.0-M1.202507-rc.1
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/e6.1.0-M2.202508
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false}
+>>>= 0
+
+./parse-git-ref.sh refs/tags/e6.1.0-M2.202508-alpha.2
+>>>
+{"profile": "emqx-enterprise", "release": true, "latest": false}
+>>>= 0
+
 ./parse-git-ref.sh refs/tags/e5.1.99
 >>>
 {"profile": "emqx-enterprise", "release": true, "latest": true}


### PR DESCRIPTION
- Recognize release-60
- Add support for internal release tagging scheme
- Add release-58 back to the list of supported branches since 5.8 family is LTS
- Do not run ds raft migrations
- Support new versioning scheme for Dashboard
- Allow import of backups from v5 to v6

Release version: 6.0.0-M1.202507

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
