### PR TITLE
chore(i18n): deduplicate rel i18n keys

### DIFF
--- a/rel/i18n/emqx_bridge_azure_event_hub.hocon
+++ b/rel/i18n/emqx_bridge_azure_event_hub.hocon
@@ -333,12 +333,6 @@ producer_kafka_opts.desc:
 producer_kafka_opts.label:
 """Azure Event Hubs Producer"""
 
-desc_config.desc:
-"""Configuration for an Azure Event Hubs bridge."""
-
-desc_config.label:
-"""Azure Event Hubs Bridge Configuration"""
-
 ssl_client_opts.desc:
 """TLS/SSL options for Azure Event Hubs client."""
 ssl_client_opts.label:

--- a/rel/i18n/emqx_bridge_couchbase_connector_schema.hocon
+++ b/rel/i18n/emqx_bridge_couchbase_connector_schema.hocon
@@ -14,11 +14,6 @@ emqx_bridge_couchbase_connector_schema {
   password.desc:
   """Password for Couchbase service."""
 
-  password.label:
-  """Password"""
-  password.desc:
-  """Password for Couchbase service."""
-
   server.label:
   """Server Host"""
   server.desc:

--- a/rel/i18n/emqx_bridge_pulsar.hocon
+++ b/rel/i18n/emqx_bridge_pulsar.hocon
@@ -67,11 +67,6 @@ buffer_per_partition_limit.desc:
  buffer_per_partition_limit.label:
 """Per-partition Buffer Limit"""
 
-desc_name.desc:
-"""Action name, a human-readable identifier."""
-desc_name.label:
-"""Action Name"""
-
 buffer_segment_bytes.desc:
 """Applicable when buffer mode is set to <code>disk</code> or <code>hybrid</code>.
 This value is to specify the size of each on-disk buffer file."""
@@ -89,9 +84,9 @@ connect_timeout.label:
 """Connect Timeout"""
 
 desc_name.desc:
-"""Bridge name, used as a human-readable description of the bridge."""
+"""Action name, a human-readable identifier."""
 desc_name.label:
-"""Bridge Name"""
+"""Action Name"""
 
 desc_type.desc:
 """The Bridge Type"""

--- a/rel/i18n/emqx_connector_schema.hocon
+++ b/rel/i18n/emqx_connector_schema.hocon
@@ -1,11 +1,5 @@
 emqx_connector_schema {
 
-config_enable.desc:
-"""Enable (true) or disable (false) this connector."""
-
-config_enable.label:
-"""Enable or Disable"""
-
 desc_connectors.desc:
 """Connectors that are used to connect to external systems"""
 desc_connectors.label:

--- a/rel/i18n/emqx_mgmt_api_clients.hocon
+++ b/rel/i18n/emqx_mgmt_api_clients.hocon
@@ -80,7 +80,7 @@ msg_publish_at.label:
 
 msg_from_clientid.desc:
 """Message publisher's client ID."""
-msg_from_clientid.desc:
+msg_from_clientid.label:
 """Message publisher's Client ID"""
 
 msg_from_username.desc:
@@ -148,11 +148,6 @@ clientid_not_found.desc:
 clientid_not_found.label:
 """Client ID not found"""
 
-bad_request.desc:
-"""Cannot handle this request."""
-bad_request.label:
-"""Bad Request"""
-
 since.desc:
 """Include sessions expired after this time (UNIX Epoch in seconds precision)"""
 since.label:
@@ -173,20 +168,10 @@ node_name.desc:
 node_name.label:
 """Node name"""
 
-username.desc:
-"""User name, multiple values can be specified by repeating the parameter: username=u1&username=u2"""
-username.label:
-"""Username"""
-
 conn_state.desc:
 """The current connection status of the client, the possible values are connected,idle,disconnected"""
 conn_state.label:
 """Connection State"""
-
-clean_start.desc:
-"""Indicate whether the client is using a brand new session"""
-clean_start.label:
-"""Clean Start"""
 
 proto_ver.desc:
 """Protocol version"""
@@ -323,11 +308,6 @@ mqueue_max.desc:
 """Maximum length of send-buffer queue"""
 mqueue_max.label:
 """Mqueue Max"""
-
-mqueue_dropped.desc:
-"""Number of messages dropped by the message queue due to exceeding the length"""
-mqueue_dropped.label:
-"""Mqueue Dropped"""
 
 client_port.desc:
 """Client's port"""

--- a/rel/i18n/emqx_mgmt_api_listeners.hocon
+++ b/rel/i18n/emqx_mgmt_api_listeners.hocon
@@ -10,11 +10,6 @@ list_listeners.desc:
 list_listeners.label:
 """List listeners per type"""
 
-listener_type.desc:
-"""Listener type"""
-listener_type.label:
-"""Listener type"""
-
 create_on_all_nodes.desc:
 """Create the specified listener on all nodes."""
 create_on_all_nodes.label:

--- a/rel/i18n/emqx_prometheus_schema.hocon
+++ b/rel/i18n/emqx_prometheus_schema.hocon
@@ -104,9 +104,6 @@ legacy_vm_statistics_collector.desc:
 legacy_vm_system_info_collector.desc:
 """Deprecated, use `prometheus.collectors.vm_system_info` instead"""
 
-legacy_deprecated_setting.desc:
-"""Deprecated since 5.4.0"""
-
 latency_buckets.desc:
 """Comma separated duration values for latency histogram buckets."""
 

--- a/rel/i18n/emqx_schema_validation_schema.hocon
+++ b/rel/i18n/emqx_schema_validation_schema.hocon
@@ -66,7 +66,7 @@ emqx_schema_validation_schema {
 
   name.desc:
   """The name for this validation.  Must be unique among all validations.  It must be a combination of alphanumeric characters and underscores, and cannot start with neither number nor an underscore."""
-  name.desc:
+  name.label:
   """Name"""
 
   strategy.desc:
@@ -74,7 +74,7 @@ emqx_schema_validation_schema {
 
   <code>all_pass</code>: All checks will be evaluated and must pass.
   <code>any_pass</code>: Any passing check will suffice.  Stops at the first success."""
-  strategy.desc:
+  strategy.label:
   """Strategy"""
 
   failure_action.desc:


### PR DESCRIPTION
## Summary
Remove duplicated i18n key definitions in rel/i18n HOCON files.

- Keep a single definition per key path
- Preserve intended wording (for example, Action wording for Pulsar `desc_name`)
- This is internal i18n housekeeping with no feature behavior change
