### PR TITLE
feat: add Gateway API HTTPRoute and TLSRoute to emqx-enterprise chart

### DIFF
--- a/deploy/charts/emqx-enterprise/templates/httproute.yaml
+++ b/deploy/charts/emqx-enterprise/templates/httproute.yaml
@@ -1,0 +1,72 @@
+{{- if .Values.httpRoute.dashboard.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-%s" (include "emqx.fullname" .) "dashboard" }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.dashboard.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.dashboard.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.dashboard.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.dashboard.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.httpRoute.dashboard.pathType | default "PathPrefix" }}
+            value: {{ .Values.httpRoute.dashboard.path | default "/" }}
+      backendRefs:
+        - name: {{ include "emqx.fullname" . }}
+          port: {{ .Values.service.dashboard }}
+---
+{{- end }}
+{{- if .Values.httpRoute.ws.enabled }}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ printf "%s-%s" (include "emqx.fullname" .) "ws" }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.httpRoute.ws.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httpRoute.ws.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.httpRoute.ws.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.httpRoute.ws.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - matches:
+        - path:
+            type: {{ .Values.httpRoute.ws.pathType | default "PathPrefix" }}
+            value: {{ .Values.httpRoute.ws.path | default "/mqtt" }}
+      backendRefs:
+        - name: {{ include "emqx.fullname" . }}
+          port: {{ .Values.service.ws }}
+---
+{{- end }}

--- a/deploy/charts/emqx-enterprise/templates/httproute.yaml
+++ b/deploy/charts/emqx-enterprise/templates/httproute.yaml
@@ -34,6 +34,9 @@ spec:
           port: {{ .Values.service.dashboard }}
 ---
 {{- end }}
+{{- if and .Values.httpRoute.ws.enabled (not .Values.service.wsEnabled) }}
+{{- fail "httpRoute.ws.enabled requires service.wsEnabled=true" }}
+{{- end }}
 {{- if .Values.httpRoute.ws.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/deploy/charts/emqx-enterprise/templates/tlsroute.yaml
+++ b/deploy/charts/emqx-enterprise/templates/tlsroute.yaml
@@ -1,0 +1,64 @@
+{{- if .Values.tlsRoute.mqtts.enabled }}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: {{ printf "%s-%s" (include "emqx.fullname" .) "mqtts" }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.tlsRoute.mqtts.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.tlsRoute.mqtts.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.tlsRoute.mqtts.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tlsRoute.mqtts.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "emqx.fullname" . }}
+          port: {{ .Values.service.mqttssl }}
+---
+{{- end }}
+{{- if .Values.tlsRoute.wss.enabled }}
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: {{ printf "%s-%s" (include "emqx.fullname" .) "wss" }}
+  labels:
+    app.kubernetes.io/name: {{ include "emqx.name" . }}
+    helm.sh/chart: {{ include "emqx.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- with .Values.tlsRoute.wss.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.tlsRoute.wss.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.tlsRoute.wss.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tlsRoute.wss.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+        - name: {{ include "emqx.fullname" . }}
+          port: {{ .Values.service.wss }}
+---
+{{- end }}

--- a/deploy/charts/emqx-enterprise/templates/tlsroute.yaml
+++ b/deploy/charts/emqx-enterprise/templates/tlsroute.yaml
@@ -30,6 +30,9 @@ spec:
           port: {{ .Values.service.mqttssl }}
 ---
 {{- end }}
+{{- if and .Values.tlsRoute.wss.enabled (not .Values.service.wsEnabled) }}
+{{- fail "tlsRoute.wss.enabled requires service.wsEnabled=true" }}
+{{- end }}
 {{- if .Values.tlsRoute.wss.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute

--- a/deploy/charts/emqx-enterprise/templates/tlsroute.yaml
+++ b/deploy/charts/emqx-enterprise/templates/tlsroute.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.tlsRoute.mqtts.enabled }}
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: {{ printf "%s-%s" (include "emqx.fullname" .) "mqtts" }}
@@ -31,7 +31,7 @@ spec:
 ---
 {{- end }}
 {{- if .Values.tlsRoute.wss.enabled }}
-apiVersion: gateway.networking.k8s.io/v1alpha2
+apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: {{ printf "%s-%s" (include "emqx.fullname" .) "wss" }}

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -284,6 +284,70 @@ ingress:
       - mqtt.emqx.local
     tls: []
 
+httpRoute:
+  ## HTTPRoute for EMQX Dashboard (Gateway API)
+  dashboard:
+    enabled: false
+    annotations: {}
+    labels: {}
+    ## Parent gateway references
+    ## Example:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     namespace: default
+    ##     sectionName: https
+    parentRefs: []
+    hostnames:
+      - dashboard.emqx.local
+    path: /
+    pathType: PathPrefix
+  ## HTTPRoute for MQTT over WebSocket (Gateway API)
+  ws:
+    enabled: false
+    annotations: {}
+    labels: {}
+    ## Parent gateway references
+    ## Example:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     namespace: default
+    ##     sectionName: https
+    parentRefs: []
+    hostnames:
+      - ws.emqx.local
+    path: /mqtt
+    pathType: PathPrefix
+
+tlsRoute:
+  ## TLSRoute for MQTT over TLS (Gateway API)
+  mqtts:
+    enabled: false
+    annotations: {}
+    labels: {}
+    ## Parent gateway references
+    ## Example:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     namespace: default
+    ##     sectionName: mqtts
+    parentRefs: []
+    hostnames:
+      - mqtt.emqx.local
+  ## TLSRoute for WSS (Gateway API)
+  wss:
+    enabled: false
+    annotations: {}
+    labels: {}
+    ## Parent gateway references
+    ## Example:
+    ## parentRefs:
+    ##   - name: my-gateway
+    ##     namespace: default
+    ##     sectionName: wss
+    parentRefs: []
+    hostnames:
+      - wss.emqx.local
+
 podSecurityContext:
   enabled: true
   fsGroup: 1000

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -154,8 +154,8 @@ service:
   ## Whether to publish the WebSocket (ws/wss) Service ports.
   ## Set to false to omit the ws and wss port entries from the Service
   ## (for example, when the corresponding EMQX listeners are disabled).
-  ## Note: if this is false, also disable ingress.ws.enabled and ingress.wss.enabled,
-  ## as those reference service.ws / service.wss.
+  ## Note: if this is false, also disable ingress.ws.enabled, httpRoute.ws.enabled,
+  ## and tlsRoute.wss.enabled, as those reference service.ws / service.wss.
   ##
   wsEnabled: true
   ## Port for WebSocket/HTTP (used only when wsEnabled is true)
@@ -319,6 +319,8 @@ httpRoute:
     pathType: PathPrefix
 
 tlsRoute:
+  ## TLSRoute v1 requires Gateway API standard-channel CRDs v1.5.0 or newer.
+  ## The referenced Gateway TLS listener must use Passthrough mode because EMQX terminates TLS.
   ## TLSRoute for MQTT over TLS (Gateway API)
   mqtts:
     enabled: false


### PR DESCRIPTION
## Summary
- Add Kubernetes Gateway API `HTTPRoute` and `TLSRoute` templates to the emqx-enterprise Helm chart as an alternative to traditional Ingress resources
- HTTPRoute supports dashboard (port 18083) and WebSocket (port 8083) routing
- TLSRoute supports MQTTS (port 8883) and WSS (port 8084) TLS passthrough routing
- All routes are disabled by default and require `parentRefs` to reference a Gateway
- Fail at Helm render time if a WS/WSS route references Service ports disabled by `service.wsEnabled`

## Test plan
- [x] `helm template` renders correctly with all routes enabled
- [x] `helm template` renders correctly with all routes disabled (default)
- [x] `helm template` fails when `httpRoute.ws` or `tlsRoute.wss` is enabled while `service.wsEnabled=false`
- [x] Verify HTTPRoute attaches to Gateway and routes dashboard traffic
- [x] Verify TLSRoute attaches to Gateway and passes through MQTTS traffic

Validated on Kind Kubernetes v1.31.2 with Envoy Gateway v1.8.3 and Gateway API v1.5.1: both routes reported `Accepted=True` and `ResolvedRefs=True`; dashboard `/status` returned HTTP 200; MQTTS completed a TLS 1.3 handshake and MQTT 5 CONNECT with CONNACK reason 0. The two invalid WS/WSS combinations fail locally with their expected Helm template errors.