### PR TITLE
test(route-helper): fix testcase flakiness [r59]

### DIFF
--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -8,6 +8,7 @@
 -compile(nowarn_export_all).
 
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
@@ -366,7 +367,6 @@ start_remote_shared_sub(Node, Group, Topic) ->
     ?assertReceive({SubPid, ok}, 5_000),
     %% NOTE: Anticipate occasional replication delay.
     ?retry(100, 5, begin
-        SharedSubs = emqx_shared_sub:subscribers(Group, Topic),
-        ?assert(lists:member(SubPid, SharedSubs), SharedSubs)
+        ?assertMatch([#route{dest = {Group, _}}], emqx_router:lookup_routes(Topic))
     end),
     SubPid.


### PR DESCRIPTION
## Summary

Backports of #15568 + #15643.