### PR TITLE
perf(os_mon): set memsup_system_only by default

### DIFF
--- a/apps/emqx/etc/vm.args.cloud
+++ b/apps/emqx/etc/vm.args.cloud
@@ -146,6 +146,8 @@
 
 ## Disable os_mon's disksup by default
 -os_mon start_disksup false
+## Only collect system-wide memory statistics
+-os_mon memsup_system_only true
 
 ## Sets unicode as the printable character range when formatting binaries
 +pc unicode

--- a/changes/ee/perf-16757.en.md
+++ b/changes/ee/perf-16757.en.md
@@ -1,0 +1,1 @@
+Set `os_mon` to collect only system-wide memory statistics by default, reducing per-process memory scanning overhead.


### PR DESCRIPTION
Forwport of #16746 to release-60.

## Summary

Set memsup_system_only=true by default to reduce os_mon overhead.