### PR TITLE
fix(oracle): retry checking prepares

### DIFF
--- a/apps/emqx_oracle/src/emqx_oracle.erl
+++ b/apps/emqx_oracle/src/emqx_oracle.erl
@@ -534,6 +534,9 @@ check_if_table_exists(Conn, SQL, Tokens0) ->
         {ok, [{proc_result, 942, _Description}]} ->
             %% Target table is not created
             {error, undefined_table};
+        {ok, [{proc_result, 1013, _Description}]} ->
+            %% "ORA-01013: user requested cancel of current operation"
+            check_if_table_exists(Conn, SQL, Tokens0);
         {ok, [{proc_result, _, Description}]} ->
             % only the last result is returned, so we need to check on description if it
             % contains the "Table doesn't exist" error as it can not be the last one.

--- a/changes/ee/fix-15806.en.md
+++ b/changes/ee/fix-15806.en.md
@@ -1,0 +1,1 @@
+For the Oracle Action, there could be rare cases when adding an Action with an invalid SQL statement would succeed.  This has been improved.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14661

This was apparently the cause for flakiness such as this:

https://github.com/emqx/emqx/actions/runs/17307909920/job/49136279660?pr=15786#step:4:94

```
%%% emqx_bridge_oracle_SUITE ==> t_update_with_invalid_prepare: FAILED
```

<!--
5.8.8
5.9.2
-->
Release version: 6.0.0


## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
