### PR TITLE
set 1 replica as default in helm chart

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -257,3 +257,4 @@ jobs:
       - sanity-checks
       - build_docker_emqx_enterprise
     uses: ./.github/workflows/run_helm_tests.yaml
+    secrets: inherit

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -6,6 +6,9 @@ concurrency:
 
 on:
   workflow_call:
+    secrets:
+      EMQX_ENTERPRISE_LICENSE:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/run_helm_tests.yaml
+++ b/.github/workflows/run_helm_tests.yaml
@@ -68,7 +68,6 @@ jobs:
           EMQX_RPC__CACERTFILE: /opt/emqx/etc/certs/cacert.pem
           EMQX_RPC__CIPHERS: TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256
           EMQX_RPC__TLS_VERSIONS: "[tlsv1.3]"
-          EMQX_LICENSE__KEY: evaluation
         EOL
     - name: Prepare emqxConfig.EMQX_RPC using ssl1.2
       working-directory: source
@@ -82,7 +81,6 @@ jobs:
           EMQX_RPC__CACERTFILE: /opt/emqx/etc/certs/cacert.pem
           EMQX_RPC__CIPHERS: TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256
           EMQX_RPC__TLS_VERSIONS: "[tlsv1.2]"
-          EMQX_LICENSE__KEY: evaluation
         EOL
     - name: run emqx on chart (k8s)
       if: matrix.discovery == 'k8s'
@@ -97,12 +95,13 @@ jobs:
             --set image.pullPolicy=Never \
             --set image.tag=$EMQX_TAG \
             --set emqxAclConfig="" \
+            --set replicaCount=3 \
             --set emqxConfig.EMQX_MQTT__RETRY_INTERVAL=2s \
             --set emqxConfig.EMQX_MQTT__MAX_TOPIC_ALIAS=10 \
             --set emqxConfig.EMQX_AUTHORIZATION__SOURCES=[] \
             --set emqxConfig.EMQX_LOG__CONSOLE__LEVEL=debug \
             --set emqxConfig.EMQX_AUTHORIZATION__NO_MATCH=allow \
-            --set emqxConfig.EMQX_LICENSE__KEY=evaluation \
+            --set emqxConfig.EMQX_LICENSE__KEY="${{ secrets.EMQX_ENTERPRISE_LICENSE }}" \
             --values rpc-overrides.yaml \
             deploy/charts/${EMQX_NAME} \
             --debug
@@ -118,12 +117,13 @@ jobs:
             --set image.pullPolicy=Never \
             --set image.tag=$EMQX_TAG \
             --set emqxAclConfig="" \
+            --set replicaCount=3 \
             --set emqxConfig.EMQX_MQTT__RETRY_INTERVAL=2s \
             --set emqxConfig.EMQX_MQTT__MAX_TOPIC_ALIAS=10 \
             --set emqxConfig.EMQX_AUTHORIZATION__SOURCES=[] \
             --set emqxConfig.EMQX_LOG__CONSOLE__LEVEL=debug \
             --set emqxConfig.EMQX_AUTHORIZATION__NO_MATCH=allow \
-            --set emqxConfig.EMQX_LICENSE__KEY=evaluation \
+            --set emqxConfig.EMQX_LICENSE__KEY="${{ secrets.EMQX_ENTERPRISE_LICENSE }}" \
             --values rpc-overrides.yaml \
             deploy/charts/${EMQX_NAME} \
             --wait \

--- a/changes/ee/fix-15550.en.md
+++ b/changes/ee/fix-15550.en.md
@@ -1,0 +1,1 @@
+Fixes an issue with helm chart when all nodes except one will be crashing if the chart is deployed with default values.

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -3,7 +3,7 @@
 ## Declare variables to be passed into your templates.
 
 ## It is recommended to have odd number of nodes in a cluster, otherwise the emqx cluster cannot be automatically healed in case of net-split.
-replicaCount: 3
+replicaCount: 1
 image:
   repository: emqx/emqx-enterprise
   pullPolicy: IfNotPresent

--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -3,7 +3,7 @@
 ## Declare variables to be passed into your templates.
 
 ## It is recommended to have odd number of nodes in a cluster, otherwise the emqx cluster cannot be automatically healed in case of net-split.
-replicaCount: 3
+replicaCount: 1
 image:
   repository: emqx/emqx
   pullPolicy: IfNotPresent


### PR DESCRIPTION
clustered setup requires a license

Fixes an issue when all nodes except one will be crashing if a user deployes helm chart as is.

Release version: 5.9.2, 5.10.1, 6.0.0-M2.202508, 6.0.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
