### PR TITLE
feat: bump greptimedb ingester

### DIFF
--- a/.ci/docker-compose-file/docker-compose-greptimedb.yaml
+++ b/.ci/docker-compose-file/docker-compose-greptimedb.yaml
@@ -2,7 +2,7 @@ services:
   greptimedb:
     container_name: greptimedb
     hostname: greptimedb
-    image: greptime/greptimedb:v0.14.2
+    image: greptime/greptimedb:v0.17.2
     expose:
       - "4000"
       - "4001"

--- a/apps/emqx_bridge_greptimedb/mix.exs
+++ b/apps/emqx_bridge_greptimedb/mix.exs
@@ -32,7 +32,7 @@ defmodule EMQXBridgeGreptimedb.MixProject do
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false},
-      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.0.1"}
+      {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.3-emqx.1"}
     ])
   end
 end

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_connector.erl
@@ -750,7 +750,7 @@ value_type(Val0) ->
             _Error ->
                 throw({unrecoverable_error, {non_utf8_string_value, Val0}})
         end,
-    #{values => #{string_values => Val}, datatype => 'STRING'}.
+    greptimedb_values:string_value(Val).
 
 key_filter(undefined) -> undefined;
 key_filter(Value) -> emqx_utils_conv:bin(Value).

--- a/changes/ee/feat-16121.en.md
+++ b/changes/ee/feat-16121.en.md
@@ -1,0 +1,2 @@
+* Upgrade the GreptimeDB ingester client to [v0.2.3](https://github.com/GreptimeTeam/greptimedb-ingester-erl/releases/tag/v0.2.3), which fixes some bugs and implements row-based gRPC protocol.
+* Upgrade the CI image to the latest stable version of GreptimeDB.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

<!--
5.8.9
5.9.2
5.10.2
6.0.1
6.1.0
-->
Release version:

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

* Upgraded the GreptimeDB ingester client to [v0.2.3](https://github.com/GreptimeTeam/greptimedb-ingester-erl/releases/tag/v0.2.3), which fixes bugs, adds row-based gRPC protocol support (the column-based protocol is deprecated), and incorporates @thalesmg’s [fix](https://github.com/GreptimeTeam/greptimedb-ingester-erl/pull/47) (thanks!).
* Updated the CI image to the latest stable GreptimeDB version.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
