### PR TITLE
fix(crl): support https distribution points in CRL cache

### DIFF
--- a/apps/emqx/src/emqx_ssl_crl_cache.erl
+++ b/apps/emqx/src/emqx_ssl_crl_cache.erl
@@ -153,11 +153,11 @@ delete({der, CRLs}) ->
     ssl_manager:delete_crls({?NO_DIST_POINT, CRLs});
 delete(URI) ->
     case uri_string:normalize(URI, [return_map]) of
-        #{scheme := "http", path := _} ->
+        #{scheme := Scheme, path := _} when Scheme =:= "http"; Scheme =:= "https" ->
             Key = cache_key(URI),
             ssl_manager:delete_crls(Key);
         _ ->
-            {error, {only_http_distribution_points_supported, URI}}
+            {error, {only_http_and_https_distribution_points_supported, URI}}
     end.
 
 %%--------------------------------------------------------------------
@@ -165,13 +165,13 @@ delete(URI) ->
 %%--------------------------------------------------------------------
 do_insert(URI, CRLs) ->
     case uri_string:normalize(URI, [return_map]) of
-        #{scheme := "http", path := _} ->
+        #{scheme := Scheme, path := _} when Scheme =:= "http"; Scheme =:= "https" ->
             Key = cache_key(URI),
             Res = ssl_manager:insert_crls(Key, CRLs),
             ?tp("emqx_ssl_crl_cache_inserted", #{key => Key}),
             Res;
         _ ->
-            {error, {only_http_distribution_points_supported, URI}}
+            {error, {only_http_and_https_distribution_points_supported, URI}}
     end.
 
 get_crls([], _) ->

--- a/changes/ee/16683.en.md
+++ b/changes/ee/16683.en.md
@@ -1,0 +1,1 @@
+Added support for HTTPS CRL Distribution Point URLs in the CRL cache, so CRLs fetched from `https://` endpoints are now cached and refreshed correctly.


### PR DESCRIPTION
Fixes  https://github.com/emqx/emqx/discussions/16667  [EMQX-15079](https://emqx.atlassian.net/browse/EMQX-15079)

Release version: 6.2.0

## Summary

This PR adds HTTPS support for CRL Distribution Point URLs in EMQX CRL cache handling.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)


[EMQX-15079]: https://emqx.atlassian.net/browse/EMQX-15079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ