### PR TITLE
Eliminate warning log `unclean_terminate` after `server_busy` is sent in `CONNACK`

### DIFF
--- a/apps/emqx/src/emqx.app.src
+++ b/apps/emqx/src/emqx.app.src
@@ -2,7 +2,7 @@
 {application, emqx, [
     {id, "emqx"},
     {description, "EMQX Core"},
-    {vsn, "5.5.4"},
+    {vsn, "5.5.5"},
     {modules, []},
     {registered, []},
     {applications, [

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1335,7 +1335,11 @@ handle_out(connack, {ReasonCode, ReasonString}, Channel = #channel{conninfo = Co
         sp(false),
         AckProps
     ),
-    shutdown(Reason, AckPacket, Channel);
+    %% Per MQTT v5: If a Server sends a CONNACK with a Reason Code other than 0x00 (Success),
+    %% the Will Message MUST NOT be published.
+    %% Per MQTT v3: If the Will Flag is set to 1 this indicates that,
+    %% if the Connect request is accepted, a Will Message MUST be stored…
+    shutdown(Reason, AckPacket, Channel#channel{will_msg = undefined});
 %% Optimize?
 handle_out(publish, [], Channel) ->
     {ok, Channel};

--- a/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
+++ b/apps/emqx/test/emqx_mqtt_protocol_v5_SUITE.erl
@@ -20,8 +20,9 @@
 -compile(nowarn_export_all).
 
 -include_lib("emqx/include/emqx_mqtt.hrl").
--include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("eunit/include/eunit.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("common_test/include/ct.hrl").
 
@@ -701,8 +702,19 @@ t_connack_client_id_unavailable(Config) ->
     ClientId = atom_to_binary(?FUNCTION_NAME),
     DeadPid = spawn(fun() -> exit(normal) end),
     ok = emqx_cm_registry:register_channel({ClientId, DeadPid}),
+    WillTopic = iolist_to_binary([atom_to_binary(?FUNCTION_NAME), "/will"]),
+    NotWillMsg = #message{topic = WillTopic, payload = <<"NotWillMsg">>},
+    Opts = [
+        {proto_ver, v5},
+        {clientid, ClientId},
+        {will_flag, true},
+        {will_topic, WillTopic},
+        {will_payload, <<"WillMsg">>}
+        | Config
+    ],
+    emqx_broker:subscribe(WillTopic),
     try
-        {ok, Client} = emqtt:start_link([{proto_ver, v5}, {clientid, ClientId} | Config]),
+        {ok, Client} = emqtt:start_link(Opts),
         unlink(Client),
         {error, ConnAck} = emqtt:ConnFun(Client),
         ?assertMatch(
@@ -714,6 +726,11 @@ t_connack_client_id_unavailable(Config) ->
     after
         ok = emqx_cm_registry:unregister_channel({ClientId, DeadPid})
     end,
+    %% Assert no will message is published for server_busy CONNACK reason
+    emqx_broker:publish(NotWillMsg),
+    ?assertReceive({deliver, WillTopic, #message{payload = <<"NotWillMsg">>}}, 1000),
+    ?assertNotReceive({deliver, WillTopic, #message{payload = <<"WillMsg">>}}, 100),
+    emqx_broker:subscriber_down(self()),
     ok.
 
 %%--------------------------------------------------------------------

--- a/changes/ee/fix-15872.en.md
+++ b/changes/ee/fix-15872.en.md
@@ -1,0 +1,1 @@
+Eliminate warning log 'unclean_terminate' when disconnected after CONNACK is sent with a non-zero reason code.


### PR DESCRIPTION
Fixes [EMQX-14686](https://emqx.atlassian.net/browse/EMQX-14686)

<!--
5.8.9
5.9.2
6.0.0
6.1.0
-->
Release version: 5.8.9, 5.9.2, 5.10.1, 6.0.0

## Summary

The attempt to publish will message when non-zero CONNACK reason code caused a warn log with stacktrace.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14686]: https://emqx.atlassian.net/browse/EMQX-14686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ