### PR TITLE
fix(conf app): return exit code 1 when config fails to load

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_app.erl
+++ b/apps/emqx_conf/src/emqx_conf_app.erl
@@ -28,12 +28,25 @@
 
 start(_StartType, _StartArgs) ->
     ok = mria:wait_for_tables(emqx_cluster_rpc:create_tables()),
-    ok = init_conf(),
+    try
+        ok = init_conf()
+    catch
+        C:E:St ->
+            ?SLOG(error, #{
+                msg => "failed_to_load_config", error => C, reason => E, stacktrace => St
+            }),
+            exit_loop(1)
+    end,
     ok = emqx_config_logger:refresh_config(),
     emqx_conf_sup:start_link().
 
 stop(_State) ->
     ok.
+
+exit_loop(ExitCode) ->
+    timer:sleep(100),
+    init:stop(ExitCode),
+    exit_loop(ExitCode).
 
 %% @doc emqx_conf relies on this flag to synchronize configuration between nodes.
 %% Therefore, we must clean up this flag when emqx application is restarted by mria.


### PR DESCRIPTION
Only when syncing a recent change to `release-60` it was detected that the exit code when config fails to load is 0.

See:
- https://github.com/emqx/emqx/pull/15729
- https://github.com/emqx/emqx/actions/runs/17050064723/job/48336139780?pr=15729#step:7:11