### PR TITLE
feat(dashboard): add cookie auth fallback for plugin API endpoints

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -275,6 +275,29 @@ authorize(Req, HandlerInfo) ->
         {bearer, Token} ->
             jwt_token_bearer_authorize(Req, HandlerInfo, Token);
         _ ->
+            %% Fallback to emqx_auth cookie (set by dashboard for plugin UI iframes).
+            case is_plugin_api(Req) of
+                true ->
+                    cookie_authorize(Req, HandlerInfo);
+                false ->
+                    return_unauthorized(
+                        <<"AUTHORIZATION_HEADER_ERROR">>,
+                        <<"Support authorization: basic/bearer ">>
+                    )
+            end
+    end.
+
+is_plugin_api(Req) ->
+    case cowboy_req:path(Req) of
+        <<"/api/v5/plugin_api/", _/binary>> -> true;
+        _ -> false
+    end.
+
+cookie_authorize(Req, HandlerInfo) ->
+    case cowboy_req:match_cookies([{emqx_auth, [], undefined}], Req) of
+        #{emqx_auth := Token} when is_binary(Token), Token =/= <<>> ->
+            jwt_token_bearer_authorize(Req, HandlerInfo, Token);
+        _ ->
             return_unauthorized(
                 <<"AUTHORIZATION_HEADER_ERROR">>,
                 <<"Support authorization: basic/bearer ">>

--- a/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_admin_SUITE.erl
@@ -110,6 +110,17 @@ to_rfc3339(Sec) ->
 
 bin(X) -> emqx_utils_conv:bin(X).
 
+create_superuser_token() ->
+    emqx_common_test_http:create_default_app(),
+    Username = <<"superuser">>,
+    Password = <<"secretP@ss1">>,
+    {ok, _} = emqx_dashboard_admin:add_user(Username, Password, ?ROLE_SUPERUSER, <<"desc">>),
+    {200, #{<<"token">> := Token}} = login(#{<<"username">> => Username, <<"password">> => Password}),
+    Token.
+
+fake_req(Path, Headers) ->
+    #{path => Path, headers => Headers}.
+
 umbrella_apps() ->
     [
         App
@@ -681,3 +692,41 @@ t_namespace_immutable(_TCConfig) ->
     ),
 
     ok.
+
+%%------------------------------------------------------------------------------
+%% Cookie auth for plugin API
+%%------------------------------------------------------------------------------
+
+t_cookie_auth_plugin_api(_TCConfig) ->
+    Token = create_superuser_token(),
+    HandlerInfo = #{method => get, module => any, function => any},
+    CookieHeader = <<"emqx_auth=", Token/binary>>,
+    Req = fake_req(<<"/api/v5/plugin_api/my_plugin/foo">>, #{<<"cookie">> => CookieHeader}),
+    ?assertMatch({ok, _}, emqx_dashboard:authorize(Req, HandlerInfo)).
+
+t_cookie_auth_non_plugin_api(_TCConfig) ->
+    Token = create_superuser_token(),
+    HandlerInfo = #{method => get, module => any, function => any},
+    CookieHeader = <<"emqx_auth=", Token/binary>>,
+    Req = fake_req(<<"/api/v5/users">>, #{<<"cookie">> => CookieHeader}),
+    ?assertMatch({401, _, _}, emqx_dashboard:authorize(Req, HandlerInfo)).
+
+t_cookie_auth_no_cookie(_TCConfig) ->
+    _Token = create_superuser_token(),
+    HandlerInfo = #{method => get, module => any, function => any},
+    Req = fake_req(<<"/api/v5/plugin_api/my_plugin/foo">>, #{}),
+    ?assertMatch({401, _, _}, emqx_dashboard:authorize(Req, HandlerInfo)).
+
+t_cookie_auth_empty_token(_TCConfig) ->
+    _Token = create_superuser_token(),
+    HandlerInfo = #{method => get, module => any, function => any},
+    CookieHeader = <<"emqx_auth=">>,
+    Req = fake_req(<<"/api/v5/plugin_api/my_plugin/foo">>, #{<<"cookie">> => CookieHeader}),
+    ?assertMatch({401, _, _}, emqx_dashboard:authorize(Req, HandlerInfo)).
+
+t_cookie_auth_bad_token(_TCConfig) ->
+    _Token = create_superuser_token(),
+    HandlerInfo = #{method => get, module => any, function => any},
+    CookieHeader = <<"emqx_auth=bad_token">>,
+    Req = fake_req(<<"/api/v5/plugin_api/my_plugin/foo">>, #{<<"cookie">> => CookieHeader}),
+    ?assertMatch({401, _, _}, emqx_dashboard:authorize(Req, HandlerInfo)).

--- a/changes/ee/feat-16849.en.md
+++ b/changes/ee/feat-16849.en.md
@@ -1,0 +1,3 @@
+Added cookie-based authentication fallback for plugin API endpoints.
+
+Plugin UI iframes served by the dashboard can now authenticate via the `emqx_auth` cookie when no `Authorization` header is present. This only applies to `/api/v5/plugin_api/...` paths.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

Add cookie-based authentication fallback for plugin API endpoints (`/api/v5/plugin_api/...`).

When no `Authorization` header is present, the dashboard now checks for an `emqx_auth` cookie
on plugin API paths. This allows plugin UI iframes served by the dashboard to authenticate
without requiring the iframe to set HTTP headers (which is not possible for embedded content).

The cookie fallback is scoped exclusively to `/api/v5/plugin_api/...` paths — all other
API endpoints retain the existing behavior of requiring an `Authorization` header.

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)