### PR TITLE
chore: update hocon -> 0.45.4

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -32,7 +32,7 @@
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.0"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.3"}}},
     {typerefl, {git, "https://github.com/ieQu1/typerefl", {tag, "0.9.6"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {recon, {git, "https://github.com/ferd/recon", {tag, "2.5.6"}}},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}}

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.app.src
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_event_hub, [
     {description, "EMQX Enterprise Azure Event Hub Bridge"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -469,8 +469,7 @@ override_documentations(Fields) ->
         fun({Name, Sc}) ->
             case hocon_schema:field_schema(Sc, desc) of
                 ?DESC(emqx_bridge_kafka, Key) ->
-                    %% to please dialyzer...
-                    Override = #{type => hocon_schema:field_schema(Sc, type), desc => ?DESC(Key)},
+                    Override = #{desc => ?DESC(Key)},
                     {Name, hocon_schema:override(Sc, Override)};
                 _ ->
                     {Name, Sc}

--- a/apps/emqx_bridge_confluent/src/emqx_bridge_confluent.app.src
+++ b/apps/emqx_bridge_confluent/src/emqx_bridge_confluent.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_confluent, [
     {description, "EMQX Enterprise Confluent Connector and Action"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_confluent/src/emqx_bridge_confluent_producer.erl
+++ b/apps/emqx_bridge_confluent/src/emqx_bridge_confluent_producer.erl
@@ -388,8 +388,7 @@ override_documentations(Fields) ->
         fun({Name, Sc}) ->
             case hocon_schema:field_schema(Sc, desc) of
                 ?DESC(emqx_bridge_kafka, Key) ->
-                    %% to please dialyzer...
-                    Override = #{type => hocon_schema:field_schema(Sc, type), desc => ?DESC(Key)},
+                    Override = #{desc => ?DESC(Key)},
                     {Name, hocon_schema:override(Sc, Override)};
                 _ ->
                     {Name, Sc}

--- a/apps/emqx_bridge_doris/src/emqx_bridge_doris.app.src
+++ b/apps/emqx_bridge_doris/src/emqx_bridge_doris.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_doris, [
     {description, "EMQX Enterprise Doris Bridge"},
-    {vsn, "1.0.0"},
+    {vsn, "1.0.1"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_doris/src/emqx_bridge_doris_connector_schema.erl
+++ b/apps/emqx_bridge_doris/src/emqx_bridge_doris_connector_schema.erl
@@ -55,11 +55,7 @@ fields(connector_config) ->
         lists:map(
             fun
                 ({server = K, Sc}) ->
-                    Override = #{
-                        %% to please dialyzer...
-                        type => hocon_schema:field_schema(Sc, type),
-                        desc => ?DESC("server")
-                    },
+                    Override = #{desc => ?DESC("server")},
                     {K, hocon_schema:override(Sc, Override)};
                 ({ssl = K, Sc}) ->
                     Override = #{type => hoconsc:ref(?MODULE, ssl)},
@@ -75,11 +71,7 @@ fields(ssl) ->
     lists:map(
         fun
             ({"middlebox_comp_mode" = K, Sc}) ->
-                Override = #{
-                    %% to please dialyzer...
-                    type => hocon_schema:field_schema(Sc, type),
-                    default => false
-                },
+                Override = #{default => false},
                 {K, hocon_schema:override(Sc, Override)};
             (Field) ->
                 Field

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_gcp_pubsub, [
     {description, "EMQX Enterprise GCP Pub/Sub Bridge"},
-    {vsn, "0.3.7"},
+    {vsn, "0.3.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_schema.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_schema.erl
@@ -67,9 +67,7 @@ fields(source_parameters) ->
     Fields = lists:map(
         fun
             ({topic_mapping = Name, Sc}) ->
-                %% to please dialyzer...
                 Override = #{
-                    type => hocon_schema:field_schema(Sc, type),
                     required => false,
                     default => [],
                     validator => fun(_) -> ok end,

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_schema.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_producer_schema.erl
@@ -64,11 +64,7 @@ fields(action_parameters) ->
     lists:map(
         fun
             ({local_topic, Sc}) ->
-                Override = #{
-                    %% to please dialyzer...
-                    type => hocon_schema:field_schema(Sc, type),
-                    importance => ?IMPORTANCE_HIDDEN
-                },
+                Override = #{importance => ?IMPORTANCE_HIDDEN},
                 {local_topic, hocon_schema:override(Sc, Override)};
             (Field) ->
                 Field

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.5.6"},
+    {vsn, "0.5.7"},
     {registered, [emqx_bridge_kafka_sup, emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_consumer_schema.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_consumer_schema.erl
@@ -62,9 +62,7 @@ fields(source_parameters) ->
     Fields = lists:map(
         fun
             ({topic_mapping = Name, Sc}) ->
-                %% to please dialyzer...
                 Override = #{
-                    type => hocon_schema:field_schema(Sc, type),
                     required => false,
                     default => [],
                     validator => fun legacy_consumer_topic_mapping_validator/1,
@@ -263,8 +261,6 @@ connector_config_fields() ->
                 %% This field was accidentally added to the consumer schema because it was
                 %% added to the shared, v1 field in the shared schema module.
                 Override = #{
-                    %% to please dialyzer...
-                    type => hocon_schema:field_schema(Sc, type),
                     deprecated => {since, "5.9.0"},
                     importance => ?IMPORTANCE_HIDDEN
                 },

--- a/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_connector_schema.erl
+++ b/apps/emqx_bridge_s3tables/src/emqx_bridge_s3tables_connector_schema.erl
@@ -96,8 +96,6 @@ fields(s3_client_params) ->
         fun
             ({K, Sc}) when K == host; K == port ->
                 Override = #{
-                    %% to please dialyzer...
-                    type => hocon_schema:field_schema(Sc, type),
                     required => false,
                     importance => ?IMPORTANCE_HIDDEN
                 },

--- a/apps/emqx_oracle/src/emqx_oracle.app.src
+++ b/apps/emqx_oracle/src/emqx_oracle.app.src
@@ -1,6 +1,6 @@
 {application, emqx_oracle, [
     {description, "EMQX Enterprise Oracle Database Connector"},
-    {vsn, "0.2.7"},
+    {vsn, "0.2.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_oracle/src/emqx_oracle_schema.erl
+++ b/apps/emqx_oracle/src/emqx_oracle_schema.erl
@@ -57,8 +57,7 @@ adjust_fields(Fields) ->
     lists:map(
         fun
             ({username, Sc}) ->
-                %% to please dialyzer...
-                Override = #{type => hocon_schema:field_schema(Sc, type), required => true},
+                Override = #{required => true},
                 {username, hocon_schema:override(Sc, Override)};
             (Field) ->
                 Field

--- a/apps/emqx_postgresql/src/emqx_postgresql.app.src
+++ b/apps/emqx_postgresql/src/emqx_postgresql.app.src
@@ -1,6 +1,6 @@
 {application, emqx_postgresql, [
     {description, "EMQX PostgreSQL Database Connector"},
-    {vsn, "0.2.8"},
+    {vsn, "0.2.9"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_postgresql/src/emqx_postgresql.erl
+++ b/apps/emqx_postgresql/src/emqx_postgresql.erl
@@ -102,8 +102,7 @@ adjust_fields(Fields) ->
     lists:map(
         fun
             ({username, Sc}) ->
-                %% to please dialyzer...
-                Override = #{type => hocon_schema:field_schema(Sc, type), required => true},
+                Override = #{required => true},
                 {username, hocon_schema:override(Sc, Override)};
             (Field) ->
                 Field

--- a/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
+++ b/apps/emqx_postgresql/src/schema/emqx_postgresql_connector_schema.erl
@@ -91,8 +91,7 @@ adjust_fields(Fields) ->
     lists:map(
         fun
             ({username, Sc}) ->
-                %% to please dialyzer...
-                Override = #{type => hocon_schema:field_schema(Sc, type), required => true},
+                Override = #{required => true},
                 {username, hocon_schema:override(Sc, Override)};
             (Field) ->
                 Field

--- a/mix.exs
+++ b/mix.exs
@@ -189,7 +189,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.0", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.14.0", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
-  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.3", override: true}
+  def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.4", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.4", override: true}
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -104,7 +104,7 @@
     {system_monitor, {git, "https://github.com/ieQu1/system_monitor", {tag, "3.0.6"}}},
     {getopt, "1.0.2"},
     {snabbkaffe, {git, "https://github.com/kafka4beam/snabbkaffe.git", {tag, "1.0.10"}}},
-    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.3"}}},
+    {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.45.4"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},
     {sasl_auth, "2.3.3"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},


### PR DESCRIPTION
https://github.com/emqx/hocon/pull/309

Fixes `hocon_schema:override/2` typespec so dialyzer doesn't yell when you don't want to override the field type.
