### PR TITLE
fix(kafka): allow topic_authorization_failed for probing topic

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_kafka, [
     {description, "EMQX Enterprise Kafka Bridge"},
-    {vsn, "0.5.4"},
+    {vsn, "0.5.5"},
     {registered, [emqx_bridge_kafka_sup, emqx_bridge_kafka_consumer_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -737,8 +737,11 @@ check_topic_status(ClientId, WolffClientPid, KafkaTopic) ->
     case wolff_client:check_topic_exists_with_client_pid(WolffClientPid, KafkaTopic) of
         ok ->
             ok;
-        {error, unknown_topic_or_partition} when KafkaTopic =:= ?PROBE_TOPIC_NAME ->
-            %% The probing topic is only used to check if metada request can be sent
+        {error, R} when
+            KafkaTopic =:= ?PROBE_TOPIC_NAME andalso
+                (R =:= unknown_topic_or_partition orelse R =:= topic_authorization_failed)
+        ->
+            %% The probing topic is only used to check if metadata request can be sent
             ok;
         {error, unknown_topic_or_partition} ->
             Msg = iolist_to_binary([<<"Unknown topic or partition: ">>, KafkaTopic]),

--- a/changes/ee/fix-15616.en.md
+++ b/changes/ee/fix-15616.en.md
@@ -1,0 +1,1 @@
+Consider Kafka connection healthy if `topic_authorization_failed` is received for the default probing topic.


### PR DESCRIPTION
Port https://github.com/emqx/emqx/pull/15116 to 5.8