### PR TITLE
feat(gcp wif): add support for specifying `audience` for initial token

### DIFF
--- a/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
+++ b/apps/emqx_bridge_bigquery/test/emqx_bridge_bigquery_SUITE.erl
@@ -828,7 +828,7 @@ t_wif_auth() ->
     [{matrix, true}].
 t_wif_auth(matrix) ->
     [[?wif_oidc]];
-t_wif_auth(TCConfig) ->
+t_wif_auth(TCConfig) when is_list(TCConfig) ->
     mock_wif_auth_calls(),
     %% Sanity check
     ensure_token_resources_cleared(),
@@ -862,4 +862,33 @@ t_wif_auth(TCConfig) ->
     emqx_bridge_v2_testlib:delete_all_rules(),
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
     ensure_token_resources_cleared(),
+    ok.
+
+-doc """
+Smoke test to ensure we accept `audience` as an optional parameter for initial token.
+""".
+t_wif_auth_optional_audience() ->
+    [{matrix, true}].
+t_wif_auth_optional_audience(matrix) ->
+    [[?wif_oidc]];
+t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
+    mock_wif_auth_calls(),
+    %% Sanity check
+    ensure_token_resources_cleared(),
+
+    ?assertMatch(
+        {201, #{
+            <<"status">> := <<"connected">>,
+            <<"authentication">> := #{
+                <<"initial_token">> := #{<<"audience">> := <<"testapi0aud">>}
+            }
+        }},
+        create_connector_api(TCConfig, #{
+            <<"authentication">> => #{
+                <<"initial_token">> => #{
+                    <<"audience">> => <<"testapi0aud">>
+                }
+            }
+        })
+    ),
     ok.

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_client.erl
@@ -514,18 +514,22 @@ prepare_initial_step(Step1Name, #{type := oidc_client_credentials} = InitialToke
         client_secret := ClientSecret,
         scope := Scope
     } = InitialTokenConfig,
+    Audience = maps:get(audience, InitialTokenConfig, undefined),
     #{
         name => Step1Name,
         method => post,
         lifetime => timer:hours(1),
         url => fun(_StepContext) -> EndpointURI end,
         body => fun(_StepContext) ->
-            uri_string:compose_query([
-                {<<"grant_type">>, <<"client_credentials">>},
-                {<<"client_id">>, ClientId},
-                {<<"client_secret">>, emqx_secret:unwrap(ClientSecret)},
-                {<<"scope">>, Scope}
-            ])
+            uri_string:compose_query(
+                lists:flatten([
+                    {<<"grant_type">>, <<"client_credentials">>},
+                    {<<"client_id">>, ClientId},
+                    {<<"client_secret">>, emqx_secret:unwrap(ClientSecret)},
+                    {<<"scope">>, Scope},
+                    [{<<"audience">>, Audience} || is_binary(Audience)]
+                ])
+            )
         end,
         headers => fun(_StepContext) ->
             [{<<"Content-Type">>, <<"application/x-www-form-urlencoded">>}]

--- a/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_schema_lib.erl
+++ b/apps/emqx_bridge_gcp_pubsub/src/emqx_bridge_gcp_pubsub_schema_lib.erl
@@ -188,6 +188,11 @@ fields(auth_wif_oidc_client_credentials) ->
             mk(binary(), #{
                 required => true,
                 desc => ?DESC("auth_wif_oidc_client_credentials_scope")
+            })},
+        {audience,
+            mk(binary(), #{
+                required => false,
+                desc => ?DESC("auth_wif_oidc_client_credentials_audience")
             })}
     ].
 

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_consumer_SUITE.erl
@@ -2317,3 +2317,32 @@ t_wif_auth(TCConfig) ->
     emqx_bridge_v2_testlib:delete_all_bridges_and_connectors(),
     ensure_token_resources_cleared(),
     ok.
+
+-doc """
+Smoke test to ensure we accept `audience` as an optional parameter for initial token.
+""".
+t_wif_auth_optional_audience() ->
+    [{matrix, true}].
+t_wif_auth_optional_audience(matrix) ->
+    [[?local, ?wif_oidc]];
+t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
+    mock_wif_auth_calls(),
+    %% Sanity check
+    ensure_token_resources_cleared(),
+
+    ?assertMatch(
+        {201, #{
+            <<"status">> := <<"connected">>,
+            <<"authentication">> := #{
+                <<"initial_token">> := #{<<"audience">> := <<"testapi0aud">>}
+            }
+        }},
+        create_connector_api(TCConfig, #{
+            <<"authentication">> => #{
+                <<"initial_token">> => #{
+                    <<"audience">> => <<"testapi0aud">>
+                }
+            }
+        })
+    ),
+    ok.

--- a/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
+++ b/apps/emqx_bridge_gcp_pubsub/test/emqx_bridge_gcp_pubsub_producer_SUITE.erl
@@ -2253,3 +2253,32 @@ t_wif_token_worker_already_started(TCConfig) ->
     ?assertMatch({ok, _}, apply(Mod, start, Args)),
 
     ok.
+
+-doc """
+Smoke test to ensure we accept `audience` as an optional parameter for initial token.
+""".
+t_wif_auth_optional_audience() ->
+    [{matrix, true}].
+t_wif_auth_optional_audience(matrix) ->
+    [[?mocked_gcp, ?wif_oidc]];
+t_wif_auth_optional_audience(TCConfig) when is_list(TCConfig) ->
+    mock_wif_auth_calls(),
+    %% Sanity check
+    ensure_token_resources_cleared(),
+
+    ?assertMatch(
+        {201, #{
+            <<"status">> := <<"connected">>,
+            <<"authentication">> := #{
+                <<"initial_token">> := #{<<"audience">> := <<"testapi0aud">>}
+            }
+        }},
+        create_connector_api(TCConfig, #{
+            <<"authentication">> => #{
+                <<"initial_token">> => #{
+                    <<"audience">> => <<"testapi0aud">>
+                }
+            }
+        })
+    ),
+    ok.

--- a/rel/i18n/emqx_bridge_gcp_pubsub_schema_lib.hocon
+++ b/rel/i18n/emqx_bridge_gcp_pubsub_schema_lib.hocon
@@ -48,7 +48,12 @@ When a GCP Service Account is created (as described in https://developers.google
 
   auth_wif_oidc_client_credentials_scope {
     label: "OAuth Request Scope"
-    desc: """If necessary, specify the `scope` to be provided when requesting the OAuth access token."""
+    desc: """Specify the `scope` to be provided when requesting the OAuth access token."""
+  }
+
+  auth_wif_oidc_client_credentials_audience {
+    label: "OAuth Request Audience"
+    desc: """If necessary, specify the `audience` to be provided when requesting the OAuth access token."""
   }
 
   auth_wif_initial_token {
@@ -81,9 +86,5 @@ When a GCP Service Account is created (as described in https://developers.google
     desc: """ID of the Workload Identity Provider being used in the WIF token exchange."""
   }
 
-  # auth_wif_oidc_client_credentials {
-  #   label: ""
-  #   desc: """"""
-  # }
 
 }


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15205

Release version:
6.2.0

## Summary

Although the initial scope of the WIF auth feature was only for Microsoft Entra ID (which already works), we add the option of specifying `audience` here to expand the possible number of OIDC providers that could be used with this authentication method.  One such example is Auth0, which then can be used by specifying this new parameter.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests (also verified manually with Auth0 and BigQuery)
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files 
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
