### PR TITLE
fix(coap): keep DTLS token takeover window aligned with keepalive

### DIFF
--- a/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
+++ b/apps/emqx_gateway_coap/src/emqx_coap_channel.erl
@@ -87,7 +87,6 @@
 -define(INFO_KEYS, [conninfo, conn_state, clientinfo, session]).
 
 -define(DEF_IDLE_SECONDS, 30).
--define(SOCK_CLOSED_TAKEOVER_GRACE_MS, 5000).
 -define(RAND_CLIENTID_BYTES, 16).
 
 -import(emqx_coap_medium, [reply/2, reply/3, reply/4, iter/3, iter/4]).
@@ -364,11 +363,16 @@ handle_info({subscribe, _AutoSubs}, Channel) ->
     {ok, Channel};
 handle_info(
     {sock_closed, _Reason},
-    #channel{connection_required = true, conn_state = connected} = Channel
+    #channel{
+        connection_required = true,
+        conn_state = connected,
+        keepalive = Keepalive
+    } = Channel
 ) ->
+    GraceMs = emqx_keepalive:info(check_interval, Keepalive),
     NChannel = ensure_timer(
         sock_closed_takeover_cleanup,
-        ?SOCK_CLOSED_TAKEOVER_GRACE_MS,
+        GraceMs,
         sock_closed_takeover_cleanup,
         Channel
     ),

--- a/apps/emqx_gateway_coap/test/emqx_coap_channel_tests.erl
+++ b/apps/emqx_gateway_coap/test/emqx_coap_channel_tests.erl
@@ -1,0 +1,37 @@
+%%--------------------------------------------------------------------
+%% Copyright (c) 2026 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+%%--------------------------------------------------------------------
+
+-module(emqx_coap_channel_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+sock_closed_cleanup_uses_keepalive_interval_test() ->
+    ok = meck:new(emqx_utils, [passthrough]),
+    ok = meck:new(emqx_keepalive, [passthrough]),
+    try
+        meck:expect(emqx_utils, start_timer, fun(Time, Msg) ->
+            erlang:send_after(Time, self(), Msg)
+        end),
+        Keepalive = keepalive_ref,
+        Expected = 30000,
+        meck:expect(emqx_keepalive, info, fun(check_interval, keepalive_ref) -> Expected end),
+        Channel = {channel, #{}, #{}, #{}, undefined, Keepalive, #{}, true, connected, undefined},
+        {ok, _Channel2} = emqx_coap_channel:handle_info({sock_closed, closed}, Channel),
+        ?assert(meck:called(emqx_utils, start_timer, [Expected, sock_closed_takeover_cleanup]))
+    after
+        meck:unload(emqx_keepalive),
+        meck:unload(emqx_utils)
+    end.


### PR DESCRIPTION
## Summary
- Fix regression introduced after #17030 merge in `connection_required` CoAP mode
- Replace fixed 5s `sock_closed` takeover cleanup window with keepalive-based interval
- This preserves stale-channel cleanup while allowing typical DTLS reconnect/publish flows to reuse token

## Root Cause
- `sock_closed` in connected + connection-required mode used a fixed 5s cleanup timer
- For clients like `coap-client` (new DTLS session per command), the next publish often comes after >5s
- Channel was already cleaned up, so token lookup failed with `Invalid token or clientid in connection mode`

## Changes
- `apps/emqx_gateway_coap/src/emqx_coap_channel.erl`
  - derive grace from `emqx_keepalive:info(check_interval, Keepalive)`
- `apps/emqx_gateway_coap/test/emqx_coap_channel_tests.erl`
  - add regression unit test to assert `sock_closed` cleanup uses keepalive interval

## Verification
- `./rebar3 as test eunit --module=emqx_coap_channel_tests`
- `./rebar3 as test eunit --module=emqx_coap_channel_tests,emqx_coap_proxy_conn_tests,emqx_coap_message_tests`

Both commands pass locally.
