### PR TITLE
fix(schemareg): use url-safe base64 encoding for GET query string payload

### DIFF
--- a/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
+++ b/apps/emqx_schema_registry/src/emqx_schema_registry_serde.erl
@@ -802,7 +802,7 @@ generate_external_http_request(Payload, EncodeOrDecode, Name, Context) ->
             {PathWithQuery, Headers, BodyBin};
         get ->
             QueryList = [
-                {<<"payload">>, base64:encode(Payload)},
+                {<<"payload">>, base64:encode(Payload, #{mode => urlsafe, padding => false})},
                 {<<"type">>, emqx_utils_conv:bin(EncodeOrDecode)},
                 {<<"schema_name">>, Name},
                 {<<"opts">>, ExternalParams}

--- a/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
+++ b/apps/emqx_schema_registry/test/emqx_schema_registry_http_api_SUITE.erl
@@ -482,7 +482,7 @@ external_http_handler(Req0, State) ->
             <<"opts">> := ExtraOpts,
             <<"payload">> := PayloadB64
         }} ?= Parsed,
-        {ok, Payload} ?= decode_base64(PayloadB64),
+        {ok, Payload} ?= decode_base64(Method, PayloadB64),
         {ok, RespBody} ?= exec_external_http_serde(EncodeOrDecode, ExtraOpts, Payload),
         RespBodyB64 = base64:encode(RespBody),
         Rep = cowboy_req:reply(
@@ -503,7 +503,14 @@ external_http_handler(Req0, State) ->
             {ok, RepErr, State}
     end.
 
-decode_base64(Bin) ->
+decode_base64(<<"GET">>, Bin) ->
+    try
+        {ok, base64:decode(Bin, #{mode => urlsafe, padding => false})}
+    catch
+        error:_ ->
+            {error, bad_base64}
+    end;
+decode_base64(_Method, Bin) ->
     try
         {ok, base64:decode(Bin)}
     catch


### PR DESCRIPTION
Fix for #16634: the GET method support added in that PR used standard base64 encoding for the payload query parameter, but standard base64 contains `+`, `/`, and `=` characters that are not URL-safe. This changes it to use url-safe base64 encoding (`#{mode => urlsafe, padding => false}`).

The test server handler is also updated to decode url-safe base64 for GET requests.