### PR TITLE
perf(broker): try to minimize number of subscriber shards

### DIFF
--- a/apps/emqx/include/emqx_instr.hrl
+++ b/apps/emqx/include/emqx_instr.hrl
@@ -1,0 +1,109 @@
+-ifndef(EMQX_INSTR_HRL).
+-define(EMQX_INSTR_HRL, true).
+
+-define(BROKER_INSTR_METRICS_WORKER, broker_instr_metrics).
+
+-ifdef(EMQX_BROKER_INSTR).
+
+-define(BROKER_INSTR_METRICS, [broker, connection]).
+-define(BROKER_INSTR_METRICS_DECL, [
+    {broker, [
+        {hist, dispatch_total_lat_us, ?BROKER_INSTR_BUCKETS_US_MEDIUM},
+        {hist, dispatch_shard_delay_us, ?BROKER_INSTR_BUCKETS_US_SHORT},
+        {hist, dispatch_shard_lat_us, ?BROKER_INSTR_BUCKETS_US_MEDIUM}
+    ]},
+    {connection, [
+        {hist, deliver_delay_us, ?BROKER_INSTR_BUCKETS_US_SHORT},
+        {hist, deliver_total_lat_us, ?BROKER_INSTR_BUCKETS_US_MEDIUM}
+    ]}
+]).
+
+-else.
+
+-define(BROKER_INSTR_METRICS, []).
+-define(BROKER_INSTR_METRICS_DECL, []).
+
+-endif.
+
+-define(BROKER_INSTR_BUCKETS_US_SHORT, [
+    100,
+    200,
+    500,
+    1000,
+    2000,
+    5000,
+    10000,
+    15000,
+    20000,
+    25000,
+    30000,
+    40000,
+    50000,
+    60000,
+    70000,
+    80000,
+    90000,
+    100000
+]).
+
+-define(BROKER_INSTR_BUCKETS_US_MEDIUM, [
+    1000,
+    2000,
+    5000,
+    10000,
+    15000,
+    20000,
+    25000,
+    30000,
+    40000,
+    50000,
+    60000,
+    70000,
+    80000,
+    90000,
+    100000,
+    200000,
+    500000
+]).
+
+-ifdef(EMQX_BROKER_INSTR).
+
+-define(BROKER_INSTR_OBSERVE_HIST(METRIC, NAME, V),
+    (emqx_metrics_worker:observe_hist(
+        ?BROKER_INSTR_METRICS_WORKER,
+        METRIC,
+        NAME,
+        V
+    ))
+).
+
+-define(BROKER_INSTR_SETMARK(X, Y), (erlang:put(X, Y))).
+-define(BROKER_INSTR_WMARK(X, MATCH, EXPR),
+    (case erlang:erase(X) of
+        MATCH -> EXPR;
+        _ -> ok
+    end)
+).
+
+-define(BROKER_INSTR_TS(), (os:perf_counter())).
+-define(BROKER_INSTR_TS(BIND), (BIND = os:perf_counter())).
+-define(BROKER_INSTR_BIND(BIND, _, X), (BIND = X)).
+
+-else.
+
+-define(BROKER_INSTR_SETMARK(X, Y), stub).
+-define(BROKER_INSTR_WMARK(X, MATCH, EXPR), stub).
+-define(BROKER_INSTR_OBSERVE_HIST(METRIC, NAME, V), stub).
+
+-define(BROKER_INSTR_TS(), stub).
+-define(BROKER_INSTR_TS(BIND), stub).
+-define(BROKER_INSTR_BIND(BIND, X, _), (BIND = X)).
+
+-endif.
+
+-define(US_SINCE(PC), ?US(os:perf_counter() - PC)).
+-define(US(PC),
+    (erlang:convert_time_unit(PC, perf_counter, microsecond))
+).
+
+-endif.

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -66,8 +66,6 @@
     code_change/3
 ]).
 
--import(emqx_utils_ets, [lookup_value/2, lookup_value/3]).
-
 -ifdef(TEST).
 -compile(export_all).
 -compile(nowarn_export_all).
@@ -805,3 +803,13 @@ regular_sync_route(add, Topic) ->
     emqx_router:do_add_route(Topic, node());
 regular_sync_route(delete, Topic) ->
     emqx_router:do_delete_route(Topic, node()).
+
+%%
+
+-compile({inline, [lookup_value/2, lookup_value/3]}).
+
+lookup_value(Tab, Key) ->
+    ets:lookup_element(Tab, Key, 2, undefined).
+
+lookup_value(Tab, Key, Def) ->
+    ets:lookup_element(Tab, Key, 2, Def).

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -94,8 +94,6 @@
     bypass_hook => boolean()
 }.
 
--elvis([{elvis_style, used_ignored_variable, disable}]).
-
 -spec start_link(atom(), pos_integer()) -> startlink_ret().
 start_link(Pool, Id) ->
     gen_server:start_link(

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -89,7 +89,7 @@ assign_sub_shard(Topic) ->
             Ix;
         _ ->
             %% Subject to races.
-            ets:update_counter(?HELPER, Topic, {2, 1, Ix + 1, Ix + 1}, Shard),
+            _ = ets:update_counter(?HELPER, Topic, {2, 1, Ix + 1, Ix + 1}, Shard),
             Ix
     end.
 
@@ -110,11 +110,13 @@ unassign_sub_shard(Topic, ShardIx) when is_integer(ShardIx) ->
                             [{const, {Topic, ShardIx}}]
                         }
                     ],
-                    _NR = ets:select_replace(?HELPER, Spec);
+                    _NR = ets:select_replace(?HELPER, Spec),
+                    ok;
                 Ix when Ix < ShardIx andalso N =:= 0 ->
                     %% Current shard is lower.
                     %% This one is empty, likely not going to be filled soon.
-                    ets:delete(?HELPER, {Shard, 0});
+                    _ = ets:delete(?HELPER, {Shard, 0}),
+                    ok;
                 _ ->
                     %% Current shard is either this or lower.
                     ok

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -80,40 +80,77 @@ lookup_subid(SubPid) when is_pid(SubPid) ->
 lookup_subpid(SubId) ->
     emqx_utils_ets:lookup_value(?SUBID, SubId).
 
+-doc """
+Assign `Topic` subscriber to some shard, where shard is simply a number between
+0 and positive infinity. Assignment strives to be optimal: for the given number
+of `Topic` subscribers (i.e. `assign_sub_shard(Topic)` calls) there should be as
+few shards assigned as possible, where each shard has fixed limited capacity
+(see `shard_capacity/0`). This limit is a soft limit, meaning going over capacity
+a bit is allowed, however it's expected to happen only under extremely high load.
+
+This operation is not idempotent.
+
+Shard numbers are used to partition subscribers into separate records in
+`emqx_subscriber` bag table, to smooth out O(N) insertion cost and O(N) memory
+requirement during record lookup.
+""".
 -spec assign_sub_shard(emqx_types:topic()) -> non_neg_integer().
 assign_sub_shard(Topic) ->
+    %% Lookup current shard:
+    %% Current shard is the shard that's being filled up now, _each_ assignment
+    %% goes into it.
     Ix = ets:lookup_element(?HELPER, Topic, 2, 0),
     Shard = {Topic, Ix},
+    %% Make assignment in the current shard:
     case ets:update_counter(?HELPER, Shard, {2, 1}, {'_', 0}) of
         N when N =< ?SHARD_CAPACITY ->
             Ix;
         _ ->
+            %% Current shard is over capacity. Switch up to the next shard.
             %% Subject to races.
             _ = ets:update_counter(?HELPER, Topic, {2, 1, Ix + 1, Ix + 1}, Shard),
             Ix
     end.
 
+-doc """
+Unassign `Topic` from the given shard `Ix`, where `Ix` was obtained before by
+calling `assign_sub_shard(Topic)`.
+
+\"Unassignment\" is performed in such a way that further assignments will tend
+towards optimality, as much as practically possible. This is why the logic is so
+complex.
+
+This operation is not idempotent.
+""".
 -spec unassign_sub_shard(emqx_types:topic(), non_neg_integer()) -> _Left :: non_neg_integer().
 unassign_sub_shard(Topic, ShardIx) when is_integer(ShardIx) ->
     Shard = {Topic, ShardIx},
+    %% Unassign subscriber from the given shard:
     case ets:update_counter(?HELPER, Shard, {2, -1, 0, 0}, {'_', 1}) of
         N when N =< ?SHARD_REFILL ->
-            %% Shard is a candidate for refilling.
+            %% After unassigment, shard has number of susbcribers fewer than threshold.
+            %% It is now a candidate for refilling. To keep assignments close to being
+            %% optimal, current shard can only switched down but not up, because it
+            %% makes "switch-up" to a new, never seen before shard less likely during
+            %% assign.
             case ets:lookup_element(?HELPER, Topic, 2, 0) of
                 Ix when Ix > ShardIx ->
                     %% Current shard is higher.
-                    %% Switch down to this shard.
+                    %% Switch down to this shard atomically.
                     Spec = [{{Topic, '$1'}, [{'>', '$1', ShardIx}], [{const, Shard}]}],
                     _ = ets:select_replace(?HELPER, Spec),
                     ok;
                 Ix when Ix < ShardIx andalso N =:= 0 ->
                     %% Current shard is lower, this one is empty.
-                    %% Likely not going to be filled soon.
+                    %% Likely not going to be filled soon. Delete the shard counter
+                    %% record atomically.
                     _ = ets:delete_object(?HELPER, {Shard, 0}),
                     ok;
                 ShardIx when ShardIx > 0 andalso N =:= 0 ->
                     %% This is the current shard, and is now empty.
-                    %% Switch down to previous shard.
+                    %% It's also not the zeroth shard, so switch-down is possible.
+                    %% Switch down to previous shard atomically and delete the shard
+                    %% counter record atomically.
                     Spec = [{Shard, [], [{const, {Topic, ShardIx - 1}}]}],
                     _ = ets:select_replace(?HELPER, Spec),
                     _ = ets:delete_object(?HELPER, {Shard, 0}),

--- a/apps/emqx/src/emqx_broker_sup.erl
+++ b/apps/emqx/src/emqx_broker_sup.erl
@@ -4,6 +4,8 @@
 
 -module(emqx_broker_sup).
 
+-include("emqx_instr.hrl").
+
 -behaviour(supervisor).
 
 -export([start_link/0]).
@@ -77,4 +79,18 @@ init([]) ->
         modules => [emqx_exclusive_subscription]
     },
 
-    {ok, {{one_for_all, 0, 1}, [SyncerPool, BrokerPool, SharedSub, Helper, ExclusiveSub]}}.
+    MetricsWorker = emqx_metrics_worker:child_spec(
+        metrics_worker,
+        ?BROKER_INSTR_METRICS_WORKER,
+        ?BROKER_INSTR_METRICS_DECL
+    ),
+
+    {ok,
+        {{one_for_all, 0, 1}, [
+            MetricsWorker,
+            SyncerPool,
+            BrokerPool,
+            SharedSub,
+            Helper,
+            ExclusiveSub
+        ]}}.

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -364,7 +364,8 @@ t_shared_subscribe_3(_) ->
 
 t_shard({init, Config}) ->
     ok = meck:new(emqx_broker_helper, [passthrough, no_history]),
-    ok = meck:expect(emqx_broker_helper, get_sub_shard, fun(_, _) -> 1 end),
+    ok = meck:expect(emqx_broker_helper, assign_sub_shard, fun(_) -> 1 end),
+    ok = meck:expect(emqx_broker_helper, unassign_sub_shard, fun(_, _) -> ok end),
     emqx_broker:subscribe(<<"topic">>, <<"clientid">>),
     Config;
 t_shard(Config) when is_list(Config) ->

--- a/apps/emqx/test/emqx_broker_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_helper_SUITE.erl
@@ -50,14 +50,6 @@ t_register_sub(_) ->
     end,
     ?assertEqual(self(), emqx_broker_helper:lookup_subpid(<<"clientid">>)).
 
-t_shard_seq(_) ->
-    TestTopic = atom_to_list(?FUNCTION_NAME),
-    ?assertEqual([], ets:lookup(emqx_subseq, TestTopic)),
-    emqx_broker_helper:create_seq(TestTopic),
-    ?assertEqual([{TestTopic, 1}], ets:lookup(emqx_subseq, TestTopic)),
-    emqx_broker_helper:reclaim_seq(TestTopic),
-    ?assertEqual([], ets:lookup(emqx_subseq, TestTopic)).
-
 t_uncovered_func(_) ->
     gen_server:call(emqx_broker_helper, test),
     gen_server:cast(emqx_broker_helper, test),

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -228,7 +228,10 @@ t_handle_msg_passive(_) ->
 
 t_handle_msg_deliver(_) ->
     ok = meck:expect(emqx_channel, handle_deliver, fun(_, Channel) -> {ok, Channel} end),
-    ?assertMatch({ok, _St}, handle_msg({deliver, topic, msg}, st())).
+    ?assertMatch(
+        {ok, _St},
+        handle_msg({deliver, <<"#">>, emqx_message:make(<<"t">>, <<>>)}, st())
+    ).
 
 t_handle_msg_inet_reply(_) ->
     ?assertMatch(

--- a/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_data_SUITE.erl
@@ -330,6 +330,8 @@ metric_meta(<<"emqx_conf_sync_txid">>) -> ?meta(0, 1, 1);
 %% END
 metric_meta(<<"emqx_cert_expiry_at">>) -> ?meta(2, 2, 2);
 metric_meta(<<"emqx_license_expiry_at">>) -> ?meta(0, 0, 0);
+%% broker instr
+metric_meta(<<"emqx_instr_", _Tail/binary>>) -> #{};
 %% mria metric with label `shard` and `node` when not in mode `node`
 metric_meta(<<"emqx_mria_", _Tail/binary>>) -> ?meta(1, 2, 2);
 %% `/prometheus/auth`

--- a/apps/emqx_utils/mix.exs
+++ b/apps/emqx_utils/mix.exs
@@ -6,7 +6,7 @@ defmodule EMQXUtils.MixProject do
   def project do
     [
       app: :emqx_utils,
-      version: "5.5.2",
+      version: "5.5.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: ["etc" | UMP.erlc_paths()],

--- a/apps/emqx_utils/src/emqx_metrics_worker.erl
+++ b/apps/emqx_utils/src/emqx_metrics_worker.erl
@@ -349,8 +349,7 @@ set(Name, Id, Metric, Val) ->
 %%
 -spec observe(handler_name(), metric_id(), atom(), integer()) -> ok.
 observe(Name, Id, Metric, Val) ->
-    #{ref := CRef, slide := Idx} = maps:get(Id, get_pterm(Name)),
-    Index = maps:get(Metric, Idx),
+    #{Id := #{ref := CRef, slide := #{Metric := Index}}} = get_pterm(Name),
     %% Update sum:
     counters:add(CRef, Index, Val),
     %% Update number of samples:
@@ -358,8 +357,7 @@ observe(Name, Id, Metric, Val) ->
 
 -spec observe_hist(handler_name(), metric_id(), atom(), integer()) -> ok.
 observe_hist(Name, Id, Metric, Val) ->
-    #{ref := CRef, hist := Idx} = maps:get(Id, get_pterm(Name)),
-    {Index, Buckets} = maps:get(Metric, Idx),
+    #{Id := #{ref := CRef, hist := #{Metric := {Index, Buckets}}}} = get_pterm(Name),
     %% Update sum:
     counters:add(CRef, Index, Val),
     %% Update bucket counter:

--- a/apps/emqx_utils/src/emqx_utils.app.src
+++ b/apps/emqx_utils/src/emqx_utils.app.src
@@ -2,7 +2,7 @@
 {application, emqx_utils, [
     {description, "Miscellaneous utilities for EMQX apps"},
     % strict semver, bump manually!
-    {vsn, "5.5.2"},
+    {vsn, "5.5.3"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/mix.exs
+++ b/mix.exs
@@ -484,8 +484,13 @@ defmodule EMQXUmbrella.MixProject do
       {:d, :snk_kind, :msg}
     ] ++
       singleton(test_env?(), {:d, :TEST}) ++
+      singleton(enable_broker_instr?(), {:d, :EMQX_BROKER_INSTR}) ++
       singleton(not enable_quicer?(), {:d, :BUILD_WITHOUT_QUIC}) ++
       singleton(store_state_in_ds?(), {:d, :STORE_STATE_IN_DS, true})
+  end
+
+  defp enable_broker_instr?() do
+    "1" == System.get_env("EMQX_BROKER_INSTR")
   end
 
   defp store_state_in_ds?() do

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -163,9 +163,6 @@ common_compile_opts(Vsn) ->
         [{d, 'EMQX_FLAVOR', get_emqx_flavor()}] ++
         [{d, 'BUILD_WITHOUT_QUIC'} || not is_quicer_supported()].
 
-dev_compile_opts() ->
-    [{d, 'EMQX_BROKER_INSTR'}].
-
 warn_profile_env() ->
     case os:getenv("PROFILE") of
         false ->
@@ -230,7 +227,7 @@ profiles_dev(_RelType) ->
         ]},
         {test, [
             {deps, test_deps()},
-            {erl_opts, common_compile_opts() ++ dev_compile_opts() ++ erl_opts_i()},
+            {erl_opts, common_compile_opts() ++ erl_opts_i()},
             {extra_src_dirs, [{"test", [{recursive, true}]}]},
             {project_app_dirs, project_app_dirs()}
         ]}

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -158,9 +158,13 @@ common_compile_opts(Vsn) ->
         {d, 'EMQX_RELEASE_EDITION', ee}
     ] ++
         [{d, 'EMQX_BENCHMARK'} || os:getenv("EMQX_BENCHMARK") =:= "1"] ++
+        [{d, 'EMQX_BROKER_INSTR'} || os:getenv("EMQX_BROKER_INSTR") =:= "1"] ++
         [{d, 'STORE_STATE_IN_DS'} || os:getenv("STORE_STATE_IN_DS") =:= "1"] ++
         [{d, 'EMQX_FLAVOR', get_emqx_flavor()}] ++
         [{d, 'BUILD_WITHOUT_QUIC'} || not is_quicer_supported()].
+
+dev_compile_opts() ->
+    [{d, 'EMQX_BROKER_INSTR'}].
 
 warn_profile_env() ->
     case os:getenv("PROFILE") of
@@ -226,7 +230,7 @@ profiles_dev(_RelType) ->
         ]},
         {test, [
             {deps, test_deps()},
-            {erl_opts, common_compile_opts() ++ erl_opts_i()},
+            {erl_opts, common_compile_opts() ++ dev_compile_opts() ++ erl_opts_i()},
             {extra_src_dirs, [{"test", [{recursive, true}]}]},
             {project_app_dirs, project_app_dirs()}
         ]}


### PR DESCRIPTION
Part of EMQX-14333.

Release version: 6.0?

## Summary

Number of shards per topic is not limited now, and each shard will hold no more that 1024 (`emqx_broker_helper:shard_capacity/0`) subscribers.

Downside is: subscriber table may now hold more than 1024 + 32 * C entries per topic, where C is number of schedulers, but in the general case number of entries now scales better with number of subscribers.

Also instrument core dispatch/delivery hot-paths with few latency metrics, disabled by default to have zero runtime impact.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
