### PR TITLE
feat(mqtt connector): add static clientid & username & password tuples

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge_mqtt, [
     {description, "EMQX MQTT Broker Bridge"},
-    {vsn, "0.2.9"},
+    {vsn, "0.2.10"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -61,13 +61,20 @@
 -define(MAX_PREFIX_BYTES, 19).
 -define(AUTO_RECONNECT_INTERVAL_S, 2).
 
+-define(available_clientid_info, available_clientid_info).
+
 -type clientid() :: binary().
+-type clientid_info() :: #{
+    clientid := clientid(),
+    username => binary(),
+    password => emqx_schema_secret:secret()
+}.
 -type channel_resource_id() :: action_resource_id() | source_resource_id().
 -type connector_state() :: #{
     pool_name := connector_resource_id(),
     installed_channels := #{channel_resource_id() => channel_state()},
     clean_start := boolean(),
-    available_clientids := [clientid()],
+    ?available_clientid_info := [clientid_info()],
     topic_to_handler_index := ets:table(),
     server := string()
 }.
@@ -211,11 +218,11 @@ on_get_channel_status(
     _ResId,
     ChannelId,
     #{
-        available_clientids := AvailableClientids,
+        ?available_clientid_info := AvailableClientidInfo,
         installed_channels := Channels
     } = _State
 ) when is_map_key(ChannelId, Channels) ->
-    case AvailableClientids of
+    case AvailableClientidInfo of
         [] ->
             %% We should mark this connector as unhealthy so messages fail fast and an
             %% alarm is raised.
@@ -232,14 +239,14 @@ start_mqtt_clients(ResourceId, Conf) ->
     ClientOpts = mk_ecpool_client_opts(ResourceId, Conf),
     start_mqtt_clients(ResourceId, Conf, ClientOpts).
 
-find_my_static_clientids(#{static_clientids := [_ | _] = Entries}) ->
+find_my_static_clientid_info(#{static_clientids := [_ | _] = Entries}) ->
     NodeBin = atom_to_binary(node()),
     MyConfig =
         lists:filtermap(
-            fun(#{node := N, ids := Ids}) ->
+            fun(#{node := N, ids := Info}) ->
                 case N =:= NodeBin of
                     true ->
-                        {true, Ids};
+                        {true, Info};
                     false ->
                         false
                 end
@@ -247,44 +254,45 @@ find_my_static_clientids(#{static_clientids := [_ | _] = Entries}) ->
             Entries
         ),
     {ok, lists:flatten(MyConfig)};
-find_my_static_clientids(#{} = _Conf) ->
+find_my_static_clientid_info(#{} = _Conf) ->
     error.
 
 start_mqtt_clients(ResourceId, StartConf, ClientOpts) ->
     PoolName = ResourceId,
     PoolSize = get_pool_size(StartConf),
-    AvailableClientids = get_available_clientids(StartConf, ClientOpts),
+    AvailableClientidInfo = get_available_clientid_info(StartConf, ClientOpts),
     Options = [
         {name, PoolName},
         {pool_size, PoolSize},
-        {available_clientids, AvailableClientids},
+        {?available_clientid_info, AvailableClientidInfo},
         {client_opts, ClientOpts},
         {auto_reconnect, ?AUTO_RECONNECT_INTERVAL_S}
     ],
     ok = emqx_resource:allocate_resource(ResourceId, pool_name, PoolName),
     case emqx_resource_pool:start(PoolName, ?MODULE, Options) of
         ok ->
-            {ok, #{pool_name => PoolName, available_clientids => AvailableClientids}};
+            {ok, #{pool_name => PoolName, ?available_clientid_info => AvailableClientidInfo}};
         {error, {start_pool_failed, _, Reason}} ->
             {error, Reason}
     end.
 
 get_pool_size(#{static_clientids := [_ | _]} = Conf) ->
-    {ok, Ids} = find_my_static_clientids(Conf),
-    length(Ids);
+    {ok, Info} = find_my_static_clientid_info(Conf),
+    length(Info);
 get_pool_size(#{pool_size := PoolSize}) ->
     PoolSize.
 
-get_available_clientids(#{} = Conf, ClientOpts) ->
-    case find_my_static_clientids(Conf) of
-        {ok, Ids} ->
-            Ids;
+get_available_clientid_info(#{} = Conf, ClientOpts) ->
+    case find_my_static_clientid_info(Conf) of
+        {ok, Info} ->
+            Info;
         error ->
             #{pool_size := PoolSize} = Conf,
             #{clientid := ClientIdPrefix} = ClientOpts,
             lists:map(
                 fun(WorkerId) ->
-                    mk_clientid(WorkerId, ClientIdPrefix)
+                    Opts = maps:with([username, password], ClientOpts),
+                    Opts#{clientid => mk_clientid(WorkerId, ClientIdPrefix)}
                 end,
                 lists:seq(1, PoolSize)
             )
@@ -460,10 +468,10 @@ combine_status(Statuses, ConnState) ->
     %% Natural order of statuses: [connected, connecting, disconnected]
     %% * `disconnected` wins over any other status
     %% * `connecting` wins over `connected`
-    #{available_clientids := AvailableClientids} = ConnState,
+    #{?available_clientid_info := AvailableClientidInfo} = ConnState,
     ExpectedNoClientids =
-        case AvailableClientids of
-            _ when length(AvailableClientids) == 0 ->
+        case AvailableClientidInfo of
+            _ when length(AvailableClientidInfo) == 0 ->
                 true;
             _ ->
                 false
@@ -532,7 +540,7 @@ mk_ecpool_client_opts(
         Config
     ),
     Name = parse_id_to_name(ResourceId),
-    mk_client_opt_password(Options#{
+    Options#{
         hosts => [HostPort],
         clientid => clientid(Name, Config),
         connect_timeout => ConnectTimeoutS,
@@ -540,17 +548,11 @@ mk_ecpool_client_opts(
         force_ping => true,
         ssl => EnableSsl,
         ssl_opts => maps:to_list(maps:remove(enable, Ssl))
-    }).
+    }.
 
 parse_id_to_name(Id) ->
     {_Type, Name} = emqx_connector_resource:parse_connector_id(Id, #{atom_name => false}),
     Name.
-
-mk_client_opt_password(Options = #{password := Secret}) ->
-    %% TODO: Teach `emqtt` to accept 0-arity closures as passwords.
-    Options#{password := emqx_secret:unwrap(Secret)};
-mk_client_opt_password(Options) ->
-    Options.
 
 ms_to_s(Ms) ->
     erlang:ceil(Ms / 1000).
@@ -573,8 +575,10 @@ connect(Options) ->
     }),
     Name = proplists:get_value(name, Options),
     ClientOpts = proplists:get_value(client_opts, Options),
-    AvailableClientids = proplists:get_value(available_clientids, Options),
-    case emqtt:start_link(mk_emqtt_client_opts(Name, WorkerId, AvailableClientids, ClientOpts)) of
+    AvailableClientidInfo = proplists:get_value(?available_clientid_info, Options),
+    EmqttClientOpts = mk_emqtt_client_opts(Name, WorkerId, AvailableClientidInfo, ClientOpts),
+    ?tp("mqtt_emqtt_client_about_to_start", #{opts => EmqttClientOpts}),
+    case emqtt:start_link(EmqttClientOpts) of
         {ok, Pid} ->
             connect(Pid, Name);
         {error, Reason} = Error ->
@@ -591,16 +595,34 @@ connect(Options) ->
 mk_emqtt_client_opts(
     Name,
     WorkerId,
-    AvailableClientids,
-    ClientOpts = #{
+    AvailableClientidInfo,
+    ClientOpts0 = #{
         topic_to_handler_index := TopicToHandlerIndex
     }
 ) ->
     %% WorkerId :: 1..inf
-    ClientOpts#{
-        clientid := lists:nth(WorkerId, AvailableClientids),
+    ClientidInfo = lists:nth(WorkerId, AvailableClientidInfo),
+    %% `clientid` is always present.
+    ClientId = maps:get(clientid, ClientidInfo),
+    Username = maps:get(username, ClientidInfo, undefined),
+    Password = maps:get(password, ClientidInfo, undefined),
+    ClientOpts1 = ClientOpts0#{
+        clientid := ClientId,
         msg_handler => mk_client_event_handler(Name, TopicToHandlerIndex)
-    }.
+    },
+    ClientOpts2 =
+        case Username /= undefined of
+            true ->
+                ClientOpts1#{username => Username};
+            false ->
+                maps:remove(username, ClientOpts1)
+        end,
+    case Password /= undefined of
+        true ->
+            ClientOpts2#{password => Password};
+        false ->
+            maps:remove(password, ClientOpts2)
+    end.
 
 mk_clientid(WorkerId, {Prefix, ClientId}) when ?IS_NO_PREFIX(Prefix) ->
     %% When there is no prefix, try to keep the client ID length within 23 bytes

--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_publisher_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_v2_publisher_SUITE.erl
@@ -463,6 +463,93 @@ t_static_clientids(Config) ->
 
     ok.
 
+%% Checks that we utilize the new tuple format of specifying static clientids along with
+%% usernames and passwords.
+t_static_clientids_username_password_tuples(TCConfig) ->
+    NodeBin = atom_to_binary(node()),
+    ?check_trace(
+        begin
+            {201, #{<<"status">> := <<"connected">>}} = create_connector_api(TCConfig, #{
+                %% Root username and password are ignored if static clientids are used.
+                <<"username">> => <<"should_not_use_this">>,
+                <<"password">> => <<"should_not_use_this">>,
+                <<"static_clientids">> => [
+                    #{
+                        <<"node">> => NodeBin,
+                        <<"ids">> => [
+                            #{
+                                <<"clientid">> => <<"1">>,
+                                <<"username">> => <<"u1">>,
+                                <<"password">> => <<"p1">>
+                            },
+                            #{
+                                <<"clientid">> => <<"2">>,
+                                <<"username">> => <<"u2">>
+                            },
+                            #{<<"clientid">> => <<"3">>}
+                        ]
+                    }
+                ]
+            }),
+            ConnectedClients0 =
+                lists:map(
+                    fun(ConnPid) ->
+                        ConnState = sys:get_state(ConnPid),
+                        emqx_connection:info({channel, [clientid, username]}, ConnState)
+                    end,
+                    emqx_cm:all_channels()
+                ),
+            ConnectedClients1 = lists:sort(ConnectedClients0),
+            ConnectedClients = lists:map(fun maps:from_list/1, ConnectedClients1),
+            ?assertMatch(
+                [
+                    #{
+                        clientid := <<"1">>,
+                        username := <<"u1">>
+                    },
+                    #{
+                        clientid := <<"2">>,
+                        username := <<"u2">>
+                    },
+                    #{
+                        clientid := <<"3">>,
+                        username := undefined
+                    }
+                ],
+                ConnectedClients
+            ),
+            ok
+        end,
+        fun(Trace) ->
+            SubTrace = ?of_kind("mqtt_emqtt_client_about_to_start", Trace),
+            Opts0 = lists:map(fun(#{opts := Opts}) -> Opts end, SubTrace),
+            Opts = lists:sort(fun(#{clientid := C1}, #{clientid := C2}) -> C1 =< C2 end, Opts0),
+            %% Checking used passwords
+            ?assertMatch(
+                [
+                    #{
+                        clientid := <<"1">>,
+                        username := <<"u1">>,
+                        password := _
+                    },
+                    #{
+                        clientid := <<"2">>,
+                        username := <<"u2">>
+                    },
+                    #{clientid := <<"3">>}
+                ],
+                Opts
+            ),
+            [C1, C2, C3] = Opts,
+            ?assertEqual(<<"p1">>, emqx_secret:unwrap(maps:get(password, C1)), #{opts => C1}),
+            ?assertNot(is_map_key(password, C2), #{opts => C2}),
+            ?assertNot(is_map_key(username, C3), #{opts => C3}),
+            ?assertNot(is_map_key(password, C3), #{opts => C3}),
+            ok
+        end
+    ),
+    ok.
+
 %% Checks that we can forward original MQTT user properties via this action.  Also
 %% verifies that extra properties may be added via templates.
 t_forward_user_properties(Config) ->

--- a/changes/ee/feat-15845.en.md
+++ b/changes/ee/feat-15845.en.md
@@ -1,0 +1,1 @@
+Extended the `static_clientids` configuration of MQTT Connector to allow specifying usernames and passwords associated with each clientid.

--- a/rel/i18n/emqx_bridge_mqtt_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_mqtt_connector_schema.hocon
@@ -159,7 +159,7 @@ mode.label:
 """MQTT Bridge Mode"""
 
 password.desc:
-"""The password of the MQTT protocol"""
+"""The password of the MQTT protocol.  Note that if static clientids are used, this option is ignored."""
 
 password.label:
 """Password"""
@@ -197,7 +197,7 @@ server_configs.label:
 """Server Configs"""
 
 username.desc:
-"""The username of the MQTT protocol"""
+"""The username of the MQTT protocol.  Note that if static clientids are used, this option is ignored."""
 
 username.label:
 """Username"""
@@ -223,7 +223,22 @@ static_clientid_entry_node.desc:
 static_clientid_entry_ids.label:
 """Static clientids"""
 static_clientid_entry_ids.desc:
-"""Array of static client IDs assigned to this node."""
+"""Array of static client IDs (and usernames/passwords) assigned to this node."""
+
+static_clientid_entry_clientid.label:
+"""Static clientid"""
+static_clientid_entry_clientid.desc:
+"""Static client ID assigned to this node."""
+
+static_clientid_entry_username.label:
+"""Username"""
+static_clientid_entry_username.desc:
+"""Username associated with the static clientid."""
+
+static_clientid_entry_password.label:
+"""Password"""
+static_clientid_entry_password.desc:
+"""Password associated with the static clientid."""
 
 connect_timeout.label:
 """Connect Timeout"""


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14679


<!--
5.9.2
6.0.0
-->
Release version: 5.8.9

## Summary

Some servers require unique usernames for each clientid, hence the need to change the previous simple clientid into a clientid & username & password tuple.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
