### PR TITLE
fix(Kafka): separate request max age config and metadata request timeout

### DIFF
--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -86,10 +86,14 @@ on_start(InstId, Config) ->
     }),
     C = fun(Key) -> check_config(Key, Config) end,
     Hosts = C(bootstrap_hosts),
+    MetadataRequestTimeout = C(metadata_request_timeout),
     ClientConfig = #{
         min_metadata_refresh_interval => C(min_metadata_refresh_interval),
         connect_timeout => C(connect_timeout),
-        request_timeout => C(metadata_request_timeout),
+        metadata_request_timeout => MetadataRequestTimeout,
+        %% Request timeout is the max age limit for a pending reply from Kafka
+        %% once reached, wolff_client will force reconnect
+        request_timeout => max(MetadataRequestTimeout * 2, timer:seconds(30)),
         extra_sock_opts => C(socket_opts),
         sasl => C(authentication),
         ssl => C(ssl),

--- a/changes/ee/fix-16542.en.md
+++ b/changes/ee/fix-16542.en.md
@@ -1,0 +1,4 @@
+Fixed an issue where Kafka producer connections could disconnect prematurely when Kafka was overloaded, causing excessive produce request retries.
+The request timeout is now automatically set to at least twice the metadata request timeout (with a minimum of 30 seconds),
+reducing unnecessary reconnections and retries when metadata requests take longer than expected.
+This is especially beneficial when metadata request timeout is configured to a small value.

--- a/mix.exs
+++ b/mix.exs
@@ -275,7 +275,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.1.3"}
+  def common_dep(:wolff), do: {:wolff, "4.1.6"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),


### PR DESCRIPTION
Fixes [EMQX-15008](https://emqx.atlassian.net/browse/EMQX-15008)

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.0.2, 6.1.1

## Summary

Fixed an issue where Kafka producer connections could disconnect prematurely when Kafka was overloaded, causing excessive produce request retries.
The request timeout is now automatically set to at least twice the metadata request timeout (with a minimum of 30 seconds),
reducing unnecessary reconnections and retries when metadata requests take longer than expected.
This is especially beneficial when metadata request timeout is configured to a small value.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15008]: https://emqx.atlassian.net/browse/EMQX-15008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ