### PR TITLE
feat(api): expose "forget site" operation in DS API

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -28,6 +28,7 @@
     node_status/1,
     this_site/0,
     forget_site/1,
+    claim_site/2,
     print_status/0
 ]).
 
@@ -313,6 +314,10 @@ forget_site(Site) ->
             %% If it's gone, it should leave the cluster first.
             {error, site_temporarily_down}
     end.
+
+-spec claim_site(site(), node()) -> ok | {error, _Reason}.
+claim_site(Site, Node) ->
+    transaction(fun ?MODULE:claim_site_trans/2, [Site, Node]).
 
 %%===============================================================================
 


### PR DESCRIPTION
Part of [EMQX-14740](https://emqx.atlassian.net/browse/EMQX-14740).

Release version: 6.0.0

## Summary

This PR exposes _forget site_ operation in DS API (in addition to CLI), to give `emqx-operator` more control over DS sites.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-14740]: https://emqx.atlassian.net/browse/EMQX-14740?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ