### PR TITLE
fix(mq): include Subscription-Identifier in queue message deliveries

### DIFF
--- a/apps/emqx/src/emqx_session.erl
+++ b/apps/emqx/src/emqx_session.erl
@@ -479,6 +479,9 @@ enrich_deliver(ClientInfo, {deliver, Topic, Msg}, UpgradeQoS, Session) ->
         case Msg of
             #message{headers = #{redispatch_to := ?REDISPATCH_TO(Group, T)}} ->
                 ?IMPL(Session):get_subscription(emqx_topic:make_shared_record(Group, T), Session);
+            %% mq_sub_topic: queue subscription topic set by emqx_mq:delivers/2
+            #message{headers = #{mq_sub_topic := SubTopic}} when is_binary(SubTopic) ->
+                ?IMPL(Session):get_subscription(SubTopic, Session);
             _ ->
                 ?IMPL(Session):get_subscription(Topic, Session)
         end,

--- a/apps/emqx_mq/mix.exs
+++ b/apps/emqx_mq/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXMQ.MixProject do
   def project do
     [
       app: :emqx_mq,
-      version: "6.1.0",
+      version: "6.1.1",
       build_path: "../../_build",
       compilers: [:elixir, :asn1, :erlang, :app],
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_mq/src/emqx_mq.erl
+++ b/apps/emqx_mq/src/emqx_mq.erl
@@ -347,11 +347,16 @@ publish_to_queue(MQHandle, #message{} = Message) ->
     emqx_mq_message_db:insert(MQHandle, Message).
 
 delivers(SubscriberRef, Messages) ->
+    SubTopic = make_sub_topic(SubscriberRef),
     lists:map(
         fun(Message0) ->
-            Message1 = emqx_message:set_headers(
-                #{?MQ_HEADER_SUBSCRIBER_ID => SubscriberRef}, Message0
-            ),
+            Headers0 = #{?MQ_HEADER_SUBSCRIBER_ID => SubscriberRef},
+            Headers =
+                case SubTopic of
+                    undefined -> Headers0;
+                    _ -> Headers0#{?MQ_HEADER_SUB_TOPIC => SubTopic}
+                end,
+            Message1 = emqx_message:set_headers(Headers, Message0),
             %% Override QoS to 1 to require ack from the client
             Message = Message1#message{qos = ?QOS_1},
             Topic = emqx_message:topic(Message),
@@ -359,6 +364,19 @@ delivers(SubscriberRef, Messages) ->
         end,
         Messages
     ).
+
+%% Reconstruct the full subscription topic filter (e.g., <<"$queue/test/t/#">>)
+%% from the subscriber's name and topic_filter. This is needed so that
+%% emqx_session:enrich_deliver can look up subscription options (including
+%% the Subscription-Identifier) for queue-delivered messages.
+make_sub_topic(SubscriberRef) ->
+    case emqx_mq_sub_registry:find(SubscriberRef) of
+        undefined ->
+            undefined;
+        Sub ->
+            {Name, TopicFilter} = emqx_mq_sub:name_topic(Sub),
+            <<"$queue/", Name/binary, "/", TopicFilter/binary>>
+    end.
 
 set_mq_supported(Ctx, SessionInfo) ->
     ProtoVer =

--- a/apps/emqx_mq/src/emqx_mq_internal.hrl
+++ b/apps/emqx_mq/src/emqx_mq_internal.hrl
@@ -16,6 +16,9 @@
 
 -define(MQ_HEADER_MESSAGE_ID, mq_msg_id).
 -define(MQ_HEADER_SUBSCRIBER_ID, mq_sub_id).
+%% The original subscription topic filter (e.g., <<"$queue/test/t/#">>)
+%% used to look up subscription options in enrich_deliver.
+-define(MQ_HEADER_SUB_TOPIC, mq_sub_topic).
 
 -define(MQ_ACK, 0).
 -define(MQ_NACK, 1).

--- a/apps/emqx_mq/test/emqx_mq_SUITE.erl
+++ b/apps/emqx_mq/test/emqx_mq_SUITE.erl
@@ -1396,6 +1396,37 @@ t_large_consumer_buffer(_Config) ->
     %% Clean up
     ok = emqtt:disconnect(CSub1).
 
+-doc "Verify that Subscription-Identifier is preserved in PUBLISH packets for mq deliveries.".
+t_subscription_identifier(_Config) ->
+    %% Create a non-lastvalue Queue
+    _ = emqx_mq_test_utils:ensure_mq_created(#{
+        name => <<"subid">>,
+        topic_filter => <<"t/#">>,
+        is_lastvalue => false
+    }),
+
+    %% Connect a subscriber with Subscription-Identifier
+    CSub = emqx_mq_test_utils:emqtt_connect([]),
+    SubId = 42,
+    SubProps = #{'Subscription-Identifier' => SubId},
+    {ok, _, [?QOS_1]} = emqtt:subscribe(CSub, SubProps, <<"$queue/subid/t/#">>, ?QOS_1),
+
+    %% Publish a message to the queue
+    emqx_mq_test_utils:populate(1, #{topic_prefix => <<"t/">>}),
+
+    %% Receive the message and verify the Subscription-Identifier
+    receive
+        {publish, #{
+            topic := <<"t/0">>,
+            properties := #{'Subscription-Identifier' := ReceivedSubId}
+        }} ->
+            ?assertEqual(SubId, ReceivedSubId)
+    after 3000 ->
+        ct:fail("t/0 message from MQ not received or missing Subscription-Identifier")
+    end,
+
+    ok = emqtt:disconnect(CSub).
+
 %%--------------------------------------------------------------------
 %% Helpers
 %%--------------------------------------------------------------------

--- a/changes/ee/fix-16999.en.md
+++ b/changes/ee/fix-16999.en.md
@@ -1,0 +1,3 @@
+Fixed an issue where MQTT source failed to receive messages from `$queue/` subscriptions when the remote broker has the Message Queue (mq) feature enabled.
+
+The root cause was that the MQ message delivery did not include the MQTT v5 Subscription-Identifier property in PUBLISH packets, which the MQTT bridge ingress relies on to route messages from queue subscriptions.


### PR DESCRIPTION
Fixes EMQX-15211

Release version: 6.2.0

## Summary

When the MQ feature delivers messages to `$queue/` subscribers, the MQTT v5
Subscription-Identifier property was missing from PUBLISH packets. This broke
MQTT bridge ingress routing for queue subscriptions — the connector received
messages but the source statistics stayed at 0 because messages could not be
dispatched to the correct channel.

**Root cause**: `emqx_session:enrich_deliver` looked up subscription options by
the actual message topic (e.g., `t/1`), but the session stores queue
subscriptions by the full queue topic (`$queue/test/t/#`). The lookup failed,
so `SubOpts` was `undefined` and no Subscription-Identifier was added.

**Fix**: Add the original queue subscription topic as a message header
(`mq_sub_topic`) in `emqx_mq:delivers/2`, and use it in `enrich_deliver` to
look up subscription options — following the same pattern as `redispatch_to`.

Key files:
- `apps/emqx_mq/src/emqx_mq.erl` — set `mq_sub_topic` header in deliveries
- `apps/emqx/src/emqx_session.erl` — use `mq_sub_topic` header in `enrich_deliver`

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)