### PR TITLE
[r59] perf: copy strings to avoid retaining large packet binaries

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -71,6 +71,7 @@
 -define(SERIALIZE_ERR(Reason), ?THROW_SERIALIZE_ERROR(Reason)).
 
 -define(MULTIPLIER_MAX, 16#200000).
+-define(SMALL_BINARY, 64).
 
 -dialyzer({no_match, [serialize_utf8_string/3]}).
 
@@ -356,7 +357,7 @@ do_parse_connect(
         _ ->
             ?PARSE_ERR(#{
                 cause => malformed_connect,
-                unexpected_trailing_bytes => size(Rest7)
+                unexpected_trailing_bytes => byte_size(Rest7)
             })
     end;
 do_parse_connect(_ProtoName, _IsBridge, _ProtoVer, Bin, _StrictMode) ->
@@ -384,7 +385,7 @@ parse_packet(
     Header = #mqtt_packet_header{type = ?PUBLISH, qos = QoS},
     #options{strict_mode = StrictMode, version = Ver}
 ) ->
-    {TopicName, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_topic),
+    {TopicName, Rest} = parse_utf8_string(Bin, StrictMode, _Cause = invalid_topic, publish_topic),
     {PacketId, Rest1} =
         case QoS of
             ?QOS_0 -> {undefined, Rest};
@@ -696,25 +697,41 @@ parse_optional(Bin, F, true) ->
 parse_optional(Bin, _F, false) ->
     {undefined, Bin}.
 
-parse_utf8_string(<<Len:16/big, Str:Len/binary, Rest/binary>>, true, _Cause) ->
+parse_utf8_string(Bin, StrictMode, Cause) ->
+    parse_utf8_string(Bin, StrictMode, Cause, always_copy).
+
+parse_utf8_string(Bin, StrictMode, Cause, Copy) ->
+    {Str, Rest} = do_parse_utf8_string(Bin, StrictMode, Cause),
+    %% Micro-optimization:
+    %% It does not worth copying if topic size is greather than rest (payload).
+    %% Benchmark for 1KB topic vs 1B payload shows about 3~5% increase in CPU use if always copy.
+    case Copy =:= publish_topic andalso byte_size(Str) > byte_size(Rest) of
+        true ->
+            {Str, Rest};
+        false ->
+            {maybe_binary_copy(Str), Rest}
+    end.
+
+do_parse_utf8_string(<<Len:16/big, Str:Len/binary, Rest/binary>>, true, _Cause) ->
     {validate_utf8(Str), Rest};
-parse_utf8_string(<<Len:16/big, Str:Len/binary, Rest/binary>>, false, _Cause) ->
+do_parse_utf8_string(<<Len:16/big, Str:Len/binary, Rest/binary>>, false, _Cause) ->
     {Str, Rest};
-parse_utf8_string(<<Len:16/big, Rest/binary>>, _, Cause) when Len > byte_size(Rest) ->
+do_parse_utf8_string(<<Len:16/big, Rest/binary>>, _, Cause) when Len > byte_size(Rest) ->
     ?PARSE_ERR(#{
         cause => Cause,
-        reason => malformed_utf8_string,
         parsed_length => Len,
         remaining_bytes_length => byte_size(Rest)
     });
-parse_utf8_string(Bin, _, Cause) when 2 > byte_size(Bin) ->
+do_parse_utf8_string(Bin, _, Cause) when 2 > byte_size(Bin) ->
     ?PARSE_ERR(#{
         cause => Cause,
         reason => malformed_utf8_string_length
     }).
 
 parse_will_payload(<<Len:16/big, Data:Len/binary, Rest/binary>>) ->
-    {Data, Rest};
+    %% So the will message payload is not a sub binary into the CONNECT packet binary.
+    %% which can be large if client ID + Username + Password is long.
+    {maybe_binary_copy(Data), Rest};
 parse_will_payload(<<Len:16/big, Rest/binary>>) when
     Len > byte_size(Rest)
 ->
@@ -728,9 +745,15 @@ parse_will_payload(Bin) when
 ->
     ?PARSE_ERR(#{
         cause => malformed_will_payload,
-        length_bytes => size(Bin),
+        length_bytes => byte_size(Bin),
         expected_bytes => 2
     }).
+
+-compile({inline, [maybe_binary_copy/1]}).
+maybe_binary_copy(Bin) when byte_size(Bin) =< ?SMALL_BINARY ->
+    Bin;
+maybe_binary_copy(Bin) ->
+    binary:copy(Bin).
 
 %%--------------------------------------------------------------------
 %% Serialize MQTT Packet

--- a/changes/ee/perf-15907.en.md
+++ b/changes/ee/perf-15907.en.md
@@ -1,0 +1,4 @@
+Improve system memory usage.
+
+- Authorization (authz) cache is now cleared immediately when a client disconnects, reducing unnecessary memory consumption.
+- Fields such as client ID, username, password, and topic are copied into new binaries (when more than 64 bytes) instead of being slices from the raw packet to reduce 'binary' part of memory usage in Erlang VM.


### PR DESCRIPTION
Fixes [EMQX-14703](https://emqx.atlassian.net/browse/EMQX-14703)
Ported from r510 PR: https://github.com/emqx/emqx/pull/15907

Release version: 5.9.2

## Summary

Previously, UTF-8 fields parsed from MQTT packets (e.g. client ID, username, password, and especially topic) were sub-binaries of the original packet buffer. Because these values may live as long as the session (e.g. stored in caches), the entire packet binary could be kept alive unnecessarily, leading to excessive RAM usage.

This change ensures all parsed UTF-8 strings are copied into standalone binaries, allowing the original packet binary to be released promptly.

## Performance Results (larger scale test is yet to be done)

In dev environment, I tested with **10,000 clients**, each publishing once per second to a randomized (fixed-length) topic
 with QoS 0.

### Test 1: 1 KB payload, 90-byte topic
- **Before patch**  
  - beam.smp RES: ~3.2 GB  
  - beam.smp CPU: ~248%  
- **After patch**  
  - beam.smp RES: ~1.9 GB (↓ ~40%)  
  - beam.smp CPU: ~207% (↓ ~16%)  

Significant improvement in both memory footprint and CPU usage.  

### Test 2: 2-byte payload, 270-byte topic
- **With patch**  
  - beam.smp RES: ~2.1 GB  
  - beam.smp CPU: ~270%  
- **Without patch**  
  - beam.smp RES: ~2.1 GB  
  - beam.smp CPU: ~276%  

No measurable CPU penalty for copying larger topic strings.  
Memory use remains stable and predictable.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14703]: https://emqx.atlassian.net/browse/EMQX-14703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ