### PR TITLE
fix(plugins): reduce plugin config not-found log to debug level

### DIFF
--- a/changes/ee/fix-16842.en.md
+++ b/changes/ee/fix-16842.en.md
@@ -1,0 +1,3 @@
+Reduced noisy plugin config warning logs when no peer node has the plugin config yet.
+
+Previously, when a node tried to fetch plugin config from peer nodes during startup, it would log a warning even when all peers simply didn't have the config (e.g., first node to load the plugin). Now this benign case is logged at debug level, and only genuine errors (RPC failures, timeouts) remain as warnings.


### PR DESCRIPTION
Releases: 6.0.3, 6.1.2, 6.2.0
## Summary

When a node starts up and tries to fetch plugin config from peer nodes,
it previously logged a warning even when all peers simply didn't have the config yet
(e.g., first node to load the plugin). This was confusing and noisy.

Now config-not-found from all peers is logged at debug level, while genuine errors
(RPC failures, timeouts) remain as warnings. Also simplified the internal error
representation by removing the redundant `config_not_found_on_node` tuple.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-16842.en.md`