### PR TITLE
fix(shared-sub): stop monitoring remote subscribers to avoid races [r58]

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {gproc, {git, "https://github.com/emqx/gproc", {tag, "0.9.0.1"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.20.0"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.44.0"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -548,9 +548,8 @@ do_unsubscribe_down(Topic, SubPid, SubOpts) ->
     case Topic of
         B when is_binary(B) ->
             do_unsubscribe_regular(Topic, SubPid, SubOpts);
-        #share{} ->
-            %% NOTE: `emqx_shared_sub` manages its own monitors and cleanups.
-            ok
+        #share{group = Group, topic = RealTopic} ->
+            emqx_shared_sub:unsubscribe_down(Group, RealTopic, SubPid)
     end.
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -37,7 +37,10 @@
 
 -export([unsubscribe/1]).
 
--export([subscriber_down/1]).
+-export([
+    subscriber_down/1,
+    purge_node/1
+]).
 
 -export([
     publish/1,
@@ -416,8 +419,11 @@ aggre([#route{topic = To, dest = Node} | Rest], Dedup, Acc) when is_atom(Node) -
         false -> NAcc = Acc
     end,
     aggre(Rest, Dedup, NAcc);
-aggre([#route{topic = To, dest = {Group, _Node}} | Rest], _Dedup, Acc) ->
-    aggre(Rest, true, [{To, Group} | Acc]);
+aggre([#route{topic = To, dest = {Group, Node}} | Rest], Dedup, Acc) ->
+    case emqx_router_helper:is_routable(Node) of
+        true -> aggre(Rest, true, [{To, Group} | Acc]);
+        false -> aggre(Rest, Dedup, Acc)
+    end;
 aggre([], false, Acc) ->
     Acc;
 aggre([], true, Acc) ->
@@ -546,6 +552,16 @@ do_unsubscribe_down(Topic, SubPid, SubOpts) ->
             %% NOTE: `emqx_shared_sub` manages its own monitors and cleanups.
             ok
     end.
+
+%%--------------------------------------------------------------------
+%% Node Cleanup APIs
+%%--------------------------------------------------------------------
+
+-spec purge_node(node()) -> ok.
+purge_node(Node) ->
+    ok = emqx_router:cleanup_routes(Node),
+    _ = emqx_shared_sub:purge_node(Node),
+    ok.
 
 %%--------------------------------------------------------------------
 %% Management APIs

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -222,24 +222,23 @@ unsubscribe(Topic) when ?IS_TOPIC(Topic) ->
 do_unsubscribe(Topic, SubPid, SubOpts) ->
     true = ets:delete(?SUBOPTION, {Topic, SubPid}),
     true = ets:delete_object(?SUBSCRIPTION, {SubPid, Topic}),
-    do_unsubscribe2(Topic, SubPid, SubOpts).
+    case Topic of
+        B when is_binary(B) ->
+            do_unsubscribe_regular(Topic, SubPid, SubOpts);
+        #share{group = Group, topic = RealTopic} ->
+            emqx_shared_sub:unsubscribe(Group, RealTopic, SubPid)
+    end.
 
--spec do_unsubscribe2(emqx_types:topic() | emqx_types:share(), pid(), emqx_types:subopts()) ->
+-spec do_unsubscribe_regular(emqx_types:topic(), pid(), emqx_types:subopts()) ->
     ok.
-do_unsubscribe2(Topic, SubPid, SubOpts) when
-    is_binary(Topic), is_pid(SubPid), is_map(SubOpts)
-->
+do_unsubscribe_regular(Topic, SubPid, SubOpts) ->
     _ = emqx_broker_helper:reclaim_seq(Topic),
     I = maps:get(shard, SubOpts, 0),
     case I of
         0 -> emqx_exclusive_subscription:unsubscribe(Topic, SubOpts);
         _ -> ok
     end,
-    cast(pick({Topic, I}), {unsubscribed, Topic, SubPid, I});
-do_unsubscribe2(#share{group = Group, topic = Topic}, SubPid, _SubOpts) when
-    is_binary(Group), is_binary(Topic), is_pid(SubPid)
-->
-    emqx_shared_sub:unsubscribe(Group, Topic, SubPid).
+    cast(pick({Topic, I}), {unsubscribed, Topic, SubPid, I}).
 
 %%--------------------------------------------------------------------
 %% Publish
@@ -529,8 +528,7 @@ subscriber_down(SubPid) ->
         fun(Topic) ->
             case lookup_value(?SUBOPTION, {Topic, SubPid}) of
                 SubOpts when is_map(SubOpts) ->
-                    true = ets:delete(?SUBOPTION, {Topic, SubPid}),
-                    do_unsubscribe2(Topic, SubPid, SubOpts);
+                    do_unsubscribe_down(Topic, SubPid, SubOpts);
                 undefined ->
                     ok
             end
@@ -538,6 +536,16 @@ subscriber_down(SubPid) ->
         lookup_value(?SUBSCRIPTION, SubPid, [])
     ),
     ets:delete(?SUBSCRIPTION, SubPid).
+
+do_unsubscribe_down(Topic, SubPid, SubOpts) ->
+    true = ets:delete(?SUBOPTION, {Topic, SubPid}),
+    case Topic of
+        B when is_binary(B) ->
+            do_unsubscribe_regular(Topic, SubPid, SubOpts);
+        #share{} ->
+            %% NOTE: `emqx_shared_sub` manages its own monitors and cleanups.
+            ok
+    end.
 
 %%--------------------------------------------------------------------
 %% Management APIs

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -195,10 +195,10 @@ code_change(_OldVsn, State, _Extra) ->
 %%--------------------------------------------------------------------
 
 collect_and_handle(Reg0, Down0) ->
-    {Reg, Down} = collect_messages(Reg0, Down0),
+    {Regs, Down} = collect_messages(Reg0, Down0),
     %% handle register before handle down to avoid race condition
     %% because down message is always the last one from a process
-    ok = handle_register(Reg),
+    ok = handle_registrations(Regs),
     ok = handle_down(Down).
 
 collect_messages(Reg, Down) ->
@@ -207,6 +207,7 @@ collect_messages(Reg, Down) ->
 %% Collect both register_sub and 'DOWN' messages in a loop.
 %% There is no other message sent to this process, so the
 %% 'receive' should not have to scan the mailbox.
+%% TODO: Double-check.
 collect_messages(Reg, Down, 0) ->
     {Reg, Down};
 collect_messages(Reg, Down, N) ->
@@ -219,14 +220,26 @@ collect_messages(Reg, Down, N) ->
         {Reg, Down}
     end.
 
-handle_register(Reg) ->
-    lists:foreach(fun do_handle_register/1, Reg).
+handle_registrations(Regs) ->
+    lists:foreach(fun handle_register/1, Regs).
 
-do_handle_register({SubId, SubPid}) ->
-    true = (SubId =:= undefined) orelse ets:insert(?SUBID, {SubId, SubPid}),
-    _ = erlang:monitor(process, SubPid),
-    true = ets:insert(?SUBMON, {SubPid, SubId}),
-    ok.
+handle_register({SubId, SubPid}) ->
+    record_subscription(SubId, SubPid),
+    monitor_subscriber(SubId, SubPid).
+
+record_subscription(undefined, _) ->
+    true;
+record_subscription(SubId, SubPid) ->
+    ets:insert(?SUBID, {SubId, SubPid}).
+
+monitor_subscriber(SubId, SubPid) ->
+    case ets:member(?SUBMON, SubPid) of
+        false ->
+            _MRef = erlang:monitor(process, SubPid),
+            ets:insert(?SUBMON, {SubPid, SubId});
+        true ->
+            true
+    end.
 
 handle_down(SubPids) ->
     ok = emqx_pool:async_submit(

--- a/apps/emqx/src/emqx_broker_helper.erl
+++ b/apps/emqx/src/emqx_broker_helper.erl
@@ -207,7 +207,6 @@ collect_messages(Reg, Down) ->
 %% Collect both register_sub and 'DOWN' messages in a loop.
 %% There is no other message sent to this process, so the
 %% 'receive' should not have to scan the mailbox.
-%% TODO: Double-check.
 collect_messages(Reg, Down, 0) ->
     {Reg, Down};
 collect_messages(Reg, Down, N) ->

--- a/apps/emqx/src/emqx_broker_sup.erl
+++ b/apps/emqx/src/emqx_broker_sup.erl
@@ -68,6 +68,13 @@ init([]) ->
         type => worker,
         modules => [emqx_shared_sub]
     },
+    SharedSubPostStart = #{
+        id => shared_sub_post_start,
+        start => {emqx_shared_sub, post_start, []},
+        restart => transient,
+        shutdown => brutal_kill,
+        type => worker
+    },
 
     %% Broker helper
     Helper = #{
@@ -89,4 +96,12 @@ init([]) ->
         modules => [emqx_exclusive_subscription]
     },
 
-    {ok, {{one_for_all, 0, 1}, [SyncerPool, BrokerPool, SharedSub, Helper, ExclusiveSub]}}.
+    {ok,
+        {{one_for_all, 0, 1}, [
+            SyncerPool,
+            BrokerPool,
+            SharedSub,
+            SharedSubPostStart,
+            Helper,
+            ExclusiveSub
+        ]}}.

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -450,13 +450,14 @@ cleanup_routes_v1(NodeOrExtDest) ->
 
 cleanup_routes_v1_fallback(NodeOrExtDest) ->
     Patterns = [make_route_rec_pat(P) || P <- ?dest_patterns(NodeOrExtDest)],
-    mria:transaction(?ROUTE_SHARD, fun() ->
+    {atomic, _} = mria:transaction(?ROUTE_SHARD, fun() ->
         [
             mnesia:delete_object(?ROUTE_TAB, Route, write)
          || Pat <- Patterns,
             Route <- mnesia:match_object(?ROUTE_TAB, Pat, write)
         ]
-    end).
+    end),
+    ok.
 
 stream_v1(Spec) ->
     mk_route_stream(?ROUTE_TAB, Spec).

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -40,6 +40,11 @@
 %% replicants _do nothing_ on connectivity loss, regardless of how long
 %% it is. Coupled with the fact that replicants are not affected by
 %% "autoheal" mechanism, this may still lead to routing inconsistencies.
+%%
+%% TODO
+%% Since this module is now responsible for purging stuff not _directly_
+%% related to the routing table, it needs to be refactored to be more
+%% generic and placed in a more suitable spot in the supervision tree.
 
 -module(emqx_router_helper).
 
@@ -415,7 +420,7 @@ handle_purge(Node, Why, State) ->
 purge_dead_node(Node) ->
     case node_has_routes(Node) of
         true ->
-            ok = cleanup_routes(Node),
+            ok = do_purge_node(Node),
             true;
         false ->
             false
@@ -430,7 +435,7 @@ purge_dead_node_trans(Node) ->
                     global:trans(
                         {?LOCK(Node), self()},
                         fun() ->
-                            ok = cleanup_routes(Node),
+                            ok = do_purge_node(Node),
                             true
                         end,
                         Nodes,
@@ -443,8 +448,8 @@ purge_dead_node_trans(Node) ->
             false
     end.
 
-cleanup_routes(Node) ->
-    emqx_router:cleanup_routes(Node),
+do_purge_node(Node) ->
+    emqx_broker:purge_node(Node),
     remove_routing_node(Node).
 
 %%

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -396,20 +396,20 @@ schedule_purge_left(Node) ->
 handle_purge(Node, Why, State) ->
     try purge_dead_node_trans(Node) of
         true ->
-            ?tp(warning, router_node_routing_table_purged, #{
+            ?tp(warning, broker_node_purged, #{
                 node => Node,
                 reason => Why,
                 hint => "Ignore if the node in question went offline due to cluster maintenance"
             }),
             forget_node(Node);
         false ->
-            ?tp(debug, router_node_purge_skipped, #{node => Node}),
+            ?tp(debug, broker_node_purge_skipped, #{node => Node}),
             forget_node(Node);
         aborted ->
-            ?tp(notice, router_node_purge_aborted, #{node => Node})
+            ?tp(notice, broker_node_purge_aborted, #{node => Node})
     catch
         Kind:Error ->
-            ?tp(warning, router_node_purge_error, #{
+            ?tp(warning, broker_node_purge_error, #{
                 node => Node,
                 kind => Kind,
                 error => Error

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -14,6 +14,10 @@
 %% limitations under the License.
 %%--------------------------------------------------------------------
 
+%% TODO
+%% This server might crash during the runtime. Naturally, `?SHARED_SUBSCRIPTION`
+%% table can be used to reconstruct local state in `init/1`.
+
 -module(emqx_shared_sub).
 
 -behaviour(gen_server).
@@ -32,11 +36,15 @@
 -export([create_tables/0]).
 
 %% APIs
--export([start_link/0]).
+-export([
+    start_link/0,
+    post_start/0
+]).
 
 -export([
     subscribe/3,
-    unsubscribe/3
+    unsubscribe/3,
+    purge_node/1
 ]).
 
 -export([
@@ -133,6 +141,14 @@ create_tables() ->
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
+-spec post_start() -> ignore.
+post_start() ->
+    %% There may be leftovers from older incarnation of this node, clean them up:
+    %% Might take lots of time.
+    _ = mria:wait_for_tables([?SHARED_SUBSCRIPTION]),
+    ok = purge_node(node()),
+    ignore.
+
 %% @doc Subscribe `SubPid` to the shared subscription group-topic.
 %% This call *is not perfectly idempotent*, and currently `emqx_broker`
 %% guarantees that it's called only once (per new shared subscription).
@@ -146,6 +162,12 @@ subscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
 -spec unsubscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 unsubscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {unsubscribe, Group, Topic, SubPid}).
+
+-spec purge_node(node()) -> ok | false.
+purge_node(Node) ->
+    %% TODO: Refactor `emqx_router_helper` to avoid this hack.
+    erlang:whereis(?SERVER) =/= undefined andalso
+        gen_server:call(?SERVER, {purge, Node}, infinity).
 
 record(Group, Topic, SubPid) ->
     #?SHARED_SUBSCRIPTION{group = Group, topic = Topic, subpid = SubPid}.
@@ -438,8 +460,6 @@ init([]) ->
     ok = emqx_utils_ets:new(?SHARED_SUBS_ROUND_ROBIN_COUNTER, [
         public, set, {write_concurrency, true}
     ]),
-    %% There may be leftovers from older incarnation of this node, clean them up:
-    cleanup_node(node()),
     %% Let `emqx_stats` periodically update stats instead of relying on mnesia events:
     ok = emqx_stats:update_interval(?MODULE, fun ?MODULE:update_stats/0),
     {ok, #state{pmon = pmon_new()}}.
@@ -469,6 +489,10 @@ handle_call({unsubscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PM
             })
     end,
     {reply, ok, State#state{pmon = NPMon}};
+handle_call({purge, Node}, _From, State) ->
+    handle_purge_node(Node),
+    update_stats(),
+    {reply, ok, State};
 handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", req => Req}),
     {reply, ignored, State}.
@@ -552,17 +576,34 @@ cleanup_down(SubPid) ->
     Records = mnesia:dirty_match_object(#?SHARED_SUBSCRIPTION{_ = '_', subpid = SubPid}),
     lists:foreach(fun handle_unsubscribe/1, Records).
 
-cleanup_node(Node) ->
-    %% TODO: Liveness checks.
+handle_purge_node(Node) ->
     Records = mnesia:dirty_select(
         ?SHARED_SUBSCRIPTION,
-        ets:fun2ms(fun(Record = #?SHARED_SUBSCRIPTION{subpid = SubPid}) when
-            node(SubPid) == Node
-        ->
-            Record
-        end)
+        ets:fun2ms(
+            fun(Record = #?SHARED_SUBSCRIPTION{subpid = SubPid}) when node(SubPid) == Node ->
+                Record
+            end
+        )
     ),
-    lists:foreach(fun handle_unsubscribe/1, Records).
+    handle_purge_node(Node, Records).
+
+handle_purge_node(Node, Records = [_ | _]) ->
+    Routes = lists:foldl(
+        fun(Record = #?SHARED_SUBSCRIPTION{group = Group, topic = Topic}, Acc) ->
+            mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
+            maps:put({Group, Topic}, true, Acc)
+        end,
+        #{},
+        Records
+    ),
+    maps:foreach(
+        fun({Group, Topic}, _) ->
+            delete_route(Group, Topic, Node)
+        end,
+        Routes
+    );
+handle_purge_node(_Node, []) ->
+    ok.
 
 update_stats() ->
     emqx_stats:setstat(
@@ -586,7 +627,10 @@ is_alive_sub(Pid) ->
     emqx_router_helper:is_routable(node(Pid)).
 
 delete_route(Group, Topic) ->
-    ok = emqx_router:do_delete_route(Topic, {Group, node()}),
+    delete_route(Group, Topic, node()).
+
+delete_route(Group, Topic, Node) ->
+    ok = emqx_router:do_delete_route(Topic, {Group, Node}),
     _ = emqx_external_broker:delete_shared_route(Topic, Group),
     ok.
 

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -25,6 +25,9 @@
 -include("logger.hrl").
 -include("types.hrl").
 
+-include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("snabbkaffe/include/trace.hrl").
+
 %% Mnesia bootstrap
 -export([create_tables/0]).
 
@@ -64,14 +67,15 @@
     init/1,
     handle_call/3,
     handle_cast/2,
-    handle_info/2,
-    terminate/2,
-    code_change/3
+    handle_info/2
 ]).
 
-%% Internal exports (RPC)
+%% Internal exports
 -export([
-    init_monitors/0
+    %% RPC Targets:
+    init_monitors/0,
+    %% Other:
+    update_stats/0
 ]).
 
 -export_type([strategy/0]).
@@ -129,10 +133,16 @@ create_tables() ->
 start_link() ->
     gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
 
+%% @doc Subscribe `SubPid` to the shared subscription group-topic.
+%% This call *is not perfectly idempotent*, and currently `emqx_broker`
+%% guarantees that it's called only once (per new shared subscription).
 -spec subscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 subscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {subscribe, Group, Topic, SubPid}).
 
+%% @doc Unsubscribe `SubPid` from the shared subscription group-topic.
+%% This call *is not perfectly idempotent*, and currently `emqx_broker`
+%% guarantees that it's called only once (per existing shared subscription).
 -spec unsubscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 unsubscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {unsubscribe, Group, Topic, SubPid}).
@@ -239,7 +249,7 @@ do_dispatch_with_ack(SubPid, Group, Topic, Msg) ->
             {error, timeout}
         end
     after
-        ok = emqx_pmon:demonitor(Ref)
+        erlang:demonitor(Ref, [flush])
     end.
 
 with_group_ack(Msg, Group, Sender, Ref) ->
@@ -422,43 +432,43 @@ subscribers(Group, Topic) ->
 %%--------------------------------------------------------------------
 
 init([]) ->
+    %% Set up tables:
     ok = mria:wait_for_tables([?SHARED_SUBSCRIPTION]),
-    {ok, _} = mnesia:subscribe({table, ?SHARED_SUBSCRIPTION, simple}),
-    {atomic, PMon} = mria:transaction(?SHARED_SUB_SHARD, fun ?MODULE:init_monitors/0),
     ok = emqx_utils_ets:new(?SHARED_SUBSCRIBER, [protected, bag]),
     ok = emqx_utils_ets:new(?SHARED_SUBS_ROUND_ROBIN_COUNTER, [
         public, set, {write_concurrency, true}
     ]),
-    {ok, update_stats(#state{pmon = PMon})}.
+    %% There may be leftovers from older incarnation of this node, clean them up:
+    cleanup_node(node()),
+    %% Let `emqx_stats` periodically update stats instead of relying on mnesia events:
+    ok = emqx_stats:update_interval(?MODULE, fun ?MODULE:update_stats/0),
+    {ok, #state{pmon = pmon_new()}}.
 
+%% Deprecated, left for backwards compatibility.
+%% Should be removed in the next release.
 init_monitors() ->
-    mnesia:foldl(
-        fun(#?SHARED_SUBSCRIPTION{subpid = SubPid}, Mon) ->
-            emqx_pmon:monitor(SubPid, Mon)
-        end,
-        emqx_pmon:new(),
-        ?SHARED_SUBSCRIPTION
-    ).
+    pmon_new().
 
 handle_call({subscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
-    mria:dirty_write(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
-    case ets:member(?SHARED_SUBSCRIBER, {Group, Topic}) of
-        true ->
+    handle_subscribe(Group, Topic, SubPid),
+    update_stats(),
+    NPMon = pmon_inc_monitor(SubPid, PMon),
+    {reply, ok, State#state{pmon = NPMon}};
+handle_call({unsubscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
+    handle_unsubscribe(Group, Topic, SubPid),
+    update_stats(),
+    case pmon_dec_monitor(SubPid, PMon) of
+        NPMon = #{} ->
             ok;
-        false ->
-            ok = emqx_router:do_add_route(Topic, {Group, node()}),
-            _ = emqx_external_broker:add_shared_route(Topic, Group),
-            ok
+        {error, inconsistent} ->
+            NPMon = PMon,
+            ?tp(warning, "shared_subcriber_monitor_inconsistent", #{
+                subpid => SubPid,
+                group => Group,
+                topic => Topic
+            })
     end,
-    ok = maybe_insert_round_robin_count({Group, Topic}),
-    true = ets:insert(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}),
-    {reply, ok, update_stats(State#state{pmon = emqx_pmon:monitor(SubPid, PMon)})};
-handle_call({unsubscribe, Group, Topic, SubPid}, _From, State) ->
-    mria:dirty_delete_object(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
-    true = ets:delete_object(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}),
-    delete_route_if_needed({Group, Topic}),
-    maybe_delete_round_robin_count({Group, Topic}),
-    {reply, ok, update_stats(State)};
+    {reply, ok, State#state{pmon = NPMon}};
 handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", req => Req}),
     {reply, ignored, State}.
@@ -467,35 +477,16 @@ handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
 
-handle_info(
-    {mnesia_table_event, {write, #?SHARED_SUBSCRIPTION{subpid = SubPid}, _}},
-    State = #state{pmon = PMon}
-) ->
-    {noreply, update_stats(State#state{pmon = emqx_pmon:monitor(SubPid, PMon)})};
-handle_info({mnesia_table_event, {delete_object, _OldRecord, _}}, State = #state{pmon = _PMon}) ->
-    %% The subscriber may have subscribed multiple topics, so we need to keep monitoring the PID until
-    %% it `unsubscribed` the last topic.
-    %% The trick is we don't demonitor the subscriber here, and (after a long time) it will eventually
-    %% be disconnected.
-    %% #?SHARED_SUBSCRIPTION{subpid = SubPid} = OldRecord,
-    %% {noreply, update_stats(State#state{pmon = emqx_pmon:demonitor(SubPid, PMon)})};
-    %%
-    %% So we only need to update stats here.
-    {noreply, update_stats(State)};
 handle_info({mnesia_table_event, _Event}, State) ->
     {noreply, State};
 handle_info({'DOWN', _MRef, process, SubPid, Reason}, State = #state{pmon = PMon}) ->
     ?SLOG(debug, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
     cleanup_down(SubPid),
-    {noreply, update_stats(State#state{pmon = emqx_pmon:erase(SubPid, PMon)})};
+    update_stats(),
+    NPMon = pmon_erase(SubPid, PMon),
+    {noreply, State#state{pmon = NPMon}};
 handle_info(_Info, State) ->
     {noreply, State}.
-
-terminate(_Reason, _State) ->
-    mnesia:unsubscribe({table, ?SHARED_SUBSCRIPTION, simple}).
-
-code_change(_OldVsn, State, _Extra) ->
-    {ok, State}.
 
 %%--------------------------------------------------------------------
 %% Internal functions
@@ -512,17 +503,43 @@ send(Pid, Topic, Msg) ->
         end,
     ok.
 
+handle_subscribe(Group, Topic, SubPid) ->
+    mria:dirty_write(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
+    case ets:member(?SHARED_SUBSCRIBER, {Group, Topic}) of
+        true ->
+            ok;
+        false ->
+            ok = emqx_router:do_add_route(Topic, {Group, node()}),
+            emqx_external_broker:add_shared_route(Topic, Group)
+    end,
+    maybe_insert_round_robin_count({Group, Topic}),
+    ets:insert(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}).
+
 maybe_insert_round_robin_count({Group, _Topic} = GroupTopic) ->
     strategy(Group) =:= round_robin_per_group andalso
-        ets:insert(?SHARED_SUBS_ROUND_ROBIN_COUNTER, {GroupTopic, 0}),
-    ok.
+        ets:insert(?SHARED_SUBS_ROUND_ROBIN_COUNTER, {GroupTopic, 0}).
 
 maybe_delete_round_robin_count({Group, _Topic} = GroupTopic) ->
     strategy(Group) =:= round_robin_per_group andalso
-        if_no_more_subscribers(GroupTopic, fun() ->
-            ets:delete(?SHARED_SUBS_ROUND_ROBIN_COUNTER, GroupTopic)
-        end),
-    ok.
+        ets:delete(?SHARED_SUBS_ROUND_ROBIN_COUNTER, GroupTopic).
+
+handle_unsubscribe(Group, Topic, SubPid) ->
+    handle_unsubscribe(record(Group, Topic, SubPid)).
+
+handle_unsubscribe(
+    Record = #?SHARED_SUBSCRIPTION{
+        group = Group,
+        topic = Topic,
+        subpid = SubPid
+    }
+) ->
+    GroupTopic = {Group, Topic},
+    mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
+    true = ets:delete_object(?SHARED_SUBSCRIBER, {GroupTopic, SubPid}),
+    if_no_more_subscribers(GroupTopic, fun() ->
+        maybe_delete_round_robin_count(GroupTopic),
+        delete_route(Group, Topic)
+    end).
 
 if_no_more_subscribers(GroupTopic, Fn) ->
     case ets:member(?SHARED_SUBSCRIBER, GroupTopic) of
@@ -532,23 +549,27 @@ if_no_more_subscribers(GroupTopic, Fn) ->
     ok.
 
 cleanup_down(SubPid) ->
-    lists:foreach(
-        fun(Record = #?SHARED_SUBSCRIPTION{topic = Topic, group = Group}) ->
-            ok = mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
-            true = ets:delete_object(?SHARED_SUBSCRIBER, {{Group, Topic}, SubPid}),
-            maybe_delete_round_robin_count({Group, Topic}),
-            delete_route_if_needed({Group, Topic})
-        end,
-        mnesia:dirty_match_object(#?SHARED_SUBSCRIPTION{_ = '_', subpid = SubPid})
-    ).
+    Records = mnesia:dirty_match_object(#?SHARED_SUBSCRIPTION{_ = '_', subpid = SubPid}),
+    lists:foreach(fun handle_unsubscribe/1, Records).
 
-update_stats(State) ->
+cleanup_node(Node) ->
+    %% TODO: Liveness checks.
+    Records = mnesia:dirty_select(
+        ?SHARED_SUBSCRIPTION,
+        ets:fun2ms(fun(Record = #?SHARED_SUBSCRIPTION{subpid = SubPid}) when
+            node(SubPid) == Node
+        ->
+            Record
+        end)
+    ),
+    lists:foreach(fun handle_unsubscribe/1, Records).
+
+update_stats() ->
     emqx_stats:setstat(
         'subscriptions.shared.count',
         'subscriptions.shared.max',
         ets:info(?SHARED_SUBSCRIPTION, size)
-    ),
-    State.
+    ).
 
 %% Return 'true' if the subscriber process is alive AND not in the failed list
 is_active_sub(Pid, FailedSubs, All) ->
@@ -564,15 +585,46 @@ is_alive_sub(Pid) ->
     %% When process is not local, the best guess is it's alive.
     emqx_router_helper:is_routable(node(Pid)).
 
-delete_route_if_needed({Group, Topic} = GroupTopic) ->
-    if_no_more_subscribers(GroupTopic, fun() ->
-        ok = emqx_router:do_delete_route(Topic, {Group, node()}),
-        _ = emqx_external_broker:delete_shared_route(Topic, Group),
-        ok
-    end).
+delete_route(Group, Topic) ->
+    ok = emqx_router:do_delete_route(Topic, {Group, node()}),
+    _ = emqx_external_broker:delete_shared_route(Topic, Group),
+    ok.
 
 get_default_shared_subscription_strategy() ->
     emqx:get_config([mqtt, shared_subscription_strategy]).
 
 get_default_shared_subscription_initial_sticky_pick() ->
     emqx:get_config([mqtt, shared_subscription_initial_sticky_pick]).
+
+%%--------------------------------------------------------------------
+
+pmon_new() ->
+    #{}.
+
+pmon_inc_monitor(Pid, PMon) ->
+    case PMon of
+        #{Pid := {MRef, N}} ->
+            %% Process is already being monitored.
+            %% Bump number of monitor requests.
+            PMon#{Pid := {MRef, N + 1}};
+        #{} ->
+            %% Process is not being monitored yet.
+            MRef = erlang:monitor(process, Pid),
+            PMon#{Pid => {MRef, 1}}
+    end.
+
+pmon_dec_monitor(Pid, PMon) ->
+    case PMon of
+        #{Pid := {MRef, N}} when N =< 1 ->
+            %% Process is being monitored once.
+            _ = erlang:demonitor(MRef, [flush]),
+            maps:remove(Pid, PMon);
+        #{Pid := {MRef, N}} ->
+            %% Decrement number of monitor requests.
+            PMon#{Pid := {MRef, N - 1}};
+        #{} ->
+            {error, inconsistent}
+    end.
+
+pmon_erase(Pid, PMon) ->
+    maps:remove(Pid, PMon).

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -30,7 +30,6 @@
 -include("types.hrl").
 
 -include_lib("stdlib/include/ms_transform.hrl").
--include_lib("snabbkaffe/include/trace.hrl").
 
 %% Mnesia bootstrap
 -export([create_tables/0]).
@@ -44,6 +43,7 @@
 -export([
     subscribe/3,
     unsubscribe/3,
+    unsubscribe_down/3,
     purge_node/1
 ]).
 
@@ -149,19 +149,17 @@ post_start() ->
     ok = purge_node(node()),
     ignore.
 
-%% @doc Subscribe `SubPid` to the shared subscription group-topic.
-%% This call *is not perfectly idempotent*, and currently `emqx_broker`
-%% guarantees that it's called only once (per new shared subscription).
 -spec subscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 subscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {subscribe, Group, Topic, SubPid}).
 
-%% @doc Unsubscribe `SubPid` from the shared subscription group-topic.
-%% This call *is not perfectly idempotent*, and currently `emqx_broker`
-%% guarantees that it's called only once (per existing shared subscription).
 -spec unsubscribe(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
 unsubscribe(Group, Topic, SubPid) when is_pid(SubPid) ->
     gen_server:call(?SERVER, {unsubscribe, Group, Topic, SubPid}).
+
+-spec unsubscribe_down(emqx_types:group(), emqx_types:topic(), pid()) -> ok.
+unsubscribe_down(Group, Topic, SubPid) when is_pid(SubPid) ->
+    gen_server:cast(?SERVER, {unsubscribe, Group, Topic, SubPid}).
 
 -spec purge_node(node()) -> ok | false.
 purge_node(Node) ->
@@ -462,33 +460,21 @@ init([]) ->
     ]),
     %% Let `emqx_stats` periodically update stats instead of relying on mnesia events:
     ok = emqx_stats:update_interval(?MODULE, fun ?MODULE:update_stats/0),
-    {ok, #state{pmon = pmon_new()}}.
+    {ok, #state{}}.
 
 %% Deprecated, left for backwards compatibility.
 %% Should be removed in the next release.
 init_monitors() ->
     emqx_pmon:new().
 
-handle_call({subscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
+handle_call({subscribe, Group, Topic, SubPid}, _From, State) ->
     handle_subscribe(Group, Topic, SubPid),
     update_stats(),
-    NPMon = pmon_inc_monitor(SubPid, PMon),
-    {reply, ok, State#state{pmon = NPMon}};
-handle_call({unsubscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
+    {reply, ok, State};
+handle_call({unsubscribe, Group, Topic, SubPid}, _From, State) ->
     handle_unsubscribe(Group, Topic, SubPid),
     update_stats(),
-    case pmon_dec_monitor(SubPid, PMon) of
-        NPMon = #{} ->
-            ok;
-        {error, inconsistent} ->
-            NPMon = PMon,
-            ?tp(warning, "shared_subcriber_monitor_inconsistent", #{
-                subpid => SubPid,
-                group => Group,
-                topic => Topic
-            })
-    end,
-    {reply, ok, State#state{pmon = NPMon}};
+    {reply, ok, State};
 handle_call({purge, Node}, _From, State) ->
     handle_purge_node(Node),
     update_stats(),
@@ -497,16 +483,14 @@ handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", req => Req}),
     {reply, ignored, State}.
 
+handle_cast({unsubscribe, Group, Topic, SubPid}, State) ->
+    handle_unsubscribe(Group, Topic, SubPid),
+    update_stats(),
+    {noreply, State};
 handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
 
-handle_info({'DOWN', _MRef, process, SubPid, Reason}, State = #state{pmon = PMon}) ->
-    ?SLOG(debug, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
-    cleanup_down(SubPid),
-    update_stats(),
-    NPMon = pmon_erase(SubPid, PMon),
-    {noreply, State#state{pmon = NPMon}};
 handle_info(_Info, State) ->
     {noreply, State}.
 
@@ -546,17 +530,8 @@ maybe_delete_round_robin_count({Group, _Topic} = GroupTopic) ->
         ets:delete(?SHARED_SUBS_ROUND_ROBIN_COUNTER, GroupTopic).
 
 handle_unsubscribe(Group, Topic, SubPid) ->
-    handle_unsubscribe(record(Group, Topic, SubPid)).
-
-handle_unsubscribe(
-    Record = #?SHARED_SUBSCRIPTION{
-        group = Group,
-        topic = Topic,
-        subpid = SubPid
-    }
-) ->
     GroupTopic = {Group, Topic},
-    mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
+    mria:dirty_delete_object(?SHARED_SUBSCRIPTION, record(Group, Topic, SubPid)),
     true = ets:delete_object(?SHARED_SUBSCRIBER, {GroupTopic, SubPid}),
     if_no_more_subscribers(GroupTopic, fun() ->
         maybe_delete_round_robin_count(GroupTopic),
@@ -569,10 +544,6 @@ if_no_more_subscribers(GroupTopic, Fn) ->
         false -> Fn()
     end,
     ok.
-
-cleanup_down(SubPid) ->
-    Records = mnesia:dirty_match_object(#?SHARED_SUBSCRIPTION{_ = '_', subpid = SubPid}),
-    lists:foreach(fun handle_unsubscribe/1, Records).
 
 handle_purge_node(Node) ->
     Records = mnesia:dirty_select(
@@ -622,36 +593,3 @@ get_default_shared_subscription_strategy() ->
 
 get_default_shared_subscription_initial_sticky_pick() ->
     emqx:get_config([mqtt, shared_subscription_initial_sticky_pick]).
-
-%%--------------------------------------------------------------------
-
-pmon_new() ->
-    #{}.
-
-pmon_inc_monitor(Pid, PMon) ->
-    case PMon of
-        #{Pid := {MRef, N}} ->
-            %% Process is already being monitored.
-            %% Bump number of monitor requests.
-            PMon#{Pid := {MRef, N + 1}};
-        #{} ->
-            %% Process is not being monitored yet.
-            MRef = erlang:monitor(process, Pid),
-            PMon#{Pid => {MRef, 1}}
-    end.
-
-pmon_dec_monitor(Pid, PMon) ->
-    case PMon of
-        #{Pid := {MRef, N}} when N =< 1 ->
-            %% Process is being monitored once.
-            _ = erlang:demonitor(MRef, [flush]),
-            maps:remove(Pid, PMon);
-        #{Pid := {MRef, N}} ->
-            %% Decrement number of monitor requests.
-            PMon#{Pid := {MRef, N - 1}};
-        #{} ->
-            {error, inconsistent}
-    end.
-
-pmon_erase(Pid, PMon) ->
-    maps:remove(Pid, PMon).

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -467,7 +467,7 @@ init([]) ->
 %% Deprecated, left for backwards compatibility.
 %% Should be removed in the next release.
 init_monitors() ->
-    pmon_new().
+    emqx_pmon:new().
 
 handle_call({subscribe, Group, Topic, SubPid}, _From, State = #state{pmon = PMon}) ->
     handle_subscribe(Group, Topic, SubPid),

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -501,8 +501,6 @@ handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", req => Msg}),
     {noreply, State}.
 
-handle_info({mnesia_table_event, _Event}, State) ->
-    {noreply, State};
 handle_info({'DOWN', _MRef, process, SubPid, Reason}, State = #state{pmon = PMon}) ->
     ?SLOG(debug, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
     cleanup_down(SubPid),

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -485,7 +485,7 @@ handle_info({mnesia_table_event, {delete_object, _OldRecord, _}}, State = #state
 handle_info({mnesia_table_event, _Event}, State) ->
     {noreply, State};
 handle_info({'DOWN', _MRef, process, SubPid, Reason}, State = #state{pmon = PMon}) ->
-    ?SLOG(info, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
+    ?SLOG(debug, #{msg => "shared_subscriber_down", sub_pid => SubPid, reason => Reason}),
     cleanup_down(SubPid),
     {noreply, update_stats(State#state{pmon = emqx_pmon:erase(SubPid, PMon)})};
 handle_info(_Info, State) ->

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -585,25 +585,10 @@ handle_purge_node(Node) ->
             end
         )
     ),
-    handle_purge_node(Node, Records).
-
-handle_purge_node(Node, Records = [_ | _]) ->
-    Routes = lists:foldl(
-        fun(Record = #?SHARED_SUBSCRIPTION{group = Group, topic = Topic}, Acc) ->
-            mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record),
-            maps:put({Group, Topic}, true, Acc)
-        end,
-        #{},
+    lists:foreach(
+        fun(Record) -> mria:dirty_delete_object(?SHARED_SUBSCRIPTION, Record) end,
         Records
-    ),
-    maps:foreach(
-        fun({Group, Topic}, _) ->
-            delete_route(Group, Topic, Node)
-        end,
-        Routes
-    );
-handle_purge_node(_Node, []) ->
-    ok.
+    ).
 
 update_stats() ->
     emqx_stats:setstat(

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -146,7 +146,7 @@ t_membership_node_leaving(_Config) ->
     {_, {ok, _}} = ?wait_async_action(
         ?ROUTER_HELPER ! {membership, {node, leaving, AnotherNode}},
         #{?snk_kind := router_node_routing_table_purged, node := AnotherNode},
-        1_000
+        5_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
 

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -20,6 +20,7 @@
 -compile(nowarn_export_all).
 
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -378,7 +379,6 @@ start_remote_shared_sub(Node, Group, Topic) ->
     ?assertReceive({SubPid, ok}, 5_000),
     %% NOTE: Anticipate occasional replication delay.
     ?retry(100, 5, begin
-        SharedSubs = emqx_shared_sub:subscribers(Group, Topic),
-        ?assert(lists:member(SubPid, SharedSubs), SharedSubs)
+        ?assertMatch([#route{dest = {Group, _}}], emqx_router:lookup_routes(Topic))
     end),
     SubPid.

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -145,7 +145,7 @@ t_membership_node_leaving(_Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {_, {ok, _}} = ?wait_async_action(
         ?ROUTER_HELPER ! {membership, {node, leaving, AnotherNode}},
-        #{?snk_kind := router_node_routing_table_purged, node := AnotherNode},
+        #{?snk_kind := broker_node_purged, node := AnotherNode},
         5_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
@@ -164,7 +164,7 @@ t_cluster_node_leaving(Config) ->
     ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, {ok, _}} = ?wait_async_action(
         erpc:call(ClusterNode, ekka, leave, []),
-        #{?snk_kind := router_node_routing_table_purged, node := ClusterNode},
+        #{?snk_kind := broker_node_purged, node := ClusterNode},
         3_000
     ),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
@@ -184,7 +184,7 @@ t_cluster_node_down(Config) ->
     ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, SRef} = snabbkaffe:subscribe(
         %% Should be purged after ~2 reconciliations.
-        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
+        ?match_event(#{?snk_kind := broker_node_purged, node := ClusterNode}),
         1,
         10_000
     ),
@@ -205,7 +205,7 @@ t_cluster_node_orphan(_Config) ->
     ?assertMatch([_, _], emqx_router:topics()),
     {ok, SRef} = snabbkaffe:subscribe(
         %% Should be purged after ~2 reconciliations.
-        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := OrphanNode}),
+        ?match_event(#{?snk_kind := broker_node_purged, node := OrphanNode}),
         1,
         10_000
     ),
@@ -225,7 +225,7 @@ t_cluster_node_force_leave(Config) ->
     ?assertMatch([_, _, _], emqx_router:topics()),
     ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, SRef} = snabbkaffe:subscribe(
-        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
+        ?match_event(#{?snk_kind := broker_node_purged, node := ClusterNode}),
         1,
         10_000
     ),
@@ -316,7 +316,7 @@ t_cluster_migration(Config) ->
     ?assertEqual([N2, N3], erpc:call(N2, emqx, running_nodes, [])),
 
     %% No routes are expected to be present in the global routing table.
-    ?block_until(#{?snk_kind := router_node_routing_table_purged, node := N1}),
+    ?block_until(#{?snk_kind := broker_node_purged, node := N1}),
     ?assertEqual([], erpc:call(N2, emqx_router, topics, [])),
     ?assertEqual([], erpc:call(N3, emqx_router, topics, [])),
 

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -43,7 +43,9 @@ groups() ->
     ],
     ClusterReplicantTCs = [
         t_cluster_node_leaving,
+        t_cluster_node_force_leave,
         t_cluster_node_down,
+        t_cluster_node_orphan,
         t_cluster_node_restart
     ],
     SchemaTCs = [
@@ -183,6 +185,25 @@ t_cluster_node_down(Config) ->
     {ok, _Event} = snabbkaffe:receive_events(SRef),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
 
+t_cluster_node_orphan('init', Config) ->
+    Config;
+t_cluster_node_orphan('end', _Config) ->
+    ok.
+
+t_cluster_node_orphan(_Config) ->
+    OrphanNode = emqx_cth_cluster:node_name(cluster_node_orphan),
+    emqx_router:add_route(<<"orphan/b/#">>, OrphanNode),
+    emqx_router:add_route(<<"test/e/f">>, node()),
+    ?assertMatch([_, _], emqx_router:topics()),
+    {ok, SRef} = snabbkaffe:subscribe(
+        %% Should be purged after ~2 reconciliations.
+        ?match_event(#{?snk_kind := router_node_routing_table_purged, node := OrphanNode}),
+        1,
+        10_000
+    ),
+    {ok, _Event} = snabbkaffe:receive_events(SRef),
+    ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
+
 t_cluster_node_force_leave('init', Config) ->
     start_join_node(cluster_node_force_leave, Config);
 t_cluster_node_force_leave('end', Config) ->
@@ -202,8 +223,14 @@ t_cluster_node_force_leave(Config) ->
     ok = emqx_cth_peer:kill(ClusterNode),
     %% Give Mria some time to recognize the node is down.
     ok = timer:sleep(500),
-    %% Force-leave it.
-    ok = ekka:force_leave(ClusterNode),
+    case ?config(group_name, Config) of
+        cluster ->
+            %% Force-leave it.
+            ok = ekka:force_leave(ClusterNode);
+        cluster_replicant ->
+            %% Replicant is considered as "left" already
+            ok
+    end,
     {ok, _Event} = snabbkaffe:receive_events(SRef),
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
 

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -19,6 +19,7 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -30,7 +31,8 @@ all() ->
         {group, smoke},
         {group, cleanup},
         {group, cluster},
-        {group, cluster_replicant}
+        {group, cluster_replicant},
+        t_cluster_migration
     ].
 
 groups() ->
@@ -265,6 +267,69 @@ t_message(_) ->
     gen_server:call(?ROUTER_HELPER, testing),
     ?assert(erlang:is_process_alive(Pid)),
     ?assertEqual(Pid, erlang:whereis(?ROUTER_HELPER)).
+
+%%
+
+t_cluster_migration('init', Config) ->
+    WorkDir = emqx_cth_suite:work_dir(Config),
+    AppSpecs = [emqx],
+    NodeSpecs = [
+        {t_cluster_migration1, #{apps => AppSpecs}},
+        {t_cluster_migration2, #{apps => AppSpecs}},
+        {t_cluster_migration3, #{apps => AppSpecs}}
+    ],
+    Nodes = emqx_cth_cluster:start(NodeSpecs, #{work_dir => WorkDir}),
+    ok = snabbkaffe:start_trace(),
+    [{cluster, Nodes} | Config];
+t_cluster_migration('end', Config) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_cth_cluster:stop(?config(cluster, Config)).
+
+t_cluster_migration(Config) ->
+    %% Ensuse that the node to leave the cluster follow `emqx_machine` behavior.
+    [N1, N2, N3] = ?config(cluster, Config),
+    ok = erpc:call(N1, ekka, callback, [stop, fun() -> application:stop(emqx) end]),
+    ok = erpc:call(N1, ekka, callback, [start, fun() -> ?tp(leave_restart_complete, #{}) end]),
+
+    %% Start client that constantly subscribes to new, unique topics.
+    %% Let it run for a while.
+    {Client, CMRef} = connect_client(N1),
+    {Loadgen, LMRef} = erlang:spawn_monitor(?MODULE, loop_subscriber, [Client]),
+    ok = timer:sleep(1000),
+
+    %% Tell the cluster to "leave" the first node, the one that holds the client.
+    %% There's a tiny time window between "leave" announcement and the node actually
+    %% disconnecting the clients.
+    ok = erpc:call(N2, ekka, force_leave, [N1]),
+    ?block_until(#{?snk_kind := leave_restart_complete, ?snk_meta := #{node := N1}}),
+    ?assertEqual([N2, N3], erpc:call(N2, emqx, running_nodes, [])),
+
+    %% No routes are expected to be present in the global routing table.
+    ?block_until(#{?snk_kind := router_node_routing_table_purged, node := N1}),
+    ?assertEqual([], erpc:call(N2, emqx_router, topics, [])),
+    ?assertEqual([], erpc:call(N3, emqx_router, topics, [])),
+
+    %% The client should have been disconnected, and subscriber died as well.
+    ?assertReceive({'DOWN', CMRef, process, Client, _Disconnected}),
+    ?assertReceive({'DOWN', LMRef, process, Loadgen, _Disconnected}).
+
+connect_client(Node) ->
+    {_, Port} = erpc:call(Node, emqx_config, get, [[listeners, tcp, default, bind]]),
+    {ok, Client} = emqtt:start_link([{port, Port}]),
+    {ok, _} = emqtt:connect(Client),
+    MRef = erlang:monitor(process, Client),
+    true = erlang:unlink(Client),
+    {Client, MRef}.
+
+loop_subscriber(Client) ->
+    Interval = 1,
+    loop_subscriber(1, Interval, Client).
+
+loop_subscriber(N, Interval, Client) ->
+    Topic = emqx_topic:join(["mig", integer_to_list(N), '#']),
+    {ok, _, [0]} = emqtt:subscribe(Client, Topic, 0),
+    ok = timer:sleep(Interval),
+    loop_subscriber(N + 1, Interval, Client).
 
 %%
 

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -159,13 +159,16 @@ t_cluster_node_leaving(Config) ->
     ClusterNode = ?config(cluster_node, Config),
     ok = emqx_router:add_route(<<"leaving/b/c">>, ClusterNode),
     ok = emqx_router:add_route(<<"test/e/f">>, node()),
-    ?assertMatch([_, _], emqx_router:topics()),
+    _SubPid = start_remote_shared_sub(ClusterNode, <<"g">>, <<"leaving/g/h">>),
+    ?assertMatch([_, _, _], emqx_router:topics()),
+    ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, {ok, _}} = ?wait_async_action(
         erpc:call(ClusterNode, ekka, leave, []),
         #{?snk_kind := router_node_routing_table_purged, node := ClusterNode},
         3_000
     ),
-    ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
+    ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
+    ?assertEqual([], emqx_shared_sub:subscribers(<<"g">>, '_')).
 
 t_cluster_node_down('init', Config) ->
     start_join_node(cluster_node_down, Config);
@@ -176,7 +179,9 @@ t_cluster_node_down(Config) ->
     ClusterNode = ?config(cluster_node, Config),
     emqx_router:add_route(<<"down/b/#">>, ClusterNode),
     emqx_router:add_route(<<"test/e/f">>, node()),
-    ?assertMatch([_, _], emqx_router:topics()),
+    _SubPid = start_remote_shared_sub(ClusterNode, <<"g">>, <<"down/g/+">>),
+    ?assertMatch([_, _, _], emqx_router:topics()),
+    ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, SRef} = snabbkaffe:subscribe(
         %% Should be purged after ~2 reconciliations.
         ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
@@ -185,7 +190,8 @@ t_cluster_node_down(Config) ->
     ),
     ok = emqx_cth_cluster:stop([ClusterNode]),
     {ok, _Event} = snabbkaffe:receive_events(SRef),
-    ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
+    ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
+    ?assertEqual([], emqx_shared_sub:subscribers(<<"g">>, '_')).
 
 t_cluster_node_orphan('init', Config) ->
     Config;
@@ -215,7 +221,9 @@ t_cluster_node_force_leave(Config) ->
     ClusterNode = ?config(cluster_node, Config),
     emqx_router:add_route(<<"forceleave/b/#">>, ClusterNode),
     emqx_router:add_route(<<"test/e/f">>, node()),
-    ?assertMatch([_, _], emqx_router:topics()),
+    _SubPid = start_remote_shared_sub(ClusterNode, <<"g">>, <<"forceleave/#">>),
+    ?assertMatch([_, _, _], emqx_router:topics()),
+    ?assertMatch([_], emqx_shared_sub:subscribers(<<"g">>, '_')),
     {ok, SRef} = snabbkaffe:subscribe(
         ?match_event(#{?snk_kind := router_node_routing_table_purged, node := ClusterNode}),
         1,
@@ -234,7 +242,8 @@ t_cluster_node_force_leave(Config) ->
             ok
     end,
     {ok, _Event} = snabbkaffe:receive_events(SRef),
-    ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
+    ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
+    ?assertEqual([], emqx_shared_sub:subscribers(<<"g">>, '_')).
 
 t_cluster_node_restart('init', Config) ->
     start_join_node(cluster_node_restart, Config);
@@ -246,10 +255,11 @@ t_cluster_node_restart(Config) ->
     ClusterSpec = ?config(cluster_node_spec, Config),
     emqx_router:add_route(<<"restart/b/+">>, ClusterNode),
     emqx_router:add_route(<<"test/e/f">>, node()),
-    ?assertMatch([_, _], emqx_router:topics()),
+    _SubPid = start_remote_shared_sub(ClusterNode, <<"g">>, <<"restart/b/#">>),
+    ?assertMatch([_, _, _], emqx_router:topics()),
     ok = emqx_cth_cluster:stop([ClusterNode]),
     %% The route should still be there, still expecting the node to come back up.
-    ?assertMatch([_, _], emqx_router:topics()),
+    ?assertMatch([_, _, _], emqx_router:topics()),
     %% Verify broker is aware there's no reason to route to a node that is down.
     ok = timer:sleep(500),
     ?assertEqual(
@@ -258,7 +268,8 @@ t_cluster_node_restart(Config) ->
     ),
     _ = emqx_cth_cluster:restart(ClusterSpec),
     %% Node should have cleaned up upon restart.
-    ?assertEqual([<<"test/e/f">>], emqx_router:topics()).
+    ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
+    ?assertEqual([], emqx_shared_sub:subscribers(<<"g">>, '_')).
 
 t_message(_) ->
     Pid = erlang:whereis(?ROUTER_HELPER),
@@ -351,3 +362,18 @@ stop_leave_node(Config) ->
     ClusterNode = ?config(cluster_node, Config),
     ekka:force_leave(ClusterNode),
     emqx_cth_cluster:stop([ClusterNode]).
+
+%%
+
+start_remote_shared_sub(Node, Group, Topic) ->
+    Pid = self(),
+    ShareTopic = emqx_topic:make_shared_record(Group, Topic),
+    SubPid = erpc:call(Node, erlang, spawn, [
+        fun() ->
+            ok = emqx_broker:subscribe(ShareTopic),
+            Pid ! {self(), ok},
+            timer:sleep(infinity)
+        end
+    ]),
+    ?assertReceive({SubPid, ok}, 5_000),
+    SubPid.

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -376,4 +376,9 @@ start_remote_shared_sub(Node, Group, Topic) ->
         end
     ]),
     ?assertReceive({SubPid, ok}, 5_000),
+    %% NOTE: Anticipate occasional replication delay.
+    ?retry(100, 5, begin
+        SharedSubs = emqx_shared_sub:subscribers(Group, Topic),
+        ?assert(lists:member(SubPid, SharedSubs), SharedSubs)
+    end),
     SubPid.

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -760,18 +760,26 @@ t_stats(Config) when is_list(Config) ->
 
     ct:pal("Shared sub table: ~p", [ets:tab2list(emqx_shared_subscription)]),
     %% Verify LOCAL stats update
-    ?assertMatch(
-        #{'subscriptions.shared.count' := 1},
-        maps:from_list(emqx_stats:getstats())
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            #{'subscriptions.shared.count' := 1},
+            maps:from_list(emqx_stats:getstats())
+        )
     ),
     emqtt:unsubscribe(ConnPid1, SharedTopic),
     ct:sleep(100),
 
     ct:pal("Shared sub table: ~p", [ets:tab2list(emqx_shared_subscription)]),
     %% Verify LOCAL stats update again
-    ?assertMatch(
-        #{'subscriptions.shared.count' := 0},
-        maps:from_list(emqx_stats:getstats())
+    ?retry(
+        200,
+        10,
+        ?assertMatch(
+            #{'subscriptions.shared.count' := 0},
+            maps:from_list(emqx_stats:getstats())
+        )
     ),
 
     %% Shutdown

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -846,6 +846,8 @@ t_qos1_random_dispatch_if_all_members_are_down(Config) when is_list(Config) ->
     ),
     ?assert(is_process_alive(Pid1)),
     ?assert(is_process_alive(Pid2)),
+    ?retry(100, 10, ?assertEqual(disconnected, get_channel_info(conn_state, Pid1))),
+    ?retry(100, 10, ?assertEqual(disconnected, get_channel_info(conn_state, Pid2))),
 
     {ok, _} = emqtt:publish(ConnPub, Topic, <<"hello11">>, 1),
     ?retry(
@@ -865,7 +867,10 @@ t_qos1_random_dispatch_if_all_members_are_down(Config) when is_list(Config) ->
     ok.
 
 get_mqueue(ConnPid) ->
-    emqx_connection:info({channel, {session, mqueue}}, sys:get_state(ConnPid)).
+    get_channel_info({session, mqueue}, ConnPid).
+
+get_channel_info(Info, ConnPid) ->
+    emqx_connection:info({channel, Info}, sys:get_state(ConnPid)).
 
 %% No ack, QoS 2 subscriptions,
 %% client1 receives one message, send pubrec, then suspend

--- a/changes/ce/fix-15884.en.md
+++ b/changes/ce/fix-15884.en.md
@@ -1,0 +1,3 @@
+Resolve an issue where, in rare cases, the global routing table could indefinitely retain routing information for nodes that had long left the cluster.
+
+Resolve a race condition that may lead to accumulating inconsistencies in the routing table and shared subscriptions state in the cluster when a large number of shared subscribers disconnect simultaneously.

--- a/mix.exs
+++ b/mix.exs
@@ -186,7 +186,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.20.0", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.21.2", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, github: "emqx/gproc", tag: "0.9.0.1", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.44.0", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -84,7 +84,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-6"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.20.0"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.1"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.8"}}},


### PR DESCRIPTION
Fixes [EMQX-14718](https://emqx.atlassian.net/browse/EMQX-14718).

Release version: 5.8.9

## Summary

Backports of #14936 + #15396 + #15518.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14477]: https://emqx.atlassian.net/browse/EMQX-14477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMQX-14718]: https://emqx.atlassian.net/browse/EMQX-14718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ