### PR TITLE
feat: add a remote_console alias 'remote'

### DIFF
--- a/bin/emqx
+++ b/bin/emqx
@@ -92,7 +92,7 @@ usage() {
         echo "through a named pipe."
         logwarn "try to use the safer alternative, remote_console command."
         ;;
-    remote_console)
+    remote_console|remote)
         echo "Start an interactive shell running an Erlang or Elixir node which "
         echo "hidden-connects to the running EMQX node".
         echo "This command is mostly used for troubleshooting."
@@ -1178,7 +1178,7 @@ case "${COMMAND}" in
         exec "$BINDIR/to_erl" "$PIPE_DIR"
         ;;
 
-    remote_console)
+    remote_console|remote)
         assert_node_alive
 
         shift


### PR DESCRIPTION
Port https://github.com/emqx/emqx/pull/15917 to v5, but no change in the usage print (i.e. hidden).