### PR TITLE
fix(a2a): override `a2a-status` and `a2a-status-source` if present

### DIFF
--- a/apps/emqx_a2a_registry/mix.exs
+++ b/apps/emqx_a2a_registry/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXA2ARegistry.MixProject do
   def project do
     [
       app: :emqx_a2a_registry,
-      version: "6.2.0",
+      version: "6.2.1",
       build_path: "../../_build",
       erlc_options: UMP.strict_erlc_options(),
       erlc_paths: UMP.erlc_paths(),

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_hookcb.erl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_hookcb.erl
@@ -136,7 +136,13 @@ augment_message_metadata(Msg0) ->
     ClientId = emqx_message:from(Msg0),
     Props0 = emqx_message:get_header(properties, Msg0, #{}),
     UserProperties0 = maps:get('User-Property', Props0, []),
+    UserProperties1 = proplists:delete(?A2A_PROP_STATUS_KEY, UserProperties0),
+    UserProperties2 = proplists:delete(?A2A_PROP_STATUS_SOURCE_KEY, UserProperties1),
     Status = emqx_a2a_registry:lookup_agent_status(ClientId),
-    UserProperties = [{?A2A_PROP_STATUS_KEY, Status} | UserProperties0],
+    UserProperties = [
+        {?A2A_PROP_STATUS_KEY, Status},
+        {?A2A_PROP_STATUS_SOURCE_KEY, <<"emqx">>}
+        | UserProperties2
+    ],
     Props = maps:put('User-Property', UserProperties, Props0),
     emqx_message:set_header(properties, Props, Msg0).

--- a/apps/emqx_a2a_registry/src/emqx_a2a_registry_internal.hrl
+++ b/apps/emqx_a2a_registry/src/emqx_a2a_registry_internal.hrl
@@ -9,6 +9,7 @@
 -define(A2A_TOPIC_DISCOVERY, <<"discovery">>).
 
 -define(A2A_PROP_STATUS_KEY, <<"a2a-status">>).
+-define(A2A_PROP_STATUS_SOURCE_KEY, <<"a2a-status-source">>).
 -define(A2A_PROP_ONLINE_VAL, <<"online">>).
 -define(A2A_PROP_ONLINE_VAL_ATOM, online).
 -define(A2A_PROP_OFFLINE_VAL, <<"offline">>).

--- a/apps/emqx_a2a_registry/test/emqx_a2a_registry_SUITE.erl
+++ b/apps/emqx_a2a_registry/test/emqx_a2a_registry_SUITE.erl
@@ -151,6 +151,14 @@ update_config(Path, Value, ValueToRestore) ->
     {ok, _} = emqx:update_config(Path, Value, #{override_to => cluster}),
     ok.
 
+get_a2a_props(UserProperties) ->
+    Props = maps:groups_from_list(
+        fun({K, _}) -> K end,
+        fun({_, V}) -> V end,
+        UserProperties
+    ),
+    maps:with([?A2A_PROP_STATUS_KEY, ?A2A_PROP_STATUS_SOURCE_KEY], Props).
+
 %%------------------------------------------------------------------------------
 %% Test cases
 %%------------------------------------------------------------------------------
@@ -164,6 +172,8 @@ Simple smoke test that explores the happy path of a2a registry.
     - It receives the card with augmented properties indicating the agent to be online.
   - The agent goes offline, the second client re-subscribes.
     - It receives the card with augmented properties indicating the agent to be offline.
+  - If the liveness properties are set by the publisher, they are overridden by the
+    broker.
 """.
 t_smoke_01(_TCConfig) ->
     AgentClientId = agent_clientid(?ORG_ID, ?UNIT_ID, ?AGENT_ID),
@@ -173,29 +183,29 @@ t_smoke_01(_TCConfig) ->
     C = start_client(#{}),
     {ok, _, _} = emqtt:subscribe(C, discovery_topic(<<"+">>, <<"+">>, <<"+">>), [{qos, 1}]),
     %% At first, the agent is connected
-    ?assertReceive(
-        {publish, #{
-            properties := #{'User-Property' := [{?A2A_PROP_STATUS_KEY, ?A2A_PROP_ONLINE_VAL}]}
-        }}
+    {publish, #{properties := #{'User-Property' := Props0}}} = ?assertReceive({publish, _}),
+    ?assertMatch(
+        #{?A2A_PROP_STATUS_KEY := [?A2A_PROP_ONLINE_VAL]},
+        get_a2a_props(Props0)
     ),
 
     %% Then, the agent disconnects and we re-subscribe
     emqtt:stop(Agent),
     ct:sleep(300),
     {ok, _, _} = emqtt:subscribe(C, discovery_topic(<<"+">>, <<"+">>, <<"+">>), [{qos, 1}]),
-    ?assertReceive(
-        {publish, #{
-            properties := #{'User-Property' := [{?A2A_PROP_STATUS_KEY, ?A2A_PROP_OFFLINE_VAL}]}
-        }}
+    {publish, #{properties := #{'User-Property' := Props1}}} = ?assertReceive({publish, _}),
+    ?assertMatch(
+        #{?A2A_PROP_STATUS_KEY := [?A2A_PROP_OFFLINE_VAL]},
+        get_a2a_props(Props1)
     ),
 
     %% Publish a card while a subscription is live.
     Agent2 = start_client(#{clientid => AgentClientId}),
     {ok, _} = publish_card(Agent2, ?ORG_ID, ?UNIT_ID, ?AGENT_ID, sample_card_bin()),
-    ?assertReceive(
-        {publish, #{
-            properties := #{'User-Property' := [{?A2A_PROP_STATUS_KEY, ?A2A_PROP_ONLINE_VAL}]}
-        }}
+    {publish, #{properties := #{'User-Property' := Props2}}} = ?assertReceive({publish, _}),
+    ?assertMatch(
+        #{?A2A_PROP_STATUS_KEY := [?A2A_PROP_ONLINE_VAL]},
+        get_a2a_props(Props2)
     ),
 
     %% Unpublish card by publishing empty retained message
@@ -203,6 +213,29 @@ t_smoke_01(_TCConfig) ->
     {ok, _} = publish_card(Agent2, ?ORG_ID, ?UNIT_ID, ?AGENT_ID, <<"">>),
     ?assertReceive({publish, _}),
     ?assertMatch([], emqx_a2a_registry_cth:all_cards()),
+
+    %% If `a2a-status` and/or `a2a-source` keys is present in user properties, they are
+    %% overridden.
+    {ok, _} = emqtt:publish(
+        Agent2,
+        discovery_topic(?ORG_ID, ?UNIT_ID, ?AGENT_ID),
+        #{
+            'User-Property' => [
+                {?A2A_PROP_STATUS_KEY, <<"whatever">>},
+                {?A2A_PROP_STATUS_SOURCE_KEY, <<"agent">>}
+            ]
+        },
+        sample_card_bin(),
+        [{qos, 1}, {retain, true}]
+    ),
+    {publish, #{properties := #{'User-Property' := Props3}}} = ?assertReceive({publish, _}),
+    ?assertMatch(
+        #{
+            ?A2A_PROP_STATUS_KEY := [?A2A_PROP_ONLINE_VAL],
+            ?A2A_PROP_STATUS_SOURCE_KEY := [<<"emqx">>]
+        },
+        get_a2a_props(Props3)
+    ),
 
     %% Feature is enabled, but message doesn't have the `retain` flag.  Must be rejected.
     {ok, _} = emqtt:publish(

--- a/changes/ee/fix-17010.en.md
+++ b/changes/ee/fix-17010.en.md
@@ -1,0 +1,1 @@
+Now, `a2a-status` and `a2a-status-source` user properties present in A2A Agent Cards are overridden with EMQX's liveness information to avoid duplicate properties.


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15213

Release version:
6.2.0

## Summary

Some agents may decide to include their own liveness in their card messages (e.g.: https://github.com/id/skitter/pull/13 ).  We then override those values with our own to avoid duplicate props.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
