### PR TITLE
chore(dsraft): bump `ra` to v2.16.13-emqx-2

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -209,7 +209,7 @@ defmodule EMQXUmbrella.MixProject do
   def common_dep(:telemetry), do: {:telemetry, "1.3.0", manager: :rebar3, override: true}
   # in conflict by grpc and eetcd
   def common_dep(:gpb), do: {:gpb, "4.21.5", override: true, runtime: false}
-  def common_dep(:ra), do: {:ra, github: "emqx/ra", tag: "v2.16.13-emqx-1", override: true}
+  def common_dep(:ra), do: {:ra, github: "emqx/ra", tag: "v2.16.13-emqx-2", override: true}
 
   # in conflict by emqx_connector and system_monitor
   def common_dep(:epgsql), do: {:epgsql, github: "emqx/epgsql", tag: "4.7.1.4", override: true}


### PR DESCRIPTION
This tag includes a minor fix for cluster change logic.

Fixes <issue-or-jira-number>

Release version: 6.0.3, 6.1.1, 6.2.0

## Summary

This tag includes a [minor fix for cluster change logic](https://github.com/emqx/ra/pull/2).

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible

