### PR TITLE
fix(ds-sharesub): handle duplicate leader-connect messages in borrower

### DIFF
--- a/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_borrower.erl
+++ b/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_borrower.erl
@@ -194,6 +194,9 @@ on_info(#{id := Id, share_topic_filter := ShareTopicFilter} = St, ?find_leader_t
 on_info(St, ?find_leader_timer) when ?is_connected(St) ->
     %% Handle late delivery of the timer.
     {ok, [], St};
+on_info(#{leader := Leader} = St, ?leader_connect_response_match(Leader)) when ?is_connected(St) ->
+    %% Tolerate duplicate messages from the same leader:
+    {ok, [], St};
 %%
 %% Ping leader, status independent
 %%


### PR DESCRIPTION
Release version: 6.1.1, 6.2.0

## Summary

This PR fixes an issue that was causing very occasional connection crashes and test flakiness, likely observable with `leader_timeout` configured to a shorter value.

```
11:56:19.180042+00:00 [terminate] #{reason => #{context => function_clause,stacktrace => [
{emqx_ds_shared_sub_borrower,on_info,[
    #{
        id => {<<"client_shared2">>,0,#Ref<104175.0.373507.3897921819.3396665345.174702>},
        status => connected,
        send_after => #Fun<emqx_persistent_session_ds_shared_subs.22.102579068>,
        session_id => <<"client_shared2">>,
        leader => <104175.2962.0>,
        streams => #{},
        timers => #{find_leader_timer => undefined,ping_leader_timer => #Ref<104175.3897921819.3412852737.101074>},
        share_topic_filter => {share,<<"g1">>,<<"t1">>}
    },
    #{message_type => leader_connect_response,from_leader => <104175.2962.0>}
],[{file,"src/emqx_ds_shared_sub/emqx_ds_shared_sub_borrower.erl"},{line,175}]},
{emqx_persistent_session_ds_shared_subs,with_borrower,4,[{file,"src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs.erl"},{line,823}]},
{emqx_persistent_session_ds_shared_subs,on_info,3,[{file,"src/emqx_persistent_session_ds/emqx_persistent_session_ds_shared_subs.erl"},{line,534}]},
{emqx_persistent_session_ds,handle_info,3,[{file,"src/emqx_persistent_session_ds.erl"},{line,683}]},
{emqx_channel,handle_info,2,[{file,"src/emqx_channel.erl"},{line,1717}]},
{emqx_connection,with_channel,3,[{file,"src/emqx_connection.erl"},{line,891}]},
{emqx_connection,process_msg,2,[{file,"src/emqx_connection.erl"},{line,505}]},
{emqx_connection,handle_recv,3,[{file,"src/emqx_connection.erl"},{line,436}]}],exception => error}}.
```

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible