### PR TITLE
build(mix): add deps helper

### DIFF
--- a/apps/emqx/mix.exs
+++ b/apps/emqx/mix.exs
@@ -53,27 +53,29 @@ defmodule EMQX.MixProject do
   end
 
   def deps() do
-    [
-      {:emqx_mix_utils, in_umbrella: true, runtime: false},
-      {:emqx_utils, in_umbrella: true},
-      {:emqx_bpapi, in_umbrella: true},
-      {:emqx_durable_storage, in_umbrella: true},
-      {:emqx_ds_backends, in_umbrella: true},
-      {:emqx_durable_timer, in_umbrella: true},
-      UMP.common_dep(:gproc),
-      UMP.common_dep(:gen_rpc),
-      UMP.common_dep(:ekka),
-      UMP.common_dep(:esockd),
-      UMP.common_dep(:cowboy),
-      UMP.common_dep(:lc),
-      UMP.common_dep(:hocon),
-      UMP.common_dep(:ranch),
-      UMP.common_dep(:bcrypt),
-      UMP.common_dep(:emqx_http_lib),
-      UMP.common_dep(:typerefl),
-      UMP.common_dep(:snabbkaffe),
-      UMP.common_dep(:recon)
-    ] ++ UMP.quicer_dep()
+    UMP.deps(
+      [
+        {:emqx_mix_utils, in_umbrella: true, runtime: false},
+        {:emqx_utils, in_umbrella: true},
+        {:emqx_bpapi, in_umbrella: true},
+        {:emqx_durable_storage, in_umbrella: true},
+        {:emqx_ds_backends, in_umbrella: true},
+        {:emqx_durable_timer, in_umbrella: true},
+        :gproc,
+        :gen_rpc,
+        :ekka,
+        :esockd,
+        :cowboy,
+        :lc,
+        :hocon,
+        :ranch,
+        :bcrypt,
+        :emqx_http_lib,
+        :typerefl,
+        :snabbkaffe,
+        :recon
+      ] ++ UMP.quicer_dep()
+    )
   end
 
   defp erlc_paths() do

--- a/apps/emqx_ai_completion/mix.exs
+++ b/apps/emqx_ai_completion/mix.exs
@@ -25,11 +25,11 @@ defmodule EMQXAICompletion.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
-      UMP.common_dep(:minirest),
-      UMP.common_dep(:hackney)
-    ]
+      :minirest,
+      :hackney
+    ])
   end
 end

--- a/apps/emqx_audit/mix.exs
+++ b/apps/emqx_audit/mix.exs
@@ -22,6 +22,6 @@ defmodule EMQXAudit.MixProject do
   end
 
   def deps() do
-    [{:emqx, in_umbrella: true}, {:emqx_utils, in_umbrella: true}]
+    UMP.deps([{:emqx, in_umbrella: true}, {:emqx_utils, in_umbrella: true}])
   end
 end

--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -27,12 +27,12 @@ defmodule EMQXAuth.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_auth_cinfo/mix.exs
+++ b/apps/emqx_auth_cinfo/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXAuthCinfo.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
-      UMP.common_dep(:jose)
-    ]
+      :jose
+    ])
   end
 end

--- a/apps/emqx_auth_http/mix.exs
+++ b/apps/emqx_auth_http/mix.exs
@@ -24,14 +24,14 @@ defmodule EMQXAuthHTTP.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_connector, in_umbrella: true},
       {:emqx_bridge_http, in_umbrella: true},
-      UMP.common_dep(:hocon)
-    ]
+      :hocon
+    ])
   end
 end

--- a/apps/emqx_auth_jwt/mix.exs
+++ b/apps/emqx_auth_jwt/mix.exs
@@ -24,13 +24,13 @@ defmodule EMQXAuthJWT.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_connector, in_umbrella: true},
-      UMP.common_dep(:jose)
-    ]
+      :jose
+    ])
   end
 end

--- a/apps/emqx_auth_kerberos/mix.exs
+++ b/apps/emqx_auth_kerberos/mix.exs
@@ -25,11 +25,11 @@ defmodule EMQXAuthKerberos.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_utils, in_umbrella: true},
       {:emqx, in_umbrella: true, runtime: false},
       {:emqx_auth, in_umbrella: true},
-      UMP.common_dep(:sasl_auth)
-    ]
+      :sasl_auth
+    ])
   end
 end

--- a/apps/emqx_auth_ldap/mix.exs
+++ b/apps/emqx_auth_ldap/mix.exs
@@ -27,13 +27,13 @@ defmodule EMQXAuthLDAP.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_connector, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_ldap, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_auth_mnesia/mix.exs
+++ b/apps/emqx_auth_mnesia/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXAuthMnesia.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
-      UMP.common_dep(:sasl_auth)
-    ]
+      :sasl_auth
+    ])
   end
 end

--- a/apps/emqx_auth_mongodb/mix.exs
+++ b/apps/emqx_auth_mongodb/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXAuthMongoDB.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_mongodb, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_auth_mysql/mix.exs
+++ b/apps/emqx_auth_mysql/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXAuthMySQL.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_mysql, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_auth_postgresql/mix.exs
+++ b/apps/emqx_auth_postgresql/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXAuthPostgreSQL.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_postgresql, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_auth_redis/mix.exs
+++ b/apps/emqx_auth_redis/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXAuthRedis.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
       {:emqx_redis, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_auto_subscribe/mix.exs
+++ b/apps/emqx_auto_subscribe/mix.exs
@@ -25,10 +25,10 @@ defmodule EMQXAutoSubscribe.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_bpapi/mix.exs
+++ b/apps/emqx_bpapi/mix.exs
@@ -25,8 +25,8 @@ defmodule EMQXBPAPI.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:snabbkaffe)
-    ]
+    UMP.deps([
+      :snabbkaffe
+    ])
   end
 end

--- a/apps/emqx_bridge/mix.exs
+++ b/apps/emqx_bridge/mix.exs
@@ -27,13 +27,13 @@ defmodule EMQXBridge.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_connector, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_alloydb/mix.exs
+++ b/apps/emqx_bridge_alloydb/mix.exs
@@ -31,10 +31,10 @@ defmodule EMQXBridgeAlloydb.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_resource, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_azure_blob_storage/mix.exs
+++ b/apps/emqx_bridge_azure_blob_storage/mix.exs
@@ -29,11 +29,11 @@ defmodule EMQXBridgeAzureBlobStorage.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_connector_aggregator, in_umbrella: true},
       {:erlazure, github: "emqx/erlazure", tag: "0.4.0.1"}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_azure_event_hub/mix.exs
+++ b/apps/emqx_bridge_azure_event_hub/mix.exs
@@ -28,16 +28,16 @@ defmodule EMQXBridgeAzureEventHub.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:wolff),
-      UMP.common_dep(:kafka_protocol),
-      UMP.common_dep(:brod_gssapi),
-      UMP.common_dep(:brod),
-      UMP.common_dep(:snappyer),
-      UMP.common_dep(:telemetry),
+    UMP.deps([
+      :wolff,
+      :kafka_protocol,
+      :brod_gssapi,
+      :brod,
+      :snappyer,
+      :telemetry,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_bigquery/mix.exs
+++ b/apps/emqx_bridge_bigquery/mix.exs
@@ -31,12 +31,12 @@ defmodule EMQXBridgeBigQuery.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_connector_jwt, in_umbrella: true},
       {:emqx_bridge_gcp_pubsub, in_umbrella: true},
-      UMP.common_dep(:ehttpc)
-    ]
+      :ehttpc
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_cassandra/mix.exs
+++ b/apps/emqx_bridge_cassandra/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeCassandra.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:ecql, github: "emqx/ecql", tag: "v0.7.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_clickhouse/mix.exs
+++ b/apps/emqx_bridge_clickhouse/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeClickhouse.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:clickhouse, github: "emqx/clickhouse-client-erl", tag: "0.3.3"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_cockroachdb/mix.exs
+++ b/apps/emqx_bridge_cockroachdb/mix.exs
@@ -31,10 +31,10 @@ defmodule EMQXBridgeCockroachdb.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_resource, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_confluent/mix.exs
+++ b/apps/emqx_bridge_confluent/mix.exs
@@ -28,16 +28,16 @@ defmodule EMQXBridgeConfluent.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:wolff),
-      UMP.common_dep(:kafka_protocol),
-      UMP.common_dep(:brod_gssapi),
-      UMP.common_dep(:brod),
-      UMP.common_dep(:snappyer),
-      UMP.common_dep(:telemetry),
+    UMP.deps([
+      :wolff,
+      :kafka_protocol,
+      :brod_gssapi,
+      :brod,
+      :snappyer,
+      :telemetry,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_couchbase/mix.exs
+++ b/apps/emqx_bridge_couchbase/mix.exs
@@ -28,10 +28,10 @@ defmodule EMQXBridgeCouchbase.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
-      UMP.common_dep(:ehttpc)
-    ]
+      :ehttpc
+    ])
   end
 end

--- a/apps/emqx_bridge_datalayers/mix.exs
+++ b/apps/emqx_bridge_datalayers/mix.exs
@@ -30,13 +30,13 @@ defmodule EMQXBridgeDatalayers.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:influxdb),
+    UMP.deps([
+      :influxdb,
       {:datalayers, github: "datalayers-io/datalayers-adapter-erl", tag: "0.1.0", override: true},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_disk_log/mix.exs
+++ b/apps/emqx_bridge_disk_log/mix.exs
@@ -28,9 +28,9 @@ defmodule EMQXBridgeDiskLog.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_doris/mix.exs
+++ b/apps/emqx_bridge_doris/mix.exs
@@ -31,10 +31,10 @@ defmodule EMQXBridgeDoris.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge_mysql, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_dynamo/mix.exs
+++ b/apps/emqx_bridge_dynamo/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeDynamo.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:erlcloud),
+    UMP.deps([
+      :erlcloud,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_es/mix.exs
+++ b/apps/emqx_bridge_es/mix.exs
@@ -28,12 +28,12 @@ defmodule EMQXBridgeEs.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_bridge_http, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_gcp_pubsub/mix.exs
+++ b/apps/emqx_bridge_gcp_pubsub/mix.exs
@@ -34,13 +34,13 @@ defmodule EMQXBridgeGcpPubsub.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector_jwt, in_umbrella: true},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_bridge_http, in_umbrella: true},
-      UMP.common_dep(:ehttpc)
-    ]
+      :ehttpc
+    ])
   end
 end

--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeGreptimedb.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:greptimedb, github: "GreptimeTeam/greptimedb-ingester-erl", tag: "v0.2.0"}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_http/mix.exs
+++ b/apps/emqx_bridge_http/mix.exs
@@ -30,10 +30,10 @@ defmodule EMQXBridgeHTTP.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
-      UMP.common_dep(:ehttpc)
-    ]
+      :ehttpc
+    ])
   end
 end

--- a/apps/emqx_bridge_influxdb/mix.exs
+++ b/apps/emqx_bridge_influxdb/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeInfluxdb.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:influxdb),
+    UMP.deps([
+      :influxdb,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_iotdb/mix.exs
+++ b/apps/emqx_bridge_iotdb/mix.exs
@@ -28,12 +28,12 @@ defmodule EMQXBridgeIotdb.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:iotdb, github: "emqx/iotdb-client-erl", tag: "0.2.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_bridge_http, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -35,18 +35,18 @@ defmodule EMQXBridgeKafka.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:wolff),
-      UMP.common_dep(:kafka_protocol),
-      UMP.common_dep(:brod_gssapi),
-      UMP.common_dep(:brod),
-      UMP.common_dep(:snappyer),
-      UMP.common_dep(:erlcloud),
-      UMP.common_dep(:brod_oauth),
-      UMP.common_dep(:telemetry),
+    UMP.deps([
+      :wolff,
+      :kafka_protocol,
+      :brod_gssapi,
+      :brod,
+      :snappyer,
+      :erlcloud,
+      :brod_oauth,
+      :telemetry,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_kinesis/mix.exs
+++ b/apps/emqx_bridge_kinesis/mix.exs
@@ -27,12 +27,12 @@ defmodule EMQXBridgeKinesis.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:erlcloud),
+    UMP.deps([
+      :erlcloud,
       {:emqx, in_umbrella: true, runtime: false},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_matrix/mix.exs
+++ b/apps/emqx_bridge_matrix/mix.exs
@@ -28,10 +28,10 @@ defmodule EMQXBridgeMatrix.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_mongodb/mix.exs
+++ b/apps/emqx_bridge_mongodb/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeMongodb.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_mongodb, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_mqtt/mix.exs
+++ b/apps/emqx_bridge_mqtt/mix.exs
@@ -30,11 +30,11 @@ defmodule EMQXBridgeMQTT.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
-      UMP.common_dep(:emqtt)
-    ]
+      :emqtt
+    ])
   end
 end

--- a/apps/emqx_bridge_mysql/mix.exs
+++ b/apps/emqx_bridge_mysql/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeMysql.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_mysql, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_opents/mix.exs
+++ b/apps/emqx_bridge_opents/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeOpents.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_oracle/mix.exs
+++ b/apps/emqx_bridge_oracle/mix.exs
@@ -28,10 +28,10 @@ defmodule EMQXBridgeOracle.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_oracle, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_pgsql/mix.exs
+++ b/apps/emqx_bridge_pgsql/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgePgsql.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_postgresql, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_pulsar/mix.exs
+++ b/apps/emqx_bridge_pulsar/mix.exs
@@ -28,13 +28,13 @@ defmodule EMQXBridgePulsar.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:crc32cer),
-      UMP.common_dep(:snappyer),
+    UMP.deps([
+      :crc32cer,
+      :snappyer,
       {:pulsar, github: "emqx/pulsar-client-erl", tag: "2.1.1", manager: :rebar3},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_rabbitmq/mix.exs
+++ b/apps/emqx_bridge_rabbitmq/mix.exs
@@ -29,11 +29,11 @@ defmodule EMQXBridgeRabbitmq.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:amqp_client, "4.0.3"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_redis/mix.exs
+++ b/apps/emqx_bridge_redis/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeRedis.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
       {:emqx_redis, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_redshift/mix.exs
+++ b/apps/emqx_bridge_redshift/mix.exs
@@ -31,10 +31,10 @@ defmodule EMQXBridgeRedshift.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_resource, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_rocketmq/mix.exs
+++ b/apps/emqx_bridge_rocketmq/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeRocketmq.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:rocketmq, github: "emqx/rocketmq-client-erl", tag: "v0.6.1"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_s3/mix.exs
+++ b/apps/emqx_bridge_s3/mix.exs
@@ -29,12 +29,12 @@ defmodule EMQXBridgeS3.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_connector_aggregator, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
-      UMP.common_dep(:erlcloud)
-    ]
+      :erlcloud
+    ])
   end
 end

--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -32,15 +32,15 @@ defmodule EMQXBridgeS3Tables.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_connector_aggregator, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
       {:parquer, github: "emqx/parquer", tag: "0.1.3", manager: :rebar3},
-      UMP.common_dep(:erlcloud),
-      UMP.common_dep(:murmerl3)
-    ]
+      :erlcloud,
+      :murmerl3
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_bridge_snowflake/mix.exs
+++ b/apps/emqx_bridge_snowflake/mix.exs
@@ -35,14 +35,14 @@ defmodule EMQXBridgeSnowflake.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_connector_jwt, in_umbrella: true},
       {:emqx_connector_aggregator, in_umbrella: true},
-      UMP.common_dep(:ehttpc),
-      UMP.common_dep(:ecpool),
-      UMP.common_dep(:gproc)
-    ]
+      :ehttpc,
+      :ecpool,
+      :gproc
+    ])
   end
 end

--- a/apps/emqx_bridge_sqlserver/mix.exs
+++ b/apps/emqx_bridge_sqlserver/mix.exs
@@ -28,10 +28,10 @@ defmodule EMQXBridgeSqlserver.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_syskeeper/mix.exs
+++ b/apps/emqx_bridge_syskeeper/mix.exs
@@ -31,10 +31,10 @@ defmodule EMQXBridgeSyskeeper.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_tablestore/mix.exs
+++ b/apps/emqx_bridge_tablestore/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeTablestore.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:ots_erl),
+    UMP.deps([
+      :ots_erl,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_tdengine/mix.exs
+++ b/apps/emqx_bridge_tdengine/mix.exs
@@ -28,11 +28,11 @@ defmodule EMQXBridgeTdengine.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:tdengine, github: "emqx/tdengine-client-erl", tag: "0.1.10"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_bridge_timescale/mix.exs
+++ b/apps/emqx_bridge_timescale/mix.exs
@@ -28,10 +28,10 @@ defmodule EMQXBridgeTimescale.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_cluster_link/mix.exs
+++ b/apps/emqx_cluster_link/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXClusterLink.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
-      UMP.common_dep(:emqtt)
-    ]
+      :emqtt
+    ])
   end
 end

--- a/apps/emqx_conf/mix.exs
+++ b/apps/emqx_conf/mix.exs
@@ -24,9 +24,9 @@ defmodule EMQXConf.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true, runtime: false},
       {:emqx_auth, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 end

--- a/apps/emqx_connector/mix.exs
+++ b/apps/emqx_connector/mix.exs
@@ -30,18 +30,18 @@ defmodule EMQXConnector.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_connector_jwt, in_umbrella: true},
-      UMP.common_dep(:minirest),
-      UMP.common_dep(:jose),
-      UMP.common_dep(:ecpool),
-      UMP.common_dep(:ehttpc),
-      UMP.common_dep(:emqtt)
-    ]
+      :minirest,
+      :jose,
+      :ecpool,
+      :ehttpc,
+      :emqtt
+    ])
   end
 end

--- a/apps/emqx_connector_aggregator/mix.exs
+++ b/apps/emqx_connector_aggregator/mix.exs
@@ -22,11 +22,13 @@ defmodule EMQXConnectorAggregator.MixProject do
   end
 
   def deps() do
-    test_deps() ++
-      [
-        {:emqx, in_umbrella: true},
-        UMP.common_dep(:gproc)
-      ]
+    UMP.deps(
+      test_deps() ++
+        [
+          {:emqx, in_umbrella: true},
+          :gproc
+        ]
+    )
   end
 
   defp test_deps() do

--- a/apps/emqx_connector_jwt/mix.exs
+++ b/apps/emqx_connector_jwt/mix.exs
@@ -26,9 +26,9 @@ defmodule EMQXConnectorJWT.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_resource, in_umbrella: true},
-      UMP.common_dep(:jose)
-    ]
+      :jose
+    ])
   end
 end

--- a/apps/emqx_ctl/mix.exs
+++ b/apps/emqx_ctl/mix.exs
@@ -22,6 +22,6 @@ defmodule EMQXCtl.MixProject do
   end
 
   def deps() do
-    []
+    UMP.deps([])
   end
 end

--- a/apps/emqx_dashboard/mix.exs
+++ b/apps/emqx_dashboard/mix.exs
@@ -24,12 +24,12 @@ defmodule EMQXDashboard.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:pot, "1.0.2"},
       {:emqx_ctl, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_dashboard_rbac/mix.exs
+++ b/apps/emqx_dashboard_rbac/mix.exs
@@ -22,6 +22,6 @@ defmodule EMQXDashboardRbac.MixProject do
   end
 
   def deps() do
-    [{:emqx_dashboard, in_umbrella: true}]
+    UMP.deps([{:emqx_dashboard, in_umbrella: true}])
   end
 end

--- a/apps/emqx_dashboard_sso/mix.exs
+++ b/apps/emqx_dashboard_sso/mix.exs
@@ -22,12 +22,12 @@ defmodule EMQXDashboardSso.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_ctl, in_umbrella: true},
       {:emqx_ldap, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true},
       {:esaml, github: "emqx/esaml", tag: "v1.1.3"},
       {:oidcc, github: "emqx/oidcc", tag: "v3.2.0-1", manager: :rebar3}
-    ]
+    ])
   end
 end

--- a/apps/emqx_ds_backends/mix.exs
+++ b/apps/emqx_ds_backends/mix.exs
@@ -37,11 +37,13 @@ defmodule EMQXDsBackends.MixProject do
         do: [{:emqx_ds_builtin_raft, in_umbrella: true}],
         else: []
 
-    ee_deps ++
-      [
-        {:emqx_utils, in_umbrella: true},
-        {:emqx_durable_storage, in_umbrella: true},
-        {:emqx_ds_builtin_local, in_umbrella: true}
-      ]
+    UMP.deps(
+      ee_deps ++
+        [
+          {:emqx_utils, in_umbrella: true},
+          {:emqx_durable_storage, in_umbrella: true},
+          {:emqx_ds_builtin_local, in_umbrella: true}
+        ]
+    )
   end
 end

--- a/apps/emqx_ds_builtin_local/mix.exs
+++ b/apps/emqx_ds_builtin_local/mix.exs
@@ -25,9 +25,9 @@ defmodule EMQXDsBuiltinLocal.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_utils, in_umbrella: true},
       {:emqx_durable_storage, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_ds_builtin_raft/mix.exs
+++ b/apps/emqx_ds_builtin_raft/mix.exs
@@ -25,11 +25,11 @@ defmodule EMQXDsBuiltinRaft.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_durable_storage, in_umbrella: true},
       {:emqx_bpapi, in_umbrella: true},
-      UMP.common_dep(:gproc),
-      UMP.common_dep(:ra)
-    ]
+      :gproc,
+      :ra
+    ])
   end
 end

--- a/apps/emqx_ds_shared_sub/mix.exs
+++ b/apps/emqx_ds_shared_sub/mix.exs
@@ -22,9 +22,9 @@ defmodule EMQXDsSharedSub.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_durable_storage/mix.exs
+++ b/apps/emqx_durable_storage/mix.exs
@@ -37,14 +37,14 @@ defmodule EMQXDurableStorage.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx_utils, in_umbrella: true},
       {:emqx_bpapi, in_umbrella: true},
-      UMP.common_dep(:rocksdb),
-      UMP.common_dep(:gproc),
-      UMP.common_dep(:gen_rpc),
-      UMP.common_dep(:ra)
-    ]
+      :rocksdb,
+      :gproc,
+      :gen_rpc,
+      :ra
+    ])
   end
 end

--- a/apps/emqx_durable_timer/mix.exs
+++ b/apps/emqx_durable_timer/mix.exs
@@ -34,10 +34,10 @@ defmodule EMQXDurableTimer.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_ds_backends, in_umbrella: true},
-      UMP.common_dep(:gproc),
-      UMP.common_dep(:optvar)
-    ]
+      :gproc,
+      :optvar
+    ])
   end
 end

--- a/apps/emqx_enterprise/mix.exs
+++ b/apps/emqx_enterprise/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXEnterprise.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:snabbkaffe),
-      UMP.common_dep(:typerefl),
-      UMP.common_dep(:hocon)
-    ]
+    UMP.deps([
+      :snabbkaffe,
+      :typerefl,
+      :hocon
+    ])
   end
 end

--- a/apps/emqx_eviction_agent/mix.exs
+++ b/apps/emqx_eviction_agent/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXEvictionAgent.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_exhook/mix.exs
+++ b/apps/emqx_exhook/mix.exs
@@ -39,13 +39,13 @@ defmodule EMQXExhook.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
-      UMP.common_dep(:minirest),
-      UMP.common_dep(:grpc)
-    ]
+      :minirest,
+      :grpc
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_ft/mix.exs
+++ b/apps/emqx_ft/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXFt.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
-      UMP.common_dep(:gproc)
-    ]
+      :gproc
+    ])
   end
 end

--- a/apps/emqx_gateway/mix.exs
+++ b/apps/emqx_gateway/mix.exs
@@ -38,13 +38,13 @@ defmodule EMQXGateway.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
       {:emqx_auth, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -22,11 +22,13 @@ defmodule EMQXGatewayCoap.MixProject do
   end
 
   def deps() do
-    [
-      {:emqx, in_umbrella: true},
-      {:emqx_utils, in_umbrella: true},
-      {:emqx_gateway, in_umbrella: true}
-    ] ++ test_deps()
+    UMP.deps(
+      [
+        {:emqx, in_umbrella: true},
+        {:emqx_utils, in_umbrella: true},
+        {:emqx_gateway, in_umbrella: true}
+      ] ++ test_deps()
+    )
   end
 
   defp test_deps() do

--- a/apps/emqx_gateway_exproto/mix.exs
+++ b/apps/emqx_gateway_exproto/mix.exs
@@ -35,13 +35,15 @@ defmodule EMQXGatewayExproto.MixProject do
     test_deps =
       if UMP.test_env?(), do: [{:emqx_exhook, in_umbrella: true, runtime: false}], else: []
 
-    test_deps ++
-      [
-        {:emqx_mix_utils, in_umbrella: true, runtime: false},
-        {:emqx, in_umbrella: true},
-        {:emqx_utils, in_umbrella: true},
-        {:emqx_gateway, in_umbrella: true},
-        UMP.common_dep(:grpc)
-      ]
+    UMP.deps(
+      test_deps ++
+        [
+          {:emqx_mix_utils, in_umbrella: true, runtime: false},
+          {:emqx, in_umbrella: true},
+          {:emqx_utils, in_umbrella: true},
+          {:emqx_gateway, in_umbrella: true},
+          UMP.common_dep(:grpc)
+        ]
+    )
   end
 end

--- a/apps/emqx_gateway_gbt32960/mix.exs
+++ b/apps/emqx_gateway_gbt32960/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXGatewayGbt32960.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_gateway_jt808/mix.exs
+++ b/apps/emqx_gateway_jt808/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXGatewayJt808.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_gateway_lwm2m/mix.exs
+++ b/apps/emqx_gateway_lwm2m/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXGatewayLwm2m.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true},
       {:emqx_gateway_coap, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_gateway_mqttsn/mix.exs
+++ b/apps/emqx_gateway_mqttsn/mix.exs
@@ -22,6 +22,6 @@ defmodule EMQXGatewayMqttsn.MixProject do
   end
 
   def deps() do
-    [{:emqx, in_umbrella: true}, {:emqx_gateway, in_umbrella: true}]
+    UMP.deps([{:emqx, in_umbrella: true}, {:emqx_gateway, in_umbrella: true}])
   end
 end

--- a/apps/emqx_gateway_nats/mix.exs
+++ b/apps/emqx_gateway_nats/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXGatewayNats.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_gateway_ocpp/mix.exs
+++ b/apps/emqx_gateway_ocpp/mix.exs
@@ -22,11 +22,11 @@ defmodule EMQXGatewayOcpp.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:jesse),
+    UMP.deps([
+      :jesse,
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_gateway_stomp/mix.exs
+++ b/apps/emqx_gateway_stomp/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXGatewayStomp.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_gcp_device/mix.exs
+++ b/apps/emqx_gcp_device/mix.exs
@@ -26,13 +26,13 @@ defmodule EMQXGCPDevice.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
-      UMP.common_dep(:jose)
-    ]
+      :jose
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_gen_bridge/mix.exs
+++ b/apps/emqx_gen_bridge/mix.exs
@@ -23,6 +23,6 @@ defmodule EMQXGenBridge.MixProject do
   end
 
   def deps() do
-    UMP.common_deps()
+    UMP.deps([])
   end
 end

--- a/apps/emqx_ldap/mix.exs
+++ b/apps/emqx_ldap/mix.exs
@@ -23,6 +23,6 @@ defmodule EMQXLdap.MixProject do
   end
 
   def deps() do
-    [{:emqx_connector, in_umbrella: true}, {:emqx_resource, in_umbrella: true}]
+    UMP.deps([{:emqx_connector, in_umbrella: true}, {:emqx_resource, in_umbrella: true}])
   end
 end

--- a/apps/emqx_license/mix.exs
+++ b/apps/emqx_license/mix.exs
@@ -25,13 +25,13 @@ defmodule EMQXLicense.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
       {:emqx_gateway, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_machine/mix.exs
+++ b/apps/emqx_machine/mix.exs
@@ -28,7 +28,7 @@ defmodule EMQXMachine.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true, runtime: false},
       {:emqx_utils, in_umbrella: true, runtime: false},
       {:emqx_ctl, in_umbrella: true},
@@ -36,7 +36,7 @@ defmodule EMQXMachine.MixProject do
       {:emqx_dashboard, in_umbrella: true, runtime: false},
       {:emqx_management, in_umbrella: true, runtime: false},
       UMP.common_dep(:system_monitor, runtime: false),
-      UMP.common_dep(:redbug)
-    ]
+      :redbug
+    ])
   end
 end

--- a/apps/emqx_management/mix.exs
+++ b/apps/emqx_management/mix.exs
@@ -22,14 +22,14 @@ defmodule EMQXManagement.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true, runtime: false},
       {:emqx_plugins, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
-      UMP.common_dep(:minirest),
-      UMP.common_dep(:emqx_http_lib)
-    ]
+      :minirest,
+      :emqx_http_lib
+    ])
   end
 end

--- a/apps/emqx_message_transformation/mix.exs
+++ b/apps/emqx_message_transformation/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXMessageTransformation.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_schema_registry, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_mix_utils/mix.exs
+++ b/apps/emqx_mix_utils/mix.exs
@@ -21,9 +21,9 @@ defmodule EMQXMixUtils.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:gpb),
-      UMP.common_dep(:proper)
-    ]
+    UMP.deps([
+      :gpb,
+      :proper
+    ])
   end
 end

--- a/apps/emqx_modules/mix.exs
+++ b/apps/emqx_modules/mix.exs
@@ -22,12 +22,12 @@ defmodule EMQXModules.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_conf, in_umbrella: true},
-      UMP.common_dep(:observer_cli)
-    ]
+      :observer_cli
+    ])
   end
 end

--- a/apps/emqx_mongodb/mix.exs
+++ b/apps/emqx_mongodb/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXMongodb.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.0.25"}
-    ]
+    ])
   end
 end

--- a/apps/emqx_mt/mix.exs
+++ b/apps/emqx_mt/mix.exs
@@ -22,11 +22,11 @@ defmodule EMQXMT.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_dashboard, in_umbrella: true, runtime: false},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_mysql/mix.exs
+++ b/apps/emqx_mysql/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXMysql.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:mysql, github: "emqx/mysql-otp", tag: "1.8.0.2"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_node_rebalance/mix.exs
+++ b/apps/emqx_node_rebalance/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXNodeRebalance.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
       {:emqx_eviction_agent, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_opentelemetry/mix.exs
+++ b/apps/emqx_opentelemetry/mix.exs
@@ -31,16 +31,16 @@ defmodule EMQXOpentelemetry.MixProject do
       override: true
     ]
 
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_resource, in_umbrella: true},
-      UMP.common_dep(:minirest),
+      :minirest,
       {:opentelemetry_api, opentelemetry ++ [sparse: "apps/opentelemetry_api"]},
       {:opentelemetry, opentelemetry ++ [sparse: "apps/opentelemetry"]},
       {:opentelemetry_experimental, opentelemetry ++ [sparse: "apps/opentelemetry_experimental"]},
       {:opentelemetry_api_experimental,
        opentelemetry ++ [sparse: "apps/opentelemetry_api_experimental"]},
       {:opentelemetry_exporter, opentelemetry ++ [sparse: "apps/opentelemetry_exporter"]}
-    ]
+    ])
   end
 end

--- a/apps/emqx_oracle/mix.exs
+++ b/apps/emqx_oracle/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXOracle.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:jamdb_oracle, github: "emqx/jamdb_oracle", tag: "0.4.9.5", manager: :rebar3},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_plugins/mix.exs
+++ b/apps/emqx_plugins/mix.exs
@@ -22,9 +22,9 @@ defmodule EMQXPlugins.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
-      UMP.common_dep(:erlavro)
-    ]
+      :erlavro
+    ])
   end
 end

--- a/apps/emqx_postgresql/mix.exs
+++ b/apps/emqx_postgresql/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXPostgresql.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:epgsql),
+    UMP.deps([
+      :epgsql,
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_prometheus/mix.exs
+++ b/apps/emqx_prometheus/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXPrometheus.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_auth, in_umbrella: true},
@@ -33,7 +33,7 @@ defmodule EMQXPrometheus.MixProject do
       {:emqx_resource, in_umbrella: true},
       {:emqx_durable_storage, in_umbrella: true},
       {:prometheus, git: "https://github.com/emqx/prometheus.erl", tag: "v4.10.0.2"}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_psk/mix.exs
+++ b/apps/emqx_psk/mix.exs
@@ -22,6 +22,6 @@ defmodule EMQXPsk.MixProject do
   end
 
   def deps() do
-    [{:emqx, in_umbrella: true}]
+    UMP.deps([{:emqx, in_umbrella: true}])
   end
 end

--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXRedis.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:eredis_cluster, github: "emqx/eredis_cluster", tag: "0.8.8"}
-    ]
+    ])
   end
 end

--- a/apps/emqx_resource/mix.exs
+++ b/apps/emqx_resource/mix.exs
@@ -24,13 +24,13 @@ defmodule EMQXResource.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
-      UMP.common_dep(:ecpool),
-      UMP.common_dep(:gproc),
-      UMP.common_dep(:telemetry),
-      UMP.common_dep(:hocon),
-      UMP.common_dep(:replayq)
-    ]
+      :ecpool,
+      :gproc,
+      :telemetry,
+      :hocon,
+      :replayq
+    ])
   end
 end

--- a/apps/emqx_retainer/mix.exs
+++ b/apps/emqx_retainer/mix.exs
@@ -24,11 +24,11 @@ defmodule EMQXRetainer.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_ctl, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_rule_engine/mix.exs
+++ b/apps/emqx_rule_engine/mix.exs
@@ -22,18 +22,20 @@ defmodule EMQXRuleEngine.MixProject do
   end
 
   def deps() do
-    UMP.jq_dep() ++
-      [
-        {:emqx, in_umbrella: true},
-        {:emqx_ctl, in_umbrella: true},
-        {:emqx_utils, in_umbrella: true},
-        {:emqx_modules, in_umbrella: true},
-        {:emqx_resource, in_umbrella: true},
-        {:emqx_connector, in_umbrella: true},
-        {:emqx_bridge, in_umbrella: true},
-        UMP.common_dep(:rulesql),
-        UMP.common_dep(:emqtt),
-        UMP.common_dep(:uuid)
-      ]
+    UMP.deps(
+      UMP.jq_dep() ++
+        [
+          {:emqx, in_umbrella: true},
+          {:emqx_ctl, in_umbrella: true},
+          {:emqx_utils, in_umbrella: true},
+          {:emqx_modules, in_umbrella: true},
+          {:emqx_resource, in_umbrella: true},
+          {:emqx_connector, in_umbrella: true},
+          {:emqx_bridge, in_umbrella: true},
+          :rulesql,
+          :emqtt,
+          :uuid
+        ]
+    )
   end
 end

--- a/apps/emqx_s3/mix.exs
+++ b/apps/emqx_s3/mix.exs
@@ -25,14 +25,14 @@ defmodule EMQXS3.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
-      UMP.common_dep(:gproc),
-      UMP.common_dep(:hackney),
-      UMP.common_dep(:erlcloud),
+      :gproc,
+      :hackney,
+      :erlcloud,
       {:emqx_bridge_http, in_umbrella: true, runtime: false}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_schema_registry/mix.exs
+++ b/apps/emqx_schema_registry/mix.exs
@@ -29,16 +29,16 @@ defmodule EMQXSchemaRegistry.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_bridge_http, in_umbrella: true},
       {:emqx_rule_engine, in_umbrella: true},
-      UMP.common_dep(:erlavro),
-      UMP.common_dep(:jesse),
+      :erlavro,
+      :jesse,
       UMP.common_dep(:gpb, runtime: true),
       {:avlizer, github: "emqx/avlizer", tag: "0.5.1.1"}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_schema_validation/mix.exs
+++ b/apps/emqx_schema_validation/mix.exs
@@ -22,11 +22,11 @@ defmodule EMQXSchemaValidation.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_rule_engine, in_umbrella: true},
       {:emqx_schema_registry, in_umbrella: true}
-    ]
+    ])
   end
 end

--- a/apps/emqx_slow_subs/mix.exs
+++ b/apps/emqx_slow_subs/mix.exs
@@ -22,10 +22,10 @@ defmodule EMQXSlowSubs.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
-      UMP.common_dep(:minirest)
-    ]
+      :minirest
+    ])
   end
 end

--- a/apps/emqx_telemetry/mix.exs
+++ b/apps/emqx_telemetry/mix.exs
@@ -25,12 +25,12 @@ defmodule EMQXTelemetry.MixProject do
   end
 
   def deps() do
-    [
+    UMP.deps([
       {:emqx_mix_utils, in_umbrella: true, runtime: false},
       {:emqx, in_umbrella: true},
       {:emqx_utils, in_umbrella: true},
       {:emqx_conf, in_umbrella: true}
-    ]
+    ])
   end
 
   defp extra_dirs() do

--- a/apps/emqx_utils/mix.exs
+++ b/apps/emqx_utils/mix.exs
@@ -26,12 +26,12 @@ defmodule EMQXUtils.MixProject do
   end
 
   def deps() do
-    [
-      UMP.common_dep(:jiffy),
-      UMP.common_dep(:emqx_http_lib),
-      UMP.common_dep(:snabbkaffe),
+    UMP.deps([
+      :jiffy,
+      :emqx_http_lib,
+      :snabbkaffe,
       {:erlang_qq, github: "k32/erlang_qq", tag: "1.0.0", override: true}
-    ]
+    ])
   end
 
   defp test_deps() do

--- a/mix.exs
+++ b/mix.exs
@@ -142,6 +142,23 @@ defmodule EMQXUmbrella.MixProject do
     ]
   end
 
+  @doc """
+  Helper function to wrap dependency specs in applications' `mix.exs` files.
+
+  Dependencies that are common dependencies (i.e., have a clause in `common_dep/1`) may be
+  specified just as their atom name.
+  """
+  def deps(dep_specs) do
+    common_deps() ++
+      Enum.map(dep_specs, fn
+        name when is_atom(name) ->
+          common_dep(name)
+
+        dep_spec ->
+          dep_spec
+      end)
+  end
+
   def common_dep(dep_name, overrides) do
     case common_dep(dep_name) do
       {^dep_name, opts} ->


### PR DESCRIPTION
To prevent unexpected issues with changing order of application compilation, and to also introduce a helper to refer to common dependencies.