### PR TITLE
fix(ds): Limit number and size of RocksDB info log files [r58]

### DIFF
--- a/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
+++ b/apps/emqx_durable_storage/src/emqx_ds_storage_layer.erl
@@ -1164,6 +1164,12 @@ rocksdb_open(Shard, Options) ->
     DBOptions = [
         {create_if_missing, true},
         {create_missing_column_families, true},
+        %% Info log file management:
+        %%    Maximal log files:
+        {keep_log_file_num, 10},
+        %%    Create a new log file when the old one exceeds:
+        %%    `max_log_file_size' (1MB):
+        {max_log_file_size, 16#100000},
         %% NOTE
         %% With WAL-less writes, it's important to have CFs flushed atomically.
         %% For example, bitfield-lts backend needs data + trie CFs to be consistent.

--- a/changes/ce/fix-14674.en.md
+++ b/changes/ce/fix-14674.en.md
@@ -1,0 +1,1 @@
+Limit number and size of RocksDB info log files created by EMQX durable storage.


### PR DESCRIPTION
Fixes: [EMQX-13851](https://emqx.atlassian.net/browse/EMQX-13851)

Release version: 5.8.9

## Summary

Backport of #14674.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible