### PR TITLE
feat: support specifying `clientid_override` in authn results

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2317,8 +2317,14 @@ merge_auth_result(ClientInfo0, AuthResult0) when is_map(ClientInfo0) andalso is_
     ClientIdOverride = maps:get(clientid_override, AuthResult0, undefined),
     ClientInfo =
         case is_binary(ClientIdOverride) andalso ClientIdOverride /= <<"">> of
-            true -> ClientInfo0#{clientid => ClientIdOverride};
-            false -> ClientInfo0
+            true ->
+                ?TRACE("MQTT", "clientid_overridden_by_authn", #{
+                    clientid => ClientIdOverride,
+                    original_clientid => maps:get(clientid, ClientInfo0, undefined)
+                }),
+                ClientInfo0#{clientid => ClientIdOverride};
+            false ->
+                ClientInfo0
         end,
     maps:merge(
         ClientInfo#{client_attrs => Attrs},

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2247,7 +2247,8 @@ authentication_pipeline(Credential, Channel) ->
             fun do_authenticate/2,
             fun fix_mountpoint/2,
             %% We call `set_log_meta' again here because authentication may have injected
-            %% different attributes.
+            %% different attributes.  Note that `clientid` might have changed as well, if
+            %% authentication returned a non-empty `clientid_override` value.
             fun set_log_meta/2,
             fun adjust_limiter/2
         ]

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_utils.erl
@@ -19,6 +19,7 @@
     parse_sql/2,
     is_superuser/1,
     client_attrs/1,
+    clientid_override/1,
     bin/1,
     ensure_apps_started/1,
     cleanup_resources/0,
@@ -131,6 +132,13 @@ client_attrs(#{<<"client_attrs">> := Attrs}) ->
     #{client_attrs => drop_invalid_attr(Attrs)};
 client_attrs(_) ->
     #{client_attrs => #{}}.
+
+clientid_override(#{<<"clientid_override">> := Value}) when
+    is_binary(Value) andalso Value /= <<"">>
+->
+    #{clientid_override => Value};
+clientid_override(_) ->
+    #{}.
 
 drop_invalid_attr(Map) when is_map(Map) ->
     maps:from_list(do_drop_invalid_attr(maps:to_list(Map))).

--- a/apps/emqx_auth_http/src/emqx_authn_http.erl
+++ b/apps/emqx_auth_http/src/emqx_authn_http.erl
@@ -224,7 +224,8 @@ extract_auth_data(Source, Body) ->
     try
         ExpireAt = expire_at(Body),
         ACL = acl(ExpireAt, Source, Body),
-        Result = merge_maps([ExpireAt, IsSuperuser, ACL, Attrs]),
+        ClientIdOverride = clientid_override(Body),
+        Result = merge_maps([ExpireAt, IsSuperuser, ACL, ClientIdOverride, Attrs]),
         {ok, Result}
     catch
         throw:{bad_acl_rule, Reason} ->
@@ -292,6 +293,13 @@ acl(_NoExpire, Source, #{<<"acl">> := Rules}) ->
         }
     };
 acl(_, _, _) ->
+    #{}.
+
+clientid_override(#{<<"clientid_override">> := ClientIdOverride} = _Body) when
+    is_binary(ClientIdOverride)
+->
+    #{clientid_override => ClientIdOverride};
+clientid_override(_Body) ->
     #{}.
 
 safely_parse_body(ContentType, Body) ->

--- a/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
+++ b/apps/emqx_auth_jwt/src/emqx_authn_jwt.erl
@@ -263,9 +263,10 @@ extra_to_auth_data(Extra, JWT, AclClaimName, DisconnectAfterExpire) ->
     IsSuperuser = emqx_authn_utils:is_superuser(Extra),
     Attrs = emqx_authn_utils:client_attrs(Extra),
     ExpireAt = expire_at(DisconnectAfterExpire, Extra),
+    ClientIdOverride = emqx_authn_utils:clientid_override(Extra),
     try
         ACL = acl(Extra, AclClaimName),
-        Result = merge_maps([ExpireAt, IsSuperuser, ACL, Attrs]),
+        Result = merge_maps([ExpireAt, IsSuperuser, ACL, Attrs, ClientIdOverride]),
         {ok, Result}
     catch
         throw:{bad_acl_rule, Reason} ->

--- a/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
+++ b/apps/emqx_auth_jwt/test/emqx_authn_jwt_SUITE.erl
@@ -858,6 +858,38 @@ t_schema(_Config) ->
         check_schema(<<"val">>)
     ).
 
+-doc """
+Checks that, if an authentication backend returns the `clientid_override` attribute, it's
+used to override.
+""".
+t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    OverriddenClientId = <<"overridden_clientid">>,
+    Username = <<"overriden_clientid">>,
+    Secret = <<"secret">>,
+    Payload = #{
+        <<"username">> => Username,
+        <<"clientid_override">> => OverriddenClientId
+    },
+    Password = generate_jws('hmac-based', Payload, <<"secret">>),
+    MkConfigFn = fun() ->
+        #{
+            <<"mechanism">> => <<"jwt">>,
+            <<"use_jwks">> => false,
+            <<"algorithm">> => <<"hmac-based">>,
+            <<"secret">> => Secret
+        }
+    end,
+    Opts = #{
+        client_opts => #{
+            username => Username,
+            password => Password
+        },
+        mk_config_fn => MkConfigFn,
+        overridden_clientid => OverriddenClientId
+    },
+    emqx_authn_test_lib:t_clientid_override(TCConfig, Opts),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap_schema.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap_schema.erl
@@ -45,12 +45,14 @@ fields(hash_method) ->
     [
         {type, method_type(hash)},
         {password_attribute, password_attribute()},
-        {is_superuser_attribute, is_superuser_attribute()}
+        {is_superuser_attribute, is_superuser_attribute()},
+        {clientid_override_attribute, clientid_override_attribute()}
     ];
 fields(bind_method) ->
     [
         {type, method_type(bind)},
         {is_superuser_attribute, is_superuser_attribute()},
+        {clientid_override_attribute, clientid_override_attribute()},
         {bind_password,
             ?HOCON(
                 binary(),
@@ -156,6 +158,15 @@ is_superuser_attribute() ->
         #{
             desc => ?DESC(?FUNCTION_NAME),
             default => <<"isSuperuser">>
+        }
+    ).
+
+clientid_override_attribute() ->
+    ?HOCON(
+        string(),
+        #{
+            desc => ?DESC(?FUNCTION_NAME),
+            default => <<"clientIdOverride">>
         }
     ).
 

--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_SUITE.erl
@@ -314,6 +314,34 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHN_CACHE)
     ).
 
+-doc """
+Checks that, if an authentication backend returns the `clientid_override` attribute, it's
+used to override.
+""".
+t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    OverriddenClientId = <<"overridden_clientid">>,
+    Username = <<"mqttuser0010">>,
+    Password = <<"mqttuser0010">>,
+    MkConfigFn = fun() ->
+        maps:merge(raw_ldap_auth_config(), #{
+            <<"base_dn">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
+            <<"method">> => #{
+                <<"type">> => <<"hash">>,
+                <<"clientid_override_attribute">> => <<"clientIdOverride">>
+            }
+        })
+    end,
+    Opts = #{
+        client_opts => #{
+            username => Username,
+            password => Password
+        },
+        mk_config_fn => MkConfigFn,
+        overridden_clientid => OverriddenClientId
+    },
+    emqx_authn_test_lib:t_clientid_override(TCConfig, Opts),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
+++ b/apps/emqx_auth_ldap/test/emqx_authn_ldap_bind_SUITE.erl
@@ -293,6 +293,35 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHN_CACHE)
     ).
 
+-doc """
+Checks that, if an authentication backend returns the `clientid_override` attribute, it's
+used to override.
+""".
+t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    OverriddenClientId = <<"overridden_clientid">>,
+    Username = <<"mqttuser0010">>,
+    Password = <<"mqttuser0010">>,
+    MkConfigFn = fun() ->
+        maps:merge(raw_ldap_auth_config(), #{
+            <<"base_dn">> => <<"uid=${username},ou=testdevice,dc=emqx,dc=io">>,
+            <<"method">> => #{
+                <<"type">> => <<"bind">>,
+                <<"bind_password">> => <<"${password}">>,
+                <<"clientid_override_attribute">> => <<"clientIdOverride">>
+            }
+        })
+    end,
+    Opts = #{
+        client_opts => #{
+            username => Username,
+            password => Password
+        },
+        mk_config_fn => MkConfigFn,
+        overridden_clientid => OverriddenClientId
+    },
+    emqx_authn_test_lib:t_clientid_override(TCConfig, Opts),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb_schema.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb_schema.erl
@@ -77,6 +77,7 @@ common_fields() ->
         {password_hash_field, fun password_hash_field/1},
         {salt_field, fun salt_field/1},
         {is_superuser_field, fun is_superuser_field/1},
+        {clientid_override_field, fun clientid_override_field/1},
         {password_hash_algorithm, fun emqx_authn_password_hashing:type_ro/1}
     ] ++ emqx_authn_schema:common_fields().
 
@@ -113,3 +114,9 @@ is_superuser_field(desc) -> ?DESC(?FUNCTION_NAME);
 is_superuser_field(required) -> false;
 is_superuser_field(default) -> <<"is_superuser">>;
 is_superuser_field(_) -> undefined.
+
+clientid_override_field(type) -> binary();
+clientid_override_field(desc) -> ?DESC(?FUNCTION_NAME);
+clientid_override_field(required) -> false;
+clientid_override_field(default) -> <<"clientid_override">>;
+clientid_override_field(_) -> undefined.

--- a/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
+++ b/apps/emqx_auth_mongodb/test/emqx_authn_mongodb_SUITE.erl
@@ -285,6 +285,37 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHN_CACHE)
     ).
 
+-doc """
+Checks that, if an authentication backend returns the `clientid_override` attribute, it's
+used to override.
+""".
+t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    OverriddenClientId = <<"overridden_clientid">>,
+    Username = <<"overriden_clientid">>,
+    Password = <<"password">>,
+    MkConfigFn = fun() ->
+        ok = create_user(#{
+            username => Username,
+            password_hash => Password,
+            salt => <<"">>,
+            clientid_override => OverriddenClientId
+        }),
+        maps:merge(
+            raw_mongo_auth_config(),
+            #{<<"clientid_override_field">> => <<"clientid_override">>}
+        )
+    end,
+    Opts = #{
+        client_opts => #{
+            username => Username,
+            password => Password
+        },
+        mk_config_fn => MkConfigFn,
+        overridden_clientid => OverriddenClientId
+    },
+    emqx_authn_test_lib:t_clientid_override(TCConfig, Opts),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -88,7 +88,7 @@ authenticate(
                 )
             of
                 ok ->
-                    {ok, emqx_authn_utils:is_superuser(Selected)};
+                    {ok, authn_result(Selected)};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -125,3 +125,12 @@ create_state(
         [query, query_timeout, password_hash_algorithm], Config
     ),
     {ok, ResourceConfig#{prepare_statement => #{?PREPARE_KEY => PrepareSql}}, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal functions
+%%------------------------------------------------------------------------------
+
+authn_result(Selected) ->
+    Res0 = emqx_authn_utils:is_superuser(Selected),
+    Res1 = emqx_authn_utils:clientid_override(Selected),
+    maps:merge(Res0, Res1).

--- a/apps/emqx_auth_mysql/test/emqx_authn_mysql_SUITE.erl
+++ b/apps/emqx_auth_mysql/test/emqx_authn_mysql_SUITE.erl
@@ -258,6 +258,45 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHN_CACHE)
     ).
 
+-doc """
+Checks that, if an authentication backend returns the `clientid_override` attribute, it's
+used to override.
+""".
+t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    OverriddenClientId = <<"overridden_clientid">>,
+    Username = <<"overriden_clientid">>,
+    Password = <<"password">>,
+    MkConfigFn = fun() ->
+        ok = create_user(#{
+            username => Username,
+            password_hash => Password,
+            salt => <<"">>,
+            clientid_override => OverriddenClientId
+        }),
+        maps:merge(
+            raw_mysql_auth_config(),
+            #{
+                <<"query">> =>
+                    iolist_to_binary([
+                        "SELECT ",
+                        ["'", OverriddenClientId, "' as clientid_override, "],
+                        "password_hash, salt FROM users ",
+                        "where username = ${username} LIMIT 1"
+                    ])
+            }
+        )
+    end,
+    Opts = #{
+        client_opts => #{
+            username => Username,
+            password => Password
+        },
+        mk_config_fn => MkConfigFn,
+        overridden_clientid => OverriddenClientId
+    },
+    emqx_authn_test_lib:t_clientid_override(TCConfig, Opts),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -93,7 +93,7 @@ authenticate(
                 )
             of
                 ok ->
-                    {ok, emqx_authn_utils:is_superuser(Selected)};
+                    {ok, authn_result(Selected)};
                 {error, Reason} ->
                     {error, Reason}
             end;
@@ -126,3 +126,12 @@ create_state(
         [query, password_hash_algorithm], Config
     ),
     {ok, ResourceConfig#{prepare_statement => #{ResourceId => Query}}, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal functions
+%%------------------------------------------------------------------------------
+
+authn_result(Selected) ->
+    Res0 = emqx_authn_utils:is_superuser(Selected),
+    Res1 = emqx_authn_utils:clientid_override(Selected),
+    maps:merge(Res0, Res1).

--- a/apps/emqx_auth_postgresql/test/emqx_authn_postgresql_SUITE.erl
+++ b/apps/emqx_auth_postgresql/test/emqx_authn_postgresql_SUITE.erl
@@ -361,6 +361,45 @@ t_node_cache(_Config) ->
         emqx_auth_cache:metrics(?AUTHN_CACHE)
     ).
 
+-doc """
+Checks that, if an authentication backend returns the `clientid_override` attribute, it's
+used to override.
+""".
+t_clientid_override(TCConfig) when is_list(TCConfig) ->
+    OverriddenClientId = <<"overridden_clientid">>,
+    Username = <<"overriden_clientid">>,
+    Password = <<"password">>,
+    MkConfigFn = fun() ->
+        ok = create_user(#{
+            username => Username,
+            password_hash => Password,
+            salt => <<"">>,
+            clientid_override => OverriddenClientId
+        }),
+        maps:merge(
+            raw_pgsql_auth_config(),
+            #{
+                <<"query">> =>
+                    iolist_to_binary([
+                        "SELECT ",
+                        ["'", OverriddenClientId, "' as clientid_override, "],
+                        "password_hash, salt FROM users ",
+                        "where username = ${username} LIMIT 1"
+                    ])
+            }
+        )
+    end,
+    Opts = #{
+        client_opts => #{
+            username => Username,
+            password => Password
+        },
+        mk_config_fn => MkConfigFn,
+        overridden_clientid => OverriddenClientId
+    },
+    emqx_authn_test_lib:t_clientid_override(TCConfig, Opts),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Helpers
 %%------------------------------------------------------------------------------

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -84,7 +84,7 @@ authenticate(
                         )
                     of
                         ok ->
-                            {ok, emqx_authn_utils:is_superuser(Selected)};
+                            {ok, authn_result(Selected)};
                         {error, _Reason} = Error ->
                             Error
                     end;
@@ -111,6 +111,11 @@ authenticate(
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
+
+authn_result(Selected) ->
+    Res0 = emqx_authn_utils:is_superuser(Selected),
+    Res1 = emqx_authn_utils:clientid_override(Selected),
+    maps:merge(Res0, Res1).
 
 create_state(
     ResourceId,
@@ -156,7 +161,13 @@ validate_cmd(Cmd) ->
         [
             not_empty,
             {command_name, [<<"hget">>, <<"hmget">>]},
-            {allowed_fields, [<<"password_hash">>, <<"password">>, <<"salt">>, <<"is_superuser">>]},
+            {allowed_fields, [
+                <<"password_hash">>,
+                <<"password">>,
+                <<"salt">>,
+                <<"is_superuser">>,
+                <<"clientid_override">>
+            ]},
             {required_field_one_of, [<<"password_hash">>, <<"password">>]}
         ],
         Cmd

--- a/apps/emqx_ldap/test/data/emqx.io.ldif
+++ b/apps/emqx_ldap/test/data/emqx.io.ldif
@@ -203,3 +203,18 @@ objectClass: dashboardUser
 uid: viewer2
 ugroup: group1
 userPassword: {SHA}SR0qZpf8pYKKAbn6ILFvX91JuQg=
+
+## create user=mqttuser0010,
+#         password=mqttuser0010,
+#         passhash={SHA}znSPP0hz/0QGs88iiEB4D8qnwOw=
+#         base64passhash=e1NIQX16blNQUDBoei8wUUdzODhpaUVCNEQ4cW53T3c9
+dn:uid=mqttuser0010,ou=testdevice,dc=emqx,dc=io
+objectClass: top
+objectClass: mqttUser
+objectClass: mqttDevice
+objectClass: mqttSecurity
+uid: mqttuser0010
+isEnabled: TRUE
+clientIdOverride: overridden_clientid
+mqttAccountName: user10
+userPassword:: e1NIQX16blNQUDBoei8wUUdzODhpaUVCNEQ4cW53T3c9

--- a/apps/emqx_ldap/test/data/emqx.schema
+++ b/apps/emqx_ldap/test/data/emqx.schema
@@ -15,6 +15,13 @@ attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.1.4 NAME 'isSuperuser'
 	SINGLE-VALUE
 	USAGE userApplications )
 
+attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.1.5 NAME 'clientIdOverride'
+	EQUALITY caseExactMatch
+	SUBSTR caseExactSubstringsMatch
+	SYNTAX 1.3.6.1.4.1.1466.115.121.1.15
+	SINGLE-VALUE
+	USAGE userApplications )
+
 attributetype ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4.1 NAME ( 'mqttPublishTopic' 'mpt' )
 	EQUALITY caseExactMatch
 	SUBSTR caseExactSubstringsMatch
@@ -66,7 +73,7 @@ objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.3 NAME 'mqttSecurity'
 
 objectclass ( 1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.4 NAME 'mqttUser'
 	AUXILIARY
-	MAY ( mqttPublishTopic $ mqttSubscriptionTopic $ mqttPubSubTopic $ mqttAclRule $ mqttAclTtl $ mqttAccountName $ isSuperuser ) )
+	MAY ( mqttPublishTopic $ mqttSubscriptionTopic $ mqttPubSubTopic $ mqttAclRule $ mqttAclTtl $ mqttAccountName $ isSuperuser $ clientIdOverride ) )
 
 objectclass (1.3.6.1.4.1.11.2.53.2.2.3.1.2.3.5 NAME 'dashboardUser'
 	SUP top

--- a/changes/ee/feat-15730.en.md
+++ b/changes/ee/feat-15730.en.md
@@ -1,0 +1,12 @@
+Added support for overriding clientid using authentication results.  If a backend returns a `clientid_override` attribute in its successful authentication result, it'll replace the connecting client's clientid.
+
+Backends/methods supporting setting `clientid_override` in the authentication result to
+override clientid:
+
+- HTTP
+- JWT
+- LDAP
+- MongoDB
+- MySQL
+- Postgres
+- Redis

--- a/rel/i18n/emqx_authn_ldap_schema.hocon
+++ b/rel/i18n/emqx_authn_ldap_schema.hocon
@@ -15,6 +15,12 @@ is_superuser_attribute.desc:
 is_superuser_attribute.label:
 """IsSuperuser Attribute"""
 
+clientid_override_attribute.desc:
+"""Indicates which attribute is used to represent a clientid override value."""
+
+clientid_override_attribute.label:
+"""ClientIdOverride Attribute"""
+
 query_timeout.desc:
 """Timeout for the LDAP query."""
 

--- a/rel/i18n/emqx_authn_mongodb_schema.hocon
+++ b/rel/i18n/emqx_authn_mongodb_schema.hocon
@@ -21,6 +21,12 @@ is_superuser_field.desc:
 is_superuser_field.label:
 """Is Superuser Field"""
 
+clientid_override_field.desc:
+"""Document field that defines a clientid override for the client."""
+
+clientid_override_field.label:
+"""ClientId Override Field"""
+
 password_hash_field.desc:
 """Document field that contains password hash."""
 


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14293

<!--
5.8.8
5.9.2
6.0.0
-->
Release version: 6.0.0

## Summary

Backends/methods supporting returning `clientid_override` in the successful authentication result to override clientid:

- HTTP
- JWT
- LDAP
- MongoDB
- MySQL
- Postgres
- Redis

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
