### PR TITLE
ci: attempt to fix push test workflow

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -175,6 +175,7 @@ jobs:
       builder: ${{ needs.init.outputs.BUILDER }}
       before_ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
       after_ref: ${{ github.sha }}
+      event_ref: ${{ github.event.inputs.ref }}
 
   run_test_cases:
     needs:

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -145,7 +145,11 @@ jobs:
         env:
           PROFILE: ${{ matrix.profile }}
           ENABLE_COVER_COMPILE: 1
+          IS_RELEASE: ${{ needs.prepare.outputs.release }}
         run: |
+          if [ "$IS_RELEASE" != true ]; then
+            make ensure-rebar3 test-compile
+          fi
           make $PROFILE
           echo "export PROFILE=${PROFILE}" | tee -a env.sh
           echo "export PKG_VSN=$(./pkg-vsn.sh ${PROFILE})" | tee -a env.sh
@@ -179,7 +183,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh --repo ${{ github.repository }} workflow run performance_test.yaml -f version=${GITHUB_REF_NAME##[v|e]} 
+          gh --repo ${{ github.repository }} workflow run performance_test.yaml -f version=${GITHUB_REF_NAME##[v|e]}
   update_emqx_i18n:
     if: needs.prepare.outputs.release == 'true'
     needs:
@@ -212,6 +216,7 @@ jobs:
       builder: ${{ needs.init.outputs.BUILDER }}
       before_ref: ${{ github.event.before }}
       after_ref: ${{ github.sha }}
+      event_ref: ${{ github.event.inputs.ref }}
 
   run_test_cases:
     if: needs.prepare.outputs.release != 'true'

--- a/.github/workflows/run_emqx_app_tests.yaml
+++ b/.github/workflows/run_emqx_app_tests.yaml
@@ -19,6 +19,9 @@ on:
       after_ref:
         required: true
         type: string
+      event_ref:
+        required: false
+        type: string
 
 env:
   IS_CI: "yes"
@@ -39,6 +42,7 @@ jobs:
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
+        ref: ${{ inputs.event_ref }}
         fetch-depth: 0
     - name: prepare test matrix
       id: matrix


### PR DESCRIPTION
I noticed that coverage reports haven't been uploaded in a while for `release-5*`, and it seems to be due the following:

```
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
===> Hook for compile failed!

make: *** [Makefile:74: eunit] Error 1
```

https://github.com/emqx/emqx/actions/runs/19102784867/job/54579280495
