### PR TITLE
chore: upgrade to brod 4.4.7

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -281,7 +281,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:kafka_protocol),
     do: {:kafka_protocol, "4.3.0", override: true}
 
-  def common_dep(:brod), do: {:brod, "4.4.6"}
+  def common_dep(:brod), do: {:brod, "4.4.7"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}


### PR DESCRIPTION
No user impact.
- Bring dependency of dependency to consitency
- brod-4.4.7 added a `warning` level log message in consumer group member process which can help to troubleshoot in some (probably rare) cases. (only observed in CI though)