### PR TITLE
fix(kafka): upgrade Kafka producer lib to wolff-4.0.12

### DIFF
--- a/apps/emqx_bridge_azure_event_hub/rebar.config
+++ b/apps/emqx_bridge_azure_event_hub/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.11"},
+    {wolff, "4.0.12"},
     {kafka_protocol, "4.2.8"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.4.6"},

--- a/apps/emqx_bridge_confluent/rebar.config
+++ b/apps/emqx_bridge_confluent/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.11"},
+    {wolff, "4.0.12"},
     {kafka_protocol, "4.2.8"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.4.6"},

--- a/apps/emqx_bridge_kafka/rebar.config
+++ b/apps/emqx_bridge_kafka/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {wolff, "4.0.11"},
+    {wolff, "4.0.12"},
     {kafka_protocol, "4.2.8"},
     {brod_gssapi, "0.1.3"},
     {brod, "4.4.6"},

--- a/changes/ee/fix-15866.en.md
+++ b/changes/ee/fix-15866.en.md
@@ -1,0 +1,5 @@
+Upgrade Kafka producer lib wollf to 4.0.12 to improve handling of temporarily missing partitions in Kafka metadata responses.
+
+In rare race conditions, Kafka may return an incomplete partition list.
+Previously, this was only handled when a topic was recreated with fewer partitions, but not when partitions were temporarily missing.
+This gap could cause the partition producer to stall and block shutdown indefinitely.

--- a/mix.exs
+++ b/mix.exs
@@ -278,7 +278,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.0.11"}
+  def common_dep(:wolff), do: {:wolff, "4.0.12"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),


### PR DESCRIPTION
Fixes [EEC-1237](https://emqx.atlassian.net/browse/EEC-1237)

<!--
5.8.9
5.9.2
6.0.0
6.1.0
-->
Release version: 5.8.9/5.9.2/5.10.1

## Summary

Upgrade Kafka producer lib wollf to 4.0.12 to improve handling of temporarily missing partitions in Kafka metadata responses.

In rare race conditions, Kafka may return an incomplete partition list.
Previously, this was only handled when a topic was recreated with fewer partitions, but not when partitions were temporarily missing.
This gap could cause the partition producer to stall and block shutdown indefinitely.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EEC-1237]: https://emqx.atlassian.net/browse/EEC-1237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ