### PR TITLE
ci: fix BASE_BRANCH name in bump-dashboard-version workflow

### DIFF
--- a/.github/workflows/bump-dashboard-version.yaml
+++ b/.github/workflows/bump-dashboard-version.yaml
@@ -58,16 +58,14 @@ jobs:
         run: |
           set -euxo pipefail
           git fetch origin
-          BASE_BRANCH="$(git branch --remotes --list 'origin/release-[0-9]*' | \
+          BASE_BRANCH="$(git branch --remotes --list 'origin/release-[0-9]*' | cut -d/ -f2 | \
             awk -F- '{
               version=$2;
               if (version !~ /\./) {
                 version = substr(version, 1, 1) "." substr(version, 2)
               }
               print version, $0
-            }' | \
-            sort -rV -k1,1 | \
-            cut -d' ' -f2- | head -n 1)"
+            }' | sort -rV -k1,1 | head -n 1 | cut -d' ' -f2-)"
           NEW_BRANCH="bump-${EMQX_NAME}-dashboard-version-$(date +"%Y%m%d-%H%M%S")"
           git checkout -b ${NEW_BRANCH} --track origin/${BASE_BRANCH}
           sed -i "s|EMQX_EE_DASHBOARD_VERSION ?= .*|EMQX_EE_DASHBOARD_VERSION ?= ${DASHBOARD_VERSION}|" Makefile


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/16365605155/job/46242001431#step:6:735

```
git checkout -b bump-emqx-enterprise-dashboard-version-20250718-081020 --track origin/ origin/release-60
fatal: '--track' cannot be used with updating paths
```