### PR TITLE
fix(mgmt): randomize generated dashboard API keys

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -120,7 +120,7 @@ try_init_bootstrap_file() ->
     end.
 
 create(Name, Enable, ExpiredAt, Desc, Role) ->
-    ApiKey = generate_unique_api_key(Name),
+    ApiKey = generate_unique_api_key(),
     ApiSecret = generate_api_secret(),
     create(Name, ApiKey, ApiSecret, Enable, ExpiredAt, Desc, Role).
 
@@ -354,9 +354,9 @@ hash_string_from_seed(Seed, PrefixLen) ->
     <<Integer:512>> = crypto:hash(sha512, Seed),
     list_to_binary(string:slice(io_lib:format("~128.16.0b", [Integer]), 0, PrefixLen)).
 
-%% Form Dashboard API Key pannel, only `Name` provided for users
-generate_unique_api_key(Name) ->
-    hash_string_from_seed(Name, ?DEFAULT_HASH_LEN).
+%% Generate a random Dashboard API key.
+generate_unique_api_key() ->
+    emqx_utils:rand_id(?DEFAULT_HASH_LEN).
 
 %% Form BootStrap File, only `ApiKey` provided from file, no `Name`
 generate_unique_name(NamePrefix, ApiKey) ->

--- a/changes/ee/fix-16928.en.md
+++ b/changes/ee/fix-16928.en.md
@@ -1,0 +1,1 @@
+Dashboard-created REST API keys are now generated randomly instead of being derived from the API key name.


### PR DESCRIPTION
Fixes 

Release version:
6.2.0

## Summary

- Generate dashboard-created REST API keys with `emqx_utils:rand_id(16)` instead of deriving them from the API key name.
- Keep API secrets on the existing cryptographically strong generation path.
- Update the management auth helper to use `generate_unique_api_key/0`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)