### PR TITLE
chore: update to opentsdb 0.5.3 for clear license info

### DIFF
--- a/apps/emqx_bridge_opents/mix.exs
+++ b/apps/emqx_bridge_opents/mix.exs
@@ -29,7 +29,7 @@ defmodule EMQXBridgeOpents.MixProject do
 
   def deps() do
     UMP.deps([
-      {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.1"},
+      {:opentsdb, github: "emqx/opentsdb-client-erl", tag: "v0.5.3"},
       {:emqx_connector, in_umbrella: true, runtime: false},
       {:emqx_resource, in_umbrella: true},
       {:emqx_bridge, in_umbrella: true, runtime: false}


### PR DESCRIPTION
opentsdb `v0.5.1...v0.5.3` only added a LICENSE file and changed licenses info in `.app.src` file
