### PR TITLE
fix(mqtt): reject retained will when retain is unavailable

### DIFF
--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -385,7 +385,7 @@ check_will_msg(#mqtt_packet_connect{will_flag = false}, _Caps) ->
     ok;
 check_will_msg(
     #mqtt_packet_connect{will_retain = true},
-    _Opts = #{mqtt_retain_available := false}
+    _Opts = #{retain_available := false}
 ) ->
     {error, ?RC_RETAIN_NOT_SUPPORTED};
 check_will_msg(

--- a/apps/emqx/test/emqx_packet_SUITE.erl
+++ b/apps/emqx/test/emqx_packet_SUITE.erl
@@ -236,7 +236,7 @@ t_check_unsubscribe(_) ->
     {error, ?RC_TOPIC_FILTER_INVALID} = emqx_packet:check(?UNSUBSCRIBE_PACKET(1, [])).
 
 t_check_connect(_) ->
-    Opts = #{max_clientid_len => 5, mqtt_retain_available => false},
+    Opts = #{max_clientid_len => 5, retain_available => false},
     ok = emqx_packet:check(#mqtt_packet_connect{}, Opts),
     ok = emqx_packet:check(
         ?CONNECT_PACKET(#mqtt_packet_connect{

--- a/changes/ee/fix-16781.en.md
+++ b/changes/ee/fix-16781.en.md
@@ -1,0 +1,3 @@
+Fixed CONNECT validation when retained messages are unavailable.
+
+When `mqtt.retain_available` is set to `false`, CONNECT packets with Will Retain set are now correctly rejected with CONNACK reason `Retain not supported (0x9A)`.


### PR DESCRIPTION
Fixes  https://emqx.atlassian.net/browse/EMQX-14953

Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

This fixes CONNECT validation for retained wills when retained messages are disabled.

When `mqtt.retain_available = false`, a CONNECT packet with `will_retain = true` is now rejected with CONNACK reason code `0x9A` (`Retain not supported`) as required by MQTT v5.

Tests were added/updated to cover packet-level validation and channel-level CONNECT handling.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
