### PR TITLE
fix: upgrade dependency version replayq to 0.5.0 (v5.10)

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -216,7 +216,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def common_dep(:jsone), do: {:jsone, github: "emqx/jsone", tag: "1.7.1", override: true}
   def common_dep(:ecpool), do: {:ecpool, github: "emqx/ecpool", tag: "0.6.2", override: true}
-  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.4.1", override: true}
+  def common_dep(:replayq), do: {:replayq, github: "emqx/replayq", tag: "0.5.0", override: true}
   def common_dep(:jsx), do: {:jsx, github: "talentdeficit/jsx", tag: "v3.1.0", override: true}
   # in conflict by emqtt and hocon
   def common_dep(:getopt), do: {:getopt, "1.0.2", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -97,7 +97,7 @@
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.2"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.10"}}},
     {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.6.2"}}},
-    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.4.1"}}},
+    {replayq, {git, "https://github.com/emqx/replayq.git", {tag, "0.5.0"}}},
     {emqtt, {git, "https://github.com/emqx/emqtt", {tag, "1.14.6"}}},
     {rulesql, {git, "https://github.com/emqx/rulesql", {tag, "0.2.1"}}},
     % NOTE: depends on recon 2.5.x


### PR DESCRIPTION
fixes: [EMQX-14876](https://emqx.atlassian.net/browse/EMQX-14876)
missed it in https://github.com/emqx/emqx/pull/16212

[EMQX-14876]: https://emqx.atlassian.net/browse/EMQX-14876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ