### PR TITLE
chore(mq): preserve DS error details if app fails to start

### DIFF
--- a/apps/emqx_mq/src/emqx_mq_message_db.erl
+++ b/apps/emqx_mq/src/emqx_mq_message_db.erl
@@ -85,11 +85,15 @@ open() ->
     Config = maps:merge(emqx_ds_schema:db_config_mq_messages(), #{
         storage => {emqx_ds_storage_skipstream_lts_v2, ?MQ_MESSAGE_DB_LTS_SETTINGS}
     }),
-    maybe
-        ok ?= emqx_ds:open_db(?MQ_MESSAGE_LASTVALUE_DB, Config),
-        ok ?= emqx_ds:open_db(?MQ_MESSAGE_REGULAR_DB, Config)
-    else
-        _ -> error(failed_to_open_mq_databases)
+    ok = open_db(?MQ_MESSAGE_LASTVALUE_DB, Config),
+    ok = open_db(?MQ_MESSAGE_REGULAR_DB, Config).
+
+open_db(DB, Config) ->
+    case emqx_ds:open_db(DB, Config) of
+        ok ->
+            ok;
+        {error, Reason} ->
+            error({failed_to_open_mq_database, DB, Reason})
     end.
 
 -spec close() -> ok.


### PR DESCRIPTION
Release version: 6.1.1, 6.2.0

## Summary

This PR aims to provide better error messages if `emqx_mq` fails to start.

See individual commits for details.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] ~~Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~~
- [x] Schema changes are backward compatible
