### PR TITLE
feat(socket): implement `esockd_socket` connection module

### DIFF
--- a/apps/emqx/src/emqx_congestion.erl
+++ b/apps/emqx/src/emqx_congestion.erl
@@ -105,6 +105,9 @@ do_cancel_alarm_congestion(Socket, Transport, Channel, Reason) ->
     emqx_alarm:ensure_deactivated(?ALARM_CONN_CONGEST(Channel, Reason), AlarmDetails, Message),
     ok.
 
+is_tcp_congested(_Socket, esockd_socket) ->
+    %% TODO: No such concept in `socket`-based sockets.
+    false;
 is_tcp_congested(Socket, Transport) ->
     case Transport:getstat(Socket, [send_pend]) of
         {ok, [{send_pend, N}]} when N > 0 -> true;

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -8,7 +8,13 @@
 %%   - TCP/TLS connection
 %%   - QUIC Stream
 %%
-%% for WebSocket @see emqx_ws_connection.erl
+%% For WebSocket transport, @see `emqx_ws_connection`.
+%% For `esockd_socket` transport, @see `emqx_socket_connection`.
+
+%% NOTE
+%% When changing this module, please make an effort to port changes to
+%% `emqx_socket_connection` module if they make sense there, and vice
+%% versa.
 -module(emqx_connection).
 
 -include("emqx.hrl").

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -288,6 +288,11 @@ stop(Pid) ->
 init(Parent, Transport, RawSocket, Options) ->
     case Transport:wait(RawSocket) of
         {ok, Socket} ->
+            ?tp(connection_started, #{
+                socket => Socket,
+                listener => maps:get(listener, Options),
+                connmod => ?MODULE
+            }),
             run_loop(Parent, init_state(Transport, Socket, Options));
         {error, Reason} ->
             ok = Transport:fast_close(RawSocket),

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -795,7 +795,7 @@ run_stream_parser(Data, Acc, N, ParseState, State) ->
     case emqx_frame:parse(Data, ParseState) of
         {Packet, Rest, NParseState} ->
             run_stream_parser(Rest, [Packet | Acc], N + 1, NParseState, State);
-        {more, NParseState} ->
+        {_More, NParseState} ->
             {N, Acc, State#state{parser = NParseState}}
     end.
 

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -946,9 +946,11 @@ send(Num, IoData, #state{transport = Transport, socket = Socket} = State) ->
                 ?BROKER_INSTR_OBSERVE_HIST(connection, deliver_total_lat_us, ?US(TSent - T0))
             end),
             Ok;
-        {error, Reason} ->
+        {error, timeout} ->
             %% Defer error handling
             %% so it's handled the same as tcp_closed or ssl_closed
+            {ok, {sock_error, send_timeout}, State};
+        {error, Reason} ->
             {ok, {sock_error, Reason}, State}
     end.
 

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -56,8 +56,8 @@
 -type parse_state_initial() :: #options{}.
 
 -type parse_result() ::
-    %% Need more bytes out of stream, `0` means it's unclear how much more.
-    {_NeedMore :: non_neg_integer(), parse_state()}
+    %% Need more bytes out of stream.
+    {some_more | _NBytesMore :: pos_integer(), parse_state()}
     %% There's a full packet.
     | {emqx_types:packet(), binary(), parse_state_initial()}.
 
@@ -144,7 +144,7 @@ parse(
 ) ->
     parse_body_frame(Bin, Header, Need, Body, Options);
 parse(<<>>, State) ->
-    {0, State}.
+    {some_more, State}.
 
 %% @doc Parses _complete_ binary frame into a single `#mqtt_packet{}`.
 -spec parse_complete(iodata(), parse_state_initial()) ->
@@ -170,7 +170,7 @@ parse_complete(
     end.
 
 parse_remaining_len(<<>>, Header, Mult, Length, Options) ->
-    {_NeedMore = 0, #remlen{hdr = Header, len = Length, mult = Mult, opts = Options}};
+    {some_more, #remlen{hdr = Header, len = Length, mult = Mult, opts = Options}};
 parse_remaining_len(<<0:8, Rest/binary>>, Header, 1, 0, Options) ->
     Packet = parse_bodyless_packet(Header),
     {Packet, Rest, Options};

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -74,8 +74,6 @@
 
 -define(MULTIPLIER_MAX, 16#200000).
 
--dialyzer({no_match, [serialize_utf8_string/3]}).
-
 %% @doc Describe state for logging.
 describe_state(Options = #options{}) ->
     #{
@@ -777,9 +775,11 @@ serialize_pkt(Packet, #{version := Ver, max_size := MaxSize, strict_mode := Stri
     end.
 
 -spec serialize(emqx_types:packet()) -> iodata().
-serialize(Packet) -> serialize(Packet, ?MQTT_PROTO_V4, false).
+serialize(Packet) ->
+    serialize(Packet, ?MQTT_PROTO_V4, false).
 
-serialize(Packet, Ver) -> serialize(Packet, Ver, false).
+serialize(Packet, Ver) ->
+    serialize(Packet, Ver, false).
 
 -spec serialize(emqx_types:packet(), emqx_types:proto_ver(), boolean()) -> iodata().
 serialize(
@@ -791,33 +791,43 @@ serialize(
     Ver,
     StrictMode
 ) ->
-    serialize(
-        Header,
-        serialize_variable(Variable, Ver, StrictMode),
-        serialize_payload(Payload),
-        StrictMode
-    ).
-
-serialize(
-    #mqtt_packet_header{
-        type = Type,
-        dup = Dup,
-        qos = QoS,
-        retain = Retain
-    },
-    VariableBin,
-    PayloadBin,
-    _StrictMode
-) when
-    ?CONNECT =< Type andalso Type =< ?AUTH
-->
-    Len = iolist_size(VariableBin) + iolist_size(PayloadBin),
+    VariableBin = serialize_variable(Variable, Ver, StrictMode),
+    PayloadBin = serialize_payload(Payload),
+    RemLen = iolist_size(VariableBin) + iolist_size(PayloadBin),
     [
-        <<Type:4, (flag(Dup)):1, (flag(QoS)):2, (flag(Retain)):1>>,
-        serialize_remaining_len(Len),
+        serialize_header(Header),
+        serialize_remaining_len(RemLen),
         VariableBin,
         PayloadBin
     ].
+
+-compile(
+    {inline, [
+        serialize_header/1,
+        serialize_payload/1,
+        serialize_remaining_len/1,
+        serialize_variable_byte_integer/1
+    ]}
+).
+
+%% erlfmt-ignore
+-define(bool(B), (case B of true -> 1; false -> 0; undefined -> 0 end):1).
+
+%% erlfmt-ignore
+-define(utf8string(X, STRICT),
+    (begin
+        true = (case STRICT of
+            true -> byte_size(unicode:characters_to_binary(X));
+            false -> byte_size(X)
+        end =< 16#ffff),
+        byte_size(X)
+    end):16/big-unsigned-integer, X/bytes
+).
+
+serialize_header(
+    #mqtt_packet_header{type = Type, dup = Dup, qos = QoS, retain = Retain}
+) when ?CONNECT =< Type andalso Type =< ?AUTH ->
+    <<Type:4, ?bool(Dup), QoS:2, ?bool(Retain)>>.
 
 serialize_variable(
     #mqtt_packet_connect{
@@ -859,19 +869,25 @@ serialize_variable(
             KeepAlive:16/big-unsigned-integer
         >>,
         serialize_properties(Properties, ProtoVer, StrictMode),
-        serialize_utf8_string(ClientId, StrictMode),
+        <<?utf8string(ClientId, StrictMode)>>,
         case WillFlag of
             true ->
                 [
                     serialize_properties(WillProps, ProtoVer, StrictMode),
-                    serialize_utf8_string(WillTopic, StrictMode),
+                    <<?utf8string(WillTopic, StrictMode)>>,
                     serialize_binary_data(WillPayload)
                 ];
             false ->
                 <<>>
         end,
-        serialize_utf8_string(Username, true, StrictMode),
-        serialize_utf8_string(Password, true, StrictMode)
+        case Username of
+            undefined -> <<>>;
+            _ -> <<?utf8string(Username, StrictMode)>>
+        end,
+        case Password of
+            undefined -> <<>>;
+            _ -> <<?utf8string(Password, StrictMode)>>
+        end
     ];
 serialize_variable(
     #mqtt_packet_connack{
@@ -893,7 +909,7 @@ serialize_variable(
     StrictMode
 ) ->
     [
-        serialize_utf8_string(TopicName, StrictMode),
+        <<?utf8string(TopicName, StrictMode)>>,
         case PacketId of
             undefined -> <<>>;
             _ -> <<PacketId:16/big-unsigned-integer>>
@@ -1036,9 +1052,9 @@ serialize_property('Payload-Format-Indicator', Val, _StrictMode) ->
 serialize_property('Message-Expiry-Interval', Val, _StrictMode) ->
     <<16#02, Val:32/big>>;
 serialize_property('Content-Type', Val, StrictMode) ->
-    <<16#03, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#03, ?utf8string(Val, StrictMode)>>;
 serialize_property('Response-Topic', Val, StrictMode) ->
-    <<16#08, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#08, ?utf8string(Val, StrictMode)>>;
 serialize_property('Correlation-Data', Val, _StrictMode) ->
     <<16#09, (byte_size(Val)):16, Val/binary>>;
 serialize_property('Subscription-Identifier', Val, _StrictMode) ->
@@ -1046,11 +1062,11 @@ serialize_property('Subscription-Identifier', Val, _StrictMode) ->
 serialize_property('Session-Expiry-Interval', Val, _StrictMode) ->
     <<16#11, Val:32/big>>;
 serialize_property('Assigned-Client-Identifier', Val, StrictMode) ->
-    <<16#12, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#12, ?utf8string(Val, StrictMode)>>;
 serialize_property('Server-Keep-Alive', Val, _StrictMode) ->
     <<16#13, Val:16/big>>;
 serialize_property('Authentication-Method', Val, StrictMode) ->
-    <<16#15, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#15, ?utf8string(Val, StrictMode)>>;
 serialize_property('Authentication-Data', Val, _StrictMode) ->
     <<16#16, (iolist_size(Val)):16, Val/binary>>;
 serialize_property('Request-Problem-Information', Val, _StrictMode) ->
@@ -1060,11 +1076,11 @@ serialize_property('Will-Delay-Interval', Val, _StrictMode) ->
 serialize_property('Request-Response-Information', Val, _StrictMode) ->
     <<16#19, Val>>;
 serialize_property('Response-Information', Val, StrictMode) ->
-    <<16#1A, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#1A, ?utf8string(Val, StrictMode)>>;
 serialize_property('Server-Reference', Val, StrictMode) ->
-    <<16#1C, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#1C, ?utf8string(Val, StrictMode)>>;
 serialize_property('Reason-String', Val, StrictMode) ->
-    <<16#1F, (serialize_utf8_string(Val, StrictMode))/binary>>;
+    <<16#1F, ?utf8string(Val, StrictMode)>>;
 serialize_property('Receive-Maximum', Val, _StrictMode) ->
     <<16#21, Val:16/big>>;
 serialize_property('Topic-Alias-Maximum', Val, _StrictMode) ->
@@ -1094,7 +1110,7 @@ serialize_property('Shared-Subscription-Available', Val, _StrictMode) ->
 serialize_topic_filters(subscribe, TopicFilters, ?MQTT_PROTO_V5, StrictMode) ->
     <<
         <<
-            (serialize_utf8_string(Topic, StrictMode))/binary,
+            ?utf8string(Topic, StrictMode),
             ?RESERVED:2,
             Rh:2,
             (flag(Rap)):1,
@@ -1105,11 +1121,11 @@ serialize_topic_filters(subscribe, TopicFilters, ?MQTT_PROTO_V5, StrictMode) ->
     >>;
 serialize_topic_filters(subscribe, TopicFilters, _Ver, StrictMode) ->
     <<
-        <<(serialize_utf8_string(Topic, StrictMode))/binary, ?RESERVED:6, QoS:2>>
+        <<?utf8string(Topic, StrictMode), ?RESERVED:6, QoS:2>>
      || {Topic, #{qos := QoS}} <- TopicFilters
     >>;
 serialize_topic_filters(unsubscribe, TopicFilters, _Ver, StrictMode) ->
-    <<<<(serialize_utf8_string(Topic, StrictMode))/binary>> || Topic <- TopicFilters>>.
+    <<<<?utf8string(Topic, StrictMode)>> || Topic <- TopicFilters>>.
 
 serialize_reason_codes(undefined) ->
     <<>>;
@@ -1117,36 +1133,36 @@ serialize_reason_codes(ReasonCodes) when is_list(ReasonCodes) ->
     <<<<Code>> || Code <- ReasonCodes>>.
 
 serialize_utf8_pair(Name, Value, StrictMode) ->
-    <<
-        (serialize_utf8_string(Name, StrictMode))/binary,
-        (serialize_utf8_string(Value, StrictMode))/binary
-    >>.
+    <<?utf8string(Name, StrictMode), ?utf8string(Value, StrictMode)>>.
 
 serialize_binary_data(Bin) ->
     [<<(byte_size(Bin)):16/big-unsigned-integer>>, Bin].
 
-serialize_utf8_string(undefined, false, _StrictMode) ->
-    ?SERIALIZE_ERR(utf8_string_undefined);
-serialize_utf8_string(undefined, true, _StrictMode) ->
-    <<>>;
-serialize_utf8_string(String, _AllowNull, StrictMode) ->
-    serialize_utf8_string(String, StrictMode).
-
-serialize_utf8_string(String, true) ->
-    StringBin = unicode:characters_to_binary(String),
-    serialize_utf8_string(StringBin, false);
-serialize_utf8_string(String, false) ->
-    Len = byte_size(String),
-    true = (Len =< 16#ffff),
-    <<Len:16/big, String/binary>>.
-
 serialize_remaining_len(I) ->
     serialize_variable_byte_integer(I).
 
-serialize_variable_byte_integer(N) when N =< ?LOWBITS ->
+serialize_variable_byte_integer(N) when N < (1 bsl 7) ->
     <<0:1, N:7>>;
-serialize_variable_byte_integer(N) ->
-    <<1:1, (N rem ?HIGHBIT):7, (serialize_variable_byte_integer(N div ?HIGHBIT))/binary>>.
+serialize_variable_byte_integer(N) when N < (1 bsl 14) ->
+    <<1:1, (N band 2#1111111):7, (N bsr 7):8>>;
+serialize_variable_byte_integer(N) when N < (1 bsl 21) ->
+    <<
+        1:1,
+        (N band 2#1111111):7,
+        1:1,
+        ((N bsr 7) band 2#1111111):7,
+        (N bsr 14):8
+    >>;
+serialize_variable_byte_integer(N) when N < (1 bsl 28) ->
+    <<
+        1:1,
+        (N band 2#1111111):7,
+        1:1,
+        ((N bsr 7) band 2#1111111):7,
+        1:1,
+        ((N bsr 14) band 2#1111111):7,
+        (N bsr 21):8
+    >>.
 
 %% Is the frame too large?
 -spec is_too_large(iodata(), pos_integer()) -> boolean().

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -1474,10 +1474,11 @@ try_get_live_session(ClientID) ->
     case emqx_cm:lookup_channels(local, ClientID) of
         [Pid] ->
             try
-                #{channel := ChanState} = emqx_connection:get_state(Pid),
-                case emqx_channel:info(impl, ChanState) of
+                ConnMod = emqx_cm:do_get_chann_conn_mod(ClientID, Pid),
+                ConnState = sys:get_state(Pid),
+                case apply(ConnMod, info, [{channel, impl}, ConnState]) of
                     ?MODULE ->
-                        {Pid, emqx_channel:info(session_state, ChanState)};
+                        {Pid, apply(ConnMod, info, [{channel, session_state}, ConnState])};
                     _ ->
                         not_persistent
                 end

--- a/apps/emqx/src/emqx_quic_data_stream.erl
+++ b/apps/emqx/src/emqx_quic_data_stream.erl
@@ -398,7 +398,7 @@ do_parse_incoming(<<>>, Packets, ParseState) ->
     {Packets, ParseState};
 do_parse_incoming(Data, Packets, ParseState) ->
     case emqx_frame:parse(Data, ParseState) of
-        {more, NParseState} ->
+        {_More, NParseState} ->
             {Packets, NParseState};
         {Packet, Rest, NParseState} ->
             do_parse_incoming(Rest, [Packet | Packets], NParseState)

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -627,6 +627,14 @@ fields("crl_cache") ->
     ];
 fields("mqtt_tcp_listener") ->
     mqtt_listener(1883) ++
+        [
+            {"tcp_backend",
+                sc(hoconsc:enum([gen_tcp, socket]), #{
+                    default => <<"gen_tcp">>,
+                    desc => ?DESC(fields_mqtt_opts_tcp_backend),
+                    importance => ?IMPORTANCE_LOW
+                })}
+        ] ++
         mqtt_parse_options() ++
         [
             {"tcp_options",

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -629,11 +629,17 @@ fields("mqtt_tcp_listener") ->
     mqtt_listener(1883) ++
         [
             {"tcp_backend",
-                sc(hoconsc:enum([gen_tcp, socket]), #{
-                    default => <<"gen_tcp">>,
-                    desc => ?DESC(fields_mqtt_opts_tcp_backend),
-                    importance => ?IMPORTANCE_LOW
-                })}
+                sc(
+                    case os:type() of
+                        {unix, _} -> hoconsc:enum([gen_tcp, socket]);
+                        {win32, _} -> hoconsc:enum([gen_tcp])
+                    end,
+                    #{
+                        default => <<"gen_tcp">>,
+                        desc => ?DESC(fields_mqtt_opts_tcp_backend),
+                        importance => ?IMPORTANCE_LOW
+                    }
+                )}
         ] ++
         mqtt_parse_options() ++
         [

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -946,7 +946,8 @@ serialize_and_inc_stats(#state{serialize = Serialize}, Packet) ->
 %%--------------------------------------------------------------------
 %% Send data
 
--spec send(non_neg_integer(), iodata(), state()) -> {ok, state()}.
+-spec send(non_neg_integer(), iodata(), state()) ->
+    {ok, state()} | {ok, {sock_error, _Reason}, state()}.
 send(Num, IoData, #state{socket = Socket, sockstate = idle} = State) ->
     Oct = iolist_size(IoData),
     Handle = make_ref(),

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1069,14 +1069,6 @@ handle_info({sock_error, Reason}, State) ->
         false -> ok
     end,
     handle_info({sock_closed, Reason}, ensure_close_socket(Reason, State));
-%% handle QUIC control stream events
-handle_info({quic, Event, Handle, Prop}, State) when is_atom(Event) ->
-    case emqx_quic_stream:Event(Handle, Prop, State) of
-        {{continue, Msgs}, NewState} ->
-            {ok, Msgs, NewState};
-        Other ->
-            Other
-    end;
 handle_info(Info, State) ->
     with_channel(handle_info, [Info], State).
 

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -349,8 +349,10 @@ run_loop(
         zone = Zone
     }
 ) ->
-    Peername = emqx_channel:info(peername, Channel),
-    emqx_logger:set_metadata_peername(esockd:format(Peername)),
+    emqx_logger:set_proc_metadata(#{
+        peername => esockd:format(emqx_channel:info(peername, Channel)),
+        connmod => ?MODULE
+    }),
     ShutdownPolicy = emqx_config:get_zone_conf(Zone, [force_shutdown]),
     _ = emqx_utils:tune_heap_size(ShutdownPolicy),
     _ = set_tcp_keepalive(Listener),

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -4,6 +4,10 @@
 
 %% This module interacts with the transport layer of MQTT
 %% Transport: esockd_socket.
+%%
+%% NOTE
+%% When changing this module, please make an effort to port changes to
+%% `emqx_connection` module if they make sense there, and vice versa.
 -module(emqx_socket_connection).
 
 -include("emqx.hrl").
@@ -20,7 +24,6 @@
 -endif.
 
 -elvis([{elvis_style, used_ignored_variable, disable}]).
--elvis([{elvis_style, invalid_dynamic_call, #{ignore => [emqx_connection]}}]).
 
 %% API
 -export([

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -428,6 +428,8 @@ wakeup_from_hib(Parent, State) ->
 
 -compile({inline, [sock_async_recv/2]}).
 
+sock_async_recv(Socket, some_more) ->
+    socket:recv(Socket, 0, [], nowait);
 sock_async_recv(Socket, Len) ->
     socket:recv(Socket, Len, [], nowait).
 

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -511,9 +511,7 @@ process_msg(Msg, State) ->
         {ok, NextMsg, NState} ->
             process_msg(NextMsg, NState);
         {stop, Reason, NState} ->
-            {stop, Reason, NState};
-        {stop, Reason} ->
-            {stop, Reason, State}
+            {stop, Reason, NState}
     catch
         exit:normal ->
             {stop, normal, State};
@@ -560,7 +558,7 @@ handle_msg({'$socket', _Socket, abort, {_Handle, Reason}}, State = #state{sockst
             handle_info({sock_error, Reason}, State);
         false ->
             %% In case there were more than 1 outstanding select:
-            {ok, State}
+            ok
     end;
 handle_msg({recv, Data}, State) ->
     handle_data(Data, false, State);

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1,0 +1,1137 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2018-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% This module interacts with the transport layer of MQTT
+%% Transport: esockd_socket.
+-module(emqx_socket_connection).
+
+-include("emqx.hrl").
+-include("emqx_mqtt.hrl").
+-include("logger.hrl").
+-include("types.hrl").
+-include("emqx_external_trace.hrl").
+-include("emqx_instr.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+
+-ifdef(TEST).
+-compile(export_all).
+-compile(nowarn_export_all).
+-endif.
+
+-elvis([{elvis_style, used_ignored_variable, disable}]).
+-elvis([{elvis_style, invalid_dynamic_call, #{ignore => [emqx_connection]}}]).
+
+%% API
+-export([
+    start_link/3,
+    stop/1
+]).
+
+-export([
+    info/1,
+    info/2,
+    stats/1
+]).
+
+-export([
+    async_set_keepalive/4,
+    async_set_socket_options/2
+]).
+
+-export([
+    call/2,
+    call/3,
+    cast/2
+]).
+
+%% Callback
+-export([init/4]).
+
+%% Sys callbacks
+-export([
+    system_continue/3,
+    system_terminate/4,
+    system_code_change/4,
+    system_get_state/1
+]).
+
+%% Internal callback
+-export([wakeup_from_hib/2, recvloop/2, get_state/1]).
+
+%% Export for CT
+-export([set_field/3]).
+
+-export_type([
+    state/0,
+    parser/0
+]).
+
+-record(state, {
+    %% TCP/TLS Socket
+    socket :: socket:socket(),
+    %% Sock State
+    sockstate :: emqx_types:sockstate(),
+    %% Packet parser / serializer
+    parser :: parser(),
+    serialize :: emqx_frame:serialize_opts(),
+    %% Channel State
+    channel :: emqx_channel:channel(),
+    %% GC State
+    gc_state :: option(emqx_gc:gc_state()),
+    %% Stats Timer
+    %% When `disabled` stats are never reported.
+    %% Until complete CONNECT packet received acts as idle timer, which shuts
+    %% the connection down once triggered.
+    stats_timer :: disabled | option(reference()) | {idle, reference()},
+    %% ActiveN + GC tracker
+    gc_tracker :: gc_tracker(),
+    %% Hibernate connection process if inactive for
+    hibernate_after :: integer() | infinity,
+    %% Zone name
+    zone :: atom(),
+    %% Listener Type and Name
+    listener :: {Type :: atom(), Name :: atom()},
+
+    %% Extra field for future hot-upgrade support
+    extra = []
+}).
+
+-type gc_tracker() ::
+    {
+        ActiveN :: non_neg_integer(),
+        {PktsIn :: non_neg_integer(), BytesIn :: non_neg_integer()},
+        {PktsOut :: non_neg_integer(), BytesOut :: non_neg_integer()}
+    }.
+
+-type parser() ::
+    %% Bytestream parser.
+    _Stream :: emqx_frame:parse_state().
+
+-opaque state() :: #state{}.
+
+-define(INFO_KEYS, [
+    socktype,
+    peername,
+    sockname,
+    sockstate
+]).
+
+-define(SOCK_STATS, [
+    recv_oct,
+    recv_cnt,
+    send_oct,
+    send_cnt,
+    send_pend
+]).
+
+-define(ENABLED(X), (X =/= undefined)).
+
+-define(LOG(Level, Data), ?SLOG(Level, (Data)#{tag => "MQTT"})).
+
+-spec start_link(esockd_socket, socket:socket(), emqx_channel:opts()) -> {ok, pid()}.
+start_link(Transport, Socket, Options) ->
+    Args = [self(), Transport, Socket, Options],
+    CPid = proc_lib:spawn_link(?MODULE, init, Args),
+    {ok, CPid}.
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+%% @doc Get infos of the connection/channel.
+-spec info(pid() | state()) -> emqx_types:infos().
+info(CPid) when is_pid(CPid) ->
+    call(CPid, info);
+info(State = #state{channel = Channel}) ->
+    ChanInfo = emqx_channel:info(Channel),
+    SockInfo = maps:from_list(info(?INFO_KEYS, State)),
+    ChanInfo#{sockinfo => SockInfo}.
+
+-spec info([atom()] | atom() | tuple(), pid() | state()) -> term().
+info(Keys, State) when is_list(Keys) ->
+    [{Key, info(Key, State)} || Key <- Keys];
+info(socktype, #state{}) ->
+    tcp;
+info(peername, #state{channel = Channel}) ->
+    emqx_channel:info(peername, Channel);
+info(sockname, #state{channel = Channel}) ->
+    emqx_channel:info(sockname, Channel);
+info(sockstate, #state{sockstate = SockSt}) ->
+    SockSt;
+info(stats_timer, #state{stats_timer = StatsTimer}) ->
+    StatsTimer;
+info({channel, Info}, #state{channel = Channel}) ->
+    emqx_channel:info(Info, Channel).
+
+%% @doc Get stats of the connection/channel.
+-spec stats(pid() | state()) -> emqx_types:stats().
+stats(CPid) when is_pid(CPid) ->
+    call(CPid, stats);
+stats(#state{socket = Socket, channel = Channel}) ->
+    #{counters := Counters} = socket:info(Socket),
+    SockStats = lists:map(
+        fun
+            (S = recv_oct) -> {S, maps:get(read_byte, Counters, 0)};
+            (S = recv_cnt) -> {S, maps:get(read_pkg, Counters, 0)};
+            (S = send_oct) -> {S, maps:get(write_byte, Counters, 0)};
+            (S = send_cnt) -> {S, maps:get(write_pkg, Counters, 0)};
+            (S = send_pend) -> {S, 0}
+        end,
+        ?SOCK_STATS
+    ),
+    ChanStats = emqx_channel:stats(Channel),
+    ProcStats = emqx_utils:proc_stats(),
+    lists:append([SockStats, ChanStats, ProcStats]).
+
+%% @doc Set TCP keepalive socket options to override system defaults.
+%% Idle: The number of seconds a connection needs to be idle before
+%%       TCP begins sending out keep-alive probes (Linux default 7200).
+%% Interval: The number of seconds between TCP keep-alive probes
+%%           (Linux default 75).
+%% Probes: The maximum number of TCP keep-alive probes to send before
+%%         giving up and killing the connection if no response is
+%%         obtained from the other end (Linux default 9).
+%%
+%% NOTE: This API sets TCP socket options, which has nothing to do with
+%%       the MQTT layer's keepalive (PINGREQ and PINGRESP).
+async_set_keepalive(Pid, Idle, Interval, Probes) ->
+    async_set_socket_options(Pid, [
+        {{socket, keepalive}, true},
+        {{tcp, keepcnt}, Probes},
+        {{tcp, keepidle}, Idle},
+        {{tcp, keepintvl}, Interval}
+    ]).
+
+%% @doc Set custom socket options.
+%% This API is made async because the call might be originated from
+%% a hookpoint callback (otherwise deadlock).
+%% If failed to set, the error message is logged.
+async_set_socket_options(Pid, Options) ->
+    cast(Pid, {async_set_socket_options, Options}).
+
+cast(Pid, Req) ->
+    gen_server:cast(Pid, Req).
+
+call(Pid, Req) ->
+    call(Pid, Req, infinity).
+call(Pid, Req, Timeout) ->
+    gen_server:call(Pid, Req, Timeout).
+
+stop(Pid) ->
+    gen_server:stop(Pid).
+
+%%--------------------------------------------------------------------
+%% callbacks
+%%--------------------------------------------------------------------
+
+init(Parent, esockd_socket, RawSocket, Options) ->
+    case esockd_socket:wait(RawSocket) of
+        {ok, Socket} ->
+            run_loop(Parent, init_state(Socket, Options));
+        {error, Reason} ->
+            ok = esockd_socket:fast_close(RawSocket),
+            exit_on_sock_error(Reason)
+    end.
+
+init_state(
+    Socket,
+    #{zone := Zone, listener := {Type, Listener}} = Opts
+) ->
+    SockType = ensure_ok_or_exit(esockd_socket:type(Socket), Socket),
+    {ok, Peername} = ensure_ok_or_exit(esockd_socket:peername(Socket), Socket),
+    {ok, Sockname} = ensure_ok_or_exit(esockd_socket:sockname(Socket), Socket),
+    Peercert = ensure_ok_or_exit(esockd_socket:peercert(Socket), Socket),
+    PeerSNI = ensure_ok_or_exit(esockd_socket:peersni(Socket), Socket),
+    ConnInfo = #{
+        socktype => SockType,
+        peername => Peername,
+        sockname => Sockname,
+        peercert => Peercert,
+        peersni => PeerSNI,
+        conn_mod => ?MODULE,
+        sock => Socket
+    },
+
+    ActiveN = get_active_n(Type, Listener),
+    FrameOpts = #{
+        strict_mode => emqx_config:get_zone_conf(Zone, [mqtt, strict_mode]),
+        max_size => emqx_config:get_zone_conf(Zone, [mqtt, max_packet_size])
+    },
+    Parser = init_parser(FrameOpts),
+    Serialize = emqx_frame:initial_serialize_opts(FrameOpts),
+    %% Init Channel
+    Channel = emqx_channel:init(ConnInfo, Opts),
+    GcState =
+        case emqx_config:get_zone_conf(Zone, [force_gc]) of
+            #{enable := false} -> undefined;
+            GcPolicy -> emqx_gc:init(GcPolicy)
+        end,
+
+    #state{
+        socket = Socket,
+        sockstate = idle,
+        parser = Parser,
+        serialize = Serialize,
+        channel = Channel,
+        gc_state = GcState,
+        gc_tracker = init_gc_tracker(ActiveN),
+        hibernate_after = maps:get(hibernate_after, Opts, get_zone_idle_timeout(Zone)),
+        zone = Zone,
+        listener = {Type, Listener},
+        extra = []
+    }.
+
+ensure_ok_or_exit(Result, Sock) ->
+    case Result of
+        {error, Reason} when Reason =:= enotconn; Reason =:= closed ->
+            esockd_socket:fast_close(Sock),
+            exit(normal);
+        {error, Reason} ->
+            esockd_socket:fast_close(Sock),
+            exit({shutdown, Reason});
+        Ok ->
+            Ok
+    end.
+
+init_gc_tracker(ActiveN) ->
+    {ActiveN, {0, 0}, {0, 0}}.
+
+run_loop(
+    Parent,
+    State = #state{
+        socket = Socket,
+        channel = Channel,
+        listener = Listener,
+        zone = Zone
+    }
+) ->
+    Peername = emqx_channel:info(peername, Channel),
+    emqx_logger:set_metadata_peername(esockd:format(Peername)),
+    ShutdownPolicy = emqx_config:get_zone_conf(Zone, [force_shutdown]),
+    _ = emqx_utils:tune_heap_size(ShutdownPolicy),
+    ok = set_tcp_keepalive(Listener),
+    case sock_async_recv(Socket, 0) of
+        {ok, Data} ->
+            NState = start_idle_timer(State),
+            handle_recv({recv_more, Data}, Parent, NState);
+        {select, _SelectInfo} ->
+            NState = start_idle_timer(State),
+            hibernate(Parent, NState);
+        {error, {Reason, _}} ->
+            _ = Reason == closed orelse esockd_socket:fast_close(Socket),
+            exit_on_sock_error(Reason);
+        {error, Reason} ->
+            _ = Reason == closed orelse esockd_socket:fast_close(Socket),
+            exit_on_sock_error(Reason)
+    end.
+
+-spec exit_on_sock_error(any()) -> no_return().
+exit_on_sock_error(Reason) when
+    Reason =:= einval;
+    Reason =:= enotconn;
+    Reason =:= closed
+->
+    erlang:exit(normal);
+exit_on_sock_error(Reason) ->
+    erlang:exit({shutdown, Reason}).
+
+%%--------------------------------------------------------------------
+%% Recv Loop
+
+recvloop(
+    Parent,
+    State = #state{
+        hibernate_after = HibernateTimeout,
+        zone = Zone
+    }
+) ->
+    receive
+        Msg ->
+            handle_recv(Msg, Parent, State)
+    after HibernateTimeout ->
+        case emqx_olp:backoff_hibernation(Zone) of
+            true ->
+                recvloop(Parent, State);
+            false ->
+                _ = try_set_chan_stats(State),
+                hibernate(Parent, cancel_stats_timer(State))
+        end
+    end.
+
+handle_recv({system, From, Request}, Parent, State) ->
+    sys:handle_system_msg(Request, From, Parent, ?MODULE, [], State);
+handle_recv({'EXIT', Parent, Reason}, Parent, State) ->
+    %% FIXME: it's not trapping exit, should never receive an EXIT
+    terminate(Reason, State);
+handle_recv(Msg, Parent, State) ->
+    case process_msg(Msg, ensure_stats_timer(State)) of
+        {ok, NewState} ->
+            ?MODULE:recvloop(Parent, NewState);
+        {stop, Reason, NewSate} ->
+            terminate(Reason, NewSate)
+    end.
+
+hibernate(Parent, State) ->
+    proc_lib:hibernate(?MODULE, wakeup_from_hib, [Parent, State]).
+
+%% Maybe do something here later.
+wakeup_from_hib(Parent, State) ->
+    ?MODULE:recvloop(Parent, State).
+
+%%--------------------------------------------------------------------
+
+-compile({inline, [sock_async_recv/2]}).
+
+sock_async_recv(Socket, Len) ->
+    socket:recv(Socket, Len, [], nowait).
+
+sock_setopts(Socket, [{Opt, Value} | Rest]) ->
+    case socket:setopt(Socket, Opt, Value) of
+        ok -> sock_setopts(Socket, Rest);
+        Error -> Error
+    end;
+sock_setopts(_Sock, []) ->
+    ok.
+
+%%--------------------------------------------------------------------
+%% Ensure/cancel stats timer
+
+init_stats_timer(#state{zone = Zone}) ->
+    case emqx_config:get_zone_conf(Zone, [stats, enable]) of
+        true -> undefined;
+        false -> disabled
+    end.
+
+-compile({inline, [ensure_stats_timer/1]}).
+ensure_stats_timer(State = #state{stats_timer = undefined}) ->
+    Timeout = get_zone_idle_timeout(State#state.zone),
+    State#state{stats_timer = start_timer(Timeout, emit_stats)};
+ensure_stats_timer(State) ->
+    %% Either already active, disabled, or paused.
+    State.
+
+-compile({inline, [cancel_stats_timer/1]}).
+cancel_stats_timer(State = #state{stats_timer = TRef}) when is_reference(TRef) ->
+    ?tp(debug, cancel_stats_timer, #{}),
+    ok = emqx_utils:cancel_timer(TRef),
+    State#state{stats_timer = undefined};
+cancel_stats_timer(State) ->
+    State.
+
+start_idle_timer(State = #state{zone = Zone}) ->
+    IdleTimeout = get_zone_idle_timeout(Zone),
+    TimerRef = start_timer(IdleTimeout, idle_timeout),
+    State#state{stats_timer = {idle, TimerRef}}.
+
+cancel_idle_timer(#state{stats_timer = {idle, TRef}}) ->
+    emqx_utils:cancel_timer(TRef);
+cancel_idle_timer(_State) ->
+    ok.
+
+-compile({inline, [get_zone_idle_timeout/1]}).
+get_zone_idle_timeout(Zone) ->
+    emqx_channel:get_mqtt_conf(Zone, idle_timeout).
+
+%%--------------------------------------------------------------------
+%% Process next Msg
+
+process_msgs([], State) ->
+    {ok, State};
+process_msgs([Msgs | More], State) when is_list(Msgs) ->
+    case process_msgs(Msgs, State) of
+        {ok, NState} ->
+            process_msgs(More, NState);
+        Stop ->
+            Stop
+    end;
+process_msgs([Msg | More], State) ->
+    case process_msg(Msg, State) of
+        {ok, NState} ->
+            process_msgs(More, NState);
+        Stop ->
+            Stop
+    end.
+
+process_msg(Msg, State) ->
+    try handle_msg(Msg, State) of
+        ok ->
+            {ok, State};
+        {ok, NState} ->
+            {ok, NState};
+        {ok, NextMsgs, NState} when is_list(NextMsgs) ->
+            process_msgs(NextMsgs, NState);
+        {ok, NextMsg, NState} ->
+            process_msg(NextMsg, NState);
+        {stop, Reason, NState} ->
+            {stop, Reason, NState};
+        {stop, Reason} ->
+            {stop, Reason, State}
+    catch
+        exit:normal ->
+            {stop, normal, State};
+        exit:shutdown ->
+            {stop, shutdown, State};
+        exit:{shutdown, _} = Shutdown ->
+            {stop, Shutdown, State};
+        Exception:Context:Stack ->
+            {stop,
+                #{
+                    exception => Exception,
+                    context => Context,
+                    stacktrace => Stack
+                },
+                State}
+    end.
+
+%%--------------------------------------------------------------------
+%% Handle a Msg
+handle_msg({'$gen_call', From, Req}, State) ->
+    case handle_call(From, Req, State) of
+        {reply, Reply, NState} ->
+            gen_server:reply(From, Reply),
+            {ok, NState};
+        {stop, Reason, Reply, NState} ->
+            gen_server:reply(From, Reply),
+            stop(Reason, NState)
+    end;
+handle_msg({'$gen_cast', Req}, State) ->
+    NewState = handle_cast(Req, State),
+    {ok, NewState};
+handle_msg({'$socket', Socket, select, _Handle}, State) ->
+    case sock_async_recv(Socket, 0) of
+        {ok, Data} ->
+            handle_data(Data, true, State);
+        {error, {closed, Data}} ->
+            {ok, [{recv, Data}, {sock_closed, tcp_closed}], socket_closed(State)};
+        {error, closed} ->
+            handle_info({sock_closed, tcp_closed}, socket_closed(State));
+        {error, {Reason, Data}} ->
+            {ok, [{recv, Data}, {sock_error, Reason}], State};
+        {error, Reason} ->
+            handle_info({sock_error, Reason}, State)
+    end;
+handle_msg({'$socket', _Socket, abort, {_Handle, Reason}}, State) ->
+    handle_info({sock_error, Reason}, State);
+handle_msg({recv, Data}, State) ->
+    handle_data(Data, false, State);
+handle_msg({recv_more, Data}, State) ->
+    handle_data(Data, true, State);
+handle_msg({incoming, Packet}, State) ->
+    ?TRACE("MQTT", "mqtt_packet_received", #{packet => Packet}),
+    handle_incoming(Packet, State);
+handle_msg({outgoing, Packets}, State) ->
+    handle_outgoing(Packets, State);
+handle_msg(
+    Deliver = {deliver, _Topic, _Msg},
+    #state{gc_tracker = {ActiveN, _, _}} = State
+) ->
+    ?BROKER_INSTR_SETMARK(t0_deliver, {_Msg#message.extra, ?BROKER_INSTR_TS()}),
+    Delivers = [Deliver | emqx_utils:drain_deliver(ActiveN)],
+    with_channel(handle_deliver, [Delivers], State);
+handle_msg({connack, ConnAck}, State) ->
+    handle_outgoing(ConnAck, State);
+handle_msg({close, Reason}, State) ->
+    %% @FIXME here it could be close due to appl error.
+    ?TRACE("SOCKET", "socket_force_closed", #{reason => Reason}),
+    handle_info({sock_closed, Reason}, close_socket(State));
+handle_msg({event, connected}, State = #state{channel = Channel}) ->
+    ClientId = emqx_channel:info(clientid, Channel),
+    emqx_cm:insert_channel_info(ClientId, info(State), stats(State)),
+    {ok, ensure_stats_timer(State)};
+handle_msg({event, disconnected}, State = #state{channel = Channel}) ->
+    ClientId = emqx_channel:info(clientid, Channel),
+    emqx_cm:set_chan_info(ClientId, info(State)),
+    {ok, State};
+handle_msg({event, _Other}, State = #state{channel = Channel}) ->
+    case emqx_channel:info(clientid, Channel) of
+        %% ClientId is yet unknown (i.e. connect packet is not received yet)
+        undefined ->
+            ok;
+        ClientId ->
+            emqx_cm:set_chan_info(ClientId, info(State)),
+            emqx_cm:set_chan_stats(ClientId, stats(State))
+    end,
+    {ok, State};
+handle_msg({timeout, TRef, TMsg}, State) ->
+    handle_timeout(TRef, TMsg, State);
+handle_msg(Shutdown = {shutdown, _Reason}, State) ->
+    stop(Shutdown, State);
+handle_msg(Msg, State) ->
+    handle_info(Msg, State).
+
+%%--------------------------------------------------------------------
+%% Terminate
+
+-spec terminate(any(), state()) -> no_return().
+terminate(
+    Reason,
+    State = #state{
+        channel = Channel,
+        socket = Socket
+    }
+) ->
+    try
+        Channel1 = emqx_channel:set_conn_state(disconnected, Channel),
+        emqx_congestion:cancel_alarms(Socket, esockd_socket, Channel1),
+        emqx_channel:terminate(Reason, Channel1),
+        close_socket_ok(State),
+        ?TRACE("SOCKET", "emqx_connection_terminated", #{reason => Reason})
+    catch
+        E:C:S ->
+            ?tp(warning, unclean_terminate, #{exception => E, context => C, stacktrace => S})
+    end,
+    ?tp(info, terminate, #{reason => Reason}),
+    maybe_raise_exception(Reason).
+
+%% close socket, discard new state, always return ok.
+close_socket_ok(State) ->
+    _ = close_socket(State),
+    ok.
+
+%% tell truth about the original exception
+-spec maybe_raise_exception(any()) -> no_return().
+maybe_raise_exception(#{
+    exception := Exception,
+    context := Context,
+    stacktrace := Stacktrace
+}) ->
+    erlang:raise(Exception, Context, Stacktrace);
+maybe_raise_exception({shutdown, normal}) ->
+    ok;
+maybe_raise_exception(normal) ->
+    ok;
+maybe_raise_exception(shutdown) ->
+    ok;
+maybe_raise_exception(Reason) ->
+    exit(Reason).
+
+%%--------------------------------------------------------------------
+%% Sys callbacks
+
+system_continue(Parent, _Debug, State) ->
+    ?MODULE:recvloop(Parent, State).
+
+system_terminate(Reason, _Parent, _Debug, State) ->
+    terminate(Reason, State).
+
+system_code_change(State, _Mod, _OldVsn, _Extra) ->
+    {ok, State}.
+
+system_get_state(State) -> {ok, State}.
+
+%%--------------------------------------------------------------------
+%% Handle call
+
+handle_call(_From, info, State) ->
+    {reply, info(State), State};
+handle_call(_From, stats, State) ->
+    {reply, stats(State), State};
+handle_call(_From, Req, State = #state{channel = Channel}) ->
+    case emqx_channel:handle_call(Req, Channel) of
+        {reply, Reply, NChannel} ->
+            {reply, Reply, State#state{channel = NChannel}};
+        {shutdown, Reason, Reply, NChannel} ->
+            shutdown(Reason, Reply, State#state{channel = NChannel});
+        {shutdown, Reason, Reply, OutPacket, NChannel} ->
+            NState = State#state{channel = NChannel},
+            {ok, NState2} = handle_outgoing(OutPacket, NState),
+            NState3 = graceful_shutdown_transport(Reason, NState2),
+            shutdown(Reason, Reply, NState3)
+    end.
+
+%%--------------------------------------------------------------------
+%% Handle timeout
+
+handle_timeout(_TRef, idle_timeout, State) ->
+    shutdown(idle_timeout, State);
+handle_timeout(
+    _TRef,
+    emit_stats,
+    State = #state{
+        channel = Channel,
+        socket = Socket
+    }
+) ->
+    ClientId = emqx_channel:info(clientid, Channel),
+    emqx_cm:set_chan_stats(ClientId, stats(State)),
+    emqx_congestion:maybe_alarm_conn_congestion(Socket, esockd_socket, Channel),
+    {ok, State#state{stats_timer = undefined}};
+handle_timeout(
+    TRef,
+    keepalive,
+    State = #state{
+        channel = Channel
+    }
+) ->
+    case emqx_channel:info(conn_state, Channel) of
+        disconnected ->
+            {ok, State};
+        _ ->
+            with_channel(handle_timeout, [TRef, keepalive], State)
+    end;
+handle_timeout(TRef, Msg, State) ->
+    with_channel(handle_timeout, [TRef, Msg], State).
+
+try_set_chan_stats(State = #state{channel = Channel}) ->
+    case emqx_channel:info(clientid, Channel) of
+        %% ClientID is not yet known, nothing to report.
+        undefined -> false;
+        ClientId -> emqx_cm:set_chan_stats(ClientId, stats(State))
+    end.
+
+%%--------------------------------------------------------------------
+%% Parse incoming data
+
+handle_data(
+    Data,
+    RequestMore,
+    State0 = #state{
+        socket = Socket,
+        sockstate = SS,
+        gc_tracker = {ActiveN, {Pubs, Bytes}, Out}
+    }
+) ->
+    Oct = iolist_size(Data),
+    emqx_metrics:inc('bytes.received', Oct),
+    ?LOG(debug, #{
+        msg => "raw_bin_received",
+        size => Oct,
+        bin => binary_to_list(binary:encode_hex(Data)),
+        type => "hex"
+    }),
+    {More, N, Packets, State1} = parse_incoming(Data, State0),
+    State = State1#state{gc_tracker = {ActiveN, {Pubs + N, Bytes + Oct}, Out}},
+    Msgs = next_incoming_msgs(Packets),
+    case RequestMore of
+        false ->
+            {ok, Msgs, State};
+        true when SS =/= closed ->
+            request_more_data(Socket, More, Msgs, State);
+        _ ->
+            {ok, Msgs, State}
+    end.
+
+-compile({inline, [request_more_data/4]}).
+request_more_data(Socket, More, Acc, State) ->
+    case sock_async_recv(Socket, More) of
+        {ok, DataMore} ->
+            {ok, [Acc, {recv_more, DataMore}], State};
+        {select, {_Info, DataMore}} ->
+            {ok, [Acc, {recv, DataMore}], State};
+        {select, _Info} ->
+            {ok, Acc, State};
+        {error, {closed, DataMore}} ->
+            NState = socket_closed(State),
+            {ok, [Acc, {recv, DataMore}, {sock_closed, tcp_closed}], NState};
+        {error, closed} ->
+            NState = socket_closed(State),
+            {ok, [Acc, {sock_closed, tcp_closed}], NState};
+        {error, {Reason, DataMore}} ->
+            {ok, [Acc, {recv, DataMore}, {sock_error, Reason}], State};
+        {error, Reason} ->
+            {ok, [Acc, {sock_error, Reason}], State}
+    end.
+
+%% @doc: return a reversed Msg list
+-compile({inline, [next_incoming_msgs/1]}).
+next_incoming_msgs([Packet]) ->
+    {incoming, Packet};
+next_incoming_msgs(Packets) ->
+    Fun = fun(Packet, Acc) -> [{incoming, Packet} | Acc] end,
+    lists:foldl(Fun, [], Packets).
+
+parse_incoming(Data, State = #state{parser = Parser}) ->
+    try
+        run_parser(Data, Parser, State)
+    catch
+        throw:{?FRAME_PARSE_ERROR, Reason} ->
+            ?LOG(info, #{
+                msg => "frame_parse_error",
+                reason => Reason,
+                at_state => describe_parser_state(Parser),
+                input_bytes => Data
+            }),
+            NState = update_state_on_parse_error(Reason, State),
+            {0, 0, [{frame_error, Reason}], NState};
+        error:Reason:Stacktrace ->
+            ?LOG(error, #{
+                msg => "frame_parse_failed",
+                at_state => describe_parser_state(Parser),
+                input_bytes => Data,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            {0, 0, [{frame_error, Reason}], State}
+    end.
+
+init_parser(FrameOpts) ->
+    %% Go with regular streaming parser.
+    emqx_frame:initial_parse_state(FrameOpts).
+
+update_state_on_parse_error(#{proto_ver := ProtoVer, parse_state := ParseState}, State) ->
+    Serialize = emqx_frame:serialize_opts(ProtoVer, ?MAX_PACKET_SIZE),
+    State#state{serialize = Serialize, parser = ParseState};
+update_state_on_parse_error(_, State) ->
+    State.
+
+run_parser(Data, ParseState, State) ->
+    run_stream_parser(Data, [], 0, ParseState, State).
+
+-compile({inline, [run_stream_parser/5]}).
+run_stream_parser(<<>>, Acc, N, NParseState, State) ->
+    {0, N, Acc, State#state{parser = NParseState}};
+run_stream_parser(Data, Acc, N, ParseState, State) ->
+    case emqx_frame:parse(Data, ParseState) of
+        {Packet, Rest, NParseState} ->
+            run_stream_parser(Rest, [Packet | Acc], N + 1, NParseState, State);
+        {More, NParseState} ->
+            {More, N, Acc, State#state{parser = NParseState}}
+    end.
+
+describe_parser_state(ParseState) ->
+    emqx_frame:describe_state(ParseState).
+
+%%--------------------------------------------------------------------
+%% Handle incoming packet
+
+handle_incoming(Packet = ?PACKET(Type), State) ->
+    inc_incoming_stats(Packet),
+    case Type of
+        ?CONNECT ->
+            %% CONNECT packet is fully received, time to cancel idle timer.
+            ok = cancel_idle_timer(State),
+            NState = State#state{
+                serialize = emqx_frame:serialize_opts(Packet#mqtt_packet.variable),
+                stats_timer = init_stats_timer(State)
+            },
+            with_channel(handle_in, [Packet], NState);
+        _ ->
+            with_channel(handle_in, [Packet], State)
+    end;
+handle_incoming(FrameError, State) ->
+    with_channel(handle_in, [FrameError], State).
+
+%%--------------------------------------------------------------------
+%% With Channel
+
+with_channel(Fun, Args, State = #state{channel = Channel}) ->
+    case erlang:apply(emqx_channel, Fun, Args ++ [Channel]) of
+        ok ->
+            {ok, State};
+        {ok, NChannel} ->
+            {ok, State#state{channel = NChannel}};
+        {ok, Replies, NChannel} ->
+            {ok, next_msgs(Replies), State#state{channel = NChannel}};
+        {continue, Replies, NChannel} ->
+            %% NOTE: Will later go back to `emqx_channel:handle_info/2`.
+            {ok, [next_msgs(Replies), continue], State#state{channel = NChannel}};
+        {shutdown, Reason, NChannel} ->
+            shutdown(Reason, State#state{channel = NChannel});
+        {shutdown, Reason, Packet, NChannel} ->
+            NState = State#state{channel = NChannel},
+            {ok, NState2} = handle_outgoing(Packet, NState),
+            shutdown(Reason, NState2)
+    end.
+
+%%--------------------------------------------------------------------
+%% Handle outgoing packets
+
+handle_outgoing(Packets, State = #state{channel = _Channel}) ->
+    Res = do_handle_outgoing(Packets, State),
+    _ = ?EXT_TRACE_OUTGOING_STOP(
+        emqx_external_trace:basic_attrs(_Channel),
+        Packets
+    ),
+    Res.
+
+do_handle_outgoing(Packets, State) when is_list(Packets) ->
+    N = length(Packets),
+    send(N, [serialize_and_inc_stats(State, Packet) || Packet <- Packets], State);
+do_handle_outgoing(Packet, State) ->
+    send(1, serialize_and_inc_stats(State, Packet), State).
+
+serialize_and_inc_stats(#state{serialize = Serialize}, Packet) ->
+    try emqx_frame:serialize_pkt(Packet, Serialize) of
+        <<>> ->
+            ?LOG(warning, #{
+                msg => "packet_is_discarded",
+                reason => "frame_is_too_large",
+                packet => emqx_packet:format(Packet, hidden)
+            }),
+            emqx_metrics:inc('delivery.dropped.too_large'),
+            emqx_metrics:inc('delivery.dropped'),
+            inc_dropped_stats(),
+            <<>>;
+        Data ->
+            ?TRACE("MQTT", "mqtt_packet_sent", #{packet => Packet}),
+            emqx_metrics:inc_sent(Packet),
+            inc_outgoing_stats(Packet),
+            Data
+    catch
+        %% Maybe Never happen.
+        throw:{?FRAME_SERIALIZE_ERROR, Reason} ->
+            ?LOG(info, #{
+                reason => Reason,
+                input_packet => Packet
+            }),
+            erlang:error({?FRAME_SERIALIZE_ERROR, Reason});
+        error:Reason:Stacktrace ->
+            ?LOG(error, #{
+                input_packet => Packet,
+                exception => Reason,
+                stacktrace => Stacktrace
+            }),
+            erlang:error(?FRAME_SERIALIZE_ERROR)
+    end.
+
+%%--------------------------------------------------------------------
+%% Send data
+
+-spec send(non_neg_integer(), iodata(), state()) -> {ok, state()}.
+send(Num, IoData, #state{socket = Socket, sockstate = SS} = State) ->
+    Oct = iolist_size(IoData),
+    emqx_metrics:inc('bytes.sent', Oct),
+    %% FIXME timeout
+    case SS =/= closed andalso socket:send(Socket, IoData, 15_000) of
+        ok ->
+            Ok = sent(Num, Oct, State),
+            ?BROKER_INSTR_WMARK(t0_deliver, {T0, TDeliver} when is_integer(T0), begin
+                TSent = ?BROKER_INSTR_TS(),
+                ?BROKER_INSTR_OBSERVE_HIST(connection, deliver_delay_us, ?US(TDeliver - T0)),
+                ?BROKER_INSTR_OBSERVE_HIST(connection, deliver_total_lat_us, ?US(TSent - T0))
+            end),
+            Ok;
+        false ->
+            {ok, State};
+        {error, {Reason, _Rest}} ->
+            %% Defer error handling:
+            {ok, {sock_error, Reason}, State};
+        {error, Reason} ->
+            {ok, {sock_error, Reason}, State}
+    end.
+
+%% Some bytes sent
+sent(_Num, _Oct, State = #state{gc_tracker = {ActiveN, {PktsIn, BytesIn}, _Out}}) when
+    PktsIn > ActiveN
+->
+    %% Run GC and check OOM after certain amount of messages or bytes received.
+    trigger_gc(PktsIn, BytesIn, ActiveN, State);
+sent(Num, Oct, State = #state{gc_tracker = {ActiveN, In, {PktsOut, BytesOut}}}) ->
+    %% Run GC and check OOM after certain amount of messages or bytes sent.
+    NBytes = BytesOut + Oct,
+    case PktsOut + Num of
+        NPkts when NPkts > ActiveN ->
+            trigger_gc(NPkts, NBytes, ActiveN, State);
+        NPkts ->
+            NState = State#state{gc_tracker = {ActiveN, In, {NPkts, NBytes}}},
+            {ok, NState}
+    end.
+
+-compile({inline, [trigger_gc/4]}).
+trigger_gc(NPkts, NBytes, ActiveN, State) ->
+    NState = State#state{gc_tracker = init_gc_tracker(ActiveN)},
+    {ok, check_oom(NPkts, NBytes, run_gc(NPkts, NBytes, NState))}.
+
+%%--------------------------------------------------------------------
+%% Handle Info
+
+handle_info({sock_error, Reason}, State) ->
+    case Reason =/= closed andalso Reason =/= einval of
+        true -> ?SLOG(warning, #{msg => "socket_error", reason => Reason});
+        false -> ok
+    end,
+    handle_info({sock_closed, Reason}, close_socket(State));
+%% handle QUIC control stream events
+handle_info({quic, Event, Handle, Prop}, State) when is_atom(Event) ->
+    case emqx_quic_stream:Event(Handle, Prop, State) of
+        {{continue, Msgs}, NewState} ->
+            {ok, Msgs, NewState};
+        Other ->
+            Other
+    end;
+handle_info(Info, State) ->
+    with_channel(handle_info, [Info], State).
+
+%%--------------------------------------------------------------------
+%% Handle Info
+
+handle_cast(
+    {async_set_socket_options, SockOpts},
+    State = #state{socket = Socket}
+) ->
+    case sock_setopts(Socket, SockOpts) of
+        ok ->
+            ?tp(debug, "custom_socket_options_successfully", #{opts => SockOpts});
+        {error, {invalid, {socket_option, SockOpt}}} ->
+            ?tp(warning, "unsupported_socket_keepalive", #{option => SockOpt});
+        {error, Reason} when Reason == closed; Reason == einval ->
+            %% socket is already closed, ignore this error
+            ?tp(debug, "socket already closed", #{reason => socket_already_closed}),
+            ok;
+        Err ->
+            %% other errors
+            ?tp(error, "failed_to_set_custom_socket_option", #{reason => Err})
+    end,
+    State;
+handle_cast(Req, State) ->
+    ?tp(error, "received_unknown_cast", #{cast => Req}),
+    State.
+
+%%--------------------------------------------------------------------
+%% Run GC and Check OOM
+
+run_gc(Pubs, Bytes, State = #state{gc_state = GcSt, zone = Zone}) ->
+    case
+        ?ENABLED(GcSt) andalso not emqx_olp:backoff_gc(Zone) andalso
+            emqx_gc:run(Pubs, Bytes, GcSt)
+    of
+        false -> State;
+        {_IsGC, GcSt1} -> State#state{gc_state = GcSt1}
+    end.
+
+check_oom(Pubs, Bytes, State = #state{zone = Zone}) ->
+    ShutdownPolicy = emqx_config:get_zone_conf(Zone, [force_shutdown]),
+    case emqx_utils:check_oom(ShutdownPolicy) of
+        {shutdown, Reason} ->
+            %% triggers terminate/2 callback immediately
+            ?tp(warning, check_oom_shutdown, #{
+                policy => ShutdownPolicy,
+                incoming_pubs => Pubs,
+                incoming_bytes => Bytes,
+                shutdown => Reason
+            }),
+            erlang:exit({shutdown, Reason});
+        Result ->
+            ?tp(debug, check_oom_ok, #{
+                policy => ShutdownPolicy,
+                incoming_pubs => Pubs,
+                incoming_bytes => Bytes,
+                result => Result
+            }),
+            ok
+    end,
+    State.
+
+%%--------------------------------------------------------------------
+%% Close Socket
+
+close_socket(State = #state{sockstate = closed}) ->
+    State;
+close_socket(State = #state{socket = Socket}) ->
+    ok = esockd_socket:fast_close(Socket),
+    State#state{sockstate = closed}.
+
+socket_closed(State) ->
+    State#state{sockstate = closed}.
+
+%%--------------------------------------------------------------------
+%% Inc incoming/outgoing stats
+
+-compile({inline, [inc_incoming_stats/1]}).
+inc_incoming_stats(Packet = ?PACKET(Type)) ->
+    inc_counter(recv_pkt, 1),
+    case Type of
+        ?PUBLISH ->
+            inc_counter(recv_msg, 1),
+            inc_qos_stats(recv_msg, Packet);
+        _ ->
+            ok
+    end,
+    emqx_metrics:inc_recv(Packet).
+
+-compile({inline, [inc_dropped_stats/0]}).
+inc_dropped_stats() ->
+    inc_counter('send_msg.dropped', 1),
+    inc_counter('send_msg.dropped.too_large', 1).
+
+-compile({inline, [inc_outgoing_stats/1]}).
+inc_outgoing_stats(Packet = ?PACKET(Type)) ->
+    inc_counter(send_pkt, 1),
+    case Type of
+        ?PUBLISH ->
+            inc_counter(send_msg, 1),
+            inc_qos_stats(send_msg, Packet);
+        _ ->
+            ok
+    end.
+
+-compile({inline, [inc_qos_stats/2]}).
+inc_qos_stats(Type, Packet) ->
+    case emqx_packet:qos(Packet) of
+        ?QOS_0 when Type =:= send_msg -> inc_counter('send_msg.qos0', 1);
+        ?QOS_1 when Type =:= send_msg -> inc_counter('send_msg.qos1', 1);
+        ?QOS_2 when Type =:= send_msg -> inc_counter('send_msg.qos2', 1);
+        ?QOS_0 when Type =:= recv_msg -> inc_counter('recv_msg.qos0', 1);
+        ?QOS_1 when Type =:= recv_msg -> inc_counter('recv_msg.qos1', 1);
+        ?QOS_2 when Type =:= recv_msg -> inc_counter('recv_msg.qos2', 1);
+        %% for bad qos
+        _ -> ok
+    end.
+
+%%--------------------------------------------------------------------
+%% Helper functions
+
+-compile({inline, [next_msgs/1]}).
+next_msgs(Packet) when is_record(Packet, mqtt_packet) ->
+    {outgoing, Packet};
+next_msgs(Event) when is_tuple(Event) ->
+    Event;
+next_msgs(More) when is_list(More) ->
+    More.
+
+-compile({inline, [shutdown/2, shutdown/3]}).
+shutdown(Reason, State) ->
+    stop({shutdown, Reason}, State).
+
+shutdown(Reason, Reply, State) ->
+    stop({shutdown, Reason}, Reply, State).
+
+-compile({inline, [stop/2, stop/3]}).
+stop(Reason, State) ->
+    {stop, Reason, State}.
+
+stop(Reason, Reply, State) ->
+    {stop, Reason, Reply, State}.
+
+inc_counter(Key, Inc) ->
+    _ = emqx_pd:inc_counter(Key, Inc),
+    ok.
+
+set_tcp_keepalive({tcp, Id}) ->
+    Conf = emqx_config:get_listener_conf(tcp, Id, [tcp_options, keepalive], "none"),
+    case Conf of
+        "none" ->
+            ok;
+        Value ->
+            {Idle, Interval, Probes} = emqx_schema:parse_tcp_keepalive(Value),
+            async_set_keepalive(self(), Idle, Interval, Probes)
+    end.
+
+-spec graceful_shutdown_transport(atom(), state()) -> state().
+graceful_shutdown_transport(_Reason, S = #state{socket = Socket}) ->
+    _ = socket:shutdown(Socket, read_write),
+    S#state{sockstate = closed}.
+
+start_timer(Time, Msg) ->
+    emqx_utils:start_timer(Time, Msg).
+
+%%--------------------------------------------------------------------
+%% For CT tests
+%%--------------------------------------------------------------------
+
+set_field(Name, Value, State) ->
+    Pos = emqx_utils:index_of(Name, record_info(fields, state)),
+    setelement(Pos + 1, State, Value).
+
+get_state(Pid) ->
+    State = sys:get_state(Pid),
+    maps:from_list(
+        lists:zip(
+            record_info(fields, state),
+            tl(tuple_to_list(State))
+        )
+    ).
+
+get_active_n(Type, Listener) ->
+    emqx_config:get_listener_conf(Type, Listener, [tcp_options, active_n]).

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -1055,7 +1055,7 @@ handle_info({sock_error, Reason}, State) ->
         true -> ?SLOG(warning, #{msg => "socket_error", reason => Reason});
         false -> ok
     end,
-    handle_info({sock_closed, Reason}, close_socket(State));
+    handle_info({sock_closed, Reason}, ensure_close_socket(Reason, State));
 %% handle QUIC control stream events
 handle_info({quic, Event, Handle, Prop}, State) when is_atom(Event) ->
     case emqx_quic_stream:Event(Handle, Prop, State) of
@@ -1129,6 +1129,11 @@ check_oom(Pubs, Bytes, State = #state{zone = Zone}) ->
 
 %%--------------------------------------------------------------------
 %% Close Socket
+
+ensure_close_socket(closed, State) ->
+    socket_closed(State);
+ensure_close_socket(_Reason, State) ->
+    close_socket(State).
 
 close_socket(State = #state{sockstate = closed}) ->
     State;

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -550,8 +550,14 @@ handle_msg({'$socket', Socket, select, Handle}, State = #state{sockstate = SS}) 
         _ ->
             handle_data_ready(Socket, State)
     end;
-handle_msg({'$socket', _Socket, abort, {_Handle, Reason}}, State) ->
-    handle_info({sock_error, Reason}, State);
+handle_msg({'$socket', _Socket, abort, {_Handle, Reason}}, State = #state{sockstate = SS}) ->
+    case SS =/= closed of
+        true ->
+            handle_info({sock_error, Reason}, State);
+        false ->
+            %% In case there were more than 1 outstanding select:
+            {ok, State}
+    end;
 handle_msg({recv, Data}, State) ->
     handle_data(Data, false, State);
 handle_msg({recv_more, Data}, State) ->

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -106,7 +106,7 @@
 -record(congested, {
     handle :: reference(),
     deadline :: _TimestampMs :: integer(),
-    sendq :: [erlang:iovec()]
+    sendq :: [erlang:iodata()]
 }).
 
 -type congested() :: #congested{}.
@@ -941,7 +941,7 @@ serialize_and_inc_stats(#state{serialize = Serialize}, Packet) ->
 send(Num, IoData, #state{socket = Socket, sockstate = idle} = State) ->
     Oct = iolist_size(IoData),
     Handle = make_ref(),
-    case socket:send(Socket, IoData, Handle) of
+    case socket:send(Socket, IoData, [], Handle) of
         ok ->
             sent(Num, Oct, State);
         {select, {_Info, Rest}} ->
@@ -969,7 +969,7 @@ send(_Num, _IoVec, #state{sockstate = closed} = State) ->
 handle_send_ready(Socket, SS = #congested{sendq = SQ}, State) ->
     IoData = sendq_to_iodata(SQ, []),
     Handle = make_ref(),
-    case socket:send(Socket, IoData, Handle) of
+    case socket:send(Socket, IoData, [], Handle) of
         ok ->
             {ok, State};
         {select, {_Info, Rest}} ->

--- a/apps/emqx/src/emqx_ws_connection.erl
+++ b/apps/emqx/src/emqx_ws_connection.erl
@@ -590,7 +590,7 @@ parse_incoming(<<>>, Packets, State) ->
     {lists:reverse(Packets), State};
 parse_incoming(Data, Packets, State = #state{parse_state = ParseState}) ->
     try emqx_frame:parse(Data, ParseState) of
-        {more, NParseState} ->
+        {_More, NParseState} ->
             {Packets, State#state{parse_state = NParseState}};
         {Packet, Rest, NParseState} ->
             NState = State#state{parse_state = NParseState},

--- a/apps/emqx/test/emqx_connection_SUITE.erl
+++ b/apps/emqx/test/emqx_connection_SUITE.erl
@@ -484,18 +484,14 @@ t_cancel_congestion_alarm(_) ->
     ),
     with_conn(
         fun(Pid) ->
-            #{
-                channel := Channel,
-                transport := Transport,
-                socket := Socket
-            } = emqx_connection:get_state(Pid),
+            State = sys:get_state(Pid),
             %% precondition
-            Zone = emqx_channel:info(zone, Channel),
+            Zone = emqx_connection:info({channel, zone}, State),
             true = emqx_config:get_zone_conf(Zone, [conn_congestion, enable_alarm]),
             %% should not raise errors
-            ok = emqx_congestion:maybe_alarm_conn_congestion(Socket, Transport, Channel),
+            ok = emqx_congestion:maybe_alarm_conn_congestion(emqx_connection, State),
             %% should not raise errors either
-            ok = emqx_congestion:cancel_alarms(Socket, Transport, Channel),
+            ok = emqx_congestion:cancel_alarms(emqx_connection, State),
             ok
         end,
         Opts

--- a/apps/emqx/test/emqx_cth_broker.erl
+++ b/apps/emqx/test/emqx_cth_broker.erl
@@ -1,0 +1,36 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2023-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_cth_broker).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-spec connection_info(_Info, pid() | emqx_types:clientid()) -> _Value.
+connection_info(Info, Client) when is_pid(Client) ->
+    connection_info(Info, emqtt_info(clientid, Client));
+connection_info(Info, ClientId) ->
+    [ChanPid] = emqx_cm:lookup_channels(ClientId),
+    ConnMod = emqx_cm:do_get_chann_conn_mod(ClientId, ChanPid),
+    get_connection_info(Info, ConnMod, sys:get_state(ChanPid)).
+
+-spec connection_state(pid() | emqx_types:clientid()) -> _Value.
+connection_state(Client) when is_pid(Client) ->
+    connection_state(emqtt_info(clientid, Client));
+connection_state(ClientId) ->
+    [ChanPid] = emqx_cm:lookup_channels(ClientId),
+    ConnMod = emqx_cm:do_get_chann_conn_mod(ClientId, ChanPid),
+    ConnMod:get_state(ChanPid).
+
+get_connection_info(connmod, ConnMod, _State) ->
+    ConnMod;
+get_connection_info(Info, emqx_connection, State) ->
+    emqx_connection:info(Info, State);
+get_connection_info(Info, emqx_socket_connection, State) ->
+    emqx_socket_connection:info(Info, State);
+get_connection_info(Info, emqx_ws_connection, {_WSState, ConnState, _}) ->
+    emqx_ws_connection:info(Info, ConnState).
+
+emqtt_info(Key, Client) ->
+    proplists:get_value(Key, emqtt:info(Client), undefined).

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -125,10 +125,10 @@ t_parse_cont(_) ->
     Packet = ?CONNECT_PACKET(#mqtt_packet_connect{}),
     ParseState = emqx_frame:initial_parse_state(),
     <<HdrBin:1/binary, LenBin:1/binary, RestBin/binary>> = serialize_to_binary(Packet),
-    {more, ContParse} = emqx_frame:parse(<<>>, ParseState),
-    {more, ContParse1} = emqx_frame:parse(HdrBin, ContParse),
-    {more, ContParse2} = emqx_frame:parse(LenBin, ContParse1),
-    {more, ContParse3} = emqx_frame:parse(<<>>, ContParse2),
+    {0, ContParse} = emqx_frame:parse(<<>>, ParseState),
+    {0, ContParse1} = emqx_frame:parse(HdrBin, ContParse),
+    {12, ContParse2} = emqx_frame:parse(LenBin, ContParse1),
+    {12, ContParse3} = emqx_frame:parse(<<>>, ContParse2),
     {Packet, <<>>, _} = emqx_frame:parse(RestBin, ContParse3).
 
 t_parse_frame_too_large(_) ->
@@ -411,7 +411,7 @@ t_parse_sticky_frames(_) ->
     Size = size(Bin),
     <<H:(Size - 2)/binary, TailTwoBytes/binary>> = Bin,
     %% needs 2 more bytes
-    {more, PState1} = emqx_frame:parse(H),
+    {2, PState1} = emqx_frame:parse(H),
     %% feed 3 bytes as if the next 1 byte belongs to the next packet.
     {_, <<42>>, PState2} = emqx_frame:parse(iolist_to_binary([TailTwoBytes, 42]), PState1),
     ?assertMatch(#{state := clean}, emqx_frame:describe_state(PState2)).

--- a/apps/emqx/test/emqx_frame_SUITE.erl
+++ b/apps/emqx/test/emqx_frame_SUITE.erl
@@ -125,8 +125,8 @@ t_parse_cont(_) ->
     Packet = ?CONNECT_PACKET(#mqtt_packet_connect{}),
     ParseState = emqx_frame:initial_parse_state(),
     <<HdrBin:1/binary, LenBin:1/binary, RestBin/binary>> = serialize_to_binary(Packet),
-    {0, ContParse} = emqx_frame:parse(<<>>, ParseState),
-    {0, ContParse1} = emqx_frame:parse(HdrBin, ContParse),
+    {some_more, ContParse} = emqx_frame:parse(<<>>, ParseState),
+    {some_more, ContParse1} = emqx_frame:parse(HdrBin, ContParse),
     {12, ContParse2} = emqx_frame:parse(LenBin, ContParse1),
     {12, ContParse3} = emqx_frame:parse(<<>>, ContParse2),
     {Packet, <<>>, _} = emqx_frame:parse(RestBin, ContParse3).

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -176,6 +176,7 @@ t_tcp_frame_parsing_conn(_Config) ->
     Port = emqx_common_test_helpers:select_free_port(tcp),
     Conf = #{
         <<"bind">> => format_bind({"127.0.0.1", Port}),
+        <<"tcp_backend">> => <<"gen_tcp">>,
         <<"parse_unit">> => <<"frame">>
     },
     with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
@@ -185,6 +186,21 @@ t_tcp_frame_parsing_conn(_Config) ->
         ?assertMatch(#{listener := {tcp, ?FUNCTION_NAME}}, CState),
         emqx_listeners:is_packet_parser_available(mqtt) andalso
             ?assertMatch(#{parser := {frame, _Options}}, CState)
+    end).
+
+t_tcp_socket_conn(_Config) ->
+    Port = emqx_common_test_helpers:select_free_port(tcp),
+    Conf = #{
+        <<"bind">> => format_bind({"127.0.0.1", Port}),
+        <<"tcp_backend">> => <<"socket">>
+    },
+    with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
+        Client = emqtt_connect_tcp({127, 0, 0, 1}, Port),
+        pong = emqtt:ping(Client),
+        ?assertEqual(
+            emqx_socket_connection,
+            emqx_cth_broker:connection_info(connmod, Client)
+        )
     end).
 
 t_ssl_frame_parsing_conn(Config) ->

--- a/apps/emqx/test/emqx_listeners_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_SUITE.erl
@@ -181,9 +181,7 @@ t_tcp_frame_parsing_conn(_Config) ->
     with_listener(tcp, ?FUNCTION_NAME, Conf, fun() ->
         Client = emqtt_connect_tcp({127, 0, 0, 1}, Port),
         pong = emqtt:ping(Client),
-        ClientId = proplists:get_value(clientid, emqtt:info(Client)),
-        [CPid] = emqx_cm:lookup_channels(ClientId),
-        CState = emqx_connection:get_state(CPid),
+        CState = emqx_cth_broker:connection_state(Client),
         ?assertMatch(#{listener := {tcp, ?FUNCTION_NAME}}, CState),
         emqx_listeners:is_packet_parser_available(mqtt) andalso
             ?assertMatch(#{parser := {frame, _Options}}, CState)

--- a/apps/emqx/test/emqx_listeners_update_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_update_SUITE.erl
@@ -235,7 +235,7 @@ test_change_parse_unit(ConfPath, ClientOpts) ->
     ?assertMatch({ok, _}, emqx:update_config(ConfPath, {update, ListenerRawConf1})),
     Client1 = emqtt_connect(ClientOpts),
     pong = emqtt:ping(Client1),
-    CState1 = get_conn_state(Client1),
+    CState1 = emqx_cth_broker:connection_state(Client1),
     emqx_listeners:is_packet_parser_available(mqtt) andalso
         ?assertMatch(
             #{parser := {frame, _Options}},
@@ -245,7 +245,7 @@ test_change_parse_unit(ConfPath, ClientOpts) ->
     ?assertMatch({ok, _}, emqx:update_config(ConfPath, {update, ListenerRawConf0})),
     Client2 = emqtt_connect(ClientOpts),
     pong = emqtt:ping(Client2),
-    CState2 = get_conn_state(Client2),
+    CState2 = emqx_cth_broker:connection_state(Client2),
     emqx_listeners:is_packet_parser_available(mqtt) andalso
         ?assertMatch(
             #{parser := Parser} when Parser =/= map_get(parser, CState1),
@@ -424,8 +424,3 @@ emqtt_connect(Opts) ->
         {error, Reason} ->
             error(Reason, [Opts])
     end.
-
-get_conn_state(Client) ->
-    ClientId = proplists:get_value(clientid, emqtt:info(Client)),
-    [CPid | _] = emqx_cm:lookup_channels(ClientId),
-    emqx_connection:get_state(CPid).

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -100,16 +100,6 @@ end_per_testcase(TestCase, Config) ->
 client_info(Key, Client) ->
     proplists:get_value(Key, emqtt:info(Client), undefined).
 
-connection_info(Info, ClientPid, Config) when is_list(Config) ->
-    connection_info(Info, ClientPid, ?config(conn_type, Config));
-connection_info(Info, ClientPid, tcp) ->
-    emqx_connection:info(Info, sys:get_state(ClientPid));
-connection_info(Info, ClientPid, quic) ->
-    emqx_connection:info(Info, sys:get_state(ClientPid));
-connection_info(Info, ClientPid, ws) ->
-    {_WSState, ConnState, _} = sys:get_state(ClientPid),
-    emqx_ws_connection:info(Info, ConnState).
-
 receive_messages(Count) ->
     receive_messages(Count, []).
 
@@ -283,8 +273,7 @@ t_connect_will_message(Config) ->
         | Config
     ]),
     {ok, _} = emqtt:ConnFun(Client1),
-    [ClientPid] = emqx_cm:lookup_channels(client_info(clientid, Client1)),
-    WillMsg = connection_info({channel, will_msg}, ClientPid, Config),
+    WillMsg = emqx_cth_broker:connection_info({channel, will_msg}, Client1),
     %% [MQTT-3.1.2-7]
     ?assertNotEqual(undefined, WillMsg),
 
@@ -468,13 +457,12 @@ t_connect_emit_stats_timeout(Config) ->
     {ok, _} = emqtt:ConnFun(Client),
     %% Poke the connection to ensure stats timer is armed.
     pong = emqtt:ping(Client),
-    [ClientPid] = emqx_cm:lookup_channels(client_info(clientid, Client)),
     ?assertMatch(
         TRef when is_reference(TRef),
-        connection_info(stats_timer, ClientPid, Config)
+        emqx_cth_broker:connection_info(stats_timer, Client)
     ),
     ?block_until(#{?snk_kind := cancel_stats_timer}, IdleTimeout * 2, _BackInTime = 0),
-    ?assertEqual(undefined, connection_info(stats_timer, ClientPid, Config)),
+    ?assertEqual(undefined, emqx_cth_broker:connection_info(stats_timer, Client)),
     ok = emqtt:disconnect(Client).
 
 %% [MQTT-3.1.2-22]

--- a/apps/emqx/test/emqx_mqtt_test_client.erl
+++ b/apps/emqx/test/emqx_mqtt_test_client.erl
@@ -151,7 +151,7 @@ terminate(_Reason, _St) ->
 
 process_incoming(PSt, Data, Packets) ->
     case emqx_frame:parse(Data, PSt) of
-        {more, NewPSt} ->
+        {_More, NewPSt} ->
             {NewPSt, lists:reverse(Packets)};
         {Packet, Rest, NewPSt} ->
             process_incoming(NewPSt, Rest, [Packet | Packets])

--- a/apps/emqx/test/emqx_persistent_session_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_SUITE.erl
@@ -355,13 +355,12 @@ t_choose_impl(Config) ->
         | Config
     ]),
     {ok, _} = emqtt:ConnFun(Client),
-    [ChanPid] = emqx_cm:lookup_channels(ClientId),
     ?assertEqual(
         case ?config(persistence, Config) of
             false -> emqx_session_mem;
             ds -> emqx_persistent_session_ds
         end,
-        emqx_connection:info({channel, {session, impl}}, sys:get_state(ChanPid))
+        emqx_cth_broker:connection_info({channel, {session, impl}}, ClientId)
     ),
     ok = emqtt:disconnect(Client).
 

--- a/apps/emqx_eviction_agent/mix.exs
+++ b/apps/emqx_eviction_agent/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXEvictionAgent.MixProject do
   def project do
     [
       app: :emqx_eviction_agent,
-      version: "5.1.11",
+      version: "5.1.12",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_eviction_agent/src/emqx_eviction_agent.erl
+++ b/apps/emqx_eviction_agent/src/emqx_eviction_agent.erl
@@ -61,7 +61,11 @@
 -export_type([server_reference/0, kind/0, options/0]).
 
 -define(CONN_MODULES, [
-    emqx_connection, emqx_ws_connection, emqx_quic_connection, emqx_eviction_agent_channel
+    emqx_connection,
+    emqx_socket_connection,
+    emqx_ws_connection,
+    emqx_quic_connection,
+    emqx_eviction_agent_channel
 ]).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1090,10 +1090,13 @@ t_keepalive(Config) ->
     {ok, _} = emqtt:connect(C1),
     [Pid] = emqx_cm:lookup_channels(list_to_binary(ClientId)),
     %% will reset to max keepalive if keepalive > max keepalive
-    #{conninfo := #{keepalive := InitKeepalive}} = emqx_connection:info(Pid),
+    ?assertMatch(
+        #{conninfo := #{keepalive := InitKeepalive}},
+        emqx_cm:get_chan_info(list_to_binary(ClientId))
+    ),
     ?assertMatch(
         #{max_idle_millisecond := 65536500},
-        emqx_connection:info({channel, keepalive}, sys:get_state(Pid))
+        emqx_cth_broker:connection_info({channel, keepalive}, list_to_binary(ClientId))
     ),
 
     ?assertMatch(

--- a/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
+++ b/apps/emqx_telemetry/test/emqx_telemetry_SUITE.erl
@@ -219,6 +219,7 @@ t_node_uuid(_) ->
     {ok, NodeUUID4} = emqx_telemetry_proto_v1:get_node_uuid(node()),
     ?assertEqual(NodeUUID2, NodeUUID3),
     ?assertEqual(NodeUUID3, NodeUUID4),
+    emqx_telemetry:stop_reporting(),
     ?assertMatch({badrpc, nodedown}, emqx_telemetry_proto_v1:get_node_uuid('fake@node')).
 
 t_cluster_uuid(Config) ->

--- a/changes/ee/perf-15451.en.md
+++ b/changes/ee/perf-15451.en.md
@@ -1,0 +1,1 @@
+Introduce experimental `socket` backend for TCP listeners, designed to improve message processing latency and reduce compute resource usage. This can be enabled via the new `tcp_backend` listener option.

--- a/mix.exs
+++ b/mix.exs
@@ -153,7 +153,10 @@ defmodule EMQXUmbrella.MixProject do
   end
 
   def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.0", override: true}
-  def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.14.0", override: true}
+
+  def common_dep(:esockd),
+    do: {:esockd, github: "emqx/esockd", tag: "5.15.0", override: true}
+
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.45.4", override: true}
   def common_dep(:lc), do: {:lc, github: "emqx/lc", tag: "0.3.4", override: true}

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -619,7 +619,9 @@ fields_mqtt_opts_tcp_backend.desc:
 - `gen_tcp`: Standard backend, in use since EMQX 5.0 release.
 
 - `socket`: Experimental backend, looking to improve message latency and compute resource usage.
-    Note that some `tcp_options` settings will have no effect when using this backend, e.g.: `high_watermark` and `send_timeout_close`."""
+    Note that some `tcp_options` settings will have no effect when using this backend, e.g.: `high_watermark` and `send_timeout_close`.
+    
+Changing the backend require restarting the listener, which will terminate all its active connections."""
 
 fields_mqtt_opts_tcp_backend.label:
 """TCP Backend"""

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -613,6 +613,17 @@ Note, the choice of `parse_unit` affects the interpretation of the `active_n` se
 fields_mqtt_opts_parse_unit.label:
 """MQTT Message Parse Unit"""
 
+fields_mqtt_opts_tcp_backend.desc:
+"""Indicates which TCP backend should be used by the listener.
+
+- `gen_tcp`: Standard backend, in use since EMQX 5.0 release.
+
+- `socket`: Experimental backend, looking to improve message latency and compute resource usage.
+    Note that some `tcp_options` settings will have no effect when using this backend, e.g.: `high_watermark` and `send_timeout_close`."""
+
+fields_mqtt_opts_tcp_backend.label:
+"""TCP Backend"""
+
 server_ssl_opts_schema_honor_cipher_order.desc:
 """An important security setting. If this setting is enabled, the server will prioritize the cipher suites it prefers most from the list of cipher suites supported by the client, thus ignoring the client's preferences.
 


### PR DESCRIPTION
Part of EMQX-14333.

Release version: 6.0.0

## Summary

This PR introduces `tcp_backend` listener option, exclusively to TCP listeners, and employs emqx/esockd#204 with a separate connection module named `emqx_socket_connection` when `tcp_backend` is `socket`. This shows consistently better wide-fanout performance, especially when combined with async shard dispatch introduced in emqx/emqx#15421, see [report](https://emqx.atlassian.net/wiki/spaces/HOTPOT/pages/1815413979/In-mem+Fanout+Performance).

This new connection module is identical to `emqx_connection` module in most of aspects, but made separate primarily because of:
* Socket-based connections use substantially different connection loop, and integrating it into `emqx_connection` might have made the latter too bloated, harder to test and reason about.
* Combined module would have larger footprint, which would lead to a bunch of "micro-deoptimizations" affecting every listener, admittedly pretty minor ones.

Obvious downside is the need to keep changes to connection modules in sync. This requires additional development processes, or perhaps some CI magic, otherwise code will eventually diverge. Ideas are welcome.

See individual commits for details.

Notes:
* Commit ed96d999565a0346d7c986bda486f2326c17b457 is part of `iovec()` experiments that I decided to include in this PR, because it shows small consistent improvements in average message processing latency (~2% less) and VM reductions (~3.5% less).
* While TLS connections are currently not supported under `esockd_socket` listeners, there's [ongoing](https://github.com/erlang/otp/pull/9398) [work](https://github.com/erlang/otp/pull/9879) in Erlang/OTP to support familiar SSL API with `socket` sockets.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
