### PR TITLE
fix(ns config): use `sync_transaction` when saving configs

### DIFF
--- a/apps/emqx/src/emqx_config.erl
+++ b/apps/emqx/src/emqx_config.erl
@@ -1010,7 +1010,7 @@ save_configs_namespaced(Namespace, RootKeyAtom, Conf, RawConf, ClusterRPCOpts, O
     maybe
         ?KIND_INITIATE ?= maps:get(kind, ClusterRPCOpts, ?KIND_INITIATE),
         ?tp("emqx_config_save_configs_namespaced_transaction", #{}),
-        {atomic, ok} = mria:transaction(?COMMON_SHARD, fun() ->
+        {atomic, ok} = mria:sync_transaction(?COMMON_SHARD, fun() ->
             ?MODULE:save_configs_namespaced_tx(Namespace, RootKeyBin, Conf, RawConf, Opts)
         end),
         ok


### PR DESCRIPTION
Attempt to fix https://emqx.atlassian.net/browse/EMQX-14728

Release version: 6.0.0

## Summary

Although I could not reproduce the reported issue (nor did the reporter), my hypothesis is that something along the following lines occurred:

~~1) Connector was created on node A (using `mria:transaction`). 
2) Action was created just after it.
3) When node B was replicating the action creation, it tried to check for the existence of the connector, but mnesia had not yet replicated the config change to this node, and then it crashed.~~

~~So, this is an attempt to reduce the chance of inconsistencies in a quick succession of config changes.~~

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [na] The changes are covered with new or existing tests (could not reproduce)
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (unreleased feature)


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
