### PR TITLE
v6: fix(dashboard): old db record (before 5.3) upgrade

### DIFF
--- a/changes/ee/fix-16308.en.md
+++ b/changes/ee/fix-16308.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where Multi-Factor Authentication (MFA) could not be enabled after upgrading EMQX from versions earlier than 5.3.0 due to incompatible login-user database records.


### PR DESCRIPTION
Before 5.3, the default value for the 'extra' record for admin table is an empty list `[]`, it was later changed to an empty map `#{}`.

Later, features like password expiration and MFA assumed the default value to be `#{}`, this made not possible to enable MFA after upgrade.

Fixes https://github.com/emqx/emqx/issues/16297

<!--
5.8.9
5.9.2
5.10.2
6.0.1
6.1.0
-->
Release version: 6.0.2, 6.1.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
