### PR TITLE
chore: bump to `ekka` 0.23.2 including `mria` 0.8.18 [r58]

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -29,7 +29,7 @@
     {gproc, "1.0.0"},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.44.0"}}},
     {emqx_http_lib, {git, "https://github.com/emqx/emqx_http_lib.git", {tag, "0.5.3"}}},

--- a/mix.exs
+++ b/mix.exs
@@ -186,7 +186,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.21.2", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.2", override: true}
   def common_dep(:esockd), do: {:esockd, github: "emqx/esockd", tag: "5.13.0", override: true}
   def common_dep(:gproc), do: {:gproc, "1.0.0", override: true}
   def common_dep(:hocon), do: {:hocon, github: "emqx/hocon", tag: "0.44.0", override: true}

--- a/rebar.config
+++ b/rebar.config
@@ -84,7 +84,7 @@
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.2"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.13.0"}}},
     {rocksdb, {git, "https://github.com/emqx/erlang-rocksdb", {tag, "1.8.0-emqx-10"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.21.2"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.23.2"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "3.4.1"}}},
     {grpc, {git, "https://github.com/emqx/grpc-erl", {tag, "0.7.1"}}},
     {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.4.8"}}},


### PR DESCRIPTION
Release version: 5.8.9

## Summary

Backport of #16123.
