### PR TITLE
fix(gateway): include hook context for session.created

### DIFF
--- a/apps/emqx_gateway/src/emqx_gateway_cm.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_cm.erl
@@ -417,7 +417,10 @@ create_session(GwName, ClientInfo, ConnInfo, CreateSessionFun, SessionMod) ->
                             Session
                     end
             end,
-        ok = emqx_hooks:run('session.created', [ClientInfo, SessionInfo]),
+        Ctx = #{
+            conn_info_fn => fun(Prop) -> maps:get(Prop, ConnInfo) end
+        },
+        ok = emqx_hooks:run('session.created', Ctx, [ClientInfo, SessionInfo]),
         Session
     catch
         Class:Reason:Stk ->


### PR DESCRIPTION
## Summary
- Add hook context when firing `session.created` in gateway session manager.
- Update related gateway test coverage.

 Ensure hooks receive complete context for downstream logic to prevent crash.
