### PR TITLE
fix(dsraft): order shards to terminate in-parallel on DB shutdown

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_lifecycle.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_lifecycle.erl
@@ -1,0 +1,115 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2024-2025 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Auxiliary process that manages various aspects of DB lifecycle.
+%% * Starting and stopping leader-tied process trees.
+%% * Parallel shard termination on DB shutdown.
+-module(emqx_ds_builtin_raft_db_lifecycle).
+
+-include_lib("snabbkaffe/include/trace.hrl").
+
+-export([start_link/1]).
+
+-export([
+    async_start_leader_sup/2,
+    async_stop_leader_sup/2
+]).
+
+-behaviour(gen_server).
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-define(name(DB), {n, l, {?MODULE, DB}}).
+-define(via(DB), {via, gproc, ?name(DB)}).
+
+%% Async requests:
+-record(start_leader_sup, {db :: emqx_ds:db(), shard :: emqx_ds:shard()}).
+-record(stop_leader_sup, {db :: emqx_ds:db(), shard :: emqx_ds:shard()}).
+
+%%
+
+-spec start_link(emqx_ds:db()) -> {ok, pid()}.
+start_link(DB) ->
+    gen_server:start_link(?via(DB), ?MODULE, DB, []).
+
+-doc "Order startup of a shard leader supervisor, asynchronously".
+-spec async_start_leader_sup(emqx_ds:db(), emqx_ds:shard()) -> ok.
+async_start_leader_sup(DB, Shard) ->
+    gen_server:cast(?via(DB), #start_leader_sup{db = DB, shard = Shard}).
+
+-doc "Order stopping of a shard leader supervisor, asynchronously".
+-spec async_stop_leader_sup(emqx_ds:db(), emqx_ds:shard()) -> ok.
+async_stop_leader_sup(DB, Shard) ->
+    gen_server:cast(?via(DB), #stop_leader_sup{db = DB, shard = Shard}).
+
+%%
+
+-type state() :: #{db := emqx_ds:db()}.
+
+-spec init(emqx_ds:db()) -> {ok, state()}.
+init(DB) ->
+    _ = erlang:process_flag(trap_exit, true),
+    {ok, #{db => DB}, hibernate}.
+
+-spec handle_call(_Call, _From, state()) -> {reply, ignored, state()}.
+handle_call(_Call, _From, State) ->
+    {reply, ignored, State}.
+
+-spec handle_cast(_Cast, state()) -> {noreply, state()}.
+handle_cast(#start_leader_sup{db = DB, shard = Shard}, State) ->
+    ?tp_span(
+        debug,
+        dsrepl_start_otx_leader,
+        #{db => DB, shard => Shard},
+        emqx_ds_builtin_raft_db_sup:start_shard_leader_sup(DB, Shard)
+    ),
+    {noreply, State};
+handle_cast(#stop_leader_sup{db = DB, shard = Shard}, State) ->
+    ?tp_span(
+        debug,
+        dsrepl_stop_otx_leader,
+        #{db => DB, shard => Shard},
+        emqx_ds_builtin_raft_db_sup:stop_shard_leader_sup(DB, Shard)
+    ),
+    {noreply, State};
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+-spec handle_info(_Cast, state()) -> {noreply, state()}.
+handle_info(_Cast, State) ->
+    {noreply, State}.
+
+-spec terminate(_Reason, state()) -> _Ok.
+terminate(_Reason, #{db := DB}) ->
+    stop_shards(DB).
+
+%%
+
+-doc """
+Stop all local DB shards.
+Shards are asked to stop all at once, so that all required teardown routines
+(e.g. `emqx_ds_builtin_raft_shard:prep_stop_server/2`) are running in parallel.
+""".
+stop_shards(DB) ->
+    Shards = emqx_ds_builtin_raft_db_sup:which_shards(DB),
+    Requests = [
+        %% Stop shard supervisors directly, w/o involvement of `shards_sup`:
+        proc_lib:spawn_link(gen_server, stop, [SupPid, shutdown, infinity])
+     || Shard <- Shards,
+        SupPid <- [emqx_ds_builtin_raft_db_sup:shard_sup({DB, Shard})],
+        is_pid(SupPid)
+    ],
+    lists:foreach(
+        fun(Pid) ->
+            receive
+                {'EXIT', Pid, _Reason} -> ok
+            end
+        end,
+        Requests
+    ).

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_lifecycle.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_lifecycle.erl
@@ -52,7 +52,7 @@ async_stop_leader_sup(DB, Shard) ->
 
 -type state() :: #{db := emqx_ds:db()}.
 
--spec init(emqx_ds:db()) -> {ok, state()}.
+-spec init(emqx_ds:db()) -> {ok, state(), hibernate}.
 init(DB) ->
     _ = erlang:process_flag(trap_exit, true),
     {ok, #{db => DB}, hibernate}.
@@ -63,7 +63,7 @@ handle_call(_Call, _From, State) ->
 
 -spec handle_cast(_Cast, state()) -> {noreply, state()}.
 handle_cast(#start_leader_sup{db = DB, shard = Shard}, State) ->
-    ?tp_span(
+    _ = ?tp_span(
         debug,
         dsrepl_start_otx_leader,
         #{db => DB, shard => Shard},
@@ -71,7 +71,7 @@ handle_cast(#start_leader_sup{db = DB, shard = Shard}, State) ->
     ),
     {noreply, State};
 handle_cast(#stop_leader_sup{db = DB, shard = Shard}, State) ->
-    ?tp_span(
+    _ = ?tp_span(
         debug,
         dsrepl_stop_otx_leader,
         #{db => DB, shard => Shard},

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_machine.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_machine.erl
@@ -374,9 +374,9 @@ state_enter(MemberState, State = #{db_shard := {DB, Shard}}) ->
     _ =
         case MemberState of
             leader ->
-                start_otx_leader(DB, Shard);
+                emqx_ds_builtin_raft_db_lifecycle:async_start_leader_sup(DB, Shard);
             _ ->
-                emqx_ds_builtin_raft_db_sup:stop_shard_leader_sup(DB, Shard)
+                emqx_ds_builtin_raft_db_lifecycle:async_stop_leader_sup(DB, Shard)
         end,
     [].
 
@@ -387,14 +387,6 @@ state_enter(MemberState, State = #{db_shard := {DB, Shard}}) ->
 %%================================================================================
 %% Internal functions
 %%================================================================================
-
-start_otx_leader(DB, Shard) ->
-    ?tp_span(
-        debug,
-        dsrepl_start_otx_leader,
-        #{db => DB, shard => Shard},
-        emqx_ds_builtin_raft_db_sup:start_shard_leader_sup(DB, Shard)
-    ).
 
 set_cache(MemberState, State = #{db_shard := DBShard, latest := Latest}) when
     MemberState =:= leader; MemberState =:= follower

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
@@ -239,9 +239,6 @@ is_server_known({_Name, Node}) ->
 get_cluster_name(DB, Shard) ->
     memoize(fun cluster_name/2, [DB, Shard]).
 
-get_local_server(DB, Shard) ->
-    memoize(fun local_server/2, [DB, Shard]).
-
 get_shard_servers(DB, Shard) ->
     persistent_term:get(?PTERM(DB, Shard, servers), []).
 
@@ -600,8 +597,7 @@ terminate(_Reason, #st{db = DB, shard = Shard}) ->
     ok = erase_shard_info(DB, Shard),
     %% NOTE: Timeouts are ignored, it's a best effort attempt.
     catch prep_stop_server(DB, Shard),
-    LocalServer = get_local_server(DB, Shard),
-    ok = ra:stop_server(DB, LocalServer).
+    ok = ra:stop_server(DB, local_server(DB, Shard)).
 
 %%
 
@@ -748,20 +744,54 @@ prep_stop_server(DB, Shard) ->
     prep_stop_server(DB, Shard, 5_000).
 
 prep_stop_server(DB, Shard, Timeout) ->
-    LocalServer = get_local_server(DB, Shard),
-    Candidates = lists:delete(LocalServer, shard_servers(DB, Shard)),
+    LocalServer = local_server(DB, Shard),
+    Servers = shard_servers(DB, Shard),
+    Candidates = [S || S <- Servers, S =/= LocalServer, is_server_known(S), is_server_online(S)],
+    HasQuorum = length(Candidates) >= (length(Servers) div 2 + 1),
     case lookup_leader(DB, Shard) of
-        LocalServer when Candidates =/= [] ->
+        LocalServer when HasQuorum andalso Candidates =/= [] ->
             %% NOTE
             %% Trigger leadership transfer *and* force to wait until the new leader
-            %% is elected and updated in the leaderboard. This should help to avoid
-            %% edge cases where entries appended right before removal are duplicated
-            %% due to client retries.
-            %% TODO: Candidate may be offline.
+            %% is elected and updated in the local server's state. This should help
+            %% to avoid edge cases where entries appended right before removal are
+            %% duplicated due to client retries.
             [Candidate | _] = Candidates,
-            _ = ra:transfer_leadership(LocalServer, Candidate),
-            wait_until(fun() -> lookup_leader(DB, Shard) == Candidate end, Timeout);
-        _Another ->
+            case ra:transfer_leadership(LocalServer, Candidate) of
+                ok ->
+                    case ra:members(LocalServer, Timeout) of
+                        {ok, _, Server} when Server =/= LocalServer ->
+                            ?tp(info, "Shard leadership transferred", #{
+                                db => DB,
+                                shard => Shard,
+                                to => Server
+                            });
+                        {ok, _, LocalServer} ->
+                            ?tp(warning, "Shard leadership transfer incomplete", #{
+                                db => DB,
+                                shard => Shard,
+                                leader => LocalServer
+                            })
+                    end;
+                already_leader ->
+                    ok;
+                Error ->
+                    ?tp(warning, "Shard leadership transfer failed", #{
+                        db => DB,
+                        shard => Shard,
+                        candidate => Candidate,
+                        error => Error
+                    })
+            end;
+        LocalServer ->
+            %% Liekly no quorum, no risk of occasional duplicates anyway.
+            ?tp(info, "Shard leadership transfer skipped", #{
+                db => DB,
+                shard => Shard,
+                quorum => HasQuorum,
+                candidates => Candidates
+            });
+        _ ->
+            %% Not a leader
             ok
     end.
 
@@ -776,25 +806,4 @@ memoize(Fun, Args) ->
             Result;
         Result ->
             Result
-    end.
-
-wait_until(Fun, Timeout) ->
-    wait_until(Fun, Timeout, 100).
-
-wait_until(Fun, Timeout, Sleep) ->
-    Deadline = erlang:monotonic_time(millisecond) + Timeout,
-    loop_until(Fun, Deadline, Sleep).
-
-loop_until(Fun, Deadline, Sleep) ->
-    case Fun() of
-        true ->
-            ok;
-        false ->
-            case erlang:monotonic_time(millisecond) of
-                Now when Now < Deadline ->
-                    timer:sleep(Sleep),
-                    loop_until(Fun, Deadline, Sleep);
-                _ ->
-                    timeout
-            end
     end.

--- a/changes/ee/feat-16040.en.md
+++ b/changes/ee/feat-16040.en.md
@@ -1,0 +1,1 @@
+Improved EMQX node shutdown routine with Session Durability enabled and backed by the DS Raft backend. EMQX now responds faster to shutdown signals during full cluster shutdown.


### PR DESCRIPTION
Fixes [EMQX-14772](https://emqx.atlassian.net/browse/EMQX-14772).

Release version: 6.0.0

## Summary

See individual commits.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)



[EMQX-14772]: https://emqx.atlassian.net/browse/EMQX-14772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ