### PR TITLE
ci(docker): fix workflow permissions

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -80,7 +80,7 @@ jobs:
         run: scripts/shelltest/run_tests.sh
       - name: Check workflow files
         env:
-          ACTIONLINT_VSN: 1.6.25
+          ACTIONLINT_VSN: 1.7.3
         run: |
           wget -q https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VSN}/actionlint_${ACTIONLINT_VSN}_linux_$(dpkg --print-architecture).tar.gz -O actionlint.tar.gz
           tar zxf actionlint.tar.gz actionlint
@@ -166,10 +166,13 @@ jobs:
     needs:
       - init
       - sanity-checks
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
+    # permissions:
+    #   contents: read
+    #   packages: write
+    #   attestations: write
+    #   id-token: write
+    ## fixme: temporary workaround for what seems to be a GHA bug
+    permissions: write-all
     uses: ./.github/workflows/build_and_push_docker_images.yaml
     with:
       profile: emqx-enterprise

--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -50,8 +50,13 @@ on:
         type: boolean
         default: false
 
-permissions:
-  contents: read
+# permissions:
+#   contents: read
+#   packages: write
+#   attestations: write
+#   id-token: write
+## fixme: temporary workaround for what seems to be a GHA bug
+permissions: write-all
 
 jobs:
   build:
@@ -97,10 +102,6 @@ jobs:
       run:
         shell: bash
 
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
 
     strategy:
       fail-fast: false
@@ -258,11 +259,6 @@ jobs:
     defaults:
       run:
         shell: bash
-
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Trying to fix this: https://github.com/emqx/emqx/actions/runs/18907693639/job/53973612772?pr=16181#step:10:657

Ref: https://docs.github.com/en/actions/tutorials/publish-packages/publish-docker-images#publishing-images-to-github-packages

<!--
5.8.9
5.9.2
5.10.2
6.0.1
6.1.0
-->
Release version: 6.0.1
