### PR TITLE
fix(mgmt): block api key access to dashboard change_mfa and change_pwd (v6)

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_auth.erl
+++ b/apps/emqx_management/src/emqx_mgmt_auth.erl
@@ -216,6 +216,10 @@ authorize(#{module := emqx_dashboard_api, function := users}, _Req, _ApiKey, _Ap
     {error, <<"not_allowed">>, <<"users">>};
 authorize(#{module := emqx_dashboard_api, function := logout}, _Req, _ApiKey, _ApiSecret) ->
     {error, <<"not_allowed">>, <<"logout">>};
+authorize(#{module := emqx_dashboard_api, function := change_pwd}, _Req, _ApiKey, _ApiSecret) ->
+    {error, <<"not_allowed">>, <<"users">>};
+authorize(#{module := emqx_dashboard_api, function := change_mfa}, _Req, _ApiKey, _ApiSecret) ->
+    {error, <<"not_allowed">>, <<"users">>};
 authorize(#{module := emqx_mgmt_api_api_keys}, _Req, _ApiKey, _ApiSecret) ->
     {error, <<"not_allowed">>, <<"api_key">>};
 authorize(HandlerInfo, Req, ApiKey, ApiSecret) ->

--- a/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl
@@ -16,6 +16,8 @@
     t_ee_update,
     t_ee_authorize_viewer,
     t_ee_authorize_admin,
+    t_ee_authorize_admin_cannot_manage_mfa,
+    t_ee_authorize_admin_cannot_manage_mfa_module_level,
     t_ee_authorize_publisher
 ]).
 
@@ -490,6 +492,118 @@ t_ee_authorize_admin(_Config) ->
     ?assertMatch(
         {ok, _}, emqx_mgmt_api_test_util:request_api(delete, BanPath, BasicHeader)
     ).
+
+-doc """
+An admin-role API key must NOT be able to reach the dashboard user-account
+management endpoints change_mfa and change_pwd via HTTP Basic auth. These
+endpoints belong to the human-facing dashboard surface and are intended
+only for bearer-token (JWT) callers.
+
+Before the fix, DELETE /api/v5/users/:username/mfa via API key Basic auth
+returned HTTP 204 and silently disabled the target user's MFA. After the
+fix it must return HTTP 401 with body code API_KEY_NOT_ALLOW, matching
+the policy already enforced on /users and /users/:username.
+""".
+t_ee_authorize_admin_cannot_manage_mfa(_Config) ->
+    Name = <<"EMQX-EE-API-AUTHORIZE-KEY-ADMIN-MFA">>,
+    {ok, #{<<"api_key">> := ApiKey, <<"api_secret">> := ApiSecret}} = create_app(Name, #{
+        role => ?ROLE_API_SUPERUSER
+    }),
+    BasicHeader = emqx_common_test_http:auth_header(
+        binary_to_list(ApiKey),
+        binary_to_list(ApiSecret)
+    ),
+    Victim = <<"mfa_victim_user">>,
+    ok = ensure_victim_user(Victim),
+    DeleteMfa = emqx_mgmt_api_test_util:api_path(["users", Victim, "mfa"]),
+    PostMfa = DeleteMfa,
+    ChangePwd = emqx_mgmt_api_test_util:api_path(["users", Victim, "change_pwd"]),
+
+    ok = assert_api_key_not_allow(
+        delete, DeleteMfa, [], BasicHeader, []
+    ),
+    ok = assert_api_key_not_allow(
+        post, PostMfa, [], BasicHeader, #{mechanism => totp}
+    ),
+    ok = assert_api_key_not_allow(
+        post,
+        ChangePwd,
+        [],
+        BasicHeader,
+        #{old_pwd => <<"mfa_victim_pass">>, new_pwd => <<"new_pass_123">>}
+    ),
+
+    %% Even the generic /users and /users/:username stay blocked — baseline
+    %% sanity that this test is not special-casing change_mfa alone.
+    UsersPath = emqx_mgmt_api_test_util:api_path(["users"]),
+    UserPath = emqx_mgmt_api_test_util:api_path(["users", Victim]),
+    ok = assert_api_key_not_allow(get, UsersPath, [], BasicHeader, []),
+    ok = assert_api_key_not_allow(delete, UserPath, [], BasicHeader, []),
+    ok.
+
+-doc """
+Lower-level companion to t_ee_authorize_admin_cannot_manage_mfa:
+call emqx_mgmt_auth:authorize/4 directly with a HandlerInfo map that
+names the dashboard change_mfa / change_pwd handlers. This pins the
+contract at the exact clause being added in the fix, independent of
+any HTTP / minirest plumbing.
+""".
+t_ee_authorize_admin_cannot_manage_mfa_module_level(_Config) ->
+    Name = <<"EMQX-EE-API-AUTH-MFA-MODULE">>,
+    {ok, #{<<"api_key">> := ApiKey, <<"api_secret">> := ApiSecret}} = create_app(Name, #{
+        role => ?ROLE_API_SUPERUSER
+    }),
+    %% FakeReq is only consulted by check_rbac — the denylist clauses we
+    %% add return before check_rbac runs, so it just needs to be a map
+    %% with method/path keys to satisfy cowboy_req helpers if called.
+    FakeReq = #{method => <<"DELETE">>, path => <<"/api/v5/users/someuser/mfa">>},
+    DeleteMfaHandler = #{
+        method => delete,
+        module => emqx_dashboard_api,
+        function => change_mfa,
+        path => "/users/:username/mfa"
+    },
+    PostMfaHandler = DeleteMfaHandler#{method => post},
+    ChangePwdHandler = #{
+        method => post,
+        module => emqx_dashboard_api,
+        function => change_pwd,
+        path => "/users/:username/change_pwd"
+    },
+    ?assertEqual(
+        {error, <<"not_allowed">>, <<"users">>},
+        emqx_mgmt_auth:authorize(DeleteMfaHandler, FakeReq, ApiKey, ApiSecret)
+    ),
+    ?assertEqual(
+        {error, <<"not_allowed">>, <<"users">>},
+        emqx_mgmt_auth:authorize(PostMfaHandler, FakeReq, ApiKey, ApiSecret)
+    ),
+    ?assertEqual(
+        {error, <<"not_allowed">>, <<"users">>},
+        emqx_mgmt_auth:authorize(ChangePwdHandler, FakeReq, ApiKey, ApiSecret)
+    ),
+    ok.
+
+ensure_victim_user(Username) ->
+    case emqx_dashboard_admin:add_user(Username, <<"mfa_victim_pass">>, ?ROLE_SUPERUSER, <<>>) of
+        {ok, _} -> ok;
+        {error, _AlreadyExists} -> ok
+    end.
+
+assert_api_key_not_allow(Method, Path, QueryParams, AuthHeader, Body) ->
+    Result = emqx_mgmt_api_test_util:request_api(
+        Method, Path, QueryParams, AuthHeader, Body, #{return_all => true}
+    ),
+    ?assertMatch(
+        {error, {{"HTTP/1.1", 401, _}, _Headers, _Body}},
+        Result
+    ),
+    {error, {_, _, ResponseBody}} = Result,
+    ?assertMatch(
+        #{<<"code">> := <<"API_KEY_NOT_ALLOW">>, <<"message">> := _},
+        emqx_utils_json:decode(ResponseBody, [return_maps])
+    ),
+    ok.
 
 t_ee_authorize_publisher(_Config) ->
     Name = <<"EMQX-EE-API-AUTHORIZE-KEY-PUBLISHER">>,

--- a/changes/ee/fix-17040.en.md
+++ b/changes/ee/fix-17040.en.md
@@ -1,0 +1,14 @@
+Restricted API key access to dashboard user-account management endpoints.
+
+Previously, an API key with the `administrator` role could call the
+dashboard user management endpoints `POST/DELETE /users/:username/mfa` and
+`POST /users/:username/change_pwd` via HTTP Basic authentication. This
+meant an API key could reset or disable another dashboard user's MFA, or
+change another dashboard user's password, bypassing the intended
+separation between human dashboard sessions and machine API keys.
+
+These endpoints now return `401 API_KEY_NOT_ALLOW` when accessed via an
+API key, matching the existing policy that already blocks API key access
+to `/users`, `/users/:username`, `/logout`, and `/api_key`. Dashboard
+users can still manage their own MFA and password from the dashboard UI
+using bearer-token (JWT) sessions as before.


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

Port of #17039 from `release-59`. API keys with the `administrator` role could previously call dashboard user-account management endpoints via HTTP Basic auth and silently disable/reset another dashboard user's MFA or password. This bypassed the intended separation between machine API keys and human dashboard sessions.

**Affected endpoints:**
- `DELETE /api/v5/users/:username/mfa`
- `POST /api/v5/users/:username/mfa`
- `POST /api/v5/users/:username/change_pwd`

**Fix** (`apps/emqx_management/src/emqx_mgmt_auth.erl`): add two new denylist clauses in `authorize/4` matching `#{module := emqx_dashboard_api, function := change_pwd}` and `function := change_mfa`. These return `{error, <<"not_allowed">>, <<"users">>}` so the request is rejected with `401 API_KEY_NOT_ALLOW`, mirroring the existing clauses for `user`, `users`, `logout`, and `api_key`. Dashboard bearer-token (JWT) callers are unaffected.

**Tests** (`apps/emqx_management/test/emqx_mgmt_api_api_keys_SUITE.erl`):
- `t_ee_authorize_admin_cannot_manage_mfa` — HTTP-level: issues the exploit via an admin-role API key and asserts each attempt returns `401 API_KEY_NOT_ALLOW`.
- `t_ee_authorize_admin_cannot_manage_mfa_module_level` — calls `emqx_mgmt_auth:authorize/4` directly with a `HandlerInfo` map, pinning the contract at the exact clause being added.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)