### PR TITLE
docs(exproto): deprecate

### DIFF
--- a/apps/emqx_gateway/include/emqx_gateway.hrl
+++ b/apps/emqx_gateway/include/emqx_gateway.hrl
@@ -29,7 +29,8 @@
     #{
         name := gateway_name(),
         callback_module := module(),
-        config_schema_module := module()
+        config_schema_module := module(),
+        config_schema_importance => term()
     }.
 
 -define(GATEWAY_SUP_NAME, emqx_gateway_sup).

--- a/apps/emqx_gateway/src/emqx_gateway_schema.erl
+++ b/apps/emqx_gateway/src/emqx_gateway_schema.erl
@@ -53,13 +53,16 @@ roots() ->
 
 fields(gateway) ->
     lists:map(
-        fun(#{name := Name, config_schema_module := Mod}) ->
+        fun(#{name := Name, config_schema_module := Mod} = GatewayDef) ->
             {Name,
                 sc(
                     ref(Mod, Name),
                     #{
                         required => {false, recursively},
-                        desc => ?DESC(Name)
+                        desc => ?DESC(Name),
+                        importance => maps:get(
+                            config_schema_importance, GatewayDef, ?IMPORTANCE_LOW
+                        )
                     }
                 )}
         end,

--- a/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_gateway_exproto.erl
@@ -7,12 +7,14 @@
 
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx_gateway/include/emqx_gateway.hrl").
+-include_lib("hocon/include/hoconsc.hrl").
 
 %% define a gateway named stomp
 -gateway(#{
     name => exproto,
     callback_module => ?MODULE,
-    config_schema_module => emqx_exproto_schema
+    config_schema_module => emqx_exproto_schema,
+    config_schema_importance => ?IMPORTANCE_NO_DOC
 }).
 
 %% callback_module must implement the emqx_gateway_impl behaviour


### PR DESCRIPTION
## Summary
- add optional `config_schema_importance` to gateway definitions
- let `emqx_gateway_schema` apply per-gateway schema importance when building `gateway` fields
- set ExProto gateway config schema importance to `?IMPORTANCE_NO_DOC` so it is excluded from default docgen output

## Notes
- internal-only change
- no changelog entry required
