### PR TITLE
test(takeover): mark test cases as flaky

### DIFF
--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -34,6 +34,11 @@ groups() ->
         {mqttv5, [], emqx_common_test_helpers:all(?MODULE)}
     ].
 
+flaky_tests() ->
+    #{
+        t_kick_session => 3
+    }.
+
 tc_v5_only() ->
     [
         t_session_expire_with_delayed_willmsg,


### PR DESCRIPTION
These test cases have been failing a lot in CI.

Having a proper fix for the cause of their flakiness is obviously the ideal correct solution.  However, until that happens, we could reduce the time that is wasted re-running CI by retrying only them a bit instead of the whole workflow run.
