### PR TITLE
feat(listener): switch to shared per-listener connrate limiters [r59]

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_exclusive.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_exclusive.erl
@@ -123,12 +123,12 @@ try_consume_regular(#{last_time := LastTime} = State0, #{interval := Interval}, 
     {false, State0};
 try_consume_regular(
     #{last_time := LastTime, tokens := Tokens0} = State0,
-    #{capacity := Capacity, burst_capacity := BurstCapacity, interval := Interval},
+    #{capacity := Capacity, interval := Interval},
     Amount,
     Now
 ) ->
     Inc = Capacity * (Now - LastTime) / Interval,
-    Tokens = erlang:min(Capacity + BurstCapacity, Tokens0 + Inc),
+    Tokens = erlang:min(Capacity, Tokens0 + Inc),
     State1 = State0#{last_time := Now, tokens := Tokens},
     case Tokens >= Amount of
         true ->

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_shared/emqx_limiter_shared.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_shared/emqx_limiter_shared.erl
@@ -7,7 +7,7 @@
 %% Shared limiter is a limiter that is shared between processes.
 %% I.e. several processes consume tokens concurrently from the same bucket.
 %%
-%% The shared limiter's capacity is modelled as time interval spanning into the past.
+%% The shared limiter's regular capacity is modelled as time interval spanning into the past.
 %% When we want to consume Amount tokens, we shrink the interval by the time
 %% corresponding to Amount tokens, i.e. having rate = N tokens / T seconds,
 %% we shrink the interval by T * Amount / N seconds.
@@ -15,6 +15,9 @@
 %% The bucket is exhausted when the interval shrinks to the current time.
 %% As the current time extends forward, the time interval naturally extends
 %% modelling the bucket being refilled.
+%%
+%% The shared limiter's burst capacity is managed more losely and
+%% modelled as a simple separate bucket that is refilled when the regular bucket is exhausted.
 
 -module(emqx_limiter_shared).
 
@@ -47,6 +50,9 @@
     mini_tokens_index := pos_integer(),
     last_time_aref := atomics:atomics_ref(),
     last_time_index := pos_integer(),
+    burst_tokens_aref := atomics:atomics_ref(),
+    burst_tokens_index := pos_integer(),
+    last_burst_time_aref := atomics:atomics_ref(),
     last_burst_time_index := pos_integer()
 }.
 
@@ -54,11 +60,9 @@
     limiter_id := emqx_limiter:id(),
     bucket_ref := bucket_ref(),
     mode := mode(),
-    options := emqx_limiter:options(),
-    last_burst_time := microsecond()
+    options := emqx_limiter:options()
 }.
 
--type microsecond() :: non_neg_integer().
 -type reason() :: emqx_limiter_client:reason().
 
 -export_type([bucket_ref/0, client_state/0]).
@@ -92,9 +96,13 @@
 create_group(Group, LimiterConfigs) when length(LimiterConfigs) > 0 ->
     Size = length(LimiterConfigs),
     MiniTokensCRef = counters:new(Size, [write_concurrency]),
-    LastTimeARef = atomics:new(Size * 2, []),
+    %% Factor 3 is because we have 3 atomics per limiter:
+    %% last_time
+    %% burst_tokens
+    %% last_burst_time
+    ARef = atomics:new(Size * 3, []),
     NowUs = now_us_monotonic(),
-    Buckets = make_buckets(LimiterConfigs, MiniTokensCRef, LastTimeARef, NowUs),
+    Buckets = make_buckets(LimiterConfigs, MiniTokensCRef, ARef, NowUs),
     ok = emqx_limiter_bucket_registry:insert_buckets(Group, Buckets).
 
 -spec delete_group(emqx_limiter:group()) -> ok | {error, term()}.
@@ -111,15 +119,13 @@ connect(LimiterId) ->
     case emqx_limiter_bucket_registry:find_bucket(LimiterId) of
         undefined ->
             error({bucket_not_found, LimiterId});
-        #{last_time_aref := LastTimeARef, last_burst_time_index := LastBurstTimeIndex} =
-                BucketRef ->
+        BucketRef ->
             Options = emqx_limiter_registry:get_limiter_options(LimiterId),
             emqx_limiter_client:new(
                 ?MODULE,
                 _State = #{
                     limiter_id => LimiterId,
                     bucket_ref => BucketRef,
-                    last_burst_time => atomics:get(LastTimeARef, LastBurstTimeIndex),
                     mode => calc_mode(Options),
                     options => Options
                 }
@@ -139,11 +145,7 @@ try_consume(#{limiter_id := LimiterId} = State, Amount) ->
             true;
         _ ->
             Result =
-                case
-                    try_consume_with_actual_mode(
-                        State, Options, Amount, now_us_monotonic()
-                    )
-                of
+                case try_consume(State, Options, Amount) of
                     {true = Success, State1} ->
                         {true, State1};
                     {false = Success, State1} ->
@@ -189,33 +191,86 @@ inspect(#{bucket_ref := BucketRef, mode := Mode, options := Options} = _State) -
 %%  Internal functions
 %%--------------------------------------------------------------------
 
-make_buckets(Names, MiniTokensCRef, LastTimeARef, NowUs) ->
-    make_buckets(Names, MiniTokensCRef, LastTimeARef, NowUs, 1, []).
+make_buckets(Names, MiniTokensCRef, ARef, NowUs) ->
+    make_buckets(Names, MiniTokensCRef, ARef, NowUs, 1, []).
 
-make_buckets([], _MiniTokensCRef, _LastTimeARef, _NowUs, _Index, Res) ->
+make_buckets([], _MiniTokensCRef, _ARef, _NowUs, _Index, Res) ->
     lists:reverse(Res);
 make_buckets(
-    [{Name, Options} | Names], MiniTokensCRef, LastTimeARef, NowUs, Index, Res
+    [{Name, Options} | Names], MiniTokensCRef, ARef, NowUs, Index, Res
 ) ->
     BucketRef = #{
         mini_tokens_cref => MiniTokensCRef,
         mini_tokens_index => Index,
-        last_time_aref => LastTimeARef,
-        last_time_index => 2 * Index - 1,
-        last_burst_time_index => 2 * Index
+        last_time_aref => ARef,
+        last_time_index => 3 * Index - 2,
+        last_burst_time_aref => ARef,
+        last_burst_time_index => 3 * Index - 1,
+        burst_tokens_aref => ARef,
+        burst_tokens_index => 3 * Index
     },
     Mode = calc_mode(Options),
-    ok = apply_burst(Mode, Options, BucketRef, NowUs),
-    make_buckets(Names, MiniTokensCRef, LastTimeARef, NowUs, Index + 1, [
+    ok = init_last_time(BucketRef, Mode, Options, NowUs),
+    ok = apply_burst(BucketRef, Options, NowUs),
+    make_buckets(Names, MiniTokensCRef, ARef, NowUs, Index + 1, [
         {Name, BucketRef} | Res
     ]).
 
-try_consume_with_actual_mode(State0, Options, Amount, NowUs) ->
+try_consume(State0, Options, Amount) ->
     {Mode, State1} = mode(State0, Options),
-    try_consume_regular(State1, Mode, Options, Amount, NowUs).
+    {try_consume(State1, Mode, Options, Amount, now_us_monotonic()), State1}.
 
-%% @doc Try to consume tokens from the bucket
-%% If there are not enough tokens, then try to obtain burst tokens.
+try_consume(State, Mode, #{burst_capacity := 0} = Options, Amount, NowUs) ->
+    case try_consume_regular(State, Mode, Options, Amount, NowUs) of
+        ok ->
+            true;
+        failed ->
+            false
+    end;
+try_consume(State, Mode, Options, Amount, NowUs) ->
+    case try_consume_accumulated_burst(State, Amount) of
+        ok ->
+            true;
+        {failed, LastBurstTimeUs} ->
+            case try_consume_regular(State, Mode, Options, Amount, NowUs) of
+                ok ->
+                    true;
+                failed ->
+                    case try_burst(State, Options, LastBurstTimeUs, NowUs) of
+                        ok ->
+                            try_consume(State, Mode, Options, Amount, now_us_monotonic());
+                        failed ->
+                            false
+                    end
+            end
+    end.
+
+-doc """
+First try to consume from the accumulated burst tokens in case there was a recent burst.
+If there are not enough burst tokens, then try to consume regular tokens.
+""".
+
+try_consume_accumulated_burst(#{bucket_ref := BucketRef}, Amount) ->
+    #{
+        burst_tokens_aref := BurstTokensARef,
+        burst_tokens_index := BurstTokensIndex,
+        last_burst_time_aref := LastBurstTimeARef,
+        last_burst_time_index := LastBurstTimeIndex
+    } = BucketRef,
+    LastBurstTimeUs = atomics:get(LastBurstTimeARef, LastBurstTimeIndex),
+    case atomics:get(BurstTokensARef, BurstTokensIndex) - Amount >= 0 of
+        true ->
+            %% We ignore possible overconsumption of burst tokens due to non-atomic get and set.
+            %% This is not a big deal, because burst tokens are granted rarely
+            %% and provide large amount of tokens.
+            ok = atomics:sub(BurstTokensARef, BurstTokensIndex, Amount);
+        false ->
+            {failed, LastBurstTimeUs}
+    end.
+
+-doc """
+Try to consume regular tokens when there are no accumulated burst tokens.
+""".
 try_consume_regular(
     #{bucket_ref := BucketRef} = State,
     #token_mode{us_per_token = UsPerToken, max_time_us = MaxTimeUs} = Mode,
@@ -227,11 +282,11 @@ try_consume_regular(
     %% To succeed, at least UsRequired microseconds must pass since the last time stored in the bucket.
     case advance_last_time(BucketRef, UsRequired, NowUs, MaxTimeUs) of
         ok ->
-            {true, State};
+            ok;
         retry ->
             try_consume_regular(State, Mode, Options, Amount, now_us_monotonic());
         failed ->
-            try_consume_burst(State, Mode, Options, Amount, NowUs)
+            failed
     end;
 try_consume_regular(
     #{bucket_ref := BucketRef} = State,
@@ -246,8 +301,7 @@ try_consume_regular(
     %% If there are not enough, we calculate the required time to advance the last_time
     case counters:get(MiniTokensCRef, MiniTokensIndex) - AmountMini >= 0 of
         true ->
-            ok = counters:sub(MiniTokensCRef, MiniTokensIndex, AmountMini),
-            {true, State};
+            ok = counters:sub(MiniTokensCRef, MiniTokensIndex, AmountMini);
         false ->
             %% In mini-token mode, we the granularity of tokens consumpton is > 1,
             %% so we may have left-over tokens
@@ -257,76 +311,56 @@ try_consume_regular(
             %% To succeed, at least UsRequired microseconds must pass since the last time stored in the bucket.
             case advance_last_time(BucketRef, UsRequired, NowUs, MaxTimeUs) of
                 ok ->
-                    ok = counters:add(MiniTokensCRef, MiniTokensIndex, LeftOver),
-                    {true, State};
+                    ok = counters:add(MiniTokensCRef, MiniTokensIndex, LeftOver);
                 retry ->
                     try_consume_regular(State, Mode, Options, Amount, now_us_monotonic());
                 failed ->
-                    try_consume_burst(State, Mode, Options, Amount, NowUs)
+                    failed
             end
     end.
 
-%% No burst capacity at all, so we can't grant any burst tokens.
-try_consume_burst(State, _Mode, #{burst_capacity := 0}, _Amount, _NowUs) ->
-    {false, State};
-%% The burst tokens were granted recently, so we can't grant any more.
-try_consume_burst(
-    #{last_burst_time := LastBurstTimeUs} = State,
-    _Mode,
-    #{burst_interval := BurstIntervalMs} = _Options,
-    _Amount,
-    NowUs
-) when NowUs < LastBurstTimeUs + BurstIntervalMs * 1000 ->
-    {false, State};
-%% We do not know from the local cache if burst tokens were granted recently, so we need to check
-%% the global last burst time.
-try_consume_burst(
-    #{bucket_ref := BucketRef} = State,
-    Mode,
+try_burst(
+    #{bucket_ref := BucketRef} = _State,
     #{burst_interval := BurstIntervalMs} = Options,
-    Amount,
+    LastBurstTimeUs,
     NowUs
 ) ->
-    #{last_time_aref := LastTimeARef, last_burst_time_index := LastBurstTimeIndex} =
-        BucketRef,
-    LastBurstTimeUs = atomics:get(LastTimeARef, LastBurstTimeIndex),
     case NowUs < LastBurstTimeUs + BurstIntervalMs * 1000 of
         true ->
             %% Some other process has granted burst tokens recently, so we can't grant any more.
-            %% Just cache the last burst time and fail.
-            {false, State#{last_burst_time := LastBurstTimeUs}};
+            failed;
         false ->
             %% We can grant burst tokens, so do it and consume the tokens again.
-            apply_burst_and_consume(State, Mode, Options, Amount, NowUs)
+            ok = apply_burst(BucketRef, Options, NowUs)
     end.
 
-apply_burst_and_consume(#{bucket_ref := BucketRef} = State, Mode, Options, Amount, NowUs) ->
-    ok = apply_burst(Mode, Options, BucketRef, NowUs),
-    try_consume_regular(State#{last_burst_time := NowUs}, Mode, Options, Amount, NowUs).
-
-apply_burst(Mode, _Options, BucketRef, NowUs) ->
+apply_burst(BucketRef, #{burst_capacity := BurstCapacity} = _Options, NowUs) ->
     #{
+        last_burst_time_aref := LastBurstTimeARef,
         last_burst_time_index := LastBurstTimeIndex,
-        last_time_aref := LastTimeARef,
-        last_time_index := LastTimeIndex
+        burst_tokens_aref := BurstTokensARef,
+        burst_tokens_index := BurstTokensIndex
     } = BucketRef,
-    %% MaxTimeUs models the maximum bucket capacity (see module description).
-    %% So here we extend the bucket time interval back by the maximum capacity.
-    LastTimeUsNew =
-        case Mode of
-            #token_mode{max_time_us = MaxTimeUs} ->
-                NowUs - MaxTimeUs;
-            #mini_token_mode{max_time_us = MaxTimeUs} ->
-                NowUs - MaxTimeUs
-        end,
     %% Here we don't care that the read and write are not atomic.
-    %% The worst case is that several processes will concurrently extend the bucket to the maximum capacity,
-    %% while some other processes will consume some (free) tokens between the extends.
+    %% The worst case is that several processes see the same old burst time
+    %% and concurrently apply the burst, while some other processes will consume some (free) tokens
+    %% between the applications.
+    %%
     %% We allow this, because burst should be configured to happen quite rarely and provide large
     %% amount of tokens. So some free tokens are not a deal.
     %% For very strict limits, one should operate with regular capacity only.
-    ok = atomics:put(LastTimeARef, LastTimeIndex, LastTimeUsNew),
-    ok = atomics:put(LastTimeARef, LastBurstTimeIndex, NowUs).
+    %%
+    %% The order is important. If we put LastBurstTime first, then another process may
+    %% * see updated last burst time
+    %% * see still not updated burst tokens
+    %% * fail
+    %% while having a right for a burst.
+    ok = atomics:put(BurstTokensARef, BurstTokensIndex, BurstCapacity),
+    ok = atomics:put(LastBurstTimeARef, LastBurstTimeIndex, NowUs);
+apply_burst(BucketRef, #{} = _Options, NowUs) ->
+    #{last_burst_time_aref := LastBurstTimeARef, last_burst_time_index := LastBurstTimeIndex} =
+        BucketRef,
+    ok = atomics:put(LastBurstTimeARef, LastBurstTimeIndex, NowUs).
 
 advance_last_time(BucketRef, UsRequired, NowUs, MaxTimeUs) ->
     #{last_time_aref := LastTimeARef, last_time_index := LastTimeIndex} = BucketRef,
@@ -350,6 +384,21 @@ advance_last_time(BucketRef, UsRequired, NowUs, MaxTimeUs) ->
             failed
     end.
 
+init_last_time(
+    #{last_time_aref := LastTimeARef, last_time_index := LastTimeIndex} = _BucketRef,
+    #token_mode{max_time_us = MaxTimeUs} = _Mode,
+    #{} = _Options,
+    NowUs
+) ->
+    ok = atomics:put(LastTimeARef, LastTimeIndex, NowUs - MaxTimeUs);
+init_last_time(
+    #{last_time_aref := LastTimeARef, last_time_index := LastTimeIndex} = _BucketRef,
+    #mini_token_mode{max_time_us = MaxTimeUs} = _Mode,
+    #{} = _Options,
+    NowUs
+) ->
+    ok = atomics:put(LastTimeARef, LastTimeIndex, NowUs - MaxTimeUs).
+
 now_us_monotonic() ->
     erlang:monotonic_time(microsecond).
 
@@ -362,9 +411,9 @@ mode(State, NewOptions) ->
 
 calc_mode(#{capacity := infinity}) ->
     #token_mode{us_per_token = 1, max_time_us = 1};
-calc_mode(#{capacity := Capacity, interval := IntervalMs, burst_capacity := BurstCapacity}) ->
-    FullCapacity = Capacity + BurstCapacity,
-    MaxTimeUs = (1000 * IntervalMs * FullCapacity) div Capacity,
+calc_mode(#{capacity := Capacity, interval := IntervalMs}) ->
+    %% MaxTimeUs models the maximum bucket capacity (see module description).
+    MaxTimeUs = 1000 * IntervalMs,
     case Capacity < IntervalMs of
         true ->
             UsPerToken = (1000 * IntervalMs) div Capacity,

--- a/apps/emqx/test/emqx_limiter_shared_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_shared_SUITE.erl
@@ -209,6 +209,45 @@ test_concurrent(Capacity, Interval) ->
     ]),
     ?assert(RelativeError < 0.01).
 
+t_try_consume_burst_wide_interval(_) ->
+    ok = emqx_limiter:create_group(shared, group1, [
+        {limiter1, #{
+            capacity => 10,
+            interval => 200,
+            %% The burst rate much higher than the regular rate, which is abnormal.
+            %% However, we check that the burst rate is not applied
+            %% once the burst tokens are consumed.
+            burst_capacity => 1000,
+            burst_interval => 3000
+        }}
+    ]),
+    Client0 = emqx_limiter:connect({group1, limiter1}),
+
+    %% Consume regular + burst capacity
+    Client1 = lists:foldl(
+        fun(_, ClientAcc0) ->
+            {true, ClientAcc1} = emqx_limiter_client:try_consume(ClientAcc0, 1),
+            ClientAcc1
+        end,
+        Client0,
+        lists:seq(1, 10 + 1000)
+    ),
+    {false, Client2, _} = emqx_limiter_client:try_consume(Client1, 1),
+
+    %% Wait for considerably more than one regular refill interval
+    ct:sleep(1000),
+
+    %% Only regularly refilled tokens are available
+    Client3 = lists:foldl(
+        fun(_, ClientAcc0) ->
+            {true, ClientAcc1} = emqx_limiter_client:try_consume(ClientAcc0, 1),
+            ClientAcc1
+        end,
+        Client2,
+        lists:seq(1, 10)
+    ),
+    {false, _Client, _} = emqx_limiter_client:try_consume(Client3, 1).
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------

--- a/apps/emqx_mt/src/emqx_mt.app.src
+++ b/apps/emqx_mt/src/emqx_mt.app.src
@@ -1,6 +1,6 @@
 {application, emqx_mt, [
     {description, "Multi-tenancy"},
-    {vsn, "0.1.1"},
+    {vsn, "0.1.2"},
     {registered, []},
     {mod, {emqx_mt_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_mt/src/emqx_mt_limiter.erl
+++ b/apps/emqx_mt/src/emqx_mt_limiter.erl
@@ -148,8 +148,8 @@ adjust_limiter(Context, _Limiter) ->
 zone_group(Zone) ->
     {zone, Zone}.
 
-listener_group(ListenerId) ->
-    {listener, ListenerId}.
+channel_group(ListenerId) ->
+    {channel, ListenerId}.
 
 tenant_group(Ns) ->
     {mt_tenant, Ns}.
@@ -204,9 +204,10 @@ create_client_limiters(ListenerId, Ns, Name) ->
             ClientLimiterClient = emqx_limiter:connect(ClientLimiterId),
             [ClientLimiterClient];
         _ ->
-            ListenerLimiterId = {listener_group(ListenerId), Name},
-            ListenerLimiterClient = emqx_limiter:connect(ListenerLimiterId),
-            [ListenerLimiterClient]
+            %% TODO: Isolate implementation details in `emqx_limiter` API.
+            ChannelLimiterId = {channel_group(ListenerId), Name},
+            ChannelLimiterClient = emqx_limiter:connect(ChannelLimiterId),
+            [ChannelLimiterClient]
     end.
 
 ensure_group_absent(Group) ->

--- a/changes/ee/breaking-15753.en.md
+++ b/changes/ee/breaking-15753.en.md
@@ -1,0 +1,1 @@
+Listener connection rate limits (`max_conn_rate` and `max_conn_burst`) are now enforced per listener rather than per acceptor, restoring the pre-5.9.0 behavior. As a result, configurations from versions 5.9.0 and 5.9.1 are incompatible: specified rates must be scaled up by the number of acceptors configured for respective listeners.


### PR DESCRIPTION
Fixes [EMQX-14614](https://emqx.atlassian.net/browse/EMQX-14614).

Release version: 5.9.2

## Summary

This PR switches listeners to use a single shared connrate limiter per listener instead of an exclusive limiter per acceptor, thus restoring pre-5.9 behavior and config compatibility.

Backport of #15743 + #15718 + #15731.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
    Tests are excluded from backporting to avoid conflicts down the line. See #15743 for relevant testcases and their results.
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] **Schema changes are intentionally breaking**


[EMQX-14614]: https://emqx.atlassian.net/browse/EMQX-14614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ