### PR TITLE
refactor: delete 'bridges' schema from schema JSON for dashboard

### DIFF
--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -1106,9 +1106,6 @@ api_spec_schemas(Root) ->
             Schemas
     end.
 
-bridges_api_spec_schemas() ->
-    api_spec_schemas("bridges").
-
 actions_api_spec_schemas() ->
     api_spec_schemas("actions").
 

--- a/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
+++ b/apps/emqx_bridge_azure_event_hub/src/emqx_bridge_azure_event_hub.erl
@@ -398,8 +398,7 @@ producer_overrides() ->
             ),
         %% NOTE: field 'kafka' is renamed to 'parameters' since e5.3.1
         %% We will keep 'kafka' for backward compatibility.
-        %% TODO: delete this override when we upgrade bridge schema json to 0.2.0
-        %% See emqx_conf:bridge_schema_json/0
+        %% TODO: delete this override when we stop supporting v1 bridge schema
         kafka =>
             mk(ref(producer_kafka_opts), #{
                 required => true,

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_tests.erl
@@ -20,7 +20,7 @@ bridges.azure_event_hub_producer.my_producer {
   }
   bootstrap_hosts = \"emqx.servicebus.windows.net:9093\"
   connect_timeout = 5s
-  kafka {
+  parameters {
     buffer {
       memory_overload_protection = false
       mode = memory

--- a/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
+++ b/apps/emqx_bridge_azure_event_hub/test/emqx_bridge_azure_event_hub_v2_SUITE.erl
@@ -270,14 +270,6 @@ make_message() ->
         timestamp => Time
     }.
 
-bridge_api_spec_props_for_get() ->
-    #{
-        <<"bridge_azure_event_hub.get_producer">> :=
-            #{<<"properties">> := Props}
-    } =
-        emqx_bridge_v2_testlib:bridges_api_spec_schemas(),
-    Props.
-
 action_api_spec_props_for_get() ->
     #{
         <<"bridge_azure_event_hub.get_bridge_v2">> :=
@@ -353,10 +345,6 @@ t_same_name_azure_kafka_bridges(Config) ->
     ok.
 
 t_parameters_key_api_spec(_Config) ->
-    BridgeProps = bridge_api_spec_props_for_get(),
-    ?assert(is_map_key(<<"kafka">>, BridgeProps), #{bridge_props => BridgeProps}),
-    ?assertNot(is_map_key(<<"parameters">>, BridgeProps), #{bridge_props => BridgeProps}),
-
     ActionProps = action_api_spec_props_for_get(),
     ?assertNot(is_map_key(<<"kafka">>, ActionProps), #{action_props => ActionProps}),
     ?assert(is_map_key(<<"parameters">>, ActionProps), #{action_props => ActionProps}),

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_kafka_tests.erl
@@ -204,13 +204,6 @@ test_keepalive_validation(Name, Conf) ->
         [?_assertThrow(_, check(C)) || C <- InvalidConfs] ++
         [?_assertThrow(_, check_atom_key(C)) || C <- InvalidConfs].
 
-%% assert compatibility
-bridge_schema_json_test() ->
-    JSON = iolist_to_binary(emqx_dashboard_schema_api:bridge_schema_json()),
-    Map = emqx_utils_json:decode(JSON),
-    Path = [<<"components">>, <<"schemas">>, <<"bridge_kafka.post_producer">>, <<"properties">>],
-    ?assertMatch(#{<<"kafka">> := _}, emqx_utils_maps:deep_get(Path, Map)).
-
 custom_group_id_test() ->
     BaseConfig = kafka_consumer_source_config(),
     BadSourceConfig = emqx_utils_maps:deep_merge(

--- a/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
+++ b/apps/emqx_bridge_kafka/test/emqx_bridge_v2_kafka_producer_SUITE.erl
@@ -358,14 +358,6 @@ remove(Type, Name) ->
     }),
     ok.
 
-bridge_api_spec_props_for_get() ->
-    #{
-        <<"bridge_kafka.get_producer">> :=
-            #{<<"properties">> := Props}
-    } =
-        emqx_bridge_v2_testlib:bridges_api_spec_schemas(),
-    Props.
-
 action_api_spec_props_for_get() ->
     #{
         <<"bridge_kafka.get_bridge_v2">> :=
@@ -634,10 +626,6 @@ t_bad_url(_Config) ->
     ok.
 
 t_parameters_key_api_spec(_Config) ->
-    BridgeProps = bridge_api_spec_props_for_get(),
-    ?assert(is_map_key(<<"kafka">>, BridgeProps), #{bridge_props => BridgeProps}),
-    ?assertNot(is_map_key(<<"parameters">>, BridgeProps), #{bridge_props => BridgeProps}),
-
     ActionProps = action_api_spec_props_for_get(),
     ?assertNot(is_map_key(<<"kafka">>, ActionProps), #{action_props => ActionProps}),
     ?assert(is_map_key(<<"parameters">>, ActionProps), #{action_props => ActionProps}),

--- a/apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_schema_api.erl
@@ -18,9 +18,6 @@
 
 -export([get_schema/2]).
 
-%% for test
--export([bridge_schema_json/0]).
-
 -define(TAGS, [<<"dashboard">>]).
 -define(BAD_REQUEST, 'BAD_REQUEST').
 
@@ -45,9 +42,8 @@ paths() ->
     ["/schemas/:name"].
 
 %% This is a rather hidden API, so we don't need to add translations for the description.
-%% TODO(5.7): delete 'bridges'
 schema("/schemas/:name") ->
-    Schemas = [hotconf, bridges, actions, connectors],
+    Schemas = [hotconf, actions, connectors],
     #{
         'operationId' => get_schema,
         get => #{
@@ -79,8 +75,6 @@ get_schema(get, _) ->
 
 gen_schema(hotconf) ->
     hotconf_schema_json();
-gen_schema(bridges) ->
-    bridge_schema_json();
 gen_schema(actions) ->
     actions_schema_json();
 gen_schema(connectors) ->
@@ -92,13 +86,6 @@ hotconf_schema_json() ->
         version => ?SCHEMA_VERSION
     },
     gen_api_schema_json_iodata(emqx_mgmt_api_configs, SchemaInfo).
-
-bridge_schema_json() ->
-    SchemaInfo = #{
-        title => <<"Data Bridge Schema">>,
-        version => ?SCHEMA_VERSION
-    },
-    gen_api_schema_json_iodata(emqx_bridge_api, SchemaInfo).
 
 actions_schema_json() ->
     SchemaInfo = #{

--- a/apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_schema_api_SUITE.erl
@@ -42,8 +42,15 @@ t_hotconf(_) ->
     _ = emqx_utils_json:decode(Body),
     ok.
 
-t_bridges(_) ->
-    Url = ?SERVER ++ "/schemas/bridges",
+t_actions(_) ->
+    Url = ?SERVER ++ "/schemas/actions",
+    {ok, 200, Body} = request(get, Url),
+    %% assert it's a valid json
+    _ = emqx_utils_json:decode(Body),
+    ok.
+
+t_connectors(_) ->
+    Url = ?SERVER ++ "/schemas/connectors",
     {ok, 200, Body} = request(get, Url),
     %% assert it's a valid json
     _ = emqx_utils_json:decode(Body),

--- a/scripts/test/emqx-smoke-test.sh
+++ b/scripts/test/emqx-smoke-test.sh
@@ -86,11 +86,10 @@ main() {
     local JSON_STATUS
     JSON_STATUS="$(json_status)"
     check_api_docs
-    ## The json status feature was added after hotconf and bridges schema API
+    ## The json status feature was added after hotconf API
     if [ "$JSON_STATUS" != 'NOT_JSON' ]; then
         check_swagger_json
         check_schema_json hotconf "Hot Conf Schema"
-        check_schema_json bridges "Data Bridge Schema"
         check_schema_json actions "Actions and Sources Schema"
         check_schema_json connectors "Connectors Schema"
     fi


### PR DESCRIPTION
To facilitate dashboard UI components, the backend exposes below API specs in JSON format

- hotconf
- bridges
- actions
- connectors

'bridges' is deprecated since EMQX 5.3.
This commit deletes the schema dump of 'bridges'

The deprecated bridge (v1) API is not deleted in this commit though.
