### PR TITLE
feat(trace): expose max trace file size limit as config option

### DIFF
--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -222,10 +222,8 @@ log_filter([{Id, FilterFun, Filter, Name} | Rest], Log0) ->
                                     )
                             end
                     end;
-                {error, {not_found, Id}} ->
-                    ok;
-                {error, Reason} ->
-                    logger:internal_log(error, {find_handle_id_failed, Id, Reason})
+                {error, {not_found, _}} ->
+                    ok
             end
     end,
     log_filter(Rest, Log0).

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -14,7 +14,6 @@
 -export([
     running/0,
     install/3,
-    install/4,
     install/5,
     install/6,
     uninstall/1,
@@ -84,15 +83,6 @@ install(Name, Type, Filter, Level, LogFile, Formatter) ->
 ) -> ok | {error, term()}.
 install(Name, Type, Filter, Level, LogFile) ->
     install(Name, Type, Filter, Level, LogFile, text).
-
--spec install(
-    Type :: clientid | topic | ip_address,
-    Filter :: emqx_types:clientid() | emqx_types:topic() | string(),
-    Level :: logger:level() | all,
-    LogFilePath :: string()
-) -> ok | {error, term()}.
-install(Type, Filter, Level, LogFile) ->
-    install(Filter, Type, Filter, Level, LogFile).
 
 -spec install(tracer(), logger:level() | all, string()) -> ok | {error, term()}.
 install(Who, all, LogFile) ->

--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -27,12 +27,6 @@ init_per_suite(Config) ->
         [emqx],
         #{work_dir => emqx_cth_suite:work_dir(Config)}
     ),
-    Listeners = emqx_listeners:list(),
-    ct:pal("emqx_listeners:list() = ~p~n", [Listeners]),
-    ?assertMatch(
-        [_ | _],
-        [ID || {ID, #{running := true}} <- Listeners]
-    ),
     [{apps, Apps} | Config].
 
 end_per_suite(Config) ->
@@ -43,7 +37,6 @@ end_per_suite(Config) ->
 init_per_testcase(_, Config) ->
     reload(),
     ok = emqx_trace:clear(),
-    ct:pal("load:~p~n", [erlang:whereis(emqx_trace)]),
     Config.
 
 end_per_testcase(_) ->

--- a/apps/emqx/test/emqx_trace_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_handler_SUITE.erl
@@ -50,7 +50,7 @@ t_trace_clientid(_Config) ->
     ok = emqx_trace_handler:install("CLI-client2", clientid, <<"client2">>, all, "tmp/client2.log"),
     ok = emqx_trace_handler:install("CLI-client3", clientid, <<"client3">>, all, "tmp/client3.log"),
     {error, {handler_not_added, {file_error, ".", eisdir}}} =
-        emqx_trace_handler:install(clientid, <<"client5">>, debug, "."),
+        emqx_trace_handler:install("CLI-client5", clientid, <<"client5">>, debug, "."),
     emqx_trace:check(),
     ok = filesync(<<"CLI-client1">>, clientid),
     ok = filesync(<<"CLI-client2">>, clientid),

--- a/changes/ee/feat-15556.en.md
+++ b/changes/ee/feat-15556.en.md
@@ -1,0 +1,1 @@
+Exposed maximum trace file size limit per each individual trace as a configuraion option `trace.max_file_size`.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1164,6 +1164,13 @@ fields_trace_payload_encode.desc:
 fields_trace_payload_encode.label:
 """Payload encode"""
 
+fields_trace_max_file_size.desc:
+"""Specifies how large _each_ trace file may become.
+Once a trace file reaches this size, no additional events will be recorded, even if the trace remains active."""
+
+fields_trace_max_file_size.label:
+"""Maximum Trace File Size"""
+
 mqtt_response_information.desc:
 """UTF-8 string, for creating the response topic, for example, if set to <code>reqrsp/</code>, the publisher/subscriber will communicate using the topic prefix <code>reqrsp/</code>.
 To disable this feature, input <code>""</code> in the text box below. Only applicable to MQTT 5.0 clients."""


### PR DESCRIPTION
Fixes [EMQX-14467](https://emqx.atlassian.net/browse/EMQX-14467).

Release version: 6.0.0

## Summary

This PR exposes trace file size limit as a configuration option, with 512 MiB preserved as a default.

Now that it's possible for the user to set much lower limits, risk of hitting this limit is increased. Currently, because tracing is implemented on top of `logger` subsystem components, there's no direct feedback: active trace does not know that the limit is hit. Instead, messages like these are printed to stdout / stderr:
```
Logger - error: {disk_log,'trace_topic_CLI-trace_max_file_size','trace_topic_CLI-trace_max_file_size',full}
Logger - error: {'trace_topic_CLI-trace_max_file_size',log,#{type=>halt,file=>"tmp/trace_max_file_size.log",max_no_bytes=>5120,max_no_files=>undefined},{error,{full,'trace_topic_CLI-trace_max_file_size'}}}
```

This is obviously poor user experience, improvements to be made in followup PRs. Proposals are outlined [here](https://emqx.atlassian.net/browse/EMQX-14537).

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14467]: https://emqx.atlassian.net/browse/EMQX-14467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ