### PR TITLE
fix(mq): make enabling non-blocking to propagate config update

### DIFF
--- a/apps/emqx_mq/src/emqx_mq_config.erl
+++ b/apps/emqx_mq/src/emqx_mq_config.erl
@@ -118,11 +118,15 @@ maybe_enable(#{enable := auto} = _NewConf, _OldConf) ->
     ok;
 %% Always allow to change the enable state to true.
 maybe_enable(#{enable := true} = _NewConf, _OldConf) ->
-    ok = emqx_mq_controller:start_mqs();
+    %% MQ components are starting.
+    %% MQ is not yet fully functional, but should be eventually.
+    %% Return as soon as `starting` is reached to propagate the intention through the cluster.
+    starting = emqx_mq_controller:start_mqs(),
+    ok;
 %% Allow to disable if there are no queues.
 maybe_enable(#{enable := false} = _NewConf, _OldConf) ->
     case emqx_mq_controller:stop_mqs() of
-        ok ->
+        stopped ->
             ok;
         {error, Reason} ->
             {error, #{reason => Reason}}

--- a/apps/emqx_mq/src/emqx_mq_controller.erl
+++ b/apps/emqx_mq/src/emqx_mq_controller.erl
@@ -7,6 +7,10 @@
 -moduledoc """
 Controller for the Message Queue application.
 Enables and disables its integration into the EMQX.
+
+Startup is split into two phases to avoid blocking config propagation:
+- `starting`: DB opened, metrics started.
+- `started`: DB readiness confirmed, hooks and services started.
 """.
 
 -include("emqx_mq_internal.hrl").
@@ -38,13 +42,14 @@ Enables and disables its integration into the EMQX.
 -type status() :: started | starting | stopped.
 
 -record(state, {
-    started = false
+    status :: status() | undefined,
+    target_status :: status()
 }).
 
 -record(start_mqs, {}).
 -record(stop_mqs, {}).
 -record(wait_status, {}).
--record(init_mqs, {need_start :: boolean()}).
+-record(control_mqs, {}).
 
 -define(STATUS_PT_KEY, ?MODULE).
 
@@ -67,11 +72,15 @@ child_spec() ->
 start_link() ->
     gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
 
--spec start_mqs() -> ok.
+-doc """
+Returns as soon as controller enters `starting` phase.
+Call `wait_status/1` to know when subsystem is fully `started`.
+""".
+-spec start_mqs() -> starting.
 start_mqs() ->
     gen_server:call(?MODULE, #start_mqs{}, infinity).
 
--spec stop_mqs() -> ok | {error, cannot_stop_mqs_with_existing_queues}.
+-spec stop_mqs() -> stopped | {error, cannot_stop_mqs_with_existing_queues}.
 stop_mqs() ->
     gen_server:call(?MODULE, #stop_mqs{}, infinity).
 
@@ -96,22 +105,46 @@ init([]) ->
     process_flag(trap_exit, true),
     case need_start() of
         true ->
-            {ok, #state{}, {continue, #init_mqs{need_start = true}}};
+            TargetStatus = started;
         false ->
-            {ok, #state{}, {continue, #init_mqs{need_start = false}}}
+            TargetStatus = stopped
+    end,
+    State = #state{
+        status = undefined,
+        target_status = TargetStatus
+    },
+    {ok, State, {continue, #control_mqs{}}}.
+
+handle_continue(#control_mqs{}, State) ->
+    NewState = control_mqs(State),
+    case status_reached(NewState) of
+        true ->
+            {noreply, NewState};
+        false ->
+            {noreply, NewState, {continue, #control_mqs{}}}
     end.
 
-handle_continue(#init_mqs{need_start = true}, State) ->
-    {noreply, do_start_mqs(State)};
-handle_continue(#init_mqs{need_start = false}, State) ->
-    {noreply, do_stop_mqs(State)}.
-
 handle_call(#start_mqs{}, _From, State) ->
-    {reply, ok, handle_start_mqs(State)};
-handle_call(#stop_mqs{}, _From, State) ->
-    case can_be_stopped() of
+    NewState = control_mqs(State#state{target_status = started}),
+    NewStatus = NewState#state.status,
+    case status_reached(NewState) of
         true ->
-            {reply, ok, handle_stop_mqs(State)};
+            {reply, NewStatus, NewState};
+        false ->
+            {reply, NewStatus, NewState, {continue, #control_mqs{}}}
+    end;
+handle_call(#stop_mqs{}, _From, State) ->
+    maybe
+        true ?= can_be_stopped(),
+        NewState = control_mqs(State#state{target_status = stopped}),
+        NewStatus = NewState#state.status,
+        case status_reached(NewState) of
+            true ->
+                {reply, NewStatus, NewState};
+            false ->
+                {reply, NewStatus, NewState, {continue, #control_mqs{}}}
+        end
+    else
         false ->
             {reply, {error, cannot_stop_mqs_with_existing_queues}, State}
     end;
@@ -128,28 +161,50 @@ handle_info(_Info, State) ->
 
 terminate(Reason, State) ->
     ?tp(info, mq_controller_terminate, #{reason => Reason}),
-    handle_stop_mqs(State).
+    control_mqs(State#state{target_status = stopped}).
 
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
 
-handle_start_mqs(#state{started = false} = State) ->
+control_mqs(#state{target_status = stopped, status = _Started} = State) ->
+    do_stop_mqs(State);
+control_mqs(#state{target_status = _Started, status = stopped} = State) ->
     do_start_mqs(State);
-handle_start_mqs(State) ->
+control_mqs(#state{target_status = _Started, status = undefined} = State) ->
+    do_start_mqs(State);
+control_mqs(#state{target_status = started, status = starting} = State) ->
+    do_ready_mqs(State);
+control_mqs(#state{target_status = Status, status = Status} = State) ->
     State.
 
+status_reached(#state{status = Status, target_status = TargetStatus}) ->
+    Status =:= TargetStatus.
+
+%% Phase 1 (starting): Open DB, start metrics.
 do_start_mqs(State) ->
     ?tp(debug, mq_controller_start_mqs, #{}),
     ok = set_status(starting),
-    %% Init DS
+
+    %% Open DB
     ok = emqx_mq_message_db:open(),
     ok = emqx_mq_state_storage:open_db(),
+
+    %% Start services that don't require DB readiness
+    ok = emqx_mq_sup:start_metrics(),
+
+    %% Defer DB-dependent components to the next phase
+    State#state{status = starting}.
+
+%% Phase 2 (started): Wait for DB readiness, then start DB-dependent components.
+do_ready_mqs(State = #state{}) ->
+    ?tp(debug, mq_controller_wait_ready, #{}),
+
+    %% Block until DB is ready (allows config to propagate to cluster first)
     ok = emqx_mq_message_db:wait_readiness(infinity),
     ok = emqx_mq_state_storage:wait_readiness(infinity),
 
-    %% Start services
-    ok = emqx_mq_sup:start_metrics(),
+    %% Start components that require DB readiness
     ok = emqx_mq_quota_buffer:start(?MQ_QUOTA_BUFFER, quota_buffer_options()),
     ok = emqx_mq_sup:start_gc_scheduler(),
 
@@ -157,35 +212,34 @@ do_start_mqs(State) ->
     %% Claim handling of `$queue` topics to ourselves
     ok = emqx_topic:enable_queue_alias_to_share(false),
     ok = emqx_mq:register_hooks(),
+
     ok = set_status(started),
-
     ?tp(debug, mq_controller_start_mqs_done, #{}),
-    State#state{started = true}.
 
-handle_stop_mqs(#state{started = true} = State) ->
-    do_stop_mqs(State);
-handle_stop_mqs(State) ->
-    State.
+    State#state{status = started}.
 
-do_stop_mqs(State) ->
+do_stop_mqs(State = #state{status = Status}) ->
     ?tp(debug, mq_controller_stop_mqs, #{}),
-    ok = clear_status(),
 
-    %% Unhook from EMQX
-    ok = emqx_topic:enable_queue_alias_to_share(true),
-    ok = emqx_mq:unregister_hooks(),
+    case Status of
+        started ->
+            ok = emqx_topic:enable_queue_alias_to_share(true),
+            ok = emqx_mq:unregister_hooks(),
+            _ = emqx_mq_quota_buffer:stop(?MQ_QUOTA_BUFFER),
+            ok = emqx_mq_sup:stop_gc_scheduler();
+        _ ->
+            %% Not fully started: only metrics and DB were started
+            ok
+    end,
 
-    %% Stop services
     ok = emqx_mq_sup:stop_metrics(),
-    _ = emqx_mq_quota_buffer:stop(?MQ_QUOTA_BUFFER),
-    ok = emqx_mq_sup:stop_gc_scheduler(),
-
-    %% Close DS
     _ = emqx_mq_message_db:close(),
     _ = emqx_mq_state_storage:close_db(),
 
+    ok = clear_status(),
     ?tp(debug, mq_controller_stop_mqs_done, #{}),
-    State#state{started = false}.
+
+    State#state{status = stopped}.
 
 need_start() ->
     case emqx_mq_config:enabled() of


### PR DESCRIPTION
Fixes [EMQX-15123](https://emqx.atlassian.net/browse/EMQX-15123).

Release version: 6.1.1, 6.2.0

## Summary

This commit ensures that enabling MQ subsystem in runtime in an already estabilished cluster does not block config handler indefinitely.

Followup to #16826.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible


[EMQX-15123]: https://emqx.atlassian.net/browse/EMQX-15123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ