### PR TITLE
fix(limiter): reset shared limiter buckets on update

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -165,9 +165,14 @@ update_group(Group, Options) ->
     case emqx_limiter_registry:find_group(Group) of
         undefined ->
             error({limiter_group_not_found, Group});
-        {Module, _OldLimiterConfigs} ->
-            ok = emqx_limiter_registry:register_group(Group, Module, Options),
-            ok = Module:update_group(Group, Options)
+        {Module, OldOptions} ->
+            Diff = lists:foldl(fun lists:delete/2, OldOptions, Options),
+            Diff =/= [] andalso
+                begin
+                    ok = emqx_limiter_registry:register_group(Group, Module, Options),
+                    ok = Module:update_group(Group, Options)
+                end,
+            ok
     end.
 
 -spec delete_group(group()) -> ok.

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -304,9 +304,9 @@ update_listener(Type, Name, Conf = #{enable := true}, #{enable := false}) ->
 update_listener(Type, Name, #{enable := false}, Conf = #{enable := true}) ->
     start_listener(Type, Name, Conf);
 update_listener(Type, Name, OldConf, NewConf) ->
+    ok = emqx_limiter:update_listener_limiters(listener_id(Type, Name), NewConf),
     case do_update_listener(Type, Name, OldConf, NewConf) of
         ok ->
-            ok = emqx_limiter:update_listener_limiters(listener_id(Type, Name), NewConf),
             ok = maybe_unregister_ocsp_stapling_refresh(Type, Name, NewConf),
             ok;
         {skip, Error} when Type =:= quic ->

--- a/apps/emqx/test/emqx_limiter_SUITE.erl
+++ b/apps/emqx/test/emqx_limiter_SUITE.erl
@@ -226,6 +226,38 @@ t_handle_global_zone_change(_Config) ->
         proplists:get_value(messages, LimiterOptions1)
     ).
 
+t_update_group_no_change(_Config) ->
+    %% Ensure that limiter impl is not asked to be updated if config hasn't changed.
+    Group = ?MODULE,
+    LConf = #{
+        capacity => 42,
+        interval => 100,
+        burst_capacity => 42_000,
+        burst_interval => 100_000
+    },
+    ok = emqx_limiter:create_group(?MODULE, Group, [{conn, LConf}, {byte, LConf}]),
+    ?assertEqual(
+        ok,
+        emqx_limiter:update_group(Group, [{byte, LConf}, {conn, LConf}])
+    ).
+
+%%--------------------------------------------------------------------
+%% Limiter implementation (see `t_update_group_no_change/1`)
+%%--------------------------------------------------------------------
+
+-spec create_group(emqx_limiter:group(), [{emqx_limiter:name(), emqx_limiter:options()}]) -> ok.
+create_group(_Group, _LimiterConfigs) ->
+    ok.
+
+-spec delete_group(emqx_limiter:group()) -> ok.
+delete_group(_Group) ->
+    ok.
+
+-spec update_group(emqx_limiter:group(), [{emqx_limiter:name(), emqx_limiter:options()}]) ->
+    ok.
+update_group(_Group, _LimiterConfigs) ->
+    error(should_not_happen).
+
 %%--------------------------------------------------------------------
 %% Internal functions
 %%--------------------------------------------------------------------

--- a/changes/ee/fix-15783.en.md
+++ b/changes/ee/fix-15783.en.md
@@ -1,0 +1,1 @@
+Ensure that any changes to connection rate limits take effect immediately after the listener update has completed. Previously, parts of internal limiter state were not directly affected by configuration changes. For example, after increasing the burst rate, the effective rate limit could appear stricter than expected.


### PR DESCRIPTION
Fixes [EMQX-14615](https://emqx.atlassian.net/browse/EMQX-14615).

Release version: 6.0.0

## Summary

This PR changes how listener configuration updates are handled when rate limits are changed: any changes to connection rate limits take effect as soon as listener update is complete.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14615]: https://emqx.atlassian.net/browse/EMQX-14615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ