### PR TITLE
feat(trace): expose "max number of traces" as config option

### DIFF
--- a/apps/emqx/include/emqx_trace.hrl
+++ b/apps/emqx/include/emqx_trace.hrl
@@ -9,20 +9,14 @@
 -include_lib("emqx/include/emqx_config.hrl").
 
 -record(?TRACE, {
-    name :: binary() | undefined | '_',
-    type :: clientid | topic | ip_address | ruleid | undefined | '_',
-    filter ::
-        emqx_types:topic()
-        | emqx_types:clientid()
-        | emqx_trace:ip_address()
-        | {?global_ns | binary(), emqx_trace:ruleid()}
-        | undefined
-        | '_',
-    enable = true :: boolean() | '_',
-    payload_encode = text :: hex | text | hidden | '_',
-    extra = #{formatter => text} :: emqx_trace:trace_extra() | '_',
-    start_at :: integer() | undefined | '_',
-    end_at :: integer() | undefined | '_'
+    name,
+    type,
+    filter,
+    enable = true,
+    payload_encode = text,
+    extra = #{formatter => text},
+    start_at,
+    end_at
 }).
 
 -record(emqx_trace_format_func_data, {

--- a/apps/emqx/include/emqx_trace.hrl
+++ b/apps/emqx/include/emqx_trace.hrl
@@ -8,12 +8,6 @@
 
 -include_lib("emqx/include/emqx_config.hrl").
 
--type trace_extra() :: #{
-    formatter => text | json,
-    payload_limit => integer(),
-    any() => term()
-}.
-
 -record(?TRACE, {
     name :: binary() | undefined | '_',
     type :: clientid | topic | ip_address | ruleid | undefined | '_',
@@ -26,7 +20,7 @@
         | '_',
     enable = true :: boolean() | '_',
     payload_encode = text :: hex | text | hidden | '_',
-    extra = #{formatter => text} :: trace_extra() | '_',
+    extra = #{formatter => text} :: emqx_trace:trace_extra() | '_',
     start_at :: integer() | undefined | '_',
     end_at :: integer() | undefined | '_'
 }).

--- a/apps/emqx/include/emqx_trace.hrl
+++ b/apps/emqx/include/emqx_trace.hrl
@@ -31,7 +31,6 @@
 }).
 
 -define(SHARD, ?COMMON_SHARD).
--define(MAX_SIZE, 30).
 
 -define(EMQX_TRACE_STOP_ACTION(REASON),
     {unrecoverable_error, {action_stopped_after_template_rendering, REASON}}

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1795,6 +1795,12 @@ fields("trace") ->
                 validator => mk_validator_bounds({10 * ?KB, "10KB"}, {10 * ?GB, "10GB"}),
                 desc => ?DESC(fields_trace_max_file_size)
             })},
+        {"max_traces",
+            sc(range(0, 100), #{
+                default => 30,
+                importance => ?IMPORTANCE_LOW,
+                desc => ?DESC(fields_trace_max_traces)
+            })},
         %% Deprecated fields:
         {"payload_encode",
             sc(hoconsc:enum([hex, text, hidden]), #{

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -272,7 +272,7 @@ list_traces(Enable) ->
 create(Trace) ->
     maybe
         {ok, TraceRecord} ?= mk_trace_record(Trace),
-        true ?= mnesia:table_info(?TRACE, size) < ?MAX_SIZE,
+        true ?= mnesia:table_info(?TRACE, size) < max_traces(),
         ok ?= insert_new_trace(TraceRecord),
         {ok, format(TraceRecord)}
     else
@@ -283,6 +283,10 @@ create(Trace) ->
                 "The number of traces created has reached the maximum"
                 " please delete the useless ones first"}
     end.
+
+-spec max_traces() -> non_neg_integer().
+max_traces() ->
+    emqx_config:get([trace, max_traces]).
 
 -spec delete(Name :: binary()) -> ok | {error, not_found}.
 delete(Name) ->

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -647,8 +647,12 @@ validate_time_range(_) ->
 
 validate_name(undefined) ->
     {error, "name required"};
-validate_name(Name) ->
-    case re:run(Name, ?NAME_RE) of
+validate_name(Name) when is_binary(Name) ->
+    case
+        Name =:= unicode:characters_to_binary(Name, utf8) andalso
+            re:run(Name, ?NAME_RE)
+    of
+        false -> {error, "Name is not a UTF-8 string"};
         nomatch -> {error, "Name should be " ?NAME_RE};
         _ -> ok
     end.

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -470,7 +470,7 @@ closest(Time, Now, Closest) -> min(Time - Now, Closest).
 disable_finished([]) ->
     ok;
 disable_finished(Traces) ->
-    transaction(fun emqx_trace_dl:delete_finished/1, [Traces]).
+    transaction(fun emqx_trace_dl:disable_finished/1, [Traces]).
 
 start_trace(Traces, Started0) ->
     Started = lists:map(fun(#{name := Name}) -> Name end, Started0),

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -288,9 +288,6 @@ create(Trace) ->
         {ok, TraceRecord} ?= mk_trace_record(Trace),
         ok ?= insert_new_trace(TraceRecord),
         {ok, format(TraceRecord)}
-    else
-        {error, Reason} ->
-            {error, Reason}
     end.
 
 -spec delete(Name :: binary()) -> ok | {error, not_found}.
@@ -626,8 +623,6 @@ mk_trace_record(Trace = #{}) ->
         }),
         ok ?= validate_time_range(Record),
         {ok, Record}
-    else
-        Error -> Error
     end.
 
 fill_default(Trace = #?TRACE{start_at = undefined}) ->

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -55,14 +55,26 @@
 ]).
 -endif.
 
--type trace() :: #{atom() => _TODO}.
-
--type trace_extra() :: #{
-    formatter => text | json,
-    payload_limit => integer(),
-    namespace => atom() | binary(),
-    slot => non_neg_integer()
+-export_type([trace/0]).
+-type trace() :: #{
+    enable => boolean(),
+    name := binary(),
+    type := clientid | topic | ip_address | ruleid,
+    filter := filter(),
+    start_at => _TimestampSeconds :: non_neg_integer(),
+    end_at => _TimestampSeconds :: non_neg_integer(),
+    formatter := text | json,
+    payload_encode => text | hex | hidden,
+    payload_limit => pos_integer(),
+    namespace => ?global_ns | binary()
 }.
+
+-export_type([filter/0]).
+-type filter() ::
+    emqx_types:clientid()
+    | emqx_types:topic()
+    | ip_address()
+    | {?global_ns | binary(), ruleid()}.
 
 -export_type([ip_address/0]).
 -type ip_address() :: string().

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -534,7 +534,7 @@ stop_trace(Finished, Started) ->
         fun(#{name := Name, id := HandlerID, dst := FilePath, type := Type, filter := Filter}) ->
             case lists:member(Name, Finished) of
                 true ->
-                    _ = maybe_sync_logfile(HandlerID),
+                    _ = emqx_trace_handler:filesync(HandlerID),
                     case file:read_file_info(FilePath) of
                         {ok, #file_info{size = Size}} when Size > 0 ->
                             ?TRACE("API", "trace_stopping", #{Type => Filter});
@@ -548,19 +548,6 @@ stop_trace(Finished, Started) ->
         end,
         Started
     ).
-
-maybe_sync_logfile(HandlerID) ->
-    case logger:get_handler_config(HandlerID) of
-        {ok, #{module := Mod}} ->
-            case erlang:function_exported(Mod, filesync, 1) of
-                true ->
-                    Mod:filesync(HandlerID);
-                false ->
-                    ok
-            end;
-        _ ->
-            ok
-    end.
 
 clean_stale_trace_files() ->
     TraceDir = trace_dir(),

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -660,7 +660,7 @@ validate_filter(ip_address, Addr) ->
 validate_filter(ruleid, _RuleId = <<_/binary>>) ->
     ok;
 validate_filter(_, _) ->
-    {error, "type=[topic,clientid,ip_address] required"}.
+    {error, "type=[topic,clientid,ip_address,ruleid] required"}.
 
 validate_end_at(undefined) ->
     ok;

--- a/apps/emqx/src/emqx_trace/emqx_trace_dl.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_dl.erl
@@ -11,7 +11,7 @@
     insert_new_trace/1,
     delete/1,
     get_trace_filename/1,
-    delete_finished/1,
+    disable_finished/1,
     get_enabled_trace/0
 ]).
 
@@ -100,7 +100,7 @@ get_trace_filename(Name) ->
     end.
 
 %% Introduced in 5.0
-delete_finished(Traces) ->
+disable_finished(Traces) ->
     lists:map(
         fun(#?TRACE{name = Name}) ->
             case mnesia:read(?TRACE, Name, write) of

--- a/apps/emqx/src/emqx_trace/emqx_trace_dl.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_dl.erl
@@ -98,6 +98,7 @@ insert_new_trace(
         ?TRACE
     ),
     Slot = emqx_trace_freelist:first(SlotList),
+    true = is_integer(Slot),
     Trace = Trace0#?TRACE{
         extra = Extra#{slot => Slot}
     },

--- a/apps/emqx/src/emqx_trace/emqx_trace_freelist.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_freelist.erl
@@ -20,22 +20,30 @@
 
 %%
 
+-doc "Contruct a freelist spanning range of integers, inclusive bounds.".
 -spec range(integer(), integer()) -> t().
 range(A, B) when A =< B ->
     [A, B].
 
+-doc "Pick a first unoccupied slot in the given freelist.".
 -spec first(t()) -> integer() | {error, full}.
 first([A | _]) ->
     A;
 first([]) ->
     {error, full}.
 
+-doc "Turn freelist into a list of all unoccupied slots.".
 -spec to_list(t()) -> [integer()].
 to_list([A, B | Rest]) ->
     lists:seq(A, B) ++ to_list(Rest);
 to_list([]) ->
     [].
 
+-doc """
+Occupy a slot in the given freelist.
+Occupying already occupied slot is not an error, consistency holds as long as results
+from `first/1` / `to_list/1` are fed into this function.
+""".
 -spec occupy(integer(), t()) -> t().
 occupy(X, [A | _] = List) when X < A ->
     List;

--- a/apps/emqx/src/emqx_trace/emqx_trace_freelist.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_freelist.erl
@@ -1,0 +1,96 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_trace_freelist).
+
+-export([
+    %% Constructor:
+    range/2,
+    %% Tracking:
+    occupy/2,
+    %% Accessors:
+    first/1,
+    to_list/1
+]).
+
+-export_type([t/0]).
+
+-opaque t() :: [integer()].
+
+%%
+
+-spec range(integer(), integer()) -> t().
+range(A, B) when A =< B ->
+    [A, B].
+
+-spec first(t()) -> integer() | {error, full}.
+first([A | _]) ->
+    A;
+first([]) ->
+    {error, full}.
+
+-spec to_list(t()) -> [integer()].
+to_list([A, B | Rest]) ->
+    lists:seq(A, B) ++ to_list(Rest);
+to_list([]) ->
+    [].
+
+-spec occupy(integer(), t()) -> t().
+occupy(X, [A | _] = List) when X < A ->
+    List;
+occupy(X, [A, B | Rest]) ->
+    case X of
+        A -> compress([A + 1, B | Rest]);
+        B -> compress([A, B - 1 | Rest]);
+        _ when X > B -> [A, B | occupy(X, Rest)];
+        _ when X > A -> compress([A, X - 1, X + 1, B | Rest])
+    end;
+occupy(_, []) ->
+    [].
+
+compress([A, B | Rest]) when A > B ->
+    compress(Rest);
+compress(Range) ->
+    Range.
+
+%%
+
+-ifdef(TEST).
+
+-include_lib("proper/include/proper_common.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+free_range_test() ->
+    ?assertEqual(10, first(range(10, 42))).
+
+full_range_test() ->
+    L0 = range(10, 20),
+    L1 = lists:foldl(fun occupy/2, L0, lists:seq(10, 20)),
+    ?assertEqual([], to_list(L1)),
+    ?assertEqual({error, full}, first(L1)).
+
+prop_test() ->
+    Opts = [{numtests, 1000}, {to_file, user}],
+    proper:quickcheck(prop_consistency(), Opts).
+
+prop_consistency() ->
+    ?FORALL(
+        {{A, B}, Occupied},
+        {t_range(), proper_types:list(t_integer())},
+        begin
+            FL0 = range(A, B),
+            FL = lists:foldl(fun occupy/2, FL0, Occupied),
+            Seq0 = lists:seq(A, B),
+            Seq = lists:foldl(fun(X, Seq) -> Seq -- [X] end, Seq0, Occupied),
+            to_list(FL) =:= Seq
+        end
+    ).
+
+t_range() ->
+    ?SUCHTHAT({A, B}, {t_integer(), t_integer()}, A =< B).
+
+t_integer() ->
+    proper_types:integer().
+
+-endif.

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -183,7 +183,9 @@ filters(#{type := ruleid, filter := Filter, name := Name} = Who) ->
     [{ruleid, {fun ?MODULE:filter_ruleid/2, {{Namespace, ensure_bin(Filter)}, Name}}}].
 
 formatter(#{
-    type := _Type, payload_encode := PayloadEncode, formatter := json, payload_limit := PayloadLimit
+    formatter := json,
+    payload_encode := PayloadEncode,
+    payload_limit := PayloadLimit
 }) ->
     PayloadFmtOpts = #{
         payload_encode => PayloadEncode,
@@ -191,7 +193,11 @@ formatter(#{
         truncate_to => PayloadLimit
     },
     {emqx_trace_json_formatter, #{payload_fmt_opts => PayloadFmtOpts}};
-formatter(#{type := _Type, payload_encode := PayloadEncode, payload_limit := PayloadLimit}) ->
+formatter(#{
+    formatter := _Text,
+    payload_encode := PayloadEncode,
+    payload_limit := PayloadLimit
+}) ->
     {emqx_trace_formatter, #{
         %% template is for ?SLOG message not ?TRACE.
         %% XXX: Don't need to print the time field in logger_formatter due to we manually concat it

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -15,7 +15,8 @@
     running/0,
     install/4,
     install/7,
-    uninstall/1
+    uninstall/1,
+    filesync/1
 ]).
 
 %% For logger handler filters callbacks
@@ -124,6 +125,20 @@ uninstall(HandlerId) ->
     ].
 running() ->
     lists:foldl(fun filter_traces/2, [], emqx_logger:get_log_handlers(started)).
+
+-spec filesync(logger:handler_id()) -> ok | {error, any()}.
+filesync(HandlerId) ->
+    case logger:get_handler_config(HandlerId) of
+        {ok, #{module := Mod}} ->
+            try
+                Mod:filesync(HandlerId)
+            catch
+                error:undef ->
+                    {error, unsupported}
+            end;
+        Error ->
+            Error
+    end.
 
 -spec filter_ruleid(logger:log_event(), {binary(), atom()}) -> logger:log_event() | stop.
 filter_ruleid(#{meta := Meta = #{rule_id := RuleId}} = Log, {{Namespace, MatchId}, _Name}) ->

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -33,8 +33,8 @@
 -type tracer() :: #{
     name := binary(),
     namespace => maybe_namespace(),
-    type := clientid | topic | ip_address,
-    filter := filter(),
+    type := clientid | topic | ip_address | ruleid,
+    filter := emqx_trace:filter(),
     payload_encode := text | hidden | hex,
     payload_limit := non_neg_integer(),
     formatter => json | text
@@ -42,12 +42,6 @@
 
 -define(LOG_HANDLER_OLP_KILL_MEM_SIZE, 50 * 1024 * 1024).
 -define(LOG_HANDLER_OLP_KILL_QLEN, 20000).
-
--type filter() ::
-    emqx_types:clientid()
-    | emqx_types:topic()
-    | {?global_ns | binary(), emqx_trace:ruleid()}
-    | string().
 
 -type namespace() :: binary().
 -type maybe_namespace() :: ?global_ns | namespace().
@@ -59,8 +53,8 @@
 -spec install(
     HandlerId :: logger:handler_id(),
     Name :: binary() | list(),
-    Type :: clientid | topic | ip_address,
-    Filter :: filter(),
+    Type :: clientid | topic | ip_address | ruleid,
+    Filter :: emqx_trace:filter(),
     Level :: logger:level() | all,
     LogFilePath :: string(),
     Formatter :: text | json
@@ -116,9 +110,9 @@ uninstall(HandlerId) ->
     [
         #{
             name => binary(),
-            type => topic | clientid | ip_address,
+            type => topic | clientid | ip_address | ruleid,
             id => atom(),
-            filter => emqx_types:topic() | emqx_types:clientid() | emqx_trace:ip_address(),
+            filter => emqx_trace:filter(),
             level => logger:level(),
             dst => file:filename() | console | unknown
         }

--- a/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace_handler.erl
@@ -46,6 +46,12 @@
 -type namespace() :: binary().
 -type maybe_namespace() :: ?global_ns | namespace().
 
+-ifdef(TEST).
+-define(LOG_HANDLER_FILESYNC_INTERVAL, 5_000).
+-else.
+-define(LOG_HANDLER_FILESYNC_INTERVAL, 100).
+-endif.
+
 %%------------------------------------------------------------------------------
 %% APIs
 %%------------------------------------------------------------------------------
@@ -92,6 +98,7 @@ logger_config(LogFile) ->
         type => halt,
         file => LogFile,
         max_no_bytes => MaxBytes,
+        filesync_repeat_interval => ?LOG_HANDLER_FILESYNC_INTERVAL,
         overload_kill_enable => true,
         overload_kill_mem_size => ?LOG_HANDLER_OLP_KILL_MEM_SIZE,
         overload_kill_qlen => ?LOG_HANDLER_OLP_KILL_QLEN,

--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -374,42 +374,6 @@ t_trace_file(_Config) ->
     ok = file:delete(File),
     ok.
 
-t_find_closed_time(_Config) ->
-    DefaultMs = 60 * 15000,
-    Now = erlang:system_time(second),
-    Traces2 = [],
-    ?assertEqual(DefaultMs, emqx_trace:find_closest_time(Traces2, Now)),
-    Traces3 = [
-        #emqx_trace{
-            name = <<"disable">>,
-            start_at = Now + 1,
-            end_at = Now + 2,
-            enable = false
-        }
-    ],
-    ?assertEqual(DefaultMs, emqx_trace:find_closest_time(Traces3, Now)),
-    Traces4 = [#emqx_trace{name = <<"running">>, start_at = Now, end_at = Now + 10, enable = true}],
-    ?assertEqual(10000, emqx_trace:find_closest_time(Traces4, Now)),
-    Traces5 = [
-        #emqx_trace{
-            name = <<"waiting">>,
-            start_at = Now + 2,
-            end_at = Now + 10,
-            enable = true
-        }
-    ],
-    ?assertEqual(2000, emqx_trace:find_closest_time(Traces5, Now)),
-    Traces = [
-        #emqx_trace{name = <<"waiting">>, start_at = Now + 1, end_at = Now + 2, enable = true},
-        #emqx_trace{name = <<"running0">>, start_at = Now, end_at = Now + 5, enable = true},
-        #emqx_trace{name = <<"running1">>, start_at = Now - 1, end_at = Now + 1, enable = true},
-        #emqx_trace{name = <<"finished">>, start_at = Now - 2, end_at = Now - 1, enable = true},
-        #emqx_trace{name = <<"waiting">>, start_at = Now + 1, end_at = Now + 1, enable = true},
-        #emqx_trace{name = <<"stopped">>, start_at = Now, end_at = Now + 10, enable = false}
-    ],
-    ?assertEqual(1000, emqx_trace:find_closest_time(Traces, Now)),
-    ok.
-
 t_migrate_trace(_Config) ->
     build_new_trace_data(),
     build_old_trace_data(),

--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -142,6 +142,16 @@ t_create_failed(_Config) ->
         })
     ).
 
+t_create_long_name(_Config) ->
+    ?assertMatch(
+        {ok, #{}},
+        emqx_trace:create(#{
+            name => binary:copy(<<"test">>, 200),
+            type => clientid,
+            filter => <<?MODULE_STRING>>
+        })
+    ).
+
 t_create_default(_Config) ->
     {error, "name required"} = emqx_trace:create(#{}),
     {ok, _} = emqx_trace:create(#{

--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -10,7 +10,6 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("emqx/include/emqx.hrl").
--include_lib("emqx/include/emqx_trace.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("kernel/include/file.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
@@ -52,7 +51,7 @@ t_base_create_delete(_Config) ->
     Trace = #{
         name => Name,
         type => clientid,
-        clientid => ClientId,
+        filter => ClientId,
         start_at => Start,
         end_at => End
     },
@@ -60,29 +59,22 @@ t_base_create_delete(_Config) ->
     {ok, _} = emqx_trace:create(Trace),
     ?assertEqual({error, {already_existed, Name}}, emqx_trace:create(Trace)),
     ?assertEqual({error, {duplicate_condition, Name}}, emqx_trace:create(AnotherTrace)),
-    [TraceRec] = emqx_trace:list(),
-    Expect = #emqx_trace{
-        name = Name,
-        type = clientid,
-        filter = ClientId,
-        start_at = Now,
-        end_at = Now + 30 * 60
-    },
-    ?assertEqual(Expect, TraceRec),
-    ExpectFormat = [
-        #{
-            filter => <<"test-device">>,
-            enable => true,
-            type => clientid,
-            name => <<"name1">>,
-            start_at => Now,
-            end_at => Now + 30 * 60,
-            payload_encode => text,
-            payload_limit => 1024,
-            formatter => text
-        }
-    ],
-    ?assertEqual(ExpectFormat, emqx_trace:format([TraceRec])),
+    ?assertEqual(
+        [
+            #{
+                filter => <<"test-device">>,
+                enable => true,
+                type => clientid,
+                name => <<"name1">>,
+                start_at => Now,
+                end_at => Now + 30 * 60,
+                payload_encode => text,
+                payload_limit => 1024,
+                formatter => text
+            }
+        ],
+        emqx_trace:list()
+    ),
     ?assertEqual(ok, emqx_trace:delete(Name)),
     ?assertEqual({error, not_found}, emqx_trace:delete(Name)),
     ?assertEqual([], emqx_trace:list()),
@@ -91,21 +83,21 @@ t_base_create_delete(_Config) ->
 t_create_size_max(_Config) ->
     lists:map(
         fun(Seq) ->
-            Name = list_to_binary("name" ++ integer_to_list(Seq)),
-            Trace = [
-                {name, Name},
-                {type, topic},
-                {topic, list_to_binary("/x/y/" ++ integer_to_list(Seq))}
-            ],
-            {ok, _} = emqx_trace:create(Trace)
+            {ok, _} = emqx_trace:create(
+                #{
+                    name => list_to_binary("name" ++ integer_to_list(Seq)),
+                    type => topic,
+                    filter => list_to_binary("/x/y/" ++ integer_to_list(Seq))
+                }
+            )
         end,
         lists:seq(1, 30)
     ),
-    Trace31 = [
-        {<<"name">>, <<"name31">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/31">>}
-    ],
+    Trace31 = #{
+        name => <<"name31">>,
+        type => topic,
+        filter => <<"/x/y/31">>
+    },
     {error, _} = emqx_trace:create(Trace31),
     ok = emqx_trace:delete(<<"name30">>),
     {ok, _} = emqx_trace:create(Trace31),
@@ -113,89 +105,81 @@ t_create_size_max(_Config) ->
     ok.
 
 t_create_failed(_Config) ->
-    Name = {<<"name">>, <<"test">>},
-    UnknownField = [Name, {<<"unknown">>, 12}],
+    Trace = #{name => <<"test">>},
+    UnknownField = Trace#{unknown => 12},
     {error, Reason1} = emqx_trace:create(UnknownField),
     ?assertEqual(<<"type=[topic,clientid,ip_address] required">>, iolist_to_binary(Reason1)),
 
-    InvalidTopic = [Name, {<<"topic">>, "#/#//"}, {<<"type">>, topic}],
+    InvalidTopic = Trace#{type => topic, filter => "#/#//"},
     {error, Reason2} = emqx_trace:create(InvalidTopic),
     ?assertEqual(<<"topic: #/#// invalid by function_clause">>, iolist_to_binary(Reason2)),
 
-    {error, Reason4} = emqx_trace:create([Name, {<<"type">>, clientid}]),
-    ?assertEqual(<<"required clientid field">>, iolist_to_binary(Reason4)),
-
-    InvalidPackets4 = [
-        {<<"name">>, <<"/test">>},
-        {<<"clientid">>, <<"t">>},
-        {<<"type">>, clientid}
-    ],
-    {error, Reason5} = emqx_trace:create(InvalidPackets4),
+    {error, Reason5} = emqx_trace:create(#{
+        name => <<"/test">>,
+        type => clientid,
+        filter => <<"t">>
+    }),
     ?assertEqual(<<"Name should be ^[A-Za-z]+[A-Za-z0-9-_]*$">>, iolist_to_binary(Reason5)),
 
     ?assertEqual(
-        {error, "type=[topic,clientid,ip_address] required"},
-        emqx_trace:create([{<<"name">>, <<"test-name">>}, {<<"clientid">>, <<"good">>}])
-    ),
-
-    ?assertEqual(
         {error, "ip address: einval"},
-        emqx_trace:create([
-            Name,
-            {<<"type">>, ip_address},
-            {<<"ip_address">>, <<"test-name">>}
-        ])
-    ),
-    ok.
+        emqx_trace:create(Trace#{
+            type => ip_address,
+            filter => <<"test-name">>
+        })
+    ).
 
 t_create_default(_Config) ->
-    {error, "name required"} = emqx_trace:create([]),
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, <<"test-name">>},
-        {<<"type">>, clientid},
-        {<<"clientid">>, <<"good">>}
-    ]),
-    [#emqx_trace{name = <<"test-name">>}] = emqx_trace:list(),
+    {error, "name required"} = emqx_trace:create(#{}),
+    {ok, _} = emqx_trace:create(#{
+        name => <<"test-name">>,
+        type => clientid,
+        filter => <<"good">>
+    }),
+    [#{name := <<"test-name">>}] = emqx_trace:list(),
     ok = emqx_trace:clear(),
-    Now = erlang:system_time(second),
-    Trace = [
-        {<<"name">>, <<"test-name">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/z">>},
-        {<<"start_at">>, Now},
-        {<<"end_at">>, Now - 1}
-    ],
+    T0 = erlang:system_time(second),
+    Trace = #{
+        name => <<"test-name">>,
+        type => topic,
+        filter => <<"/x/y/z">>,
+        start_at => T0,
+        end_at => T0 - 1
+    },
     {error, "end_at time has already passed"} = emqx_trace:create(Trace),
-    Trace2 = [
-        {<<"name">>, <<"test-name">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/z">>},
-        {<<"start_at">>, Now + 10},
-        {<<"end_at">>, Now + 3}
-    ],
+    Trace2 = #{
+        name => <<"test-name">>,
+        type => topic,
+        filter => <<"/x/y/z">>,
+        start_at => T0 + 10,
+        end_at => T0 + 3
+    },
     {error, "failed by start_at >= end_at"} = emqx_trace:create(Trace2),
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, <<"test-name">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/z">>}
-    ]),
-    [#emqx_trace{start_at = Start, end_at = End}] = emqx_trace:list(),
-    ?assertEqual(10 * 60, End - Start),
-    ?assertEqual(true, Start - erlang:system_time(second) < 5),
-    ok.
+    {ok, _} = emqx_trace:create(#{
+        name => <<"test-name">>,
+        type => topic,
+        filter => <<"/x/y/z">>
+    }),
+    T1 = erlang:system_time(second),
+    ?assertMatch(
+        [#{start_at := Start, end_at := End}] when
+            (End - Start =:= 10 * 60) andalso (Start - T1 < 5),
+        emqx_trace:list(),
+        T1
+    ).
 
 t_create_with_extra_fields(_Config) ->
     ok = emqx_trace:clear(),
-    Trace = [
-        {<<"name">>, <<"test-name">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/z">>},
-        {<<"clientid">>, <<"dev001">>},
-        {<<"ip_address">>, <<"127.0.0.1">>}
-    ],
+    Trace = #{
+        name => <<"test-name">>,
+        type => topic,
+        filter => <<"/x/y/z">>,
+        clientid => <<"dev001">>,
+        ip_address => <<"127.0.0.1">>
+    },
     {ok, _} = emqx_trace:create(Trace),
     ?assertMatch(
-        [#emqx_trace{name = <<"test-name">>, filter = <<"/x/y/z">>, type = topic}],
+        [#{name := <<"test-name">>, type := topic, filter := <<"/x/y/z">>}],
         emqx_trace:list()
     ),
     ok.
@@ -203,22 +187,21 @@ t_create_with_extra_fields(_Config) ->
 t_update_enable(_Config) ->
     Name = <<"test-name">>,
     Now = erlang:system_time(second),
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, Name},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/z">>},
-        {<<"end_at">>, Now + 2}
-    ]),
-    [#emqx_trace{enable = Enable}] = emqx_trace:list(),
-    ?assertEqual(Enable, true),
+    {ok, _} = emqx_trace:create(#{
+        name => Name,
+        type => topic,
+        filter => <<"/x/y/z">>,
+        end_at => Now + 2
+    }),
+    [#{enable := true}] = emqx_trace:list(),
     ok = emqx_trace:update(Name, false),
-    [#emqx_trace{enable = false}] = emqx_trace:list(),
+    [#{enable := false}] = emqx_trace:list(),
     ok = emqx_trace:update(Name, false),
-    [#emqx_trace{enable = false}] = emqx_trace:list(),
+    [#{enable := false}] = emqx_trace:list(),
     ok = emqx_trace:update(Name, true),
-    [#emqx_trace{enable = true}] = emqx_trace:list(),
+    [#{enable := true}] = emqx_trace:list(),
     ok = emqx_trace:update(Name, false),
-    [#emqx_trace{enable = false}] = emqx_trace:list(),
+    [#{enable := false}] = emqx_trace:list(),
     ?assertEqual({error, not_found}, emqx_trace:update(<<"Name not found">>, true)),
     ct:sleep(2100),
     ?assertEqual({error, finished}, emqx_trace:update(Name, true)),
@@ -229,50 +212,54 @@ t_load_state(_Config) ->
     Running = #{
         name => <<"Running">>,
         type => topic,
-        topic => <<"/x/y/1">>,
+        filter => <<"/x/y/1">>,
         start_at => Now - 1,
         end_at => Now + 2
     },
-    Waiting = [
-        {<<"name">>, <<"Waiting">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/2">>},
-        {<<"start_at">>, Now + 3},
-        {<<"end_at">>, Now + 8}
-    ],
-    Finished = [
-        {<<"name">>, <<"Finished">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/x/y/3">>},
-        {<<"start_at">>, Now - 5},
-        {<<"end_at">>, Now}
-    ],
+    Waiting = #{
+        name => <<"Waiting">>,
+        type => topic,
+        filter => <<"/x/y/2">>,
+        start_at => Now + 3,
+        end_at => Now + 8
+    },
+    Finished = #{
+        name => <<"Finished">>,
+        type => topic,
+        filter => <<"/x/y/3">>,
+        start_at => Now - 5,
+        end_at => Now
+    },
     {ok, _} = emqx_trace:create(Running),
     {ok, _} = emqx_trace:create(Waiting),
     {error, "end_at time has already passed"} = emqx_trace:create(Finished),
-    Traces = emqx_trace:format(emqx_trace:list()),
-    ?assertEqual(2, erlang:length(Traces)),
-    Enables = lists:map(fun(#{name := Name, enable := Enable}) -> {Name, Enable} end, Traces),
-    ExpectEnables = [{<<"Running">>, true}, {<<"Waiting">>, true}],
-    ?assertEqual(ExpectEnables, lists:sort(Enables)),
+    ?assertMatch(
+        [
+            #{name := <<"Running">>, enable := true},
+            #{name := <<"Waiting">>, enable := true}
+        ],
+        lists:sort(emqx_trace:list())
+    ),
     ct:sleep(3500),
-    Traces2 = emqx_trace:format(emqx_trace:list()),
-    ?assertEqual(2, erlang:length(Traces2)),
-    Enables2 = lists:map(fun(#{name := Name, enable := Enable}) -> {Name, Enable} end, Traces2),
-    ExpectEnables2 = [{<<"Running">>, false}, {<<"Waiting">>, true}],
-    ?assertEqual(ExpectEnables2, lists:sort(Enables2)),
+    ?assertMatch(
+        [
+            #{name := <<"Running">>, enable := false},
+            #{name := <<"Waiting">>, enable := true}
+        ],
+        lists:sort(emqx_trace:list())
+    ),
     ok.
 
 t_client_event(_Config) ->
     ClientId = <<"client-test">>,
     Now = erlang:system_time(second),
     Name = <<"test_client_id_event">>,
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, Name},
-        {<<"type">>, clientid},
-        {<<"clientid">>, ClientId},
-        {<<"start_at">>, Now}
-    ]),
+    {ok, _} = emqx_trace:create(#{
+        name => Name,
+        type => clientid,
+        filter => ClientId,
+        start_at => Now
+    }),
     ok = emqx_trace_handler_SUITE:filesync(Name, clientid),
     {ok, Client} = emqtt:start_link([{clean_start, true}, {clientid, ClientId}]),
     {ok, _} = emqtt:connect(Client),
@@ -280,12 +267,12 @@ t_client_event(_Config) ->
     ok = emqtt:publish(Client, <<"/test">>, #{}, <<"1">>, [{qos, 0}]),
     ok = emqtt:publish(Client, <<"/test">>, #{}, <<"2">>, [{qos, 0}]),
     ok = emqx_trace_handler_SUITE:filesync(Name, clientid),
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, <<"test_topic">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/test">>},
-        {<<"start_at">>, Now}
-    ]),
+    {ok, _} = emqx_trace:create(#{
+        name => <<"test_topic">>,
+        type => topic,
+        filter => <<"/test">>,
+        start_at => Now
+    }),
     ok = emqx_trace_handler_SUITE:filesync(<<"test_topic">>, topic),
     {ok, Bin} = file:read_file(emqx_trace:log_file(Name, Now)),
     ok = emqtt:publish(Client, <<"/test">>, #{}, <<"3">>, [{qos, 0}]),
@@ -305,12 +292,12 @@ t_client_huge_payload_truncated(_Config) ->
     ClientId = <<"client-truncated1">>,
     Now = erlang:system_time(second),
     Name = <<"test_client_id_truncated1">>,
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, Name},
-        {<<"type">>, clientid},
-        {<<"clientid">>, ClientId},
-        {<<"start_at">>, Now}
-    ]),
+    {ok, _} = emqx_trace:create(#{
+        name => Name,
+        type => clientid,
+        filter => ClientId,
+        start_at => Now
+    }),
     ok = emqx_trace_handler_SUITE:filesync(Name, clientid),
     {ok, Client} = emqtt:start_link([{clean_start, true}, {clientid, ClientId}]),
     {ok, _} = emqtt:connect(Client),
@@ -325,13 +312,13 @@ t_client_huge_payload_truncated(_Config) ->
     TruncatedBytes2 = Size2 - PayloadLimit,
     ok = emqtt:publish(Client, <<"/test">>, #{}, NormalPayload, [{qos, 0}]),
     ok = emqx_trace_handler_SUITE:filesync(Name, clientid),
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, <<"test_topic">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/test">>},
-        {<<"start_at">>, Now},
-        {<<"payload_limit">>, PayloadLimit}
-    ]),
+    {ok, _} = emqx_trace:create(#{
+        name => <<"test_topic">>,
+        type => topic,
+        filter => <<"/test">>,
+        start_at => Now,
+        payload_limit => PayloadLimit
+    }),
     ok = emqx_trace_handler_SUITE:filesync(<<"test_topic">>, topic),
     {ok, Bin} = file:read_file(emqx_trace:log_file(Name, Now)),
     ok = emqtt:publish(Client, <<"/test">>, #{}, NormalPayload, [{qos, 0}]),
@@ -361,13 +348,13 @@ t_client_huge_payload_truncated(_Config) ->
 t_get_log_filename(_Config) ->
     Now = erlang:system_time(second),
     Name = <<"name1">>,
-    Trace = [
-        {<<"name">>, Name},
-        {<<"type">>, ip_address},
-        {<<"ip_address">>, <<"127.0.0.1">>},
-        {<<"start_at">>, Now},
-        {<<"end_at">>, Now + 2}
-    ],
+    Trace = #{
+        name => Name,
+        type => ip_address,
+        filter => <<"127.0.0.1">>,
+        start_at => Now,
+        end_at => Now + 2
+    },
     {ok, _} = emqx_trace:create(Trace),
     ?assertEqual({error, not_found}, emqx_trace:get_trace_filename(<<"test">>)),
     ?assertEqual(ok, element(1, emqx_trace:get_trace_filename(Name))),
@@ -427,13 +414,12 @@ t_migrate_trace(_Config) ->
     build_new_trace_data(),
     build_old_trace_data(),
     reload(),
-    Traces = emqx_trace:format(emqx_trace:list()),
-    ?assertEqual(2, erlang:length(Traces)),
-    lists:foreach(
-        fun(#{name := Name, enable := Enable}) ->
-            ?assertEqual(true, Enable, Name)
-        end,
-        Traces
+    ?assertMatch(
+        [
+            #{name := _N1, enable := true},
+            #{name := _N2, enable := true}
+        ],
+        emqx_trace:list()
     ),
     LoggerIds = logger:get_handler_ids(),
     lists:foreach(
@@ -453,13 +439,13 @@ t_empty_trace_log_file(_Config) ->
         begin
             Now = erlang:system_time(second),
             Name = <<"empty_trace_log">>,
-            Trace = [
-                {<<"name">>, Name},
-                {<<"type">>, clientid},
-                {<<"clientid">>, <<"test_trace_no_clientid_1">>},
-                {<<"start_at">>, Now},
-                {<<"end_at">>, Now + 100}
-            ],
+            Trace = #{
+                name => Name,
+                type => clientid,
+                filter => <<"test_trace_no_clientid_1">>,
+                start_at => Now,
+                end_at => Now + 100
+            },
             ?wait_async_action(
                 ?assertMatch({ok, _}, emqx_trace:create(Trace)),
                 #{?snk_kind := update_trace_done}
@@ -479,12 +465,12 @@ t_empty_trace_log_file(_Config) ->
 
 build_new_trace_data() ->
     Now = erlang:system_time(second),
-    {ok, _} = emqx_trace:create([
-        {<<"name">>, <<"test_topic_migrate_new">>},
-        {<<"type">>, topic},
-        {<<"topic">>, <<"/test/migrate/new">>},
-        {<<"start_at">>, Now - 10}
-    ]).
+    {ok, _} = emqx_trace:create(#{
+        name => <<"test_topic_migrate_new">>,
+        type => topic,
+        filter => <<"/test/migrate/new">>,
+        start_at => Now - 10
+    }).
 
 build_old_trace_data() ->
     Now = erlang:system_time(second),

--- a/apps/emqx/test/emqx_trace_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_SUITE.erl
@@ -121,7 +121,7 @@ t_create_failed(_Config) ->
     Trace = #{name => <<"test">>},
     UnknownField = Trace#{unknown => 12},
     {error, Reason1} = emqx_trace:create(UnknownField),
-    ?assertEqual(<<"type=[topic,clientid,ip_address] required">>, iolist_to_binary(Reason1)),
+    ?assertEqual(<<"type=[topic,clientid,ip_address,ruleid] required">>, iolist_to_binary(Reason1)),
 
     InvalidTopic = Trace#{type => topic, filter => "#/#//"},
     {error, Reason2} = emqx_trace:create(InvalidTopic),

--- a/apps/emqx/test/emqx_trace_handler_SUITE.erl
+++ b/apps/emqx/test/emqx_trace_handler_SUITE.erl
@@ -47,11 +47,11 @@ end_per_testcase(_Case, _Config) ->
 t_trace_clientid(_Config) ->
     %% Start tracing
     %% add list clientid
-    ok = emqx_trace_handler:install("CLI-client1", clientid, "client", debug, "tmp/client.log"),
-    ok = emqx_trace_handler:install("CLI-client2", clientid, <<"client2">>, all, "tmp/client2.log"),
-    ok = emqx_trace_handler:install("CLI-client3", clientid, <<"client3">>, all, "tmp/client3.log"),
+    ok = install_handler("CLI-client1", clientid, "client", debug, "tmp/client.log"),
+    ok = install_handler("CLI-client2", clientid, <<"client2">>, all, "tmp/client2.log"),
+    ok = install_handler("CLI-client3", clientid, <<"client3">>, all, "tmp/client3.log"),
     {error, {handler_not_added, {file_error, ".", eisdir}}} =
-        emqx_trace_handler:install("CLI-client5", clientid, <<"client5">>, debug, "."),
+        install_handler("CLI-client5", clientid, <<"client5">>, debug, "."),
     emqx_trace:check(),
     ok = filesync(<<"CLI-client1">>, clientid),
     ok = filesync(<<"CLI-client2">>, clientid),
@@ -108,16 +108,16 @@ t_trace_clientid(_Config) ->
     ?assert(filelib:file_size("tmp/client2.log") == 0),
 
     %% Stop tracing
-    ok = emqx_trace_handler:uninstall(clientid, <<"CLI-client1">>),
-    ok = emqx_trace_handler:uninstall(clientid, <<"CLI-client2">>),
-    ok = emqx_trace_handler:uninstall(clientid, <<"CLI-client3">>),
+    ok = uninstall_handler("CLI-client1"),
+    ok = uninstall_handler("CLI-client2"),
+    ok = uninstall_handler("CLI-client3"),
 
     emqtt:disconnect(T),
     ?assertEqual([], emqx_trace_handler:running()).
 
 t_trace_clientid_utf8(_) ->
     Utf8Id = <<"client 漢字編碼"/utf8>>,
-    ok = emqx_trace_handler:install("CLI-UTF8", clientid, Utf8Id, debug, "tmp/client-utf8.log"),
+    ok = install_handler("CLI-UTF8", clientid, Utf8Id, debug, "tmp/client-utf8.log"),
     emqx_trace:check(),
     {ok, T} = emqtt:start_link([{clientid, Utf8Id}]),
     emqtt:connect(T),
@@ -130,7 +130,7 @@ t_trace_clientid_utf8(_) ->
     emqtt:ping(T),
 
     ok = filesync("CLI-UTF8", clientid),
-    ok = emqx_trace_handler:uninstall(clientid, "CLI-UTF8"),
+    ok = uninstall_handler("CLI-UTF8"),
     emqtt:disconnect(T),
     ?assertEqual([], emqx_trace_handler:running()),
     ok.
@@ -140,8 +140,8 @@ t_trace_topic(_Config) ->
     emqtt:connect(T),
 
     %% Start tracing
-    ok = emqx_trace_handler:install("CLI-TOPIC-1", topic, <<"x/#">>, all, "tmp/topic_trace_x.log"),
-    ok = emqx_trace_handler:install("CLI-TOPIC-2", topic, <<"y/#">>, all, "tmp/topic_trace_y.log"),
+    ok = install_handler("CLI-TOPIC-1", topic, <<"x/#">>, all, "tmp/topic_trace_x.log"),
+    ok = install_handler("CLI-TOPIC-2", topic, <<"y/#">>, all, "tmp/topic_trace_y.log"),
     emqx_trace:check(),
     ok = filesync("CLI-TOPIC-1", topic),
     ok = filesync("CLI-TOPIC-2", topic),
@@ -188,9 +188,9 @@ t_trace_topic(_Config) ->
     ?assert(filelib:file_size("tmp/topic_trace_y.log") =:= 0),
 
     %% Stop tracing
-    ok = emqx_trace_handler:uninstall(topic, <<"CLI-TOPIC-1">>),
-    ok = emqx_trace_handler:uninstall(topic, <<"CLI-TOPIC-2">>),
-    {error, _Reason} = emqx_trace_handler:uninstall(topic, <<"z/#">>),
+    ok = uninstall_handler("CLI-TOPIC-1"),
+    ok = uninstall_handler("CLI-TOPIC-2"),
+    {error, _Reason} = uninstall_handler("z/#"),
     ?assertEqual([], emqx_trace_handler:running()),
     emqtt:disconnect(T).
 
@@ -199,14 +199,8 @@ t_trace_ip_address(_Config) ->
     emqtt:connect(T),
 
     %% Start tracing
-    ok = emqx_trace_handler:install("CLI-IP-1", ip_address, "127.0.0.1", all, "tmp/ip_trace_x.log"),
-    ok = emqx_trace_handler:install(
-        "CLI-IP-2",
-        ip_address,
-        "192.168.1.1",
-        all,
-        "tmp/ip_trace_y.log"
-    ),
+    ok = install_handler("CLI-IP-1", ip_address, "127.0.0.1", all, "tmp/ip_trace_x.log"),
+    ok = install_handler("CLI-IP-2", ip_address, "192.168.1.1", all, "tmp/ip_trace_y.log"),
     emqx_trace:check(),
     ok = filesync(<<"CLI-IP-1">>, ip_address),
     ok = filesync(<<"CLI-IP-2">>, ip_address),
@@ -253,9 +247,9 @@ t_trace_ip_address(_Config) ->
     ?assert(filelib:file_size("tmp/ip_trace_y.log") =:= 0),
 
     %% Stop tracing
-    ok = emqx_trace_handler:uninstall(ip_address, <<"CLI-IP-1">>),
-    ok = emqx_trace_handler:uninstall(ip_address, <<"CLI-IP-2">>),
-    {error, _Reason} = emqx_trace_handler:uninstall(ip_address, <<"127.0.0.2">>),
+    ok = uninstall_handler("CLI-IP-1"),
+    ok = uninstall_handler("CLI-IP-2"),
+    {error, _Reason} = uninstall_handler("127.0.0.2"),
     emqtt:disconnect(T),
     ?assertEqual([], emqx_trace_handler:running()).
 
@@ -267,7 +261,7 @@ t_trace_max_file_size(_Config) ->
     MaxSizeDefault = emqx_config:get([trace, max_file_size]),
     ok = emqx_config:put([trace, max_file_size], MaxSize),
     %% Start tracing:
-    ok = emqx_trace_handler:install(Name, topic, <<"t/#">>, all, FileName),
+    ok = emqx_trace_handler:install(?FUNCTION_NAME, Name, topic, <<"t/#">>, all, FileName, text),
     ok = emqx_trace:check(),
     ?assertMatch(
         [#{name := Name, type := topic, filter := <<"t/#">>}],
@@ -297,7 +291,7 @@ t_trace_max_file_size(_Config) ->
     ?assertEqual(FileSize, filelib:file_size(FileName)),
     %% Cleanup:
     ok = emqtt:disconnect(C),
-    ok = emqx_trace_handler:uninstall(topic, Name),
+    ok = emqx_trace_handler:uninstall(?FUNCTION_NAME),
     ok = emqx_config:put([trace, max_file_size], MaxSizeDefault).
 
 filesync(Name, Type) ->
@@ -322,6 +316,14 @@ filesync(Name0, Type, Retry) ->
             ct:sleep(100),
             filesync(Name, Type, Retry - 1)
     end.
+
+install_handler(Name, Type, Filter, Level, LogFile) ->
+    HandlerId = list_to_atom(?MODULE_STRING ++ ":" ++ Name),
+    emqx_trace_handler:install(HandlerId, Name, Type, Filter, Level, LogFile, text).
+
+uninstall_handler(Name) ->
+    HandlerId = list_to_atom(?MODULE_STRING ++ ":" ++ Name),
+    emqx_trace_handler:uninstall(HandlerId).
 
 init() ->
     emqx_trace:start_link().

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -392,7 +392,7 @@ t_send_get_trace_messages(Config) ->
     Trace = #{
         name => TraceName,
         type => ruleid,
-        ruleid => RuleId,
+        filter => RuleId,
         start_at => Start,
         end_at => End
     },

--- a/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
+++ b/apps/emqx_bridge_http/test/emqx_bridge_http_SUITE.erl
@@ -431,8 +431,7 @@ t_send_get_trace_messages(Config) ->
         )
     ),
 
-    ok = emqx_trace_handler_SUITE:filesync(TraceName, ruleid),
-    {ok, Bin} = file:read_file(emqx_trace:log_file(TraceName, Now)),
+    Bin = read_rule_trace_file(TraceName, Now),
 
     ?retry(
         _Interval0 = 200,
@@ -451,7 +450,8 @@ t_send_get_trace_messages(Config) ->
 
 read_rule_trace_file(TraceName, From) ->
     emqx_trace:check(),
-    ok = emqx_trace_handler_SUITE:filesync(TraceName, ruleid),
+    %% NOTE: Twice as long as `?LOG_HANDLER_FILESYNC_INTERVAL` in `emqx_trace_handler`.
+    timer:sleep(2 * 100),
     {ok, Bin} = file:read_file(emqx_trace:log_file(TraceName, From)),
     Bin.
 

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -1186,7 +1186,8 @@ indent_print({Key, Val}) ->
     emqx_ctl:print("  ~-16s: ~w~n", [Key, Val]).
 
 name(Filter) ->
-    iolist_to_binary(["CLI-", Filter]).
+    Name = iolist_to_binary(["CLI-", Filter]),
+    Name = unicode:characters_to_binary(Name, utf8).
 
 for_node(Fun, Node) ->
     try list_to_existing_atom(Node) of

--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -669,7 +669,7 @@ trace_cluster_on(Name, Type, Filter, DurationS0, Formatter) ->
     Trace = #{
         name => bin(Name),
         type => Type,
-        Type => bin(Filter),
+        filter => bin(Filter),
         start_at => Now,
         end_at => Now + DurationS,
         formatter => Formatter

--- a/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_trace_SUITE.erl
@@ -734,7 +734,8 @@ t_download_empty_trace(_Config) ->
     ok.
 
 wait_filesync() ->
-    timer:sleep(100).
+    %% NOTE: Twice `?LOG_HANDLER_FILESYNC_INTERVAL` in `emqx_trace_handler`.
+    timer:sleep(2 * 100).
 
 to_rfc3339(Second) ->
     list_to_binary(calendar:system_time_to_rfc3339(Second)).

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -21,6 +21,7 @@ init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
             emqx_conf,
+            emqx_modules,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
@@ -195,6 +196,8 @@ t_trace(_Config) ->
     emqx_ctl:run_command(["trace", "list"]),
     %% trace start client <ClientId> <File> [<Level>]    # Traces for a client on local node
     %% trace stop  client <ClientId>                     # Stop tracing for a client on local node
+    ok = emqx_ctl:run_command(["trace", "start", "client", ?MODULE_STRING, "trace/t1.log"]),
+    ok = emqx_ctl:run_command(["trace", "stop", "client", ?MODULE_STRING]),
     %% trace start topic  <Topic>    <File> [<Level>]    # Traces for a topic on local node
     %% trace stop  topic  <Topic>                        # Stop tracing for a topic on local node
     %% trace start ip_address  <IP>    <File> [<Level>]  # Traces for a client ip on local node

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -3979,10 +3979,10 @@ t_trace_rule_id(_Config) ->
     ),
     %% Start tracing
     ok = emqx_trace_handler:install(
-        "CLI-RULE-1", ruleid, <<"test_rule_id_1">>, all, "tmp/rule_trace_1.log"
+        'CLI-RULE-1', "CLI-RULE-1", ruleid, <<"test_rule_id_1">>, all, "tmp/rule_trace_1.log", text
     ),
     ok = emqx_trace_handler:install(
-        "CLI-RULE-2", ruleid, <<"test_rule_id_2">>, all, "tmp/rule_trace_2.log"
+        'CLI-RULE-2', "CLI-RULE-2", ruleid, <<"test_rule_id_2">>, all, "tmp/rule_trace_2.log", text
     ),
     emqx_trace:check(),
     ok = filesync("CLI-RULE-1", ruleid),
@@ -4028,8 +4028,8 @@ t_trace_rule_id(_Config) ->
     ?assert(filelib:file_size("tmp/rule_trace_2.log") =:= 0),
 
     %% Stop tracing
-    ok = emqx_trace_handler:uninstall(ruleid, <<"CLI-RULE-1">>),
-    ok = emqx_trace_handler:uninstall(ruleid, <<"CLI-RULE-2">>),
+    ok = emqx_trace_handler:uninstall('CLI-RULE-1'),
+    ok = emqx_trace_handler:uninstall('CLI-RULE-2'),
     ?assertEqual([], emqx_trace_handler:running()),
     emqtt:disconnect(T).
 
@@ -4046,6 +4046,7 @@ t_trace_truncated(_Config) ->
 
     %% Start tracing
     ok = emqx_trace_handler:install(
+        'CLI-RULE-3',
         #{
             type => ruleid,
             filter => <<"test_rule_truncated">>,
@@ -4098,7 +4099,7 @@ t_trace_truncated(_Config) ->
     ),
 
     %% Stop tracing
-    ok = emqx_trace_handler:uninstall(ruleid, <<"CLI-RULE-3">>),
+    ok = emqx_trace_handler:uninstall('CLI-RULE-3'),
     ?assertEqual([], emqx_trace_handler:running()),
     emqtt:disconnect(T),
 

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -3941,27 +3941,21 @@ emqtt_client_config() ->
         {password, <<"pass">>}
     ].
 
-filesync(Name, Type) ->
+filesync(HandlerId) ->
     ct:sleep(50),
-    filesync(Name, Type, 5).
+    filesync(HandlerId, 5).
 
 %% sometime the handler process is not started yet.
-filesync(Name, Type, 0) ->
-    ct:fail("Handler process not started ~p ~p", [Name, Type]);
-filesync(Name0, Type, Retry) ->
-    Name =
-        case is_binary(Name0) of
-            true -> Name0;
-            false -> list_to_binary(Name0)
-        end,
+filesync(HandlerId, 0) ->
+    ct:fail("Handler process not started ~p", [HandlerId]);
+filesync(HandlerId, Retry) ->
     try
-        Handler = binary_to_atom(<<"trace_", (atom_to_binary(Type))/binary, "_", Name/binary>>),
-        ok = logger_disk_log_h:filesync(Handler)
+        ok = emqx_trace_handler:filesync(HandlerId)
     catch
         E:R ->
-            ct:pal("Filesync error:~p ~p~n", [{Name, Type, Retry}, {E, R}]),
+            ct:pal("Filesync error:~p ~p~n", [HandlerId, {E, R}]),
             ct:sleep(100),
-            filesync(Name, Type, Retry - 1)
+            filesync(HandlerId, Retry - 1)
     end.
 
 t_trace_rule_id(_Config) ->
@@ -3985,8 +3979,8 @@ t_trace_rule_id(_Config) ->
         'CLI-RULE-2', "CLI-RULE-2", ruleid, <<"test_rule_id_2">>, all, "tmp/rule_trace_2.log", text
     ),
     emqx_trace:check(),
-    ok = filesync("CLI-RULE-1", ruleid),
-    ok = filesync("CLI-RULE-2", ruleid),
+    ok = filesync('CLI-RULE-1'),
+    ok = filesync('CLI-RULE-2'),
 
     %% Verify the tracing file exits
     ?assert(filelib:is_regular("tmp/rule_trace_1.log")),
@@ -4019,12 +4013,12 @@ t_trace_rule_id(_Config) ->
         100,
         5,
         begin
-            ok = filesync("CLI-RULE-1", ruleid),
+            ok = filesync('CLI-RULE-1'),
             {ok, Bin} = file:read_file("tmp/rule_trace_1.log"),
             ?assertNotEqual(nomatch, binary:match(Bin, [<<"my_traced_message">>]))
         end
     ),
-    ok = filesync("CLI-RULE-2", ruleid),
+    ok = filesync('CLI-RULE-2'),
     ?assert(filelib:file_size("tmp/rule_trace_2.log") =:= 0),
 
     %% Stop tracing
@@ -4061,7 +4055,7 @@ t_trace_truncated(_Config) ->
         "tmp/rule_trace_truncated.log"
     ),
     emqx_trace:check(),
-    ok = filesync("CLI-RULE-3", ruleid),
+    ok = filesync('CLI-RULE-3'),
 
     %% Verify the tracing file exits
     ?assert(filelib:is_regular("tmp/rule_trace_truncated.log")),
@@ -4086,7 +4080,7 @@ t_trace_truncated(_Config) ->
         100,
         5,
         begin
-            ok = filesync(<<"CLI-RULE-3">>, ruleid),
+            ok = filesync('CLI-RULE-3'),
             {ok, Bin} = file:read_file("tmp/rule_trace_truncated.log"),
             ?assertNotEqual(
                 nomatch,

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -694,8 +694,9 @@ maybe_json_decode(X) ->
         {error, _} -> X
     end.
 
-read_rule_trace_file(TraceName, TraceType, From) ->
+read_rule_trace_file(TraceName, _TraceType, From) ->
     emqx_trace:check(),
-    ok = emqx_trace_handler_SUITE:filesync(TraceName, TraceType),
+    %% NOTE: Twice as long as `?LOG_HANDLER_FILESYNC_INTERVAL` in `emqx_trace_handler`.
+    timer:sleep(2 * 100),
     {ok, Bin} = file:read_file(emqx_trace:log_file(TraceName, From)),
     Bin.

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_rule_apply_SUITE.erl
@@ -274,7 +274,7 @@ create_trace(TraceName, TraceType, TraceValue, PayloadEncode) ->
     Trace = #{
         name => TraceName,
         type => TraceType,
-        TraceType => TraceValue,
+        filter => TraceValue,
         start_at => Start,
         end_at => End,
         formatter => json,

--- a/changes/ee/feat-15594.en.md
+++ b/changes/ee/feat-15594.en.md
@@ -1,3 +1,3 @@
-Exposed maximum number of traces allowed to exist in the cluster simultaneously as a configuraion option `trace.max_traces`. This limit does not apply to node-local traces managed through `emqx ctl traces`.
+Exposed maximum number of traces allowed to exist in the cluster simultaneously as a configuration option `trace.max_traces`. This limit does not apply to node-local traces managed through `emqx ctl traces`.
 
 Optimized tracing implementation to eliminate potential atom leaks per created trace.

--- a/changes/ee/feat-15594.en.md
+++ b/changes/ee/feat-15594.en.md
@@ -1,0 +1,3 @@
+Exposed maximum number of traces allowed to exist in the cluster simultaneously as a configuraion option `trace.max_traces`. This limit does not apply to node-local traces managed through `emqx ctl traces`.
+
+Optimized tracing implementation to eliminate potential atom leaks per created trace.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1182,7 +1182,13 @@ fields_trace_max_file_size.desc:
 Once a trace file reaches this size, no additional events will be recorded, even if the trace remains active."""
 
 fields_trace_max_file_size.label:
-"""Maximum Trace File Size"""
+"""Max Trace File Size"""
+
+fields_trace_max_traces.desc:
+"""Specifies how many traces are allowed to exist at the same time, irrespective of their statuses."""
+
+fields_trace_max_traces.label:
+"""Max Traces"""
 
 mqtt_response_information.desc:
 """UTF-8 string, for creating the response topic, for example, if set to <code>reqrsp/</code>, the publisher/subscriber will communicate using the topic prefix <code>reqrsp/</code>.


### PR DESCRIPTION
Fixes [EMQX-14467](https://emqx.atlassian.net/browse/EMQX-14467).

Release version: 6.0.0

## Summary

This PR also includes:
* Refactoring effort to make core, data layer and API concerns slightly better separated into their own modules.
* Attempt to avoid unconstrained atom creation through reusing integer "slots" for `logger`-level handler IDs.
    Notably, the latter _does not_ cover Traces CLI.

See individual commits for details.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible



[EMQX-14467]: https://emqx.atlassian.net/browse/EMQX-14467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ