### PR TITLE
feat(mix): Add --repeat option to `ct` task

### DIFF
--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
@@ -102,8 +102,10 @@ defmodule Mix.Tasks.Emqx.Ct do
   end
 
   def sum_results(l) do
-    Enum.reduce(l, fn {success, failed, {skipped, auto_skipped}},
-                      {s_acc, f_acc, {sk_acc, as_acc}} ->
+    init_acc = {0, 0, {0, 0}}
+
+    Enum.reduce(l, init_acc, fn {success, failed, {skipped, auto_skipped}},
+                                {s_acc, f_acc, {sk_acc, as_acc}} ->
       {success + s_acc, failed + f_acc, {skipped + sk_acc, auto_skipped + as_acc}}
     end)
   end

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
@@ -27,6 +27,8 @@ defmodule Mix.Tasks.Emqx.Ct do
     * `--cover-export-name` - filename to export cover data to.  Defaults to `ct`.  Always
       get `.coverdata` appended to it.
 
+    * `--repeat N` - repeat the tests N times
+
   ## Examples
 
       $ mix emqx.ct --suites apps/emqx/test/emqx_SUITE.erl,apps/emqx/test/emqx_alarm_SUITE.erl
@@ -86,7 +88,7 @@ defmodule Mix.Tasks.Emqx.Ct do
 
     symlink_to_last_run(logdir)
 
-    case results do
+    case sum_results(results) do
       {_success, failed, {_user_skipped, auto_skipped}} when failed > 0 or auto_skipped > 0 ->
         Mix.raise("failures running tests: #{failed} failed, #{auto_skipped} auto skipped")
 
@@ -97,6 +99,13 @@ defmodule Mix.Tasks.Emqx.Ct do
 
         if cover_enabled?(), do: write_coverdata(opts)
     end
+  end
+
+  def sum_results(l) do
+    Enum.reduce(l, fn {success, failed, {skipped, auto_skipped}},
+                      {s_acc, f_acc, {sk_acc, as_acc}} ->
+      {success + s_acc, failed + f_acc, {skipped + sk_acc, auto_skipped + as_acc}}
+    end)
   end
 
   def run_suites(opts, context) do
@@ -117,7 +126,8 @@ defmodule Mix.Tasks.Emqx.Ct do
       readable: ~c"true",
       name: node_name,
       ct_hooks: [:cth_readable_shell, :cth_readable_failonly],
-      logdir: to_charlist(logdir)
+      logdir: to_charlist(logdir),
+      repeat: opts[:repeat]
     )
   end
 
@@ -136,7 +146,8 @@ defmodule Mix.Tasks.Emqx.Ct do
       readable: ~c"true",
       name: node_name,
       ct_hooks: [:cth_readable_shell, :cth_readable_failonly],
-      logdir: to_charlist(logdir)
+      logdir: to_charlist(logdir),
+      repeat: opts[:repeat]
     )
   end
 
@@ -317,7 +328,8 @@ defmodule Mix.Tasks.Emqx.Ct do
           suites: :string,
           group_paths: :string,
           cases: :string,
-          spec: :string
+          spec: :string,
+          repeat: :integer
         ]
       )
 
@@ -349,7 +361,8 @@ defmodule Mix.Tasks.Emqx.Ct do
       suites: suites,
       group_paths: group_paths,
       cases: cases,
-      spec: spec
+      spec: spec,
+      repeat: Keyword.get(opts, :repeat, 1)
     }
   end
 


### PR DESCRIPTION
Fixes [EMQX-14568](https://emqx.atlassian.net/browse/EMQX-14568)

Release version: 6.0.0

## Summary

Add `--repeat` option to `mix ct` task.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14568]: https://emqx.atlassian.net/browse/EMQX-14568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ