### PR TITLE
feat: move base64 encode/decode functions to variform bif

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -1132,102 +1132,23 @@ zip_uncompress(S) when is_binary(S) ->
 %% Data encode and decode Funcs
 %%------------------------------------------------------------------------------
 
--doc """
-Helper function to process base64 encoding/decoding options.
-
-Supported options:
-- `<<"no_padding">>` - Disable padding in base64 encoding/decoding
-- `<<"urlsafe">>` - Use URL-safe base64 encoding/decoding (replaces + with -, / with _)
-- Any other option - Returns Opts unchanged (no-op)
-""".
-base64_opts(Opts, <<"no_padding">>) ->
-    Opts#{padding => false};
-base64_opts(Opts, <<"urlsafe">>) ->
-    Opts#{mode => urlsafe};
-base64_opts(Opts, _) ->
-    Opts.
-
 base64_encode(Data) when is_binary(Data) ->
-    base64:encode(Data).
+    emqx_variform_bif:base64_encode(Data).
 
--doc """
-Encode binary data to base64 string with a single option.
+base64_encode(Data, Opt) when is_binary(Data) ->
+    emqx_variform_bif:base64_encode(Data, Opt).
 
-Options:
-- `<<"no_padding">>` - Encode without padding characters (=)
-- `<<"urlsafe">>` - Use URL-safe encoding (replaces + with -, / with _)
-
-Examples:
-  base64_encode(<<"hello">>, <<"no_padding">>)
-  base64_encode(<<"test">>, <<"urlsafe">>)
-""".
-base64_encode(Data, Opt) ->
-    Options = base64_opts(#{}, Opt),
-    base64:encode(Data, Options).
-
--doc """
-Encode binary data to base64 string with two options.
-
-Options:
-- `<<"no_padding">>` - Encode without padding characters (=)
-- `<<"urlsafe">>` - Use URL-safe encoding (replaces + with -, / with _)
-
-Both options can be specified in any order. If the same option is specified twice,
-it will be applied once.
-
-Examples:
-  base64_encode(<<"hello">>, <<"no_padding">>, <<"urlsafe">>)
-  base64_encode(<<"test">>, <<"urlsafe">>, <<"no_padding">>)
-""".
-base64_encode(Data, Opt1, Opt2) ->
-    Options0 = base64_opts(#{}, Opt1),
-    Options = base64_opts(Options0, Opt2),
-    base64:encode(Data, Options).
+base64_encode(Data, Opt1, Opt2) when is_binary(Data) ->
+    emqx_variform_bif:base64_encode(Data, Opt1, Opt2).
 
 base64_decode(Data) when is_binary(Data) ->
-    base64:decode(Data).
+    emqx_variform_bif:base64_decode(Data).
 
--doc """
-Decode base64 string to binary data with a single option.
+base64_decode(Data, Opt) when is_binary(Data) ->
+    emqx_variform_bif:base64_decode(Data, Opt).
 
-By default, this function requires padding. Use `<<"no_padding">>` to decode
-strings without padding.
-
-Options:
-- `<<"no_padding">>` - Allow decoding without padding characters (=)
-- `<<"urlsafe">>` - Decode URL-safe base64 (handles - and _ characters)
-
-Examples:
-  base64_decode(<<"aGVsbG8=">>) - Decode padded string (default)
-  base64_decode(<<"aGVsbG8">>, <<"no_padding">>) - Decode unpadded string
-  base64_decode(<<"aGVsbG8-">>, <<"urlsafe">>) - Decode padded URL-safe string
-  base64_decode(<<"aGVsbG8-">>, <<"urlsafe">>, <<"no_padding">>) - Decode unpadded URL-safe string
-""".
-base64_decode(Data, Opt) ->
-    Options = base64_opts(#{}, Opt),
-    base64:decode(Data, Options).
-
--doc """
-Decode base64 string to binary data with two options.
-
-By default, this function requires padding. Use `<<"no_padding">>` to decode
-strings without padding.
-
-Options:
-- `<<"no_padding">>` - Allow decoding without padding characters (=)
-- `<<"urlsafe">>` - Decode URL-safe base64 (handles - and _ characters)
-
-Both options can be specified in any order. If the same option is specified twice,
-it will be applied once.
-
-Examples:
-  base64_decode(<<"aGVsbG8-">>, <<"urlsafe">>, <<"no_padding">>)
-  base64_decode(<<"aGVsbG8-">>, <<"no_padding">>, <<"urlsafe">>)
-""".
 base64_decode(Data, Opt1, Opt2) ->
-    Options0 = base64_opts(#{}, Opt1),
-    Options = base64_opts(Options0, Opt2),
-    base64:decode(Data, Options).
+    emqx_variform_bif:base64_decode(Data, Opt1, Opt2).
 
 json_encode(Data) ->
     emqx_utils_json:encode(Data).


### PR DESCRIPTION
A follow up of PR https://github.com/emqx/emqx/pull/16524.
Move them to varifrom bif functions so it can be used in auth configs.