### PR TITLE
build: allow make docker in git worktree

### DIFF
--- a/build
+++ b/build
@@ -59,8 +59,10 @@ export PROFILE
 # ensure dir
 cd -P -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
-PKG_VSN="${PKG_VSN:-$(./pkg-vsn.sh "$PROFILE")}"
-export PKG_VSN
+if [ -z "${PKG_VSN:-}" ]; then
+    PKG_VSN="$(./pkg-vsn.sh "$PROFILE")"
+    export PKG_VSN
+fi
 
 SYSTEM="$(./scripts/get-distro.sh)"
 
@@ -350,7 +352,7 @@ make_docker() {
     local EXTRA_DEPS='libsasl2-2,libsasl2-modules-gssapi-mit'
     local ISO_8601_DATE GIT_REVISION
     ISO_8601_DATE="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-    GIT_REVISION="$(git rev-parse HEAD)"
+    GIT_REVISION="$(git rev-parse HEAD 2>/dev/null || echo "$PKG_VSN")"
     export BUILDX_NO_DEFAULT_ATTESTATIONS=1
     local DOCKER_BUILDX_ARGS=(
        --build-arg BUILD_FROM="${BUILD_FROM}" \

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM} AS builder_src
 ONBUILD COPY . /emqx
 
 FROM ${RUN_FROM} AS builder_tgz
-ARG PROFILE=emqx
+ARG PROFILE=emqx-enterprise
 ARG PKG_VSN
 ARG SUFFIX
 ARG TARGETARCH
@@ -14,7 +14,8 @@ ONBUILD COPY ${PROFILE}-${PKG_VSN}${SUFFIX}-debian13-$TARGETARCH.tar.gz /${PROFI
 
 FROM builder_${SOURCE_TYPE} AS builder
 
-ARG PROFILE=emqx
+ARG PROFILE=emqx-enterprise
+ARG PKG_VSN
 ARG DEBUG
 
 ENV EMQX_RELUP=false
@@ -32,8 +33,8 @@ RUN mkdir -p /emqx-rel/emqx && \
         export REBAR_GIT_CACHE_DIR='/emqx/.cache' && \
         export REBAR_GIT_CACHE_REF_AUTOFILL=0; \
       fi && \
+      export PKG_VSN="${PKG_VSN}" && \
       export EMQX_REL_PATH="/emqx/_build/${PROFILE}/rel/emqx" && \
-      git config --global --add safe.directory '*' && \
       make ${PROFILE}-tgz && \
       tar zxf _packages/${PROFILE}/*.tar.gz -C /emqx-rel/emqx; \
     fi && \

--- a/pkg-vsn.sh
+++ b/pkg-vsn.sh
@@ -75,22 +75,24 @@ if [ "${RELEASE_VERSION:-}" = 'yes' ]; then
     exit 0
 fi
 
-git_exact_vsn() {
-    git describe --tags --exact 2>/dev/null || true
-}
+if [ "${PKG_VSN:-novalue}" = 'novalue' ]; then
+    git_exact_vsn() {
+        git describe --tags --exact 2>/dev/null || true
+    }
 
-GIT_EXACT_VSN="$(git_exact_vsn)"
-if [ "$GIT_EXACT_VSN" != '' ]; then
-    if [ "$GIT_EXACT_VSN" != "$RELEASE" ]; then
-        echo "ERROR: Tagged $GIT_EXACT_VSN, but $RELEASE in include/emqx_release.hrl" 1>&2
-        exit 1
+    GIT_EXACT_VSN="$(git_exact_vsn)"
+    if [ "$GIT_EXACT_VSN" != '' ]; then
+        if [ "$GIT_EXACT_VSN" != "$RELEASE" ]; then
+            echo "ERROR: Tagged $GIT_EXACT_VSN, but $RELEASE in include/emqx_release.hrl" 1>&2
+            exit 1
+        fi
+        SUFFIX=''
+    else
+        SUFFIX="-g$(git rev-parse HEAD | cut -b1-8)"
     fi
-    SUFFIX=''
-else
-    SUFFIX="-g$(git rev-parse HEAD | cut -b1-8)"
-fi
 
-PKG_VSN="${PKG_VSN:-${RELEASE}${SUFFIX}}"
+    PKG_VSN="${RELEASE}${SUFFIX}"
+fi
 
 if [ "${LONG_VERSION:-}" != 'yes' ]; then
     echo "$PKG_VSN"


### PR DESCRIPTION
There is no need for it to be a git repo when building docker image (`COPY . /emqx`).
The `build` script already set and exports `PKG_VSN`, and the docker build `--build-arg` already passes `PKG_VSN`,
So all needed is to export `PKG_VSN` before `make ${PROFILE}-tgz`

This makes possible to build image from git worktree.