### PR TITLE
feat(metrics): add actions.messages counter and rate

### DIFF
--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -614,6 +614,8 @@ reserved_idx('messages.transformation_succeeded') -> 98;
 reserved_idx('messages.transformation_failed') -> 99;
 reserved_idx('rules.matched') -> 100;
 reserved_idx('actions.executed') -> 101;
+%% NOTE: idx 102 is reserved for 'delivery.dropped.filter' in release-62+
+reserved_idx('actions.messages') -> 103;
 reserved_idx(_) -> undefined.
 
 all_metrics() ->
@@ -715,7 +717,8 @@ message_metrics() ->
 data_integration_metrics() ->
     [
         {counter, 'rules.matched', ?DESC("rules_matched")},
-        {counter, 'actions.executed', ?DESC("actions_executed")}
+        {counter, 'actions.executed', ?DESC("actions_executed")},
+        {counter, 'actions.messages', ?DESC("actions_messages")}
     ].
 
 %% Delivery metrics

--- a/apps/emqx_dashboard/include/emqx_dashboard.hrl
+++ b/apps/emqx_dashboard/include/emqx_dashboard.hrl
@@ -70,7 +70,8 @@
     dropped,
     persisted,
     rules_matched,
-    actions_executed
+    actions_executed,
+    actions_messages
 ]).
 
 -define(GAUGE_SAMPLER_LIST, [
@@ -94,7 +95,8 @@
     dropped => dropped_msg_rate,
     persisted => persisted_rate,
     rules_matched => rules_matched_rate,
-    actions_executed => actions_executed_rate
+    actions_executed => actions_executed_rate,
+    actions_messages => actions_messages_rate
 }).
 
 -define(CURRENT_SAMPLE_NON_RATE, [

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor.erl
@@ -872,7 +872,9 @@ stats(persisted) ->
 stats(rules_matched) ->
     emqx_metrics:val_global('rules.matched');
 stats(actions_executed) ->
-    emqx_metrics:val_global('actions.executed').
+    emqx_metrics:val_global('actions.executed');
+stats(actions_messages) ->
+    emqx_metrics:val_global('actions.messages').
 
 %% -------------------------------------------------------------------------------------------------
 %% Retained && License Quota

--- a/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
+++ b/apps/emqx_dashboard/src/emqx_dashboard_monitor_api.erl
@@ -229,8 +229,10 @@ swagger_desc(node_uptime) -> ?DESC("node_uptime");
 swagger_desc(license_quota) -> ?DESC("license_quota");
 swagger_desc(rules_matched) -> ?DESC("rules_matched");
 swagger_desc(actions_executed) -> ?DESC("actions_executed");
+swagger_desc(actions_messages) -> ?DESC("actions_messages");
 swagger_desc(rules_matched_rate) -> ?DESC("rules_matched_rate");
-swagger_desc(actions_executed_rate) -> ?DESC("actions_executed_rate").
+swagger_desc(actions_executed_rate) -> ?DESC("actions_executed_rate");
+swagger_desc(actions_messages_rate) -> ?DESC("actions_messages_rate").
 
 maybe_reject_cluster_only_metrics(<<"all">>, Rates) ->
     Rates;

--- a/apps/emqx_resource/mix.exs
+++ b/apps/emqx_resource/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXResource.MixProject do
   def project do
     [
       app: :emqx_resource,
-      version: "6.1.0",
+      version: "6.1.1",
       build_path: "../../_build",
       # config_path: "../../config/config.exs",
       erlc_options: UMP.erlc_options(),

--- a/apps/emqx_resource/src/emqx_resource_metrics.erl
+++ b/apps/emqx_resource/src/emqx_resource_metrics.erl
@@ -200,7 +200,7 @@ handle_counter_telemetry_event(Event, ID, Val, Metadata) ->
         late_reply ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'late_reply', Val);
         failed ->
-            inc_actions_executed(Metadata),
+            inc_actions_executed(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'failed', Val);
         matched ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'matched', Val);
@@ -208,16 +208,16 @@ handle_counter_telemetry_event(Event, ID, Val, Metadata) ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'received', Val);
         retried_failed ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried', Val),
-            inc_actions_executed(Metadata),
+            inc_actions_executed(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'failed', Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried.failed', Val);
         retried_success ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried', Val),
-            inc_actions_executed(Metadata),
+            inc_actions_executed(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'success', Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'retried.success', Val);
         success ->
-            inc_actions_executed(Metadata),
+            inc_actions_executed(Metadata, Val),
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'success', Val);
         aggregated_upload_success ->
             emqx_metrics_worker:inc(?RES_METRICS, ID, 'aggregated_upload.success', Val);
@@ -537,7 +537,9 @@ on_delivery_finished(Result, ActionResId) ->
             emqx_resource_metrics:aggregated_upload_failure_inc(ActionResId)
     end.
 
-inc_actions_executed(#{namespace := Namespace}) ->
-    emqx_metrics:inc(Namespace, 'actions.executed');
-inc_actions_executed(_Metadata) ->
-    emqx_metrics:inc_global('actions.executed').
+inc_actions_executed(#{namespace := Namespace}, Val) ->
+    emqx_metrics:inc(Namespace, 'actions.executed'),
+    emqx_metrics:inc(Namespace, 'actions.messages', Val);
+inc_actions_executed(_Metadata, Val) ->
+    emqx_metrics:inc_global('actions.executed'),
+    emqx_metrics:inc_global('actions.messages', Val).

--- a/changes/ee/feat-17046.en.md
+++ b/changes/ee/feat-17046.en.md
@@ -1,0 +1,3 @@
+Added a new metric `actions.messages` (and the corresponding `actions_messages_rate` in the dashboard monitor API) that counts the total number of messages handled by rule-engine action executions.
+
+Because a single action execution may handle a batch of messages, `actions.messages` is greater than or equal to `actions.executed`, and `actions_messages_rate` reflects the true per-message throughput of actions.

--- a/rel/i18n/emqx_dashboard_monitor_api.hocon
+++ b/rel/i18n/emqx_dashboard_monitor_api.hocon
@@ -115,6 +115,11 @@ actions_executed: {
     label: "Actions Executed"
 }
 
+actions_messages: {
+    desc: "Number of messages handled by Action executions (failures + successes) in the last sample window. An Action execution may handle a batch of messages, so this count is greater than or equal to the number of Action executions."
+    label: "Action Messages"
+}
+
 disconnected_durable_sessions: {
     desc: "Number of disconnected durable sessions at the time of sampling. Can only represent an approximation."
     label: "Disconnected Durable Sessions"
@@ -197,6 +202,11 @@ rules_matched_rate: {
 actions_executed_rate: {
     desc: "Action execution rate in the last sampling window."
     label: "Action Execution Rate"
+}
+
+actions_messages_rate: {
+    desc: "Rate of messages handled by Action executions in the last sampling window. Equal to or greater than the action execution rate because a single Action execution may handle a batch of messages."
+    label: "Action Message Rate"
 }
 
 retained_msg_count: {

--- a/rel/i18n/emqx_metrics.hocon
+++ b/rel/i18n/emqx_metrics.hocon
@@ -221,6 +221,9 @@ emqx_metrics {
     actions_executed {
         desc: "Number of rule-engine actions executed"
     }
+    actions_messages {
+        desc: "Number of messages handled by rule-engine action executions. An action execution may handle a batch of messages, so this count is greater than or equal to the number of action executions."
+    }
     client_connected {
         desc: "Number of successful client connected"
     }


### PR DESCRIPTION
Fixes EMQX-15133

Release version: 6.1.2, 6.2.1

## Summary

The existing `actions.executed` counter (and `actions_executed_rate` in the dashboard monitor API) counts **action invocations**. A single action invocation may, however, handle a **batch of messages** — so this counter understates the true per-message throughput of rule-engine actions.

This PR adds a new counter `actions.messages` (and corresponding `actions_messages_rate` in the dashboard monitor API) that is incremented by the batch size on each action success/failure event. As a result, `actions.messages >= actions.executed`, and the new rate reflects the real per-message throughput.

Key changes:
- `apps/emqx/src/emqx_metrics.erl`: register new global counter `actions.messages`.
- `apps/emqx_resource/src/emqx_resource_metrics.erl`: bump `actions.messages` by the batch `Val` alongside existing `actions.executed` bumps (success / failed / retried_success / retried_failed).
- `apps/emqx_dashboard/*`: wire `actions_messages` into the monitor sampler and rate map so the dashboard API exposes `actions_messages` and `actions_messages_rate`.
- i18n descriptions added.

## PR Checklist
- [x] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)