### PR TITLE
test(ds): fix flaky test

### DIFF
--- a/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_session_ds_SUITE.erl
@@ -1499,7 +1499,8 @@ no_abnormal_session_terminate(Trace) ->
                 case E of
                     #{reason := takenover} -> ok;
                     #{reason := kicked} -> ok;
-                    #{reason := {shutdown, tcp_closed}} -> ok
+                    #{reason := {shutdown, tcp_closed}} -> ok;
+                    #{reason := {shutdown, closed}} -> ok
                 end;
             (_) ->
                 ok


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/18007799880/job/51233260164?pr=16017#step:5:1339

```
=CRITICAL REPORT==== 25-Sep-2025::13:05:20.821092 ===
["#Fun<emqx_persistent_session_ds_SUITE.84.113343446>"] failed: error
{case_clause,#{id => <<"emqx_persistent_session_ds_fuzzer">>,
               reason => {shutdown,closed},
               msg => sessds_terminate,
               '~meta' =>
                   #{node => 'test@127.0.0.1',pid => <0.104270.0>,
                     time => -576460239734847,peername => "127.0.0.1:57522",
                     gl => <0.101711.0>,
                     location => #Fun<emqx_persistent_session_ds.7.92624647>,
                     clientid => <<"emqx_persistent_session_ds_fuzzer">>}}}
Stacktrace: [{emqx_persistent_session_ds_SUITE,
                 '-no_abnormal_session_terminate/1-fun-0-',1,
                 [{file,"test/emqx_persistent_session_ds_SUITE.erl"},
                  {line,1499}]},
             {lists,foreach_1,2,[{file,"lists.erl"},{line,2310}]},
             {emqx_persistent_session_ds_SUITE,'-t_fuzz/1-fun-3-',1,
                 [{file,"test/emqx_persistent_session_ds_SUITE.erl"},
                  {line,981}]}]
```
