### PR TITLE
fix(broker): anticipate dangling nodes in routing table

### DIFF
--- a/apps/emqx/src/emqx_broker.erl
+++ b/apps/emqx/src/emqx_broker.erl
@@ -407,20 +407,20 @@ do_route2({To, Group}, Delivery) when is_tuple(Group); is_binary(Group) ->
 aggre([]) ->
     [];
 aggre([#route{topic = To, dest = Node}]) when is_atom(Node) ->
-    [{To, Node} || emqx_router_helper:is_routable(Node)];
+    [{To, Node} || verify_node_routable(Node)];
 aggre([#route{topic = To, dest = {Group, _Node}}]) ->
     [{To, Group}];
 aggre(Routes) ->
     aggre(Routes, false, []).
 
 aggre([#route{topic = To, dest = Node} | Rest], Dedup, Acc) when is_atom(Node) ->
-    case emqx_router_helper:is_routable(Node) of
+    case verify_node_routable(Node) of
         true -> NAcc = [{To, Node} | Acc];
         false -> NAcc = Acc
     end,
     aggre(Rest, Dedup, NAcc);
 aggre([#route{topic = To, dest = {Group, Node}} | Rest], Dedup, Acc) ->
-    case emqx_router_helper:is_routable(Node) of
+    case verify_node_routable(Node) of
         true -> aggre(Rest, true, [{To, Group} | Acc]);
         false -> aggre(Rest, Dedup, Acc)
     end;
@@ -428,6 +428,17 @@ aggre([], false, Acc) ->
     Acc;
 aggre([], true, Acc) ->
     lists:usort(Acc).
+
+verify_node_routable(Node) ->
+    case emqx_router_helper:assess_node_routable(Node) of
+        true ->
+            true;
+        false ->
+            false;
+        unknown ->
+            emqx_router_helper:report_dangling_node(Node),
+            false
+    end.
 
 do_forward_external(Delivery, RouteRes) ->
     emqx_external_broker:forward(Delivery) ++ RouteRes.
@@ -802,6 +813,7 @@ maybe_delete_route(Topic) ->
     end.
 
 sync_route(Action, Topic, ReplyTo) ->
+    ok = emqx_router_helper:mark_routing_node(node()),
     EnabledOn = emqx_config:get([broker, routing, batch_sync, enable_on]),
     Res =
         case EnabledOn of

--- a/apps/emqx/src/emqx_router.erl
+++ b/apps/emqx/src/emqx_router.erl
@@ -192,7 +192,6 @@ do_add_route(Topic) when is_binary(Topic) ->
 
 -spec do_add_route(emqx_types:topic(), dest()) -> ok | {error, term()}.
 do_add_route(Topic, Dest) when is_binary(Topic) ->
-    ok = emqx_router_helper:monitor(Dest),
     mria_insert_route(get_schema_vsn(), Topic, Dest, single).
 
 mria_insert_route(v2, Topic, Dest, Ctx) ->
@@ -841,6 +840,7 @@ init([Pool, Id]) ->
     {ok, #{pool => Pool, id => Id}}.
 
 handle_call({add_route, Topic, Dest}, _From, State) ->
+    ok = emqx_router_helper:mark_routing_node(Dest),
     Ok = do_add_route(Topic, Dest),
     {reply, Ok, State};
 handle_call({delete_route, Topic, Dest}, _From, State) ->

--- a/apps/emqx/src/emqx_router_helper.erl
+++ b/apps/emqx/src/emqx_router_helper.erl
@@ -64,8 +64,9 @@
 -export([
     start_link/0,
     post_start/0,
-    monitor/1,
-    is_routable/1,
+    mark_routing_node/1,
+    assess_node_routable/1,
+    report_dangling_node/1,
     schedule_purge/0,
     schedule_force_purge/0
 ]).
@@ -143,23 +144,45 @@ post_start() ->
     ignore.
 
 %% @doc Monitor routing node
--spec monitor(node() | {binary(), node()}) -> ok.
-monitor({_Group, Node}) ->
-    monitor(Node);
-monitor(Node) when is_atom(Node) ->
+-spec mark_routing_node(node() | {binary(), node()}) -> ok.
+mark_routing_node({_Group, Node}) ->
+    mark_routing_node(Node);
+mark_routing_node(Node) when is_atom(Node) ->
     add_routing_node(Node).
+
+%% @doc Report dangling routing node
+-spec report_dangling_node(node()) -> ok.
+report_dangling_node(Node) when is_atom(Node) ->
+    gen_server:cast(?MODULE, {dangling_node, Node}).
 
 %% @doc Is given node considered routable?
 %% I.e. should the broker attempt to forward messages there, even if there are
 %% routes to this node in the routing table?
--spec is_routable(node()) -> boolean().
-is_routable(Node) when Node == node() ->
+%% NOTE: This function has side effects.
+-spec assess_node_routable(node()) -> boolean() | unknown.
+assess_node_routable(Node) when Node == node() ->
     true;
-is_routable(Node) ->
+assess_node_routable(Node) ->
     try
-        lookup_node_reachable(Node)
+        case lookup_node_reachable(Node) of
+            %% No existing "node down" / "node left" record:
+            true ->
+                case is_routing_node(Node) of
+                    true ->
+                        %% Node is marked as a "routing node":
+                        true;
+                    false ->
+                        %% Node is *not* marked as a "routing node":
+                        unknown
+                end;
+            false ->
+                %% Node is either down or left the cluster and going to be purged:
+                false
+        end
     catch
-        error:badarg -> true
+        error:badarg ->
+            %% Safe fallback
+            true
     end.
 
 %% @doc Schedule dead node purges.
@@ -215,6 +238,18 @@ handle_call(Req, _From, State) ->
     ?SLOG(error, #{msg => "unexpected_call", call => Req}),
     {reply, ignored, State}.
 
+handle_cast({dangling_node, Node}, State) when Node =:= node() ->
+    ok = add_routing_node(node()),
+    {noreply, State};
+handle_cast({dangling_node, Node}, State) ->
+    case is_routing_node(Node) of
+        true ->
+            ok;
+        false ->
+            ?tp(notice, "broker_dangling_routing_node_found", #{node => Node}),
+            record_dangling_node(Node)
+    end,
+    {noreply, State};
 handle_cast(Msg, State) ->
     ?SLOG(error, #{msg => "unexpected_cast", cast => Msg}),
     {noreply, State}.
@@ -336,6 +371,16 @@ reconcile(State = #{last_membership := MembersLast}) ->
     ok = lists:foreach(fun record_node_alive/1, RunningNodes),
     State#{last_membership := Members}.
 
+record_dangling_node(Node) ->
+    ok = add_routing_node(Node),
+    NodeStatus = lookup_node_status(Node),
+    case lists:member(Node, mria:running_nodes()) of
+        false when NodeStatus == notfound ->
+            record_node_down(Node);
+        _ ->
+            ok
+    end.
+
 select(Status) ->
     MS = ets:fun2ms(fun(#ns{node = Node, status = S}) when S == Status -> Node end),
     ets:select(?TAB_STATUS, MS).
@@ -418,7 +463,7 @@ handle_purge(Node, Why, State) ->
     State.
 
 purge_dead_node(Node) ->
-    case node_has_routes(Node) of
+    case is_routing_node(Node) of
         true ->
             ok = do_purge_node(Node),
             true;
@@ -428,7 +473,7 @@ purge_dead_node(Node) ->
 
 purge_dead_node_trans(Node) ->
     StillKnown = lookup_node_status(Node) =/= notfound,
-    case StillKnown andalso node_has_routes(Node) of
+    case StillKnown andalso is_routing_node(Node) of
         true ->
             case cores() of
                 Nodes = [_ | _] ->
@@ -455,7 +500,7 @@ do_purge_node(Node) ->
 %%
 
 add_routing_node(Node) ->
-    case ets:member(?ROUTING_NODE, Node) of
+    case is_routing_node(Node) of
         true -> ok;
         false -> mria:dirty_write(?ROUTING_NODE, #routing_node{name = Node})
     end.
@@ -466,7 +511,7 @@ remove_routing_node(Node) ->
 list_routing_nodes() ->
     ets:select(?ROUTING_NODE, ets:fun2ms(fun(#routing_node{name = N}) -> N end)).
 
-node_has_routes(Node) ->
+is_routing_node(Node) ->
     ets:member(?ROUTING_NODE, Node).
 
 %%

--- a/apps/emqx/src/emqx_shared_sub.erl
+++ b/apps/emqx/src/emqx_shared_sub.erl
@@ -515,7 +515,7 @@ handle_subscribe(Group, Topic, SubPid) ->
         true ->
             ok;
         false ->
-            ok = emqx_router:do_add_route(Topic, {Group, node()}),
+            ok = emqx_router:add_route(Topic, {Group, node()}),
             emqx_external_broker:add_shared_route(Topic, Group)
     end,
     maybe_insert_round_robin_count({Group, Topic}),
@@ -578,7 +578,7 @@ is_alive_sub(Pid) when node(Pid) == node() ->
     erlang:is_process_alive(Pid);
 is_alive_sub(Pid) ->
     %% When process is not local, the best guess is it's alive.
-    emqx_router_helper:is_routable(node(Pid)).
+    emqx_router_helper:assess_node_routable(node(Pid)) =:= true.
 
 delete_route(Group, Topic) ->
     delete_route(Group, Topic, node()).

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -136,8 +136,8 @@ end_per_testcase(TC, Config) ->
     emqx_common_test_helpers:end_per_testcase(?MODULE, TC, Config).
 
 t_monitor(_) ->
-    ok = emqx_router_helper:monitor({undefined, node()}),
-    ok = emqx_router_helper:monitor(undefined).
+    ok = emqx_router_helper:mark_routing_node({undefined, node()}),
+    ok = emqx_router_helper:mark_routing_node(undefined).
 
 t_membership_node_leaving(_Config) ->
     AnotherNode = emqx_cth_cluster:node_name(leaving),

--- a/apps/emqx/test/emqx_router_helper_SUITE.erl
+++ b/apps/emqx/test/emqx_router_helper_SUITE.erl
@@ -246,6 +246,36 @@ t_cluster_node_force_leave(Config) ->
     ?assertEqual([<<"test/e/f">>], emqx_router:topics()),
     ?assertEqual([], emqx_shared_sub:subscribers(<<"g">>, '_')).
 
+%% Test that dangling routes (routes without a corresponding `emqx_routing_node` entry)
+%% are detected on-demand during message routing and eventually cleaned up.
+t_cluster_node_dangling_route(_Config) ->
+    DanglingNode = emqx_cth_cluster:node_name(cluster_node_dangling),
+    DanglingTopic = <<"dangling/route/topic">>,
+    LocalTopic = <<"test/e/f">>,
+    %% Insert a route directly, bypassing the normal add_route path which would
+    %% also create a `routing_node` entry. This simulates the inconsistent state
+    %% where routes exist but the `emqx_routing_node` entry was cleaned up.
+    ok = mria:dirty_write(emqx_route, #route{topic = DanglingTopic, dest = DanglingNode}),
+    ok = emqx_router:add_route(LocalTopic, node()),
+    ?assertMatch([_, _], emqx_router:topics()),
+    %% Verify the dangling state: route exists, but no routing_node entry.
+    ?assertNot(ets:member(emqx_routing_node, DanglingNode)),
+    ?assertEqual(unknown, emqx_router_helper:assess_node_routable(DanglingNode)),
+    {_, {ok, _}} = ?wait_async_action(
+        %% Publish a message to the dangling topic.
+        emqx_broker:publish(emqx_message:make(<<?MODULE_STRING>>, DanglingTopic, <<"test">>)),
+        %% The dangling node should be detected and reported.
+        #{?snk_kind := "broker_dangling_routing_node_found", node := DanglingNode}
+    ),
+    %% After detection, a routing_node entry should have been created, and the node should
+    %% be considered not routable.
+    ok = timer:sleep(100),
+    ?assert(ets:member(emqx_routing_node, DanglingNode)),
+    ?assertEqual(false, emqx_router_helper:assess_node_routable(DanglingNode)),
+    %% Wait for the purge to clean up the routes.
+    {ok, _} = ?block_until(#{?snk_kind := broker_node_purged, node := DanglingNode}),
+    ?assertEqual([LocalTopic], emqx_router:topics()).
+
 t_cluster_node_restart('init', Config) ->
     start_join_node(cluster_node_restart, Config);
 t_cluster_node_restart('end', Config) ->

--- a/apps/emqx/test/emqx_routing_SUITE.erl
+++ b/apps/emqx/test/emqx_routing_SUITE.erl
@@ -64,28 +64,18 @@ init_per_group(routing_schema_v2, Config) ->
 init_per_group(batch_sync_on, Config) ->
     [{emqx_config, "broker.routing.batch_sync.enable_on = all"} | Config];
 init_per_group(batch_sync_replicants, Config) ->
-    case emqx_cth_suite:skip_if_oss() of
-        false ->
-            [{emqx_config, "broker.routing.batch_sync.enable_on = replicant"} | Config];
-        True ->
-            True
-    end;
+    [{emqx_config, "broker.routing.batch_sync.enable_on = replicant"} | Config];
 init_per_group(batch_sync_off, Config) ->
     [{emqx_config, "broker.routing.batch_sync.enable_on = none"} | Config];
 init_per_group(cluster, Config) ->
-    case emqx_cth_suite:skip_if_oss() of
-        false ->
-            WorkDir = emqx_cth_suite:work_dir(Config),
-            NodeSpecs = [
-                {emqx_routing_SUITE1, #{apps => [mk_emqx_appspec(1, Config)], role => core}},
-                {emqx_routing_SUITE2, #{apps => [mk_emqx_appspec(2, Config)], role => core}},
-                {emqx_routing_SUITE3, #{apps => [mk_emqx_appspec(3, Config)], role => replicant}}
-            ],
-            Nodes = emqx_cth_cluster:start(NodeSpecs, #{work_dir => WorkDir}),
-            [{cluster, Nodes} | Config];
-        True ->
-            True
-    end;
+    WorkDir = emqx_cth_suite:work_dir(Config),
+    NodeSpecs = [
+        {emqx_routing_SUITE1, #{apps => [mk_emqx_appspec(1, Config)], role => core}},
+        {emqx_routing_SUITE2, #{apps => [mk_emqx_appspec(2, Config)], role => core}},
+        {emqx_routing_SUITE3, #{apps => [mk_emqx_appspec(3, Config)], role => replicant}}
+    ],
+    Nodes = emqx_cth_cluster:start(NodeSpecs, #{work_dir => WorkDir}),
+    [{cluster, Nodes} | Config];
 init_per_group(GroupName, Config) when
     GroupName =:= single_batch_on;
     GroupName =:= single


### PR DESCRIPTION
Release version: 5.8.10, 5.10.4

## Summary

This PR (partially) addresses situations when cluster routing state can become inconsistent. Specifically, when a stopped node that already left the cluster still has routes in the routing table but is not marked as a "routing node" already, due to potential data races between `emqx_router_helper:do_purge_node/1` and the node in question still serving subscriptions.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
