### PR TITLE
feat(variform): add jq function to variform bif

### DIFF
--- a/apps/emqx_utils/test/emqx_variform_bif_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_bif_tests.erl
@@ -73,6 +73,15 @@ base64_encode_decode_test() ->
     Encoded = emqx_variform_bif:base64_encode(RandBytes),
     ?assertEqual(RandBytes, emqx_variform_bif:base64_decode(Encoded)).
 
+jq1_test_() ->
+    [
+        ?_assertEqual(#{<<"b">> => 2}, emqx_variform_bif:jq1(<<".">>, <<"{\"b\":2}">>)),
+        ?_assertEqual(6, emqx_variform_bif:jq1(<<".+1">>, <<"5">>)),
+        ?_assertEqual(#{<<"b">> => 2}, emqx_variform_bif:jq1(<<".">>, #{<<"b">> => 2})),
+        ?_assertEqual(#{<<"b">> => 2}, emqx_variform_bif:jq1(<<".">>, <<"{\"b\":2}">>, 10000)),
+        ?_assertEqual(<<"">>, emqx_variform_bif:jq1(<<".[]">>, <<"[]">>))
+    ].
+
 system_test() ->
     EnvName = erlang:atom_to_list(?MODULE),
     EnvVal = erlang:atom_to_list(?FUNCTION_NAME),
@@ -161,6 +170,11 @@ null_badarg_test_() ->
         ?ASSERT_BADARG(emqx_variform_bif:regex_replace(null, <<"a">>, <<"b">>)),
         ?ASSERT_BADARG(emqx_variform_bif:regex_extract(undefined, <<"a">>)),
         ?ASSERT_BADARG(emqx_variform_bif:regex_extract(null, <<"a">>)),
+        ?ASSERT_BADARG(emqx_variform_bif:jq1(undefined, <<"{}">>)),
+        ?ASSERT_BADARG(emqx_variform_bif:jq1(null, <<"{}">>)),
+        ?ASSERT_BADARG(emqx_variform_bif:jq1(<<".">>, undefined)),
+        ?ASSERT_BADARG(emqx_variform_bif:jq1(<<".">>, null)),
+        ?ASSERT_BADARG(emqx_variform_bif:jq1(<<".">>, <<"{}">>, -1)),
         ?ASSERT_BADARG(emqx_variform_bif:ascii(undefined)),
         ?ASSERT_BADARG(emqx_variform_bif:ascii(null)),
         ?ASSERT_BADARG(emqx_variform_bif:find(undefined, <<"a">>)),

--- a/apps/emqx_utils/test/emqx_variform_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_tests.erl
@@ -211,6 +211,14 @@ literal_test_() ->
         ?_assertEqual({ok, <<"string">>}, render(<<"\"string\"">>, #{}))
     ].
 
+jq1_test_() ->
+    [
+        ?_assertEqual(
+            {ok, <<"6">>},
+            render("jq1('.+1', '5')", #{})
+        )
+    ].
+
 boolean_literal_test_() ->
     [
         ?_assertEqual({ok, <<"T">>}, render("iif(true,'T','F')", #{}))
@@ -304,6 +312,9 @@ maps_test_() ->
 
 render(Expression, Bindings) ->
     emqx_variform:render(Expression, Bindings).
+
+render(Expression, Bindings, Opts) ->
+    emqx_variform:render(Expression, Bindings, Opts).
 
 hash_pick_test() ->
     lists:foreach(

--- a/changes/ee/fix-16786.en.md
+++ b/changes/ee/fix-16786.en.md
@@ -1,0 +1,7 @@
+Add `jq` as a supported function in variform expressions.
+
+You can now use `jq1(filter, json)` and `jq1(filter, json, timeout_ms)` in variform, including in places that evaluate variform templates.
+
+Example:
+`jq1('if index("write") then "writer" else "reader" end', jwt_value(password, 'scp'))`
+returns `"writer"` when the `scp` array contains `"write"`, otherwise `"reader"`.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

Add `jq` as a supported built-in function in variform expressions.

This PR adds `jq/2` and `jq/3` to `emqx_variform_bif` so variform expressions can evaluate jq filters against JSON input (binary JSON text or Erlang terms). It keeps variform-style argument validation and propagates jq runtime errors as `{jq_exception, Reason}`.

Tests were added for both direct BIF usage and expression-level rendering paths.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
