### PR TITLE
fix(saml): default signature verification to false for backwards compatibility

### DIFF
--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
@@ -110,12 +110,16 @@ sp_private_key(_) -> undefined.
 
 idp_signs_envelopes(type) -> boolean();
 idp_signs_envelopes(desc) -> ?DESC(idp_signs_envelopes);
-idp_signs_envelopes(default) -> true;
+%% Default to false for backwards compatibility - signature verification
+%% was not working correctly before this fix was introduced.
+idp_signs_envelopes(default) -> false;
 idp_signs_envelopes(_) -> undefined.
 
 idp_signs_assertions(type) -> boolean();
 idp_signs_assertions(desc) -> ?DESC(idp_signs_assertions);
-idp_signs_assertions(default) -> true;
+%% Default to false for backwards compatibility - signature verification
+%% was not working correctly before this fix was introduced.
+idp_signs_assertions(default) -> false;
 idp_signs_assertions(_) -> undefined.
 
 desc(saml) ->

--- a/changes/ee/feat-16625.en.md
+++ b/changes/ee/feat-16625.en.md
@@ -1,4 +1,5 @@
 Added configuration options `idp_signs_envelopes` and `idp_signs_assertions` to SAML SSO backend to control signature verification behavior.
 
 Previously, SAML signature verification was not working correctly because the IdP certificate fingerprint was not being extracted from metadata and passed to esaml for verification.
-This fix ensures proper signature validation of SAML responses from the Identity Provider.
+
+Both options default to `false` for backwards compatibility with existing configurations. Users who want to enable signature verification should explicitly set these to `true` when their IdP is configured to sign SAML responses.


### PR DESCRIPTION
Fixes [EMQX-15060](https://emqx.atlassian.net/browse/EMQX-15060)

Follow #16625

- _New added config term. NO schema conflict._
- ~keep same name style with existing `sp_sign_request`~ esaml used ___signs___

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: e5.10.3

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- ~[] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- ~[ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)~
- ~[ ] Change log has been added to `changes/` dir for user-facing artifacts update~
-->


[EMQX-15060]: https://emqx.atlassian.net/browse/EMQX-15060?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ