### PR TITLE
fix(authn): let auth chain continue when password is undefined

### DIFF
--- a/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
+++ b/apps/emqx_auth_ldap/src/emqx_authn_ldap.erl
@@ -56,7 +56,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(Credential, #{method := #{type := hash}} = State) ->
     emqx_authn_ldap_hash:authenticate(Credential, State);
 authenticate(Credential, #{method := #{type := bind}} = State) ->

--- a/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
+++ b/apps/emqx_auth_mnesia/src/emqx_authn_mnesia.erl
@@ -121,7 +121,7 @@ update(Config, _State) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -115,7 +115,7 @@ test_authenticator_users(PathPrefix) ->
                 <<"metrics">> := #{
                     <<"total">> := 1,
                     <<"success">> := 0,
-                    <<"failed">> := 1
+                    <<"nomatch">> := 1
                 }
             } = emqx_utils_json:decode(PageData0);
         ["listeners", 'tcp:default'] ->
@@ -175,7 +175,7 @@ test_authenticator_users(PathPrefix) ->
                 <<"metrics">> := #{
                     <<"total">> := 2,
                     <<"success">> := 1,
-                    <<"failed">> := 1
+                    <<"nomatch">> := 1
                 }
             } = emqx_utils_json:decode(PageData01);
         ["listeners", 'tcp:default'] ->

--- a/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
+++ b/apps/emqx_auth_mongodb/src/emqx_authn_mongodb.erl
@@ -59,7 +59,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     Credential, #{filter_template := FilterTemplate} = State
 ) ->

--- a/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
+++ b/apps/emqx_auth_mysql/src/emqx_authn_mysql.erl
@@ -61,7 +61,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
+++ b/apps/emqx_auth_postgresql/src/emqx_authn_postgresql.erl
@@ -65,7 +65,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/apps/emqx_auth_redis/src/emqx_authn_redis.erl
+++ b/apps/emqx_auth_redis/src/emqx_authn_redis.erl
@@ -59,7 +59,7 @@ destroy(#{resource_id := ResourceId}) ->
 authenticate(#{auth_method := _}, _) ->
     ignore;
 authenticate(#{password := undefined}, _) ->
-    {error, bad_username_or_password};
+    ignore;
 authenticate(
     #{password := Password} = Credential,
     #{

--- a/changes/ee/fix-17045.en.md
+++ b/changes/ee/fix-17045.en.md
@@ -1,0 +1,3 @@
+Fixed password-based authentication backends to let the auth chain continue when the CONNECT packet has no password, instead of rejecting the connection immediately.
+
+Previously, if a client connected without a password, the first password-based authenticator (built-in database, MySQL, PostgreSQL, MongoDB, Redis, or LDAP) in the chain would return an error, blocking any subsequent authenticators from being tried.


### PR DESCRIPTION
Fixes 

Release version:

## Summary

When a client sends a CONNECT packet without a password, password-based authenticators should return `ignore` so the authentication chain can continue instead of failing immediately.

This ports the fix to the v6 release-60 branch for the built-in database, MySQL, PostgreSQL, MongoDB, Redis, and LDAP authenticators, and updates the Mnesia API suite assertions to expect `nomatch` metrics for undefined-password attempts.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (no schema changes)
