### PR TITLE
fix(ds-sharesub): handle duplicate leader-connect messages in borrower

### DIFF
--- a/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_borrower.erl
+++ b/apps/emqx/src/emqx_ds_shared_sub/emqx_ds_shared_sub_borrower.erl
@@ -193,6 +193,9 @@ on_info(#{id := Id, share_topic_filter := ShareTopicFilter} = St, ?find_leader_t
 on_info(St, ?find_leader_timer) when ?is_connected(St) ->
     %% Handle late delivery of the timer.
     {ok, [], St};
+on_info(#{leader := Leader} = St, ?leader_connect_response_match(Leader)) when ?is_connected(St) ->
+    %% Tolerate duplicate messages from the same leader:
+    {ok, [], St};
 %%
 %% Ping leader, status independent
 %%


### PR DESCRIPTION
Backport of #16789.