### PR TITLE
test(s3tables): disable flaky scenario

### DIFF
--- a/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
+++ b/apps/emqx_bridge_s3tables/test/emqx_bridge_s3tables_SUITE.erl
@@ -957,11 +957,11 @@ t_conflicting_transactions() ->
     [{matrix, true}].
 t_conflicting_transactions(matrix) ->
     [
-        [second_commit],
+        [second_commit]
         %% N.B.: the apache iceberg-rest fixture container is extremely buggy, and tends
         %% to crash and enter a corrupt state that does not recover without restarting the
         %% service/container when running this case...
-        [first_commit]
+        %% [first_commit]
     ];
 t_conflicting_transactions(Config) ->
     ct:timetrap({seconds, 15}),


### PR DESCRIPTION
Even though now the retry/restart workarounds seem to be working properly, this test case is still very flaky and may fail 5 times in a row in CI.  I believe we have a net gain disabling it, even though we'll stop testing this very particular scenario.

e.g.:

https://github.com/emqx/emqx/actions/runs/16274083953/job/45949204895?pr=15490