### PR TITLE
fix(coap): fix connection-mode dtls

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway.app.src
+++ b/apps/emqx_gateway/src/emqx_gateway.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway, [
     {description, "The Gateway management application"},
-    {vsn, "0.2.5"},
+    {vsn, "0.2.6"},
     {registered, []},
     {mod, {emqx_gateway_app, []}},
     {applications, [

--- a/apps/emqx_gateway/src/emqx_gateway_utils.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_utils.erl
@@ -155,7 +155,10 @@ when
         frame_mod := atom(),
         chann_mod := atom(),
         connection_mod => atom(),
-        esockd_proxy_opts => map()
+        esockd_proxy_opts => map(),
+        %% Dynamically generate the connection options for the listener
+        %% based on the listener type
+        connection_opts => fun((Type :: udp | dtls) -> map())
     }.
 start_listeners(Listeners, GwName, Ctx, ModCfg) ->
     start_listeners(Listeners, GwName, Ctx, ModCfg, []).
@@ -225,9 +228,16 @@ start_listener(
             emqx_gateway_utils:supervisor_ret({error, Reason})
     end.
 
-start_listener(GwName, Ctx, Type, LisName, ListenOn, Confs, ModCfg) when
+start_listener(GwName, Ctx, Type, LisName, ListenOn, Confs, ModCfg0) when
     ?IS_ESOCKD_LISTENER(Type)
 ->
+    ModCfg =
+        case ModCfg0 of
+            #{connection_opts := ConnectionOptsFun} ->
+                maps:without([connection_opts], maps:merge(ModCfg0, ConnectionOptsFun(Type)));
+            _ ->
+                ModCfg0
+        end,
     Name = emqx_gateway_utils:listener_id(GwName, Type, LisName),
     SocketOpts = merge_default(Type, esockd_opts(Type, Confs)),
     HighLevelCfgs0 = filter_out_low_level_opts(Type, Confs),

--- a/apps/emqx_gateway_coap/src/emqx_gateway_coap.app.src
+++ b/apps/emqx_gateway_coap/src/emqx_gateway_coap.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_coap, [
     {description, "CoAP Gateway"},
-    {vsn, "0.1.13"},
+    {vsn, "0.1.14"},
     {registered, []},
     {applications, [kernel, stdlib, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_gateway_coap/src/emqx_gateway_coap.erl
+++ b/apps/emqx_gateway_coap/src/emqx_gateway_coap.erl
@@ -108,11 +108,26 @@ on_gateway_unload(
     stop_listeners(GwName, Listeners).
 
 connection_opts(#{connection_required := false}) ->
-    #{};
+    #{
+        connection_opts => fun(_) ->
+            #{
+                connection_mod => emqx_gateway_conn
+            }
+        end
+    };
 connection_opts(_) ->
     #{
-        connection_mod => esockd_udp_proxy,
-        esockd_proxy_opts => #{
-            connection_mod => emqx_coap_proxy_conn
-        }
+        connection_opts => fun
+            (dtls) ->
+                #{
+                    connection_mod => emqx_gateway_conn
+                };
+            (udp) ->
+                #{
+                    connection_mod => esockd_udp_proxy,
+                    esockd_proxy_opts => #{
+                        connection_mod => emqx_coap_proxy_conn
+                    }
+                }
+        end
     }.

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_client_socket.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_client_socket.erl
@@ -1,0 +1,50 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_dtls_client_socket).
+-behaviour(gen_server).
+
+-export([connect/2, connect/3, close/1, get_channel/1]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2]).
+
+-record(state, {sock, channel}).
+
+connect(Host, Port) ->
+    connect(Host, Port, []).
+
+connect(Host, Port, ConnectOpts) ->
+    {ok, Socket} = gen_server:start_link(?MODULE, [connect, Host, Port, ConnectOpts], []),
+    {ok, Channel} = get_channel(Socket),
+    {ok, Socket, Channel}.
+
+close(Pid) ->
+    gen_server:cast(Pid, shutdown).
+
+get_channel(Pid) ->
+    gen_server:call(Pid, get_channel).
+
+init([connect, Host, Port, ConnectOpts]) ->
+    {ok, Sock} = ssl:connect(Host, Port, [binary, {protocol, dtls} | ConnectOpts]),
+    ChId = {Host, Port},
+    {ok, Pid} = er_coap_channel:start_link(self(), ChId),
+    {ok, #state{sock = Sock, channel = Pid}}.
+
+handle_call(get_channel, _From, State = #state{channel = Chan}) ->
+    {reply, {ok, Chan}, State};
+handle_call(_Unknown, _From, State) ->
+    {reply, unknown_call, State}.
+
+handle_cast(shutdown, State) ->
+    {stop, normal, State}.
+
+handle_info({ssl, _Socket, Data}, State = #state{channel = Chan}) ->
+    Chan ! {datagram, Data},
+    {noreply, State};
+handle_info({ssl_closed, _Socket}, State) ->
+    {stop, normal, State};
+handle_info({datagram, _ChId, Data}, State = #state{sock = Socket}) ->
+    ok = ssl:send(Socket, Data),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -1,0 +1,106 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_dtls_connection_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+-include_lib("er_coap_client/include/coap.hrl").
+-include_lib("emqx/include/asserts.hrl").
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+
+-define(CONF_DEFAULT, <<
+    "\n"
+    "gateway.coap {\n"
+    "  idle_timeout = 30s\n"
+    "  enable_stats = false\n"
+    "  mountpoint = \"\"\n"
+    "  notify_type = qos\n"
+    "  connection_required = true\n"
+    "  subscribe_qos = qos1\n"
+    "  publish_qos = qos1\n"
+    "  listeners.dtls.default {\n"
+    "    bind = 5684\n"
+    "    dtls_options {\n"
+    "      verify = verify_none\n"
+    "    }\n"
+    "  }\n"
+    "}\n"
+>>).
+
+-define(MQTT_PREFIX, "coaps://127.0.0.1/mqtt").
+
+all() -> emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    application:load(emqx_gateway_coap),
+    Apps = emqx_cth_suite:start(
+        [
+            {emqx_conf, ?CONF_DEFAULT},
+            emqx_gateway,
+            emqx_auth
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    emqx_cth_suite:stop(?config(suite_apps, Config)),
+    emqx_config:delete_override_conf_files(),
+    ok.
+
+init_per_testcase(_CaseName, Config) ->
+    ok = meck:new(emqx_access_control, [passthrough]),
+    Config.
+
+end_per_testcase(_CaseName, _Config) ->
+    ok = meck:unload(emqx_access_control).
+
+%%--------------------------------------------------------------------
+%% Test Cases
+%%--------------------------------------------------------------------
+
+t_connection(_Config) ->
+    emqx_gateway_test_utils:meck_emqx_hook_calls(),
+
+    {ok, Sock, Channel} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    ?assertMatch(
+        ['client.connect' | _],
+        emqx_gateway_test_utils:collect_emqx_hooks_calls()
+    ),
+
+    %% heartbeat
+    Queries1 = #{
+        "clientid" => <<"client1">>,
+        "token" => Token
+    },
+    URI1 = emqx_coap_SUITE:compose_uri(Prefix, Queries1, false),
+    Req1 = emqx_coap_SUITE:make_req(put),
+    {ok, changed, _} = emqx_coap_SUITE:do_request(Channel, URI1, Req1),
+
+    er_coap_channel:close(Channel),
+    emqx_coap_dtls_client_socket:close(Sock).

--- a/changes/ee/fix-16606.en.md
+++ b/changes/ee/fix-16606.en.md
@@ -1,0 +1,1 @@
+Fixed CoAP Gateway working in connection mode over DTLS.


### PR DESCRIPTION
Fixes [EMQX-15030](https://emqx.atlassian.net/browse/EMQX-15030)

Release version: 5.8.10

## Summary

Backport of https://github.com/emqx/emqx/pull/16536.

The code is too diverged to merge the whole update, so I fixed with one more config indirection hack (which I tried to avoid in recent branches).

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15030]: https://emqx.atlassian.net/browse/EMQX-15030?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ