### PR TITLE
refactor: lower the default net_ticktime from 2m to 1m

### DIFF
--- a/apps/emqx_conf/src/emqx_conf_schema.erl
+++ b/apps/emqx_conf/src/emqx_conf_schema.erl
@@ -588,7 +588,7 @@ fields("node") ->
                 emqx_schema:timeout_duration_s(),
                 #{
                     mapping => "vm_args.-kernel net_ticktime",
-                    default => <<"2m">>,
+                    default => <<"60s">>,
                     'readOnly' => true,
                     importance => ?IMPORTANCE_HIDDEN,
                     desc => ?DESC(node_dist_net_ticktime)

--- a/bin/emqx
+++ b/bin/emqx
@@ -603,7 +603,7 @@ get_boot_config() {
 
 EPMD_ARGS="${EPMD_ARGS:-"-start_epmd false -epmd_module ekka_epmd -proto_dist ekka"}"
 PROTO_DIST="$(get_boot_config 'cluster.proto_dist' || true)"
-TICKTIME="$(get_boot_config 'node.dist_net_ticktime' || echo '120')"
+TICKTIME="$(get_boot_config 'node.dist_net_ticktime' || echo '60')"
 # this environment variable is required by ekka_dist module
 # because proto_dist is overriden to ekka, and there is a lack of ekka_tls module
 export EKKA_PROTO_DIST_MOD="${PROTO_DIST:-inet_tcp}"

--- a/changes/ee/fix-16534.en.md
+++ b/changes/ee/fix-16534.en.md
@@ -1,0 +1,4 @@
+Lowered the default `net_ticktime` from 2 minutes to 1 minute to improve cluster node failure detection.
+
+In the event of a network outage or abrupt node termination, remaining nodes will detect the down node sooner,
+reducing the time before failover mechanisms activate and improving overall cluster resilience and user experience.


### PR DESCRIPTION

Fixes [EMQX-15014](https://emqx.atlassian.net/browse/EMQX-15014)

<!--
5.8.9
5.9.3
5.10.3
6.0.2
6.1.0
-->
Release version: 6.2.0

## Summary

Make the down node disovery sooner in the event of intra-cluster network outage, or abrupt kill of a peer node.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15014]: https://emqx.atlassian.net/browse/EMQX-15014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ