### PR TITLE
test(datalayers): fix flaky test

### DIFF
--- a/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
+++ b/apps/emqx_bridge_datalayers/test/emqx_bridge_datalayers_SUITE.erl
@@ -579,7 +579,9 @@ t_start_ok_no_subject_tags_write_syntax(Config) ->
 
 t_const_timestamp(Config) ->
     QueryMode = ?config(query_mode, Config),
-    Const = erlang:system_time(nanosecond),
+    %% If the time is "too round", there may be some formatting issues later.
+    %% Const = erlang:system_time(nanosecond),
+    Const = 1773078804209825307,
     ConstBin = integer_to_binary(Const),
     TsStr = iolist_to_binary(
         calendar:system_time_to_rfc3339(Const, [{unit, nanosecond}, {offset, 0}])


### PR DESCRIPTION
```
%%% emqx_bridge_datalayers_SUITE ==> without_batch.sync_query.apiv1_https.t_const_timestamp: FAILED
%%% emqx_bridge_datalayers_SUITE ==>
Failure/Error: ?assertEqual(<<50,48,50,54,45,48,51,45,48,57,84,49,55,58,52,50,58,52,51,46,57,50,53,55,56,52,48,48,48,43,48,48,58,48,48>>, TimeReturned)
  expected: <<"2026-03-09T17:42:43.925784000+00:00">>
       got: <<"2026-03-09T17:42:43.925784+00:00">>
      line: 637
```

https://github.com/emqx/emqx/actions/runs/22865833638/job/66334377370?pr=16893#step:5:462
