### PR TITLE
docs: hide durable queues config doc

### DIFF
--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub.app.src
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub.app.src
@@ -1,6 +1,6 @@
 {application, emqx_ds_shared_sub, [
     {description, "EMQX DS Shared Subscriptions"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, [emqx_ds_shared_sub_sup]},
     {mod, {emqx_ds_shared_sub_app, []}},
     {applications, [

--- a/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_schema.erl
+++ b/apps/emqx_ds_shared_sub/src/emqx_ds_shared_sub_schema.erl
@@ -21,7 +21,8 @@ namespace() -> emqx_shared_subs.
 
 roots() ->
     [
-        durable_queues
+        {durable_queues,
+            ?HOCON(hoconsc:ref(?MODULE, durable_queues), #{importance => ?IMPORTANCE_HIDDEN})}
     ].
 
 fields(durable_queues) ->


### PR DESCRIPTION
Durable storage for shared-subscription was not documented and probably no one ever tried it out.
Given that this schema is deleted in v6, we hide it from newer releases in v5.