### PR TITLE
chore: bump dashboard version to 1.9.2-beta.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ include env.sh
 # Dashboard version
 # from https://github.com/emqx/emqx-dashboard5
 export EMQX_DASHBOARD_VERSION ?= v1.10.6
-export EMQX_EE_DASHBOARD_VERSION ?= e1.9.2
+export EMQX_EE_DASHBOARD_VERSION ?= e1.9.2-beta.2
 
 export EMQX_RELUP ?= true
 export EMQX_REL_FORM ?= tgz


### PR DESCRIPTION
previously the version was set to 5.9.2 prematurely

Release version: 5.9.2