### PR TITLE
test(dsraft): another attempt to stabilize flaky test

### DIFF
--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -1092,7 +1092,7 @@ sort_canonical_forms(Msgs) ->
 
 %%
 
-suite() -> [{timetrap, {seconds, 120}}].
+suite() -> [{timetrap, {seconds, 120}}, {ct_hooks, [emqx_cth_ct_hook_flaky]}].
 
 all() ->
     Broken = [


### PR DESCRIPTION
Sequence to https://github.com/emqx/emqx/pull/16190

I vaguely remember seeing memory issues with snabbkaffe tracepoints in hot loops.  The
last ran test case just before the VM is killed is `t_rebalance`:

https://github.com/emqx/emqx/actions/runs/18918819109/job/54011970231?pr=16189
```
%%% emqx_ds_builtin_raft_SUITE ==> t_rebalance: OK
Testing apps.emqx_ds_builtin_raft.emqx_ds_builtin_raft_SUITE: Stopping test case repeat operation: {flaky,3}
Killed
make: *** [Makefile:143: apps/emqx_ds_builtin_raft-ct] Error 137
```

... Which suggests the problematic case is `t_rebalance_chaotic_converges`, which is
indeed wrapped in a check trace.

See also the individual commits.