### PR TITLE
feat(broker): allow async shard dispatch through broker pool

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -744,13 +744,8 @@ do_dispatch2(Topic, #delivery{message = MsgIn}) ->
 %% Don't dispatch to share subscriber here.
 %% we do it in `emqx_shared_sub.erl` with configured strategy
 do_dispatch_chans(Topic, Msg, [SubPid | Rest], N) ->
-    case erlang:is_process_alive(SubPid) of
-        true ->
-            SubPid ! {deliver, Topic, Msg},
-            do_dispatch_chans(Topic, Msg, Rest, N + 1);
-        false ->
-            do_dispatch_chans(Topic, Msg, Rest, N)
-    end;
+    SubPid ! {deliver, Topic, Msg},
+    do_dispatch_chans(Topic, Msg, Rest, N + 1);
 do_dispatch_chans(_Topic, _Msg, [], N) ->
     N.
 

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -77,7 +77,7 @@
 %% Guards
 -define(IS_SUBID(Id), (is_binary(Id) orelse is_atom(Id))).
 
--define(PT_FLAG_ASYNC_SHARD_DISPATCH, async_fanout_shard_dispatch).
+-define(PT_FLAG_ASYNC_SHARD_DISPATCH, '$emqx_broker__async_fanout_shard_dispatch').
 
 -define(cast_or_eval(PICK, Msg, Expr),
     case PICK of

--- a/apps/emqx/src/emqx_broker_sup.erl
+++ b/apps/emqx/src/emqx_broker_sup.erl
@@ -34,6 +34,7 @@ get_broker_pool_workers() ->
 init([]) ->
     %% Broker pool
     ok = emqx_broker:create_tabs(),
+    ok = emqx_broker:init_config(),
     PoolSize = emqx:get_config([node, broker_pool_size], emqx_vm:schedulers() * 2),
     BrokerPool = emqx_pool_sup:spec(broker_pool_sup, permanent, [
         ?broker_pool,

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1422,6 +1422,14 @@ fields("shared_subscription_group") ->
     ];
 fields("broker_perf") ->
     [
+        {"async_fanout_shard_dispatch",
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(broker_perf_async_fanout_shard_dispatch)
+                }
+            )},
         {"route_lock_type",
             sc(
                 hoconsc:enum([key, tab, global]),

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1443,6 +1443,7 @@ fields("broker_perf") ->
                 boolean(),
                 #{
                     default => true,
+                    deprecated => {since, "5.10.0"},
                     desc => ?DESC(broker_perf_trie_compaction)
                 }
             )}

--- a/apps/emqx/src/emqx_stats.erl
+++ b/apps/emqx/src/emqx_stats.erl
@@ -45,6 +45,10 @@
     code_change/3
 ]).
 
+-ifdef(TEST).
+-export([reset/0]).
+-endif.
+
 -export_type([stats/0]).
 
 -record(update, {name, countdown, interval, func}).
@@ -219,7 +223,17 @@ cancel_update(Name) ->
 rec(Name, Secs, UpFun) ->
     #update{name = Name, countdown = Secs, interval = Secs, func = UpFun}.
 
-cast(Msg) -> gen_server:cast(?SERVER, Msg).
+cast(Msg) ->
+    gen_server:cast(?SERVER, Msg).
+
+-ifdef(TEST).
+
+-spec reset() -> ok.
+reset() ->
+    true = ets:delete_all_objects(?TAB),
+    ok.
+
+-endif.
 
 %%--------------------------------------------------------------------
 %% gen_server callbacks

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -342,7 +342,7 @@ t_shared_subscribe_3(_) ->
 t_fanout({init, Config}) ->
     Config;
 t_fanout({'end', _Config}) ->
-    ok;
+    emqx_stats:reset();
 t_fanout(_Config) ->
     NSubscribers = 2500,
     Subscribers = [
@@ -364,6 +364,16 @@ t_fanout(_Config) ->
         10,
         false = lists:any(fun erlang:is_process_alive/1, Subscribers)
     ).
+
+t_fanout_async_dispatch({init, Config}) ->
+    emqx_config:put([broker, perf, async_fanout_shard_dispatch], true),
+    emqx_broker:init_config(),
+    Config;
+t_fanout_async_dispatch({'end', _Config}) ->
+    emqx_config:put([broker, perf, async_fanout_shard_dispatch], false),
+    emqx_broker:init_config();
+t_fanout_async_dispatch(Config) ->
+    t_fanout(Config).
 
 %% persistent sessions, when gone, do not contribute to connected
 %% client count

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -115,32 +115,8 @@ end_per_testcase(Case, Config) ->
 %%--------------------------------------------------------------------
 
 t_stats_fun({init, Config}) ->
-    Parent = self(),
-    F = fun Loop() ->
-        N1 = emqx_stats:getstat('subscribers.count'),
-        N2 = emqx_stats:getstat('subscriptions.count'),
-        N3 = emqx_stats:getstat('suboptions.count'),
-        case N1 + N2 + N3 =:= 0 of
-            true ->
-                Parent ! {ready, self()},
-                exit(normal);
-            false ->
-                receive
-                    stop ->
-                        exit(normal)
-                after 100 ->
-                    Loop()
-                end
-        end
-    end,
-    Pid = spawn_link(F),
-    receive
-        {ready, P} when P =:= Pid ->
-            Config
-    after 5000 ->
-        Pid ! stop,
-        ct:fail("timedout_waiting_for_sub_stats_to_reach_zero")
-    end;
+    ok = emqx_stats:reset(),
+    Config;
 t_stats_fun(Config) when is_list(Config) ->
     ok = emqx_broker:subscribe(<<"topic">>, <<"clientid">>),
     ok = emqx_broker:subscribe(<<"topic2">>, <<"clientid">>),

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -60,8 +60,8 @@ t_fill_default_values(C) when is_list(C) ->
                     <<"enable_session_registry">> := true,
                     <<"perf">> :=
                         #{
-                            <<"route_lock_type">> := <<"key">>,
-                            <<"trie_compaction">> := true
+                            <<"async_fanout_shard_dispatch">> := false,
+                            <<"route_lock_type">> := <<"key">>
                         },
                     <<"route_batch_clean">> := false,
                     <<"session_history_retain">> := <<"0s">>

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1032,6 +1032,9 @@ overload_protection_backoff_gc.desc:
 overload_protection_backoff_gc.label:
 """Skip GC"""
 
+broker_perf_async_fanout_shard_dispatch.desc:
+"""When enabled, subscribers residing in subscriber shards in high-fanout topics are dispatched asynchronously and concurrently through the broker pool."""
+
 broker_perf_route_lock_type.desc:
 """Performance tuning for subscribing/unsubscribing a wildcard topic.
 Change this parameter only when there are many wildcard topics.


### PR DESCRIPTION
Part of EMQX-14333.

Release version: 6.0?

## Summary

On top of #15407.

Add feature flag that enables dispatching of subscriber shards through the broker pool. This feature is hidden and disabled by default.

* Impact on high-fanout performance varies, see [report](https://emqx.atlassian.net/wiki/spaces/HOTPOT/pages/1815413979/In-mem+Fanout+Performance).
* No decisive negative impact on 1-to-1 performance, however it proved to be very hard to measure. Work in progress.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
