### PR TITLE
fix(mq): do not show hasnext on the last page of MQ list in API

### DIFF
--- a/apps/emqx_mq/test/emqx_mq_api_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_api_SUITE.erl
@@ -1,5 +1,5 @@
 %%--------------------------------------------------------------------
-%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
 %%--------------------------------------------------------------------
 
 -module(emqx_mq_api_SUITE).
@@ -135,6 +135,11 @@ t_pagination(_Config) ->
     {ok, 200, #{<<"data">> := Data1, <<"meta">> := #{<<"hasnext">> := false}}} =
         api_get([message_queues, queues, "?limit=6&cursor=" ++ urlencode(Cursor)]),
     ?assertEqual(4, length(Data1)),
+
+    %% Check that the last page does not have `hasnext
+    {ok, 200, #{<<"data">> := Data2, <<"meta">> := #{<<"hasnext">> := false}}} =
+        api_get([message_queues, queues, "?limit=4&cursor=" ++ urlencode(Cursor)]),
+    ?assertEqual(4, length(Data2)),
 
     %% Check that we do not crash on invalid cursor
     ?assertMatch(


### PR DESCRIPTION
Fixes [EMQX-14692](https://emqx.atlassian.net/browse/EMQX-14692)

Release version: 6.0.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14692]: https://emqx.atlassian.net/browse/EMQX-14692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ