### PR TITLE
fix(test): fix flaky t_reconnect in mqtt action suite

### DIFF
--- a/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
+++ b/apps/emqx_bridge_mqtt/test/emqx_bridge_mqtt_action_SUITE.erl
@@ -341,6 +341,19 @@ start_client(Node, Opts) when is_atom(Node) ->
     {ok, _} = emqtt:connect(C),
     C.
 
+recv_downs(N, Timeout) ->
+    recv_downs(N, Timeout, []).
+
+recv_downs(0, _Timeout, Acc) ->
+    lists:reverse(Acc);
+recv_downs(N, Timeout, Acc) ->
+    receive
+        {'DOWN', _MRef, process, Pid, _Reason} ->
+            recv_downs(N - 1, Timeout, [Pid | Acc])
+    after Timeout ->
+        ct:fail("timeout waiting for ~b more DOWN messages, got: ~p", [N, lists:reverse(Acc)])
+    end.
+
 get_emqtt_clients(PoolName) ->
     lists:filtermap(
         fun({_Id, Worker}) ->
@@ -783,7 +796,7 @@ t_reconnect(TCConfig) ->
             lists:foreach(fun(Pid) -> monitor(process, Pid) end, ChanPids),
             ct:pal("kicking ~p (leaving 1 client alive)", [ClientIds]),
             {204, _} = emqx_bridge_v2_testlib:kick_clients_http(ClientIds),
-            DownPids = emqx_utils:drain_down(PoolSize - 1),
+            DownPids = recv_downs(PoolSize - 1, 5_000),
             ?assertEqual(lists:sort(ChanPids), lists:sort(DownPids)),
             %% Recovery
             ct:pal("clients kicked; waiting for recovery..."),


### PR DESCRIPTION
## Summary
- Replace `emqx_utils:drain_down/1` (zero timeout) with a proper receive loop that waits up to 5s for DOWN messages in `t_reconnect`
- `drain_down/1` uses `after 0` so it only collects messages already in the mailbox; after the HTTP kick returns, channel processes may not have terminated yet, causing intermittent assertion failures