### PR TITLE
fix(bridge): ignore computed config cache during config import

### DIFF
--- a/apps/emqx_bridge/src/emqx_bridge.app.src
+++ b/apps/emqx_bridge/src/emqx_bridge.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_bridge, [
     {description, "EMQX bridges"},
-    {vsn, "0.2.12"},
+    {vsn, "0.2.13"},
     {registered, [emqx_bridge_sup]},
     {mod, {emqx_bridge_app, []}},
     {applications, [

--- a/apps/emqx_bridge/src/emqx_bridge_v2.erl
+++ b/apps/emqx_bridge/src/emqx_bridge_v2.erl
@@ -1199,9 +1199,11 @@ pre_config_update([ConfRootKey], Conf = #{}, OldConfs) when
 
 %% This top level handler will be triggered when the actions path is updated
 %% with calls to emqx_conf:update([actions], BridgesConf, #{}).
-post_config_update([ConfRootKey], _Req, NewConf, OldConf, _AppEnv) when
+post_config_update([ConfRootKey], _Req, NewConf0, OldConf0, _AppEnv) when
     ConfRootKey =:= ?ROOT_KEY_ACTIONS; ConfRootKey =:= ?ROOT_KEY_SOURCES
 ->
+    NewConf = remove_computed_fields(NewConf0),
+    OldConf = remove_computed_fields(OldConf0),
     #{added := Added, removed := Removed, changed := Updated} =
         diff_confs(NewConf, OldConf),
     RemoveFun = fun(Type, Name, Conf) ->
@@ -1290,6 +1292,14 @@ flatten_confs(Conf0) ->
 
 do_flatten_confs(Type, Conf0) ->
     [{{Type, Name}, Conf} || {Name, Conf} <- maps:to_list(Conf0)].
+
+remove_computed_fields(#{} = Map) ->
+    maps:map(
+        fun(_K, V) -> remove_computed_fields(V) end,
+        maps:remove(?COMPUTED, Map)
+    );
+remove_computed_fields(X) ->
+    X.
 
 perform_bridge_changes(Tasks) ->
     perform_bridge_changes(Tasks, []).

--- a/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
+++ b/apps/emqx_bridge/test/emqx_bridge_v2_SUITE.erl
@@ -850,6 +850,62 @@ t_load_config_success(_Config) ->
 
     ok.
 
+%% Regression test: config import with reference-kind fallback actions must not crash.
+%% The hocon schema injects a '_computed' key (fallback_actions_index) into the checked
+%% config. Without the fix, flatten_confs treats '_computed' as a bridge type and crashes
+%% with badarity during post_config_update.
+%% Reproduces: export from 5.10.0, import into 5.10.3 => 400 BAD_REQUEST badarity.
+t_load_config_with_fallback_action_reference(_Config) ->
+    Conf = bridge_config(),
+    BridgeType = bridge_type(),
+    BridgeTypeBin = atom_to_binary(BridgeType),
+    FallbackName = <<"fallback_action">>,
+    PrimaryName = <<"primary_action">>,
+
+    %% First, load a config with a reference-kind fallback action.
+    %% This triggers the hocon computed callback (fallback_actions_reverse_index_compute)
+    %% which injects '_computed' => #{fallback_actions_index => ...} into checked config.
+    PrimaryConf = Conf#{
+        <<"fallback_actions">> => [
+            #{
+                <<"kind">> => <<"reference">>,
+                <<"type">> => BridgeTypeBin,
+                <<"name">> => FallbackName
+            }
+        ]
+    },
+    RootConf0 = #{
+        BridgeTypeBin => #{
+            FallbackName => Conf,
+            PrimaryName => PrimaryConf
+        }
+    },
+    ?assertMatch({ok, _}, update_root_config(RootConf0)),
+
+    %% Verify '_computed' is in the checked config (precondition for the bug).
+    ?assertMatch(
+        #{?COMPUTED := #{fallback_actions_index := _}},
+        emqx_config:get([actions])
+    ),
+
+    %% Now update the root config again (simulates a second import or any config change).
+    %% Before the fix, this crashed with badarity because flatten_confs in
+    %% post_config_update tried to iterate over '_computed' as a bridge type.
+    UpdatedPrimaryConf = PrimaryConf#{<<"description">> => <<"updated">>},
+    RootConf1 = #{
+        BridgeTypeBin => #{
+            FallbackName => Conf,
+            PrimaryName => UpdatedPrimaryConf
+        }
+    },
+    ?assertMatch({ok, _}, update_root_config(RootConf1)),
+
+    %% Verify both actions are alive.
+    ?assertMatch({ok, _}, emqx_bridge_v2:lookup(BridgeType, fallback_action)),
+    ?assertMatch({ok, _}, emqx_bridge_v2:lookup(BridgeType, primary_action)),
+
+    ok.
+
 t_create_no_matching_connector(_Config) ->
     Conf = (bridge_config())#{<<"connector">> => <<"wrong_connector_name">>},
     ?assertMatch(

--- a/changes/ee/fix-16854.en.md
+++ b/changes/ee/fix-16854.en.md
@@ -1,0 +1,5 @@
+Fix bridge config import crash.
+
+Previously when bulk importing configs, the request may fail with a crash message like below.
+
+`Failed to import the following config path: "actions", reason: {error, {config_update_crashed, {badarity, {#Fun<emqx_bridge_v2.16.79877859>, ['_computed',...`


### PR DESCRIPTION
Release version: 5.10.4

<!-- uncomment for v6:
6.0.3, 6.1.1, 6.2.0
-->

## Summary

Fix a config import crash like below
```
400 BAD_REQUEST: Failed to import the following config path: "actions", reason: {error, {config_update_crashed, {badarity, {#Fun<emqx_bridge_v2.16.79877859>, ['_computed',
```


<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
