### PR TITLE
refactor: delete system_monitor app and sysmon_top config

### DIFF
--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -1538,13 +1538,6 @@ fields("sysmon") ->
                 ref("sysmon_os"),
                 #{}
             )},
-        {"top",
-            sc(
-                ref("sysmon_top"),
-                %% Userful monitoring solution when benchmarking,
-                %% but hardly common enough for regular users.
-                #{importance => ?IMPORTANCE_HIDDEN}
-            )},
         {"mnesia_tm_mailbox_size_alarm_threshold",
             sc(
                 pos_integer(),
@@ -1677,83 +1670,6 @@ fields("sysmon_os") ->
                 #{
                     default => <<"5%">>,
                     desc => ?DESC(sysmon_os_procmem_high_watermark)
-                }
-            )}
-    ];
-fields("sysmon_top") ->
-    [
-        {"num_items",
-            sc(
-                non_neg_integer(),
-                #{
-                    mapping => "system_monitor.top_num_items",
-                    default => 10,
-                    desc => ?DESC(sysmon_top_num_items)
-                }
-            )},
-        {"sample_interval",
-            sc(
-                emqx_schema:duration(),
-                #{
-                    mapping => "system_monitor.top_sample_interval",
-                    default => <<"2s">>,
-                    desc => ?DESC(sysmon_top_sample_interval)
-                }
-            )},
-        {"max_procs",
-            sc(
-                non_neg_integer(),
-                #{
-                    mapping => "system_monitor.top_max_procs",
-                    default => 1_000_000,
-                    desc => ?DESC(sysmon_top_max_procs)
-                }
-            )},
-        {"db_hostname",
-            sc(
-                string(),
-                #{
-                    mapping => "system_monitor.db_hostname",
-                    desc => ?DESC(sysmon_top_db_hostname),
-                    default => <<>>
-                }
-            )},
-        {"db_port",
-            sc(
-                integer(),
-                #{
-                    mapping => "system_monitor.db_port",
-                    default => 5432,
-                    desc => ?DESC(sysmon_top_db_port)
-                }
-            )},
-        {"db_username",
-            sc(
-                string(),
-                #{
-                    mapping => "system_monitor.db_username",
-                    default => <<"system_monitor">>,
-                    desc => ?DESC(sysmon_top_db_username)
-                }
-            )},
-        {"db_password",
-            sc(
-                binary(),
-                #{
-                    mapping => "system_monitor.db_password",
-                    default => <<"system_monitor_password">>,
-                    desc => ?DESC(sysmon_top_db_password),
-                    converter => fun password_converter/2,
-                    sensitive => true
-                }
-            )},
-        {"db_name",
-            sc(
-                string(),
-                #{
-                    mapping => "system_monitor.db_name",
-                    default => <<"postgres">>,
-                    desc => ?DESC(sysmon_top_db_name)
                 }
             )}
     ];
@@ -2383,10 +2299,6 @@ desc("sysmon_vm") ->
 desc("sysmon_os") ->
     "This part of the configuration is responsible for monitoring\n"
     " the host OS health, such as free memory, disk space, CPU load, etc.";
-desc("sysmon_top") ->
-    "This part of the configuration is responsible for monitoring\n"
-    " the Erlang processes in the VM. This information can be sent to an external\n"
-    " PostgreSQL database. This feature is inactive unless the PostgreSQL sink is configured.";
 desc("alarm") ->
     "Settings for the alarms.";
 desc("trace") ->

--- a/apps/emqx/test/emqx_common_test_helpers.erl
+++ b/apps/emqx/test/emqx_common_test_helpers.erl
@@ -273,16 +273,7 @@ boot_modules(Mods) ->
 
 -spec start_apps(Apps :: apps()) -> ok.
 start_apps(Apps) ->
-    %% to avoid keeping the `db_hostname' that is set when loading
-    %% `system_monitor' application in `emqx_machine', and then it
-    %% crashing when trying to connect.
-    %% FIXME: add an `enable' option to sysmon_top and use that to
-    %% decide whether to start it or not.
-    DefaultHandler =
-        fun(_) ->
-            application:set_env(system_monitor, db_hostname, ""),
-            ok
-        end,
+    DefaultHandler = fun(_) -> ok end,
     start_apps(Apps, DefaultHandler, #{}).
 
 -spec start_apps(Apps :: apps(), Handler :: special_config_handler()) -> ok.

--- a/apps/emqx_machine/mix.exs
+++ b/apps/emqx_machine/mix.exs
@@ -22,7 +22,7 @@ defmodule EMQXMachine.MixProject do
   def application do
     [
       extra_applications: UMP.extra_applications(),
-      included_applications: [:system_monitor],
+      included_applications: [],
       mod: {:emqx_machine_app, []}
     ]
   end
@@ -35,7 +35,6 @@ defmodule EMQXMachine.MixProject do
       {:emqx_conf, in_umbrella: true, runtime: false},
       {:emqx_dashboard, in_umbrella: true, runtime: false},
       {:emqx_management, in_umbrella: true, runtime: false},
-      UMP.common_dep(:system_monitor, runtime: false),
       :redbug
     ])
   end

--- a/apps/emqx_machine/priv/reboot_lists.eterm
+++ b/apps/emqx_machine/priv/reboot_lists.eterm
@@ -30,7 +30,6 @@
             observer_cli,
             tools,
             observer,
-            {system_monitor, load},
             jq
         ],
     %% must always be of type `load'

--- a/apps/emqx_machine/src/emqx_machine.erl
+++ b/apps/emqx_machine/src/emqx_machine.erl
@@ -10,8 +10,7 @@
     brutal_shutdown/0,
     is_ready/0,
 
-    node_status/0,
-    update_vips/0
+    node_status/0
 ]).
 
 -export([open_ports_check/0]).
@@ -36,7 +35,6 @@ start() ->
             os:set_signal(sigterm, handle)
     end,
     ok = set_backtrace_depth(),
-    ok = start_sysmon(),
     configure_shard_transports(),
     set_mnesia_extra_diagnostic_checks(),
     ok = configure_otel_deps(),
@@ -66,29 +64,11 @@ set_backtrace_depth() ->
 is_ready() ->
     emqx_machine_terminator:is_running().
 
-start_sysmon() ->
-    _ = application:load(system_monitor),
-    application:set_env(system_monitor, node_status_fun, {?MODULE, node_status}),
-    application:set_env(system_monitor, status_checks, [{?MODULE, update_vips, false, 10}]),
-    case application:get_env(system_monitor, db_hostname) of
-        {ok, [_ | _]} ->
-            application:set_env(system_monitor, callback_mod, system_monitor_pg),
-            _ = application:ensure_all_started(system_monitor, temporary),
-            ok;
-        _ ->
-            %% If there is no sink for the events, there is no reason
-            %% to run system_monitor_top, ignore start
-            ok
-    end.
-
 node_status() ->
     emqx_utils_json:encode(#{
         backend => mria_rlog:backend(),
         role => mria_rlog:role()
     }).
-
-update_vips() ->
-    system_monitor:add_vip(mria_status:shards_up()).
 
 configure_shard_transports() ->
     ShardTransports = application:get_env(emqx_machine, custom_shard_transports, #{}),

--- a/mix.exs
+++ b/mix.exs
@@ -99,7 +99,6 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:jose),
       # in conflict by ehttpc and emqtt
       common_dep(:gun),
-      # in conflict by emqx_connector and system_monitor
       common_dep(:epgsql),
       # in conflict by emqx and observer_cli
       common_dep(:recon),
@@ -138,8 +137,7 @@ defmodule EMQXUmbrella.MixProject do
   def extra_release_apps() do
     [
       common_dep(:redbug),
-      common_dep(:observer_cli),
-      common_dep(:system_monitor)
+      common_dep(:observer_cli)
     ]
   end
 
@@ -210,13 +208,9 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:gpb), do: {:gpb, "4.21.5", override: true, runtime: false}
   def common_dep(:ra), do: {:ra, github: "emqx/ra", tag: "v2.16.13-emqx-1", override: true}
 
-  # in conflict by emqx_connector and system_monitor
   def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.4", override: true}
   def common_dep(:sasl_auth), do: {:sasl_auth, "2.3.3", override: true}
   def common_dep(:gen_rpc), do: {:gen_rpc, github: "emqx/gen_rpc", tag: "3.4.3", override: true}
-
-  def common_dep(:system_monitor),
-    do: {:system_monitor, github: "ieQu1/system_monitor", tag: "3.0.6"}
 
   def common_dep(:uuid), do: {:uuid, github: "okeuday/uuid", tag: "v2.0.7.1", override: true}
   def common_dep(:redbug), do: {:redbug, github: "emqx/redbug", tag: "2.0.10"}

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -15,12 +15,6 @@ Find more details in 'authorization.sources' config."""
 fields_authorization_no_match.label:
 """Authorization no match"""
 
-sysmon_top_db_hostname.desc:
-"""Hostname of the PostgreSQL database that collects the data points"""
-
-sysmon_top_db_hostname.label:
-"""DB Hostname"""
-
 zones.desc:
 """A zone is a set of configs grouped by the zone <code>name</code>.
 For flexible configuration mapping, the <code>name</code> can be set to a listener's <code>zone</code> config.
@@ -103,13 +97,6 @@ fields_listeners_wss.desc:
 
 fields_listeners_wss.label:
 """HTTPS websocket listeners"""
-
-sysmon_top_max_procs.desc:
-"""Stop collecting data when the number of processes
-in the VM exceeds this value"""
-
-sysmon_top_max_procs.label:
-"""Max procs"""
 
 mqtt_use_username_as_clientid.desc:
 """Whether to use Username as Client ID.
@@ -257,12 +244,6 @@ flapping_detect_enable.desc:
 flapping_detect_enable.label:
 """Enable flapping detection"""
 
-sysmon_top_db_password.desc:
-"""EMQX user password in the PostgreSQL database"""
-
-sysmon_top_db_password.label:
-"""DB Password"""
-
 fields_ws_opts_check_origins.desc:
 """List of allowed origins.<br/>See <code>check_origin_enable</code>."""
 
@@ -402,12 +383,6 @@ flapping_detect_ban_time.desc:
 
 flapping_detect_ban_time.label:
 """Ban time"""
-
-sysmon_top_num_items.desc:
-"""The number of top processes per monitoring group"""
-
-sysmon_top_num_items.label:
-"""Top num items"""
 
 mqtt_upgrade_qos.desc:
 """Force upgrade of QoS level according to subscription."""
@@ -1015,12 +990,6 @@ sys_topics.desc:
 sys_event_client_subscribed.desc:
 """Enable to publish event message that client subscribed a topic successfully."""
 
-sysmon_top_db_port.desc:
-"""Port of the PostgreSQL database that collects the data points."""
-
-sysmon_top_db_port.label:
-"""DB Port"""
-
 fields_mqtt_quic_listener_max_operations_per_drain.desc:
 """The maximum number of operations to drain per connection quantum. Default: 16"""
 
@@ -1082,12 +1051,6 @@ Default: 'none', Set to 'none' to use OS default keepalive settings (still activ
 
 fields_tcp_opts_keepalive.label:
 """TCP keepalive options"""
-
-sysmon_top_db_username.desc:
-"""Username of the PostgreSQL database"""
-
-sysmon_top_db_username.label:
-"""DB Username"""
 
 broker.desc:
 """Message broker options."""
@@ -1264,12 +1227,6 @@ fields_mqtt_quic_listener_maximum_mtu.desc:
 
 fields_mqtt_quic_listener_maximum_mtu.label:
 """Maximum MTU"""
-
-sysmon_top_db_name.desc:
-"""PostgreSQL database name"""
-
-sysmon_top_db_name.label:
-"""DB Name"""
 
 mqtt_strict_mode.desc:
 """Whether to parse MQTT messages in strict mode.
@@ -1682,12 +1639,6 @@ sysmon_os_cpu_check_interval.desc:
 
 sysmon_os_cpu_check_interval.label:
 """The time interval for the periodic CPU check."""
-
-sysmon_top_sample_interval.desc:
-"""Specifies how often process top should be collected"""
-
-sysmon_top_sample_interval.label:
-"""Top sample interval"""
 
 fields_mqtt_quic_listener_idle_timeout_ms.desc:
 """How long a connection can go idle before it is gracefully shut down. 0 to disable timeout"""


### PR DESCRIPTION
system_monitor is a hidden feature since long ago, time to remove it.
this also gets rid of the indirect dependency of `supervisor3`