### PR TITLE
fix(oidc-sso): prevent trailing slash normalization on issuer URL

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc.erl
@@ -12,7 +12,8 @@
 -export([
     namespace/0,
     fields/1,
-    desc/1
+    desc/1,
+    validate_issuer_url/1
 ]).
 
 -export([
@@ -53,11 +54,12 @@ fields(oidc) ->
         [
             {issuer,
                 ?HOCON(
-                    emqx_schema:url(),
+                    binary(),
                     #{
                         desc => ?DESC(issuer),
                         required => true,
-                        example => <<"https://issuer.com">>
+                        example => <<"https://issuer.com">>,
+                        validator => fun ?MODULE:validate_issuer_url/1
                     }
                 )},
             {clientid,
@@ -270,6 +272,16 @@ convert_certs(_Dir, Conf) ->
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
+
+validate_issuer_url(Value) ->
+    maybe
+        #{scheme := Scheme, host := _Host} ?= uri_string:parse(Value),
+        true ?= (Scheme =:= <<"http">> orelse Scheme =:= <<"https">>),
+        ok
+    else
+        _ ->
+            throw(invalid_issuer_url)
+    end.
 
 save_jwks_file(Dir, Content) ->
     case filelib:is_file(Content) of

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -310,6 +310,8 @@ do_smoke_tests(TestCase, Opts, TCConfig) ->
 do_smoke_tests1(Node, LoginNode, FinalReqNode, _TCConfig) ->
     %% Create the provider
     ProviderParams = oidc_provider_params(),
+    BadParams = ProviderParams#{<<"issuer">> => <<"httpx://authn-server">>},
+    ?assertMatch({400, _}, create_backend(Node, BadParams, #{})),
     ?assertMatch({200, _}, create_backend(Node, ProviderParams, #{})),
     ?assertMatch(
         {200, [

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_tests.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_tests.erl
@@ -64,15 +64,22 @@ issuer_validation_test_() ->
                 )
             )},
         {"no scheme",
-            ?_assertMatch(
-                #{<<"issuer">> := <<"http://string/">>},
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := invalid_issuer_url,
+                        value := <<"string">>,
+                        path := "dashboard.sso.oidc.issuer",
+                        kind := validation_error
+                    }
+                ]},
                 parse_and_check(oidc_config(#{<<"issuer">> => <<"string">>}))
             )},
         {"bad scheme",
             ?_assertThrow(
                 {_, [
                     #{
-                        reason := {unsupported_scheme, <<"pulsar+ssl">>},
+                        reason := invalid_issuer_url,
                         value := _,
                         path := "dashboard.sso.oidc.issuer",
                         kind := validation_error

--- a/changes/ee/16540.en.md
+++ b/changes/ee/16540.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where OIDC issuer URLs were automatically normalized with a trailing slash when saved to the configuration file, causing issuer mismatch errors when the OIDC provider's discovery document returned the issuer without a trailing slash.


### PR DESCRIPTION
Fixes #16503 [EMQX-15016](https://emqx.atlassian.net/browse/EMQX-15016)

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.0.2, 6.1.1


## Summary

EMQX was automatically adding a trailing slash to OIDC issuer URLs during config save, causing issuer mismatch errors when the provider's discovery document returns the issuer without a trailing slash.

The schema change is not perfectly compatible because previously `http` scheme is automatically added if missing.
For example, if configured with `example.com`, it's converted to `http://example.com`.
I believe using the `url` type was mostly for validation, but not conversion, when it was first introduced in https://github.com/emqx/emqx/pull/15489

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [~] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15016]: https://emqx.atlassian.net/browse/EMQX-15016?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ