### PR TITLE
fix(aggreg deliveries): add missing callback

### DIFF
--- a/apps/emqx_bridge_azure_blob_storage/mix.exs
+++ b/apps/emqx_bridge_azure_blob_storage/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeAzureBlobStorage.MixProject do
   def project do
     [
       app: :emqx_bridge_azure_blob_storage,
-      version: "0.1.4",
+      version: "0.1.5",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_blob_storage, [
     {description, "EMQX Enterprise Azure Blob Storage Bridge"},
-    {vsn, "0.1.4"},
+    {vsn, "0.1.5"},
     {registered, [emqx_bridge_azure_blob_storage_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -41,7 +41,8 @@
     process_append/2,
     process_write/1,
     process_complete/1,
-    process_terminate/1
+    process_terminate/1,
+    process_format_status/1
 ]).
 
 %% `emqx_template' API
@@ -435,6 +436,15 @@ process_complete(TransferState) ->
 process_terminate(_TransferState) ->
     %% todo: delete uploaded blocks?
     ok.
+
+-spec process_format_status(transfer_state()) -> map().
+process_format_status(TransferState) ->
+    #{next_block := NextBlock} = TransferState,
+    TransferState#{
+        buffer := [<<"...">>],
+        next_block := [queue:len(NextBlock), <<"items">>],
+        driver_state := <<"...">>
+    }.
 
 %%------------------------------------------------------------------------------
 %% `emqx_template' API

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_connector.erl
@@ -52,7 +52,8 @@
     process_append/2,
     process_write/1,
     process_complete/1,
-    process_terminate/1
+    process_terminate/1,
+    process_format_status/1
 ]).
 
 %% API
@@ -659,6 +660,17 @@ process_complete(TransferState0) ->
 process_terminate(_TransferState) ->
     %% todo: cleanup staged files?
     ok.
+
+-spec process_format_status(transfer_state()) -> map().
+process_format_status(TransferState) ->
+    #{
+        http_client_config := HTTPClientConfig,
+        next_file := NextFile
+    } = TransferState,
+    TransferState#{
+        http_client_config := HTTPClientConfig#{jwt_config := <<"...">>},
+        next_file := queue:to_list(NextFile)
+    }.
 
 %%------------------------------------------------------------------------------
 %% Internal fns

--- a/apps/emqx_connector_aggregator/mix.exs
+++ b/apps/emqx_connector_aggregator/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConnectorAggregator.MixProject do
   def project do
     [
       app: :emqx_connector_aggregator,
-      version: "0.1.6",
+      version: "0.1.7",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_connector_aggregator/src/emqx_connector_aggreg_delivery.erl
+++ b/apps/emqx_connector_aggregator/src/emqx_connector_aggreg_delivery.erl
@@ -58,28 +58,44 @@
 
 -type transfer_state() :: term().
 
-%% @doc Initialize the transfer state, such as blob storage path, transfer options, client
-%% credentials, etc. .  Also returns options to initialize container, if dynamic settings
-%% are needed.
+-doc """
+Initialize the transfer state, such as blob storage path, transfer options, client
+credentials, etc. .  Also returns options to initialize container, if dynamic settings are
+needed.
+""".
 -callback init_transfer_state_and_container_opts(buffer(), map()) ->
     {ok, transfer_state(), ContainerOpts} | {error, term()}
 when
     ContainerOpts :: map().
 
-%% @doc Append data to the transfer before sending.  Usually should not fail.
+-doc """
+Append data to the transfer before sending.  Usually should not fail.
+""".
 -callback process_append(iodata() | term(), transfer_state()) ->
     transfer_state().
 
-%% @doc Push appended transfer data to its destination (e.g.: upload a part of a
-%% multi-part upload).  May fail.
+-doc """
+Push appended transfer data to its destination (e.g.: upload a part of a multi-part
+upload).  May fail.
+""".
 -callback process_write(transfer_state()) -> {ok, transfer_state()} | {error, term()}.
 
-%% @doc Finalize the transfer and clean up any resources.  May return a term summarizing
-%% the transfer.
+-doc """
+Finalize the transfer and clean up any resources.  May return a term summarizing the
+transfer.
+""".
 -callback process_complete(transfer_state()) -> {ok, term()}.
 
-%% @doc Clean up any resources when the process finishes abnormally.  Result is ignored.
+-doc """
+Clean up any resources when the process finishes abnormally.  Result is ignored.
+""".
 -callback process_terminate(transfer_state()) -> any().
+
+-doc """
+When a delivery fails (or simply when `gen_server:format_status/1` is called on a delivery
+process), this callback is used to format the internal transfer status.
+""".
+-callback process_format_status(transfer_state()) -> term().
 
 %%------------------------------------------------------------------------------
 %% API

--- a/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.app.src
+++ b/apps/emqx_connector_aggregator/src/emqx_connector_aggregator.app.src
@@ -1,6 +1,6 @@
 {application, emqx_connector_aggregator, [
     {description, "EMQX Enterprise Connector Data Aggregator"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [
         kernel,

--- a/changes/ee/fix-15476.en.md
+++ b/changes/ee/fix-15476.en.md
@@ -1,0 +1,7 @@
+When most of the Actions that use aggregated mode (Azure Blob Storage, Snowflake, S3Tables) had a delivery that failed, the following log would be printed:
+
+```
+"emqx_connector_aggreg_delivery:format_status/1 crashed"
+```
+
+This has been fixed, and more information about the delivery process will now be logged.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14465

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 6.0.0

## Summary

`emqx_connector_aggreg_delivery` has a `process_format_status` callback that was missed by all aggregated bridges but S3.  This callback formats the inner transfer state when the delivery process crashes (or simply when one calls `gen_server:format_status` on the delivery process).


<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [na] The changes are covered with new or existing tests (presence of callback is now checked by xref/dialyzer, though)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
