### PR TITLE
ci: handle empty workflow matrices in GitHub Actions

### DIFF
--- a/.github/workflows/_pr_entrypoint.yaml
+++ b/.github/workflows/_pr_entrypoint.yaml
@@ -169,7 +169,6 @@ jobs:
     uses: ./.github/workflows/static_checks.yaml
     with:
       builder: ${{ needs.init.outputs.BUILDER }}
-      ct-matrix: ${{ needs.sanity-checks.outputs.ct-matrix }}
 
   build_slim_packages:
     needs:

--- a/.github/workflows/_push-entrypoint.yaml
+++ b/.github/workflows/_push-entrypoint.yaml
@@ -213,7 +213,6 @@ jobs:
     uses: ./.github/workflows/static_checks.yaml
     with:
       builder: ${{ needs.init.outputs.BUILDER }}
-      ct-matrix: ${{ needs.prepare.outputs.ct-matrix }}
 
   update-emqx-docs:
     if: needs.prepare.outputs.release == 'true'

--- a/.github/workflows/run_test_cases.yaml
+++ b/.github/workflows/run_test_cases.yaml
@@ -31,12 +31,14 @@ env:
 
 jobs:
   eunit_and_proper:
+    if: inputs.ct-matrix != '[]'
     runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
     name: "eunit_and_proper"
     strategy:
       fail-fast: false
       matrix:
-        include: ${{ fromJson(inputs.ct-matrix) }}
+        # GitHub validates strategy.matrix before job-level if, so keep include non-empty and let the job skip.
+        include: ${{ inputs.ct-matrix == '[]' && fromJson('[{"profile":"skip"}]') || fromJson(inputs.ct-matrix) }}
 
     defaults:
       run:

--- a/.github/workflows/static_checks.yaml
+++ b/.github/workflows/static_checks.yaml
@@ -10,9 +10,6 @@ on:
       builder:
         required: true
         type: string
-      ct-matrix:
-        required: true
-        type: string
 
 env:
   IS_CI: "yes"
@@ -23,26 +20,24 @@ permissions:
 jobs:
   static_checks:
     runs-on: ${{ github.repository_owner == 'emqx' && 'aws-ubuntu22.04-amd64' || 'ubuntu-22.04' }}
-    name: "static_checks (${{ matrix.profile }})"
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(inputs.ct-matrix) }}
+    name: "static_checks"
     container: "${{ inputs.builder }}"
+    env:
+      PROFILE: emqx-enterprise
     steps:
       - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          name: ${{ matrix.profile }}-release
+          name: ${{ env.PROFILE }}-release
       - name: extract artifact
         run: |
-          unzip -o -q ${{ matrix.profile }}-release.zip
+          unzip -o -q ${{ env.PROFILE }}-release.zip
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: "emqx_dialyzer_${{ matrix.profile }}_plt"
-          key: rebar3-dialyzer-plt-${{ matrix.profile }}-${{ hashFiles('rebar.*', 'apps/*/rebar.*') }}
+          path: "emqx_dialyzer_${{ env.PROFILE }}_plt"
+          key: rebar3-dialyzer-plt-${{ env.PROFILE }}-${{ hashFiles('rebar.*', 'apps/*/rebar.*') }}
           restore-keys: |
-            rebar3-dialyzer-plt-${{ matrix.profile }}-
+            rebar3-dialyzer-plt-${{ env.PROFILE }}-
       - name: check deps.txt is up to date
         run: |
           # Install Hex non-interactively (required for mix commands)


### PR DESCRIPTION
## Summary
- make `run_test_cases` skip `eunit_and_proper` cleanly when `ct-matrix` is empty
- simplify `static_checks` to always run with the `emqx-enterprise` profile
- remove the unused `ct-matrix` input from the `static_checks` reusable workflow callers