### PR TITLE
test(shared sub): attempt to stabilize flaky test

### DIFF
--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -971,8 +971,8 @@ t_session_takeover(Config) when is_list(Config) ->
     {true, _} = last_message(<<"hello2">>, [ConnPid2]),
     %% We may or may not recv dup hello2 due to QoS1 redelivery
     _ = last_message(<<"hello2">>, [ConnPid2]),
-    {true, _} = last_message(<<"hello3">>, [ConnPid2]),
-    {true, _} = last_message(<<"hello4">>, [ConnPid2]),
+    {true, _} = last_message(<<"hello3">>, [ConnPid2], 5_000),
+    {true, _} = last_message(<<"hello4">>, [ConnPid2], 5_000),
     ?assertEqual([], collect_msgs(timer:seconds(2))),
     emqtt:unsubscribe(ConnPid2, SharedTopic),
     emqtt:stop(ConnPid2),


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/16756740480/job/47441963112?pr=15629#step:5:127

```
%%% emqx_shared_sub_SUITE ==> t_session_takeover: FAILED
%%% emqx_shared_sub_SUITE ==> {{badmatch,<<"not yet?">>},
 [{emqx_shared_sub_SUITE,t_session_takeover,1,
                         [{file,"test/emqx_shared_sub_SUITE.erl"},{line,974}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```
