### PR TITLE
feat(scram_authn): return correct user_id after creation

### DIFF
--- a/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_scram_mnesia.erl
@@ -152,7 +152,7 @@ add_user(UserInfo, State) ->
     trans(fun ?MODULE:do_add_user/1, [UserInfoRecord]).
 
 do_add_user(
-    #user_info{user_id = {UserID, _} = DBUserID, is_superuser = IsSuperuser} = UserInfoRecord
+    #user_info{user_id = {_, UserID} = DBUserID, is_superuser = IsSuperuser} = UserInfoRecord
 ) ->
     case mnesia:read(?TAB, DBUserID, write) of
         [] ->

--- a/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_scram_mnesia_SUITE.erl
@@ -266,10 +266,11 @@ t_destroy(_) ->
 
 t_add_user(_) ->
     Config = config(),
-    {ok, State} = emqx_authn_scram_mnesia:create(<<"id">>, Config),
+    {ok, State} = emqx_authn_scram_mnesia:create(<<"authn-id">>, Config),
 
     User = #{user_id => <<"u">>, password => <<"p">>},
-    {ok, _} = emqx_authn_scram_mnesia:add_user(User, State),
+    {ok, #{is_superuser := false, user_id := <<"u">>}} =
+        emqx_authn_scram_mnesia:add_user(User, State),
     {error, already_exist} = emqx_authn_scram_mnesia:add_user(User, State).
 
 t_delete_user(_) ->

--- a/changes/ee/fix-16459.en.md
+++ b/changes/ee/fix-16459.en.md
@@ -1,0 +1,1 @@
+Fixed the ussue in SCRAM authentication HTTP API. Previously, incorrect user ID was returned for the created user in the user creation API call.


### PR DESCRIPTION
Fixes [14982](https://emqx.atlassian.net/browse/EMQX-14982)

Release version: 6.0.2

## Summary

In 6.1, due to introduction of tenants, the code changed and the bug was implicitly fixed.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
