### PR TITLE
refactor(mqtt source): make state slimmer

### DIFF
--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_connector.erl
@@ -511,9 +511,13 @@ mk_ingress_config(
 ) ->
     #{namespace := Namespace} = emqx_resource:parse_channel_id(ChannelId),
     HookPoints = maps:get(hookpoints, IngressChannelConfig, []),
+    Ingress0 = maps:with([remote, local, server], IngressChannelConfig),
+    Ingress = Ingress0#{
+        on_message_received => {?MODULE, on_message_received, [HookPoints, ChannelId, Namespace]}
+    },
     NewConf = IngressChannelConfig#{
-        on_message_received => {?MODULE, on_message_received, [HookPoints, ChannelId, Namespace]},
-        ingress_list => [IngressChannelConfig]
+        hookpoints => HookPoints,
+        ingress_list => [Ingress]
     },
     emqx_bridge_mqtt_ingress:config(NewConf, ChannelId, TopicToHandlerIndex).
 

--- a/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
+++ b/apps/emqx_bridge_mqtt/src/emqx_bridge_mqtt_ingress.erl
@@ -219,12 +219,12 @@ unsubscribe_remote_topic(
 
 config(#{ingress_list := IngressList} = Conf, Name, TopicToHandlerIndex) ->
     NewIngressList = [
-        fix_remote_config(Ingress, Name, TopicToHandlerIndex, Conf)
+        fix_remote_config(Ingress, Name, TopicToHandlerIndex)
      || Ingress <- IngressList
     ],
-    Conf#{ingress_list => NewIngressList}.
+    Conf#{ingress_list := NewIngressList}.
 
-fix_remote_config(#{remote := RC}, BridgeName, TopicToHandlerIndex, Conf) ->
+fix_remote_config(#{remote := RC} = Conf, BridgeName, TopicToHandlerIndex) ->
     FixedConf0 = Conf#{
         remote => parse_remote(RC, BridgeName)
     },


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-12141

Release version:
6.2.0

## Summary

After patch:

```elixir
iex(emqx@127.0.0.1)2> :emqx_resource.get_instance("connector:mqtt:a") |> elem(2) |> get_in([:state, :installed_channels])
%{
  "source:mqtt:a:connector:mqtt:a" => %{
    local: %{retain: "${retain}", qos: "${qos}"},
    remote: %{no_local: false, topic: "bah/bah", qos: 1},
    server: ~c"127.0.0.1:1883",
    hookpoints: ["$bridges/mqtt:a", "$sources/mqtt:a"],
    config_root: :sources,
    ingress_list: [
      %{
        local: %{retain: [var: ["retain"]], qos: [var: ["qos"]]},
        remote: %{no_local: false, topic: "bah/bah", qos: 1},
        server: ~c"127.0.0.1:1883",
        on_message_received: {:emqx_bridge_mqtt_connector, :on_message_received,
         [
           ["$bridges/mqtt:a", "$sources/mqtt:a"],
           "source:mqtt:a:connector:mqtt:a",
           :global
         ]}
      }
    ]
  }
}
```

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
