### PR TITLE
chore: correct changelog entry wording

### DIFF
--- a/changes/ee/feat-15594.en.md
+++ b/changes/ee/feat-15594.en.md
@@ -1,3 +1,3 @@
-Exposed maximum number of traces allowed to exist in the cluster simultaneously as a configuration option `trace.max_traces`. This limit does not apply to node-local traces managed through `emqx ctl traces`.
+Exposed maximum number of traces allowed to exist in the cluster simultaneously as a configuration option `trace.max_traces`. This limit does not apply to node-local traces managed through `emqx ctl trace`.
 
 Optimized tracing implementation to eliminate potential atom leaks per created trace.


### PR DESCRIPTION
Part of [EMQX-14467](https://emqx.atlassian.net/browse/EMQX-14467).

Release version: 6.0.0

## Summary

Corrects changelog entry wording.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [ ] ~~The changes are covered with new or existing tests~~
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible


[EMQX-14467]: https://emqx.atlassian.net/browse/EMQX-14467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ