### PR TITLE
fix(mqtt): accept max subscription identifier

### DIFF
--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -258,7 +258,7 @@ check(#mqtt_packet_publish{topic_name = TopicName, properties = Props}) ->
             {error, ?RC_TOPIC_NAME_INVALID}
     end;
 check(#mqtt_packet_subscribe{properties = #{'Subscription-Identifier' := I}}) when
-    I =< 0; I >= 16#FFFFFFF
+    I =< 0; I > 16#FFFFFFF
 ->
     {error, ?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED};
 check(#mqtt_packet_subscribe{topic_filters = []}) ->

--- a/apps/emqx/test/emqx_packet_SUITE.erl
+++ b/apps/emqx/test/emqx_packet_SUITE.erl
@@ -221,12 +221,27 @@ t_check_subscribe(_) ->
             [{<<"topic">>, #{qos => ?QOS_0}}]
         )
     ),
+    ok = emqx_packet:check(
+        ?SUBSCRIBE_PACKET(
+            1,
+            #{'Subscription-Identifier' => 16#FFFFFFF},
+            [{<<"topic">>, #{qos => ?QOS_0}}]
+        )
+    ),
     {error, ?RC_TOPIC_FILTER_INVALID} = emqx_packet:check(#mqtt_packet_subscribe{topic_filters = []}),
     {error, ?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED} =
         emqx_packet:check(
             ?SUBSCRIBE_PACKET(
                 1,
                 #{'Subscription-Identifier' => -1},
+                [{<<"topic">>, #{qos => ?QOS_0, rp => 0}}]
+            )
+        ),
+    {error, ?RC_SUBSCRIPTION_IDENTIFIERS_NOT_SUPPORTED} =
+        emqx_packet:check(
+            ?SUBSCRIBE_PACKET(
+                1,
+                #{'Subscription-Identifier' => 16#10000000},
                 [{<<"topic">>, #{qos => ?QOS_0, rp => 0}}]
             )
         ).

--- a/changes/ee/fix-16783.en.md
+++ b/changes/ee/fix-16783.en.md
@@ -1,0 +1,3 @@
+Fixed MQTT v5 SUBSCRIBE validation for `Subscription-Identifier` upper bound.
+
+EMQX now accepts `268435455` (0x0FFFFFFF), which is the maximum valid Subscription Identifier value defined by the MQTT spec.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14955

Release version:
- 6.0.3
- 6.1.2
- 6.2.0

## Summary

This fixes MQTT v5 SUBSCRIBE validation for the `Subscription-Identifier` boundary.

The value `268435455` (`0x0FFFFFFF`) is now accepted as valid, while values above that limit are still rejected.

Tests were updated to cover both the max valid value and an overflow value.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
