### PR TITLE
ci: skip job if matrix is empty

### DIFF
--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -72,6 +72,7 @@ jobs:
           retention-days: 1
 
   ct_docker:
+    if: inputs.ct-docker != '[]'
     runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
     name: "${{ matrix.app }}-${{ matrix.suitegroup }}"
     strategy:
@@ -136,6 +137,7 @@ jobs:
           retention-days: 7
 
   ct:
+    if: inputs.ct-host != '[]'
     runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
     name: "${{ matrix.app }}-${{ matrix.suitegroup }}"
     strategy:


### PR DESCRIPTION
https://github.com/emqx/emqx/actions/runs/21869383620?pr=16723

> Error when evaluating 'strategy' for job 'ct'. emqx/emqx/.github/workflows/run_test_cases.yaml@51e685e92addfb2504ad6c38dbc0b5fb21081d2a (Line: 144, Col: 9): matrix must define at least one vector
