### PR TITLE
fix: bring crc32cer to the latest version

### DIFF
--- a/changes/ee/fix-16620.en.md
+++ b/changes/ee/fix-16620.en.md
@@ -1,0 +1,1 @@
+Fix CRC32C dynamic library load issue on aarch64.

--- a/mix.exs
+++ b/mix.exs
@@ -126,8 +126,9 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:sasl_auth),
       # avlizer currently uses older :erlavro version
       common_dep(:erlavro),
-      # in conflict by erlavro
+      # in conflict by erlavro and pulsar
       common_dep(:snappyer),
+      # used by pulsar
       common_dep(:crc32cer),
       # transitive dependency of pulsar-client-erl, and direct dep in s3tables bridge
       common_dep(:murmerl3),
@@ -275,17 +276,17 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:influxdb),
     do: {:influxdb, github: "emqx/influxdb-client-erl", tag: "1.1.13", override: true}
 
-  def common_dep(:wolff), do: {:wolff, "4.1.6"}
+  def common_dep(:wolff), do: {:wolff, "4.1.7"}
   def common_dep(:brod_gssapi), do: {:brod_gssapi, "0.1.3"}
 
   def common_dep(:kafka_protocol),
-    do: {:kafka_protocol, "4.3.1", override: true}
+    do: {:kafka_protocol, "4.3.2", override: true}
 
-  def common_dep(:brod), do: {:brod, "4.5.1"}
+  def common_dep(:brod), do: {:brod, "4.5.2"}
   ## TODO: remove `mix.exs` from `wolff` and remove this override
   ## TODO: remove `mix.exs` from `pulsar` and remove this override
   def common_dep(:snappyer), do: {:snappyer, "1.2.10", override: true}
-  def common_dep(:crc32cer), do: {:crc32cer, "1.1.0", override: true}
+  def common_dep(:crc32cer), do: {:crc32cer, "1.1.2", override: true}
   def common_dep(:jesse), do: {:jesse, github: "emqx/jesse", tag: "1.8.1.1"}
 
   def common_dep(:erlavro),


### PR DESCRIPTION
Previously the CRC32C nif may not load on aarch64.

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version:

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
