### PR TITLE
test(oracle): refactor suites to standardize drop bridges v1 apis

### DIFF
--- a/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
+++ b/apps/emqx_bridge_oracle/test/emqx_bridge_oracle_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2023-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 -module(emqx_bridge_oracle_SUITE).
 
@@ -9,160 +9,173 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
--include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx_resource/include/emqx_resource.hrl").
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 
--define(BRIDGE_TYPE_BIN, <<"oracle">>).
+-define(CONNECTOR_TYPE, oracle).
+-define(CONNECTOR_TYPE_BIN, <<"oracle">>).
+-define(ACTION_TYPE, oracle).
+-define(ACTION_TYPE_BIN, <<"oracle">>).
+
+-define(PROXY_NAME, "oracle").
+-define(PROXY_HOST, "toxiproxy").
+-define(PROXY_PORT, 8474).
+
 -define(SID, "XE").
--define(RULE_TOPIC, "mqtt/rule").
+
+-define(with_batch, with_batch).
+-define(without_batch, without_batch).
 
 %%------------------------------------------------------------------------------
 %% CT boilerplate
 %%------------------------------------------------------------------------------
 
 all() ->
-    [
-        {group, plain}
-    ].
+    emqx_common_test_helpers:all_with_matrix(?MODULE).
 
 groups() ->
-    AllTCs = emqx_common_test_helpers:all(?MODULE),
-    [
-        {plain, AllTCs}
-    ].
+    emqx_common_test_helpers:groups_with_matrix(?MODULE).
 
-init_per_suite(Config) ->
-    Config.
-
-end_per_suite(_Config) ->
-    ok.
-
-init_per_group(plain = Type, Config) ->
-    OracleHost = os:getenv("ORACLE_PLAIN_HOST", "toxiproxy.emqx.net"),
-    OraclePort = list_to_integer(os:getenv("ORACLE_PLAIN_PORT", "1521")),
-    ProxyName = "oracle",
-    case emqx_common_test_helpers:is_tcp_server_available(OracleHost, OraclePort) of
-        true ->
-            Config1 = common_init_per_group(Config),
-            [
-                {proxy_name, ProxyName},
-                {oracle_host, OracleHost},
-                {oracle_port, OraclePort},
-                {connection_type, Type}
-                | Config1 ++ Config
-            ];
-        false ->
-            case os:getenv("IS_CI") of
-                "yes" ->
-                    throw(no_oracle);
-                _ ->
-                    {skip, no_oracle}
-            end
-    end;
-init_per_group(_Group, Config) ->
-    Config.
-
-end_per_group(Group, Config) when
-    Group =:= plain
-->
-    common_end_per_group(Config),
-    Apps = ?config(apps, Config),
-    emqx_cth_suite:stop(Apps),
-    ok;
-end_per_group(_Group, _Config) ->
-    ok.
-
-common_init_per_group(Config) ->
-    ProxyHost = os:getenv("PROXY_HOST", "toxiproxy"),
-    ProxyPort = list_to_integer(os:getenv("PROXY_PORT", "8474")),
-    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-    %% Ensure enterprise bridge module is loaded
+init_per_suite(TCConfig) ->
+    reset_proxy(),
     Apps = emqx_cth_suite:start(
         [
+            emqx,
             emqx_conf,
-            emqx_oracle,
             emqx_bridge_oracle,
             emqx_bridge,
             emqx_rule_engine,
             emqx_management,
             emqx_mgmt_api_test_util:emqx_dashboard()
         ],
-        #{work_dir => emqx_cth_suite:work_dir(Config)}
+        #{work_dir => emqx_cth_suite:work_dir(TCConfig)}
     ),
-    UniqueNum = integer_to_binary(erlang:unique_integer()),
-    MQTTTopic = <<"mqtt/topic/", UniqueNum/binary>>,
     [
         {apps, Apps},
-        {proxy_host, ProxyHost},
-        {proxy_port, ProxyPort},
-        {mqtt_topic, MQTTTopic}
+        {proxy_host, ?PROXY_HOST},
+        {proxy_port, ?PROXY_PORT},
+        {proxy_name, ?PROXY_NAME}
+        | TCConfig
     ].
 
-common_end_per_group(Config) ->
-    ProxyHost = ?config(proxy_host, Config),
-    ProxyPort = ?config(proxy_port, Config),
-    emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-    delete_all_bridges(),
+end_per_suite(Config) ->
+    Apps = ?config(apps, Config),
+    emqx_cth_suite:stop(Apps),
+    reset_proxy(),
     ok.
 
-init_per_testcase(TestCase, Config) ->
-    common_init_per_testcase(TestCase, Config).
+init_per_group(?with_batch, TCConfig0) ->
+    [{batch_size, 100}, {batch_time, <<"200ms">>} | TCConfig0];
+init_per_group(?without_batch, TCConfig0) ->
+    [{batch_size, 1} | TCConfig0];
+init_per_group(_Group, TCConfig) ->
+    TCConfig.
 
-end_per_testcase(_Testcase, Config) ->
-    common_end_per_testcase(_Testcase, Config).
+end_per_group(_Group, _TCConfig) ->
+    ok.
 
-common_init_per_testcase(TestCase, Config0) ->
-    ct:timetrap(timer:seconds(60)),
-    delete_all_bridges(),
-    UniqueNum = integer_to_binary(erlang:unique_integer()),
-    OracleTopic =
-        <<
-            (atom_to_binary(TestCase))/binary,
-            UniqueNum/binary
-        >>,
-    ConnectionType = ?config(connection_type, Config0),
-    Config = [{oracle_topic, OracleTopic} | Config0],
-    {Name, ConfigString, OracleConfig} = oracle_config(
-        TestCase, ConnectionType, Config
-    ),
-    ok = snabbkaffe:start_trace(),
+init_per_testcase(TestCase, TCConfig) ->
+    reset_proxy(),
+    Path = group_path(TCConfig, no_groups),
+    ct:pal(asciiart:visible($%, "~p - ~s", [Path, TestCase])),
+    ConnectorName = atom_to_binary(TestCase),
+    ConnectorConfig = connector_config(#{}),
+    ActionName = ConnectorName,
+    ActionConfig = action_config(#{
+        <<"connector">> => ConnectorName,
+        <<"resource_opts">> => #{
+            <<"batch_size">> => get_config(batch_size, TCConfig, 1),
+            <<"batch_time">> => get_config(batch_time, TCConfig, <<"0ms">>),
+            <<"query_mode">> => get_config(query_mode, TCConfig, <<"sync">>)
+        }
+    }),
+    reset_table(TCConfig),
+    snabbkaffe:start_trace(),
     [
-        {bridge_type, ?BRIDGE_TYPE_BIN},
-        {bridge_name, Name},
-        {oracle_name, Name},
-        {oracle_config_string, ConfigString},
-        {oracle_config, OracleConfig}
-        | Config
+        {bridge_kind, action},
+        {connector_type, ?CONNECTOR_TYPE},
+        {connector_name, ConnectorName},
+        {connector_config, ConnectorConfig},
+        {action_type, ?ACTION_TYPE},
+        {action_name, ActionName},
+        {action_config, ActionConfig}
+        | TCConfig
     ].
 
-common_end_per_testcase(_Testcase, Config) ->
-    case proplists:get_bool(skip_does_not_apply, Config) of
-        true ->
-            ok;
-        false ->
-            ProxyHost = ?config(proxy_host, Config),
-            ProxyPort = ?config(proxy_port, Config),
-            emqx_common_test_helpers:reset_proxy(ProxyHost, ProxyPort),
-            delete_all_bridges(),
-            %% in CI, apparently this needs more time since the
-            %% machines struggle with all the containers running...
-            emqx_common_test_helpers:call_janitor(60_000),
-            ok = snabbkaffe:stop(),
-            ok
-    end.
-
-delete_all_bridges() ->
-    lists:foreach(
-        fun(#{name := Name, type := Type}) ->
-            emqx_bridge:remove(Type, Name)
-        end,
-        emqx_bridge:list()
-    ).
+end_per_testcase(_TestCase, _TCConfig) ->
+    snabbkaffe:stop(),
+    emqx_bridge_v2_testlib:delete_all_rules(),
+    emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
+    emqx_common_test_helpers:call_janitor(),
+    ok.
 
 %%------------------------------------------------------------------------------
 %% Helper fns
 %%------------------------------------------------------------------------------
+
+connector_config(Overrides) ->
+    Defaults = #{
+        <<"enable">> => true,
+        <<"description">> => <<"my connector">>,
+        <<"tags">> => [<<"some">>, <<"tags">>],
+        <<"sid">> => bin(?SID),
+        <<"server">> => <<"toxiproxy.emqx.net:1521">>,
+        <<"username">> => <<"system">>,
+        <<"password">> => <<"oracle">>,
+        <<"pool_size">> => 1,
+        <<"resource_opts">> =>
+            emqx_bridge_v2_testlib:common_connector_resource_opts()
+    },
+    InnerConfigMap = emqx_utils_maps:deep_merge(Defaults, Overrides),
+    emqx_bridge_v2_testlib:parse_and_check_connector(?CONNECTOR_TYPE_BIN, <<"x">>, InnerConfigMap).
+
+action_config(Overrides) ->
+    Defaults = #{
+        <<"enable">> => true,
+        <<"description">> => <<"my action">>,
+        <<"tags">> => [<<"some">>, <<"tags">>],
+        <<"parameters">> => #{
+            <<"sql">> => bin(sql_insert_template_for_bridge())
+        },
+        <<"resource_opts">> =>
+            emqx_bridge_v2_testlib:common_action_resource_opts()
+    },
+    InnerConfigMap = emqx_utils_maps:deep_merge(Defaults, Overrides),
+    emqx_bridge_v2_testlib:parse_and_check(action, ?ACTION_TYPE_BIN, <<"x">>, InnerConfigMap).
+
+bin(X) -> emqx_utils_conv:bin(X).
+str(X) -> emqx_utils_conv:str(X).
+
+get_config(K, TCConfig) -> emqx_bridge_v2_testlib:get_value(K, TCConfig).
+get_config(K, TCConfig, Default) -> proplists:get_value(K, TCConfig, Default).
+
+group_path(Config, Default) ->
+    case emqx_common_test_helpers:group_path(Config) of
+        [] -> Default;
+        Path -> Path
+    end.
+
+get_tc_prop(TestCase, Key, Default) ->
+    maybe
+        true ?= erlang:function_exported(?MODULE, TestCase, 0),
+        {Key, Val} ?= proplists:lookup(Key, ?MODULE:TestCase()),
+        Val
+    else
+        _ -> Default
+    end.
+
+reset_proxy() ->
+    emqx_common_test_helpers:reset_proxy(?PROXY_HOST, ?PROXY_PORT).
+
+with_failure(FailureType, Fn) ->
+    emqx_common_test_helpers:with_failure(FailureType, ?PROXY_NAME, ?PROXY_HOST, ?PROXY_PORT, Fn).
+
 sql_insert_template_for_bridge() ->
     "INSERT INTO mqtt_test(topic, msgid, payload, retain) VALUES (${topic}, ${id}, ${payload}, ${retain})".
 
@@ -198,8 +211,8 @@ sql_check_table_exist() ->
 
 new_jamdb_connection(Config) ->
     JamdbOpts = [
-        {host, ?config(oracle_host, Config)},
-        {port, ?config(oracle_port, Config)},
+        {host, get_config(oracle_host, Config, "toxiproxy.emqx.net")},
+        {port, get_config(oracle_port, Config, 1521)},
         {user, "system"},
         {password, "oracle"},
         {sid, ?SID}
@@ -231,728 +244,253 @@ drop_table_if_exists(Config) ->
     end,
     ok.
 
-oracle_config(TestCase, _ConnectionType, Config) ->
-    UniqueNum = integer_to_binary(erlang:unique_integer()),
-    OracleHost = ?config(oracle_host, Config),
-    OraclePort = ?config(oracle_port, Config),
-    Name = <<
-        (atom_to_binary(TestCase))/binary, UniqueNum/binary
-    >>,
-    ServerURL = iolist_to_binary([
-        OracleHost,
-        ":",
-        integer_to_binary(OraclePort)
-    ]),
-    ConfigString =
-        io_lib:format(
-            "bridges.oracle.~s {\n"
-            "  enable = true\n"
-            "  sid = \"~s\"\n"
-            "  server = \"~s\"\n"
-            "  username = \"system\"\n"
-            "  password = \"oracle\"\n"
-            "  pool_size = 1\n"
-            "  sql = \"~s\"\n"
-            "  resource_opts = {\n"
-            "     health_check_interval = \"15s\"\n"
-            "     request_ttl = \"30s\"\n"
-            "     query_mode = \"async\"\n"
-            "     batch_size = 3\n"
-            "     batch_time = \"3s\"\n"
-            "     worker_pool_size = 1\n"
-            "  }\n"
-            "}\n",
-            [
-                Name,
-                ?SID,
-                ServerURL,
-                sql_insert_template_for_bridge()
-            ]
-        ),
-    {Name, ConfigString, parse_and_check(ConfigString, Name)}.
-
-parse_and_check(ConfigString, Name) ->
-    {ok, RawConf} = hocon:binary(ConfigString, #{format => map}),
-    TypeBin = ?BRIDGE_TYPE_BIN,
-    hocon_tconf:check_plain(emqx_bridge_schema, RawConf, #{required => false, atom_key => false}),
-    #{<<"bridges">> := #{TypeBin := #{Name := Config}}} = RawConf,
-    Config.
-
-resource_id(Config) ->
-    Type = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    <<"connector:", Type/binary, ":", Name/binary>>.
-
-action_id(Config) ->
-    Type = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    id(Type, Name).
-
-bridge_id(Config) ->
-    Type = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    emqx_bridge_resource:bridge_id(Type, Name).
-
-create_bridge(Config) ->
-    create_bridge(Config, _Overrides = #{}).
-
-create_bridge(Config, Overrides) ->
-    Type = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    OracleConfig0 = ?config(oracle_config, Config),
-    OracleConfig = emqx_utils_maps:deep_merge(OracleConfig0, Overrides),
-    emqx_bridge_testlib:create_bridge_api(Type, Name, OracleConfig).
-
-create_bridge_api(Config) ->
-    create_bridge_api(Config, _Overrides = #{}).
-
-create_bridge_api(Config, Overrides) ->
-    TypeBin = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    OracleConfig0 = ?config(oracle_config, Config),
-    OracleConfig = emqx_utils_maps:deep_merge(OracleConfig0, Overrides),
-    Params = OracleConfig#{<<"type">> => TypeBin, <<"name">> => Name},
-    Path = emqx_mgmt_api_test_util:api_path(["bridges"]),
-    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
-    Opts = #{return_all => true},
-    ct:pal("creating bridge (via http): ~p", [Params]),
-    Res =
-        case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params, Opts) of
-            {ok, {Status, Headers, Body0}} ->
-                _ = emqx_bridge_v2_testlib:kickoff_action_health_check(TypeBin, Name),
-                {ok, {Status, Headers, emqx_utils_json:decode(Body0)}};
-            {error, {Status, Headers, Body0}} ->
-                {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
-            Error ->
-                Error
-        end,
-    ct:pal("bridge create result: ~p", [Res]),
-    Res.
-
-update_bridge_api(Config) ->
-    update_bridge_api(Config, _Overrides = #{}).
-
-update_bridge_api(Config, Overrides) ->
-    TypeBin = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    OracleConfig0 = ?config(oracle_config, Config),
-    OracleConfig = emqx_utils_maps:deep_merge(OracleConfig0, Overrides),
-    BridgeId = emqx_bridge_resource:bridge_id(TypeBin, Name),
-    Params = OracleConfig#{<<"type">> => TypeBin, <<"name">> => Name},
-    Path = emqx_mgmt_api_test_util:api_path(["bridges", BridgeId]),
-    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
-    Opts = #{return_all => true},
-    ct:pal("updating bridge (via http): ~p", [Params]),
-    Res =
-        case emqx_mgmt_api_test_util:request_api(put, Path, "", AuthHeader, Params, Opts) of
-            {ok, {_Status, _Headers, Body0}} ->
-                _ = emqx_bridge_v2_testlib:kickoff_action_health_check(TypeBin, Name),
-                {ok, emqx_utils_json:decode(Body0)};
-            Error ->
-                Error
-        end,
-    ct:pal("bridge update result: ~p", [Res]),
-    Res.
-
-probe_bridge_api(Config) ->
-    probe_bridge_api(Config, _Overrides = #{}).
-
-probe_bridge_api(Config, Overrides) ->
-    TypeBin = ?BRIDGE_TYPE_BIN,
-    Name = ?config(oracle_name, Config),
-    OracleConfig0 = ?config(oracle_config, Config),
-    OracleConfig = emqx_utils_maps:deep_merge(OracleConfig0, Overrides),
-    case emqx_bridge_testlib:probe_bridge_api(TypeBin, Name, OracleConfig) of
-        {ok, {{_, 204, _}, _Headers, _Body0} = Res0} ->
-            {ok, Res0};
-        {error, {Status, Headers, Body0}} ->
-            {error, {Status, Headers, emqx_bridge_testlib:try_decode_error(Body0)}};
-        Error ->
-            Error
+scan_table(TCConfig) ->
+    {ok, Conn} = new_jamdb_connection(TCConfig),
+    try
+        jamdb_oracle:sql_query(Conn, "select * from mqtt_test")
+    after
+        close_jamdb_connection(Conn)
     end.
 
-create_rule_and_action_http(Config) ->
-    OracleName = ?config(oracle_name, Config),
-    BridgeId = emqx_bridge_resource:bridge_id(?BRIDGE_TYPE_BIN, OracleName),
-    Params = #{
-        enable => true,
-        sql => <<"SELECT * FROM \"", ?RULE_TOPIC, "\"">>,
-        actions => [BridgeId]
-    },
-    Path = emqx_mgmt_api_test_util:api_path(["rules"]),
-    AuthHeader = emqx_mgmt_api_test_util:auth_header_(),
-    ct:pal("rule action params: ~p", [Params]),
-    case emqx_mgmt_api_test_util:request_api(post, Path, "", AuthHeader, Params) of
-        {ok, Res} -> {ok, emqx_utils_json:decode(Res)};
-        Error -> Error
-    end.
+probe_action_api(TCConfig, Overrides) ->
+    emqx_bridge_v2_testlib:simplify_result(
+        emqx_bridge_v2_testlib:probe_bridge_api(TCConfig, Overrides)
+    ).
 
-%% todo: messages should be sent via rules in tests...
-send_message(Type, Name, Msg, QueryOpts) ->
-    emqx_bridge_v2:send_message(?global_ns, Type, Name, Msg, QueryOpts).
+create_connector_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:create_connector_api2(Config, Overrides).
 
-health_check(Type, Name) ->
-    emqx_bridge_v2_testlib:force_health_check(#{
-        type => Type,
-        name => Name,
-        resource_namespace => ?global_ns,
-        kind => action
-    }).
+create_action_api(Config, Overrides) ->
+    emqx_bridge_v2_testlib:create_action_api2(Config, Overrides).
 
-id(Type, Name) ->
-    emqx_bridge_v2_testlib:lookup_chan_id_in_conf(#{
-        kind => action,
-        type => Type,
-        name => Name
-    }).
+get_action_api(TCConfig) ->
+    emqx_bridge_v2_testlib:get_action_api2(TCConfig).
+
+start_client() ->
+    {ok, C} = emqtt:start_link(),
+    on_exit(fun() -> emqtt:stop(C) end),
+    {ok, _} = emqtt:connect(C),
+    C.
+
+unique_payload() ->
+    integer_to_binary(erlang:unique_integer()).
+
+simple_create_rule_api(TCConfig) ->
+    emqx_bridge_v2_testlib:simple_create_rule_api(TCConfig).
 
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
 
-t_sync_query(Config) ->
-    ResourceId = resource_id(Config),
-    Name = ?config(oracle_name, Config),
-    ?check_trace(
-        begin
-            reset_table(Config),
-            ?assertMatch({ok, _}, create_bridge_api(Config)),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 20,
-                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-            ),
-            ?retry(
-                _Sleep1 = 1_000,
-                _Attempts1 = 30,
-                ?assertMatch(
-                    #{status := connected},
-                    health_check(
-                        ?BRIDGE_TYPE_BIN,
-                        Name
-                    )
-                )
-            ),
-            ActionId = action_id(Config),
-            MsgId = erlang:unique_integer(),
-            Params = #{
-                topic => ?config(mqtt_topic, Config),
-                id => MsgId,
-                payload => ?config(oracle_name, Config),
-                retain => true
-            },
-            Message = {ActionId, Params},
-            ?assertEqual(
-                {ok, [{affected_rows, 1}]}, emqx_resource:simple_sync_query(ResourceId, Message)
-            ),
-            ok
-        end,
-        []
-    ),
-    ok.
+t_start_stop(TCConfig) when is_list(TCConfig) ->
+    emqx_bridge_v2_testlib:t_start_stop(TCConfig, oracle_bridge_stopped).
 
-t_batch_sync_query(Config) ->
-    ProxyPort = ?config(proxy_port, Config),
-    ProxyHost = ?config(proxy_host, Config),
-    ProxyName = ?config(proxy_name, Config),
-    ResourceId = resource_id(Config),
-    Name = ?config(oracle_name, Config),
-    ?check_trace(
-        begin
-            reset_table(Config),
-            ?assertMatch({ok, _}, create_bridge_api(Config)),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 30,
-                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-            ),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 30,
-                ?assertMatch(
-                    #{status := connected},
-                    health_check(
-                        ?BRIDGE_TYPE_BIN,
-                        Name
-                    )
-                )
-            ),
-            MsgId = erlang:unique_integer(),
-            Params = #{
-                topic => ?config(mqtt_topic, Config),
-                id => MsgId,
-                payload => ?config(oracle_name, Config),
-                retain => false
-            },
-            % Send 3 async messages while resource is down. When it comes back, these messages
-            % will be delivered in sync way. If we try to send sync messages directly, it will
-            % be sent async as callback_mode is set to async_if_possible.
-            emqx_common_test_helpers:with_failure(down, ProxyName, ProxyHost, ProxyPort, fun() ->
-                ct:sleep(1000),
-                send_message(?BRIDGE_TYPE_BIN, Name, Params, #{}),
-                send_message(?BRIDGE_TYPE_BIN, Name, Params, #{}),
-                send_message(?BRIDGE_TYPE_BIN, Name, Params, #{}),
-                ok
-            end),
-            % Wait for reconnection.
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 30,
-                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-            ),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 30,
-                ?assertMatch(
-                    #{status := connected},
-                    health_check(
-                        ?BRIDGE_TYPE_BIN,
-                        Name
-                    )
-                )
-            ),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 30,
-                ?assertMatch(
-                    {ok, [{result_set, _, _, [[{3}]]}]},
-                    emqx_resource:simple_sync_query(
-                        ResourceId, {query, "SELECT COUNT(*) FROM mqtt_test"}
-                    )
-                )
-            ),
-            ok
-        end,
-        []
-    ),
-    ok.
+t_on_get_status(TCConfig) when is_list(TCConfig) ->
+    emqx_bridge_v2_testlib:t_on_get_status(TCConfig).
 
-t_create_via_http(Config) ->
-    ?check_trace(
-        begin
-            ?assertMatch({ok, _}, create_bridge_api(Config)),
-
-            %% lightweight matrix testing some configs
+t_rule_action() ->
+    [{matrix, true}].
+t_rule_action(matrix) ->
+    [[?without_batch], [?with_batch]];
+t_rule_action(TCConfig) when is_list(TCConfig) ->
+    PostPublishFn = fun(Context) ->
+        #{payload := Payload} = Context,
+        PayloadStr = str(Payload),
+        ?retry(
+            200,
+            20,
             ?assertMatch(
-                {ok, _},
-                update_bridge_api(
-                    Config,
-                    #{
-                        <<"resource_opts">> =>
-                            #{<<"batch_size">> => 4}
-                    }
-                )
-            ),
-            ?assertMatch(
-                {ok, _},
-                update_bridge_api(
-                    Config,
-                    #{
-                        <<"resource_opts">> =>
-                            #{<<"batch_time">> => <<"4s">>}
-                    }
-                )
-            ),
-            ok
-        end,
-        []
-    ),
-    ResourceId = resource_id(Config),
-    ?assertMatch(1, length(ecpool:workers(ResourceId))),
-    ok.
-
-t_start_stop(Config) ->
-    OracleName = ?config(oracle_name, Config),
-    ResourceId = resource_id(Config),
-    ?check_trace(
-        begin
-            reset_table(Config),
-            ?assertMatch({ok, _}, create_bridge(Config)),
-            %% Since the connection process is async, we give it some time to
-            %% stabilize and avoid flakiness.
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 20,
-                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-            ),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 20,
-                ?assertMatch(
-                    #{status := connected},
-                    health_check(
-                        ?BRIDGE_TYPE_BIN,
-                        OracleName
-                    )
-                )
-            ),
-
-            %% Check that the bridge probe API doesn't leak atoms.
-            ProbeRes0 = probe_bridge_api(
-                Config,
-                #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}}
-            ),
-            ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0),
-            AtomsBefore = erlang:system_info(atom_count),
-            %% Probe again; shouldn't have created more atoms.
-            ProbeRes1 = probe_bridge_api(
-                Config,
-                #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}}
-            ),
-
-            ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes1),
-            AtomsAfter = erlang:system_info(atom_count),
-            ?assertEqual(AtomsBefore, AtomsAfter),
-
-            %% Now stop the bridge.
-            ?assertMatch(
-                {{ok, _}, {ok, _}},
-                ?wait_async_action(
-                    emqx_bridge:disable_enable(disable, ?BRIDGE_TYPE_BIN, OracleName),
-                    #{?snk_kind := oracle_bridge_stopped},
-                    5_000
-                )
-            ),
-
-            ok
-        end,
-        fun(Trace) ->
-            %% one for each probe, one for real
-            ?assertMatch([_, _, _], ?of_kind(oracle_bridge_stopped, Trace)),
-            ok
-        end
-    ),
-    ok.
-
-t_probe_with_nested_tokens(Config) ->
-    ProbeRes0 = probe_bridge_api(
-        Config,
-        #{<<"sql">> => sql_insert_template_with_nested_token_for_bridge()}
-    ),
-    ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0).
-
-t_probe_with_large_value(Config) ->
-    ProbeRes0 = probe_bridge_api(
-        Config,
-        #{<<"sql">> => sql_insert_template_with_large_value()}
-    ),
-    ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0).
-
-t_message_with_nested_tokens(Config) ->
-    BridgeId = bridge_id(Config),
-    ResourceId = resource_id(Config),
-    Name = ?config(oracle_name, Config),
-    reset_table(Config),
-    ?assertMatch(
-        {ok, _},
-        create_bridge(Config, #{
-            <<"sql">> => sql_insert_template_with_nested_token_for_bridge()
-        })
-    ),
-    %% Since the connection process is async, we give it some time to
-    %% stabilize and avoid flakiness.
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-    ),
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertMatch(
-            #{status := connected},
-            health_check(
-                ?BRIDGE_TYPE_BIN,
-                Name
+                {ok, [{result_set, _ColNames, _, [[_, _MsgId, PayloadStr, _]]}]},
+                scan_table(TCConfig),
+                #{payload => Payload}
             )
         )
-    ),
-    MsgId = erlang:unique_integer(),
-    Data = binary_to_list(?config(oracle_name, Config)),
-    Params = #{
-        topic => ?config(mqtt_topic, Config),
-        id => MsgId,
-        payload => emqx_utils_json:encode(#{<<"msg">> => Data}),
-        retain => false
+    end,
+    Opts = #{
+        post_publish_fn => PostPublishFn
     },
-    emqx_bridge:send_message(BridgeId, Params),
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertMatch(
-            {ok, [{result_set, [<<"PAYLOAD">>], _, [[Data]]}]},
-            emqx_resource:simple_sync_query(
-                ResourceId, {query, "SELECT payload FROM mqtt_test"}
-            )
-        )
-    ),
-    ok.
+    emqx_bridge_v2_testlib:t_rule_action(TCConfig, Opts).
 
-t_message_with_null_value(Config) ->
-    BridgeId = bridge_id(Config),
-    ResourceId = resource_id(Config),
-    Name = ?config(oracle_name, Config),
-    reset_table(Config),
-    ?assertMatch(
-        {ok, _},
-        create_bridge(Config, #{
-            <<"sql">> => sql_insert_template_with_null_value()
-        })
-    ),
-    %% Since the connection process is async, we give it some time to
-    %% stabilize and avoid flakiness.
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-    ),
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertMatch(
-            #{status := connected},
-            health_check(
-                ?BRIDGE_TYPE_BIN,
-                Name
-            )
-        )
-    ),
-    MsgId = erlang:unique_integer(),
-    %% no nullkey in payload
-    Params = #{
-        topic => ?config(mqtt_topic, Config),
-        id => MsgId,
-        payload => emqx_utils_json:encode(#{}),
-        retain => false
-    },
-    emqx_bridge:send_message(BridgeId, Params),
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertMatch(
-            {ok, [{result_set, [<<"PAYLOAD">>], _, [[null]]}]},
-            emqx_resource:simple_sync_query(
-                ResourceId, {query, "SELECT payload FROM mqtt_test"}
-            )
-        )
-    ),
-    ok.
-
-t_probe_with_inconsistent_datatype(Config) ->
-    ProbeRes0 = probe_bridge_api(
-        Config,
-        #{<<"sql">> => sql_insert_template_with_inconsistent_datatype()}
-    ),
-    ?assertMatch({ok, {{_, 204, _}, _Headers, _Body}}, ProbeRes0).
-
-t_on_get_status(Config) ->
-    ProxyPort = ?config(proxy_port, Config),
-    ProxyHost = ?config(proxy_host, Config),
-    ProxyName = ?config(proxy_name, Config),
-    Name = ?config(oracle_name, Config),
-    ResourceId = resource_id(Config),
-    reset_table(Config),
-    ?assertMatch({ok, _}, create_bridge(Config)),
-    %% Since the connection process is async, we give it some time to
-    %% stabilize and avoid flakiness.
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-    ),
-    emqx_common_test_helpers:with_failure(down, ProxyName, ProxyHost, ProxyPort, fun() ->
-        ct:sleep(500),
-        ?assertEqual({ok, disconnected}, emqx_resource_manager:health_check(ResourceId)),
-        ?assertMatch(
-            #{status := disconnected},
-            health_check(?BRIDGE_TYPE_BIN, Name)
-        )
-    end),
-    %% Check that it recovers itself.
-    ?retry(
-        _Sleep = 1_000,
-        _Attempts = 20,
-        begin
-            ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId)),
-            ?assertMatch(
-                #{status := connected},
-                health_check(?BRIDGE_TYPE_BIN, Name)
-            )
-        end
-    ),
-    ok.
-
-t_no_sid_nor_service_name(Config0) ->
-    OracleConfig0 = ?config(oracle_config, Config0),
-    OracleConfig1 = maps:remove(<<"sid">>, OracleConfig0),
-    OracleConfig = maps:remove(<<"service_name">>, OracleConfig1),
-    NewOracleConfig = {oracle_config, OracleConfig},
-    Config = lists:keyreplace(oracle_config, 1, Config0, NewOracleConfig),
-    ?assertMatch(
-        {error,
-            {{_, 400, _}, _, #{
-                <<"message">> := #{
-                    <<"kind">> := <<"validation_error">>,
-                    <<"reason">> := <<"neither SID nor Service Name was set">>,
-                    %% should be censored as it contains secrets
-                    <<"value">> := #{<<"password">> := <<"******">>}
-                }
-            }}},
-        create_bridge_api(Config)
-    ),
-    ?assertMatch(
-        {error,
-            {{_, 400, _}, _, #{
-                <<"message">> := #{
-                    <<"kind">> := <<"validation_error">>,
-                    <<"reason">> := <<"neither SID nor Service Name was set">>,
-                    %% should be censored as it contains secrets
-                    <<"value">> := #{<<"password">> := <<"******">>}
-                }
-            }}},
-        probe_bridge_api(Config)
-    ),
-    ok.
-
-t_missing_table(Config) ->
-    Name = ?config(bridge_name, Config),
-    ?check_trace(
-        begin
-            drop_table_if_exists(Config),
-            ct:sleep(500),
-            ?assertMatch(
-                {ok, _},
-                create_bridge_api(
-                    Config,
-                    #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}}
-                )
-            ),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 20,
-                ?assertMatch(
-                    {ok, #{
-                        <<"status">> := <<"disconnected">>,
-                        <<"status_reason">> := <<"{unhealthy_target,", _/binary>>
-                    }},
-                    emqx_bridge_testlib:get_bridge_api(Config)
-                )
-            ),
-            MsgId = erlang:unique_integer(),
-            Params = #{
-                topic => ?config(mqtt_topic, Config),
-                id => MsgId,
-                payload => ?config(oracle_name, Config),
-                retain => true
-            },
-            ?assertMatch(
-                {error, {resource_error, #{reason := unhealthy_target}}},
-                send_message(?BRIDGE_TYPE_BIN, Name, Params, _QueryOpts = #{})
-            ),
-            ok
-        end,
-        []
-    ).
-
-t_table_removed(Config) ->
-    ResourceId = resource_id(Config),
-    ?check_trace(
-        begin
-            reset_table(Config),
-            ?assertMatch({ok, _}, create_bridge_api(Config)),
-            ActionId = id(?BRIDGE_TYPE_BIN, ?config(oracle_name, Config)),
-            ?retry(
-                _Sleep = 1_000,
-                _Attempts = 20,
-                ?assertEqual({ok, connected}, emqx_resource_manager:health_check(ResourceId))
-            ),
-            drop_table_if_exists(Config),
-            MsgId = erlang:unique_integer(),
-            Params = #{
-                topic => ?config(mqtt_topic, Config),
-                id => MsgId,
-                payload => ?config(oracle_name, Config),
-                retain => true
-            },
-            Message = {ActionId, Params},
-            %% Sometimes, this may fail with "ORA-01013: user requested cancel of current
-            %% operation", probably due to unknown race condition.
-            ?retry(
-                200,
-                10,
-                ?assertEqual(
-                    {error,
-                        {unrecoverable_error, {942, "ORA-00942: table or view does not exist\n"}}},
-                    emqx_resource:simple_sync_query(ResourceId, Message)
-                )
-            ),
-            ok
-        end,
-        []
-    ),
-    ok.
-
-t_update_with_invalid_prepare(Config) ->
-    reset_table(Config),
-
-    {ok, _} = create_bridge_api(
-        Config,
-        #{<<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}}
-    ),
-
-    %% retainx is a bad column name
-    BadSQL =
-        <<"INSERT INTO mqtt_test(topic, msgid, payload, retainx) VALUES (${topic}, ${id}, ${payload}, ${retain})">>,
-
-    Override = #{
-        <<"sql">> => BadSQL,
-        <<"resource_opts">> => #{<<"health_check_interval">> => <<"1s">>}
-    },
-    {ok, _} = update_bridge_api(Config, Override),
-
-    ?retry(
-        1_000,
-        20,
-        begin
-            {ok, Body1} = emqx_bridge_testlib:get_bridge_api(Config),
-            ?assertMatch(#{<<"status_reason">> := _, <<"status">> := <<"disconnected">>}, Body1),
-            Error1 = maps:get(<<"status_reason">>, Body1),
-            case re:run(Error1, <<"unhealthy_target">>, [{capture, none}]) of
+t_update_with_invalid_prepare(TCConfig) ->
+    Opts = #{
+        bad_sql =>
+            %% retainx is a bad column name
+            <<
+                "INSERT INTO mqtt_test(topic, msgid, payload, retainx) "
+                "VALUES (${topic}, ${id}, ${payload}, ${retain})"
+            >>,
+        reconnect_cb => {emqx_oracle, prepare_sql_to_conn},
+        get_sig_fn => fun emqx_postgresql:get_reconnect_callback_signature/1,
+        check_expected_error_fn => fun(Error) ->
+            case re:run(Error, <<"unhealthy_target">>, [{capture, none}]) of
                 match ->
                     ok;
                 nomatch ->
                     ct:fail(#{
                         expected_pattern => "undefined_column",
-                        got => Error1
+                        got => Error
                     })
             end
         end
+    },
+    emqx_bridge_v2_testlib:t_update_with_invalid_prepare(TCConfig, Opts),
+    ok.
+
+t_probe_with_nested_tokens(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    ?assertMatch(
+        {204, _},
+        probe_action_api(
+            TCConfig,
+            #{
+                <<"parameters">> => #{
+                    <<"sql">> => sql_insert_template_with_nested_token_for_bridge()
+                }
+            }
+        )
+    ).
+
+t_probe_with_large_value(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    ?assertMatch(
+        {204, _},
+        probe_action_api(
+            TCConfig,
+            #{<<"parameters">> => #{<<"sql">> => sql_insert_template_with_large_value()}}
+        )
+    ).
+
+t_probe_with_inconsistent_datatype(TCConfig) ->
+    {201, _} = create_connector_api(TCConfig, #{}),
+    ?assertMatch(
+        {204, _},
+        probe_action_api(
+            TCConfig,
+            #{<<"parameters">> => #{<<"sql">> => sql_insert_template_with_inconsistent_datatype()}}
+        )
+    ).
+
+t_no_sid_nor_service_name(TCConfig0) ->
+    TCConfig = emqx_bridge_v2_testlib:proplist_update(
+        TCConfig0,
+        connector_config,
+        fun(Cfg0) ->
+            {_, Cfg} = maps:take(<<"sid">>, Cfg0),
+            Cfg
+        end
     ),
+    ?assertMatch(
+        {400, #{
+            <<"message">> := #{
+                <<"kind">> := <<"validation_error">>,
+                <<"reason">> := <<"neither SID nor Service Name was set">>,
+                %% should be censored as it contains secrets
+                <<"value">> := #{<<"password">> := <<"******">>}
+            }
+        }},
+        create_connector_api(TCConfig, #{})
+    ),
+    ?assertMatch(
+        {400, #{
+            <<"message">> := #{
+                <<"kind">> := <<"validation_error">>,
+                <<"reason">> := <<"neither SID nor Service Name was set">>,
+                %% should be censored as it contains secrets
+                <<"value">> := #{<<"password">> := <<"******">>}
+            }
+        }},
+        emqx_bridge_v2_testlib:probe_connector_api2(TCConfig, #{})
+    ),
+    ok.
 
-    %% assert that although there was an error returned, the invliad SQL is actually put
-    BridgeName = ?config(oracle_name, Config),
-    C1 = [{action_name, BridgeName}, {action_type, oracle} | Config],
-    {ok, {{_, 200, "OK"}, _, Action}} = emqx_bridge_v2_testlib:get_action_api(C1),
-    #{<<"parameters">> := #{<<"sql">> := FetchedSQL}} = Action,
-    ?assertEqual(FetchedSQL, BadSQL),
-
-    %% update again with the original sql
-    {ok, _} = update_bridge_api(Config),
-    {ok, Body2} = emqx_bridge_testlib:get_bridge_api(Config),
-    %% the error should be gone now, and status should be 'connected'
-    ?assertMatch(#{<<"status">> := <<"connected">>}, Body2),
-    %% finally check if ecpool worker should have exactly one of reconnect callback
-    ConnectorResId = <<"connector:oracle:", BridgeName/binary>>,
-    Workers = ecpool:workers(ConnectorResId),
-    [_ | _] = WorkerPids = lists:map(fun({_, Pid}) -> Pid end, Workers),
-    lists:foreach(
-        fun(Pid) ->
-            [{emqx_oracle, prepare_sql_to_conn, Args}] =
-                ecpool_worker:get_reconnect_callbacks(Pid),
-            Sig = emqx_postgresql:get_reconnect_callback_signature(Args),
-            BridgeResId = <<"action:oracle:", BridgeName/binary, $:, ConnectorResId/binary>>,
-            ?assertEqual(BridgeResId, Sig)
+t_table_removed(TCConfig) ->
+    ?check_trace(
+        begin
+            {201, _} = create_connector_api(TCConfig, #{}),
+            {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{}),
+            #{topic := Topic} = simple_create_rule_api(TCConfig),
+            C = start_client(),
+            ct:pal("dropping table"),
+            drop_table_if_exists(TCConfig),
+            Payload = unique_payload(),
+            ct:pal("sending query"),
+            {_, {ok, Event}} =
+                ?wait_async_action(
+                    emqtt:publish(C, Topic, Payload, [{qos, 1}]),
+                    #{?snk_kind := buffer_worker_flush_ack},
+                    15_000
+                ),
+            ?assertMatch(
+                #{result := {error, {unrecoverable_error, _}}},
+                Event
+            ),
+            ok
         end,
-        WorkerPids
+        []
+    ),
+    ok.
+
+t_missing_table(TCConfig) ->
+    ?check_trace(
+        begin
+            drop_table_if_exists(TCConfig),
+            {201, _} = create_connector_api(TCConfig, #{}),
+            {201, _} = create_action_api(TCConfig, #{}),
+            ?retry(
+                _Sleep = 1_000,
+                _Attempts = 20,
+                ?assertMatch(
+                    {200, #{
+                        <<"status">> := Status,
+                        <<"status_reason">> := <<"{unhealthy_target,", _/binary>>
+                    }} when
+                        Status == <<"connecting">> orelse Status == <<"disconnected">>,
+                    get_action_api(TCConfig)
+                )
+            ),
+            ok
+        end,
+        []
+    ),
+    ok.
+
+t_message_with_null_value(TCConfig) ->
+    reset_table(TCConfig),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{<<"sql">> => sql_insert_template_with_null_value()}
+    }),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    %% no nullkey in payload
+    Payload = emqx_utils_json:encode(#{}),
+    emqtt:publish(C, Topic, Payload),
+    ?retry(
+        _Sleep = 200,
+        _Attempts = 20,
+        ?assertMatch(
+            {ok, [{result_set, _, _, [[_, _, null, _]]}]},
+            scan_table(TCConfig)
+        )
+    ),
+    ok.
+
+t_message_with_nested_tokens(TCConfig) ->
+    reset_table(TCConfig),
+    {201, _} = create_connector_api(TCConfig, #{}),
+    {201, #{<<"status">> := <<"connected">>}} = create_action_api(TCConfig, #{
+        <<"parameters">> => #{<<"sql">> => sql_insert_template_with_nested_token_for_bridge()}
+    }),
+    #{topic := Topic} = simple_create_rule_api(TCConfig),
+    C = start_client(),
+    Payload = emqx_utils_json:encode(#{<<"msg">> => <<"hello">>}),
+    emqtt:publish(C, Topic, Payload),
+    ?retry(
+        _Sleep = 200,
+        _Attempts = 20,
+        ?assertMatch(
+            {ok, [{result_set, _, _, [[_, _, "hello", _]]}]},
+            scan_table(TCConfig)
+        )
     ),
     ok.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14606

**N.B.**: this <ins>**does not introduce new test cases**</ins>, only refactors existing suites to adhere to a more standardized way to test bridges that use the test library and uses HTTP APIs as much as possible, and at the same time stop using bridges V1 APIs so we may drop it.

<!--
5.8.8
5.9.2
6.0.0
-->
Release version: 6.0.0


## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
