### PR TITLE
test(mgmt clients): attempt to fix flaky test

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -1514,7 +1514,7 @@ t_subscribe_shared_topic(Config) ->
     ),
 
     %% assert subscription
-    ?assertEqual([], ets:tab2list(?SUBSCRIPTION)),
+    ?retry(200, 10, ?assertEqual([], ets:tab2list(?SUBSCRIPTION))),
     ?assertEqual([], ets:tab2list(?SUBOPTION)),
     ?assertEqual([], ets:tab2list(emqx_shared_subscription)),
 


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/16808468466/job/47607945825?pr=15654#step:5:206

```
%%% emqx_mgmt_api_clients_SUITE ==> general.t_subscribe_shared_topic: FAILED
%%% emqx_mgmt_api_clients_SUITE ==>
Failure/Error: ?assertEqual([], ets : tab2list ( ? SUBSCRIPTION ))
  expected: []
       got: [{<0.56136.0>,<<"t/#">>}]
      line: 1517
```
