### PR TITLE
chore(dsraft): consult only `shard_info/2` for shard readiness

### DIFF
--- a/apps/emqx/mix.exs
+++ b/apps/emqx/mix.exs
@@ -6,7 +6,7 @@ defmodule EMQX.MixProject do
   def project do
     [
       app: :emqx,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_paths: erlc_paths(),
       erlc_options: [

--- a/apps/emqx_ai_completion/mix.exs
+++ b/apps/emqx_ai_completion/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAICompletion.MixProject do
   def project do
     [
       app: :emqx_ai_completion,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_audit/mix.exs
+++ b/apps/emqx_audit/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAudit.MixProject do
   def project do
     [
       app: :emqx_audit,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuth.MixProject do
   def project do
     [
       app: :emqx_auth,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_auth_cinfo/mix.exs
+++ b/apps/emqx_auth_cinfo/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthCinfo.MixProject do
   def project do
     [
       app: :emqx_auth_cinfo,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_http/mix.exs
+++ b/apps/emqx_auth_http/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthHTTP.MixProject do
   def project do
     [
       app: :emqx_auth_http,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_jwt/mix.exs
+++ b/apps/emqx_auth_jwt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthJWT.MixProject do
   def project do
     [
       app: :emqx_auth_jwt,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_kerberos/mix.exs
+++ b/apps/emqx_auth_kerberos/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthKerberos.MixProject do
   def project do
     [
       app: :emqx_auth_kerberos,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_auth_ldap/mix.exs
+++ b/apps/emqx_auth_ldap/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthLDAP.MixProject do
   def project do
     [
       app: :emqx_auth_ldap,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_mnesia/mix.exs
+++ b/apps/emqx_auth_mnesia/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthMnesia.MixProject do
   def project do
     [
       app: :emqx_auth_mnesia,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_mongodb/mix.exs
+++ b/apps/emqx_auth_mongodb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthMongoDB.MixProject do
   def project do
     [
       app: :emqx_auth_mongodb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_mysql/mix.exs
+++ b/apps/emqx_auth_mysql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthMySQL.MixProject do
   def project do
     [
       app: :emqx_auth_mysql,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_postgresql/mix.exs
+++ b/apps/emqx_auth_postgresql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthPostgreSQL.MixProject do
   def project do
     [
       app: :emqx_auth_postgresql,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_redis/mix.exs
+++ b/apps/emqx_auth_redis/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthRedis.MixProject do
   def project do
     [
       app: :emqx_auth_redis,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auto_subscribe/mix.exs
+++ b/apps/emqx_auto_subscribe/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAutoSubscribe.MixProject do
   def project do
     [
       app: :emqx_auto_subscribe,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bpapi/mix.exs
+++ b/apps/emqx_bpapi/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBPAPI.MixProject do
   def project do
     [
       app: :emqx_bpapi,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge/mix.exs
+++ b/apps/emqx_bridge/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridge.MixProject do
   def project do
     [
       app: :emqx_bridge,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_alloydb/mix.exs
+++ b/apps/emqx_bridge_alloydb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeAlloydb.MixProject do
   def project do
     [
       app: :emqx_bridge_alloydb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_azure_blob_storage/mix.exs
+++ b/apps/emqx_bridge_azure_blob_storage/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeAzureBlobStorage.MixProject do
   def project do
     [
       app: :emqx_bridge_azure_blob_storage,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_azure_event_hub/mix.exs
+++ b/apps/emqx_bridge_azure_event_hub/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeAzureEventHub.MixProject do
   def project do
     [
       app: :emqx_bridge_azure_event_hub,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_bigquery/mix.exs
+++ b/apps/emqx_bridge_bigquery/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeBigQuery.MixProject do
   def project do
     [
       app: :emqx_bridge_bigquery,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_cassandra/mix.exs
+++ b/apps/emqx_bridge_cassandra/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeCassandra.MixProject do
   def project do
     [
       app: :emqx_bridge_cassandra,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_clickhouse/mix.exs
+++ b/apps/emqx_bridge_clickhouse/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeClickhouse.MixProject do
   def project do
     [
       app: :emqx_bridge_clickhouse,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_cockroachdb/mix.exs
+++ b/apps/emqx_bridge_cockroachdb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeCockroachdb.MixProject do
   def project do
     [
       app: :emqx_bridge_cockroachdb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_confluent/mix.exs
+++ b/apps/emqx_bridge_confluent/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeConfluent.MixProject do
   def project do
     [
       app: :emqx_bridge_confluent,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_couchbase/mix.exs
+++ b/apps/emqx_bridge_couchbase/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeCouchbase.MixProject do
   def project do
     [
       app: :emqx_bridge_couchbase,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_datalayers/mix.exs
+++ b/apps/emqx_bridge_datalayers/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeDatalayers.MixProject do
   def project do
     [
       app: :emqx_bridge_datalayers,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_bridge_disk_log/mix.exs
+++ b/apps/emqx_bridge_disk_log/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeDiskLog.MixProject do
   def project do
     [
       app: :emqx_bridge_disk_log,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_doris/mix.exs
+++ b/apps/emqx_bridge_doris/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeDoris.MixProject do
   def project do
     [
       app: :emqx_bridge_doris,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_dynamo/mix.exs
+++ b/apps/emqx_bridge_dynamo/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeDynamo.MixProject do
   def project do
     [
       app: :emqx_bridge_dynamo,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_es/mix.exs
+++ b/apps/emqx_bridge_es/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeEs.MixProject do
   def project do
     [
       app: :emqx_bridge_es,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_gcp_pubsub/mix.exs
+++ b/apps/emqx_bridge_gcp_pubsub/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGcpPubsub.MixProject do
   def project do
     [
       app: :emqx_bridge_gcp_pubsub,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
   def project do
     [
       app: :emqx_bridge_greptimedb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_http/mix.exs
+++ b/apps/emqx_bridge_http/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeHTTP.MixProject do
   def project do
     [
       app: :emqx_bridge_http,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_bridge_influxdb/mix.exs
+++ b/apps/emqx_bridge_influxdb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeInfluxdb.MixProject do
   def project do
     [
       app: :emqx_bridge_influxdb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_iotdb/mix.exs
+++ b/apps/emqx_bridge_iotdb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeIotdb.MixProject do
   def project do
     [
       app: :emqx_bridge_iotdb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeKafka.MixProject do
   def project do
     [
       app: :emqx_bridge_kafka,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_kinesis/mix.exs
+++ b/apps/emqx_bridge_kinesis/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeKinesis.MixProject do
   def project do
     [
       app: :emqx_bridge_kinesis,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_matrix/mix.exs
+++ b/apps/emqx_bridge_matrix/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeMatrix.MixProject do
   def project do
     [
       app: :emqx_bridge_matrix,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_mongodb/mix.exs
+++ b/apps/emqx_bridge_mongodb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeMongodb.MixProject do
   def project do
     [
       app: :emqx_bridge_mongodb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_mqtt/mix.exs
+++ b/apps/emqx_bridge_mqtt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeMQTT.MixProject do
   def project do
     [
       app: :emqx_bridge_mqtt,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_bridge_mysql/mix.exs
+++ b/apps/emqx_bridge_mysql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeMysql.MixProject do
   def project do
     [
       app: :emqx_bridge_mysql,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_opents/mix.exs
+++ b/apps/emqx_bridge_opents/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeOpents.MixProject do
   def project do
     [
       app: :emqx_bridge_opents,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_oracle/mix.exs
+++ b/apps/emqx_bridge_oracle/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeOracle.MixProject do
   def project do
     [
       app: :emqx_bridge_oracle,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_pgsql/mix.exs
+++ b/apps/emqx_bridge_pgsql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgePgsql.MixProject do
   def project do
     [
       app: :emqx_bridge_pgsql,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_pulsar/mix.exs
+++ b/apps/emqx_bridge_pulsar/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgePulsar.MixProject do
   def project do
     [
       app: :emqx_bridge_pulsar,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_rabbitmq/mix.exs
+++ b/apps/emqx_bridge_rabbitmq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeRabbitmq.MixProject do
   def project do
     [
       app: :emqx_bridge_rabbitmq,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_redis/mix.exs
+++ b/apps/emqx_bridge_redis/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeRedis.MixProject do
   def project do
     [
       app: :emqx_bridge_redis,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_redshift/mix.exs
+++ b/apps/emqx_bridge_redshift/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeRedshift.MixProject do
   def project do
     [
       app: :emqx_bridge_redshift,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_rocketmq/mix.exs
+++ b/apps/emqx_bridge_rocketmq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeRocketmq.MixProject do
   def project do
     [
       app: :emqx_bridge_rocketmq,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_s3/mix.exs
+++ b/apps/emqx_bridge_s3/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeS3.MixProject do
   def project do
     [
       app: :emqx_bridge_s3,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeS3Tables.MixProject do
   def project do
     [
       app: :emqx_bridge_s3tables,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_bridge_snowflake/mix.exs
+++ b/apps/emqx_bridge_snowflake/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeSnowflake.MixProject do
   def project do
     [
       app: :emqx_bridge_snowflake,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_sqlserver/mix.exs
+++ b/apps/emqx_bridge_sqlserver/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeSqlserver.MixProject do
   def project do
     [
       app: :emqx_bridge_sqlserver,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_syskeeper/mix.exs
+++ b/apps/emqx_bridge_syskeeper/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeSyskeeper.MixProject do
   def project do
     [
       app: :emqx_bridge_syskeeper,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_tablestore/mix.exs
+++ b/apps/emqx_bridge_tablestore/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeTablestore.MixProject do
   def project do
     [
       app: :emqx_bridge_tablestore,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_tdengine/mix.exs
+++ b/apps/emqx_bridge_tdengine/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeTdengine.MixProject do
   def project do
     [
       app: :emqx_bridge_tdengine,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_timescale/mix.exs
+++ b/apps/emqx_bridge_timescale/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeTimescale.MixProject do
   def project do
     [
       app: :emqx_bridge_timescale,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_cluster_link/mix.exs
+++ b/apps/emqx_cluster_link/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXClusterLink.MixProject do
   def project do
     [
       app: :emqx_cluster_link,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_conf/mix.exs
+++ b/apps/emqx_conf/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConf.MixProject do
   def project do
     [
       app: :emqx_conf,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_connector/mix.exs
+++ b/apps/emqx_connector/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConnector.MixProject do
   def project do
     [
       app: :emqx_connector,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # erlc_options: [
       #   # config_path: "../../config/config.exs",

--- a/apps/emqx_connector_aggregator/mix.exs
+++ b/apps/emqx_connector_aggregator/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConnectorAggregator.MixProject do
   def project do
     [
       app: :emqx_connector_aggregator,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_connector_jwt/mix.exs
+++ b/apps/emqx_connector_jwt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConnectorJWT.MixProject do
   def project do
     [
       app: :emqx_connector_jwt,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ctl/mix.exs
+++ b/apps/emqx_ctl/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXCtl.MixProject do
   def project do
     [
       app: :emqx_ctl,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_dashboard/mix.exs
+++ b/apps/emqx_dashboard/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboard.MixProject do
   def project do
     [
       app: :emqx_dashboard,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: [{:d, :APPLICATION, :emqx} | UMP.strict_erlc_options()],

--- a/apps/emqx_dashboard_rbac/mix.exs
+++ b/apps/emqx_dashboard_rbac/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboardRbac.MixProject do
   def project do
     [
       app: :emqx_dashboard_rbac,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_dashboard_sso/mix.exs
+++ b/apps/emqx_dashboard_sso/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDashboardSso.MixProject do
   def project do
     [
       app: :emqx_dashboard_sso,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ds_backends/mix.exs
+++ b/apps/emqx_ds_backends/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDsBackends.MixProject do
   def project do
     [
       app: :emqx_ds_backends,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ds_builtin_local/mix.exs
+++ b/apps/emqx_ds_builtin_local/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDsBuiltinLocal.MixProject do
   def project do
     [
       app: :emqx_ds_builtin_local,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ds_builtin_raft/mix.exs
+++ b/apps/emqx_ds_builtin_raft/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDsBuiltinRaft.MixProject do
   def project do
     [
       app: :emqx_ds_builtin_raft,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -847,7 +847,11 @@ do_next_v1(DB, Iter = #'Iterator'{shard = Shard}, NextLimit) ->
 ) ->
     {ok, tx_context()} | emqx_ds:error(_).
 do_new_kv_tx_ctx_v1(DB, Shard, Generation, Options) ->
-    emqx_ds_optimistic_tx:new_kv_tx_ctx(?MODULE, DB, Shard, Generation, Options).
+    ?IF_SHARD_READY(
+        DB,
+        Shard,
+        emqx_ds_optimistic_tx:new_kv_tx_ctx(?MODULE, DB, Shard, Generation, Options)
+    ).
 
 %%================================================================================
 %% Internal functions

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
@@ -247,6 +247,11 @@ local_site() ->
 
 %%
 
+%% @doc Shard information.
+%% * `ready` :: boolean()
+%%    Shard is considered ready when the backend is running, the shard process is up,
+%%    and shard has bootstrapped and caught up with the leader (including when it is
+%%    the leader).
 -spec shard_info(emqx_ds:db(), emqx_ds:shard(), _Info) -> _Value.
 shard_info(DB, Shard, ready) ->
     get_shard_info(DB, Shard, ready, false).

--- a/apps/emqx_durable_storage/mix.exs
+++ b/apps/emqx_durable_storage/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDurableStorage.MixProject do
   def project do
     [
       app: :emqx_durable_storage,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: [:yecc, :leex, :elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_durable_timer/mix.exs
+++ b/apps/emqx_durable_timer/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXDurableTimer.MixProject do
   def project do
     [
       app: :emqx_durable_timer,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_enterprise/mix.exs
+++ b/apps/emqx_enterprise/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXEnterprise.MixProject do
   def project do
     [
       app: :emqx_enterprise,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_eviction_agent/mix.exs
+++ b/apps/emqx_eviction_agent/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXEvictionAgent.MixProject do
   def project do
     [
       app: :emqx_eviction_agent,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_exhook/mix.exs
+++ b/apps/emqx_exhook/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXExhook.MixProject do
   def project do
     [
       app: :emqx_exhook,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: [:elixir, :grpc, :erlang, :app, :copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_ft/mix.exs
+++ b/apps/emqx_ft/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXFt.MixProject do
   def project do
     [
       app: :emqx_ft,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway/mix.exs
+++ b/apps/emqx_gateway/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGateway.MixProject do
   def project do
     [
       app: :emqx_gateway,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_gateway_coap/mix.exs
+++ b/apps/emqx_gateway_coap/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayCoap.MixProject do
   def project do
     [
       app: :emqx_gateway_coap,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_exproto/mix.exs
+++ b/apps/emqx_gateway_exproto/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayExproto.MixProject do
   def project do
     [
       app: :emqx_gateway_exproto,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: [:elixir, :grpc, :erlang, :app],
       # used by our `Mix.Tasks.Compile.Grpc` compiler

--- a/apps/emqx_gateway_gbt32960/mix.exs
+++ b/apps/emqx_gateway_gbt32960/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayGbt32960.MixProject do
   def project do
     [
       app: :emqx_gateway_gbt32960,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_jt808/mix.exs
+++ b/apps/emqx_gateway_jt808/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayJt808.MixProject do
   def project do
     [
       app: :emqx_gateway_jt808,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_lwm2m/mix.exs
+++ b/apps/emqx_gateway_lwm2m/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayLwm2m.MixProject do
   def project do
     [
       app: :emqx_gateway_lwm2m,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_mqttsn/mix.exs
+++ b/apps/emqx_gateway_mqttsn/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayMqttsn.MixProject do
   def project do
     [
       app: :emqx_gateway_mqttsn,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_nats/mix.exs
+++ b/apps/emqx_gateway_nats/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayNats.MixProject do
   def project do
     [
       app: :emqx_gateway_nats,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_ocpp/mix.exs
+++ b/apps/emqx_gateway_ocpp/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayOcpp.MixProject do
   def project do
     [
       app: :emqx_gateway_ocpp,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gateway_stomp/mix.exs
+++ b/apps/emqx_gateway_stomp/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGatewayStomp.MixProject do
   def project do
     [
       app: :emqx_gateway_stomp,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_gcp_device/mix.exs
+++ b/apps/emqx_gcp_device/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGCPDevice.MixProject do
   def project do
     [
       app: :emqx_gcp_device,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_gen_bridge/mix.exs
+++ b/apps/emqx_gen_bridge/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGenBridge.MixProject do
   def project do
     [
       app: :emqx_gen_bridge,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ldap/mix.exs
+++ b/apps/emqx_ldap/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXLdap.MixProject do
   def project do
     [
       app: :emqx_ldap,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: [:yecc, :leex] ++ Mix.compilers(),
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_license/mix.exs
+++ b/apps/emqx_license/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXLicense.MixProject do
   def project do
     [
       app: :emqx_license,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_machine/mix.exs
+++ b/apps/emqx_machine/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMachine.MixProject do
   def project do
     [
       app: :emqx_machine,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_management/mix.exs
+++ b/apps/emqx_management/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXManagement.MixProject do
   def project do
     [
       app: :emqx_management,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_message_transformation/mix.exs
+++ b/apps/emqx_message_transformation/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMessageTransformation.MixProject do
   def project do
     [
       app: :emqx_message_transformation,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mix_utils/mix.exs
+++ b/apps/emqx_mix_utils/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMixUtils.MixProject do
   def project do
     [
       app: :emqx_mix_utils,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       deps_path: "../../deps",
       lockfile: "../../mix.lock",

--- a/apps/emqx_modules/mix.exs
+++ b/apps/emqx_modules/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXModules.MixProject do
   def project do
     [
       app: :emqx_modules,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mongodb/mix.exs
+++ b/apps/emqx_mongodb/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMongodb.MixProject do
   def project do
     [
       app: :emqx_mongodb,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mq/mix.exs
+++ b/apps/emqx_mq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMQ.MixProject do
   def project do
     [
       app: :emqx_mq,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: [:elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_mt/mix.exs
+++ b/apps/emqx_mt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMT.MixProject do
   def project do
     [
       app: :emqx_mt,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mysql/mix.exs
+++ b/apps/emqx_mysql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMysql.MixProject do
   def project do
     [
       app: :emqx_mysql,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_node_rebalance/mix.exs
+++ b/apps/emqx_node_rebalance/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXNodeRebalance.MixProject do
   def project do
     [
       app: :emqx_node_rebalance,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_opentelemetry/mix.exs
+++ b/apps/emqx_opentelemetry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXOpentelemetry.MixProject do
   def project do
     [
       app: :emqx_opentelemetry,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_oracle/mix.exs
+++ b/apps/emqx_oracle/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXOracle.MixProject do
   def project do
     [
       app: :emqx_oracle,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_plugins/mix.exs
+++ b/apps/emqx_plugins/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPlugins.MixProject do
   def project do
     [
       app: :emqx_plugins,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_postgresql/mix.exs
+++ b/apps/emqx_postgresql/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPostgresql.MixProject do
   def project do
     [
       app: :emqx_postgresql,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_prometheus/mix.exs
+++ b/apps/emqx_prometheus/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPrometheus.MixProject do
   def project do
     [
       app: :emqx_prometheus,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_psk/mix.exs
+++ b/apps/emqx_psk/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXPsk.MixProject do
   def project do
     [
       app: :emqx_psk,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_redis/mix.exs
+++ b/apps/emqx_redis/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRedis.MixProject do
   def project do
     [
       app: :emqx_redis,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_resource/mix.exs
+++ b/apps/emqx_resource/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXResource.MixProject do
   def project do
     [
       app: :emqx_resource,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_retainer/mix.exs
+++ b/apps/emqx_retainer/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRetainer.MixProject do
   def project do
     [
       app: :emqx_retainer,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_rule_engine/mix.exs
+++ b/apps/emqx_rule_engine/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRuleEngine.MixProject do
   def project do
     [
       app: :emqx_rule_engine,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_s3/mix.exs
+++ b/apps/emqx_s3/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXS3.MixProject do
   def project do
     [
       app: :emqx_s3,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_schema_registry/mix.exs
+++ b/apps/emqx_schema_registry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXSchemaRegistry.MixProject do
   def project do
     [
       app: :emqx_schema_registry,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_schema_validation/mix.exs
+++ b/apps/emqx_schema_validation/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXSchemaValidation.MixProject do
   def project do
     [
       app: :emqx_schema_validation,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_slow_subs/mix.exs
+++ b/apps/emqx_slow_subs/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXSlowSubs.MixProject do
   def project do
     [
       app: :emqx_slow_subs,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_telemetry/mix.exs
+++ b/apps/emqx_telemetry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXTelemetry.MixProject do
   def project do
     [
       app: :emqx_telemetry,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_utils/mix.exs
+++ b/apps/emqx_utils/mix.exs
@@ -6,7 +6,7 @@ defmodule EMQXUtils.MixProject do
   def project do
     [
       app: :emqx_utils,
-      version: "6.0.0",
+      version: "6.0.1",
       build_path: "../../_build",
       compilers: [:yecc, :leex] ++ Mix.compilers(),
       erlc_options: UMP.erlc_options(),


### PR DESCRIPTION
Part of [EMQX-14788](https://emqx.atlassian.net/browse/EMQX-14788).

Release version: 6.0.1

## Summary

This PR makes sure that RPCs arriving very early in the node startup sequence do not crash because the backend application or even dependencies (e.g. `gproc` / `optvar`) has not yet started.

See individual commits for further details.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible

[EMQX-14788]: https://emqx.atlassian.net/browse/EMQX-14788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ