### PR TITLE
fix(retainer): ignore non-MQTT external subscribers

### DIFF
--- a/apps/emqx_retainer/src/emqx_retainer_extsub_handler.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_extsub_handler.erl
@@ -65,6 +65,12 @@
 
 handle_subscribe(_SubscribeType, _SubscribeCtx, _Handler, #share{}) ->
     ignore;
+handle_subscribe(
+    _SubscribeType, #{clientinfo := #{protocol := Protocol}}, _Handler, _TopicFilter
+) when
+    Protocol =/= mqtt
+->
+    ignore;
 handle_subscribe(SubscribeType, SubscribeCtx, Handler, TopicFilter) ->
     IsNew =
         case {SubscribeType, SubscribeCtx} of


### PR DESCRIPTION
## Summary
- Retainer external subscriber handler now ignores non-MQTT subscribers.
- Add regression test coverage for this behavior.

Prevent invalid subscriber types from affecting retainer processing.
```
2026-02-14T01:56:26.330253+00:00 [error] clientid: testlwm2mclient, msg: unexpected_info, peername: 
10.50.0.0:33696, pid: <0.56127.0>, info: {info_to_extsub,#Ref<0.3599599245.1102839809.23071>,{next,1000}}
```
