### PR TITLE
build: include plugins dir in mix format scope

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,6 +4,7 @@
     "config/*.exs",
     "scripts/*.exs",
     "apps/*/mix.exs",
+    "plugins/*/mix.exs",
     "apps/emqx_mix_utils/**/*.ex{,s}",
   ]
 ]


### PR DESCRIPTION
## Summary

- Add `plugins/*/mix.exs` to `.formatter.exs` so `mix format` covers plugin mix files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)