### PR TITLE
feat: add variform json/jwt helpers

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2005,9 +2005,16 @@ maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
             {ok, ClientInfo};
         Inits ->
             UserProperty = get_user_property_as_map(ConnPkt),
-            ClientInfo1 = initialize_client_attrs(Inits, ClientInfo#{user_property => UserProperty}),
-            {ok, maps:remove(user_property, ClientInfo1)}
+            Password = get_connect_password(ConnPkt),
+            ClientInfo1 = initialize_client_attrs(
+                Inits,
+                ClientInfo#{user_property => UserProperty, password => Password}
+            ),
+            {ok, maps:without([user_property, password], ClientInfo1)}
     end.
+
+get_connect_password(#mqtt_packet_connect{password = Password}) ->
+    Password.
 
 initialize_client_attrs(Inits, #{clientid := ClientId} = ClientInfo) ->
     lists:foldl(

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -227,7 +227,11 @@
 %% Data encode and decode
 -export([
     base64_encode/1,
+    base64_encode/2,
+    base64_encode/3,
     base64_decode/1,
+    base64_decode/2,
+    base64_decode/3,
     json_decode/1,
     json_encode/1,
     term_decode/1,
@@ -1139,10 +1143,22 @@ zip_uncompress(S) when is_binary(S) ->
 %%------------------------------------------------------------------------------
 
 base64_encode(Data) when is_binary(Data) ->
-    base64:encode(Data).
+    emqx_variform_bif:base64_encode(Data).
+
+base64_encode(Data, Opt) when is_binary(Data) ->
+    emqx_variform_bif:base64_encode(Data, Opt).
+
+base64_encode(Data, Opt1, Opt2) when is_binary(Data) ->
+    emqx_variform_bif:base64_encode(Data, Opt1, Opt2).
 
 base64_decode(Data) when is_binary(Data) ->
-    base64:decode(Data).
+    emqx_variform_bif:base64_decode(Data).
+
+base64_decode(Data, Opt) when is_binary(Data) ->
+    emqx_variform_bif:base64_decode(Data, Opt).
+
+base64_decode(Data, Opt1, Opt2) ->
+    emqx_variform_bif:base64_decode(Data, Opt1, Opt2).
 
 json_encode(Data) ->
     emqx_utils_json:encode(Data).

--- a/apps/emqx_utils/src/emqx_variform_bif.erl
+++ b/apps/emqx_utils/src/emqx_variform_bif.erl
@@ -70,7 +70,13 @@
     hexstr2bin/1,
     int2hexstr/1,
     base64_encode/1,
-    base64_decode/1
+    base64_encode/2,
+    base64_encode/3,
+    base64_decode/1,
+    base64_decode/2,
+    base64_decode/3,
+    json_value/2,
+    jwt_value/2
 ]).
 
 %% Hash functions
@@ -577,13 +583,203 @@ bin2hexstr(Bin) when is_bitstring(Bin) ->
 hexstr2bin(Str) when is_binary(Str) ->
     emqx_utils:hexstr_to_bin(Str).
 
-%% @doc Encode any bytes to base64.
-base64_encode(Bin) ->
-    base64:encode(Bin).
+-doc """
+Helper function to process base64 encoding/decoding options.
 
-%% @doc Decode base64 encoded string.
-base64_decode(Bin) ->
-    base64:decode(Bin).
+Supported options:
+- `<<"no_padding">>` - Disable padding in base64 encoding/decoding
+- `<<"urlsafe">>` - Use URL-safe base64 encoding/decoding (replaces + with -, / with _)
+- Any other option - Returns Opts unchanged (no-op)
+""".
+base64_opts(Opts, <<"no_padding">>) ->
+    Opts#{padding => false};
+base64_opts(Opts, <<"urlsafe">>) ->
+    Opts#{mode => urlsafe};
+base64_opts(Opts, _) ->
+    Opts.
+
+base64_encode(Data) when is_binary(Data) ->
+    base64:encode(Data).
+
+-doc """
+Encode binary data to base64 string with a single option.
+
+Options:
+- `<<"no_padding">>` - Encode without padding characters (=)
+- `<<"urlsafe">>` - Use URL-safe encoding (replaces + with -, / with _)
+
+Examples:
+  base64_encode(<<"hello">>, <<"no_padding">>)
+  base64_encode(<<"test">>, <<"urlsafe">>)
+""".
+base64_encode(Data, Opt) ->
+    Options = base64_opts(#{}, Opt),
+    base64:encode(Data, Options).
+
+-doc """
+Encode binary data to base64 string with two options.
+
+Options:
+- `<<"no_padding">>` - Encode without padding characters (=)
+- `<<"urlsafe">>` - Use URL-safe encoding (replaces + with -, / with _)
+
+Both options can be specified in any order. If the same option is specified twice,
+it will be applied once.
+
+Examples:
+  base64_encode(<<"hello">>, <<"no_padding">>, <<"urlsafe">>)
+  base64_encode(<<"test">>, <<"urlsafe">>, <<"no_padding">>)
+""".
+base64_encode(Data, Opt1, Opt2) ->
+    Options0 = base64_opts(#{}, Opt1),
+    Options = base64_opts(Options0, Opt2),
+    base64:encode(Data, Options).
+
+base64_decode(Data) when is_binary(Data) ->
+    base64:decode(Data).
+
+-doc """
+Decode base64 string to binary data with a single option.
+
+By default, this function requires padding. Use `<<"no_padding">>` to decode
+strings without padding.
+
+Options:
+- `<<"no_padding">>` - Allow decoding without padding characters (=)
+- `<<"urlsafe">>` - Decode URL-safe base64 (handles - and _ characters)
+
+Examples:
+  base64_decode(<<"aGVsbG8=">>) - Decode padded string (default)
+  base64_decode(<<"aGVsbG8">>, <<"no_padding">>) - Decode unpadded string
+  base64_decode(<<"aGVsbG8-">>, <<"urlsafe">>) - Decode padded URL-safe string
+  base64_decode(<<"aGVsbG8-">>, <<"urlsafe">>, <<"no_padding">>) - Decode unpadded URL-safe string
+""".
+base64_decode(Data, Opt) ->
+    Options = base64_opts(#{}, Opt),
+    base64:decode(Data, Options).
+
+-doc """
+Decode base64 string to binary data with two options.
+
+By default, this function requires padding. Use `<<"no_padding">>` to decode
+strings without padding.
+
+Options:
+- `<<"no_padding">>` - Allow decoding without padding characters (=)
+- `<<"urlsafe">>` - Decode URL-safe base64 (handles - and _ characters)
+
+Both options can be specified in any order. If the same option is specified twice,
+it will be applied once.
+
+Examples:
+  base64_decode(<<"aGVsbG8-">>, <<"urlsafe">>, <<"no_padding">>)
+  base64_decode(<<"aGVsbG8-">>, <<"no_padding">>, <<"urlsafe">>)
+""".
+base64_decode(Data, Opt1, Opt2) ->
+    Options0 = base64_opts(#{}, Opt1),
+    Options = base64_opts(Options0, Opt2),
+    base64:decode(Data, Options).
+
+-doc """
+Extract a value from a JSON binary using a dot-separated key path.
+
+This function decodes a JSON binary string and extracts a value using a
+dot-separated path to navigate nested structures.
+
+Args:
+  JsonBin: A binary containing JSON data (e.g., <<"{\"sub\":\"123\",\"name\":\"John\"}">>)
+  KeyPath: A dot-separated binary path to the value (e.g., "sub", "user.name", "user.profile.age")
+
+Returns:
+  The extracted value from the JSON, or undefined if the path is not found or JSON is invalid.
+
+Examples:
+  json_value(<<"{\"sub\":\"123\",\"name\":\"John\"}">>, <<"sub">>)
+  json_value(JsonBin, <<"user.name">>)
+  json_value(JsonBin, <<"user.profile.age">>)
+""".
+-spec json_value(null() | binary(), binary()) ->
+    term() | undefined.
+json_value(NULL, _) when ?IS_NULL(NULL) ->
+    ?BADARG();
+json_value(_, <<"">>) ->
+    ?BADARG();
+json_value(JsonBin, KeyPath) when is_binary(JsonBin), is_binary(KeyPath) ->
+    try
+        JsonMap = emqx_utils_json:decode(JsonBin, [return_maps]),
+        KeyPathList = split_keypath(KeyPath),
+        json_get_value(KeyPathList, JsonMap)
+    catch
+        _:_ ->
+            undefined
+    end;
+json_value(_JsonBin, _KeyPath) ->
+    undefined.
+
+-doc """
+Extract a claim value from a JWT token using a dot-separated key path.
+
+This function decodes the JWT token payload and extracts a value using a dot-separated
+path to navigate nested JSON structures. The token should be a valid JWT string with
+three parts separated by dots (header.payload.signature).
+
+Args:
+  Token: A binary containing the JWT token
+  KeyPath: A dot-separated binary path to the claim value (e.g., "sub", "user.name", "user.profile.age")
+
+Returns:
+  The extracted value from the JWT payload, or undefined if the path is not found.
+
+Examples:
+  jwt_value(<<"xxx.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIn0.xxx">>, <<"sub">>)
+  jwt_value(Token, <<"user.name">>)
+  jwt_value(Token, <<"user.profile.age">>)
+""".
+-spec jwt_value(null() | binary(), binary()) ->
+    term() | undefined.
+jwt_value(NULL, _) when ?IS_NULL(NULL) ->
+    ?BADARG();
+jwt_value(_, <<"">>) ->
+    ?BADARG();
+jwt_value(Token, KeyPath) when is_binary(Token), is_binary(KeyPath) ->
+    try
+        %% Split JWT token into parts (header.payload.signature)
+        Parts = binary:split(Token, <<".">>, [global]),
+        case Parts of
+            [_, Payload, _] ->
+                PayloadBin = base64:decode(Payload, #{mode => urlsafe, padding => false}),
+                %% Decode JSON payload and extract value using json_value
+                json_value(PayloadBin, KeyPath);
+            _ ->
+                throw(#{reason => invalid_jwt_token, function => ?FUNCTION_NAME})
+        end
+    catch
+        throw:#{reason := invalid_jwt_token} = Error ->
+            %% Re-throw invalid_jwt_token without wrapping
+            throw(Error);
+        Exception:Cause ->
+            throw(#{
+                reason => jwt_decode_error,
+                function => ?FUNCTION_NAME,
+                cause => Cause,
+                exception => Exception
+            })
+    end.
+
+%% Helper function to split dot-separated keypath into a list
+split_keypath(KeyPath) when is_binary(KeyPath) ->
+    binary:split(KeyPath, <<".">>, [global]).
+
+%% Helper function to get value using deep_get
+json_get_value(KeyPath, Map) when is_map(Map) ->
+    try
+        emqx_utils_maps:deep_get(KeyPath, Map)
+    catch
+        error:{config_not_found, _} ->
+            undefined
+    end;
+json_get_value(_KeyPath, _Value) ->
+    undefined.
 
 %%------------------------------------------------------------------------------
 %% Hash functions

--- a/apps/emqx_utils/test/emqx_variform_tests.erl
+++ b/apps/emqx_utils/test/emqx_variform_tests.erl
@@ -305,6 +305,9 @@ maps_test_() ->
 render(Expression, Bindings) ->
     emqx_variform:render(Expression, Bindings).
 
+render(Expression, Bindings, Opts) ->
+    emqx_variform:render(Expression, Bindings, Opts).
+
 hash_pick_test() ->
     lists:foreach(
         fun(_) ->
@@ -353,3 +356,164 @@ iif_test_() ->
         ?_assertEqual({ok, <<"">>}, render(Expr1, #{clientid => <<"a">>})),
         ?_assertEqual({ok, <<"suffix/#">>}, render(Expr1, #{clientid => <<"a-suffix">>}))
     ].
+
+json_value_test_() ->
+    SimpleJson = emqx_utils_json:encode(#{
+        <<"sub">> => <<"user123">>,
+        <<"name">> => <<"John Doe">>,
+        <<"age">> => 30
+    }),
+    NestedJson = emqx_utils_json:encode(#{
+        <<"user">> => #{
+            <<"profile">> => #{
+                <<"name">> => <<"Alice">>,
+                <<"email">> => <<"alice@example.com">>
+            }
+        }
+    }),
+    [
+        {"simple key", fun() ->
+            ?assertEqual(
+                {ok, <<"user123">>},
+                render("json_value(json, 'sub')", #{json => SimpleJson})
+            )
+        end},
+        {"nested key", fun() ->
+            ?assertEqual(
+                {ok, <<"Alice">>},
+                render("json_value(json, 'user.profile.name')", #{json => NestedJson})
+            )
+        end},
+        {"nested key email", fun() ->
+            ?assertEqual(
+                {ok, <<"alice@example.com">>},
+                render("json_value(json, 'user.profile.email')", #{json => NestedJson})
+            )
+        end},
+        {"numeric value", fun() ->
+            ?assertEqual(
+                {ok, <<"30">>},
+                render("json_value(json, 'age')", #{json => SimpleJson})
+            )
+        end},
+        {"non-existent key", fun() ->
+            ?assertEqual(
+                {ok, <<>>},
+                render("json_value(json, 'nonexistent')", #{json => SimpleJson})
+            )
+        end},
+        {"non-existent nested key", fun() ->
+            ?_assertEqual(
+                {ok, <<>>},
+                render("json_value(json, 'user.profile.missing')", #{json => NestedJson})
+            )
+        end},
+        {"invalid JSON", fun() ->
+            ?assertEqual(
+                {ok, <<>>},
+                render("json_value(json, 'key')", #{json => <<"invalid json">>})
+            )
+        end},
+        {"empty JSON", fun() ->
+            ?assertEqual(
+                {ok, <<>>},
+                render("json_value(json, 'key')", #{json => <<"{}">>})
+            )
+        end},
+        {"direct JSON string", fun() ->
+            JsonStr = emqx_utils_json:encode(#{<<"test">> => <<"value">>}),
+            ?assertEqual(
+                {ok, <<"value">>},
+                render("json_value('" ++ binary_to_list(JsonStr) ++ "', 'test')", #{})
+            )
+        end}
+    ].
+
+jwt_value_test_() ->
+    %% Create valid JWT tokens for testing
+    SimplePayload = #{
+        <<"sub">> => <<"user123">>,
+        <<"name">> => <<"John Doe">>,
+        <<"iat">> => 1516239022
+    },
+    SimpleToken = create_jwt_token(SimplePayload),
+    NestedPayload = #{
+        <<"user">> => #{
+            <<"name">> => <<"Alice">>,
+            <<"email">> => <<"alice@example.com">>,
+            <<"profile">> => #{
+                <<"age">> => 30,
+                <<"city">> => <<"New York">>
+            }
+        }
+    },
+    NestedToken = create_jwt_token(NestedPayload),
+    [
+        {"simple claim", fun() ->
+            ?assertEqual(
+                {ok, <<"user123">>},
+                render("jwt_value(token, 'sub')", #{token => SimpleToken})
+            )
+        end},
+        {"nested claim", fun() ->
+            ?assertEqual(
+                {ok, <<"Alice">>},
+                render("jwt_value(token, 'user.name')", #{token => NestedToken})
+            )
+        end},
+        {"deeply nested claim", fun() ->
+            ?assertEqual(
+                {ok, <<"New York">>},
+                render("jwt_value(token, 'user.profile.city')", #{token => NestedToken})
+            )
+        end},
+        {"numeric claim", fun() ->
+            ?assertEqual(
+                {ok, <<"30">>},
+                render("jwt_value(token, 'user.profile.age')", #{token => NestedToken})
+            )
+        end},
+        {"non-existent claim", fun() ->
+            ?assertEqual(
+                {ok, <<>>},
+                render("jwt_value(token, 'nonexistent')", #{token => SimpleToken})
+            )
+        end},
+        {"invalid token format", fun() ->
+            ?assertMatch(
+                {error, #{reason := _}},
+                render("jwt_value(token, 'sub')", #{token => <<"invalid.token">>})
+            )
+        end},
+        {"token with wrong parts", fun() ->
+            ?assertMatch(
+                {error, #{reason := _}},
+                render("jwt_value(token, 'sub')", #{token => <<"not.a.valid.jwt.token.format">>})
+            )
+        end},
+        {"direct token string", fun() ->
+            ?assertEqual(
+                {ok, <<"user123">>},
+                render("jwt_value('" ++ binary_to_list(SimpleToken) ++ "', 'sub')", #{})
+            )
+        end}
+    ].
+
+%% Helper function to create a JWT token from payload (same as in emqx_variform_bif_tests.erl)
+create_jwt_token(PayloadMap) ->
+    Header = base64url_encode(<<"{\"alg\":\"none\",\"typ\":\"JWT\"}">>),
+    Payload = base64url_encode(emqx_utils_json:encode(PayloadMap)),
+    Signature = <<"signature">>,
+    <<Header/binary, ".", Payload/binary, ".", Signature/binary>>.
+
+base64url_encode(Bin) ->
+    %% Simple base64url encoding (replace + with -, / with _, remove padding)
+    Base64 = base64:encode(Bin),
+    Base64Url = binary:replace(
+        binary:replace(Base64, <<"+">>, <<"-">>, [global]),
+        <<"/">>,
+        <<"_">>,
+        [global]
+    ),
+    %% Remove padding
+    binary:replace(Base64Url, <<"=">>, <<>>, [global]).

--- a/changes/ee/feat-16792.en.md
+++ b/changes/ee/feat-16792.en.md
@@ -1,0 +1,7 @@
+Added two new Variform expression helper functions `json_value` and `jwt_value` to extract values from JSON data and JWT tokens using dot-separated key paths.
+
+The `json_value` function extracts values from JSON binary strings using a dot-separated path to navigate nested structures.
+The `jwt_value` function decodes JWT token payloads and extracts claim values using the same path syntax.
+
+For example, if `username` is a JSON object, you can access field with `json_value(username, 'shop.floor')`;
+if `password` is JWT with a customized claim, you can access the nested value with `jwt_value(password, 'client_attrs.unitid')`.


### PR DESCRIPTION
Release: 5.10.4
Backport of #16533 and #16786 to release-510.

## Summary

- Add variform helper functions `json_value` and `jwt_value` for JSON/JWT field access.