### PR TITLE
ci(mix): make args parsing stricter

### DIFF
--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.cover.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.cover.ex
@@ -21,7 +21,11 @@ defmodule Mix.Tasks.Emqx.Cover do
   """
 
   @impl true
-  def run(_args) do
+  def run(args) do
+    if args != [] do
+      Mix.raise("Unknown options:\n  #{inspect(args, pretty: true)}")
+    end
+
     ECt.ensure_test_mix_env!()
     UMP.set_test_env!(true)
 

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.ct.ex
@@ -322,7 +322,7 @@ defmodule Mix.Tasks.Emqx.Ct do
   end
 
   defp parse_args!(args) do
-    {opts, _rest} =
+    {opts, rest} =
       OptionParser.parse!(
         args,
         strict: [
@@ -334,6 +334,10 @@ defmodule Mix.Tasks.Emqx.Ct do
           repeat: :integer
         ]
       )
+
+    if rest != [] do
+      Mix.raise("Unknown options:\n  #{inspect(rest, pretty: true)}")
+    end
 
     suites = get_name_list(opts, :suites)
 

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.dialyzer.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.dialyzer.ex
@@ -206,13 +206,17 @@ defmodule Mix.Tasks.Emqx.Dialyzer do
   end
 
   defp parse_args!(args) do
-    {opts, _rest} =
+    {opts, rest} =
       OptionParser.parse!(
         args,
         strict: [
           mode: :string
         ]
       )
+
+    if rest != [] do
+      Mix.raise("Unknown options:\n  #{inspect(rest, pretty: true)}")
+    end
 
     mode =
       opts

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.eunit.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.eunit.ex
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.Emqx.Eunit do
   end
 
   defp parse_args!(args) do
-    {opts, _rest} =
+    {opts, rest} =
       OptionParser.parse!(
         args,
         strict: [
@@ -87,6 +87,10 @@ defmodule Mix.Tasks.Emqx.Eunit do
           modules: :string
         ]
       )
+
+    if rest != [] do
+      Mix.raise("Unknown options:\n  #{inspect(rest, pretty: true)}")
+    end
 
     cases =
       opts

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.proper.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.proper.ex
@@ -106,13 +106,17 @@ defmodule Mix.Tasks.Emqx.Proper do
   end
 
   defp parse_args!(args) do
-    {opts, _rest} =
+    {opts, rest} =
       OptionParser.parse!(
         args,
         strict: [
           cover_export_name: :string
         ]
       )
+
+    if rest != [] do
+      Mix.raise("Unknown options:\n  #{inspect(rest, pretty: true)}")
+    end
 
     %{
       cover_export_name: Keyword.get(opts, :cover_export_name, "proper")

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.static_checks.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.static_checks.ex
@@ -22,7 +22,11 @@ defmodule Mix.Tasks.Emqx.StaticChecks do
   @test_script_src ~c"apps/emqx/test/emqx_static_checks.erl"
 
   @impl true
-  def run(_args) do
+  def run(args) do
+    if args != [] do
+      Mix.raise("Unknown options:\n  #{inspect(args, pretty: true)}")
+    end
+
     ensure_compiled_and_loaded!(@common_helpers_src)
     ensure_compiled_and_loaded!(@bpapi_test_src)
     ECt.ensure_whole_emqx_project_is_loaded()

--- a/apps/emqx_mix_utils/lib/mix/tasks/emqx.xref.ex
+++ b/apps/emqx_mix_utils/lib/mix/tasks/emqx.xref.ex
@@ -34,7 +34,11 @@ defmodule Mix.Tasks.Emqx.Xref do
               ])
 
   @impl true
-  def run(_args) do
+  def run(args) do
+    if args != [] do
+      Mix.raise("Unknown options:\n  #{inspect(args, pretty: true)}")
+    end
+
     start_xref()
     set_library_path()
     set_default()


### PR DESCRIPTION
So we can detect call errors more readily.
