### PR TITLE
fix(resource): add warning log for async reply to expired request

### DIFF
--- a/apps/emqx_resource/src/emqx_resource.app.src
+++ b/apps/emqx_resource/src/emqx_resource.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_resource, [
     {description, "Manager for all external resources"},
-    {vsn, "0.2.3"},
+    {vsn, "0.2.4"},
     {registered, []},
     {mod, {emqx_resource_app, []}},
     {applications, [

--- a/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
+++ b/apps/emqx_resource/src/emqx_resource_buffer_worker.erl
@@ -1753,6 +1753,15 @@ handle_async_reply1(
             IsAcked andalso
                 begin
                     emqx_resource_metrics:late_reply_inc(Id),
+                    ?SLOG(
+                        warning,
+                        #{
+                            msg => "async_reply_to_expired_request",
+                            resource_id => Id,
+                            expired_count => 1
+                        },
+                        #{tag => ?TAG}
+                    ),
                     reply_dropped(Id, Query, {error, late_reply})
                 end,
             ?tp(handle_async_reply_expired, #{expired => [Query]}),
@@ -1875,6 +1884,16 @@ handle_async_batch_reply2([Inflight], ReplyContext, Results0, Now) ->
     %% evalutate metrics call here since we're not inside buffer
     %% worker
     emqx_resource_metrics:late_reply_inc(Id, NumExpired),
+    NumExpired > 0 andalso
+        ?SLOG(
+            warning,
+            #{
+                msg => "async_reply_to_expired_request",
+                resource_id => Id,
+                expired_count => NumExpired
+            },
+            #{tag => ?TAG}
+        ),
     batch_reply_dropped(Id, RealExpired, {error, late_reply}),
     case RealNotExpired of
         [] ->

--- a/changes/ee/fix-16862.en.md
+++ b/changes/ee/fix-16862.en.md
@@ -1,0 +1,1 @@
+Added a warning log when an async reply is received for an already-expired request.


### PR DESCRIPTION
Release version: 5.10.4

## Summary

Added a warning log when an async reply is received for an already-expired request.
Previously only the `late_reply` metric counter was bumped, making it hard to notice
these events without checking metrics. Now a warning is logged with the resource ID
and expired count.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)