### PR TITLE
chore(api keys): return `null` for global namespace

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -515,7 +515,16 @@ check_rbac(Req, HandlerInfo, ApiKey, Role, Namespace) ->
     end.
 
 format_app_extend(App) ->
-    App.
+    emqx_utils_maps:update_if_present(
+        ?namespace,
+        fun
+            (?global_ns) ->
+                null;
+            (Namespace) ->
+                Namespace
+        end,
+        App
+    ).
 
 parse_role(Role) ->
     emqx_dashboard_rbac:parse_api_role(Role).


### PR DESCRIPTION
The frontend needs to differentiate between global and namespaced API keys to correctly display its pages.

<!--
5.8.9
5.9.2
6.0.0
6.1.0
-->
Release version: 6.0.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (unreleased feature)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
