### PR TITLE
chore(iceberg / s3tables): update parquer -> 0.1.4

### DIFF
--- a/.ci/docker-compose-file/docker-compose-iceberg.yaml
+++ b/.ci/docker-compose-file/docker-compose-iceberg.yaml
@@ -46,7 +46,7 @@ services:
   ## 7890 for nREPL access
 
   query:
-    image: ghcr.io/emqx/spark-query:1.0.7
+    image: ghcr.io/emqx/spark-query:1.0.8
     container_name: query
     networks:
       emqx_bridge:

--- a/apps/emqx_bridge_s3tables/mix.exs
+++ b/apps/emqx_bridge_s3tables/mix.exs
@@ -37,7 +37,7 @@ defmodule EMQXBridgeS3Tables.MixProject do
       {:emqx_connector_aggregator, in_umbrella: true},
       {:emqx_gen_bridge, in_umbrella: true},
       {:emqx_s3, in_umbrella: true},
-      {:parquer, github: "emqx/parquer", tag: "0.1.3", manager: :rebar3},
+      {:parquer, github: "emqx/parquer", tag: "0.1.4", manager: :rebar3},
       :erlcloud,
       :murmerl3
     ])

--- a/changes/ee/feat-16169.en.md
+++ b/changes/ee/feat-16169.en.md
@@ -1,0 +1,1 @@
+Updated our `parquer` dependency to support encoding `timestamp` Iceberg types to Parquet files.


### PR DESCRIPTION
To support timestamp types.

See https://github.com/emqx/parquer/pull/3

Fixes https://emqx.atlassian.net/browse/EMQX-14852

<!--
5.8.9
5.9.2
5.10.2
6.0.1
6.1.0
-->
Release version: 6.1.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
