### PR TITLE
feat: add config namespace_as_mountpoint

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2154,9 +2154,19 @@ get_user_property_as_map(#mqtt_packet_connect{properties = #{'User-Property' := 
 get_user_property_as_map(_) ->
     #{}.
 
-fix_mountpoint(#{mountpoint := undefined} = ClientInfo) ->
-    ClientInfo;
-fix_mountpoint(ClientInfo = #{mountpoint := MountPoint}) ->
+fix_mountpoint(#{mountpoint := undefined, zone := Zone} = ClientInfo) ->
+    case get_mqtt_conf(Zone, namespace_as_mountpoint, false) of
+        true ->
+            case get_tenant_namespace(ClientInfo) of
+                undefined ->
+                    ClientInfo;
+                Tns ->
+                    ClientInfo#{mountpoint => iolist_to_binary([Tns, "/"])}
+            end;
+        false ->
+            ClientInfo
+    end;
+fix_mountpoint(#{mountpoint := MountPoint} = ClientInfo) ->
     MountPoint1 = emqx_mountpoint:replvar(MountPoint, ClientInfo),
     ClientInfo#{mountpoint := MountPoint1}.
 

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4079,7 +4079,12 @@ mqtt_general() ->
                     desc => ?DESC("clientid_override"),
                     converter => fun compile_variform_allow_disabled/2
                 }
-            )}
+            )},
+        {"namespace_as_mountpoint",
+            sc(boolean(), #{
+                default => false,
+                desc => ?DESC("namespace_as_mountpoint")
+            })}
     ].
 %% All session's importance should be lower than general part to organize document.
 mqtt_session() ->

--- a/apps/emqx/test/emqx_config_SUITE.erl
+++ b/apps/emqx/test/emqx_config_SUITE.erl
@@ -519,7 +519,8 @@ zone_global_defaults() ->
                 use_username_as_clientid => false,
                 wildcard_subscription => true,
                 client_attrs_init => [],
-                clientid_override => disabled
+                clientid_override => disabled,
+                namespace_as_mountpoint => false
             },
         overload_protection =>
             #{

--- a/changes/ee/feat-16472.en.md
+++ b/changes/ee/feat-16472.en.md
@@ -1,0 +1,4 @@
+Added a new configuration option `namespace_as_mountpoint` to enable automatic topic isolation using client namespaces.
+When enabled, EMQX uses the client's namespace (from `client_attrs.tns`) as a topic mountpoint if no mountpoint is configured on the listener.
+Topics are automatically prefixed with the namespace for PUBLISH, SUBSCRIBE, UNSUBSCRIBE, and Will messages, and the prefix is stripped when delivering messages to clients.
+This setting is ignored if the listener already has a mountpoint configured, ensuring existing configurations take precedence.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1841,28 +1841,28 @@ client_attrs_init_set_as_attr {
 clientid_override {
   label: "Client ID Override Expression"
   desc: """~
-    A one line expression to evaluate a set of predefined string functions (like in the rule engine SQL statements).
-    The expression can be a function call with nested calls as its arguments, or direct variable reference.
-    So far, it does not provide user-defined variable binding (like `var a=1`) or user-defined functions.
-    As an example, to extract the prefix of username delimited by a dot: `nth(1, tokens(username, '.'))`.
+    Override the Client ID using a Variform expression.
+    Example: `concat(client_attrs.tns, '-', clientid)` adds the namespace as a prefix.
+    This allows clients in different namespaces to connect using the same Client ID without conflict.
+    See EMQX documentation for expression syntax.~"""
+}
 
-    The variables pre-bound variables are:
-    - `clientid`: The original MQTT Client ID.
-    - `username`: MQTT Client's username.
-    - `client_attrs.{NAME}`: Client attributes initialized by per config `client_attrs_init`.
-    For TLS clients, connected directly or via proxy-protocol (v2) enabled load balancer,
-    some extra variables can be used:
-    - `cn`: Client's TLS certificate common name.
-    - `dn`: Client's TLS certificate distinguished name (the subject).
-    - `peersni`: TLS server name indication sent by the client.
-
-    You can read more about variform expressions in EMQX docs."""
+namespace_as_mountpoint {
+  label: "Use Namespace as Topic Mountpoint"
+  desc: """~
+    Uses the client's namespace as a topic mountpoint. This setting is ignored if the listener already has a `mountpoint` configured.
+    When enabled, EMQX isolates topics by:
+      - Prepending the namespace to topics in PUBLISH, SUBSCRIBE, UNSUBSCRIBE, and Will messages.
+      - Stripping this prefix from messages delivered to the client.
+    Example (Namespace `n1`):
+      - Client subscribes to `sensors/#` -> Broker registers `n1/sensors/#`.
+      - Broker routes `n1/sensors/data` -> Client receives `sensors/data`.~"""
 }
 
 authz_include_mountpoint {
   label: "Mount Prefix for Authorization"
   desc: """~
-    When enabled, the target topics and topic filters are prefixed by the listener's configured mountpoint before being checked by authorization backends.~"""
+    When enabled, the target topics and topic filters are prefixed by the topic mountpoint before being matched against ACL rules or by authorization backends.~"""
 }
 
 banned_bootstrap_file.desc:


### PR DESCRIPTION
Fixes [EMQX-14988](https://emqx.atlassian.net/browse/EMQX-14988)

<!--
5.8.9
5.9.3
5.10.3
6.0.2
6.1.0
-->
Release version: 6.1.0

## Summary

Topic isolation for namespaces is an after-math of the legacy 'mountpoint' feature which is configured in listener.
Previously, to configure namespace isolation, one will need to configure at different places.

1. Extract namespace from client info (MQTT settings)
2. Client ID override (MQTT settings)
3. Mount prefix for ACL (Authorization settings)
4. Mountpoint (Listener)

1 ~ 3 are relatively straightforward because they are global settings
4 is a bit tricky, because there can be multiple listeners.

This PR makes it easier for 4 by introducing a new config named `namespace_as_mountpoint` (MQTT setting).
When set to true, it uses `{namespace}/` as mountpoint given namespace has been successfully extracted.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14988]: https://emqx.atlassian.net/browse/EMQX-14988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ