### PR TITLE
test: assert ds readiness

### DIFF
--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -1585,7 +1585,8 @@ start_cluster_ds(Config, ClusterSpec0, Opts) when is_list(ClusterSpec0) ->
     ClusterOpts = #{work_dir => WorkDir},
     NodeSpecs = emqx_cth_cluster:mk_nodespecs(ClusterSpec, ClusterOpts),
     Nodes = emqx_cth_cluster:start(ClusterSpec, ClusterOpts),
-    erpc:multicall(Nodes, emqx_persistent_message, wait_readiness, [5_000], infinity),
+    ExpectedOk = lists:duplicate(length(Nodes), {ok, ok}),
+    ExpectedOk = erpc:multicall(Nodes, emqx_persistent_message, wait_readiness, [15_000], infinity),
     [{cluster_nodes, Nodes}, {node_specs, NodeSpecs}, {work_dir, WorkDir} | Config].
 
 stop_cluster_ds(Config) ->


### PR DESCRIPTION
I suspect the DB might not be ready, given this:

https://github.com/emqx/emqx/actions/runs/18204039165/job/51830843969?pr=16081#step:5:196

Also, managed to observe this locally, after asserting:

```
=== Location: [{emqx_common_test_helpers,start_cluster_ds,1589},
              {test_server,ts_tc,1794},
              {test_server,run_test_case_eval1,1391},
              {test_server,run_test_case_eval,1235}]
=== === Reason: no match of right hand side value [{ok,timeout},{ok,timeout}]
  in function  emqx_common_test_helpers:start_cluster_ds/3 (test/emqx_common_test_helpers.erl, line 1589)
  in call from test_server:ts_tc/3 (test_server.erl, line 1794)
  in call from test_server:run_test_case_eval1/6 (test_server.erl, line 1391)
  in call from test_server:run_test_case_eval/9 (test_server.erl, line 1235)
```
