### PR TITLE
build: bump emqx-builder version to 5.6-2

### DIFF
--- a/.ci/docker-compose-file/docker-compose-kdc.yaml
+++ b/.ci/docker-compose-file/docker-compose-kdc.yaml
@@ -3,7 +3,7 @@ version: '3.9'
 services:
   kdc:
     hostname: kdc.emqx.net
-    image:  ghcr.io/emqx/emqx-builder/5.6-1:1.15.7-26.2.5.14-1-ubuntu22.04
+    image:  ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-ubuntu22.04
     container_name: kdc.emqx.net
     expose:
       - 88 # kdc

--- a/.ci/docker-compose-file/docker-compose.yaml
+++ b/.ci/docker-compose-file/docker-compose.yaml
@@ -2,7 +2,7 @@ services:
   erlang:
     hostname: erlang.emqx.net
     container_name: erlang
-    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.6-1:1.15.7-26.2.5.14-1-ubuntu22.04}
+    image: ${DOCKER_CT_RUNNER_IMAGE:-ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-ubuntu22.04}
     env_file:
       - credentials.env
       - conf.env

--- a/.github/workflows/build_packages.yaml
+++ b/.github/workflows/build_packages.yaml
@@ -63,7 +63,7 @@ on:
       builder_vsn:
         required: false
         type: string
-        default: '5.6-1'
+        default: '5.6-2'
 
 permissions:
   contents: read

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.6-1:1.15.7-26.2.5.14-1-debian13
+ARG BUILD_FROM=ghcr.io/emqx/emqx-builder/5.6-2:1.15.7-26.2.5.14-1-debian13
 ARG RUN_FROM=debian:13-slim
 ARG SOURCE_TYPE=src # tgz
 

--- a/env.sh
+++ b/env.sh
@@ -1,5 +1,5 @@
 # https://github.com/emqx/emqx-builder
-export EMQX_BUILDER_VSN=5.6-1
+export EMQX_BUILDER_VSN=5.6-2
 export OTP_VSN=26.2.5.14-1
 export ELIXIR_VSN=1.15.7
 export EMQX_BUILDER=ghcr.io/emqx/emqx-builder/${EMQX_BUILDER_VSN}:${ELIXIR_VSN}-${OTP_VSN}-ubuntu22.04


### PR DESCRIPTION
Release version: 5.8.9, 5.9.2, 6.0.0

## Summary

See emqx/emqx-builder#138 and emqx/rebar3#24.
`emqx-builder:5.6-2` contains fix for OTP 27 and patch for rebar3 to fix an issue when fetching dependencies over SSL on CentOS7

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
