### PR TITLE
test(conf app): mark test as flaky

### DIFF
--- a/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
+++ b/apps/emqx_conf/test/emqx_conf_app_SUITE.erl
@@ -16,6 +16,11 @@
 all() ->
     emqx_common_test_helpers:all(?MODULE).
 
+flaky_tests() ->
+    #{
+        t_copy_new_data_dir => 3
+    }.
+
 t_copy_conf_override_on_restarts(Config) ->
     ct:timetrap({seconds, 120}),
     Cluster = cluster(


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/17645948595/job/50145141209?pr=15901#step:5:215

```
Testing apps.emqx_conf.emqx_conf_app_SUITE: *** FAILED test case 3 of 5 ***
%%% emqx_conf_app_SUITE ==> t_copy_new_data_dir: FAILED
%%% emqx_conf_app_SUITE ==>
Failure/Error: ?assertEqual({ok,<<47,95,95,119,47,101,109,113,120,47,101,109,113,120,47,95,98,117,105,108,100,47,101,109,113,120,45,101,110,116,101,114,112,114,105,115,101,45,116,101,115,116,47,108,111,103,115,47,99,116,95,114,117,110,46,116,101,115,116,64,49,50,55,46,48,46,48,46,49,46,50,48,50,53,45,48,57,45,49,49,95,49,51,46,52,49,46,49,57,47,97,112,112,115,46,101,109,113,120,95,99,111,110,102,46,101,109,113,120,95,99,111,110,102,95,97,112,112,95,83,85,73,84,69,46,108,111,103,115,47,114,117,110,46,50,48,50,53,45,48,57,45,49,49,95,49,51,46,52,51,46,49,53,47,108,111,103,95,112,114,105,118,97,116,101,47,101,109,113,120,95,99,111,110,102,95,97,112,112,95,83,85,73,84,69,95,100,97,116,97,47,116,95,99,111,112,121,95,110,101,119,95,100,97,116,97,95,100,105,114,47,101,109,113,120,95,99,111,110,102,95,97,112,112,95,83,85,73,84,69,52,64,49,50,55,46,48,46,48,46,49>>}, file : read_file ( NodeDataDir ++ "/certs/fake-cert" ))
  expected: {ok,<<"/__w/emqx/emqx/_build/emqx-enterprise-test/logs/ct_run.test@127.0.0.1.2025-09-11_13.41.19/apps.emqx_conf.emqx_conf_app_SUITE.logs/run.2025-09-11_13.43.15/log_private/emqx_conf_app_SUITE_data/t_copy_new_data_dir/emqx_conf_app_SUITE4@127.0.0.1">>}
       got: {error,enoent}
      line: 232
   comment: #{node => 'emqx_conf_app_SUITE6@127.0.0.1'}
```
