### PR TITLE
chore: enable inet driver mqtt packet frame parser by default

### DIFF
--- a/apps/emqx/src/config/emqx_config_zones.erl
+++ b/apps/emqx/src/config/emqx_config_zones.erl
@@ -21,6 +21,7 @@
 %% _before_ most of the EMQX applications are started.
 post_update(OldZones, NewZones) ->
     ok = emqx_flapping:update_config(),
+    ok = emqx_listeners:post_zone_config_update(OldZones, NewZones),
     ok = emqx_limiter:post_zone_config_update(OldZones, NewZones),
     ok = run_update_hook(OldZones, NewZones).
 

--- a/apps/emqx/src/emqx_frame.erl
+++ b/apps/emqx/src/emqx_frame.erl
@@ -76,6 +76,11 @@
 -dialyzer({no_match, [serialize_utf8_string/3]}).
 
 %% @doc Describe state for logging.
+describe_state({frame, Options = #options{}}) ->
+    #{
+        state => frame,
+        proto_ver => Options#options.version
+    };
 describe_state(Options = #options{}) ->
     #{
         state => clean,
@@ -151,7 +156,7 @@ parse(<<>>, State) ->
 -spec parse_complete(iodata(), parse_state_initial()) ->
     emqx_types:packet() | [emqx_types:packet() | parse_state_initial()].
 parse_complete(
-    <<Type:4, Dup:1, QoS:2, Retain:1, Rest1/binary>>,
+    <<Type:4, Dup:1, QoS:2, Retain:1, Rest1/binary>> = MaybeComplete,
     Options = #options{strict_mode = StrictMode}
 ) ->
     %% Validate header if strict mode.
@@ -166,8 +171,21 @@ parse_complete(
         <<0:8>> ->
             parse_bodyless_packet(Header);
         _ ->
-            {_RemLen, Rest2} = parse_variable_byte_integer(Rest1),
-            parse_packet_complete(Rest2, Header, Options)
+            {RemLen, Rest2} = parse_variable_byte_integer(Rest1),
+            case RemLen > byte_size(Rest2) of
+                true ->
+                    %% inet delivers an incomplete packet which means it's too large
+                    %% according to the [{packet_size, MaxPacketSize}] set to listener
+                    HeaderLen = byte_size(MaybeComplete) - byte_size(Rest2),
+                    FrameLen = HeaderLen + RemLen,
+                    ?PARSE_ERR(#{
+                        cause => frame_too_large,
+                        received => FrameLen,
+                        note => "controlled by zone config mqtt.max_packet_size"
+                    });
+                false ->
+                    parse_packet_complete(Rest2, Header, Options)
+            end
     end.
 
 parse_remaining_len(<<>>, Header, Mult, Length, Options) ->

--- a/apps/emqx/src/emqx_listeners.erl
+++ b/apps/emqx/src/emqx_listeners.erl
@@ -44,6 +44,7 @@
 -export([is_packet_parser_available/1]).
 
 -export([pre_config_update/3, post_config_update/5]).
+-export([post_zone_config_update/2, update_listener_for_zone_changes/3]).
 
 -export([format_bind/1]).
 
@@ -233,7 +234,7 @@ start() ->
 
 -spec start_listener(listener_id()) -> ok | {error, term()}.
 start_listener(ListenerId) ->
-    apply_on_listener(ListenerId, fun start_listener/3).
+    apply_on_listener(ListenerId, fun ?MODULE:start_listener/3).
 
 -spec start_listener(listener_type(), atom(), map()) -> ok | {error, term()}.
 start_listener(Type, Name, #{bind := Bind, enable := true} = Conf) ->
@@ -291,11 +292,17 @@ restart() ->
 
 -spec restart_listener(listener_id()) -> ok | {error, term()}.
 restart_listener(ListenerId) ->
-    apply_on_listener(ListenerId, fun restart_listener/3).
+    apply_on_listener(ListenerId, fun ?MODULE:restart_listener/3).
 
 -spec restart_listener(listener_type(), atom(), map()) -> ok | {error, term()}.
 restart_listener(Type, ListenerName, Conf) ->
     restart_listener(Type, ListenerName, Conf, Conf).
+
+update_listener_for_zone_changes(Type, Name, Conf) ->
+    %% Listener config is not changed, so pass the current Conf as olad AND new
+    Res = update_listener(Type, Name, _Old = Conf, _New = Conf),
+    ?SLOG(info, #{msg => ?FUNCTION_NAME, result => Res, listener => listener_id(Type, Name)}),
+    ok.
 
 update_listener(_Type, _Name, #{enable := false}, #{enable := false}) ->
     ok;
@@ -562,6 +569,51 @@ post_config_update([?ROOT_KEY], _Request, NewConf, OldConf, _AppEnvs) ->
 post_config_update(_Path, _Request, _NewConf, _OldConf, _AppEnvs) ->
     ok.
 
+post_zone_config_update(OldZones, NewZones) ->
+    Zones0 = maps:keys(OldZones),
+    case find_zones_with_relevant_changes(Zones0, OldZones, NewZones, []) of
+        [] ->
+            ok;
+        Zones ->
+            Listeners = emqx_config:get([listeners], #{}),
+            maps:foreach(
+                fun(Type, NameConfig) ->
+                    update_listeners_in_zones(Type, NameConfig, Zones)
+                end,
+                Listeners
+            )
+    end.
+
+find_zones_with_relevant_changes([], _OldZones, _NewZones, Acc) ->
+    Acc;
+find_zones_with_relevant_changes([Zone | Zones], OldZones, NewZones, Acc) ->
+    OldConfig = emqx_utils_maps:deep_get([Zone, mqtt, max_packet_size], OldZones, none),
+    NewConfig = emqx_utils_maps:deep_get([Zone, mqtt, max_packet_size], NewZones, none),
+    case OldConfig =:= NewConfig of
+        true ->
+            find_zones_with_relevant_changes(Zones, OldZones, NewZones, Acc);
+        false ->
+            find_zones_with_relevant_changes(Zones, OldZones, NewZones, [Zone | Acc])
+    end.
+
+%% So far zone config change only impacts tcp and ssl listeners
+update_listeners_in_zones(Type, NameConfig, Zones) when Type =:= tcp orelse Type =:= ssl ->
+    maps:foreach(
+        fun(Name, Config) ->
+            Zone = maps:get(zone, Config),
+            case lists:member(Zone, Zones) of
+                true ->
+                    ListenerId = listener_id(Type, Name),
+                    apply_on_listener(ListenerId, fun ?MODULE:update_listener_for_zone_changes/3);
+                false ->
+                    ok
+            end
+        end,
+        NameConfig
+    );
+update_listeners_in_zones(_Type, _NameConfig, _Zones) ->
+    ok.
+
 perform_listener_changes([]) ->
     ok;
 perform_listener_changes([{Action, Listener} | Rest]) ->
@@ -653,7 +705,7 @@ ranch_opts(Type, Opts = #{bind := ListenOn}) ->
     }.
 
 choose_packet_opts(Opts) ->
-    ParseUnit = maps:get(parse_unit, Opts, chunk),
+    ParseUnit = maps:get(parse_unit, Opts, frame),
     HasPacketParser = is_packet_parser_available(mqtt),
     case ParseUnit of
         frame when HasPacketParser ->

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1933,7 +1933,7 @@ mqtt_parse_options() ->
             sc(
                 hoconsc:enum([chunk, frame]),
                 #{
-                    default => <<"chunk">>,
+                    default => <<"frame">>,
                     desc => ?DESC(fields_mqtt_opts_parse_unit),
                     importance => ?IMPORTANCE_LOW
                 }

--- a/apps/emqx/test/emqx_listeners_update_SUITE.erl
+++ b/apps/emqx/test/emqx_listeners_update_SUITE.erl
@@ -227,9 +227,9 @@ t_ssl_change_parse_unit(_Conf) ->
     }).
 
 test_change_parse_unit(ConfPath, ClientOpts) ->
-    ListenerRawConf0 = #{<<"parse_unit">> := <<"chunk">>} = emqx:get_raw_config(ConfPath),
+    ListenerRawConf0 = #{<<"parse_unit">> := <<"frame">>} = emqx:get_raw_config(ConfPath),
     ListenerRawConf1 = ListenerRawConf0#{
-        <<"parse_unit">> := <<"frame">>
+        <<"parse_unit">> := <<"chunk">>
     },
     %% Update listener and verify `parse_unit` came into effect:
     ?assertMatch({ok, _}, emqx:update_config(ConfPath, {update, ListenerRawConf1})),
@@ -238,7 +238,7 @@ test_change_parse_unit(ConfPath, ClientOpts) ->
     CState1 = get_conn_state(Client1),
     emqx_listeners:is_packet_parser_available(mqtt) andalso
         ?assertMatch(
-            #{parser := {frame, _Options}},
+            #{parser := Tuple} when element(1, Tuple) =:= options,
             CState1
         ),
     %% Restore original config and verify original `parse_unit` came into effect as well:

--- a/changes/ee/perf-15949.en.md
+++ b/changes/ee/perf-15949.en.md
@@ -1,0 +1,2 @@
+Change listener config default value for `parse_unit` from `chunk` to `frame`.
+This should significantly lower CPU usage when payload is greater than socket buffer (default = 4KB).

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1395,7 +1395,8 @@ sysmon_vm_process_low_watermark.label:
 """Process low watermark"""
 
 mqtt_max_packet_size.desc:
-"""Maximum MQTT packet size allowed. Default: 1 MB, Maximum: 256 MB"""
+"""Maximum MQTT packet size allowed. Default: 1 MB, Maximum: 256 MB.
+Note: changing this config at runtime may only take effect for newly established connections after the change."""
 
 mqtt_max_packet_size.label:
 """Max Packet Size"""


### PR DESCRIPTION
<!--
5.8.9
5.9.2
6.0.0
6.1.0
-->
Release version: 5.9.2, 5.10.2

## Summary

The config was introduced since 5.9.
In a recent load test, with 64KB payload, with `parse_unit=frame`, CPU 40%; with `parse_unit=chunk`, CPU 70%


<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
