### PR TITLE
test(mqttsn): attempt to fix flaky test

### DIFF
--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -251,7 +251,7 @@ t_auth_expire(_) ->
         ?wait_async_action(
             begin
                 {ok, Socket} = gen_udp:open(0, [binary]),
-                send_connect_msg(Socket, <<"client_id_test1">>),
+                send_connect_msg(Socket, ClientId),
                 ?assertEqual(<<3, ?SN_CONNACK, 0>>, receive_response(Socket)),
                 ?assertEqual(<<2, ?SN_DISCONNECT>>, receive_response(Socket)),
                 gen_udp:close(Socket)


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/16606039166/job/46978605631?pr=15610#step:5:97

```
%%% emqx_sn_protocol_SUITE ==> t_auth_expire: FAILED
%%% emqx_sn_protocol_SUITE ==>
Failure/Error: ?assertMatch({ _ , { ok , # { ? snk_kind := conn_process_terminated , clientid := << "client_id_test1" >> , reason := { shutdown , expired } } } }, ? wait_async_action ( begin { ok , Socket } = gen_udp : open ( 0 , [ binary ] ) , send_connect_msg ( Socket , << "client_id_test1" >> ) , ? assertEqual ( << 3 , ? SN_CONNACK , 0 >> , receive_response ( Socket ) ) , ? assertEqual ( << 2 , ? SN_DISCONNECT >> , receive_response ( Socket ) ) , gen_udp : close ( Socket ) end , # { ? snk_kind := conn_process_terminated , clientid := << "client_id_test1" >> , reason := { shutdown , expired } } , 5000 ))
  expected: = { _ , { ok , # { ? snk_kind := conn_process_terminated , clientid := << "client_id_test1" >> , reason := { shutdown , expired } } } }
       got: {ok,timeout}
      line: 262
```

Seems like the `receive_response/1` function in this suite was capturing snabbkaffe events and throwing them away...  🫠

```
*** User 2025-07-29 20:25:23.333 ***
🔗

TEST: receive_response() Other message: {unexpected_udp_data,
                                         {#Ref<0.3651163317.1881145350.242221>,
                                          #{reason => {shutdown,expired},
                                            msg => conn_process_terminated,
                                            '~meta' =>
                                             #{node => 'test@127.0.0.1',
                                               pid => <0.36654.0>,
                                               time => -576460743790342,
                                               peername => "127.0.0.1:56883",
                                               gl => <0.35737.0>,
                                               location =>
                                                #Fun,
                                               clientid =>
                                                <<"client_id_test1">>},
                                            clientid =>
                                             <<"client_id_test1">>}}}
```


