### PR TITLE
fix(mqtt): disconnect on publish subscription identifier

### DIFF
--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -285,7 +285,7 @@ check(#mqtt_packet_unsubscribe{topic_filters = TopicFilters}) ->
 
 check_pub_props(#{'Topic-Alias' := 0}) ->
     {error, ?RC_TOPIC_ALIAS_INVALID};
-check_pub_props(#{'Subscription-Identifier' := 0}) ->
+check_pub_props(#{'Subscription-Identifier' := _}) ->
     {error, ?RC_PROTOCOL_ERROR};
 check_pub_props(#{'Response-Topic' := ResponseTopic}) ->
     try emqx_topic:validate(name, ResponseTopic) of

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -196,6 +196,15 @@ t_handle_in_unexpected_packet(_) ->
     {ok, [{outgoing, Packet}, {close, protocol_error}], Channel} =
         emqx_channel:handle_in(?PUBLISH_PACKET(?QOS_0), Channel).
 
+t_handle_in_publish_with_subscription_identifier(_) ->
+    Channel = channel(#{conn_state => connected}),
+    Publish = ?PUBLISH_PACKET(
+        ?QOS_1, <<"topic">>, 1, #{'Subscription-Identifier' => 1}, <<"payload">>
+    ),
+    Packet = ?DISCONNECT_PACKET(?RC_PROTOCOL_ERROR),
+    {ok, [{outgoing, Packet}, {close, protocol_error}], Channel} =
+        emqx_channel:handle_in(Publish, Channel).
+
 % t_handle_in_connect_auth_failed(_) ->
 %     ConnPkt = #mqtt_packet_connect{
 %                                 proto_name  = <<"MQTT">>,

--- a/apps/emqx/test/emqx_packet_SUITE.erl
+++ b/apps/emqx/test/emqx_packet_SUITE.erl
@@ -199,11 +199,7 @@ t_check_publish(_) ->
     {error, ?RC_TOPIC_ALIAS_INVALID} = emqx_packet:check(
         ?PUBLISH_PACKET(1, <<"topic">>, 1, #{'Topic-Alias' => 0}, <<"payload">>)
     ),
-    %% TODO::
-    %% {error, ?RC_PROTOCOL_ERROR} = emqx_packet:check(
-    %%    ?PUBLISH_PACKET(1, <<"topic">>, 1, #{'Subscription-Identifier' => 10}, <<"payload">>)
-    %%),
-    ok = emqx_packet:check(
+    {error, ?RC_PROTOCOL_ERROR} = emqx_packet:check(
         ?PUBLISH_PACKET(1, <<"topic">>, 1, #{'Subscription-Identifier' => 10}, <<"payload">>)
     ),
     {error, ?RC_PROTOCOL_ERROR} = emqx_packet:check(

--- a/changes/ee/fix-16782.en.md
+++ b/changes/ee/fix-16782.en.md
@@ -1,0 +1,3 @@
+Fixed MQTT v5 protocol handling for invalid PUBLISH properties.
+
+If a client sends a PUBLISH packet containing `Subscription-Identifier`, EMQX now treats it as a protocol error and disconnects the client.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14954

Release version:
- 6.0.3
- 6.1.1/2 (depending on if it's synced before 6.1.1 release).
- 6.2.0 

## Summary

This change enforces MQTT v5 protocol validation for inbound PUBLISH packets.

If a client sends a PUBLISH with the `Subscription-Identifier` property, EMQX now treats it as a protocol error and disconnects the client.

Tests were updated to cover packet-level validation and channel-level disconnect behavior.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
