### PR TITLE
chore: bump `minirest` to 1.4.12

### DIFF
--- a/changes/ee/fix-17002.en.md
+++ b/changes/ee/fix-17002.en.md
@@ -1,0 +1,1 @@
+Updated `minirest` library to version 1.4.12. This version fixes a bug that caused EMQX API to produce malformed API responses with `204 No Content` status line, emitting invalid `content-length` header.

--- a/mix.exs
+++ b/mix.exs
@@ -233,7 +233,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:bcrypt, github: "emqx/erlang-bcrypt", tag: "0.6.3", override: true}
 
   def common_dep(:minirest),
-    do: {:minirest, github: "emqx/minirest", tag: "1.4.10", override: true}
+    do: {:minirest, github: "emqx/minirest", tag: "1.4.12", override: true}
 
   # maybe forbid to fetch quicer
   def common_dep(:emqtt),


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

This PR bumps `minirest` to 1.4.12 that includes emqx/minirest#136.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
