### PR TITLE
chore(mix): ensure crash reports are visible in CT logs

### DIFF
--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
@@ -142,9 +142,36 @@ defmodule Mix.Tasks.Emqx.Ct do
     )
   end
 
+  defmodule Formatter do
+    @config %{single_line: false, legacy_header: true}
+    @colors %{
+      error: :red,
+      warning: :yellow,
+      notice: :bright,
+      info: :normal,
+      debug: :cyan
+    }
+
+    @doc false
+    def new(), do: {__MODULE__, IO.ANSI.enabled?()}
+
+    @doc false
+    def format(%{level: level} = event, true) do
+      color = Access.get(@colors, level, :red)
+      [IO.ANSI.format_fragment(color, true), format_erlang_default(event), IO.ANSI.reset()]
+    end
+
+    def format(event, false) do
+      format_erlang_default(event)
+    end
+
+    defp format_erlang_default(event) do
+      :logger_formatter.format(event, @config)
+    end
+  end
+
   def replace_elixir_formatter() do
-    erl_formatter = {:logger_formatter, %{single_line: false, legacy_header: true}}
-    :logger.update_handler_config(:default, %{formatter: erl_formatter})
+    :logger.update_handler_config(:default, %{formatter: Formatter.new()})
   end
 
   @doc """


### PR DESCRIPTION
## Summary

Without this change, Elixir's `Logger` silences [crash](https://github.com/elixir-lang/elixir/blob/7b20c281d521aa7aa2ad2baa1e9ae6c579d79d0c/lib/logger/lib/logger/utils.ex#L8) and [supervisor](https://github.com/elixir-lang/elixir/blob/7b20c281d521aa7aa2ad2baa1e9ae6c579d79d0c/lib/logger/lib/logger/utils.ex#L9) reports, which makes debugging efforts a bit more cumbersome.

See individual commits.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~The changes are covered with new or existing tests~~
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
