### PR TITLE
chore: Log cache cleanup only when records are deleted

### DIFF
--- a/apps/emqx_auth/src/emqx_auth_cache.erl
+++ b/apps/emqx_auth/src/emqx_auth_cache.erl
@@ -274,10 +274,11 @@ cleanup(#{name := Name, tab := Tab}) ->
     Now = now_ms_monotonic(),
     MS = ets:fun2ms(fun(#cache_record{expire_at = ExpireAt}) when ExpireAt < Now -> true end),
     NumDeleted = ets:select_delete(Tab, MS),
-    ?tp(debug, auth_cache_cleanup, #{
-        name => Name,
-        num_deleted => NumDeleted
-    }),
+    NumDeleted > 0 andalso
+        ?tp(debug, auth_cache_cleanup, #{
+            name => Name,
+            num_deleted => NumDeleted
+        }),
     ok.
 
 update_stats(#{tab := Tab, stat_tab := StatTab} = PtState) ->


### PR DESCRIPTION
Updated the cleanup function to log cache cleanup events only if records were actually deleted, reducing unnecessary debug logs.
port https://github.com/emqx/emqx/pull/16231 to v6