### PR TITLE
fix(rule-engine): guard event msgid hex conversion

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_events.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_events.erl
@@ -54,7 +54,8 @@
 -ifdef(TEST).
 -export([
     reason/1,
-    hook_fun/1
+    hook_fun/1,
+    msgid_to_hex/1
 ]).
 -endif.
 
@@ -362,7 +363,7 @@ eventmsg_publish(
     with_basic_columns(
         'message.publish',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             clientid => ClientId,
             username => emqx_message:get_header(username, Message, undefined),
             payload => Payload,
@@ -628,7 +629,7 @@ eventmsg_dropped(
     with_basic_columns(
         'message.dropped',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             reason => Reason,
             clientid => ClientId,
             username => emqx_message:get_header(username, Message, undefined),
@@ -663,7 +664,7 @@ eventmsg_transformation_failed(
     with_basic_columns(
         'message.transformation_failed',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             transformation => TransformationName,
             clientid => ClientId,
             username => emqx_message:get_header(username, Message, undefined),
@@ -697,7 +698,7 @@ eventmsg_validation_failed(
     with_basic_columns(
         'schema.validation_failed',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             validation => ValidationName,
             clientid => ClientId,
             username => emqx_message:get_header(username, Message, undefined),
@@ -736,7 +737,7 @@ eventmsg_delivered(
     with_basic_columns(
         'message.delivered',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             from_clientid => ClientId,
             from_username => emqx_message:get_header(username, Message, undefined),
             clientid => ReceiverCId,
@@ -776,7 +777,7 @@ eventmsg_acked(
     with_basic_columns(
         'message.acked',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             from_clientid => ClientId,
             from_username => emqx_message:get_header(username, Message, undefined),
             clientid => ReceiverCId,
@@ -820,7 +821,7 @@ eventmsg_delivery_dropped(
     with_basic_columns(
         'delivery.dropped',
         #{
-            id => emqx_guid:to_hexstr(Id),
+            id => msgid_to_hex(Id),
             reason => Reason,
             from_clientid => ClientId,
             from_username => emqx_message:get_header(username, Message, undefined),
@@ -852,6 +853,12 @@ with_basic_columns(EventName, Columns, Envs) when is_map(Columns) ->
         },
         Envs
     }.
+
+-spec msgid_to_hex(binary()) -> binary().
+msgid_to_hex(Id) when byte_size(Id) =:= 16 ->
+    emqx_guid:to_hexstr(Id);
+msgid_to_hex(Id) ->
+    emqx_utils:bin_to_hexstr(Id, upper).
 
 %%--------------------------------------------------------------------
 %% rules applying

--- a/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
+++ b/apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl
@@ -38,6 +38,12 @@ t_special_events_name_topic_conversion(_) ->
     ?assertEqual('message.publish', emqx_rule_events:event_name(NonExisting)),
     ?assertEqual(NonExisting, emqx_rule_events:event_topic('message.publish')).
 
+t_msgid_to_hex(_) ->
+    MsgId = emqx_guid:gen(),
+    ?assertEqual(emqx_guid:to_hexstr(MsgId), emqx_rule_events:msgid_to_hex(MsgId)),
+    ?assertEqual(<<>>, emqx_rule_events:msgid_to_hex(<<>>)),
+    ?assertEqual(<<"A1FF">>, emqx_rule_events:msgid_to_hex(<<16#a1, 16#ff>>)).
+
 %% Checks that `emqx_rule_events:event_topics_enum`, `_:event_names` and `_:event_info`
 %% are consistent amongst themselves.
 t_event_topics_enum_and_names_consistency(_Config) ->

--- a/changes/ce/fix-16836.en.md
+++ b/changes/ce/fix-16836.en.md
@@ -1,0 +1,1 @@
+Fixed a rule engine issue where message event processing could raise `function_clause` when converting non-16-byte message IDs to hexadecimal strings.


### PR DESCRIPTION
https://askemq.com/t/topic/12779/14

https://github.com/emqx/emqx/blob/master/apps/emqx_durable_storage/src/emqx_ds_payload_transform.erl#L103-L107
this cause msg_id is <<>> .
```
message_to_ttv(Msg = #message{topic = TopicBin}) ->
    {
        emqx_ds:topic_words(TopicBin),
        ?ds_tx_ts_monotonic,
        Msg#message{topic = <<>>, timestamp = 0, id = <<>>}
    }.
```

```
2026-02-26T18:21:21.440001+08:00 [error] clientid: mqttx_66d26a62, msg: hook_callback_exception, peername: 10.10.10.44:63208, username: test, reason: function_clause, stacktrace: [{emqx_guid,to_hexstr,[<<>>],[{file,"emqx_guid.erl"},{line,133}]},{emqx_rule_events,eventmsg_delivered,2,[{file,"emqx_rule_events.erl"},{line,781}]},{emqx_rule_events,apply_event,3,[{file,"emqx_rule_events.erl"},{line,918}]},
{emqx_rule_events,on_message_delivered,3,[{file,"emqx_rule_events.erl"},{line,322}]},{emqx_hooks,safe_execute,2,[{file,"emqx_hooks.erl"},{line,197}]},{emqx_hooks,do_run_fold,3,[{file,"emqx_hooks.erl"},{line,177}]},{emqx_channel,do_deliver,2,[{file,"emqx_channel.erl"},{line,3340}]},{emqx_channel,handle_out,3,
[{file,"emqx_channel.erl"},{line,1332}]},{emqx_connection,with_channel,3,[{file,"emqx_connection.erl"},{line,885}]},{emqx_connection,process_msg,2,[{file,"emqx_connection.erl"},{line,504}]},{emqx_connection,handle_recv,3,[{file,"emqx_connection.erl"},{line,435}]},{proc_lib,wake_up,3,[{file,"proc_lib.erl"},{line,344}]}], exception: error, callback_module: emqx_rule_events, callback_args: [#{peername => {{10,10,10,44},63208},protocol => 
mqtt,username => <<"test">>,peerhost => {10,10,10,44},client_attrs => #{},listener => 'tcp:default',peersni => undefined,clientid => <<"mqttx_66d26a62">>,enable_authn => true,mountpoint => undefined,is_superuser => false,is_bridge => false,zone => default,sockport => 1883,auth_expire_at => undefined},{message,<<>>,1,<<"mqttx_cdac1997">>,#{dup => false,sys => false,retain => false},#{peername => {{10,10,10,44},49975},protocol => mqtt,username => <<"test">>,peerhost => {10,10,10,44},properties => #{'Payload-Format-Indicator' => 
0,'Response-Topic' => <<"resp/msg.ack">>,'Correlation-Data' => <<"11">>},proto_ver => 5},<<"testtopic/22222222222">>,<<"222222222222">>,1772101281438,#{}},#{event_topic => <<"$events/message/delivered">>}], callback_function: on_message_delivered

```

## Summary
- avoid `function_clause` in rule event hooks when message id is not a 16-byte GUID
- add `msgid_to_hex/1` in `emqx_rule_events` and use it across message event builders
- keep existing 16-byte GUID behavior unchanged

## Testing
- added `t_msgid_to_hex` in `apps/emqx_rule_engine/test/emqx_rule_events_SUITE.erl`

