### PR TITLE
chore: bump `erlang-rocksdb` -> 1.8.0-emqx-10 (r58)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -254,7 +254,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:erlang_qq, github: "k32/erlang_qq", tag: "1.0.0", override: true}
 
   def common_dep(:rocksdb),
-    do: {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-6", override: true}
+    do: {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-10", override: true}
 
   def common_dep(:emqx_http_lib),
     do: {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.3", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -83,7 +83,7 @@
     {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.6"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
-    {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-6"}}},
+    {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-10"}}},
     {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.1"}}},


### PR DESCRIPTION
See emqx/erlang-rocksdb#45 and emqx/erlang-rocksdb#48

To speed up build.

<!--
5.8.9
5.9.2
5.10.1
6.0.0
6.1.0
-->
Release version: 5.8.9, 5.9.2, 5.10.2
