### PR TITLE
ci: bump OTP version to 26.2.5.14-1

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-ubuntu22.04
+    image:  ghcr.io/emqx/emqx-builder/5.5-4:1.15.7-26.2.5.14-1-ubuntu22.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-ubuntu22.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.5-4:1.15.7-26.2.5.14-1-ubuntu22.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -55,7 +55,7 @@ on:
       otp_vsn:
         required: false
         type: string
-        default: '26.2.5.2-3'
+        default: '26.2.5.14-1'
       elixir_vsn:
         required: false
         type: string
@@ -63,7 +63,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '5.4-4'
+        default: '5.5-4'
 
 permissions:
   contents: read

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.2.5.2-3
+erlang 26.2.5.14-1
 elixir 1.15.7-otp-26

--- a/apps/emqx_auth_ext/test/emqx_auth_ext_listener_tls_verify_keyusage_SUITE.erl
+++ b/apps/emqx_auth_ext/test/emqx_auth_ext_listener_tls_verify_keyusage_SUITE.erl
@@ -294,7 +294,7 @@ t_conn_fail_client_keyusage_unmatch(Config) ->
         1000
     ),
     %% Then connecion should fail.
-    fail_when_no_ssl_alert(Socket, handshake_failure),
+    fail_when_no_ssl_alert(Socket, unsupported_certificate),
     ok = ssl:close(Socket).
 
 t_conn_fail_client_keyusage_incomplete(Config) ->

--- a/changes/ee/fix-15581.en.md
+++ b/changes/ee/fix-15581.en.md
@@ -1,0 +1,7 @@
+Upgrade OTP version from 26.2.5.2 to 26.2.5.14
+
+This upgrade includes two TLS-related fixes relevant to EMQX:
+
+- Fixed a crash in TLS connections caused by a race condition during certificate renewal.
+- Added support for RSA certificates signed with PSS parameters. Previously TLS handshake may fail with `invalid_signature`.
+

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-debian12
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.5-4:1.15.7-26.2.5.14-1-debian12
 ARG RUN_FROM=debian:12-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,6 +1,6 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=5.4-4
-export OTP_VSN=26.2.5.2-3
+export EMQX_BUILDER_VSN=5.5-4
+export OTP_VSN=26.2.5.14-1
 export ELIXIR_VSN=1.15.7
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu22.04
 export EMQX_DOCKER_BUILD_FROM=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-debian12

--- a/scripts/buildx.sh
+++ b/scripts/buildx.sh
@@ -12,6 +12,11 @@
 
 set -euo pipefail
 
+# ensure dir
+cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
+# shellcheck disable=SC1091
+source ./env.sh
+
 help() {
     echo
     echo "-h|--help:"
@@ -36,7 +41,7 @@ help() {
     echo ""
     echo "--builder <BUILDER>:"
     echo "    Docker image to use for building"
-    echo "    E.g. ghcr.io/emqx/emqx-builder/5.4-4:1.15.7-26.2.5.2-3-debian12"
+    echo "    E.g. ${EMQX_BUILDER}"
     echo "    For hot upgrading tar.gz, specify a builder image with the same OS distribution as the running one."
     echo "    Specifically, for EMQX's docker containers hot upgrading, please use the debian12-based builder. "
 }
@@ -47,11 +52,6 @@ die() {
     help
     exit 1
 }
-
-# ensure dir
-cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")/.."
-# shellcheck disable=SC1091
-source ./env.sh
 
 while [ "$#" -gt 0 ]; do
     case $1 in


### PR DESCRIPTION
Fixies the issue reported in a discussion: https://github.com/emqx/emqx/discussions/14924

Release version:
5.8.7


## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
