### PR TITLE
fix(emqx_ds_schema): escape dot in bytes size regex pattern

### DIFF
--- a/apps/emqx/src/emqx_ds_schema.erl
+++ b/apps/emqx/src/emqx_ds_schema.erl
@@ -694,7 +694,7 @@ to_size_limit(In) when is_integer(In), In > 0 ->
 to_size_limit(In) when In =:= infinity; In =:= "infinity"; In =:= <<"infinity">> ->
     {ok, infinity};
 to_size_limit(In) when is_list(In); is_binary(In) ->
-    RE = "^([0-9]+)(.[0-9]{1,3})? *([kKMGTPEZYRQ]i?B)?$",
+    RE = "^([0-9]+)(\\.[0-9]{1,3})? *([kKMGTPEZYRQ]i?B)?$",
     case re:run(In, RE, [{capture, all_but_first, list}]) of
         {match, [Nstr]} ->
             {ok, list_to_integer(Nstr)};


### PR DESCRIPTION
No significant user experience impact unless someone is actually using a invalid number for size configs for DS.

e.g. `foo_bar_size = 2a0KB` instead of `2.0KB`.