### PR TITLE
chore: bump `erlang-rocksdb` -> 1.8.0-emqx-10

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -245,7 +245,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:erlang_qq, github: "k32/erlang_qq", tag: "1.0.0", override: true}
 
   def common_dep(:rocksdb),
-    do: {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-8", override: true}
+    do: {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-10", override: true}
 
   def common_dep(:emqx_http_lib),
     do: {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.3", override: true}


### PR DESCRIPTION
See https://github.com/emqx/erlang-rocksdb/pull/45 and https://github.com/emqx/erlang-rocksdb/pull/48

<!--
5.8.9
5.9.2
5.10.1
6.0.0
6.1.0
-->
Release version: 6.0.1, 6.1.0