### PR TITLE
chore: remove version prefix in shell prompt

### DIFF
--- a/apps/emqx_machine/src/emqx_restricted_shell.erl
+++ b/apps/emqx_machine/src/emqx_restricted_shell.erl
@@ -48,10 +48,9 @@ set_prompt_func() ->
 prompt_func(PropList) ->
     Line = proplists:get_value(history, PropList, 1),
     Version = emqx_release:version(),
-    Prefix = emqx_release:edition_vsn_prefix(),
     case is_alive() of
-        true -> io_lib:format(<<"~ts~ts(~s)~w> ">>, [Prefix, Version, node(), Line]);
-        false -> io_lib:format(<<"~ts~ts ~w> ">>, [Prefix, Version, Line])
+        true -> io_lib:format(<<"~ts(~s)~w> ">>, [Version, node(), Line]);
+        false -> io_lib:format(<<"~ts ~w> ">>, [Version, Line])
     end.
 
 local_allowed(MF, Args, State) ->


### PR DESCRIPTION
Since we no longer use prefix for git tags.
This is only a display change when EMQX is started in console mode or the prompt in remote console. Should not impact any user interface contact.