### PR TITLE
fix(crl-cache): clear URL state on eviction

### DIFF
--- a/apps/emqx/src/emqx_crl_cache.erl
+++ b/apps/emqx/src/emqx_crl_cache.erl
@@ -120,12 +120,26 @@ init([]) ->
 handle_call(Call, _From, State) ->
     {reply, {error, {bad_call, Call}}, State}.
 
-handle_cast({evict, URL}, State0 = #state{refresh_timers = RefreshTimers0}) ->
+handle_cast(
+    {evict, URL0},
+    State0 = #state{
+        refresh_timers = RefreshTimers0,
+        cached_urls = CachedURLs0,
+        insertion_times = InsertionTimes0
+    }
+) ->
+    URL = to_string(URL0),
     emqx_ssl_crl_cache:delete(URL),
     MTimer = maps:get(URL, RefreshTimers0, undefined),
     emqx_utils:cancel_timer(MTimer),
     RefreshTimers = maps:without([URL], RefreshTimers0),
-    State = State0#state{refresh_timers = RefreshTimers},
+    CachedURLs = sets:del_element(URL, CachedURLs0),
+    InsertionTimes = remove_url_from_insertion_times(URL, InsertionTimes0),
+    State = State0#state{
+        refresh_timers = RefreshTimers,
+        cached_urls = CachedURLs,
+        insertion_times = InsertionTimes
+    },
     ?tp(
         crl_cache_evict,
         #{url => URL}
@@ -349,3 +363,8 @@ to_string(L) when is_list(L) ->
 
 now_ms() ->
     erlang:system_time(millisecond).
+
+remove_url_from_insertion_times(URL, InsertionTimes0) ->
+    gb_trees:from_orddict(
+        [KV || KV = {_Time, CachedURL} <- gb_trees:to_list(InsertionTimes0), CachedURL =/= URL]
+    ).

--- a/apps/emqx/test/emqx_crl_cache_SUITE.erl
+++ b/apps/emqx/test/emqx_crl_cache_SUITE.erl
@@ -650,23 +650,39 @@ t_unknown_messages(_Config) ->
     emqx_config_handler:stop(),
     ok.
 
-t_evict(_Config) ->
+t_evict(Config) ->
     emqx_config_handler:start_link(),
     {ok, _} = emqx_crl_cache:start_link(),
     URL = "http://localhost/crl.pem",
     URLBin = iolist_to_binary(URL),
-    ?wait_async_action(
-        ?assertEqual(ok, emqx_crl_cache:refresh(URL)),
-        #{?snk_kind := crl_cache_insert},
-        5_000
+    CRLDer = ?config(crl_der, Config),
+    {ok, {ok, _}} = ?wait_async_action(
+        emqx_crl_cache:register_der_crls(URL, [CRLDer]),
+        #{?snk_kind := new_crl_url_inserted}
     ),
     Ref = get_crl_cache_table(),
-    ?assertMatch([{URLBin, _}], ets:tab2list(Ref)),
+    ?assertMatch([{URLBin, [CRLDer]}], ets:tab2list(Ref)),
+    StateBeforeEvict = emqx_crl_cache:info(),
+    ?assertEqual(true, sets:is_element(URL, maps:get(cached_urls, StateBeforeEvict))),
+    ?assertMatch(#{URL := _}, maps:get(refresh_timers, StateBeforeEvict)),
     {ok, {ok, _}} = ?wait_async_action(
         emqx_crl_cache:evict(URL),
         #{?snk_kind := crl_cache_evict}
     ),
     ?assertEqual([], ets:tab2list(Ref)),
+    StateAfterEvict = emqx_crl_cache:info(),
+    ?assertEqual(false, sets:is_element(URL, maps:get(cached_urls, StateAfterEvict))),
+    ?assertEqual(
+        [],
+        [U || {_Time, U} <- gb_trees:to_list(maps:get(insertion_times, StateAfterEvict)), U =:= URL]
+    ),
+    {ok, {ok, _}} = ?wait_async_action(
+        emqx_crl_cache:register_der_crls(URL, [CRLDer]),
+        #{?snk_kind := new_crl_url_inserted}
+    ),
+    ?assertMatch([{URLBin, [CRLDer]}], ets:tab2list(Ref)),
+    StateAfterReRegister = emqx_crl_cache:info(),
+    ?assertMatch(#{URL := _}, maps:get(refresh_timers, StateAfterReRegister)),
     emqx_config_handler:stop(),
     ok.
 

--- a/changes/ee/fix-16692.en.md
+++ b/changes/ee/fix-16692.en.md
@@ -1,0 +1,2 @@
+Fixed a CRL cache regression where `emqx_crl_cache:evict/1` did not fully clear internal URL state.
+After eviction, the same CRL URL now re-registers correctly on next use, restores its refresh timer, and avoids repeated HTTP fetches per connection.


### PR DESCRIPTION
Backport of #16690 to release-60.

Fixes [EMQX-15087](https://emqx.atlassian.net/browse/EMQX-15087)

Release version: 6.0.?

## Summary

Fix CRL cache eviction state handling in `emqx_crl_cache`.

`emqx_crl_cache:evict/1` previously removed only the SSL cache entry and refresh timer, but left URL bookkeeping in `cached_urls` and `insertion_times`. That caused the same URL to be treated as already cached after eviction and skipped re-registration, leading to repeated CRL HTTP fetches.

This change makes eviction fully clear URL state (`refresh_timers`, `cached_urls`, `insertion_times`) and normalizes URL type during eviction.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-16692.en.md`
- [x] Schema changes are backward compatible or intentionally breaking

[EMQX-15087]: https://emqx.atlassian.net/browse/EMQX-15087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ