### PR TITLE
test(mgmt): fix flaky t_persistent_sessions5

### DIFF
--- a/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_clients_SUITE.erl
@@ -161,11 +161,13 @@ end_per_group(_Group, _Config) ->
 init_per_testcase(_TC, Config) ->
     %% NOTE
     %% Wait until there are no stale clients data before running the testcase.
+    %% Also check that the count is 0 to ensure the persistent session bookkeeper's
+    %% cached disconnected session count has been refreshed.
     ?retry(
         _Timeout = 100,
         _N = 10,
         ?assertMatch(
-            {ok, {?HTTP200, _, #{<<"data">> := []}}},
+            {ok, {?HTTP200, _, #{<<"data">> := [], <<"meta">> := #{<<"count">> := 0}}}},
             list_request(Config)
         )
     ),


### PR DESCRIPTION
## Summary

- Fix flaky `t_persistent_sessions5` by also asserting `count=0` in `init_per_testcase`, not just empty data.
- The persistent session bookkeeper's cached disconnected session count can be stale from a previous test, causing the total count to overshoot (e.g. 5 instead of expected 4).
- The retry now waits for the bookkeeper to refresh its cached count (100ms interval) before proceeding.

Release version: 6.2.0