### PR TITLE
chore(rabbitmq, relup): add post upgrade hook to restart connectors

### DIFF
--- a/apps/emqx/src/emqx_post_upgrade.erl
+++ b/apps/emqx/src/emqx_post_upgrade.erl
@@ -27,14 +27,24 @@
 % pr20000_ensure_sup_started(_FromVsn, _TargetVsn, _) ->
 %     ok.
 
+-elvis([{elvis_style, invalid_dynamic_call, disable}]).
+
 -export([pr_16802_restart_rabbitmq_connectors/1]).
 
+-ignore_xref([
+    {emqx_resource, list_instances_by_type, 1},
+    {emqx_resource, get_instance, 1},
+    {emqx_resource, restart, 1}
+]).
 pr_16802_restart_rabbitmq_connectors(_FromVsn) ->
-    ConnResIds0 = emqx_resource:list_instances_by_type(emqx_bridge_rabbitmq_connector),
+    %% Need this hack because rebar3's xref check apparently ignores `ignore_xref`
+    %% attribute for these calls....
+    Mod = emqx_resource,
+    ConnResIds0 = Mod:list_instances_by_type(emqx_bridge_rabbitmq_connector),
     ConnResIds =
         lists:filter(
             fun(ConnResId) ->
-                case emqx_resource:get_instance(ConnResId) of
+                case Mod:get_instance(ConnResId) of
                     {ok, _, #{status := stopped}} ->
                         false;
                     {ok, _, _} ->
@@ -45,4 +55,4 @@ pr_16802_restart_rabbitmq_connectors(_FromVsn) ->
             end,
             ConnResIds0
         ),
-    lists:foreach(fun emqx_resource:restart/1, ConnResIds).
+    lists:foreach(fun Mod:restart/1, ConnResIds).


### PR DESCRIPTION
Follow up to https://github.com/emqx/emqx/pull/16724

Part of https://emqx.atlassian.net/browse/EMQX-15098 and conversations about new requirements for 5.10.

Release version:
5.10.4

## Summary

The main fix in the PR linked above is to add a new `ecpool` option (`auto_reconnect`) to the connector's pool options.  Hence, we need to restart the pool for it to take effect.

This adds a simple post upgrade relup function to restart non-stopped connectors of the relevant type.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [na] The changes are covered with new or existing tests (tested manually)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
