### PR TITLE
fix(jq): upgrade to 0.3.14

### DIFF
--- a/changes/ee/fix-16025.en.md
+++ b/changes/ee/fix-16025.en.md
@@ -1,0 +1,3 @@
+Fixed rule engine `jq` function memory leak.
+
+Previously if `jq` built-in function `index` is used (e.g. `.key | index("name")`), it would result in memory leak.

--- a/mix.exs
+++ b/mix.exs
@@ -1128,7 +1128,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.12", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.14", override: true}],
       else: []
   end
 


### PR DESCRIPTION
fixed mem leak of jq builtin function index
previously rules using jq function like '.keys | index("name")' would result in mem leak

Release version: 6.0.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
