### PR TITLE
fix(audit): Clean audit logs via dirty operation

### DIFF
--- a/apps/emqx_audit/src/emqx_audit.app.src
+++ b/apps/emqx_audit/src/emqx_audit.app.src
@@ -1,6 +1,6 @@
 {application, emqx_audit, [
     {description, "Audit log for EMQX"},
-    {vsn, "0.1.3"},
+    {vsn, "0.1.4"},
     {registered, []},
     {mod, {emqx_audit_app, []}},
     {applications, [kernel, stdlib, emqx]},

--- a/apps/emqx_audit/src/emqx_audit.erl
+++ b/apps/emqx_audit/src/emqx_audit.erl
@@ -178,15 +178,15 @@ clean_expired_logs() ->
     case CurSize - MaxSize of
         DelSize when DelSize > 0 ->
             case
-                mria:transaction(
+                mria:sync_dirty(
                     ?COMMON_SHARD,
                     fun ?MODULE:trans_clean_expired/2,
                     [Oldest, DelSize]
                 )
             of
-                {atomic, ok} ->
+                ok ->
                     0;
-                {aborted, Reason} ->
+                {error, Reason} ->
                     ?SLOG(error, #{
                         msg => "clean_expired_audit_aborted",
                         reason => Reason,


### PR DESCRIPTION
Before this fix, the audit process would start a huge transaction if the emqx_audit table stored a large number of items. It's hard to execute, which causes the emqx_audit to be cleared.

### How to reproduce this bug

Whenever a large number of calls are executed on the remote_console, for example:
```
spawn_link(fun() -> lists:foreach(fun(_) -> ets:info(emqx_audit, size) end, lists:seq(1, 200000)) end).
```
200K records are temporarily stored in the emqx_audit table. This type of operation is common when running a maintenance script on a production system.

It casued the emqx_audit can't be cleared
```
mnesia:info().
---> Processes holding locks <---
Lock: {{emqx_audit,1757942217435345},write,{tid,460,<0.4084.0>}}
Lock: {{emqx_audit,1757942220881245},write,{tid,460,<0.4084.0>}}
Lock: {{emqx_audit,1757942235399604},write,{tid,460,<0.4084.0>}}
...

299 transactions committed, 49 aborted, 6 restarted, 200293 logged to disc
19911 held locks, 0 in queue; 1 local transactions, 0 remote
0 transactions waits for other nodes: []
```


<!--
5.8.9
5.9.2
6.0.0
6.1.0
-->
Release version:

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
