### PR TITLE
refactor: do not cache subscribe authz (ACL) result

### DIFF
--- a/apps/emqx/include/emqx_access_control.hrl
+++ b/apps/emqx/include/emqx_access_control.hrl
@@ -25,7 +25,6 @@
 
 -define(authz_action(PUBSUB, QOS), #{action_type := PUBSUB, qos := QOS}).
 -define(authz_action(PUBSUB), ?authz_action(PUBSUB, _)).
--define(authz_action, ?authz_action(_)).
 
 -define(AUTHN_TRACE_TAG, "AUTHN").
 

--- a/apps/emqx/src/emqx_authz_cache.erl
+++ b/apps/emqx/src/emqx_authz_cache.erl
@@ -30,6 +30,7 @@
 ]).
 
 -define(KEY(Topic, QoS, Retain), {?MODULE, Topic, QoS, Retain}).
+-define(KEY_PAT, {?MODULE, _, _, _}).
 -type authz_result() :: allow | deny.
 -type system_time() :: integer().
 -type retain_flag() :: 0 | 1.
@@ -174,7 +175,7 @@ map_authz_cache(Fun) ->
 map_authz_cache(Fun, Dict) ->
     [
         Fun(R)
-     || R = {{?MODULE, _T, _QoS, _Retain}, _Authz} <- Dict
+     || R = {?KEY_PAT, _Authz} <- Dict
     ].
 
 foreach_authz_cache(Fun) ->

--- a/apps/emqx/src/emqx_authz_cache.erl
+++ b/apps/emqx/src/emqx_authz_cache.erl
@@ -16,7 +16,8 @@
     get_cache_ttl/0,
     is_enabled/1,
     drain_cache/0,
-    drain_cache/1
+    drain_cache/1,
+    parse_key/1
 ]).
 
 %% export for test
@@ -28,15 +29,27 @@
     get_oldest_key/0
 ]).
 
+-define(KEY(Topic, QoS, Retain), {?MODULE, Topic, QoS, Retain}).
 -type authz_result() :: allow | deny.
 -type system_time() :: integer().
--type cache_key() :: {emqx_types:pubsub(), emqx_types:topic()}.
+-type retain_flag() :: 0 | 1.
+-type cache_key() :: ?KEY(emqx_types:topic(), emqx_types:qos(), retain_flag()).
 -type cache_val() :: {authz_result(), system_time()}.
 
 -type authz_cache_entry() :: {cache_key(), cache_val()}.
 
+parse_key(?KEY(Topic, QoS, Retain)) ->
+    Access = #{
+        action_type => publish,
+        qos => QoS,
+        retain => retain_flag_to_bool(Retain)
+    },
+    {Access, Topic}.
+
 %% Wrappers for key and value
-cache_k(PubSub, Topic) -> {PubSub, Topic}.
+cache_k(#{action_type := publish, qos := QoS, retain := Retain}, Topic) ->
+    ?KEY(Topic, QoS, retain_flag(Retain)).
+
 cache_v(AuthzResult) -> {AuthzResult, time_now()}.
 drain_k() -> {?MODULE, drain_timestamp}.
 
@@ -71,6 +84,8 @@ list_authz_cache() ->
 %% We'll cleanup the cache before replacing an expired authz.
 -spec get_authz_cache(emqx_types:pubsub(), emqx_types:topic()) ->
     authz_result() | not_found.
+get_authz_cache(#{action_type := subscribe}, _Topic) ->
+    not_found;
 get_authz_cache(PubSub, Topic) ->
     case erlang:get(cache_k(PubSub, Topic)) of
         undefined ->
@@ -93,13 +108,15 @@ get_authz_cache(PubSub, Topic) ->
 %%   is expired, then delete all the cache entries
 -spec put_authz_cache(emqx_types:pubsub(), emqx_types:topic(), authz_result()) ->
     ok.
-put_authz_cache(PubSub, Topic, AuthzResult) ->
+put_authz_cache(#{action_type := subscribe}, _Topic, _AuthzResult) ->
+    ok;
+put_authz_cache(Pub, Topic, AuthzResult) ->
     MaxSize = get_cache_max_size(),
     true = (MaxSize =/= 0),
     Size = get_cache_size(),
     case Size < MaxSize of
         true ->
-            add_authz(PubSub, Topic, AuthzResult);
+            add_authz(Pub, Topic, AuthzResult);
         false ->
             NewestK = get_newest_key(),
             {_AuthzResult, CachedAt} = erlang:get(NewestK),
@@ -110,11 +127,11 @@ put_authz_cache(PubSub, Topic, AuthzResult) ->
                     (true) ->
                         % all cache expired, cleanup first
                         empty_authz_cache(),
-                        add_authz(PubSub, Topic, AuthzResult);
+                        add_authz(Pub, Topic, AuthzResult);
                     (false) ->
                         % cache full, perform cache replacement
                         evict_authz_cache(),
-                        add_authz(PubSub, Topic, AuthzResult)
+                        add_authz(Pub, Topic, AuthzResult)
                 end
             )
     end.
@@ -157,7 +174,7 @@ map_authz_cache(Fun) ->
 map_authz_cache(Fun, Dict) ->
     [
         Fun(R)
-     || R = {{?authz_action, _T}, _Authz} <- Dict
+     || R = {{?MODULE, _T, _QoS, _Retain}, _Authz} <- Dict
     ].
 
 foreach_authz_cache(Fun) ->
@@ -293,3 +310,9 @@ if_expired(TTL, CachedAt, Fun) ->
         true -> Fun(true);
         false -> Fun(false)
     end.
+
+retain_flag(true) -> 1;
+retain_flag(false) -> 0.
+
+retain_flag_to_bool(0) -> false;
+retain_flag_to_bool(1) -> true.

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_api_cache_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_api_cache_SUITE.erl
@@ -76,9 +76,11 @@ t_clean_cache(_) ->
     {ok, _} = emqtt:connect(C),
     {ok, _, _} = emqtt:subscribe(C, <<"a/b/c">>, 0),
     ok = emqtt:publish(C, <<"a/b/c">>, <<"{\"x\":1,\"y\":1}">>, 0),
-
+    %% wait for async publish to be processed and cached
+    ct:sleep(100),
+    %% only publish is cached now (subscribe is not cached)
     {ok, 200, Result3} = request(get, uri(["clients", "emqx0", "authorization", "cache"])),
-    ?assertEqual(2, length(emqx_utils_json:decode(Result3))),
+    ?assertEqual(1, length(emqx_utils_json:decode(Result3))),
 
     request(delete, uri(["authorization", "cache"])),
 

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -1954,9 +1954,10 @@ peername_dispart({Addr, Port}) ->
 convert_expiry_interval_unit(ClientInfoMap = #{expiry_interval := Interval}) ->
     ClientInfoMap#{expiry_interval := Interval div 1000}.
 
-format_authz_cache({{PubSub, Topic}, {AuthzResult, Timestamp}}) ->
+format_authz_cache({Key, {AuthzResult, Timestamp}}) ->
+    {Access, Topic} = emqx_authz_cache:parse_key(Key),
     #{
-        access => PubSub,
+        access => Access,
         topic => Topic,
         result => AuthzResult,
         updated_time => Timestamp

--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -627,7 +627,8 @@ t_authz_cache(Config) ->
 
     {ok, C} = emqtt:start_link(#{clientid => ClientId}),
     {ok, _} = emqtt:connect(C),
-    {ok, _, _} = emqtt:subscribe(C, <<"topic/1">>, 1),
+    %% NOTE: subscribe authz results are not cached, use publish instead
+    {ok, _} = emqtt:publish(C, <<"topic/1">>, <<"payload">>, 1),
 
     ClientAuthzCachePath = emqx_mgmt_api_test_util:api_path([
         "clients",
@@ -639,7 +640,11 @@ t_authz_cache(Config) ->
         {ok,
             {{_HTTP, 200, _}, _, [
                 #{
-                    <<"access">> := #{<<"action_type">> := <<"subscribe">>, <<"qos">> := 1},
+                    <<"access">> := #{
+                        <<"action_type">> := <<"publish">>,
+                        <<"qos">> := 1,
+                        <<"retain">> := false
+                    },
                     <<"result">> := <<"allow">>,
                     <<"topic">> := <<"topic/1">>,
                     <<"updated_time">> := _

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -271,14 +271,15 @@ t_authz(_Config) ->
     ?assertMatch({error, not_found}, emqx_ctl:run_command(["authz", "cache-clean", ClientId])),
     {ok, C} = emqtt:start_link([{clean_start, true}, {clientid, ClientId}]),
     {ok, _} = emqtt:connect(C),
-    {ok, _, _} = emqtt:subscribe(C, <<"topic/1">>, 1),
+    %% NOTE: subscribe authz results are not cached, use publish instead
+    {ok, _} = emqtt:publish(C, <<"topic/1">>, <<"payload">>, 1),
     [Pid] = emqx_cm:lookup_channels(ClientIdBin),
     ?assertMatch([_], gen_server:call(Pid, list_authz_cache)),
 
     ?assertMatch(ok, emqx_ctl:run_command(["authz", "cache-clean", ClientId])),
     ?assertMatch([], gen_server:call(Pid, list_authz_cache)),
     %% authz cache-clean node <Node> # Clears authorization cache on given node
-    {ok, _, _} = emqtt:subscribe(C, <<"topic/2">>, 1),
+    {ok, _} = emqtt:publish(C, <<"topic/2">>, <<"payload">>, 1),
     ?assertMatch([_], gen_server:call(Pid, list_authz_cache)),
     ?assertMatch(ok, emqx_ctl:run_command(["authz", "cache-clean", "node", atom_to_list(node())])),
     ?assertMatch([], gen_server:call(Pid, list_authz_cache)),

--- a/changes/ee/fix-16550.en.md
+++ b/changes/ee/fix-16550.en.md
@@ -1,0 +1,4 @@
+Stop caching subscribe ACL check results.
+
+MQTT subsription is mostly done once per connection life cycle.
+Hoding the subsribe ACL check result in cache is most of the time a waste of RAM.


### PR DESCRIPTION
Fixes [EMQX-14701](https://emqx.atlassian.net/browse/EMQX-14701)

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.2.0

## Summary

The per-client authz (ACL) cache is not very useful because 'SUBSCRIBE' requests are mostly sent only once, also, session takeover does not inherit the cache

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-14701]: https://emqx.atlassian.net/browse/EMQX-14701?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ