### PR TITLE
fix: log emsgsize termination at warning level

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -626,13 +626,16 @@ terminate(
         E:C:S ->
             ?tp(warning, unclean_terminate, #{exception => E, context => C, stacktrace => S})
     end,
-    ?tp(info, terminate, #{reason => Reason}),
+    ?tp(terminate_log_level(Reason), terminate, #{reason => Reason}),
     maybe_raise_exception(Reason).
 
 %% close socket, discard new state, always return ok.
 close_socket_ok(State) ->
     _ = close_socket(State),
     ok.
+
+terminate_log_level({shutdown, emsgsize}) -> warning;
+terminate_log_level(_Reason) -> info.
 
 %% tell truth about the original exception
 -spec maybe_raise_exception(any()) -> no_return().

--- a/changes/ee/fix-16954.en.md
+++ b/changes/ee/fix-16954.en.md
@@ -1,1 +1,1 @@
-Log client connection termination at warning level instead of info when the reason is `emsgsize` (message too large for the socket send buffer).
+Log client connection termination at warning level instead of info when the reason is `emsgsize` (received packet exceeds `mqtt.max_packet_size`).

--- a/changes/ee/fix-16954.en.md
+++ b/changes/ee/fix-16954.en.md
@@ -1,0 +1,1 @@
+Log client connection termination at warning level instead of info when the reason is `emsgsize` (message too large for the socket send buffer).


### PR DESCRIPTION
Release version: 5.10.3
Note: this is not needed for 5.8 because the `frame` packet option is not available there.

## Summary

When a client connection terminates due to `emsgsize` (received packet exceeds
`mqtt.max_packet_size`), the termination was logged at `info` level, making it easy to miss.

This change raises the log level to `warning` for `emsgsize` terminations to improve
visibility of this error condition. Other termination reasons remain at `info` level.

**File**: `apps/emqx/src/emqx_connection.erl`

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)