### PR TITLE
chore: pin jq 0.3.17 due to autoconf gen -std-23 for supported gcc

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1227,7 +1227,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.16", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.17", override: true}],
       else: []
   end
 

--- a/rebar.config.erl
+++ b/rebar.config.erl
@@ -39,7 +39,7 @@ quicer() ->
     {quicer, {git, "https://github.com/emqx/quic.git", {tag, "0.1.11"}}}.
 
 jq() ->
-    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.16"}}}.
+    {jq, {git, "https://github.com/emqx/jq", {tag, "v0.3.17"}}}.
 
 deps(Config) ->
     {deps, OldDeps} = lists:keyfind(deps, 1, Config),


### PR DESCRIPTION
~Fixes <issue-or-jira-number>~

see also https://github.com/emqx/jq/pull/65

Release version:

5.8.10, 5.10.4

<!-- uncomment for v6:
6.0.3, 6.1.2, 6.2.0
-->

## Summary

<!--
Please compose a nontrivial summary in case of significant changes.
* Point out the crucial changes in logic
* Point out the most relevant files and modules for the change
* Provide some reasoning for the decisions taken
-->

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- ~[ ] The changes are covered with new or existing tests~
- ~[ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files~
- ~[ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)~

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
