### PR TITLE
fix(emqx_mt): format delivery_bytes rate with byte unit in API response

### DIFF
--- a/apps/emqx_mt/src/emqx_mt_api.erl
+++ b/apps/emqx_mt/src/emqx_mt_api.erl
@@ -916,6 +916,7 @@ limiter_config_out(Unit0, LimiterConfig) ->
     Unit =
         case Unit0 of
             bytes -> bytes;
+            delivery_bytes -> bytes;
             _ -> no_unit
         end,
     maps:map(


### PR DESCRIPTION
## Summary

`GET /mt/ns/:ns/config` rendered the `client.delivery_bytes` rate as a plain number (e.g. `1024/1s`) instead of the human-readable form (`1KB/1s`) used for `client.bytes` / `tenant.bytes`.

Root cause: `limiter_config_out/2` in `emqx_mt_api.erl` only matched the `bytes` key when selecting the byte unit for `emqx_limiter_schema:rate_to_str/2`. `delivery_bytes` fell through to `no_unit`.

Not released yet — internal fix.