### PR TITLE
fix(mqtt connector): handle "impossible" raw config case regarding binary static clientids

### DIFF
--- a/apps/emqx_connector/src/emqx_connector_api.erl
+++ b/apps/emqx_connector/src/emqx_connector_api.erl
@@ -900,8 +900,17 @@ deobfuscate_mqtt_connector_for_node(NewInfo0, OldInfo) ->
     OldIds = maps:get(<<"ids">>, OldInfo, []),
     NewIds0 = maps:get(<<"ids">>, NewInfo0, []),
     OldIndex = lists:foldl(
-        fun(#{<<"clientid">> := ClientId} = Id, Acc) ->
-            Acc#{ClientId => Id}
+        fun
+            (ClientId, Acc) when is_binary(ClientId) ->
+                %% N.B. this case is "impossible", as the converter has already converted
+                %% older configs (which were simple binaries).  But there was a report
+                %% where, somehow, someone managed to sneak a binary clientid in the raw
+                %% config and this clause was hit...  So, this was added as extra
+                %% precaution.
+                Id = #{<<"clientid">> => ClientId},
+                Acc#{ClientId => Id};
+            (#{<<"clientid">> := ClientId} = Id, Acc) ->
+                Acc#{ClientId => Id}
         end,
         #{},
         OldIds


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15061

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.0.3, 6.1.1, 6.2.0

## Summary

Even though it's currently not possible to reproduce the path that lead to this, we
attempt to emulate the reported issue by storing an "impossible" value for static
clientids in the raw config.  It's "impossible" because a hocon converter should have
transformed a list of binary clientids into a list of more structured maps.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
