### PR TITLE
refactor: delete unused code

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -54,11 +54,6 @@
     foldl_topics/2
 ]).
 
--export([
-    get_subopts/2,
-    set_subopts/2
-]).
-
 -export([topics/0]).
 
 %% gen_server callbacks
@@ -600,21 +595,6 @@ subscribed(SubPid, Topic) when is_pid(SubPid) ->
 subscribed(SubId, Topic) when ?IS_SUBID(SubId) ->
     SubPid = emqx_broker_helper:lookup_subpid(SubId),
     ets:member(?SUBOPTION, {Topic, SubPid}).
-
--spec get_subopts(pid(), emqx_types:topic() | emqx_types:share()) -> option(emqx_types:subopts()).
-get_subopts(SubPid, Topic) when is_pid(SubPid), ?IS_TOPIC(Topic) ->
-    lookup_value(?SUBOPTION, {Topic, SubPid});
-get_subopts(SubId, Topic) when ?IS_SUBID(SubId) ->
-    case emqx_broker_helper:lookup_subpid(SubId) of
-        SubPid when is_pid(SubPid) ->
-            get_subopts(SubPid, Topic);
-        undefined ->
-            undefined
-    end.
-
--spec set_subopts(emqx_types:topic() | emqx_types:share(), emqx_types:subopts()) -> boolean().
-set_subopts(Topic, NewOpts) when is_binary(Topic), is_map(NewOpts) ->
-    set_subopts(self(), Topic, NewOpts).
 
 %% @private
 set_subopts(SubPid, Topic, NewOpts) ->

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -152,37 +152,6 @@ t_subscribed_2(Config) when is_list(Config) ->
 t_subscribed_2({'end', _Config}) ->
     emqx_broker:unsubscribe(<<"topic">>).
 
-t_subopts({init, Config}) ->
-    Config;
-t_subopts(Config) when is_list(Config) ->
-    ?assertEqual(false, emqx_broker:set_subopts(<<"topic">>, #{qos => 1})),
-    ?assertEqual(undefined, emqx_broker:get_subopts(self(), <<"topic">>)),
-    ?assertEqual(undefined, emqx_broker:get_subopts(<<"clientid">>, <<"topic">>)),
-    emqx_broker:subscribe(<<"topic">>, <<"clientid">>, #{qos => 1}),
-    timer:sleep(200),
-    ?assertEqual(
-        #{nl => 0, qos => 1, rap => 0, rh => 0, subid => <<"clientid">>},
-        emqx_broker:get_subopts(self(), <<"topic">>)
-    ),
-    ?assertEqual(
-        #{nl => 0, qos => 1, rap => 0, rh => 0, subid => <<"clientid">>},
-        emqx_broker:get_subopts(<<"clientid">>, <<"topic">>)
-    ),
-
-    emqx_broker:subscribe(<<"topic">>, <<"clientid">>, #{qos => 2}),
-    ?assertEqual(
-        #{nl => 0, qos => 2, rap => 0, rh => 0, subid => <<"clientid">>},
-        emqx_broker:get_subopts(self(), <<"topic">>)
-    ),
-
-    ?assertEqual(true, emqx_broker:set_subopts(<<"topic">>, #{qos => 0})),
-    ?assertEqual(
-        #{nl => 0, qos => 0, rap => 0, rh => 0, subid => <<"clientid">>},
-        emqx_broker:get_subopts(self(), <<"topic">>)
-    );
-t_subopts({'end', _Config}) ->
-    emqx_broker:unsubscribe(<<"topic">>).
-
 t_topics({init, Config}) ->
     Topics = [<<"topic">>, <<"topic/1">>, <<"topic/2">>],
     [{topics, Topics} | Config];

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -1162,11 +1162,7 @@ t_different_groups_update_subopts(Config) when is_list(Config) ->
     SharedTopicGroupB = format_share(GroupB, Topic),
 
     Fun = fun(Group, QoS) ->
-        ?UPDATE_SUB_QOS(C, format_share(Group, Topic), QoS),
-        ?assertMatch(
-            #{qos := QoS},
-            emqx_broker:get_subopts(ClientId, emqx_topic:make_shared_record(Group, Topic))
-        )
+        ?UPDATE_SUB_QOS(C, format_share(Group, Topic), QoS)
     end,
 
     [Fun(Group, QoS) || QoS <- [?QOS_0, ?QOS_1, ?QOS_2], Group <- [GroupA, GroupB]],

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -439,7 +439,6 @@ t_subscribe_with_qos_opt(_) ->
         timer:sleep(100),
         [SubPid] = emqx:subscribers(Topic),
         ?assert(is_pid(SubPid)),
-        ?assertEqual(Qos, maps:get(qos, emqx_broker:get_subopts(SubPid, Topic))),
         %% publish a message
         emqx:publish(emqx_message:make(Topic, Payload)),
         {ok, content, Notify} = with_response(Channel),


### PR DESCRIPTION
emqx_broker:get_subopts was only used in tests.
it is now deleted as a pre-step to decommission the SUBID table