### PR TITLE
fix(mq): handle undefined topic_filter in make_sub_topic

### DIFF
--- a/apps/emqx_mq/src/emqx_mq.erl
+++ b/apps/emqx_mq/src/emqx_mq.erl
@@ -374,8 +374,12 @@ make_sub_topic(SubscriberRef) ->
         undefined ->
             undefined;
         Sub ->
-            {Name, TopicFilter} = emqx_mq_sub:name_topic(Sub),
-            <<"$queue/", Name/binary, "/", TopicFilter/binary>>
+            case emqx_mq_sub:name_topic(Sub) of
+                {Name, undefined} ->
+                    <<"$queue/", Name/binary>>;
+                {Name, TopicFilter} ->
+                    <<"$queue/", Name/binary, "/", TopicFilter/binary>>
+            end
     end.
 
 set_mq_supported(Ctx, SessionInfo) ->


### PR DESCRIPTION
Fixes a regression introduced in #16999.

Release version: 6.2.0

## Summary

When subscribing to a queue without a topic filter (e.g., `$queue/name`),
`emqx_mq_sub:name_topic/1` returns `{Name, undefined}`. The binary
construction in `make_sub_topic/1` crashed with `badarg` because
`undefined` is not a binary, causing all MQ message deliveries in that
session to fail with `hook_callback_exception`.

Fix by pattern-matching the `undefined` case and constructing
`<<"$queue/", Name/binary>>` without the topic filter suffix.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)