### PR TITLE
perf(ns api): optimize deletion of implicit namespaces

### DIFF
--- a/apps/emqx_mt/src/emqx_mt_config.erl
+++ b/apps/emqx_mt/src/emqx_mt_config.erl
@@ -191,7 +191,8 @@ create_managed_ns(Ns) ->
 delete_managed_ns(Ns) ->
     maybe
         {ok, Configs} ?= emqx_mt_state:delete_managed_ns(Ns),
-        emqx_mt_config_proto_v1:cleanup_managed_ns_configs(Ns, maps:to_list(Configs)),
+        map_size(Configs) > 0 andalso
+            emqx_mt_config_proto_v1:cleanup_managed_ns_configs(Ns, maps:to_list(Configs)),
         _ = emqx_mt_client_kicker:start_kicking(Ns),
         ok = emqx_mt_config_janitor:clean_namespace(Ns),
         ok


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14933

Release version: 6.1.0

## Summary

```elixir
nss = 1..500 |> Enum.map(& "deleteme#{&1}")

nss |> Enum.each(&:emqx_mt_state.ensure_ns_added/1)

:timer.tc(fn -> :emqx_mt_api."/mt/bulk_delete_ns"(:delete, %{body: %{nss: nss}}) end, :millisecond)
```

Before: ~ 3434 ms

After: ~ 41 ms

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
