### PR TITLE
fix(kafka consumer/source): treat group acl denied as healthy connection (r58)

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kafka.yaml
+++ b/.ci/docker-compose-file/docker-compose-kafka.yaml
@@ -58,6 +58,7 @@ services:
       - ./kerberos/krb5.conf:/etc/kdc/krb5.conf
       - ./kerberos/krb5.conf:/etc/krb5.conf
     command: kafka-entrypoint.sh
+
   kafka_2:
     <<: *kafka
     container_name: kafka-2.emqx.net
@@ -73,3 +74,43 @@ services:
       - ./kafka/kafka-entrypoint.sh:/bin/kafka-entrypoint.sh
       - ./kerberos/krb5.conf:/etc/kdc/krb5.conf
       - ./kerberos/krb5.conf:/etc/krb5.conf
+
+  kafka_setup_acls:
+    image: wurstmeister/kafka:2.13-2.8.1
+    container_name: kafka_setup_acls
+    depends_on:
+      kafka_1:
+        condition: service_started
+      kafka_2:
+        condition: service_started
+    networks:
+      emqx_bridge:
+    restart: no
+    command:
+      - bash
+      - "-c"
+      - |
+        cd /opt/kafka
+
+        bin/kafka-acls.sh --bootstrap-server kafka-1.emqx.net:9092 \
+            --add \
+            --deny-principal User:limiteduser \
+            --group ____emqx_consumer_probe
+
+        bin/kafka-acls.sh --bootstrap-server kafka-1.emqx.net:9092 \
+            --add \
+            --allow-principal "User:*" \
+            --group "*"
+
+  kafka_setup_acls_done:
+    image: wurstmeister/kafka:2.13-2.8.1
+    container_name: kafka_setup_acls_done
+    depends_on:
+      kafka_setup_acls:
+        condition: service_completed_successfully
+    networks:
+      emqx_bridge:
+    command:
+      - bash
+      - "-c"
+      - tail -f /dev/null

--- a/.ci/docker-compose-file/kafka/jaas.conf
+++ b/.ci/docker-compose-file/kafka/jaas.conf
@@ -1,7 +1,8 @@
 KafkaServer {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    user_admin="password"
-   user_emqxuser="password";
+   user_emqxuser="password"
+   user_limiteduser="password";
 
    org.apache.kafka.common.security.scram.ScramLoginModule required
    username="admin"

--- a/.ci/docker-compose-file/kafka/jaas2.conf
+++ b/.ci/docker-compose-file/kafka/jaas2.conf
@@ -1,7 +1,8 @@
 KafkaServer {
    org.apache.kafka.common.security.plain.PlainLoginModule required
    user_admin="password"
-   user_emqxuser="password";
+   user_emqxuser="password"
+   user_limiteduser="password";
 
    org.apache.kafka.common.security.scram.ScramLoginModule required
    username="admin"

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_consumer.erl
@@ -669,7 +669,14 @@ check_client_connectivity(ClientPid) ->
             {?status_disconnected, maybe_clean_error(Reason)};
         {error, Reason} ->
             %% `brod' should have already logged the client being down.
-            {?status_disconnected, maybe_clean_error(Reason)};
+            case maybe_clean_error(Reason) of
+                {group_authorization_failed, _} ->
+                    %% We're connected.
+                    ?tp("kafka_consumer_hc_group_acl_deny", #{}),
+                    ?status_connected;
+                CleanReason ->
+                    {?status_disconnected, CleanReason}
+            end;
         {ok, _Metadata} ->
             ?status_connected
     end.

--- a/changes/ee/fix-15826.en.md
+++ b/changes/ee/fix-15826.en.md
@@ -1,0 +1,1 @@
+Previously, if the user used in a Kafka Consumer Connector did not have permissions to read the special `____emqx_consumer_probe` group used for health checks, the health check would fail.  Now, if the Kafka broker returns an ACL denied response, the connection is considered healthy.


### PR DESCRIPTION
Port of https://github.com/emqx/emqx/pull/15826

Fixes https://emqx.atlassian.net/browse/EMQX-14668

Release version: 5.8.x
