### PR TITLE
test(raft): mark test cases as flaky

### DIFF
--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -1436,6 +1436,12 @@ groups() ->
                 ]}
     ].
 
+flaky_tests() ->
+    #{
+        t_rebalance => 3,
+        t_crash_restart_recover => 3
+    }.
+
 init_per_group(Group, Config) ->
     LayoutConf =
         case Group of


### PR DESCRIPTION
These two test cases (`t_rebalance`, `t_crash_restart_recover`) have been failing a lot in CI.

Having a proper fix for the cause of their flakiness is obviously the ideal correct solution.  However, until that happens, we could reduce the time that is wasted re-running CI by retrying only them a bit instead of the whole workflow run, which is quite slow.

Ex: https://github.com/emqx/emqx/actions/runs/16377217654/job/46282627060#step:5:5939
