### PR TITLE
fix(listener): make WS/WSS `max_connections` limit work per-listener

### DIFF
--- a/apps/emqx/test/emqx_listeners_limits_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_limits_SUITE.erl
@@ -43,7 +43,6 @@ t_max_conns(Config) ->
         Type,
         #{
             <<"bind">> => format_bind({"127.0.0.1", Port}),
-            <<"acceptors">> => 1,
             <<"max_connections">> => MaxConns
         },
         Config
@@ -78,8 +77,9 @@ t_max_conn_rate(Config) ->
         Type,
         #{
             <<"bind">> => format_bind({"127.0.0.1", Port}),
-            <<"acceptors">> => 1,
-            <<"max_conn_rate">> => <<"5/500ms">>
+            <<"max_conn_rate">> => <<"5/500ms">>,
+            %% NOTE: Rate limits are per-acceptor, use single acceptor for predictability.
+            <<"acceptors">> => 1
         },
         Config
     ),

--- a/mix.exs
+++ b/mix.exs
@@ -163,7 +163,7 @@ defmodule EMQXUmbrella.MixProject do
   # in conflict by ehttpc and emqtt
   def common_dep(:gun), do: {:gun, "2.1.0", override: true}
   # in conflict by cowboy_swagger and cowboy
-  def common_dep(:ranch), do: {:ranch, github: "emqx/ranch", tag: "2.2.0-emqx-2", override: true}
+  def common_dep(:ranch), do: {:ranch, github: "emqx/ranch", tag: "2.2.0-emqx-3", override: true}
 
   def common_dep(:ehttpc),
     do: {:ehttpc, github: "emqx/ehttpc", tag: "0.7.1", override: true}


### PR DESCRIPTION
Fixes [EMQX-14393](https://emqx.atlassian.net/browse/EMQX-14393).

Release version: 6.0.0

## Summary

This PR ensures `max_connections` limit for WS/WSS listeners is respected regardless of configured number of acceptors. In other words, it's now enforced per-whole-listener, similar how TCP listeners enforce it.

This is a followup to #15696.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible



[EMQX-14393]: https://emqx.atlassian.net/browse/EMQX-14393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ