### PR TITLE
backport(coap): pick #16996/#17004 takeover routing fixes for release-58

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -605,13 +605,9 @@ metrics_inc(Name, Ctx) ->
 %%--------------------------------------------------------------------
 %% Ensure connected
 
-ensure_connected(
-    Channel = #channel{
-        ctx = Ctx,
-        conninfo = ConnInfo,
-        clientinfo = ClientInfo
-    }
-) ->
+ensure_connected(Channel) ->
+    #channel{ctx = Ctx, conninfo = ConnInfo0, clientinfo = ClientInfo} = Channel,
+    ConnInfo = ensure_conninfo_required_fields(ClientInfo, ConnInfo0),
     NConnInfo = ConnInfo#{connected_at => erlang:system_time(millisecond)},
     _ = run_hooks(Ctx, 'client.connack', [NConnInfo, connection_accepted, #{}]),
     ok = run_hooks(Ctx, 'client.connected', [ClientInfo, NConnInfo]),
@@ -620,15 +616,21 @@ ensure_connected(
 %%--------------------------------------------------------------------
 %% Ensure disconnected
 
-ensure_disconnected(
-    Reason,
-    Channel = #channel{
-        ctx = Ctx,
-        conninfo = ConnInfo,
-        clientinfo = ClientInfo,
-        conn_state = ConnState
-    }
-) ->
+ensure_conninfo_required_fields(ClientInfo, ConnInfo0) ->
+    ClientId = maps:get(clientid, ClientInfo, maps:get(clientid, ConnInfo0, undefined)),
+    ConnInfo1 =
+        case ClientId of
+            undefined -> ConnInfo0;
+            _ -> ConnInfo0#{clientid => ClientId}
+        end,
+    ConnInfo1#{
+        proto_name => maps:get(proto_name, ConnInfo1, <<"CoAP">>),
+        proto_ver => maps:get(proto_ver, ConnInfo1, <<"1">>)
+    }.
+
+ensure_disconnected(Reason, Channel) ->
+    #channel{ctx = Ctx, conninfo = ConnInfo, clientinfo = ClientInfo, conn_state = ConnState} =
+        Channel,
     NConnInfo = ConnInfo#{disconnected_at => erlang:system_time(millisecond)},
 
     case ConnState of

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -87,6 +87,7 @@
 -define(INFO_KEYS, [conninfo, conn_state, clientinfo, session]).
 
 -define(DEF_IDLE_SECONDS, 30).
+-define(SOCK_CLOSED_TAKEOVER_GRACE_MS, 5000).
 -define(RAND_CLIENTID_BYTES, 16).
 
 -import(emqx_coap_medium, [reply/2, reply/3, reply/4, iter/3, iter/4]).
@@ -218,6 +219,8 @@ handle_timeout(_, {keepalive, NewVal}, #channel{keepalive = KeepAlive} = Channel
     end;
 handle_timeout(_, {transport, Msg}, Channel) ->
     call_session(timeout, Msg, Channel);
+handle_timeout(_, sock_closed_takeover_cleanup, Channel) ->
+    {shutdown, sock_closed, ensure_disconnected(sock_closed, Channel)};
 handle_timeout(_, disconnect, Channel) ->
     {shutdown, normal, Channel};
 handle_timeout(_, connection_expire, Channel) ->
@@ -363,7 +366,13 @@ handle_info(
     {sock_closed, _Reason},
     #channel{connection_required = true, conn_state = connected} = Channel
 ) ->
-    {ok, Channel};
+    NChannel = ensure_timer(
+        sock_closed_takeover_cleanup,
+        ?SOCK_CLOSED_TAKEOVER_GRACE_MS,
+        sock_closed_takeover_cleanup,
+        Channel
+    ),
+    {ok, NChannel};
 handle_info({sock_closed, Reason}, Channel) ->
     shutdown(Reason, Channel);
 handle_info(Info, Channel) ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -309,11 +309,28 @@ handle_call(subscriptions, _From, Channel = #channel{session = Session}) ->
     {reply, {ok, maps:to_list(Subs)}, Channel};
 handle_call({check_token, ReqToken}, _From, Channel = #channel{token = Token}) ->
     {reply, ReqToken == Token, Channel};
+handle_call(
+    {check_token_and_get_clientinfo, ReqToken},
+    _From,
+    Channel = #channel{token = Token, clientinfo = ClientInfo}
+) ->
+    SanitizedClientInfo = maps:remove(password, ClientInfo),
+    Reply =
+        case ReqToken == Token of
+            true -> {ok, SanitizedClientInfo};
+            false -> false
+        end,
+    {reply, Reply, Channel};
 handle_call(kick, _From, Channel) ->
     NChannel = ensure_disconnected(kicked, Channel),
     shutdown_and_reply(kicked, ok, NChannel);
 handle_call(discard, _From, Channel) ->
     shutdown_and_reply(discarded, ok, Channel);
+handle_call({takeover, 'begin'}, _From, Channel = #channel{session = Session}) ->
+    {reply, Session, Channel};
+handle_call({takeover, 'end'}, _From, Channel) ->
+    NChannel = ensure_disconnected(takenover, Channel),
+    shutdown_and_reply(takenover, [], NChannel);
 handle_call(Req, _From, Channel) ->
     ?SLOG(error, #{msg => "unexpected_call", call => Req}),
     {reply, ignored, Channel}.
@@ -342,6 +359,13 @@ handle_cast(Req, Channel) ->
     ok | {ok, channel()} | {shutdown, Reason :: term(), channel()}.
 handle_info({subscribe, _AutoSubs}, Channel) ->
     {ok, Channel};
+handle_info(
+    {sock_closed, _Reason},
+    #channel{connection_required = true, conn_state = connected} = Channel
+) ->
+    {ok, Channel};
+handle_info({sock_closed, Reason}, Channel) ->
+    shutdown(Reason, Channel);
 handle_info(Info, Channel) ->
     ?SLOG(warning, #{msg => "unexpected_info", info => Info}),
     {ok, Channel}.
@@ -395,9 +419,10 @@ check_auth_state(Msg, #channel{connection_required = true} = Channel) ->
             call_session(handle_request, Msg, Channel);
         false ->
             URIQuery = emqx_coap_message:extract_uri_query(Msg),
-            case maps:get(<<"token">>, URIQuery, undefined) of
+            case get_query_value(<<"token">>, URIQuery) of
                 undefined ->
-                    ?SLOG(debug, #{msg => "token_required_in_conn_mode", message => Msg});
+                    ?SLOG(debug, #{msg => "token_required_in_conn_mode", message => Msg}),
+                    missing_token_or_clientid_reply(Msg, Channel);
                 _ ->
                     check_token(Msg, Channel)
             end
@@ -437,23 +462,124 @@ check_token(
     } = Channel
 ) ->
     #{clientid := ClientId} = ClientInfo,
-    case emqx_coap_message:extract_uri_query(Msg) of
-        #{
-            <<"clientid">> := ClientId,
-            <<"token">> := Token
-        } ->
-            call_session(handle_request, Msg, Channel);
-        _ ->
-            %% This channel is create by this DELETE command, so here can safely close this channel
-            case Token =:= undefined andalso is_delete_connection_request(Msg) of
-                true ->
-                    Reply = emqx_coap_message:piggyback({ok, deleted}, Msg),
-                    {shutdown, normal, Reply, Channel};
-                false ->
-                    ErrMsg = <<"Missing token or clientid in connection mode">>,
-                    Reply = emqx_coap_message:piggyback({error, bad_request}, ErrMsg, Msg),
-                    {ok, {outgoing, Reply}, Channel}
+    URIQuery = emqx_coap_message:extract_uri_query(Msg),
+    ReqClientId = get_query_value(<<"clientid">>, URIQuery),
+    ReqToken = get_query_value(<<"token">>, URIQuery),
+    case Token =:= undefined andalso is_delete_connection_request(Msg) of
+        true ->
+            Reply = emqx_coap_message:piggyback({ok, deleted}, Msg),
+            {shutdown, normal, Reply, Channel};
+        false ->
+            case {ReqClientId, ReqToken} of
+                {ClientId, Token} when ReqClientId =/= undefined, ReqToken =/= undefined ->
+                    call_session(handle_request, Msg, Channel);
+                {ClientId, ReqToken1} when
+                    ReqClientId =/= undefined, ReqToken1 =/= undefined, ReqToken1 =/= Token
+                ->
+                    invalid_token_reply(Msg, Channel);
+                {ReqClientId1, ReqToken1} when
+                    ReqClientId1 =/= undefined,
+                    ReqToken1 =/= undefined,
+                    ReqClientId1 =/= ClientId
+                ->
+                    try_takeover_with_token(Msg, ReqClientId1, ReqToken1, Channel);
+                _ ->
+                    missing_token_or_clientid_reply(Msg, Channel)
             end
+    end.
+
+try_takeover_with_token(Msg, ReqClientId, ReqToken, Channel) ->
+    case emqx_gateway_cm:call(coap, ReqClientId, {check_token_and_get_clientinfo, ReqToken}) of
+        {ok, ResumeClientInfo} ->
+            takeover_and_handle_request(Msg, ReqClientId, ReqToken, ResumeClientInfo, Channel);
+        undefined ->
+            invalid_token_reply(Msg, Channel);
+        false ->
+            invalid_token_reply(Msg, Channel);
+        _ ->
+            invalid_token_reply(Msg, Channel)
+    end.
+
+takeover_and_handle_request(Msg, ReqClientId, ReqToken, ResumeClientInfo, Channel) ->
+    #channel{ctx = Ctx, conninfo = ConnInfo, clientinfo = ClientInfo0} = Channel,
+    NClientInfo = merge_takeover_clientinfo(ReqClientId, ClientInfo0, ResumeClientInfo),
+    CreateSessionFun = fun(_, _) -> emqx_coap_session:new() end,
+    case
+        emqx_gateway_ctx:open_session(
+            Ctx, false, NClientInfo, ConnInfo, CreateSessionFun, emqx_coap_session
+        )
+    of
+        {ok, #{session := Session, present := true}} ->
+            Channel0 = Channel#channel{
+                session = Session,
+                clientinfo = NClientInfo,
+                token = ReqToken
+            },
+            NChannel = ensure_connected(Channel0),
+            call_session(handle_request, Msg, NChannel);
+        {ok, #{present := false}} ->
+            ok = maybe_unregister_channel(ReqClientId),
+            invalid_token_reply(Msg, Channel);
+        _ ->
+            invalid_token_reply(Msg, Channel)
+    end.
+
+merge_takeover_clientinfo(ReqClientId, ClientInfo0, ResumeClientInfo) ->
+    BaseClientInfo = ClientInfo0#{clientid => ReqClientId},
+    lists:foldl(
+        fun(Key, Acc) ->
+            case maps:find(Key, ResumeClientInfo) of
+                {ok, Value} ->
+                    Acc#{Key => Value};
+                error ->
+                    Acc
+            end
+        end,
+        BaseClientInfo,
+        [username, is_superuser, auth_expire_at, mountpoint, enable_authn]
+    ).
+
+invalid_token_reply(Msg, Channel) ->
+    ErrMsg = <<"Invalid token or clientid in connection mode">>,
+    Reply = emqx_coap_message:piggyback({error, unauthorized}, ErrMsg, Msg),
+    {ok, {outgoing, Reply}, Channel}.
+
+missing_token_or_clientid_reply(Msg, Channel) ->
+    ErrMsg = <<"Missing token or clientid in connection mode">>,
+    Reply = emqx_coap_message:piggyback({error, bad_request}, ErrMsg, Msg),
+    {ok, {outgoing, Reply}, Channel}.
+
+maybe_unregister_channel(ReqClientId) ->
+    try emqx_gateway_cm:unregister_channel(coap, ReqClientId) of
+        ok ->
+            ok
+    catch
+        _:Reason ->
+            ?SLOG(warning, #{
+                msg => "failed_unregister_takeover_fallback_channel",
+                clientid => ReqClientId,
+                reason => Reason
+            }),
+            ok
+    end.
+
+get_query_value(Key, URIQuery) ->
+    case maps:get(Key, URIQuery, undefined) of
+        undefined ->
+            case find_short_key(Key) of
+                undefined -> undefined;
+                ShortKey -> maps:get(ShortKey, URIQuery, undefined)
+            end;
+        Value ->
+            Value
+    end.
+
+find_short_key(LongKey) ->
+    case lists:keyfind(LongKey, 2, emqx_coap_message:query_params_mapping_table()) of
+        {ShortKey, _Long} ->
+            ShortKey;
+        false ->
+            undefined
     end.
 
 run_conn_hooks(

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -1,5 +1,17 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2021-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
 %%--------------------------------------------------------------------
 
 -module(emqx_coap_proxy_conn).

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -32,18 +32,7 @@ get_connection_id(_Transport, Peer, State, Data) ->
                 #coap_message{} ->
                     {CId, NBoundCId} = choose_cid(Msg, BoundCId, Peer),
                     {ok, CId, Packets, merge_state(NState, NBoundCId)};
-                {coap_ignore, _} ->
-                    %% RFC 7252 Section 3: unknown versions must be silently ignored.
-                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)};
-                {coap_format_error, Type, MsgId, _} ->
-                    %% RFC 7252 Section 4.2: reject CON format errors with Reset.
-                    _ = {Type, MsgId},
-                    %% RFC 7252 Section 4.2: per-message errors must not stop the listener.
-                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)};
-                {coap_request_error, Req, Error} ->
-                    %% RFC 7252 Section 5.4.1/5.8: reply with a 4.xx error for bad requests.
-                    _ = {Req, Error},
-                    %% RFC 7252 Section 4.2: per-message errors must not stop the listener.
+                _ ->
                     {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)}
             end;
         _Error ->

--- a/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_proxy_conn.erl
@@ -1,17 +1,5 @@
 %%--------------------------------------------------------------------
 %% Copyright (c) 2021-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
-%%
-%% Licensed under the Apache License, Version 2.0 (the "License");
-%% you may not use this file except in compliance with the License.
-%% You may obtain a copy of the License at
-%%
-%%     http://www.apache.org/licenses/LICENSE-2.0
-%%
-%% Unless required by applicable law or agreed to in writing, software
-%% distributed under the License is distributed on an "AS IS" BASIS,
-%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-%% See the License for the specific language governing permissions and
-%% limitations under the License.
 %%--------------------------------------------------------------------
 
 -module(emqx_coap_proxy_conn).
@@ -36,23 +24,80 @@ find_or_create(CId, Transport, Peer, Opts) ->
             emqx_gateway_conn:start_link(Transport, Peer, Opts)
     end.
 
-get_connection_id(_Transport, _Peer, State, Data) ->
-    case parse_incoming(Data, [], State) of
+get_connection_id(_Transport, Peer, State, Data) ->
+    {ParseState, BoundCId} = split_state(State),
+    case parse_incoming(Data, [], ParseState) of
         {[Msg | _] = Packets, NState} ->
-            case emqx_coap_message:extract_uri_query(Msg) of
-                #{
-                    <<"clientid">> := ClientId
-                } ->
-                    {ok, ClientId, Packets, NState};
-                _ ->
-                    ErrMsg = <<"Missing token or clientid in connection mode">>,
-                    Reply = emqx_coap_message:piggyback({error, bad_request}, ErrMsg, Msg),
-                    Bin = emqx_coap_frame:serialize_pkt(Reply, emqx_coap_frame:serialize_opts()),
-                    {error, Bin}
+            case Msg of
+                #coap_message{} ->
+                    {CId, NBoundCId} = choose_cid(Msg, BoundCId, Peer),
+                    {ok, CId, Packets, merge_state(NState, NBoundCId)};
+                {coap_ignore, _} ->
+                    %% RFC 7252 Section 3: unknown versions must be silently ignored.
+                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)};
+                {coap_format_error, Type, MsgId, _} ->
+                    %% RFC 7252 Section 4.2: reject CON format errors with Reset.
+                    _ = {Type, MsgId},
+                    %% RFC 7252 Section 4.2: per-message errors must not stop the listener.
+                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)};
+                {coap_request_error, Req, Error} ->
+                    %% RFC 7252 Section 5.4.1/5.8: reply with a 4.xx error for bad requests.
+                    _ = {Req, Error},
+                    %% RFC 7252 Section 4.2: per-message errors must not stop the listener.
+                    {ok, route_cid(BoundCId, Peer), Packets, merge_state(NState, BoundCId)}
             end;
         _Error ->
             invalid
     end.
+
+peer_id(Peer) ->
+    {peer, Peer}.
+
+split_state(#{parse_state := ParseState, cid := BoundCId}) ->
+    {ParseState, BoundCId};
+split_state(#{parse_state := ParseState}) ->
+    {ParseState, undefined};
+split_state(ParseState) ->
+    {ParseState, undefined}.
+
+merge_state(ParseState, BoundCId) ->
+    #{parse_state => ParseState, cid => BoundCId}.
+
+route_cid(undefined, Peer) ->
+    peer_id(Peer);
+route_cid(BoundCId, _Peer) ->
+    BoundCId.
+
+choose_cid(Msg, BoundCId, Peer) ->
+    URIQuery = emqx_coap_message:extract_uri_query(Msg),
+    ReqClientId = normalize_clientid(extract_clientid(URIQuery)),
+    select_cid(ReqClientId, BoundCId, Peer).
+
+extract_clientid(URIQuery) ->
+    case maps:find(<<"clientid">>, URIQuery) of
+        {ok, ClientId} ->
+            ClientId;
+        error ->
+            maps:get("clientid", URIQuery, undefined)
+    end.
+
+normalize_clientid(undefined) ->
+    undefined;
+normalize_clientid(ClientId) when is_binary(ClientId) ->
+    ClientId;
+normalize_clientid(ClientId) when is_list(ClientId) ->
+    list_to_binary(ClientId);
+normalize_clientid(_Other) ->
+    undefined.
+
+select_cid(undefined, undefined, Peer) ->
+    {peer_id(Peer), undefined};
+select_cid(undefined, BoundCId, _Peer) ->
+    {BoundCId, BoundCId};
+select_cid(ReqClientId, undefined, _Peer) ->
+    {ReqClientId, ReqClientId};
+select_cid(_ReqClientId, BoundCId, _Peer) ->
+    {BoundCId, BoundCId}.
 
 dispatch(Pid, _State, Packet) ->
     erlang:send(Pid, Packet).

--- a/apps/emqx_gateway_coap/src/emqx_coap_session.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_session.erl
@@ -23,6 +23,7 @@
 %% API
 -export([
     new/0,
+    resume/2,
     process_subscribe/4
 ]).
 
@@ -87,6 +88,10 @@ new() ->
         observe_manager = emqx_coap_observe_res:new_manager(),
         created_at = erlang:system_time(millisecond)
     }.
+
+-spec resume(emqx_types:clientinfo(), session()) -> session().
+resume(_ClientInfo, Session = #session{}) ->
+    Session.
 
 %%--------------------------------------------------------------------
 %% Info, Stats

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -751,10 +751,7 @@ t_invalid_token_rejected_across_udp_sessions(_) ->
         false
     ),
     Req = make_req(post, <<"x">>),
-    case do_request(Channel2, URI, Req) of
-        {error, unauthorized, _} -> ok;
-        {error, uauthorized, _} -> ok
-    end,
+    assert_unauthorized_error(do_request(Channel2, URI, Req)),
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).
@@ -783,16 +780,20 @@ t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
         false
     ),
     Req = make_req(post, <<"x">>),
-    case do_request(Channel2, URI, Req) of
-        {error, unauthorized, _} -> ok;
-        {error, uauthorized, _} -> ok
-    end,
+    assert_unauthorized_error(do_request(Channel2, URI, Req)),
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
     er_coap_udp_socket:close(Sock2).
 
 %%--------------------------------------------------------------------
 %% helpers
+
+assert_unauthorized_error({error, unauthorized, _}) ->
+    ok;
+assert_unauthorized_error({error, uauthorized, _}) ->
+    ok;
+assert_unauthorized_error(Result) ->
+    ?assertMatch({error, unauthorized, _}, Result).
 
 send_heartbeat(Token) ->
     send_heartbeat(Token, false).

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -660,6 +660,137 @@ t_connectionless_pubsub(_) ->
     do(Fun),
     restart_coap_with_connection_mode(true).
 
+t_request_with_partial_token_params(_) ->
+    Action = fun(Channel) ->
+        Token = connection(Channel),
+        URI1 = compose_uri(
+            ?PS_PREFIX ++ "/only_clientid",
+            #{
+                "clientid" => <<"client1">>
+            },
+            false
+        ),
+        Req1 = make_req(get, <<>>, [{observe, 0}]),
+        {error, bad_request, _} = do_request(Channel, URI1, Req1),
+
+        URI2 = compose_uri(
+            ?PS_PREFIX ++ "/only_token",
+            #{
+                "token" => list_to_binary(Token)
+            },
+            false
+        ),
+        Req2 = make_req(get, <<>>, [{observe, 0}]),
+        {error, bad_request, _} = do_request(Channel, URI2, Req2),
+        disconnection(Channel, Token)
+    end,
+    do(Action).
+
+t_token_takeover_across_udp_sessions(_) ->
+    ChId = {{127, 0, 0, 1}, 5683},
+    {ok, Sock1} = er_coap_udp_socket:start_link(),
+    {ok, Channel1} = er_coap_udp_socket:get_channel(Sock1, ChId),
+    Token = connection(Channel1),
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+    er_coap_channel:close(Channel1),
+    er_coap_udp_socket:close(Sock1),
+
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    {ok, Sock2} = er_coap_udp_socket:start_link(),
+    {ok, Channel2} = er_coap_udp_socket:get_channel(Sock2, ChId),
+    URI = compose_uri(
+        ?PS_PREFIX ++ "/coap/udp_takeover",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => list_to_binary(Token)
+        },
+        false
+    ),
+    Req = make_req(post, <<"x">>),
+    {ok, changed, _} = do_request(Channel2, URI, Req),
+    timer:sleep(100),
+    ?assertEqual(
+        1,
+        length(emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>))
+    ),
+
+    disconnection(Channel2, Token),
+    er_coap_channel:close(Channel2),
+    er_coap_udp_socket:close(Sock2).
+
+t_invalid_token_rejected_across_udp_sessions(_) ->
+    ChId = {{127, 0, 0, 1}, 5683},
+    {ok, Sock1} = er_coap_udp_socket:start_link(),
+    {ok, Channel1} = er_coap_udp_socket:get_channel(Sock1, ChId),
+    Token = connection(Channel1),
+    er_coap_channel:close(Channel1),
+    er_coap_udp_socket:close(Sock1),
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    {ok, Sock2} = er_coap_udp_socket:start_link(),
+    {ok, Channel2} = er_coap_udp_socket:get_channel(Sock2, ChId),
+    URI = compose_uri(
+        ?PS_PREFIX ++ "/coap/udp_invalid_token",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => <<"wrong-token">>
+        },
+        false
+    ),
+    Req = make_req(post, <<"x">>),
+    case do_request(Channel2, URI, Req) of
+        {error, unauthorized, _} -> ok;
+        {error, uauthorized, _} -> ok
+    end,
+    disconnection(Channel2, Token),
+    er_coap_channel:close(Channel2),
+    er_coap_udp_socket:close(Sock2).
+
+t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
+    ChId = {{127, 0, 0, 1}, 5683},
+    {ok, Sock1} = er_coap_udp_socket:start_link(),
+    {ok, Channel1} = er_coap_udp_socket:get_channel(Sock1, ChId),
+    Token = connection(Channel1),
+    er_coap_channel:close(Channel1),
+    er_coap_udp_socket:close(Sock1),
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    {ok, Sock2} = er_coap_udp_socket:start_link(),
+    {ok, Channel2} = er_coap_udp_socket:get_channel(Sock2, ChId),
+    URI = compose_uri(
+        ?PS_PREFIX ++ "/coap/udp_wrong_clientid",
+        #{
+            "clientid" => <<"client2">>,
+            "token" => list_to_binary(Token)
+        },
+        false
+    ),
+    Req = make_req(post, <<"x">>),
+    case do_request(Channel2, URI, Req) of
+        {error, unauthorized, _} -> ok;
+        {error, uauthorized, _} -> ok
+    end,
+    disconnection(Channel2, Token),
+    er_coap_channel:close(Channel2),
+    er_coap_udp_socket:close(Sock2).
+
 %%--------------------------------------------------------------------
 %% helpers
 

--- a/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl
@@ -691,19 +691,11 @@ t_token_takeover_across_udp_sessions(_) ->
     {ok, Sock1} = er_coap_udp_socket:start_link(),
     {ok, Channel1} = er_coap_udp_socket:get_channel(Sock1, ChId),
     Token = connection(Channel1),
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
     er_coap_channel:close(Channel1),
     er_coap_udp_socket:close(Sock1),
 
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     {ok, Sock2} = er_coap_udp_socket:start_link(),
     {ok, Channel2} = er_coap_udp_socket:get_channel(Sock2, ChId),
@@ -717,11 +709,7 @@ t_token_takeover_across_udp_sessions(_) ->
     ),
     Req = make_req(post, <<"x">>),
     {ok, changed, _} = do_request(Channel2, URI, Req),
-    timer:sleep(100),
-    ?assertEqual(
-        1,
-        length(emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>))
-    ),
+    wait_until_channels_count(<<"client1">>, 1),
 
     disconnection(Channel2, Token),
     er_coap_channel:close(Channel2),
@@ -734,11 +722,7 @@ t_invalid_token_rejected_across_udp_sessions(_) ->
     Token = connection(Channel1),
     er_coap_channel:close(Channel1),
     er_coap_udp_socket:close(Sock1),
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     {ok, Sock2} = er_coap_udp_socket:start_link(),
     {ok, Channel2} = er_coap_udp_socket:get_channel(Sock2, ChId),
@@ -763,11 +747,7 @@ t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
     Token = connection(Channel1),
     er_coap_channel:close(Channel1),
     er_coap_udp_socket:close(Sock1),
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     {ok, Sock2} = er_coap_udp_socket:start_link(),
     {ok, Channel2} = er_coap_udp_socket:get_channel(Sock2, ChId),
@@ -790,10 +770,38 @@ t_wrong_clientid_with_valid_token_rejected_across_udp_sessions(_) ->
 
 assert_unauthorized_error({error, unauthorized, _}) ->
     ok;
-assert_unauthorized_error({error, uauthorized, _}) ->
-    ok;
-assert_unauthorized_error(Result) ->
+assert_unauthorized_error(Result0) ->
+    Result = normalize_unauthorized_error(Result0),
     ?assertMatch({error, unauthorized, _}, Result).
+
+normalize_unauthorized_error({error, uauthorized, Payload}) ->
+    {error, unauthorized, Payload};
+normalize_unauthorized_error(Result) ->
+    Result.
+
+wait_until_channels_non_empty(ClientId) ->
+    wait_until(fun() ->
+        emqx_gateway_cm_registry:lookup_channels(coap, ClientId) =/= []
+    end).
+
+wait_until_channels_count(ClientId, Count) ->
+    wait_until(fun() ->
+        length(emqx_gateway_cm_registry:lookup_channels(coap, ClientId)) =:= Count
+    end).
+
+wait_until(Pred) ->
+    wait_until(Pred, 30).
+
+wait_until(Pred, 0) ->
+    ?assert(Pred());
+wait_until(Pred, RetriesLeft) ->
+    case Pred() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(100),
+            wait_until(Pred, RetriesLeft - 1)
+    end.
 
 send_heartbeat(Token) ->
     send_heartbeat(Token, false).

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -233,10 +233,7 @@ t_invalid_token_rejected(_Config) ->
         false
     ),
     Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
-    case emqx_coap_SUITE:do_request(Channel2, URI1, Req1) of
-        {error, unauthorized, _} -> ok;
-        {error, uauthorized, _} -> ok
-    end,
+    assert_unauthorized_error(emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
     {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel2, Token),
 
     er_coap_channel:close(Channel2),
@@ -280,10 +277,7 @@ t_wrong_clientid_with_valid_token_rejected(_Config) ->
         false
     ),
     Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
-    case emqx_coap_SUITE:do_request(Channel2, URI1, Req1) of
-        {error, unauthorized, _} -> ok;
-        {error, uauthorized, _} -> ok
-    end,
+    assert_unauthorized_error(emqx_coap_SUITE:do_request(Channel2, URI1, Req1)),
     {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel2, Token),
 
     er_coap_channel:close(Channel2),
@@ -329,3 +323,10 @@ t_partial_token_params_rejected(_Config) ->
 
     er_coap_channel:close(Channel),
     emqx_coap_dtls_client_socket:close(Sock).
+
+assert_unauthorized_error({error, unauthorized, _}) ->
+    ok;
+assert_unauthorized_error({error, uauthorized, _}) ->
+    ok;
+assert_unauthorized_error(Result) ->
+    ?assertMatch({error, unauthorized, _}, Result).

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -155,20 +155,12 @@ t_token_takeover_across_dtls_sessions(_Config) ->
     #coap_content{payload = BinToken} = Data,
     Token = binary_to_list(BinToken),
 
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     er_coap_channel:close(Channel1),
     emqx_coap_dtls_client_socket:close(Sock1),
 
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     {ok, Sock2, Channel2} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
         {verify, verify_none}
@@ -185,11 +177,7 @@ t_token_takeover_across_dtls_sessions(_Config) ->
     Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
     {ok, changed, _} = emqx_coap_SUITE:do_request(Channel2, URI1, Req1),
 
-    timer:sleep(100),
-    ?assertEqual(
-        1,
-        length(emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>))
-    ),
+    wait_until_channels_count(<<"client1">>, 1),
     {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel2, Token),
 
     er_coap_channel:close(Channel2),
@@ -215,11 +203,7 @@ t_invalid_token_rejected(_Config) ->
     er_coap_channel:close(Channel1),
     emqx_coap_dtls_client_socket:close(Sock1),
 
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     {ok, Sock2, Channel2} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
         {verify, verify_none}
@@ -259,11 +243,7 @@ t_wrong_clientid_with_valid_token_rejected(_Config) ->
     er_coap_channel:close(Channel1),
     emqx_coap_dtls_client_socket:close(Sock1),
 
-    timer:sleep(100),
-    ?assertNotEqual(
-        [],
-        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
-    ),
+    wait_until_channels_non_empty(<<"client1">>),
 
     {ok, Sock2, Channel2} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
         {verify, verify_none}
@@ -326,7 +306,35 @@ t_partial_token_params_rejected(_Config) ->
 
 assert_unauthorized_error({error, unauthorized, _}) ->
     ok;
-assert_unauthorized_error({error, uauthorized, _}) ->
-    ok;
-assert_unauthorized_error(Result) ->
+assert_unauthorized_error(Result0) ->
+    Result = normalize_unauthorized_error(Result0),
     ?assertMatch({error, unauthorized, _}, Result).
+
+normalize_unauthorized_error({error, uauthorized, Payload}) ->
+    {error, unauthorized, Payload};
+normalize_unauthorized_error(Result) ->
+    Result.
+
+wait_until_channels_non_empty(ClientId) ->
+    wait_until(fun() ->
+        emqx_gateway_cm_registry:lookup_channels(coap, ClientId) =/= []
+    end).
+
+wait_until_channels_count(ClientId, Count) ->
+    wait_until(fun() ->
+        length(emqx_gateway_cm_registry:lookup_channels(coap, ClientId)) =:= Count
+    end).
+
+wait_until(Pred) ->
+    wait_until(Pred, 30).
+
+wait_until(Pred, 0) ->
+    ?assert(Pred());
+wait_until(Pred, RetriesLeft) ->
+    case Pred() of
+        true ->
+            ok;
+        false ->
+            timer:sleep(100),
+            wait_until(Pred, RetriesLeft - 1)
+    end.

--- a/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
@@ -101,6 +101,231 @@ t_connection(_Config) ->
     URI1 = emqx_coap_SUITE:compose_uri(Prefix, Queries1, false),
     Req1 = emqx_coap_SUITE:make_req(put),
     {ok, changed, _} = emqx_coap_SUITE:do_request(Channel, URI1, Req1),
+    {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel, Token),
+
+    er_coap_channel:close(Channel),
+    emqx_coap_dtls_client_socket:close(Sock).
+
+t_same_dtls_session_token_request(_Config) ->
+    {ok, Sock, Channel} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/same_session",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => Token
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    {ok, changed, _} = emqx_coap_SUITE:do_request(Channel, URI1, Req1),
+    {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel, Token),
+
+    er_coap_channel:close(Channel),
+    emqx_coap_dtls_client_socket:close(Sock).
+
+t_token_takeover_across_dtls_sessions(_Config) ->
+    {ok, Sock1, Channel1} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel1, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    er_coap_channel:close(Channel1),
+    emqx_coap_dtls_client_socket:close(Sock1),
+
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    {ok, Sock2, Channel2} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/test",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => Token
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    {ok, changed, _} = emqx_coap_SUITE:do_request(Channel2, URI1, Req1),
+
+    timer:sleep(100),
+    ?assertEqual(
+        1,
+        length(emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>))
+    ),
+    {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel2, Token),
+
+    er_coap_channel:close(Channel2),
+    emqx_coap_dtls_client_socket:close(Sock2).
+
+t_invalid_token_rejected(_Config) ->
+    {ok, Sock1, Channel1} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel1, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    er_coap_channel:close(Channel1),
+    emqx_coap_dtls_client_socket:close(Sock1),
+
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    {ok, Sock2, Channel2} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/test",
+        #{
+            "clientid" => <<"client1">>,
+            "token" => <<"wrong-token">>
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    case emqx_coap_SUITE:do_request(Channel2, URI1, Req1) of
+        {error, unauthorized, _} -> ok;
+        {error, uauthorized, _} -> ok
+    end,
+    {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel2, Token),
+
+    er_coap_channel:close(Channel2),
+    emqx_coap_dtls_client_socket:close(Sock2).
+
+t_wrong_clientid_with_valid_token_rejected(_Config) ->
+    {ok, Sock1, Channel1} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel1, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    er_coap_channel:close(Channel1),
+    emqx_coap_dtls_client_socket:close(Sock1),
+
+    timer:sleep(100),
+    ?assertNotEqual(
+        [],
+        emqx_gateway_cm_registry:lookup_channels(coap, <<"client1">>)
+    ),
+
+    {ok, Sock2, Channel2} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/test",
+        #{
+            "clientid" => <<"client2">>,
+            "token" => Token
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    case emqx_coap_SUITE:do_request(Channel2, URI1, Req1) of
+        {error, unauthorized, _} -> ok;
+        {error, uauthorized, _} -> ok
+    end,
+    {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel2, Token),
+
+    er_coap_channel:close(Channel2),
+    emqx_coap_dtls_client_socket:close(Sock2).
+
+t_partial_token_params_rejected(_Config) ->
+    {ok, Sock, Channel} = emqx_coap_dtls_client_socket:connect({127, 0, 0, 1}, 5684, [
+        {verify, verify_none}
+    ]),
+
+    Prefix = ?MQTT_PREFIX ++ "/connection",
+    Queries0 = #{
+        "clientid" => <<"client1">>,
+        "username" => <<"admin">>,
+        "password" => <<"public">>
+    },
+    URI0 = emqx_coap_SUITE:compose_uri(Prefix, Queries0, false),
+    Req0 = emqx_coap_SUITE:make_req(post),
+    {ok, created, Data} = emqx_coap_SUITE:do_request(Channel, URI0, Req0),
+    #coap_content{payload = BinToken} = Data,
+    Token = binary_to_list(BinToken),
+
+    URI1 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/missing_token",
+        #{
+            "clientid" => <<"client1">>
+        },
+        false
+    ),
+    Req1 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    {error, bad_request, _} = emqx_coap_SUITE:do_request(Channel, URI1, Req1),
+
+    URI2 = emqx_coap_SUITE:compose_uri(
+        "coaps://127.0.0.1/ps/coap/missing_clientid",
+        #{
+            "token" => Token
+        },
+        false
+    ),
+    Req2 = emqx_coap_SUITE:make_req(post, <<"x">>),
+    {error, bad_request, _} = emqx_coap_SUITE:do_request(Channel, URI2, Req2),
+    {ok, deleted, _} = emqx_coap_SUITE:disconnection(Channel, Token),
 
     er_coap_channel:close(Channel),
     emqx_coap_dtls_client_socket:close(Sock).

--- a/apps/emqx_gateway_coap/test/emqx_coap_proxy_conn_tests.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_proxy_conn_tests.erl
@@ -17,7 +17,7 @@
 -module(emqx_coap_proxy_conn_tests).
 
 -include_lib("eunit/include/eunit.hrl").
--include("../include/emqx_coap.hrl").
+-include("emqx_coap.hrl").
 
 get_connection_id_reuses_bound_clientid_without_query_clientid_test() ->
     Peer = {{127, 0, 0, 1}, 5683},

--- a/apps/emqx_gateway_coap/test/emqx_coap_proxy_conn_tests.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_proxy_conn_tests.erl
@@ -1,0 +1,58 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_proxy_conn_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include("../include/emqx_coap.hrl").
+
+get_connection_id_reuses_bound_clientid_without_query_clientid_test() ->
+    Peer = {{127, 0, 0, 1}, 5683},
+    State0 = emqx_coap_proxy_conn:initialize(#{}),
+    Data1 = build_request_data(#{
+        <<"clientid">> => <<"client1">>,
+        <<"token">> => <<"token1">>
+    }),
+    {ok, <<"client1">>, _Packets1, State1} =
+        emqx_coap_proxy_conn:get_connection_id(udp, Peer, State0, Data1),
+
+    Data2 = build_request_data(#{
+        <<"token">> => <<"token1">>
+    }),
+    {ok, <<"client1">>, _Packets2, _State2} =
+        emqx_coap_proxy_conn:get_connection_id(udp, Peer, State1, Data2).
+
+get_connection_id_falls_back_to_peerid_when_clientid_missing_test() ->
+    Peer = {{127, 0, 0, 1}, 5683},
+    State0 = emqx_coap_proxy_conn:initialize(#{}),
+    Data = build_request_data(#{
+        <<"token">> => <<"token1">>
+    }),
+    {ok, {peer, Peer}, _Packets, _State1} =
+        emqx_coap_proxy_conn:get_connection_id(udp, Peer, State0, Data).
+
+build_request_data(UriQuery) ->
+    Msg0 = emqx_coap_message:request(
+        con,
+        post,
+        <<>>,
+        #{
+            uri_path => [<<"ps">>, <<"coap">>, <<"test">>],
+            uri_query => UriQuery
+        }
+    ),
+    Msg = Msg0#coap_message{id = 1},
+    emqx_coap_frame:serialize_pkt(Msg, emqx_coap_frame:serialize_opts()).


### PR DESCRIPTION
## Summary
Backport CoAP takeover fixes from:
- #16996
- #17004

to `release-58` with conflict adaptation.

This PR now includes:
- `emqx_coap_channel` takeover-path logic (`check_token_and_get_clientinfo`, `{takeover, begin/end}`, token validation branches, fallback cleanup, missing/invalid token replies)
- `emqx_coap_session:resume/2` for gateway CM resume path
- earlier `emqx_coap_proxy_conn` takeover routing hardening
- integration test backports for UDP/DTLS takeover scenarios

## Does release-58 have the issue?
Yes.

Before fix, DTLS takeover case failed on `release-58`:

```bash
PATH=/home/moo/erlang/erl26/bin:$PATH \
  ./rebar3 ct --suite apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl \
  --case t_token_takeover_across_dtls_sessions
```

Failure (before fix):
- `{error,bad_request,...<<"Missing token or clientid in connection mode">>}`

## Verification after backport
Passed:

```bash
PATH=/home/moo/erlang/erl26/bin:$PATH ./rebar3 eunit --app emqx_gateway_coap -m emqx_coap_proxy_conn_tests
PATH=/home/moo/erlang/erl26/bin:$PATH ./rebar3 ct --suite apps/emqx_gateway_coap/test/emqx_coap_dtls_connection_SUITE.erl
PATH=/home/moo/erlang/erl26/bin:$PATH ./rebar3 ct --suite apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl --case t_request_with_partial_token_params
PATH=/home/moo/erlang/erl26/bin:$PATH ./rebar3 ct --suite apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl --case t_token_takeover_across_udp_sessions
PATH=/home/moo/erlang/erl26/bin:$PATH ./rebar3 ct --suite apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl --case t_invalid_token_rejected_across_udp_sessions
PATH=/home/moo/erlang/erl26/bin:$PATH ./rebar3 ct --suite apps/emqx_gateway_coap/test/emqx_coap_SUITE.erl --case t_wrong_clientid_with_valid_token_rejected_across_udp_sessions
```

## Backport notes
`release-62` and `release-58` differ in CoAP test/layout details. Conflicts were resolved by keeping `release-58` structure and adapting only applicable source/test changes.

## Commits
- `d3c8d3e531` fix(coap): harden token takeover checks and cover UDP/DTLS takeover
- `79b9af1847` fix(coap): fill required conninfo fields on takeover connect
- `d1475c4916` test(coap): add proxy conn takeover routing eunit cases
- `43c3c404c8` fix(coap): support DTLS takeover and token validation flow
- `f609146c89` test(coap): backport UDP/DTLS takeover integration cases
