### PR TITLE
feat(mqtt): add cert aliases for client_attrs_init context

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2025,7 +2025,9 @@ maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
         Inits ->
             UserProperty = get_user_property_as_map(ConnPkt),
             Password = get_connect_password(ConnPkt),
-            RenderCtx = ClientInfo#{user_property => UserProperty, password => Password},
+            RenderCtx = client_attrs_init_render_ctx(
+                ClientInfo#{user_property => UserProperty, password => Password}
+            ),
             Attrs0 = maps:get(client_attrs, ClientInfo, #{}),
             Attrs1 = initialize_client_attrs(Inits, RenderCtx),
             {ok, ClientInfo#{client_attrs => maps:merge(Attrs0, Attrs1)}}
@@ -2033,6 +2035,16 @@ maybe_set_client_initial_attrs(ConnPkt, #{zone := Zone} = ClientInfo) ->
 
 get_connect_password(#mqtt_packet_connect{password = Password}) ->
     Password.
+
+client_attrs_init_render_ctx(#{cn := CN} = Ctx) ->
+    client_attrs_init_render_ctx_dn(Ctx#{cert_common_name => CN});
+client_attrs_init_render_ctx(Ctx) ->
+    client_attrs_init_render_ctx_dn(Ctx).
+
+client_attrs_init_render_ctx_dn(#{dn := DN} = Ctx) ->
+    Ctx#{cert_subject => DN};
+client_attrs_init_render_ctx_dn(Ctx) ->
+    Ctx.
 
 initialize_client_attrs(Inits, #{clientid := ClientId} = ClientInfo) ->
     lists:foldl(

--- a/apps/emqx/test/emqx_client_SUITE.erl
+++ b/apps/emqx/test/emqx_client_SUITE.erl
@@ -378,6 +378,12 @@ t_certcn_as_alias(_) ->
 t_certdn_as_alias(_) ->
     test_cert_extraction_as_alias(dn).
 
+t_cert_common_name_as_alias(_) ->
+    test_cert_extraction_as_alias(cert_common_name).
+
+t_cert_subject_as_alias(_) ->
+    test_cert_extraction_as_alias(cert_subject).
+
 test_cert_extraction_as_alias(Which) ->
     %% extract the first two chars
     ClientId = iolist_to_binary(["ClientIdFor_", atom_to_list(Which)]),

--- a/changes/ee/fix-16865.en.md
+++ b/changes/ee/fix-16865.en.md
@@ -1,0 +1,1 @@
+Added `cert_common_name` and `cert_subject` aliases for `mqtt.client_attrs_init` expressions, alongside the existing `cn` and `dn` variables.

--- a/rel/i18n/emqx_schema.hocon
+++ b/rel/i18n/emqx_schema.hocon
@@ -1890,7 +1890,9 @@ client_attrs_init_expression {
     For TLS clients, connected directly or via proxy-protocol (v2) enabled load balancer,
     some extra variables can be used:
     - `cn`: Client's TLS certificate common name.
+    - `cert_common_name`: Alias of `cn`.
     - `dn`: Client's TLS certificate distinguished name (the subject).
+    - `cert_subject`: Alias of `dn`.
     - `peersni`: TLS server name indication sent by the client.
 
     You can read more about variform expressions in EMQX docs."""


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-14632

Release version:
6.0.3, 6.1.2, 6.2.0

## Summary

Add `cert_common_name` and `cert_subject` aliases to the `mqtt.client_attrs_init` expression context.

This keeps existing `cn`/`dn` behavior intact and allows using the same cert field names used in authentication templates.

## PR Checklist

- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
