### PR TITLE
fix(resource): Handle already started and present errors in ensure_child

### DIFF
--- a/apps/emqx_resource/src/emqx_resource_manager_sup.erl
+++ b/apps/emqx_resource/src/emqx_resource_manager_sup.erl
@@ -15,6 +15,10 @@
 
 ensure_child(ResId, Group, ResourceType, Config, Opts) ->
     case supervisor:start_child(?MODULE, child_spec(ResId, Group, ResourceType, Config, Opts)) of
+        {error, {already_started, _}} ->
+            ok;
+        {error, already_present} ->
+            ok;
         {error, Reason} ->
             %% This should not happen in production but it can be a huge time sink in
             %% development environments if the error is just silently ignored.


### PR DESCRIPTION
Added explicit handling for {already_started, _} and already_present errors in ensure_child/5 to prevent unnecessary error propagation when a child process is already running or present.

Having multiple processes create the same resource concurrently is fine if at least one succeeds. This should not cause a crash.

```
2025-10-27T02:05:37.744917+00:00 [error] crasher: initial call: my_plugin_receiver_parser:init/1, pid: <0.4940.0>, registered_name: [], exit: {{handshake_callback_failed,{already_present,[{emqx_resource_manager_sup,ensure_child,5,[{file,"emqx_resource_manager_sup.erl"},{line,21}]},{emqx_resource_manager,create,5,[{file,"emqx_resource_manager.erl"},{line,269}]},{emqx_resource_manager,create_and_return_data,5,[{file,"emqx_resource_manager.erl"},{line,262}]},{my_plugin_resource,create,5,[{file,"xyz_resource.erl"},{line,27}]},
```

Fixes <issue-or-jira-number>


5.10.2

Release version:

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
