### PR TITLE
250912 perf optimize ram usage for r510

### DIFF
--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -714,6 +714,8 @@ parse_utf8_string(Bin, StrictMode, Cause, Copy) ->
     case Copy =:= publish_topic andalso size(Str) > size(Rest) of
         true ->
             {Str, Rest};
+        false when size(Str) =< 64 ->
+            {Str, Rest};
         false ->
             {binary:copy(Str), Rest}
     end.

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -659,7 +659,7 @@ choose_packet_opts(Opts) ->
     case ParseUnit of
         frame when HasPacketParser ->
             PacketSize = emqx_config:get_zone_conf(zone(Opts), [mqtt, max_packet_size]),
-            [{packet, mqtt}, {packet_size, PacketSize}];
+            [{packet, mqtt}, {packet_size, PacketSize}, {mode, binary}];
         frame ->
             %% NOTE: Silently ignoring the setting if BEAM does not provide `mqtt` parser.
             [{packet, raw}];

--- a/changes/ee/perf-15907.en.md
+++ b/changes/ee/perf-15907.en.md
@@ -1,0 +1,4 @@
+Improve system memory usage.
+
+- Authorization (authz) cache is now cleared immediately when a client disconnects, reducing unnecessary memory consumption.
+- Fields such as client ID, username, password, and topic are copied into new binaries (when more than 64 bytes) instead of being slices from the raw packet to reduce 'binary' part of memory usage in Erlang VM.


### PR DESCRIPTION
Fixes [EMQX-14702](https://emqx.atlassian.net/browse/EMQX-14702) [EMQX-14703](https://emqx.atlassian.net/browse/EMQX-14703)

For 5.8.9 5.9.2: https://github.com/emqx/emqx/pull/15899 and https://github.com/emqx/emqx/pull/15900
<!--
5.8.9
5.9.2
6.0.0
6.1.0
-->
Release version: 5.10.1 6.0.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14702]: https://emqx.atlassian.net/browse/EMQX-14702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMQX-14703]: https://emqx.atlassian.net/browse/EMQX-14703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ