### PR TITLE
chore: bump erlcloud -> 3.8.3.0 (port of #15542 to release-58)

### DIFF
--- a/apps/emqx_bridge_dynamo/rebar.config
+++ b/apps/emqx_bridge_dynamo/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.7.0.3"}}},
+    {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.8.3.0"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_bridge_kinesis/rebar.config
+++ b/apps/emqx_bridge_kinesis/rebar.config
@@ -2,7 +2,8 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.7.0.3"}}},
+    {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.8.3.0"}}},
+    {emqx, {path, "../../apps/emqx"}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/apps/emqx_s3/rebar.config
+++ b/apps/emqx_s3/rebar.config
@@ -2,7 +2,7 @@
 
 {deps, [
     {emqx, {path, "../../apps/emqx"}},
-    {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.7.0.3"}}},
+    {erlcloud, {git, "https://github.com/emqx/erlcloud", {tag, "3.8.3.0"}}},
     {emqx_bridge_http, {path, "../emqx_bridge_http"}}
 ]}.
 

--- a/changes/ee/feat-15542.en.md
+++ b/changes/ee/feat-15542.en.md
@@ -1,0 +1,1 @@
+Upgraded our `erlcoud` library to `3.8.3.0`.  This allows one to setup a S3 Connector without specifying Access Key Id and Secret Access Key, so long as the EC2 instance EMQX is running in has the correct IAM permissions to read/write to the configured bucket(s).

--- a/mix.exs
+++ b/mix.exs
@@ -292,6 +292,8 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.1.1"}
   def common_dep(:erlavro), do: {:erlavro, github: "emqx/erlavro", tag: "2.10.0", override: true}
 
+  def common_dep(:erlcloud), do: {:erlcloud, github: "emqx/erlcloud", tag: "3.8.3.0"}
+
   def common_dep(:unicode_util_compat),
     do: {:unicode_util_compat, "0.7.1", override: true}
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14526

Mainly to get https://github.com/erlcloud/erlcloud/pull/755


<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 5.8.8?

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
