### PR TITLE
chore: unhide root schema docs for rule_engine, message_transformation, and schema_validation

### DIFF
--- a/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
+++ b/apps/emqx_rule_engine/src/emqx_rule_engine_schema.erl
@@ -39,7 +39,7 @@ tags() ->
     [<<"Rule Engine">>].
 
 roots() ->
-    [{"rule_engine", ?HOCON(?R_REF("rule_engine"), #{importance => ?IMPORTANCE_HIDDEN})}].
+    [{"rule_engine", ?HOCON(?R_REF("rule_engine"), #{})}].
 
 fields("rule_engine") ->
     rule_engine_settings() ++
@@ -207,13 +207,15 @@ fields("republish_args") ->
 fields("republish_mqtt_properties") ->
     [
         {'Payload-Format-Indicator',
-            ?HOCON(binary(), #{required => false, desc => ?DESC('Payload-Format-Indicator')})},
+            ?HOCON(binary(), #{required => false, desc => ?DESC("republish_mqtt_properties_prop")})},
         {'Message-Expiry-Interval',
-            ?HOCON(binary(), #{required => false, desc => ?DESC('Message-Expiry-Interval')})},
-        {'Content-Type', ?HOCON(binary(), #{required => false, desc => ?DESC('Content-Type')})},
-        {'Response-Topic', ?HOCON(binary(), #{required => false, desc => ?DESC('Response-Topic')})},
+            ?HOCON(binary(), #{required => false, desc => ?DESC("republish_mqtt_properties_prop")})},
+        {'Content-Type',
+            ?HOCON(binary(), #{required => false, desc => ?DESC("republish_mqtt_properties_prop")})},
+        {'Response-Topic',
+            ?HOCON(binary(), #{required => false, desc => ?DESC("republish_mqtt_properties_prop")})},
         {'Correlation-Data',
-            ?HOCON(binary(), #{required => false, desc => ?DESC('Correlation-Data')})}
+            ?HOCON(binary(), #{required => false, desc => ?DESC("republish_mqtt_properties_prop")})}
     ].
 
 desc("rule_engine") ->
@@ -228,6 +230,8 @@ desc("user_provided_function") ->
     ?DESC("desc_user_provided_function");
 desc("republish_args") ->
     ?DESC("desc_republish_args");
+desc("republish_mqtt_properties") ->
+    ?DESC("republish_args_mqtt_properties");
 desc(_) ->
     undefined.
 

--- a/rel/i18n/emqx_rule_engine_schema.hocon
+++ b/rel/i18n/emqx_rule_engine_schema.hocon
@@ -113,6 +113,9 @@ Placeholders like <code>${.payload.content_type}</code> may be used."""
 republish_args_mqtt_properties.label:
 """MQTT Properties"""
 
+republish_mqtt_properties_prop.desc:
+"""An MQTT property that can be set while republishing."""
+
 republish_args_direct_dispatch.desc:
 """Enable direct dispatch to subscribers without initiating a new message publish event.
 When set to `true`, this prevents the recursive processing of a message by the same action


### PR DESCRIPTION
Release versions: 5.8.10, 5.9.3, 5.10.4
These roots were marked as `IMPORTANCE_HIDDEN`, which excluded them
from the generated schema documentation (`schema-en.json`).

Since users may need to reference these configurations in the docs,
unhide them so they appear in the schema doc dump.

Follows the same approach as commit 69377e237e which unhid `rule_engine`
for v6.0+ (EMQX-14408). This backports the same fix to `release-58`
and extends it to `message_transformation` and `schema_validation`.