### PR TITLE
fix(gcp pubsub producer & http actions): treat `gun`'s `closing` as recoverable error (r60)

### DIFF
--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -393,8 +393,10 @@ handle_response(Result, ResourceId, QueryMode) ->
         {error, Reason} when
             Reason =:= econnrefused;
             %% this comes directly from `gun'...
-            Reason =:= {closed, "The connection was lost."};
+            %% `{closed, "The connection was lost."}`
+            element(1, Reason) =:= closed;
             Reason =:= closed;
+            Reason =:= closing;
             %% The normal reason happens when the HTTP connection times out before
             %% the request has been fully processed
             Reason =:= normal;

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_impl_producer.erl
@@ -458,6 +458,7 @@ handle_result({error, Reason}, _Request, QueryMode, ConnResId) when
     %% this comes directly from `gun'...
     element(1, Reason) =:= closed;
     Reason =:= closed;
+    Reason =:= closing;
     %% The normal reason happens when the HTTP connection times out before
     %% the request has been fully processed
     Reason =:= normal;

--- a/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
+++ b/apps/emqx_bridge_http/src/emqx_bridge_http_connector.erl
@@ -887,6 +887,7 @@ transform_result(Result) ->
             Reason =:= timeout;
             Reason =:= normal;
             Reason =:= closed;
+            Reason =:= closing;
             %% {closed, "The connection was lost."}
             element(1, Reason) =:= closed
         ->

--- a/changes/ee/fix-16972.en.md
+++ b/changes/ee/fix-16972.en.md
@@ -1,0 +1,1 @@
+HTTP and GCP PubSub Actions were patched to treat transient connection errors with reason `closing` as recoverable errors, reducing log noise.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15201

Release version:
6.0.3, 6.1.2, 6.2.0

## Summary

A customer observed errors like:

```
2026-03-23 13:15:02 (UTC-07:00) [emqx-node-2] error
pid: <0.913359.0>, reason: closing, resource_id: action:gcp_pubsub_producer:a:connector:gcp_pubsub_producer:c, tag: RESOURCE, msg: unrecoverable_resource_error

2026-03-23 13:15:02 (UTC-07:00) [emqx-node-2] error
pid: <0.913359.0>, line: 517, connector: connector:gcp_pubsub_producer:c, query_mode:
async, reason: closing, recoverable_error: false, msg: gcp_pubsub_request_failed
```

We already have some checks to ignore and retry a similar reason (closed) that appears randomly during usage (maybe some race condition), but closing hadn't appeared so far, AFAIK.  Maybe we could also treat it as a recoverable error and retry with less noise.

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
