### PR TITLE
refactor: Remove SubId-to-Pid lookup from subscription checking

### DIFF
--- a/apps/emqx/src/emqx.erl
+++ b/apps/emqx/src/emqx.erl
@@ -167,7 +167,13 @@ subscriptions(SubPid) when is_pid(SubPid) ->
 subscribed(SubPid, Topic) when is_pid(SubPid) ->
     emqx_broker:subscribed(SubPid, iolist_to_binary(Topic));
 subscribed(SubId, Topic) when is_atom(SubId); is_binary(SubId) ->
-    emqx_broker:subscribed(SubId, iolist_to_binary(Topic)).
+    case emqx_cm:lookup_channels(local, SubId) of
+        [] ->
+            false;
+        Pids ->
+            %% last is the latest (hopefully)
+            subscribed(lists:last(Pids), Topic)
+    end.
 
 %%--------------------------------------------------------------------
 %% Config API

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -587,13 +587,8 @@ subscriptions_via_topic(Topic) ->
     MatchSpec = [{{{Topic, '_'}, '_'}, [], ['$_']}],
     ets:select(?SUBOPTION, MatchSpec).
 
--spec subscribed(
-    pid() | emqx_types:subid(), emqx_types:topic() | emqx_types:share()
-) -> boolean().
+-spec subscribed(pid(), emqx_types:topic() | emqx_types:share()) -> boolean().
 subscribed(SubPid, Topic) when is_pid(SubPid) ->
-    ets:member(?SUBOPTION, {Topic, SubPid});
-subscribed(SubId, Topic) when ?IS_SUBID(SubId) ->
-    SubPid = emqx_broker_helper:lookup_subpid(SubId),
     ets:member(?SUBOPTION, {Topic, SubPid}).
 
 %% @private

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_subs.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_subs.erl
@@ -595,7 +595,7 @@ assert_runtime_direct_subscription(Topic, _SubOpts, #{id := SessionId}) ->
                 "broker routes"
             ]
     end,
-    case emqx_broker:subscribed(SessionId, Topic) of
+    case emqx:subscribed(SessionId, Topic) of
         true ->
             Acc2 = [];
         false ->

--- a/apps/emqx/test/emqx_SUITE.erl
+++ b/apps/emqx/test/emqx_SUITE.erl
@@ -47,14 +47,11 @@ t_emqx_pubsub_api(_) ->
         ],
         emqx:subscriptions(self())
     ),
-    ?assertEqual(true, emqx:subscribed(self(), Topic)),
-    ?assertEqual(true, emqx:subscribed(ClientId, Topic)),
-    ?assertEqual(true, emqx:subscribed(self(), Topic1)),
-    ?assertEqual(true, emqx:subscribed(ClientId, Topic1)),
-    ?assertEqual(true, emqx:subscribed(self(), Topic2)),
-    ?assertEqual(true, emqx:subscribed(ClientId, Topic2)),
-    ?assertEqual(false, emqx:subscribed(self(), Topic3)),
-    ?assertEqual(false, emqx:subscribed(ClientId, Topic3)),
+    SubscribedTopics = [Topic, Topic1, Topic2],
+    ?assert(lists:all(fun(T) -> emqx:subscribed(self(), T) end, SubscribedTopics)),
+    ?assertNot(emqx:subscribed(self(), Topic3)),
+    %% These emqx_broker_helper do not track client IDs from emqx:subscribe/2 calls
+    ?assertNot(lists:any(fun(T) -> emqx:subscribed(ClientId, T) end, [Topic3 | SubscribedTopics])),
     emqx:publish(emqx_message:make(Topic, Payload)),
     receive
         {deliver, Topic, #message{payload = Payload}} ->

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -139,8 +139,7 @@ t_subscribed({init, Config}) ->
     emqx_broker:subscribe(<<"topic">>),
     Config;
 t_subscribed(Config) when is_list(Config) ->
-    ?assertEqual(false, emqx_broker:subscribed(undefined, <<"topic">>)),
-    ?assertEqual(true, emqx_broker:subscribed(self(), <<"topic">>));
+    ?assertEqual(true, emqx:subscribed(self(), <<"topic">>));
 t_subscribed({'end', _Config}) ->
     emqx_broker:unsubscribe(<<"topic">>).
 

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -170,6 +170,8 @@ t_cm(_) ->
     {ok, _} = emqtt:connect(C),
     ?WAIT(#{clientinfo := #{clientid := ClientId}} = emqx_cm:get_chan_info(ClientId), 2),
     emqtt:subscribe(C, <<"mytopic">>, 0),
+    ?assert(emqx:subscribed(ClientId, <<"mytopic">>)),
+    ?assertNot(emqx:subscribed(<<"dummy">>, <<"mytopic">>)),
     ?WAIT(
         begin
             Stats = emqx_cm:get_chan_stats(ClientId),


### PR DESCRIPTION
This refactoring removes the dependency on `emqx_broker_helper:lookup_subpid`
when checking if a subscriber has subscribed to a given topic.

**Changes:**
- `emqx_broker:subscribed/2` now only accepts process IDs (Pid), removing
  the SubId overload that previously used `lookup_subpid`
- `emqx:subscribed/2` (public API) maintains backward compatibility by
  handling `SubId` lookups via `emqx_cm:lookup_channels` instead of
  `emqx_broker_helper:lookup_subpid`
- Updated `emqx_persistent_session_ds_subs` (test code) to use the public API

**Impact:**
- Internal usage of `emqx_broker:subscribed/2` with SubId was only in tests,
  which have been updated
- The public `emqx:subscribed/2` API remains backward compatible for plugins
  and external code that pass SubId (client ID)
- This change is a step toward eventually removing the `SUBID` ETS table, as
  subscription checking no longer depends on the SubId→Pid mapping

**Note:** The `lookup_subpid` function is still used by `emqx_broker:subscriptions/1`,
more fixes will follow.