### PR TITLE
perf(list clients v2): disable repeatedly counting totals

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_api.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api.erl
@@ -8,6 +8,7 @@
 -include("emqx_mgmt.hrl").
 
 -elvis([{elvis_style, dont_repeat_yourself, #{min_complexity => 100}}]).
+-elvis([{elvis_style, no_catch_expressions, disable}]).
 
 -define(LONG_QUERY_TIMEOUT, 50000).
 
@@ -507,6 +508,8 @@ apply_total_query(QueryState = #{table := Tab}) ->
             Fun(Tab)
     end.
 
+counting_total_fun(#{qs := {[], []}, options := #{total_counting := disable}}) ->
+    false;
 counting_total_fun(_QueryState = #{qs := {[], []}, options := #{fast_total_counting := true}}) ->
     fun(Tab) -> ets:info(Tab, size) end;
 counting_total_fun(_QueryState = #{match_spec := Ms, fuzzy_fun := undefined}) ->

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1158,7 +1158,7 @@ do_local_ets_select_v1(#{} = Params, Acc) ->
         fun ?MODULE:qs2ms/2,
         %% Note: we set limit to 1 here so we may avoid overshooting desired batch size.
         _Meta = #{page => unused, limit => 1},
-        _Options = #{}
+        _Options = #{total_counting => disable}
     ),
     QueryState = QueryState0#{continuation => Cont},
     case emqx_mgmt_api:do_query(node(), QueryState) of

--- a/changes/ee/perf-16165.en.md
+++ b/changes/ee/perf-16165.en.md
@@ -1,0 +1,1 @@
+Fixed the performance of `GET /clients_v2`.  Previously, when a cluster had about 50 k clients or more, calls to this API would take a long time or even time out.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14835

<!--
5.8.9
5.9.2
5.10.2
6.0.1
6.1.0
-->
Release version: 6.0.1

## Summary

<details>

```
:eprof.profile(fn -> :emqx_mgmt_api_clients.list_clients_v2(:get, %{query_string: %{}}) end)

****** Process <13041.544545.0>    -- 99.92 % of profiled time *** 
FUNCTION                                        CALLS        %      TIME  [uS / CALLS]
--------                                        -----  -------      ----  [----------]
emqx_mgmt_api_clients:local_ets_select_v1/1         1     0.00         0  [      0.00]
erlang:exit/1                                       1     0.00         0  [      0.00]
erpc:execute_call/4                                 1     0.00         2  [      2.00]
erts_internal:spawn_init/1                          1     0.00         2  [      2.00]
lists:reverse/2                                     1     0.00        11  [     11.00]
ets:select_reverse/3                                1     0.00        22  [     22.00]
emqx_mgmt_api_clients:fuzzy_filter_fun/1          100     0.00        29  [      0.29]
emqx_mgmt_api:do_query/2                          100     0.00        29  [      0.29]
emqx_mgmt_api:maybe_apply_fuzzy_filter/2          100     0.00        39  [      0.39]
lists:reverse/1                                   101     0.00        42  [      0.42]
emqx_mgmt_api_clients:qs2ms/1                     100     0.00        55  [      0.55]
ets:is_compiled_ms/1                               99     0.00        56  [      0.57]
emqx_mgmt_api:apply_total_query/1                 100     0.00        74  [      0.74]
emqx_mgmt_api_clients:qs2ms/3                     100     0.00        75  [      0.75]
emqx_mgmt_api:'-counting_total_fun/1-fun-1-'/2    100     0.00        87  [      0.87]
emqx_mgmt_api:counting_total_fun/1                200     0.00       100  [      0.50]
emqx_mgmt_api_clients:qs2ms/2                     100     0.00       103  [      1.03]
erlang:'++'/2                                     100     0.00       119  [      1.19]
ets:repair_continuation/2                          99     0.00       138  [      1.39]
emqx_mgmt_api:maybe_apply_total_query/2           100     0.00       171  [      1.71]
emqx_mgmt_api:init_query_state/5                  100     0.00       224  [      2.24]
emqx_mgmt_api:do_select/2                         100     0.00       299  [      2.99]
emqx_mgmt_api_clients:do_local_ets_select_v1/2    101     0.00       309  [      3.06]
ets:select_reverse/1                               99     0.01      1661  [     16.78]
ets:select_count/2                                100    99.97  13281372  [ 132813.72]
----------------------------------------------  -----  -------  --------  [----------]
Total:                                           2005  100.00%  13285019  [   6625.94]
```

</details>

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
