### PR TITLE
fix(message_transformation): handle unicode in prettify_operation

### DIFF
--- a/apps/emqx_message_transformation/src/emqx_message_transformation.erl
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation.erl
@@ -177,7 +177,7 @@ prettify_operation(Operation0) ->
     %% TODO: remove injected bif module
     Operation = maps:update_with(
         value,
-        fun(V) -> iolist_to_binary(emqx_variform:decompile(V)) end,
+        fun(V) -> unicode:characters_to_binary(emqx_variform:decompile(V)) end,
         Operation0
     ),
     maps:update_with(

--- a/apps/emqx_message_transformation/test/emqx_message_transformation_tests.erl
+++ b/apps/emqx_message_transformation/test/emqx_message_transformation_tests.erl
@@ -156,6 +156,18 @@ schema_test_() ->
             )}
     ].
 
+%% Variform expressions containing non-ASCII unicode characters should not
+%% crash prettify_operation/1.  emqx_variform:compile/1 stores the expression
+%% as a unicode codepoint list, and emqx_variform:decompile/1 returns it as-is.
+%% iolist_to_binary/1 cannot handle codepoints > 255, so prettify_operation
+%% must use unicode:characters_to_binary/1 instead.
+prettify_unicode_operation_test() ->
+    Expr = <<"concat(['你好世界'])"/utf8>>,
+    {ok, Compiled} = emqx_variform:compile(Expr),
+    Operation = #{key => [<<"payload">>, <<"msg">>], value => Compiled},
+    Result = emqx_message_transformation:prettify_operation(Operation),
+    ?assertMatch(#{key := <<"payload.msg">>, value := <<"concat(['你好世界'])"/utf8>>}, Result).
+
 invalid_names_test_() ->
     [
         {InvalidName,


### PR DESCRIPTION
## Summary

Fix crash in `prettify_operation/1` when variform expressions contain non-ASCII
unicode characters (e.g. Chinese characters in string literals).

`emqx_variform:compile/1` converts the expression binary to a unicode codepoint
list via `unicode:characters_to_list/1`. When `decompile/1` returns this list,
`iolist_to_binary/1` crashes with `badarg` because codepoints > 255 are not
valid iolist elements. Replaced with `unicode:characters_to_binary/1`.

Fix versions: 6.0.3, 6.1.2, 6.2.0

https://emqx.atlassian.net/browse/EEC-1297