### PR TITLE
feat: make Erlang distribution listen address configurable

### DIFF
--- a/changes/ee/feat-16653.en.md
+++ b/changes/ee/feat-16653.en.md
@@ -1,0 +1,3 @@
+Made Erlang distribution listener address configurable via `node.dist_bind_address`.
+For example: `node.dist_bind_address = "10.0.1.5"`.
+Previously required configuration in `vm.args` as `-kernel inet_dist_use_interface {10,0,1,5}`.

--- a/rel/i18n/emqx_conf_schema.hocon
+++ b/rel/i18n/emqx_conf_schema.hocon
@@ -423,6 +423,15 @@ node_dist_net_ticktime.desc:
 node_dist_net_ticktime.label:
 """Dist Net TickTime"""
 
+node_dist_bind_address.desc:
+"""Specify which IP address to use for Erlang distribution.
+This should be an IP address (e.g., "192.168.1.100" for IPv4 or "::1" for IPv6).
+When set, Erlang distribution will bind to the specified IP address.
+Note: If an IPv6 address is used, <code>cluster.proto_dist</code> must be set to <code>inet6_tcp</code>."""
+
+node_dist_bind_address.label:
+"""Dist Bind Address"""
+
 desc_cluster_k8s.desc:
 """Service discovery via Kubernetes API server."""
 


### PR DESCRIPTION
Fixes [EMQX-15065](https://emqx.atlassian.net/browse/EMQX-15065)

<!--
5.8.10
5.10.3
6.0.2
6.1.1
6.2.0
-->
Release version: 6.2

## Summary

Small requirement discovered while exploring how to secure Erlang distribution when drafting a blog post.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->


[EMQX-15065]: https://emqx.atlassian.net/browse/EMQX-15065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ