### PR TITLE
feat(license): add session high-watermark history

### DIFF
--- a/apps/emqx_license/include/emqx_license.hrl
+++ b/apps/emqx_license/include/emqx_license.hrl
@@ -5,6 +5,8 @@
 -ifndef(_EMQX_LICENSE_).
 -define(_EMQX_LICENSE_, true).
 
+-define(LICENSE_SHARD, emqx_license_shard).
+
 %% The new default ltype=community&ctype=developer license key since 5.9
 %% limit=0 is encoded in the license key,
 %% resolved to DEFAULT_MAX_SESSIONS_LTYPE2 at runtime.

--- a/apps/emqx_license/mix.exs
+++ b/apps/emqx_license/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXLicense.MixProject do
   def project do
     [
       app: :emqx_license,
-      version: "6.0.2",
+      version: "6.0.3",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_license/src/emqx_license_app.erl
+++ b/apps/emqx_license/src/emqx_license_app.erl
@@ -13,6 +13,8 @@ start(_Type, _Args) ->
     Reader = fun emqx_license:read_license/0,
     case validate_license(Reader) of
         ok ->
+            Tables = emqx_license_session_hwm:create_tables(),
+            ok = mria:wait_for_tables(Tables),
             ok = emqx_license:load(),
             emqx_license_sup:start_link(Reader);
         {error, 'SINGLE_NODE_LICENSE'} ->

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -86,16 +86,16 @@ parse_history_args([Arg | Rest], Acc) ->
             {error, <<"bad_history_argument">>}
     end.
 
-print_history(Period, true = _IsJson, Rows) ->
+print_history(Period, true = _IsJSON, Rows) ->
     Payload = #{
         <<"period">> => atom_to_binary(Period),
         <<"count">> => length(Rows),
         <<"data">> => [format_json_row(Row) || Row <- Rows]
     },
     ?PRINT("~ts~n", [emqx_utils_json:best_effort_json(Payload)]);
-print_history(_Period, false = _IsJson, []) ->
+print_history(_Period, false = _IsJSON, []) ->
     ?PRINT_MSG("No session high-watermark history recorded.~n");
-print_history(_Period, false = _IsJson, Rows) ->
+print_history(_Period, false = _IsJSON, Rows) ->
     lists:foreach(
         fun(#{period := Period, high_watermark := HighWatermark, observed_at := ObservedAt}) ->
             ?PRINT(

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -39,17 +39,76 @@ license(["info"]) ->
         end,
         emqx_license_checker:dump()
     );
+license(["history" | Args]) ->
+    case parse_history_args(Args, #{json => false, limit => 24, period => monthly}) of
+        {ok, #{json := IsJSON, limit := Limit, period := Period}} ->
+            Rows = emqx_license_session_hwm:list_history(Period, Limit),
+            print_history(Period, IsJSON, Rows);
+        {error, Reason} ->
+            ?PRINT("Error: ~ts~n", [Reason]),
+            usage()
+    end;
 license(_) ->
-    emqx_ctl:usage(
-        [
-            {"license info", "Show license info"},
-            {"license update '<License>'|'file:///tmp/emqx.lic'",
-                "Update license given as a string\nor referenced by a file path via 'file://' prefix"}
-        ]
-    ).
+    usage().
 
 unload() ->
     ok = emqx_ctl:unregister_command(license).
 
 print_warnings(Warnings) ->
     emqx_license_checker:print_warnings(Warnings).
+
+usage() ->
+    emqx_ctl:usage(
+        [
+            {"license info", "Show license info"},
+            {"license history [N] [--period daily|monthly] [--json]",
+                "Show session high-watermark history in plain text or JSON"},
+            {"license update '<License>'|'file:///tmp/emqx.lic'",
+                "Update license given as a string\nor referenced by a file path via 'file://' prefix"}
+        ]
+    ).
+
+parse_history_args([], Acc) ->
+    {ok, Acc};
+parse_history_args(["--json" | Rest], Acc) ->
+    parse_history_args(Rest, Acc#{json => true});
+parse_history_args(["--period", "daily" | Rest], Acc) ->
+    parse_history_args(Rest, Acc#{period => daily});
+parse_history_args(["--period", "monthly" | Rest], Acc) ->
+    parse_history_args(Rest, Acc#{period => monthly});
+parse_history_args(["--period", _ | _], _Acc) ->
+    {error, <<"bad_history_period">>};
+parse_history_args([Arg | Rest], Acc) ->
+    case string:to_integer(Arg) of
+        {Limit, []} when Limit > 0 ->
+            parse_history_args(Rest, Acc#{limit => Limit});
+        _ ->
+            {error, <<"bad_history_argument">>}
+    end.
+
+print_history(Period, true, Rows) ->
+    Payload = #{
+        <<"period">> => atom_to_binary(Period),
+        <<"count">> => length(Rows),
+        <<"data">> => [format_json_row(Row) || Row <- Rows]
+    },
+    ?PRINT("~ts~n", [emqx_utils_json:best_effort_json(Payload)]);
+print_history(_Period, false, []) ->
+    ?PRINT_MSG("No session high-watermark history recorded.~n");
+print_history(_Period, false, Rows) ->
+    lists:foreach(
+        fun(#{period := Period, high_watermark := HighWatermark, observed_at := ObservedAt}) ->
+            ?PRINT(
+                "period=~ts high_watermark=~p observed_at=~ts~n",
+                [Period, HighWatermark, ObservedAt]
+            )
+        end,
+        Rows
+    ).
+
+format_json_row(#{period := Period, high_watermark := HighWatermark, observed_at := ObservedAt}) ->
+    #{
+        <<"period">> => Period,
+        <<"high_watermark">> => HighWatermark,
+        <<"observed_at">> => ObservedAt
+    }.

--- a/apps/emqx_license/src/emqx_license_cli.erl
+++ b/apps/emqx_license/src/emqx_license_cli.erl
@@ -86,16 +86,16 @@ parse_history_args([Arg | Rest], Acc) ->
             {error, <<"bad_history_argument">>}
     end.
 
-print_history(Period, true, Rows) ->
+print_history(Period, true = _IsJson, Rows) ->
     Payload = #{
         <<"period">> => atom_to_binary(Period),
         <<"count">> => length(Rows),
         <<"data">> => [format_json_row(Row) || Row <- Rows]
     },
     ?PRINT("~ts~n", [emqx_utils_json:best_effort_json(Payload)]);
-print_history(_Period, false, []) ->
+print_history(_Period, false = _IsJson, []) ->
     ?PRINT_MSG("No session high-watermark history recorded.~n");
-print_history(_Period, false, Rows) ->
+print_history(_Period, false = _IsJson, Rows) ->
     lists:foreach(
         fun(#{period := Period, high_watermark := HighWatermark, observed_at := ObservedAt}) ->
             ?PRINT(

--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -117,14 +117,14 @@ schema("/license/session_hwm_history") ->
                     hoconsc:mk(hoconsc:enum([daily, monthly]), #{
                         in => query,
                         required => false,
-                        default => monthly,
+                        default => daily,
                         desc => ?DESC("param_history_period")
                     })},
                 {limit,
                     hoconsc:mk(pos_integer(), #{
                         in => query,
                         required => false,
-                        default => 100,
+                        default => 30,
                         desc => ?DESC("param_history_limit")
                     })}
             ],
@@ -179,16 +179,20 @@ error_msg(Code, Msg) ->
     {400, error_msg(?BAD_REQUEST, <<"Invalid request params">>)}.
 
 '/license/session_hwm_history'(get, #{query_string := QS}) ->
-    Period = maps:get(<<"period">>, QS, <<"monthly">>),
-    Limit = maps:get(<<"limit">>, QS, 100),
-    PeriodAtom =
-        case Period of
-            <<"daily">> -> daily;
-            _ -> monthly
+    Period =
+        case maps:get(<<"period">>, QS, <<"daily">>) of
+            <<"monthly">> -> monthly;
+            _ -> daily
         end,
-    Rows = emqx_license_session_hwm:list_history(PeriodAtom, Limit),
+    %% Daily defaults to 30 rows; monthly has no practical limit (retention is 24 months).
+    Limit =
+        case Period of
+            monthly -> 1_000_000;
+            daily -> maps:get(<<"limit">>, QS, 30)
+        end,
+    Rows = emqx_license_session_hwm:list_history(Period, Limit),
     Data = [maps:remove(observed_at_ms, Row) || Row <- Rows],
-    {200, #{period => PeriodAtom, count => length(Data), data => Data}}.
+    {200, #{period => Period, count => length(Data), data => Data}}.
 
 '/license/setting'(get, _Params) ->
     {200, get_setting()};

--- a/apps/emqx_license/src/emqx_license_http_api.erl
+++ b/apps/emqx_license/src/emqx_license_http_api.erl
@@ -20,7 +20,8 @@
 
 -export([
     '/license'/2,
-    '/license/setting'/2
+    '/license/setting'/2,
+    '/license/session_hwm_history'/2
 ]).
 
 -define(BAD_REQUEST, 'BAD_REQUEST').
@@ -35,7 +36,8 @@ api_spec() ->
 paths() ->
     [
         "/license",
-        "/license/setting"
+        "/license/setting",
+        "/license/session_hwm_history"
     ].
 
 schema("/license") ->
@@ -103,6 +105,33 @@ schema("/license/setting") ->
                 )
             }
         }
+    };
+schema("/license/session_hwm_history") ->
+    #{
+        'operationId' => '/license/session_hwm_history',
+        get => #{
+            tags => ?LICENSE_TAGS,
+            description => ?DESC("desc_session_hwm_history_api"),
+            parameters => [
+                {period,
+                    hoconsc:mk(hoconsc:enum([daily, monthly]), #{
+                        in => query,
+                        required => false,
+                        default => monthly,
+                        desc => ?DESC("param_history_period")
+                    })},
+                {limit,
+                    hoconsc:mk(pos_integer(), #{
+                        in => query,
+                        required => false,
+                        default => 100,
+                        desc => ?DESC("param_history_limit")
+                    })}
+            ],
+            responses => #{
+                200 => hoconsc:mk(hoconsc:ref(?MODULE, session_hwm_history), #{})
+            }
+        }
     }.
 
 sample_license_info_response() ->
@@ -149,6 +178,18 @@ error_msg(Code, Msg) ->
 '/license'(post, _Params) ->
     {400, error_msg(?BAD_REQUEST, <<"Invalid request params">>)}.
 
+'/license/session_hwm_history'(get, #{query_string := QS}) ->
+    Period = maps:get(<<"period">>, QS, <<"monthly">>),
+    Limit = maps:get(<<"limit">>, QS, 100),
+    PeriodAtom =
+        case Period of
+            <<"daily">> -> daily;
+            _ -> monthly
+        end,
+    Rows = emqx_license_session_hwm:list_history(PeriodAtom, Limit),
+    Data = [maps:remove(observed_at_ms, Row) || Row <- Rows],
+    {200, #{period => PeriodAtom, count => length(Data), data => Data}}.
+
 '/license/setting'(get, _Params) ->
     {200, get_setting()};
 '/license/setting'(put, #{body := Setting}) ->
@@ -175,7 +216,22 @@ update_setting(_Setting) ->
     {error, "bad content-type"}.
 
 fields(key_license) ->
-    [lists:keyfind(key, 1, emqx_license_schema:fields(key_license))].
+    [lists:keyfind(key, 1, emqx_license_schema:fields(key_license))];
+fields(session_hwm_history) ->
+    [
+        {period, hoconsc:mk(hoconsc:enum([daily, monthly]), #{desc => ?DESC("resp_period")})},
+        {count, hoconsc:mk(non_neg_integer(), #{desc => ?DESC("resp_count")})},
+        {data,
+            hoconsc:mk(hoconsc:array(hoconsc:ref(?MODULE, session_hwm_row)), #{
+                desc => ?DESC("resp_data")
+            })}
+    ];
+fields(session_hwm_row) ->
+    [
+        {period, hoconsc:mk(binary(), #{desc => ?DESC("resp_row_period")})},
+        {high_watermark, hoconsc:mk(non_neg_integer(), #{desc => ?DESC("resp_row_hwm")})},
+        {observed_at, hoconsc:mk(binary(), #{desc => ?DESC("resp_row_observed_at")})}
+    ].
 
 setting() ->
     lists:keydelete(key, 1, emqx_license_schema:fields(key_license)).

--- a/apps/emqx_license/src/emqx_license_resources.erl
+++ b/apps/emqx_license/src/emqx_license_resources.erl
@@ -195,12 +195,14 @@ cached_max_tps() ->
     ?SAFE_CACHE_LOOKUP(max_cluster_tps, 0).
 
 update_resources() ->
+    Now = erlang:system_time(millisecond),
     #{sessions := Sessions, tps := TPS} = stats(),
     ets:insert(?MODULE, {total_connection_count, Sessions}),
     Max0 = cached_max_tps(),
     Max = max(Max0, TPS),
     ets:insert(?MODULE, {latest_cluster_tps, TPS}),
     ets:insert(?MODULE, {max_cluster_tps, Max}),
+    ok = emqx_license_session_hwm:observe(Now, Sessions),
     ok.
 
 ensure_timer(#{check_peer_interval := CheckInterval} = State) ->

--- a/apps/emqx_license/src/emqx_license_schema.erl
+++ b/apps/emqx_license/src/emqx_license_schema.erl
@@ -67,6 +67,13 @@ fields(key_license) ->
             default => default(connection_high_watermark),
             example => default(connection_high_watermark),
             desc => ?DESC(connection_high_watermark_field)
+        }},
+        {high_watermark_timezone, #{
+            type => hoconsc:union([system, binary()]),
+            default => default(high_watermark_timezone),
+            required => false,
+            importance => ?IMPORTANCE_LOW,
+            desc => ?DESC(high_watermark_timezone)
         }}
     ].
 
@@ -76,7 +83,10 @@ desc(_) ->
     undefined.
 
 validations() ->
-    [{check_license_watermark, fun check_license_watermark/1}].
+    [
+        {check_license_watermark, fun check_license_watermark/1},
+        {check_high_watermark_timezone, fun check_high_watermark_timezone/1}
+    ].
 
 check_license_watermark(Conf) ->
     case hocon_maps:get("license.connection_low_watermark", Conf) of
@@ -96,13 +106,32 @@ check_license_watermark(Conf) ->
             end
     end.
 
+check_high_watermark_timezone(Conf) ->
+    case hocon_maps:get("license.high_watermark_timezone", Conf) of
+        undefined ->
+            true;
+        system ->
+            true;
+        <<"system">> ->
+            true;
+        Offset ->
+            try
+                _ = emqx_utils_calendar:offset_second(Offset),
+                true
+            catch
+                error:_ ->
+                    {bad_license_high_watermark_timezone, #{timezone => Offset}}
+            end
+    end.
+
 %% @doc Exported for testing
 default_setting() ->
     Keys =
         [
             connection_low_watermark,
             connection_high_watermark,
-            dynamic_max_connections
+            dynamic_max_connections,
+            high_watermark_timezone
         ],
     maps:from_list(
         lists:map(
@@ -117,6 +146,8 @@ default(connection_low_watermark) ->
     <<"75%">>;
 default(connection_high_watermark) ->
     <<"80%">>;
+default(high_watermark_timezone) ->
+    system;
 default(dynamic_max_connections) ->
     %% This config is only applicable to CTYPE3
     ?DEFAULT_MAX_SESSIONS_CTYPE3.

--- a/apps/emqx_license/src/emqx_license_session_hwm.erl
+++ b/apps/emqx_license/src/emqx_license_session_hwm.erl
@@ -1,0 +1,314 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_license_session_hwm).
+
+-moduledoc """
+Maintains a durable daily history of cluster session high-watermarks.
+
+Each calendar day (in the configured timezone) gets at most one row.
+Monthly billing peaks are derived at query time by folding daily rows.
+The table uses `ordered_set` so that GC of old periods is efficient.
+""".
+
+-behaviour(gen_server).
+
+-include_lib("emqx/include/emqx.hrl").
+-include_lib("emqx/include/logger.hrl").
+
+-export([
+    create_tables/0,
+    start_link/0,
+    observe/2,
+    sync/0,
+    list_history/2,
+    gc/0
+]).
+
+-export([
+    init/1,
+    handle_continue/2,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2
+]).
+
+-define(TAB, ?MODULE).
+
+-record(emqx_license_session_hwm, {
+    %% Integer date key, e.g. 20260409 for 2026-04-09.
+    period :: non_neg_integer(),
+    high_watermark :: non_neg_integer(),
+    observed_at :: non_neg_integer(),
+    updated_at :: non_neg_integer()
+}).
+
+-doc "Create the MRIA table. Safe to call on repeated application starts.".
+create_tables() ->
+    ok = mria:create_table(?TAB, [
+        {type, ordered_set},
+        {storage, disc_copies},
+        {rlog_shard, ?COMMON_SHARD},
+        {record_name, emqx_license_session_hwm},
+        {attributes, record_info(fields, emqx_license_session_hwm)}
+    ]),
+    [?TAB].
+
+-doc "Start the recorder worker. Returns `ignore` on replicant nodes.".
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+-doc "Feed an observed session total to the recorder. Always returns `ok`.".
+observe(Timestamp, Count) when is_integer(Timestamp), is_integer(Count), Count >= 0 ->
+    case should_observe(Timestamp, Count) of
+        true ->
+            gen_server:cast(?MODULE, {observe, Timestamp, Count});
+        false ->
+            ok
+    end.
+
+-doc "Synchronize with the recorder — blocks until all prior casts are processed.".
+sync() ->
+    gen_server:call(?MODULE, sync, timer:seconds(5)).
+
+-doc "Query history rows. `Period` is `daily` or `monthly`; `Limit` caps the result count.".
+list_history(Period, Limit) when (Period =:= daily orelse Period =:= monthly), is_integer(Limit) ->
+    Limit1 = max(1, Limit),
+    Rows = read_rows(),
+    case Period of
+        daily ->
+            lists:sublist([format_row(Row) || Row <- Rows], Limit1);
+        monthly ->
+            lists:sublist(fold_monthly(Rows), Limit1)
+    end.
+
+-doc "Remove rows older than the retention window (24 months).".
+gc() ->
+    gc(erlang:system_time(millisecond)).
+
+init([]) ->
+    case mria_rlog:role() of
+        replicant ->
+            ignore;
+        _ ->
+            {ok, #{last_gc_period => undefined}, {continue, gc}}
+    end.
+
+handle_continue(gc, State) ->
+    ok = gc(),
+    {noreply, State};
+handle_continue(_, State) ->
+    {noreply, State}.
+
+handle_call(sync, _From, State) ->
+    {reply, ok, State};
+handle_call(_Req, _From, State) ->
+    {reply, ignored, State}.
+
+handle_cast({observe, Timestamp, Count}, State) ->
+    State1 =
+        case maybe_store(Timestamp, Count) of
+            ok ->
+                maybe_gc_on_day_change(Timestamp, State);
+            {error, Reason} ->
+                ?SLOG(
+                    error,
+                    #{
+                        msg => "failed_to_store_license_session_hwm",
+                        reason => Reason,
+                        timestamp => Timestamp,
+                        count => Count
+                    },
+                    #{tag => "LICENSE"}
+                ),
+                State
+        end,
+    {noreply, State1};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+maybe_store(Timestamp, Count) ->
+    Period = period(Timestamp),
+    case
+        mria:transaction(
+            ?COMMON_SHARD,
+            fun() -> maybe_update_in_transaction(Period, Timestamp, Count) end
+        )
+    of
+        {atomic, _Result} ->
+            ok;
+        {aborted, Reason} ->
+            {error, Reason}
+    end.
+
+%% Run gc only when the day period changes, to avoid scanning the table on every write.
+maybe_gc_on_day_change(Timestamp, #{last_gc_period := LastPeriod} = State) ->
+    CurrentPeriod = period(Timestamp),
+    case CurrentPeriod of
+        LastPeriod ->
+            State;
+        _ ->
+            _ = gc(Timestamp),
+            State#{last_gc_period => CurrentPeriod}
+    end.
+
+should_observe(Timestamp, Count) ->
+    case whereis(?MODULE) of
+        undefined ->
+            false;
+        _Pid ->
+            Period = period(Timestamp),
+            try
+                case mnesia:dirty_read(?TAB, Period) of
+                    [] ->
+                        true;
+                    [#emqx_license_session_hwm{high_watermark = High}] ->
+                        Count > High
+                end
+            catch
+                _:_ ->
+                    true
+            end
+    end.
+
+maybe_update_in_transaction(Period, Timestamp, Count) ->
+    case mnesia:read(?TAB, Period, write) of
+        [] ->
+            mnesia:write(?TAB, new_record(Period, Timestamp, Count), write),
+            inserted;
+        [#emqx_license_session_hwm{high_watermark = High} = Record] when Count > High ->
+            mnesia:write(
+                ?TAB,
+                Record#emqx_license_session_hwm{
+                    high_watermark = Count,
+                    observed_at = Timestamp,
+                    updated_at = Timestamp
+                },
+                write
+            ),
+            updated;
+        [#emqx_license_session_hwm{}] ->
+            unchanged
+    end.
+
+new_record(Period, Timestamp, Count) ->
+    #emqx_license_session_hwm{
+        period = Period,
+        high_watermark = Count,
+        observed_at = Timestamp,
+        updated_at = Timestamp
+    }.
+
+read_rows() ->
+    lists:reverse(ets:tab2list(?TAB)).
+
+format_row(#emqx_license_session_hwm{
+    period = Period,
+    high_watermark = HighWatermark,
+    observed_at = ObservedAt
+}) ->
+    #{
+        period => format_period(Period),
+        high_watermark => HighWatermark,
+        observed_at => format_timestamp(ObservedAt),
+        observed_at_ms => ObservedAt
+    }.
+
+%% 20260409 -> <<"2026-04-09">>
+format_period(Period) when is_integer(Period) ->
+    Year = Period div 10000,
+    Month = (Period rem 10000) div 100,
+    Day = Period rem 100,
+    iolist_to_binary(io_lib:format("~4..0B-~2..0B-~2..0B", [Year, Month, Day])).
+
+fold_monthly(Rows) ->
+    Monthly = lists:foldl(
+        fun(#emqx_license_session_hwm{period = Period} = Row, Acc) ->
+            %% Group by YYYYMM integer key, e.g. 20260409 -> 202604
+            MonthKey = Period div 100,
+            Formatted = format_row(Row),
+            MonthLabel = format_month(MonthKey),
+            Candidate = Formatted#{period => MonthLabel},
+            maps:update_with(
+                MonthKey,
+                fun(Existing) -> pick_better_monthly(Candidate, Existing) end,
+                Candidate,
+                Acc
+            )
+        end,
+        #{},
+        Rows
+    ),
+    lists:sort(
+        fun(#{period := P1}, #{period := P2}) -> P1 >= P2 end,
+        maps:values(Monthly)
+    ).
+
+%% 202604 -> <<"2026-04">>
+format_month(MonthKey) when is_integer(MonthKey) ->
+    Year = MonthKey div 100,
+    Month = MonthKey rem 100,
+    iolist_to_binary(io_lib:format("~4..0B-~2..0B", [Year, Month])).
+
+pick_better_monthly(
+    #{high_watermark := High1, observed_at_ms := ObservedAt1} = Candidate,
+    #{high_watermark := High2, observed_at_ms := ObservedAt2} = Existing
+) ->
+    case (High1 > High2) orelse ((High1 =:= High2) andalso (ObservedAt1 > ObservedAt2)) of
+        true -> Candidate;
+        false -> Existing
+    end.
+
+gc(Now) ->
+    Earliest = earliest_period_to_keep(Now),
+    gc_before(mnesia:dirty_first(?TAB), Earliest).
+
+gc_before(Key, Earliest) when is_integer(Key), Key < Earliest ->
+    Next = mnesia:dirty_next(?TAB, Key),
+    mria:dirty_delete(?TAB, Key),
+    gc_before(Next, Earliest);
+gc_before(_Key, _Earliest) ->
+    ok.
+
+%% Keep 24 months: subtract 20000 from the integer period to go back 2 years,
+%% then zero out the day to get the first of that month.
+earliest_period_to_keep(Now) ->
+    period(Now) div 100 * 100 + 1 - 20000.
+
+period(Timestamp) ->
+    {Year, Month, Day} = local_date_parts(Timestamp),
+    Year * 10000 + Month * 100 + Day.
+
+local_date_parts(Timestamp) ->
+    OffsetSec = timezone_offset_seconds(),
+    {Date, _Time} = calendar:system_time_to_universal_time(
+        Timestamp div 1000 + OffsetSec, second
+    ),
+    Date.
+
+timezone_offset_seconds() ->
+    case timezone() of
+        system -> emqx_utils_calendar:offset_second(local);
+        Offset -> emqx_utils_calendar:offset_second(Offset)
+    end.
+
+format_timestamp(ObservedAt) ->
+    case timezone() of
+        system ->
+            emqx_utils_calendar:epoch_to_rfc3339(ObservedAt, millisecond);
+        Offset ->
+            iolist_to_binary(
+                emqx_utils_calendar:format(ObservedAt, millisecond, Offset, <<"%Y-%m-%dT%H:%M:%S">>)
+            )
+    end.
+
+timezone() ->
+    emqx_conf:get([license, high_watermark_timezone], system).

--- a/apps/emqx_license/src/emqx_license_session_hwm.erl
+++ b/apps/emqx_license/src/emqx_license_session_hwm.erl
@@ -14,7 +14,7 @@ The table uses `ordered_set` so that GC of old periods is efficient.
 
 -behaviour(gen_server).
 
--include_lib("emqx/include/emqx.hrl").
+-include("emqx_license.hrl").
 -include_lib("emqx/include/logger.hrl").
 
 -export([
@@ -35,14 +35,13 @@ The table uses `ordered_set` so that GC of old periods is efficient.
     terminate/2
 ]).
 
--define(TAB, ?MODULE).
+-define(TAB, emqx_license_session_hwm).
 
 -record(emqx_license_session_hwm, {
-    %% Integer date key, e.g. 20260409 for 2026-04-09.
-    period :: non_neg_integer(),
+    %% Calendar tuple `{Year, Month, Day}` — sorts naturally in ordered_set.
+    period :: {non_neg_integer(), non_neg_integer(), non_neg_integer()},
     high_watermark :: non_neg_integer(),
-    observed_at :: non_neg_integer(),
-    updated_at :: non_neg_integer()
+    observed_at :: non_neg_integer()
 }).
 
 -doc "Create the MRIA table. Safe to call on repeated application starts.".
@@ -50,7 +49,7 @@ create_tables() ->
     ok = mria:create_table(?TAB, [
         {type, ordered_set},
         {storage, disc_copies},
-        {rlog_shard, ?COMMON_SHARD},
+        {rlog_shard, ?LICENSE_SHARD},
         {record_name, emqx_license_session_hwm},
         {attributes, record_info(fields, emqx_license_session_hwm)}
     ]),
@@ -139,7 +138,7 @@ maybe_store(Timestamp, Count) ->
     Period = period(Timestamp),
     case
         mria:transaction(
-            ?COMMON_SHARD,
+            ?LICENSE_SHARD,
             fun() -> maybe_update_in_transaction(Period, Timestamp, Count) end
         )
     of
@@ -189,8 +188,7 @@ maybe_update_in_transaction(Period, Timestamp, Count) ->
                 ?TAB,
                 Record#emqx_license_session_hwm{
                     high_watermark = Count,
-                    observed_at = Timestamp,
-                    updated_at = Timestamp
+                    observed_at = Timestamp
                 },
                 write
             ),
@@ -203,8 +201,7 @@ new_record(Period, Timestamp, Count) ->
     #emqx_license_session_hwm{
         period = Period,
         high_watermark = Count,
-        observed_at = Timestamp,
-        updated_at = Timestamp
+        observed_at = Timestamp
     }.
 
 read_rows() ->
@@ -222,21 +219,15 @@ format_row(#emqx_license_session_hwm{
         observed_at_ms => ObservedAt
     }.
 
-%% 20260409 -> <<"2026-04-09">>
-format_period(Period) when is_integer(Period) ->
-    Year = Period div 10000,
-    Month = (Period rem 10000) div 100,
-    Day = Period rem 100,
+format_period({Year, Month, Day}) ->
     iolist_to_binary(io_lib:format("~4..0B-~2..0B-~2..0B", [Year, Month, Day])).
 
 fold_monthly(Rows) ->
     Monthly = lists:foldl(
-        fun(#emqx_license_session_hwm{period = Period} = Row, Acc) ->
-            %% Group by YYYYMM integer key, e.g. 20260409 -> 202604
-            MonthKey = Period div 100,
+        fun(#emqx_license_session_hwm{period = {Y, M, _}} = Row, Acc) ->
+            MonthKey = {Y, M},
             Formatted = format_row(Row),
-            MonthLabel = format_month(MonthKey),
-            Candidate = Formatted#{period => MonthLabel},
+            Candidate = Formatted#{period => format_month(MonthKey)},
             maps:update_with(
                 MonthKey,
                 fun(Existing) -> pick_better_monthly(Candidate, Existing) end,
@@ -252,10 +243,7 @@ fold_monthly(Rows) ->
         maps:values(Monthly)
     ).
 
-%% 202604 -> <<"2026-04">>
-format_month(MonthKey) when is_integer(MonthKey) ->
-    Year = MonthKey div 100,
-    Month = MonthKey rem 100,
+format_month({Year, Month}) ->
     iolist_to_binary(io_lib:format("~4..0B-~2..0B", [Year, Month])).
 
 pick_better_monthly(
@@ -271,23 +259,19 @@ gc(Now) ->
     Earliest = earliest_period_to_keep(Now),
     gc_before(mnesia:dirty_first(?TAB), Earliest).
 
-gc_before(Key, Earliest) when is_integer(Key), Key < Earliest ->
+gc_before({_, _, _} = Key, Earliest) when Key < Earliest ->
     Next = mnesia:dirty_next(?TAB, Key),
     mria:dirty_delete(?TAB, Key),
     gc_before(Next, Earliest);
 gc_before(_Key, _Earliest) ->
     ok.
 
-%% Keep 24 months: subtract 20000 from the integer period to go back 2 years,
-%% then zero out the day to get the first of that month.
+%% Keep 24 months — earliest kept period is the 1st of the same month two years ago.
 earliest_period_to_keep(Now) ->
-    period(Now) div 100 * 100 + 1 - 20000.
+    {Y, M, _} = period(Now),
+    {Y - 2, M, 1}.
 
 period(Timestamp) ->
-    {Year, Month, Day} = local_date_parts(Timestamp),
-    Year * 10000 + Month * 100 + Day.
-
-local_date_parts(Timestamp) ->
     OffsetSec = timezone_offset_seconds(),
     {Date, _Time} = calendar:system_time_to_universal_time(
         Timestamp div 1000 + OffsetSec, second

--- a/apps/emqx_license/src/emqx_license_sup.erl
+++ b/apps/emqx_license/src/emqx_license_sup.erl
@@ -23,6 +23,15 @@ init([Reader]) ->
     Children =
         [
             #{
+                id => license_session_hwm,
+                start => {emqx_license_session_hwm, start_link, []},
+                restart => transient,
+                shutdown => 5000,
+                type => worker,
+                modules => [emqx_license_session_hwm]
+            },
+
+            #{
                 id => license_checker,
                 start => {emqx_license_checker, start_link, [Reader]},
                 restart => permanent,

--- a/apps/emqx_license/test/emqx_license_cli_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_cli_SUITE.erl
@@ -45,6 +45,7 @@ end_per_testcase(Case, Config) ->
 %% Tests
 %%------------------------------------------------------------------------------
 
+-doc "Print usage when no subcommand is given.".
 t_help({init, Config}) ->
     Config;
 t_help({'end', _Config}) ->
@@ -52,6 +53,7 @@ t_help({'end', _Config}) ->
 t_help(_Config) ->
     _ = emqx_license_cli:license([]).
 
+-doc "Show license info.".
 t_info({init, Config}) ->
     Config;
 t_info({'end', _Config}) ->
@@ -59,6 +61,80 @@ t_info({'end', _Config}) ->
 t_info(_Config) ->
     _ = emqx_license_cli:license(["info"]).
 
+-doc "History command shows monthly plain-text and JSON output.".
+t_history({init, Config}) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
+    %% Use explicit UTC to avoid host-timezone dependence.
+    emqx_config:put([license, high_watermark_timezone], <<"+00:00">>),
+    ok = emqx_license_session_hwm:observe(1_776_520_385_000, 25),
+    ok = emqx_license_session_hwm:sync(),
+    ok = emqx_license_session_hwm:observe(1_778_889_600_000, 18),
+    ok = emqx_license_session_hwm:sync(),
+    Config;
+t_history({'end', _Config}) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm);
+t_history(_Config) ->
+    {ok, Out} = ?CAPTURE(emqx_license_cli:license(["history"])),
+    OutBin = iolist_to_binary(Out),
+    ?assertMatch(
+        {match, _},
+        re:run(OutBin, <<"period=2026-05 high_watermark=18 observed_at=\\S+">>)
+    ),
+    {ok, JsonOut} = ?CAPTURE(emqx_license_cli:license(["history", "--json"])),
+    [Json] = JsonOut,
+    Decoded = emqx_utils_json:decode(Json),
+    ?assertMatch(
+        #{
+            <<"period">> := <<"monthly">>,
+            <<"count">> := 2,
+            <<"data">> := [#{<<"period">> := <<"2026-05">>} | _]
+        },
+        Decoded
+    ).
+
+-doc "Empty history prints a clear message in text mode and empty array in JSON.".
+t_history_empty({init, Config}) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
+    Config;
+t_history_empty({'end', _Config}) ->
+    ok;
+t_history_empty(_Config) ->
+    {ok, Out} = ?CAPTURE(emqx_license_cli:license(["history"])),
+    ?assertMatch([<<"No session high-watermark history recorded.\n">>], Out),
+    {ok, JsonOut} = ?CAPTURE(emqx_license_cli:license(["history", "--json"])),
+    [Json] = JsonOut,
+    Decoded = emqx_utils_json:decode(Json),
+    ?assertMatch(#{<<"count">> := 0, <<"data">> := []}, Decoded).
+
+-doc "Daily mode output shows daily period labels.".
+t_history_daily({init, Config}) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
+    emqx_config:put([license, high_watermark_timezone], <<"+00:00">>),
+    ok = emqx_license_session_hwm:observe(1_776_520_385_000, 25),
+    ok = emqx_license_session_hwm:sync(),
+    Config;
+t_history_daily({'end', _Config}) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm);
+t_history_daily(_Config) ->
+    {ok, Out} = ?CAPTURE(emqx_license_cli:license(["history", "--period", "daily"])),
+    OutBin = iolist_to_binary(Out),
+    ?assertMatch(
+        {match, _},
+        re:run(OutBin, <<"period=2026-04-18 high_watermark=25 observed_at=\\S+">>)
+    ).
+
+-doc "Invalid arguments to history command produce error messages.".
+t_history_bad_args({init, Config}) ->
+    Config;
+t_history_bad_args({'end', _Config}) ->
+    ok;
+t_history_bad_args(_Config) ->
+    {ok, Out1} = ?CAPTURE(emqx_license_cli:license(["history", "--period", "yearly"])),
+    ?assertMatch([<<"Error: bad_history_period\n">> | _], Out1),
+    {ok, Out2} = ?CAPTURE(emqx_license_cli:license(["history", "0"])),
+    ?assertMatch([<<"Error: bad_history_argument\n">> | _], Out2).
+
+-doc "Update license via CLI.".
 t_update({init, Config}) ->
     Config;
 t_update({'end', _Config}) ->
@@ -69,6 +145,7 @@ t_update(_Config) ->
     _ = emqx_license_cli:license(["reload"]),
     _ = emqx_license_cli:license(["update", "Invalid License Value"]).
 
+-doc "Reject single-node license keys in multi-node cluster.".
 t_update_with_invalid_license_value({init, Config}) ->
     _ = emqx_license_cli:license(["update", "evaluation"]),
     meck:new(emqx, [passthrough, no_history]),
@@ -92,6 +169,7 @@ t_update_with_invalid_license_value(_Config) ->
     ),
     ok.
 
+-doc "Config update via emqx:update_config persists license settings.".
 t_conf_update({init, Config}) ->
     Config;
 t_conf_update({'end', _Config}) ->
@@ -109,6 +187,7 @@ t_conf_update(_Config) ->
             connection_high_watermark => 0.5,
             connection_low_watermark => 0.45,
             dynamic_max_connections => ?DEFAULT_MAX_SESSIONS_CTYPE3,
+            high_watermark_timezone => system,
             key => LicenseKey
         },
         emqx:get_config([license])

--- a/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_http_api_SUITE.erl
@@ -355,10 +355,10 @@ request_dump() ->
 validate_setting(Res, ExpectLow, ExpectHigh) ->
     ?assertMatch({ok, 200, _}, Res),
     {ok, 200, Payload} = Res,
-    ?assertEqual(
+    ?assertMatch(
         #{
-            <<"connection_low_watermark">> => ExpectLow,
-            <<"connection_high_watermark">> => ExpectHigh
+            <<"connection_low_watermark">> := ExpectLow,
+            <<"connection_high_watermark">> := ExpectHigh
         },
         emqx_utils_json:decode(Payload)
     ).

--- a/apps/emqx_license/test/emqx_license_resources_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_resources_SUITE.erl
@@ -43,9 +43,10 @@ end_per_suite(Config) ->
 %%------------------------------------------------------------------------------
 
 t_connection_count({init, Config}) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
     Config;
 t_connection_count({'end', _Config}) ->
-    ok;
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm);
 t_connection_count(Config) when is_list(Config) ->
     ?check_trace(
         begin
@@ -104,6 +105,8 @@ t_connection_count(Config) when is_list(Config) ->
         end
     ),
     ?assertReceive({alarm_activated, <<"License: sessions quota exceeds 80%">>}, 100),
+    ok = emqx_license_session_hwm:sync(),
+    [#{period := _, high_watermark := 21}] = emqx_license_session_hwm:list_history(daily, 10),
 
     meck:expect(
         emqx_license_proto_v3,
@@ -128,6 +131,8 @@ t_connection_count(Config) when is_list(Config) ->
         end
     ),
     ?assertReceive(alarm_deactivated, 100),
+    ok = emqx_license_session_hwm:sync(),
+    [#{period := _, high_watermark := 21}] = emqx_license_session_hwm:list_history(daily, 10),
 
     meck:unload(emqx_license_proto_v3),
     meck:unload(emqx_cm),

--- a/apps/emqx_license/test/emqx_license_session_hwm_SUITE.erl
+++ b/apps/emqx_license/test/emqx_license_session_hwm_SUITE.erl
@@ -1,0 +1,157 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2022-2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%--------------------------------------------------------------------
+
+-module(emqx_license_session_hwm_SUITE).
+
+-compile(nowarn_export_all).
+-compile(export_all).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("common_test/include/ct.hrl").
+-include("emqx_license.hrl").
+
+all() ->
+    emqx_common_test_helpers:all(?MODULE).
+
+init_per_suite(Config) ->
+    Apps = emqx_cth_suite:start(
+        [
+            emqx,
+            emqx_conf,
+            {emqx_license, #{
+                config => #{license => #{key => ?DEFAULT_EVALUATION_LICENSE_KEY}}
+            }}
+        ],
+        #{work_dir => emqx_cth_suite:work_dir(Config)}
+    ),
+    [{suite_apps, Apps} | Config].
+
+end_per_suite(Config) ->
+    ok = emqx_cth_suite:stop(?config(suite_apps, Config)).
+
+init_per_testcase(_Case, Config) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm),
+    %% Use an explicit timezone in all tests to avoid host-timezone dependence.
+    emqx_config:put([license, high_watermark_timezone], <<"+00:00">>),
+    Config.
+
+end_per_testcase(_Case, _Config) ->
+    {atomic, ok} = mria:clear_table(emqx_license_session_hwm).
+
+-doc "A single day produces one row; lower observations do not reduce the peak.".
+t_daily_high_watermark(_Config) ->
+    %% 1_776_520_385_000 = 2026-04-18T13:53:05Z
+    Ts = 1_776_520_385_000,
+    ok = emqx_license_session_hwm:observe(Ts, 10),
+    ok = emqx_license_session_hwm:sync(),
+    ok = emqx_license_session_hwm:observe(Ts + 10, 9),
+    ok = emqx_license_session_hwm:sync(),
+    ok = emqx_license_session_hwm:observe(Ts + 20, 12),
+    ok = emqx_license_session_hwm:sync(),
+    [#{period := <<"2026-04-18">>, high_watermark := 12}] =
+        emqx_license_session_hwm:list_history(daily, 10).
+
+-doc "Day rollover produces separate rows for each day.".
+t_day_rollover(_Config) ->
+    %% 2026-04-18T19:00:00Z
+    Day1 = 1_776_538_800_000,
+    %% 2026-04-19T00:00:00Z (next day)
+    Day2 = 1_776_556_800_000,
+    ok = emqx_license_session_hwm:observe(Day1, 10),
+    ok = emqx_license_session_hwm:sync(),
+    ok = emqx_license_session_hwm:observe(Day2, 5),
+    ok = emqx_license_session_hwm:sync(),
+    [
+        #{period := <<"2026-04-19">>, high_watermark := 5},
+        #{period := <<"2026-04-18">>, high_watermark := 10}
+    ] = emqx_license_session_hwm:list_history(daily, 10).
+
+-doc "Monthly query folds multiple daily rows into month-level peaks.".
+t_monthly_fold(_Config) ->
+    %% 2026-04-07T04:00:00Z
+    ok = emqx_license_session_hwm:observe(1_775_534_400_000, 10),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-04-18T04:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_484_800_000, 25),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-05-16T00:00:00Z (different month)
+    ok = emqx_license_session_hwm:observe(1_778_889_600_000, 18),
+    ok = emqx_license_session_hwm:sync(),
+    [
+        #{period := <<"2026-05">>, high_watermark := 18},
+        #{period := <<"2026-04">>, high_watermark := 25}
+    ] =
+        emqx_license_session_hwm:list_history(monthly, 10).
+
+-doc "Monthly fold tie-break: when two days have the same peak, later observed_at wins.".
+t_monthly_fold_tiebreak(_Config) ->
+    %% Two days in the same month with the same peak.
+    %% 2025-04-10T12:00:00Z
+    Day1 = 1_744_286_400_000,
+    %% 2025-04-15T12:00:00Z
+    Day2 = 1_744_718_400_000,
+    ok = emqx_license_session_hwm:observe(Day1, 100),
+    ok = emqx_license_session_hwm:sync(),
+    ok = emqx_license_session_hwm:observe(Day2, 100),
+    ok = emqx_license_session_hwm:sync(),
+    [#{period := <<"2025-04">>, high_watermark := 100, observed_at := ObservedAt}] =
+        emqx_license_session_hwm:list_history(monthly, 10),
+    %% The later observation should win the tie-break.
+    ?assertNotEqual(nomatch, binary:match(ObservedAt, <<"2025-04-15">>)).
+
+-doc "A +02:00 timezone shifts a late-UTC timestamp into the next day.".
+t_timezone_daily_boundary(_Config) ->
+    emqx_config:put([license, high_watermark_timezone], <<"+02:00">>),
+    %% 2026-04-18T22:30:00Z => 2026-04-19 in +02:00
+    ok = emqx_license_session_hwm:observe(1_776_551_400_000, 20),
+    ok = emqx_license_session_hwm:sync(),
+    [#{period := <<"2026-04-19">>, high_watermark := 20}] =
+        emqx_license_session_hwm:list_history(daily, 10).
+
+-doc "GC removes rows older than 24 months while retaining recent ones.".
+t_gc_retains_recent_months(_Config) ->
+    %% 2024-03-30T00:00:00Z — should be GC'd when current month is 2026-04.
+    ok = emqx_license_session_hwm:observe(1_711_756_800_000, 1),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2025-05-18T01:46:40Z
+    ok = emqx_license_session_hwm:observe(1_747_532_800_000, 2),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-04-18T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_470_400_000, 3),
+    ok = emqx_license_session_hwm:sync(),
+    ok = emqx_license_session_hwm:gc(),
+    Rows = emqx_license_session_hwm:list_history(daily, 10),
+    ?assertEqual([<<"2026-04-18">>, <<"2025-05-18">>], [maps:get(period, R) || R <- Rows]).
+
+-doc "Data survives application stop/start because the table uses disc_copies.".
+t_persist_after_restart(_Config) ->
+    %% 1_776_520_385_000 = 2026-04-18T13:53:05Z
+    Ts = 1_776_520_385_000,
+    ok = emqx_license_session_hwm:observe(Ts, 15),
+    ok = emqx_license_session_hwm:sync(),
+    ok = application:stop(emqx_license),
+    ok = application:start(emqx_license),
+    [#{period := <<"2026-04-18">>, high_watermark := 15}] =
+        emqx_license_session_hwm:list_history(daily, 10).
+
+-doc "list_history returns empty list when no data exists.".
+t_empty_history(_Config) ->
+    ?assertEqual([], emqx_license_session_hwm:list_history(daily, 10)),
+    ?assertEqual([], emqx_license_session_hwm:list_history(monthly, 10)).
+
+-doc "list_history limit parameter caps the number of returned rows.".
+t_list_history_limit(_Config) ->
+    %% Insert 3 days of data.
+    %% 2026-04-18T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_470_400_000, 10),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-04-19T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_556_800_000, 20),
+    ok = emqx_license_session_hwm:sync(),
+    %% 2026-04-20T00:00:00Z
+    ok = emqx_license_session_hwm:observe(1_776_643_200_000, 30),
+    ok = emqx_license_session_hwm:sync(),
+    ?assertEqual(3, length(emqx_license_session_hwm:list_history(daily, 10))),
+    ?assertEqual(2, length(emqx_license_session_hwm:list_history(daily, 2))),
+    ?assertEqual(1, length(emqx_license_session_hwm:list_history(daily, 1))).

--- a/changes/ee/feat-17031.en.md
+++ b/changes/ee/feat-17031.en.md
@@ -1,0 +1,5 @@
+Added session high-watermark history for license usage auditing.
+
+EMQX now records the daily peak session count and retains at least 24 months of history.
+Operators can query this data via `emqx ctl license history` with optional `--period daily|monthly` and `--json` flags.
+A new `license.high_watermark_timezone` config controls the day boundary for bucketing.

--- a/rel/i18n/emqx_license_http_api.hocon
+++ b/rel/i18n/emqx_license_http_api.hocon
@@ -33,4 +33,49 @@ example_license_key_string.desc:
 example_license_key_string.label:
 """License Key String Example"""
 
+desc_session_hwm_history_api.desc:
+"""Get session high-watermark history. Returns daily or monthly peak session counts."""
+desc_session_hwm_history_api.label:
+"""Session High-Watermark History"""
+
+param_history_period.desc:
+"""Aggregation period: `daily` returns one row per day, `monthly` folds daily peaks into month-level maximums."""
+param_history_period.label:
+"""Period"""
+
+param_history_limit.desc:
+"""Maximum number of rows to return."""
+param_history_limit.label:
+"""Limit"""
+
+resp_period.desc:
+"""The aggregation period used for this response (`daily` or `monthly`)."""
+resp_period.label:
+"""Period"""
+
+resp_count.desc:
+"""Number of data rows returned."""
+resp_count.label:
+"""Count"""
+
+resp_data.desc:
+"""Array of high-watermark rows, newest first."""
+resp_data.label:
+"""Data"""
+
+resp_row_period.desc:
+"""Calendar period label, e.g. `2026-04-18` for daily or `2026-04` for monthly."""
+resp_row_period.label:
+"""Row Period"""
+
+resp_row_hwm.desc:
+"""Peak session count observed during this period."""
+resp_row_hwm.label:
+"""High Watermark"""
+
+resp_row_observed_at.desc:
+"""Timestamp (RFC 3339) when the peak was observed."""
+resp_row_observed_at.label:
+"""Observed At"""
+
 }

--- a/rel/i18n/emqx_license_http_api.hocon
+++ b/rel/i18n/emqx_license_http_api.hocon
@@ -44,7 +44,7 @@ param_history_period.label:
 """Period"""
 
 param_history_limit.desc:
-"""Maximum number of rows to return."""
+"""Maximum number of rows to return. Applies only to `daily` period (defaults to 30). Ignored for `monthly` period, which always returns the full 24-month retention window."""
 param_history_limit.label:
 """Limit"""
 

--- a/rel/i18n/emqx_license_schema.hocon
+++ b/rel/i18n/emqx_license_schema.hocon
@@ -12,6 +12,13 @@ connection_low_watermark_field.desc:
 connection_low_watermark_field.label:
 """Connection low watermark"""
 
+high_watermark_timezone {
+    label: "Session High Watermark Timezone"
+    desc: """~
+        Timezone used to determine the local day boundary for session high-watermark history.
+        Use `system` to follow the node host local timezone, or provide an explicit offset such as `+02:00`."""
+}
+
 dynamic_max_connections {
     label: "Dynamic Connections Limit"
     desc: """~


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.0

Fixes https://emqx.atlassian.net/browse/EEC-1311

## Summary

Add a durable daily session high-watermark history to `emqx_license` for billing audits.

- New module `emqx_license_session_hwm` records the daily peak cluster session count
  in a MRIA `ordered_set` / `disc_copies` table, surviving node restarts.
- Piggybacks on the existing 5-second sampling loop in `emqx_license_resources`.
- Monthly peaks are derived at query time by folding daily rows.
- New CLI: `emqx ctl license history [N] [--period daily|monthly] [--json]`
- New config: `license.high_watermark_timezone` (default `system`) controls day-boundary calculation.
- Retains at least 24 months of history; cleanup runs on day rollover and at startup.

Key modules:
- `apps/emqx_license/src/emqx_license_session_hwm.erl` — storage, recording, queries
- `apps/emqx_license/src/emqx_license_cli.erl` — CLI surface
- `apps/emqx_license/src/emqx_license_schema.erl` — timezone config field

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)