### PR TITLE
feat(config): stop keeping unknown config roots in global rawconf

### DIFF
--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -126,12 +126,12 @@ t_unknown_root_keys(C) when is_list(C) ->
             ok = emqx_config:init_load(
                 emqx_schema, <<"test_1 {}\n test_2 {sub = 100}\n listeners {}">>
             ),
-            ?block_until(#{?snk_kind := unknown_config_keys})
+            ?block_until(#{?snk_kind := "config_roots_not_recognized"})
         end,
         fun(Trace) ->
             ?assertMatch(
-                [#{unknown_config_keys := "test_1,test_2"}],
-                ?of_kind(unknown_config_keys, Trace)
+                [#{config_roots := ["test_1", "test_2"]}],
+                ?of_kind("config_roots_not_recognized", Trace)
             )
         end
     ),


### PR DESCRIPTION
## Summary

This PR includes revert of fe343d327cb45d0d20f1c3658945896fc897e9c9, see https://github.com/emqx/emqx/pull/16128#discussion_r2445892020 for details.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible
