### PR TITLE
fix(wsconn): update `cowboy` to 2.13.0-emqx-2

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -27,7 +27,7 @@
     {emqx_ds_backends, {path, "../emqx_ds_backends"}},
     {lc, {git, "https://github.com/emqx/lc.git", {tag, "0.3.4"}}},
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
-    {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-1"}}},
+    {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.14.0"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.3"}}},

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -604,7 +604,7 @@ t_process_dies_session_expires(Config) ->
             ?assertEqual(0, client_info(session_present, Client2)),
 
             %% We should not receive the pending message
-            ?assertEqual([], receive_messages(1)),
+            ?assertEqual([], receive_messages(1, 5000)),
 
             emqtt:disconnect(Client2)
         end,

--- a/changes/ee/fix-15416.en.md
+++ b/changes/ee/fix-15416.en.md
@@ -1,0 +1,3 @@
+Fixed occasional warning-level log events and crashes during session expiration of WebSocket connections, introduced by recent WebSocket performance improvements. These had no impact on broker capacity, but produced log entries like the following:
+* `error: {function_clause,[{gen_tcp,send,[closed,[]],[{file,“gen_tcp.erl”},{line,966}]},{cowboy_websocket_linger,commands,3,[{file,“cowboy_websocket_linger.erl”},{line,665}]},...`
+* `message: {tcp,#Port<0.364>,<<136,130,...>>}, msg: emqx_session_mem_unknown_message`

--- a/mix.exs
+++ b/mix.exs
@@ -207,7 +207,7 @@ defmodule EMQXUmbrella.MixProject do
        github: "emqx/grpc-erl", tag: "0.7.2", override: true, system_env: emqx_app_system_env()}
 
   def common_dep(:cowboy),
-    do: {:cowboy, github: "emqx/cowboy", tag: "2.13.0-emqx-1", override: true}
+    do: {:cowboy, github: "emqx/cowboy", tag: "2.13.0-emqx-2", override: true}
 
   def common_dep(:hackney),
     do: {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -88,7 +88,7 @@
     {jiffy, "1.1.2"},
     {cowlib, "2.14.0"},
     {ranch, {git, "https://github.com/emqx/ranch", {tag, "1.8.1-emqx-1"}}},
-    {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-1"}}},
+    {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.14.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-8"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.0"}}},


### PR DESCRIPTION
Fixes [EMQX-14429](https://emqx.atlassian.net/browse/EMQX-14429).

Release version: 5.10.1?

## Summary

emqx/cowboy#13 includes fixes for "crash-on-shutdown" bug in `cowboy_websocket_linger` logic.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
    No new testcases: existing tests (namely, `emqx_persistent_session_SUITE.persistence_disabled.ws` test group) are now free of crash reports and "unknown message" warnings.

- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14429]: https://emqx.atlassian.net/browse/EMQX-14429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ