### PR TITLE
fix(kafka & gcp pubsub consumers): add deprecated field

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_schema.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_consumer_schema.erl
@@ -64,6 +64,15 @@ fields(consumer_source) ->
 fields(source_parameters) ->
     Fields = emqx_bridge_gcp_pubsub:fields(consumer),
     [
+        {topic_mapping,
+            mk(
+                any(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_HIDDEN,
+                    deprecated => {since, "6.0.0"}
+                }
+            )},
         {topic,
             mk(
                 binary(),

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_consumer_schema.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_consumer_schema.erl
@@ -61,6 +61,15 @@ fields(source_parameters) ->
     Fields2 = proplists:delete(kafka, Fields1),
     Fields = Fields0 ++ Fields2,
     [
+        {topic_mapping,
+            mk(
+                any(),
+                #{
+                    required => false,
+                    importance => ?IMPORTANCE_HIDDEN,
+                    deprecated => {since, "6.0.0"}
+                }
+            )},
         {topic,
             mk(
                 binary(),


### PR DESCRIPTION
This field was kept in the code as hidden field for backwards compatibility, but long deprecated in practice since the transition to connectors + sources.

<!--
5.8.9
5.9.2
5.10.1
6.0.0
6.1.0
-->
Release version: 6.0.1, 6.1.0
