### PR TITLE
fix(dsraft): use Cluster ID as part of Ra server UID

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -892,7 +892,7 @@ site_shards_trans(Site) ->
     Target = [
         {target, R#?SHARD_TAB.shard}
      || R <- ShardRecords,
-        {_T, S} <- pending_transitions(R, shard_transition_trans(R, read)),
+        {add, S} <- pending_transitions(R, shard_transition_trans(R, read)),
         S == Site
     ],
     Current ++ Target.

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -27,6 +27,7 @@
     node/1,
     node_status/1,
     this_site/0,
+    this_cluster/0,
     forget_site/1,
     claim_site/2,
     print_status/0
@@ -77,6 +78,7 @@
     drop_db_trans/1,
     claim_site_trans/2,
     forget_site_trans/1,
+    ensure_cluster_trans/1,
     n_shards/1
 ]).
 
@@ -114,9 +116,14 @@
     db_props :: emqx_ds_builtin_raft:db_opts()
 }).
 
+-define(cluster, cluster).
+
+%% Contains:
+%% * exactly one record `?cluster => cluster()`,
+%% * one `site() => node()` per each known site.
 -record(?NODE_TAB, {
-    site :: site(),
-    node :: node(),
+    site :: site() | ?cluster,
+    node :: node() | cluster(),
     misc = #{} :: map()
 }).
 
@@ -135,6 +142,10 @@
     transition :: transition(),
     misc = #{} :: map()
 }).
+
+%% Persistent ID of the cluster:
+%% Changes only if the node leaves the cluser or joins another one.
+-type cluster() :: binary().
 
 %% Persistent ID of the node (independent from the IP/FQDN):
 -type site() :: binary().
@@ -168,11 +179,6 @@
 -define(emqx_ds_builtin_site, emqx_ds_builtin_site).
 
 %% Make Dialyzer happy
--define(NODE_PAT(),
-    %% Equivalent of `#?NODE_TAB{_ = '_'}`:
-    erlang:make_tuple(record_info(size, ?NODE_TAB), '_')
-).
-
 -define(NODE_PAT(NODE),
     %% Equivalent of `#?NODE_TAB{node = NODE, _ = '_'}`:
     erlang:make_tuple(record_info(size, ?NODE_TAB), '_', [{#?NODE_TAB.node, NODE}])
@@ -195,6 +201,13 @@
 -spec this_site() -> site().
 this_site() ->
     persistent_term:get(?emqx_ds_builtin_site).
+
+-spec this_cluster() -> cluster().
+this_cluster() ->
+    case mnesia:dirty_read(?NODE_TAB, ?cluster) of
+        [#?NODE_TAB{node = ClusterID}] -> ClusterID;
+        [] -> error(cluster_unknown)
+    end.
 
 -spec n_shards(emqx_ds:db()) -> pos_integer().
 n_shards(DB) ->
@@ -281,7 +294,7 @@ sites(lost) ->
     [S || #?NODE_TAB{site = S, node = N} <- all_nodes(), node_status(N) == lost].
 
 -spec node(site()) -> node() | undefined.
-node(Site) ->
+node(Site) when is_binary(Site) ->
     case mnesia:dirty_read(?NODE_TAB, Site) of
         [#?NODE_TAB{node = Node}] ->
             Node;
@@ -298,7 +311,7 @@ node_status(Node) when is_atom(Node) ->
     end.
 
 -spec forget_site(site()) -> ok | {error, _Reason}.
-forget_site(Site) ->
+forget_site(Site) when is_binary(Site) ->
     maybe
         [Record] ?= mnesia:dirty_read(?NODE_TAB, Site),
         lost ?= node_status(Record#?NODE_TAB.node),
@@ -316,7 +329,7 @@ forget_site(Site) ->
     end.
 
 -spec claim_site(site(), node()) -> ok | {error, _Reason}.
-claim_site(Site, Node) ->
+claim_site(Site, Node) when is_binary(Site) ->
     transaction(fun ?MODULE:claim_site_trans/2, [Site, Node]).
 
 %%===============================================================================
@@ -582,6 +595,7 @@ init([]) ->
     ensure_tables(),
     run_migrations(),
     ensure_site(),
+    ensure_cluster(),
     {ok, _Node} = mnesia:subscribe({table, ?SHARD_TAB, simple}),
     {ok, #s{}}.
 
@@ -840,6 +854,16 @@ claim_site_trans(Site, Node) ->
             mnesia:abort({conflicting_node_site, ExistingSites})
     end.
 
+-spec ensure_cluster_trans(cluster()) -> ok.
+ensure_cluster_trans(ClusterID) ->
+    %% NOTE: Reusing existing `?NODE_TAB` table.
+    case mnesia:read(?NODE_TAB, ?cluster, write) of
+        [#?NODE_TAB{node = _RegisteredClusterID}] ->
+            ok;
+        [] ->
+            mnesia:write(#?NODE_TAB{site = ?cluster, node = ClusterID})
+    end.
+
 -spec forget_site_trans(_Record :: tuple()) -> ok.
 forget_site_trans(Record = #?NODE_TAB{site = Site}) ->
     %% Safeguards.
@@ -877,7 +901,7 @@ node_sites_trans(Node) ->
     mnesia:match_object(?NODE_TAB, ?NODE_PAT(Node), write).
 
 all_nodes() ->
-    mnesia:dirty_match_object(?NODE_TAB, ?NODE_PAT()).
+    mnesia:dirty_select(?NODE_TAB, [{?NODE_PAT('$1'), [{is_atom, '$1'}], ['$_']}]).
 
 all_shards() ->
     mnesia:dirty_match_object(?SHARD_TAB, ?SHARD_PAT('_')).
@@ -938,7 +962,12 @@ ensure_site() ->
             logger:error("Attempt to claim site with ID=~s failed: ~p", [Site, Reason])
     end.
 
-forget_node(Node) ->
+ensure_cluster() ->
+    %% NOTE: Using Site ID as a provisional Cluster ID, for simplicity.
+    ClusterID = emqx_dsch:this_site(),
+    transaction(fun ?MODULE:ensure_cluster_trans/1, [ClusterID]).
+
+forget_node(Node) when is_atom(Node) ->
     Sites = node_sites(Node),
     Result = transaction(fun lists:map/2, [fun ?MODULE:forget_site_trans/1, Sites]),
     case Result of

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
@@ -628,39 +628,61 @@ bootstrap(St = #st{stage = {wait_log_index, RaftIdx}, db = DB, shard = Shard, se
 
 %%
 
-start_server(DB, Shard, Schema, #{replication_options := ReplicationOpts}) ->
-    ClusterName = cluster_name(DB, Shard),
+start_server(DB, Shard, Schema, RTConf) ->
     LocalServer = local_server(DB, Shard),
-    Servers = known_shard_servers(DB, Shard),
+    UID = server_uid(DB, Shard),
+    case ra_directory:uid_of(DB, LocalServer) of
+        UID ->
+            %% Server is known, and has the expected UID, restart it.
+            restart_server(DB, Shard, LocalServer);
+        undefined ->
+            %% Server is unknown, start a fresh one:
+            create_start_server(DB, Shard, LocalServer, UID, Schema, RTConf);
+        ExistingUID ->
+            %% Server has unexpected UID, might have been part of the previous cluster.
+            %% Start a fresh server, effectively abandoning existing one:
+            ?tp(notice, "Recreating existing DS shard server", #{
+                db => DB,
+                shard => Shard,
+                server_uid => UID,
+                existing_server_uid => ExistingUID
+            }),
+            create_start_server(DB, Shard, LocalServer, UID, Schema, RTConf)
+    end.
+
+restart_server(DB, _Shard, LocalServer) ->
     MutableConfig = #{},
     case ra:restart_server(DB, LocalServer, MutableConfig) of
-        {error, name_not_registered} ->
-            UID = server_uid(DB, Shard),
-            Machine =
-                {module, emqx_ds_builtin_raft_machine, #{
-                    db => DB, shard => Shard, schema => Schema
-                }},
-            LogOpts = maps:with(
-                [
-                    snapshot_interval,
-                    resend_window
-                ],
-                ReplicationOpts
-            ),
-            ok = ra:start_server(DB, MutableConfig#{
-                id => LocalServer,
-                uid => UID,
-                cluster_name => ClusterName,
-                initial_members => Servers,
-                machine => Machine,
-                log_init_args => LogOpts#{uid => UID}
-            }),
-            {_NewServer = true, LocalServer};
         ok ->
             {_NewServer = false, LocalServer};
         {error, {already_started, _}} ->
             {_NewServer = false, LocalServer}
     end.
+
+create_start_server(DB, Shard, LocalServer, UID, Schema, RTConf) ->
+    #{replication_options := ReplicationOpts} = RTConf,
+    ClusterName = cluster_name(DB, Shard),
+    Servers = known_shard_servers(DB, Shard),
+    Machine =
+        {module, emqx_ds_builtin_raft_machine, #{
+            db => DB, shard => Shard, schema => Schema
+        }},
+    LogOpts = maps:with(
+        [
+            snapshot_interval,
+            resend_window
+        ],
+        ReplicationOpts
+    ),
+    ok = ra:start_server(DB, #{
+        id => LocalServer,
+        uid => UID,
+        cluster_name => ClusterName,
+        initial_members => Servers,
+        machine => Machine,
+        log_init_args => LogOpts#{uid => UID}
+    }),
+    {_NewServer = true, LocalServer}.
 
 trigger_election(Server) ->
     %% NOTE
@@ -682,15 +704,13 @@ trigger_election(Server) ->
 announce_shard_ready(DB, Shard) ->
     set_shard_info(DB, Shard, ready, true).
 
-server_uid(_DB, Shard) ->
+server_uid(DB, Shard) ->
     %% NOTE
     %% Each new "instance" of a server should have a unique identifier. Otherwise,
     %% if some server migrates to another node during rebalancing, and then comes
     %% back, `ra` will be very confused by it having the same UID as before.
-    %% Keeping the shard ID as a prefix to make it easier to identify the server
-    %% in the filesystem / logs / etc.
-    Ts = integer_to_binary(erlang:system_time(microsecond)),
-    <<Shard/binary, "_", Ts/binary>>.
+    ClusterID = emqx_ds_builtin_raft_meta:this_cluster(),
+    iolist_to_binary([atom_to_binary(DB), Shard, $_, ClusterID]).
 
 %%
 

--- a/mix.exs
+++ b/mix.exs
@@ -207,7 +207,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:telemetry), do: {:telemetry, "1.3.0", manager: :rebar3, override: true}
   # in conflict by grpc and eetcd
   def common_dep(:gpb), do: {:gpb, "4.21.5", override: true, runtime: false}
-  def common_dep(:ra), do: {:ra, github: "emqx/ra", tag: "v2.15.2-emqx-3", override: true}
+  def common_dep(:ra), do: {:ra, github: "emqx/ra", tag: "v2.16.13-emqx-1", override: true}
 
   # in conflict by emqx_connector and system_monitor
   def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.4", override: true}


### PR DESCRIPTION
Fixes [EMQX-14756](https://emqx.atlassian.net/browse/EMQX-14756).

Release version: 6.0.0

## Summary

See individual commits.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [ ] Schema changes are backward compatible
    Layout of data directory slightly changed, consider part of DS-related breaking changes.
