### PR TITLE
250525 Throttle client ID registration

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -47,7 +47,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.7"}}}
         ]},
         {extra_src_dirs, [
             {"test", [recursive]},
@@ -59,7 +59,7 @@
             {meck, "0.9.2"},
             {proper, "1.4.0"},
             {bbmustache, "1.10.0"},
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.7"}}}
         ]},
         {extra_src_dirs, [{"test", [recursive]}]}
     ]}

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -609,7 +609,7 @@ post_process_connect(
             handle_out(connack, {?RC_SUCCESS, sp(true), AckProps}, ensure_connected(NChannel));
         {error, client_id_unavailable} ->
             ReasonString = <<"THROTTLED">>,
-            handle_out(connack, {?RC_CLIENT_IDENTIFIER_NOT_VALID, ReasonString}, Channel);
+            handle_out(connack, {?RC_SERVER_BUSY, ReasonString}, Channel);
         {error, Reason} ->
             ?SLOG(error, #{msg => "failed_to_open_session", reason => Reason}),
             handle_out(connack, ?RC_UNSPECIFIED_ERROR, Channel)

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -608,12 +608,11 @@ post_process_connect(
             },
             handle_out(connack, {?RC_SUCCESS, sp(true), AckProps}, ensure_connected(NChannel));
         {error, client_id_unavailable} ->
-            ReasonString = <<"In progress Client ID registration/deregistration. Retry later!">>,
+            ReasonString = <<"THROTTLED">>,
             handle_out(connack, {?RC_CLIENT_IDENTIFIER_NOT_VALID, ReasonString}, Channel);
         {error, Reason} ->
-            ReasonString = <<"Failed to open session">>,
             ?SLOG(error, #{msg => "failed_to_open_session", reason => Reason}),
-            handle_out(connack, {?RC_UNSPECIFIED_ERROR, ReasonString}, Channel)
+            handle_out(connack, ?RC_UNSPECIFIED_ERROR, Channel)
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1320,7 +1320,13 @@ handle_out(connack, ReasonCode, Channel) when is_integer(ReasonCode) ->
 handle_out(connack, {ReasonCode, ReasonString}, Channel = #channel{conninfo = ConnInfo}) ->
     Reason = emqx_reason_codes:name(ReasonCode),
     AckProps0 = emqx_mqtt_props:new(),
-    AckProps1 = emqx_mqtt_props:set('Reason-String', ReasonString, AckProps0),
+    AckProps1 =
+        case ReasonString =:= <<>> of
+            true ->
+                AckProps0;
+            false ->
+                emqx_mqtt_props:set('Reason-String', ReasonString, AckProps0)
+        end,
     AckProps = run_hooks('client.connack', [ConnInfo, Reason], AckProps1),
     AckPacket = ?CONNACK_PACKET(
         case maps:get(proto_ver, ConnInfo) of

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -805,6 +805,9 @@ code_change(_OldVsn, State, _Extra) ->
 handle_reg_pids(Pids) ->
     lists:foreach(fun(Pid) -> _ = erlang:monitor(process, Pid) end, Pids).
 
+handle_down_pids([]) ->
+    %% do not submit a no-op async task
+    ok;
 handle_down_pids(Pids) ->
     lists:foreach(fun mark_channel_disconnected/1, Pids),
     ok = emqx_pool:async_submit_to_pool(?CM_POOL, fun ?MODULE:clean_down/1, [Pids]).

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -69,7 +69,8 @@
 %% Test/debug interface
 -export([
     all_channels/0,
-    all_client_ids/0
+    all_client_ids/0,
+    do_unregister_channel/1
 ]).
 
 %% Client management

--- a/apps/emqx/src/emqx_reason_codes.erl
+++ b/apps/emqx/src/emqx_reason_codes.erl
@@ -42,7 +42,7 @@ name(1, _Ver) ->
 name(2, _Ver) ->
     client_identifier_not_valid;
 name(3, _Ver) ->
-    server_unavaliable;
+    server_unavailable;
 name(4, _Ver) ->
     malformed_username_or_password;
 name(5, _Ver) ->
@@ -104,7 +104,7 @@ text(1, _Ver) ->
 text(2, _Ver) ->
     <<"client_identifier_not_valid">>;
 text(3, _Ver) ->
-    <<"server_unavaliable">>;
+    <<"server_unavailable">>;
 text(4, _Ver) ->
     <<"malformed_username_or_password">>;
 text(5, _Ver) ->

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -492,6 +492,8 @@ t_live_connection_stream(_) ->
     ?assertEqual(ExpectedPids, StreamedPids),
     ok.
 
+%% Stub the channel registry with a local dead pid to verify
+%% that emqx_cm:open_session will return client_id_unavailable error
 t_clientid_registration_throttled(_) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     ClientInfo = #{
@@ -506,6 +508,7 @@ t_clientid_registration_throttled(_) ->
     #{conninfo := ConnInfo} = ChanInfo,
     ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
     ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
+    ok = emqx_cm:unregister_channel(ClientId, DeadPid),
     ok.
 
 spawn_dummy_chann(Mod, Count) ->

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -492,6 +492,22 @@ t_live_connection_stream(_) ->
     ?assertEqual(ExpectedPids, StreamedPids),
     ok.
 
+t_clientid_registration_throttled(_) ->
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    ClientInfo = #{
+        zone => default,
+        listener => 'tcp:default',
+        clientid => ClientId,
+        username => <<"username">>,
+        peerhost => {127, 0, 0, 1}
+    },
+    DeadPid = spawn(fun() -> exit(normal) end),
+    ChanInfo = ?ChanInfo,
+    #{conninfo := ConnInfo} = ChanInfo,
+    ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
+    ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
+    ok.
+
 spawn_dummy_chann(Mod, Count) ->
     #{conninfo := ConnInfo0} = ?ChanInfo,
     ConnInfo = ConnInfo0#{conn_mod => Mod},

--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -508,7 +508,7 @@ t_clientid_registration_throttled(_) ->
     #{conninfo := ConnInfo} = ChanInfo,
     ok = emqx_cm:register_channel(ClientId, DeadPid, ChanInfo#{conn_mod => emqx_connection}),
     ?assertEqual({error, client_id_unavailable}, open_session(true, ClientInfo, ConnInfo)),
-    ok = emqx_cm:unregister_channel(ClientId, DeadPid),
+    true = emqx_cm:do_unregister_channel({ClientId, DeadPid}),
     ok.
 
 spawn_dummy_chann(Mod, Count) ->

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -706,7 +706,7 @@ t_connack_client_id_unavailable(Config) ->
         unlink(Client),
         {error, ConnAck} = emqtt:ConnFun(Client),
         ?assertMatch(
-            {client_identifier_not_valid, #{
+            {server_busy, #{
                 'Reason-String' := <<"THROTTLED">>
             }},
             ConnAck

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -696,6 +696,27 @@ t_connack_assigned_clientid(Config) ->
     ?assert(is_binary(client_info(clientid, Client1))),
     ok = emqtt:disconnect(Client1).
 
+t_connack_client_id_unavailable(Config) ->
+    ConnFun = ?config(conn_fun, Config),
+    ClientId = atom_to_binary(?FUNCTION_NAME),
+    DeadPid = spawn(fun() -> exit(normal) end),
+    ok = emqx_cm_registry:register_channel({ClientId, DeadPid}),
+    try
+        {ok, Client} = emqtt:start_link([{proto_ver, v5}, {clientid, ClientId} | Config]),
+        unlink(Client),
+        {error, ConnAck} = emqtt:ConnFun(Client),
+        ?assertMatch(
+            {client_identifier_not_valid, #{
+                'Reason-String' :=
+                    <<"In progress", _/binary>>
+            }},
+            ConnAck
+        )
+    after
+        ok = emqx_cm_registry:unregister_channel({ClientId, DeadPid})
+    end,
+    ok.
+
 %%--------------------------------------------------------------------
 %% Publish
 %%--------------------------------------------------------------------

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -707,8 +707,7 @@ t_connack_client_id_unavailable(Config) ->
         {error, ConnAck} = emqtt:ConnFun(Client),
         ?assertMatch(
             {client_identifier_not_valid, #{
-                'Reason-String' :=
-                    <<"In progress", _/binary>>
+                'Reason-String' := <<"THROTTLED">>
             }},
             ConnAck
         )

--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -929,6 +929,56 @@ t_kick_session(Config) ->
     ?assert(not is_process_alive(CPid1)),
     ok.
 
+t_ongoing_takeover(Config) ->
+    process_flag(trap_exit, true),
+    MqttVer = ?config(mqtt_vsn, Config),
+    ClientId = make_client_id(?FUNCTION_NAME, Config),
+    Topic = atom_to_binary(?FUNCTION_NAME),
+    InitCtx = #{},
+    QoS = 0,
+    ClientOpts = [
+        {proto_ver, MqttVer},
+        {clean_start, false}
+        | [{properties, #{'Session-Expiry-Interval' => 6000}} || v5 == MqttVer]
+    ],
+
+    true = emqx:get_config([broker, enable_session_registry]),
+
+    _ = start_client(InitCtx, ClientId, Topic, QoS, ClientOpts),
+    ?retry(
+        3_000,
+        100,
+        true = is_map(emqx_cm:get_chan_info(ClientId))
+    ),
+
+    [ServerPid1] = emqx_cm:lookup_channels(ClientId),
+    sys:suspend(ServerPid1),
+
+    %% GIVEN: A ongoing session takeover stuck
+    _ = start_client(InitCtx, ClientId, Topic, QoS, ClientOpts),
+
+    timer:sleep(500),
+
+    %% WHEN: Yet another client connects to takeover
+    _ = start_client(InitCtx, ClientId, Topic, QoS, ClientOpts),
+
+    {ok, CPid} = emqtt:start_link([{clientid, ClientId} | ClientOpts]),
+
+    %% THEN: This client get connack with or RC_SERVER_BUSY
+    case MqttVer of
+        v3 ->
+            ?assertMatch({error, {server_unavailable, _}}, emqtt:connect(CPid));
+        v5 ->
+            ?assertMatch({error, {server_busy, _}}, emqtt:connect(CPid))
+    end,
+    sys:resume(ServerPid1),
+    receive
+        {'EXIT', CPid, {shutdown, _}} = Msg ->
+            ok
+    after 1000 -> ct:fail("No EXIT")
+    end,
+    ok.
+
 wait_for_chan_reg(CTX, ClientId) ->
     ?retry(
         3_000,

--- a/apps/emqx_retainer/rebar.config
+++ b/apps/emqx_retainer/rebar.config
@@ -30,7 +30,7 @@
 {profiles, [
     {test, [
         {deps, [
-            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}}
+            {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.7"}}}
         ]}
     ]}
 ]}.

--- a/changes/ee/feat-15773.en.md
+++ b/changes/ee/feat-15773.en.md
@@ -2,5 +2,5 @@ Throttle client ID registration during reconnects
 
 Added throttling for client ID registration if the previous session cleanup is still in progress.
 This prevents instability when clients reconnect aggressively with the same client ID.
-Affected clients will receive reason code `133` (Client Identifier not valid) in `CONNACK`.
+Affected clients will receive reason code `133` (Client Identifier not valid) in `CONNACK` with Reason-String "THROTTLED".
 Clients should retry after the previous session cleanup has completed.

--- a/changes/ee/feat-15773.en.md
+++ b/changes/ee/feat-15773.en.md
@@ -1,0 +1,6 @@
+Throttle client ID registration during reconnects
+
+Added throttling for client ID registration if the previous session cleanup is still in progress.
+This prevents instability when clients reconnect aggressively with the same client ID.
+Affected clients will receive reason code `133` (Client Identifier not valid) in `CONNACK`.
+Clients should retry after the previous session cleanup has completed.

--- a/changes/ee/feat-15773.en.md
+++ b/changes/ee/feat-15773.en.md
@@ -2,5 +2,7 @@ Throttle client ID registration during reconnects
 
 Added throttling for client ID registration if the previous session cleanup is still in progress.
 This prevents instability when clients reconnect aggressively with the same client ID.
-Affected clients will receive reason code `133` (Client Identifier not valid) in `CONNACK` with Reason-String "THROTTLED".
+Affected clients will receive reason code `137` (Server Busy) in `CONNACK` with Reason-String "THROTTLED".
 Clients should retry after the previous session cleanup has completed.
+
+Also fixed the reason code from `133` to `137` when there is another connection in the middle of registering the same client ID.

--- a/mix.exs
+++ b/mix.exs
@@ -245,7 +245,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:emqtt),
     do:
       {:emqtt,
-       github: "emqx/emqtt", tag: "1.13.6", override: true, system_env: maybe_no_quic_env()}
+       github: "emqx/emqtt", tag: "1.13.7", override: true, system_env: maybe_no_quic_env()}
 
   def common_dep(:typerefl),
     do: {:typerefl, github: "ieQu1/typerefl", tag: "0.9.1", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -91,7 +91,7 @@
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.8"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.1"}}},
     {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.1"}}},
-    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.6"}}},
+    {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.13.7"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x
     {observer_cli, "1.7.5"},


### PR DESCRIPTION
Fixes [EMQX-14648](https://emqx.atlassian.net/browse/EMQX-14648)

Release version: 5.8.8

## Summary

Throttle client ID registration during reconnects

Added throttling for client ID registration if the previous session cleanup is still in progress.
This prevents instability when clients reconnect aggressively with the same client ID.
Affected clients will receive reason code `137` (Server Busy) in `CONNACK` with Reason-String "THROTTLED".
Clients should retry after the previous session cleanup has completed.

Also fixed the reason code from `133` to `137` when there is another connection in the middle of registering the same client ID.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14648]: https://emqx.atlassian.net/browse/EMQX-14648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ