### PR TITLE
fix(shared-sub): stop monitoring remote subscribers to avoid races

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -26,7 +26,10 @@
 
 -export([unsubscribe/1]).
 
--export([subscriber_down/1]).
+-export([
+    subscriber_down/1,
+    purge_node/1
+]).
 
 -export([
     publish/1,
@@ -412,8 +415,11 @@ aggre([#route{topic = To, dest = Node} | Rest], Dedup, Acc) when is_atom(Node) -
         false -> NAcc = Acc
     end,
     aggre(Rest, Dedup, NAcc);
-aggre([#route{topic = To, dest = {Group, _Node}} | Rest], _Dedup, Acc) ->
-    aggre(Rest, true, [{To, Group} | Acc]);
+aggre([#route{topic = To, dest = {Group, Node}} | Rest], Dedup, Acc) ->
+    case emqx_router_helper:is_routable(Node) of
+        true -> aggre(Rest, true, [{To, Group} | Acc]);
+        false -> aggre(Rest, Dedup, Acc)
+    end;
 aggre([], false, Acc) ->
     Acc;
 aggre([], true, Acc) ->
@@ -542,6 +548,16 @@ do_unsubscribe_down(Topic, SubPid, SubOpts) ->
             %% NOTE: `emqx_shared_sub` manages its own monitors and cleanups.
             ok
     end.
+
+%%--------------------------------------------------------------------
+%% Node Cleanup APIs
+%%--------------------------------------------------------------------
+
+-spec purge_node(node()) -> ok.
+purge_node(Node) ->
+    ok = emqx_router:cleanup_routes(Node),
+    _ = emqx_shared_sub:purge_node(Node),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Management APIs

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -544,9 +544,8 @@ do_unsubscribe_down(Topic, SubPid, SubOpts) ->
     case Topic of
         B when is_binary(B) ->
             do_unsubscribe_regular(Topic, SubPid, SubOpts);
-        #share{} ->
-            %% NOTE: `emqx_shared_sub` manages its own monitors and cleanups.
-            ok
+        #share{group = Group, topic = RealTopic} ->
+            emqx_shared_sub:unsubscribe_down(Group, RealTopic, SubPid)
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -267,7 +267,6 @@ collect_messages(Reg, Down) ->
 %% Collect both register_sub and 'DOWN' messages in a loop.
 %% There is no other message sent to this process, so the
 %% 'receive' should not have to scan the mailbox.
-%% TODO: Double-check.
 collect_messages(Reg, Down, 0) ->
     {Reg, Down};
 collect_messages(Reg, Down, N) ->

--- a/apps/emqx/src/emqx_broker_sup.erl
+++ b/apps/emqx/src/emqx_broker_sup.erl
@@ -59,6 +59,13 @@ init([]) ->
         type => worker,
         modules => [emqx_shared_sub]
     },
+    SharedSubPostStart = #{
+        id => shared_sub_post_start,
+        start => {emqx_shared_sub, post_start, []},
+        restart => transient,
+        shutdown => brutal_kill,
+        type => worker
+    },
 
     %% Broker helper
     Helper = #{
@@ -92,6 +99,7 @@ init([]) ->
             SyncerPool,
             BrokerPool,
             SharedSub,
+            SharedSubPostStart,
             Helper,
             ExclusiveSub
         ]}}.

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -384,20 +384,20 @@ schedule_purge_left(Node) ->
 handle_purge(Node, Why, State) ->
     try purge_dead_node_trans(Node) of
         true ->
-            ?tp(warning, router_node_routing_table_purged, #{
+            ?tp(warning, broker_node_purged, #{
                 node => Node,
                 reason => Why,
                 hint => "Ignore if the node in question went offline due to cluster maintenance"
             }),
             forget_node(Node);
         false ->
-            ?tp(debug, router_node_purge_skipped, #{node => Node}),
+            ?tp(debug, broker_node_purge_skipped, #{node => Node}),
             forget_node(Node);
         aborted ->
-            ?tp(notice, router_node_purge_aborted, #{node => Node})
+            ?tp(notice, broker_node_purge_aborted, #{node => Node})
     catch
         Kind:Error ->
-            ?tp(warning, router_node_purge_error, #{
+            ?tp(warning, broker_node_purge_error, #{
                 node => Node,
                 kind => Kind,
                 error => Error

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -573,25 +573,10 @@ handle_purge_node(Node) ->
             end
         )
     ),
-    handle_purge_node(Node, Records).
-
-handle_purge_node(Node, Records = [_ | _]) ->
-    Routes = lists:foldl(
-        fun(Record = #?SHARED_SUBSCRIPTION{group = Group, topic = Topic}, Acc) ->
-            mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
-            maps:put({Group, Topic}, true, Acc)
-        end,
-        #{},
+    lists:foreach(
+        fun(Record) -> mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record) end,
         Records
-    ),
-    maps:foreach(
-        fun({Group, Topic}, _) ->
-            delete_route(Group, Topic, Node)
-        end,
-        Routes
-    );
-handle_purge_node(_Node, []) ->
-    ok.
+    ).
 
 update_stats() ->
     emqx_stats:setstat(

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -455,7 +455,7 @@ init([]) ->
 %% Deprecated, left for backwards compatibility.
 %% Should be removed in the next release.
 init_monitors() ->
-    pmon_new().
+    emqx_pmon:new().
 
 handle_call({subscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
     handle_subscribe(Group, Topic, SubPid),

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -489,8 +489,6 @@ handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
 
-handle_info({mnesia_table_event, _Event}, State) ->
-    {noreply, State};
 handle_info({'DOWN', _MRef, process, SubPid, Reason}, State = #state{pmon = PMon}) ->
     ?SLOG(debug, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
     cleanup_down(SubPid),

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -13,6 +13,9 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
 %% Mnesia bootstrap
 -export([create_tables/0]).
 
@@ -52,14 +55,15 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
-%% Internal exports (RPC)
+%% Internal exports
 -export([
-    init_monitors/0
+    %% RPC Targets:
+    init_monitors/0,
+    %% Other:
+    update_stats/0
 ]).
 
 -export_type([strategy/0]).
@@ -117,10 +121,16 @@ create_tables() ->
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
+%% @doc Subscribe `SubPid` to the shared subscription group-topic.
+%% This call *is not perfectly idempotent*, and currently `emqx_broker`
+%% guarantees that it's called only once (per new shared subscription).
 -spec subscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 subscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {subscribe, Group, Topic, SubPid}).
 
+%% @doc Unsubscribe `SubPid` from the shared subscription group-topic.
+%% This call *is not perfectly idempotent*, and currently `emqx_broker`
+%% guarantees that it's called only once (per existing shared subscription).
 -spec unsubscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 unsubscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {unsubscribe, Group, Topic, SubPid}).
@@ -227,7 +237,7 @@ do_dispatch_with_ack(SubPid, Group, Topic, Msg) ->
             {error, timeout}
         end
     after
-        ok = emqx_pmon:demonitor(Ref)
+        erlang:demonitor(Ref, [flush])
     end.
 
 with_group_ack(Msg, Group, Sender, Ref) ->
@@ -410,43 +420,43 @@ subscribers(Group, Topic) ->
 %%--------------------------------------------------------------------
 
 init([]) ->
+    %% Set up tables:
     ok = mria:wait_for_tables([?SHARED_SUBSCRIPTION]),
-    {ok, _} = mnesia:subscribe({table, ?SHARED_SUBSCRIPTION, simple}),
-    {atomic, PMon} = mria:transaction(?SHARED_SUB_SHARD, fun ?MODULE:init_monitors/0),
     ok = emqx_utils_ets:new(?SHARED_SUBSCRIBER, [protected, bag]),
     ok = emqx_utils_ets:new(?SHARED_SUBS_ROUND_ROBIN_COUNTER, [
         public, set, {write_concurrency, true}
     ]),
-    {ok, update_stats(#state{pmon = PMon})}.
+    %% There may be leftovers from older incarnation of this node, clean them up:
+    cleanup_node(node()),
+    %% Let `emqx_stats` periodically update stats instead of relying on mnesia events:
+    ok = emqx_stats:update_interval(?MODULE, fun ?MODULE:update_stats/0),
+    {ok, #state{pmon = pmon_new()}}.
 
+%% Deprecated, left for backwards compatibility.
+%% Should be removed in the next release.
 init_monitors() ->
-    mnesia:foldl(
-        fun(#?SHARED_SUBSCRIPTION{subpid = SubPid}, Mon) ->
-            emqx_pmon:monitor(SubPid, Mon)
-        end,
-        emqx_pmon:new(),
-        ?SHARED_SUBSCRIPTION
-    ).
+    pmon_new().
 
 handle_call({subscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
-    mria:dirty_write(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
-    case ets:member(?SHARED_SUBSCRIBER, {Group, Topic}) of
-        true ->
+    handle_subscribe(Group, Topic, SubPid),
+    update_stats(),
+    NPMon = pmon_inc_monitor(SubPid, PMon),
+    {reply, ok, State#state{pmon = NPMon}};
+handle_call({unsubscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
+    handle_unsubscribe(Group, Topic, SubPid),
+    update_stats(),
+    case pmon_dec_monitor(SubPid, PMon) of
+        NPMon = #{} ->
             ok;
-        false ->
-            ok = emqx_router:do_add_route(Topic, {Group, node()}),
-            _ = emqx_external_broker:add_shared_route(Topic, Group),
-            ok
+        {error, inconsistent} ->
+            NPMon = PMon,
+            ?tp(warning, "shared_subcriber_monitor_inconsistent", #{
+                subpid => SubPid,
+                group => Group,
+                topic => Topic
+            })
     end,
-    ok = maybe_insert_round_robin_count({Group, Topic}),
-    true = ets:insert(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}),
-    {reply, ok, update_stats(State#state{pmon = emqx_pmon:monitor(SubPid, PMon)})};
-handle_call({unsubscribe, Group, Topic, SubPid}, _From, State) ->
-    mria:dirty_delete_object(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
-    true = ets:delete_object(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}),
-    delete_route_if_needed({Group, Topic}),
-    maybe_delete_round_robin_count({Group, Topic}),
-    {reply, ok, update_stats(State)};
+    {reply, ok, State#state{pmon = NPMon}};
 handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", req => Req}),
     {reply, ignored, State}.
@@ -455,35 +465,16 @@ handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
 
-handle_info(
-    {mnesia_table_event, {write, #?SHARED_SUBSCRIPTION{subpid = SubPid}, _}},
-    State = #state{pmon = PMon}
-) ->
-    {noreply, update_stats(State#state{pmon = emqx_pmon:monitor(SubPid, PMon)})};
-handle_info({mnesia_table_event, {delete_object, _OldRecord, _}}, State = #state{pmon = _PMon}) ->
-    %% The subscriber may have subscribed multiple topics, so we need to keep monitoring the PID until
-    %% it `unsubscribed` the last topic.
-    %% The trick is we don't demonitor the subscriber here, and (after a long time) it will eventually
-    %% be disconnected.
-    %% #?SHARED_SUBSCRIPTION{subpid = SubPid} = OldRecord,
-    %% {noreply, update_stats(State#state{pmon = emqx_pmon:demonitor(SubPid, PMon)})};
-    %%
-    %% So we only need to update stats here.
-    {noreply, update_stats(State)};
 handle_info({mnesia_table_event, _Event}, State) ->
     {noreply, State};
 handle_info({'DOWN', _MRef, process, SubPid, Reason}, State = #state{pmon = PMon}) ->
     ?SLOG(debug, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
     cleanup_down(SubPid),
-    {noreply, update_stats(State#state{pmon = emqx_pmon:erase(SubPid, PMon)})};
+    update_stats(),
+    NPMon = pmon_erase(SubPid, PMon),
+    {noreply, State#state{pmon = NPMon}};
 handle_info(_Info, State) ->
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    mnesia:unsubscribe({table, ?SHARED_SUBSCRIPTION, simple}).
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 %%--------------------------------------------------------------------
 %% Internal functions
@@ -500,17 +491,43 @@ send(Pid, Topic, Msg) ->
         end,
     ok.
 
+handle_subscribe(Group, Topic, SubPid) ->
+    mria:dirty_write(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
+    case ets:member(?SHARED_SUBSCRIBER, {Group, Topic}) of
+        true ->
+            ok;
+        false ->
+            ok = emqx_router:do_add_route(Topic, {Group, node()}),
+            emqx_external_broker:add_shared_route(Topic, Group)
+    end,
+    maybe_insert_round_robin_count({Group, Topic}),
+    ets:insert(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}).
+
 maybe_insert_round_robin_count({Group, _Topic} = GroupTopic) ->
     strategy(Group) =:= round_robin_per_group andalso
-        ets:insert(?SHARED_SUBS_ROUND_ROBIN_COUNTER, {GroupTopic, 0}),
-    ok.
+        ets:insert(?SHARED_SUBS_ROUND_ROBIN_COUNTER, {GroupTopic, 0}).
 
 maybe_delete_round_robin_count({Group, _Topic} = GroupTopic) ->
     strategy(Group) =:= round_robin_per_group andalso
-        if_no_more_subscribers(GroupTopic, fun() ->
-            ets:delete(?SHARED_SUBS_ROUND_ROBIN_COUNTER, GroupTopic)
-        end),
-    ok.
+        ets:delete(?SHARED_SUBS_ROUND_ROBIN_COUNTER, GroupTopic).
+
+handle_unsubscribe(Group, Topic, SubPid) ->
+    handle_unsubscribe(record(Group, Topic, SubPid)).
+
+handle_unsubscribe(
+    Record = #?SHARED_SUBSCRIPTION{
+        group = Group,
+        topic = Topic,
+        subpid = SubPid
+    }
+) ->
+    GroupTopic = {Group, Topic},
+    mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
+    true = ets:delete_object(?SHARED_SUBSCRIBER, {GroupTopic, SubPid}),
+    if_no_more_subscribers(GroupTopic, fun() ->
+        maybe_delete_round_robin_count(GroupTopic),
+        delete_route(Group, Topic)
+    end).
 
 if_no_more_subscribers(GroupTopic, Fn) ->
     case ets:member(?SHARED_SUBSCRIBER, GroupTopic) of
@@ -520,23 +537,27 @@ if_no_more_subscribers(GroupTopic, Fn) ->
     ok.
 
 cleanup_down(SubPid) ->
-    lists:foreach(
-        fun(Record = #?SHARED_SUBSCRIPTION{topic = Topic, group = Group}) ->
-            ok = mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
-            true = ets:delete_object(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}),
-            maybe_delete_round_robin_count({Group, Topic}),
-            delete_route_if_needed({Group, Topic})
-        end,
-        mnesia:dirty_match_object(#?SHARED_SUBSCRIPTION{_ = '_', subpid = SubPid})
-    ).
+    Records = mnesia:dirty_match_object(#?SHARED_SUBSCRIPTION{_ = '_', subpid = SubPid}),
+    lists:foreach(fun handle_unsubscribe/1, Records).
 
-update_stats(State) ->
+cleanup_node(Node) ->
+    %% TODO: Liveness checks.
+    Records = mnesia:dirty_select(
+        ?SHARED_SUBSCRIPTION,
+        ets:fun2ms(fun(Record = #?SHARED_SUBSCRIPTION{subpid = SubPid}) when
+            node(SubPid) == Node
+        ->
+            Record
+        end)
+    ),
+    lists:foreach(fun handle_unsubscribe/1, Records).
+
+update_stats() ->
     emqx_stats:setstat(
         'subscriptions.shared.count',
         'subscriptions.shared.max',
         ets:info(?SHARED_SUBSCRIPTION, size)
-    ),
-    State.
+    ).
 
 %% Return 'true' if the subscriber process is alive AND not in the failed list
 is_active_sub(Pid, FailedSubs, All) ->
@@ -552,15 +573,46 @@ is_alive_sub(Pid) ->
     %% When process is not local, the best guess is it's alive.
     emqx_router_helper:is_routable(node(Pid)).
 
-delete_route_if_needed({Group, Topic} = GroupTopic) ->
-    if_no_more_subscribers(GroupTopic, fun() ->
-        ok = emqx_router:do_delete_route(Topic, {Group, node()}),
-        _ = emqx_external_broker:delete_shared_route(Topic, Group),
-        ok
-    end).
+delete_route(Group, Topic) ->
+    ok = emqx_router:do_delete_route(Topic, {Group, node()}),
+    _ = emqx_external_broker:delete_shared_route(Topic, Group),
+    ok.
 
 get_default_shared_subscription_strategy() ->
     emqx:get_config([mqtt, shared_subscription_strategy]).
 
 get_default_shared_subscription_initial_sticky_pick() ->
     emqx:get_config([mqtt, shared_subscription_initial_sticky_pick]).
+
+%%--------------------------------------------------------------------
+
+pmon_new() ->
+    #{}.
+
+pmon_inc_monitor(Pid, PMon) ->
+    case PMon of
+        #{Pid := {MRef, N}} ->
+            %% Process is already being monitored.
+            %% Bump number of monitor requests.
+            PMon#{Pid := {MRef, N + 1}};
+        #{} ->
+            %% Process is not being monitored yet.
+            MRef = erlang:monitor(process, Pid),
+            PMon#{Pid => {MRef, 1}}
+    end.
+
+pmon_dec_monitor(Pid, PMon) ->
+    case PMon of
+        #{Pid := {MRef, N}} when N =< 1 ->
+            %% Process is being monitored once.
+            _ = erlang:demonitor(MRef, [flush]),
+            maps:remove(Pid, PMon);
+        #{Pid := {MRef, N}} ->
+            %% Decrement number of monitor requests.
+            PMon#{Pid := {MRef, N - 1}};
+        #{} ->
+            {error, inconsistent}
+    end.
+
+pmon_erase(Pid, PMon) ->
+    maps:remove(Pid, PMon).

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -120,7 +120,7 @@ t_membership_node_leaving(_Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {_, {ok, _}} = ?wait_async_action(
         ?ROUTER_HELPER ! {membership, {node, leaving, AnotherNode}},
-        #{?snk_kind := router_node_routing_table_purged, node := AnotherNode},
+        #{?snk_kind := broker_node_purged, node := AnotherNode},
         5_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
@@ -139,7 +139,7 @@ t_cluster_node_leaving(Config) ->
     ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, {ok, _}} = ?wait_async_action(
         erpc:call(ClusterNode, ekka, leave, []),
-        #{?snk_kind := router_node_routing_table_purged, node := ClusterNode},
+        #{?snk_kind := broker_node_purged, node := ClusterNode},
         3_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
@@ -159,7 +159,7 @@ t_cluster_node_down(Config) ->
     ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, SRef} = snabbkaffe:subscribe(
         %% Should be purged after ~2 reconciliations.
-        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
+        ?match_event(#{?snk_kind := broker_node_purged, node := ClusterNode}),
         1,
         10_000
     ),
@@ -180,7 +180,7 @@ t_cluster_node_orphan(_Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {ok, SRef} = snabbkaffe:subscribe(
         %% Should be purged after ~2 reconciliations.
-        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := OrphanNode}),
+        ?match_event(#{?snk_kind := broker_node_purged, node := OrphanNode}),
         1,
         10_000
     ),
@@ -200,7 +200,7 @@ t_cluster_node_force_leave(Config) ->
     ?assertMatch([_, _, _], emqx_router:topics()),
     ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, SRef} = snabbkaffe:subscribe(
-        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
+        ?match_event(#{?snk_kind := broker_node_purged, node := ClusterNode}),
         1,
         10_000
     ),
@@ -291,7 +291,7 @@ t_cluster_migration(Config) ->
     ?assertEqual([N2, N3], erpc:call(N2, emqx, running_nodes, [])),
 
     %% No routes are expected to be present in the global routing table.
-    ?block_until(#{?snk_kind := router_node_routing_table_purged, node := N1}),
+    ?block_until(#{?snk_kind := broker_node_purged, node := N1}),
     ?assertEqual([], erpc:call(N2, emqx_router, topics, [])),
     ?assertEqual([], erpc:call(N3, emqx_router, topics, [])),
 

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -710,8 +710,8 @@ t_stats(Config) when is_list(Config) ->
     emqtt:subscribe(ConnPid1, {SharedTopic, 0}),
     %% Verify LOCAL stats update
     ?retry(
-        100,
-        5,
+        200,
+        10,
         ?assertMatch(
             #{'subscriptions.shared.count' := 1},
             maps:from_list(emqx_stats:getstats())
@@ -720,8 +720,8 @@ t_stats(Config) when is_list(Config) ->
     emqtt:unsubscribe(ConnPid1, SharedTopic),
     %% Verify LOCAL stats update again
     ?retry(
-        100,
-        5,
+        200,
+        10,
         ?assertMatch(
             #{'subscriptions.shared.count' := 0},
             maps:from_list(emqx_stats:getstats())

--- a/changes/ee/fix-15518.en.md
+++ b/changes/ee/fix-15518.en.md
@@ -1,0 +1,1 @@
+Resolve a race condition that may lead to accumulating inconsistencies in the routing table and shared subscriptions state in the cluster when a large number of shared subscribers disconnect simultaneously.


### PR DESCRIPTION
Fixes [EMQX-14477](https://emqx.atlassian.net/browse/EMQX-14477).

Release version: 6.0.0-M1.202507

## Summary

Prior to these changes, multiple EMQX nodes could in general react simultaneously to a single shared subscriber going down. If, due to load skew, remote node reacted to this event earlier than local node, leftover state started to accumulate. This would have eventually manifested in global routing table inconsistencies.

This PR changes `emqx_shared_sub` such that there's no monitoring of subscribers anymore. Local node is the only node responsible for cleaning up after local subscribers going down, as signaled by `emqx_broker_helper` that is now the component responsible for monitoring subcribers. In case whole node goes down, responsibility for cleaning up is shifted to `emqx_router_helper` and now follows the common logic. This breaks dependency chain a little, will be refactored in a follow up PR.

See individual commits for details.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)


[EMQX-14477]: https://emqx.atlassian.net/browse/EMQX-14477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ