### PR TITLE
fix(authz): return BAD_REQUEST when source type is missing

### DIFF
--- a/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
+++ b/apps/emqx_auth/src/emqx_authz/emqx_authz_schema.erl
@@ -254,7 +254,10 @@ select_union_member(#{<<"type">> := _} = Value, [Mod | Mods], Type) ->
             Member
     end;
 select_union_member(_Value, _Mods, _Type) ->
-    throw("missing_type_field").
+    throw(#{
+        reason => "missing_type_field",
+        missing_field => <<"type">>
+    }).
 
 default_authz() ->
     #{

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_schema_tests.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_schema_tests.erl
@@ -18,6 +18,18 @@ bad_authz_type_test() ->
         check(Txt)
     ).
 
+missing_authz_type_test() ->
+    Txt = "[{enable: true}]",
+    ?assertThrow(
+        [
+            #{
+                reason := "missing_type_field",
+                missing_field := <<"type">>
+            }
+        ],
+        check(Txt)
+    ).
+
 bad_mongodb_type_test() ->
     Txt = "[{type: mongodb, mongo_type: foobar}]",
     ?assertThrow(

--- a/changes/ee/fix-16780.en.md
+++ b/changes/ee/fix-16780.en.md
@@ -1,0 +1,3 @@
+Fixed an issue in authorization source validation where requests missing the `type` field could trigger an internal error.
+
+Now EMQX returns a clear `BAD_REQUEST` validation error for this case.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14755

Release version:
- 6.0.3
- 6.1.2
- 6.2.0

## Summary

When creating authorization sources, a payload without `type` could trigger an internal validation failure path.

This change makes the missing `type` case return a clear `BAD_REQUEST` validation error, and adds coverage in schema and API tests.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
