### PR TITLE
[r60] upgrade mogodb driver to 3.1.0

### DIFF
--- a/apps/emqx_mongodb/mix.exs
+++ b/apps/emqx_mongodb/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXMongodb.MixProject do
     UMP.deps([
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
-      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.0.25"}
+      {:mongodb, github: "emqx/mongodb-erlang", tag: "v3.1.0"}
     ])
   end
 end


### PR DESCRIPTION
This removes elrang-pbkdf2 (which is not used anyway) dependency from the release