### PR TITLE
fix(logger): formatter crash when 'packet' is not binary or tuple (v6)

### DIFF
--- a/apps/emqx/src/emqx_logger_textfmt.erl
+++ b/apps/emqx/src/emqx_logger_textfmt.erl
@@ -139,10 +139,10 @@ enrich_report(ReportRaw0, Meta, Config) ->
 
 try_format_unicode(undefined) ->
     undefined;
-try_format_unicode(Char) ->
+try_format_unicode(Chars) ->
     List =
         try
-            case unicode:characters_to_list(Char) of
+            case unicode:characters_to_list(Chars) of
                 {error, _, _} -> error;
                 {incomplete, _, _} -> error;
                 List1 -> List1
@@ -152,7 +152,7 @@ try_format_unicode(Char) ->
                 error
         end,
     case List of
-        error -> io_lib:format("~0tp", [Char]);
+        error -> io_lib:format("~0tp", [Chars]);
         _ -> List
     end.
 
@@ -233,7 +233,9 @@ format_packet(undefined, #{payload_encode := Encode}) ->
 format_packet(Packet, #{payload_encode := Encode}) when is_list(Packet); is_binary(Packet) ->
     {try_format_unicode(Packet), Encode};
 format_packet(Packet, #{payload_encode := Encode}) when is_tuple(Packet) ->
-    {try_format_unicode(emqx_packet:format(Packet, Encode)), Encode}.
+    {try_format_unicode(emqx_packet:format(Packet, Encode)), Encode};
+format_packet(Packet, #{payload_encode := Encode}) ->
+    {try_format_unicode(Packet), Encode}.
 
 format_payload(undefined, #{payload_encode := Encode}) ->
     {"", Encode};

--- a/apps/emqx/test/emqx_logger_fmt_SUITE.erl
+++ b/apps/emqx/test/emqx_logger_fmt_SUITE.erl
@@ -27,6 +27,9 @@ t_text_fmt_lazy_values_only_in_debug_level_events(_) ->
 t_text_payload(_) ->
     check_fmt_payload(emqx_logger_textfmt).
 
+t_text_fmt_gen_rpc_packet(_) ->
+    check_fmt_gen_rpc_packet(emqx_logger_textfmt).
+
 t_json_fmt_lazy_values(_) ->
     check_fmt_lazy_values(emqx_logger_jsonfmt).
 
@@ -63,6 +66,9 @@ t_nested_report_with_utf8_strings(_TCConfig) ->
     ?assertMatch({match, _}, re:run(Formatted, UTF8Msg)),
     ok.
 
+t_json_fmt_gen_rpc_packet(_) ->
+    check_fmt_gen_rpc_packet(emqx_logger_jsonfmt).
+
 check_fmt_lazy_values(FormatModule) ->
     LogEntryIOData = FormatModule:format(event_with_lazy_value(), conf()),
     LogEntryBin = unicode:characters_to_binary(LogEntryIOData),
@@ -92,6 +98,43 @@ check_fmt_payload(FormatModule) ->
     ?assertEqual(nomatch, binary:match(LogEntryBin, [<<"content">>])),
     %% The lazy value should not have been evaluated
     ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"******">>])),
+    ok.
+
+%% Test that gen_rpc error reports with packet field (atom) don't crash the formatter
+%% The issue: packet => cast (atom) was causing format_packet/2 to crash because
+%% format_packet/2 only handled undefined, lists/binaries, and tuples, but not atoms.
+%% Fixed by adding a catch-all clause that formats non-packet values using io_lib:format/2.
+%% This simulates the gen_rpc error: {report,#{error => transmission_failed,driver => tcp,
+%% packet => cast,reason => {badtcp,timeout},socket => ["#Port<0.132>"],
+%% domain => [gen_rpc,client],msg => gen_rpc_error}}
+check_fmt_gen_rpc_packet(FormatModule) ->
+    GenRpcEvent = #{
+        meta => #{
+            pid => self(),
+            time => erlang:system_time(microsecond),
+            gl => group_leader(),
+            report_cb => fun logger:format_otp_report/1
+        },
+        msg =>
+            {report, #{
+                error => transmission_failed,
+                driver => tcp,
+                packet => cast,
+                reason => {badtcp, timeout},
+                socket => ["#Port<0.132>"],
+                domain => [gen_rpc, client],
+                msg => gen_rpc_error
+            }},
+        level => error
+    },
+    LogEntryIOData = FormatModule:format(GenRpcEvent, conf()),
+    LogEntryBin = unicode:characters_to_binary(LogEntryIOData),
+    %% Verify the formatter did not crash and produced output
+    ?assert(is_list(LogEntryIOData) orelse is_binary(LogEntryIOData)),
+    %% Verify the error information is present
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"transmission_failed">>])),
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"gen_rpc_error">>])),
+    ?assertNotEqual(nomatch, binary:match(LogEntryBin, [<<"packet">>])),
     ok.
 
 conf() ->

--- a/changes/ee/fix-16537.en.md
+++ b/changes/ee/fix-16537.en.md
@@ -1,0 +1,3 @@
+Fixed formatter crash when logging gen_rpc errors.
+
+Prior to this fix, EMQX would crash with "FORMATTER CRASH" errors when gen_rpc logged certain error messages (e.g., transmission timeout errors). The formatter now handles these error messages correctly without crashing.


### PR DESCRIPTION
Fixes [EMQX-15004](https://emqx.atlassian.net/browse/EMQX-15004)

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.0.2, 6.1.1

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15004]: https://emqx.atlassian.net/browse/EMQX-15004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ