### PR TITLE
feat(limiter): add `delivery_messages` and `delivery_bytes` limiter kinds

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -1431,7 +1431,48 @@ wrap_list(X) ->
 %% return list(emqx_types:packet())
 do_deliver({pubrel, PacketId}, Channel) ->
     {[?PUBREL_PACKET(PacketId, ?RC_SUCCESS)], Channel};
-do_deliver(
+do_deliver({_PacketId, Msg} = Publish, Channel0) ->
+    #channel{quota = Limiter0} = Channel0,
+    #message{payload = Payload, topic = Topic} = Msg,
+    Result = emqx_limiter_client_container:try_consume(
+        Limiter0,
+        [
+            {delivery_bytes, iolist_size(Payload)},
+            {delivery_messages, 1}
+        ]
+    ),
+    case Result of
+        {true, Limiter} ->
+            Channel = Channel0#channel{quota = Limiter},
+            do_deliver1(Publish, Channel);
+        {false, Limiter, Reason} ->
+            ?SLOG_THROTTLE(
+                warning,
+                #{
+                    msg => cannot_deliver_from_topic_due_to_quota_exceeded,
+                    reason => Reason
+                },
+                #{topic => Topic, tag => "QUOTA"}
+            ),
+            ?tp("chan_delivery_rate_limit", #{limiter => Limiter, reason => Reason}),
+            Channel = Channel0#channel{quota = Limiter},
+            {[], Channel}
+    end;
+do_deliver([Publish], Channel) ->
+    do_deliver(Publish, Channel);
+do_deliver(Publishes, Channel) when is_list(Publishes) ->
+    {Packets, NChannel} =
+        lists:foldl(
+            fun(Publish, {Acc, Chann}) ->
+                {Packets, NChann} = do_deliver(Publish, Chann),
+                {Packets ++ Acc, NChann}
+            end,
+            {[], Channel},
+            Publishes
+        ),
+    {lists:reverse(Packets), NChannel}.
+
+do_deliver1(
     {PacketId, Msg},
     Channel = #channel{
         clientinfo = ClientInfo = #{mountpoint := MountPoint}
@@ -1447,20 +1488,7 @@ do_deliver(
     Msg2 = emqx_mountpoint:unmount(MountPoint, Msg1),
     Packet = emqx_message:to_packet(PacketId, Msg2),
     {NPacket, NChannel} = packing_alias(Packet, Channel),
-    {[NPacket], NChannel};
-do_deliver([Publish], Channel) ->
-    do_deliver(Publish, Channel);
-do_deliver(Publishes, Channel) when is_list(Publishes) ->
-    {Packets, NChannel} =
-        lists:foldl(
-            fun(Publish, {Acc, Chann}) ->
-                {Packets, NChann} = do_deliver(Publish, Chann),
-                {Packets ++ Acc, NChann}
-            end,
-            {[], Channel},
-            Publishes
-        ),
-    {lists:reverse(Packets), NChannel}.
+    {[NPacket], NChannel}.
 
 %%--------------------------------------------------------------------
 %% Handle out suback

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter.erl
@@ -74,6 +74,12 @@
 }.
 
 %%--------------------------------------------------------------------
+%% Defs
+%%--------------------------------------------------------------------
+
+-define(CHANNEL_LIM_NAMES, [messages, bytes, delivery_bytes, delivery_messages]).
+
+%%--------------------------------------------------------------------
 %% Callbacks
 %%--------------------------------------------------------------------
 
@@ -99,14 +105,14 @@ create_zone_limiters() ->
 -spec create_listener_limiters(listener_id(), term()) -> ok.
 create_listener_limiters(ListenerId, ListenerConfig) ->
     ListenerLimiters = limiter_options([max_conn], ListenerConfig),
-    ChannelLimiters = limiter_options([messages, bytes], ListenerConfig),
+    ChannelLimiters = limiter_options(?CHANNEL_LIM_NAMES, ListenerConfig),
     ok = create_group(shared, listener_group(ListenerId), ListenerLimiters),
     ok = create_group(exclusive, channel_group(ListenerId), ChannelLimiters).
 
 -spec update_listener_limiters(listener_id(), term()) -> ok.
 update_listener_limiters(ListenerId, ListenerConfig) ->
     ListenerLimiters = limiter_options([max_conn], ListenerConfig),
-    ChannelLimiters = limiter_options([messages, bytes], ListenerConfig),
+    ChannelLimiters = limiter_options(?CHANNEL_LIM_NAMES, ListenerConfig),
     ok = update_group(listener_group(ListenerId), ListenerLimiters),
     ok = update_group(channel_group(ListenerId), ChannelLimiters).
 
@@ -125,7 +131,7 @@ try_delete_group(Group) ->
 
 -spec create_channel_client_container(zone(), listener_id()) -> emqx_limiter_client_container:t().
 create_channel_client_container(ZoneName, ListenerId) ->
-    create_client_container(ZoneName, ListenerId, [messages, bytes]).
+    create_client_container(ZoneName, ListenerId, ?CHANNEL_LIM_NAMES).
 
 -spec create_esockd_limiter_client(zone(), listener_id()) -> emqx_esockd_limiter:create_options().
 create_esockd_limiter_client(ZoneName, ListenerId) ->

--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -93,7 +93,9 @@ mqtt_limiter_names() ->
     [
         max_conn,
         messages,
-        bytes
+        bytes,
+        delivery_messages,
+        delivery_bytes
     ].
 
 to_rate(Str) ->

--- a/apps/emqx_mt/mix.exs
+++ b/apps/emqx_mt/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMT.MixProject do
   def project do
     [
       app: :emqx_mt,
-      version: "6.1.0",
+      version: "6.1.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_mt/src/emqx_mt_api.erl
+++ b/apps/emqx_mt/src/emqx_mt_api.erl
@@ -427,13 +427,15 @@ fields(config_in) ->
     ];
 fields(limiter_config_in) ->
     [
-        {tenant, mk(hoconsc:union([disabled, ref(limiter_in)]), #{})},
-        {client, mk(hoconsc:union([disabled, ref(limiter_in)]), #{})}
+        {tenant, mk(hoconsc:union([disabled, ref(limiter_in)]), #{default => disabled})},
+        {client, mk(hoconsc:union([disabled, ref(limiter_in)]), #{default => disabled})}
     ];
 fields(limiter_in) ->
     [
         {bytes, mk(ref(limiter_options), #{})},
-        {messages, mk(ref(limiter_options), #{})}
+        {messages, mk(ref(limiter_options), #{})},
+        {delivery_bytes, mk(ref(limiter_options), #{})},
+        {delivery_messages, mk(ref(limiter_options), #{})}
     ];
 fields(session_config_in) ->
     [
@@ -465,8 +467,8 @@ fields(limiter_out) ->
     fields(limiter_in);
 fields(limiter_options) ->
     [
-        {rate, mk(emqx_limiter_schema:rate_type(), #{})},
-        {burst, mk(emqx_limiter_schema:burst_type(), #{})}
+        {rate, mk(emqx_limiter_schema:rate_type(), #{default => <<"infinity">>})},
+        {burst, mk(emqx_limiter_schema:burst_type(), #{default => <<"0/s">>})}
     ];
 fields(ns_with_details_out) ->
     [

--- a/apps/emqx_mt/src/emqx_mt_limiter.erl
+++ b/apps/emqx_mt/src/emqx_mt_limiter.erl
@@ -53,6 +53,8 @@ If one of the limiters lack configuration, we simply don't do each action above.
 
 -define(BYTES_LIM_NAME, bytes).
 -define(MESSAGES_LIM_NAME, messages).
+-define(DELIVERY_BYTES_LIM_NAME, delivery_bytes).
+-define(DELIVERY_MESSAGES_LIM_NAME, delivery_messages).
 
 -define(tenant, tenant).
 -define(client, client).
@@ -158,7 +160,12 @@ client_group(Ns) ->
     {mt_client, Ns}.
 
 limiter_names() ->
-    [?MESSAGES_LIM_NAME, ?BYTES_LIM_NAME].
+    [
+        ?MESSAGES_LIM_NAME,
+        ?BYTES_LIM_NAME,
+        ?DELIVERY_MESSAGES_LIM_NAME,
+        ?DELIVERY_BYTES_LIM_NAME
+    ].
 
 to_limiter_options(Config) ->
     lists:map(

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -44,7 +44,10 @@ init_per_suite(Config) ->
 end_per_suite(_Config) ->
     ok.
 
-init_per_testcase(t_adjust_limiters = TestCase, Config) ->
+init_per_testcase(TestCase, Config) when
+    TestCase == t_adjust_limiters;
+    TestCase == t_delivery_rate_limit
+->
     Apps = [
         emqx,
         {emqx_conf, "mqtt.client_attrs_init = [{expression = username, set_as_attr = tns}]"},
@@ -104,7 +107,10 @@ init_per_testcase(TestCase, Config) ->
     snabbkaffe:start_trace(),
     [{apps, Apps} | Config].
 
-end_per_testcase(t_adjust_limiters, Config) ->
+end_per_testcase(TestCase, Config) when
+    TestCase == t_adjust_limiters;
+    TestCase == t_delivery_rate_limit
+->
     Cluster = ?config(cluster, Config),
     snabbkaffe:stop(),
     emqx_common_test_helpers:call_janitor(),
@@ -1628,4 +1634,74 @@ t_managed_certs_inexistent_ns(_TCConfig) ->
     {204, _} = create_managed_ns(Ns),
     ?assertMatch({204, _}, upload_file_ns(Ns, Bundle, ?FILE_KIND_CA, CA)),
 
+    ok.
+
+t_delivery_rate_limit(Config) when is_list(Config) ->
+    [N | _] = ?config(cluster, Config),
+    %% Need to set this, otherwise, with the default `infinity`, the channel never retries
+    %% and delivery gets stuck.
+    ?ON(
+        N,
+        {ok, _} = emqx:update_config(
+            [mqtt, retry_interval],
+            <<"1s">>,
+            #{override_to => cluster}
+        )
+    ),
+    %% Setup namespace with limiters
+    Params1 = client_limiter_params(#{
+        <<"delivery_bytes">> => #{
+            <<"rate">> => <<"10MB/s">>,
+            <<"burst">> => <<"0MB/s">>
+        },
+        <<"delivery_messages">> => #{
+            <<"rate">> => <<"1/2s">>,
+            <<"burst">> => <<"0/s">>
+        }
+    }),
+    Ns = atom_to_binary(?FUNCTION_NAME),
+    {204, _} = create_managed_ns(Ns),
+    ?assertMatch({200, _}, update_managed_ns_config(Ns, Params1)),
+    ?check_trace(
+        begin
+            C1 = ?NEW_CLIENTID(1),
+            {ok, Pid1} = emqtt:start_link(#{
+                username => Ns,
+                clientid => C1,
+                proto_ver => v5,
+                port => emqx_mt_api_SUITE:get_mqtt_tcp_port(N)
+            }),
+            {ok, _} = emqtt:connect(Pid1),
+            Topic = <<"rate/limit">>,
+            {ok, _, _} = emqtt:subscribe(Pid1, Topic, 2),
+            %% Publish a few messages in quick succession
+            lists:foreach(
+                fun(M) ->
+                    Payload = integer_to_binary(M),
+                    emqtt:publish(Pid1, Topic, Payload, [{qos, 1}])
+                end,
+                lists:seq(1, 3)
+            ),
+            %% Eventually, must receive all messages (if retry_interval is finite)
+            ?assertReceive({publish, #{packet_id := 1, dup := false, payload := <<"1">>}}),
+            ?assertReceive({publish, #{packet_id := 2, dup := true, payload := <<"2">>}}, 3_000),
+            ?assertReceive({publish, #{packet_id := 3, dup := true, payload := <<"3">>}}, 3_000),
+            ?assertNotReceive({publish, _}),
+            emqtt:stop(Pid1)
+        end,
+        fun(Trace) ->
+            ?assertEqual([], ?of_kind(["hook_callback_exception"], Trace)),
+            ?assertMatch(
+                [
+                    #{
+                        reason :=
+                            {failed_to_consume_from_limiter, {{mt_client, _}, delivery_messages}}
+                    }
+                    | _
+                ],
+                ?of_kind(["chan_delivery_rate_limit"], Trace)
+            ),
+            ok
+        end
+    ),
     ok.

--- a/rel/i18n/emqx_limiter_schema.hocon
+++ b/rel/i18n/emqx_limiter_schema.hocon
@@ -67,6 +67,30 @@ For example: `100MB/60m`: Once every 60 minutes, up to 100 megabytes can be sent
 bytes_burst.label:
 """Data Publish Burst"""
 
+delivery_bytes_rate.desc:
+"""Todo."""
+
+delivery_bytes_rate.label:
+"""Data Delivery Rate"""
+
+delivery_bytes_burst.desc:
+"""Todo."""
+
+delivery_bytes_rate.label:
+"""Data Delivery Burst"""
+
+delivery_messages_rate.desc:
+"""Todo."""
+
+delivery_messages_rate.label:
+"""Message Delivery Rate"""
+
+delivery_messages_burst.desc:
+"""Todo."""
+
+delivery_messages_burst.label:
+"""Message Delivery Burst"""
+
 mqtt.desc:
 """MQTT related limiters."""
 


### PR DESCRIPTION

Fixes <issue-or-jira-number>

Release version:
6.1.2, 6.2.0

## Summary

We already have _outgoing_ rate limit on message number and size.  Here, _outgoing_ is from the point of view of the client: we rate limit the `PUBLISH` packets in the publisher client context, hence the limiter tokens consumed are from this publisher.

The new requirement is to impose rate limiting on the _incoming_ message rate and size: the _deliveries_ a subscriber client channel receives.

For this, we introduce here two new limiter kinds: `delivery_messages` and `delivery_bytes`.  They are checked before the delivery is turned into a packet, and before executing the `'message.delivered'` hook, on a one-by-one basis.  If a delivery hits the limit, we drop it and it does not get sent on the wire.

On the one hand, this may pose a problem if some user sets a finite `delivery_{messages,bytes}` limit, but sets `mqtt.retry_interval = infinity` (which, unfortunately, is the default value).  In this case, the channel will get stuck if a QoS 1 or 2 delivery is dropped.  On the other hand, if `mqtt.retry_interval` is finite, the client channel will eventually recover and deliver all QoS > 0 messages naturally, and drop QoS 0 ones without retrying.

If unspecified, the default values are unlimited, thus keeping backwards compatibility.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
