### PR TITLE
refactor: do not include_lib in emqx.hrl

### DIFF
--- a/apps/emqx/include/emqx.hrl
+++ b/apps/emqx/include/emqx.hrl
@@ -39,13 +39,11 @@
 
 -record(subscription, {topic, subid, subopts}).
 
--include_lib("emqx_utils/include/emqx_message.hrl").
-
 -record(delivery, {
     %% Sender of the delivery
     sender :: pid(),
     %% The message delivered
-    message :: #message{}
+    message :: emqx_types:message()
 }).
 
 %%--------------------------------------------------------------------

--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -9,6 +9,7 @@
 -include("emqx.hrl").
 -include("emqx_router.hrl").
 -include("emqx_external_trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include("logger.hrl").
 -include("emqx_instr.hrl").

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -13,6 +13,7 @@
 -include("logger.hrl").
 -include("types.hrl").
 -include("emqx_external_trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 

--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -24,6 +24,7 @@
 -include("emqx_external_trace.hrl").
 -include("emqx_instr.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_message.erl
+++ b/apps/emqx/src/emqx_message.erl
@@ -9,6 +9,7 @@
 -include("emqx.hrl").
 -include("emqx_mqtt.hrl").
 -include("types.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% Create
 -export([

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -10,6 +10,7 @@
 -include("logger.hrl").
 -include("types.hrl").
 -include("emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 
 -export([

--- a/apps/emqx/src/emqx_mountpoint.erl
+++ b/apps/emqx/src/emqx_mountpoint.erl
@@ -8,6 +8,7 @@
 -include("emqx_mqtt.hrl").
 -include("emqx_placeholder.hrl").
 -include("types.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     mount/2,

--- a/apps/emqx/src/emqx_mqueue.erl
+++ b/apps/emqx/src/emqx_mqueue.erl
@@ -40,6 +40,7 @@
 -include("emqx.hrl").
 -include("types.hrl").
 -include("emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     init/1,

--- a/apps/emqx/src/emqx_packet.erl
+++ b/apps/emqx/src/emqx_packet.erl
@@ -9,6 +9,7 @@
 -include("emqx.hrl").
 -include("emqx_mqtt.hrl").
 -include("emqx_trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% Header APIs
 -export([

--- a/apps/emqx/src/emqx_persistent_message.erl
+++ b/apps/emqx/src/emqx_persistent_message.erl
@@ -9,6 +9,7 @@
 
 -include("emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([start_link/0, init/1, terminate/2, handle_continue/2, handle_call/3, handle_cast/2]).
 -export([

--- a/apps/emqx/src/emqx_persistent_session_ds.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds.erl
@@ -24,6 +24,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include("emqx_mqtt.hrl").
 

--- a/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_inflight.erl
+++ b/apps/emqx/src/emqx_persistent_session_ds/emqx_persistent_session_ds_inflight.erl
@@ -23,6 +23,7 @@
 
 -include("emqx.hrl").
 -include("emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -ifdef(TEST).
 -include_lib("proper/include/proper.hrl").

--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -37,6 +37,7 @@
 -include("emqx_session.hrl").
 -include("emqx_mqtt.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_session_events.erl
+++ b/apps/emqx/src/emqx_session_events.erl
@@ -6,6 +6,7 @@
 
 -include("emqx.hrl").
 -include("logger.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([handle_event/2]).
 

--- a/apps/emqx/src/emqx_session_mem.erl
+++ b/apps/emqx/src/emqx_session_mem.erl
@@ -39,6 +39,7 @@
 -include("emqx_session_mem.hrl").
 -include("logger.hrl").
 -include("types.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -16,6 +16,7 @@
 -include("emqx_shared_sub.hrl").
 -include("logger.hrl").
 -include("types.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("stdlib/include/ms_transform.hrl").
 

--- a/apps/emqx/src/emqx_socket_connection.erl
+++ b/apps/emqx/src/emqx_socket_connection.erl
@@ -17,6 +17,7 @@
 -include("emqx_external_trace.hrl").
 -include("emqx_instr.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -ifdef(TEST).
 -compile(export_all).

--- a/apps/emqx/src/emqx_trace/emqx_trace.erl
+++ b/apps/emqx/src/emqx_trace/emqx_trace.erl
@@ -7,6 +7,7 @@
 -include("logger.hrl").
 -include("emqx_trace.hrl").
 -include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("kernel/include/file.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").

--- a/apps/emqx/src/emqx_types.erl
+++ b/apps/emqx/src/emqx_types.erl
@@ -9,6 +9,7 @@
 -include("emqx.hrl").
 -include("emqx_mqtt.hrl").
 -include("types.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export_type([
     proto_ver/0,

--- a/apps/emqx/test/emqx_SUITE.erl
+++ b/apps/emqx/test/emqx_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 

--- a/apps/emqx/test/emqx_broker_SUITE.erl
+++ b/apps/emqx/test/emqx_broker_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").

--- a/apps/emqx/test/emqx_channel_SUITE.erl
+++ b/apps/emqx/test/emqx_channel_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 

--- a/apps/emqx/test/emqx_message_SUITE.erl
+++ b/apps/emqx/test/emqx_message_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 

--- a/apps/emqx/test/emqx_mountpoint_SUITE.erl
+++ b/apps/emqx/test/emqx_mountpoint_SUITE.erl
@@ -19,6 +19,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 

--- a/apps/emqx/test/emqx_mqueue_SUITE.erl
+++ b/apps/emqx/test/emqx_mqueue_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("proper/include/proper.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/apps/emqx/test/emqx_packet_SUITE.erl
+++ b/apps/emqx/test/emqx_packet_SUITE.erl
@@ -9,6 +9,7 @@
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
 

--- a/apps/emqx/test/emqx_persistent_messages_SUITE.erl
+++ b/apps/emqx/test/emqx_persistent_messages_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -compile(export_all).
 -compile(nowarn_export_all).

--- a/apps/emqx/test/emqx_proper_types.erl
+++ b/apps/emqx/test/emqx_proper_types.erl
@@ -10,6 +10,7 @@
 -include("emqx.hrl").
 -include("emqx_session_mem.hrl").
 -include("emqx_access_control.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% High level Types
 -export([

--- a/apps/emqx/test/emqx_session_mem_SUITE.erl
+++ b/apps/emqx/test/emqx_session_mem_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 all() -> emqx_common_test_helpers:all(?MODULE).
 

--- a/apps/emqx/test/emqx_shared_sub_SUITE.erl
+++ b/apps/emqx/test/emqx_shared_sub_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(SUITE, ?MODULE).
 

--- a/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
+++ b/apps/emqx_auth/test/emqx_authz/emqx_authz_SUITE.erl
@@ -14,6 +14,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/emqx_placeholder.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 

--- a/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_testlib.erl
@@ -15,6 +15,7 @@
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx_config.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 

--- a/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
+++ b/apps/emqx_bridge_disk_log/test/emqx_bridge_disk_log_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include("../src/emqx_bridge_disk_log.hrl").
 -include_lib("kernel/include/file.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -import(emqx_common_test_helpers, [on_exit/1]).
 

--- a/apps/emqx_bridge_kafka/mix.exs
+++ b/apps/emqx_bridge_kafka/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeKafka.MixProject do
   def project do
     [
       app: :emqx_bridge_kafka,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
+++ b/apps/emqx_bridge_kafka/src/emqx_bridge_kafka_impl_producer.erl
@@ -9,6 +9,7 @@
 
 -include_lib("emqx_resource/include/emqx_resource.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% callbacks of behaviour emqx_resource
 -export([

--- a/apps/emqx_bridge_mqtt/mix.exs
+++ b/apps/emqx_bridge_mqtt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXBridgeMQTT.MixProject do
   def project do
     [
       app: :emqx_bridge_mqtt,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_egress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_egress.erl
@@ -8,6 +8,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     config/1,

--- a/apps/emqx_cluster_link/src/emqx_cluster_link.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link.erl
@@ -33,6 +33,7 @@
 -include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %%--------------------------------------------------------------------
 %% emqx_external_broker API

--- a/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
+++ b/apps/emqx_cluster_link/src/emqx_cluster_link_mqtt.erl
@@ -5,6 +5,7 @@
 
 -include("emqx_cluster_link.hrl").
 -include("emqx_cluster_link_internal.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").

--- a/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
+++ b/apps/emqx_ds_backends/test/emqx_ds_backends_SUITE.erl
@@ -13,6 +13,7 @@
 -include_lib("stdlib/include/assert.hrl").
 -include("../../emqx/include/asserts.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(msg_fields, [topic, from, payload]).
 

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("stdlib/include/assert.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(DB, testdb).
 

--- a/apps/emqx_exhook/mix.exs
+++ b/apps/emqx_exhook/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXExhook.MixProject do
   def project do
     [
       app: :emqx_exhook,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       compilers: [:elixir, :grpc, :erlang, :app, :copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_exhook/src/emqx_exhook_handler.erl
+++ b/apps/emqx_exhook/src/emqx_exhook_handler.erl
@@ -7,6 +7,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_access_control.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     on_client_connect/2,

--- a/apps/emqx_ft/mix.exs
+++ b/apps/emqx_ft/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXFt.MixProject do
   def project do
     [
       app: :emqx_ft,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_ft/src/emqx_ft.erl
+++ b/apps/emqx_ft/src/emqx_ft.erl
@@ -8,6 +8,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx_channel.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("snabbkaffe/include/trace.hrl").
 

--- a/apps/emqx_gateway/test/test_mqtt_broker.erl
+++ b/apps/emqx_gateway/test/test_mqtt_broker.erl
@@ -13,6 +13,7 @@
 
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_router.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("emqx/include/emqx_mqtt.hrl").
 

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -7,6 +7,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -20,6 +20,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(CONF_DEFAULT, <<
     "\n"

--- a/apps/emqx_gateway_exproto/test/emqx_exproto_SUITE.erl
+++ b/apps/emqx_gateway_exproto/test/emqx_exproto_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -import(
     emqx_exproto_echo_svr,

--- a/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
+++ b/apps/emqx_gateway_gbt32960/src/emqx_gbt32960_channel.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     info/1,

--- a/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
+++ b/apps/emqx_gateway_gbt32960/test/emqx_gbt32960_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("emqx/include/asserts.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(BYTE, 8 / big - integer).
 -define(WORD, 16 / big - integer).

--- a/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
+++ b/apps/emqx_gateway_jt808/src/emqx_jt808_channel.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 

--- a/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
+++ b/apps/emqx_gateway_jt808/test/emqx_jt808_SUITE.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_channel.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_channel.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx_gateway_coap/include/emqx_coap.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([

--- a/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
+++ b/apps/emqx_gateway_lwm2m/src/emqx_lwm2m_session.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx_gateway_coap/include/emqx_coap.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([

--- a/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
+++ b/apps/emqx_gateway_mqttsn/src/emqx_mqttsn_channel.erl
@@ -13,6 +13,7 @@
 -include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([

--- a/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
+++ b/apps/emqx_gateway_mqttsn/test/emqx_sn_protocol_SUITE.erl
@@ -16,6 +16,7 @@
 ).
 
 -include("emqx_mqttsn.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").

--- a/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
+++ b/apps/emqx_gateway_ocpp/src/emqx_ocpp_channel.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/types.hrl").
 -include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -logger_header("[OCPP-Chann]").
 

--- a/apps/emqx_gcp_device/mix.exs
+++ b/apps/emqx_gcp_device/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXGCPDevice.MixProject do
   def project do
     [
       app: :emqx_gcp_device,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_gcp_device/src/emqx_gcp_device.erl
+++ b/apps/emqx_gcp_device/src/emqx_gcp_device.erl
@@ -7,6 +7,7 @@
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% NOTE
 %% We share the shard with `emqx_auth_mnesia` to ensure backward compatibility

--- a/apps/emqx_gcp_device/test/emqx_gcp_device_api_SUITE.erl
+++ b/apps/emqx_gcp_device/test/emqx_gcp_device_api_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx_auth/include/emqx_authn.hrl").
 -include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(PATH, [authentication]).
 

--- a/apps/emqx_management/src/emqx_mgmt_api_clients.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_clients.erl
@@ -15,6 +15,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_utils/include/emqx_http_api.hrl").
 -include_lib("emqx/include/emqx_durable_session_metadata.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 

--- a/apps/emqx_management/src/emqx_mgmt_api_publish.erl
+++ b/apps/emqx_management/src/emqx_mgmt_api_publish.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/emqx_external_trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(ALL_IS_WELL, 200).
 -define(PARTIALLY_OK, 202).

--- a/apps/emqx_modules/src/emqx_delayed.erl
+++ b/apps/emqx_modules/src/emqx_delayed.erl
@@ -12,6 +12,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     create_tables/0,

--- a/apps/emqx_modules/src/emqx_rewrite.erl
+++ b/apps/emqx_modules/src/emqx_rewrite.erl
@@ -8,6 +8,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -ifdef(TEST).
 -export([

--- a/apps/emqx_modules/src/emqx_topic_metrics.erl
+++ b/apps/emqx_modules/src/emqx_topic_metrics.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     on_message_publish/1,

--- a/apps/emqx_modules/test/emqx_delayed_SUITE.erl
+++ b/apps/emqx_modules/test/emqx_delayed_SUITE.erl
@@ -15,6 +15,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %%--------------------------------------------------------------------
 %% Setups

--- a/apps/emqx_mq/mix.exs
+++ b/apps/emqx_mq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMQ.MixProject do
   def project do
     [
       app: :emqx_mq,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       compilers: [:elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_mq/src/emqx_mq.erl
+++ b/apps/emqx_mq/src/emqx_mq.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([register_hooks/0, unregister_hooks/0]).
 

--- a/apps/emqx_opentelemetry/src/emqx_otel_trace.erl
+++ b/apps/emqx_opentelemetry/src/emqx_otel_trace.erl
@@ -82,6 +82,7 @@
 -include_lib("emqx/include/emqx_external_trace.hrl").
 -include_lib("opentelemetry_api/include/otel_tracer.hrl").
 -include_lib("opentelemetry_api/include/opentelemetry.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(EMQX_OTEL_CTX, emqx_otel_ctx).
 

--- a/apps/emqx_retainer/mix.exs
+++ b/apps/emqx_retainer/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXRetainer.MixProject do
   def project do
     [
       app: :emqx_retainer,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.strict_erlc_options(),

--- a/apps/emqx_retainer/src/emqx_retainer.erl
+++ b/apps/emqx_retainer/src/emqx_retainer.erl
@@ -11,6 +11,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([start_link/0]).
 

--- a/apps/emqx_retainer/src/emqx_retainer_api.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_api.erl
@@ -8,6 +8,7 @@
 
 -include("emqx_retainer.hrl").
 -include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([api_spec/0, paths/0, schema/1, namespace/0, fields/1]).

--- a/apps/emqx_retainer/src/emqx_retainer_dispatcher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_dispatcher.erl
@@ -9,6 +9,7 @@
 -include("emqx_retainer.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([

--- a/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_mnesia.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
 -include_lib("stdlib/include/ms_transform.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -behaviour(emqx_retainer).
 -export([

--- a/apps/emqx_retainer/src/emqx_retainer_publisher.erl
+++ b/apps/emqx_retainer/src/emqx_retainer_publisher.erl
@@ -14,6 +14,7 @@
 -include("emqx_retainer.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% API
 -export([

--- a/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
+++ b/apps/emqx_retainer/test/emqx_retainer_SUITE.erl
@@ -8,6 +8,7 @@
 -compile(nowarn_export_all).
 
 -include("emqx_retainer.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("eunit/include/eunit.hrl").

--- a/apps/emqx_rule_engine/src/emqx_rule_actions.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_actions.erl
@@ -9,6 +9,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("snabbkaffe/include/trace.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 %% APIs
 -export([parse_action/1]).

--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/emqx_hooks.hrl").
 -include_lib("emqx/include/emqx_access_control.hrl").
 -include_lib("emqx_bridge/include/emqx_bridge_resource.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     reload/0,

--- a/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_engine_SUITE.erl
@@ -10,6 +10,7 @@
 -include_lib("eunit/include/eunit.hrl").
 -include_lib("common_test/include/ct.hrl").
 -include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -include_lib("emqx/include/asserts.hrl").
 -include_lib("emqx/include/emqx.hrl").

--- a/apps/emqx_slow_subs/mix.exs
+++ b/apps/emqx_slow_subs/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXSlowSubs.MixProject do
   def project do
     [
       app: :emqx_slow_subs,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_slow_subs/src/emqx_slow_subs.erl
+++ b/apps/emqx_slow_subs/src/emqx_slow_subs.erl
@@ -10,6 +10,7 @@
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_slow_subs/include/emqx_slow_subs.hrl").
 -include_lib("emqx/include/emqx_hooks.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -export([
     start_link/0,

--- a/apps/emqx_slow_subs/test/emqx_slow_subs_SUITE.erl
+++ b/apps/emqx_slow_subs/test/emqx_slow_subs_SUITE.erl
@@ -12,6 +12,7 @@
 -include_lib("emqx/include/emqx_mqtt.hrl").
 -include_lib("emqx/include/emqx.hrl").
 -include_lib("emqx_slow_subs/include/emqx_slow_subs.hrl").
+-include_lib("emqx_utils/include/emqx_message.hrl").
 
 -define(NOW, erlang:system_time(millisecond)).
 -define(LANTENCY, 101).


### PR DESCRIPTION
`include_lib` makes `include("emqx.hrl")` not possible to use for plugins.

This PR only adds `include_lib` in the modules which require `#message{}` record.