### PR TITLE
test: fix flaky tests

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_source_SUITE.erl
@@ -512,13 +512,9 @@ t_static_clientids(TCConfig) ->
                 Publishes0
             )
         ),
-    ?assertMatch(
-        #{
-            N2Bin := [<<"1">>, <<"2">>, <<"3">>],
-            N3Bin := [<<"1">>, <<"2">>, <<"3">>]
-        },
-        Publishes
-    ),
+    #{N2Bin := Msgs2, N3Bin := Msgs3} = Publishes,
+    ?assertEqual([<<"1">>, <<"2">>, <<"3">>], lists:sort(Msgs2)),
+    ?assertEqual([<<"1">>, <<"2">>, <<"3">>], lists:sort(Msgs3)),
     ?assertEqual([], emqx_common_test_helpers:wait_publishes(10, 100)),
     ?retry(
         500,


### PR DESCRIPTION
The publishes are sent by 3 MQTT clients connected to 3 nodes and collected by 2 subscribers.
Ordering can be quite loose