### PR TITLE
test(retainer): attempt to stabilize flaky test

### DIFF
--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -155,9 +155,11 @@ t_store_and_clean(_) ->
     ),
 
     {ok, #{}, [0]} = emqtt:unsubscribe(C1, <<"retained">>),
+    timer:sleep(100),
 
     emqtt:publish(C1, <<"retained">>, <<"">>, [{qos, 0}, {retain, true}]),
     timer:sleep(100),
+
     {ok, #{}, [0]} = emqtt:subscribe(C1, <<"retained">>, [{qos, 0}, {rh, 0}]),
     ?assertEqual(0, length(receive_messages(1))),
     ?assertMatch(


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/17978740909/job/51140015197?pr=16009#step:5:73

```
%%% emqx_retainer_SUITE ==> mnesia_with_indices.t_store_and_clean: FAILED
%%% emqx_retainer_SUITE ==>
Failure/Error: ?assertEqual(0, length ( receive_messages ( 1 ) ))
  expected: 0
       got: 1
      line: 162
```
