### PR TITLE
fix(azure blob storage aggregated action): list at most 1 blob during health check (r58)

### DIFF
--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage.app.src
@@ -1,6 +1,6 @@
 {application, emqx_bridge_azure_blob_storage, [
     {description, "EMQX Enterprise Azure Blob Storage Bridge"},
-    {vsn, "0.1.2"},
+    {vsn, "0.1.3"},
     {registered, [emqx_bridge_azure_blob_storage_sup]},
     {applications, [
         kernel,

--- a/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
+++ b/apps/emqx_bridge_azure_blob_storage/src/emqx_bridge_azure_blob_storage_connector.erl
@@ -283,7 +283,7 @@ do_put_block_blob(DriverState, Container, Blob, IOData) ->
     erlazure:put_block_blob(DriverState, Container, Blob, IOData, []).
 
 do_list_blobs(DriverState, Container) ->
-    try erlazure:list_blobs(DriverState, Container, []) of
+    try erlazure:list_blobs(DriverState, Container, [{max_results, "1"}]) of
         {L, _} when is_list(L) ->
             ok
     catch

--- a/changes/ee/fix-16935.en.md
+++ b/changes/ee/fix-16935.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the health check of an Azure Blob Storage Action in aggregate mode could timeout if the container contained too many blobs.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15188


Release version:
5.8.10, 5.10.4

## Summary

If a container contains too many blobs, the request might timeout.
<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files


<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
