### PR TITLE
fix(a2a): add agent status to real-time card messages

### DIFF
--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_hookcb.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_hookcb.erl
@@ -69,15 +69,13 @@ do_on_message_publish(Msg = #message{flags = Flags, topic = Topic}) ->
             {stop, Msg#message{headers = Headers#{allow_publish => false}}}
     end.
 
-on_message_delivered(_ClientInfo, #message{headers = #{retained := true}} = Msg0) ->
+on_message_delivered(_ClientInfo, #message{} = Msg0) ->
     case emqx_a2a_registry_config:is_enabled() of
         false ->
             {ok, Msg0};
         true ->
             do_on_message_delivered(Msg0)
-    end;
-on_message_delivered(_ClientInfo, Msg) ->
-    {ok, Msg}.
+    end.
 
 do_on_message_delivered(Msg0) ->
     Msg = maybe_augment_message_metadata(Msg0),

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_SUITE.erl
@@ -189,8 +189,16 @@ t_smoke_01(_TCConfig) ->
         }}
     ),
 
-    %% Feature is enabled, but message doesn't have the `retain` flag.  Must be rejected.
+    %% Publish a card while a subscription is live.
     Agent2 = start_client(#{clientid => AgentClientId}),
+    {ok, _} = publish_card(Agent2, ?ORG_ID, ?UNIT_ID, ?AGENT_ID, sample_card_bin()),
+    ?assertReceive(
+        {publish, #{
+            properties := #{'User-Property' := [{?A2A_PROP_STATUS_KEY, ?A2A_PROP_ONLINE_VAL}]}
+        }}
+    ),
+
+    %% Feature is enabled, but message doesn't have the `retain` flag.  Must be rejected.
     {ok, _} = emqtt:publish(
         Agent2,
         discovery_topic(?ORG_ID, ?UNIT_ID, ?AGENT_ID),


### PR DESCRIPTION
Release version:
6.2.0

## Summary

The `retained` header is only set when iterating retained messages, but not in real-time message flow.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [na] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (unreleased feature)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
