### PR TITLE
chore(ocpp): Fix conns crashs on reached the active_n

### DIFF
--- a/apps/emqx_gateway_ocpp/src/emqx_gateway_ocpp.app.src
+++ b/apps/emqx_gateway_ocpp/src/emqx_gateway_ocpp.app.src
@@ -1,6 +1,6 @@
 {application, emqx_gateway_ocpp, [
     {description, "OCPP-J 1.6 Gateway for EMQX"},
-    {vsn, "0.1.6"},
+    {vsn, "0.1.7"},
     {registered, []},
     {applications, [kernel, stdlib, jesse, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_connection.erl
@@ -692,9 +692,9 @@ handle_outgoing(Packets, State = #state{active_n = ActiveN, piggyback = Piggybac
     NState =
         case emqx_pd:get_counter(outgoing_pubs) > ActiveN of
             true ->
-                Cnt = emqx_pd:reset_counter(outgoing_pubs),
-                Oct = emqx_pd:reset_counter(outgoing_bytes),
-                postpone({check_gc, Cnt, Oct}, State);
+                Cnt1 = emqx_pd:reset_counter(outgoing_pubs),
+                Oct1 = emqx_pd:reset_counter(outgoing_bytes),
+                postpone({check_gc, Cnt1, Oct1}, State);
             false ->
                 State
         end,

--- a/changes/ee/fix-15822.en.md
+++ b/changes/ee/fix-15822.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the OCPP connection would crash after sending a certain number of messages.


### PR DESCRIPTION
Fixes the follow crash logs
```
clientid: VN001001, peername: 36.43.27.143:35587, pid: <0.31957511.0>, line: 948, domain: ["otp","sasl"], error_logger: {"type":"crash_report","tag":"error_report"}, logger_formatter: {"title":"CRASH REPORT"}, msg: crasher: initial call: cowboy_clear:connection_process/4, pid: <0.31957511.0>, registered_name: [], error: {{badmatch,889},[{emqx_ocpp_connection,handle_outgoing,2,[{file,"emqx_ocpp_connection.erl"},{line,682}]},{emqx_ocpp_connection,websocket_info,2,[{file,"emqx_ocpp_connection.erl"},{line,821}]},{cowboy_websocket_linger,handler_call,6,[{file,"cowboy_websocket_linger.erl"},{line,582}]},{cowboy_http,loop,1,[{file,"cowboy_http.erl"},{line,279}]},{proc_lib,init_p_do_apply,3,[{file,"proc_lib.erl"},{line,329}]}]}, ancestors: [<0.20769133.0>,<0.20769183.0>,ranch_sup,<0.3711.0>], message_queue_len: 0, messages: [], links: [#Port<0.10349327>,<0.20769133.0>], dictionary: [{send_cnt,11},{send_msg,11},{incoming_pubs,0},{recv_oct,959},{recv_cnt,11},{outgoing_bytes,0},{incoming_bytes,0},{recv_msg,11},{'recv_msg.qos1',11},{recv_pkt,11},{outgoing_pubs,0},{'$logger_metadata$',#{peername => "36.43.27.143:35587",clientid => <<"VN001001">>}},{send_pkt,11},{'send_msg.qos1',11},{send_oct,889},{guid,{1756713748453879,63617087545863,12}}], trap_exit: false, status: running, heap_size: 1598, stack_size: 29, reductions: 29020; neighbours:
```
<!--
5.8.8
5.9.2
6.0.0
-->
Release version: e5.8.9

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
