### PR TITLE
[r58]: upgrade mogodb driver

### DIFF
--- a/apps/emqx_mongodb/rebar.config
+++ b/apps/emqx_mongodb/rebar.config
@@ -4,5 +4,5 @@
 {deps, [
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
-    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.0.25"}}}
+    {mongodb, {git, "https://github.com/emqx/mongodb-erlang", {tag, "v3.1.0"}}}
 ]}.


### PR DESCRIPTION
This removes the erlang-pbkdf2 dependency from the release.