### PR TITLE
Disable MQs for durable sessions

### DIFF
--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -163,7 +163,8 @@
     subscriptions,
     upgrade_qos,
     retry_interval,
-    await_rel_timeout
+    await_rel_timeout,
+    impl
 ]).
 
 -define(IMPL(S), (get_impl_mod(S))).
@@ -262,7 +263,9 @@ open(ClientInfo, ConnInfo, MaybeWillMsg) ->
     %% Try to look the existing session up in session stores corresponding to the given
     %% `Mods` in order, starting from the last one.
     case try_open(Mods, ClientInfo, ConnInfo, MaybeWillMsg, Conf) of
-        {_IsPresent = true, _, _} = Present ->
+        {_IsPresent = true, Session, _} = Present ->
+            ok = emqx_metrics:inc('session.resumed'),
+            ok = emqx_hooks:run('session.resumed', [ClientInfo, info(Session)]),
             Present;
         false ->
             %% NOTE

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -705,7 +705,7 @@ takeover(#session{subscriptions = Subs}) ->
 
 -spec resume(emqx_types:clientinfo(), session()) ->
     session().
-resume(ClientInfo = #{clientid := ClientId}, Session = #session{subscriptions = Subs}) ->
+resume(_ClientInfo = #{clientid := ClientId}, Session = #session{subscriptions = Subs}) ->
     ok = maps:foreach(
         fun(TopicFilter, SubOpts) ->
             ok = emqx_broker:subscribe(TopicFilter, ClientId, SubOpts)

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -712,8 +712,6 @@ resume(ClientInfo = #{clientid := ClientId}, Session = #session{subscriptions = 
         end,
         Subs
     ),
-    ok = emqx_metrics:inc('session.resumed'),
-    ok = emqx_hooks:run('session.resumed', [ClientInfo, emqx_session:info(Session)]),
     Session.
 
 -spec replay(emqx_types:clientinfo(), replayctx(), session()) ->

--- a/apps/emqx_mq/src/emqx_mq.erl
+++ b/apps/emqx_mq/src/emqx_mq.erl
@@ -77,8 +77,8 @@ on_message_publish(#message{topic = Topic} = Message) ->
     {ok, Message}.
 
 on_delivery_completed(Msg, Info) ->
-    MessageId = emqx_message:get_header(?MQ_HEADER_MESSAGE_ID, Msg, undefined),
-    ?tp_mq_client(mq_on_delivery_completed, #{message_id => MessageId}),
+    _MessageId = emqx_message:get_header(?MQ_HEADER_MESSAGE_ID, Msg, undefined),
+    ?tp_mq_client(mq_on_delivery_completed, #{message_id => _MessageId}),
     case emqx_message:get_header(?MQ_HEADER_SUBSCRIBER_ID, Msg, undefined) of
         undefined ->
             ok;
@@ -200,8 +200,8 @@ on_session_disconnected(ClientInfo, #{subscriptions := Subs} = _SessionInfo) ->
         Subs
     ).
 
-on_session_created(ClientInfo, SessionInfo) ->
-    ?tp_mq_client(mq_on_session_created, #{client_info => ClientInfo, session_info => SessionInfo}),
+on_session_created(_ClientInfo, SessionInfo) ->
+    ?tp_mq_client(mq_on_session_created, #{client_info => _ClientInfo, session_info => SessionInfo}),
     ok = set_mq_supported(SessionInfo).
 
 on_client_authorize(

--- a/apps/emqx_mq/src/emqx_mq.erl
+++ b/apps/emqx_mq/src/emqx_mq.erl
@@ -14,6 +14,7 @@
 
 -export([
     on_message_publish/1,
+    on_session_created/2,
     on_session_subscribed/3,
     on_session_unsubscribed/3,
     on_session_resumed/2,
@@ -27,10 +28,15 @@
     inspect/2
 ]).
 
+-define(tp_mq_client(KIND, EVENT), ?tp_debug(KIND, EVENT)).
+
+-define(IS_MQ_SUPPORTED_PD_KEY, {?MODULE, is_mq_supported}).
+
 -spec register_hooks() -> ok.
 register_hooks() ->
     ok = emqx_hooks:add('message.publish', {?MODULE, on_message_publish, []}, ?HP_RETAINER + 1),
     ok = emqx_hooks:add('delivery.completed', {?MODULE, on_delivery_completed, []}, ?HP_LOWEST),
+    ok = emqx_hooks:add('session.created', {?MODULE, on_session_created, []}, ?HP_LOWEST),
     ok = emqx_hooks:add('session.subscribed', {?MODULE, on_session_subscribed, []}, ?HP_LOWEST),
     ok = emqx_hooks:add('session.unsubscribed', {?MODULE, on_session_unsubscribed, []}, ?HP_LOWEST),
     ok = emqx_hooks:add('session.resumed', {?MODULE, on_session_resumed, []}, ?HP_LOWEST),
@@ -42,6 +48,7 @@ register_hooks() ->
 unregister_hooks() ->
     emqx_hooks:del('message.publish', {?MODULE, on_message_publish}),
     emqx_hooks:del('delivery.completed', {?MODULE, on_delivery_completed}),
+    emqx_hooks:del('session.created', {?MODULE, on_session_created}),
     emqx_hooks:del('session.subscribed', {?MODULE, on_session_subscribed}),
     emqx_hooks:del('session.unsubscribed', {?MODULE, on_session_unsubscribed}),
     emqx_hooks:del('session.resumed', {?MODULE, on_session_resumed}),
@@ -56,6 +63,7 @@ unregister_hooks() ->
 on_message_publish(#message{topic = <<"$SYS/", _/binary>>} = Message) ->
     {ok, Message};
 on_message_publish(#message{topic = Topic} = Message) ->
+    ?tp_mq_client(mq_on_message_publish, #{topic => Topic}),
     Queues = emqx_mq_registry:match(Topic),
     ok = lists:foreach(
         fun(Queue) ->
@@ -66,6 +74,8 @@ on_message_publish(#message{topic = Topic} = Message) ->
     {ok, Message}.
 
 on_delivery_completed(Msg, Info) ->
+    MessageId = emqx_message:get_header(?MQ_HEADER_MESSAGE_ID, Msg, undefined),
+    ?tp_mq_client(mq_on_delivery_completed, #{message_id => MessageId}),
     case emqx_message:get_header(?MQ_HEADER_SUBSCRIBER_ID, Msg, undefined) of
         undefined ->
             ok;
@@ -75,27 +85,47 @@ on_delivery_completed(Msg, Info) ->
     end.
 
 on_session_subscribed(ClientInfo, <<"$q/", Topic/binary>> = _FullTopic, _SubOpts) ->
-    ?tp_debug(mq_on_session_subscribed, #{full_topic => _FullTopic, handle => true}),
-    Sub = emqx_mq_sub:handle_connect(ClientInfo, Topic),
-    ok = emqx_mq_sub_registry:register(Sub);
+    ?tp_mq_client(mq_on_session_subscribed, #{
+        full_topic => _FullTopic, handle => true, client_info => ClientInfo
+    }),
+    case is_mq_supported() of
+        true ->
+            case emqx_mq_sub_registry:find(Topic) of
+                undefined ->
+                    Sub = emqx_mq_sub:handle_connect(ClientInfo, Topic),
+                    ok = emqx_mq_sub_registry:register(Sub);
+                _Sub ->
+                    ok
+            end;
+        false ->
+            ?tp(info, mq_cannot_subscribe_to_mq, #{
+                reason => "mq is not supported for this type of session"
+            }),
+            ok
+    end;
 on_session_subscribed(_ClientInfo, _FullTopic, _SubOpts) ->
-    ?tp_debug(mq_on_session_subscribed, #{full_topic => _FullTopic, handle => false}),
+    ?tp_mq_client(mq_on_session_subscribed, #{full_topic => _FullTopic, handle => false}),
     ok.
 
 on_session_unsubscribed(ClientInfo, Topic, _SubOpts) ->
     on_session_unsubscribed(ClientInfo, Topic).
 
 on_session_unsubscribed(_ClientInfo, <<"$q/", Topic/binary>> = _FullTopic) ->
+    ?tp_mq_client(mq_on_session_unsubscribed, #{full_topic => _FullTopic}),
     case emqx_mq_sub_registry:delete(Topic) of
         undefined ->
             ok;
         Sub ->
+            ?tp_mq_client(mq_on_session_unsubscribed_sub_deleted, #{full_topic => _FullTopic}),
             ok = emqx_mq_sub:handle_disconnect(Sub)
     end;
 on_session_unsubscribed(_ClientInfo, _FullTopic) ->
+    ?tp_mq_client(mq_on_session_unsubscribed_unknown, #{full_topic => _FullTopic}),
     ok.
 
-on_session_resumed(ClientInfo, #{subscriptions := Subs} = _SessionInfo) ->
+on_session_resumed(ClientInfo, #{subscriptions := Subs} = SessionInfo) ->
+    ?tp_mq_client(mq_on_session_resumed, #{subscriptions => Subs, session_info => SessionInfo}),
+    ok = set_mq_supported(SessionInfo),
     ok = maps:foreach(
         fun
             (<<"$q/", _/binary>> = FullTopic, SubOpts) ->
@@ -107,6 +137,7 @@ on_session_resumed(ClientInfo, #{subscriptions := Subs} = _SessionInfo) ->
     ).
 
 on_message_nack(Msg, false) ->
+    ?tp_mq_client(mq_on_message_nack, #{msg => Msg}),
     SubscriberRef = emqx_message:get_header(?MQ_HEADER_SUBSCRIBER_ID, Msg),
     case with_sub(SubscriberRef, handle_ack, [Msg, ?MQ_NACK]) of
         not_found ->
@@ -123,6 +154,7 @@ on_message_nack(_Msg, true) ->
 on_client_handle_info(
     _ClientInfo, #info_mq_inspect{receiver = Receiver, topic_filter = TopicFilter}, Acc
 ) ->
+    ?tp_mq_client(mq_on_client_handle_info_inspect, #{topic_filter => TopicFilter}),
     Info =
         case emqx_mq_sub_registry:find(TopicFilter) of
             undefined ->
@@ -137,21 +169,24 @@ on_client_handle_info(
     #info_to_mq_sub{subscriber_ref = SubscriberRef, info = InfoMsg},
     #{deliver := Delivers} = Acc
 ) ->
+    ?tp_mq_client(mq_on_client_handle_info_to_mq_sub, #{info => InfoMsg}),
     case with_sub(SubscriberRef, handle_info, [InfoMsg]) of
         not_found ->
             ok;
         ok ->
             ok;
         {ok, Messages} ->
+            ?tp_mq_client(mq_on_client_handle_info_to_mq_sub_messages, #{messages => Messages}),
             {ok, Acc#{deliver => delivers(SubscriberRef, Messages) ++ Delivers}};
         {error, recreate} ->
             ok = recreate_sub(SubscriberRef, ClientInfo)
     end;
 on_client_handle_info(_ClientInfo, _Message, Acc) ->
-    ?tp_debug(mq_on_client_handle_info, #{message => _Message}),
+    ?tp_mq_client(mq_on_client_handle_info_unknown, #{message => _Message}),
     {ok, Acc}.
 
 on_session_disconnected(ClientInfo, #{subscriptions := Subs} = _SessionInfo) ->
+    ?tp_mq_client(mq_on_session_disconnected, #{subscriptions => Subs}),
     ok = maps:foreach(
         fun
             (<<"$q/", _/binary>> = FullTopic, _SubOpts) ->
@@ -173,6 +208,10 @@ inspect(ChannelPid, TopicFilter) ->
         {Self, Info} ->
             Info
     end.
+
+on_session_created(ClientInfo, SessionInfo) ->
+    ?tp_mq_client(mq_on_session_created, #{client_info => ClientInfo, session_info => SessionInfo}),
+    ok = set_mq_supported(SessionInfo).
 
 %%--------------------------------------------------------------------
 %% Internal functions
@@ -224,3 +263,13 @@ delivers(SubscriberRef, Messages) ->
         end,
         Messages
     ).
+
+set_mq_supported(#{impl := emqx_session_mem} = _SessionInfo) ->
+    _ = erlang:put(?IS_MQ_SUPPORTED_PD_KEY, true),
+    ok;
+set_mq_supported(_SessionInfo) ->
+    _ = erlang:put(?IS_MQ_SUPPORTED_PD_KEY, false),
+    ok.
+
+is_mq_supported() ->
+    erlang:get(?IS_MQ_SUPPORTED_PD_KEY).

--- a/apps/emqx_mq/src/emqx_mq_sub_registry.erl
+++ b/apps/emqx_mq/src/emqx_mq_sub_registry.erl
@@ -30,6 +30,13 @@ of channels to the Message Queue consumers.
 register(Sub) ->
     SubscriberRef = emqx_mq_sub:subscriber_ref(Sub),
     MQTopicFilter = emqx_mq_sub:mq_topic_filter(Sub),
+    case erlang:get(?TOPIC_PD_KEY(MQTopicFilter)) of
+        undefined ->
+            ok;
+        _OldSubscriberRef ->
+            %% This should never happen.
+            error({mq_sub_registry_topic_conflict, MQTopicFilter})
+    end,
     ?tp_debug(mq_sub_registry_register, #{
         subscriber_ref => SubscriberRef, mq_topic_filter => MQTopicFilter, sub => Sub
     }),

--- a/apps/emqx_mq/test/emqx_mq_durable_sessions_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_durable_sessions_SUITE.erl
@@ -1,0 +1,74 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_mq_durable_sessions_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx/include/emqx_mqtt.hrl").
+
+-include("../src/emqx_mq_internal.hrl").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps =
+        emqx_cth_suite:start(
+            [
+                emqx_durable_storage,
+                {emqx,
+                    emqx_mq_test_utils:cth_config(emqx, #{
+                        <<"durable_sessions">> => #{
+                            <<"enable">> => true
+                        }
+                    })},
+                {emqx_mq, emqx_mq_test_utils:cth_config(emqx_mq)}
+            ],
+            #{work_dir => emqx_cth_suite:work_dir(Config)}
+        ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+init_per_testcase(_CaseName, Config) ->
+    ok = emqx_mq_test_utils:cleanup_mqs(),
+    ok = snabbkaffe:start_trace(),
+    Config.
+
+end_per_testcase(_CaseName, _Config) ->
+    ok = snabbkaffe:stop(),
+    ok = emqx_mq_test_utils:cleanup_mqs().
+
+%%--------------------------------------------------------------------
+%% Test cases
+%%--------------------------------------------------------------------
+
+%% Verify that a client cannot subscribe to an MQ if the session is durable.
+t_forbid_subscribe_to_mq_for_durable_sessions(_Config) ->
+    %% Create an MQ
+    _ = emqx_mq_test_utils:create_mq(#{topic_filter => <<"t/#">>, is_lastvalue => false}),
+
+    %% When having a durable session, try to subscribe to an MQ and expect an error.
+    CSub0 = emqx_mq_test_utils:emqtt_connect([
+        {clientid, <<"csub">>},
+        {properties, #{'Session-Expiry-Interval' => 10000}},
+        {clean_start, false}
+    ]),
+    {ok, _, [?RC_NOT_AUTHORIZED]} = emqtt:subscribe(CSub0, {<<"$q/t/#">>, 1}),
+    ok = emqtt:disconnect(CSub0),
+
+    %% Reconnect and still expect an error.
+    CSub1 = emqx_mq_test_utils:emqtt_connect([
+        {clientid, <<"csub">>},
+        {properties, #{'Session-Expiry-Interval' => 10000}},
+        {clean_start, false}
+    ]),
+    {ok, _, [?RC_NOT_AUTHORIZED]} = emqtt:subscribe(CSub1, {<<"$q/t/#">>, 1}),
+    ok = emqtt:disconnect(CSub1).


### PR DESCRIPTION
Fixes [EMQX-14770](https://emqx.atlassian.net/browse/EMQX-14770)

Release version: 6.0.0

## Summary

The original issue contains several symptoms of MQs not working properly with durable sessions. In the PR we disable MQs for such sessions.

The main commits are:
[f29e98ce8d01eb2f34fac920265b263059f854fa](https://github.com/emqx/emqx/pull/16038/commits/f29e98ce8d01eb2f34fac920265b263059f854fa) — here we ignore subscriptions to MQs for durable sessions. The reason is that durable sessions has little support for transient messages, e.g. it does not save them into the inflight buffer and passes a fake message to the deliver callback. So we are unable to ack Queue's messages.

[bf224f16802c9c2821b064cb283f828ea841966e](https://github.com/emqx/emqx/pull/16038/commits/bf224f16802c9c2821b064cb283f828ea841966e) — here we additionally forbid (with an authz hook) to subscribe to queue's topics if the session is durable. This should improve feedback to the client.

Also other minor fixes (see individual commits).

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14770]: https://emqx.atlassian.net/browse/EMQX-14770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ