### PR TITLE
r58: Upgrade Kafka client dependencies to latest

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,10 +2,10 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.9"},
-    {kafka_protocol, "4.2.3"},
+    {wolff, "4.0.10"},
+    {kafka_protocol, "4.2.7"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.4.4"},
+    {brod, "4.4.5"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,10 +2,10 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.9"},
-    {kafka_protocol, "4.2.3"},
+    {wolff, "4.0.10"},
+    {kafka_protocol, "4.2.7"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.4.4"},
+    {brod, "4.4.5"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,10 +2,10 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.9"},
-    {kafka_protocol, "4.2.3"},
+    {wolff, "4.0.10"},
+    {kafka_protocol, "4.2.7"},
     {brod_gssapi, "0.1.3"},
-    {brod, "4.4.4"},
+    {brod, "4.4.5"},
     {snappyer, "1.2.10"},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},

--- a/mix.exs
+++ b/mix.exs
@@ -288,7 +288,7 @@ defmodule EMQXUmbrella.MixProject do
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}
-  def common_dep(:crc32cer), do: {:crc32cer, "0.1.12", override: true}
+  def common_dep(:crc32cer), do: {:crc32cer, "1.0.3", override: true}
   def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.1.1"}
   def common_dep(:erlavro), do: {:erlavro, github: "emqx/erlavro", tag: "2.10.0", override: true}
 

--- a/mix.exs
+++ b/mix.exs
@@ -278,13 +278,13 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.9"}
+  def common_dep(:wolff), do: {:wolff, "4.0.10"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),
-    do: {:kafka_protocol, "4.2.3", override: true}
+    do: {:kafka_protocol, "4.2.7", override: true}
 
-  def common_dep(:brod), do: {:brod, "4.4.4"}
+  def common_dep(:brod), do: {:brod, "4.4.5"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}


### PR DESCRIPTION
Release: 5.8.8

Mostly bring the Kafka clients to latest versions (moslty irrelevant changes).
The only impact on EMQX is the transient update of `crc32cer` from 0.1.12 to 1.0.3.
See more details in [kafka_protocol changelog](https://github.com/kafka4beam/kafka_protocol/blob/master/changelog.md)
