### PR TITLE
fix(authn): skip warning for missing default bootstrap file

### DIFF
--- a/apps/emqx_auth_mnesia/mix.exs
+++ b/apps/emqx_auth_mnesia/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuthMnesia.MixProject do
   def project do
     [
       app: :emqx_auth_mnesia,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -112,7 +112,7 @@ create(
         user_id_type => Type,
         password_hash_algorithm => Algorithm
     },
-    ok = boostrap_user_from_file(Config, State),
+    ok = bootstrap_user_from_file(Config, State),
     {ok, State}.
 
 update(Config, _State) ->
@@ -511,13 +511,13 @@ convertor(PasswordType, State) ->
     end.
 
 convert_user(
-    User = #{<<"user_id">> := UserId},
+    User = #{<<"user_id">> := UserID},
     PasswordType,
     #{user_group := UserGroup, password_hash_algorithm := Algorithm}
 ) ->
     {PasswordHash, Salt} = find_password_hash(PasswordType, User, Algorithm),
     #{
-        <<"user_id">> => UserId,
+        <<"user_id">> => UserID,
         <<"password_hash">> => PasswordHash,
         <<"salt">> => Salt,
         <<"is_superuser">> => is_superuser(User),
@@ -541,22 +541,25 @@ is_superuser(#{<<"is_superuser">> := <<"true">>}) -> true;
 is_superuser(#{<<"is_superuser">> := true}) -> true;
 is_superuser(_) -> false.
 
-boostrap_user_from_file(Config, State) ->
+bootstrap_user_from_file(Config, State) ->
     case maps:get(bootstrap_file, Config, <<>>) of
         <<>> ->
             ok;
-        FileName0 ->
+        Filename0 ->
             #{bootstrap_type := Type} = Config,
-            FileName = emqx_schema:naive_env_interpolation(FileName0),
-            case file:read_file(FileName) of
+            IsDefault = (Filename0 =:= emqx_authn_mnesia_schema:default_bootstrap_file_path()),
+            Filename = emqx_schema:naive_env_interpolation(Filename0),
+            case file:read_file(Filename) of
                 {ok, FileData} ->
-                    _ = import_users({Type, FileName, FileData}, State, #{override => false}),
+                    _ = import_users({Type, Filename, FileData}, State, #{override => false}),
+                    ok;
+                {error, enoent} when IsDefault ->
                     ok;
                 {error, Reason} ->
                     ?SLOG(warning, #{
-                        msg => "boostrap_authn_built_in_database_failed",
-                        boostrap_file => FileName,
-                        boostrap_type => Type,
+                        msg => "bootstrap_authn_built_in_database_failed",
+                        bootstrap_file => Filename,
+                        bootstrap_type => Type,
                         reason => emqx_utils:explain_posix(Reason)
                     })
             end

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia_schema.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia_schema.erl
@@ -14,7 +14,8 @@
     desc/1,
     refs/1,
     select_union_member/2,
-    namespace/0
+    namespace/0,
+    default_bootstrap_file_path/0
 ]).
 
 namespace() -> "authn".
@@ -67,7 +68,7 @@ bootstrap_fields() ->
                 #{
                     desc => ?DESC(bootstrap_file),
                     required => false,
-                    default => <<"${EMQX_ETC_DIR}/auth-built-in-db-bootstrap.csv">>
+                    default => default_bootstrap_file_path()
                 }
             )},
         {bootstrap_type,
@@ -79,3 +80,6 @@ bootstrap_fields() ->
                 }
             )}
     ].
+
+default_bootstrap_file_path() ->
+    <<"${EMQX_ETC_DIR}/auth-built-in-db-bootstrap.csv">>.

--- a/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl
@@ -106,6 +106,15 @@ t_bootstrap_file(_) ->
     ),
     ok.
 
+t_default_bootstrap_file_missing(_) ->
+    Config = (config())#{
+        bootstrap_file => emqx_authn_mnesia_schema:default_bootstrap_file_path(),
+        bootstrap_type => hash
+    },
+    {ok, State} = emqx_authn_mnesia:create(?AUTHN_ID, Config),
+    ?assertMatch([], ets:tab2list(emqx_authn_mnesia)),
+    ok = emqx_authn_mnesia:destroy(State).
+
 test_bootstrap_file(Config0, Type, File) ->
     test_bootstrap_file(Config0, Type, File, #{clean => true}).
 

--- a/changes/ee/fix-16939.en.md
+++ b/changes/ee/fix-16939.en.md
@@ -1,0 +1,1 @@
+Fixed the built-in database authenticator so it no longer logs a warning when the default bootstrap file path is configured but the file does not exist.


### PR DESCRIPTION
Fixes 

Release version: 6.0.3, 6.1.2, 6.2.0

## Summary

- Skip the warning when the built-in database authenticator uses the default bootstrap file path and that file is absent.
- Keep warnings for non-default bootstrap file errors.
- Add a focused Common Test case for the missing-default-file path.
- Bump `apps/emqx_auth_mnesia` version to `6.0.3` and add changelog `changes/ee/fix-16939.en.md`.

Local verification:

- `make fmt-diff`
- Attempted `/home/zaiming.shi/.codex/skills/emqx-ct/scripts/run-ct.sh apps/emqx_auth_mnesia/test/emqx_authn_mnesia_SUITE.erl t_default_bootstrap_file_missing`
- CT is currently blocked locally because `mix ct` reports an outdated `hocon` lock entry relative to `mix.exs`.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
