### PR TITLE
fix: log emsgsize termination at warning level

### DIFF
--- a/apps/emqx/src/emqx_connection.erl
+++ b/apps/emqx/src/emqx_connection.erl
@@ -650,13 +650,16 @@ terminate(
         E:C:S ->
             ?tp(warning, unclean_terminate, #{exception => E, context => C, stacktrace => S})
     end,
-    ?tp(info, terminate, #{reason => Reason}),
+    ?tp(terminate_log_level(Reason), terminate, #{reason => Reason}),
     maybe_raise_exception(Reason).
 
 %% close socket, discard new state, always return ok.
 close_socket_ok(State) ->
     _ = close_socket(State),
     ok.
+
+terminate_log_level({shutdown, emsgsize}) -> warning;
+terminate_log_level(_Reason) -> info.
 
 %% tell truth about the original exception
 -spec maybe_raise_exception(any()) -> no_return().

--- a/changes/ee/fix-16956.en.md
+++ b/changes/ee/fix-16956.en.md
@@ -1,0 +1,1 @@
+Log client connection termination at warning level instead of info when the reason is `emsgsize` (received packet exceeds `mqtt.max_packet_size`).


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

NOTE: no need to fix module `emqx_socket_connection` because if packet size is too large, `emqx_socket_connection` would return `RC_PACKET_TOO_LARGE` (`0x95`) to client in `DISCONNECT`.

## Summary
- forward-port #16954 to raise emsgsize termination logs from info to warning for better visibility
- only affects logging level in apps/emqx/src/emqx_connection.erl

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
