### PR TITLE
perf: reduce memsup process scan overhead

### DIFF
--- a/apps/emqx/etc/vm.args.cloud
+++ b/apps/emqx/etc/vm.args.cloud
@@ -146,6 +146,8 @@
 
 ## Disable os_mon's disksup by default
 -os_mon start_disksup false
+## Only collect system-wide memory statistics
+-os_mon memsup_system_only true
 
 ## Sets unicode as the printable character range when formatting binaries
 +pc unicode

--- a/changes/ee/perf-16746.en.md
+++ b/changes/ee/perf-16746.en.md
@@ -1,0 +1,1 @@
+Set `os_mon` to collect only system-wide memory statistics by default, reducing per-process memory scanning overhead.


### PR DESCRIPTION
Release version: 5.8.10, 5.10.4

## Summary
- set `-os_mon memsup_system_only true` in `apps/emqx/etc/vm.args.cloud` so releases default to system-wide memory stats only
- reduce per-process memsup scan overhead on running nodes

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

```
  GET /api/v5/prometheus/stats
    → emqx_prometheus_api:stats/2
    → emqx_prometheus:collect/1
    → emqx_prometheus:vm_data/1
    → emqx_mgmt:vm_stats/0
    → emqx_mgmt:get_sys_memory/0
    → emqx_mgmt_cache:get_sys_memory/0       (3-sec timeout)
    → emqx_mgmt_cache:refresh_sys_memory/2
    → load_ctl:get_sys_memory/0
    → lc_lib:get_sys_memory/0
    → lc_lib:do_get_sys_memory_usage/1
    → memsup:get_system_memory_data()         ← BOTTLENECK
```