### PR TITLE
fix: use safe binary_to_term in external decode paths

### DIFF
--- a/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_frame.erl
+++ b/apps/emqx_bridge_syskeeper/src/emqx_bridge_syskeeper_frame.erl
@@ -120,7 +120,7 @@ int2bool(_) ->
     false.
 
 marshaller(Item) when is_binary(Item) ->
-    erlang:binary_to_term(Item);
+    erlang:binary_to_term(Item, [safe]);
 marshaller(Item) ->
     erlang:term_to_binary(Item).
 

--- a/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
+++ b/apps/emqx_gateway_exproto/src/emqx_exproto_gsvr.erl
@@ -172,7 +172,7 @@ unsubscribe(Req = #{conn := Conn, topic := Topic}, Md) ->
 %%--------------------------------------------------------------------
 
 to_pid(ConnStr) ->
-    binary_to_term(base64:decode(ConnStr)).
+    binary_to_term(base64:decode(ConnStr), [safe]).
 
 call(ConnStr, Req) ->
     try

--- a/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_funcs.erl
@@ -1170,7 +1170,7 @@ term_encode(Term) ->
     erlang:term_to_binary(Term).
 
 term_decode(Data) when is_binary(Data) ->
-    erlang:binary_to_term(Data).
+    erlang:binary_to_term(Data, [safe]).
 
 %%------------------------------------------------------------------------------
 %% Random Funcs


### PR DESCRIPTION
Port 1d3806854fbc847214dc39acf7b6b031cb42e39d to release-60.

## Summary

- Use safe binary_to_term in external decode paths.