### PR TITLE
test(cm): construct realistic conninfo with `expiry_interval` set

### DIFF
--- a/apps/emqx/test/emqx_cm_SUITE.erl
+++ b/apps/emqx/test/emqx_cm_SUITE.erl
@@ -20,7 +20,8 @@
             sockname => {{127, 0, 0, 1}, 1883},
             peercert => nossl,
             conn_mod => emqx_connection,
-            receive_maximum => 100
+            receive_maximum => 100,
+            expiry_interval => 0
         }
 }).
 


### PR DESCRIPTION
## Summary

ConnInfo is not generally expected to have no `expiry_interval` set.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] ~~The changes are covered with new or existing tests~~
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible
