### PR TITLE
fix(ns config): use cluster-wide config change when bulk importing configs

### DIFF
--- a/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
+++ b/apps/emqx_bridge_pulsar/test/emqx_bridge_pulsar_SUITE.erl
@@ -804,10 +804,13 @@ t_resource_manager_crash_after_producers_started(TCConfig) ->
                         InstanceId =/= undefined,
                     10_000
                 ),
-            ?assertEqual([], get_pulsar_producers()),
             ok
         end,
-        []
+        fun(Trace) ->
+            ?assertMatch([_ | _], ?of_kind(pulsar_bridge_client_stopped, Trace)),
+            ?assertMatch([_ | _], ?of_kind(pulsar_bridge_producer_stopped, Trace)),
+            ok
+        end
     ),
     ok.
 
@@ -839,10 +842,12 @@ t_resource_manager_crash_before_producers_started(TCConfig) ->
                     #{?snk_kind := pulsar_bridge_stopped},
                     10_000
                 ),
-            ?assertEqual([], get_pulsar_producers()),
             ok
         end,
-        []
+        fun(Trace) ->
+            ?assertMatch([_ | _], ?of_kind(pulsar_bridge_client_stopped, Trace)),
+            ok
+        end
     ),
     ok.
 

--- a/apps/emqx_mt/src/emqx_mt_api.erl
+++ b/apps/emqx_mt/src/emqx_mt_api.erl
@@ -946,7 +946,7 @@ save_config(_IsDryRun = false, Namespace, NewConfig0, OldConfig) ->
             maybe
                 {ok, Config} ?= maps:find(RootKey, NewConfig),
                 ?tp("mt_bulk_importing_config", #{root_key => RootKey, namespace => Namespace}),
-                {ok, _} = emqx:update_config([RootKey], Config, #{namespace => Namespace})
+                {ok, _} = emqx_conf:update([RootKey], Config, #{namespace => Namespace})
             end
         end,
         SortedRootKeys

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -2711,7 +2711,7 @@ t_namespaced_bulk_import_order(matrix) ->
     [[?custom_cluster]];
 t_namespaced_bulk_import_order(TCConfig0) when is_list(TCConfig0) ->
     #{
-        tc_config := _TCConfigNS,
+        tc_config := TCConfigNS,
         source_hookpoint := _SourceHookPoint,
         namespace := Namespace,
         action_name := ActionName,
@@ -2759,6 +2759,24 @@ t_namespaced_bulk_import_order(TCConfig0) when is_list(TCConfig0) ->
                         )
                     )
                 )
+            ),
+            ?assertMatch(
+                {200, [
+                    #{
+                        <<"description">> := <<"action ns1">>,
+                        <<"status">> := <<"connected">>
+                    }
+                ]},
+                emqx_bridge_v2_api_SUITE:list([{conf_root_key, actions} | TCConfigNS])
+            ),
+            ?assertMatch(
+                {200, [
+                    #{
+                        <<"description">> := <<"source ns1">>,
+                        <<"status">> := <<"connected">>
+                    }
+                ]},
+                emqx_bridge_v2_api_SUITE:list([{conf_root_key, sources} | TCConfigNS])
             ),
             ok
         end,

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_api_2_SUITE.erl
@@ -27,6 +27,8 @@
 
 -define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
 
+-define(ON_ALL(NODES, BODY), erpc:multicall(NODES, fun() -> BODY end)).
+
 -define(assertReceivePublish(TOPIC, EXPR), begin
     ?assertMatch(
         EXPR,
@@ -640,6 +642,9 @@ setup_namespaced_actions_sources_scenario2(TCConfig0) ->
 
     #{
         namespace => Namespace,
+        action_name => ActionName,
+        source_name => SourceName,
+        connector_name => ConnectorName,
         auth_header => AuthHeader,
         source_hookpoint => SourceHookPoint,
         tc_config => TCConfigNS
@@ -692,6 +697,9 @@ setup_namespaced_actions_sources_deletion_scenario(TestCase, TCConfig0) ->
         GlobalAdminHeader
     ),
     #{
+        action_name := ActionName,
+        source_name := SourceName,
+        connector_name := ConnectorName,
         tc_config := TCConfigNS,
         source_hookpoint := SourceHookPoint
     } = setup_namespaced_actions_sources_scenario2([
@@ -716,6 +724,9 @@ setup_namespaced_actions_sources_deletion_scenario(TestCase, TCConfig0) ->
         tc_config => TCConfigNS,
         source_hookpoint => SourceHookPoint,
         namespace => Namespace,
+        action_name => ActionName,
+        source_name => SourceName,
+        connector_name => ConnectorName,
         username => Username,
         nodes => Nodes
     }.
@@ -2703,19 +2714,26 @@ t_namespaced_bulk_import_order(TCConfig0) when is_list(TCConfig0) ->
         tc_config := _TCConfigNS,
         source_hookpoint := _SourceHookPoint,
         namespace := Namespace,
+        action_name := ActionName,
         username := _Username,
-        nodes := [N1 | _] = _Nodes
+        nodes := Nodes
     } = setup_namespaced_actions_sources_deletion_scenario(?FUNCTION_NAME, TCConfig0),
     {200, OriginalConfig} = emqx_mt_api_SUITE:bulk_export_ns_configs(#{
         <<"namespaces">> => [Namespace]
     }),
     %% Clear all resource befores re-importing
-    ?ON(N1, begin
+    ?ON_ALL(Nodes, begin
         emqx_bridge_v2_testlib:delete_all_rules(),
         emqx_bridge_v2_testlib:delete_all_bridges_and_connectors()
     end),
     %% Sanity check
-    [] = ?ON(N1, emqx_resource:list_instances()),
+    [{ok, []}] = lists:usort(?ON_ALL(Nodes, emqx_resource:list_instances())),
+    [{ok, missing}] =
+        lists:usort(
+            ?ON_ALL(
+                Nodes, emqx:get_namespaced_config(Namespace, [actions, mqtt, ActionName], missing)
+            )
+        ),
     %% Re-importing the config should work.
     %% The original issue was that actions could be created before their connectors.
     ?check_trace(
@@ -2726,6 +2744,21 @@ t_namespaced_bulk_import_order(TCConfig0) when is_list(TCConfig0) ->
                     <<"configs">> => OriginalConfig,
                     <<"dry_run">> => false
                 })
+            ),
+            ?assertMatch(
+                [{ok, [_]}],
+                lists:usort(?ON_ALL(Nodes, emqx_resource:list_instances()))
+            ),
+            ?assertMatch(
+                [{ok, <<"action ns1">>}],
+                lists:usort(
+                    ?ON_ALL(
+                        Nodes,
+                        emqx:get_namespaced_config(
+                            Namespace, [actions, mqtt, ActionName, description], missing
+                        )
+                    )
+                )
             ),
             ok
         end,


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14728

Fixes https://emqx.atlassian.net/browse/EMQX-14736

<!--
5.8.9
5.9.2
5.10.1
6.0.0
6.1.0
-->
Release version: 6.0.0

## Summary

The wrong config update function was being used: it was altering only the local node...

Also, made an improvement to resource manager: when adding channels, we now add a trigger for channel health check, instead of waiting for connector health check to run (which might take a long time, depending on configuration) or manually kicking it off (like we do in `emqx_bridge_v2_api:wait_for_ready`).  This should improve feedback when importing configurations.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
