### PR TITLE
test: attempt to stabilize flaky helpers

### DIFF
--- a/apps/emqx_mq/test/emqx_mq_test_utils.erl
+++ b/apps/emqx_mq/test/emqx_mq_test_utils.erl
@@ -83,7 +83,7 @@ create_mq(#{topic_filter := TopicFilter} = MQ0) ->
     SampleTopic0 = string:replace(TopicFilter, "#", "x", all),
     SampleTopic1 = string:replace(SampleTopic0, "+", "x", all),
     SampleTopic = iolist_to_binary(SampleTopic1),
-    {ok, MQ} = emqx_mq_registry:create(MQ1),
+    {ok, MQ} = ?retry(50, 100, {ok, _} = emqx_mq_registry:create(MQ1)),
     ?retry(
         5,
         100,
@@ -195,7 +195,7 @@ cth_config(emqx_mq, ConfigOverrides) ->
     Config = emqx_utils_maps:deep_merge(DefaultConfig, ConfigOverrides),
     #{
         config => Config,
-        after_start => fun() -> emqx_mq_app:wait_readiness(5_000) end
+        after_start => fun() -> ok = emqx_mq_app:wait_readiness(15_000) end
     };
 cth_config(emqx, ConfigOverrides) ->
     DefaultConfig = #{


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/18222744561/job/51887205034?pr=16088#step:5:89

```
%%% emqx_mq_cluster_SUITE ==> t_cluster_smoke: FAILED
%%% emqx_mq_cluster_SUITE ==> {{exception,
     {badmatch,
         {error,{failed_to_create_mq_state,{error,recoverable,leader_down}}}},
     [{emqx_mq_test_utils,create_mq,1,
          [{file,"test/emqx_mq_test_utils.erl"},{line,86}]}]},
 [{erpc,call,5,[{file,"erpc.erl"},{line,1368}]},
  {emqx_mq_cluster_SUITE,t_cluster_smoke,1,
      [{file,"test/emqx_mq_cluster_SUITE.erl"},{line,59}]},
  {test_server,ts_tc,3,[{file,"test_server.erl"},{line,1794}]},
  {test_server,run_test_case_eval1,6,[{file,"test_server.erl"},{line,1303}]},
  {test_server,run_test_case_eval,9,[{file,"test_server.erl"},{line,1235}]}]}
```
