### PR TITLE
ci: fix mix warning in otp 28

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ ct: $(REBAR) merge-config
 static_checks: $(ELIXIR_COMMON_DEPS)
 	@env BPAPI_BUILD_PROFILE=$(PROFILE:%-test=%) \
 	    $(MIX) do \
-	    emqx.xref, dialyzer --mode classic, \
+	    emqx.xref + dialyzer --mode classic + \
 	    emqx.static_checks
 	./scripts/check-i18n-style.sh
 	./scripts/check_missing_reboot_apps.exs


### PR DESCRIPTION
```
warning: using commas as separators in "mix do" is deprecated, use + between commands instead
  (mix 1.19.1) lib/mix/tasks/do.ex:129: Mix.Tasks.Do.gather_commands/3
  (mix 1.19.1) lib/mix/tasks/do.ex:75: Mix.Tasks.Do.run/1
  (mix 1.19.1) lib/mix/task.ex:499: anonymous fn/3 in Mix.Task.run_task/5
  (mix 1.19.1) lib/mix/cli.ex:131: Mix.CLI.run_task/2
  /usr/local/bin/mix:7: (file)
  (elixir 1.19.1) src/elixir_compiler.erl:81: :elixir_compiler.dispatch/4
```
