### PR TITLE
feat(rocketmq): add key and tag template configs

### DIFF
--- a/.ci/docker-compose-file/rocketmq/conf/plain_acl.yml
+++ b/.ci/docker-compose-file/rocketmq/conf/plain_acl.yml
@@ -10,3 +10,13 @@ accounts:
     topicPerms:
       - TopicTest=PUB|SUB
       - Topic2=PUB|SUB
+
+  - accessKey: rocketmq2
+    secretKey: 12345678
+    whiteRemoteAddress:
+    admin: true
+    defaultTopicPerm: ALLOW
+    defaultGroupPerm: PUB|SUB
+    topicPerms:
+      - TopicTest=PUB|SUB
+      - Topic2=PUB|SUB

--- a/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.erl
+++ b/apps/emqx_bridge_rocketmq/src/emqx_bridge_rocketmq.erl
@@ -166,8 +166,18 @@ fields(action_parameters) ->
                 )},
             {strategy,
                 mk(
-                    hoconsc:union([roundrobin, binary()]),
+                    hoconsc:union([roundrobin, key_dispatch, binary()]),
                     #{desc => ?DESC("strategy"), default => roundrobin}
+                )},
+            {key,
+                mk(
+                    emqx_schema:template(),
+                    #{desc => ?DESC("key"), required => false}
+                )},
+            {tag,
+                mk(
+                    emqx_schema:template(),
+                    #{desc => ?DESC("tag"), required => false}
                 )}
         ] ++ emqx_bridge_rocketmq_connector:fields(config),
     lists:foldl(

--- a/changes/ee/breaking-15635.en.md
+++ b/changes/ee/breaking-15635.en.md
@@ -1,0 +1,1 @@
+We no longer support setting key templates (and thus implicitly specifying key dispatch strategy) in the `parameters.strategy` field of RocketMQ Action.  Instead, users should set `parameters.strategy = key_dispatch` and specify the template in `parameters.key`.

--- a/changes/ee/feat-15635.en.md
+++ b/changes/ee/feat-15635.en.md
@@ -1,0 +1,1 @@
+Added new `key` and `tag` template fields for the RocketMQ Action which sets the message's key and tag, respectively.  Also, added a new `key_dispatch` value for the `strategy` field.

--- a/rel/i18n/emqx_bridge_rocketmq.hocon
+++ b/rel/i18n/emqx_bridge_rocketmq.hocon
@@ -60,6 +60,16 @@ config_connector.label:
 """RocketMQ Client Configuration"""
 
 strategy.desc:
-"""Producer key dispatch strategy, the default is `roundrobin`, also supports placeholders, such as: `clientid`, `messageid`, `username`."""
+"""Producer key dispatch strategy.  Possible values: `key_dispatch`, `roundrobin`.  The default is `roundrobin`."""
+
+key.label:
+"""Key"""
+key.desc:
+"""Value to use for message key.  Supports placeholders, e.g.: `${payload.key}`."""
+
+tag.label:
+"""Tag"""
+tag.desc:
+"""Value to use for message tag.  Supports placeholders, e.g.: `${payload.tag}`."""
 
 }


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14481


<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 6.0.0-M2.202508

## Summary

There was already a way to configure key templates before, but that used templates directly in the `strategy` config instead of having a `key_dispatch` strategy type and a dedicated `key` template field.  Here, we deprecate using key templates in `strategy`, add a new `key_dispatch` enum constructor for `strategy`, and add new template fields `key` and `tag`.  We log a warn if we detect templates in the `strategy` field telling the user this is deprecated.

Checking tag and key manually:

```
[rocketmq@59a1662db0a9 bin]$ ./mqadmin consumeMessage -t TopicTest
MessageQueue [topic=TopicTest, brokerName=broker-a, queueId=3] print msg finished. status=NO_NEW_MSG, offset=0
MessageQueue [topic=TopicTest, brokerName=broker-a, queueId=2] print msg finished. status=NO_NEW_MSG, offset=0
MessageQueue [topic=TopicTest, brokerName=broker-a, queueId=1] print msg finished. status=NO_NEW_MSG, offset=0
Consume ok
MSGID: AC64EF0700002A9F0000000000000000 MessageExt [brokerName=broker-a, queueId=0, storeSize=647, queueOffset=0, sysFlag=0, bornTimestamp=1754315276463, bornHost=/172.100.239.3:49834, storeTimestamp=1754315276477, storeHost=/172.100.239.7:10911, msgId=AC64EF0700002A9F0000000000000000, commitLogOffset=0, bodyCRC=1897358939, reconsumeTimes=0, preparedTransactionOffset=0, toString()=Message{topic='TopicTest', flag=0, properties={MIN_OFFSET=0, MAX_OFFSET=1, KEYS=k1, CLUSTER=DefaultCluster, TAGS=t1}, ....
```

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
