### PR TITLE
chore: update hackney

### DIFF
--- a/apps/emqx_ai_completion/rebar.config
+++ b/apps/emqx_ai_completion/rebar.config
@@ -11,5 +11,7 @@
 {deps, [
     {emqx, {path, "../emqx"}},
     {emqx_utils, {path, "../emqx_utils"}},
-    {hackney, {git, "https://github.com/emqx/hackney.git", {tag, "1.18.1-1"}}}
+    {hackney,
+        {git, "https://github.com/savonarola/hackney.git",
+            {branch, "20250723-fix-ssl-connect-with-sni"}}}
 ]}.

--- a/apps/emqx_s3/src/emqx_s3.app.src
+++ b/apps/emqx_s3/src/emqx_s3.app.src
@@ -1,6 +1,6 @@
 {application, emqx_s3, [
     {description, "EMQX S3"},
-    {vsn, "5.1.4"},
+    {vsn, "5.1.5"},
     {modules, []},
     {registered, [emqx_s3_sup]},
     {applications, [

--- a/apps/emqx_s3/test/emqx_s3_profile_conf_SUITE.erl
+++ b/apps/emqx_s3/test/emqx_s3_profile_conf_SUITE.erl
@@ -60,7 +60,8 @@ t_httpc_pool_start_error(Config) ->
     ?assertMatch(
         {error, _},
         emqx_s3:start_profile(<<"profile">>, ?config(profile_config, Config))
-    ).
+    ),
+    meck:unload(hackney_pool).
 
 t_httpc_pool_update_error(Config) ->
     %% `hackney_pool`s are lazy so it is difficult to trigger an error
@@ -77,7 +78,8 @@ t_httpc_pool_update_error(Config) ->
     ?assertMatch(
         {error, _},
         emqx_s3:start_profile(<<"profile">>, NewProfileConfig)
-    ).
+    ),
+    meck:unload(hackney_pool).
 
 t_orphaned_pools_cleanup(_Config) ->
     ProfileId = profile_id(),

--- a/apps/emqx_s3/test/emqx_s3_test_helpers.erl
+++ b/apps/emqx_s3/test/emqx_s3_test_helpers.erl
@@ -87,6 +87,7 @@ base_raw_config(tls) ->
         <<"transport_options">> =>
             #{
                 <<"request_timeout">> => <<"2s">>,
+                <<"connect_timeout">> => <<"5s">>,
                 <<"ssl">> => #{
                     <<"enable">> => true,
                     <<"cacertfile">> => bin(cert_path("ca.crt")),

--- a/mix.exs
+++ b/mix.exs
@@ -150,12 +150,13 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:gpb),
       common_dep(:hackney),
       # set by hackney (dependency)
+
       {:ssl_verify_fun, "1.1.7", override: true},
       common_dep(:bcrypt),
       common_dep(:uuid),
       {:quickrand, github: "okeuday/quickrand", tag: "v2.0.6", override: true},
       common_dep(:ra),
-      {:mimerl, "1.2.0", override: true},
+      {:mimerl, "1.4.0", override: true},
       common_dep(:sasl_auth),
       # avlizer currently uses older :erlavro version
       common_dep(:erlavro),
@@ -210,7 +211,9 @@ defmodule EMQXUmbrella.MixProject do
     do: {:cowboy, github: "emqx/cowboy", tag: "2.13.0-emqx-2", override: true}
 
   def common_dep(:hackney),
-    do: {:hackney, github: "emqx/hackney", tag: "1.18.1-1", override: true}
+    do:
+      {:hackney,
+       github: "savonarola/hackney", branch: "20250723-fix-ssl-connect-with-sni", override: true}
 
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
   def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.6.1", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -109,7 +109,9 @@
     {sasl_auth, "2.3.3"},
     {jose, {git, "https://github.com/potatosalad/erlang-jose", {tag, "1.11.2"}}},
     {telemetry, "1.3.0"},
-    {hackney, {git, "https://github.com/emqx/hackney.git", {tag, "1.18.1-1"}}},
+    {hackney,
+        {git, "https://github.com/savonarola/hackney.git",
+            {branch, "20250723-fix-ssl-connect-with-sni"}}},
     %% to keep in sync with mix.exs
     {ssl_verify_fun, "1.1.7"},
     %% in conflict by erlavro and rocketmq


### PR DESCRIPTION
Release version: 5.10.1, 6.0.0

## Summary

The upstream already updated  the dependencies that we updated in the fork. https://github.com/benoitc/hackney/compare/master...emqx:hackney:master

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

