### PR TITLE
fix(actions api): correctly fetch fallback action tags

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2_api.erl
@@ -1556,7 +1556,7 @@ enrich_fallback_actions_info(Info) ->
             lists:map(
                 fun
                     (#{<<"kind">> := <<"reference">>, <<"type">> := T, <<"name">> := N} = FBA) ->
-                        Tags = emqx_config:get([actions, T, N], []),
+                        Tags = emqx_config:get_raw([<<"actions">>, T, N, <<"tags">>], []),
                         FBA#{<<"tags">> => Tags};
                     (A) ->
                         %% Republish

--- a/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_api_SUITE.erl
@@ -717,7 +717,10 @@ summary_scenarios_setup(Config) ->
                     {connector_type, ConnectorType}
                 ]),
             Type = ?ACTION_TYPE_2,
-            CreateConfig = mqtt_action_create_config(#{<<"connector">> => ConnectorName}),
+            CreateConfig = mqtt_action_create_config(#{
+                <<"connector">> => ConnectorName,
+                <<"tags">> => [<<"tag1">>]
+            }),
             {201, _} = create_action_api(Name, Type, CreateConfig),
             Summarize = fun emqx_bridge_v2_testlib:summarize_actions_api/0;
         sources ->
@@ -729,7 +732,10 @@ summary_scenarios_setup(Config) ->
                     {connector_type, ConnectorType}
                 ]),
             Type = ?SOURCE_TYPE,
-            CreateConfig = source_create_config(#{<<"connector">> => ConnectorName}),
+            CreateConfig = source_create_config(#{
+                <<"connector">> => ConnectorName,
+                <<"tags">> => [<<"tag1">>]
+            }),
             {201, _} = create_source_api(Name, Type, CreateConfig),
             Summarize = fun emqx_bridge_v2_testlib:summarize_sources_api/0
     end,
@@ -2051,7 +2057,7 @@ t_fallback_actions_returned_info(Config) ->
             <<"fallback_actions">> := [
                 #{
                     <<"kind">> := <<"reference">>,
-                    <<"tags">> := _
+                    <<"tags">> := [<<"tag1">>]
                 }
             ]
         }},
@@ -2062,7 +2068,7 @@ t_fallback_actions_returned_info(Config) ->
             <<"fallback_actions">> := [
                 #{
                     <<"kind">> := <<"reference">>,
-                    <<"tags">> := _
+                    <<"tags">> := [<<"tag1">>]
                 }
             ]
         }},


### PR DESCRIPTION
Backport of #15511.

Fixes [EMQX-14723](https://emqx.atlassian.net/browse/EMQX-14723)

Release version: 5.10.1

[EMQX-14723]: https://emqx.atlassian.net/browse/EMQX-14723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ