### PR TITLE
chore: bump emqx-builder version to 5.5-3 to support Debian 10

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -1,7 +1,7 @@
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/5.5-2:1.18.3-27.2-3-ubuntu24.04
+    image:  ghcr.io/emqx/emqx-builder/5.5-3:1.18.3-27.2-3-ubuntu24.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.5-2:1.18.3-27.2-3-ubuntu24.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.5-3:1.18.3-27.2-3-ubuntu24.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -67,7 +67,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '5.5-2'
+        default: '5.5-3'
 
 permissions:
   contents: read

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.5-2:1.18.3-27.2-3-debian12
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.5-3:1.18.3-27.2-3-debian12
 ARG RUN_FROM=debian:12-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=5.5-2
+export EMQX_BUILDER_VSN=5.5-3
 export OTP_VSN=27.2-3
 export ELIXIR_VSN=1.18.3
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu24.04

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -38,7 +38,7 @@ help() {
     echo ""
     echo "--builder <BUILDER>:"
     echo "    Docker image to use for building"
-    echo "    E.g. ghcr.io/emqx/emqx-builder/5.5-2:1.18.3-27.2-3-debian12"
+    echo "    E.g. ghcr.io/emqx/emqx-builder/5.5-3:1.18.3-27.2-3-debian12"
     echo "    For hot upgrading tar.gz, specify a builder image with the same OS distribution as the running one."
     echo "    Specifically, for EMQX's docker containers hot upgrading, please use the debian12-based builder. "
     echo "    Defaults to builder configured in env.sh."


### PR DESCRIPTION
Fixes building packages for Debian 10.

Release version: 6.0.0-M1.202507