### PR TITLE
chore: Bump ekka version to 0.23.3

### DIFF
--- a/changes/ee/fix-16544.en.md
+++ b/changes/ee/fix-16544.en.md
@@ -1,0 +1,4 @@
+Improve robustness of cluster autoclean procedure.
+
+Previously, if autoclean feature was disabled during initial start of the node, it would never activate after configuration change.
+This fix resolves this issue.

--- a/mix.exs
+++ b/mix.exs
@@ -170,7 +170,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.2", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.3", override: true}
 
   def common_dep(:esockd),
     do: {:esockd, github: "emqx/esockd", tag: "5.15.0", override: true}


### PR DESCRIPTION
Fixes [EMQX-14924](https://emqx.atlassian.net/browse/EMQX-14924)

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.1.1

## Summary

Improve robustness of cluster autoclean procedure.

Previously, if autoclean feature was disabled during initial start of the node, it would never activate after configuration change.
This fix resolves this issue.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14924]: https://emqx.atlassian.net/browse/EMQX-14924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ