### PR TITLE
perf: tune some default VM args

### DIFF
--- a/apps/emqx/etc/vm.args.cloud
+++ b/apps/emqx/etc/vm.args.cloud
@@ -37,9 +37,10 @@
 ## Prevent user from accidentally calling a function from the prompt that could harm a running system.
 -stdlib restricted_shell emqx_restricted_shell
 
-## Sets the distribution buffer busy limit (dist_buf_busy_limit).
-## Preferably set in `emqx.conf`,
-#+zdbbl 8192
+## Sets the distribution buffer busy limit (dist_buf_busy_limit) in kilobytes.
+## The default 1024 may not be sufficient when mnesia operations are intensive,
+##  and could result in busy_dist_port alarms.
++zdbbl 32768
 
 ## Sets default scheduler hint for port parallelism.
 +spp true
@@ -87,12 +88,26 @@
 ## Suggested stack size, in kilowords, for dirty IO scheduler threads.
 #+sssdio 40
 
-## Sets scheduler bind type.
-## Can be one of: u, ns, ts, ps, s, nnts, nnps, tnnps, db
-#+sbt db
-
 ## Sets a user-defined CPU topology.
 #+sct L0-3c0-3p0N0:L4-7c0-3p1N1
+
+## Sets scheduler bind type. Setting to 'db' may achieve lower message latency
+##  than the default 'u' in most scenarios.
+## If binding of schedulers is not supported by the OS, or no available CPU
+##  topology detected, the runtime system silently ignores the error, and start
+##  up using unbound schedulers 'u'.
++stbt db
+
+## Sets scheduler busy wait threshold. Setting to 'none' disables busy waiting.
+## This can significantly reduce the CPU usage observed by the OS, but may
+##  increase message latency in some scenarios.
++sbwt none
+
+## As +sbwt but affects dirty CPU schedulers.
++sbwtdcpu none
+
+## As +sbwt but affects dirty IO schedulers.
++sbwtdio none
 
 ## Sets the mapping of warning messages for error_logger
 #+W w

--- a/changes/ce/perf-15539.en.md
+++ b/changes/ce/perf-15539.en.md
@@ -1,0 +1,5 @@
+Optimize Erlang VM parameters.
+
+- Increase the buffer sizes for distributed channels to 32MB to avoid `busy_dist_port` alarms during intensive Mnesia operations: `+zdbbl 32768`
+- Disable scheduler busy-waiting to reduce CPU usage observed by the operating system: `+sbwt none +sbwtdcpu none +sbwtdio none`
+- Set scheduler binding type to `db` to reduce message latency: `+stbt db`


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14522

Refs:

- Some of the tune suggestions of RabbitMQ: https://www.rabbitmq.com/docs/runtime#scheduling
- Why Erlang introduced the busy wait feature: https://dieswaytoofast.blogspot.com/2012/09/cpu-utilization-in-erlang-r15b02.html
- Some discuss of the busy wait feature: https://elixirforum.com/t/performance-of-erlang-elixir-in-docker-kubernetes/21493
- This article shows the latency is acceptable even the busy wait feature is disabled, which is consistent with our own test findings: https://stressgrid.com/blog/beam_cpu_usage/

Tests about these vm args on e4.4.31: https://emqx.atlassian.net/wiki/spaces/QA/pages/1864237057/FlowMQ+0.22.0+Performance+Testing+Report

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 5.8.8

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
