### PR TITLE
feat(bin/emqx): add `--iex` to drop into iex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,7 +264,7 @@ run-console:
 
 .PHONY: run-console-iex
 run-console-iex:
-	env EMQX_CONSOLE_FLAVOR=iex _build/$(PROFILE)/rel/emqx/bin/emqx console
+	_build/$(PROFILE)/rel/emqx/bin/emqx console --iex
 
 .PHONY: repl
 repl:

--- a/bin/emqx
+++ b/bin/emqx
@@ -66,11 +66,13 @@ usage() {
     console)
         echo "Boot up EMQX service in an interactive Erlang or Elixir shell"
         echo "This command needs a tty"
+        echo "Passing it the --iex flag will run an IEx (Elixir console)"
         ;;
     console_clean)
         echo "This command does NOT boot up the EMQX service"
         echo "It only starts an interactive Erlang or Elixir console with all the"
         echo "EMQX code available"
+        echo "Passing it the --iex flag will run an IEx (Elixir console)"
         ;;
     foreground)
         echo "Start EMQX in foreground mode without an interactive shell"
@@ -96,6 +98,7 @@ usage() {
         echo "Start an interactive shell running an Erlang or Elixir node which "
         echo "hidden-connects to the running EMQX node".
         echo "This command is mostly used for troubleshooting."
+        echo "Passing it the --iex flag will run an IEx (Elixir console)"
         ;;
     ertspath)
         echo "Print path to Erlang runtime bin dir"
@@ -174,14 +177,14 @@ usage() {
         echo "Usage: $progname COMMAND [help]"
         echo ''
         echo "Commonly used COMMANDs:"
-        echo "  start:      Start EMQX in daemon mode"
-        echo "  console:    Start EMQX in an interactive Erlang or Elixir shell"
-        echo "  foreground: Start EMQX in foreground mode without an interactive shell"
-        echo "  stop:       Stop the running EMQX node"
-        echo "  ctl:        Administration commands, execute '$progname ctl help' for more details"
+        echo "  start:            Start EMQX in daemon mode"
+        echo "  console [--iex]:  Start EMQX in an interactive Erlang or Elixir shell"
+        echo "  foreground:       Start EMQX in foreground mode without an interactive shell"
+        echo "  stop:             Stop the running EMQX node"
+        echo "  ctl:              Administration commands, execute '$progname ctl help' for more details"
         echo ''
         echo "More:"
-        echo "  Shell attach:     remote_console | attach"
+        echo "  Shell attach:     remote_console [--iex] | attach"
 #       echo "  Up/Down-grade:    upgrade | downgrade | install | uninstall | versions" # TODO enable when supported
         echo "  Install Info:     ertspath | root_dir"
         echo "  Runtime Status:   pid | ping"
@@ -1178,6 +1181,18 @@ case "${COMMAND}" in
     remote_console)
         assert_node_alive
 
+        case "${2:-}" in
+            --iex)
+                EMQX_CONSOLE_FLAVOR=iex
+                shift
+                ;;
+            "")
+                ;;
+            *)
+                echo "Usage: $REL_NAME $COMMAND [--iex]"
+                exit 1
+                ;;
+        esac
         shift
         remsh
         ;;
@@ -1266,6 +1281,25 @@ case "${COMMAND}" in
 
         export EMU
         export PROGNAME
+
+        case "${COMMAND}" in
+            console|console_clean)
+                case "${2:-}" in
+                    --iex)
+                        EMQX_CONSOLE_FLAVOR=iex
+                        shift
+                        ;;
+                    "")
+                        ;;
+                    *)
+                        echo "Usage: $REL_NAME $COMMAND [--iex]"
+                        exit 1
+                        ;;
+                esac
+                ;;
+            *)
+                ;;
+        esac
 
         # Store passed arguments since they will be erased by `set`
         ARGS="$*"


### PR DESCRIPTION
While setting `EMQX_CONSOLE_FLAVOR` works for running the build locally, in packages one typically runs `sudo emqx ...`, which drops any custom environment variable value due to `su -` being used.

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 6.0.0-M2.202508

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [na] For internal contributor: there is a jira ticket to track this change
- [na] The changes are covered with new or existing tests (tried out manually)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
