### PR TITLE
fix(pulsar): upgrade pulsar client to 2.1.2

### DIFF
--- a/apps/emqx_bridge_pulsar/mix.exs
+++ b/apps/emqx_bridge_pulsar/mix.exs
@@ -25,7 +25,7 @@ defmodule EMQXBridgePulsar.MixProject do
     [
       UMP.common_dep(:crc32cer),
       UMP.common_dep(:snappyer),
-      {:pulsar, github: "emqx/pulsar-client-erl", tag: "2.1.0", manager: :rebar3},
+      {:pulsar, github: "emqx/pulsar-client-erl", tag: "2.1.2", manager: :rebar3},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}

--- a/apps/emqx_bridge_pulsar/rebar.config
+++ b/apps/emqx_bridge_pulsar/rebar.config
@@ -2,7 +2,7 @@
 
 {erl_opts, [debug_info]}.
 {deps, [
-    {pulsar, {git, "https://github.com/emqx/pulsar-client-erl.git", {tag, "2.1.0"}}},
+    {pulsar, {git, "https://github.com/emqx/pulsar-client-erl.git", {tag, "2.1.2"}}},
     {emqx_connector, {path, "../../apps/emqx_connector"}},
     {emqx_resource, {path, "../../apps/emqx_resource"}},
     {emqx_bridge, {path, "../../apps/emqx_bridge"}}

--- a/changes/ee/fix-16415.en.md
+++ b/changes/ee/fix-16415.en.md
@@ -1,0 +1,4 @@
+Upgrade Apache Pulsar client to 2.1.2.
+
+When Pulsar producer action's `batch_size` is configured to `1`, the producer will now encode single messages instead of single-element batch.
+This should make consumers to share load using Key Share strategy.


### PR DESCRIPTION
Fixes [EMQX-14926](https://emqx.atlassian.net/browse/EMQX-14926)

<!--
5.8.9
5.9.3
5.10.3
6.0.2
6.1.0
-->
Release version: 5.8.9, 5.9.3, 5.10.3

## Summary

Now, when Pulsar producer action's `batch_size` is configured to `1`, the producer will now encode single messages instead of single-element batch.
This should make consumers to share load using Key Share strategy.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14926]: https://emqx.atlassian.net/browse/EMQX-14926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ