### PR TITLE
Fix incorrect counting of the packets.subscribe.auth_error metric.

### DIFF
--- a/apps/emqx/include/emqx_metrics.hrl
+++ b/apps/emqx/include/emqx_metrics.hrl
@@ -87,10 +87,10 @@
     {counter, 'packets.subscribe.received', <<"Number of received SUBSCRIBE packet">>},
     %% SUBSCRIBE error
     {counter, 'packets.subscribe.error',
-        <<"Number of received SUBSCRIBE packet with failed subscriptions">>},
+        <<"Number of received SUBSCRIBE packet containing failed subscriptions">>},
     %% SUBSCRIBE failed for not auth
     {counter, 'packets.subscribe.auth_error',
-        <<"Number of received SUBACK packet with failed Authorization check">>},
+        <<"Number of received SUBSCRIBE packet containing failed Authorization check">>},
     %% SUBACK packets sent
     {counter, 'packets.suback.sent', <<"Number of sent SUBACK packet">>},
     %% UNSUBSCRIBE Packets received

--- a/apps/emqx/include/emqx_metrics.hrl
+++ b/apps/emqx/include/emqx_metrics.hrl
@@ -87,10 +87,10 @@
     {counter, 'packets.subscribe.received', <<"Number of received SUBSCRIBE packet">>},
     %% SUBSCRIBE error
     {counter, 'packets.subscribe.error',
-        <<"Number of received SUBSCRIBE packet containing failed subscriptions">>},
+        <<"Number of received SUBSCRIBE packet with failed subscriptions">>},
     %% SUBSCRIBE failed for not auth
     {counter, 'packets.subscribe.auth_error',
-        <<"Number of received SUBSCRIBE packet containing failed Authorization check">>},
+        <<"Number of received SUBSCRIBE packet with failed Authorization check">>},
     %% SUBACK packets sent
     {counter, 'packets.suback.sent', <<"Number of sent SUBACK packet">>},
     %% UNSUBSCRIBE Packets received

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -333,7 +333,10 @@ do_inc_sent(?PACKET(?PUBREL)) ->
     inc('packets.pubrel.sent');
 do_inc_sent(?PACKET(?PUBCOMP)) ->
     inc('packets.pubcomp.sent');
-do_inc_sent(?PACKET(?SUBACK)) ->
+do_inc_sent(?SUBACK_PACKET(_PacketId, ReasonCodes)) ->
+    lists:any(fun(Code) -> Code >= ?RC_UNSPECIFIED_ERROR end, ReasonCodes) andalso
+        inc('packets.subscribe.error'),
+    lists:member(?RC_NOT_AUTHORIZED, ReasonCodes) andalso inc('packets.subscribe.auth_error'),
     inc('packets.suback.sent');
 do_inc_sent(?PACKET(?UNSUBACK)) ->
     inc('packets.unsuback.sent');

--- a/apps/emqx/test/emqx_metrics_SUITE.erl
+++ b/apps/emqx/test/emqx_metrics_SUITE.erl
@@ -140,7 +140,7 @@ t_inc_sent(_) ->
             ok = emqx_metrics:inc_sent(?PUBREC_PACKET(3, 0)),
             ok = emqx_metrics:inc_sent(?PACKET(?PUBREL)),
             ok = emqx_metrics:inc_sent(?PACKET(?PUBCOMP)),
-            ok = emqx_metrics:inc_sent(?PACKET(?SUBACK)),
+            ok = emqx_metrics:inc_sent(?SUBACK_PACKET(0, [?RC_SUCCESS])),
             ok = emqx_metrics:inc_sent(?PACKET(?UNSUBACK)),
             ok = emqx_metrics:inc_sent(?PACKET(?PINGRESP)),
             ok = emqx_metrics:inc_sent(?PACKET(?DISCONNECT)),
@@ -161,6 +161,30 @@ t_inc_sent(_) ->
             ?assertEqual(1, emqx_metrics:val('packets.pingresp.sent')),
             ?assertEqual(1, emqx_metrics:val('packets.disconnect.sent')),
             ?assertEqual(1, emqx_metrics:val('packets.auth.sent'))
+        end
+    ).
+
+t_inc_sent_auth_error(_) ->
+    with_metrics_server(
+        fun() ->
+            %% Subscribe
+            ok = emqx_metrics:inc_sent(?SUBACK_PACKET(0, [?RC_NOT_AUTHORIZED])),
+            ok = emqx_metrics:inc_sent(?SUBACK_PACKET(0, [?RC_UNSPECIFIED_ERROR])),
+            ?assertEqual(1, emqx_metrics:val('packets.subscribe.auth_error')),
+            ?assertEqual(2, emqx_metrics:val('packets.subscribe.error')),
+            ?assertEqual(2, emqx_metrics:val('packets.suback.sent')),
+            %% Publish - puback
+            ok = emqx_metrics:inc_sent(?PUBACK_PACKET(0, ?RC_UNSPECIFIED_ERROR)),
+            ok = emqx_metrics:inc_sent(?PUBACK_PACKET(0, ?RC_NOT_AUTHORIZED)),
+            ?assertEqual(1, emqx_metrics:val('packets.publish.auth_error')),
+            ?assertEqual(2, emqx_metrics:val('packets.publish.error')),
+            ?assertEqual(2, emqx_metrics:val('packets.puback.sent')),
+            %% Publish - pubrec
+            ok = emqx_metrics:inc_sent(?PUBREC_PACKET(0, ?RC_UNSPECIFIED_ERROR)),
+            ok = emqx_metrics:inc_sent(?PUBREC_PACKET(0, ?RC_NOT_AUTHORIZED)),
+            ?assertEqual(2, emqx_metrics:val('packets.publish.auth_error')),
+            ?assertEqual(4, emqx_metrics:val('packets.publish.error')),
+            ?assertEqual(2, emqx_metrics:val('packets.pubrec.sent'))
         end
     ).
 

--- a/apps/emqx/test/emqx_metrics_SUITE.erl
+++ b/apps/emqx/test/emqx_metrics_SUITE.erl
@@ -165,6 +165,8 @@ t_inc_sent(_) ->
     ).
 
 t_inc_sent_auth_error(_) ->
+    %% verify the packets.publish.error, packets.publish.auth_error,
+    %% packets.subscribe.error, packets.subscribe.auth_error can be incremented correctly
     with_metrics_server(
         fun() ->
             %% Subscribe

--- a/changes/ce/fix-15639.en.md
+++ b/changes/ce/fix-15639.en.md
@@ -1,0 +1,1 @@
+Fix incorrect counting of the packets.subscribe.auth_error metric.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14455

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: e5.8.8

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- ~Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)~

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
