### PR TITLE
feat(exhook): allow gRPC hooks to modify topic filters on subscribe/u…

### DIFF
--- a/apps/emqx_exhook/docs/design-cn.md
+++ b/apps/emqx_exhook/docs/design-cn.md
@@ -72,6 +72,8 @@ service HookProvider {
 
   rpc OnClientSubscribe(ClientSubscribeRequest) returns (EmptySuccess) {};
 
+  rpc OnClientSubscribeRewrite(ClientSubscribeRequest) returns (ValuedResponse) {};
+
   rpc OnClientUnsubscribe(ClientUnsubscribeRequest) returns (EmptySuccess) {};
 
   rpc OnSessionCreated(SessionCreatedRequest) returns (EmptySuccess) {};

--- a/apps/emqx_exhook/mix.exs
+++ b/apps/emqx_exhook/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXExhook.MixProject do
   def project do
     [
       app: :emqx_exhook,
-      version: "6.3.0",
+      version: "6.3.1",
       build_path: "../../_build",
       compilers: [:elixir, :grpc, :erlang, :app, :copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_exhook/priv/protos/exhook.proto
+++ b/apps/emqx_exhook/priv/protos/exhook.proto
@@ -48,6 +48,15 @@ service HookProvider {
 
   rpc OnClientSubscribe(ClientSubscribeRequest) returns (EmptySuccess) {};
 
+  // Same event as `OnClientSubscribe`, but the server may rewrite the topic
+  // filters. Register it under the `client.subscribe.rewrite` hook name.
+  //
+  // Do not rename this to a digit suffix such as `OnClientSubscribeV2`: the
+  // generated client stub would be `on_client_subscribe_v2` while the server
+  // dispatch in `grpc_stream:init/2` resolves `on_client_subscribe_v_2`, and
+  // every call fails with `badarg` in `list_to_existing_atom/1`.
+  rpc OnClientSubscribeRewrite(ClientSubscribeRequest) returns (ValuedResponse) {};
+
   rpc OnClientUnsubscribe(ClientUnsubscribeRequest) returns (EmptySuccess) {};
 
   rpc OnSessionCreated(SessionCreatedRequest) returns (EmptySuccess) {};
@@ -314,7 +323,7 @@ message LoadedResponse {
 }
 
 // Responsed by `ClientAuthenticateRequest` `ClientAuthorizeRequest`
-// `MessageIngressRequest` `MessagePublishRequest`
+// `MessageIngressRequest` `MessagePublishRequest` `ClientSubscribeRequest`
 
 message ValuedResponse {
 
@@ -341,7 +350,26 @@ message ValuedResponse {
 
     // Message result, used on the 'message.*' hooks
     Message message = 4;
+
+    // Rewritten topic filters, used on the 'client.subscribe.rewrite' hook
+    TopicFilters topic_filters = 5;
   }
+}
+
+// The topic filters a `client.subscribe.rewrite` hook wants the client to be
+// subscribed to, in place of the ones it requested.
+//
+// `filters` MUST hold exactly as many entries as the request did, in the same
+// order: SUBACK carries one reason code per requested topic filter, ordered as
+// the filters were received (MQTT-3.9.3-1). A response of a different length is
+// rejected as a whole and the requested filters are used unchanged.
+//
+// A rewritten filter is re-authorized and re-checked against the subscribe
+// capabilities of the zone, so a hook cannot grant more than the client could
+// have asked for itself.
+message TopicFilters {
+
+  repeated TopicFilter filters = 1;
 }
 
 // no Response by other Requests
@@ -373,6 +401,7 @@ message HookSpec {
   //   "client.connected",    "client.disconnected"
   //   "client.authenticate", "client.authorize"
   //   "client.subscribe",    "client.unsubscribe"
+  //   "client.subscribe.rewrite"
   //
   //   "session.created",      "session.subscribed"
   //   "session.unsubscribed", "session.resumed"

--- a/apps/emqx_exhook/src/emqx_exhook.erl
+++ b/apps/emqx_exhook/src/emqx_exhook.erl
@@ -106,6 +106,10 @@ deny_action_result('client.authenticate', _) ->
     #{result => false};
 deny_action_result('client.authorize', _) ->
     #{result => false};
+%% The hook may only rewrite topic filters, so denying it means: do not rewrite.
+%% What the client asked for has already been authorized by the channel.
+deny_action_result('client.subscribe', Req) ->
+    Req;
 deny_action_result('message.ingress', _) ->
     #{result => false};
 deny_action_result('message.publish', Req) ->

--- a/apps/emqx_exhook/src/emqx_exhook.erl
+++ b/apps/emqx_exhook/src/emqx_exhook.erl
@@ -92,6 +92,13 @@ call_fold(IsIgnore, Hookpoint, Req, AccFun, [ServerName | More]) ->
                 ignore ->
                     call_fold(IsIgnore, Hookpoint, Req, AccFun, More)
             end;
+        ignore ->
+            %% The server does not advertise this hookpoint, or a message
+            %% hook's topic filter did not match. Nothing was attempted, so
+            %% this is not a failure and must not reach `failed_action':
+            %% under the default `deny' that would stop the chain and starve
+            %% every server behind this one.
+            call_fold(IsIgnore, Hookpoint, Req, AccFun, More);
         _ ->
             case emqx_exhook_server:failed_action(Server) of
                 ignore ->

--- a/apps/emqx_exhook/src/emqx_exhook.erl
+++ b/apps/emqx_exhook/src/emqx_exhook.erl
@@ -95,9 +95,9 @@ call_fold(IsIgnore, Hookpoint, Req, AccFun, [ServerName | More]) ->
         ignore ->
             %% The server does not advertise this hookpoint, or a message
             %% hook's topic filter did not match. Nothing was attempted, so
-            %% this is not a failure and must not reach `failed_action':
-            %% under the default `deny' that would stop the chain and starve
-            %% every server behind this one.
+            %% there is no failure to act on: continue with the next server
+            %% rather than applying `failed_action', which under the default
+            %% `deny' would stop the chain and skip the remaining servers.
             call_fold(IsIgnore, Hookpoint, Req, AccFun, More);
         _ ->
             case emqx_exhook_server:failed_action(Server) of

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -164,15 +164,14 @@ on_client_subscribe(ClientInfo, Props, TopicFilters) ->
         {StopOrOk, #{topic_filters := RespTfs}} ->
             case rewrite_topicfilters(ClientInfo, TopicFilters, RespTfs) of
                 {ok, TopicFilters} ->
-                    %% Nothing was rewritten. Leave the accumulator alone so the
-                    %% rest of the `client.subscribe' chain still runs, as it did
-                    %% while this hook was fire-and-forget -- but only when the
-                    %% server said to continue. Returning the filters unchanged is
-                    %% a reasonable way for a server to say "I have looked at this
-                    %% and no later hook should touch it", and `ignore' would
-                    %% silently downgrade that to "continue": `emqx_hooks' treats
-                    %% any term other than `stop' or `{stop, Acc}' as continue.
-                    %% `{stop, TopicFilters}' keeps both properties.
+                    %% Nothing was rewritten, so the accumulator is left alone
+                    %% and the rest of the `client.subscribe' chain runs -- but
+                    %% only when the server said to continue. Returning the
+                    %% filters unchanged is how a server says "I have looked at
+                    %% this and no later hook should touch it", and `ignore'
+                    %% would downgrade that to "continue", because `emqx_hooks'
+                    %% treats any term other than `stop' or `{stop, Acc}' as
+                    %% continue. `{stop, TopicFilters}' keeps both properties.
                     unchanged_topicfilters(StopOrOk, TopicFilters);
                 {ok, NTopicFilters} ->
                     {StopOrOk, NTopicFilters};

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -164,10 +164,16 @@ on_client_subscribe(ClientInfo, Props, TopicFilters) ->
         {StopOrOk, #{topic_filters := RespTfs}} ->
             case rewrite_topicfilters(ClientInfo, TopicFilters, RespTfs) of
                 {ok, TopicFilters} ->
-                    %% Nothing was rewritten. Leave the accumulator alone so the rest
-                    %% of the `client.subscribe' chain still runs, as it did while
-                    %% this hook was fire-and-forget.
-                    ignore;
+                    %% Nothing was rewritten. Leave the accumulator alone so the
+                    %% rest of the `client.subscribe' chain still runs, as it did
+                    %% while this hook was fire-and-forget -- but only when the
+                    %% server said to continue. Returning the filters unchanged is
+                    %% a reasonable way for a server to say "I have looked at this
+                    %% and no later hook should touch it", and `ignore' would
+                    %% silently downgrade that to "continue": `emqx_hooks' treats
+                    %% any term other than `stop' or `{stop, Acc}' as continue.
+                    %% `{stop, TopicFilters}' keeps both properties.
+                    unchanged_topicfilters(StopOrOk, TopicFilters);
                 {ok, NTopicFilters} ->
                     {StopOrOk, NTopicFilters};
                 {error, _Reason} ->
@@ -176,6 +182,11 @@ on_client_subscribe(ClientInfo, Props, TopicFilters) ->
         ignore ->
             ignore
     end.
+
+unchanged_topicfilters(stop, TopicFilters) ->
+    {stop, TopicFilters};
+unchanged_topicfilters(_Ok, _TopicFilters) ->
+    ignore.
 
 on_client_unsubscribe(ClientInfo, Props, TopicFilters) ->
     {UserProps, SystemProps} = format_props(Props),

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -45,6 +45,7 @@
     stringfy/1,
     merge_responsed_bool/2,
     merge_responsed_message/2,
+    merge_responsed_topicfilters/2,
     assign_to_message/2,
     clientinfo/1,
     request_meta/0
@@ -159,7 +160,22 @@ on_client_subscribe(ClientInfo, Props, TopicFilters) ->
         props => SystemProps,
         topic_filters => topicfilters(TopicFilters)
     },
-    emqx_exhook:cast('client.subscribe', Req).
+    case emqx_exhook:call_fold('client.subscribe', Req, fun merge_responsed_topicfilters/2) of
+        {StopOrOk, #{topic_filters := RespTfs}} ->
+            case rewrite_topicfilters(ClientInfo, TopicFilters, RespTfs) of
+                {ok, TopicFilters} ->
+                    %% Nothing was rewritten. Leave the accumulator alone so the rest
+                    %% of the `client.subscribe' chain still runs, as it did while
+                    %% this hook was fire-and-forget.
+                    ignore;
+                {ok, NTopicFilters} ->
+                    {StopOrOk, NTopicFilters};
+                {error, _Reason} ->
+                    ignore
+            end;
+        ignore ->
+            ignore
+    end.
 
 on_client_unsubscribe(ClientInfo, Props, TopicFilters) ->
     {UserProps, SystemProps} = format_props(Props),
@@ -462,6 +478,131 @@ topicfilters(Tfs) when is_list(Tfs) ->
      || {Topic, SubOpts} <- Tfs
     ].
 
+%% Apply the topic filters a `client.subscribe.rewrite' hook responded with.
+%%
+%% The hook runs after `check_sub_authzs'/`check_sub_caps' and its result goes
+%% straight to the session, so what the broker guarantees about a SUBSCRIBE has
+%% to be re-established here:
+%%
+%%   * one filter back per requested filter, in the same order, because SUBACK
+%%     carries one reason code per requested topic filter, ordered as the
+%%     filters were received (MQTT-3.9.3-1);
+%%   * `subopts' within their MQTT ranges, since they end up as the granted QoS;
+%%   * a rewritten filter authorized and within the zone's subscribe caps.
+%%
+%% A response breaking any of these is rejected as a whole: applying it in part
+%% would subscribe the client to a set nobody asked for.
+rewrite_topicfilters(ClientInfo, TopicFilters, RespTfs) when
+    length(RespTfs) =:= length(TopicFilters)
+->
+    try
+        {ok,
+            lists:zipwith(
+                fun(TopicFilter, RespTf) ->
+                    rewrite_topicfilter(ClientInfo, TopicFilter, RespTf)
+                end,
+                TopicFilters,
+                RespTfs
+            )}
+    catch
+        throw:{Reason, Meta} ->
+            ?SLOG(error, Meta#{
+                msg => "exhook_topic_filter_rewrite_rejected",
+                reason => Reason
+            }),
+            {error, Reason}
+    end;
+rewrite_topicfilters(_ClientInfo, TopicFilters, RespTfs) ->
+    ?SLOG(error, #{
+        msg => "exhook_topic_filter_rewrite_rejected",
+        reason => topic_filter_count_mismatch,
+        requested => length(TopicFilters),
+        responded => length(RespTfs)
+    }),
+    {error, topic_filter_count_mismatch}.
+
+rewrite_topicfilter(ClientInfo, TopicFilter = {Topic, SubOpts}, RespTf) ->
+    NSubOpts = rewrite_subopts(SubOpts, maps:get(subopts, RespTf, undefined)),
+    case rewrite_topic(Topic, NSubOpts, maps:get(name, RespTf, undefined)) of
+        TopicFilter -> TopicFilter;
+        NTopicFilter -> recheck_topicfilter(ClientInfo, NTopicFilter)
+    end.
+
+%% `topicfilters/1' flattens a shared subscription into its wire form
+%% (`$share/<group>/<filter>'). Re-parse only a name the hook actually changed,
+%% so an untouched filter keeps its original term: session subscriptions are
+%% keyed by the `#share{}' record, and a flattened binary would no longer match
+%% it on unsubscribe.
+rewrite_topic(Topic, SubOpts, Name) when is_binary(Name) ->
+    case emqx_topic:maybe_format_share(Topic) of
+        Name ->
+            {Topic, SubOpts};
+        _ ->
+            try
+                true = emqx_topic:validate(filter, Name),
+                emqx_topic:parse({Name, SubOpts})
+            catch
+                _:_ -> throw({invalid_topic_filter, #{topic => Name}})
+            end
+    end;
+rewrite_topic(_Topic, _SubOpts, Name) ->
+    throw({invalid_topic_filter, #{topic => Name}}).
+
+%% A hook that only rewrites the topic can leave `subopts' unset, in which case
+%% the client's own options stand. Whatever it does set is range-checked: these
+%% become the granted QoS in the SUBACK, and an out-of-range value is either an
+%% illegal reason code or, on MQTT 3.1.1, not serializable at all.
+rewrite_subopts(SubOpts, undefined) ->
+    SubOpts;
+rewrite_subopts(SubOpts, NSubOpts) when is_map(NSubOpts) ->
+    SubOpts#{
+        qos => subopt(qos, NSubOpts, 0, 2),
+        rh => subopt(rh, NSubOpts, 0, 2),
+        rap => subopt(rap, NSubOpts, 0, 1),
+        nl => subopt(nl, NSubOpts, 0, 1)
+    };
+rewrite_subopts(_SubOpts, NSubOpts) ->
+    throw({invalid_subopts, #{subopts => NSubOpts}}).
+
+subopt(Key, SubOpts, Min, Max) ->
+    case maps:get(Key, SubOpts, Min) of
+        Value when is_integer(Value), Value >= Min, Value =< Max ->
+            Value;
+        Value ->
+            throw({invalid_subopts, #{Key => Value}})
+    end.
+
+%% `client.subscribe' runs once the channel has authorized the filters the
+%% client asked for, so a rewritten one has never been checked. Re-run both
+%% checks here, or a hook could hand the client a subscription it could not
+%% have requested itself.
+recheck_topicfilter(ClientInfo, {Topic, SubOpts = #{qos := QoS}}) ->
+    AuthzContext = emqx_authz_context:make(ClientInfo),
+    %% As in `emqx_channel', a shared subscription is authorized on its real topic
+    case
+        emqx_access_control:authorize(
+            AuthzContext,
+            ?AUTHZ_SUBSCRIBE(QoS),
+            emqx_topic:get_shared_real_topic(Topic)
+        )
+    of
+        deny ->
+            throw({not_authorized, #{topic => emqx_topic:maybe_format_share(Topic)}});
+        allow ->
+            case emqx_mqtt_caps:check_sub(ClientInfo, Topic, SubOpts) of
+                ok ->
+                    {Topic, SubOpts};
+                {ok, MaxQoS} ->
+                    {Topic, SubOpts#{qos => MaxQoS}};
+                {error, NRC} ->
+                    throw(
+                        {emqx_reason_codes:name(NRC), #{
+                            topic => emqx_topic:maybe_format_share(Topic)
+                        }}
+                    )
+            end
+    end.
+
 subopts(SubOpts) ->
     #{
         qos => maps:get(qos, SubOpts, 0),
@@ -519,6 +660,25 @@ merge_responsed_message(_Req, #{type := 'IGNORE'}) ->
 merge_responsed_message(Req, #{type := Type, value := {message, NMessage}}) ->
     {ret(Type), Req#{message => NMessage}};
 merge_responsed_message(_Req, Resp) ->
+    ?SLOG(warning, #{msg => "unknown_response_value", resp => Resp}),
+    ignore.
+
+merge_responsed_topicfilters(_Req, #{type := 'IGNORE'}) ->
+    ignore;
+merge_responsed_topicfilters(Req, #{
+    type := Type, value := {topic_filters, #{filters := TopicFilters}}
+}) when is_list(TopicFilters) ->
+    {ret(Type), Req#{topic_filters => TopicFilters}};
+%% A server registered as `client.subscribe' rather than `client.subscribe.rewrite'
+%% answers `OnClientSubscribe' with an empty `EmptySuccess', which decodes to a
+%% response carrying no value. Nothing to merge, and nothing worth warning about.
+merge_responsed_topicfilters(_Req, #{value := undefined}) ->
+    ignore;
+merge_responsed_topicfilters(_Req, Resp) when map_size(Resp) =:= 0 ->
+    ignore;
+merge_responsed_topicfilters(_Req, #{type := 'CONTINUE'} = Resp) when map_size(Resp) =:= 1 ->
+    ignore;
+merge_responsed_topicfilters(_Req, Resp) ->
     ?SLOG(warning, #{msg => "unknown_response_value", resp => Resp}),
     ignore.
 

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -587,13 +587,13 @@ subopt(Key, SubOpts, Min, Max) ->
 %% client asked for, so a rewritten one has never been checked. Re-run both
 %% checks here, or a hook could hand the client a subscription it could not
 %% have requested itself.
-recheck_topicfilter(ClientInfo, {Topic, SubOpts = #{qos := QoS}}) ->
+recheck_topicfilter(ClientInfo, {Topic, SubOpts = #{qos := Qos}}) ->
     AuthzContext = emqx_authz_context:make(ClientInfo),
     %% As in `emqx_channel', a shared subscription is authorized on its real topic
     case
         emqx_access_control:authorize(
             AuthzContext,
-            ?AUTHZ_SUBSCRIBE(QoS),
+            ?AUTHZ_SUBSCRIBE(Qos),
             emqx_topic:get_shared_real_topic(Topic)
         )
     of

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -198,17 +198,12 @@ resolve_hookspec(HookSpecs) when is_list(HookSpecs) ->
                 undefined ->
                     Acc;
                 Name0 ->
-                    Name =
-                        try
-                            binary_to_existing_atom(Name0, utf8)
-                        catch
-                            T:R:_ -> {T, R}
-                        end,
+                    {Name, Opts} = resolve_hook_name(Name0),
                     case {lists:member(Name, AvailableHooks), lists:member(Name, MessageHooks)} of
                         {false, _} ->
                             error({unknown_hookpoint, Name0});
                         {true, false} ->
-                            Acc#{Name => #{}};
+                            Acc#{Name => Opts};
                         {true, true} ->
                             Acc#{
                                 Name => #{
@@ -221,6 +216,22 @@ resolve_hookspec(HookSpecs) when is_list(HookSpecs) ->
         #{},
         HookSpecs
     ).
+
+%% @private
+%% `client.subscribe.rewrite' is the `client.subscribe' hookpoint served by the
+%% `OnClientSubscribeRewrite' RPC, which -- unlike `OnClientSubscribe' -- may rewrite
+%% the topic filters. It is registered under a distinct name so that a server
+%% generated from an older .proto keeps answering the RPC it was built with.
+resolve_hook_name(<<"client.subscribe.rewrite">>) ->
+    {'client.subscribe', #{valued => true}};
+resolve_hook_name(Name0) ->
+    Name =
+        try
+            binary_to_existing_atom(Name0, utf8)
+        catch
+            T:R:_ -> {T, R}
+        end,
+    {Name, #{}}.
 
 %% @private
 ensure_hooks(HookSpecs) ->
@@ -355,7 +366,7 @@ call(
                 false ->
                     ignore;
                 _ ->
-                    GrpcFun = hk2func(Hookpoint),
+                    GrpcFun = hk2func(Hookpoint, Opts),
                     do_call(ChannName, Hookpoint, GrpcFun, Req, ReqOpts)
             end
     end.
@@ -443,6 +454,10 @@ failed_action(#{options := Opts}) ->
 %%--------------------------------------------------------------------
 %% Internal funcs
 %%--------------------------------------------------------------------
+
+-compile({inline, [hk2func/2]}).
+hk2func('client.subscribe', #{valued := true}) -> 'on_client_subscribe_rewrite';
+hk2func(Hookpoint, _Opts) -> hk2func(Hookpoint).
 
 -compile({inline, [hk2func/1]}).
 hk2func('client.connect') -> 'on_client_connect';

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -219,11 +219,10 @@ resolve_hookspec(HookSpecs) when is_list(HookSpecs) ->
 
 %% @private
 %% `client.subscribe' and `client.subscribe.rewrite' resolve to the same
-%% hookpoint, so a server that registers both -- the plausible shape while
-%% migrating from one to the other -- would otherwise get whichever its
-%% `HookSpec' list happened to end on. The server cannot observe which was
-%% chosen short of watching which RPC arrives, so pick the richer one and say
-%% so rather than leaving it to list order.
+%% hookpoint. A server that registers both -- the plausible shape while
+%% migrating from one to the other -- gets the `OnClientSubscribeRewrite' RPC
+%% regardless of its `HookSpec' order, plus a warning naming the RPC in use,
+%% since the server cannot otherwise observe which one was chosen.
 resolve_duplicate(Name, New, Acc) ->
     case maps:find(Name, Acc) of
         error ->

--- a/apps/emqx_exhook/src/emqx_exhook_server.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_server.erl
@@ -31,7 +31,7 @@
 ]).
 
 -ifdef(TEST).
--export([hk2func/1]).
+-export([hk2func/1, resolve_hookspec/1]).
 -endif.
 
 -type service() :: #{
@@ -203,7 +203,7 @@ resolve_hookspec(HookSpecs) when is_list(HookSpecs) ->
                         {false, _} ->
                             error({unknown_hookpoint, Name0});
                         {true, false} ->
-                            Acc#{Name => Opts};
+                            Acc#{Name => resolve_duplicate(Name, Opts, Acc)};
                         {true, true} ->
                             Acc#{
                                 Name => #{
@@ -216,6 +216,34 @@ resolve_hookspec(HookSpecs) when is_list(HookSpecs) ->
         #{},
         HookSpecs
     ).
+
+%% @private
+%% `client.subscribe' and `client.subscribe.rewrite' resolve to the same
+%% hookpoint, so a server that registers both -- the plausible shape while
+%% migrating from one to the other -- would otherwise get whichever its
+%% `HookSpec' list happened to end on. The server cannot observe which was
+%% chosen short of watching which RPC arrives, so pick the richer one and say
+%% so rather than leaving it to list order.
+resolve_duplicate(Name, New, Acc) ->
+    case maps:find(Name, Acc) of
+        error ->
+            New;
+        {ok, Existing} ->
+            Winner = prefer_valued(Existing, New),
+            ?SLOG(warning, #{
+                msg => "duplicate_hookpoint_registration",
+                hookpoint => Name,
+                using => rpc_of(Winner)
+            }),
+            Winner
+    end.
+
+prefer_valued(#{valued := true} = Valued, _Other) -> Valued;
+prefer_valued(_Other, #{valued := true} = Valued) -> Valued;
+prefer_valued(Existing, _New) -> Existing.
+
+rpc_of(#{valued := true}) -> 'OnClientSubscribeRewrite';
+rpc_of(_) -> 'OnClientSubscribe'.
 
 %% @private
 %% `client.subscribe.rewrite' is the `client.subscribe' hookpoint served by the

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -88,6 +88,16 @@ init_per_testcase(t_update_order_with_unhealthy_server = TC, Config) ->
     _ = emqx_exhook_demo_svr:start(),
     _ = emqx_exhook_demo_svr:start(<<"test1">>, 9001),
     common_init(TC, Config);
+init_per_testcase(TC, Config) when
+    TC =:= t_subscribe_rewrite;
+    TC =:= t_subscribe_rewrite_rejects_count_mismatch;
+    TC =:= t_subscribe_rewrite_rejects_invalid_subopts;
+    TC =:= t_subscribe_rewrite_rejects_beyond_caps;
+    TC =:= t_subscribe_rewrite_keeps_shared_subscription
+->
+    ok = emqx_exhook_demo_svr:enable_rewrite_hook(),
+    _ = emqx_exhook_demo_svr:start(),
+    common_init(TC, Config);
 init_per_testcase(TC, Config) ->
     _ = emqx_exhook_demo_svr:start(),
     common_init(TC, Config).
@@ -104,6 +114,8 @@ end_per_testcase(TC, Config) ->
 
 emqx_conf(t_cluster_name) ->
     io_lib:format("cluster.name = ~p", [?OTHER_CLUSTER_NAME_STRING]);
+emqx_conf(t_subscribe_rewrite_rejects_beyond_caps) ->
+    "mqtt.wildcard_subscription = false";
 emqx_conf(t_access_failed_if_no_server_running) ->
     "authorization.sources = []";
 emqx_conf(_) ->
@@ -129,6 +141,7 @@ common_init(TC, Config) ->
     emqx_common_test_helpers:init_per_testcase(?MODULE, TC, [{tc_apps, Apps} | Config]).
 
 common_stop(TC, Config) ->
+    ok = emqx_exhook_demo_svr:reset_rewrite_hook(),
     emqx_common_test_helpers:end_per_testcase(?MODULE, TC, Config),
     emqx_common_test_helpers:call_janitor(),
     ok = emqx_cth_suite:stop(?config(tc_apps, Config)).
@@ -841,6 +854,88 @@ t_ssl_clear(_) ->
     {ok, _} = emqx_tls_certfile_gc:force(),
     ?assertMatch({error, enoent}, list_pem_dir(SvrName)),
     ok.
+
+%%--------------------------------------------------------------------
+%% `client.subscribe.rewrite' topic filter rewrite
+%%--------------------------------------------------------------------
+
+t_subscribe_rewrite(_) ->
+    ok = emqx_exhook_demo_svr:set_rewrite_fun(
+        fun(TopicFilters) ->
+            [Tf#{name => <<"rewritten/", Name/binary>>} || Tf = #{name := Name} <- TopicFilters]
+        end
+    ),
+    ClientId = <<"exhook_sub_rw">>,
+    C = connect(ClientId),
+    ?assertMatch({ok, _, [0]}, emqtt:subscribe(C, <<"t/1">>, qos0)),
+    %% the client is subscribed to what the hook asked for, and only to that
+    ?assertEqual([<<"rewritten/t/1">>], subscribed_topics(ClientId)),
+    ok = emqtt:stop(C).
+
+t_subscribe_rewrite_rejects_count_mismatch(_) ->
+    %% SUBACK owes the client exactly one reason code per requested topic filter,
+    %% ordered as requested (MQTT-3.9.3-1). A hook handing back a different number
+    %% of filters is refused as a whole rather than applied in part.
+    ok = emqx_exhook_demo_svr:set_rewrite_fun(
+        fun(TopicFilters) ->
+            TopicFilters ++ [#{name => <<"extra/topic">>, subopts => #{qos => 0}}]
+        end
+    ),
+    ClientId = <<"exhook_sub_rw_count">>,
+    C = connect(ClientId),
+    ?assertMatch({ok, _, [0]}, emqtt:subscribe(C, <<"t/1">>, qos0)),
+    ?assertEqual([<<"t/1">>], subscribed_topics(ClientId)),
+    ok = emqtt:stop(C).
+
+t_subscribe_rewrite_rejects_invalid_subopts(_) ->
+    %% `qos' is what the SUBACK reports as the granted QoS: 200 is not a reason
+    %% code the client could act on, and on MQTT 3.1.1 it would not serialize.
+    ok = emqx_exhook_demo_svr:set_rewrite_fun(
+        fun(TopicFilters) -> [Tf#{subopts => #{qos => 200}} || Tf <- TopicFilters] end
+    ),
+    ClientId = <<"exhook_sub_rw_qos">>,
+    C = connect(ClientId),
+    ?assertMatch({ok, _, [1]}, emqtt:subscribe(C, <<"t/1">>, qos1)),
+    ?assertEqual([<<"t/1">>], subscribed_topics(ClientId)),
+    ok = emqtt:stop(C).
+
+t_subscribe_rewrite_rejects_beyond_caps(_) ->
+    %% The hook runs after `check_sub_caps', so a rewritten filter is re-checked
+    %% where the rewrite happens; otherwise it would defeat the zone's own limits.
+    ok = emqx_exhook_demo_svr:set_rewrite_fun(
+        fun(TopicFilters) -> [Tf#{name => <<"t/#">>} || Tf <- TopicFilters] end
+    ),
+    ClientId = <<"exhook_sub_rw_caps">>,
+    C = connect(ClientId),
+    ?assertMatch({ok, _, [0]}, emqtt:subscribe(C, <<"t/1">>, qos0)),
+    ?assertEqual([<<"t/1">>], subscribed_topics(ClientId)),
+    ok = emqtt:stop(C).
+
+t_subscribe_rewrite_keeps_shared_subscription(_) ->
+    %% Filters echoed back unchanged must stay exactly as they were: session
+    %% subscriptions are keyed by the `#share{}' record, so one that came back
+    %% flattened to its `$share/...' wire form would no longer match on unsubscribe.
+    ok = emqx_exhook_demo_svr:set_rewrite_fun(fun(TopicFilters) -> TopicFilters end),
+    ClientId = <<"exhook_sub_rw_share">>,
+    C = connect(ClientId),
+    ?assertMatch({ok, _, [0]}, emqtt:subscribe(C, <<"$share/g/t/1">>, qos0)),
+    ?assertEqual([<<"$share/g/t/1">>], subscribed_topics(ClientId)),
+    ?assertMatch({ok, _, [0]}, emqtt:unsubscribe(C, <<"$share/g/t/1">>)),
+    ?assertEqual([], subscribed_topics(ClientId)),
+    ok = emqtt:stop(C).
+
+connect(ClientId) ->
+    {ok, C} = emqtt:start_link([
+        {host, "localhost"},
+        {port, 1883},
+        {clientid, ClientId},
+        {proto_ver, v5}
+    ]),
+    {ok, _} = emqtt:connect(C),
+    C.
+
+subscribed_topics(ClientId) ->
+    [emqx_topic:maybe_format_share(T) || {T, _SubOpts} <- emqx_broker:subscriptions(ClientId)].
 
 t_format_props(_) ->
     ?assertMatch(

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -920,8 +920,8 @@ t_subscribe_unchanged_filters_still_stop(_) ->
             {stop, TopicFilters},
             emqx_exhook_handler:on_client_subscribe(clientinfo_for_test(), #{}, TopicFilters)
         ),
-        %% A server that answered CONTINUE keeps the old behaviour: the
-        %% accumulator is left alone so the rest of the chain runs.
+        %% A server that answered CONTINUE leaves the accumulator alone, so
+        %% the rest of the chain runs.
         meck:expect(emqx_exhook, call_fold, fun('client.subscribe', Req, _Fun) ->
             {ok, #{topic_filters => maps:get(topic_filters, Req)}}
         end),
@@ -947,10 +947,9 @@ clientinfo_for_test() ->
         dn => undefined
     }.
 
-%% Both names resolve to the `client.subscribe' hookpoint, so a server that
-%% registers the two -- the plausible shape while migrating -- used to get
-%% whichever its HookSpec list happened to end on, with no way to observe the
-%% choice. The richer RPC wins now, in either order.
+%% Both names resolve to the `client.subscribe' hookpoint. A server that
+%% registers the two -- the plausible shape while migrating -- gets the
+%% `OnClientSubscribeRewrite' RPC, in either HookSpec order.
 t_duplicate_subscribe_registration_prefers_rewrite(_) ->
     Plain = #{name => <<"client.subscribe">>},
     Rewrite = #{name => <<"client.subscribe.rewrite">>},

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -158,6 +158,40 @@ profile_cases() ->
 %% Test cases
 %%--------------------------------------------------------------------
 
+%% A server that does not advertise the hookpoint answers `ignore'. That is
+%% not a failure, so it must not be routed through `failed_action': under
+%% the default `deny' that stops the chain and every server behind it stops
+%% seeing the event, silently.
+t_call_fold_skips_servers_without_the_hookpoint(_Config) ->
+    ok = meck:new(emqx_exhook_mgr, [passthrough, no_history]),
+    ok = meck:new(emqx_exhook_server, [passthrough, no_history]),
+    Tester = self(),
+    try
+        meck:expect(emqx_exhook_mgr, running, fun() -> [<<"a">>, <<"b">>] end),
+        meck:expect(emqx_exhook_mgr, service, fun(Name) -> #{name => Name} end),
+        meck:expect(emqx_exhook_server, call, fun
+            (_Hookpoint, _Req, #{name := <<"a">>}) ->
+                ignore;
+            (_Hookpoint, Req, #{name := <<"b">>}) ->
+                Tester ! reached_second_server,
+                {ok, Req}
+        end),
+        meck:expect(emqx_exhook_server, failed_action, fun(_Server) -> deny end),
+        Req = #{topic_filters => []},
+        ?assertMatch(
+            {ok, _},
+            emqx_exhook:call_fold('client.subscribe', Req, fun(_Req, Resp) -> {ok, Resp} end)
+        ),
+        receive
+            reached_second_server -> ok
+        after 0 ->
+            ct:fail("the server behind the one without the hookpoint was never called")
+        end
+    after
+        meck:unload(emqx_exhook_server),
+        meck:unload(emqx_exhook_mgr)
+    end.
+
 t_access_failed_if_no_server_running(Config) ->
     ClientInfo = #{
         clientid => <<"user-id-1">>,

--- a/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_SUITE.erl
@@ -197,7 +197,6 @@ t_access_failed_if_no_server_running(Config) ->
         clientid => <<"user-id-1">>,
         username => <<"usera">>,
         peername => {{127, 0, 0, 1}, 3456},
-        peerhost => {127, 0, 0, 1},
         sockport => 1883,
         protocol => mqtt,
         mountpoint => undefined
@@ -905,6 +904,73 @@ t_subscribe_rewrite(_) ->
     %% the client is subscribed to what the hook asked for, and only to that
     ?assertEqual([<<"rewritten/t/1">>], subscribed_topics(ClientId)),
     ok = emqtt:stop(C).
+
+%% Returning the filters unchanged is how a server says "I have looked at this
+%% and no later hook should touch it". `emqx_hooks' continues the chain on any
+%% term other than `stop'/`{stop, Acc}', so answering `ignore' here would
+%% silently downgrade STOP_AND_RETURN to CONTINUE.
+t_subscribe_unchanged_filters_still_stop(_) ->
+    ok = meck:new(emqx_exhook, [passthrough, no_history]),
+    try
+        TopicFilters = [{<<"t/1">>, #{qos => 0, rh => 0, rap => 0, nl => 0}}],
+        meck:expect(emqx_exhook, call_fold, fun('client.subscribe', Req, _Fun) ->
+            {stop, #{topic_filters => maps:get(topic_filters, Req)}}
+        end),
+        ?assertEqual(
+            {stop, TopicFilters},
+            emqx_exhook_handler:on_client_subscribe(clientinfo_for_test(), #{}, TopicFilters)
+        ),
+        %% A server that answered CONTINUE keeps the old behaviour: the
+        %% accumulator is left alone so the rest of the chain runs.
+        meck:expect(emqx_exhook, call_fold, fun('client.subscribe', Req, _Fun) ->
+            {ok, #{topic_filters => maps:get(topic_filters, Req)}}
+        end),
+        ?assertEqual(
+            ignore,
+            emqx_exhook_handler:on_client_subscribe(clientinfo_for_test(), #{}, TopicFilters)
+        )
+    after
+        meck:unload(emqx_exhook)
+    end.
+
+clientinfo_for_test() ->
+    #{
+        clientid => <<"exhook_stop_test">>,
+        username => <<"u">>,
+        peername => {{127, 0, 0, 1}, 54321},
+        sockport => 1883,
+        protocol => mqtt,
+        mountpoint => undefined,
+        is_superuser => false,
+        anonymous => false,
+        cn => undefined,
+        dn => undefined
+    }.
+
+%% Both names resolve to the `client.subscribe' hookpoint, so a server that
+%% registers the two -- the plausible shape while migrating -- used to get
+%% whichever its HookSpec list happened to end on, with no way to observe the
+%% choice. The richer RPC wins now, in either order.
+t_duplicate_subscribe_registration_prefers_rewrite(_) ->
+    Plain = #{name => <<"client.subscribe">>},
+    Rewrite = #{name => <<"client.subscribe.rewrite">>},
+    ?assertEqual(
+        #{'client.subscribe' => #{valued => true}},
+        emqx_exhook_server:resolve_hookspec([Plain, Rewrite])
+    ),
+    ?assertEqual(
+        #{'client.subscribe' => #{valued => true}},
+        emqx_exhook_server:resolve_hookspec([Rewrite, Plain])
+    ),
+    %% A single registration of either name is unaffected.
+    ?assertEqual(
+        #{'client.subscribe' => #{}},
+        emqx_exhook_server:resolve_hookspec([Plain])
+    ),
+    ?assertEqual(
+        #{'client.subscribe' => #{valued => true}},
+        emqx_exhook_server:resolve_hookspec([Rewrite])
+    ).
 
 t_subscribe_rewrite_rejects_count_mismatch(_) ->
     %% SUBACK owes the client exactly one reason code per requested topic filter,

--- a/apps/emqx_exhook/test/emqx_exhook_demo_svr.erl
+++ b/apps/emqx_exhook/test/emqx_exhook_demo_svr.erl
@@ -13,7 +13,10 @@
     stop/0,
     stop/1,
     take/0,
-    flush/0
+    flush/0,
+    enable_rewrite_hook/0,
+    set_rewrite_fun/1,
+    reset_rewrite_hook/0
 ]).
 
 -behaviour(gen_server).
@@ -35,6 +38,7 @@
     on_client_authenticate/2,
     on_client_authorize/2,
     on_client_subscribe/2,
+    on_client_subscribe_rewrite/2,
     on_client_unsubscribe/2,
     on_session_created/2,
     on_session_subscribed/2,
@@ -51,6 +55,13 @@
 ]).
 
 -define(PORT, 9000).
+%% Registering `client.subscribe.rewrite' swaps `OnClientSubscribe' for
+%% `OnClientSubscribeRewrite'; off by default, since every other case here expects the
+%% fire-and-forget hook.
+-define(REWRITE_HOOK_KEY, {?MODULE, rewrite_hook}).
+%% What `OnClientSubscribeRewrite' answers with: a fun over the requested topic
+%% filters, or `undefined' to respond `IGNORE'.
+-define(REWRITE_FUN_KEY, {?MODULE, subscribe_rewrite}).
 -define(NAME, ?MODULE).
 -define(DEFAULT_CLUSTER_NAME, <<"emqxcl">>).
 -define(OTHER_CLUSTER_NAME_BIN, <<"test_emqx_cluster">>).
@@ -68,6 +79,20 @@ start(Name, Port) ->
 
 stop() ->
     stop(?NAME).
+
+enable_rewrite_hook() ->
+    persistent_term:put(?REWRITE_HOOK_KEY, true).
+
+%% `Fun' takes the requested topic filters and returns the ones to respond with,
+%% so a case can hand back a list of a different length, an out-of-range qos, or
+%% the filters unchanged.
+set_rewrite_fun(Fun) when is_function(Fun, 1) ->
+    persistent_term:put(?REWRITE_FUN_KEY, Fun).
+
+reset_rewrite_hook() ->
+    _ = persistent_term:erase(?REWRITE_HOOK_KEY),
+    _ = persistent_term:erase(?REWRITE_FUN_KEY),
+    ok.
 
 stop(Name) ->
     case whereis(to_atom_name(Name)) of
@@ -159,7 +184,7 @@ on_provider_loaded(#{meta := #{cluster_name := Name}} = Req, Md) ->
             #{name => <<"client.disconnected">>},
             #{name => <<"client.authenticate">>},
             #{name => <<"client.authorize">>},
-            #{name => <<"client.subscribe">>},
+            #{name => subscribe_hook_name()},
             #{name => <<"client.unsubscribe">>}
         ],
     HooksSession =
@@ -299,6 +324,29 @@ on_client_subscribe(Req, Md) ->
     in(?FUNCTION_NAME, Req),
     %io:format("fun: ~p, req: ~0p~n", [?FUNCTION_NAME, Req]),
     {ok, #{}, Md}.
+
+-spec on_client_subscribe_rewrite(emqx_exhook_pb:client_subscribe_request(), grpc:metadata()) ->
+    {ok, emqx_exhook_pb:valued_response(), grpc:metadata()}
+    | {error, grpc_cowboy_h:error_response()}.
+on_client_subscribe_rewrite(#{topic_filters := TopicFilters} = Req, Md) ->
+    in(?FUNCTION_NAME, Req),
+    case persistent_term:get(?REWRITE_FUN_KEY, undefined) of
+        undefined ->
+            {ok, #{type => 'IGNORE'}, Md};
+        Fun ->
+            {ok,
+                #{
+                    type => 'STOP_AND_RETURN',
+                    value => {topic_filters, #{filters => Fun(TopicFilters)}}
+                },
+                Md}
+    end.
+
+subscribe_hook_name() ->
+    case persistent_term:get(?REWRITE_HOOK_KEY, false) of
+        true -> <<"client.subscribe.rewrite">>;
+        false -> <<"client.subscribe">>
+    end.
 
 -spec on_client_unsubscribe(emqx_exhook_pb:client_unsubscribe_request(), grpc:metadata()) ->
     {ok, emqx_exhook_pb:empty_success(), grpc:metadata()}

--- a/changes/ce/feat-16112.en.md
+++ b/changes/ce/feat-16112.en.md
@@ -1,0 +1,5 @@
+Added the `client.subscribe.rewrite` ExHook hook, which lets a gRPC server rewrite the topic filters of a SUBSCRIBE.
+
+A server registers `client.subscribe.rewrite` instead of `client.subscribe` and answers the new `OnClientSubscribeRewrite` RPC with a `ValuedResponse` carrying `topic_filters`. Servers registered as `client.subscribe` keep the fire-and-forget `OnClientSubscribe` RPC and are unaffected.
+
+The response must hold exactly as many filters as the request did, in the same order, because SUBACK carries one reason code per requested topic filter, ordered as the filters were received. A rewritten filter is re-authorized and re-checked against the zone's subscribe capabilities, so a hook cannot grant a subscription the client could not have requested itself. A response that breaks either rule is discarded in full and the requested filters are used unchanged.


### PR DESCRIPTION
Fixes #16102

Release version: 7.0.0

Introduced in: N/A

## Summary

`client.subscribe` is dispatched with `emqx_exhook:cast/2`, which discards the server's
response, so a gRPC hook can observe a SUBSCRIBE but never act on it — unlike an Erlang
callback such as `emqx_rewrite:rewrite_subscribe/4`, whose `{ok, TopicFilters}` the channel
honours.

The new RPC is `OnClientSubscribeRewrite`, returning `ValuedResponse` with a `topic_filters`
value, registered under the hook name `client.subscribe.rewrite`. `OnClientSubscribe` keeps
its `EmptySuccess` return type, so a server generated from an earlier .proto keeps compiling
and keeps being called as before — that is the answer to the backward-compatibility question
in review: no change to the published `emqx.exhook.v3` contract.

On the reason-code comments: the hook runs after `check_sub_authzs`/`check_sub_caps` and its
result reaches the session directly, so `emqx_exhook_handler` re-establishes what the broker
otherwise guarantees:

* one filter back per requested filter, in the same order — SUBACK carries one reason code
  per requested topic filter, ordered as received [MQTT-3.9.3-1], and `do_gen_reason_codes/3`
  pairs the two lists positionally with no clause for a longer one;
* `subopts` are range-checked, since `qos` becomes the granted QoS;
* a rewritten filter is re-authorized and re-checked against the zone's subscribe
  capabilities, so a hook cannot grant what the client could not have requested itself;
* an unchanged filter keeps its original term instead of being re-parsed, so a shared
  subscription stays keyed by its `#share{}` record and still matches on unsubscribe.

A response breaking any of these is discarded whole and the requested filters are used
unchanged.

`emqx_channel.erl` is untouched — the change there in the previous revision was an identity
no-op. `client.unsubscribe` is dropped: #16102 does not ask for it, and UNSUBACK reason codes
come straight from `post_process_unsubscribe/4` with no re-derivation step, so a hook there
could change the reason code count in the packet itself.

The RPC deliberately has no digit suffix: `OnClientSubscribeV2` generates the client stub
`on_client_subscribe_v2` while `grpc_stream:init/2` resolves the server handler as
`on_client_subscribe_v_2`, so every call dies in `list_to_existing_atom/1`.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log added: `changes/ce/feat-16112.en.md`
- [x] Schema changes are backward compatible
