### PR TITLE
fix(resource manager): return consistent reply type when channel health check aborts (r60)

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_manager.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager.erl
@@ -2488,7 +2488,7 @@ abort_all_channel_health_checks(Data0) ->
     } = Data0,
     lists:foreach(
         fun(From) ->
-            gen_statem:reply(From, {error, resource_disconnected})
+            gen_statem:reply(From, channel_error_status(resource_disconnected))
         end,
         lists:flatten(maps:values(CPending))
     ),
@@ -2545,7 +2545,7 @@ abort_health_checks_for_channel(Data0, ChannelId) ->
     {Callers, CPending} = map_take_or(CPending0, ChannelId, []),
     lists:foreach(
         fun(From) ->
-            gen_statem:reply(From, {error, resource_disconnected})
+            gen_statem:reply(From, channel_error_status(resource_disconnected))
         end,
         Callers
     ),


### PR DESCRIPTION
The expected result type is `#{status := resource_status(), error := term()}`.

Release version: 6.0.1, 6.1.0
