### PR TITLE
test: use per test case client ID

### DIFF
--- a/apps/emqx_eviction_agent/test/emqx_eviction_agent_channel_SUITE.erl
+++ b/apps/emqx_eviction_agent/test/emqx_eviction_agent_channel_SUITE.erl
@@ -11,7 +11,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_channel.hrl").
 
--define(CLIENT_ID, <<"client_with_session">>).
+-define(CLIENT_ID, iolist_to_binary(["client_with_session-", atom_to_list(?FUNCTION_NAME)])).
 
 -import(
     emqx_eviction_agent_test_helpers,


### PR DESCRIPTION
The test become flaky after the client ID registration throttling.