### PR TITLE
refactor: do not catch exception during config init_load

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -28,14 +28,7 @@
 
 start(_StartType, _StartArgs) ->
     ok = mria:wait_for_tables(emqx_cluster_rpc:create_tables()),
-    try
-        ok = init_conf()
-    catch
-        C:E:St ->
-            %% logger is not quite ready.
-            io:format(standard_error, "Failed to load config~n~p~n~p~n~p~n", [C, E, St]),
-            init:stop(1)
-    end,
+    ok = init_conf(),
     ok = emqx_config_logger:refresh_config(),
     emqx_conf_sup:start_link().
 


### PR DESCRIPTION
previsouly the assumption about logger being not ready during initial config load is not entirely true.
the logger config is maybe not in sync with other nodes in the cluster but should be ready to at least log app start errors because the default log config is a part of the kernel app.

Release: 5.8.8