### PR TITLE
feat(a2a api): expose ids for easier deletion

### DIFF
--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry.erl
@@ -63,9 +63,9 @@ list_cards(Opts) ->
     MatchOpts = #{batch_read_number => all_remaining},
     {ok, Msgs, undefined} = emqx_retainer:match_messages(TopicFilter, Cursor, MatchOpts),
     lists:map(
-        fun(#message{from = From, payload = PayloadRaw}) ->
+        fun(#message{from = From, topic = Topic, payload = PayloadRaw}) ->
             Card = emqx_utils_json:decode(PayloadRaw),
-            format_card(Card, PayloadRaw, From)
+            format_card(Card, PayloadRaw, Topic, From)
         end,
         Msgs
     ).
@@ -119,7 +119,7 @@ agent_card_schema_source() ->
     {ok, Source} = file:read_file(agent_card_schema_path()),
     Source.
 
-format_card(Card0, CardRaw, ClientId) ->
+format_card(Card0, CardRaw, Topic, ClientId) ->
     Card = maps:with(
         [
             <<"name">>,
@@ -128,8 +128,24 @@ format_card(Card0, CardRaw, ClientId) ->
         ],
         Card0
     ),
+    case emqx_a2a_registry_utils:parse_a2a_discovery_topic(Topic) of
+        {ok, {OrgId, UnitId, AgentId}} ->
+            ok;
+        error ->
+            %% Impossible
+            OrgId = undefined,
+            UnitId = undefined,
+            AgentId = undefined
+    end,
     Status = lookup_agent_status(ClientId),
-    Card#{<<"id">> => ClientId, <<"status">> => Status, <<"raw">> => CardRaw}.
+    Card#{
+        <<"id">> => ClientId,
+        <<"org_id">> => OrgId,
+        <<"unit_id">> => UnitId,
+        <<"agent_id">> => AgentId,
+        <<"status">> => Status,
+        <<"raw">> => CardRaw
+    }.
 
 agent_card_clientid(OrgId, UnitId, AgentId) ->
     emqx_topic:join([OrgId, UnitId, AgentId]).

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_hookcb.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_hookcb.erl
@@ -86,12 +86,7 @@ do_on_message_delivered(Msg0) ->
 %%------------------------------------------------------------------------------
 
 parse_a2a_discovery_topic(Topic) ->
-    case emqx_topic:words(Topic) of
-        [?A2A_TOPIC_NS, ?A2A_TOPIC_V1, ?A2A_TOPIC_DISCOVERY, OrgId, UnitId, AgentId] ->
-            {ok, {OrgId, UnitId, AgentId}};
-        _ ->
-            error
-    end.
+    emqx_a2a_registry_utils:parse_a2a_discovery_topic(Topic).
 
 validate_card_message(Msg, Id) ->
     maybe

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_utils.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_utils.erl
@@ -5,6 +5,7 @@
 
 %% API
 -export([
+    parse_a2a_discovery_topic/1,
     validate_card_schema/1,
     validate_id/3
 ]).
@@ -18,6 +19,14 @@
 %%------------------------------------------------------------------------------
 %% API
 %%------------------------------------------------------------------------------
+
+parse_a2a_discovery_topic(Topic) ->
+    case emqx_topic:words(Topic) of
+        [?A2A_TOPIC_NS, ?A2A_TOPIC_V1, ?A2A_TOPIC_DISCOVERY, OrgId, UnitId, AgentId] ->
+            {ok, {OrgId, UnitId, AgentId}};
+        _ ->
+            error
+    end.
 
 validate_card_schema(CardBin) ->
     case emqx_a2a_registry_config:is_schema_validation_enabled() of

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_api_SUITE.erl
@@ -127,7 +127,17 @@ t_crud(_TCConfig) ->
     Name1 = <<"1">>,
     Card1 = sample_card_bin(#{<<"name">> => Name1}),
     ?assertMatch({204, _}, register_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID, Card1)),
-    ?assertMatch({200, [_]}, list_cards(#{})),
+    ?assertMatch(
+        {200, [
+            #{
+                <<"id">> := _,
+                <<"org_id">> := ?ORG_ID,
+                <<"unit_id">> := ?UNIT_ID,
+                <<"agent_id">> := ?AGENT_ID
+            }
+        ]},
+        list_cards(#{})
+    ),
     ?assertMatch({200, _}, get_card(?ORG_ID, ?UNIT_ID, ?AGENT_ID)),
 
     %% List filters


### PR DESCRIPTION
Release version:
6.2.0

## Summary

So the frontend may delete listed cards more easily.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
