### PR TITLE
feat(snowflake): detach streaming mode to separate connector type

### DIFF
--- a/apps/emqx_bridge_snowflake/docs/user-guide.md
+++ b/apps/emqx_bridge_snowflake/docs/user-guide.md
@@ -82,9 +82,8 @@ MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
 CREATE PIPE IF NOT EXISTS testdatabase.public.emqxstreaming AS
 COPY INTO testdatabase.public.emqx FROM (
   SELECT $1:clientid, $1:topic, $1:payload, $1:publish_received_at
-  FROM TABLE(DATA_SOURCE(TYPE => 'STREAMING')
-)
-MATCH_BY_COLUMN_NAME = CASE_INSENSITIVE;
+  FROM TABLE(DATA_SOURCE(TYPE => 'STREAMING'))
+);
 
 CREATE USER IF NOT EXISTS snowpipeuser
     PASSWORD = 'Snowpipeuser99'

--- a/apps/emqx_bridge_snowflake/mix.exs
+++ b/apps/emqx_bridge_snowflake/mix.exs
@@ -22,8 +22,8 @@ defmodule EMQXBridgeSnowflake.MixProject do
       extra_applications: [:ssl, :odbc] ++ UMP.extra_applications(),
       mod: {:emqx_bridge_snowflake_app, []},
       env: [
-        emqx_action_info_modules: [:emqx_bridge_snowflake_action_info],
-        emqx_connector_info_modules: [:emqx_bridge_snowflake_connector_info]
+        emqx_action_info_modules: [:emqx_bridge_snowflake_aggregated_action_info],
+        emqx_connector_info_modules: [:emqx_bridge_snowflake_aggregated_connector_info]
       ]
     ]
   end

--- a/apps/emqx_bridge_snowflake/mix.exs
+++ b/apps/emqx_bridge_snowflake/mix.exs
@@ -22,8 +22,14 @@ defmodule EMQXBridgeSnowflake.MixProject do
       extra_applications: [:ssl, :odbc] ++ UMP.extra_applications(),
       mod: {:emqx_bridge_snowflake_app, []},
       env: [
-        emqx_action_info_modules: [:emqx_bridge_snowflake_aggregated_action_info],
-        emqx_connector_info_modules: [:emqx_bridge_snowflake_aggregated_connector_info]
+        emqx_action_info_modules: [
+          :emqx_bridge_snowflake_aggregated_action_info,
+          :emqx_bridge_snowflake_streaming_action_info
+        ],
+        emqx_connector_info_modules: [
+          :emqx_bridge_snowflake_aggregated_connector_info,
+          :emqx_bridge_snowflake_streaming_connector_info
+        ]
       ]
     ]
   end

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.hrl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.hrl
@@ -5,11 +5,11 @@
 -ifndef(__EMQX_BRIDGE_SNOWFLAKE_HRL__).
 -define(__EMQX_BRIDGE_SNOWFLAKE_HRL__, true).
 
--define(CONNECTOR_TYPE, snowflake).
--define(CONNECTOR_TYPE_BIN, <<"snowflake">>).
+-define(CONNECTOR_TYPE_AGGREG, snowflake).
+-define(CONNECTOR_TYPE_AGGREG_BIN, <<"snowflake">>).
 
--define(ACTION_TYPE, snowflake).
--define(ACTION_TYPE_BIN, <<"snowflake">>).
+-define(ACTION_TYPE_AGGREG, snowflake).
+-define(ACTION_TYPE_AGGREG_BIN, <<"snowflake">>).
 
 -define(SERVER_OPTS, #{
     default_port => 443

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.hrl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake.hrl
@@ -8,8 +8,14 @@
 -define(CONNECTOR_TYPE_AGGREG, snowflake).
 -define(CONNECTOR_TYPE_AGGREG_BIN, <<"snowflake">>).
 
+-define(CONNECTOR_TYPE_STREAM, snowflake_streaming).
+-define(CONNECTOR_TYPE_STREAM_BIN, <<"snowflake_streaming">>).
+
 -define(ACTION_TYPE_AGGREG, snowflake).
 -define(ACTION_TYPE_AGGREG_BIN, <<"snowflake">>).
+
+-define(ACTION_TYPE_STREAM, snowflake_streaming).
+-define(ACTION_TYPE_STREAM_BIN, <<"snowflake_streaming">>).
 
 -define(SERVER_OPTS, #{
     default_port => 443
@@ -20,17 +26,20 @@
 -define(streaming, streaming).
 -define(aggregated, aggregated).
 
+-define(account, account).
 -define(action_res_id, action_res_id).
 -define(append_rows_path, append_rows_path).
 -define(append_rows_path_template, append_rows_path_template).
 -define(channel, channel).
 -define(channel_name, channel_name).
+-define(common_pool_opts, common_pool_opts).
 -define(connect_timeout, connect_timeout).
 -define(database, database).
 -define(generate_jwt_fn, generate_jwt_fn).
 -define(health_check_timeout, health_check_timeout).
 -define(hostname, hostname).
 -define(id, id).
+-define(installed_actions, installed_actions).
 -define(jwt_config, jwt_config).
 -define(max_inactive, max_inactive).
 -define(max_retries, max_retries).
@@ -38,6 +47,9 @@
 -define(open_channel_path, open_channel_path).
 -define(open_channel_path_template, open_channel_path_template).
 -define(pipe, pipe).
+-define(pipe_user, pipe_user).
+-define(private_key, private_key).
+-define(private_key_password, private_key_password).
 -define(request_ttl, request_ttl).
 -define(schema, schema).
 -define(setup, setup).

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_action_info.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_action_info.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_bridge_snowflake_action_info).
+-module(emqx_bridge_snowflake_aggregated_action_info).
 
 -behaviour(emqx_action_info).
 
@@ -23,11 +23,11 @@
 %% `emqx_action_info' API
 %%------------------------------------------------------------------------------
 
-action_type_name() -> ?ACTION_TYPE.
+action_type_name() -> ?ACTION_TYPE_AGGREG.
 
-connector_type_name() -> ?CONNECTOR_TYPE.
+connector_type_name() -> ?CONNECTOR_TYPE_AGGREG.
 
-schema_module() -> emqx_bridge_snowflake_action_schema.
+schema_module() -> emqx_bridge_snowflake_aggregated_action_schema.
 
 %%------------------------------------------------------------------------------
 %% Internal fns

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_action_schema.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_action_schema.erl
@@ -1,8 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
-
--module(emqx_bridge_snowflake_action_schema).
+-module(emqx_bridge_snowflake_aggregated_action_schema).
 
 -include_lib("typerefl/include/types.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
@@ -33,7 +32,7 @@
 %%-------------------------------------------------------------------------------------------------
 
 namespace() ->
-    "action_snowflake".
+    "action_snowflake_aggregated".
 
 roots() ->
     [].
@@ -43,17 +42,17 @@ fields(Field) when
     Field == "put_bridge_v2";
     Field == "post_bridge_v2"
 ->
-    emqx_bridge_v2_schema:api_fields(Field, ?ACTION_TYPE, fields(?ACTION_TYPE));
+    emqx_bridge_v2_schema:api_fields(Field, ?ACTION_TYPE_AGGREG, fields(?ACTION_TYPE_AGGREG));
 fields(action) ->
-    {?ACTION_TYPE,
+    {?ACTION_TYPE_AGGREG,
         mk(
-            hoconsc:map(name, hoconsc:ref(?MODULE, ?ACTION_TYPE)),
+            hoconsc:map(name, hoconsc:ref(?MODULE, ?ACTION_TYPE_AGGREG)),
             #{
                 desc => <<"Snowflake Action Config">>,
                 required => false
             }
         )};
-fields(?ACTION_TYPE) ->
+fields(?ACTION_TYPE_AGGREG) ->
     emqx_bridge_v2_schema:make_producer_action_schema(
         mk(
             mkunion(mode, #{
@@ -180,7 +179,7 @@ fields(action_resource_opts) ->
     ]).
 
 desc(Name) when
-    Name =:= ?ACTION_TYPE;
+    Name =:= ?ACTION_TYPE_AGGREG;
     Name =:= aggreg_parameters;
     Name =:= streaming_parameters;
     Name =:= aggregation;
@@ -200,8 +199,8 @@ desc(_Name) ->
 bridge_v2_examples(Method) ->
     [
         #{
-            ?ACTION_TYPE_BIN => #{
-                summary => <<"Snowflake Action">>,
+            ?ACTION_TYPE_AGGREG_BIN => #{
+                summary => <<"Snowflake Aggregated Action">>,
                 value => action_example(Method)
             }
         }
@@ -211,7 +210,7 @@ action_example(post) ->
     maps:merge(
         action_example(put),
         #{
-            type => ?ACTION_TYPE_BIN,
+            type => ?ACTION_TYPE_AGGREG_BIN,
             name => <<"my_action">>
         }
     );

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_action_schema.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_action_schema.erl
@@ -56,8 +56,9 @@ fields(?ACTION_TYPE_AGGREG) ->
     emqx_bridge_v2_schema:make_producer_action_schema(
         mk(
             mkunion(mode, #{
-                <<"aggregated">> => ref(aggreg_parameters),
-                <<"streaming">> => ref(streaming_parameters)
+                %% To be implemented
+                %% <<"direct">> => ref(direct_parameters),
+                <<"aggregated">> => ref(aggreg_parameters)
             }),
             #{
                 required => true,
@@ -113,33 +114,6 @@ fields(aggreg_parameters) ->
                 #{default => none, desc => ?DESC("proxy_config")}
             )}
     ];
-fields(streaming_parameters) ->
-    [
-        {mode, mk(?streaming, #{required => true, desc => ?DESC("streaming_mode")})},
-        {private_key, emqx_schema_secret:mk(#{required => true, desc => ?DESC("private_key")})},
-        {private_key_password,
-            emqx_schema_secret:mk(#{
-                required => false,
-                desc => ?DESC("private_key_password")
-            })},
-        {database, mk(binary(), #{required => true, desc => ?DESC("database")})},
-        {schema, mk(binary(), #{required => true, desc => ?DESC("schema")})},
-        {pipe, mk(binary(), #{required => true, desc => ?DESC("pipe")})},
-        {pipe_user, mk(binary(), #{required => true, desc => ?DESC("pipe_user")})},
-        {connect_timeout,
-            mk(emqx_schema:timeout_duration_ms(), #{
-                default => <<"15s">>, desc => ?DESC("connect_timeout")
-            })},
-        {pipelining, mk(pos_integer(), #{default => 100, desc => ?DESC("pipelining")})},
-        {pool_size, mk(pos_integer(), #{default => 8, desc => ?DESC("pool_size")})},
-        {max_retries, mk(non_neg_integer(), #{default => 3, desc => ?DESC("max_retries")})},
-        emqx_connector_schema:ehttpc_max_inactive_sc(),
-        {proxy,
-            mk(
-                hoconsc:union([none, ref(proxy_config)]),
-                #{default => none, desc => ?DESC("proxy_config")}
-            )}
-    ];
 fields(aggregation) ->
     [
         emqx_connector_aggregator_schema:container(#{
@@ -181,7 +155,6 @@ fields(action_resource_opts) ->
 desc(Name) when
     Name =:= ?ACTION_TYPE_AGGREG;
     Name =:= aggreg_parameters;
-    Name =:= streaming_parameters;
     Name =:= aggregation;
     Name =:= parameters;
     Name =:= proxy_config

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_connector_info.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_connector_info.erl
@@ -2,7 +2,7 @@
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
--module(emqx_bridge_snowflake_connector_info).
+-module(emqx_bridge_snowflake_aggregated_connector_info).
 
 -behaviour(emqx_connector_info).
 
@@ -25,7 +25,7 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
--define(SCHEMA_MOD, emqx_bridge_snowflake_connector_schema).
+-define(SCHEMA_MOD, emqx_bridge_snowflake_aggregated_connector_schema).
 
 %%------------------------------------------------------------------------------
 %% API
@@ -36,16 +36,16 @@
 %%------------------------------------------------------------------------------
 
 type_name() ->
-    ?CONNECTOR_TYPE.
+    ?CONNECTOR_TYPE_AGGREG.
 
 bridge_types() ->
-    [?ACTION_TYPE].
+    [?ACTION_TYPE_AGGREG].
 
 resource_callback_module() ->
-    emqx_bridge_snowflake_connector.
+    emqx_bridge_snowflake_aggregated_impl.
 
 config_schema() ->
-    {?CONNECTOR_TYPE,
+    {?CONNECTOR_TYPE_AGGREG,
         hoconsc:mk(
             hoconsc:map(
                 name,
@@ -55,7 +55,7 @@ config_schema() ->
                 )
             ),
             #{
-                desc => <<"Snowflake Connector Config">>,
+                desc => <<"Snowflake Aggregated Connector Config">>,
                 required => false
             }
         )}.
@@ -65,7 +65,7 @@ schema_module() ->
 
 api_schema(Method) ->
     emqx_connector_schema:api_ref(
-        ?SCHEMA_MOD, ?CONNECTOR_TYPE_BIN, Method ++ "_connector"
+        ?SCHEMA_MOD, ?CONNECTOR_TYPE_AGGREG_BIN, Method ++ "_connector"
     ).
 
 %%------------------------------------------------------------------------------

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_connector_schema.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_connector_schema.erl
@@ -1,8 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
-
--module(emqx_bridge_snowflake_connector_schema).
+-module(emqx_bridge_snowflake_aggregated_connector_schema).
 
 -behaviour(hocon_schema).
 -behaviour(emqx_connector_examples).
@@ -40,7 +39,7 @@
 %%-------------------------------------------------------------------------------------------------
 
 namespace() ->
-    "connector_snowflake".
+    "connector_snowflake_aggregated".
 
 roots() ->
     [].
@@ -50,7 +49,7 @@ fields(Field) when
     Field == "put_connector";
     Field == "post_connector"
 ->
-    emqx_connector_schema:api_fields(Field, ?CONNECTOR_TYPE, fields(connector_config));
+    emqx_connector_schema:api_fields(Field, ?CONNECTOR_TYPE_AGGREG, fields(connector_config));
 fields("config_connector") ->
     emqx_connector_schema:common_fields() ++ fields(connector_config);
 fields(connector_config) ->
@@ -129,7 +128,7 @@ connector_examples(Method) ->
     [
         #{
             <<"snowflake">> => #{
-                summary => <<"Snowflake Connector">>,
+                summary => <<"Snowflake Aggregated Connector">>,
                 value => connector_example(Method)
             }
         }
@@ -152,7 +151,7 @@ connector_example(post) ->
     maps:merge(
         connector_example(put),
         #{
-            type => atom_to_binary(?CONNECTOR_TYPE),
+            type => atom_to_binary(?CONNECTOR_TYPE_AGGREG),
             name => <<"my_connector">>
         }
     );

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_impl.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_aggregated_impl.erl
@@ -1,7 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_bridge_snowflake_connector).
+-module(emqx_bridge_snowflake_aggregated_impl).
 
 -feature(maybe_expr, enable).
 
@@ -231,7 +231,7 @@
 
 -spec resource_type() -> atom().
 resource_type() ->
-    snowflake.
+    snowflake_aggregated.
 
 -spec callback_mode() -> callback_mode().
 callback_mode() ->
@@ -965,7 +965,7 @@ start_aggregator(ConnResId, ActionResId, ActionConfig, ActionState0) ->
         }
     } = ActionConfig,
     #{http := HTTPClientConfig} = ActionState0,
-    Type = ?ACTION_TYPE_BIN,
+    Type = ?ACTION_TYPE_AGGREG_BIN,
     AggregId = {Type, Name},
     WorkDir = work_dir(Type, Name),
     AggregOpts = #{

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_channel_client.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_channel_client.erl
@@ -111,15 +111,14 @@ init(Opts) ->
     #{
         ecpool_worker_id := Id,
         ?action_res_id := ActionResId,
+        ?database := Database,
+        ?schema := Schema,
+        ?pipe := Pipe,
         ?jwt_config := JWTConfig,
         ?max_retries := MaxRetries,
         ?request_ttl := RequestTTL,
         ?setup_pool_id := SetupPoolId,
-        ?setup_pool_state := #{
-            ?database := Database,
-            ?schema := Schema,
-            ?pipe := Pipe
-        } = SetupPoolState0,
+        ?setup_pool_state := SetupPoolState0,
         ?write_pool_id := WritePoolId
     } = Opts,
     ChannelName = channel_name(ActionResId, Id),

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_lib.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_lib.erl
@@ -1,0 +1,145 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_snowflake_lib).
+
+%% API
+-export([
+    account_id_validator/1,
+    common_ehttpc_pool_opts/1,
+    jwt_config/2,
+    http_pool_workers_healthy/2
+]).
+
+-include_lib("public_key/include/public_key.hrl").
+-include_lib("emqx/include/logger.hrl").
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+account_id_validator(AccountId) ->
+    case binary:split(AccountId, <<"-">>) of
+        [_, _] ->
+            ok;
+        _ ->
+            {error, <<"Account identifier must be of form ORGID-ACCOUNTNAME">>}
+    end.
+
+common_ehttpc_pool_opts(Params) ->
+    #{
+        connect_timeout := ConnectTimeout,
+        pipelining := Pipelining,
+        max_inactive := MaxInactive,
+        proxy := ProxyConfig0
+    } = Params,
+    TransportOpts = emqx_tls_lib:to_client_opts(#{enable => true, verify => verify_none}),
+    ProxyConfig =
+        case ProxyConfig0 of
+            none ->
+                [];
+            #{host := ProxyHost, port := ProxyPort} ->
+                [
+                    {proxy, #{
+                        host => str(ProxyHost),
+                        port => ProxyPort
+                    }}
+                ]
+        end,
+    ProxyConfig ++
+        [
+            {connect_timeout, ConnectTimeout},
+            {keepalive, 30_000},
+            {transport, tls},
+            {transport_opts, TransportOpts},
+            {max_inactive, MaxInactive},
+            {enable_pipelining, Pipelining}
+        ].
+
+jwt_config(ResId, Params) ->
+    #{
+        account := Account,
+        private_key := PrivateKeyPEM,
+        private_key_password := PrivateKeyPassword,
+        pipe_user := PipeUser
+    } = Params,
+    PrivateJWK =
+        case PrivateKeyPassword /= undefined of
+            true ->
+                jose_jwk:from_pem(
+                    emqx_secret:unwrap(PrivateKeyPassword),
+                    emqx_secret:unwrap(PrivateKeyPEM)
+                );
+            false ->
+                jose_jwk:from_pem(emqx_secret:unwrap(PrivateKeyPEM))
+        end,
+    %% N.B.
+    %% The account_identifier and user values must use all uppercase characters
+    %% https://docs.snowflake.com/en/developer-guide/sql-api/authenticating#using-key-pair-authentication
+    AccountUp = string:uppercase(Account),
+    PipeUserUp = string:uppercase(PipeUser),
+    Fingerprint = fingerprint(PrivateJWK),
+    Sub = iolist_to_binary([AccountUp, <<".">>, PipeUserUp]),
+    Iss = iolist_to_binary([Sub, <<".">>, Fingerprint]),
+    #{
+        expiration => 360_000,
+        resource_id => ResId,
+        jwk => emqx_secret:wrap(PrivateJWK),
+        iss => Iss,
+        sub => Sub,
+        aud => <<"unused">>,
+        kid => <<"unused">>,
+        alg => <<"RS256">>
+    }.
+
+http_pool_workers_healthy(HTTPPool, Timeout) ->
+    Workers = [Worker || {_WorkerName, Worker} <- ehttpc:workers(HTTPPool)],
+    DoPerWorker =
+        fun(Worker) ->
+            case ehttpc:health_check(Worker, Timeout) of
+                ok ->
+                    ok;
+                {error, Reason} ->
+                    ?SLOG(error, #{
+                        msg => "snowflake_ehttpc_health_check_failed",
+                        pool => HTTPPool,
+                        reason => Reason,
+                        worker => Worker,
+                        wait_time => Timeout
+                    }),
+                    {error, Reason}
+            end
+        end,
+    try emqx_utils:pmap(DoPerWorker, Workers, Timeout) of
+        [_ | _] = Status0 ->
+            Errors = lists:filter(fun(St) -> St =/= ok end, Status0),
+            case Errors of
+                [] ->
+                    ok;
+                [Error | _] ->
+                    {error, Error}
+            end;
+        [] ->
+            {error, {<<"http_pool_initializing">>, HTTPPool}}
+    catch
+        exit:timeout ->
+            {error, timeout}
+    end.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+str(X) -> emqx_utils_conv:str(X).
+
+fingerprint(PrivateJWK) ->
+    {_, PublicRSAKey} = jose_jwk:to_public_key(PrivateJWK),
+    #'SubjectPublicKeyInfo'{algorithm = DEREncoded} =
+        public_key:pem_entry_encode('SubjectPublicKeyInfo', PublicRSAKey),
+    Hash = crypto:hash(sha256, DEREncoded),
+    Hash64 = base64:encode(Hash),
+    <<"SHA256:", Hash64/binary>>.

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_action_info.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_action_info.erl
@@ -1,0 +1,34 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_snowflake_streaming_action_info).
+
+-behaviour(emqx_action_info).
+
+-include("emqx_bridge_snowflake.hrl").
+
+%% `emqx_action_info' API
+-export([
+    action_type_name/0,
+    connector_type_name/0,
+    schema_module/0
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% `emqx_action_info' API
+%%------------------------------------------------------------------------------
+
+action_type_name() -> ?ACTION_TYPE_STREAM.
+
+connector_type_name() -> ?CONNECTOR_TYPE_STREAM.
+
+schema_module() -> emqx_bridge_snowflake_streaming_action_schema.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_action_schema.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_action_schema.erl
@@ -1,0 +1,177 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_snowflake_streaming_action_schema).
+
+-include_lib("typerefl/include/types.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
+-include("emqx_bridge_snowflake.hrl").
+
+%% `hocon_schema' API
+-export([
+    namespace/0,
+    roots/0,
+    fields/1,
+    desc/1
+]).
+
+%% `emqx_bridge_v2_schema' "unofficial" API
+-export([
+    bridge_v2_examples/1
+]).
+
+%% API
+-export([]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-define(AGGREG_CONN_SCHEMA_MOD, emqx_bridge_snowflake_aggregated_connector_schema).
+-define(AGGREG_ACTION_SCHEMA_MOD, emqx_bridge_snowflake_aggregated_action_schema).
+
+%%-------------------------------------------------------------------------------------------------
+%% `hocon_schema' API
+%%-------------------------------------------------------------------------------------------------
+
+namespace() ->
+    "action_snowflake_streaming".
+
+roots() ->
+    [].
+
+fields(Field) when
+    Field == "get_bridge_v2";
+    Field == "put_bridge_v2";
+    Field == "post_bridge_v2"
+->
+    emqx_bridge_v2_schema:api_fields(Field, ?ACTION_TYPE_STREAM, fields(?ACTION_TYPE_STREAM));
+fields(action) ->
+    {?ACTION_TYPE_STREAM,
+        mk(
+            hoconsc:map(name, hoconsc:ref(?MODULE, ?ACTION_TYPE_STREAM)),
+            #{
+                desc => <<"Snowflake Streaming Action Config">>,
+                required => false
+            }
+        )};
+fields(?ACTION_TYPE_STREAM) ->
+    emqx_bridge_v2_schema:make_producer_action_schema(
+        mk(
+            ref(parameters),
+            #{
+                required => true,
+                desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "parameters")
+            }
+        ),
+        #{resource_opts_ref => ref(action_resource_opts)}
+    );
+fields(parameters) ->
+    [
+        {database,
+            mk(binary(), #{required => true, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "database")})},
+        {schema,
+            mk(binary(), #{required => true, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "schema")})},
+        {pipe, mk(binary(), #{required => true, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "pipe")})},
+        {connect_timeout,
+            mk(emqx_schema:timeout_duration_ms(), #{
+                default => <<"15s">>, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "connect_timeout")
+            })},
+        {pipelining,
+            mk(pos_integer(), #{
+                default => 100, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "pipelining")
+            })},
+        {pool_size,
+            mk(pos_integer(), #{default => 8, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "pool_size")})},
+        {max_retries,
+            mk(non_neg_integer(), #{
+                default => 3, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "max_retries")
+            })},
+        emqx_connector_schema:ehttpc_max_inactive_sc()
+    ];
+fields(action_resource_opts) ->
+    emqx_bridge_v2_schema:action_resource_opts_fields([
+        {batch_size, #{default => 100}},
+        {batch_time, #{default => <<"10ms">>}}
+    ]).
+
+desc(Name) when
+    Name =:= ?ACTION_TYPE_STREAM
+->
+    ?DESC(Name);
+desc(parameters) ->
+    ?DESC(?AGGREG_ACTION_SCHEMA_MOD, parameters);
+desc(action_resource_opts) ->
+    ?DESC(emqx_resource_schema, "creation_opts");
+desc(_Name) ->
+    undefined.
+
+%%-------------------------------------------------------------------------------------------------
+%% `emqx_bridge_v2_schema' "unofficial" API
+%%-------------------------------------------------------------------------------------------------
+
+bridge_v2_examples(Method) ->
+    [
+        #{
+            ?ACTION_TYPE_STREAM_BIN => #{
+                summary => <<"Snowflake Streaming Action">>,
+                value => action_example(Method)
+            }
+        }
+    ].
+
+action_example(post) ->
+    maps:merge(
+        action_example(put),
+        #{
+            type => ?ACTION_TYPE_STREAM_BIN,
+            name => <<"my_action">>
+        }
+    );
+action_example(get) ->
+    maps:merge(
+        action_example(put),
+        #{
+            status => <<"connected">>,
+            node_status => [
+                #{
+                    node => <<"emqx@localhost">>,
+                    status => <<"connected">>
+                }
+            ]
+        }
+    );
+action_example(put) ->
+    #{
+        enable => true,
+        description => <<"my action">>,
+        connector => <<"my_connector">>,
+        parameters =>
+            #{
+                connect_timeout => <<"15s">>,
+                database => <<"testdatabase">>,
+                pipe => <<"testpipe">>,
+                pipe_user => <<"pipeuser">>,
+                schema => <<"public">>,
+                max_retries => 3,
+                pipelining => 100,
+                pool_size => 16
+            },
+        resource_opts =>
+            #{
+                batch_time => <<"60s">>,
+                batch_size => 10_000,
+                health_check_interval => <<"30s">>,
+                inflight_window => 100,
+                query_mode => <<"sync">>,
+                request_ttl => <<"45s">>,
+                worker_pool_size => 16
+            }
+    }.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+ref(Name) -> hoconsc:ref(?MODULE, Name).
+mk(Type, Meta) -> hoconsc:mk(Type, Meta).

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_connector_info.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_connector_info.erl
@@ -1,0 +1,73 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_bridge_snowflake_streaming_connector_info).
+
+-behaviour(emqx_connector_info).
+
+-include("emqx_bridge_snowflake.hrl").
+
+%% `emqx_connector_info' API
+-export([
+    type_name/0,
+    bridge_types/0,
+    resource_callback_module/0,
+    config_schema/0,
+    schema_module/0,
+    api_schema/1
+]).
+
+%% API
+-export([]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-define(SCHEMA_MOD, emqx_bridge_snowflake_streaming_connector_schema).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% `emqx_connector_info' API
+%%------------------------------------------------------------------------------
+
+type_name() ->
+    ?CONNECTOR_TYPE_STREAM.
+
+bridge_types() ->
+    [?ACTION_TYPE_STREAM].
+
+resource_callback_module() ->
+    emqx_bridge_snowflake_streaming_impl.
+
+config_schema() ->
+    {?CONNECTOR_TYPE_STREAM,
+        hoconsc:mk(
+            hoconsc:map(
+                name,
+                hoconsc:ref(
+                    ?SCHEMA_MOD,
+                    "config_connector"
+                )
+            ),
+            #{
+                desc => <<"Snowflake Streaming Connector Config">>,
+                required => false
+            }
+        )}.
+
+schema_module() ->
+    ?SCHEMA_MOD.
+
+api_schema(Method) ->
+    emqx_connector_schema:api_ref(
+        ?SCHEMA_MOD, ?CONNECTOR_TYPE_STREAM_BIN, Method ++ "_connector"
+    ).
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_connector_schema.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_connector_schema.erl
@@ -1,7 +1,7 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
--module(emqx_bridge_snowflake_aggregated_connector_schema).
+-module(emqx_bridge_snowflake_streaming_connector_schema).
 
 -behaviour(hocon_schema).
 -behaviour(emqx_connector_examples).
@@ -18,10 +18,6 @@
     desc/1
 ]).
 
-%% `emqx_schema_hooks' API
--export([injected_fields/0]).
--export([authn_mode_selection_validator/1]).
-
 %% `emqx_connector_examples' API
 -export([
     connector_examples/1
@@ -34,12 +30,15 @@
 %% Type declarations
 %%------------------------------------------------------------------------------
 
+-define(AGGREG_CONN_SCHEMA_MOD, emqx_bridge_snowflake_aggregated_connector_schema).
+-define(AGGREG_ACTION_SCHEMA_MOD, emqx_bridge_snowflake_aggregated_action_schema).
+
 %%-------------------------------------------------------------------------------------------------
 %% `hocon_schema' API
 %%-------------------------------------------------------------------------------------------------
 
 namespace() ->
-    "connector_snowflake_aggregated".
+    "connector_snowflake_streaming".
 
 roots() ->
     [].
@@ -49,74 +48,78 @@ fields(Field) when
     Field == "put_connector";
     Field == "post_connector"
 ->
-    emqx_connector_schema:api_fields(Field, ?CONNECTOR_TYPE_AGGREG, fields(connector_config));
+    emqx_connector_schema:api_fields(Field, ?CONNECTOR_TYPE_STREAM, fields(connector_config));
 fields("config_connector") ->
     emqx_connector_schema:common_fields() ++ fields(connector_config);
 fields(connector_config) ->
-    Fields0 = emqx_connector_schema_lib:relational_db_fields(),
-    Fields1 = proplists:delete(database, Fields0),
-    Fields = lists:map(
-        fun
-            ({Field, Sc}) when Field =:= username; Field =:= password ->
-                Override = #{type => hocon_schema:field_schema(Sc, type), required => false},
-                {Field, hocon_schema:override(Sc, Override)};
-            ({Field, Sc}) ->
-                {Field, Sc}
-        end,
-        Fields1
-    ),
     [
+        {connect_timeout,
+            mk(emqx_schema:timeout_duration_ms(), #{
+                default => <<"15s">>, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "connect_timeout")
+            })},
+        {pipelining,
+            mk(pos_integer(), #{
+                default => 100, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "pipelining")
+            })},
+        {max_retries,
+            mk(non_neg_integer(), #{
+                default => 3, desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "max_retries")
+            })},
+        emqx_connector_schema:ehttpc_max_inactive_sc(),
         {server,
             emqx_schema:servers_sc(
-                #{required => true, desc => ?DESC("server")},
+                #{required => true, desc => ?DESC(?AGGREG_CONN_SCHEMA_MOD, "server")},
                 ?SERVER_OPTS
             )},
         {account,
             mk(binary(), #{
                 required => true,
-                desc => ?DESC("account"),
+                desc => ?DESC(?AGGREG_CONN_SCHEMA_MOD, "account"),
                 validator => fun emqx_bridge_snowflake_lib:account_id_validator/1
             })},
-        {dsn, mk(binary(), #{required => true, desc => ?DESC("dsn")})},
-        {private_key_path, mk(binary(), #{required => false, desc => ?DESC("private_key_path")})},
+        {pipe_user,
+            mk(binary(), #{
+                required => true,
+                desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "pipe_user")
+            })},
+        {private_key,
+            emqx_schema_secret:mk(#{
+                required => true,
+                desc => ?DESC(?AGGREG_ACTION_SCHEMA_MOD, "private_key")
+            })},
         {private_key_password,
             emqx_schema_secret:mk(#{
                 required => false,
-                desc => ?DESC("private_key_password")
+                desc => ?DESC(?AGGREG_CONN_SCHEMA_MOD, "private_key_password")
             })},
         {proxy,
             mk(
                 hoconsc:union([none, hoconsc:ref(?MODULE, proxy_config)]),
-                #{default => none, desc => ?DESC("proxy_config")}
+                #{default => none, desc => ?DESC(?AGGREG_CONN_SCHEMA_MOD, "proxy_config")}
             )}
-        | Fields
     ] ++
         emqx_connector_schema:resource_opts() ++
         emqx_connector_schema_lib:ssl_fields();
 fields(proxy_config) ->
     [
-        {host, mk(binary(), #{required => true, desc => ?DESC("proxy_config_host")})},
+        {host,
+            mk(binary(), #{
+                required => true,
+                desc => ?DESC(?AGGREG_CONN_SCHEMA_MOD, "proxy_config_host")
+            })},
         {port,
-            mk(emqx_schema:port_number(), #{required => true, desc => ?DESC("proxy_config_port")})}
+            mk(emqx_schema:port_number(), #{
+                required => true,
+                desc => ?DESC(?AGGREG_CONN_SCHEMA_MOD, "proxy_config_port")
+            })}
     ].
-
-injected_fields() ->
-    #{
-        'connectors.validators' => [fun ?MODULE:authn_mode_selection_validator/1]
-    }.
-
-authn_mode_selection_validator(#{?CONNECTOR_TYPE_AGGREG_BIN := SnowflakeConns}) ->
-    Iter = maps:iterator(SnowflakeConns),
-    do_authn_mode_selection_validator(maps:next(Iter));
-authn_mode_selection_validator(_) ->
-    ok.
 
 desc("config_connector") ->
     ?DESC("config_connector");
 desc(resource_opts) ->
     ?DESC(emqx_resource_schema, resource_opts);
 desc(proxy_config) ->
-    ?DESC("proxy_config");
+    ?DESC(?AGGREG_CONN_SCHEMA_MOD, "proxy_config");
 desc(_Name) ->
     undefined.
 
@@ -128,7 +131,7 @@ connector_examples(Method) ->
     [
         #{
             <<"snowflake">> => #{
-                summary => <<"Snowflake Aggregated Connector">>,
+                summary => <<"Snowflake Connector">>,
                 value => connector_example(Method)
             }
         }
@@ -181,17 +184,3 @@ connector_example(put) ->
 %%------------------------------------------------------------------------------
 
 mk(Type, Meta) -> hoconsc:mk(Type, Meta).
-
-do_authn_mode_selection_validator(none) ->
-    ok;
-do_authn_mode_selection_validator({_Name, Conf, Iter}) ->
-    case Conf of
-        #{<<"password">> := _, <<"private_key_path">> := _} ->
-            Msg = <<
-                "At most one of `password` or `private_key_path`"
-                " must be set, but not both"
-            >>,
-            {error, Msg};
-        _ ->
-            do_authn_mode_selection_validator(maps:next(Iter))
-    end.

--- a/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_impl.erl
+++ b/apps/emqx_bridge_snowflake/src/emqx_bridge_snowflake_streaming_impl.erl
@@ -1,0 +1,608 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_snowflake_streaming_impl).
+
+-behaviour(emqx_resource).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
+-include_lib("emqx/include/emqx_trace.hrl").
+-include("emqx_bridge_snowflake.hrl").
+-include_lib("emqx_connector_jwt/include/emqx_connector_jwt_tables.hrl").
+
+%% `emqx_resource' API
+-export([
+    resource_type/0,
+    callback_mode/0,
+
+    on_start/2,
+    on_stop/2,
+    on_get_status/2,
+
+    on_get_channels/1,
+    on_add_channel/4,
+    on_remove_channel/3,
+    on_get_channel_status/3,
+
+    on_query/3,
+    on_batch_query/3
+]).
+
+%% Internal exports only for mocking
+-export([
+    do_get_streaming_hostname/4
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+%% Allocatable resources
+-define(setup_pool, setup_pool).
+-define(channel_pool(RES_ID), {channel_pool, RES_ID}).
+-define(write_pool(RES_ID), {write_pool, RES_ID}).
+-define(streaming_jwt(RES_ID), {streaming_jwt, RES_ID}).
+
+-define(HC_TIMEOUT, 15_000).
+%% Seconds
+-define(AUTO_RECONNECT_INTERVAL, 2).
+
+-ifdef(TEST).
+-define(STREAMING_PORT, persistent_term:get({?MODULE, streaming_port}, 443)).
+-else.
+-define(STREAMING_PORT, 443).
+-endif.
+
+-type connector_config() :: #{
+    account := account(),
+    connect_timeout := emqx_schema:timeout_duration_ms(),
+    max_inactive := emqx_schema:timeout_duration_ms(),
+    max_retries := non_neg_integer(),
+    pipelining := non_neg_integer(),
+    pipe_user := pipe_user(),
+    private_key := emqx_schema_secret:secret(),
+    private_key_password => emqx_schema_secret:secret(),
+    proxy := none | proxy_config(),
+    %% request_ttl := timeout(),
+    server := binary()
+}.
+-type connector_state() :: #{
+    ?installed_actions := #{action_resource_id() => action_state()},
+    ?connect_timeout := emqx_schema:timeout_duration_ms(),
+    ?jwt_config := emqx_connector_jwt:jwt_config(),
+    ?max_inactive := emqx_schema:timeout_duration_ms(),
+    ?max_retries := non_neg_integer(),
+    ?request_ttl := timeout()
+}.
+
+-type action_config() :: #{
+    parameters := #{
+        database := database(),
+        schema := schema(),
+        pipe := pipe()
+    }
+}.
+-type action_state() :: #{
+    ?health_check_timeout := timeout(),
+    ?connect_timeout := timeout(),
+    ?setup := setup_pool_state(),
+    ?write := write_pool_state(),
+    ?channel := chan_pool_state()
+}.
+
+%% todo: refine
+-type setup_pool_state() :: map().
+-type write_pool_state() :: map().
+-type chan_pool_state() :: map().
+
+-type account() :: binary().
+-type database() :: binary().
+-type schema() :: binary().
+-type pipe() :: binary().
+-type pipe_user() :: binary().
+
+-type proxy_config() :: #{
+    host := binary(),
+    port := emqx_schema:port_number()
+}.
+
+-type query() :: action_query().
+-type action_query() :: {_Tag :: channel_id(), _Data :: map()}.
+
+%%------------------------------------------------------------------------------
+%% `emqx_resource' API
+%%------------------------------------------------------------------------------
+
+-spec resource_type() -> atom().
+resource_type() ->
+    snowflake_streaming.
+
+-spec callback_mode() -> callback_mode().
+callback_mode() ->
+    always_sync.
+
+-spec on_start(connector_resource_id(), connector_config()) ->
+    {ok, connector_state()} | {error, _Reason}.
+on_start(ConnResId, ConnConfig) ->
+    case init_setup_pool(ConnResId, ConnConfig) of
+        {ok, State0} ->
+            State = State0#{?installed_actions => #{}},
+            {ok, State};
+        {error, {start_pool_failed, _, Reason}} ->
+            {error, Reason}
+    end.
+
+-spec on_stop(connector_resource_id(), connector_state()) -> ok.
+on_stop(ConnResId, _ConnState) ->
+    streaming_destroy_allocated_resources(ConnResId),
+    Res = emqx_resource_pool:stop(ConnResId),
+    ?tp("snowflake_connector_stop", #{instance_id => ConnResId}),
+    Res.
+
+-spec on_get_status(connector_resource_id(), connector_state()) ->
+    ?status_connected | ?status_disconnected.
+on_get_status(ConnResId, ConnState) ->
+    #{?connect_timeout := ConnectTimeout} = ConnState,
+    SetupPoolId = setup_pool(ConnResId),
+    maybe
+        ok ?= http_pool_workers_healthy(SetupPoolId, ConnectTimeout),
+        ?status_connected
+    else
+        {error, Reason} ->
+            {?status_disconnected, Reason}
+    end.
+
+-spec on_add_channel(
+    connector_resource_id(),
+    connector_state(),
+    action_resource_id(),
+    action_config()
+) ->
+    {ok, connector_state()}.
+on_add_channel(ConnResId, ConnState0, ActionResId, ActionConfig) ->
+    maybe
+        {ok, ActionState} ?= create_action(ConnResId, ActionResId, ActionConfig, ConnState0),
+        ConnState = emqx_utils_maps:deep_put(
+            [?installed_actions, ActionResId], ConnState0, ActionState
+        ),
+        {ok, ConnState}
+    end.
+
+-spec on_remove_channel(
+    connector_resource_id(),
+    connector_state(),
+    action_resource_id()
+) ->
+    {ok, connector_state()}.
+on_remove_channel(
+    ConnResId, ConnState0 = #{?installed_actions := InstalledActions0}, ActionResId
+) when
+    is_map_key(ActionResId, InstalledActions0)
+->
+    {ActionState, InstalledActions} = maps:take(ActionResId, InstalledActions0),
+    destroy_action(ConnResId, ActionResId, ActionState),
+    ConnState = ConnState0#{?installed_actions := InstalledActions},
+    {ok, ConnState};
+on_remove_channel(_ConnResId, ConnState, ActionResId) ->
+    ensure_common_action_destroyed(ActionResId),
+    {ok, ConnState}.
+
+-spec on_get_channels(connector_resource_id()) ->
+    [{action_resource_id(), action_config()}].
+on_get_channels(ConnResId) ->
+    emqx_bridge_v2:get_channels_for_connector(ConnResId).
+
+-spec on_get_channel_status(
+    connector_resource_id(),
+    action_resource_id(),
+    connector_state()
+) ->
+    ?status_connected | ?status_disconnected.
+on_get_channel_status(
+    ConnResId,
+    ActionResId,
+    _ConnState = #{?installed_actions := InstalledActions}
+) when is_map_key(ActionResId, InstalledActions) ->
+    ActionState = maps:get(ActionResId, InstalledActions),
+    action_status(ConnResId, ActionResId, ActionState);
+on_get_channel_status(_ConnResId, _ActionResId, _ConnState) ->
+    ?status_disconnected.
+
+-spec on_query(connector_resource_id(), query(), connector_state()) ->
+    {ok, _Result} | {error, _Reason}.
+on_query(
+    _ConnResId, {ActionResId, Data}, #{?installed_actions := InstalledActions} = _ConnState
+) when
+    is_map_key(ActionResId, InstalledActions)
+->
+    #{ActionResId := ActionState} = InstalledActions,
+    run_streaming_action([Data], ActionResId, ActionState);
+on_query(_ConnResId, Query, _ConnState) ->
+    {error, {unrecoverable_error, {invalid_query, Query}}}.
+
+-spec on_batch_query(connector_resource_id(), [query()], connector_state()) ->
+    {ok, _Result} | {error, _Reason}.
+on_batch_query(_ConnResId, [{ActionResId, _} | _] = Batch0, #{
+    ?installed_actions := InstalledActions
+}) when
+    is_map_key(ActionResId, InstalledActions)
+->
+    #{ActionResId := ActionState} = InstalledActions,
+    Batch = [Data || {_, Data} <- Batch0],
+    run_streaming_action(Batch, ActionResId, ActionState);
+on_batch_query(_ConnResId, Batch, _ConnState) ->
+    {error, {unrecoverable_error, {bad_batch, Batch}}}.
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+-spec create_action(
+    connector_resource_id(), action_resource_id(), action_config(), connector_state()
+) ->
+    {ok, action_state()} | {error, term()}.
+create_action(ConnResId, ActionResId, ActionConfig, ConnState) ->
+    ok = emqx_connector_jwt:delete_jwt(?JWT_TABLE, ActionResId),
+    ConnectTimeout = emqx_utils_maps:deep_get([parameters, connect_timeout], ActionConfig),
+    HCTimeout = emqx_resource:get_health_check_timeout(ActionConfig),
+    maybe
+        {ok, WritePoolState, ChanPoolState} ?=
+            start_streaming_pools(ConnResId, ActionResId, ActionConfig, ConnState),
+        ok ?= open_channels(ActionResId),
+        ActionState = #{
+            ?mode => ?streaming,
+            ?health_check_timeout => HCTimeout,
+            ?connect_timeout => ConnectTimeout,
+            ?write => WritePoolState,
+            ?channel => ChanPoolState
+        },
+        {ok, ActionState}
+    else
+        Error ->
+            streaming_destroy_allocated_resources(ConnResId, ActionResId),
+            Error
+    end.
+
+start_streaming_pools(ConnResId, ActionResId, ActionConfig, ConnState) ->
+    maybe
+        {ok, WritePoolState} ?=
+            init_write_pool(ConnResId, ActionResId, ActionConfig, ConnState),
+        {ok, ChanPoolState} ?=
+            init_channel_pool(ConnResId, ConnState, ActionResId, ActionConfig),
+        {ok, WritePoolState, ChanPoolState}
+    end.
+
+init_setup_pool(ConnResId, ConnConfig) ->
+    #{
+        account := Account,
+        connect_timeout := ConnectTimeout,
+        max_inactive := MaxInactive,
+        max_retries := MaxRetries,
+        pipe_user := PipeUser,
+        pipelining := Pipelining,
+        private_key := PrivateKey,
+        proxy := ProxyConfig,
+        server := Server
+    } = ConnConfig,
+    %% Maybe make this configurable in the future; it's used mostly during initialization
+    %% only.
+    RequestTTL = maps:get(request_ttl, ConnConfig, timer:seconds(14)),
+    #{hostname := Host, port := Port} = emqx_schema:parse_server(Server, ?SERVER_OPTS),
+    PrivateKeyPassword = maps:get(private_key_password, ConnConfig, undefined),
+    JWTParams = #{
+        account => Account,
+        pipe_user => PipeUser,
+        private_key => PrivateKey,
+        private_key_password => PrivateKeyPassword
+    },
+    SetupPoolId = setup_pool(ConnResId),
+    ok = emqx_connector_jwt:delete_jwt(?JWT_TABLE, SetupPoolId),
+    JWTConfig = emqx_bridge_snowflake_lib:jwt_config(SetupPoolId, JWTParams),
+    CommonPoolOpts = emqx_bridge_snowflake_lib:common_ehttpc_pool_opts(#{
+        connect_timeout => ConnectTimeout,
+        pipelining => Pipelining,
+        max_inactive => MaxInactive,
+        proxy => ProxyConfig
+    }),
+    SetupPoolOpts =
+        [
+            {host, Host},
+            {port, Port},
+            {pool_type, random},
+            %% Just for setup, so no need for big pool.
+            {pool_size, 1}
+            | CommonPoolOpts
+        ],
+    SetupPoolState0 = #{
+        ?common_pool_opts => CommonPoolOpts,
+        ?connect_timeout => ConnectTimeout,
+        ?jwt_config => JWTConfig,
+        ?max_inactive => MaxInactive,
+        ?max_retries => MaxRetries,
+        ?request_ttl => RequestTTL
+    },
+    allocate(ConnResId, ?setup_pool, SetupPoolId),
+    maybe
+        {ok, _} ?= ehttpc_sup:start_pool(SetupPoolId, SetupPoolOpts),
+        {ok, Hostname} ?= get_streaming_hostname(SetupPoolId, SetupPoolState0),
+        SetupPoolState = SetupPoolState0#{?hostname => Hostname},
+        {ok, SetupPoolState}
+    else
+        {error, {already_started, _}} ->
+            _ = ehttpc_sup:stop_pool(SetupPoolId),
+            init_setup_pool(ConnResId, ConnConfig);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+init_write_pool(ConnResId, ActionResId, ActionConfig, ConnState) ->
+    #{
+        ?common_pool_opts := CommonPoolOpts,
+        ?hostname := Hostname
+    } = ConnState,
+    #{
+        parameters := #{
+            pool_size := PoolSize,
+            max_retries := MaxRetries,
+            max_inactive := MaxInactive
+        },
+        resource_opts := #{request_ttl := RequestTTL}
+    } = ActionConfig,
+    WritePoolOpts =
+        [
+            {host, emqx_utils_conv:str(Hostname)},
+            {port, ?STREAMING_PORT},
+            {pool_type, direct},
+            {pool_size, PoolSize}
+            | CommonPoolOpts
+        ],
+    WritePoolState = #{
+        ?hostname => Hostname,
+        ?max_inactive => MaxInactive,
+        ?max_retries => MaxRetries,
+        ?request_ttl => RequestTTL
+    },
+    WritePoolId = write_pool(ActionResId),
+    allocate(ConnResId, ?write_pool(ActionResId), WritePoolId),
+    maybe
+        ?SLOG(debug, #{
+            msg => "snowflake_streaming_starting_write_http_pool",
+            write_pool_id => WritePoolId,
+            hostname => Hostname
+        }),
+        ok ?= do_start_streaming_write_http_pool(ActionResId, WritePoolOpts),
+        {ok, WritePoolState}
+    end.
+
+init_channel_pool(ConnResId, ConnState, ActionResId, ActionConfig) ->
+    #{
+        ?hostname := Hostname,
+        ?jwt_config := JWTConfig
+    } = ConnState,
+    #{
+        parameters := #{
+            database := Database,
+            schema := Schema,
+            pipe := Pipe,
+            pool_size := PoolSize,
+            max_retries := MaxRetries
+        },
+        resource_opts := #{request_ttl := RequestTTL}
+    } = ActionConfig,
+    SetupPoolId = setup_pool(ConnResId),
+    WritePoolId = write_pool(ActionResId),
+    ChanPoolId = channel_pool(ActionResId),
+    SetupPoolState = maps:with([?jwt_config, ?max_retries, ?request_ttl], ConnState),
+    ChanOpts = [
+        {auto_reconnect, ?AUTO_RECONNECT_INTERVAL},
+        {pool_type, hash},
+        {pool_size, PoolSize},
+        {?action_res_id, ActionResId},
+        {?database, Database},
+        {?schema, Schema},
+        {?pipe, Pipe},
+        {?jwt_config, JWTConfig},
+        {?max_retries, MaxRetries},
+        {?request_ttl, RequestTTL},
+        {?setup_pool_id, SetupPoolId},
+        {?setup_pool_state, SetupPoolState},
+        {?write_pool_id, WritePoolId}
+    ],
+    ?SLOG(debug, #{
+        msg => "snowflake_streaming_starting_channel_pool",
+        channel_pool_id => ChanPoolId,
+        hostname => Hostname
+    }),
+    allocate(ConnResId, ?channel_pool(ActionResId), ChanPoolId),
+    allocate(ConnResId, ?streaming_jwt(ActionResId), ActionResId),
+    case emqx_resource_pool:start(ChanPoolId, emqx_bridge_snowflake_channel_client, ChanOpts) of
+        ok ->
+            ChanPoolState = #{?jwt_config => JWTConfig},
+            {ok, ChanPoolState};
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+do_start_streaming_write_http_pool(ActionResId, WritePoolOpts) ->
+    WritePoolId = write_pool(ActionResId),
+    case ehttpc_sup:start_pool(WritePoolId, WritePoolOpts) of
+        {ok, _} ->
+            ok;
+        {error, {already_started, _}} ->
+            _ = ehttpc_sup:stop_pool(WritePoolId),
+            do_start_streaming_write_http_pool(ActionResId, WritePoolOpts);
+        {error, Reason} ->
+            {error, Reason}
+    end.
+
+-spec destroy_action(connector_resource_id(), action_resource_id(), action_state()) -> ok.
+destroy_action(ConnResId, ActionResId, _ActionState) ->
+    streaming_destroy_allocated_resources(ConnResId, ActionResId),
+    ok = ensure_common_action_destroyed(ActionResId),
+    ok.
+
+ensure_common_action_destroyed(ActionResId) ->
+    ok = ehttpc_sup:stop_pool(ActionResId),
+    ok = emqx_connector_jwt:delete_jwt(?JWT_TABLE, ActionResId),
+    ok.
+
+run_streaming_action(Batch, ActionResId, _ActionState) ->
+    emqx_trace:rendered_action_template(ActionResId, #{records => Batch}),
+    ecpool:pick_and_do(
+        {channel_pool(ActionResId), self()},
+        fun(ChanClient) ->
+            emqx_bridge_snowflake_channel_client:append_rows(ChanClient, Batch)
+        end,
+        handover
+    ).
+
+get_streaming_hostname(SetupPoolId, SetupPoolState) ->
+    #{
+        jwt_config := JWTConfig,
+        request_ttl := RequestTTL,
+        max_retries := MaxRetries
+    } = SetupPoolState,
+    JWTToken = emqx_connector_jwt:ensure_jwt(JWTConfig),
+    AuthnHeader = [<<"BEARER ">>, JWTToken],
+    Headers = [
+        {<<"X-Snowflake-Authorization-Token-Type">>, <<"KEYPAIR_JWT">>},
+        {<<"Content-Type">>, <<"application/json">>},
+        {<<"Accept">>, <<"application/json">>},
+        {<<"User-Agent">>, <<"emqx">>},
+        {<<"Authorization">>, AuthnHeader}
+    ],
+    Path = <<"/v2/streaming/hostname">>,
+    Req = {Path, Headers},
+    ?tp(debug, "snowflake_streaming_get_hostname_request", #{
+        setup_pool_id => SetupPoolId
+    }),
+    maybe
+        {ok, 200, _Headers, Hostname} ?=
+            ?MODULE:do_get_streaming_hostname(SetupPoolId, Req, RequestTTL, MaxRetries),
+        {ok, Hostname}
+    else
+        Res ->
+            {error, #{reason => <<"get_hostname_unexpected_response">>, response => Res}}
+    end.
+
+%% Internal export exposed ONLY for mocking
+do_get_streaming_hostname(HTTPPool, Req, RequestTTL, MaxRetries) ->
+    ehttpc:request(HTTPPool, get, Req, RequestTTL, MaxRetries).
+
+action_status(_ConnResId, ActionResId, ActionState) ->
+    #{
+        health_check_timeout := HCTimeout,
+        connect_timeout := ConnectTimeout
+    } = ActionState,
+    WritePoolId = write_pool(ActionResId),
+    maybe
+        ok ?= channel_pool_workers_healthy(ActionResId, HCTimeout),
+        ok ?= http_pool_workers_healthy(WritePoolId, ConnectTimeout),
+        ?status_connected
+    else
+        {error, Reason} ->
+            {?status_disconnected, Reason}
+    end.
+
+http_pool_workers_healthy(HTTPPool, Timeout) ->
+    emqx_bridge_snowflake_lib:http_pool_workers_healthy(HTTPPool, Timeout).
+
+channel_pool_workers_healthy(ActionResId, Timeout) ->
+    ChanPoolId = channel_pool(ActionResId),
+    Fn = fun(_) -> ok end,
+    Res0 = emqx_resource_pool:health_check_workers(
+        ChanPoolId, Fn, Timeout, #{return_values => true}
+    ),
+    case Res0 of
+        {ok, []} ->
+            {error, {<<"channel_pool_initializing">>, ChanPoolId}};
+        {ok, Sts} ->
+            case lists:filter(fun(X) -> X /= ok end, Sts) of
+                [] ->
+                    ok;
+                [Err | _] ->
+                    Err
+            end;
+        {error, _} = Err ->
+            Err
+    end.
+
+setup_pool(ResId) -> <<ResId/binary, ":setup">>.
+write_pool(ResId) -> <<ResId/binary, ":write">>.
+channel_pool(ResId) -> <<ResId/binary, ":channel">>.
+
+open_channels(ActionResId) ->
+    ChannelPoolId = channel_pool(ActionResId),
+    emqx_utils:foldl_while(
+        fun({_, Worker}, _Acc) ->
+            {ok, ChanClient} = ecpool_worker:client(Worker),
+            case emqx_bridge_snowflake_channel_client:ensure_channel_opened(ChanClient) of
+                ok ->
+                    {cont, ok};
+                {error,
+                    #{response := {_, _, #{<<"error">> := <<"ERR_PIPE_KIND_NOT_SUPPORTED">>}}} =
+                        Error} ->
+                    Context = #{
+                        reason => <<"error_opening_channel">>,
+                        hint => <<"specified pipe does not support streaming">>,
+                        error => Error
+                    },
+                    {halt, {error, {unhealthy_target, Context}}};
+                Error ->
+                    Context = #{reason => <<"error_opening_channel">>, error => Error},
+                    {halt, {error, Context}}
+            end
+        end,
+        ok,
+        ecpool:workers(ChannelPoolId)
+    ).
+
+streaming_destroy_allocated_resources(ConnResId) ->
+    streaming_destroy_allocated_resources(ConnResId, _ActionResId = '_').
+
+streaming_destroy_allocated_resources(ConnResId, ActionResId) ->
+    maps:foreach(
+        fun
+            (?channel_pool(Id) = Key, _) when
+                ActionResId == '_' orelse Id == ActionResId
+            ->
+                ChanPoolId = channel_pool(Id),
+                _ = emqx_resource_pool:stop(ChanPoolId),
+                deallocate(ConnResId, Key),
+                ok;
+            (?write_pool(Id) = Key, _) when
+                ActionResId == '_' orelse Id == ActionResId
+            ->
+                WritePoolId = write_pool(Id),
+                _ = ehttpc_sup:stop_pool(WritePoolId),
+                deallocate(ConnResId, Key),
+                ok;
+            (?setup_pool = Key, SetupPoolId) when
+                ActionResId == '_'
+            ->
+                _ = ehttpc_sup:stop_pool(SetupPoolId),
+                deallocate(ConnResId, Key),
+                ok;
+            (?streaming_jwt(Id) = Key, _) when
+                ActionResId == '_' orelse Id == ActionResId
+            ->
+                ok = emqx_connector_jwt:delete_jwt(?JWT_TABLE, Id),
+                deallocate(ConnResId, Key),
+                ok;
+            (_, _) ->
+                ok
+        end,
+        emqx_resource:get_allocated_resources(ConnResId)
+    ).
+
+allocate(ConnResId, Key, Value) ->
+    ok = emqx_resource:allocate_resource(ConnResId, ?MODULE, Key, Value).
+
+deallocate(ConnResId, Key) ->
+    ok = emqx_resource:deallocate_resource(ConnResId, Key).

--- a/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_streaming_SUITE.erl
+++ b/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_streaming_SUITE.erl
@@ -1,0 +1,535 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_bridge_snowflake_streaming_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-elvis([{elvis_text_style, line_length, #{skip_comments => whole_line}}]).
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+-import(emqx_utils_conv, [bin/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include("../src/emqx_bridge_snowflake.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
+
+%%------------------------------------------------------------------------------
+%% Definitions
+%%------------------------------------------------------------------------------
+
+-define(CONN_MOD_STREAM, emqx_bridge_snowflake_streaming_impl).
+-define(CHAN_CLIENT_MOD, emqx_bridge_snowflake_channel_client).
+
+-define(DATABASE, <<"testdatabase">>).
+-define(SCHEMA, <<"public">>).
+-define(TABLE, <<"test0">>).
+-define(TABLE_STREAMING, <<"emqx">>).
+-define(WAREHOUSE, <<"testwarehouse">>).
+-define(PIPE_STREAMING, <<"emqxstreaming">>).
+-define(PIPE_USER, <<"snowpipeuser">>).
+
+-define(tpal(MSG), begin
+    ct:pal(MSG),
+    ?tp(notice, MSG, #{})
+end).
+
+-define(batching, batching).
+-define(not_batching, not_batching).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    All0 = emqx_common_test_helpers:all(?MODULE),
+    All = All0 -- matrix_cases(),
+    Groups = lists:map(fun({G, _, _}) -> {group, G} end, groups()),
+    Groups ++ All.
+
+matrix_cases() ->
+    lists:filter(
+        fun
+            ({testcase, TestCase, _Opts}) ->
+                get_tc_prop(TestCase, matrix, false);
+            (TestCase) ->
+                get_tc_prop(TestCase, matrix, false)
+        end,
+        emqx_common_test_helpers:all(?MODULE)
+    ).
+
+groups() ->
+    emqx_common_test_helpers:matrix_to_groups(?MODULE, matrix_cases()).
+
+init_per_suite(Config) ->
+    case os:getenv("SNOWFLAKE_ACCOUNT_ID", "") of
+        "" ->
+            Mock = true,
+            AccountId = "mocked_orgid-mocked_account_id",
+            Server = <<"mocked_orgid-mocked_account_id.snowflakecomputing.com">>,
+            Username = <<"mock_username">>,
+            Password = <<"mock_password">>;
+        AccountId ->
+            Mock = false,
+            Server = iolist_to_binary([AccountId, ".snowflakecomputing.com"]),
+            Username = os:getenv("SNOWFLAKE_USERNAME"),
+            Password = os:getenv("SNOWFLAKE_PASSWORD")
+    end,
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            emqx_bridge_snowflake,
+            emqx_bridge,
+            emqx_rule_engine,
+            emqx_management,
+            emqx_mgmt_api_test_util:emqx_dashboard()
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    case Mock of
+        true ->
+            ct:print(asciiart:visible($%, "running with MOCKED snowflake", []));
+        false ->
+            ct:print(asciiart:visible($%, "running with REAL snowflake", []))
+    end,
+    [
+        {mock, Mock},
+        {apps, Apps},
+        {account_id, AccountId},
+        {server, Server},
+        {username, Username},
+        {password, Password}
+        | Config
+    ].
+
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    emqx_cth_suite:stop(Apps),
+    ok.
+
+init_per_testcase(TestCase, Config0) ->
+    %% See `../docs/dev-quick-ref.md' for how to create the DB objects and roles.
+    ct:timetrap(timetrap(Config0)),
+    AccountId = ?config(account_id, Config0),
+    Server = ?config(server, Config0),
+    UniqueNum = integer_to_binary(erlang:unique_integer()),
+    Name = <<(atom_to_binary(TestCase))/binary, UniqueNum/binary>>,
+    ConnectorConfig = connector_config(Name, AccountId, Server),
+    ActionConfig0 = action_config(#{connector => Name}, Config0),
+    ActionConfig = emqx_bridge_v2_testlib:parse_and_check(
+        ?ACTION_TYPE_STREAM_BIN, Name, ActionConfig0
+    ),
+    ExtraConfig0 = maybe_mock_snowflake(Config0),
+    ConnPid = emqx_bridge_snowflake_aggregated_SUITE:new_odbc_client(Config0),
+    Config =
+        ExtraConfig0 ++
+            [
+                {bridge_kind, action},
+                {action_type, ?ACTION_TYPE_STREAM_BIN},
+                {action_name, Name},
+                {action_config, ActionConfig},
+                {connector_name, Name},
+                {connector_type, ?CONNECTOR_TYPE_STREAM_BIN},
+                {connector_config, ConnectorConfig},
+                {odbc_client, ConnPid}
+                | Config0
+            ],
+    ok = truncate_table(Config),
+    case erlang:function_exported(?MODULE, TestCase, 2) of
+        true ->
+            ?MODULE:TestCase(init, Config);
+        false ->
+            Config
+    end.
+
+end_per_testcase(_Testcase, Config) ->
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    ok = truncate_table(Config),
+    emqx_bridge_snowflake_aggregated_SUITE:stop_odbc_client(Config),
+    emqx_common_test_helpers:call_janitor(),
+    ok = snabbkaffe:stop(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+timetrap(Config) ->
+    case ?config(mock, Config) of
+        true ->
+            {seconds, 20};
+        false ->
+            {seconds, 150}
+    end.
+
+group_path(Config, Default) ->
+    case emqx_common_test_helpers:group_path(Config) of
+        [] -> Default;
+        Path -> Path
+    end.
+
+get_tc_prop(TestCase, Key, Default) ->
+    maybe
+        true ?= erlang:function_exported(?MODULE, TestCase, 0),
+        {Key, Val} ?= proplists:lookup(Key, ?MODULE:TestCase()),
+        Val
+    else
+        _ -> Default
+    end.
+
+get_matrix_prop(TCConfig, Alternatives, Default) ->
+    GroupPath = group_path(TCConfig, [Default]),
+    case lists:filter(fun(G) -> lists:member(G, Alternatives) end, GroupPath) of
+        [] ->
+            Default;
+        [Opt] ->
+            Opt
+    end.
+
+is_batching(TCConfig) ->
+    get_matrix_prop(TCConfig, [?not_batching, ?batching], ?batching).
+
+maybe_mock_snowflake(Config) when is_list(Config) ->
+    maybe_mock_snowflake(maps:from_list(Config));
+maybe_mock_snowflake(#{mock := true}) ->
+    mock_snowflake();
+maybe_mock_snowflake(#{mock := false}) ->
+    [].
+
+mock_snowflake() ->
+    TId = ets:new(snowflake, [public, ordered_set]),
+    Mod = ?CONN_MOD_STREAM,
+    ok = meck:new(Mod, [passthrough, no_history]),
+    ok = meck:new(?CHAN_CLIENT_MOD, [passthrough, no_history]),
+    on_exit(fun() -> meck:unload() end),
+    {ok, {Port, _}} = emqx_utils_http_test_server:start_link(random, "/", server_ssl_opts()),
+    on_exit(fun() ->
+        persistent_term:erase({?CONN_MOD_STREAM, streaming_port})
+    end),
+    persistent_term:put({?CONN_MOD_STREAM, streaming_port}, Port),
+    meck:expect(Mod, do_get_streaming_hostname, fun(_HTTPPool, _Req, _RequestTTL, _MaxRetries) ->
+        Headers = [],
+        Body = <<"127.0.0.1">>,
+        ?tp("mock_snowflake_get_streaming_hostname", #{}),
+        {ok, 200, Headers, Body}
+    end),
+    meck:expect(?CHAN_CLIENT_MOD, do_open_channel, fun(_HTTPPool, _Req, _RequestTTL, _MaxRetries) ->
+        Headers = [],
+        Body = emqx_utils_json:encode(#{<<"next_continuation_token">> => <<"0_1">>}),
+        ?tp("mock_snowflake_open_channel", #{}),
+        {ok, 200, Headers, Body}
+    end),
+    meck:expect(?CHAN_CLIENT_MOD, do_append_rows, fun(_HTTPPool, Req, _RequestTTL, _MaxRetries) ->
+        {_, _, BodyRaw} = Req,
+        Records = emqx_connector_aggreg_json_lines_test_utils:decode(iolist_to_binary(BodyRaw)),
+        Rows = lists:map(fun streaming_record_to_mocked_row/1, Records),
+        ets:insert(TId, {erlang:monotonic_time(), Rows}),
+        Headers = [],
+        Body = emqx_utils_json:encode(#{<<"next_continuation_token">> => <<"1_1">>}),
+        ?tp("mock_snowflake_append_rows", #{}),
+        {ok, 200, Headers, Body}
+    end),
+    [{mocked_table, TId}].
+
+generate_dummy_jwt() ->
+    NowS = erlang:system_time(second),
+    Exp = erlang:convert_time_unit(timer:hours(1), millisecond, second),
+    ExpTime = NowS + Exp,
+    Key = crypto:strong_rand_bytes(32),
+    JWK = #{
+        <<"kty">> => <<"oct">>,
+        <<"k">> => jose_base64url:encode(Key)
+    },
+    JWS = #{
+        <<"alg">> => <<"HS256">>
+    },
+    JWT = #{
+        <<"iss">> => <<"ct">>,
+        <<"exp">> => ExpTime
+    },
+    Signed = jose_jwt:sign(JWK, JWS, JWT),
+    {_, Token} = jose_jws:compact(Signed),
+    Token.
+
+server_ssl_opts() ->
+    [
+        {keyfile, cert_path("server.key")},
+        {certfile, cert_path("server.crt")},
+        {cacertfile, cert_path("ca.crt")},
+        {verify, verify_none},
+        {versions, ['tlsv1.2', 'tlsv1.3']},
+        {ciphers, ["ECDHE-RSA-AES256-GCM-SHA384", "TLS_CHACHA20_POLY1305_SHA256"]}
+    ].
+
+cert_path(FileName) ->
+    Dir = code:lib_dir(emqx_auth),
+    filename:join([Dir, <<"test/data/certs">>, FileName]).
+
+streaming_record_to_mocked_row(Record0) ->
+    maps:fold(
+        fun
+            (<<"payload">> = K, <<"">>, Acc) ->
+                Acc#{string:uppercase(K) => null};
+            (K, V, Acc) ->
+                Acc#{string:uppercase(K) => V}
+        end,
+        #{},
+        Record0
+    ).
+
+spawn_dummy_connection_pid() ->
+    DummyConnPid = spawn_link(fun() ->
+        receive
+            die -> ok
+        end
+    end),
+    on_exit(fun() ->
+        Ref = monitor(process, DummyConnPid),
+        DummyConnPid ! die,
+        receive
+            {'DOWN', Ref, process, DummyConnPid, _} ->
+                ok
+        after 200 ->
+            ct:fail("dummy connection ~p didn't die", [DummyConnPid])
+        end
+    end),
+    {ok, DummyConnPid}.
+
+connector_config(Name, AccountId, Server) ->
+    InnerConfigMap0 =
+        #{
+            <<"enable">> => true,
+            <<"tags">> => [<<"bridge">>],
+            <<"description">> => <<"my cool bridge">>,
+            <<"private_key">> => private_key(),
+            <<"private_key_password">> => null,
+            <<"pipe_user">> => ?PIPE_USER,
+            <<"account">> => AccountId,
+            <<"server">> => Server,
+            <<"connect_timeout">> => <<"5s">>,
+            <<"max_inactive">> => <<"10s">>,
+            <<"pipelining">> => 100,
+            <<"max_retries">> => 3,
+            <<"ssl">> => #{<<"enable">> => false},
+            <<"resource_opts">> =>
+                #{
+                    <<"health_check_interval">> => <<"1s">>,
+                    <<"start_after_created">> => true,
+                    <<"start_timeout">> => <<"5s">>
+                }
+        },
+    emqx_bridge_v2_testlib:parse_and_check_connector(
+        ?CONNECTOR_TYPE_STREAM_BIN, Name, InnerConfigMap0
+    ).
+
+action_config(Overrides0, TCConfig) ->
+    Overrides = emqx_utils_maps:binary_key_map(Overrides0),
+    CommonConfig =
+        #{
+            <<"enable">> => true,
+            <<"connector">> => <<"please override">>,
+            <<"parameters">> =>
+                #{
+                    <<"database">> => ?DATABASE,
+                    <<"schema">> => ?SCHEMA,
+                    <<"pipe">> => ?PIPE_STREAMING,
+                    <<"connect_timeout">> => <<"5s">>,
+                    <<"max_inactive">> => <<"10s">>,
+                    <<"pipelining">> => 100,
+                    <<"pool_size">> => 1,
+                    <<"max_retries">> => 3
+                },
+            <<"resource_opts">> =>
+                maps:merge(
+                    emqx_bridge_v2_testlib:common_action_resource_opts(),
+                    batch_opts(TCConfig)
+                )
+        },
+    emqx_utils_maps:deep_merge(CommonConfig, Overrides).
+
+batch_opts(TCConfig) ->
+    case is_batching(TCConfig) of
+        ?batching ->
+            #{
+                <<"batch_size">> => 10,
+                <<"batch_time">> => <<"100ms">>
+            };
+        ?not_batching ->
+            #{
+                <<"batch_size">> => 1,
+                <<"batch_time">> => <<"0ms">>
+            }
+    end.
+
+private_key() ->
+    case os:getenv("SNOWFLAKE_PRIVATE_KEY") of
+        false ->
+            JWK = jose_jwk:generate_key({rsa, 2048}),
+            {_, PEM} = jose_jwk:to_pem(JWK),
+            PEM;
+        FileURI ->
+            %% file:///path/to/private-key.pem
+            list_to_binary(FileURI)
+    end.
+
+private_key_path() ->
+    case os:getenv("SNOWFLAKE_PRIVATE_KEY_PATH") of
+        false ->
+            <<"/path/to/private.key">>;
+        Filepath ->
+            emqx_utils_conv:bin(Filepath)
+    end.
+
+private_key_password() ->
+    case os:getenv("SNOWFLAKE_PRIVATE_KEY_PASSWORD") of
+        false ->
+            <<"supersecret">>;
+        Password ->
+            emqx_utils_conv:bin(Password)
+    end.
+
+str(IOList) ->
+    emqx_utils_conv:str(iolist_to_binary(IOList)).
+
+fqn(Database, Schema, Thing) ->
+    [Database, <<".">>, Schema, <<".">>, Thing].
+
+sql_query(ConnPid, SQL) ->
+    emqx_bridge_snowflake_aggregated_SUITE:sql_query(ConnPid, SQL).
+
+create_table(Config) ->
+    ConnPid = ?config(odbc_client, Config),
+    SQL = str([
+        <<"create or replace table ">>,
+        fqn(?DATABASE, ?SCHEMA, ?TABLE),
+        <<" (">>,
+        <<"clientid string">>,
+        <<", topic string">>,
+        <<", payload binary">>,
+        <<", publish_received_at timestamp_ltz">>,
+        <<")">>
+    ]),
+    {updated, _} = sql_query(ConnPid, SQL),
+    ok.
+
+truncate_table(Config) when is_list(Config) ->
+    truncate_table(maps:from_list(Config));
+truncate_table(#{mock := true} = _Config) ->
+    ok;
+truncate_table(Config) ->
+    #{odbc_client := ConnPid} = Config,
+    SQL = str([
+        <<"truncate ">>,
+        fqn(?DATABASE, ?SCHEMA, table_of(Config))
+    ]),
+    {updated, _} = sql_query(ConnPid, SQL),
+    ok.
+
+table_of(_TCConfig) ->
+    ?TABLE_STREAMING.
+
+row_to_map(Row0, Headers) ->
+    Row1 = tuple_to_list(Row0),
+    Row2 = lists:map(
+        fun
+            (Str) when is_list(Str) ->
+                emqx_utils_conv:bin(Str);
+            (Cell) ->
+                Cell
+        end,
+        Row1
+    ),
+    Row = lists:zip(Headers, Row2),
+    maps:from_list(Row).
+
+get_all_rows(Config) when is_list(Config) ->
+    get_all_rows(maps:from_list(Config));
+get_all_rows(#{mock := true} = Config) ->
+    #{mocked_table := TId} = Config,
+    lists:sort(
+        fun(#{<<"CLIENTID">> := CIdA}, #{<<"CLIENTID">> := CIdB}) ->
+            CIdA =< CIdB
+        end,
+        [Row || {_File, Rows} <- ets:tab2list(TId), Row <- Rows]
+    );
+get_all_rows(#{mock := false} = Config) ->
+    #{odbc_client := ConnPid} = Config,
+    SQL0 = str([
+        <<"use warehouse ">>,
+        ?WAREHOUSE
+    ]),
+    {updated, _} = sql_query(ConnPid, SQL0),
+    Table = table_of(Config),
+    SQL1 = str([
+        <<"select * from ">>,
+        fqn(?DATABASE, ?SCHEMA, Table),
+        <<" order by clientid">>
+    ]),
+    {selected, Headers0, Rows} = sql_query(ConnPid, SQL1),
+    Headers = lists:map(fun list_to_binary/1, Headers0),
+    lists:map(fun(R) -> row_to_map(R, Headers) end, Rows).
+
+mk_message({ClientId, Topic, Payload}) ->
+    emqx_message:make(bin(ClientId), bin(Topic), Payload).
+
+publish_messages(MessageEvents) ->
+    lists:foreach(fun emqx:publish/1, MessageEvents).
+
+bin2hex(Bin) ->
+    emqx_rule_funcs:bin2hexstr(Bin).
+
+create_connector_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:create_connector_api(Config, Overrides)
+    ).
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+t_start_stop(TCConfig) when is_list(TCConfig) ->
+    ok = emqx_bridge_v2_testlib:t_start_stop(TCConfig, "snowflake_connector_stop"),
+    ok.
+
+t_create_via_http(Config) ->
+    ok = emqx_bridge_v2_testlib:t_create_via_http(Config),
+    ok.
+
+%% Unfortunately, there's no way to use toxiproxy to proxy to the real snowflake, as it
+%% requires SSL and the hostname mismatch impedes the connection...
+t_on_get_status(Config) ->
+    ok = emqx_bridge_v2_testlib:t_on_get_status(Config),
+    ok.
+
+t_rule_test_trace(Config) ->
+    Opts = #{},
+    emqx_bridge_v2_testlib:t_rule_test_trace(Config, Opts).
+
+%% Smoke test for streaming mode.
+t_streaming() ->
+    [{matrix, true}].
+t_streaming(matrix) ->
+    [
+        [?batching],
+        [?not_batching]
+    ];
+t_streaming(TCConfig) when is_list(TCConfig) ->
+    PostPublishFn = fun(Context) ->
+        #{payload := Payload} = Context,
+        ?retry(
+            2_000,
+            10,
+            ?assertMatch(
+                [#{<<"PAYLOAD">> := Payload}],
+                get_all_rows(TCConfig)
+            )
+        )
+    end,
+    Opts = #{
+        post_publish_fn => PostPublishFn
+    },
+    emqx_bridge_v2_testlib:t_rule_action(TCConfig, Opts).

--- a/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_tests.erl
+++ b/apps/emqx_bridge_snowflake/test/emqx_bridge_snowflake_tests.erl
@@ -16,13 +16,13 @@ parse_and_check_connector(InnerConfig) ->
     %% To trigger schema injections
     _ = emqx_conf_schema:roots(),
     emqx_bridge_v2_testlib:parse_and_check_connector(
-        ?CONNECTOR_TYPE_BIN,
+        ?CONNECTOR_TYPE_AGGREG_BIN,
         ?CONNECTOR_NAME,
         InnerConfig
     ).
 
 connector_config(Overrides) ->
-    Base = emqx_bridge_snowflake_SUITE:connector_config(
+    Base = emqx_bridge_snowflake_aggregated_SUITE:connector_config(
         ?CONNECTOR_NAME,
         <<"orgid-accountid">>,
         <<"orgid-accountid.snowflakecomputing.com">>,

--- a/apps/emqx_conf/src/emqx_conf_schema_inject.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema_inject.erl
@@ -67,7 +67,7 @@ bridges(ee) ->
     [
         emqx_bridge_disk_log_connector_schema,
         emqx_bridge_mqtt_connector_schema,
-        emqx_bridge_snowflake_connector_schema
+        emqx_bridge_snowflake_aggregated_connector_schema
     ].
 
 namespaced_root_keys() ->

--- a/apps/emqx_gen_bridge/src/emqx_action_info.erl
+++ b/apps/emqx_gen_bridge/src/emqx_action_info.erl
@@ -110,6 +110,7 @@ hard_coded_action_info_modules_ee() ->
         emqx_bridge_s3_upload_action_info,
         emqx_bridge_s3tables_action_info,
         emqx_bridge_snowflake_aggregated_action_info,
+        emqx_bridge_snowflake_streaming_action_info,
         emqx_bridge_sqlserver_action_info,
         emqx_bridge_syskeeper_action_info,
         emqx_bridge_tdengine_action_info,

--- a/apps/emqx_gen_bridge/src/emqx_action_info.erl
+++ b/apps/emqx_gen_bridge/src/emqx_action_info.erl
@@ -109,7 +109,7 @@ hard_coded_action_info_modules_ee() ->
         emqx_bridge_rocketmq_action_info,
         emqx_bridge_s3_upload_action_info,
         emqx_bridge_s3tables_action_info,
-        emqx_bridge_snowflake_action_info,
+        emqx_bridge_snowflake_aggregated_action_info,
         emqx_bridge_sqlserver_action_info,
         emqx_bridge_syskeeper_action_info,
         emqx_bridge_tdengine_action_info,

--- a/apps/emqx_gen_bridge/src/emqx_connector_info.erl
+++ b/apps/emqx_gen_bridge/src/emqx_connector_info.erl
@@ -99,6 +99,7 @@ hard_coded_connector_info_modules_ee() ->
         emqx_bridge_s3_connector_info,
         emqx_bridge_s3tables_connector_info,
         emqx_bridge_snowflake_aggregated_connector_info,
+        emqx_bridge_snowflake_streaming_connector_info,
         emqx_bridge_sqlserver_connector_info,
         emqx_bridge_syskeeper_connector_info,
         emqx_bridge_syskeeper_proxy_connector_info,

--- a/apps/emqx_gen_bridge/src/emqx_connector_info.erl
+++ b/apps/emqx_gen_bridge/src/emqx_connector_info.erl
@@ -98,7 +98,7 @@ hard_coded_connector_info_modules_ee() ->
         emqx_bridge_rocketmq_connector_info,
         emqx_bridge_s3_connector_info,
         emqx_bridge_s3tables_connector_info,
-        emqx_bridge_snowflake_connector_info,
+        emqx_bridge_snowflake_aggregated_connector_info,
         emqx_bridge_sqlserver_connector_info,
         emqx_bridge_syskeeper_connector_info,
         emqx_bridge_syskeeper_proxy_connector_info,

--- a/apps/emqx_s3/test/emqx_s3_profile_conf_SUITE.erl
+++ b/apps/emqx_s3/test/emqx_s3_profile_conf_SUITE.erl
@@ -37,6 +37,7 @@ init_per_testcase(_TestCase, Config) ->
     [{profile_config, ProfileConfig} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
+    meck:unload(),
     ok = snabbkaffe:stop(),
     _ = emqx_s3:stop_profile(profile_id()).
 

--- a/rel/i18n/emqx_bridge_snowflake_aggregated_action_schema.hocon
+++ b/rel/i18n/emqx_bridge_snowflake_aggregated_action_schema.hocon
@@ -1,4 +1,4 @@
-emqx_bridge_snowflake_action_schema {
+emqx_bridge_snowflake_aggregated_action_schema {
   snowflake.label:
   """Upload to Snowflake"""
   snowflake.desc:

--- a/rel/i18n/emqx_bridge_snowflake_aggregated_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_snowflake_aggregated_connector_schema.hocon
@@ -1,8 +1,8 @@
-emqx_bridge_snowflake_connector_schema {
+emqx_bridge_snowflake_aggregated_connector_schema {
   config_connector.label:
-  """Snowflake Connector Configuration"""
+  """Snowflake Aggregated Connector Configuration"""
   config_connector.desc:
-  """Configuration for a connector to Snowflake service."""
+  """Configuration for a connector to Snowflake service using aggregated uploads."""
 
   server.label:
   """Server Host"""

--- a/rel/i18n/emqx_bridge_snowflake_streaming_action_schema.hocon
+++ b/rel/i18n/emqx_bridge_snowflake_streaming_action_schema.hocon
@@ -1,0 +1,7 @@
+emqx_bridge_snowflake_streaming_action_schema {
+  snowflake_streaming.label:
+  """Upload to Snowflake"""
+  snowflake_streaming.desc:
+  """Action that takes incoming events and uploads them to the Snowflake."""
+
+}

--- a/rel/i18n/emqx_bridge_snowflake_streaming_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_snowflake_streaming_connector_schema.hocon
@@ -1,0 +1,7 @@
+emqx_bridge_snowflake_streaming_connector_schema {
+  config_connector.label:
+  """Snowflake Streaming Connector Configuration"""
+  config_connector.desc:
+  """Configuration for a connector to Snowflake service using high-performance streaming API."""
+
+}


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14523

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 6.0.0-M2.202508

## Summary

The new Snowflake Snowpipe Streaming APIs do not require ODBC connections, which simplify the setup required to use Snowflake integration.  Since the connection is so different from the aggregated mode from existing integration, it's cleaner to make a new connector type than to graft streaming as an Action mode onto the old connector.

The previously added Streaming Action mode was only released in 6.0.0-M1, an internal release.  So, although this is a breaking schema change (we're dropping `mode = streaming` from `snowflake` Action type), it should be fine, as it's not publicly released.

A couple common functions used in both connectors are moved to `emqx_bridge_snowflake_lib` for shared usage.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests (ran test suites against real snowflake)
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (previous streaming mode was only in internal release)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
