### PR TITLE
fix: use safe binary_to_term for three external decode paths

### DIFF
--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.app.src
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_syskeeper, [
     {description, "EMQX Enterprise Data bridge for Syskeeper"},
-    {vsn, "0.1.7"},
+    {vsn, "0.1.8"},
     {registered, []},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_frame.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_frame.erl
@@ -122,7 +122,7 @@ int2bool(_) ->
     false.
 
 marshaller(Item) when is_binary(Item) ->
-    erlang:binary_to_term(Item);
+    erlang:binary_to_term(Item, [safe]);
 marshaller(Item) ->
     erlang:term_to_binary(Item).
 

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
@@ -184,7 +184,7 @@ unsubscribe(Req = #{conn := Conn, topic := Topic}, Md) ->
 %%--------------------------------------------------------------------
 
 to_pid(ConnStr) ->
-    binary_to_term(base64:decode(ConnStr)).
+    binary_to_term(base64:decode(ConnStr), [safe]).
 
 call(ConnStr, Req) ->
     try

--- a/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.app.src
+++ b/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_gateway_exproto, [
     {description, "ExProto Gateway"},
-    {vsn, "0.1.18"},
+    {vsn, "0.1.19"},
     {registered, []},
     {applications, [kernel, stdlib, grpc, emqx, emqx_gateway]},
     {env, []},

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -1160,7 +1160,7 @@ term_encode(Term) ->
     erlang:term_to_binary(Term).
 
 term_decode(Data) when is_binary(Data) ->
-    erlang:binary_to_term(Data).
+    erlang:binary_to_term(Data, [safe]).
 
 %%------------------------------------------------------------------------------
 %% Random Funcs


### PR DESCRIPTION
## Summary
- add `[safe]` to `term_decode/1` in rule engine
- add `[safe]` to ExProto `to_pid/1` decoding path
- add `[safe]` to Syskeeper frame marshaller binary decoding
- bump app versions for `emqx_gateway_exproto` and `emqx_bridge_syskeeper` as required on `release-58`

## Notes
- internal hardening change with no end-user feature impact