### PR TITLE
ci: don't push pr images to registries

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build and push docker image to ghcr.io
         env:
-          DOCKER_PUSH: true
+          DOCKER_PUSH: ${{ inputs.publish }}
           DOCKER_BUILD_NOCACHE: true
           DOCKER_PLATFORMS: linux/amd64,linux/arm64
           DOCKER_LOAD: false
@@ -173,10 +173,6 @@ jobs:
           echo "==========="
           echo "_EMQX_DOCKER_IMAGE_TAG=$(head -n 1 .emqx_docker_image_tags)" >> $GITHUB_ENV
           head -n 1 .emqx_docker_image_tags > docker-image-tag
-
-      - name: Pull image from ghcr.io for local testing
-        run: |
-          docker pull $_EMQX_DOCKER_IMAGE_TAG
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -308,7 +304,7 @@ jobs:
 
       - name: Build and push multiarch docker image to ghcr.io
         env:
-          DOCKER_PUSH: true
+          DOCKER_PUSH: ${{ inputs.publish }}
           DOCKER_BUILD_NOCACHE: true
           DOCKER_PLATFORMS: linux/amd64,linux/arm64
           DOCKER_LOAD: false
@@ -326,10 +322,6 @@ jobs:
           echo "==========="
           echo "_EMQX_DOCKER_IMAGE_TAG=$(head -n 1 .emqx_docker_image_tags)" >> $GITHUB_ENV
           head -n 1 .emqx_docker_image_tags > docker-image-tag
-
-      - name: Pull image from ghcr.io for local testing
-        run: |
-          docker pull $_EMQX_DOCKER_IMAGE_TAG
 
       - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:


### PR DESCRIPTION
Trying to fix this: https://github.com/emqx/emqx/actions/runs/18907693639/job/53973612772?pr=16181#step:10:657

See also https://github.com/emqx/emqx/pull/16186

<!--
5.8.9
5.9.2
5.10.2
6.0.1
6.1.0
-->
Release version: 6.0.1
