### PR TITLE
perf(prometheus): avoid doing further rpc calls while gathering mria stats (r60)

### DIFF
--- a/apps/emqx_prometheus/src/emqx_prometheus.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus.erl
@@ -1153,6 +1153,7 @@ mria_data(Mode) ->
             #{}
     end.
 
+%% Local-node gathering function, does not perform rpc calls.
 mria_data(Role, Mode) ->
     Labels =
         case Mode of
@@ -1160,7 +1161,7 @@ mria_data(Role, Mode) ->
             _ -> [{node, node()}]
         end,
     ShardMetrics = [
-        {Shard, ?SAFELY(mria_status:get_shard_stats(Shard), #{})}
+        {Shard, ?SAFELY(get_local_shard_stats(Role, Shard), #{})}
      || Shard <- mria_schema:shards(), Shard =/= undefined
     ],
     lists:foldl(
@@ -1171,6 +1172,13 @@ mria_data(Role, Mode) ->
         #{},
         mria_metric_meta(Role)
     ).
+
+get_local_shard_stats(core = _Role, Shard) ->
+    mria_status:get_local_shard_stats(Shard);
+get_local_shard_stats(replicant = _Role, Shard) ->
+    LocalStats = mria_status:get_local_shard_stats(Shard),
+    ShardLag = emqx_prometheus_cache:get_mria_shard_lag(Shard),
+    LocalStats#{lag => ShardLag}.
 
 get_shard_metrics(Labels, replicants, ShardMetrics) ->
     [

--- a/apps/emqx_prometheus/src/emqx_prometheus_cache.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_cache.erl
@@ -1,0 +1,124 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_prometheus_cache).
+
+-behaviour(gen_server).
+
+%% API
+-export([
+    start_link/1,
+
+    get_mria_shard_lag/1
+]).
+
+%% `gen_server' API
+-export([
+    init/1,
+    terminate/2,
+    handle_continue/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2
+]).
+
+%%------------------------------------------------------------------------------
+%% Type declarations
+%%------------------------------------------------------------------------------
+
+-include_lib("emqx/include/logger.hrl").
+
+-define(TAB, emqx_prometheus_cache).
+-define(VAL_POS, 2).
+-define(DEFAULT_MRIA_SHARD_LAG, 0).
+
+-define(MRIA_SHARD_LAG_KEY(SHARD), {mria_shard_lag, SHARD}).
+
+-define(mria_refresh_shard_lag_timer, mria_refresh_shard_lag_timer).
+-define(undefined, undefined).
+
+%% Calls/casts/infos/continues
+-record(refresh_mria_shard_lag, {}).
+
+%%------------------------------------------------------------------------------
+%% API
+%%------------------------------------------------------------------------------
+
+start_link(Opts) ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, Opts, []).
+
+get_mria_shard_lag(Shard) ->
+    try
+        ets:lookup_element(?TAB, ?MRIA_SHARD_LAG_KEY(Shard), ?VAL_POS, ?DEFAULT_MRIA_SHARD_LAG)
+    catch
+        error:badarg ->
+            ?DEFAULT_MRIA_SHARD_LAG
+    end.
+
+%%------------------------------------------------------------------------------
+%% `gen_server' API
+%%------------------------------------------------------------------------------
+
+init(_Opts) ->
+    _ = ets:new(?TAB, [named_table, public, ordered_set, {read_concurrency, true}]),
+    State = #{?mria_refresh_shard_lag_timer => ?undefined},
+    {ok, State, {continue, #refresh_mria_shard_lag{}}}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+handle_continue(#refresh_mria_shard_lag{}, State0) ->
+    State = handle_refresh_mria_shard_lag(State0),
+    {noreply, State}.
+
+handle_call(Call, _From, State) ->
+    {reply, {error, {unknown_call, Call}}, State}.
+
+handle_cast(_Cast, State) ->
+    {noreply, State}.
+
+handle_info(
+    {timeout, TRef, #refresh_mria_shard_lag{}},
+    #{?mria_refresh_shard_lag_timer := TRef} = State0
+) ->
+    State = handle_refresh_mria_shard_lag(State0),
+    {noreply, State};
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+%%------------------------------------------------------------------------------
+%% Internal fns
+%%------------------------------------------------------------------------------
+
+handle_refresh_mria_shard_lag(State0) ->
+    Shards = [S || S <- mria_schema:shards(), S =/= undefined],
+    lists:foreach(fun do_refresh_mria_shard_lag/1, Shards),
+    ensure_refresh_mria_shard_lag_timer(State0).
+
+do_refresh_mria_shard_lag(Shard) ->
+    try mria_status:get_shard_lag(Shard) of
+        Val ->
+            true = ets:insert(?TAB, {?MRIA_SHARD_LAG_KEY(Shard), Val}),
+            ok
+    catch
+        Kind:Reason:Stacktrace ->
+            %% Likely an `erpc` timeout
+            ?SLOG(warning, #{
+                msg => "prometheus_mria_shard_lag_refresh_exception",
+                shard => Shard,
+                kind => Kind,
+                reason => Reason,
+                stacktrace => Stacktrace
+            }),
+            ok
+    end.
+
+ensure_refresh_mria_shard_lag_timer(State0) ->
+    #{?mria_refresh_shard_lag_timer := TRef0} = State0,
+    emqx_utils:cancel_timer(TRef0),
+    Interval = refresh_mria_shard_lag_interval(),
+    TRef = emqx_utils:start_timer(Interval, self(), #refresh_mria_shard_lag{}),
+    State0#{?mria_refresh_shard_lag_timer := TRef}.
+
+refresh_mria_shard_lag_interval() ->
+    emqx_prometheus_config:mria_lag_refresh_interval().

--- a/apps/emqx_prometheus/src/emqx_prometheus_config.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_config.erl
@@ -12,6 +12,7 @@
 -export([update/1]).
 -export([conf/0, is_push_gateway_server_enabled/1]).
 -export([to_recommend_type/1]).
+-export([mria_lag_refresh_interval/0]).
 
 -ifdef(TEST).
 -export([all_collectors/0]).
@@ -38,6 +39,9 @@ add_handler() ->
 remove_handler() ->
     ok = emqx_config_handler:remove_handler(?PROMETHEUS),
     ok.
+
+mria_lag_refresh_interval() ->
+    emqx_config:get([prometheus, mria_lag_refresh_interval], 10_000).
 
 %% when we import the config with the old version
 %% we need to respect it, and convert to new schema.

--- a/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_schema.erl
@@ -58,7 +58,12 @@ fields(recommend_setting) ->
                 desc => ?DESC(collectors)
             })},
         {latency_buckets,
-            emqx_schema:latency_histogram_buckets_sc(#{desc => ?DESC(latency_buckets)})}
+            emqx_schema:latency_histogram_buckets_sc(#{desc => ?DESC(latency_buckets)})},
+        {mria_lag_refresh_interval,
+            ?HOCON(emqx_schema:timeout_duration_ms(), #{
+                default => <<"10s">>,
+                importance => ?IMPORTANCE_HIDDEN
+            })}
     ];
 fields(push_gateway) ->
     [

--- a/apps/emqx_prometheus/src/emqx_prometheus_sup.erl
+++ b/apps/emqx_prometheus/src/emqx_prometheus_sup.erl
@@ -52,7 +52,7 @@ stop_child(ChildId) ->
 
 init([]) ->
     Conf = emqx_prometheus_config:conf(),
-    Children =
+    Children0 =
         case emqx_prometheus_config:is_push_gateway_server_enabled(Conf) of
             false -> [];
             %% TODO: add push gateway for endpoints
@@ -60,7 +60,13 @@ init([]) ->
             %% `/prometheus/data_integration`
             true -> [?CHILD(emqx_prometheus, Conf)]
         end,
-    {ok, {{one_for_one, 10, 3600}, Children}}.
+    Children = [?CHILD(emqx_prometheus_cache, #{}) | Children0],
+    SupFlags = #{
+        strategy => one_for_one,
+        intensity => 10,
+        period => 3600
+    },
+    {ok, {SupFlags, Children}}.
 
 %%--------------------------------------------------------------------
 %% Internal functions

--- a/apps/emqx_prometheus/test/emqx_prometheus_cluster_SUITE.erl
+++ b/apps/emqx_prometheus/test/emqx_prometheus_cluster_SUITE.erl
@@ -1,0 +1,185 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+-module(emqx_prometheus_cluster_SUITE).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+%%------------------------------------------------------------------------------
+%% Defs
+%%------------------------------------------------------------------------------
+
+-import(emqx_common_test_helpers, [on_exit/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include_lib("emqx_prometheus/include/emqx_prometheus.hrl").
+
+-define(ON(NODE, BODY), erpc:call(NODE, fun() -> BODY end)).
+-define(ON_ALL(NODES, BODY), erpc:multicall(NODES, fun() -> BODY end)).
+
+%%------------------------------------------------------------------------------
+%% CT boilerplate
+%%------------------------------------------------------------------------------
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(TCConfig) ->
+    TCConfig.
+
+end_per_suite(_TCConfig) ->
+    ok.
+
+init_per_testcase(_TestCase, TCConfig) ->
+    snabbkaffe:start_trace(),
+    TCConfig.
+
+end_per_testcase(_TestCase, _TCConfig) ->
+    snabbkaffe:stop(),
+    emqx_common_test_helpers:call_janitor(),
+    ok.
+
+%%------------------------------------------------------------------------------
+%% Helper fns
+%%------------------------------------------------------------------------------
+
+mk_cluster(TestCase, #{n := NumNodes} = Opts, TCConfig) ->
+    Overrides0 = maps:get(overrides, Opts, #{}),
+    AppSpecs0 = [
+        emqx_conf,
+        emqx_management,
+        emqx_prometheus
+    ],
+    NodeSpecs0 = lists:map(
+        fun(N) ->
+            Overrides = maps:get(N, Overrides0, #{}),
+            Role = maps:get(role, Overrides, core),
+            Name = mk_node_name(TestCase, N),
+            Apps = lists:flatten([
+                AppSpecs0,
+                [emqx_mgmt_api_test_util:emqx_dashboard() || N == 1]
+            ]),
+            {Name, #{apps => Apps, role => Role}}
+        end,
+        lists:seq(1, NumNodes)
+    ),
+    Nodes = emqx_cth_cluster:start(
+        NodeSpecs0,
+        #{work_dir => emqx_cth_suite:work_dir(TestCase, TCConfig)}
+    ),
+    on_exit(fun() -> ok = emqx_cth_cluster:stop(Nodes) end),
+    ?ON_ALL(Nodes, begin
+        meck:new(emqx_license_checker, [non_strict, passthrough, no_link]),
+        meck:expect(emqx_license_checker, expiry_epoch, fun() -> 1859673600 end)
+    end),
+    Nodes.
+
+mk_node_name(TestCase, N) ->
+    Name0 = iolist_to_binary([atom_to_binary(TestCase), "_", integer_to_binary(N)]),
+    binary_to_atom(Name0).
+
+get_prometheus_stats(Mode, Format) ->
+    Headers =
+        case Format of
+            json -> [{"accept", "application/json"}];
+            prometheus -> []
+        end,
+    QueryString = uri_string:compose_query([{"mode", atom_to_binary(Mode)}]),
+    URL = emqx_mgmt_api_test_util:api_path(["prometheus", "stats"]),
+    {Status, Response} = emqx_mgmt_api_test_util:simple_request(#{
+        method => get,
+        url => URL,
+        extra_headers => Headers,
+        query_params => QueryString,
+        auth_header => {"no", "auth"}
+    }),
+    case Format of
+        json ->
+            {Status, Response};
+        prometheus when Status == 200 ->
+            {Status, parse_prometheus(Response)};
+        prometheus ->
+            {Status, Response}
+    end.
+
+parse_prometheus(RawData) ->
+    lists:foldl(
+        fun
+            (<<"#", _/binary>>, Acc) ->
+                Acc;
+            (Line, Acc) ->
+                {Name, Labels, Value} = parse_prometheus_line(Line),
+                maps:update_with(
+                    Name,
+                    fun(Old) -> Old#{Labels => Value} end,
+                    #{Labels => Value},
+                    Acc
+                )
+        end,
+        #{},
+        binary:split(iolist_to_binary(RawData), <<"\n">>, [global, trim_all])
+    ).
+
+parse_prometheus_line(Line) ->
+    RE = <<"(?<name>[a-z0-9A-Z_]+)(\\{(?<labels>[^)]*)\\})? *(?<value>[0-9]+(\\.[0-9]+)?)">>,
+    {match, [Name, Labels0, Value0]} = re:run(
+        Line, RE, [{capture, [<<"name">>, <<"labels">>, <<"value">>], binary}]
+    ),
+    Labels = parse_prometheus_labels(Labels0),
+    Value =
+        try
+            binary_to_float(Value0)
+        catch
+            error:badarg ->
+                binary_to_integer(Value0)
+        end,
+    {Name, Labels, Value}.
+
+parse_prometheus_labels(<<"">>) ->
+    #{};
+parse_prometheus_labels(Labels) ->
+    lists:foldl(
+        fun(Label, Acc) ->
+            [K, V0] = binary:split(Label, <<"=">>),
+            V = binary:replace(V0, <<"\"">>, <<"">>, [global]),
+            Acc#{K => V}
+        end,
+        #{},
+        binary:split(Labels, <<",">>, [global])
+    ).
+
+%%------------------------------------------------------------------------------
+%% Test cases
+%%------------------------------------------------------------------------------
+
+t_mria_shard_lag_cache(TCConfig) ->
+    Opts = #{
+        n => 2,
+        overrides => #{2 => #{role => replicant}}
+    },
+    Nodes = mk_cluster(?FUNCTION_NAME, Opts, TCConfig),
+    %% Sync cache process to ensure it has already cached some stuff.
+    ?ON_ALL(Nodes, gen_server:call(emqx_prometheus_cache, i_dont_exist)),
+    %% We make getting the shard lag take a long time.  Calling the API shouldn't timeout
+    %% due to that.
+    ?ON_ALL(Nodes, begin
+        ok = meck:new(mria_status, [passthrough, no_link]),
+        ok = meck:expect(mria_status, get_stat, fun(Shard, Metric) ->
+            case Metric of
+                core_intercept ->
+                    timer:sleep(30_000);
+                _ ->
+                    ok
+            end,
+            meck:passthrough([Shard, Metric])
+        end)
+    end),
+    T0 = erlang:monotonic_time(millisecond),
+    {200, Stats0} = get_prometheus_stats(?PROM_DATA_MODE__ALL_NODES_AGGREGATED, prometheus),
+    T1 = erlang:monotonic_time(millisecond),
+    ct:pal("call took ~b ms", [T1 - T0]),
+    #{<<"emqx_mria_lag">> := Stats1} = Stats0,
+    ?assert(lists:all(fun is_number/1, maps:values(Stats1)), #{stats => Stats1}),
+    ok.

--- a/changes/ee/perf-17018.en.md
+++ b/changes/ee/perf-17018.en.md
@@ -1,0 +1,3 @@
+Reduced the number of calls to other nodes performed when calling the Prometheus scraping API endpoint.  This makes the API call return faster and reduces the chance of it timing out when the cluster is under strain.
+
+Specifically, `emqx_mria_lag` metric that is of interest to replicant nodes is now refreshed periodically (every 10 seconds by default) instead of refreshed on demand for each API call.

--- a/mix.exs
+++ b/mix.exs
@@ -171,7 +171,7 @@ defmodule EMQXUmbrella.MixProject do
     end
   end
 
-  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.4", override: true}
+  def common_dep(:ekka), do: {:ekka, github: "emqx/ekka", tag: "0.23.5", override: true}
 
   def common_dep(:esockd),
     do: {:esockd, github: "emqx/esockd", tag: "5.15.0", override: true}


### PR DESCRIPTION
Fixes https://emqx.atlassian.net/browse/EMQX-15217

Fixes https://github.com/emqx/emqx/issues/16924

Release version:
6.0.3, 6.1.2, 6.2.0

## Summary

With https://github.com/emqx/mria/pull/202, we introduce a new stats gathering function that does not perform RPC calls, which currently means that, only for replicants, we don't call `mria_status:get_shard_lag/1` in it.  In `emqx_prometheus`, we introduce a cache process that periodically calls `mria_status:get_shard_lag/1` for all shards and store their value in a cache table.  This table is then read when the Prometheus scraping endpoint is called, thus avoiding having to do one RPC call per shard per API call.

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
