### PR TITLE
fix(cli): avoid subscriptions ctl crash on shared topics

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_cli.erl
+++ b/apps/emqx_management/src/emqx_mgmt_cli.erl
@@ -1389,7 +1389,9 @@ print({?SUBOPTION, {{Topic, Pid}, Options}}) when is_pid(Pid) ->
     NL = maps:get(nl, Options, 0),
     RH = maps:get(rh, Options, 0),
     RAP = maps:get(rap, Options, 0),
-    emqx_ctl:print("~ts -> topic:~ts qos:~p nl:~p rh:~p rap:~p~n", [SubId, Topic, QoS, NL, RH, RAP]);
+    emqx_ctl:print("~ts -> topic:~ts qos:~p nl:~p rh:~p rap:~p~n", [
+        SubId, emqx_topic:maybe_format_share(Topic), QoS, NL, RH, RAP
+    ]);
 print({exclusive, {exclusive_subscription, Topic, ClientId}}) ->
     emqx_ctl:print("topic:~ts -> ClientId:~ts~n", [Topic, ClientId]).
 

--- a/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_cli_SUITE.erl
@@ -137,6 +137,21 @@ t_subscriptions(_Config) ->
     %% subscriptions del <ClientId> <Topic>       # Delete a static subscription manually
     ok.
 
+t_subscriptions_shared_topic_list(_Config) ->
+    SubPid = self(),
+    Topic =
+        {share, <<"fos_device_data_service">>,
+            <<"spBv1.0/flnc246/DBIRTH/A_C039_N001_DAC01/Inverter">>},
+    Key = {Topic, SubPid},
+    true = ets:insert(
+        emqx_suboption, {Key, #{subid => <<"test_client">>, qos => 0, nl => 0, rh => 0, rap => 0}}
+    ),
+    try
+        ?assertEqual(ok, emqx_ctl:run_command(["subscriptions", "list"]))
+    after
+        true = ets:delete(emqx_suboption, Key)
+    end.
+
 t_plugins(_Config) ->
     %% plugins <command> [Name-Vsn]          # e.g. 'start emqx_plugin_template-5.0-rc.1'
     %% plugins list                          # List all installed plugins

--- a/changes/ee/fix-16731.en.md
+++ b/changes/ee/fix-16731.en.md
@@ -1,0 +1,5 @@
+Fixed a crash in `emqx ctl subscriptions list` that could happen when shared subscriptions were present.
+
+Before this fix, listing subscriptions could fail for some clients and return no output.
+
+After this fix, `emqx ctl subscriptions list` works reliably with both regular and shared subscriptions.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.1, 6.2.0

## Summary

This PR fixes a crash in `emqx ctl subscriptions list` when subscription entries contain shared-subscription topics.

`emqx_mgmt_cli` now formats subscription topics via `emqx_topic:maybe_format_share/1` before printing, so both normal and shared topics are handled safely.

A regression test was added in `emqx_mgmt_cli_SUITE` to cover listing subscriptions with a shared topic term.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
