### PR TITLE
feat: add an option to fast-forward qos0 messages

### DIFF
--- a/apps/emqx/include/emqx_router.hrl
+++ b/apps/emqx/include/emqx_router.hrl
@@ -16,5 +16,6 @@
 -define(SUBOPTION, emqx_suboption).
 -define(SUBSCRIBER, emqx_subscriber).
 -define(SUBSCRIPTION, emqx_subscription).
+-define(SUB_SOCKET, emqx_subsocket).
 
 -endif.

--- a/apps/emqx/src/emqx_cm.erl
+++ b/apps/emqx/src/emqx_cm.erl
@@ -814,6 +814,7 @@ clean_down([Pid | Pids]) ->
     ok = clean_down(Pid),
     clean_down(Pids);
 clean_down(Pid) when is_pid(Pid) ->
+    ok = emqx_broker:remove_sub_socket(Pid),
     try ets:lookup_element(?CHAN_CONN_TAB, Pid, #chan_conn.clientid) of
         ClientId ->
             do_clean_down(ClientId, Pid)

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -1165,7 +1165,9 @@ serialize_variable_byte_integer(N) when N < (1 bsl 28) ->
     >>.
 
 %% Is the frame too large?
--spec is_too_large(iodata(), pos_integer()) -> boolean().
+-spec is_too_large(iodata(), pos_integer() | infinity) -> boolean().
+is_too_large(_IoData, infinity) ->
+    false;
 is_too_large(IoData, MaxSize) ->
     iolist_size(IoData) >= MaxSize.
 

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4074,6 +4074,15 @@ mqtt_session() ->
                     importance => ?IMPORTANCE_LOW
                 }
             )},
+        {fast_forward_qos0,
+            sc(
+                boolean(),
+                #{
+                    default => false,
+                    desc => ?DESC(mqtt_fast_forward_qos0),
+                    importance => ?IMPORTANCE_LOW
+                }
+            )},
         {"max_mqueue_len",
             sc(
                 hoconsc:union([non_neg_integer(), infinity]),

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -873,6 +873,15 @@ handle_incoming(Packet = ?PACKET(Type), State) ->
                 stats_timer = init_stats_timer(State)
             },
             with_channel(handle_in, [Packet], NState);
+        ?SUBSCRIBE ->
+            Zone = State#state.zone,
+            case emqx_config:get_zone_conf(Zone, [mqtt, fast_forward_qos0], false) of
+                true ->
+                    ok = emqx_broker:ensure_sub_socket(self(), State#state.socket);
+                false ->
+                    ok
+            end,
+            with_channel(handle_in, [Packet], State);
         _ ->
             with_channel(handle_in, [Packet], State)
     end;

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1112,7 +1112,7 @@ fields_ws_opts_supported_subprotocols.label:
 
 mqtt_shared_subscription_strategy.desc: """~
   Dispatch strategy for shared subscription.
-  EMQX keeps **dispatch state** (such as random seeds, round-robin position, and sticky subscriber choice) as part of the **publishing client’s connection state**.  
+  EMQX keeps **dispatch state** (such as random seeds, round-robin position, and sticky subscriber choice) as part of the **publishing client's connection state**.
   If the publishing client disconnects and reconnects, this state is lost and must be re-initialized
 
   - `random`: Randomly select a subscriber for dispatch;
@@ -1290,7 +1290,7 @@ fields_deflate_opts_strategy.label:
 
 shared_subscription_strategy_enum.desc: """~
   Dispatch strategy for shared subscription.
-  EMQX keeps **dispatch state** (such as random seeds, round-robin position, and sticky subscriber choice) as part of the **publishing client’s connection state**.  
+  EMQX keeps **dispatch state** (such as random seeds, round-robin position, and sticky subscriber choice) as part of the **publishing client's connection state**.
   If the publishing client disconnects and reconnects, this state is lost and must be re-initialized
 
   - `random`: Randomly select a subscriber for dispatch;
@@ -1313,6 +1313,19 @@ mqtt_mqueue_store_qos0.desc:
 
 mqtt_mqueue_store_qos0.label:
 """Store QoS 0 Message"""
+
+mqtt_fast_forward_qos0.desc: """~
+  When enabled, QoS 0 messages will be forwarded directly to subscriber sockets without entering the session state. If the socket buffer is full, the message is silently dropped.
+  Fast forwarding improves message delivery latency but has the following limitations:
+  - Publisher and subscriber must use the same MQTT version.
+  - No support for subscription identifier.
+  - No support for topic alias.
+  - No metrics are recorded for these messages.
+  - No events are emitted when messages are dropped.
+  - Message ordering becomes non-deterministic when mixed with QoS 1 and 2 messages that route through subscriber sessions.~"""
+
+mqtt_fast_forward_qos0.label:
+"""Fast Forward QoS 0"""
 
 server_ssl_opts_schema_client_renegotiation.desc:
 """In protocols that support client-initiated renegotiation,


### PR DESCRIPTION
Experimental.

Start with below configs:

```
EMQX_mqtt__fast_forward_qos0=true \
EMQX_listeners__tcp__default__tcp_backend=socket \
EMQX_broker__perf__async_fanout_shard_dispatch=true \
```

Created a socket table so the publisher process can directly lookup subscriber's socket and write messages to it.
In contrast, the regular publish path is send an Erlang message `{deliver, ...}` to the subscriber client, the subscriber client receives the `deliver` message, enqueue, update counters etc, upgrade/downgrade qos etc, serialize to byte stream, then send to its own socket.