### PR TITLE
fix(resource): don't trigger fallback actions before casting query (r60)

### DIFF
--- a/apps/emqx_resource/src/emqx_resource.erl
+++ b/apps/emqx_resource/src/emqx_resource.erl
@@ -426,16 +426,6 @@ query(ResId, Request, QueryOpts) ->
             );
         {ok, {sync, _}} ->
             emqx_resource_buffer_worker:sync_query(ResId, Request, QueryOpts);
-        {ok, {async, ?not_added_yet_error_atom}} ->
-            %% Since the request is async and the action has not yet been added to the
-            %% state, the message will be cast into the void, and will not trigger any
-            %% trace events that someone may be expecting...  So we trigger them here and
-            %% now...
-            emqx_resource_buffer_worker:unhealthy_target_maybe_trigger_fallback_actions(
-                ResId, Request, "action_not_added_yet", #{}, QueryOpts
-            ),
-            %% ... and still cast the message in the void, to keep counters consistent.
-            emqx_resource_buffer_worker:async_query(ResId, Request, QueryOpts);
         {ok, {async, _}} ->
             emqx_resource_buffer_worker:async_query(ResId, Request, QueryOpts)
     end.

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -188,6 +188,10 @@ async_query(Id, Request, Opts0) ->
     Opts = ensure_expire_at(Opts1),
     PickKey = maps:get(pick_key, Opts, self()),
     emqx_resource_metrics:matched_inc(Id),
+    %% When a fallback action is itself unavailable, we emit this initial trace event so
+    %% that the frontend can see it was triggered when tracing rules...  Otherwise, if the
+    %% fallback never recovers, there will be no trace indicating it was received.
+    ?TRACE("QUERY", "async_query_received", #{action_id => Id}),
     pick_cast(Id, PickKey, #query{request = Request, query_opts = Opts}).
 
 %% simple query the resource without batching and queuing.

--- a/changes/ee/fix-16622.en.md
+++ b/changes/ee/fix-16622.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where, if an Action used async query mode and its Connector was disconnect after more than one health check, its Fallback Actions could be triggered twice.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15053

Fixes https://github.com/emqx/emqx/discussions/16608

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.0.3, 6.1.1, 6.2.0

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
