### PR TITLE
Refactor: const module for `sni_fun`

### DIFF
--- a/apps/emqx/src/emqx_const_v1.erl
+++ b/apps/emqx/src/emqx_const_v1.erl
@@ -4,7 +4,18 @@
 
 -module(emqx_const_v1).
 
--export([make_sni_fun/1]).
+-export([make_sni_fun/1, make_managed_certs_sni_fun/1]).
 
 make_sni_fun(ListenerID) ->
     fun(SN) -> emqx_ocsp_cache:sni_fun(SN, ListenerID) end.
+
+make_managed_certs_sni_fun(PerSNIOpts) ->
+    fun(ServerName) ->
+        case maps:find(ServerName, PerSNIOpts) of
+            {ok, SNIOpts} ->
+                SNIOpts;
+            error ->
+                %% Fallback to default opts
+                undefined
+        end
+    end.

--- a/apps/emqx/src/emqx_tls_lib.erl
+++ b/apps/emqx/src/emqx_tls_lib.erl
@@ -777,15 +777,7 @@ mk_managed_certs_sni_fun([_ | _] = ManagedCertOpts, Opts) ->
         true ->
             [];
         false ->
-            SNIFn = fun(ServerName) ->
-                case maps:find(ServerName, PerSNIOpts) of
-                    {ok, SNIOpts} ->
-                        SNIOpts;
-                    error ->
-                        %% Fallback to default opts
-                        undefined
-                end
-            end,
+            SNIFn = emqx_const_v1:make_managed_certs_sni_fun(PerSNIOpts),
             [{sni_fun, SNIFn}]
     end.
 


### PR DESCRIPTION
So far, no hot-upgrade on `release-61` yet, so we can still mutate the const module.