### PR TITLE
test(takeover): add timetrap for faster failures

### DIFF
--- a/apps/emqx/test/emqx_takeover_SUITE.erl
+++ b/apps/emqx/test/emqx_takeover_SUITE.erl
@@ -101,6 +101,13 @@ end_per_group(Group, Config) when
 end_per_group(_Group, _Config) ->
     ok.
 
+init_per_testcase(_TestCase, Config) ->
+    ct:timetrap({seconds, 120}),
+    Config.
+
+end_per_testcase(_TestCase, _Config) ->
+    ok.
+
 %%--------------------------------------------------------------------
 %% Testcases
 


### PR DESCRIPTION
Sometimes, tests in this suite apparently hang forever:

https://github.com/emqx/emqx/actions/runs/17800172837/job/50598995676?pr=15953

https://github.com/emqx/emqx/actions/runs/17806025506/job/50618893280?pr=15956

Adding a timetrap will make them fail sooner than waiting for more than 30 minutes.
