### PR TITLE
fix(greptime): atom and process leaks, and function clause error

### DIFF
--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -26,7 +26,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "GreptimeTeam/greptimedb-ingester-erl", tag: "v0.1.8"}
-    ]
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.0.1"}
+    ])
   end
 end

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -718,7 +718,14 @@ value_type([<<"False">>]) ->
     greptimedb_values:boolean_value(false);
 value_type([Float]) when is_float(Float) ->
     Float;
-value_type(Val) ->
+value_type(Val0) ->
+    Val =
+        case unicode:characters_to_binary(Val0, utf8) of
+            Val1 when is_binary(Val1) ->
+                [Val1];
+            Error ->
+                throw({unrecoverable_error, {non_utf8_string_value, Val0}})
+        end,
     #{values => #{string_values => Val}, datatype => 'STRING'}.
 
 key_filter(undefined) -> undefined;

--- a/changes/ee/fix-15827.en.md
+++ b/changes/ee/fix-15827.en.md
@@ -1,0 +1,3 @@
+Fixed atom and process leaks in the GreptimeDB driver.
+
+Fixed a `function_clause` error that could arise if certain incorrect write syntaxes were used in GreptimeDB Actions.


### PR DESCRIPTION
Port of https://github.com/emqx/emqx/pull/15827

Fixes https://emqx.atlassian.net/browse/EMQX-14673

Fixes https://emqx.atlassian.net/browse/EMQX-14492

Previously, the channel name would use `list_to_atom(pid_to_list(self()))`, which leads to an atom leak.

Not only that, but the `greptime_worker` `gen_server` process did not set `trap_exit` to true, which means that the `terminate` callback was not called, leaking `grpcbox_channel` processes.

Also, a function clause error was fixed.

```
stacktrace => [{greptimedb_encoder,flatten,[[<<"emqx_NzU0MT">>,<<"\"">>]],[{file,"greptimedb_encoder.erl"},{line,198}]},{maps,map_1,3,[{file,"maps.erl"},{line,904}]},{maps,map,2,[{file,"maps.erl"},{line,889}]},{maps,update_with,3,[{file,"maps.erl"},{line,627}]},{lists,map_1,2,[{file,"lists.erl"},{line,2082}]},{lists,map_1,2,[{file,"lists.erl"},{line,2082}]},{lists,map,2,[{file,"lists.erl"},{line,2077}]},{greptimedb_encoder,insert_request,3,[{file,"greptimedb_encoder.erl"},{line,47}]},{greptimedb_encoder,insert_requests,4,[{file,"greptimedb_encoder.erl"},{line,36}]},{greptimedb,async_write_batch,3,[{file,"greptimedb.erl"},{line,102}]},{emqx_bridge_greptimedb_connector,do_async_query,5,[{file,"emqx_bridge_greptimedb_connector.erl"},{line,491}]},{emqx_resource_buffer_worker,apply_query_fun,9
```

Release version: 5.8.x
