### PR TITLE
feat: support namespaced actions/sources

### DIFF
--- a/apps/emqx/priv/bpapi.versions
+++ b/apps/emqx/priv/bpapi.versions
@@ -11,6 +11,7 @@
 {emqx_bridge,5}.
 {emqx_bridge,6}.
 {emqx_bridge,7}.
+{emqx_bridge,8}.
 {emqx_bridge_kinesis,1}.
 {emqx_broker,1}.
 {emqx_cluster,1}.

--- a/apps/emqx/test/emqx_common_test_http.erl
+++ b/apps/emqx/test/emqx_common_test_http.erl
@@ -95,7 +95,8 @@ create_default_app() ->
         {ok, App} ->
             {ok, App};
         {error, name_already_exists} ->
-            {ok, _} = emqx_mgmt_auth:read(?DEFAULT_APP_ID)
+            {ok, App} = emqx_mgmt_auth:read(?DEFAULT_APP_ID),
+            {ok, App#{api_secret => ?DEFAULT_APP_SECRET}}
     end.
 
 delete_default_app() ->

--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuth.MixProject do
   def project do
     [
       app: :emqx_auth,
-      version: "0.4.7",
+      version: "0.4.8",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_auth/src/emqx_auth.app.src
+++ b/apps/emqx_auth/src/emqx_auth.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth, [
     {description, "EMQX Authentication and authorization"},
-    {vsn, "0.4.7"},
+    {vsn, "0.4.8"},
     {modules, []},
     {registered, [emqx_auth_sup]},
     {applications, [

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -30,6 +30,7 @@
 
 -define(DEFAULT_RESOURCE_OPTS(OWNER_ID), #{
     start_after_created => false,
+    spawn_buffer_workers => false,
     owner_id => OWNER_ID
 }).
 

--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_utils.erl
@@ -34,6 +34,7 @@
 
 -define(DEFAULT_RESOURCE_OPTS(Type), #{
     start_after_created => false,
+    spawn_buffer_workers => false,
     owner_id => Type
 }).
 

--- a/apps/emqx_bridge/include/emqx_bridge_proto.hrl
+++ b/apps/emqx_bridge/include/emqx_bridge_proto.hrl
@@ -5,6 +5,8 @@
 -ifndef(EMQX_BRIDGE_PROTO_HRL).
 -define(EMQX_BRIDGE_PROTO_HRL, true).
 
+%% Note: this version stops at 7 because we no longer keep copying old, deprecated BPAPIs
+%% to newer modules (8+).
 -define(MAX_SUPPORTED_PROTO_VERSION, 7).
 
 -endif.

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -export([
     pre_config_update/3,
@@ -232,7 +233,7 @@ send_message(BridgeId, Message) ->
     case emqx_bridge_v2:is_bridge_v2_type(BridgeV1Type) of
         true ->
             ActionType = emqx_action_info:bridge_v1_type_to_action_type(BridgeV1Type),
-            emqx_bridge_v2:send_message(ActionType, BridgeName, Message, #{});
+            emqx_bridge_v2:send_message(?global_ns, ActionType, BridgeName, Message, #{});
         false ->
             ResId = emqx_bridge_resource:resource_id(BridgeV1Type, BridgeName),
             send_message(BridgeV1Type, BridgeName, ResId, Message, #{})
@@ -350,9 +351,9 @@ get_metrics(ActionType, Name) ->
                     BridgeV2Type = emqx_bridge_v2:bridge_v1_type_to_bridge_v2_type(ActionType),
                     try
                         ConfRootKey = emqx_bridge_v2:get_conf_root_key_if_only_one(
-                            BridgeV2Type, Name
+                            ?global_ns, BridgeV2Type, Name
                         ),
-                        emqx_bridge_v2:get_metrics(ConfRootKey, BridgeV2Type, Name)
+                        emqx_bridge_v2:get_metrics(?global_ns, ConfRootKey, BridgeV2Type, Name)
                     catch
                         error:Reason ->
                             {error, Reason}

--- a/apps/emqx_bridge/src/emqx_bridge.erl
+++ b/apps/emqx_bridge/src/emqx_bridge.erl
@@ -227,7 +227,8 @@ send_to_matched_egress_bridges_loop(Topic, Msg, [Id | Ids]) ->
     send_to_matched_egress_bridges_loop(Topic, Msg, Ids).
 
 send_message(BridgeId, Message) ->
-    {BridgeV1Type, BridgeName} = emqx_bridge_resource:parse_bridge_id(BridgeId),
+    #{type := BridgeV1Type, name := BridgeName} =
+        emqx_bridge_resource:parse_bridge_id(BridgeId),
     case emqx_bridge_v2:is_bridge_v2_type(BridgeV1Type) of
         true ->
             ActionType = emqx_action_info:bridge_v1_type_to_action_type(BridgeV1Type),
@@ -313,7 +314,7 @@ list() ->
     BridgeV1Bridges ++ BridgeV2Bridges.
 
 lookup(Id) ->
-    {Type, Name} = emqx_bridge_resource:parse_bridge_id(Id),
+    #{type := Type, name := Name} = emqx_bridge_resource:parse_bridge_id(Id),
     lookup(Type, Name).
 
 is_exist_v1(Type, Name) ->

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -62,7 +62,7 @@
 %% Don't turn bridge_name to atom, it's maybe not a existing atom.
 -define(TRY_PARSE_ID(ID, EXPR),
     try emqx_bridge_resource:parse_bridge_id(Id, #{atom_name => false}) of
-        {BridgeType, BridgeName} ->
+        #{type := BridgeType, name := BridgeName} ->
             EXPR
     catch
         throw:#{reason := Reason} ->

--- a/apps/emqx_bridge/src/emqx_bridge_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_api.erl
@@ -47,6 +47,7 @@
 -export([format_bridge_metrics/1, format_metrics/1]).
 
 -define(BPAPI_NAME, emqx_bridge).
+-define(DEPRECATED_V1_BPAPI_MAX_PROTO_VSN, 4).
 
 -define(BRIDGE_NOT_ENABLED,
     ?BAD_REQUEST(<<"Forbidden operation, bridge not enabled">>)
@@ -1105,13 +1106,13 @@ maybe_try_restart(_, _, _) ->
     ?NOT_IMPLEMENTED.
 
 do_bpapi_call(all, Call, Args) ->
-    maybe_unwrap(
-        do_bpapi_call_vsn(emqx_bpapi:supported_version(?BPAPI_NAME), Call, Args)
-    );
+    Vsn = max_supported_version(emqx_bpapi:supported_version(?BPAPI_NAME)),
+    maybe_unwrap(do_bpapi_call_vsn(Vsn, Call, Args));
 do_bpapi_call(Node, Call, Args) ->
     case lists:member(Node, mria:running_nodes()) of
         true ->
-            do_bpapi_call_vsn(emqx_bpapi:supported_version(Node, ?BPAPI_NAME), Call, Args);
+            Vsn = max_supported_version(emqx_bpapi:supported_version(Node, ?BPAPI_NAME)),
+            do_bpapi_call_vsn(Vsn, Call, Args);
         false ->
             {error, {node_not_found, Node}}
     end.
@@ -1128,6 +1129,11 @@ maybe_unwrap({error, not_implemented}) ->
     {error, not_implemented};
 maybe_unwrap(RpcMulticallResult) ->
     emqx_rpc:unwrap_erpc(RpcMulticallResult).
+
+max_supported_version(undefined) ->
+    undefined;
+max_supported_version(N) when is_integer(N) ->
+    min(N, ?DEPRECATED_V1_BPAPI_MAX_PROTO_VSN).
 
 supported_versions(start_bridge_to_node) ->
     bpapi_version_range(2, ?MAX_SUPPORTED_PROTO_VERSION);

--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -840,7 +840,7 @@ create_dry_run_helper(ConfRootKey, BridgeV2Type, ConnectorRawConf, BridgeV2RawCo
     ConnectorType = connector_type(BridgeV2Type),
     OnReadyCallback =
         fun(ConnectorId) ->
-            {_, ConnectorName} = emqx_connector_resource:parse_connector_id(ConnectorId),
+            #{name := ConnectorName} = emqx_connector_resource:parse_connector_id(ConnectorId),
             ChannelTestId = id(BridgeV2Type, BridgeName, ConnectorName),
             BridgeV2Conf0 = fill_defaults(
                 BridgeV2Type,
@@ -1022,7 +1022,7 @@ get_channels_for_connector(ConnectorId) ->
 
 get_channels_for_connector(SourcesOrActions, ConnectorId) ->
     try emqx_connector_resource:parse_connector_id(ConnectorId) of
-        {ConnectorType, ConnectorName} ->
+        #{type := ConnectorType, type := ConnectorName} ->
             RootConf = maps:keys(emqx:get_config([SourcesOrActions], #{})),
             RelevantBridgeV2Types = [
                 Type

--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -16,12 +16,23 @@
 -include_lib("hocon/include/hocon.hrl").
 -include_lib("emqx/include/emqx_config.hrl").
 
+%% Deprecated RPC target (`emqx_bridge_proto_v5`).
+-deprecated({list, 0, "use list/3 instead"}).
+%% Deprecated RPC target (`emqx_bridge_proto_v{6,7}`).
+-deprecated({list, 1, "use list/3 instead"}).
+%% Deprecated RPC target (`emqx_bridge_proto_v5`).
+-deprecated({start, 2, "use start/4 instead"}).
+%% Deprecated RPC target (`emqx_bridge_proto_v6`).
+-deprecated({start, 3, "use start/4 instead"}).
+
 %% Note: this is strange right now, because it lives in `emqx_bridge_v2', but it shall be
 %% refactored into a new module/application with appropriate name.
 -define(ROOT_KEY_ACTIONS, actions).
 -define(ROOT_KEY_ACTIONS_BIN, <<"actions">>).
 -define(ROOT_KEY_SOURCES, sources).
 -define(ROOT_KEY_SOURCES_BIN, <<"sources">>).
+
+-define(ENABLE_OR_DISABLE(A), (A =:= disable orelse A =:= enable)).
 
 %% Loading and unloading config when EMQX starts and stops
 -export([
@@ -32,41 +43,39 @@
 %% CRUD API
 
 -export([
+    %% Deprecated RPC target (`emqx_bridge_proto_v5`).
     list/0,
+    %% Deprecated RPC target (`emqx_bridge_proto_v{6,7}`).
     list/1,
-    lookup/2,
-    lookup/3,
-    lookup_raw_conf/3,
-    is_exist/3,
-    create/3,
-    create/4,
-    %% The remove/2 function is only for internal use as it may create
+    list/2,
+    lookup/4,
+    lookup_raw_conf/4,
+    is_exist/4,
+    create/5,
+    %% The remove/4 function is only for internal use as it may create
     %% rules with broken dependencies
-    remove/2,
-    remove/3,
+    remove/4,
     %% The following is the remove function that is called by the HTTP API
     %% It also checks for rule action dependencies and optionally removes
     %% them
-    check_deps_and_remove/3,
-    check_deps_and_remove/4
+    check_deps_and_remove/5
 ]).
--export([is_action_exist/2, is_source_exist/2]).
+-export([is_action_exist/3, is_source_exist/3]).
 
 %% Operations
 
 -export([
-    disable_enable/3,
-    disable_enable/4,
-    send_message/4,
-    query/4,
+    disable_enable/5,
+    send_message/5,
+    query/5,
+    %% Deprecated RPC target (`emqx_bridge_proto_v5`).
     start/2,
+    %% Deprecated RPC target (`emqx_bridge_proto_v6`).
     start/3,
-    reset_metrics/2,
-    reset_metrics/3,
-    create_dry_run/2,
-    create_dry_run/3,
-    get_metrics/2,
-    get_metrics/3
+    start/4,
+    reset_metrics/4,
+    create_dry_run/4,
+    get_metrics/4
 ]).
 
 %% On message publish hook (for local_topics)
@@ -77,18 +86,19 @@
 
 -export([
     parse_id/1,
-    get_resource_ids/3,
+    get_resource_ids/4,
     get_channels_for_connector/1
 ]).
 
 -export([diff_confs/2]).
 
+%% Internal export for buffer worker (and tests)
+-export([lookup_chan_id_in_conf/4]).
+
 %% Exported for tests
 -export([
-    id/2,
-    id/3,
-    health_check/2,
-    health_check/3,
+    id_with_root_and_connector_names/5,
+    health_check/4,
     source_id/3,
     source_hookpoint/1,
     bridge_v1_is_valid/2,
@@ -99,8 +109,8 @@
 %% Config Update Handler API
 
 -export([
-    post_config_update/5,
-    pre_config_update/3
+    pre_config_update/4,
+    post_config_update/6
 ]).
 
 %% Data backup
@@ -138,12 +148,14 @@
     bridge_v1_reset_metrics/2,
     %% For test cases only
     bridge_v1_remove/2,
-    get_conf_root_key_if_only_one/2
+    get_conf_root_key_if_only_one/3
 ]).
 
 %%====================================================================
 %% Types
 %%====================================================================
+
+-type namespace() :: binary().
 
 -type bridge_v2_info() :: #{
     type := binary(),
@@ -159,6 +171,8 @@
 -type bridge_v2_name() :: binary() | atom() | [byte()].
 
 -type root_cfg_key() :: ?ROOT_KEY_ACTIONS | ?ROOT_KEY_SOURCES.
+
+-type maybe_namespace() :: ?global_ns | binary().
 
 -export_type([root_cfg_key/0, bridge_v2_type/0, bridge_v2_name/0]).
 
@@ -181,7 +195,17 @@ load() ->
     ok.
 
 load_bridges(RootName) ->
-    Bridges = emqx:get_config([RootName], #{}),
+    NamespaceToRoots = get_root_config_from_all_namespaces(RootName, #{}),
+    emqx_utils:pforeach(
+        fun({Namespace, RootConfig}) ->
+            do_load_bridges(Namespace, RootName, RootConfig)
+        end,
+        maps:to_list(NamespaceToRoots),
+        infinity
+    ),
+    ok.
+
+do_load_bridges(Namespace, RootName, RootConfig) ->
     emqx_utils:pforeach(
         fun
             ({?COMPUTED, _}) ->
@@ -189,16 +213,15 @@ load_bridges(RootName) ->
             ({Type, Bridge}) ->
                 emqx_utils:pmap(
                     fun({Name, BridgeConf}) ->
-                        install_bridge_v2(RootName, Type, Name, BridgeConf)
+                        install_bridge_v2(Namespace, RootName, Type, Name, BridgeConf)
                     end,
                     maps:to_list(Bridge),
                     infinity
                 )
         end,
-        maps:to_list(Bridges),
+        maps:to_list(RootConfig),
         infinity
-    ),
-    ok.
+    ).
 
 unload() ->
     unload_bridges(?ROOT_KEY_ACTIONS),
@@ -208,8 +231,18 @@ unload() ->
     emqx_conf:remove_handler(config_key_path_leaf()),
     ok.
 
-unload_bridges(ConfRootKey) ->
-    Bridges = emqx:get_config([ConfRootKey], #{}),
+unload_bridges(RootName) ->
+    NamespaceToRoots = get_root_config_from_all_namespaces(RootName, #{}),
+    emqx_utils:pforeach(
+        fun({Namespace, RootConfig}) ->
+            do_unload_bridges(Namespace, RootName, RootConfig)
+        end,
+        maps:to_list(NamespaceToRoots),
+        infinity
+    ),
+    ok.
+
+do_unload_bridges(Namespace, RootName, RootConfig) ->
     emqx_utils:pforeach(
         fun
             ({?COMPUTED, _}) ->
@@ -217,13 +250,13 @@ unload_bridges(ConfRootKey) ->
             ({Type, Bridge}) ->
                 emqx_utils:pmap(
                     fun({Name, BridgeConf}) ->
-                        uninstall_bridge_v2(ConfRootKey, Type, Name, BridgeConf)
+                        uninstall_bridge_v2(Namespace, RootName, Type, Name, BridgeConf)
                     end,
                     maps:to_list(Bridge),
                     infinity
                 )
         end,
-        maps:to_list(Bridges),
+        maps:to_list(RootConfig),
         infinity
     ),
     ok.
@@ -232,36 +265,32 @@ unload_bridges(ConfRootKey) ->
 %% CRUD API
 %%====================================================================
 
--spec lookup(bridge_v2_type(), bridge_v2_name()) -> {ok, bridge_v2_info()} | {error, not_found}.
-lookup(Type, Name) ->
-    lookup(?ROOT_KEY_ACTIONS, Type, Name).
+is_action_exist(Namespace, Type, Name) ->
+    is_exist(Namespace, ?ROOT_KEY_ACTIONS, Type, Name).
 
-is_action_exist(Type, Name) ->
-    is_exist(?ROOT_KEY_ACTIONS, Type, Name).
+is_source_exist(Namespace, Type, Name) ->
+    is_exist(Namespace, ?ROOT_KEY_SOURCES, Type, Name).
 
-is_source_exist(Type, Name) ->
-    is_exist(?ROOT_KEY_SOURCES, Type, Name).
+is_exist(Namespace, ConfRootName, Type, Name) ->
+    {error, not_found} =/= lookup_raw_conf(Namespace, ConfRootName, Type, Name).
 
-is_exist(ConfRootName, Type, Name) ->
-    {error, not_found} =/= lookup_raw_conf(ConfRootName, Type, Name).
-
-lookup_raw_conf(ConfRootName, Type, Name) ->
-    case emqx:get_raw_config([ConfRootName, Type, Name], not_found) of
+lookup_raw_conf(Namespace, ConfRootName, Type, Name) ->
+    case get_raw_config(Namespace, [ConfRootName, Type, Name], not_found) of
         not_found ->
             {error, not_found};
         #{<<"connector">> := _} = RawConf ->
             {ok, RawConf}
     end.
 
--spec lookup(root_cfg_key(), bridge_v2_type(), bridge_v2_name()) ->
+-spec lookup(maybe_namespace(), root_cfg_key(), bridge_v2_type(), bridge_v2_name()) ->
     {ok, bridge_v2_info()} | {error, not_found}.
-lookup(ConfRootName, Type, Name) ->
-    case emqx:get_raw_config([ConfRootName, Type, Name], not_found) of
+lookup(Namespace, ConfRootName, Type, Name) ->
+    case get_raw_config(Namespace, [ConfRootName, Type, Name], not_found) of
         not_found ->
             {error, not_found};
-        #{<<"connector">> := BridgeConnector} = RawConf ->
+        #{<<"connector">> := ConnectorName} = RawConf ->
             ConnectorId = emqx_connector_resource:resource_id(
-                connector_type(Type), BridgeConnector
+                Namespace, connector_type(Type), ConnectorName
             ),
             %% The connector should always exist
             %% ... but, in theory, there might be no channels associated to it when we try
@@ -276,7 +305,9 @@ lookup(ConfRootName, Type, Name) ->
             %% Find the Bridge V2 status from the ConnectorData
             ConnectorStatus = maps:get(status, ConnectorData, undefined),
             Channels = maps:get(added_channels, ConnectorData, #{}),
-            BridgeV2Id = id_with_root_name(ConfRootName, Type, Name, BridgeConnector),
+            BridgeV2Id = id_with_root_and_connector_names(
+                Namespace, ConfRootName, Type, Name, ConnectorName
+            ),
             ChannelStatus = maps:get(BridgeV2Id, Channels, undefined),
             {DisplayBridgeV2Status, ErrorMsg} =
                 case {ChannelStatus, ConnectorStatus} of
@@ -305,23 +336,27 @@ lookup(ConfRootName, Type, Name) ->
             }}
     end.
 
+%% Deprecated RPC target (`emqx_bridge_proto_v5`).
 -spec list() -> [bridge_v2_info()] | {error, term()}.
 list() ->
-    list_with_lookup_fun(?ROOT_KEY_ACTIONS, fun lookup/2).
+    list(?ROOT_KEY_ACTIONS).
 
+%% Deprecated RPC target (`emqx_bridge_proto_v{6,7}`).
 list(ConfRootKey) ->
+    list(?global_ns, ConfRootKey).
+
+-spec list(maybe_namespace(), root_cfg_key()) -> [bridge_v2_info()] | {error, term()}.
+list(Namespace, ConfRootKey) ->
     LookupFun = fun(Type, Name) ->
-        lookup(ConfRootKey, Type, Name)
+        lookup(Namespace, ConfRootKey, Type, Name)
     end,
-    list_with_lookup_fun(ConfRootKey, LookupFun).
+    list_with_lookup_fun(Namespace, ConfRootKey, LookupFun).
 
--spec create(bridge_v2_type(), bridge_v2_name(), map()) ->
+-spec create(maybe_namespace(), root_cfg_key(), bridge_v2_type(), bridge_v2_name(), map()) ->
     {ok, emqx_config:update_result()} | {error, any()}.
-create(BridgeType, BridgeName, RawConf) ->
-    create(?ROOT_KEY_ACTIONS, BridgeType, BridgeName, RawConf).
-
-create(ConfRootKey, BridgeType, BridgeName, RawConf0) ->
+create(Namespace, ConfRootKey, BridgeType, BridgeName, RawConf0) ->
     ?SLOG(debug, #{
+        namespace => Namespace,
         bridge_action => create,
         bridge_version => 2,
         bridge_type => BridgeType,
@@ -334,39 +369,33 @@ create(ConfRootKey, BridgeType, BridgeName, RawConf0) ->
     emqx_conf:update(
         [ConfRootKey, BridgeType, BridgeName],
         RawConf,
-        #{override_to => cluster}
+        with_namespace(#{override_to => cluster}, Namespace)
     ).
 
--spec remove(bridge_v2_type(), bridge_v2_name()) -> ok | {error, any()}.
-remove(BridgeType, BridgeName) ->
-    %% NOTE: This function can cause broken references from rules but it is only
-    %% called directly from test cases.
-    remove(?ROOT_KEY_ACTIONS, BridgeType, BridgeName).
-
-remove(ConfRootKey, BridgeType, BridgeName) ->
+-spec remove(maybe_namespace(), root_cfg_key(), bridge_v2_type(), bridge_v2_name()) ->
+    ok | {error, any()}.
+remove(Namespace, ConfRootKey, BridgeType, BridgeName) ->
     ?SLOG(debug, #{
         bridge_action => remove,
         bridge_version => 2,
+        namespace => Namespace,
         bridge_type => BridgeType,
         bridge_name => BridgeName
     }),
-    case
-        emqx_conf:remove(
-            [ConfRootKey, BridgeType, BridgeName],
-            #{override_to => cluster}
-        )
-    of
+    Res = emqx_conf:remove(
+        [ConfRootKey, BridgeType, BridgeName],
+        with_namespace(#{override_to => cluster}, Namespace)
+    ),
+    case Res of
         {ok, _} -> ok;
         {error, Reason} -> {error, Reason}
     end.
 
--spec check_deps_and_remove(bridge_v2_type(), bridge_v2_name(), boolean()) -> ok | {error, any()}.
-check_deps_and_remove(BridgeType, BridgeName, AlsoDeleteActions) ->
-    check_deps_and_remove(?ROOT_KEY_ACTIONS, BridgeType, BridgeName, AlsoDeleteActions).
-
--spec check_deps_and_remove(root_cfg_key(), bridge_v2_type(), bridge_v2_name(), boolean()) ->
+-spec check_deps_and_remove(
+    maybe_namespace(), root_cfg_key(), bridge_v2_type(), bridge_v2_name(), boolean()
+) ->
     ok | {error, any()}.
-check_deps_and_remove(ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions) ->
+check_deps_and_remove(Namespace, ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions) ->
     AlsoDelete =
         case AlsoDeleteActions of
             true -> [rule_actions];
@@ -374,6 +403,7 @@ check_deps_and_remove(ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions) ->
         end,
     case
         maybe_withdraw_rule_action(
+            Namespace,
             ConfRootKey,
             BridgeType,
             BridgeName,
@@ -381,7 +411,7 @@ check_deps_and_remove(ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions) ->
         )
     of
         ok ->
-            remove(ConfRootKey, BridgeType, BridgeName);
+            remove(Namespace, ConfRootKey, BridgeType, BridgeName);
         {error, Reason} ->
             {error, Reason}
     end.
@@ -390,10 +420,11 @@ check_deps_and_remove(ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions) ->
 %% Helpers for CRUD API
 %%--------------------------------------------------------------------
 
-maybe_withdraw_rule_action(ConfRootKey, BridgeType, BridgeName, DeleteDeps) ->
-    BridgeIds = emqx_bridge_lib:external_ids(ConfRootKey, BridgeType, BridgeName),
+maybe_withdraw_rule_action(Namespace, ConfRootKey, BridgeType, BridgeName, DeleteDeps) ->
+    BridgeIds = emqx_bridge_lib:external_ids(Namespace, ConfRootKey, BridgeType, BridgeName),
     DeleteActions = lists:member(rule_actions, DeleteDeps),
     GetFn =
+        %% TODO: namespace
         case ConfRootKey of
             ?ROOT_KEY_ACTIONS ->
                 fun emqx_rule_engine:get_rule_ids_by_bridge_action/1;
@@ -424,7 +455,7 @@ maybe_withdraw_rule_action_loop([BridgeId | More], DeleteActions, GetFn) ->
             }}
     end.
 
-list_with_lookup_fun(ConfRootName, LookupFun) ->
+list_with_lookup_fun(Namespace, ConfRootName, LookupFun) ->
     maps:fold(
         fun(Type, NameAndConf, Bridges) ->
             maps:fold(
@@ -447,10 +478,11 @@ list_with_lookup_fun(ConfRootName, LookupFun) ->
             )
         end,
         [],
-        emqx:get_raw_config([ConfRootName], #{})
+        get_raw_config(Namespace, [ConfRootName], #{})
     ).
 
 install_bridge_v2(
+    _Namespace,
     _RootName,
     _BridgeType,
     _BridgeName,
@@ -458,37 +490,42 @@ install_bridge_v2(
 ) ->
     ok;
 install_bridge_v2(
+    Namespace,
     RootName,
     BridgeV2Type,
     BridgeName,
     Config
 ) ->
-    install_bridge_v2_helper(
-        RootName,
+    CombinedConfig = combine_connector_and_bridge_v2_config(
+        Namespace,
         BridgeV2Type,
         BridgeName,
-        combine_connector_and_bridge_v2_config(
-            BridgeV2Type,
-            BridgeName,
-            Config
-        )
-    ).
+        Config
+    ),
+    case CombinedConfig of
+        {error, Reason} = Error ->
+            ?SLOG(warning, Reason),
+            Error;
+        #{} ->
+            install_bridge_v2_helper(
+                Namespace,
+                RootName,
+                BridgeV2Type,
+                BridgeName,
+                CombinedConfig
+            )
+    end.
 
 install_bridge_v2_helper(
-    _RootName,
-    _BridgeV2Type,
-    _BridgeName,
-    {error, Reason} = Error
-) ->
-    ?SLOG(warning, Reason),
-    Error;
-install_bridge_v2_helper(
+    Namespace,
     RootName,
     BridgeV2Type,
     BridgeName,
     #{connector := ConnectorName} = Config
 ) ->
-    BridgeV2Id = id_with_root_name(RootName, BridgeV2Type, BridgeName, ConnectorName),
+    BridgeV2Id = id_with_root_and_connector_names(
+        Namespace, RootName, BridgeV2Type, BridgeName, ConnectorName
+    ),
     CreationOpts = emqx_resource:fetch_creation_opts(Config),
     %% Create metrics for Bridge V2
     ok = emqx_resource:create_metrics(BridgeV2Id),
@@ -508,7 +545,7 @@ install_bridge_v2_helper(
     end,
     %% If there is a running connector, we need to install the Bridge V2 in it
     ConnectorId = emqx_connector_resource:resource_id(
-        connector_type(BridgeV2Type), ConnectorName
+        Namespace, connector_type(BridgeV2Type), ConnectorName
     ),
     _ = emqx_resource_manager:add_channel_async(
         ConnectorId,
@@ -548,6 +585,7 @@ source_hookpoint(BridgeId) ->
     <<"$sources/", (bin(BridgeId))/binary>>.
 
 uninstall_bridge_v2(
+    _Namespace,
     _ConfRootKey,
     _BridgeType,
     _BridgeName,
@@ -556,33 +594,58 @@ uninstall_bridge_v2(
     %% Already not installed
     ok;
 uninstall_bridge_v2(
+    Namespace,
     ConfRootKey,
     BridgeV2Type,
     BridgeName,
     #{connector := ConnectorName} = Config
 ) ->
-    BridgeV2Id = id_with_root_name(ConfRootKey, BridgeV2Type, BridgeName, ConnectorName),
+    BridgeV2Id = id_with_root_and_connector_names(
+        Namespace, ConfRootKey, BridgeV2Type, BridgeName, ConnectorName
+    ),
     CreationOpts = emqx_resource:fetch_creation_opts(Config),
     ok = emqx_resource_buffer_worker_sup:stop_workers(BridgeV2Id, CreationOpts),
-    case referenced_connectors_exist(BridgeV2Type, ConnectorName, BridgeName) of
+    case referenced_connectors_exist(Namespace, BridgeV2Type, ConnectorName, BridgeName) of
         {error, _} ->
             ok;
         ok ->
             %% uninstall from connector
             ConnectorId = emqx_connector_resource:resource_id(
-                connector_type(BridgeV2Type), ConnectorName
+                Namespace, connector_type(BridgeV2Type), ConnectorName
             ),
             emqx_resource_manager:remove_channel_async(ConnectorId, BridgeV2Id)
     end.
 
 combine_connector_and_bridge_v2_config(
+    Namespace,
     BridgeV2Type,
     BridgeName,
     #{connector := ConnectorName} = BridgeV2Config
 ) ->
     ConnectorType = connector_type(BridgeV2Type),
-    try emqx_config:get([connectors, ConnectorType, to_existing_atom(ConnectorName)]) of
-        ConnectorConfig ->
+    ConnectorConfig =
+        try
+            get_config(
+                Namespace,
+                [connectors, ConnectorType, to_existing_atom(ConnectorName)],
+                undefined
+            )
+        catch
+            _:_ ->
+                %% inexistent atom = unknown name
+                undefined
+        end,
+    case ConnectorConfig of
+        undefined ->
+            alarm_connector_not_found(BridgeV2Type, BridgeName, ConnectorName),
+            {error, #{
+                reason => <<"connector_not_found_or_wrong_type">>,
+                namespace => Namespace,
+                bridge_type => BridgeV2Type,
+                bridge_name => BridgeName,
+                connector_name => ConnectorName
+            }};
+        #{} ->
             ConnectorCreationOpts = emqx_resource:fetch_creation_opts(ConnectorConfig),
             BridgeV2CreationOpts = emqx_resource:fetch_creation_opts(BridgeV2Config),
             CombinedCreationOpts0 = emqx_utils_maps:deep_merge(
@@ -591,15 +654,6 @@ combine_connector_and_bridge_v2_config(
             ),
             CombinedCreationOpts = remove_connector_only_resource_opts(CombinedCreationOpts0),
             BridgeV2Config#{resource_opts => CombinedCreationOpts}
-    catch
-        _:_ ->
-            alarm_connector_not_found(BridgeV2Type, BridgeName, ConnectorName),
-            {error, #{
-                reason => <<"connector_not_found_or_wrong_type">>,
-                bridge_type => BridgeV2Type,
-                bridge_name => BridgeName,
-                connector_name => ConnectorName
-            }}
     end.
 
 remove_connector_only_resource_opts(ResourceOpts) ->
@@ -608,21 +662,29 @@ remove_connector_only_resource_opts(ResourceOpts) ->
 %%====================================================================
 %% Operations
 %%====================================================================
--define(ENABLE_OR_DISABLE(A), (A =:= disable orelse A =:= enable)).
 
--spec disable_enable(disable | enable, bridge_v2_type(), bridge_v2_name()) ->
+-spec disable_enable(
+    maybe_namespace(), root_cfg_key(), disable | enable, bridge_v2_type(), bridge_v2_name()
+) ->
     {ok, any()} | {error, any()}.
-disable_enable(Action, BridgeType, BridgeName) when ?ENABLE_OR_DISABLE(Action) ->
-    disable_enable(?ROOT_KEY_ACTIONS, Action, BridgeType, BridgeName).
-
-disable_enable(ConfRootKey, EnableOrDisable, BridgeType, BridgeName) when
+disable_enable(Namespace, ConfRootKey, EnableOrDisable, BridgeType, BridgeName) when
     ?ENABLE_OR_DISABLE(EnableOrDisable)
 ->
     emqx_conf:update(
         [ConfRootKey, BridgeType, BridgeName],
         {EnableOrDisable, #{now => now_ms()}},
-        #{override_to => cluster}
+        with_namespace(#{override_to => cluster}, Namespace)
     ).
+
+%% Deprecated RPC target (`emqx_bridge_proto_v5`).
+-spec start(term(), term()) -> ok | {error, Reason :: term()}.
+start(ActionOrSourceType, Name) ->
+    start(?global_ns, ?ROOT_KEY_ACTIONS, ActionOrSourceType, Name).
+
+%% Deprecated RPC target (`emqx_bridge_proto_v6`).
+-spec start(root_cfg_key(), term(), term()) -> ok | {error, Reason :: term()}.
+start(ConfRootKey, ActionOrSourceType, Name) ->
+    start(?global_ns, ConfRootKey, ActionOrSourceType, Name).
 
 %% Manually start connector. This function can speed up reconnection when
 %% waiting for auto reconnection. The function forwards the start request to
@@ -630,37 +692,31 @@ disable_enable(ConfRootKey, EnableOrDisable, BridgeType, BridgeName) when
 %% starting the connector. Returns {error, Reason} if the status of the bridge
 %% is something else than connected after starting the connector or if an
 %% error occurred when the connector was started.
--spec start(term(), term()) -> ok | {error, Reason :: term()}.
-start(ActionOrSourceType, Name) ->
-    start(?ROOT_KEY_ACTIONS, ActionOrSourceType, Name).
-
--spec start(root_cfg_key(), term(), term()) -> ok | {error, Reason :: term()}.
-start(ConfRootKey, BridgeV2Type, Name) ->
+-spec start(maybe_namespace(), root_cfg_key(), term(), term()) -> ok | {error, Reason :: term()}.
+start(Namespace, ConfRootKey, BridgeV2Type, Name) ->
     ConnectorOpFun = fun(ConnectorType, ConnectorName) ->
-        emqx_connector_resource:start(?global_ns, ConnectorType, ConnectorName)
+        emqx_connector_resource:start(Namespace, ConnectorType, ConnectorName)
     end,
-    connector_operation_helper(ConfRootKey, BridgeV2Type, Name, ConnectorOpFun, true).
+    connector_operation_helper(Namespace, ConfRootKey, BridgeV2Type, Name, ConnectorOpFun, true).
 
-connector_operation_helper(ConfRootKey, BridgeV2Type, Name, ConnectorOpFun, DoHealthCheck) ->
-    connector_operation_helper_with_conf(
-        ConfRootKey,
-        BridgeV2Type,
-        Name,
-        lookup_conf(ConfRootKey, BridgeV2Type, Name),
-        ConnectorOpFun,
-        DoHealthCheck
-    ).
-
-connector_operation_helper_with_conf(
-    _ConfRootKey,
-    _BridgeV2Type,
-    _Name,
-    {error, _} = Error,
-    _ConnectorOpFun,
-    _DoHealthCheck
+connector_operation_helper(
+    Namespace, ConfRootKey, BridgeV2Type, Name, ConnectorOpFun, DoHealthCheck
 ) ->
-    Error;
+    maybe
+        #{} = PreviousConf ?= lookup_conf(Namespace, ConfRootKey, BridgeV2Type, Name),
+        connector_operation_helper_with_conf(
+            Namespace,
+            ConfRootKey,
+            BridgeV2Type,
+            Name,
+            PreviousConf,
+            ConnectorOpFun,
+            DoHealthCheck
+        )
+    end.
+
 connector_operation_helper_with_conf(
+    _Namespace,
     _ConfRootKey,
     _BridgeV2Type,
     _Name,
@@ -670,6 +726,7 @@ connector_operation_helper_with_conf(
 ) ->
     ok;
 connector_operation_helper_with_conf(
+    Namespace,
     ConfRootKey,
     BridgeV2Type,
     Name,
@@ -685,8 +742,8 @@ connector_operation_helper_with_conf(
         {true, {error, Reason}} ->
             {error, Reason};
         {true, ok} ->
-            case health_check(ConfRootKey, BridgeV2Type, Name) of
-                #{status := connected} ->
+            case health_check(Namespace, ConfRootKey, BridgeV2Type, Name) of
+                #{status := ?status_connected} ->
                     ok;
                 {error, Reason} ->
                     {error, Reason};
@@ -700,20 +757,21 @@ connector_operation_helper_with_conf(
             end
     end.
 
--spec reset_metrics(bridge_v2_type(), bridge_v2_name()) -> ok | {error, not_found}.
-reset_metrics(Type, Name) ->
-    reset_metrics(?ROOT_KEY_ACTIONS, Type, Name).
+reset_metrics(Namespace, ConfRootKey, Type, Name) ->
+    case lookup_conf(Namespace, ConfRootKey, Type, Name) of
+        #{} = PreviousConf ->
+            reset_metrics_helper(Namespace, ConfRootKey, Type, Name, PreviousConf);
+        {error, bridge_not_found} ->
+            {error, not_found}
+    end.
 
-reset_metrics(ConfRootKey, Type, Name) ->
-    reset_metrics_helper(ConfRootKey, Type, Name, lookup_conf(ConfRootKey, Type, Name)).
-
-reset_metrics_helper(_ConfRootKey, _Type, _Name, #{enable := false}) ->
+reset_metrics_helper(_Namespace, _ConfRootKey, _Type, _Name, #{enable := false}) ->
     ok;
-reset_metrics_helper(ConfRootKey, BridgeV2Type, BridgeName, #{connector := ConnectorName}) ->
-    ResourceId = id_with_root_name(ConfRootKey, BridgeV2Type, BridgeName, ConnectorName),
-    emqx_resource:reset_metrics(ResourceId);
-reset_metrics_helper(_, _, _, _) ->
-    {error, not_found}.
+reset_metrics_helper(Namespace, ConfRootKey, BridgeV2Type, BridgeName, #{connector := ConnectorName}) ->
+    ResourceId = id_with_root_and_connector_names(
+        Namespace, ConfRootKey, BridgeV2Type, BridgeName, ConnectorName
+    ),
+    emqx_resource:reset_metrics(ResourceId).
 
 get_resource_query_mode(ActionType, Config) ->
     CreationOpts = emqx_resource:fetch_creation_opts(Config),
@@ -721,40 +779,47 @@ get_resource_query_mode(ActionType, Config) ->
     ResourceMod = emqx_connector_resource:connector_to_resource_type(ConnectorType),
     emqx_resource:query_mode(ResourceMod, Config, CreationOpts).
 
--spec query(bridge_v2_type(), bridge_v2_name(), Message :: term(), QueryOpts :: map()) ->
+-spec query(
+    maybe_namespace(), bridge_v2_type(), bridge_v2_name(), Message :: term(), QueryOpts :: map()
+) ->
     term() | {error, term()}.
-query(BridgeType, BridgeName, Message, QueryOpts0) ->
-    case lookup_conf(BridgeType, BridgeName) of
+query(Namespace, Type, Name, Message, QueryOpts0) ->
+    case lookup_conf(Namespace, ?ROOT_KEY_ACTIONS, Type, Name) of
         #{enable := true} = Config0 ->
-            Config = combine_connector_and_bridge_v2_config(BridgeType, BridgeName, Config0),
-            do_query_with_enabled_config(BridgeType, BridgeName, Message, QueryOpts0, Config);
+            Config = combine_connector_and_bridge_v2_config(
+                Namespace, Type, Name, Config0
+            ),
+            case Config of
+                {error, Reason} ->
+                    ?SLOG(warning, Reason),
+                    {error, Reason};
+                #{} ->
+                    do_query_with_enabled_config(Namespace, Type, Name, Message, QueryOpts0, Config)
+            end;
         #{enable := false} ->
             {error, bridge_disabled};
         {error, bridge_not_found} ->
-            %% race
+            %% race or bad configuration (e.g.: referenced fallback action does not exist)
             {error, bridge_not_found}
     end.
 
 do_query_with_enabled_config(
-    _BridgeType, _BridgeName, _Message, _QueryOpts0, {error, Reason} = Error
-) ->
-    ?SLOG(warning, Reason),
-    Error;
-do_query_with_enabled_config(
-    BridgeType, BridgeName, Message, QueryOpts0, Config
+    Namespace, Type, Name, Message, QueryOpts0, Config
 ) ->
     ConnectorName = maps:get(connector, Config),
     FallbackActions = maps:get(fallback_actions, Config, []),
-    ConnectorType = emqx_action_info:action_type_to_connector_type(BridgeType),
-    ConnectorResId = emqx_connector_resource:resource_id(ConnectorType, ConnectorName),
+    ConnectorType = emqx_action_info:action_type_to_connector_type(Type),
+    ConnectorResId = emqx_connector_resource:resource_id(Namespace, ConnectorType, ConnectorName),
     QueryOpts = maps:merge(
-        query_opts(BridgeType, Config),
+        query_opts(Type, Config),
         QueryOpts0#{
             connector_resource_id => ConnectorResId,
             fallback_actions => FallbackActions
         }
     ),
-    BridgeV2Id = id(BridgeType, BridgeName),
+    BridgeV2Id = id_with_root_and_connector_names(
+        Namespace, ?ROOT_KEY_ACTIONS, Type, Name, ConnectorName
+    ),
     case Message of
         {send_message, Msg} ->
             emqx_resource:query(BridgeV2Id, {BridgeV2Id, Msg}, QueryOpts);
@@ -762,10 +827,12 @@ do_query_with_enabled_config(
             emqx_resource:query(BridgeV2Id, Msg, QueryOpts)
     end.
 
--spec send_message(bridge_v2_type(), bridge_v2_name(), Message :: term(), QueryOpts :: map()) ->
+-spec send_message(
+    maybe_namespace(), bridge_v2_type(), bridge_v2_name(), Message :: term(), QueryOpts :: map()
+) ->
     term() | {error, term()}.
-send_message(BridgeType, BridgeName, Message, QueryOpts0) ->
-    query(BridgeType, BridgeName, {send_message, Message}, QueryOpts0).
+send_message(Namespace, Type, Name, Message, QueryOpts0) ->
+    query(Namespace, Type, Name, {send_message, Message}, QueryOpts0).
 
 query_opts(ActionOrSourceType, Config) ->
     ConnectorType = connector_type(ActionOrSourceType),
@@ -774,25 +841,19 @@ query_opts(ActionOrSourceType, Config) ->
 
 %% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
 %% process.  Avoid doing manual health checks outside tests.
--spec health_check(BridgeType :: term(), BridgeName :: term()) ->
-    #{status := emqx_resource:resource_status(), error := term()} | {error, Reason :: term()}.
-health_check(BridgeType, BridgeName) ->
-    health_check(?ROOT_KEY_ACTIONS, BridgeType, BridgeName).
-
-%% N.B.: This ONLY for tests; actual health checks should be triggered by timers in the
-%% process.  Avoid doing manual health checks outside tests.
-health_check(ConfRootKey, BridgeType, BridgeName) ->
-    case lookup_conf(ConfRootKey, BridgeType, BridgeName) of
+health_check(Namespace, ConfRootKey, BridgeType, BridgeName) ->
+    case lookup_conf(Namespace, ConfRootKey, BridgeType, BridgeName) of
         #{
             enable := true,
             connector := ConnectorName
         } ->
             ConnectorId = emqx_connector_resource:resource_id(
-                connector_type(BridgeType), ConnectorName
+                Namespace, connector_type(BridgeType), ConnectorName
             ),
-            emqx_resource_manager:channel_health_check(
-                ConnectorId, id_with_root_name(ConfRootKey, BridgeType, BridgeName, ConnectorName)
-            );
+            ChannelId = id_with_root_and_connector_names(
+                Namespace, ConfRootKey, BridgeType, BridgeName, ConnectorName
+            ),
+            emqx_resource_manager:channel_health_check(ConnectorId, ChannelId);
         #{enable := false} ->
             {error, bridge_disabled};
         {error, bridge_not_found} ->
@@ -800,12 +861,9 @@ health_check(ConfRootKey, BridgeType, BridgeName) ->
             {error, bridge_not_found}
     end.
 
--spec create_dry_run(bridge_v2_type(), Config :: map()) -> ok | {error, term()}.
-create_dry_run(Type, Conf) ->
-    create_dry_run(?ROOT_KEY_ACTIONS, Type, Conf).
-
--spec create_dry_run(root_cfg_key(), bridge_v2_type(), Config :: map()) -> ok | {error, term()}.
-create_dry_run(ConfRootKey, Type, Conf0) ->
+-spec create_dry_run(maybe_namespace(), root_cfg_key(), bridge_v2_type(), Config :: map()) ->
+    ok | {error, term()}.
+create_dry_run(Namespace, ConfRootKey, Type, Conf0) ->
     Conf1 = maps:without([<<"name">>], Conf0),
     TypeBin = bin(Type),
     ConfRootKeyBin = bin(ConfRootKey),
@@ -821,12 +879,12 @@ create_dry_run(ConfRootKey, Type, Conf0) ->
         #{<<"connector">> := ConnectorName} = Conf1,
         %% Check that the connector exists and do the dry run if it exists
         ConnectorType = connector_type(Type),
-        case emqx:get_raw_config([connectors, ConnectorType, ConnectorName], not_found) of
+        case get_raw_config(Namespace, [connectors, ConnectorType, ConnectorName], not_found) of
             not_found ->
                 {error, iolist_to_binary(io_lib:format("Connector ~p not found", [ConnectorName]))};
             ConnectorRawConf ->
                 create_dry_run_helper(
-                    ensure_atom_root_key(ConfRootKey), Type, ConnectorRawConf, Conf1
+                    Namespace, ensure_atom_root_key(ConfRootKey), Type, ConnectorRawConf, Conf1
                 )
         end
     catch
@@ -835,13 +893,15 @@ create_dry_run(ConfRootKey, Type, Conf0) ->
             {error, Reason1}
     end.
 
-create_dry_run_helper(ConfRootKey, BridgeV2Type, ConnectorRawConf, BridgeV2RawConf) ->
+create_dry_run_helper(Namespace, ConfRootKey, BridgeV2Type, ConnectorRawConf, BridgeV2RawConf) ->
     BridgeName = ?PROBE_ID_NEW(),
     ConnectorType = connector_type(BridgeV2Type),
     OnReadyCallback =
         fun(ConnectorId) ->
             #{name := ConnectorName} = emqx_connector_resource:parse_connector_id(ConnectorId),
-            ChannelTestId = id(BridgeV2Type, BridgeName, ConnectorName),
+            ChannelTestId = id_with_root_and_connector_names(
+                Namespace, ConfRootKey, BridgeV2Type, BridgeName, ConnectorName
+            ),
             BridgeV2Conf0 = fill_defaults(
                 BridgeV2Type,
                 BridgeV2RawConf,
@@ -869,7 +929,7 @@ create_dry_run_helper(ConfRootKey, BridgeV2Type, ConnectorRawConf, BridgeV2RawCo
                         ConnectorId, ChannelTestId
                     ),
                     case HealthCheckResult of
-                        #{status := connected} ->
+                        #{status := ?status_connected} ->
                             ok;
                         #{status := Status, error := Error} ->
                             {error, {Status, Error}}
@@ -878,14 +938,9 @@ create_dry_run_helper(ConfRootKey, BridgeV2Type, ConnectorRawConf, BridgeV2RawCo
         end,
     emqx_connector_resource:create_dry_run(ConnectorType, ConnectorRawConf, OnReadyCallback).
 
--spec get_metrics(bridge_v2_type(), bridge_v2_name()) -> emqx_metrics_worker:metrics().
-get_metrics(Type, Name) ->
-    get_metrics(?ROOT_KEY_ACTIONS, Type, Name).
-
--spec get_metrics(root_cfg_key(), bridge_v2_type(), bridge_v2_name()) ->
-    emqx_metrics_worker:metrics().
-get_metrics(ConfRootKey, Type, Name) ->
-    emqx_resource:get_metrics(id_with_root_name(ConfRootKey, Type, Name)).
+get_metrics(Namespace, ConfRootKey, Type, Name) ->
+    ChanResId = lookup_chan_id_in_conf(Namespace, ConfRootKey, Type, Name),
+    emqx_resource:get_metrics(ChanResId).
 
 %%====================================================================
 %% On message publish hook (for local topics)
@@ -893,15 +948,20 @@ get_metrics(ConfRootKey, Type, Name) ->
 
 %% The following functions are more or less copied from emqx_bridge.erl
 
-reload_message_publish_hook(Bridges) ->
+reload_message_publish_hook(NamespaceOverride) ->
     ok = unload_message_publish_hook(),
-    ok = load_message_publish_hook(Bridges).
+    ok = load_message_publish_hook(NamespaceOverride).
 
 load_message_publish_hook() ->
-    Bridges = emqx:get_config([?ROOT_KEY_ACTIONS], #{}),
-    load_message_publish_hook(Bridges).
+    load_message_publish_hook(_NamespaceOverride = #{}).
 
-load_message_publish_hook(Bridges) ->
+load_message_publish_hook(NamespaceOverride) ->
+    NamespaceToRoots0 = get_root_config_from_all_namespaces(?ROOT_KEY_ACTIONS, #{}),
+    NamespaceToRoots = maps:merge(NamespaceToRoots0, NamespaceOverride),
+    RootConfigs = maps:values(NamespaceToRoots),
+    lists:foreach(fun load_message_publish_hook1/1, RootConfigs).
+
+load_message_publish_hook1(Bridges) ->
     lists:foreach(
         fun
             ({?COMPUTED, _}) ->
@@ -925,6 +985,10 @@ do_load_message_publish_hook(_Type, _Conf) ->
 unload_message_publish_hook() ->
     ok = emqx_hooks:del('message.publish', {?MODULE, on_message_publish}).
 
+%% This is a deprecated hook: it only hooks up actions that have the also deprecated
+%% `local_topic` parameters, which is a legacy config from before
+%% connectors/actions/sources were introduced.  Currently, the only official and correct
+%% way to funnel messages into actions is via rules.
 on_message_publish(Message = #message{topic = Topic, flags = Flags}) ->
     case maps:get(sys, Flags, false) of
         false ->
@@ -938,8 +1002,8 @@ on_message_publish(Message = #message{topic = Topic, flags = Flags}) ->
 send_to_matched_egress_bridges(Topic, Msg) ->
     MatchedBridgeIds = get_matched_egress_bridges(Topic),
     lists:foreach(
-        fun({Type, Name}) ->
-            try send_message(Type, Name, Msg, #{}) of
+        fun({Namespace, Type, Name}) ->
+            try send_message(Namespace, Type, Name, Msg, #{}) of
                 {error, Reason} ->
                     ?SLOG(error, #{
                         msg => "send_message_to_bridge_failed",
@@ -965,7 +1029,16 @@ send_to_matched_egress_bridges(Topic, Msg) ->
     ).
 
 get_matched_egress_bridges(Topic) ->
-    Bridges = emqx:get_config([?ROOT_KEY_ACTIONS], #{}),
+    NamespaceToActions = get_root_config_from_all_namespaces(?ROOT_KEY_ACTIONS, #{}),
+    maps:fold(
+        fun(Namespace, RootConfig, Acc) ->
+            do_get_matched_egress_bridges(Topic, Namespace, RootConfig, Acc)
+        end,
+        [],
+        NamespaceToActions
+    ).
+
+do_get_matched_egress_bridges(Topic, Namespace, RootConfig, AccIn) ->
     maps:fold(
         fun
             (?COMPUTED, _, Acc) ->
@@ -973,29 +1046,29 @@ get_matched_egress_bridges(Topic) ->
             (BType, Conf, Acc0) ->
                 maps:fold(
                     fun(BName, BConf, Acc1) ->
-                        get_matched_bridge_id(BType, BConf, Topic, BName, Acc1)
+                        get_matched_bridge_id(Namespace, BType, BConf, Topic, BName, Acc1)
                     end,
                     Acc0,
                     Conf
                 )
         end,
-        [],
-        Bridges
+        AccIn,
+        RootConfig
     ).
 
-get_matched_bridge_id(_BType, #{enable := false}, _Topic, _BName, Acc) ->
+get_matched_bridge_id(_Namespace, _BType, #{enable := false}, _Topic, _BName, Acc) ->
     Acc;
-get_matched_bridge_id(BType, Conf, Topic, BName, Acc) ->
+get_matched_bridge_id(Namespace, BType, Conf, Topic, BName, Acc) ->
     case maps:get(local_topic, Conf, undefined) of
         undefined ->
             Acc;
         Filter ->
-            do_get_matched_bridge_id(Topic, Filter, BType, BName, Acc)
+            do_get_matched_bridge_id(Namespace, Topic, Filter, BType, BName, Acc)
     end.
 
-do_get_matched_bridge_id(Topic, Filter, BType, BName, Acc) ->
+do_get_matched_bridge_id(Namespace, Topic, Filter, BType, BName, Acc) ->
     case emqx_topic:match(Topic, Filter) of
-        true -> [{BType, BName} | Acc];
+        true -> [{Namespace, BType, BName} | Acc];
         false -> Acc
     end.
 
@@ -1003,17 +1076,25 @@ do_get_matched_bridge_id(Topic, Filter, BType, BName, Acc) ->
 %% Convenience functions for connector implementations
 %%====================================================================
 
+-doc """
+Parses a binary action or source resource id into a structured map.
+
+Throws `{invalid_id, Id}` if the input `Id` has an invalid format.
+
+See [`emqx_resource:parse_channel_id/1`].
+""".
+-doc #{equiv => fun emqx_resource:parse_channel_id/1}.
+-spec parse_id(binary()) ->
+    #{
+        namespace := ?global_ns | namespace(),
+        kind := action | source,
+        type := binary(),
+        name := binary(),
+        connector_type := binary(),
+        connector_name := binary()
+    }.
 parse_id(Id) ->
-    case binary:split(Id, <<":">>, [global]) of
-        [Type, Name] ->
-            #{kind => undefined, type => Type, name => Name};
-        [<<"action">>, Type, Name | _] ->
-            #{kind => action, type => Type, name => Name};
-        [<<"source">>, Type, Name | _] ->
-            #{kind => source, type => Type, name => Name};
-        _ ->
-            error({error, iolist_to_binary(io_lib:format("Invalid id: ~p", [Id]))})
-    end.
+    emqx_resource:parse_channel_id(Id).
 
 get_channels_for_connector(ConnectorId) ->
     Actions = get_channels_for_connector(?ROOT_KEY_ACTIONS, ConnectorId),
@@ -1022,15 +1103,16 @@ get_channels_for_connector(ConnectorId) ->
 
 get_channels_for_connector(SourcesOrActions, ConnectorId) ->
     try emqx_connector_resource:parse_connector_id(ConnectorId) of
-        #{type := ConnectorType, type := ConnectorName} ->
-            RootConf = maps:keys(emqx:get_config([SourcesOrActions], #{})),
+        #{type := ConnectorType, name := ConnectorName, namespace := Namespace} ->
+            RootConf = get_config(Namespace, [SourcesOrActions], #{}),
+            Types = maps:keys(RootConf),
             RelevantBridgeV2Types = [
                 Type
-             || Type <- RootConf,
+             || Type <- Types,
                 connector_type(Type) =:= ConnectorType
             ],
             lists:flatten([
-                get_channels_for_connector(SourcesOrActions, ConnectorName, BridgeV2Type)
+                get_channels_for_connector(Namespace, SourcesOrActions, ConnectorName, BridgeV2Type)
              || BridgeV2Type <- RelevantBridgeV2Types
             ])
     catch
@@ -1040,11 +1122,13 @@ get_channels_for_connector(SourcesOrActions, ConnectorId) ->
             []
     end.
 
-get_channels_for_connector(SourcesOrActions, ConnectorName, BridgeV2Type) ->
-    BridgeV2s = emqx:get_config([SourcesOrActions, BridgeV2Type], #{}),
+get_channels_for_connector(Namespace, SourcesOrActions, ConnectorName, BridgeV2Type) ->
+    BridgeV2s = get_config(Namespace, [SourcesOrActions, BridgeV2Type], #{}),
     [
         {
-            id_with_root_name(SourcesOrActions, BridgeV2Type, Name, ConnectorName),
+            id_with_root_and_connector_names(
+                Namespace, SourcesOrActions, BridgeV2Type, Name, ConnectorName
+            ),
             augment_channel_config(SourcesOrActions, BridgeV2Type, Name, Conf)
         }
      || {Name, Conf} <- maps:to_list(BridgeV2s),
@@ -1055,19 +1139,15 @@ get_channels_for_connector(SourcesOrActions, ConnectorName, BridgeV2Type) ->
 %% ID related functions
 %%====================================================================
 
-id(BridgeType, BridgeName) ->
-    id_with_root_name(?ROOT_KEY_ACTIONS, BridgeType, BridgeName).
-
-id(BridgeType, BridgeName, ConnectorName) ->
-    id_with_root_name(?ROOT_KEY_ACTIONS, BridgeType, BridgeName, ConnectorName).
-
 source_id(BridgeType, BridgeName, ConnectorName) ->
-    id_with_root_name(?ROOT_KEY_SOURCES, BridgeType, BridgeName, ConnectorName).
+    id_with_root_and_connector_names(
+        ?global_ns, ?ROOT_KEY_SOURCES, BridgeType, BridgeName, ConnectorName
+    ).
 
-get_resource_ids(ConfRootKey, Type, Name) ->
+get_resource_ids(Namespace, ConfRootKey, Type, Name) ->
     try
         maybe
-            ChannelResId = id_with_root_name(ConfRootKey, Type, Name),
+            ChannelResId = lookup_chan_id_in_conf(Namespace, ConfRootKey, Type, Name),
             {ok, ConnResId} ?= extract_connector_id_from_bridge_v2_id(ChannelResId),
             {ok, {ConnResId, ChannelResId}}
         end
@@ -1076,10 +1156,12 @@ get_resource_ids(ConfRootKey, Type, Name) ->
             {error, Reason}
     end.
 
-id_with_root_name(RootName, BridgeType, BridgeName) ->
-    case lookup_conf(RootName, BridgeType, BridgeName) of
+lookup_chan_id_in_conf(Namespace, RootName, BridgeType, BridgeName) ->
+    case lookup_conf(Namespace, RootName, BridgeType, BridgeName) of
         #{connector := ConnectorName} ->
-            id_with_root_name(RootName, BridgeType, BridgeName, ConnectorName);
+            id_with_root_and_connector_names(
+                Namespace, RootName, BridgeType, BridgeName, ConnectorName
+            );
         {error, Reason} ->
             throw(
                 {action_source_not_found, #{
@@ -1091,14 +1173,20 @@ id_with_root_name(RootName, BridgeType, BridgeName) ->
             )
     end.
 
-id_with_root_name(RootName0, BridgeType, BridgeName, ConnectorName) ->
+id_with_root_and_connector_names(Namespace, RootName0, BridgeType, BridgeName, ConnectorName) ->
     RootName =
         case bin(RootName0) of
             <<"actions">> -> <<"action">>;
             <<"sources">> -> <<"source">>
         end,
     ConnectorType = bin(connector_type(BridgeType)),
+    NSTag =
+        case is_binary(Namespace) of
+            true -> <<"ns:", Namespace/binary, ":">>;
+            false -> <<"">>
+        end,
     <<
+        NSTag/binary,
         (bin(RootName))/binary,
         ":",
         (bin(BridgeType))/binary,
@@ -1161,22 +1249,24 @@ config_key_path_leaf_sources() ->
     [?ROOT_KEY_SOURCES, '?', '?'].
 
 %% enable or disable action
-pre_config_update([ConfRootKey, _Type, _Name], Oper, undefined) when
+pre_config_update([ConfRootKey, _Type, _Name], Oper, undefined, _ExtraContext) when
     ?ENABLE_OR_DISABLE(Oper) andalso
         (ConfRootKey =:= ?ROOT_KEY_ACTIONS orelse ConfRootKey =:= ?ROOT_KEY_SOURCES)
 ->
     {error, bridge_not_found};
-pre_config_update([ConfRootKey, _Type, _Name], {Oper, #{}}, undefined) when
+pre_config_update([ConfRootKey, _Type, _Name], {Oper, #{}}, undefined, _ExtraContext) when
     ?ENABLE_OR_DISABLE(Oper) andalso
         (ConfRootKey =:= ?ROOT_KEY_ACTIONS orelse ConfRootKey =:= ?ROOT_KEY_SOURCES)
 ->
     {error, bridge_not_found};
-pre_config_update([ConfRootKey, _Type, _Name], Oper, OldAction) when
+pre_config_update([ConfRootKey, _Type, _Name], Oper, OldAction, _ExtraContext) when
     ?ENABLE_OR_DISABLE(Oper) andalso
         (ConfRootKey =:= ?ROOT_KEY_ACTIONS orelse ConfRootKey =:= ?ROOT_KEY_SOURCES)
 ->
     {ok, OldAction#{<<"enable">> => operation_to_enable(Oper)}};
-pre_config_update([ConfRootKey, _Type, _Name], {Oper, #{now := NowMS}}, OldAction) when
+pre_config_update(
+    [ConfRootKey, _Type, _Name], {Oper, #{now := NowMS}}, OldAction, _ExtraContext
+) when
     ?ENABLE_OR_DISABLE(Oper) andalso
         (ConfRootKey =:= ?ROOT_KEY_ACTIONS orelse ConfRootKey =:= ?ROOT_KEY_SOURCES)
 ->
@@ -1187,33 +1277,36 @@ pre_config_update([ConfRootKey, _Type, _Name], {Oper, #{now := NowMS}}, OldActio
     {ok, Action};
 %% Updates a single action from a specific HTTP API.
 %% If the connector is not found, the update operation fails.
-pre_config_update([ConfRootKey, Type, Name], Conf = #{}, _OldConf) when
+pre_config_update([ConfRootKey, Type, Name], Conf = #{}, _OldConf, ExtraContext) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS orelse ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
-    convert_from_connector(ConfRootKey, Type, Name, Conf);
+    Namespace = emqx_config_handler:get_namespace(ExtraContext),
+    convert_from_connector(Namespace, ConfRootKey, Type, Name, Conf);
 %% Batch updates actions when importing a configuration or executing a CLI command.
 %% Update succeeded even if the connector is not found, alarm in post_config_update
-pre_config_update([ConfRootKey], Conf = #{}, OldConfs) when
+pre_config_update([ConfRootKey], Conf = #{}, OldConfs, ExtraContext) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS orelse ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
-    {ok, convert_from_connectors(ConfRootKey, Conf, OldConfs)}.
+    Namespace = emqx_config_handler:get_namespace(ExtraContext),
+    {ok, convert_from_connectors(Namespace, ConfRootKey, Conf, OldConfs)}.
 
 %% This top level handler will be triggered when the actions path is updated
 %% with calls to emqx_conf:update([actions], BridgesConf, #{}).
-post_config_update([ConfRootKey], _Req, NewConf, OldConf, _AppEnv) when
+post_config_update([ConfRootKey], _Req, NewConf, OldConf, _AppEnv, ExtraContext) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS; ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
+    Namespace = emqx_config_handler:get_namespace(ExtraContext),
     #{added := Added, removed := Removed, changed := Updated} =
         diff_confs(NewConf, OldConf),
     RemoveFun = fun(Type, Name, Conf) ->
-        uninstall_bridge_v2(ConfRootKey, Type, Name, Conf)
+        uninstall_bridge_v2(Namespace, ConfRootKey, Type, Name, Conf)
     end,
     CreateFun = fun(Type, Name, Conf) ->
-        install_bridge_v2(ConfRootKey, Type, Name, Conf)
+        install_bridge_v2(Namespace, ConfRootKey, Type, Name, Conf)
     end,
     UpdateFun = fun(Type, Name, {OldBridgeConf, Conf}) ->
-        _ = uninstall_bridge_v2(ConfRootKey, Type, Name, OldBridgeConf),
-        install_bridge_v2(ConfRootKey, Type, Name, Conf)
+        _ = uninstall_bridge_v2(Namespace, ConfRootKey, Type, Name, OldBridgeConf),
+        install_bridge_v2(Namespace, ConfRootKey, Type, Name, Conf)
     end,
     Result = perform_bridge_changes([
         #{action => RemoveFun, action_name => remove, data => Removed},
@@ -1221,55 +1314,64 @@ post_config_update([ConfRootKey], _Req, NewConf, OldConf, _AppEnv) when
             action => CreateFun,
             action_name => create,
             data => Added,
-            on_exception_fn => fun emqx_bridge_resource:remove/4
+            on_exception_fn => fun(Type, Name, Conf, _Opts) ->
+                RemoveFun(Type, Name, Conf)
+            end
         },
         #{action => UpdateFun, action_name => update, data => Updated}
     ]),
-    reload_message_publish_hook(NewConf),
+    reload_message_publish_hook(#{Namespace => NewConf}),
     ?tp(bridge_post_config_update_done, #{}),
     Result;
 %% Don't crash even when the bridge is not found
-post_config_update([ConfRootKey, Type, Name], '$remove', _, _OldConf, _AppEnvs) when
+post_config_update([ConfRootKey, Type, Name], '$remove', _, _OldConf, _AppEnvs, ExtraContext) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS; ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
-    AllBridges = emqx:get_config([ConfRootKey]),
+    Namespace = emqx_config_handler:get_namespace(ExtraContext),
+    AllBridges = get_config(Namespace, [ConfRootKey], #{}),
     case emqx_utils_maps:deep_get([Type, Name], AllBridges, undefined) of
         undefined ->
             ok;
         Action ->
-            ok = uninstall_bridge_v2(ConfRootKey, Type, Name, Action),
+            ok = uninstall_bridge_v2(Namespace, ConfRootKey, Type, Name, Action),
             Bridges = emqx_utils_maps:deep_remove([Type, Name], AllBridges),
-            reload_message_publish_hook(Bridges)
+            reload_message_publish_hook(#{Namespace => Bridges})
     end,
     ?tp(bridge_post_config_update_done, #{}),
     ok;
 %% Create a single bridge fails if the connector is not found (already checked in pre_config_update)
-post_config_update([ConfRootKey, BridgeType, BridgeName], _Req, NewConf, undefined, _AppEnvs) when
+post_config_update(
+    [ConfRootKey, BridgeType, BridgeName], _Req, NewConf, undefined, _AppEnvs, ExtraContext
+) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS; ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
-    ok = install_bridge_v2(ConfRootKey, BridgeType, BridgeName, NewConf),
+    Namespace = emqx_config_handler:get_namespace(ExtraContext),
+    ok = install_bridge_v2(Namespace, ConfRootKey, BridgeType, BridgeName, NewConf),
+    PreviousConfig = get_config(Namespace, [ConfRootKey], #{}),
     Bridges = emqx_utils_maps:deep_put(
-        [BridgeType, BridgeName], emqx:get_config([ConfRootKey]), NewConf
+        [BridgeType, BridgeName], PreviousConfig, NewConf
     ),
-    reload_message_publish_hook(Bridges),
+    reload_message_publish_hook(#{Namespace => Bridges}),
     ?tp(bridge_post_config_update_done, #{}),
     ok;
 %% update bridges fails if the connector is not found (already checked in pre_config_update)
-post_config_update([ConfRootKey, BridgeType, BridgeName], _Req, NewConf, OldConf, _AppEnvs) when
+post_config_update(
+    [ConfRootKey, BridgeType, BridgeName], _Req, NewConf, OldConf, _AppEnvs, ExtraContext
+) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS; ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
-    case uninstall_bridge_v2(ConfRootKey, BridgeType, BridgeName, OldConf) of
+    Namespace = emqx_config_handler:get_namespace(ExtraContext),
+    case uninstall_bridge_v2(Namespace, ConfRootKey, BridgeType, BridgeName, OldConf) of
         ok ->
             ok;
         {error, not_found} ->
             %% Should not happen, unless config is inconsistent.
             throw(<<"Referenced connector not found">>)
     end,
-    ok = install_bridge_v2(ConfRootKey, BridgeType, BridgeName, NewConf),
-    Bridges = emqx_utils_maps:deep_put(
-        [BridgeType, BridgeName], emqx:get_config([ConfRootKey]), NewConf
-    ),
-    reload_message_publish_hook(Bridges),
+    ok = install_bridge_v2(Namespace, ConfRootKey, BridgeType, BridgeName, NewConf),
+    PreviousRootConf = get_config(Namespace, [ConfRootKey], #{}),
+    Bridges = emqx_utils_maps:deep_put([BridgeType, BridgeName], PreviousRootConf, NewConf),
+    reload_message_publish_hook(#{Namespace => Bridges}),
     ?tp(bridge_post_config_update_done, #{}),
     ok.
 
@@ -1376,7 +1478,7 @@ bridge_v1_is_valid(?ROOT_KEY_SOURCES, rabbitmq, _BridgeName) ->
     false;
 bridge_v1_is_valid(ConfRootKey, BridgeV1Type, BridgeName) ->
     BridgeV2Type = ?MODULE:bridge_v1_type_to_bridge_v2_type(BridgeV1Type),
-    case lookup_conf(ConfRootKey, BridgeV2Type, BridgeName) of
+    case lookup_conf(?global_ns, ConfRootKey, BridgeV2Type, BridgeName) of
         {error, _} ->
             %% If the bridge v2 does not exist, it is a valid bridge v1
             true;
@@ -1400,7 +1502,10 @@ is_bridge_v2_type(Type) ->
     emqx_action_info:is_action_type(Type).
 
 bridge_v1_list_and_transform() ->
+    %% deprecated, legacy V1 shall not support namespaced resources.
+    GlobalNamespace = ?global_ns,
     BridgesFromActions0 = list_with_lookup_fun(
+        GlobalNamespace,
         ?ROOT_KEY_ACTIONS,
         fun bridge_v1_lookup_and_transform/2
     ),
@@ -1411,6 +1516,7 @@ bridge_v1_list_and_transform() ->
     ],
     FromActionsNames = maps:from_keys([Name || #{name := Name} <- BridgesFromActions1], true),
     BridgesFromSources0 = list_with_lookup_fun(
+        GlobalNamespace,
         ?ROOT_KEY_SOURCES,
         fun bridge_v1_lookup_and_transform/2
     ),
@@ -1456,10 +1562,11 @@ bridge_v1_lookup_and_transform(ActionType, Name) ->
             Error
     end.
 
+%% legacy bridge v1 helper
 lookup_in_actions_or_sources(ActionType, Name) ->
-    case lookup(?ROOT_KEY_ACTIONS, ActionType, Name) of
+    case lookup(?global_ns, ?ROOT_KEY_ACTIONS, ActionType, Name) of
         {error, not_found} ->
-            case lookup(?ROOT_KEY_SOURCES, ActionType, Name) of
+            case lookup(?global_ns, ?ROOT_KEY_SOURCES, ActionType, Name) of
                 {ok, SourceInfo} ->
                     {ok, ?ROOT_KEY_SOURCES, SourceInfo};
                 Error ->
@@ -1506,9 +1613,9 @@ bridge_v1_lookup_and_transform_helper(
     ResourceData2 = maps:put(id, BridgeV1Id, ResourceData1),
     ConnectorStatus = maps:get(status, ResourceData2, undefined),
     case ConnectorStatus of
-        connected ->
+        ?status_connected ->
             case BridgeV2Status of
-                connected ->
+                ?status_connected ->
                     %% No need to modify the status
                     {ok, BridgeV1#{resource_data => ResourceData2}};
                 NotConnected ->
@@ -1522,12 +1629,18 @@ bridge_v1_lookup_and_transform_helper(
             {ok, BridgeV1#{resource_data => ResourceData2}}
     end.
 
-lookup_conf(Type, Name) ->
-    lookup_conf(?ROOT_KEY_ACTIONS, Type, Name).
+lookup_conf(Namespace, RootName, Type, Name) ->
+    case get_config(Namespace, [RootName, Type, Name], not_found) of
+        not_found ->
+            {error, bridge_not_found};
+        Config ->
+            Config
+    end.
 
+%% helper for deprecated bridge v1 api
 lookup_conf_if_exists_in_exactly_one_of_sources_and_actions(Type, Name) ->
-    LookUpConfActions = lookup_conf(?ROOT_KEY_ACTIONS, Type, Name),
-    LookUpConfSources = lookup_conf(?ROOT_KEY_SOURCES, Type, Name),
+    LookUpConfActions = lookup_conf(?global_ns, ?ROOT_KEY_ACTIONS, Type, Name),
+    LookUpConfSources = lookup_conf(?global_ns, ?ROOT_KEY_SOURCES, Type, Name),
     case {LookUpConfActions, LookUpConfSources} of
         {{error, bridge_not_found}, {error, bridge_not_found}} ->
             {error, bridge_not_found};
@@ -1539,9 +1652,10 @@ lookup_conf_if_exists_in_exactly_one_of_sources_and_actions(Type, Name) ->
             {error, name_conflict_sources_actions}
     end.
 
+%% helper for deprecated bridge v1 api
 is_only_source(BridgeType, BridgeName) ->
-    LookUpConfActions = lookup_conf(?ROOT_KEY_ACTIONS, BridgeType, BridgeName),
-    LookUpConfSources = lookup_conf(?ROOT_KEY_SOURCES, BridgeType, BridgeName),
+    LookUpConfActions = lookup_conf(?global_ns, ?ROOT_KEY_ACTIONS, BridgeType, BridgeName),
+    LookUpConfSources = lookup_conf(?global_ns, ?ROOT_KEY_SOURCES, BridgeType, BridgeName),
     case {LookUpConfActions, LookUpConfSources} of
         {{error, bridge_not_found}, {error, bridge_not_found}} ->
             false;
@@ -1553,9 +1667,9 @@ is_only_source(BridgeType, BridgeName) ->
             false
     end.
 
-get_conf_root_key_if_only_one(BridgeType, BridgeName) ->
-    LookUpConfActions = lookup_conf(?ROOT_KEY_ACTIONS, BridgeType, BridgeName),
-    LookUpConfSources = lookup_conf(?ROOT_KEY_SOURCES, BridgeType, BridgeName),
+get_conf_root_key_if_only_one(Namespace, BridgeType, BridgeName) ->
+    LookUpConfActions = lookup_conf(Namespace, ?ROOT_KEY_ACTIONS, BridgeType, BridgeName),
+    LookUpConfSources = lookup_conf(Namespace, ?ROOT_KEY_SOURCES, BridgeType, BridgeName),
     case {LookUpConfActions, LookUpConfSources} of
         {{error, bridge_not_found}, {error, bridge_not_found}} ->
             error({action_or_source_not_found, BridgeType, BridgeName});
@@ -1565,14 +1679,6 @@ get_conf_root_key_if_only_one(BridgeType, BridgeName) ->
             ?ROOT_KEY_ACTIONS;
         {_Conf1, _Conf2} ->
             error({name_clash_action_source, BridgeType, BridgeName})
-    end.
-
-lookup_conf(RootName, Type, Name) ->
-    case emqx:get_config([RootName, Type, Name], not_found) of
-        not_found ->
-            {error, bridge_not_found};
-        Config ->
-            Config
     end.
 
 bridge_v1_split_config_and_create(BridgeV1Type, BridgeName, RawConf) ->
@@ -1590,7 +1696,9 @@ bridge_v1_split_config_and_create(BridgeV1Type, BridgeName, RawConf) ->
                 true ->
                     %% Using remove + create as update, hence do not delete deps.
                     RemoveDeps = [],
-                    ConfRootKey = get_conf_root_key_if_only_one(BridgeV2Type, BridgeName),
+                    ConfRootKey = get_conf_root_key_if_only_one(
+                        ?global_ns, BridgeV2Type, BridgeName
+                    ),
                     PreviousRawConf = emqx:get_raw_config(
                         [ConfRootKey, BridgeV2Type, BridgeName], undefined
                     ),
@@ -1617,7 +1725,7 @@ split_bridge_v1_config_and_create_helper(
             connector_name := NewConnectorName,
             connector_conf := NewConnectorRawConf,
             bridge_v2_type := BridgeType,
-            bridge_v2_name := BridgeName,
+            bridge_v2_name := BridgeV2Name,
             bridge_v2_conf := NewBridgeV2RawConf,
             conf_root_key := ConfRootName
         } = split_and_validate_bridge_v1_config(
@@ -1627,14 +1735,13 @@ split_bridge_v1_config_and_create_helper(
             PreviousRawConf
         ),
         _ = PreCreateFun(),
-
         do_connector_and_bridge_create(
             ConfRootName,
             ConnectorType,
             NewConnectorName,
             NewConnectorRawConf,
             BridgeType,
-            BridgeName,
+            BridgeV2Name,
             NewBridgeV2RawConf,
             RawConf
         )
@@ -1643,6 +1750,7 @@ split_bridge_v1_config_and_create_helper(
             {error, Reason}
     end.
 
+%% legacy bridge v1 helper
 do_connector_and_bridge_create(
     ConfRootName,
     ConnectorType,
@@ -1655,7 +1763,15 @@ do_connector_and_bridge_create(
 ) ->
     case emqx_connector:create(?global_ns, ConnectorType, NewConnectorName, NewConnectorRawConf) of
         {ok, _} ->
-            case create(ConfRootName, BridgeType, BridgeName, NewBridgeV2RawConf) of
+            case
+                create(
+                    ?global_ns,
+                    ConfRootName,
+                    BridgeType,
+                    BridgeName,
+                    NewBridgeV2RawConf
+                )
+            of
                 {ok, _} = Result ->
                     Result;
                 {error, Reason1} ->
@@ -1694,7 +1810,7 @@ split_and_validate_bridge_v1_config(BridgeV1Type, BridgeName, RawConf, PreviousR
     },
     ConfRootKeyPrevRawConf =
         case PreviousRawConf =/= undefined of
-            true -> get_conf_root_key_if_only_one(BridgeV2Type, BridgeName);
+            true -> get_conf_root_key_if_only_one(?global_ns, BridgeV2Type, BridgeName);
             false -> not_used
         end,
     FakeGlobalConfig =
@@ -1713,7 +1829,7 @@ split_and_validate_bridge_v1_config(BridgeV1Type, BridgeName, RawConf, PreviousR
     NewBridgeV2RawConf =
         emqx_utils_maps:deep_get(
             [
-                ConfRootKey,
+                bin(ConfRootKey),
                 bin(BridgeV2Type),
                 bin(BridgeName)
             ],
@@ -1721,7 +1837,7 @@ split_and_validate_bridge_v1_config(BridgeV1Type, BridgeName, RawConf, PreviousR
         ),
     ConnectorName = emqx_utils_maps:deep_get(
         [
-            ConfRootKey,
+            bin(ConfRootKey),
             bin(BridgeV2Type),
             bin(BridgeName),
             <<"connector">>
@@ -1783,13 +1899,15 @@ split_and_validate_bridge_v1_config(BridgeV1Type, BridgeName, RawConf, PreviousR
     end.
 
 get_conf_root_key(#{<<"actions">> := _}) ->
-    <<"actions">>;
+    ?ROOT_KEY_ACTIONS;
 get_conf_root_key(#{<<"sources">> := _}) ->
-    <<"sources">>;
+    ?ROOT_KEY_SOURCES;
 get_conf_root_key(_NoMatch) ->
     error({incompatible_bridge_v1, no_action_or_source}).
 
 bridge_v1_create_dry_run(BridgeType, RawConfig0) ->
+    %% deprecated, legacy V1 shall not support namespaced resources.
+    GlobalNamespace = ?global_ns,
     RawConf = maps:without([<<"name">>], RawConfig0),
     TmpName = ?PROBE_ID_NEW(),
     PreviousRawConf = undefined,
@@ -1807,7 +1925,11 @@ bridge_v1_create_dry_run(BridgeType, RawConfig0) ->
             BridgeType, ConnectorRawConf, BridgeV2RawConf0
         ),
         create_dry_run_helper(
-            ensure_atom_root_key(ConfRootKey), BridgeV2Type, ConnectorRawConf, BridgeV2RawConf
+            GlobalNamespace,
+            ensure_atom_root_key(ConfRootKey),
+            BridgeV2Type,
+            ConnectorRawConf,
+            BridgeV2RawConf
         )
     catch
         throw:Reason ->
@@ -1828,8 +1950,8 @@ bridge_v1_remove(
     Name,
     #{connector := ConnectorName}
 ) ->
-    ConfRootKey = get_conf_root_key_if_only_one(ActionType, Name),
-    case remove(ConfRootKey, ActionType, Name) of
+    ConfRootKey = get_conf_root_key_if_only_one(?global_ns, ActionType, Name),
+    case remove(?global_ns, ConfRootKey, ActionType, Name) of
         ok ->
             ConnectorType = connector_type(ActionType),
             emqx_connector:remove(?global_ns, ConnectorType, ConnectorName);
@@ -1865,8 +1987,8 @@ bridge_v1_check_deps_and_remove(
     RemoveConnector = lists:member(connector, RemoveDeps),
     case maybe_withdraw_rule_action(BridgeType, BridgeName, RemoveDeps) of
         ok ->
-            ConfRootKey = get_conf_root_key_if_only_one(BridgeType, BridgeName),
-            case remove(ConfRootKey, BridgeType, BridgeName) of
+            ConfRootKey = get_conf_root_key_if_only_one(?global_ns, BridgeType, BridgeName),
+            case remove(?global_ns, ConfRootKey, BridgeType, BridgeName) of
                 ok when RemoveConnector ->
                     maybe_delete_channels(BridgeType, BridgeName, ConnectorName);
                 ok ->
@@ -1881,6 +2003,7 @@ bridge_v1_check_deps_and_remove(_BridgeType, _BridgeName, _RemoveDeps, Error) ->
     %% TODO: the connector is gone, for whatever reason, maybe call remove/2 anyway?
     Error.
 
+%% helper for deprecated bridge v1 api
 maybe_withdraw_rule_action(BridgeType, BridgeName, RemoveDeps) ->
     case is_only_source(BridgeType, BridgeName) of
         true ->
@@ -1889,6 +2012,7 @@ maybe_withdraw_rule_action(BridgeType, BridgeName, RemoveDeps) ->
             emqx_bridge_lib:maybe_withdraw_rule_action(BridgeType, BridgeName, RemoveDeps)
     end.
 
+%% Only used by legacy bridge v1 helpers
 maybe_delete_channels(BridgeType, BridgeName, ConnectorName) ->
     case connector_has_channels(BridgeType, ConnectorName) of
         true ->
@@ -1910,6 +2034,7 @@ maybe_delete_channels(BridgeType, BridgeName, ConnectorName) ->
             end
     end.
 
+%% Only used by legacy bridge v1 helpers
 connector_has_channels(BridgeV2Type, ConnectorName) ->
     ConnectorType = connector_type(BridgeV2Type),
     case emqx_connector_resource:get_channels(?global_ns, ConnectorType, ConnectorName) of
@@ -1926,7 +2051,7 @@ bridge_v1_id_to_connector_resource_id(ConfRootKey, BridgeId) ->
     [Type, Name] = binary:split(BridgeId, <<":">>),
     BridgeV2Type = bin(bridge_v1_type_to_bridge_v2_type(Type)),
     ConnectorName =
-        case lookup_conf(ConfRootKey, BridgeV2Type, Name) of
+        case lookup_conf(?global_ns, ConfRootKey, BridgeV2Type, Name) of
             #{connector := Con} ->
                 Con;
             {error, Reason} ->
@@ -1954,13 +2079,15 @@ bridge_v1_enable_disable_helper(enable, BridgeType, BridgeName, #{connector := C
     BridgeV2Type = ?MODULE:bridge_v1_type_to_bridge_v2_type(BridgeType),
     ConnectorType = connector_type(BridgeV2Type),
     {ok, _} = emqx_connector:disable_enable(?global_ns, enable, ConnectorType, ConnectorName),
-    ConfRootKey = get_conf_root_key_if_only_one(BridgeType, BridgeName),
-    emqx_bridge_v2:disable_enable(ConfRootKey, enable, BridgeV2Type, BridgeName);
+    ConfRootKey = get_conf_root_key_if_only_one(?global_ns, BridgeType, BridgeName),
+    emqx_bridge_v2:disable_enable(?global_ns, ConfRootKey, enable, BridgeV2Type, BridgeName);
 bridge_v1_enable_disable_helper(disable, BridgeType, BridgeName, #{connector := ConnectorName}) ->
     BridgeV2Type = emqx_bridge_v2:bridge_v1_type_to_bridge_v2_type(BridgeType),
     ConnectorType = connector_type(BridgeV2Type),
-    ConfRootKey = get_conf_root_key_if_only_one(BridgeType, BridgeName),
-    {ok, _} = emqx_bridge_v2:disable_enable(ConfRootKey, disable, BridgeV2Type, BridgeName),
+    ConfRootKey = get_conf_root_key_if_only_one(?global_ns, BridgeType, BridgeName),
+    {ok, _} = emqx_bridge_v2:disable_enable(
+        ?global_ns, ConfRootKey, disable, BridgeV2Type, BridgeName
+    ),
     emqx_connector:disable_enable(?global_ns, disable, ConnectorType, ConnectorName).
 
 bridge_v1_restart(BridgeV1Type, Name) ->
@@ -1982,11 +2109,14 @@ bridge_v1_start(BridgeV1Type, Name) ->
     bridge_v1_operation_helper(BridgeV1Type, Name, ConnectorOpFun, true).
 
 bridge_v1_operation_helper(BridgeV1Type, Name, ConnectorOpFun, DoHealthCheck) ->
+    %% deprecated, legacy V1 shall not support namespaced resources.
+    GlobalNamespace = ?global_ns,
     BridgeV2Type = ?MODULE:bridge_v1_type_to_bridge_v2_type(BridgeV1Type),
     case emqx_bridge_v2:bridge_v1_is_valid(BridgeV1Type, Name) of
         true ->
-            ConfRootKey = get_conf_root_key_if_only_one(BridgeV2Type, Name),
+            ConfRootKey = get_conf_root_key_if_only_one(GlobalNamespace, BridgeV2Type, Name),
             connector_operation_helper_with_conf(
+                GlobalNamespace,
                 ConfRootKey,
                 BridgeV2Type,
                 Name,
@@ -2001,9 +2131,9 @@ bridge_v1_operation_helper(BridgeV1Type, Name, ConnectorOpFun, DoHealthCheck) ->
 bridge_v1_reset_metrics(BridgeV1Type, BridgeName) ->
     BridgeV2Type = bridge_v1_type_to_bridge_v2_type(BridgeV1Type),
     ConfRootKey = get_conf_root_key_if_only_one(
-        BridgeV2Type, BridgeName
+        ?global_ns, BridgeV2Type, BridgeName
     ),
-    ok = reset_metrics(ConfRootKey, BridgeV2Type, BridgeName).
+    ok = reset_metrics(?global_ns, ConfRootKey, BridgeV2Type, BridgeName).
 
 %%====================================================================
 %% Misc helper functions
@@ -2017,14 +2147,7 @@ bin(Str) when is_list(Str) -> list_to_binary(Str);
 bin(Atom) when is_atom(Atom) -> atom_to_binary(Atom, utf8).
 
 extract_connector_id_from_bridge_v2_id(Id) ->
-    case binary:split(Id, <<":">>, [global]) of
-        [<<"action">>, _Type, _Name, <<"connector">>, ConnectorType, ConnecorName] ->
-            {ok, <<"connector:", ConnectorType/binary, ":", ConnecorName/binary>>};
-        [<<"source">>, _Type, _Name, <<"connector">>, ConnectorType, ConnecorName] ->
-            {ok, <<"connector:", ConnectorType/binary, ":", ConnecorName/binary>>};
-        _X ->
-            {error, iolist_to_binary(io_lib:format("Invalid action ID: ~p", [Id]))}
-    end.
+    emqx_resource:parse_connector_id_from_channel_id(Id).
 
 ensure_atom_root_key(ConfRootKey) when is_atom(ConfRootKey) ->
     ConfRootKey;
@@ -2039,13 +2162,14 @@ to_existing_atom(X) ->
         {error, _} -> throw(bad_atom)
     end.
 
-referenced_connectors_exist(BridgeType, ConnectorNameBin, BridgeName) ->
+referenced_connectors_exist(Namespace, BridgeType, ConnectorNameBin, BridgeName) ->
     %% N.B.: assumes that, for all bridgeV2 types, the name of the bridge type is
     %% identical to its matching connector type name.
-    case get_connector_info(ConnectorNameBin, BridgeType) of
+    case get_connector_info(Namespace, ConnectorNameBin, BridgeType) of
         {error, not_found} ->
             {error, #{
                 reason => "connector_not_found_or_wrong_type",
+                namespace => Namespace,
                 connector_name => ConnectorNameBin,
                 bridge_name => BridgeName,
                 bridge_type => BridgeType
@@ -2054,7 +2178,7 @@ referenced_connectors_exist(BridgeType, ConnectorNameBin, BridgeName) ->
             ok
     end.
 
-convert_from_connectors(ConfRootKey, Conf, OldRootConfig) ->
+convert_from_connectors(Namespace, ConfRootKey, Conf, OldRootConfig) ->
     maps:map(
         fun(ActionType, Actions) ->
             maps:map(
@@ -2063,7 +2187,11 @@ convert_from_connectors(ConfRootKey, Conf, OldRootConfig) ->
                     Action = ensure_last_modified_at(
                         Action1, ActionType, ActionName, OldRootConfig
                     ),
-                    case convert_from_connector(ConfRootKey, ActionType, ActionName, Action) of
+                    case
+                        convert_from_connector(
+                            Namespace, ConfRootKey, ActionType, ActionName, Action
+                        )
+                    of
                         {ok, NewAction} -> NewAction;
                         {error, _} -> Action
                     end
@@ -2074,8 +2202,9 @@ convert_from_connectors(ConfRootKey, Conf, OldRootConfig) ->
         Conf
     ).
 
-convert_from_connector(ConfRootKey, Type, Name, Action = #{<<"connector">> := ConnectorName}) ->
-    case get_connector_info(ConnectorName, Type) of
+convert_from_connector(Namespace, ConfRootKey, Type, Name, Action) ->
+    #{<<"connector">> := ConnectorName} = Action,
+    case get_connector_info(Namespace, ConnectorName, Type) of
         {ok, Connector} ->
             TypeAtom = to_existing_atom(Type),
             Action1 = emqx_action_info:action_convert_from_connector(TypeAtom, Connector, Action),
@@ -2108,12 +2237,12 @@ ensure_created_at(RawConfig) when is_map_key(<<"created_at">>, RawConfig) ->
 ensure_created_at(RawConfig) ->
     RawConfig#{<<"created_at">> => now_ms()}.
 
-get_connector_info(ConnectorNameBin, BridgeType) ->
+get_connector_info(Namespace, ConnectorNameBin, BridgeType) ->
     case to_connector(ConnectorNameBin, BridgeType) of
         {error, not_found} ->
             {error, not_found};
         {ConnectorName, ConnectorType} ->
-            case emqx_config:get_raw([connectors, ConnectorType, ConnectorName], undefined) of
+            case get_raw_config(Namespace, [connectors, ConnectorType, ConnectorName], undefined) of
                 undefined -> {error, not_found};
                 Connector -> {ok, Connector}
             end
@@ -2148,3 +2277,22 @@ alarm_connector_not_found(ActionType, ActionName, ConnectorName) ->
 
 now_ms() ->
     erlang:system_time(millisecond).
+
+get_config(Namespace, KeyPath, Default) when is_binary(Namespace) ->
+    emqx:get_namespaced_config(Namespace, KeyPath, Default);
+get_config(?global_ns, KeyPath, Default) ->
+    emqx:get_config(KeyPath, Default).
+
+get_raw_config(Namespace, KeyPath, Default) when is_binary(Namespace) ->
+    emqx:get_raw_namespaced_config(Namespace, KeyPath, Default);
+get_raw_config(?global_ns, KeyPath, Default) ->
+    emqx:get_raw_config(KeyPath, Default).
+
+with_namespace(UpdateOpts, ?global_ns) ->
+    UpdateOpts;
+with_namespace(UpdateOpts, Namespace) when is_binary(Namespace) ->
+    UpdateOpts#{namespace => Namespace}.
+
+get_root_config_from_all_namespaces(RootKey, Default) ->
+    NamespacedConfigs = emqx_config:get_root_from_all_namespaces(RootKey, Default),
+    NamespacedConfigs#{?global_ns => emqx:get_config([RootKey], Default)}.

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -13,6 +13,7 @@
 -include_lib("emqx_bridge/include/emqx_bridge.hrl").
 -include_lib("emqx_bridge/include/emqx_bridge_proto.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -import(hoconsc, [mk/2, array/1, enum/1]).
 -import(emqx_utils, [redact/1]).
@@ -64,11 +65,16 @@
     lookup_from_local_node_v6/3,
     get_metrics_from_local_node_v6/3,
     summary_from_local_node_v7/1,
-    wait_for_ready_local_node_v7/3
+    wait_for_ready_local_node_v7/3,
+
+    lookup_v8/4,
+    summary_v8/2,
+    wait_for_ready_v8/4,
+    get_metrics_v8/4
 ]).
 
 %% Internal exports; used by rule engine api
--export([do_handle_summary/1]).
+-export([do_handle_summary/2]).
 
 -define(BPAPI_NAME, emqx_bridge).
 
@@ -88,6 +94,8 @@
             ?NOT_FOUND(<<"Invalid bridge ID, ", Reason/binary>>)
     end
 ).
+
+-type maybe_namespace() :: ?global_ns | binary().
 
 namespace() -> "actions_and_sources".
 
@@ -754,88 +762,132 @@ refine_api_schema(Schema, ReqMeta = #{path := Path, method := Method}) ->
 %%================================================================================
 %% Actions
 %%================================================================================
-'/actions'(post, #{body := #{<<"type">> := BridgeType, <<"name">> := BridgeName} = Conf0}) ->
-    handle_create(?ROOT_KEY_ACTIONS, BridgeType, BridgeName, Conf0);
-'/actions'(get, _Params) ->
-    handle_list(?ROOT_KEY_ACTIONS).
+'/actions'(post, #{body := #{<<"type">> := BridgeType, <<"name">> := BridgeName} = Conf0} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_create(Namespace, ?ROOT_KEY_ACTIONS, BridgeType, BridgeName, Conf0);
+'/actions'(get, Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_list(Namespace, ?ROOT_KEY_ACTIONS).
 
-'/actions/:id'(get, #{bindings := #{id := Id}}) ->
-    ?TRY_PARSE_ID(Id, lookup_from_all_nodes(?ROOT_KEY_ACTIONS, BridgeType, BridgeName, 200));
-'/actions/:id'(put, #{bindings := #{id := Id}, body := Conf0}) ->
-    handle_update(?ROOT_KEY_ACTIONS, Id, Conf0);
-'/actions/:id'(delete, #{bindings := #{id := Id}, query_string := Qs}) ->
-    handle_delete(?ROOT_KEY_ACTIONS, Id, Qs).
+'/actions/:id'(get, #{bindings := #{id := Id}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    ?TRY_PARSE_ID(
+        Id, lookup_from_all_nodes(Namespace, ?ROOT_KEY_ACTIONS, BridgeType, BridgeName, 200)
+    );
+'/actions/:id'(put, #{bindings := #{id := Id}, body := Conf0} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_update(Namespace, ?ROOT_KEY_ACTIONS, Id, Conf0);
+'/actions/:id'(delete, #{bindings := #{id := Id}, query_string := Qs} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_delete(Namespace, ?ROOT_KEY_ACTIONS, Id, Qs).
 
-'/actions/:id/metrics'(get, #{bindings := #{id := Id}}) ->
-    ?TRY_PARSE_ID(Id, get_metrics_from_all_nodes(?ROOT_KEY_ACTIONS, BridgeType, BridgeName)).
+'/actions/:id/metrics'(get, #{bindings := #{id := Id}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    ?TRY_PARSE_ID(
+        Id, get_metrics_from_all_nodes(Namespace, ?ROOT_KEY_ACTIONS, BridgeType, BridgeName)
+    ).
 
-'/actions/:id/metrics/reset'(put, #{bindings := #{id := Id}}) ->
-    handle_reset_metrics(?ROOT_KEY_ACTIONS, Id).
+'/actions/:id/metrics/reset'(put, #{bindings := #{id := Id}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_reset_metrics(Namespace, ?ROOT_KEY_ACTIONS, Id).
 
-'/actions/:id/enable/:enable'(put, #{bindings := #{id := Id, enable := Enable}}) ->
-    handle_disable_enable(?ROOT_KEY_ACTIONS, Id, Enable).
+'/actions/:id/enable/:enable'(put, #{bindings := #{id := Id, enable := Enable}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_disable_enable(Namespace, ?ROOT_KEY_ACTIONS, Id, Enable).
 
-'/actions/:id/:operation'(post, #{
-    bindings :=
-        #{id := Id, operation := Op}
-}) ->
-    handle_operation(?ROOT_KEY_ACTIONS, Id, Op).
+'/actions/:id/:operation'(
+    post,
+    #{
+        bindings :=
+            #{id := Id, operation := Op}
+    } = Req
+) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_operation(Namespace, ?ROOT_KEY_ACTIONS, Id, Op).
 
-'/nodes/:node/actions/:id/:operation'(post, #{
-    bindings :=
-        #{id := Id, operation := Op, node := Node}
-}) ->
-    handle_node_operation(?ROOT_KEY_ACTIONS, Node, Id, Op).
+'/nodes/:node/actions/:id/:operation'(
+    post,
+    #{
+        bindings :=
+            #{id := Id, operation := Op, node := Node}
+    } = Req
+) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_node_operation(Namespace, ?ROOT_KEY_ACTIONS, Node, Id, Op).
 
 '/actions_probe'(post, Request) ->
-    handle_probe(?ROOT_KEY_ACTIONS, Request).
+    Namespace = emqx_dashboard:get_namespace(Request),
+    handle_probe(Namespace, ?ROOT_KEY_ACTIONS, Request).
 
-'/actions_summary'(get, _Request) ->
-    handle_summary(?ROOT_KEY_ACTIONS).
+'/actions_summary'(get, Request) ->
+    Namespace = emqx_dashboard:get_namespace(Request),
+    handle_summary(Namespace, ?ROOT_KEY_ACTIONS).
 
 '/action_types'(get, _Request) ->
     ?OK(emqx_bridge_v2_schema:action_types()).
 %%================================================================================
 %% Sources
 %%================================================================================
-'/sources'(post, #{body := #{<<"type">> := BridgeType, <<"name">> := BridgeName} = Conf0}) ->
-    handle_create(?ROOT_KEY_SOURCES, BridgeType, BridgeName, Conf0);
-'/sources'(get, _Params) ->
-    handle_list(?ROOT_KEY_SOURCES).
+'/sources'(post, #{body := #{<<"type">> := BridgeType, <<"name">> := BridgeName} = Conf0} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_create(Namespace, ?ROOT_KEY_SOURCES, BridgeType, BridgeName, Conf0);
+'/sources'(get, Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_list(Namespace, ?ROOT_KEY_SOURCES).
 
-'/sources/:id'(get, #{bindings := #{id := Id}}) ->
-    ?TRY_PARSE_ID(Id, lookup_from_all_nodes(?ROOT_KEY_SOURCES, BridgeType, BridgeName, 200));
-'/sources/:id'(put, #{bindings := #{id := Id}, body := Conf0}) ->
-    handle_update(?ROOT_KEY_SOURCES, Id, Conf0);
-'/sources/:id'(delete, #{bindings := #{id := Id}, query_string := Qs}) ->
-    handle_delete(?ROOT_KEY_SOURCES, Id, Qs).
+'/sources/:id'(get, #{bindings := #{id := Id}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    ?TRY_PARSE_ID(
+        Id, lookup_from_all_nodes(Namespace, ?ROOT_KEY_SOURCES, BridgeType, BridgeName, 200)
+    );
+'/sources/:id'(put, #{bindings := #{id := Id}, body := Conf0} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_update(Namespace, ?ROOT_KEY_SOURCES, Id, Conf0);
+'/sources/:id'(delete, #{bindings := #{id := Id}, query_string := Qs} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_delete(Namespace, ?ROOT_KEY_SOURCES, Id, Qs).
 
-'/sources/:id/metrics'(get, #{bindings := #{id := Id}}) ->
-    ?TRY_PARSE_ID(Id, get_metrics_from_all_nodes(?ROOT_KEY_SOURCES, BridgeType, BridgeName)).
+'/sources/:id/metrics'(get, #{bindings := #{id := Id}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    ?TRY_PARSE_ID(
+        Id, get_metrics_from_all_nodes(Namespace, ?ROOT_KEY_SOURCES, BridgeType, BridgeName)
+    ).
 
-'/sources/:id/metrics/reset'(put, #{bindings := #{id := Id}}) ->
-    handle_reset_metrics(?ROOT_KEY_SOURCES, Id).
+'/sources/:id/metrics/reset'(put, #{bindings := #{id := Id}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_reset_metrics(Namespace, ?ROOT_KEY_SOURCES, Id).
 
-'/sources/:id/enable/:enable'(put, #{bindings := #{id := Id, enable := Enable}}) ->
-    handle_disable_enable(?ROOT_KEY_SOURCES, Id, Enable).
+'/sources/:id/enable/:enable'(put, #{bindings := #{id := Id, enable := Enable}} = Req) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_disable_enable(Namespace, ?ROOT_KEY_SOURCES, Id, Enable).
 
-'/sources/:id/:operation'(post, #{
-    bindings :=
-        #{id := Id, operation := Op}
-}) ->
-    handle_operation(?ROOT_KEY_SOURCES, Id, Op).
+'/sources/:id/:operation'(
+    post,
+    #{
+        bindings :=
+            #{id := Id, operation := Op}
+    } = Req
+) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_operation(Namespace, ?ROOT_KEY_SOURCES, Id, Op).
 
-'/nodes/:node/sources/:id/:operation'(post, #{
-    bindings :=
-        #{id := Id, operation := Op, node := Node}
-}) ->
-    handle_node_operation(?ROOT_KEY_SOURCES, Node, Id, Op).
+'/nodes/:node/sources/:id/:operation'(
+    post,
+    #{
+        bindings :=
+            #{id := Id, operation := Op, node := Node}
+    } = Req
+) ->
+    Namespace = emqx_dashboard:get_namespace(Req),
+    handle_node_operation(Namespace, ?ROOT_KEY_SOURCES, Node, Id, Op).
 
 '/sources_probe'(post, Request) ->
-    handle_probe(?ROOT_KEY_SOURCES, Request).
+    Namespace = emqx_dashboard:get_namespace(Request),
+    handle_probe(Namespace, ?ROOT_KEY_SOURCES, Request).
 
-'/sources_summary'(get, _Request) ->
-    handle_summary(?ROOT_KEY_SOURCES).
+'/sources_summary'(get, Request) ->
+    Namespace = emqx_dashboard:get_namespace(Request),
+    handle_summary(Namespace, ?ROOT_KEY_SOURCES).
 
 '/source_types'(get, _Request) ->
     ?OK(emqx_bridge_v2_schema:source_types()).
@@ -844,9 +896,9 @@ refine_api_schema(Schema, ReqMeta = #{path := Path, method := Method}) ->
 %% Handlers
 %%------------------------------------------------------------------------------
 
-handle_list(ConfRootKey) ->
-    Nodes = nodes_supporting_bpapi_version(6),
-    NodeReplies = emqx_bridge_proto_v6:v2_list_bridges_on_nodes_v6(Nodes, ConfRootKey),
+handle_list(Namespace, ConfRootKey) ->
+    Nodes = nodes_supporting_bpapi_version(8),
+    NodeReplies = emqx_bridge_proto_v8:list(Nodes, Namespace, ConfRootKey),
     case is_ok(NodeReplies) of
         {ok, NodeBridges} ->
             AllBridges = [
@@ -858,50 +910,50 @@ handle_list(ConfRootKey) ->
             ?INTERNAL_ERROR(Reason)
     end.
 
-handle_summary(ConfRootKey) ->
-    case do_handle_summary(ConfRootKey) of
+handle_summary(Namespace, ConfRootKey) ->
+    case do_handle_summary(Namespace, ConfRootKey) of
         {ok, ZippedBridges} ->
             ?OK(ZippedBridges);
         {error, Reason} ->
             ?INTERNAL_ERROR(Reason)
     end.
 
-do_handle_summary(ConfRootKey) ->
-    Nodes = nodes_supporting_bpapi_version(7),
-    NodeReplies = emqx_bridge_proto_v7:v2_list_summary_v7(Nodes, ConfRootKey),
+do_handle_summary(Namespace, ConfRootKey) ->
+    Nodes = nodes_supporting_bpapi_version(8),
+    NodeReplies = emqx_bridge_proto_v8:summary(Nodes, Namespace, ConfRootKey),
     maybe
         {ok, AllBridges} ?= is_ok(NodeReplies),
         ZippedBridges = zip_bridges(ConfRootKey, AllBridges),
-        {ok, add_fallback_actions_references(ConfRootKey, ZippedBridges)}
+        {ok, add_fallback_actions_references(Namespace, ConfRootKey, ZippedBridges)}
     end.
 
-handle_create(ConfRootKey, Type, Name, Conf0) ->
-    case emqx_bridge_v2:is_exist(ConfRootKey, Type, Name) of
+handle_create(Namespace, ConfRootKey, Type, Name, Conf0) ->
+    case emqx_bridge_v2:is_exist(Namespace, ConfRootKey, Type, Name) of
         true ->
             ?BAD_REQUEST('ALREADY_EXISTS', <<"bridge already exists">>);
         false ->
             Conf = filter_out_request_body(Conf0),
-            create_bridge(ConfRootKey, Type, Name, Conf)
+            create_bridge(Namespace, ConfRootKey, Type, Name, Conf)
     end.
 
-handle_update(ConfRootKey, Id, Conf0) ->
+handle_update(Namespace, ConfRootKey, Id, Conf0) ->
     Conf1 = filter_out_request_body(Conf0),
     ?TRY_PARSE_ID(
         Id,
-        case emqx_bridge_v2:is_exist(ConfRootKey, BridgeType, BridgeName) of
+        case emqx_bridge_v2:is_exist(Namespace, ConfRootKey, BridgeType, BridgeName) of
             true ->
-                RawConf = emqx:get_raw_config([ConfRootKey, BridgeType, BridgeName], #{}),
+                RawConf = get_raw_config(Namespace, [ConfRootKey, BridgeType, BridgeName], #{}),
                 Conf = emqx_utils:deobfuscate(Conf1, RawConf),
-                update_bridge(ConfRootKey, BridgeType, BridgeName, Conf);
+                update_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf);
             false ->
                 ?BRIDGE_NOT_FOUND(BridgeType, BridgeName)
         end
     ).
 
-handle_delete(ConfRootKey, Id, QueryStringOpts) ->
+handle_delete(Namespace, ConfRootKey, Id, QueryStringOpts) ->
     ?TRY_PARSE_ID(
         Id,
-        case emqx_bridge_v2:is_exist(ConfRootKey, BridgeType, BridgeName) of
+        case emqx_bridge_v2:is_exist(Namespace, ConfRootKey, BridgeType, BridgeName) of
             true ->
                 AlsoDeleteActions =
                     case maps:get(<<"also_delete_dep_actions">>, QueryStringOpts, <<"false">>) of
@@ -911,7 +963,7 @@ handle_delete(ConfRootKey, Id, QueryStringOpts) ->
                     end,
                 case
                     emqx_bridge_v2:check_deps_and_remove(
-                        ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions
+                        Namespace, ConfRootKey, BridgeType, BridgeName, AlsoDeleteActions
                     )
                 of
                     ok ->
@@ -936,24 +988,26 @@ handle_delete(ConfRootKey, Id, QueryStringOpts) ->
         end
     ).
 
-handle_reset_metrics(ConfRootKey, Id) ->
+handle_reset_metrics(Namespace, ConfRootKey, Id) ->
     ?TRY_PARSE_ID(
         Id,
         begin
             ActionType = emqx_bridge_v2:bridge_v2_type_to_connector_type(BridgeType),
-            ok = emqx_bridge_v2:reset_metrics(ConfRootKey, ActionType, BridgeName),
+            ok = emqx_bridge_v2:reset_metrics(Namespace, ConfRootKey, ActionType, BridgeName),
             ?NO_CONTENT
         end
     ).
 
-handle_disable_enable(ConfRootKey, Id, Enable) ->
+handle_disable_enable(Namespace, ConfRootKey, Id, Enable) ->
     ?TRY_PARSE_ID(
         Id,
         case
-            emqx_bridge_v2:disable_enable(ConfRootKey, enable_func(Enable), BridgeType, BridgeName)
+            emqx_bridge_v2:disable_enable(
+                Namespace, ConfRootKey, enable_func(Enable), BridgeType, BridgeName
+            )
         of
             {ok, _} ->
-                wait_for_ready(ConfRootKey, BridgeType, BridgeName),
+                wait_for_ready(Namespace, ConfRootKey, BridgeType, BridgeName),
                 ?NO_CONTENT;
             {error, {pre_config_update, _, bridge_not_found}} ->
                 ?BRIDGE_NOT_FOUND(BridgeType, BridgeName);
@@ -968,31 +1022,35 @@ handle_disable_enable(ConfRootKey, Id, Enable) ->
         end
     ).
 
-handle_operation(ConfRootKey, Id, Op) ->
+handle_operation(Namespace, ConfRootKey, Id, Op) ->
     ?TRY_PARSE_ID(
         Id,
         begin
-            OperFunc = operation_func(all, Op),
-            Nodes = emqx:running_nodes(),
-            call_operation_if_enabled(all, OperFunc, [Nodes, ConfRootKey, BridgeType, BridgeName])
+            {ProtoMod, OperFunc} = operation_func(Op),
+            Nodes = nodes_supporting_bpapi_version(8),
+            BPAPIArgs = [Nodes, Namespace, ConfRootKey, BridgeType, BridgeName],
+            call_operation_if_enabled(
+                ProtoMod, OperFunc, Namespace, ConfRootKey, BridgeType, BridgeName, BPAPIArgs
+            )
         end
     ).
 
-handle_node_operation(ConfRootKey, Node, Id, Op) ->
+handle_node_operation(Namespace, ConfRootKey, Node, Id, Op) ->
     ?TRY_PARSE_ID(
         Id,
         case emqx_utils:safe_to_existing_atom(Node, utf8) of
             {ok, TargetNode} ->
-                OperFunc = operation_func(TargetNode, Op),
-                call_operation_if_enabled(TargetNode, OperFunc, [
-                    TargetNode, ConfRootKey, BridgeType, BridgeName
-                ]);
+                {ProtoMod, OperFunc} = operation_func(Op),
+                BPAPIArgs = [[TargetNode], Namespace, ConfRootKey, BridgeType, BridgeName],
+                call_operation_if_enabled(
+                    ProtoMod, OperFunc, Namespace, ConfRootKey, BridgeType, BridgeName, BPAPIArgs
+                );
             {error, _} ->
                 ?NOT_FOUND(<<"Invalid node name: ", Node/binary>>)
         end
     ).
 
-handle_probe(ConfRootKey, Request) ->
+handle_probe(Namespace, ConfRootKey, Request) ->
     Path =
         case ConfRootKey of
             ?ROOT_KEY_ACTIONS -> "/actions_probe";
@@ -1001,9 +1059,9 @@ handle_probe(ConfRootKey, Request) ->
     RequestMeta = #{module => ?MODULE, method => post, path => Path},
     case emqx_dashboard_swagger:filter_check_request_and_translate_body(Request, RequestMeta) of
         {ok, #{body := #{<<"type">> := Type} = Params}} ->
-            Params1 = maybe_deobfuscate_bridge_probe(ConfRootKey, Params),
+            Params1 = maybe_deobfuscate_bridge_probe(Namespace, ConfRootKey, Params),
             Params2 = maps:remove(<<"type">>, Params1),
-            case emqx_bridge_v2:create_dry_run(ConfRootKey, Type, Params2) of
+            case emqx_bridge_v2:create_dry_run(Namespace, ConfRootKey, Type, Params2) of
                 ok ->
                     ?NO_CONTENT;
                 {error, #{kind := validation_error} = Reason0} ->
@@ -1024,18 +1082,18 @@ handle_probe(ConfRootKey, Request) ->
 
 %%% API helpers
 maybe_deobfuscate_bridge_probe(
-    ConfRootKey, #{<<"type">> := ActionType, <<"name">> := BridgeName} = Params
+    Namespace,
+    ConfRootKey,
+    #{<<"type">> := ActionType, <<"name">> := BridgeName} = Params
 ) ->
-    case emqx_bridge_v2:lookup_raw_conf(ConfRootKey, ActionType, BridgeName) of
+    case emqx_bridge_v2:lookup_raw_conf(Namespace, ConfRootKey, ActionType, BridgeName) of
         {ok, RawConf} ->
-            %% TODO check if RawConf obtained above is compatible with the commented out code below
-            %% RawConf = emqx:get_raw_config([bridges, BridgeType, BridgeName], #{}),
             emqx_utils:deobfuscate(Params, RawConf);
         _ ->
             %% A bridge may be probed before it's created, so not finding it here is fine
             Params
     end;
-maybe_deobfuscate_bridge_probe(_ConfRootKey, Params) ->
+maybe_deobfuscate_bridge_probe(_Namespace, _ConfRootKey, Params) ->
     Params.
 
 is_ok(ok) ->
@@ -1060,13 +1118,13 @@ is_ok(ResL) ->
     end.
 
 %% bridge helpers
--spec lookup_from_all_nodes(emqx_bridge_v2:root_cfg_key(), _, _, _) -> _.
-lookup_from_all_nodes(ConfRootKey, BridgeType, BridgeName, SuccCode) ->
-    Nodes = nodes_supporting_bpapi_version(6),
+-spec lookup_from_all_nodes(maybe_namespace(), emqx_bridge_v2:root_cfg_key(), _, _, _) -> _.
+lookup_from_all_nodes(Namespace, ConfRootKey, BridgeType, BridgeName, SuccCode) ->
+    Nodes = nodes_supporting_bpapi_version(8),
     case
         is_ok(
-            emqx_bridge_proto_v6:v2_lookup_from_all_nodes_v6(
-                Nodes, ConfRootKey, BridgeType, BridgeName
+            emqx_bridge_proto_v8:lookup(
+                Nodes, Namespace, ConfRootKey, BridgeType, BridgeName
             )
         )
     of
@@ -1079,10 +1137,10 @@ lookup_from_all_nodes(ConfRootKey, BridgeType, BridgeName, SuccCode) ->
             ?INTERNAL_ERROR(Reason)
     end.
 
-get_metrics_from_all_nodes(ConfRootKey, Type, Name) ->
-    Nodes = nodes_supporting_bpapi_version(6),
+get_metrics_from_all_nodes(Namespace, ConfRootKey, Type, Name) ->
+    Nodes = nodes_supporting_bpapi_version(8),
     Result = maybe_unwrap(
-        emqx_bridge_proto_v6:v2_get_metrics_from_all_nodes_v6(Nodes, ConfRootKey, Type, Name)
+        emqx_bridge_proto_v8:get_metrics(Nodes, Namespace, ConfRootKey, Type, Name)
     ),
     case Result of
         Metrics when is_list(Metrics) ->
@@ -1091,30 +1149,30 @@ get_metrics_from_all_nodes(ConfRootKey, Type, Name) ->
             ?INTERNAL_ERROR(Reason)
     end.
 
-operation_func(all, start) -> v2_start_bridge_on_all_nodes_v6;
-operation_func(_Node, start) -> v2_start_bridge_on_node_v6;
-operation_func(all, lookup) -> v2_lookup_from_all_nodes_v6;
-operation_func(all, list) -> v2_list_bridges_on_nodes_v6;
-operation_func(all, get_metrics) -> v2_get_metrics_from_all_nodes_v6.
+operation_func(start) ->
+    {emqx_bridge_proto_v8, start}.
 
-call_operation_if_enabled(NodeOrAll, OperFunc, [Nodes, ConfRootKey, BridgeType, BridgeName]) ->
-    try is_enabled_bridge(ConfRootKey, BridgeType, BridgeName) of
+call_operation_if_enabled(ProtoMod, OperFunc, Namespace, ConfRootKey, Type, Name, BPAPIArgs) ->
+    try is_enabled_bridge(Namespace, ConfRootKey, Type, Name) of
         false ->
             ?BAD_REQUEST(<<"Forbidden operation, connector not enabled">>);
         true ->
-            call_operation(NodeOrAll, OperFunc, [Nodes, ConfRootKey, BridgeType, BridgeName])
+            call_operation(ProtoMod, OperFunc, Namespace, ConfRootKey, Type, Name, BPAPIArgs)
     catch
         throw:not_found ->
-            ?BRIDGE_NOT_FOUND(BridgeType, BridgeName)
+            ?BRIDGE_NOT_FOUND(Type, Name)
     end.
 
-is_enabled_bridge(ConfRootKey, ActionOrSourceType, BridgeName) ->
+is_enabled_bridge(Namespace, ConfRootKey, ActionOrSourceType, BridgeName) ->
     try
-        emqx_bridge_v2:lookup(ConfRootKey, ActionOrSourceType, binary_to_existing_atom(BridgeName))
+        emqx_bridge_v2:lookup(
+            Namespace, ConfRootKey, ActionOrSourceType, binary_to_existing_atom(BridgeName)
+        )
     of
         {ok, #{raw_config := ConfMap}} ->
             maps:get(<<"enable">>, ConfMap, true) andalso
                 is_connector_enabled(
+                    Namespace,
                     ActionOrSourceType,
                     maps:get(<<"connector">>, ConfMap)
                 );
@@ -1131,11 +1189,11 @@ is_enabled_bridge(ConfRootKey, ActionOrSourceType, BridgeName) ->
             throw(not_found)
     end.
 
-is_connector_enabled(ActionOrSourceType, ConnectorName0) ->
+is_connector_enabled(Namespace, ActionOrSourceType, ConnectorName0) ->
     try
         ConnectorType = emqx_bridge_v2:connector_type(ActionOrSourceType),
         ConnectorName = to_existing_atom(ConnectorName0),
-        case emqx_config:get([connectors, ConnectorType, ConnectorName], undefined) of
+        case get_config(Namespace, [connectors, ConnectorType, ConnectorName], undefined) of
             undefined ->
                 throw(not_found);
             Config = #{} ->
@@ -1152,30 +1210,34 @@ is_connector_enabled(ActionOrSourceType, ConnectorName0) ->
             throw(not_found)
     end.
 
-call_operation(NodeOrAll, OperFunc, Args = [_Nodes, _ConfRootKey, BridgeType, BridgeName]) ->
-    case is_ok(do_bpapi_call(NodeOrAll, OperFunc, Args)) of
+call_operation(ProtoMod, OperFunc, Namespace, ConfRootKey, Type, Name, BPAPIArgs) ->
+    case is_ok(do_bpapi_call(ProtoMod, OperFunc, BPAPIArgs)) of
         Ok when Ok =:= ok; is_tuple(Ok), element(1, Ok) =:= ok ->
             ?NO_CONTENT;
         {error, not_implemented} ->
             ?NOT_IMPLEMENTED;
         {error, timeout} ->
-            BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
+            BridgeId = emqx_bridge_resource:bridge_id(Type, Name),
             ?SLOG(warning, #{
                 msg => "bridge_bpapi_call_timeout",
+                namespace => Namespace,
+                kind => ConfRootKey,
                 bridge => BridgeId,
                 call => OperFunc
             }),
             ?SERVICE_UNAVAILABLE(<<"Request timeout">>);
-        {error, {start_pool_failed, Name, Reason}} ->
+        {error, {start_pool_failed, Name1, Reason}} ->
             Msg = bin(
-                io_lib:format("Failed to start ~p pool for reason ~p", [Name, redact(Reason)])
+                io_lib:format("Failed to start ~p pool for reason ~p", [Name1, redact(Reason)])
             ),
             ?BAD_REQUEST(Msg);
         {error, not_found} ->
-            BridgeId = emqx_bridge_resource:bridge_id(BridgeType, BridgeName),
+            BridgeId = emqx_bridge_resource:bridge_id(Type, Name),
             ?SLOG(warning, #{
                 msg => "bridge_inconsistent_in_cluster_for_call_operation",
                 reason => not_found,
+                namespace => Namespace,
+                kind => ConfRootKey,
                 bridge => BridgeId,
                 call => OperFunc
             }),
@@ -1186,40 +1248,12 @@ call_operation(NodeOrAll, OperFunc, Args = [_Nodes, _ConfRootKey, BridgeType, Br
             ?BAD_REQUEST(redact(Reason))
     end.
 
-do_bpapi_call(all, Call, Args) ->
-    maybe_unwrap(
-        do_bpapi_call_vsn(emqx_bpapi:supported_version(?BPAPI_NAME), Call, Args)
-    );
-do_bpapi_call(Node, Call, Args) ->
-    case lists:member(Node, emqx:running_nodes()) of
-        true ->
-            do_bpapi_call_vsn(emqx_bpapi:supported_version(Node, ?BPAPI_NAME), Call, Args);
-        false ->
-            {error, {node_not_found, Node}}
-    end.
-
-do_bpapi_call_vsn(Version, Call, Args) ->
-    case is_supported_version(Version, Call) of
-        true ->
-            apply(emqx_bridge_proto_v6, Call, Args);
-        false ->
-            {error, not_implemented}
-    end.
-
-is_supported_version(Version, Call) ->
-    lists:member(Version, supported_versions(Call)).
-
-supported_versions(_Call) -> bpapi_version_range(6, ?MAX_SUPPORTED_PROTO_VERSION).
-
-%% [From, To] (inclusive on both ends)
-bpapi_version_range(From, To) ->
-    lists:seq(From, To).
+do_bpapi_call(ProtoMod, OperFunc, Args) ->
+    maybe_unwrap(apply(ProtoMod, OperFunc, Args)).
 
 nodes_supporting_bpapi_version(Vsn) ->
     emqx_bpapi:nodes_supporting_bpapi_version(?BPAPI_NAME, Vsn).
 
-maybe_unwrap({error, not_implemented}) ->
-    {error, not_implemented};
 maybe_unwrap(RpcMulticallResult) ->
     emqx_rpc:unwrap_erpc(RpcMulticallResult).
 
@@ -1236,21 +1270,30 @@ zip_bridges(ConfRootKey, [BridgesFirstNode | _] = BridgesAllNodes) ->
     ).
 
 %% This works on the output of `zip_bridges`.
-add_fallback_actions_references(?ROOT_KEY_ACTIONS = ConfRootKey, ZippedBridges) ->
-    #{?COMPUTED := #{fallback_actions_index := Index}} = emqx_config:get([ConfRootKey]),
-    lists:map(
-        fun(#{type := ReferencedType, name := ReferencedName} = Info) ->
-            Referencing0 = maps:get(
-                {bin(ReferencedType), bin(ReferencedName)},
-                Index,
-                []
-            ),
-            Referencing = lists:map(fun(R) -> maps:with([type, name], R) end, Referencing0),
-            Info#{referenced_as_fallback_action_by => Referencing}
-        end,
-        ZippedBridges
-    );
-add_fallback_actions_references(?ROOT_KEY_SOURCES, ZippedBridges) ->
+add_fallback_actions_references(Namespace, ?ROOT_KEY_ACTIONS = ConfRootKey, ZippedBridges) ->
+    Conf = get_config(Namespace, [ConfRootKey], #{}),
+    case Conf of
+        #{?COMPUTED := #{fallback_actions_index := Index}} ->
+            lists:map(
+                fun(#{type := ReferencedType, name := ReferencedName} = Info) ->
+                    Referencing0 = maps:get(
+                        {bin(ReferencedType), bin(ReferencedName)},
+                        Index,
+                        []
+                    ),
+                    Referencing = lists:map(fun(R) -> maps:with([type, name], R) end, Referencing0),
+                    Info#{referenced_as_fallback_action_by => Referencing}
+                end,
+                ZippedBridges
+            );
+        #{} ->
+            %% Namespaced config not initialized properly?
+            lists:map(
+                fun(Info) -> Info#{referenced_as_fallback_action_by => []} end,
+                ZippedBridges
+            )
+    end;
+add_fallback_actions_references(_Namespace, ?ROOT_KEY_SOURCES, ZippedBridges) ->
     ZippedBridges.
 
 pick_bridges_by_id(Type, Name, BridgesAllNodes) ->
@@ -1318,30 +1361,40 @@ aggregate_status(AllStatus) ->
     end.
 
 %% RPC Target
-lookup_from_local_node(BridgeType, BridgeName) ->
-    case emqx_bridge_v2:lookup(BridgeType, BridgeName) of
-        {ok, Res} -> {ok, format_resource(?ROOT_KEY_ACTIONS, Res, node())};
-        Error -> Error
-    end.
+lookup_from_local_node(Type, Name) ->
+    lookup_v8(?global_ns, ?ROOT_KEY_ACTIONS, Type, Name).
 
 %% RPC Target
 -spec lookup_from_local_node_v6(emqx_bridge_v2:root_cfg_key(), _, _) -> _.
-lookup_from_local_node_v6(ConfRootKey, BridgeType, BridgeName) ->
-    case emqx_bridge_v2:lookup(ConfRootKey, BridgeType, BridgeName) of
+lookup_from_local_node_v6(ConfRootKey, Type, Name) ->
+    lookup_v8(?global_ns, ConfRootKey, Type, Name).
+
+%% RPC Target
+-spec lookup_v8(maybe_namespace(), emqx_bridge_v2:root_cfg_key(), _, _) -> _.
+lookup_v8(Namespace, ConfRootKey, Type, Name) ->
+    case emqx_bridge_v2:lookup(Namespace, ConfRootKey, Type, Name) of
         {ok, Res} -> {ok, format_resource(ConfRootKey, Res, node())};
         Error -> Error
     end.
 
 %% RPC Target
 get_metrics_from_local_node(ActionType, ActionName) ->
-    format_metrics(emqx_bridge_v2:get_metrics(ActionType, ActionName)).
+    get_metrics_v8(?global_ns, ?ROOT_KEY_ACTIONS, ActionType, ActionName).
 
 %% RPC Target
 get_metrics_from_local_node_v6(ConfRootKey, Type, Name) ->
-    format_metrics(emqx_bridge_v2:get_metrics(ConfRootKey, Type, Name)).
+    get_metrics_v8(?global_ns, ConfRootKey, Type, Name).
+
+%% RPC Target
+get_metrics_v8(Namespace, ConfRootKey, Type, Name) ->
+    format_metrics(emqx_bridge_v2:get_metrics(Namespace, ConfRootKey, Type, Name)).
 
 %% RPC Target
 summary_from_local_node_v7(ConfRootKey) ->
+    summary_v8(?global_ns, ConfRootKey).
+
+%% RPC Target
+summary_v8(Namespace, ConfRootKey) ->
     lists:map(
         fun(BridgeInfo) ->
             #{
@@ -1370,15 +1423,16 @@ summary_from_local_node_v7(ConfRootKey) ->
                 format_bridge_status_and_error(#{status => Status, error => Error})
             )
         end,
-        emqx_bridge_v2:list(ConfRootKey)
+        emqx_bridge_v2:list(Namespace, ConfRootKey)
     ).
 
-wait_for_ready(ConfRootKey, Type, Name) ->
-    Nodes = nodes_supporting_bpapi_version(7),
+wait_for_ready(Namespace, ConfRootKey, Type, Name) ->
+    Nodes = nodes_supporting_bpapi_version(8),
     CallsTimeout = 2 * 5_000,
     RPCTimeout = CallsTimeout + 1_000,
-    _R = emqx_bridge_proto_v7:v2_wait_for_ready_v7(
+    _ = emqx_bridge_proto_v8:wait_for_ready(
         Nodes,
+        Namespace,
         ConfRootKey,
         Type,
         Name,
@@ -1388,9 +1442,13 @@ wait_for_ready(ConfRootKey, Type, Name) ->
 
 %% RPC Target
 wait_for_ready_local_node_v7(ConfRootKey, Type, Name) ->
+    wait_for_ready_v8(?global_ns, ConfRootKey, Type, Name).
+
+%% RPC Target
+wait_for_ready_v8(Namespace, ConfRootKey, Type, Name) ->
     try
         {ok, {ConnResId, ChannelResId}} =
-            emqx_bridge_v2:get_resource_ids(ConfRootKey, Type, Name),
+            emqx_bridge_v2:get_resource_ids(Namespace, ConfRootKey, Type, Name),
         emqx_resource_manager:channel_health_check(ConnResId, ChannelResId)
     catch
         exit:{timeout, _} ->
@@ -1593,13 +1651,13 @@ format_resource_data(error, Error, Result) ->
 format_resource_data(K, V, Result) ->
     Result#{K => V}.
 
-create_bridge(ConfRootKey, BridgeType, BridgeName, Conf) ->
-    create_or_update_bridge(ConfRootKey, BridgeType, BridgeName, Conf, 201).
+create_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf) ->
+    create_or_update_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf, 201).
 
-update_bridge(ConfRootKey, BridgeType, BridgeName, Conf) ->
-    create_or_update_bridge(ConfRootKey, BridgeType, BridgeName, Conf, 200).
+update_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf) ->
+    create_or_update_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf, 200).
 
-create_or_update_bridge(ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCode) ->
+create_or_update_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCode) ->
     Check =
         try
             is_binary(BridgeType) andalso emqx_resource:validate_type(BridgeType),
@@ -1608,18 +1666,18 @@ create_or_update_bridge(ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCod
             throw:Error ->
                 ?BAD_REQUEST(emqx_mgmt_api_lib:to_json(Error))
         end,
-    case Check of
-        ok ->
-            do_create_or_update_bridge(ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCode);
-        BadRequest ->
-            BadRequest
+    maybe
+        ok ?= Check,
+        do_create_or_update_bridge(
+            Namespace, ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCode
+        )
     end.
 
-do_create_or_update_bridge(ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCode) ->
-    case emqx_bridge_v2:create(ConfRootKey, BridgeType, BridgeName, Conf) of
+do_create_or_update_bridge(Namespace, ConfRootKey, BridgeType, BridgeName, Conf, HttpStatusCode) ->
+    case emqx_bridge_v2:create(Namespace, ConfRootKey, BridgeType, BridgeName, Conf) of
         {ok, _} ->
-            wait_for_ready(ConfRootKey, BridgeType, BridgeName),
-            lookup_from_all_nodes(ConfRootKey, BridgeType, BridgeName, HttpStatusCode);
+            wait_for_ready(Namespace, ConfRootKey, BridgeType, BridgeName),
+            lookup_from_all_nodes(Namespace, ConfRootKey, BridgeType, BridgeName, HttpStatusCode);
         {error, {PreOrPostConfigUpdate, _HandlerMod, Reason}} when
             PreOrPostConfigUpdate =:= pre_config_update;
             PreOrPostConfigUpdate =:= post_config_update
@@ -1661,3 +1719,13 @@ to_existing_atom(X) ->
         {ok, A} -> A;
         {error, _} -> throw(bad_atom)
     end.
+
+get_config(Namespace, KeyPath, Default) when is_binary(Namespace) ->
+    emqx:get_namespaced_config(Namespace, KeyPath, Default);
+get_config(?global_ns, KeyPath, Default) ->
+    emqx:get_config(KeyPath, Default).
+
+get_raw_config(Namespace, KeyPath, Default) when is_binary(Namespace) ->
+    emqx:get_raw_namespaced_config(Namespace, KeyPath, Default);
+get_raw_config(?global_ns, KeyPath, Default) ->
+    emqx:get_raw_config(KeyPath, Default).

--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -81,7 +81,7 @@
 
 -define(TRY_PARSE_ID(ID, EXPR),
     try emqx_bridge_resource:parse_bridge_id(Id, #{atom_name => false}) of
-        {BridgeType, BridgeName} ->
+        #{type := BridgeType, name := BridgeName} ->
             EXPR
     catch
         throw:#{reason := Reason} ->
@@ -721,7 +721,7 @@ check_api_schema(Request, ReqMeta = #{path := "/actions/:id", method := put}) ->
     try emqx_bridge_resource:parse_bridge_id(BridgeId, #{atom_name => false}) of
         %% NOTE
         %% Bridge type is known, refine the API schema to get more specific error messages.
-        {BridgeType, _Name} ->
+        #{type := BridgeType} ->
             Schema = emqx_bridge_v2_schema:action_api_schema("put", BridgeType),
             emqx_dashboard_swagger:filter_check_request(Request, refine_api_schema(Schema, ReqMeta))
     catch
@@ -733,7 +733,7 @@ check_api_schema(Request, ReqMeta = #{path := "/sources/:id", method := put}) ->
     try emqx_bridge_resource:parse_bridge_id(SourceId, #{atom_name => false}) of
         %% NOTE
         %% Source type is known, refine the API schema to get more specific error messages.
-        {BridgeType, _Name} ->
+        #{type := BridgeType} ->
             Schema = emqx_bridge_v2_schema:source_api_schema("put", BridgeType),
             emqx_dashboard_swagger:filter_check_request(Request, refine_api_schema(Schema, ReqMeta))
     catch

--- a/apps/emqx_bridge/src/proto/emqx_bridge_proto_v8.erl
+++ b/apps/emqx_bridge/src/proto/emqx_bridge_proto_v8.erl
@@ -1,0 +1,102 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_proto_v8).
+
+-behaviour(emqx_bpapi).
+
+-export([
+    introduced_in/0,
+
+    %% introduced in v8
+    list/3,
+    lookup/5,
+    summary/3,
+    wait_for_ready/6,
+    start/5,
+    get_metrics/5
+]).
+
+-include_lib("emqx/include/bpapi.hrl").
+
+-include_lib("emqx/include/emqx_config.hrl").
+
+-define(TIMEOUT, 15_000).
+
+-type key() :: atom() | binary() | [byte()].
+-type maybe_namespace() :: ?global_ns | binary().
+
+introduced_in() ->
+    "6.0.0".
+
+%%--------------------------------------------------------------------------------
+%% introduced in v8
+%%--------------------------------------------------------------------------------
+
+-spec list([node()], maybe_namespace(), emqx_bridge_v2:root_cfg_key()) ->
+    emqx_rpc:erpc_multicall([emqx_resource:resource_data()]).
+list(Nodes, Namespace, ConfRootKey) ->
+    erpc:multicall(Nodes, emqx_bridge_v2, list, [Namespace, ConfRootKey], ?TIMEOUT).
+
+-spec lookup([node()], maybe_namespace(), emqx_bridge_v2:root_cfg_key(), key(), key()) ->
+    emqx_rpc:erpc_multicall(term()).
+lookup(Nodes, Namespace, ConfRootKey, BridgeType, BridgeName) ->
+    erpc:multicall(
+        Nodes,
+        emqx_bridge_v2_api,
+        lookup_v8,
+        [Namespace, ConfRootKey, BridgeType, BridgeName],
+        ?TIMEOUT
+    ).
+
+-spec summary([node()], maybe_namespace(), emqx_bridge_v2:root_cfg_key()) ->
+    emqx_rpc:erpc_multicall([emqx_resource:resource_data()]).
+summary(Nodes, Namespace, ConfRootKey) ->
+    erpc:multicall(
+        Nodes,
+        emqx_bridge_v2_api,
+        summary_v8,
+        [Namespace, ConfRootKey],
+        ?TIMEOUT
+    ).
+
+-spec wait_for_ready(
+    [node()],
+    maybe_namespace(),
+    emqx_bridge_v2:root_cfg_key(),
+    atom(),
+    binary(),
+    integer()
+) ->
+    emqx_rpc:erpc_multicall([_]).
+wait_for_ready(Nodes, Namespace, ConfRootKey, Type, Name, RPCTimeout) ->
+    erpc:multicall(
+        Nodes,
+        emqx_bridge_v2_api,
+        wait_for_ready_v8,
+        [Namespace, ConfRootKey, Type, Name],
+        RPCTimeout
+    ).
+
+-spec start([node()], maybe_namespace(), emqx_bridge_v2:root_cfg_key(), key(), key()) ->
+    emqx_rpc:erpc_multicall(ok).
+start(Nodes, Namespace, ConfRootKey, BridgeType, BridgeName) ->
+    erpc:multicall(
+        Nodes,
+        emqx_bridge_v2,
+        start,
+        [Namespace, ConfRootKey, BridgeType, BridgeName],
+        ?TIMEOUT
+    ).
+
+-spec get_metrics([node()], maybe_namespace(), emqx_bridge_v2:root_cfg_key(), key(), key()) ->
+    emqx_rpc:erpc_multicall(term()).
+get_metrics(Nodes, Namespace, ConfRootKey, ActionType, ActionName) ->
+    erpc:multicall(
+        Nodes,
+        emqx_bridge_v2_api,
+        get_metrics_v8,
+        [Namespace, ConfRootKey, ActionType, ActionName],
+        ?TIMEOUT
+    ).

--- a/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
+++ b/apps/emqx_bridge/src/schema/emqx_bridge_v2_schema.erl
@@ -67,6 +67,9 @@
 
 -export_type([action_type/0, source_type/0]).
 
+%% `emqx_schema_hooks' API
+-export([injected_fields/0]).
+
 %% Should we explicitly list them here so dialyzer may be more helpful?
 -type action_type() :: atom().
 -type source_type() :: atom().
@@ -529,6 +532,15 @@ top_level_common_source_keys() ->
         <<"parameters">>,
         <<"resource_opts">>
     ].
+
+%%======================================================================================
+%% `emqx_schema_hooks' API
+%%======================================================================================
+
+injected_fields() ->
+    #{
+        'config.allowed_namespaced_roots' => [<<"actions">>, <<"sources">>]
+    }.
 
 %%======================================================================================
 %% Helper functions for making HOCON Schema

--- a/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_api_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/test_macros.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -define(ACTION_HTTP_TYPE, <<"http">>).
 -define(BRIDGE_TYPE_HTTP, <<"webhook">>).
@@ -1493,7 +1494,7 @@ validate_resource_request_ttl(_Cluster, _Timeout, _Name) ->
 
 do_send_message(BridgeV1Type, Name, Message) ->
     Type = emqx_bridge_v2:bridge_v1_type_to_bridge_v2_type(BridgeV1Type),
-    emqx_bridge_v2:send_message(Type, Name, Message, #{}).
+    emqx_bridge_v2:send_message(?global_ns, Type, Name, Message, #{}).
 
 %%
 

--- a/apps/emqx_bridge/test/emqx_bridge_v1_compatibility_layer_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v1_compatibility_layer_SUITE.erl
@@ -264,20 +264,7 @@ registered_process_name() ->
     my_registered_process.
 
 delete_all_bridges_and_connectors() ->
-    lists:foreach(
-        fun(#{name := Name, type := Type}) ->
-            ct:pal("removing bridge ~p", [{Type, Name}]),
-            emqx_bridge_v2:remove(Type, Name)
-        end,
-        emqx_bridge_v2:list()
-    ),
-    lists:foreach(
-        fun(#{name := Name, type := Type}) ->
-            ct:pal("removing connector ~p", [{Type, Name}]),
-            emqx_connector:remove(?global_ns, Type, Name)
-        end,
-        emqx_connector:list(?global_ns)
-    ),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
     update_root_config(#{}),
     ok.
 

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -110,25 +110,41 @@ delete_all_bridges_and_connectors() ->
     delete_all_connectors().
 
 delete_all_bridges() ->
+    Namespaces = lists:usort(
+        emqx_config:get_all_namespaces_containing(<<"actions">>) ++
+            emqx_config:get_all_namespaces_containing(<<"sources">>)
+    ),
+    lists:foreach(
+        fun delete_all_bridges/1,
+        [?global_ns | Namespaces]
+    ).
+
+delete_all_bridges(Namespace) ->
     lists:foreach(
         fun(#{name := Name, type := Type}) ->
-            emqx_bridge_v2:remove(actions, Type, Name)
+            emqx_bridge_v2:remove(Namespace, actions, Type, Name)
         end,
-        emqx_bridge_v2:list(actions)
+        emqx_bridge_v2:list(Namespace, actions)
     ),
     lists:foreach(
         fun(#{name := Name, type := Type}) ->
-            emqx_bridge_v2:remove(sources, Type, Name)
+            emqx_bridge_v2:remove(Namespace, sources, Type, Name)
         end,
-        emqx_bridge_v2:list(sources)
+        emqx_bridge_v2:list(Namespace, sources)
     ).
 
 delete_all_connectors() ->
     lists:foreach(
+        fun delete_all_connectors/1,
+        [?global_ns | emqx_config:get_all_namespaces_containing(<<"connectors">>)]
+    ).
+
+delete_all_connectors(Namespace) ->
+    lists:foreach(
         fun(#{name := Name, type := Type}) ->
-            emqx_connector:remove(?global_ns, Type, Name)
+            emqx_connector:remove(Namespace, Type, Name)
         end,
-        emqx_connector:list(?global_ns)
+        emqx_connector:list(Namespace)
     ).
 
 %% test helpers
@@ -228,7 +244,7 @@ create_bridge(Config, Overrides) ->
         emqx_connector:create(?global_ns, ConnectorType, ConnectorName, ConnectorConfig),
 
     ct:pal("creating bridge with config:\n  ~p", [ActionConfig]),
-    emqx_bridge_v2:create(ActionType, ActionName, ActionConfig).
+    emqx_bridge_v2:create(?global_ns, ?ROOT_KEY_ACTIONS, ActionType, ActionName, ActionConfig).
 
 get_ct_config_with_fallback(Config, [Key]) ->
     ?config(Key, Config);
@@ -573,6 +589,16 @@ get_connector_api(ConnectorType, ConnectorName) ->
     ct:pal("get connector (http) result:\n  ~p", [Res]),
     Res.
 
+delete_connector_api(TCConfig) ->
+    Type = get_value(connector_type, TCConfig),
+    Name = get_value(connector_name, TCConfig),
+    Id = emqx_connector_resource:connector_id(Type, Name),
+    URL = emqx_mgmt_api_test_util:api_path(["connectors", Id]),
+    simple_request(#{
+        method => delete,
+        url => URL
+    }).
+
 create_action_api(Config) ->
     create_action_api(Config, _Overrides = #{}).
 
@@ -607,8 +633,8 @@ create_source_api(Config, Overrides) ->
     simplify_result(Res).
 
 get_action_api(Config) ->
-    ActionName = ?config(action_name, Config),
-    ActionType = ?config(action_type, Config),
+    ActionName = get_value(action_name, Config),
+    ActionType = get_value(action_type, Config),
     ActionId = emqx_bridge_resource:bridge_id(ActionType, ActionName),
     Path = emqx_mgmt_api_test_util:api_path(["actions", ActionId]),
     ct:pal("getting action (http)"),
@@ -645,13 +671,20 @@ update_bridge_api(Config, Overrides) ->
     Res.
 
 delete_kind_api(Kind, Type, Name) ->
+    delete_kind_api(Kind, Type, Name, _Opts = #{}).
+
+delete_kind_api(Kind, Type, Name, Opts) ->
     BridgeId = emqx_bridge_resource:bridge_id(Type, Name),
     PathRoot = api_path_root(Kind),
     Path = emqx_mgmt_api_test_util:api_path([PathRoot, BridgeId]),
     ct:pal("deleting bridge (~s, http)", [Kind]),
-    Res = request(delete, Path, _Params = []),
+    Res = simple_request(#{
+        method => delete,
+        url => Path,
+        query_params => maps:get(query_params, Opts, #{})
+    }),
     ct:pal("delete bridge (~s, http) result:\n  ~p", [Kind, Res]),
-    simplify_result(Res).
+    Res.
 
 op_bridge_api(Op, BridgeType, BridgeName) ->
     op_bridge_api(_Kind = action, Op, BridgeType, BridgeName).
@@ -878,6 +911,23 @@ create_rule_and_action_http(BridgeType, RuleTopic, Config, Opts) ->
             Error
     end.
 
+create_rule_api2(Params) ->
+    create_rule_api2(Params, _Opts = #{}).
+
+create_rule_api2(Params, Opts) ->
+    AuthHeader = emqx_utils_maps:get_lazy(
+        auth_header,
+        Opts,
+        fun auth_header/0
+    ),
+    URL = emqx_mgmt_api_test_util:api_path(["rules"]),
+    simple_request(#{
+        method => post,
+        url => URL,
+        body => Params,
+        auth_header => AuthHeader
+    }).
+
 delete_rule_api(RuleId) ->
     Path = emqx_mgmt_api_test_util:api_path(["rules", RuleId]),
     simplify_result(request(delete, Path, "")).
@@ -970,6 +1020,7 @@ get_common_values(Config) ->
     case Kind of
         action ->
             #{
+                resource_namespace => proplists:get_value(resource_namespace, Config, ?global_ns),
                 conf_root_key => actions,
                 kind => Kind,
                 type => get_ct_config_with_fallback(Config, [action_type, bridge_type]),
@@ -979,6 +1030,7 @@ get_common_values(Config) ->
             };
         source ->
             #{
+                resource_namespace => proplists:get_value(resource_namespace, Config, ?global_ns),
                 conf_root_key => sources,
                 kind => Kind,
                 type => get_value(source_type, Config),
@@ -997,12 +1049,48 @@ health_check_connector(Config) ->
     emqx_resource_manager:health_check(ConnectorResId).
 
 health_check_channel(Config) ->
+    Opts = get_common_values(Config),
+    force_health_check(Opts).
+
+lookup_chan_id_in_conf(Opts) ->
     #{
-        conf_root_key := ConfRootKey,
         type := Type,
         name := Name
-    } = get_common_values(Config),
-    emqx_bridge_v2:health_check(ConfRootKey, Type, Name).
+    } = Opts,
+    Namespace = maps:get(resource_namespace, Opts, ?global_ns),
+    ConfRootKey =
+        case maps:get(kind, Opts, action) of
+            action -> actions;
+            source -> sources
+        end,
+    emqx_bridge_v2:lookup_chan_id_in_conf(Namespace, ConfRootKey, Type, Name).
+
+make_chan_id(Opts) ->
+    #{
+        type := Type,
+        name := Name,
+        connector_name := ConnName
+    } = Opts,
+    Namespace = maps:get(resource_namespace, Opts, ?global_ns),
+    ConfRootKey =
+        case maps:get(kind, Opts, action) of
+            action -> actions;
+            source -> sources
+        end,
+    emqx_bridge_v2:id_with_root_and_connector_names(Namespace, ConfRootKey, Type, Name, ConnName).
+
+get_metrics(Opts) ->
+    #{
+        type := Type,
+        name := Name
+    } = Opts,
+    Namespace = maps:get(resource_namespace, Opts, ?global_ns),
+    ConfRootKey =
+        case maps:get(kind, Opts, action) of
+            action -> actions;
+            source -> sources
+        end,
+    emqx_bridge_v2:get_metrics(Namespace, ConfRootKey, Type, Name).
 
 %%------------------------------------------------------------------------------
 %% Internal export
@@ -1059,7 +1147,7 @@ t_async_query(Config, MakeMessageFun, IsSuccessCheck, TracePoint) ->
             ?assertMatch(
                 {ok, {ok, _}},
                 ?wait_async_action(
-                    emqx_bridge_v2:query(ActionType, ActionName, Message, #{
+                    emqx_bridge_v2:query(?global_ns, ActionType, ActionName, Message, #{
                         async_reply_fun => {ReplyFun, [self()]}
                     }),
                     #{?snk_kind := TracePoint, instance_id := ResourceId},
@@ -1655,6 +1743,7 @@ This is done by the frontend via:
 """.
 t_rule_test_trace(Config, Opts) ->
     #{
+        resource_namespace := Namespace,
         type := ActionType0,
         name := ActionName0
     } = get_common_values(Config),
@@ -1934,7 +2023,7 @@ t_rule_test_trace(Config, Opts) ->
         )
     end),
     {ok, {_ConnResId, PrimaryActionResId}} =
-        emqx_bridge_v2:get_resource_ids(actions, ActionType, ActionName),
+        emqx_bridge_v2:get_resource_ids(Namespace, actions, ActionType, ActionName),
     emqx_common_test_helpers:with_mock(
         emqx_trace,
         rendered_action_template,
@@ -1986,11 +2075,30 @@ kickoff_source_health_check(Type, Name) ->
     kickoff_kind_health_check(sources, Type, Name).
 
 kickoff_kind_health_check(ConfRootKey, Type, Name) ->
+    Kind =
+        case ConfRootKey of
+            sources -> source;
+            actions -> action
+        end,
+    kickoff_kind_health_check(#{
+        kind => Kind,
+        type => Type,
+        name => Name
+    }).
+
+kickoff_kind_health_check(Opts) ->
+    #{
+        kind := Kind,
+        type := Type,
+        name := Name
+    } = Opts,
+    Namespace = maps:get(namespace, Opts, ?global_ns),
+    ConfRootKey = conf_root_key(Kind),
     Res =
         try
             maybe
                 {ok, {ConnResId, ChannelResId}} ?=
-                    emqx_bridge_v2:get_resource_ids(ConfRootKey, Type, Name),
+                    emqx_bridge_v2:get_resource_ids(Namespace, ConfRootKey, Type, Name),
                 _ = emqx_resource_manager:channel_health_check(ConnResId, ChannelResId),
                 ok
             end
@@ -2086,3 +2194,16 @@ do_all_atoms(N, Acc) ->
         error:badarg ->
             Acc
     end.
+
+force_health_check(Opts) ->
+    #{
+        type := Type,
+        name := Name
+    } = Opts,
+    Namespace = maps:get(resource_namespace, Opts, ?global_ns),
+    ConfRootKey =
+        case maps:get(kind, Opts, action) of
+            action -> actions;
+            source -> sources
+        end,
+    emqx_bridge_v2:health_check(Namespace, ConfRootKey, Type, Name).

--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_SUITE.erl
@@ -321,7 +321,7 @@ send_message(Config, Payload) ->
 query_resource(Config, Request) ->
     Name = ?config(cassa_name, Config),
     BridgeType = ?config(cassa_bridge_type, Config),
-    BridgeV2Id = emqx_bridge_v2:id(BridgeType, Name),
+    BridgeV2Id = id(BridgeType, Name),
     ConnectorResId = emqx_connector_resource:resource_id(BridgeType, Name),
     emqx_resource:query(BridgeV2Id, Request, #{
         timeout => 1_000, connector_resource_id => ConnectorResId
@@ -332,7 +332,7 @@ query_resource_async(Config, Request) ->
     BridgeType = ?config(cassa_bridge_type, Config),
     Ref = alias([reply]),
     AsyncReplyFun = fun(#{result := Result}) -> Ref ! {result, Ref, Result} end,
-    BridgeV2Id = emqx_bridge_v2:id(BridgeType, Name),
+    BridgeV2Id = id(BridgeType, Name),
     ConnectorResId = emqx_connector_resource:resource_id(BridgeType, Name),
     Return = emqx_resource:query(BridgeV2Id, Request, #{
         timeout => 500,
@@ -417,8 +417,15 @@ with_direct_conn(Config, Fn) ->
         ok = ecql:close(Conn)
     end.
 
+id(Type, Name) ->
+    emqx_bridge_v2_testlib:lookup_chan_id_in_conf(#{
+        kind => action,
+        type => Type,
+        name => Name
+    }).
+
 %%------------------------------------------------------------------------------
-%% Testcases
+%% Test cases
 %%------------------------------------------------------------------------------
 
 t_setup_via_config_and_publish(Config) ->

--- a/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_connector_SUITE.erl
+++ b/apps/emqx_bridge_cassandra/test/emqx_bridge_cassandra_connector_SUITE.erl
@@ -216,7 +216,7 @@ create_local_resource(ResourceId, CheckedConfig) ->
             ?CONNECTOR_RESOURCE_GROUP,
             ?CASSANDRA_RESOURCE_MOD,
             CheckedConfig,
-            #{}
+            #{spawn_buffer_workers => true}
         ),
     Bridge.
 

--- a/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_connector_SUITE.erl
+++ b/apps/emqx_bridge_clickhouse/test/emqx_bridge_clickhouse_connector_SUITE.erl
@@ -141,7 +141,7 @@ perform_lifecycle_check(ResourceID, InitialConfig) ->
             ?CONNECTOR_RESOURCE_GROUP,
             ?CLICKHOUSE_RESOURCE_MOD,
             CheckedConfig,
-            #{}
+            #{spawn_buffer_workers => true}
         ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -9,6 +9,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
@@ -305,10 +306,11 @@ create_rule_and_action_http(Config, Overrides) ->
         Error -> Error
     end.
 
+%% todo: messages should be sent via rules in tests...
 send_message(Config, Payload) ->
     Type = ?config(bridge_type, Config),
     Name = ?config(bridge_name, Config),
-    emqx_bridge_v2:send_message(Type, Name, Payload, #{}).
+    emqx_bridge_v2:send_message(?global_ns, Type, Name, Payload, #{}).
 
 query_by_clientid(Table, ClientId, Config) ->
     SQL = <<"SELECT * FROM ", Table/binary, " WHERE clientid = '", ClientId/binary, "'">>,

--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_connector_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_connector_SUITE.erl
@@ -106,7 +106,7 @@ perform_lifecycle_check(PoolName, InitialConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?DATALAYERS_RESOURCE_MOD,
         FullConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_bridge_dynamo/test/emqx_bridge_dynamo_SUITE.erl
+++ b/apps/emqx_bridge_dynamo/test/emqx_bridge_dynamo_SUITE.erl
@@ -329,7 +329,7 @@ send_message(Config, Payload) ->
 query_resource(Config, Request) ->
     Name = ?config(dynamo_name, Config),
     BridgeType = ?config(dynamo_bridge_type, Config),
-    ID = emqx_bridge_v2:id(BridgeType, Name),
+    ID = id(BridgeType, Name),
     ResID = emqx_connector_resource:resource_id(BridgeType, Name),
     emqx_resource:query(ID, Request, #{timeout => 500, connector_resource_id => ResID}).
 
@@ -373,8 +373,15 @@ directly_get_field(Key, Field) ->
             Error
     end.
 
+id(Type, Name) ->
+    emqx_bridge_v2_testlib:lookup_chan_id_in_conf(#{
+        kind => action,
+        type => Type,
+        name => Name
+    }).
+
 %%------------------------------------------------------------------------------
-%% Testcases
+%% Test cases
 %%------------------------------------------------------------------------------
 
 t_setup_via_config_and_publish(Config) ->
@@ -568,7 +575,7 @@ t_simple_query(Config) ->
     ),
     BridgeType = ?config(dynamo_bridge_type, Config),
     Name = ?config(dynamo_name, Config),
-    ActionID = emqx_bridge_v2:id(BridgeType, Name),
+    ActionID = id(BridgeType, Name),
     Request = {ActionID, {get_item, {<<"id">>, <<"not_exists">>}}},
     Result = query_resource(Config, Request),
     case ?config(batch_size, Config) of
@@ -604,7 +611,7 @@ t_bad_parameter(Config) ->
     ),
     BridgeType = ?config(dynamo_bridge_type, Config),
     Name = ?config(dynamo_name, Config),
-    ActionID = emqx_bridge_v2:id(BridgeType, Name),
+    ActionID = id(BridgeType, Name),
     Request = {ActionID, {insert_item, bad_parameter}},
     Result = query_resource(Config, Request),
     ?assertMatch({error, {unrecoverable_error, {invalid_request, _}}}, Result),

--- a/apps/emqx_bridge_es/test/emqx_bridge_es_SUITE.erl
+++ b/apps/emqx_bridge_es/test/emqx_bridge_es_SUITE.erl
@@ -112,7 +112,11 @@ send_message(Topic) ->
     ok.
 
 check_action_metrics(ActionName, ConnectorName, Expect, Line) ->
-    ActionId = emqx_bridge_v2:id(?TYPE, ActionName, ConnectorName),
+    ActionId = emqx_bridge_v2_testlib:make_chan_id(#{
+        type => ?TYPE,
+        name => ActionName,
+        connector_name => ConnectorName
+    }),
     ?retry(
         300,
         20,
@@ -220,31 +224,23 @@ action_api_spec_props_for_get() ->
         emqx_bridge_v2_testlib:actions_api_spec_schemas(),
     Props.
 
-%%------------------------------------------------------------------------------
-%% Testcases
-%%------------------------------------------------------------------------------
-
-t_create_remove_list(Config) ->
-    [] = emqx_bridge_v2:list(),
-    ConnectorConfig = connector_config(Config),
-    {ok, _} = create_connector(test_connector, ConnectorConfig),
-    ActionConfig = action(<<"test_connector">>),
-    {ok, _} = create_action(test_action_1, ActionConfig),
-    [ActionInfo] = emqx_bridge_v2:list(),
-    #{
-        name := <<"test_action_1">>,
-        type := <<"elasticsearch">>,
-        raw_config := _,
-        status := connected
-    } = ActionInfo,
-    {ok, _} = create_action(test_action_2, ActionConfig),
-    2 = length(emqx_bridge_v2:list()),
-    ok = emqx_bridge_v2:remove(?TYPE, test_action_1),
-    1 = length(emqx_bridge_v2:list()),
-    ok = emqx_bridge_v2:remove(?TYPE, test_action_2),
-    [] = emqx_bridge_v2:list(),
-    emqx_connector:remove(?global_ns, ?TYPE, test_connector),
+remove(Name) ->
+    {204, _} = emqx_bridge_v2_testlib:delete_kind_api(action, ?TYPE, Name, #{
+        query_params => #{<<"also_delete_dep_actions">> => <<"true">>}
+    }),
     ok.
+
+health_check(Type, Name) ->
+    emqx_bridge_v2_testlib:force_health_check(#{
+        type => Type,
+        name => Name,
+        resource_namespace => ?global_ns,
+        kind => action
+    }).
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
 
 %% Test sending a message to a bridge V2
 t_create_message(Config) ->
@@ -288,7 +284,7 @@ t_create_message(Config) ->
     %% Remove all the bridges
     lists:foreach(
         fun(BridgeName) ->
-            ok = emqx_bridge_v2:remove(?TYPE, BridgeName)
+            ok = remove(BridgeName)
         end,
         ActionNames
     ),
@@ -353,7 +349,7 @@ t_update_message(Config) ->
     Expect2 = #{match => 1, success => 1, dropped => 0, failed => 0, queuing => 0},
     check_send_message_with_action(<<"es/1">>, update_action, update_connector, Expect2, ?LINE),
     %% Clean
-    ok = emqx_bridge_v2:remove(?TYPE, update_action),
+    ok = remove(update_action),
     emqx_connector:remove(?global_ns, ?TYPE, update_connector),
     lists:foreach(
         fun(#{id := Id}) ->
@@ -369,10 +365,10 @@ t_health_check(Config) ->
     ConnectorConfig = connector_config(Config),
     {ok, _} = create_connector(test_connector3, ConnectorConfig),
     {ok, _} = create_action(test_bridge_v2, BridgeV2Config),
-    #{status := connected} = emqx_bridge_v2:health_check(?TYPE, test_bridge_v2),
-    ok = emqx_bridge_v2:remove(?TYPE, test_bridge_v2),
+    #{status := connected} = health_check(?TYPE, test_bridge_v2),
+    ok = remove(test_bridge_v2),
     %% Check behaviour when bridge does not exist
-    {error, bridge_not_found} = emqx_bridge_v2:health_check(?TYPE, test_bridge_v2),
+    {error, bridge_not_found} = health_check(?TYPE, test_bridge_v2),
     ok = emqx_connector:remove(?global_ns, ?TYPE, test_connector3),
     ok.
 
@@ -385,16 +381,20 @@ t_bad_url(Config) ->
     ?assertMatch({ok, _}, create_connector(ConnectorName, ConnectorConfig)),
     ?assertMatch({ok, _}, create_action(ActionName, ActionConfig)),
     ?assertMatch(
-        {ok, #{
-            resource_data :=
-                #{
-                    status := ?status_disconnected,
-                    error := failed_to_start_elasticsearch_bridge
-                }
-        }},
-        emqx_connector:lookup(?global_ns, ?TYPE, ConnectorName)
+        {ok,
+            {{_, 200, _}, _, #{
+                <<"status">> := <<"disconnected">>,
+                <<"status_reason">> := <<"failed_to_start_elasticsearch_bridge">>
+            }}},
+        emqx_bridge_v2_testlib:get_connector_api(?TYPE, ConnectorName)
     ),
-    ?assertMatch({ok, #{status := ?status_disconnected}}, emqx_bridge_v2:lookup(?TYPE, ActionName)),
+    ?assertMatch(
+        {ok, {{_, 200, _}, _, #{<<"status">> := <<"disconnected">>}}},
+        emqx_bridge_v2_testlib:get_action_api([
+            {action_type, ?TYPE},
+            {action_name, ActionName}
+        ])
+    ),
     ok.
 
 t_parameters_key_api_spec(_Config) ->

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -157,11 +157,13 @@ generate_config(Config0) ->
         pubsub_config := PubSubConfig,
         service_account_json := ServiceAccountJSON
     } = gcp_pubsub_config(Config0),
-    %% FIXME
-    %% `emqx_bridge_resource:resource_id' requires an existing connector in the config.....
     ConnectorName = ActionName,
     ConnectorResourceId = <<"connector:", ?CONNECTOR_TYPE_BIN/binary, ":", ConnectorName/binary>>,
-    ActionResourceId = emqx_bridge_v2:id(?ACTION_TYPE_BIN, ActionName, ConnectorName),
+    ActionResourceId = emqx_bridge_v2_testlib:make_chan_id(#{
+        type => ?ACTION_TYPE_BIN,
+        name => ActionName,
+        connector_name => ConnectorName
+    }),
     BridgeId = emqx_bridge_resource:bridge_id(?BRIDGE_V1_TYPE_BIN, ActionName),
     [
         {gcp_pubsub_name, ActionName},

--- a/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_connector_SUITE.erl
+++ b/apps/emqx_bridge_greptimedb/test/emqx_bridge_greptimedb_connector_SUITE.erl
@@ -87,7 +87,7 @@ perform_lifecycle_check(PoolName, InitialConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?GREPTIMEDB_RESOURCE_MOD,
         FullConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -18,6 +18,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -define(BRIDGE_TYPE, emqx_bridge_http_test_lib:bridge_type()).
 -define(BRIDGE_NAME, emqx_bridge_http_test_lib:bridge_name()).
@@ -792,7 +793,7 @@ t_bridge_probes_header_atoms(Config) ->
 
 do_send_message(Message) ->
     Type = emqx_bridge_v2:bridge_v1_type_to_bridge_v2_type(?BRIDGE_TYPE),
-    emqx_bridge_v2:send_message(Type, ?BRIDGE_NAME, Message, #{}).
+    emqx_bridge_v2:send_message(?global_ns, Type, ?BRIDGE_NAME, Message, #{}).
 
 do_t_async_retries(TestCase, TestContext, Error, Fn) ->
     #{error_attempts := ErrorAttempts} = TestContext,

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_v2_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_v2_SUITE.erl
@@ -99,7 +99,7 @@ t_compose_connector_url_and_action_path(Config) ->
         {connector_name, ?CONNECTOR_NAME},
         {connector_config, ConnectorCfg}
     ],
-    {ok, _} = emqx_bridge_v2_testlib:create_bridge(CreateConfig),
+    {ok, _} = emqx_bridge_v2_testlib:create_bridge_api(CreateConfig),
 
     %% assert: the url returned v1 api is composed by the url of the connector and the
     %% path of the action

--- a/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_connector_SUITE.erl
+++ b/apps/emqx_bridge_influxdb/test/emqx_bridge_influxdb_connector_SUITE.erl
@@ -90,7 +90,7 @@ perform_lifecycle_check(PoolName, InitialConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?INFLUXDB_RESOURCE_MOD,
         FullConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeKafka.MixProject do
   def project do
     [
       app: :emqx_bridge_kafka,
-      version: "0.5.7",
+      version: "0.5.8",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.5.7"},
+    {vsn, "0.5.8"},
     {registered, [emqx_bridge_kafka_sup, emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl.erl
@@ -7,7 +7,6 @@
 
 -export([
     hosts/1,
-    make_client_id/2,
     sasl/1,
     socket_opts/1
 ]).
@@ -22,12 +21,6 @@ hosts([#{hostname := _, port := _} | _] = Servers) ->
     [{Hostname, Port} || #{hostname := Hostname, port := Port} <- Servers];
 hosts(Hosts) when is_list(Hosts) ->
     kpro:parse_endpoints(Hosts).
-
-%% Client ID is better to be unique to make it easier for Kafka side trouble shooting.
-make_client_id(BridgeType0, BridgeName0) ->
-    BridgeType = to_bin(BridgeType0),
-    BridgeName = to_bin(BridgeName0),
-    iolist_to_binary([BridgeType, ":", BridgeName, ":", atom_to_list(node())]).
 
 sasl(none) ->
     undefined;
@@ -75,10 +68,3 @@ adjust_socket_buffer(Bytes, Opts) ->
 
 tcp_keepalive(String) ->
     emqx_schema:tcp_keepalive_opts(String).
-
-to_bin(A) when is_atom(A) ->
-    atom_to_binary(A);
-to_bin(L) when is_list(L) ->
-    list_to_binary(L);
-to_bin(B) when is_binary(B) ->
-    B.

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_consumer_SUITE.erl
@@ -928,7 +928,8 @@ ensure_connected(Config) ->
 consumer_clientid(Config) ->
     BridgeType = ?config(bridge_type, Config),
     KafkaName = ?config(kafka_name, Config),
-    binary_to_atom(emqx_bridge_kafka_impl:make_client_id(BridgeType, KafkaName)).
+    ConnResId = emqx_connector_resource:resource_id(BridgeType, KafkaName),
+    emqx_bridge_kafka_impl_consumer:make_client_id(ConnResId).
 
 get_client_connection(Config) ->
     KafkaHost = ?config(kafka_host, Config),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_impl_producer_SUITE.erl
@@ -957,12 +957,8 @@ config(Args0, More, ConfigTemplateFun) ->
     ConfText = hocon_config(Args, ConfigTemplateFun),
     {ok, Conf} = hocon:binary(ConfText, #{format => map}),
     Name = bin(maps:get("bridge_name", Args)),
-    %% TODO can we skip this old check?
     ct:pal("Running tests with conf:\n~p", [Conf]),
-    % % InstId = maps:get("instance_id", Args),
     TypeBin = ?BRIDGE_TYPE_BIN,
-    % <<"connector:", BridgeId/binary>> = InstId,
-    % {Type, Name} = emqx_bridge_resource:parse_bridge_id(BridgeId, #{atom_name => false}),
     hocon_tconf:check_plain(
         emqx_bridge_schema,
         Conf,

--- a/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_v2_SUITE.erl
+++ b/apps/emqx_bridge_kinesis/test/emqx_bridge_kinesis_v2_SUITE.erl
@@ -14,6 +14,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx_resource/include/emqx_resource_runtime.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
@@ -773,7 +774,7 @@ t_action_health_check_no_core(TCConfig) when is_list(TCConfig) ->
                 <<"resource_opts">> => #{<<"health_check_interval">> => <<"200ms">>}
             }),
             {ok, {_ConnResId, ActionResId}} =
-                ?ON(R1, emqx_bridge_v2:get_resource_ids(actions, Type, Name)),
+                ?ON(R1, emqx_bridge_v2:get_resource_ids(?global_ns, actions, Type, Name)),
             ?assertMatch(
                 {ok, #rt{channel_status = ?status_connected}},
                 ?ON(R1, emqx_resource_cache:get_runtime(ActionResId))

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -495,7 +495,7 @@ mk_ingress_config(
     emqx_bridge_mqtt_ingress:config(NewConf, ChannelId, TopicToHandlerIndex).
 
 mk_ecpool_client_opts(
-    ResourceId,
+    ConnResId,
     Config = #{
         connect_timeout := ConnectTimeoutS,
         server := Server,
@@ -521,20 +521,20 @@ mk_ecpool_client_opts(
         ],
         Config
     ),
-    Name = parse_id_to_name(ResourceId),
+    #{
+        name := Name,
+        namespace := Namespace
+    } =
+        emqx_connector_resource:parse_connector_id(ConnResId, #{atom_name => false}),
     mk_client_opt_password(Options#{
         hosts => [HostPort],
-        clientid => clientid(Name, Config),
+        clientid => clientid(Namespace, Name, Config),
         connect_timeout => ConnectTimeoutS,
         keepalive => ms_to_s(KeepAlive),
         force_ping => true,
         ssl => EnableSsl,
         ssl_opts => maps:to_list(maps:remove(enable, Ssl))
     }).
-
-parse_id_to_name(Id) ->
-    #{name := Name} = emqx_connector_resource:parse_connector_id(Id, #{atom_name => false}),
-    Name.
 
 mk_client_opt_password(Options = #{password := Secret}) ->
     %% TODO: Teach `emqtt` to accept 0-arity closures as passwords.
@@ -545,12 +545,19 @@ mk_client_opt_password(Options) ->
 ms_to_s(Ms) ->
     erlang:ceil(Ms / 1000).
 
-clientid(Name, _Conf = #{clientid_prefix := Prefix}) when
+clientid(Namespace, Name0, _Conf = #{clientid_prefix := Prefix}) when
     is_binary(Prefix) andalso Prefix =/= <<>>
 ->
+    Name = maybe_prefix_namespce(Namespace, Name0),
     {Prefix, emqx_bridge_mqtt_lib:clientid_base(Name)};
-clientid(Name, _Conf) ->
+clientid(Namespace, Name0, _Conf) ->
+    Name = maybe_prefix_namespce(Namespace, Name0),
     {?NO_PREFIX, emqx_bridge_mqtt_lib:clientid_base(Name)}.
+
+maybe_prefix_namespce(Namespace, Name) when is_binary(Namespace) ->
+    <<Namespace/binary, ":", Name/binary>>;
+maybe_prefix_namespce(_Namespace, Name) ->
+    Name.
 
 %% @doc Start an ingress bridge worker.
 -spec connect([option() | {ecpool_worker_id, pos_integer()}]) ->

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -533,7 +533,7 @@ mk_ecpool_client_opts(
     }).
 
 parse_id_to_name(Id) ->
-    {_Type, Name} = emqx_connector_resource:parse_connector_id(Id, #{atom_name => false}),
+    #{name := Name} = emqx_connector_resource:parse_connector_id(Id, #{atom_name => false}),
     Name.
 
 mk_client_opt_password(Options = #{password := Secret}) ->

--- a/apps/emqx_bridge_pulsar/mix.exs
+++ b/apps/emqx_bridge_pulsar/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgePulsar.MixProject do
   def project do
     [
       app: :emqx_bridge_pulsar,
-      version: "0.2.10",
+      version: "0.2.11",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_pulsar, [
     {description, "EMQX Pulsar Bridge"},
-    {vsn, "0.2.10"},
+    {vsn, "0.2.11"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -351,9 +351,17 @@ make_client_id(ConnResId) ->
         true ->
             pulsar_producer_probe;
         false ->
-            #{name := Name} = emqx_connector_resource:parse_connector_id(ConnResId),
-            %% TODO: handle namespaces
+            #{
+                namespace := Namespace,
+                name := Name
+            } = emqx_connector_resource:parse_connector_id(ConnResId),
+            NSTag =
+                case is_binary(Namespace) of
+                    true -> <<"ns:", Namespace/binary, ":">>;
+                    false -> <<"">>
+                end,
             ClientIdBin = iolist_to_binary([
+                NSTag,
                 <<"pulsar:">>,
                 emqx_utils_conv:bin(Name),
                 <<":">>,

--- a/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
+++ b/apps/emqx_bridge_pulsar/src/emqx_bridge_pulsar_connector.erl
@@ -351,7 +351,8 @@ make_client_id(ConnResId) ->
         true ->
             pulsar_producer_probe;
         false ->
-            {pulsar, Name} = emqx_connector_resource:parse_connector_id(ConnResId),
+            #{name := Name} = emqx_connector_resource:parse_connector_id(ConnResId),
+            %% TODO: handle namespaces
             ClientIdBin = iolist_to_binary([
                 <<"pulsar:">>,
                 emqx_utils_conv:bin(Name),

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_connector_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_connector_SUITE.erl
@@ -139,7 +139,7 @@ create_local_resource(ResourceID, CheckedConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         emqx_bridge_rabbitmq_connector,
         CheckedConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     Bridge.
 

--- a/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
+++ b/apps/emqx_bridge_rabbitmq/test/emqx_bridge_rabbitmq_v2_SUITE.erl
@@ -146,7 +146,10 @@ create_source(Name) ->
     ]).
 
 delete_source(Name) ->
-    ok = emqx_bridge_v2:remove(sources, ?TYPE, Name).
+    {204, _} = emqx_bridge_v2_testlib:delete_kind_api(source, ?TYPE, Name, #{
+        query_params => #{<<"also_delete_dep_actions">> => <<"true">>}
+    }),
+    ok.
 
 create_action(TestCase, Name) ->
     create_action(TestCase, Name, rabbit_mq_exchange(TestCase)).
@@ -161,7 +164,10 @@ create_action(TestCase, Name, Exchange) ->
     ]).
 
 delete_action(Name) ->
-    ok = emqx_bridge_v2:remove(actions, ?TYPE, Name).
+    {204, _} = emqx_bridge_v2_testlib:delete_kind_api(action, ?TYPE, Name, #{
+        query_params => #{<<"also_delete_dep_actions">> => <<"true">>}
+    }),
+    ok.
 
 %%------------------------------------------------------------------------------
 %% Test Cases

--- a/apps/emqx_bridge_s3/test/emqx_bridge_s3_SUITE.erl
+++ b/apps/emqx_bridge_s3/test/emqx_bridge_s3_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/test_macros.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 %% See `emqx_bridge_s3.hrl`.
 -define(BRIDGE_TYPE, <<"s3">>).
@@ -246,7 +247,8 @@ t_query_retry_recoverable(Config) ->
     ),
     Message = emqx_bridge_s3_test_helpers:mk_message_event(Bucket, Topic, Payload),
     %% Verify that the message is sent eventually.
-    ok = emqx_bridge_v2:send_message(?BRIDGE_TYPE, BridgeName, Message, #{}),
+    %% todo: messages should be sent via rules in tests...
+    ok = emqx_bridge_v2:send_message(?global_ns, ?BRIDGE_TYPE, BridgeName, Message, #{}),
     ?assertMatch(
         #{content := Payload},
         maps:from_list(erlcloud_s3:get_object(Bucket, Topic, AwsConfig))

--- a/apps/emqx_bridge_s3/test/emqx_bridge_s3_aggreg_upload_SUITE.erl
+++ b/apps/emqx_bridge_s3/test/emqx_bridge_s3_aggreg_upload_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/test_macros.hrl").
 -include_lib("emqx_utils/include/emqx_message.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -import(emqx_utils_conv, [bin/1]).
 
@@ -597,8 +598,11 @@ send_messages_delayed(BridgeName, MessageEvents, Delay) ->
         MessageEvents
     ).
 
+%% todo: messages should be sent via rules in tests...
 send_message(BridgeName, Message) ->
-    ?assertEqual(ok, emqx_bridge_v2:send_message(?BRIDGE_TYPE, BridgeName, Message, #{})).
+    ?assertEqual(
+        ok, emqx_bridge_v2:send_message(?global_ns, ?BRIDGE_TYPE, BridgeName, Message, #{})
+    ).
 
 fetch_parse_csv(Bucket, Key) ->
     #{content := Content} = emqx_bridge_s3_test_helpers:get_object(Bucket, Key),

--- a/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
+++ b/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
@@ -16,6 +16,7 @@
 -include_lib("emqx_utils/include/emqx_message.hrl").
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("erlcloud/include/erlcloud_aws.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
@@ -754,6 +755,9 @@ restart_server() ->
         )
     ),
     ok.
+
+health_check(TCConfig) ->
+    emqx_bridge_v2_testlib:health_check_channel(TCConfig).
 
 %%------------------------------------------------------------------------------
 %% Test cases
@@ -1637,7 +1641,7 @@ do_t_upload_data_file_failure(S3UploadFnName, Config) ->
                         }},
                     status := ?status_disconnected
                 },
-                emqx_bridge_v2_testlib:health_check_channel(Config)
+                health_check(Config)
             );
         partitioned ->
             ?assertMatch(
@@ -1650,7 +1654,7 @@ do_t_upload_data_file_failure(S3UploadFnName, Config) ->
                         }},
                     status := ?status_disconnected
                 },
-                emqx_bridge_v2_testlib:health_check_channel(Config)
+                health_check(Config)
             )
     end,
     ok.
@@ -1701,7 +1705,7 @@ t_upload_manifest_entry_failure(Config) ->
                         }},
                     status := ?status_disconnected
                 },
-                emqx_bridge_v2_testlib:health_check_channel(Config)
+                health_check(Config)
             )
         end
     ),
@@ -1744,7 +1748,7 @@ t_upload_manifest_file_list_failure(Config) ->
                         }},
                     status := ?status_disconnected
                 },
-                emqx_bridge_v2_testlib:health_check_channel(Config)
+                health_check(Config)
             )
         end
     ),
@@ -1797,7 +1801,7 @@ t_commit_failure(Config) ->
                         }},
                     status := ?status_disconnected
                 },
-                emqx_bridge_v2_testlib:health_check_channel(Config)
+                health_check(Config)
             )
         end
     ),

--- a/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
+++ b/apps/emqx_bridge_tdengine/test/emqx_bridge_tdengine_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 % SQL definitions
 -define(SQL_BRIDGE,
@@ -307,11 +308,12 @@ to_bin(Atom) when is_atom(Atom) ->
 to_bin(Bin) when is_binary(Bin) ->
     Bin.
 
+%% todo: messages should be sent via rules in tests...
 send_message(Config, Payload) ->
     BridgeType = ?config(bridge_type, Config),
     Name = ?config(bridge_name, Config),
     ct:print(">>> Name:~p~n BridgeType:~p~n", [Name, BridgeType]),
-    emqx_bridge_v2:send_message(BridgeType, Name, Payload, #{}).
+    emqx_bridge_v2:send_message(?global_ns, BridgeType, Name, Payload, #{}).
 
 receive_result(Ref, Timeout) ->
     receive
@@ -463,7 +465,7 @@ t_undefined_vars_as_null(Config0) ->
 t_batch_insert(Config) ->
     Name = ?config(bridge_name, Config),
     connect_and_clear_table(Config),
-    ?assertMatch({ok, _}, emqx_bridge_v2_testlib:create_bridge(Config)),
+    ?assertMatch({ok, _}, emqx_bridge_v2_testlib:create_bridge_api(Config)),
     _ = emqx_bridge_v2_testlib:kickoff_action_health_check(?BRIDGE_TYPE_BIN, Name),
 
     Size = 5,
@@ -534,7 +536,7 @@ t_auto_create_batch_insert(Config) ->
     Name = ?config(bridge_name, Config),
     ClientId1 = "client1",
     ClientId2 = "client2",
-    ?assertMatch({ok, _}, emqx_bridge_v2_testlib:create_bridge(Config)),
+    ?assertMatch({ok, _}, emqx_bridge_v2_testlib:create_bridge_api(Config)),
     _ = emqx_bridge_v2_testlib:kickoff_action_health_check(?BRIDGE_TYPE_BIN, Name),
 
     Size1 = 2,

--- a/apps/emqx_cluster_link/mix.exs
+++ b/apps/emqx_cluster_link/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXClusterLink.MixProject do
   def project do
     [
       app: :emqx_cluster_link,
-      version: "0.1.7",
+      version: "0.1.8",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_cluster_link/src/emqx_cluster_link.app.src
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link.app.src
@@ -2,7 +2,7 @@
 {application, emqx_cluster_link, [
     {description, "EMQX Cluster Linking"},
     % strict semver, bump manually!
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -101,6 +101,7 @@ resource_id(ClusterName) ->
 ensure_msg_fwd_resource(#{name := Name, resource_opts := ResOpts} = ClusterConf) ->
     ResOpts1 = ResOpts#{
         query_mode => async,
+        spawn_buffer_workers => true,
         start_after_created => true
     },
     emqx_resource:create_local(?MSG_RES_ID(Name), ?RES_GROUP, ?MODULE, ClusterConf, ResOpts1).

--- a/apps/emqx_conf/src/emqx_conf_cli.erl
+++ b/apps/emqx_conf/src/emqx_conf_cli.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx_auth/include/emqx_authn_chains.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_schema.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -export([
     load/0,
@@ -423,7 +424,8 @@ uninstall(ActionOrSource, Conf, #{mode := replace}) ->
             #{removed := Removed} = emqx_bridge_v2:diff_confs(New, Old),
             maps:foreach(
                 fun({Type, Name}, _) ->
-                    case emqx_bridge_v2:remove(ActionOrSourceAtom, Type, Name) of
+                    %% TODO: namespace
+                    case emqx_bridge_v2:remove(?global_ns, ActionOrSourceAtom, Type, Name) of
                         ok ->
                             ok;
                         {error, Reason} ->

--- a/apps/emqx_conf/src/emqx_conf_schema_inject.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema_inject.erl
@@ -72,7 +72,8 @@ bridges(ee) ->
 
 namespaced_root_keys() ->
     [
-        emqx_connector_schema
+        emqx_connector_schema,
+        emqx_bridge_v2_schema
     ].
 
 %% Add more schemas here.

--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -56,7 +56,7 @@
 %% Don't turn connector_name to atom, it's maybe not a existing atom.
 -define(TRY_PARSE_ID(ID, EXPR),
     try emqx_connector_resource:parse_connector_id(Id, #{atom_name => false}) of
-        {ConnectorType, ConnectorName} ->
+        #{type := ConnectorType, name := ConnectorName} ->
             EXPR
     catch
         throw:#{reason := Reason} ->
@@ -72,7 +72,7 @@ api_spec() ->
 check_api_schema(Request, #{path := "/connectors/:id", method := put = Method} = Metadata) ->
     ConnectorId = emqx_utils_maps:deep_get([bindings, id], Request),
     try emqx_connector_resource:parse_connector_id(ConnectorId, #{atom_name => false}) of
-        {ConnectorType, _ConnectorName} ->
+        #{type := ConnectorType} ->
             %% Since we know the connector type, we refine the schema to get more decent
             %% error messages.
             {_, Ref} = emqx_connector_info:api_schema(ConnectorType, atom_to_list(Method)),

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -86,7 +86,7 @@ parse_connector_id(ConnectorId) ->
     parse_connector_id(ConnectorId, #{atom_name => true}).
 
 -spec parse_connector_id(binary() | atom(), #{atom_name => boolean()}) ->
-    #{type := atom(), name := atom() | binary(), namespace := undefined | binary()}.
+    #{type := atom(), name := atom() | binary(), namespace := ?global_ns | binary()}.
 parse_connector_id(<<"ns:", NSConnectorId/binary>>, Opts) ->
     case binary:split(NSConnectorId, <<":">>) of
         [Namespace, ConnectorId] when size(Namespace) > 0 ->
@@ -105,7 +105,7 @@ parse_connector_id(?PROBE_ID_MATCH(Suffix), Opts) ->
     parse_connector_id(ConnectorId, Opts);
 parse_connector_id(ConnectorId, Opts) ->
     {Type, Name} = emqx_resource:parse_resource_id(ConnectorId, Opts),
-    #{type => Type, name => Name, namespace => undefined}.
+    #{type => Type, name => Name, namespace => ?global_ns}.
 
 connector_hookpoint(ConnectorId) ->
     <<"$connectors/", (bin(ConnectorId))/binary>>.

--- a/apps/emqx_connector/src/emqx_connector_resource.erl
+++ b/apps/emqx_connector/src/emqx_connector_resource.erl
@@ -86,11 +86,12 @@ parse_connector_id(ConnectorId) ->
     parse_connector_id(ConnectorId, #{atom_name => true}).
 
 -spec parse_connector_id(binary() | atom(), #{atom_name => boolean()}) ->
-    {atom(), atom() | binary()}.
+    #{type := atom(), name := atom() | binary(), namespace := undefined | binary()}.
 parse_connector_id(<<"ns:", NSConnectorId/binary>>, Opts) ->
     case binary:split(NSConnectorId, <<":">>) of
         [Namespace, ConnectorId] when size(Namespace) > 0 ->
-            parse_connector_id(ConnectorId, Opts);
+            Parsed = parse_connector_id(ConnectorId, Opts),
+            Parsed#{namespace => Namespace};
         _ ->
             throw(#{
                 kind => validation_error,
@@ -103,7 +104,8 @@ parse_connector_id(?PROBE_ID_MATCH(Suffix), Opts) ->
     <<?PROBE_ID_SEP, ConnectorId/binary>> = Suffix,
     parse_connector_id(ConnectorId, Opts);
 parse_connector_id(ConnectorId, Opts) ->
-    emqx_resource:parse_resource_id(ConnectorId, Opts).
+    {Type, Name} = emqx_resource:parse_resource_id(ConnectorId, Opts),
+    #{type => Type, name => Name, namespace => undefined}.
 
 connector_hookpoint(ConnectorId) ->
     <<"$connectors/", (bin(ConnectorId))/binary>>.

--- a/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
+++ b/apps/emqx_connector/test/emqx_connector_api_SUITE.erl
@@ -287,17 +287,13 @@ init_mocks(_TestCase) ->
 
 clear_resources(_) ->
     lists:foreach(
-        fun(#{type := Type, name := Name}) ->
-            ok = emqx_bridge_v2:remove(Type, Name)
+        fun(#{id := Id}) ->
+            {204, _} = emqx_bridge_v2_testlib:delete_rule_api(Id)
         end,
-        emqx_bridge_v2:list()
+        emqx_rule_engine:get_rules()
     ),
-    lists:foreach(
-        fun(#{type := Type, name := Name}) ->
-            ok = emqx_connector:remove(?global_ns, Type, Name)
-        end,
-        emqx_connector:list(?global_ns)
-    ).
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    ok.
 
 clear_mocks(TCConfig) ->
     case ?config(cluster_nodes, TCConfig) of
@@ -1550,7 +1546,6 @@ t_namespaced_crud(TCConfig) ->
         get_resource(NS2, ConnectorType, ConnectorName1, TCConfigNS1)
     ),
 
-    %% Delete
     ?assertMatch({204, _}, delete(ConnectorType, ConnectorName1, TCConfigNS1)),
     ?assertMatch({200, []}, list(TCConfig)),
     ?assertMatch({200, [_]}, list(TCConfigNS1)),

--- a/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
+++ b/apps/emqx_dashboard_rbac/src/emqx_dashboard_rbac.erl
@@ -31,8 +31,10 @@
 -type role() :: binary().
 -type namespace() :: binary().
 
--define(DASHBOARD_API(METHOD, FN), #{method := METHOD, module := emqx_dashboard_api, function := FN}).
--define(CONNECTOR_API(METHOD, FN), #{method := METHOD, module := emqx_connector_api, function := FN}).
+-define(API(MOD, METHOD, FN), #{method := METHOD, module := MOD, function := FN}).
+-define(DASHBOARD_API(METHOD, FN), ?API(emqx_dashboard_api, METHOD, FN)).
+-define(CONNECTOR_API(METHOD, FN), ?API(emqx_connector_api, METHOD, FN)).
+-define(BRIDGE_V2_API(METHOD, FN), ?API(emqx_bridge_v2_api, METHOD, FN)).
 
 %%=====================================================================
 %% API
@@ -146,6 +148,13 @@ do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?CONNE
     %% Namespaced connector API; may only alter resources in its own namespace.
     %% This is enforced by the handlers themselves, by only fetching/acting on the
     %% appropriate namespace.
+    true;
+do_check_rbac(#{?role := ?ROLE_SUPERUSER, ?namespace := Namespace}, _Req, ?BRIDGE_V2_API(_, _)) when
+    is_binary(Namespace)
+->
+    %% Namespaced action/source APIs; may only alter resources in its own namespace.  This
+    %% is enforced by the handlers themselves, by only fetching/acting on the appropriate
+    %% namespace.
     true;
 do_check_rbac(_, _, _) ->
     false.

--- a/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
+++ b/apps/emqx_ldap/test/emqx_ldap_SUITE.erl
@@ -89,7 +89,7 @@ perform_lifecycle_check(ResourceId, InitialConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?LDAP_RESOURCE_MOD,
         CheckedConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_mongodb/test/emqx_mongodb_SUITE.erl
+++ b/apps/emqx_mongodb/test/emqx_mongodb_SUITE.erl
@@ -136,7 +136,7 @@ create_local_resource(ResourceId, CheckedConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?MONGO_RESOURCE_MOD,
         CheckedConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     Bridge.
 

--- a/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
+++ b/apps/emqx_mysql/test/emqx_mysql_SUITE.erl
@@ -60,7 +60,7 @@ perform_lifecycle_check(ResourceId, InitialConfig) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?MYSQL_RESOURCE_MOD,
         CheckedConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_opentelemetry/test/emqx_otel_api_SUITE.erl
+++ b/apps/emqx_opentelemetry/test/emqx_otel_api_SUITE.erl
@@ -46,7 +46,7 @@ init_per_suite(Config) ->
         [
             emqx_conf,
             emqx_management,
-            {emqx_dashboard, "dashboard.listeners.http { enable = true, bind = 18083 }"},
+            emqx_mgmt_api_test_util:emqx_dashboard(),
             emqx_opentelemetry
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}

--- a/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
+++ b/apps/emqx_postgresql/test/emqx_postgresql_SUITE.erl
@@ -68,7 +68,7 @@ perform_lifecycle_check(ResourceId, InitialConfig) ->
             ?CONNECTOR_RESOURCE_GROUP,
             ?PGSQL_RESOURCE_MOD,
             CheckedConfig,
-            #{}
+            #{spawn_buffer_workers => true}
         ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_data_integration.erl
@@ -63,7 +63,7 @@
 fetch_from_local_node(Mode) ->
     Rules = emqx_rule_engine:get_rules(),
     BridgesV1 = emqx:get_config([bridges], #{}),
-    BridgeV2Actions = emqx_bridge_v2:list(?ROOT_KEY_ACTIONS),
+    BridgeV2Actions = emqx_bridge_v2:list(?global_ns, ?ROOT_KEY_ACTIONS),
     Connectors = emqx_connector:list(?global_ns),
     {node(self()), #{
         rule_metric_data => rule_metric_data(Mode, Rules),
@@ -477,7 +477,9 @@ action_point(Mode, Id, V) ->
     {with_node_label(Mode, [{id, Id}]), V}.
 
 get_action_metric(Type, Name) ->
-    #{counters := Counters, gauges := Gauges} = emqx_bridge_v2:get_metrics(Type, Name),
+    #{counters := Counters, gauges := Gauges} = emqx_bridge_v2:get_metrics(
+        ?global_ns, actions, Type, Name
+    ),
     #{
         emqx_action_matched => ?MG0(matched, Counters),
         emqx_action_dropped => ?MG0(dropped, Counters),

--- a/apps/emqx_redis/test/emqx_redis_SUITE.erl
+++ b/apps/emqx_redis/test/emqx_redis_SUITE.erl
@@ -109,7 +109,7 @@ perform_lifecycle_check(ResourceId, InitialConfig, RedisCommand) ->
         ?CONNECTOR_RESOURCE_GROUP,
         ?REDIS_RESOURCE_MOD,
         CheckedConfig,
-        #{}
+        #{spawn_buffer_workers => true}
     ),
     ?assertEqual(InitialStatus, connected),
     % Instance should match the state and status of the just started resource

--- a/apps/emqx_resource/include/emqx_resource_id.hrl
+++ b/apps/emqx_resource/include/emqx_resource_id.hrl
@@ -1,0 +1,41 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-ifndef(EMQX_RESOURCE_RUNTIME_ID).
+-define(EMQX_RESOURCE_RUNTIME_ID, true).
+
+-define(NS_SEG, <<"ns">>).
+-define(NS_SEG_PREFIX_STR, "ns:").
+-define(CONN_SEG, <<"connector">>).
+-define(ACTION_SEG, <<"action">>).
+-define(SOURCE_SEG, <<"source">>).
+-define(RES_SEP, <<":">>).
+
+-define(NAMESPACED_CHANNEL(NS, KIND, CHAN_TYPE, CHAN_NAME, CONN_TYPE, CONN_NAME), [
+    ?NS_SEG, NS, KIND, CHAN_TYPE, CHAN_NAME, ?CONN_SEG, CONN_TYPE, CONN_NAME
+]).
+-define(NAMESPACED_CHANNEL_PAT(NS, KIND, CHAN_TYPE, CHAN_NAME, CONN_TYPE, CONN_NAME),
+    ?NAMESPACED_CHANNEL(NS, KIND, CHAN_TYPE, CHAN_NAME, CONN_TYPE, CONN_NAME) when
+        size(NS) > 0 andalso KIND == ?ACTION_SEG orelse KIND == ?SOURCE_SEG
+).
+-define(NAMESPACED_CONNECTOR(NS, CONN_TYPE, CONN_NAME), [
+    ?NS_SEG, NS, ?CONN_SEG, CONN_TYPE, CONN_NAME
+]).
+-define(NAMESPACED_CONNECTOR_PAT(NS, CONN_TYPE, CONN_NAME),
+    ?NAMESPACED_CONNECTOR(NS, CONN_TYPE, CONN_NAME) when size(NS) > 0
+).
+
+-define(NON_NAMESPACED_CHANNEL(KIND, CHAN_TYPE, CHAN_NAME, CONN_TYPE, CONN_NAME), [
+    KIND, CHAN_TYPE, CHAN_NAME, ?CONN_SEG, CONN_TYPE, CONN_NAME
+]).
+-define(NON_NAMESPACED_CHANNEL_PAT(KIND, CHAN_TYPE, CHAN_NAME, CONN_TYPE, CONN_NAME),
+    ?NON_NAMESPACED_CHANNEL(KIND, CHAN_TYPE, CHAN_NAME, CONN_TYPE, CONN_NAME) when
+        KIND == ?ACTION_SEG orelse KIND == ?SOURCE_SEG
+).
+-define(NON_NAMESPACED_CONNECTOR(CONN_TYPE, CONN_NAME), [?CONN_SEG, CONN_TYPE, CONN_NAME]).
+-define(NON_NAMESPACED_CONNECTOR_PAT(CONN_TYPE, CONN_NAME),
+    ?NON_NAMESPACED_CONNECTOR(CONN_TYPE, CONN_NAME)
+).
+
+-endif.

--- a/apps/emqx_resource/mix.exs
+++ b/apps/emqx_resource/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXResource.MixProject do
   def project do
     [
       app: :emqx_resource,
-      version: "0.2.1",
+      version: "0.2.2",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.2.1"},
+    {vsn, "0.2.2"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [

--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -271,7 +271,7 @@ create(ResId, Group, ResourceType, Config, Opts) ->
     % Create metrics for the resource
     ok = emqx_resource:create_metrics(ResId),
     QueryMode = emqx_resource:query_mode(ResourceType, Config, Opts),
-    SpawnBufferWorkers = maps:get(spawn_buffer_workers, Opts, true),
+    SpawnBufferWorkers = maps:get(spawn_buffer_workers, Opts, false),
     case SpawnBufferWorkers andalso lists:member(QueryMode, [sync, async]) of
         true ->
             %% start resource workers as the query type requires them

--- a/apps/emqx_rule_engine/mix.exs
+++ b/apps/emqx_rule_engine/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRuleEngine.MixProject do
   def project do
     [
       app: :emqx_rule_engine,
-      version: "5.2.9",
+      version: "5.2.10",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -34,19 +34,13 @@
 %% APIs
 %%--------------------------------------------------------------------
 parse_action(BridgeId) when is_binary(BridgeId) ->
-    {Type, Name} = emqx_bridge_resource:parse_bridge_id(BridgeId),
+    #{
+        type := Type,
+        name := Name
+    } = emqx_bridge_resource:parse_bridge_id(BridgeId),
     case emqx_bridge_v2:is_bridge_v2_type(Type) of
         true ->
-            %% Could be an old bridge V1 type that should be converted to a V2 type
-            try emqx_bridge_v2:bridge_v1_type_to_bridge_v2_type(Type) of
-                BridgeV2Type ->
-                    {bridge_v2, BridgeV2Type, Name}
-            catch
-                _:_ ->
-                    %% We got a bridge v2 type that is not also a bridge v1
-                    %% type
-                    {bridge_v2, Type, Name}
-            end;
+            {bridge_v2, Type, Name};
         false ->
             {bridge, Type, Name, emqx_bridge_resource:resource_id(Type, Name)}
     end;

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.app.src
@@ -2,7 +2,7 @@
 {application, emqx_rule_engine, [
     {description, "EMQX Rule Engine"},
     % strict semver, bump manually!
-    {vsn, "5.2.9"},
+    {vsn, "5.2.10"},
     {modules, []},
     {registered, [emqx_rule_engine_sup, emqx_rule_engine]},
     {applications, [

--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -444,7 +444,7 @@ get_basic_usage_info() ->
 tally_referenced_bridges(BridgeIds, Acc0) ->
     lists:foldl(
         fun(BridgeId, Acc) ->
-            {BridgeType, _BridgeName} = emqx_bridge_resource:parse_bridge_id(
+            #{type := BridgeType} = emqx_bridge_resource:parse_bridge_id(
                 BridgeId,
                 #{atom_name => false}
             ),
@@ -748,7 +748,7 @@ validate_bridge_existence_in_actions(#{actions := Actions, from := Froms} = _Rul
             fun(BridgeId) ->
                 %% FIXME: this supposedly returns an upgraded type, but it's fuzzy: it
                 %% returns v1 types when attempting to "upgrade".....
-                {Type, Name} =
+                #{type := Type, name := Name} =
                     emqx_bridge_resource:parse_bridge_id(BridgeId, #{atom_name => false}),
                 case emqx_action_info:is_action_type(Type) of
                     true -> {source, Type, Name};

--- a/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_api.erl
@@ -9,6 +9,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("typerefl/include/types.hrl").
 -include_lib("emqx_utils/include/emqx_http_api.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -behaviour(minirest_api).
 
@@ -555,7 +556,8 @@ encode_nested_error(RuleError, Reason) ->
 mk_format_fn() ->
     SummaryIndex =
         maybe
-            {ok, Summary} = emqx_bridge_v2_api:do_handle_summary(actions),
+            %% TODO: should receive namespace as argument here.
+            {ok, Summary} = emqx_bridge_v2_api:do_handle_summary(?global_ns, actions),
             lists:foldl(
                 fun(#{name := N, type := T, status := S}, Acc) ->
                     Acc#{{T, N} => S}

--- a/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_runtime.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/emqx_external_trace.hrl").
 -include_lib("emqx_resource/include/emqx_resource_errors.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx/include/emqx_config.hrl").
 
 -export([
     apply_rule/3,
@@ -507,8 +508,10 @@ do_handle_action2(
         [IncCtx],
         ?EXT_TRACE_WITH_ACTION_METADATA(_Envs, #{reply_dropped => true})
     },
+    %% TODO FIXME: namespace
     case
         emqx_bridge_v2:send_message(
+            ?global_ns,
             BridgeType,
             BridgeName,
             Selected,

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -99,9 +99,10 @@ get_action(Config) ->
 make_http_bridge(Config) ->
     HTTPServerConfig = ?config(http_server, Config),
     emqx_bridge_http_test_lib:make_bridge(HTTPServerConfig),
-    #{status := connected} = emqx_bridge_v2:health_check(
-        http, emqx_bridge_http_test_lib:bridge_name()
-    ),
+    #{status := connected} = emqx_bridge_v2_testlib:force_health_check(#{
+        type => http,
+        name => emqx_bridge_http_test_lib:bridge_name()
+    }),
     BridgeName = ?config(bridge_name, Config),
     emqx_bridge_resource:bridge_id(http, BridgeName).
 


### PR DESCRIPTION
Part of https://emqx.atlassian.net/browse/EMQX-14385

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 6.0.?

## Summary

Continuation of the multi-tenancy namespaced users/resources epic, direct continuation of https://github.com/emqx/emqx/pull/15490 .

Each manged namespace has its own set of actions/sources, and having the same action/source name on different namespaces should not clash.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (part of a bigger epic, changes are not officially visible)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
