### PR TITLE
ci: rename runner macos-14-arm64 to macos-14

### DIFF
--- a/.github/workflows/build_packages_cron.yaml
+++ b/.github/workflows/build_packages_cron.yaml
@@ -81,7 +81,7 @@ jobs:
           - master
           - release-58
         os:
-          - macos-14-arm64
+          - macos-14
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/build_slim_packages.yaml
+++ b/.github/workflows/build_slim_packages.yaml
@@ -55,7 +55,7 @@ jobs:
         profile:
         - emqx
         os:
-        - macos-14-arm64
+        - macos-14
 
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
macos-14-arm64 is self-hosted runner. now we can use github hosted runner for macos-14.
