### PR TITLE
chore: unhide root schema docs for message_transformation and schema_validation

### DIFF
--- a/apps/emqx_message_transformation/mix.exs
+++ b/apps/emqx_message_transformation/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMessageTransformation.MixProject do
   def project do
     [
       app: :emqx_message_transformation,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_message_transformation/src/emqx_message_transformation_schema.erl
+++ b/apps/emqx_message_transformation/src/emqx_message_transformation_schema.erl
@@ -10,7 +10,8 @@
 -export([
     namespace/0,
     roots/0,
-    fields/1
+    fields/1,
+    desc/1
 ]).
 
 %% `minirest_trails' API
@@ -43,8 +44,7 @@ namespace() -> message_transformation.
 
 roots() ->
     [
-        {message_transformation,
-            mk(ref(message_transformation), #{importance => ?IMPORTANCE_HIDDEN})}
+        {message_transformation, mk(ref(message_transformation), #{})}
     ].
 
 fields(message_transformation) ->
@@ -166,6 +166,17 @@ fields(payload_serde_external_http) ->
         {schema,
             mk(binary(), #{required => true, desc => ?DESC("payload_serde_external_http_schema")})}
     ].
+
+desc(message_transformation) ->
+    ?DESC("desc_message_transformation");
+desc(transformation) ->
+    ?DESC("desc_transformation");
+desc(operation) ->
+    ?DESC("desc_operation");
+desc(log_failure) ->
+    ?DESC("desc_log_failure");
+desc(_) ->
+    undefined.
 
 %%------------------------------------------------------------------------------
 %% `minirest_trails' API

--- a/apps/emqx_schema_validation/mix.exs
+++ b/apps/emqx_schema_validation/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXSchemaValidation.MixProject do
   def project do
     [
       app: :emqx_schema_validation,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_schema_validation/src/emqx_schema_validation_schema.erl
+++ b/apps/emqx_schema_validation/src/emqx_schema_validation_schema.erl
@@ -10,7 +10,8 @@
 -export([
     namespace/0,
     roots/0,
-    fields/1
+    fields/1,
+    desc/1
 ]).
 
 %% `minirest_trails' API
@@ -29,7 +30,7 @@
 namespace() -> schema_validation.
 
 roots() ->
-    [{schema_validation, mk(ref(schema_validation), #{importance => ?IMPORTANCE_HIDDEN})}].
+    [{schema_validation, mk(ref(schema_validation), #{})}].
 
 fields(schema_validation) ->
     [
@@ -138,6 +139,25 @@ fields(check_avro) ->
         {type, mk(avro, #{default => avro, desc => ?DESC("check_avro_type")})},
         {schema, mk(binary(), #{required => true, desc => ?DESC("check_avro_schema")})}
     ].
+
+desc(schema_validation) ->
+    ?DESC("desc_schema_validation");
+desc(validation) ->
+    ?DESC("desc_validation");
+desc(log_failure) ->
+    ?DESC("desc_log_failure");
+desc(check_sql) ->
+    ?DESC("desc_check_sql");
+desc(check_json) ->
+    ?DESC("desc_check_json");
+desc(check_avro) ->
+    ?DESC("desc_check_avro");
+desc(check_protobuf) ->
+    ?DESC("desc_check_protobuf");
+desc(check_external_http) ->
+    ?DESC("desc_check_external_http");
+desc(_) ->
+    undefined.
 
 checks_union_member_selector(all_union_members) ->
     checks_refs();

--- a/rel/i18n/emqx_message_transformation_schema.hocon
+++ b/rel/i18n/emqx_message_transformation_schema.hocon
@@ -1,5 +1,29 @@
 emqx_message_transformation_schema {
 
+desc_message_transformation.desc:
+"""Message transformation configuration."""
+desc_message_transformation.label:
+"""Message Transformation"""
+
+desc_transformation.desc:
+"""A single message transformation rule."""
+desc_transformation.label:
+"""Transformation"""
+
+desc_operation.desc:
+"""A transformation operation that assigns a value to a key."""
+desc_operation.label:
+"""Operation"""
+
+desc_log_failure.desc:
+"""Configuration for logging transformation failures."""
+desc_log_failure.label:
+"""Log Failure"""
+
+transformations.desc:
+"""List of message transformation rules."""
+transformations.label:
+"""Transformations"""
 
 config_enable.desc:
 """Whether this feature is enabled."""

--- a/rel/i18n/emqx_schema_validation_schema.hocon
+++ b/rel/i18n/emqx_schema_validation_schema.hocon
@@ -1,5 +1,50 @@
 emqx_schema_validation_schema {
 
+  desc_schema_validation.desc:
+  """Schema validation configuration."""
+  desc_schema_validation.label:
+  """Schema Validation"""
+
+  desc_validation.desc:
+  """A single schema validation rule."""
+  desc_validation.label:
+  """Validation"""
+
+  desc_log_failure.desc:
+  """Configuration for logging validation failures."""
+  desc_log_failure.label:
+  """Log Failure"""
+
+  desc_check_sql.desc:
+  """Validate using a SQL expression."""
+  desc_check_sql.label:
+  """SQL Check"""
+
+  desc_check_json.desc:
+  """Validate using a JSON schema."""
+  desc_check_json.label:
+  """JSON Check"""
+
+  desc_check_avro.desc:
+  """Validate using an Avro schema."""
+  desc_check_avro.label:
+  """Avro Check"""
+
+  desc_check_protobuf.desc:
+  """Validate using a Protobuf schema."""
+  desc_check_protobuf.label:
+  """Protobuf Check"""
+
+  desc_check_external_http.desc:
+  """Validate using an external HTTP schema."""
+  desc_check_external_http.label:
+  """External HTTP Check"""
+
+  validations.desc:
+  """List of schema validation rules."""
+  validations.label:
+  """Validations"""
+
   check_avro_type.desc:
   """Avro schema check"""
   check_avro_type.label:


### PR DESCRIPTION
Release versions: 6.0.3, 6.1.2, 6.2.0
These roots were marked as `IMPORTANCE_HIDDEN`, which excluded them
from the generated schema documentation (`schema-en.json`).

`rule_engine` was already unhidden on this branch (69377e237e).
This extends the same fix to `message_transformation` and `schema_validation`.

Ref: EMQX-14408