### PR TITLE
fix(dashboard): improve API auth error messages to hint about API keys

### DIFF
--- a/apps/emqx_dashboard/src/emqx_dashboard.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard.erl
@@ -282,7 +282,13 @@ authorize(Req, HandlerInfo) ->
                 false ->
                     return_unauthorized(
                         <<"AUTHORIZATION_HEADER_ERROR">>,
-                        <<"Support authorization: basic/bearer ">>
+                        <<
+                            "Missing authorization header. "
+                            "Use Basic auth with API key/secret, "
+                            "or Bearer token from POST /api/v5/login. "
+                            "API keys can be bootstrapped from config "
+                            "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
+                        >>
                     )
             end
     end.
@@ -300,7 +306,13 @@ cookie_authorize(Req, HandlerInfo) ->
         _ ->
             return_unauthorized(
                 <<"AUTHORIZATION_HEADER_ERROR">>,
-                <<"Support authorization: basic/bearer ">>
+                <<
+                    "Missing authorization header. "
+                    "Use Basic auth with API key/secret, "
+                    "or Bearer token from POST /api/v5/login. "
+                    "API keys can be bootstrapped from config "
+                    "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
+                >>
             )
     end.
 
@@ -356,9 +368,20 @@ jwt_token_bearer_authorize(Req, HandlerInfo, Token) ->
             },
             {ok, AuthnMeta};
         {error, token_timeout} ->
-            {401, 'TOKEN_TIME_OUT', <<"Token expired, get new token by POST /login">>};
+            {401, 'TOKEN_TIME_OUT', <<
+                "Token expired. "
+                "Consider using API key (Basic auth) instead of bearer tokens "
+                "to avoid expiration. "
+                "Otherwise get a new token by POST /api/v5/login"
+            >>};
         {error, not_found} ->
-            {401, 'BAD_TOKEN', <<"Get a token by POST /login">>};
+            {401, 'BAD_TOKEN', <<
+                "Invalid bearer token. "
+                "Use API key (Basic auth) for persistent access, "
+                "or get a new bearer token by POST /api/v5/login. "
+                "API keys can be bootstrapped from config "
+                "(api_key.bootstrap_file) or created via POST /api/v5/api_key"
+            >>};
         {error, unauthorized_role} ->
             {403, 'UNAUTHORIZED_ROLE', <<"You don't have permission to access this resource">>}
     end.

--- a/changes/ee/fix-16868.en.md
+++ b/changes/ee/fix-16868.en.md
@@ -1,0 +1,1 @@
+Improved REST API authentication error messages to guide programmatic clients toward using API keys (Basic auth) instead of repeatedly logging in for bearer tokens. Error responses now mention the `api_key.bootstrap_file` configuration option and the `POST /api_key` endpoint for creating persistent API keys.


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

Improved REST API 401 error messages to reduce friction for programmatic clients (e.g. AI agents).

Previously, error responses only pointed to `POST /login`, causing clients to log in for every request.
Now the messages clearly explain:

- Use **Basic auth** with `api_key:api_secret` for persistent, token-free access
- Bootstrap API keys via `api_key.bootstrap_file` config (no interactive setup needed)
- Create API keys programmatically via `POST /api_key`

Updated messages in `apps/emqx_dashboard/src/emqx_dashboard.erl`:
- `AUTHORIZATION_HEADER_ERROR` — missing auth header
- `TOKEN_TIME_OUT` — expired bearer token
- `BAD_TOKEN` — invalid bearer token

## PR Checklist

- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)