### PR TITLE
feat(limiter): do not refill from burst capacity on regular consume

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_exclusive.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_exclusive.erl
@@ -123,12 +123,12 @@ try_consume_regular(#{last_time := LastTime} = State0, #{interval := Interval}, 
     {false, State0};
 try_consume_regular(
     #{last_time := LastTime, tokens := Tokens0} = State0,
-    #{capacity := Capacity, burst_capacity := BurstCapacity, interval := Interval},
+    #{capacity := Capacity, interval := Interval},
     Amount,
     Now
 ) ->
     Inc = Capacity * (Now - LastTime) / Interval,
-    Tokens = erlang:min(Capacity + BurstCapacity, Tokens0 + Inc),
+    Tokens = erlang:min(Capacity, Tokens0 + Inc),
     State1 = State0#{last_time := Now, tokens := Tokens},
     case Tokens >= Amount of
         true ->


### PR DESCRIPTION
Part of [EMQX-14610](https://emqx.atlassian.net/browse/EMQX-14610).

Release version: 6.0.0

## Summary

See individual commits.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14610]: https://emqx.atlassian.net/browse/EMQX-14610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ