### PR TITLE
fix(rule engine): ensure metrics exist when creating/updating rule (r58)

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine.erl
@@ -318,6 +318,7 @@ load_hooks_for_rule(#{from := Topics}) ->
 maybe_add_metrics_for_rule(Id) ->
     case emqx_metrics_worker:has_metrics(rule_metrics, Id) of
         true ->
+            _ = emqx_metrics_worker:ensure_metrics(rule_metrics, Id, ?METRICS, ?RATE_METRICS),
             ok = reset_metrics_for_rule(Id);
         false ->
             ok = emqx_metrics_worker:create_metrics(rule_metrics, Id, ?METRICS, ?RATE_METRICS)
@@ -333,7 +334,13 @@ reset_metrics_for_rule(Id) ->
 
 -spec reset_metrics_for_rule(rule_id(), map()) -> ok.
 reset_metrics_for_rule(Id, _Opts) ->
-    emqx_metrics_worker:reset_metrics(rule_metrics, Id).
+    case emqx_metrics_worker:has_metrics(rule_metrics, Id) of
+        true ->
+            _ = emqx_metrics_worker:ensure_metrics(rule_metrics, Id, ?METRICS, ?RATE_METRICS),
+            emqx_metrics_worker:reset_metrics(rule_metrics, Id);
+        false ->
+            ok
+    end.
 
 unload_hooks_for_rule(#{id := Id, from := Topics}) ->
     lists:foreach(


### PR DESCRIPTION
Fixes (?) https://emqx.atlassian.net/browse/EMQX-15088

Release version:
5.8.10, 5.10.4

## Summary

Attempt to fix/mitigate errors such as:

```
Reason: {{badkey,'actions.success'},[{erlang,map_get,['actions.success',#{}],[{error_info,#{module => erl_erts_errors}}]},{emqx_metrics_worker,idx_metric,4,[{file,"emqx_metrics_worker.erl"},{line,683}]},{emqx_metrics_worker,inc,4,[{file,"emqx_metrics_worker.erl"},{line,322}]},{emqx_rule_runtime,do_eval_action_reply_to,2,[{file,"emqx_rule_runtime.erl"},{line,819}]}...
```

Although, at the time of writing, it is not known how the rule metrics disappear from the map stored in the persistent term...  Maybe the metrics worker process is dying (though that would entirely remove it from PT).

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [~] The changes are covered with new or existing tests
- [~] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files  (unsure if it really fixes, since it's not known how it's being triggered)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
