### PR TITLE
feat(ds-otx): make CBM responsible for locating OTX leaders

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -991,8 +991,9 @@ communicate with the Raft machine.
     ra:server_id() | unknown.
 local_raft_leader(DB, Shard) ->
     LocalServer = emqx_ds_builtin_raft_shard:local_server(DB, Shard),
-    case emqx_ds_builtin_raft_shard:server_info(leader, LocalServer) of
-        LocalServer ->
+    case ra:ping(LocalServer, 1_000) of
+        {pong, leader} ->
+            %% Local server still considers itself a leader:
             LocalServer;
         _ ->
             unknown

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
@@ -360,8 +360,7 @@ shard_optimistic_tx_spec(DB, Shard) ->
         type => worker,
         shutdown => 1_000,
         restart => permanent,
-        start =>
-            {emqx_ds_optimistic_tx, start_link, [DB, Shard, emqx_ds_builtin_raft]}
+        start => {emqx_ds_optimistic_tx, start_link, [DB, Shard, emqx_ds_builtin_raft]}
     }.
 
 shard_sentinel_spec(DB, Shard) ->


### PR DESCRIPTION
Part of
* [EMQX-14760](https://emqx.atlassian.net/browse/EMQX-14760)
* [EMQX-14766](https://emqx.atlassian.net/browse/EMQX-14766)

Release version: 6.0.0

## Summary

This PR:
* Moves responsibility for OTX leadership announcements to CBM implementations.
* Updates `emqx_ds_builtin_raft` to register OTX leaders under cluster-id-aware names, to make sure out-of-cluster nodes do not cause global name conflicts.

See individual commits for details.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible


[EMQX-14760]: https://emqx.atlassian.net/browse/EMQX-14760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMQX-14766]: https://emqx.atlassian.net/browse/EMQX-14766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ