### PR TITLE
fix(postgres): use allocation apis to avoid leaking resource pool

### DIFF
--- a/changes/ee/fix-15693.en.md
+++ b/changes/ee/fix-15693.en.md
@@ -1,0 +1,1 @@
+Postgres-based bridges were patched to avoid leaking connection pools.  Previously, depending on race conditions when initializing the pool, if one later deleted the Connector, the pool could still be present.


### PR DESCRIPTION
Possibly fixes https://emqx.atlassian.net/browse/EMQX-14600

<!--
5.8.7
5.9.1
6.0.0-M1.202507
6.0.0-M2.202508
6.0.0
-->
Release version: 6.0.0-M2.202508


## Summary

I could not reproduce the problem locally.  I suspect it might have been some kind of race while starting the pool, and the `close_connections` functions might have crashed or was not called.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
