### PR TITLE
fix(authn): let auth chain continue when password is undefined

### DIFF
--- a/apps/emqx_auth_ldap/src/emqx_auth_ldap.app.src
+++ b/apps/emqx_auth_ldap/src/emqx_auth_ldap.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_ldap, [
     {description, "EMQX LDAP Authentication and Authorization"},
-    {vsn, "0.1.5"},
+    {vsn, "0.1.6"},
     {registered, []},
     {mod, {emqx_auth_ldap_app, []}},
     {applications, [

--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
@@ -59,7 +59,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(Credential, #{method := #{type := Type}} = State) ->
     case Type of
         hash ->

--- a/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
+++ b/apps/emqx_auth_mnesia/src/emqx_auth_mnesia.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mnesia, [
     {description, "EMQX Buitl-in Database Authentication and Authorization"},
-    {vsn, "0.2.2"},
+    {vsn, "0.2.3"},
     {registered, []},
     {mod, {emqx_auth_mnesia_app, []}},
     {applications, [

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -133,7 +133,7 @@ update(Config, _State) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -169,24 +169,13 @@ test_authenticator_users(PathPrefix) ->
     timer:sleep(300),
     UsersUri01 = uri(PathPrefix ++ [?CONF_NS, "password_based:built_in_database", "status"]),
     {ok, 200, PageData01} = request(get, UsersUri01),
-    case PathPrefix of
-        [] ->
-            #{
-                <<"metrics">> := #{
-                    <<"total">> := 2,
-                    <<"success">> := 1,
-                    <<"failed">> := 1
-                }
-            } = emqx_utils_json:decode(PageData01, [return_maps]);
-        ["listeners", 'tcp:default'] ->
-            #{
-                <<"metrics">> := #{
-                    <<"total">> := 2,
-                    <<"success">> := 1,
-                    <<"nomatch">> := 1
-                }
-            } = emqx_utils_json:decode(PageData01, [return_maps])
-    end,
+    #{
+        <<"metrics">> := #{
+            <<"total">> := 2,
+            <<"success">> := 1,
+            <<"nomatch">> := 1
+        }
+    } = emqx_utils_json:decode(PageData01, [return_maps]),
 
     {ok, 200, Page1Data} = request(get, UsersUri ++ "?page=1&limit=2"),
 

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -120,24 +120,13 @@ test_authenticator_users(PathPrefix) ->
 
     UsersUri0 = uri(PathPrefix ++ [?CONF_NS, "password_based:built_in_database", "status"]),
     {ok, 200, PageData0} = request(get, UsersUri0),
-    case PathPrefix of
-        [] ->
-            #{
-                <<"metrics">> := #{
-                    <<"total">> := 1,
-                    <<"success">> := 0,
-                    <<"failed">> := 1
-                }
-            } = emqx_utils_json:decode(PageData0, [return_maps]);
-        ["listeners", 'tcp:default'] ->
-            #{
-                <<"metrics">> := #{
-                    <<"total">> := 1,
-                    <<"success">> := 0,
-                    <<"nomatch">> := 1
-                }
-            } = emqx_utils_json:decode(PageData0, [return_maps])
-    end,
+    #{
+        <<"metrics">> := #{
+            <<"total">> := 1,
+            <<"success">> := 0,
+            <<"nomatch">> := 1
+        }
+    } = emqx_utils_json:decode(PageData0, [return_maps]),
 
     InvalidUsers = [
         #{clientid => <<"u1">>, password => <<"p1">>},

--- a/apps/emqx_auth_mongodb/src/emqx_auth_mongodb.app.src
+++ b/apps/emqx_auth_mongodb/src/emqx_auth_mongodb.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mongodb, [
     {description, "EMQX MongoDB Authentication and Authorization"},
-    {vsn, "0.3.1"},
+    {vsn, "0.3.2"},
     {registered, []},
     {mod, {emqx_auth_mongodb_app, []}},
     {applications, [

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
@@ -59,7 +59,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     Credential, #{filter_template := FilterTemplate} = State
 ) ->

--- a/apps/emqx_auth_mysql/src/emqx_auth_mysql.app.src
+++ b/apps/emqx_auth_mysql/src/emqx_auth_mysql.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_mysql, [
     {description, "EMQX MySQL Authentication and Authorization"},
-    {vsn, "0.3.1"},
+    {vsn, "0.3.2"},
     {registered, []},
     {mod, {emqx_auth_mysql_app, []}},
     {applications, [

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -58,7 +58,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/apps/emqx_auth_postgresql/src/emqx_auth_postgresql.app.src
+++ b/apps/emqx_auth_postgresql/src/emqx_auth_postgresql.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_postgresql, [
     {description, "EMQX PostgreSQL Authentication and Authorization"},
-    {vsn, "0.3.1"},
+    {vsn, "0.3.2"},
     {registered, []},
     {mod, {emqx_auth_postgresql_app, []}},
     {applications, [

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -67,7 +67,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/apps/emqx_auth_redis/src/emqx_auth_redis.app.src
+++ b/apps/emqx_auth_redis/src/emqx_auth_redis.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, emqx_auth_redis, [
     {description, "EMQX Redis Authentication and Authorization"},
-    {vsn, "0.3.1"},
+    {vsn, "0.3.2"},
     {registered, []},
     {mod, {emqx_auth_redis_app, []}},
     {applications, [

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -65,7 +65,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/changes/ee/fix-17012.en.md
+++ b/changes/ee/fix-17012.en.md
@@ -1,0 +1,3 @@
+Fixed password-based authentication backends to let the auth chain continue when the CONNECT packet has no password, instead of rejecting the connection immediately.
+
+Previously, if a client connected without a password, the first password-based authenticator (built-in database, MySQL, PostgreSQL, MongoDB, Redis, or LDAP) in the chain would return an error, blocking any subsequent authenticators from being tried.


### PR DESCRIPTION
Fixes EMQX-15214

Release version: 5.8.10, 5.10.4

## Summary

When a client connects without a password (password field absent in CONNECT packet),
password-based authenticators (built-in DB, MySQL, PostgreSQL, MongoDB, Redis, LDAP)
previously returned `{error, bad_username_or_password}`, which stopped the entire
authentication chain.

This was introduced in PR #11490 as a "quick return" optimization, but the choice of
`{error, ...}` over `ignore` was incorrect — it prevents subsequent authenticators
(e.g. HTTP, JWT, or certificate-based) from being tried.

Now these backends return `ignore` when password is `undefined`, consistent with
the "user not found" behavior, allowing the auth chain to continue.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)