### PR TITLE
Change authz `no_match` action default value to `deny`

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,3 @@
 erlang 27.3.4.2-2
 elixir 1.18.3-otp-27
+rust 1.88.0

--- a/apps/emqx/src/emqx_access_control.erl
+++ b/apps/emqx/src/emqx_access_control.erl
@@ -225,7 +225,7 @@ check_authorization_cache(ClientInfo, Action, Topic) ->
     end.
 
 do_authorize(ClientInfo, Action, Topic) ->
-    NoMatch = emqx:get_config([authorization, no_match], allow),
+    NoMatch = emqx:get_config([authorization, no_match], deny),
     Default = #{result => NoMatch, from => default},
     case run_hooks('client.authorize', [ClientInfo, Action, Topic], Default) of
         AuthzResult = #{result := Result} when Result == allow; Result == deny ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -2729,7 +2729,7 @@ authz_fields() ->
             sc(
                 hoconsc:enum([allow, deny]),
                 #{
-                    default => allow,
+                    default => deny,
                     required => true,
                     desc => ?DESC(fields_authorization_no_match)
                 }

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -30,8 +30,11 @@ init_per_suite(Config) ->
     %% Session Meck
     ok = meck:new(emqx_session, [passthrough, no_history, no_link]),
     %% Ban
-    meck:new(emqx_banned, [passthrough, no_history, no_link]),
+    ok = meck:new(emqx_banned, [passthrough, no_history, no_link]),
     ok = meck:expect(emqx_banned, check, fun(_ConnInfo) -> false end),
+    %% Authz
+    ok = meck:new(emqx_access_control, [passthrough, no_history, no_link]),
+    ok = meck:expect(emqx_access_control, authorize, fun(_, _, _) -> allow end),
     Apps = emqx_cth_suite:start(
         [
             {emqx, #{
@@ -65,7 +68,8 @@ end_per_suite(Config) ->
         emqx_session,
         emqx_broker,
         emqx_cm,
-        emqx_banned
+        emqx_banned,
+        emqx_access_control
     ]).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/test/emqx_cth_suite.erl
+++ b/apps/emqx/test/emqx_cth_suite.erl
@@ -257,7 +257,8 @@ maybe_configure_app(_App, #{}) ->
 
 configure_app(SchemaModule, Config) ->
     _ = emqx_config:create_tables(),
-    ok = emqx_config:init_load(SchemaModule, render_config(Config)),
+    Rendered = render_config(Config),
+    ok = emqx_config:init_load(SchemaModule, Rendered),
     ok.
 
 maybe_override_env(App, #{override_env := Env = [{_, _} | _]}) ->
@@ -326,7 +327,8 @@ default_appspec(emqx, SuiteOpts) ->
         % NOTE
         % We inform `emqx` of our config loader before starting it so that it won't
         % overwrite everything with a default configuration.
-        before_start => fun inhibit_config_loader/2
+        before_start => fun inhibit_config_loader/2,
+        config => #{authorization => #{no_match => allow}}
     };
 default_appspec(emqx_conf, SuiteOpts) ->
     Config = #{
@@ -334,7 +336,8 @@ default_appspec(emqx_conf, SuiteOpts) ->
             name => node(),
             cookie => erlang:get_cookie(),
             data_dir => unicode:characters_to_binary(maps:get(work_dir, SuiteOpts, "data"))
-        }
+        },
+        authorization => #{no_match => allow}
     },
     % NOTE
     % Since `emqx_conf_schema` manages config for a lot of applications, it's good to include

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1408,6 +1408,7 @@ setup_node(Node, Port) ->
             ok = emqx_config:put([listeners, ssl, default, bind], {{127, 0, 0, 1}, Port + 1}),
             ok = emqx_config:put([listeners, ws, default, bind], {{127, 0, 0, 1}, Port + 3}),
             ok = emqx_config:put([listeners, wss, default, bind], {{127, 0, 0, 1}, Port + 4}),
+            ok = emqx_config:put([authorization, no_match], allow),
             ok
         end,
 

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_file_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_file_SUITE.erl
@@ -31,8 +31,8 @@ groups() ->
 init_per_testcase(TestCase, Config) ->
     Apps = emqx_cth_suite:start(
         [
-            {emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"},
             emqx,
+            {emqx_conf, "authorization.no_match = deny, authorization.cache.enable = false"},
             emqx_auth
         ],
         #{work_dir => filename:join(?config(priv_dir, Config), TestCase)}

--- a/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authz_api_mnesia_SUITE.erl
@@ -23,11 +23,11 @@ groups() ->
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
+            emqx,
             {emqx_conf,
                 "authorization.cache { enable = false },"
                 "authorization.no_match = deny,"
                 "authorization.sources = [{type = built_in_database, max_rules = 7}]"},
-            emqx,
             emqx_auth,
             emqx_auth_mnesia,
             emqx_management,

--- a/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_SUITE.erl
+++ b/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_SUITE.erl
@@ -36,30 +36,30 @@ groups_per_testcase(TC, Groups) ->
     end.
 
 init_per_suite(Config) ->
+    AppConfig = #{
+        <<"rpc">> => #{
+            <<"port_discovery">> => <<"manual">>
+        },
+        <<"durable_sessions">> => #{
+            <<"enable">> => true
+        },
+        <<"durable_storage">> => #{
+            <<"messages">> => #{
+                <<"backend">> => <<"builtin_raft">>
+            },
+            <<"queues">> => #{
+                <<"backend">> => <<"builtin_raft">>,
+                <<"local_write_buffer">> => #{
+                    <<"flush_interval">> => <<"10ms">>
+                }
+            }
+        },
+        <<"authorization">> => #{<<"no_match">> => <<"allow">>}
+    },
+
     Apps = emqx_cth_suite:start(
         [
-            {emqx_conf, #{
-                config => #{
-                    <<"rpc">> => #{
-                        <<"port_discovery">> => <<"manual">>
-                    },
-                    <<"durable_sessions">> => #{
-                        <<"enable">> => true
-                    },
-                    <<"durable_storage">> => #{
-                        <<"messages">> => #{
-                            <<"backend">> => <<"builtin_raft">>
-                        },
-                        <<"queues">> => #{
-                            <<"backend">> => <<"builtin_raft">>,
-                            <<"local_write_buffer">> => #{
-                                <<"flush_interval">> => <<"10ms">>
-                            }
-                        }
-                    }
-                }
-            }},
-            emqx,
+            {emqx, #{config => AppConfig}},
             {emqx_ds_shared_sub, #{
                 config => "durable_queues { enable = true }"
             }}

--- a/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_api_SUITE.erl
+++ b/apps/emqx_ds_shared_sub/test/emqx_ds_shared_sub_api_SUITE.erl
@@ -16,26 +16,27 @@ all() ->
     emqx_common_test_helpers:all(?MODULE).
 
 init_per_suite(Config) ->
+    AppConfig = #{
+        <<"durable_sessions">> => #{
+            <<"enable">> => true
+        },
+        <<"durable_storage">> => #{
+            <<"messages">> => #{
+                <<"backend">> => <<"builtin_raft">>,
+                <<"n_shards">> => 4
+            },
+            <<"queues">> => #{
+                <<"backend">> => <<"builtin_raft">>,
+                <<"n_shards">> => 4
+            }
+        },
+        <<"authorization">> => #{<<"no_match">> => <<"allow">>}
+    },
+
     Apps = emqx_cth_suite:start(
         [
-            {emqx_conf, #{
-                config => #{
-                    <<"durable_sessions">> => #{
-                        <<"enable">> => true
-                    },
-                    <<"durable_storage">> => #{
-                        <<"messages">> => #{
-                            <<"backend">> => <<"builtin_raft">>,
-                            <<"n_shards">> => 4
-                        },
-                        <<"queues">> => #{
-                            <<"backend">> => <<"builtin_raft">>,
-                            <<"n_shards">> => 4
-                        }
-                    }
-                }
-            }},
-            emqx,
+            {emqx, #{config => AppConfig}},
+            {emqx_conf, #{config => AppConfig}},
             {emqx_ds_shared_sub, #{
                 config => #{
                     <<"durable_queues">> => #{

--- a/apps/emqx_ft/test/emqx_ft_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_SUITE.erl
@@ -72,6 +72,7 @@ init_per_suite(Config) ->
     FTConfig = emqx_ft_test_helpers:config(Storage, #{<<"assemble_timeout">> => <<"2s">>}),
     Apps = emqx_cth_suite:start(
         [
+            emqx,
             {emqx_ft, #{config => FTConfig}}
         ],
         #{work_dir => emqx_cth_suite:work_dir(Config)}

--- a/apps/emqx_ft/test/emqx_ft_request_SUITE.erl
+++ b/apps/emqx_ft/test/emqx_ft_request_SUITE.erl
@@ -15,6 +15,7 @@ all() -> emqx_common_test_helpers:all(?MODULE).
 init_per_suite(Config) ->
     Apps = emqx_cth_suite:start(
         [
+            emqx,
             {emqx_ft, "file_transfer { enable = true, assemble_timeout = 1s}"}
         ],
         #{work_dir => ?config(priv_dir, Config)}

--- a/changes/ee/feat-15820.en.md
+++ b/changes/ee/feat-15820.en.md
@@ -1,0 +1,1 @@
+Change default value of cnofig `authorization.no_match` from `allow` to `deny` for better security defaults.


### PR DESCRIPTION
Fixes [EMQX-14667](https://emqx.atlassian.net/browse/EMQX-14667)

<!--
5.8.8
5.9.2
6.0.0
-->
Release version: 6.0.0

## Summary

This PR changes the default config value for `authorization.no_match` from `allow` to `deny` for more secure defaults.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14667]: https://emqx.atlassian.net/browse/EMQX-14667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ