### PR TITLE
chore: update optimus to fix elixir 1.19 warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -131,7 +131,9 @@ defmodule EMQXUmbrella.MixProject do
       common_dep(:crc32cer),
       # transitive dependency of pulsar-client-erl, and direct dep in s3tables bridge
       common_dep(:murmerl3),
-      common_dep(:unicode_util_compat)
+      common_dep(:unicode_util_compat),
+      # Used by :sbom, remove after https://github.com/erlef/mix_sbom/pull/84 or similar is merged & released
+      {:optimus, "~> 0.6.1", override: true}
     ]
   end
 


### PR DESCRIPTION
Release version: 6.1.1, 6.2.0

used by `sbom` package