### PR TITLE
fix(streams): make enabling non-blocking to propagate config update

### DIFF
--- a/apps/emqx_streams/src/emqx_streams_config.erl
+++ b/apps/emqx_streams/src/emqx_streams_config.erl
@@ -166,11 +166,15 @@ maybe_enable(#{enable := auto} = _NewConf, _OldConf) ->
     ok;
 %% Always allow to change the enable state to true.
 maybe_enable(#{enable := true} = _NewConf, _OldConf) ->
-    ok = emqx_streams_controller:start_streams();
+    %% Streams components are starting.
+    %% Streams are not yet fully functional, but should be eventually.
+    %% Return as soon as `starting` is reached to propagate the intention through the cluster.
+    starting = emqx_streams_controller:start_streams(),
+    ok;
 %% Allow to disable if there are no streams.
 maybe_enable(#{enable := false} = _NewConf, _OldConf) ->
     case emqx_streams_controller:stop_streams() of
-        ok ->
+        stopped ->
             ok;
         {error, Reason} ->
             {error, #{reason => Reason}}

--- a/apps/emqx_streams/src/emqx_streams_controller.erl
+++ b/apps/emqx_streams/src/emqx_streams_controller.erl
@@ -7,6 +7,10 @@
 -moduledoc """
 Controller for the Message Streams application.
 Enables and disables its integration into the EMQX.
+
+Startup is split into two phases to avoid blocking config propagation:
+- `starting`: DB opened, metrics started.
+- `started`: DB readiness confirmed, hooks and services started.
 """.
 
 -include("emqx_streams_internal.hrl").
@@ -38,13 +42,14 @@ Enables and disables its integration into the EMQX.
 -type status() :: started | starting | stopped.
 
 -record(state, {
-    started = false
+    status :: status() | undefined,
+    target_status :: status()
 }).
 
 -record(start_streams, {}).
 -record(stop_streams, {}).
 -record(wait_status, {}).
--record(init_streams, {need_start :: boolean()}).
+-record(control_streams, {}).
 
 -define(STATUS_PT_KEY, ?MODULE).
 
@@ -67,11 +72,15 @@ child_spec() ->
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec start_streams() -> ok.
+-doc """
+Returns as soon as contoller enters `starting` phase.
+Call `wait_status/1` to know when subsystem is fully `started`.
+""".
+-spec start_streams() -> starting.
 start_streams() ->
     gen_server:call(?MODULE, #start_streams{}, infinity).
 
--spec stop_streams() -> ok | {error, cannot_stop_streams_with_existing_streams}.
+-spec stop_streams() -> stopped | {error, cannot_stop_streams_with_existing_streams}.
 stop_streams() ->
     gen_server:call(?MODULE, #stop_streams{}, infinity).
 
@@ -96,22 +105,46 @@ init([]) ->
     process_flag(trap_exit, true),
     case need_start() of
         true ->
-            {ok, #state{}, {continue, #init_streams{need_start = true}}};
+            TargetStatus = started;
         false ->
-            {ok, #state{}, {continue, #init_streams{need_start = false}}}
+            TargetStatus = stopped
+    end,
+    State = #state{
+        status = undefined,
+        target_status = TargetStatus
+    },
+    {ok, State, {continue, #control_streams{}}}.
+
+handle_continue(#control_streams{}, State) ->
+    NewState = control_streams(State),
+    case status_reached(NewState) of
+        true ->
+            {noreply, NewState};
+        false ->
+            {noreply, NewState, {continue, #control_streams{}}}
     end.
 
-handle_continue(#init_streams{need_start = true}, State) ->
-    {noreply, do_start_streams(State)};
-handle_continue(#init_streams{need_start = false}, State) ->
-    {noreply, do_stop_streams(State)}.
-
 handle_call(#start_streams{}, _From, State) ->
-    {reply, ok, handle_start_streams(State)};
-handle_call(#stop_streams{}, _From, State) ->
-    case can_be_stopped() of
+    NewState = control_streams(State#state{target_status = started}),
+    NewStatus = NewState#state.status,
+    case status_reached(NewState) of
         true ->
-            {reply, ok, handle_stop_streams(State)};
+            {reply, NewStatus, NewState};
+        false ->
+            {reply, NewStatus, NewState, {continue, #control_streams{}}}
+    end;
+handle_call(#stop_streams{}, _From, State) ->
+    maybe
+        true ?= can_be_stopped(),
+        NewState = control_streams(State#state{target_status = stopped}),
+        NewStatus = NewState#state.status,
+        case status_reached(NewState) of
+            true ->
+                {reply, NewStatus, NewState};
+            false ->
+                {reply, NewStatus, NewState, {continue, #control_streams{}}}
+        end
+    else
         false ->
             {reply, {error, cannot_stop_streams_with_existing_streams}, State}
     end;
@@ -128,59 +161,77 @@ handle_info(_Info, State) ->
 
 terminate(Reason, State) ->
     ?tp(info, streams_controller_terminate, #{reason => Reason}),
-    handle_stop_streams(State).
+    control_streams(State#state{target_status = stopped}).
 
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
 
-handle_start_streams(#state{started = false} = State) ->
+control_streams(#state{target_status = stopped, status = _Started} = State) ->
+    do_stop_streams(State);
+control_streams(#state{target_status = _Started, status = stopped} = State) ->
     do_start_streams(State);
-handle_start_streams(State) ->
+control_streams(#state{target_status = _Started, status = undefined} = State) ->
+    do_start_streams(State);
+control_streams(#state{target_status = started, status = starting} = State) ->
+    do_ready_streams(State);
+control_streams(#state{target_status = Status, status = Status} = State) ->
     State.
 
+status_reached(#state{status = Status, target_status = TargetStatus}) ->
+    Status =:= TargetStatus.
+
+%% Phase 1 (starting): Open DB, start metrics.
 do_start_streams(State) ->
     ?tp(debug, streams_controller_start_streams, #{}),
     ok = set_status(starting),
 
-    %% Init DS
+    %% Open DB
     ok = emqx_streams_message_db:open(),
+
+    %% Start services that don't require DB readiness
+    ok = emqx_streams_sup:start_metrics(),
+
+    %% Defer DB-dependent components to the next phase
+    State#state{status = starting}.
+
+%% Phase 2 (started): Wait for DB readiness, then start DB-dependent components.
+do_ready_streams(State = #state{}) ->
+    ?tp(debug, streams_controller_wait_ready, #{}),
+
+    %% Block until DB is ready (allows config to propagate to cluster first)
     ok = emqx_streams_message_db:wait_readiness(infinity),
 
-    %% Start services
-    ok = emqx_streams_sup:start_metrics(),
+    %% Start components that require DB readiness
     ok = emqx_mq_quota_buffer:start(?STREAMS_QUOTA_BUFFER, quota_buffer_options()),
     ok = emqx_streams_sup:start_gc_scheduler(),
-
-    %% Hook into EMQX
     ok = emqx_streams:register_hooks(),
+
     ok = set_status(started),
-
     ?tp(debug, streams_controller_start_streams_done, #{}),
-    State#state{started = true}.
 
-handle_stop_streams(#state{started = true} = State) ->
-    do_stop_streams(State);
-handle_stop_streams(State) ->
-    State.
+    State#state{status = started}.
 
-do_stop_streams(State) ->
+do_stop_streams(State = #state{status = Status}) ->
     ?tp(debug, streams_controller_stop_streams, #{}),
-    ok = clear_status(),
 
-    %% Unhook from EMQX
-    ok = emqx_streams:unregister_hooks(),
+    case Status of
+        started ->
+            ok = emqx_streams:unregister_hooks(),
+            _ = emqx_mq_quota_buffer:stop(?STREAMS_QUOTA_BUFFER),
+            ok = emqx_streams_sup:stop_gc_scheduler();
+        _ ->
+            %% Not fully started: only metrics and DB were started
+            ok
+    end,
 
-    %% Stop services
     ok = emqx_streams_sup:stop_metrics(),
-    _ = emqx_mq_quota_buffer:stop(?STREAMS_QUOTA_BUFFER),
-    ok = emqx_streams_sup:stop_gc_scheduler(),
-
-    %% Close DS
     _ = emqx_streams_message_db:close(),
 
+    ok = clear_status(),
     ?tp(debug, streams_controller_stop_streams_done, #{}),
-    State#state{started = false}.
+
+    State#state{status = stopped}.
 
 need_start() ->
     case emqx_streams_config:enabled() of


### PR DESCRIPTION
Fixes [EMQX-15123](https://emqx.atlassian.net/browse/EMQX-15123).

Release version: 6.1.1, 6.2.0

## Summary

This PR ensures that enabling the Streams subsystem in runtime in an already established cluster does not block config handler indefinitely.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-15123]: https://emqx.atlassian.net/browse/EMQX-15123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ