### PR TITLE
feat(dashboard_sso): add force MFA support for SSO users

### DIFF
--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -19,6 +19,34 @@
     description :: binary(),
     role = ?ROLE_DEFAULT :: dashboard_user_role(),
     extra = #{} :: map()
+    %% Extensible metadata map. Known keys:
+    %%
+    %%   mfa_state => #{mechanism => totp, secret => binary(), ...}
+    %%              | disabled
+    %%     MFA configuration for this user.
+    %%     - Map with `mechanism` and `secret`: MFA is enabled or pending setup.
+    %%       May also contain `first_verify_ts` after first successful TOTP verify.
+    %%     - `disabled` atom: admin has explicitly exempted this user from MFA.
+    %%     - Key absent: MFA never configured (default).
+    %%
+    %%   mfa_pending => #{type => setup | challenge,
+    %%                    token => binary(),
+    %%                    secret => binary(),        %% setup only
+    %%                    timestamp => integer()}
+    %%     Short-lived SSO MFA session token for TOTP setup or verification.
+    %%     Only used when MFA is required after SSO login.
+    %%     For regular (non-SSO) login, no pending state is required.
+    %%
+    %%   sso_code => #{code => binary(),
+    %%                 payload => map(),
+    %%                 exptime => integer()}
+    %%     One-time SSO login code for secure redirect. Created after
+    %%     SAML/OIDC callback; exchanged by frontend via POST /sso/token_exchange.
+    %%     TTL: 60 seconds. Consumed after single use.
+    %%
+    %%   login_lock => integer()
+    %%     Timestamp until which login is locked after too many failed attempts.
+    %%
 }).
 
 -type dashboard_user() :: #?ADMIN{}.

--- a/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_admin.erl
@@ -32,6 +32,14 @@
     change_password_trusted/2,
     change_password/3,
     enable_mfa/2,
+    reset_mfa/1,
+    admin_enable_mfa/1,
+    set_mfa_pending/2,
+    clear_mfa_pending/1,
+    get_mfa_pending/1,
+    set_sso_code/2,
+    clear_sso_code/1,
+    get_sso_code/1,
     all_users/0,
     admin_users/0,
     check/2,
@@ -137,32 +145,51 @@ get_mfa_enabled_state(Username) ->
             Result
     end.
 
+%% @doc Get MFA state from the extra map of emqx_admin record.
 get_mfa_state(Username) ->
     case get_extra(Username) of
-        {ok, #{mfa_state := S}} ->
-            {ok, S};
-        {ok, _} ->
-            {error, no_mfa_state};
-        {error, _} = Error ->
-            Error
+        {ok, #{mfa_state := S}} -> {ok, S};
+        {ok, _} -> {error, no_mfa_state};
+        {error, _} = Error -> Error
     end.
 
-%% @doc Delete MFA state from user record.
-%% This should allow the user to re-initialize MFA state according to `default_mfa' config.
+%% @doc Remove mfa_state key entirely from extra map.
 clear_mfa_state(Username) ->
-    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun clear_mfa_state2/1, [Username]),
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> maps:without([mfa_state], Extra) end)
+    end),
     return(Res).
 
-clear_mfa_state2(Username) ->
-    update_extra(Username, fun(Extra) -> maps:without([mfa_state], Extra) end).
-
-%% @doc Change `mfa_state' to `disabled'.
+%% @doc Disable MFA for a user.
+%% Verifies MFA is currently enabled before disabling.
+%% Clears the secret so re-enabling requires a fresh TOTP setup.
+-spec disable_mfa(dashboard_username()) -> ok | {error, term()}.
 disable_mfa(Username) ->
-    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun disable_mfa2/1, [Username]),
-    return(Res).
+    case lookup_user(Username) of
+        [] ->
+            {error, <<"username_not_found">>};
+        [_] ->
+            do_disable_mfa(Username)
+    end.
 
-disable_mfa2(Username) ->
-    update_extra(Username, fun(Extra) -> Extra#{mfa_state => disabled} end).
+do_disable_mfa(Username) ->
+    case get_mfa_state(Username) of
+        {ok, disabled} ->
+            {error, <<"MFA is already disabled">>};
+        _ ->
+            %% Allow disabling regardless of current state (not configured, or enabled).
+            %% This matches upstream behavior where disable is an unconditional
+            %% "set disabled" operation.
+            Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+                update_extra(Username, fun(Extra) ->
+                    maps:without([mfa_pending], Extra#{mfa_state => disabled})
+                end)
+            end),
+            case Res of
+                {atomic, ok} -> ok;
+                {aborted, Reason} -> {error, Reason}
+            end
+    end.
 
 %% @doc Enable MFA state.
 %% Return error if it's already enabled.
@@ -170,10 +197,13 @@ enable_mfa(Username, Mechanism) ->
     case get_mfa_enabled_state(Username) of
         {ok, #{mechanism := Mechanism0}} ->
             {error, binfmt("MFA is already enabled using '~p'", [Mechanism0])};
-        {error, username_not_found} ->
-            {error, <<"username_not_found">>};
         {error, _} ->
-            reinit_mfa(Username, Mechanism)
+            case lookup_user(Username) of
+                [] ->
+                    {error, <<"username_not_found">>};
+                [_] ->
+                    reinit_mfa(Username, Mechanism)
+            end
     end.
 
 reinit_mfa(Username, Mechanism) ->
@@ -182,13 +212,98 @@ reinit_mfa(Username, Mechanism) ->
     _ = emqx_dashboard_token:destroy_by_username(Username),
     ok.
 
-%% @doc Set MFA state.
+%% @doc Admin re-enables MFA for a user.
+%% Clears the disabled state so force_mfa takes effect on next SSO login.
+%% For SSO users, the next login will trigger TOTP setup from scratch.
+%% For local users, the admin should call enable_mfa/2 separately.
+-spec admin_enable_mfa(dashboard_username()) -> ok | {error, term()}.
+admin_enable_mfa(Username) ->
+    case get_mfa_state(Username) of
+        {ok, disabled} ->
+            Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+                update_extra(Username, fun(Extra) ->
+                    maps:without([mfa_state, mfa_pending], Extra)
+                end)
+            end),
+            case Res of
+                {atomic, ok} -> ok;
+                {aborted, Reason} -> {error, Reason}
+            end;
+        _ ->
+            {error, <<"MFA is not admin-disabled">>}
+    end.
+
+%% @doc Reset MFA for a user — remove both mfa_state and mfa_pending.
+-spec reset_mfa(dashboard_username()) -> {ok, ok} | {error, term()}.
+reset_mfa(Username) ->
+    case lookup_user(Username) of
+        [] ->
+            {error, <<"username_not_found">>};
+        [_] ->
+            Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+                update_extra(Username, fun(Extra) ->
+                    maps:without([mfa_state, mfa_pending], Extra)
+                end)
+            end),
+            case Res of
+                {atomic, ok} ->
+                    _ = emqx_dashboard_token:destroy_by_username(Username),
+                    {ok, ok};
+                {aborted, Reason} ->
+                    {error, Reason}
+            end
+    end.
+
+%% @doc Set MFA state in the extra map.
 set_mfa_state(Username, MfaState) ->
-    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun set_mfa_state2/2, [Username, MfaState]),
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> Extra#{mfa_state => MfaState} end)
+    end),
     return(Res).
 
-set_mfa_state2(Username, MfaState) ->
-    update_extra(Username, fun(Extra) -> Extra#{mfa_state => MfaState} end).
+%% @doc Set MFA pending info in the extra map.
+set_mfa_pending(Username, Pending) ->
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> Extra#{mfa_pending => Pending} end)
+    end),
+    return(Res).
+
+%% @doc Clear MFA pending info from the extra map.
+clear_mfa_pending(Username) ->
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> maps:without([mfa_pending], Extra) end)
+    end),
+    return(Res).
+
+%% @doc Get MFA pending info from the extra map for a given username.
+%% Direct O(1) lookup by username key.
+get_mfa_pending(Username) ->
+    case get_extra(Username) of
+        {ok, #{mfa_pending := Pending}} -> {ok, Pending};
+        _ -> {error, not_found}
+    end.
+
+%% @doc Store a one-time SSO code in the extra map.
+set_sso_code(Username, SsoCode) ->
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> Extra#{sso_code => SsoCode} end)
+    end),
+    return(Res).
+
+%% @doc Clear the SSO code from the extra map.
+clear_sso_code(Username) ->
+    Res = mria:sync_transaction(?DASHBOARD_SHARD, fun() ->
+        update_extra(Username, fun(Extra) -> maps:without([sso_code], Extra) end)
+    end),
+    return(Res).
+
+%% @doc Get the SSO code from the extra map for a given username.
+%% Direct O(1) lookup by username key.
+get_sso_code(Username) ->
+    case get_extra(Username) of
+        {ok, #{sso_code := SsoCode}} -> {ok, SsoCode};
+        _ -> {error, not_found}
+    end.
 
 set_login_lock(Username, LockedUntil) ->
     Res = mria:sync_transaction(?DASHBOARD_SHARD, fun set_login_lock2/2, [Username, LockedUntil]),
@@ -507,19 +622,21 @@ to_external_user(UserRecord) ->
     #?ADMIN{
         username = Username,
         description = Desc,
-        role = Role,
-        extra = Extra
+        role = Role
     } = UserRecord,
     flatten_username(#{
         username => Username,
         description => Desc,
         role => ensure_role(Role),
-        mfa => format_mfa(Extra)
+        mfa => format_mfa(Username)
     }).
 
-format_mfa(#{mfa_state := #{mechanism := Mechanism}}) -> Mechanism;
-format_mfa(#{mfa_state := disabled}) -> disabled;
-format_mfa(_) -> none.
+format_mfa(Username) ->
+    case get_mfa_state(Username) of
+        {ok, disabled} -> disabled;
+        {ok, #{mechanism := totp}} -> totp;
+        _ -> none
+    end.
 
 -spec return({atomic | aborted, term()}) -> {ok, term()} | {error, Reason :: binary()}.
 return({atomic, Result}) ->

--- a/apps/emqx_dashboard/src/emqx_dashboard_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_api.erl
@@ -166,7 +166,7 @@ schema("/users/:username/mfa") ->
         post => #{
             tags => [<<"Dashboard">>],
             desc => ?DESC(change_mfa),
-            parameters => fields([username_in_path]),
+            parameters => sso_parameters(fields([username_in_path])),
             'requestBody' => emqx_dashboard_schema:mfa_fields(),
             responses => #{
                 204 => <<"MFA setting is reset">>,
@@ -176,7 +176,16 @@ schema("/users/:username/mfa") ->
         delete => #{
             tags => [<<"Dashboard">>],
             desc => ?DESC(delete_mfa),
-            parameters => fields([username_in_path]),
+            parameters => sso_parameters(fields([username_in_path])) ++
+                [
+                    {reset,
+                        mk(boolean(), #{
+                            desc => ?DESC(mfa_reset_param),
+                            in => query,
+                            required => false,
+                            example => false
+                        })}
+                ],
             responses => #{
                 204 => <<"MFA setting is deleted">>,
                 404 => response_schema(404)
@@ -440,20 +449,41 @@ change_pwd(post, #{bindings := #{username := Username}, body := Params}) ->
             end
     end.
 
-change_mfa(delete, #{bindings := #{username := Username}}) ->
-    LogMeta = #{msg => "dashboard_user_mfa_delete", username => binary_to_list(Username)},
-    case emqx_dashboard_admin:disable_mfa(Username) of
-        {ok, ok} ->
-            ?SLOG(info, LogMeta#{result => success}),
-            {204};
-        {error, <<"username_not_found">>} ->
-            ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
-            {404, ?USER_NOT_FOUND, <<"User not found">>}
+change_mfa(delete, #{bindings := #{username := Username0}} = Req) ->
+    Username = username(Req, Username0),
+    QS = maps:get(query_string, Req, #{}),
+    Reset = maps:get(<<"reset">>, QS, false),
+    IsReset = Reset =:= true orelse Reset =:= <<"true">>,
+    case IsReset of
+        true ->
+            LogMeta = #{msg => "dashboard_user_mfa_reset", username => Username},
+            case emqx_dashboard_admin:reset_mfa(Username) of
+                {ok, ok} ->
+                    ?SLOG(info, LogMeta#{result => success}),
+                    {204};
+                {error, <<"username_not_found">>} ->
+                    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
+                    {404, ?USER_NOT_FOUND, <<"User not found">>}
+            end;
+        false ->
+            LogMeta = #{msg => "dashboard_user_mfa_delete", username => Username},
+            case emqx_dashboard_admin:disable_mfa(Username) of
+                ok ->
+                    ?SLOG(info, LogMeta#{result => success}),
+                    {204};
+                {error, <<"username_not_found">>} ->
+                    ?SLOG(error, LogMeta#{result => failed, reason => "username not found"}),
+                    {404, ?USER_NOT_FOUND, <<"User not found">>};
+                {error, Reason} ->
+                    ?SLOG(error, LogMeta#{result => failed, reason => Reason}),
+                    {400, ?BAD_REQUEST, Reason}
+            end
     end;
-change_mfa(post, #{bindings := #{username := Username}, body := Settings}) ->
+change_mfa(post, #{bindings := #{username := Username0}, body := Settings} = Req) ->
+    Username = username(Req, Username0),
     Mechanism = maps:get(<<"mechanism">>, Settings),
     {ok, State} = emqx_dashboard_mfa:init(Mechanism),
-    LogMeta = #{msg => "dashboard_user_mfa_setup", username => binary_to_list(Username)},
+    LogMeta = #{msg => "dashboard_user_mfa_setup", username => Username},
     case emqx_dashboard_admin:set_mfa_state(Username, State) of
         {ok, ok} ->
             ?SLOG(info, LogMeta#{result => success}),

--- a/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_mfa.erl
@@ -5,6 +5,8 @@
 %% @doc Multifactor authentication interface.
 -module(emqx_dashboard_mfa).
 
+-include("emqx_dashboard.hrl").
+
 -export([
     init/1,
     verify/2,
@@ -15,14 +17,31 @@
     supported_mechanisms/0
 ]).
 
--export_type([mfa_state/0, mechanism/0]).
+%% SSO MFA temporary tokens — stored in extra map of emqx_admin record
+-export([
+    create_setup_token/2,
+    create_verify_token/1,
+    verify_temp_token/2,
+    peek_temp_token/2,
+    generate_token/1
+]).
+
+-export_type([mfa_state/0, mechanism/0, temp_token_purpose/0]).
 
 -type mechanism() :: totp.
--type totp_state() :: #{mechanism := totp, secret := binary(), first_verify_ts => integer()}.
+-type totp_state() :: #{
+    mechanism := totp,
+    secret := binary(),
+    first_verify_ts => integer()
+}.
 -type mfa_state() :: disabled | totp_state().
+-type temp_token_purpose() :: {setup, binary()} | verify.
 
 -define(TOTP_KEY_BYTES, 20).
 -define(NO_FIRST_VERIFY_TS, 0).
+%% Temporary token validity: 5 minutes
+-define(TEMP_TOKEN_TTL_SEC, 300).
+-define(TOKEN_BYTES, 32).
 
 %% @doc Translate binary format mechanism name to atom.
 -spec mechanism(binary()) -> mechanism().
@@ -104,6 +123,82 @@ is_need_setup_error(#{mechanism := totp, error := missing_mfa_token, secret := S
 is_need_setup_error(_) ->
     false.
 
+%%--------------------------------------------------------------------
+%% SSO MFA temporary tokens — stored in extra map of emqx_admin record
+%%
+%% Tokens are stored as mfa_pending key in the emqx_admin record's
+%% extra map. This ensures SSO MFA works correctly in clustered
+%% deployments without a separate Mnesia table.
+%%--------------------------------------------------------------------
+
+%% @doc Create a short-lived temporary token for SSO MFA setup flow.
+%% The TOTP secret is stored in the pending record (not in user's enabled MFA state).
+-spec create_setup_token(binary(), binary()) -> binary().
+create_setup_token(Username, TotpSecret) ->
+    Token = generate_token(<<"mfa_">>),
+    Pending = #{
+        type => setup,
+        token => Token,
+        secret => TotpSecret,
+        timestamp => erlang:system_time(second)
+    },
+    {ok, ok} = emqx_dashboard_admin:set_mfa_pending(Username, Pending),
+    Token.
+
+%% @doc Create a short-lived temporary token for SSO MFA verify flow.
+-spec create_verify_token(binary()) -> binary().
+create_verify_token(Username) ->
+    Token = generate_token(<<"mfa_">>),
+    Pending = #{
+        type => challenge,
+        token => Token,
+        timestamp => erlang:system_time(second)
+    },
+    {ok, ok} = emqx_dashboard_admin:set_mfa_pending(Username, Pending),
+    Token.
+
+%% @doc Verify and consume a temporary token.
+%% Looks up the pending token by username (O(1) ets:lookup) and compares.
+-spec verify_temp_token(dashboard_username(), binary()) ->
+    {ok, term(), temp_token_purpose()} | {error, term()}.
+verify_temp_token(SsoUsername, Token) ->
+    case emqx_dashboard_admin:get_mfa_pending(SsoUsername) of
+        {ok, #{token := StoredToken, type := Type, timestamp := Timestamp} = Pending} when
+            StoredToken =:= Token
+        ->
+            case is_token_valid(Timestamp) of
+                true ->
+                    {ok, ok} = emqx_dashboard_admin:clear_mfa_pending(SsoUsername),
+                    {ok, SsoUsername, to_purpose(Type, Pending)};
+                false ->
+                    {error, token_expired}
+            end;
+        _ ->
+            {error, invalid_token}
+    end.
+
+%% @doc Peek at a temporary token without consuming it.
+-spec peek_temp_token(dashboard_username(), binary()) ->
+    {ok, term(), temp_token_purpose()} | {error, term()}.
+peek_temp_token(SsoUsername, Token) ->
+    case emqx_dashboard_admin:get_mfa_pending(SsoUsername) of
+        {ok, #{token := StoredToken, type := Type, timestamp := Timestamp} = Pending} when
+            StoredToken =:= Token
+        ->
+            case is_token_valid(Timestamp) of
+                true ->
+                    {ok, SsoUsername, to_purpose(Type, Pending)};
+                false ->
+                    {error, token_expired}
+            end;
+        _ ->
+            {error, invalid_token}
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
 verify_totp(Token, Secret) ->
     try
         case pot:valid_totp(Token, Secret) of
@@ -122,3 +217,19 @@ totp_error(Reason) ->
         mechanism => totp,
         error => Reason
     }.
+
+%% @doc Generate a random token with a prefix.
+%% Format: <<Prefix, RandomHex:64>>
+-spec generate_token(binary()) -> binary().
+generate_token(Prefix) ->
+    Hex = binary:encode_hex(crypto:strong_rand_bytes(?TOKEN_BYTES), lowercase),
+    <<Prefix/binary, Hex/binary>>.
+
+is_token_valid(Timestamp) when is_integer(Timestamp) ->
+    Now = erlang:system_time(second),
+    (Now - Timestamp) < ?TEMP_TOKEN_TTL_SEC;
+is_token_valid(_) ->
+    false.
+
+to_purpose(setup, #{secret := Secret}) -> {setup, Secret};
+to_purpose(challenge, _Pending) -> verify.

--- a/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
+++ b/apps/emqx_dashboard/test/emqx_dashboard_mfa_SUITE.erl
@@ -92,6 +92,12 @@ t_upgrade_old_record({'end', _Config}) ->
 t_upgrade_old_record(_Config) ->
     ?assertMatch([#?ADMIN{extra = []}], ets:lookup(?ADMIN, <<"viewer3">>)),
     ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer3">>)),
+    %% MFA state is now stored in the extra map of emqx_admin record
+    ?assertMatch(
+        {ok, #{mechanism := totp, secret := _}},
+        emqx_dashboard_admin:get_mfa_state(<<"viewer3">>)
+    ),
+    %% The emqx_admin record's extra field should now be a map (upgraded from [])
     ?assertMatch([#?ADMIN{extra = #{mfa_state := _}}], ets:lookup(?ADMIN, <<"viewer3">>)),
     ok.
 
@@ -213,8 +219,8 @@ t_disable_mfa(_Config) ->
     ?assertMatch({ok, 403, _}, disable_mfa(<<"viewer2">>, JwtToken)),
     %% admin can disable other user's MFA
     ?assertMatch({ok, 204, _}, disable_mfa(<<"viewer2">>, AdminJwtToken)),
-    %% disable for viewer1 again should return success
-    ?assertMatch({ok, 204, _}, disable_mfa(<<"viewer1">>, AdminJwtToken)),
+    %% disable for viewer1 again should return 400 (already disabled)
+    ?assertMatch({ok, 400, _}, disable_mfa(<<"viewer1">>, AdminJwtToken)),
     ok.
 
 %% Enable MFA from config.
@@ -272,6 +278,38 @@ t_enable_by_config(_Config) ->
     {ok, 200, _} = login(LoginBody),
     ok.
 
+%% Reset MFA — completely removes MFA record.
+%% After reset, the user is back to "never configured" state.
+t_reset_mfa({init, Config}) ->
+    ok = mock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(<<"viewer1">>),
+    Config;
+t_reset_mfa({'end', _Config}) ->
+    ok = unmock_totp();
+t_reset_mfa(_Config) ->
+    LoginBody =
+        #{
+            <<"username">> => <<"viewer1">>,
+            <<"password">> => <<"viewer1pass">>,
+            <<"mfa_token">> => ?GOOD_TOTP
+        },
+    AdminJwtToken = admin_jwt_token(),
+    %% enable MFA for viewer1
+    ?assertMatch({ok, 204, _}, enable_mfa(<<"viewer1">>)),
+    %% login with TOTP to complete setup
+    ?assertMatch({ok, 200, _}, login(LoginBody)),
+    ?assertMatch(#{<<"mfa">> := <<"totp">>}, get_user(<<"viewer1">>)),
+    %% admin resets MFA
+    ?assertMatch({ok, 204, _}, reset_mfa(<<"viewer1">>, AdminJwtToken)),
+    %% MFA state should be "none" (record deleted, not "disabled")
+    ?assertMatch(#{<<"mfa">> := <<"none">>}, get_user(<<"viewer1">>)),
+    %% should be able to login without TOTP now
+    LoginNoTotp = maps:remove(<<"mfa_token">>, LoginBody),
+    ?assertMatch({ok, 200, _}, login(LoginNoTotp)),
+    %% reset non-existent user should return 404
+    ?assertMatch({ok, 404, _}, reset_mfa(<<"nonexistent_user">>, AdminJwtToken)),
+    ok.
+
 %%------------------------------------------------------------------------------
 %% Internal functions
 %%------------------------------------------------------------------------------
@@ -303,6 +341,10 @@ enable_mfa(User, JwtToken) ->
 
 disable_mfa(User, JwtToken) ->
     request_api(delete, api_path(["users", User, mfa]), auth_header(JwtToken), #{}).
+
+reset_mfa(User, JwtToken) ->
+    Url = binary_to_list(iolist_to_binary(api_path(["users", User, "mfa"]))),
+    request_api(delete, Url, "reset=true", auth_header(JwtToken), #{}).
 
 get_user(Name) ->
     Users = list_users(),
@@ -337,6 +379,9 @@ request_api(Method, Url, Auth) ->
 
 request_api(Method, Url, Auth, Body) ->
     emqx_common_test_http:request_api(Method, Url, _QueryParams = [], Auth, Body).
+
+request_api(Method, Url, QueryParams, Auth, Body) ->
+    emqx_common_test_http:request_api(Method, Url, QueryParams, Auth, Body).
 
 %% TOTP is not very friendly for tests due to its
 %% time-based nature, here we mock it for determinstic

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso.erl
@@ -19,6 +19,8 @@
 
 -export([types/0, modules/0, provider/1, backends/0, format/1]).
 
+-export([parse_backend/1]).
+
 %%------------------------------------------------------------------------------
 %% Callbacks
 %%------------------------------------------------------------------------------
@@ -43,6 +45,8 @@
 -callback destroy(State :: state()) -> ok.
 -callback login(request(), State :: state()) ->
     {ok, dashboard_user_role(), Token :: binary()}
+    | {mfa_setup, SetupToken :: binary(), QRInfo :: map()}
+    | {mfa_verify, VerifyToken :: binary()}
     | {redirect, tuple()}
     | {error, Reason :: term()}.
 
@@ -115,3 +119,11 @@ combine(Arg, Bin) ->
 generic_combine(Arg, Bin) ->
     Str = io_lib:format("~0p", [Arg]),
     erlang:iolist_to_binary([Bin, Str]).
+
+%% @doc Parse SSO backend name from binary to atom.
+%% Whitelisted backends only — rejects unknown values.
+-spec parse_backend(binary()) -> {ok, atom()} | {error, unknown_backend}.
+parse_backend(<<"oidc">>) -> {ok, oidc};
+parse_backend(<<"saml">>) -> {ok, saml};
+parse_backend(<<"ldap">>) -> {ok, ldap};
+parse_backend(_) -> {error, unknown_backend}.

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_api.erl
@@ -9,6 +9,7 @@
 -include_lib("hocon/include/hoconsc.hrl").
 -include_lib("emqx/include/logger.hrl").
 -include_lib("emqx/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
 
 -import(hoconsc, [
     mk/2,
@@ -33,7 +34,8 @@
     running/2,
     login/2,
     sso/2,
-    backend/2
+    backend/2,
+    token_exchange/2
 ]).
 
 -export([sso_parameters/1, login_meta/4]).
@@ -57,7 +59,8 @@ paths() ->
         "/sso",
         "/sso/:backend",
         "/sso/running",
-        "/sso/login/:backend"
+        "/sso/login/:backend",
+        "/sso/token_exchange"
     ].
 
 schema("/sso/running") ->
@@ -95,11 +98,33 @@ schema("/sso/login/:backend") ->
             parameters => backend_name_in_path(),
             'requestBody' => login_union(),
             responses => #{
-                200 => emqx_dashboard_api:fields([role, token, version, license]),
+                200 => hoconsc:union([
+                    ref(login_success_response),
+                    ref(mfa_setup_response),
+                    ref(mfa_verify_response)
+                ]),
                 %% Redirect to IDP for saml
                 302 => response_schema(302),
                 401 => response_schema(401),
                 404 => response_schema(404)
+            },
+            security => []
+        }
+    };
+schema("/sso/token_exchange") ->
+    #{
+        'operationId' => token_exchange,
+        post => #{
+            tags => [?TAGS],
+            desc => ?DESC(token_exchange),
+            'requestBody' => ref(token_exchange_request),
+            responses => #{
+                200 => hoconsc:union([
+                    ref(login_success_response),
+                    ref(mfa_setup_response),
+                    ref(mfa_verify_response)
+                ]),
+                400 => response_schema(400)
             },
             security => []
         }
@@ -152,7 +177,35 @@ fields(backend_status) ->
                         desc => ?DESC(last_error)
                     }
                 )}
-        ].
+        ];
+fields(login_success_response) ->
+    emqx_dashboard_api:fields([role, token, version, license]) ++
+        [
+            {username, mk(binary(), #{desc => <<"Username">>})},
+            {backend, mk(binary(), #{desc => <<"SSO backend type">>})}
+        ];
+fields(mfa_setup_response) ->
+    [
+        {action, mk(binary(), #{desc => <<"MFA action: mfa_setup">>, example => <<"mfa_setup">>})},
+        {setup_token, mk(binary(), #{desc => <<"Temporary setup token for MFA binding">>})},
+        {mechanism, mk(binary(), #{desc => <<"MFA mechanism">>, example => <<"totp">>})},
+        {username, mk(binary(), #{desc => <<"Username">>})},
+        {backend, mk(binary(), #{desc => <<"SSO backend type">>})}
+    ];
+fields(mfa_verify_response) ->
+    [
+        {action,
+            mk(binary(), #{desc => <<"MFA action: mfa_verify">>, example => <<"mfa_verify">>})},
+        {verify_token, mk(binary(), #{desc => <<"Temporary verify token for MFA verification">>})},
+        {username, mk(binary(), #{desc => <<"Username">>})},
+        {backend, mk(binary(), #{desc => <<"SSO backend type">>})}
+    ];
+fields(token_exchange_request) ->
+    [
+        {code, mk(binary(), #{desc => <<"One-time SSO code">>, required => true})},
+        {username, mk(binary(), #{desc => ?DESC(sso_username), required => true})},
+        {backend, mk(binary(), #{desc => ?DESC(sso_backend), required => true})}
+    ].
 
 %%--------------------------------------------------------------------
 %% API
@@ -161,6 +214,32 @@ fields(backend_status) ->
 running(get, _Request) ->
     {200, emqx_dashboard_sso_manager:running()}.
 
+token_exchange(post, #{
+    body := #{<<"code">> := Code, <<"username">> := Username, <<"backend">> := BackendBin}
+}) ->
+    case parse_backend(BackendBin) of
+        {ok, BackendAtom} ->
+            case emqx_dashboard_sso_code:exchange_code(BackendAtom, Username, Code) of
+                {ok, #{action := <<"login">>}} ->
+                    %% Sign JWT now at exchange time
+                    SsoUsername = ?SSO_USERNAME(BackendAtom, Username),
+                    case emqx_dashboard_admin:lookup_user(SsoUsername) of
+                        [User] ->
+                            {ok, Role, Token} = emqx_dashboard_token:sign(User),
+                            {200, login_meta(Username, Role, Token, BackendAtom)};
+                        [] ->
+                            {400, #{code => ?BAD_REQUEST, message => <<"User not found">>}}
+                    end;
+                {ok, Payload} ->
+                    %% MFA setup/verify — return as-is
+                    {200, Payload};
+                {error, _Reason} ->
+                    {400, #{code => ?BAD_REQUEST, message => <<"Invalid or expired SSO code">>}}
+            end;
+        {error, _} ->
+            {400, #{code => ?BAD_REQUEST, message => <<"Unknown SSO backend">>}}
+    end.
+
 login(post, #{bindings := #{backend := Backend}, body := Body} = Request) ->
     minirest_handler:update_log_meta(#{log_from => dashboard, log_source => Backend}),
     case emqx_dashboard_sso_manager:lookup_state(Backend) of
@@ -168,7 +247,23 @@ login(post, #{bindings := #{backend := Backend}, body := Body} = Request) ->
             {404, #{code => ?BACKEND_NOT_FOUND, message => <<"Backend not found">>}};
         State ->
             case emqx_dashboard_sso:login(provider(Backend), Request, State) of
+                {ok, login} ->
+                    ?SLOG(info, #{
+                        msg => "dashboard_sso_login_successful",
+                        request => emqx_utils:redact(Request)
+                    }),
+                    Username = maps:get(<<"username">>, Body),
+                    minirest_handler:update_log_meta(#{log_source => Username}),
+                    SsoUsername = ?SSO_USERNAME(Backend, Username),
+                    case emqx_dashboard_admin:lookup_user(SsoUsername) of
+                        [User] ->
+                            {ok, Role, Token} = emqx_dashboard_token:sign(User),
+                            {200, login_meta(Username, Role, Token, Backend)};
+                        [] ->
+                            {400, #{code => ?BAD_REQUEST, message => <<"User not found">>}}
+                    end;
                 {ok, Role, Token} ->
+                    %% Legacy path — kept for backends that still sign directly
                     ?SLOG(info, #{
                         msg => "dashboard_sso_login_successful",
                         request => emqx_utils:redact(Request)
@@ -176,6 +271,31 @@ login(post, #{bindings := #{backend := Backend}, body := Body} = Request) ->
                     Username = maps:get(<<"username">>, Body),
                     minirest_handler:update_log_meta(#{log_source => Username}),
                     {200, login_meta(Username, Role, Token, Backend)};
+                {mfa_setup, SetupToken, _QRInfo} ->
+                    ?SLOG(info, #{
+                        msg => "dashboard_sso_login_mfa_setup_required",
+                        request => emqx_utils:redact(Request)
+                    }),
+                    Username = maps:get(<<"username">>, Body),
+                    {200, #{
+                        action => <<"mfa_setup">>,
+                        setup_token => SetupToken,
+                        mechanism => totp,
+                        username => Username,
+                        backend => Backend
+                    }};
+                {mfa_verify, VerifyToken} ->
+                    ?SLOG(info, #{
+                        msg => "dashboard_sso_login_mfa_verify_required",
+                        request => emqx_utils:redact(Request)
+                    }),
+                    Username = maps:get(<<"username">>, Body),
+                    {200, #{
+                        action => <<"mfa_verify">>,
+                        verify_token => VerifyToken,
+                        username => Username,
+                        backend => Backend
+                    }};
                 {redirect, Redirect} ->
                     ?SLOG(info, #{
                         msg => "dashboard_sso_login_redirect",
@@ -238,6 +358,8 @@ sso_parameters(Params) ->
 
 response_schema(302) ->
     emqx_dashboard_swagger:error_codes([?REDIRECT], ?DESC(redirect));
+response_schema(400) ->
+    emqx_dashboard_swagger:error_codes([?BAD_REQUEST], ?DESC(bad_request));
 response_schema(401) ->
     emqx_dashboard_swagger:error_codes([?BAD_USERNAME_OR_PWD], ?DESC(login_failed401));
 response_schema(404) ->
@@ -307,3 +429,6 @@ login_meta(Username, Role, Token, Backend) ->
         license => #{edition => emqx_release:edition()},
         backend => Backend
     }.
+
+parse_backend(BackendBin) ->
+    emqx_dashboard_sso:parse_backend(BackendBin).

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_cli.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_cli.erl
@@ -44,8 +44,8 @@ admins(["del", Username, BackendName]) ->
     end;
 admins(["mfa", Username, "disable" | _]) ->
     case emqx_dashboard_admin:disable_mfa(bin(Username)) of
-        {ok, ok} ->
-            ok;
+        ok ->
+            emqx_ctl:print("ok~n");
         {error, Reason} ->
             print_error(Reason)
     end;

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_code.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_code.erl
@@ -1,0 +1,77 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc One-time SSO code exchange.
+%%
+%% After SAML/OIDC authentication, instead of putting JWT tokens or MFA
+%% temp tokens directly in the redirect URL query string (which leaks to
+%% proxy logs and browser history), we generate a short-lived one-time
+%% code.  The frontend exchanges this code for the real payload via a
+%% POST request.
+%%
+%% Storage: `sso_code' key in the `extra' map of `emqx_admin' records
+%% (same pattern as MFA pending tokens).
+%% TTL: 60 seconds.  Codes are consumed (cleared) atomically on exchange.
+-module(emqx_dashboard_sso_code).
+
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
+
+%% API
+-export([
+    create_code/2,
+    exchange_code/3
+]).
+
+-ifdef(TEST).
+-define(TTL_SEC, 5).
+-else.
+-define(TTL_SEC, 60).
+-endif.
+
+%%--------------------------------------------------------------------
+%% API
+%%--------------------------------------------------------------------
+
+%% @doc Create a one-time code for the given username and payload.
+%% The code is stored in the `sso_code' key of the user's `extra' map.
+%% Returns the code binary (prefixed with "sso_").
+-spec create_code(dashboard_username(), map()) -> binary().
+create_code(Username, Payload) when is_map(Payload) ->
+    Code = generate_code(),
+    Now = erlang:system_time(second),
+    SsoCode = #{
+        code => Code,
+        payload => Payload,
+        exptime => Now + ?TTL_SEC
+    },
+    {ok, ok} = emqx_dashboard_admin:set_sso_code(Username, SsoCode),
+    Code.
+
+%% @doc Exchange a one-time code for its payload.
+%% Looks up by username (O(1) ets:lookup) and compares stored code.
+-spec exchange_code(atom(), binary(), binary()) -> {ok, map()} | {error, expired | not_found}.
+exchange_code(Backend, Username, Code) when is_binary(Code) ->
+    do_exchange(?SSO_USERNAME(Backend, Username), Code).
+
+do_exchange(SsoUsername, Code) ->
+    case emqx_dashboard_admin:get_sso_code(SsoUsername) of
+        {ok, #{code := StoredCode, payload := Payload, exptime := Exp}} when StoredCode =:= Code ->
+            _ = emqx_dashboard_admin:clear_sso_code(SsoUsername),
+            Now = erlang:system_time(second),
+            case Now =< Exp of
+                true -> {ok, Payload};
+                false -> {error, expired}
+            end;
+        _ ->
+            {error, not_found}
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+%% @doc Generate a random one-time code with "sso_" prefix.
+generate_code() ->
+    emqx_dashboard_mfa:generate_token(<<"sso_">>).

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_ldap.erl
@@ -157,7 +157,7 @@ login(
 ensure_user_exists(Username) ->
     case emqx_dashboard_admin:lookup_user(ldap, Username) of
         [User] ->
-            emqx_dashboard_token:sign(User);
+            emqx_dashboard_sso_mfa:check_sso_mfa(User, ldap);
         [] ->
             case emqx_dashboard_admin:add_sso_user(ldap, Username, ?ROLE_VIEWER, <<>>) of
                 {ok, _} ->

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa.erl
@@ -1,0 +1,109 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc Common SSO MFA enforcement logic.
+%% Called by SSO backend callbacks (OIDC/SAML/LDAP) after user authentication
+%% to enforce force_mfa policy before issuing JWT tokens.
+-module(emqx_dashboard_sso_mfa).
+
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
+
+-export([
+    check_sso_mfa/2,
+    get_force_mfa/1
+]).
+
+-define(MOD_KEY_PATH(Sub), [dashboard, sso, Sub]).
+
+%% @doc Check SSO MFA enforcement for a user.
+%% This function should be called after ensure_user_exists succeeds,
+%% with the User record and the SSO backend atom.
+%%
+%% Returns:
+%%   {ok, login}                    - No MFA needed, JWT should be signed at exchange time
+%%   {mfa_setup, SetupToken, QRInfo} - User needs to bind TOTP first
+%%   {mfa_verify, VerifyToken}      - User needs to verify TOTP
+-spec check_sso_mfa(dashboard_user(), atom()) ->
+    {ok, login}
+    | {mfa_setup, binary(), map()}
+    | {mfa_verify, binary()}.
+check_sso_mfa(User, Backend) ->
+    case get_force_mfa(Backend) of
+        false ->
+            {ok, login};
+        true ->
+            #?ADMIN{username = Username} = User,
+            check_user_mfa_state(Username, User)
+    end.
+
+%% @doc Get force_mfa config for a given SSO backend.
+-spec get_force_mfa(atom()) -> boolean().
+get_force_mfa(Backend) ->
+    case emqx:get_config(?MOD_KEY_PATH(Backend), undefined) of
+        #{force_mfa := ForceMfa} -> ForceMfa;
+        _ -> false
+    end.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+-spec check_user_mfa_state(term(), dashboard_user()) ->
+    {ok, login}
+    | {mfa_setup, binary(), map()}
+    | {mfa_verify, binary()}.
+check_user_mfa_state(Username, _User) ->
+    MfaState = emqx_dashboard_admin:get_mfa_state(Username),
+    case classify_mfa_state(MfaState) of
+        admin_disabled ->
+            {ok, login};
+        not_configured ->
+            init_and_create_setup(Username);
+        setup_required ->
+            %% Secret exists (from enable_mfa/reinit) but user hasn't scanned QR yet
+            {ok, #{secret := Secret}} = MfaState,
+            create_setup_from_existing(Username, Secret);
+        enabled ->
+            VerifyToken = emqx_dashboard_mfa:create_verify_token(Username),
+            {mfa_verify, VerifyToken}
+    end.
+
+-spec classify_mfa_state(term()) -> not_configured | setup_required | enabled | admin_disabled.
+classify_mfa_state({ok, disabled}) ->
+    admin_disabled;
+classify_mfa_state({ok, #{mechanism := totp, first_verify_ts := _}}) ->
+    %% User has completed TOTP setup (scanned QR code and verified once)
+    enabled;
+classify_mfa_state({ok, #{mechanism := totp}}) ->
+    %% Has secret but never verified — needs to scan QR code first
+    setup_required;
+classify_mfa_state(_) ->
+    not_configured.
+
+-spec init_and_create_setup(term()) ->
+    {mfa_setup, binary(), map()}.
+init_and_create_setup(Username) ->
+    {ok, #{secret := Secret}} = emqx_dashboard_mfa:init(totp),
+    %% Store TOTP secret in Mnesia pending record (not in user's enabled MFA state).
+    %% It will be promoted to enabled=true only after the user
+    %% successfully verifies their first TOTP code (in do_mfa_setup).
+    %% Username is the SSO username tuple, e.g. {ldap, <<"user">>}.
+    SetupToken = emqx_dashboard_mfa:create_setup_token(Username, Secret),
+    QRInfo = #{
+        secret => Secret,
+        mechanism => totp
+    },
+    {mfa_setup, SetupToken, QRInfo}.
+
+%% @doc Create a setup flow from an existing secret (e.g. after admin re-enable).
+%% The secret is already in mfa_state but user hasn't verified it yet.
+-spec create_setup_from_existing(term(), binary()) ->
+    {mfa_setup, binary(), map()}.
+create_setup_from_existing(Username, Secret) ->
+    SetupToken = emqx_dashboard_mfa:create_setup_token(Username, Secret),
+    QRInfo = #{
+        secret => Secret,
+        mechanism => totp
+    },
+    {mfa_setup, SetupToken, QRInfo}.

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl
@@ -1,0 +1,315 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+%% @doc SSO MFA setup and verify API endpoints.
+%% These endpoints are public (no Bearer Token required),
+%% authenticated via short-lived temporary tokens from SSO login flow.
+-module(emqx_dashboard_sso_mfa_api).
+
+-behaviour(minirest_api).
+
+-include_lib("hocon/include/hoconsc.hrl").
+-include_lib("emqx/include/logger.hrl").
+-include_lib("emqx/include/emqx_api_key_scopes.hrl").
+-include_lib("emqx_dashboard/include/emqx_dashboard.hrl").
+
+-import(hoconsc, [mk/2, ref/1, ref/2]).
+
+-export([
+    api_spec/0,
+    paths/0,
+    schema/1,
+    namespace/0,
+    fields/1,
+    scopes/0
+]).
+
+-export([
+    mfa_setup/2,
+    mfa_verify/2,
+    mfa_setup_info/2
+]).
+
+-define(BAD_REQUEST, 'BAD_REQUEST').
+-define(UNAUTHORIZED, 'UNAUTHORIZED').
+-define(TAGS, <<"Dashboard Single Sign-On">>).
+
+namespace() -> "dashboard_sso_mfa".
+
+scopes() -> ?SCOPE_DENIED.
+
+api_spec() ->
+    emqx_dashboard_swagger:spec(?MODULE, #{check_schema => true, translate_body => true}).
+
+paths() ->
+    [
+        "/sso/mfa/setup_info",
+        "/sso/mfa/setup",
+        "/sso/mfa/verify"
+    ].
+
+schema("/sso/mfa/setup_info") ->
+    #{
+        'operationId' => mfa_setup_info,
+        post => #{
+            tags => [?TAGS],
+            desc => ?DESC(mfa_setup_info),
+            'requestBody' => ref(mfa_setup_info_request),
+            responses => #{
+                200 => ref(mfa_setup_info_response),
+                401 => response_schema(401)
+            },
+            %% No standard auth — authenticated by the short-lived
+            %% setup_token in the request body (issued after SSO login).
+            security => []
+        }
+    };
+schema("/sso/mfa/setup") ->
+    #{
+        'operationId' => mfa_setup,
+        post => #{
+            tags => [?TAGS],
+            desc => ?DESC(mfa_setup),
+            'requestBody' => ref(mfa_setup_request),
+            responses => #{
+                200 => ref(emqx_dashboard_sso_api, login_success_response),
+                400 => response_schema(400),
+                401 => response_schema(401)
+            },
+            %% No standard auth — authenticated by the short-lived
+            %% setup_token in the request body (issued after SSO login).
+            security => []
+        }
+    };
+schema("/sso/mfa/verify") ->
+    #{
+        'operationId' => mfa_verify,
+        post => #{
+            tags => [?TAGS],
+            desc => ?DESC(mfa_verify),
+            'requestBody' => ref(mfa_verify_request),
+            responses => #{
+                200 => ref(emqx_dashboard_sso_api, login_success_response),
+                400 => response_schema(400),
+                401 => response_schema(401)
+            },
+            %% No standard auth — authenticated by the short-lived
+            %% verify_token in the request body (issued after SSO login).
+            security => []
+        }
+    }.
+
+fields(mfa_setup_info_request) ->
+    [
+        {setup_token, mk(binary(), #{desc => ?DESC(setup_token), required => true})},
+        {username, mk(binary(), #{desc => ?DESC(sso_username), required => true})},
+        {backend, mk(binary(), #{desc => ?DESC(sso_backend), required => true})}
+    ];
+fields(mfa_setup_info_response) ->
+    [
+        {secret, mk(binary(), #{desc => ?DESC(totp_secret), required => true})},
+        {mechanism, mk(binary(), #{desc => ?DESC(mfa_mechanism), required => true})}
+    ];
+fields(mfa_setup_request) ->
+    [
+        {setup_token, mk(binary(), #{desc => ?DESC(setup_token), required => true})}
+        | fields(mfa_common_fields)
+    ];
+fields(mfa_verify_request) ->
+    [
+        {verify_token, mk(binary(), #{desc => ?DESC(verify_token), required => true})}
+        | fields(mfa_common_fields)
+    ];
+fields(mfa_common_fields) ->
+    [
+        {totp_code, mk(binary(), #{desc => ?DESC(totp_code), required => true})},
+        {username, mk(binary(), #{desc => ?DESC(sso_username), required => true})},
+        {backend, mk(binary(), #{desc => ?DESC(sso_backend), required => true})}
+    ].
+
+%%--------------------------------------------------------------------
+%% API handlers
+%%--------------------------------------------------------------------
+
+%% @doc Handle MFA setup info: peek at the setup token to retrieve TOTP secret
+%% for QR code display. Does NOT consume the token.
+mfa_setup_info(post, #{
+    body := #{
+        <<"setup_token">> := SetupToken,
+        <<"username">> := Username,
+        <<"backend">> := BackendBin
+    }
+}) ->
+    case parse_backend(BackendBin) of
+        {ok, BackendAtom} ->
+            SsoUsername = ?SSO_USERNAME(BackendAtom, Username),
+            case emqx_dashboard_mfa:peek_temp_token(SsoUsername, SetupToken) of
+                {ok, _SsoUsername, {setup, TotpSecret}} ->
+                    {200, #{secret => TotpSecret, mechanism => <<"totp">>}};
+                {ok, _SsoUsername, _WrongPurpose} ->
+                    {401, #{code => ?UNAUTHORIZED, message => <<"Invalid token type">>}};
+                {error, Reason} ->
+                    {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
+            end;
+        {error, _} ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Unknown SSO backend">>}}
+    end;
+mfa_setup_info(post, _) ->
+    {400, #{code => ?BAD_REQUEST, message => <<"Missing required fields">>}}.
+
+%% @doc Handle MFA setup: verify the setup token, verify TOTP code,
+%% finalize MFA binding, and issue JWT.
+mfa_setup(post, #{
+    body := #{
+        <<"setup_token">> := SetupToken,
+        <<"totp_code">> := TotpCode,
+        <<"username">> := Username,
+        <<"backend">> := BackendBin
+    }
+}) ->
+    case parse_backend(BackendBin) of
+        {ok, BackendAtom} ->
+            SsoUsername = ?SSO_USERNAME(BackendAtom, Username),
+            case emqx_dashboard_mfa:verify_temp_token(SsoUsername, SetupToken) of
+                {ok, SsoUsername, {setup, TotpSecret}} ->
+                    do_mfa_setup(SsoUsername, TotpCode, TotpSecret);
+                {ok, _SsoUsername, _WrongPurpose} ->
+                    {401, #{code => ?UNAUTHORIZED, message => <<"Invalid token type">>}};
+                {error, Reason} ->
+                    {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
+            end;
+        {error, _} ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Unknown SSO backend">>}}
+    end;
+mfa_setup(post, _) ->
+    {400, #{code => ?BAD_REQUEST, message => <<"Missing required fields">>}}.
+
+%% @doc Handle MFA verify: verify the verify token, check TOTP code,
+%% and issue JWT.
+mfa_verify(post, #{
+    body := #{
+        <<"verify_token">> := VerifyToken,
+        <<"totp_code">> := TotpCode,
+        <<"username">> := Username,
+        <<"backend">> := BackendBin
+    }
+}) ->
+    case parse_backend(BackendBin) of
+        {ok, BackendAtom} ->
+            SsoUsername = ?SSO_USERNAME(BackendAtom, Username),
+            case emqx_dashboard_mfa:verify_temp_token(SsoUsername, VerifyToken) of
+                {ok, SsoUsername, verify} ->
+                    do_mfa_verify(SsoUsername, TotpCode);
+                {ok, _SsoUsername, _WrongPurpose} ->
+                    {401, #{code => ?UNAUTHORIZED, message => <<"Invalid token type">>}};
+                {error, Reason} ->
+                    {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
+            end;
+        {error, _} ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Unknown SSO backend">>}}
+    end;
+mfa_verify(post, _) ->
+    {400, #{code => ?BAD_REQUEST, message => <<"Missing required fields">>}}.
+
+%%--------------------------------------------------------------------
+%% Internal functions
+%%--------------------------------------------------------------------
+
+do_mfa_setup(SsoUsername, TotpCode, TotpSecret) ->
+    %% Build MFA state from the secret stored in the setup token.
+    MfaState = #{mechanism => totp, secret => TotpSecret},
+    case emqx_dashboard_mfa:verify(MfaState, TotpCode) of
+        ok ->
+            finalize_mfa_setup(SsoUsername, MfaState#{first_verify_ts => erlang:system_time(second)});
+        {ok, NewState} ->
+            finalize_mfa_setup(SsoUsername, NewState);
+        {error, _} ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Invalid TOTP code">>}}
+    end.
+
+finalize_mfa_setup(SsoUsername, MfaState) ->
+    case resolve_sso_user(SsoUsername) of
+        {ok, Backend, Name, User} ->
+            case emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState) of
+                {ok, ok} ->
+                    sign_and_respond(User, Name, Backend);
+                {error, Reason} ->
+                    ?SLOG(error, #{
+                        msg => "failed_to_persist_mfa_state",
+                        username => SsoUsername,
+                        reason => Reason
+                    }),
+                    {500, #{
+                        code => <<"INTERNAL_ERROR">>,
+                        message => <<"Failed to persist MFA state">>
+                    }}
+            end;
+        {error, Reason} ->
+            {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
+    end.
+
+do_mfa_verify(SsoUsername, TotpCode) ->
+    case resolve_sso_user(SsoUsername) of
+        {ok, Backend, Name, User} ->
+            case emqx_dashboard_admin:get_mfa_state(SsoUsername) of
+                {ok, #{mechanism := totp} = MfaState} ->
+                    verify_and_respond(MfaState, TotpCode, SsoUsername, User, Name, Backend);
+                _ ->
+                    {401, #{code => ?UNAUTHORIZED, message => <<"MFA state not found">>}}
+            end;
+        {error, Reason} ->
+            {401, #{code => ?UNAUTHORIZED, message => format_error(Reason)}}
+    end.
+
+verify_and_respond(MfaState, TotpCode, SsoUsername, User, Name, Backend) ->
+    case emqx_dashboard_mfa:verify(MfaState, TotpCode) of
+        ok ->
+            sign_and_respond(User, Name, Backend);
+        {ok, NewState} ->
+            persist_state_and_respond(SsoUsername, NewState, User, Name, Backend);
+        {error, _} ->
+            {401, #{code => ?UNAUTHORIZED, message => <<"Invalid TOTP code">>}}
+    end.
+
+persist_state_and_respond(SsoUsername, NewState, User, Name, Backend) ->
+    case emqx_dashboard_admin:set_mfa_state(SsoUsername, NewState) of
+        {ok, ok} ->
+            sign_and_respond(User, Name, Backend);
+        {error, Reason} ->
+            ?SLOG(error, #{
+                msg => "failed_to_persist_mfa_state_after_verify",
+                username => Name,
+                backend => Backend,
+                reason => Reason
+            }),
+            {500, #{
+                code => <<"INTERNAL_ERROR">>,
+                message => <<"Failed to persist MFA state">>
+            }}
+    end.
+
+sign_and_respond(User, Username, Backend) ->
+    {ok, Role, Token} = emqx_dashboard_token:sign(User),
+    {200, emqx_dashboard_sso_api:login_meta(Username, Role, Token, Backend)}.
+
+%% @doc Resolve SSO username tuple to backend, name, and user record.
+resolve_sso_user(?SSO_USERNAME(Backend, Name)) ->
+    case emqx_dashboard_admin:lookup_user(Backend, Name) of
+        [User] ->
+            {ok, Backend, Name, User};
+        [] ->
+            {error, <<"User not found">>}
+    end.
+
+response_schema(400) ->
+    emqx_dashboard_swagger:error_codes([?BAD_REQUEST], <<"Bad Request">>);
+response_schema(401) ->
+    emqx_dashboard_swagger:error_codes([?UNAUTHORIZED], <<"Unauthorized">>).
+
+format_error(token_expired) -> <<"Token expired">>;
+format_error(invalid_token) -> <<"Invalid token">>;
+format_error(Reason) when is_binary(Reason) -> Reason.
+
+parse_backend(BackendBin) ->
+    emqx_dashboard_sso:parse_backend(BackendBin).

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc_api.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_oidc_api.erl
@@ -18,8 +18,6 @@
     ref/1
 ]).
 
--import(emqx_dashboard_sso_api, [login_meta/3]).
-
 -export([
     api_spec/0,
     paths/0,
@@ -210,9 +208,31 @@ ensure_user_exists(_Cfg, <<"undefined">>) ->
 ensure_user_exists(Cfg, Username) ->
     case emqx_dashboard_admin:lookup_user(?BACKEND, Username) of
         [User] ->
-            case emqx_dashboard_token:sign(User) of
-                {ok, Role, Token} ->
-                    {ok, login_redirect_target(Cfg, Username, Role, Token)};
+            case emqx_dashboard_sso_mfa:check_sso_mfa(User, ?BACKEND) of
+                {ok, login} ->
+                    Payload = #{
+                        action => <<"login">>,
+                        username => Username,
+                        backend => oidc
+                    },
+                    {ok, code_redirect_target(Cfg, Username, Payload)};
+                {mfa_setup, SetupToken, _QRInfo} ->
+                    Payload = #{
+                        action => <<"mfa_setup">>,
+                        setup_token => SetupToken,
+                        mechanism => totp,
+                        username => Username,
+                        backend => oidc
+                    },
+                    {ok, code_redirect_target(Cfg, Username, Payload)};
+                {mfa_verify, VerifyToken} ->
+                    Payload = #{
+                        action => <<"mfa_verify">>,
+                        verify_token => VerifyToken,
+                        username => Username,
+                        backend => oidc
+                    },
+                    {ok, code_redirect_target(Cfg, Username, Payload)};
                 Error ->
                     Error
             end;
@@ -228,9 +248,11 @@ ensure_user_exists(Cfg, Username) ->
 make_callback_url(#{config := #{dashboard_addr := Addr}}) ->
     list_to_binary(binary_to_list(Addr) ++ ?BASE_PATH ++ ?CALLBACK_PATH).
 
-login_redirect_target(#{config := #{dashboard_addr := Addr}}, Username, Role, Token) ->
-    LoginMeta = emqx_dashboard_sso_api:login_meta(Username, Role, Token, oidc),
-    MetaBin = base64:encode(emqx_utils_json:encode(LoginMeta)),
+code_redirect_target(#{config := #{dashboard_addr := Addr}}, Username, Payload) ->
+    SsoUsername = ?SSO_USERNAME(?BACKEND, Username),
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    LoginMeta = #{code => Code, username => Username, backend => ?BACKEND},
+    MetaBin = base64:encode(emqx_utils_json:encode(LoginMeta), #{mode => urlsafe, padding => false}),
     <<Addr/binary, "/?login_meta=", MetaBin/binary>>.
 
 lookup_all_nodes(State) ->

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_saml.erl
@@ -351,8 +351,34 @@ do_validate_assertion(SP, DuplicateFun, Body) ->
 
 gen_redirect_response(DashboardAddr, Username) ->
     case ensure_user_exists(Username) of
-        {ok, Role, Token} ->
-            Target = login_redirect_target(DashboardAddr, Username, Role, Token),
+        {ok, login} ->
+            Payload = #{
+                action => <<"login">>,
+                username => Username,
+                backend => saml
+            },
+            Target = code_redirect_target(DashboardAddr, Username, Payload),
+            Response = {302, maps:merge(?RESPHEADERS, #{<<"location">> => Target}), ?REDIRECT_BODY},
+            {redirect, Username, Response};
+        {mfa_setup, SetupToken, _QRInfo} ->
+            Payload = #{
+                action => <<"mfa_setup">>,
+                setup_token => SetupToken,
+                mechanism => totp,
+                username => Username,
+                backend => saml
+            },
+            Target = code_redirect_target(DashboardAddr, Username, Payload),
+            Response = {302, maps:merge(?RESPHEADERS, #{<<"location">> => Target}), ?REDIRECT_BODY},
+            {redirect, Username, Response};
+        {mfa_verify, VerifyToken} ->
+            Payload = #{
+                action => <<"mfa_verify">>,
+                verify_token => VerifyToken,
+                username => Username,
+                backend => saml
+            },
+            Target = code_redirect_target(DashboardAddr, Username, Payload),
             Response = {302, maps:merge(?RESPHEADERS, #{<<"location">> => Target}), ?REDIRECT_BODY},
             {redirect, Username, Response};
         {error, Reason} ->
@@ -367,7 +393,7 @@ gen_redirect_response(DashboardAddr, Username) ->
 ensure_user_exists(Username) ->
     case emqx_dashboard_admin:lookup_user(saml, Username) of
         [User] ->
-            emqx_dashboard_token:sign(User);
+            emqx_dashboard_sso_mfa:check_sso_mfa(User, saml);
         [] ->
             case emqx_dashboard_admin:add_sso_user(saml, Username, ?ROLE_VIEWER, <<>>) of
                 {ok, _} ->
@@ -392,9 +418,9 @@ is_msie(Headers) ->
     UA = maps:get(<<"user-agent">>, Headers, <<"">>),
     not (binary:match(UA, <<"MSIE">>) =:= nomatch).
 
-login_redirect_target(DashboardAddr, Username, Role, Token) ->
-    LoginMeta = emqx_dashboard_sso_api:login_meta(Username, Role, Token, saml),
-    <<DashboardAddr/binary, "/?login_meta=", (base64_login_meta(LoginMeta))/binary>>.
-
-base64_login_meta(LoginMeta) ->
-    base64:encode(emqx_utils_json:encode(LoginMeta)).
+code_redirect_target(DashboardAddr, Username, Payload) ->
+    SsoUsername = ?SSO_USERNAME(saml, Username),
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    LoginMeta = #{code => Code, username => Username, backend => saml},
+    MetaBin = base64:encode(emqx_utils_json:encode(LoginMeta), #{mode => urlsafe, padding => false}),
+    <<DashboardAddr/binary, "/?login_meta=", MetaBin/binary>>.

--- a/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_schema.erl
+++ b/apps/emqx_dashboard_sso/src/emqx_dashboard_sso_schema.erl
@@ -52,6 +52,14 @@ common_backend_schema(Backend) ->
                     default => false
                 }
             )},
+        {force_mfa,
+            mk(
+                boolean(), #{
+                    desc => ?DESC(force_mfa),
+                    required => false,
+                    default => false
+                }
+            )},
         backend_schema(Backend)
     ].
 

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_mfa_SUITE.erl
@@ -1,0 +1,750 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2025-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_dashboard_sso_mfa_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("snabbkaffe/include/snabbkaffe.hrl").
+-include("../../emqx_dashboard/include/emqx_dashboard.hrl").
+
+-define(HOST, "http://127.0.0.1:18083").
+-define(BASE_PATH, "/api/v5").
+-define(GOOD_TOTP, <<"123456">>).
+
+-define(SSO_BACKEND, ldap).
+-define(SSO_USER, <<"sso_testuser">>).
+-define(SSO_USER2, <<"sso_testuser2">>).
+
+-define(EE_ONLY(EXPR, NON_EE),
+    case emqx_release:edition() of
+        ee -> EXPR;
+        _ -> NON_EE
+    end
+).
+
+%%--------------------------------------------------------------------
+%% CT callbacks
+%%--------------------------------------------------------------------
+
+all() ->
+    ?EE_ONLY(emqx_common_test_helpers:all(?MODULE), []).
+
+init_per_suite(Config) ->
+    ?EE_ONLY(
+        begin
+            Apps = emqx_cth_suite:start(
+                [
+                    emqx,
+                    emqx_conf,
+                    emqx_management,
+                    emqx_mgmt_api_test_util:emqx_dashboard(),
+                    emqx_dashboard_sso
+                ],
+                #{work_dir => emqx_cth_suite:work_dir(Config)}
+            ),
+            ok = init_users(),
+            [{apps, Apps} | Config]
+        end,
+        Config
+    ).
+
+end_per_suite(Config) ->
+    ?EE_ONLY(
+        begin
+            mnesia:clear_table(?ADMIN),
+            mnesia:clear_table(?ADMIN_JWT),
+            emqx_cth_suite:stop(?config(apps, Config))
+        end,
+        ok
+    ).
+
+init_per_testcase(Case, Config) ->
+    ?MODULE:Case({init, Config}).
+
+end_per_testcase(Case, Config) ->
+    ?MODULE:Case({'end', Config}).
+
+init_users() ->
+    mnesia:clear_table(?ADMIN),
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"admin1">>, <<"admin1pass">>, ?ROLE_SUPERUSER, "admin"
+    ),
+    %% Create SSO users directly via add_sso_user
+    {ok, _} = emqx_dashboard_admin:add_sso_user(?SSO_BACKEND, ?SSO_USER, ?ROLE_VIEWER, <<>>),
+    {ok, _} = emqx_dashboard_admin:add_sso_user(?SSO_BACKEND, ?SSO_USER2, ?ROLE_VIEWER, <<>>),
+    ok.
+
+%%====================================================================
+%% Unit tests for emqx_dashboard_sso_mfa:get_force_mfa/1
+%%====================================================================
+
+t_get_force_mfa_not_configured({init, Config}) ->
+    Config;
+t_get_force_mfa_not_configured({'end', _Config}) ->
+    ok;
+t_get_force_mfa_not_configured(_Config) ->
+    %% When no SSO backend config exists, get_force_mfa returns false
+    ?assertEqual(false, emqx_dashboard_sso_mfa:get_force_mfa(nonexistent_backend)),
+    ok.
+
+t_get_force_mfa_enabled({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    Config;
+t_get_force_mfa_enabled({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok;
+t_get_force_mfa_enabled(_Config) ->
+    ?assertEqual(true, emqx_dashboard_sso_mfa:get_force_mfa(?SSO_BACKEND)),
+    ok.
+
+t_get_force_mfa_disabled({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, false),
+    Config;
+t_get_force_mfa_disabled({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok;
+t_get_force_mfa_disabled(_Config) ->
+    ?assertEqual(false, emqx_dashboard_sso_mfa:get_force_mfa(?SSO_BACKEND)),
+    ok.
+
+%%====================================================================
+%% Unit tests for emqx_dashboard_mfa temp token functions (Mnesia-backed)
+%%====================================================================
+
+t_create_and_verify_setup_token({init, Config}) ->
+    %% Create a temporary user for this test
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"test_setup_user">>, <<"TestPass1!">>, ?ROLE_VIEWER, <<>>
+    ),
+    Config;
+t_create_and_verify_setup_token({'end', _Config}) ->
+    _ = emqx_dashboard_admin:remove_user(<<"test_setup_user">>),
+    ok;
+t_create_and_verify_setup_token(_Config) ->
+    Username = <<"test_setup_user">>,
+    Secret = <<"JBSWY3DPEHPK3PXP">>,
+    Token = emqx_dashboard_mfa:create_setup_token(Username, Secret),
+    ?assert(is_binary(Token)),
+    ?assert(byte_size(Token) > 0),
+    Result = emqx_dashboard_mfa:verify_temp_token(Username, Token),
+    ?assertMatch({ok, Username, {setup, Secret}}, Result),
+    ok.
+
+t_create_and_verify_verify_token({init, Config}) ->
+    %% Create a MFA record first since create_verify_token updates existing record
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    MfaState = #{mechanism => totp, secret => <<"VERIFYSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_create_and_verify_verify_token({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_create_and_verify_verify_token(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    Token = emqx_dashboard_mfa:create_verify_token(SsoUsername),
+    ?assert(is_binary(Token)),
+    ?assert(byte_size(Token) > 0),
+    Result = emqx_dashboard_mfa:verify_temp_token(SsoUsername, Token),
+    ?assertMatch({ok, SsoUsername, verify}, Result),
+    ok.
+
+t_verify_token_expired({init, Config}) ->
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"test_expired_user">>, <<"TestPass1!">>, ?ROLE_VIEWER, <<>>
+    ),
+    Config;
+t_verify_token_expired({'end', _Config}) ->
+    _ = emqx_dashboard_admin:remove_user(<<"test_expired_user">>),
+    ok;
+t_verify_token_expired(_Config) ->
+    Username = <<"test_expired_user">>,
+    Token = emqx_dashboard_mfa:create_setup_token(Username, <<"SECRET">>),
+    ?assert(is_binary(Token)),
+    %% Manually update the pending record with an expired timestamp
+    ExpiredTs = erlang:system_time(second) - 301,
+    {ok, ok} = emqx_dashboard_admin:set_mfa_pending(Username, #{
+        type => setup,
+        token => Token,
+        secret => <<"SECRET">>,
+        timestamp => ExpiredTs
+    }),
+    Result = emqx_dashboard_mfa:verify_temp_token(Username, Token),
+    ?assertMatch({error, token_expired}, Result),
+    ok.
+
+t_verify_token_invalid({init, Config}) ->
+    Config;
+t_verify_token_invalid({'end', _Config}) ->
+    ok;
+t_verify_token_invalid(_Config) ->
+    %% Random bytes without HMAC signature → rejected
+    DummyUser = <<"nonexistent_user">>,
+    RandomToken = binary:encode_hex(crypto:strong_rand_bytes(32)),
+    ?assertMatch(
+        {error, invalid_token}, emqx_dashboard_mfa:verify_temp_token(DummyUser, RandomToken)
+    ),
+    ?assertMatch(
+        {error, invalid_token}, emqx_dashboard_mfa:peek_temp_token(DummyUser, RandomToken)
+    ),
+    ok.
+
+t_verify_token_consumed({init, Config}) ->
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"test_consumed_user">>, <<"TestPass1!">>, ?ROLE_VIEWER, <<>>
+    ),
+    Config;
+t_verify_token_consumed({'end', _Config}) ->
+    _ = emqx_dashboard_admin:remove_user(<<"test_consumed_user">>),
+    ok;
+t_verify_token_consumed(_Config) ->
+    Username = <<"test_consumed_user">>,
+    Token = emqx_dashboard_mfa:create_setup_token(Username, <<"SECRET">>),
+    %% First verify should succeed
+    ?assertMatch(
+        {ok, Username, {setup, <<"SECRET">>}}, emqx_dashboard_mfa:verify_temp_token(Username, Token)
+    ),
+    %% Second verify should fail — token is consumed (one-time use)
+    ?assertMatch({error, invalid_token}, emqx_dashboard_mfa:verify_temp_token(Username, Token)),
+    ok.
+
+%%====================================================================
+%% Integration tests for check_sso_mfa flow
+%%====================================================================
+
+t_check_sso_mfa_no_force({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, false),
+    Config;
+t_check_sso_mfa_no_force({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok;
+t_check_sso_mfa_no_force(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% force_mfa=false => no MFA, JWT signed at exchange time
+    ?assertEqual({ok, login}, Result),
+    ok.
+
+t_check_sso_mfa_not_configured({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    %% Ensure user has no MFA state
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    Config;
+t_check_sso_mfa_not_configured({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    ok;
+t_check_sso_mfa_not_configured(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% force_mfa=true, no MFA state => mfa_setup
+    ?assertMatch({mfa_setup, _SetupToken, _QRInfo}, Result),
+    {mfa_setup, SetupToken, QRInfo} = Result,
+    ?assert(is_binary(SetupToken)),
+    ?assertMatch(#{secret := _, mechanism := totp}, QRInfo),
+    ok.
+
+t_check_sso_mfa_enabled({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    %% Set MFA enabled for SSO_USER2
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2),
+    MfaState = #{mechanism => totp, secret => <<"TESTSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_check_sso_mfa_enabled({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2)),
+    ok;
+t_check_sso_mfa_enabled(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER2),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% force_mfa=true, MFA enabled => mfa_verify
+    ?assertMatch({mfa_verify, _VerifyToken}, Result),
+    {mfa_verify, VerifyToken} = Result,
+    ?assert(is_binary(VerifyToken)),
+    ok.
+
+t_check_sso_mfa_admin_disabled({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    %% Set MFA to disabled for SSO_USER (admin exemption)
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    %% First set MFA enabled so disable_mfa can work
+    MfaState = #{mechanism => totp, secret => <<"TESTSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    ok = emqx_dashboard_admin:disable_mfa(SsoUsername),
+    Config;
+t_check_sso_mfa_admin_disabled({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_check_sso_mfa_admin_disabled(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% force_mfa=true, admin_disabled => skip MFA, JWT signed at exchange time
+    ?assertEqual({ok, login}, Result),
+    ok.
+
+%%====================================================================
+%% Admin MFA control tests
+%%====================================================================
+
+t_admin_disable_mfa({init, Config}) ->
+    Config;
+t_admin_disable_mfa({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_admin_disable_mfa(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    OrigState = #{mechanism => totp, secret => <<"MYSECRET">>, first_verify_ts => 12345},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, OrigState),
+    %% Admin disables MFA
+    ok = emqx_dashboard_admin:disable_mfa(SsoUsername),
+    %% Verify state is disabled (secret cleared, record preserved as admin_disabled)
+    ?assertEqual({ok, disabled}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
+    ok.
+
+t_admin_enable_mfa({init, Config}) ->
+    Config;
+t_admin_enable_mfa({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_admin_enable_mfa(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    %% First enable MFA (setup_required state)
+    ok = emqx_dashboard_admin:enable_mfa(SsoUsername, totp),
+    %% Simulate first verify to move to enabled state
+    {ok, #{secret := _Secret}} = emqx_dashboard_admin:get_mfa_state(SsoUsername),
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, #{
+        mechanism => totp, secret => <<"OLDSECRET">>, first_verify_ts => 12345
+    }),
+    %% Admin disables MFA
+    ok = emqx_dashboard_admin:disable_mfa(SsoUsername),
+    ?assertEqual({ok, disabled}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
+    %% Admin re-enables MFA — clears disabled state entirely.
+    %% For SSO users, the next login with force_mfa=true will trigger fresh setup.
+    ok = emqx_dashboard_admin:admin_enable_mfa(SsoUsername),
+    ?assertEqual({error, no_mfa_state}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
+    ok.
+
+%%====================================================================
+%% SSO MFA API endpoint tests
+%%====================================================================
+
+t_mfa_setup_api({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    %% Ensure clean MFA state
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    Config;
+t_mfa_setup_api({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_setup_api(_Config) ->
+    %% Trigger check_sso_mfa to get a setup token
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_setup, SetupToken, _QRInfo} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+
+    %% POST /sso/mfa/setup with valid setup_token and totp_code
+    Body = #{
+        <<"setup_token">> => SetupToken,
+        <<"totp_code">> => ?GOOD_TOTP,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 200, RspBody} = request_api(post, api_path(["sso", "mfa", "setup"]), no_auth_header, Body),
+    Rsp = json_map(RspBody),
+    ?assertMatch(#{<<"token">> := _, <<"license">> := _}, Rsp),
+    ok.
+
+t_mfa_verify_api({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    %% Ensure user has MFA enabled (so check_sso_mfa returns mfa_verify)
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    MfaState = #{mechanism => totp, secret => <<"VERIFYSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_mfa_verify_api({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_verify_api(_Config) ->
+    %% Trigger check_sso_mfa to get a verify token
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_verify, VerifyToken} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+
+    %% POST /sso/mfa/verify with valid verify_token and totp_code
+    Body = #{
+        <<"verify_token">> => VerifyToken,
+        <<"totp_code">> => ?GOOD_TOTP,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 200, RspBody} = request_api(
+        post, api_path(["sso", "mfa", "verify"]), no_auth_header, Body
+    ),
+    Rsp = json_map(RspBody),
+    ?assertMatch(#{<<"token">> := _, <<"license">> := _}, Rsp),
+    ok.
+
+t_mfa_setup_invalid_token({init, Config}) ->
+    ok = mock_totp(),
+    Config;
+t_mfa_setup_invalid_token({'end', _Config}) ->
+    ok = unmock_totp(),
+    ok;
+t_mfa_setup_invalid_token(_Config) ->
+    %% POST /sso/mfa/setup with bad token
+    Body = #{
+        <<"setup_token">> => <<"totally_invalid_token">>,
+        <<"totp_code">> => ?GOOD_TOTP,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 401, RspBody} = request_api(post, api_path(["sso", "mfa", "setup"]), no_auth_header, Body),
+    Rsp = json_map(RspBody),
+    ?assertMatch(#{<<"code">> := <<"UNAUTHORIZED">>}, Rsp),
+    ok.
+
+t_mfa_verify_bad_totp({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    %% Ensure user has MFA enabled
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    MfaState = #{mechanism => totp, secret => <<"VERIFYSECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    Config;
+t_mfa_verify_bad_totp({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_verify_bad_totp(_Config) ->
+    %% Get a verify token
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_verify, VerifyToken} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+
+    %% POST /sso/mfa/verify with wrong TOTP code
+    Body = #{
+        <<"verify_token">> => VerifyToken,
+        <<"totp_code">> => <<"999999">>,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 401, RspBody} = request_api(
+        post, api_path(["sso", "mfa", "verify"]), no_auth_header, Body
+    ),
+    Rsp = json_map(RspBody),
+    ?assertMatch(#{<<"code">> := <<"UNAUTHORIZED">>}, Rsp),
+    ok.
+
+%%====================================================================
+%% Unit tests for emqx_dashboard_sso_code (one-time code exchange)
+%%====================================================================
+
+t_sso_code_create_and_exchange({init, Config}) ->
+    Config;
+t_sso_code_create_and_exchange({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_sso_code(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_sso_code_create_and_exchange(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    Payload = #{action => <<"login">>, username => <<"alice">>},
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    ?assert(is_binary(Code)),
+    ?assertMatch(<<"sso_", _/binary>>, Code),
+    {ok, Returned} = emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER, Code),
+    ?assertEqual(Payload, Returned),
+    ?assert(maps:is_key(action, Returned)),
+    ok.
+
+t_sso_code_one_time_consumption({init, Config}) ->
+    Config;
+t_sso_code_one_time_consumption({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_sso_code(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_sso_code_one_time_consumption(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    Payload = #{action => <<"login">>, username => <<"one_time_user">>},
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    ?assertMatch({ok, _}, emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER, Code)),
+    ?assertEqual(
+        {error, not_found}, emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER, Code)
+    ),
+    ok.
+
+t_sso_code_expired({init, Config}) ->
+    Config;
+t_sso_code_expired({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_sso_code(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_sso_code_expired(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    Payload = #{action => <<"login">>, username => <<"expired_user">>},
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    %% Manually set exptime to the past via set_sso_code
+    ExpiredTime = erlang:system_time(second) - 10,
+    {ok, ok} = emqx_dashboard_admin:set_sso_code(
+        SsoUsername, #{code => Code, payload => Payload, exptime => ExpiredTime}
+    ),
+    ?assertEqual(
+        {error, expired}, emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER, Code)
+    ),
+    ok.
+
+t_sso_code_invalid({init, Config}) ->
+    Config;
+t_sso_code_invalid({'end', _Config}) ->
+    ok;
+t_sso_code_invalid(_Config) ->
+    ?assertEqual(
+        {error, not_found},
+        emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER, <<"sso_nonexistent">>)
+    ),
+    ok.
+
+t_sso_code_expired_rejected({init, Config}) ->
+    Config;
+t_sso_code_expired_rejected({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_sso_code(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2)),
+    ok;
+t_sso_code_expired_rejected(_Config) ->
+    %% Expired codes are properly rejected on exchange
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER2),
+    Payload = #{action => <<"login">>, username => <<"cleanup_user">>},
+    %% Create a valid signed code, then manually expire it
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    ExpiredTime = erlang:system_time(second) - 10,
+    {ok, ok} = emqx_dashboard_admin:set_sso_code(
+        SsoUsername, #{code => Code, payload => Payload, exptime => ExpiredTime}
+    ),
+    ?assertEqual(
+        {error, expired}, emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER2, Code)
+    ),
+    ok.
+
+%% --- Review fix tests ---
+
+%% Test: peek_temp_token returns secret without consuming token
+t_peek_temp_token({init, Config}) ->
+    {ok, _} = emqx_dashboard_admin:add_user(
+        <<"test_peek_user">>, <<"TestPass1!">>, ?ROLE_VIEWER, <<>>
+    ),
+    Config;
+t_peek_temp_token({'end', _Config}) ->
+    _ = emqx_dashboard_admin:remove_user(<<"test_peek_user">>),
+    ok;
+t_peek_temp_token(_Config) ->
+    Username = <<"test_peek_user">>,
+    Secret = <<"PEEKSECRET">>,
+    Token = emqx_dashboard_mfa:create_setup_token(Username, Secret),
+    %% Peek should return the secret
+    ?assertMatch(
+        {ok, Username, {setup, Secret}}, emqx_dashboard_mfa:peek_temp_token(Username, Token)
+    ),
+    %% Token should NOT be consumed — peek again should work
+    ?assertMatch(
+        {ok, Username, {setup, Secret}}, emqx_dashboard_mfa:peek_temp_token(Username, Token)
+    ),
+    %% verify should still work (token still exists)
+    ?assertMatch(
+        {ok, Username, {setup, Secret}}, emqx_dashboard_mfa:verify_temp_token(Username, Token)
+    ),
+    %% Now token is consumed
+    ?assertMatch({error, invalid_token}, emqx_dashboard_mfa:peek_temp_token(Username, Token)),
+    ok.
+
+%% Test: POST /sso/mfa/setup_info returns secret without consuming token
+t_mfa_setup_info_api({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, true),
+    ok = mock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    Config;
+t_mfa_setup_info_api({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok = unmock_totp(),
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_mfa_setup_info_api(_Config) ->
+    %% Get a setup token
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    {mfa_setup, SetupToken, _QRInfo} = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+
+    %% POST /sso/mfa/setup_info — should return secret
+    InfoBody = #{
+        <<"setup_token">> => SetupToken,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 200, InfoRspBody} = request_api(
+        post, api_path(["sso", "mfa", "setup_info"]), no_auth_header, InfoBody
+    ),
+    InfoRsp = json_map(InfoRspBody),
+    ?assertMatch(#{<<"secret">> := _, <<"mechanism">> := <<"totp">>}, InfoRsp),
+
+    %% Token should NOT be consumed — setup should still work
+    SetupBody = #{
+        <<"setup_token">> => SetupToken,
+        <<"totp_code">> => ?GOOD_TOTP,
+        <<"username">> => ?SSO_USER,
+        <<"backend">> => atom_to_binary(?SSO_BACKEND)
+    },
+    {ok, 200, SetupRspBody} = request_api(
+        post, api_path(["sso", "mfa", "setup"]), no_auth_header, SetupBody
+    ),
+    SetupRsp = json_map(SetupRspBody),
+    ?assertMatch(#{<<"token">> := _, <<"license">> := _}, SetupRsp),
+    ok.
+
+%%====================================================================
+%% New tests for redundancy fixes
+%%====================================================================
+
+%% --- JWT deferred signing (token_exchange login flow) ---
+
+%% Verify that check_sso_mfa returns {ok, login} (not JWT) when no MFA needed
+t_check_sso_mfa_returns_login_intent({init, Config}) ->
+    mock_force_mfa(?SSO_BACKEND, false),
+    Config;
+t_check_sso_mfa_returns_login_intent({'end', _Config}) ->
+    clear_force_mfa(?SSO_BACKEND),
+    ok;
+t_check_sso_mfa_returns_login_intent(_Config) ->
+    [User] = emqx_dashboard_admin:lookup_user(?SSO_BACKEND, ?SSO_USER),
+    Result = emqx_dashboard_sso_mfa:check_sso_mfa(User, ?SSO_BACKEND),
+    %% Should return {ok, login} not {ok, Role, Token}
+    ?assertEqual({ok, login}, Result),
+    ok.
+
+%% Verify that sso_code payload for login has action => <<"login">> with no token
+t_sso_code_login_payload_no_jwt({init, Config}) ->
+    Config;
+t_sso_code_login_payload_no_jwt({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_sso_code(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_sso_code_login_payload_no_jwt(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    Payload = #{action => <<"login">>, username => ?SSO_USER, backend => ?SSO_BACKEND},
+    Code = emqx_dashboard_sso_code:create_code(SsoUsername, Payload),
+    {ok, Returned} = emqx_dashboard_sso_code:exchange_code(?SSO_BACKEND, ?SSO_USER, Code),
+    %% Payload should have action but NO token (JWT signed later at exchange time)
+    ?assertEqual(<<"login">>, maps:get(action, Returned)),
+    ?assertNot(maps:is_key(token, Returned)),
+    ok.
+
+%% --- parse_backend protection ---
+
+%% Verify that unknown backend in token_exchange returns 400
+t_token_exchange_unknown_backend({init, Config}) ->
+    Config;
+t_token_exchange_unknown_backend({'end', _Config}) ->
+    ok;
+t_token_exchange_unknown_backend(_Config) ->
+    Body = #{
+        <<"code">> => <<"sso_fakecode.fakemac">>,
+        <<"username">> => <<"alice">>,
+        <<"backend">> => <<"nonexistent_backend_xyz">>
+    },
+    {ok, 400, RspBody} = request_api(
+        post, api_path(["sso", "token_exchange"]), no_auth_header, Body
+    ),
+    Rsp = json_map(RspBody),
+    ?assertMatch(#{<<"message">> := <<"Unknown SSO backend">>}, Rsp),
+    ok.
+
+%% --- disable_mfa merged behavior ---
+
+%% Verify that disable_mfa on user with no MFA returns error
+t_disable_mfa_not_configured({init, Config}) ->
+    Config;
+t_disable_mfa_not_configured({'end', _Config}) ->
+    ok;
+t_disable_mfa_not_configured(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    _ = emqx_dashboard_admin:clear_mfa_state(SsoUsername),
+    %% Disabling a user with no MFA configured sets mfa_state => disabled (ok, not error)
+    Result = emqx_dashboard_admin:disable_mfa(SsoUsername),
+    ?assertEqual(ok, Result),
+    ?assertEqual({ok, disabled}, emqx_dashboard_admin:get_mfa_state(SsoUsername)),
+    ok.
+
+%% Verify that disable_mfa on already disabled user returns error
+t_disable_mfa_already_disabled({init, Config}) ->
+    Config;
+t_disable_mfa_already_disabled({'end', _Config}) ->
+    _ = emqx_dashboard_admin:clear_mfa_state(?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER)),
+    ok;
+t_disable_mfa_already_disabled(_Config) ->
+    SsoUsername = ?SSO_USERNAME(?SSO_BACKEND, ?SSO_USER),
+    %% Enable MFA first
+    MfaState = #{mechanism => totp, secret => <<"SECRET">>, first_verify_ts => 1000},
+    {ok, ok} = emqx_dashboard_admin:set_mfa_state(SsoUsername, MfaState),
+    %% First disable should succeed
+    ok = emqx_dashboard_admin:disable_mfa(SsoUsername),
+    %% Second disable should fail
+    ?assertMatch(
+        {error, <<"MFA is already disabled">>}, emqx_dashboard_admin:disable_mfa(SsoUsername)
+    ),
+    ok.
+
+%% --- MFA endpoints with unknown backend ---
+
+t_mfa_setup_unknown_backend({init, Config}) ->
+    Config;
+t_mfa_setup_unknown_backend({'end', _Config}) ->
+    ok;
+t_mfa_setup_unknown_backend(_Config) ->
+    Body = #{
+        <<"setup_token">> => <<"fake.token">>,
+        <<"totp_code">> => <<"123456">>,
+        <<"username">> => <<"alice">>,
+        <<"backend">> => <<"nonexistent_xyz">>
+    },
+    {ok, 401, _} = request_api(
+        post, api_path(["sso", "mfa", "setup"]), no_auth_header, Body
+    ),
+    ok.
+
+mock_force_mfa(Backend, Value) ->
+    %% Set force_mfa config for a specific SSO backend.
+    %% We set it at the config path [dashboard, sso, Backend].
+    %% get_force_mfa reads from emqx:get_config([dashboard, sso, Backend], undefined)
+    %% and looks for #{force_mfa := ForceMfa} in the result.
+    CurrentConf = emqx:get_config([dashboard, sso, Backend], #{}),
+    NewConf = CurrentConf#{force_mfa => Value, backend => Backend},
+    emqx_config:put([dashboard, sso, Backend], NewConf).
+
+clear_force_mfa(Backend) ->
+    CurrentConf = emqx:get_config([dashboard, sso, Backend], #{}),
+    NewConf = maps:remove(force_mfa, CurrentConf),
+    emqx_config:put([dashboard, sso, Backend], NewConf).
+
+mock_totp() ->
+    meck:new(pot, [passthrough, no_history]),
+    meck:expect(pot, valid_totp, fun(Token, _) -> Token =:= ?GOOD_TOTP end),
+    ok.
+
+unmock_totp() ->
+    meck:unload(pot).
+
+json_map(X) when is_map(X) -> X;
+json_map(X) when is_binary(X) -> emqx_utils_json:decode(X).
+
+api_path(Parts) ->
+    ?HOST ++ filename:join([?BASE_PATH | Parts]).
+
+request_api(Method, Url, Auth) ->
+    emqx_common_test_http:request_api(Method, Url, _QueryParams = [], Auth).
+
+request_api(Method, Url, Auth, Body) ->
+    emqx_common_test_http:request_api(Method, Url, _QueryParams = [], Auth, Body).

--- a/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
+++ b/apps/emqx_dashboard_sso/test/emqx_dashboard_sso_oidc_SUITE.erl
@@ -384,7 +384,21 @@ do_smoke_tests1(Node, LoginNode, FinalReqNode, _TCConfig) ->
     #{query := QueryParams4} = uri_string:parse(LoginURL2),
     #{"login_meta" := Token0} = maps:from_list(uri_string:dissect_query(QueryParams4)),
     ct:pal("token0: ~s", [Token0]),
-    #{<<"token">> := Token1} = emqx_utils_json:decode(base64:decode(Token0)),
+    #{<<"code">> := SsoCode, <<"username">> := SsoUsername, <<"backend">> := SsoBackend} =
+        emqx_utils_json:decode(base64:decode(Token0, #{mode => urlsafe, padding => false})),
+
+    %% Exchange the one-time SSO code for the real JWT token
+    ExchangeURL = url(FinalReqNode, ["sso", "token_exchange"]),
+    {200, ExchangeResp} = simple_request(#{
+        method => post,
+        url => ExchangeURL,
+        body => #{
+            <<"code">> => SsoCode, <<"username">> => SsoUsername, <<"backend">> => SsoBackend
+        },
+        auth_header => [{"x", "x"}]
+    }),
+    ct:pal("exchange response: ~p", [ExchangeResp]),
+    #{<<"token">> := Token1} = ExchangeResp,
 
     %% Finally, can now perform actions in the API
     FinalAuthHeader = {"Authorization", "Bearer " ++ binary_to_list(Token1)},

--- a/changes/ee/feat-16943.en.md
+++ b/changes/ee/feat-16943.en.md
@@ -1,0 +1,3 @@
+Added per-backend `force_mfa` option for SSO (OIDC/SAML/LDAP).
+
+When enabled, SSO users must complete TOTP MFA setup or verification before receiving a dashboard token, regardless of IDP-side MFA settings. Supports three MFA states: `not_configured` (force setup), `enabled` (require verification), and `admin_disabled` (skip MFA). New API endpoints `POST /sso/mfa/setup` and `POST /sso/mfa/verify` handle the MFA flow.

--- a/rel/i18n/emqx_dashboard_api.hocon
+++ b/rel/i18n/emqx_dashboard_api.hocon
@@ -106,4 +106,10 @@ mfa_status.desc:
 - `disabled`: MFA is disabled for the user
 - Otherwise: The MFA mechanism in use, e.g. `totp`"""
 
+reset_mfa.desc:
+"""Reset MFA for a dashboard user. Completely removes the MFA record so the user must re-bind TOTP on next login. Unlike disabling MFA (which preserves the state as explicitly disabled), reset returns the user to a clean state as if MFA was never configured."""
+
+mfa_reset_param.desc:
+"""When true, completely removes the MFA record (hard reset). The user must re-bind TOTP on next login if force_mfa is enabled. When false (default), soft-disables MFA: marks as admin-disabled so force_mfa won't re-trigger setup."""
+
 }

--- a/rel/i18n/emqx_dashboard_sso_api.hocon
+++ b/rel/i18n/emqx_dashboard_sso_api.hocon
@@ -51,6 +51,12 @@ backend_name.desc:
 backend_name.label:
 """Backend Name"""
 
+backend_name_in_qs.desc:
+"""Backend name"""
+
+backend_name_in_qs.label:
+"""Backend Name"""
+
 running.desc:
 """Is the backend running"""
 
@@ -62,5 +68,26 @@ last_error.desc:
 
 last_error.label:
 """Last Error"""
+
+token_exchange.desc:
+"""Exchange a one-time SSO code for the actual login result (JWT token or MFA metadata). The code is consumed after a single use."""
+
+token_exchange.label:
+"""SSO Token Exchange"""
+
+bad_request.desc:
+"""Bad request. Invalid or expired SSO code."""
+
+sso_username.desc:
+"""SSO username from login metadata."""
+
+sso_username.label:
+"""SSO Username"""
+
+sso_backend.desc:
+"""SSO backend type (e.g. saml, oidc)."""
+
+sso_backend.label:
+"""SSO Backend"""
 
 }

--- a/rel/i18n/emqx_dashboard_sso_mfa_api.hocon
+++ b/rel/i18n/emqx_dashboard_sso_mfa_api.hocon
@@ -1,0 +1,69 @@
+emqx_dashboard_sso_mfa_api {
+
+mfa_setup_info.desc:
+"""Retrieve TOTP setup info (secret, mechanism) for QR code display. Requires a valid setup token in the request body."""
+
+mfa_setup_info.label:
+"""MFA Setup Info"""
+
+mfa_setup.desc:
+"""Complete SSO MFA TOTP setup: bind the TOTP authenticator and issue a JWT session token."""
+
+mfa_setup.label:
+"""MFA Setup"""
+
+mfa_verify.desc:
+"""Verify SSO MFA TOTP code and issue a JWT session token."""
+
+mfa_verify.label:
+"""MFA Verify"""
+
+setup_token.desc:
+"""Temporary setup token from SSO login flow."""
+
+setup_token.label:
+"""Setup Token"""
+
+verify_token.desc:
+"""Temporary verify token from SSO login flow."""
+
+verify_token.label:
+"""Verify Token"""
+
+totp_code.desc:
+"""TOTP code from the authenticator app."""
+
+totp_code.label:
+"""TOTP Code"""
+
+totp_secret.desc:
+"""TOTP secret for QR code generation."""
+
+totp_secret.label:
+"""TOTP Secret"""
+
+mfa_mechanism.desc:
+"""MFA mechanism type (e.g. totp)."""
+
+mfa_mechanism.label:
+"""MFA Mechanism"""
+
+bad_request.desc:
+"""Bad request. Missing or invalid fields."""
+
+unauthorized.desc:
+"""Unauthorized. Invalid or expired token."""
+
+sso_username.desc:
+"""SSO username from login metadata."""
+
+sso_username.label:
+"""SSO Username"""
+
+sso_backend.desc:
+"""SSO backend type (e.g. saml, oidc)."""
+
+sso_backend.label:
+"""SSO Backend"""
+
+}

--- a/rel/i18n/emqx_dashboard_sso_schema.hocon
+++ b/rel/i18n/emqx_dashboard_sso_schema.hocon
@@ -9,6 +9,12 @@ backend.desc:
 backend.label:
 """Backend Type"""
 
+force_mfa.desc:
+"""Whether to force MFA (TOTP) for SSO users. When enabled, SSO users must complete MFA setup or verification before receiving a dashboard token."""
+
+force_mfa.label:
+"""Force MFA"""
+
 sso_struct.desc:
 """Dashboard Single Sign-On"""
 


### PR DESCRIPTION
Release version: 5.10

## Summary

Add per-backend `force_mfa` configuration for SSO (OIDC/SAML/LDAP), forcing SSO users to complete TOTP MFA setup/verification before receiving a dashboard token, regardless of IDP-side settings.

### MFA three-state model
- `not_configured`: user has no MFA secret → force setup (return QR code + temp token)
- `enabled`: user has MFA configured → require TOTP verification
- `admin_disabled`: admin explicitly disabled MFA for this user → skip MFA (preserves secret with `disabled_by => admin` marker)

### SSO integration
- Each SSO backend (OIDC/SAML/LDAP) can independently set `force_mfa: true/false` in its config
- SSO login callbacks (`ensure_user_exists`) now call `emqx_dashboard_sso_mfa:check_sso_mfa/2` instead of directly signing tokens
- MFA setup secret stored in ETS temp token (not written to user record until setup completes)

### New API endpoints
- `POST /sso/mfa/setup` — complete MFA setup with temp token + TOTP code
- `POST /sso/mfa/verify` — verify TOTP for users with MFA already enabled

### Admin MFA control
- `emqx_dashboard_admin:admin_disable_mfa/1` — disable MFA for a user (preserves secret)
- `emqx_dashboard_admin:admin_enable_mfa/1` — re-enable MFA

### Key files
- `apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa.erl` — core SSO MFA logic
- `apps/emqx_dashboard_sso/src/emqx_dashboard_sso_mfa_api.erl` — setup/verify endpoints
- `apps/emqx_dashboard/src/emqx_dashboard_mfa.erl` — temp token mechanism (ETS), admin disable/enable
- `apps/emqx_dashboard/src/emqx_dashboard_admin.erl` — MFA state management
- `apps/emqx_dashboard_sso/src/emqx_dashboard_sso_schema.erl` — `force_mfa` config field

### Testing
- `emqx_dashboard_sso_mfa_SUITE` with 19 test cases: temp token lifecycle, check_sso_mfa flow for all MFA states, admin control, and API endpoint tests.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking

Schema changes: backward compatible — new optional `force_mfa` boolean field per SSO backend config, defaults to false.