### PR TITLE
chore: Log cache cleanup only when records are deleted

### DIFF
--- a/apps/emqx_auth/src/emqx_auth.app.src
+++ b/apps/emqx_auth/src/emqx_auth.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth, [
     {description, "EMQX Authentication and authorization"},
-    {vsn, "0.4.7"},
+    {vsn, "0.4.8"},
     {modules, []},
     {registered, [emqx_auth_sup]},
     {applications, [

--- a/apps/emqx_auth/src/emqx_auth_cache.erl
+++ b/apps/emqx_auth/src/emqx_auth_cache.erl
@@ -274,10 +274,11 @@ cleanup(#{name := Name, tab := Tab}) ->
     Now = now_ms_monotonic(),
     MS = ets:fun2ms(fun(#cache_record{expire_at = ExpireAt}) when ExpireAt < Now -> true end),
     NumDeleted = ets:select_delete(Tab, MS),
-    ?tp(debug, auth_cache_cleanup, #{
-        name => Name,
-        num_deleted => NumDeleted
-    }),
+    NumDeleted > 0 andalso
+        ?tp(debug, auth_cache_cleanup, #{
+            name => Name,
+            num_deleted => NumDeleted
+        }),
     ok.
 
 update_stats(#{tab := Tab, stat_tab := StatTab} = PtState) ->


### PR DESCRIPTION
Updated the cleanup function to log cache cleanup events only if records were actually deleted, reducing unnecessary debug logs.

A large number of useless log prints are extremely annoying.

```
2025-11-06T02:11:47.365519+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:11:47.365910+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:12:47.372490+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:12:47.372661+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:13:47.373763+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:13:47.373763+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:14:47.375182+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:14:47.375810+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:15:47.385230+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:15:47.385230+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:16:47.387658+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:16:47.388297+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:17:47.392900+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:17:47.393277+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:18:47.396505+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:18:47.396879+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:19:47.400066+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
2025-11-06T02:19:47.400066+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:20:47.401915+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authn_cache, num_deleted: 0
2025-11-06T02:20:47.401915+00:00 [debug] msg: auth_cache_cleanup, name: emqx_authz_cache, num_deleted: 0
```

Fixes <issue-or-jira-number>


5.10.2
6.0.1
6.1.0


Release version:

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
