### PR TITLE
test(s3): attempt to fix flaky test

### DIFF
--- a/apps/emqx_s3/test/emqx_s3_profile_conf_SUITE.erl
+++ b/apps/emqx_s3/test/emqx_s3_profile_conf_SUITE.erl
@@ -37,6 +37,7 @@ init_per_testcase(_TestCase, Config) ->
     [{profile_config, ProfileConfig} | Config].
 
 end_per_testcase(_TestCase, _Config) ->
+    meck:unload(),
     ok = snabbkaffe:stop(),
     _ = emqx_s3:stop_profile(profile_id()).
 


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/16569998287/job/46860227425?pr=15587#step:4:159

```
 Testing apps.emqx_s3.emqx_s3_profile_conf_SUITE: *** FAILED test case 4 of 7 ***
%%% emqx_s3_profile_conf_SUITE ==> t_httpc_pool_update_error: FAILED
%%% emqx_s3_profile_conf_SUITE ==> {{already_started,<0.42140.0>},
 [{meck_proc,start,
             [hackney_pool,[passthrough]],
             [{file,"/__w/emqx/emqx/deps/meck/src/meck_proc.erl"},{line,93}]},
  {emqx_s3_profile_conf_SUITE,t_httpc_pool_update_error,1,
                              [{file,"test/emqx_s3_profile_conf_SUITE.erl"},
                               {line,69}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```
