### PR TITLE
fix(limiter schema): do not expose unsupported limiter types in `mqtt`

### DIFF
--- a/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
+++ b/apps/emqx/src/emqx_limiter/src/emqx_limiter_schema.erl
@@ -55,7 +55,10 @@ roots() ->
     [].
 
 fields(mqtt) ->
-    lists:foldl(fun make_mqtt_limiters_schema/2, [], mqtt_limiter_names()).
+    lists:foldl(fun make_mqtt_limiters_schema/2, [], mqtt_limiter_names());
+fields(mqtt_shared_limiters) ->
+    %% Supported shared limiters (for zones/listeners).
+    lists:foldl(fun make_mqtt_limiters_schema/2, [], mqtt_shared_limiter_names()).
 
 make_mqtt_limiters_schema(Name, Fields) ->
     NameStr = erlang:atom_to_list(Name),
@@ -83,12 +86,23 @@ burst_type() ->
 
 desc(mqtt) ->
     ?DESC(mqtt);
+desc(mqtt_shared_limiters) ->
+    ?DESC(mqtt);
 desc(_) ->
     undefined.
 
 %%--------------------------------------------------------------------
 %% API
 %%--------------------------------------------------------------------
+
+mqtt_shared_limiter_names() ->
+    %% Currently, `delivery_*` are not supported
+    [
+        max_conn,
+        messages,
+        bytes
+    ].
+
 mqtt_limiter_names() ->
     [
         max_conn,

--- a/apps/emqx/src/emqx_schema.erl
+++ b/apps/emqx/src/emqx_schema.erl
@@ -4245,7 +4245,7 @@ mqtt_limiter() ->
     [
         {limiter,
             sc(
-                ref(emqx_limiter_schema, mqtt),
+                ref(emqx_limiter_schema, mqtt_shared_limiters),
                 #{
                     required => {false, recursively},
                     desc => ?DESC(mqtt_limiter)

--- a/apps/emqx/test/emqx_schema_tests.erl
+++ b/apps/emqx/test/emqx_schema_tests.erl
@@ -1074,3 +1074,136 @@ max_heap_size_test_() ->
                 Check(<<"force_shutdown.max_heap_size = 0KB">>)
             )}
     ].
+
+delivery_rate_limiter_test_() ->
+    CheckMqtt = fun(Input) ->
+        {ok, Hocon} = hocon:binary(Input),
+        hocon_tconf:check_plain(emqx_schema, Hocon, #{}, [mqtt])
+    end,
+    CheckZone = fun(Input) ->
+        {ok, Hocon} = hocon:binary(Input),
+        hocon_tconf:check_plain(emqx_schema, Hocon, #{required => false}, [zones])
+    end,
+    CheckListener = fun(Input) ->
+        {ok, Hocon} = hocon:binary(Input),
+        hocon_tconf:check_plain(emqx_schema, Hocon, #{required => false}, [listeners])
+    end,
+    [
+        {"delivery_messages_rate is not supported for shared limiters (mqtt)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "mqtt.limiter",
+                        unknown := "delivery_messages_rate"
+                    }
+                ]},
+                CheckMqtt("mqtt.limiter.delivery_messages_rate = \"1/s\" ")
+            )},
+        {"delivery_messages_rate is not supported for shared limiters (zone)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "zones.default.mqtt.limiter",
+                        unknown := "delivery_messages_rate"
+                    }
+                    | _
+                ]},
+                CheckZone("zones.default.mqtt.limiter.delivery_messages_rate = \"1/s\" ")
+            )},
+        {"delivery_messages_burst is not supported for shared limiters (mqtt)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "mqtt.limiter",
+                        unknown := "delivery_messages_burst"
+                    }
+                ]},
+                CheckMqtt("mqtt.limiter.delivery_messages_burst = \"1/s\" ")
+            )},
+        {"delivery_messages_burst is not supported for shared limiters (zone)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "zones.default.mqtt.limiter",
+                        unknown := "delivery_messages_burst"
+                    }
+                    | _
+                ]},
+                CheckZone("zones.default.mqtt.limiter.delivery_messages_burst = \"1/s\" ")
+            )},
+        {"delivery_bytes_rate is not supported for shared limiters (mqtt)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "mqtt.limiter",
+                        unknown := "delivery_bytes_rate"
+                    }
+                ]},
+                CheckMqtt("mqtt.limiter.delivery_bytes_rate = \"1/s\" ")
+            )},
+        {"delivery_bytes_rate is not supported for shared limiters (zone)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "zones.default.mqtt.limiter",
+                        unknown := "delivery_bytes_rate"
+                    }
+                    | _
+                ]},
+                CheckZone("zones.default.mqtt.limiter.delivery_bytes_rate = \"1/s\" ")
+            )},
+        {"delivery_bytes_burst is not supported for shared limiters (mqtt)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "mqtt.limiter",
+                        unknown := "delivery_bytes_burst"
+                    }
+                ]},
+                CheckMqtt("mqtt.limiter.delivery_bytes_burst = \"1/s\" ")
+            )},
+        {"delivery_bytes_burst is not supported for shared limiters (zone)",
+            ?_assertThrow(
+                {_, [
+                    #{
+                        reason := unknown_fields,
+                        path := "zones.default.mqtt.limiter",
+                        unknown := "delivery_bytes_burst"
+                    }
+                    | _
+                ]},
+                CheckZone("zones.default.mqtt.limiter.delivery_bytes_burst = \"1/s\" ")
+            )},
+        {"delivery_* is allowed for listeners",
+            ?_assertMatch(
+                #{
+                    <<"listeners">> := #{
+                        <<"tcp">> := #{
+                            <<"default">> := #{
+                                <<"delivery_messages_rate">> := _,
+                                <<"delivery_messages_burst">> := _,
+                                <<"delivery_bytes_rate">> := _,
+                                <<"delivery_bytes_burst">> := _
+                            }
+                        }
+                    }
+                },
+                CheckListener(
+                    ~b"""
+                    listeners.tcp.default = {
+                      delivery_messages_rate = "1/s"
+                      delivery_messages_burst = "2/s"
+                      delivery_bytes_rate = "3/s"
+                      delivery_bytes_burst = "4/s"
+                    }
+                    """
+                )
+            )}
+    ].


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15203

Release version:
6.1.2, 6.2.0

## Summary

The issue is that shared limiters (i.e., those configured in `mqtt` or `zones.*.mqtt`) do not support `delivery_*` limiters.  Only exclusive limiters (`listeners`) support them.

I’ve removed `delivery_*` from shared limiter schema herein.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [na] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files (unreleased feature)
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
