### PR TITLE
feat(emqx_mt): add post_auth_tns_expression to reinit tns after authn

### DIFF
--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2456,15 +2456,17 @@ do_authenticate(
     Properties = #{'Authentication-Method' => AuthMethod},
     case emqx_access_control:authenticate(Credential) of
         {ok, AuthResult} ->
-            {ok, Properties, Channel#channel{
+            Channel1 = Channel#channel{
                 clientinfo = merge_auth_result(ClientInfo, AuthResult),
                 auth_cache = #{}
-            }};
+            },
+            with_post_authn(Channel1, Properties);
         {ok, AuthResult, AuthData} ->
-            {ok, Properties#{'Authentication-Data' => AuthData}, Channel#channel{
+            Channel1 = Channel#channel{
                 clientinfo = merge_auth_result(ClientInfo, AuthResult),
                 auth_cache = #{}
-            }};
+            },
+            with_post_authn(Channel1, Properties#{'Authentication-Data' => AuthData});
         {continue, AuthCache} ->
             {continue, Properties, Channel#channel{auth_cache = AuthCache}};
         {continue, AuthData, AuthCache} ->
@@ -2478,10 +2480,23 @@ do_authenticate(
 do_authenticate(Credential, #channel{clientinfo = ClientInfo} = Channel) ->
     case emqx_access_control:authenticate(Credential) of
         {ok, AuthResult} ->
-            {ok, #{}, Channel#channel{clientinfo = merge_auth_result(ClientInfo, AuthResult)}};
+            Channel1 = Channel#channel{clientinfo = merge_auth_result(ClientInfo, AuthResult)},
+            with_post_authn(Channel1, #{});
         {error, Reason} ->
             log_auth_failure(Reason),
             {error, emqx_reason_codes:connack_error(Reason)}
+    end.
+
+%% Runs the 'client.post_authn' hook with ClientInfo as the fold accumulator.
+%% A callback may return `{ok, NewClientInfo}' to replace ClientInfo, or
+%% `{stop, {error, Reason}}' to reject the client (treated like an authn failure).
+with_post_authn(#channel{clientinfo = ClientInfo} = Channel, Properties) ->
+    case run_hooks('client.post_authn', [], ClientInfo, Channel) of
+        {error, Reason} ->
+            log_auth_failure(Reason),
+            {error, emqx_reason_codes:connack_error(Reason)};
+        NewClientInfo when is_map(NewClientInfo) ->
+            {ok, Properties, Channel#channel{clientinfo = NewClientInfo}}
     end.
 
 log_auth_failure(Reason) ->

--- a/apps/emqx/src/emqx_channel.erl
+++ b/apps/emqx/src/emqx_channel.erl
@@ -2487,15 +2487,18 @@ do_authenticate(Credential, #channel{clientinfo = ClientInfo} = Channel) ->
             {error, emqx_reason_codes:connack_error(Reason)}
     end.
 
-%% Runs the 'client.post_authn' hook with ClientInfo as the fold accumulator.
-%% A callback may return `{ok, NewClientInfo}' to replace ClientInfo, or
-%% `{stop, {error, Reason}}' to reject the client (treated like an authn failure).
+%% Runs the 'client.post_authn' hook. The accumulator is a context map
+%% (`emqx_hookpoints:post_authn_context()'); a callback may return
+%% `{ok, NewContext}' to replace it, or `{stop, {error, Reason}}' to reject
+%% the client (treated like an authn failure). Using a map leaves room to
+%% pass additional inputs/outputs in the future without breaking callbacks.
 with_post_authn(#channel{clientinfo = ClientInfo} = Channel, Properties) ->
-    case run_hooks('client.post_authn', [], ClientInfo, Channel) of
+    Ctx0 = #{client_info => ClientInfo},
+    case run_hooks('client.post_authn', [], Ctx0, Channel) of
         {error, Reason} ->
             log_auth_failure(Reason),
             {error, emqx_reason_codes:connack_error(Reason)};
-        NewClientInfo when is_map(NewClientInfo) ->
+        #{client_info := NewClientInfo} ->
             {ok, Properties, Channel#channel{clientinfo = NewClientInfo}}
     end.
 

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -36,6 +36,7 @@
     'client.check_authz_complete',
     'client.check_authn_complete',
     'client.authenticate',
+    'client.post_authn',
     'client.subscribe',
     'client.unsubscribe',
     'client.timeout',
@@ -155,6 +156,9 @@ when
     emqx_types:clientinfo(), emqx_access_control:authenticate_hook_result()
 ) ->
     fold_callback_result(emqx_access_control:authenticate_hook_result()).
+
+-callback 'client.post_authn'(emqx_types:clientinfo()) ->
+    fold_callback_result(emqx_types:clientinfo() | {error, term()}).
 
 -callback 'client.subscribe'(emqx_types:clientinfo(), emqx_types:properties(), TopicFilters) ->
     fold_callback_result(TopicFilters)

--- a/apps/emqx/src/emqx_hookpoints.erl
+++ b/apps/emqx/src/emqx_hookpoints.erl
@@ -157,8 +157,17 @@ when
 ) ->
     fold_callback_result(emqx_access_control:authenticate_hook_result()).
 
--callback 'client.post_authn'(emqx_types:clientinfo()) ->
-    fold_callback_result(emqx_types:clientinfo() | {error, term()}).
+-type post_authn_context() :: #{
+    client_info := emqx_types:clientinfo()
+    %% Future-proofing: more input fields (e.g. conninfo) and/or extra output
+    %% fields (e.g. log_metadata) may be added without breaking callbacks that
+    %% ignore unknown keys.
+}.
+
+-export_type([post_authn_context/0]).
+
+-callback 'client.post_authn'(post_authn_context()) ->
+    fold_callback_result(post_authn_context() | {error, term()}).
 
 -callback 'client.subscribe'(emqx_types:clientinfo(), emqx_types:properties(), TopicFilters) ->
     fold_callback_result(TopicFilters)

--- a/apps/emqx/src/emqx_metrics.erl
+++ b/apps/emqx/src/emqx_metrics.erl
@@ -616,6 +616,7 @@ reserved_idx('rules.matched') -> 100;
 reserved_idx('actions.executed') -> 101;
 %% NOTE: idx 102 is reserved for 'delivery.dropped.filter' in release-62+
 reserved_idx('actions.messages') -> 103;
+reserved_idx('client.post_authn') -> 104;
 reserved_idx(_) -> undefined.
 
 all_metrics() ->
@@ -739,6 +740,7 @@ client_metrics() ->
         {counter, 'client.connack', ?DESC("client_connack")},
         {counter, 'client.connected', ?DESC("client_connected")},
         {counter, 'client.authenticate', ?DESC("client_authenticate")},
+        {counter, 'client.post_authn', ?DESC("client_post_authn")},
         {counter, 'client.auth.anonymous', ?DESC("client_auth_anonymous")},
         {counter, 'client.authorize', ?DESC("client_authorize")},
         {counter, 'client.subscribe', ?DESC("client_subscribe")},

--- a/apps/emqx_mt/include/emqx_mt.hrl
+++ b/apps/emqx_mt/include/emqx_mt.hrl
@@ -17,4 +17,8 @@
 -define(CONF_ROOT_KEY, multi_tenancy).
 -define(CONF_ROOT_KEY_BIN, <<"multi_tenancy">>).
 
+%% Matches the "unset" representations of a config value: undefined (key absent)
+%% and the empty binary (explicit empty string from hocon).
+-define(IS_NOT_SET(V), (V =:= undefined orelse V =:= <<>>)).
+
 -endif.

--- a/apps/emqx_mt/src/emqx_mt_config.erl
+++ b/apps/emqx_mt/src/emqx_mt_config.erl
@@ -16,6 +16,7 @@
     get_max_sessions/1,
     get_allow_only_managed_namespaces/0,
     set_allow_only_managed_namespaces/1,
+    get_post_auth_tns_expression/0,
 
     create_managed_ns/1,
     delete_managed_ns/1,
@@ -135,6 +136,18 @@ set_allow_only_managed_namespaces(Bool) ->
                 #{override_to => cluster}
             ),
         ok
+    end.
+
+-doc """
+Returns the compiled variform expression used to (re)initialize `client_attrs.tns`
+after the authentication chain has run. Returns `undefined` when the expression is
+not configured (empty string), in which case the post-authn hook is not registered.
+""".
+-spec get_post_auth_tns_expression() -> undefined | term().
+get_post_auth_tns_expression() ->
+    case emqx_config:get([multi_tenancy, post_auth_tns_expression], <<>>) of
+        V when ?IS_NOT_SET(V) -> undefined;
+        Compiled -> Compiled
     end.
 
 -spec get_managed_ns_config(emqx_mt:tns()) ->

--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -10,6 +10,7 @@
     unregister_hooks/0,
     on_session_created/2,
     on_authenticate/2,
+    on_post_authn/1,
     on_api_actor_will_be_created/2,
     on_namespace_resource_pre_create/2
 ]).
@@ -23,12 +24,14 @@
 -define(TRACE(MSG, META), ?TRACE("MULTI_TENANCY", MSG, META)).
 -define(SESSION_HOOK, {?MODULE, on_session_created, []}).
 -define(AUTHN_HOOK, {?MODULE, on_authenticate, []}).
+-define(POST_AUTHN_HOOK, {?MODULE, on_post_authn, []}).
 -define(LIMITER_HOOK, {emqx_mt_limiter, adjust_limiter, []}).
 -define(USER_CREATION_HOOK, {?MODULE, on_api_actor_will_be_created, []}).
 
 register_hooks() ->
     ok = emqx_hooks:add('session.created', ?SESSION_HOOK, ?HP_HIGHEST),
     ok = emqx_hooks:add('client.authenticate', ?AUTHN_HOOK, ?HP_HIGHEST),
+    ok = emqx_hooks:add('client.post_authn', ?POST_AUTHN_HOOK, ?HP_HIGHEST),
     ok = emqx_hooks:add('channel.limiter_adjustment', ?LIMITER_HOOK, ?HP_HIGHEST),
     ok = emqx_hooks:add('api_actor.pre_create', ?USER_CREATION_HOOK, ?HP_HIGHEST),
     ok = emqx_hooks:add(
@@ -41,6 +44,7 @@ register_hooks() ->
 unregister_hooks() ->
     ok = emqx_hooks:del('session.created', ?SESSION_HOOK),
     ok = emqx_hooks:del('client.authenticate', ?AUTHN_HOOK),
+    ok = emqx_hooks:del('client.post_authn', ?POST_AUTHN_HOOK),
     ok = emqx_hooks:del('channel.limiter_adjustment', ?LIMITER_HOOK),
     ok = emqx_hooks:del('api_actor.pre_create', ?USER_CREATION_HOOK),
     ok = emqx_hooks:del(
@@ -68,6 +72,7 @@ on_authenticate(
         undefined ->
             do_on_authenticate(ClientId, Tns, DefaultResult);
         #{} ->
+            ?TRACE("deny_due_to_namespace_config_errors", #{tns => Tns}),
             {stop, {error, server_unavailable}}
     end;
 on_authenticate(_, DefaultResult) ->
@@ -82,13 +87,20 @@ on_authenticate(_, DefaultResult) ->
     end.
 
 do_on_authenticate(ClientId, Tns, DefaultResult) ->
+    decide(ClientId, Tns, DefaultResult).
+
+%% Pure namespace/quota decision shared between the pre-auth `client.authenticate'
+%% and post-auth `client.post_authn' callbacks. `OnPass' is whatever the caller
+%% wants returned when the check passes (e.g. the auth-hook's DefaultResult, or a
+%% {ok, ClientInfo} for the post-authn path).
+decide(ClientId, Tns, OnPass) ->
     case emqx_mt_state:is_known_client(Tns, ClientId) of
         {true, Node} ->
             %% the client is re-connecting
             %% allow it to continue without checking the session count
             %% because the session count is already checked when the client is registered
             ?TRACE("existing_session_found", #{reside_in => Node}),
-            DefaultResult;
+            OnPass;
         false ->
             case emqx_mt_state:count_clients(Tns) of
                 {ok, Count} ->
@@ -99,7 +111,7 @@ do_on_authenticate(ClientId, Tns, DefaultResult) ->
                             {stop, {error, quota_exceeded}};
                         false ->
                             ?TRACE("session_count_quota_available", #{}),
-                            DefaultResult
+                            OnPass
                     end;
                 {error, not_found} ->
                     AllowOnlyManagedNSs = emqx_mt_config:get_allow_only_managed_namespaces(),
@@ -109,10 +121,55 @@ do_on_authenticate(ClientId, Tns, DefaultResult) ->
                             {stop, {error, not_authorized}};
                         false ->
                             ?TRACE("first_clientid_in_namespace", #{}),
-                            DefaultResult
+                            OnPass
                     end
             end
     end.
+
+%% Invoked on the `client.post_authn' hook. If the operator has configured
+%% `multi_tenancy.post_auth_tns_expression', evaluate it against the merged
+%% ClientInfo (which already contains pre-auth + authn-response client_attrs),
+%% write the rendered value into `client_attrs.tns', and run namespace/quota
+%% checks against that value.
+%%
+%% Returns:
+%%   * `ok' or unchanged ClientInfo to accept without modification;
+%%   * `{ok, NewClientInfo}' to replace the accumulator (with rewritten tns);
+%%   * `{stop, {error, Reason}}' to reject the client with a CONNACK error.
+on_post_authn(#{clientid := ClientId} = ClientInfo) ->
+    case emqx_mt_config:get_post_auth_tns_expression() of
+        undefined -> ok;
+        Compiled -> eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo)
+    end.
+
+eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo) ->
+    case emqx_variform:render(Compiled, ClientInfo) of
+        {ok, <<>>} ->
+            ?TRACE("post_auth_tns_expression_rendered_empty", #{}),
+            ok;
+        {ok, Tns} ->
+            decide_with_rewritten_tns(ClientId, Tns, ClientInfo);
+        {error, Reason} ->
+            ?SLOG(
+                warning,
+                #{msg => "post_auth_tns_expression_error", reason => Reason},
+                #{clientid => ClientId}
+            ),
+            ok
+    end.
+
+decide_with_rewritten_tns(ClientId, Tns, ClientInfo) ->
+    case emqx_config:get_namespace_config_errors(Tns) of
+        undefined ->
+            decide(ClientId, Tns, {ok, set_tns(ClientInfo, Tns)});
+        #{} ->
+            ?TRACE("deny_due_to_namespace_config_errors", #{tns => Tns}),
+            {stop, {error, server_unavailable}}
+    end.
+
+set_tns(ClientInfo, Tns) ->
+    Attrs = maps:get(client_attrs, ClientInfo, #{}),
+    ClientInfo#{client_attrs => Attrs#{?CLIENT_ATTR_NAME_TNS => Tns}}.
 
 on_api_actor_will_be_created(#{?namespace := ?global_ns}, Ok) ->
     Ok;

--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -132,23 +132,24 @@ decide(ClientId, Tns, OnPass) ->
 %% write the rendered value into `client_attrs.tns', and run namespace/quota
 %% checks against that value.
 %%
-%% Returns:
-%%   * `ok' or unchanged ClientInfo to accept without modification;
-%%   * `{ok, NewClientInfo}' to replace the accumulator (with rewritten tns);
+%% The accumulator is a `post_authn_context()' map (currently `#{client_info
+%% := ClientInfo}'). Returns:
+%%   * `ok' to accept without modification;
+%%   * `{ok, NewCtx}' to replace the accumulator (with rewritten tns);
 %%   * `{stop, {error, Reason}}' to reject the client with a CONNACK error.
-on_post_authn(#{clientid := ClientId} = ClientInfo) ->
+on_post_authn(#{client_info := #{clientid := ClientId} = ClientInfo} = Ctx) ->
     case emqx_mt_config:get_post_auth_tns_expression() of
         undefined -> ok;
-        Compiled -> eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo)
+        Compiled -> eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo, Ctx)
     end.
 
-eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo) ->
+eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo, Ctx) ->
     case emqx_variform:render(Compiled, ClientInfo) of
         {ok, <<>>} ->
             ?TRACE("post_auth_tns_expression_rendered_empty", #{}),
             ok;
         {ok, Tns} ->
-            decide_with_rewritten_tns(ClientId, Tns, ClientInfo);
+            decide_with_rewritten_tns(ClientId, Tns, ClientInfo, Ctx);
         {error, Reason} ->
             ?SLOG(
                 warning,
@@ -158,10 +159,10 @@ eval_post_auth_tns_expression(Compiled, ClientId, ClientInfo) ->
             ok
     end.
 
-decide_with_rewritten_tns(ClientId, Tns, ClientInfo) ->
+decide_with_rewritten_tns(ClientId, Tns, ClientInfo, Ctx) ->
     case emqx_config:get_namespace_config_errors(Tns) of
         undefined ->
-            decide(ClientId, Tns, {ok, set_tns(ClientInfo, Tns)});
+            decide(ClientId, Tns, {ok, Ctx#{client_info := set_tns(ClientInfo, Tns)}});
         #{} ->
             ?TRACE("deny_due_to_namespace_config_errors", #{tns => Tns}),
             {stop, {error, server_unavailable}}

--- a/apps/emqx_mt/src/emqx_mt_schema.erl
+++ b/apps/emqx_mt/src/emqx_mt_schema.erl
@@ -24,6 +24,7 @@
 -reflect_type([default_max_sessions/0]).
 -typerefl_from_string({default_max_sessions/0, emqx_mt_schema, to_default_max_sessions}).
 -export([to_default_max_sessions/1]).
+-export([compile_post_auth_tns_expression/2]).
 
 namespace() -> emqx_mt.
 
@@ -51,6 +52,16 @@ fields("config") ->
                     importance => ?IMPORTANCE_HIGH,
                     default => false
                 }
+            )},
+        {post_auth_tns_expression,
+            mk(
+                typerefl:alias("string", any()),
+                #{
+                    desc => ?DESC("post_auth_tns_expression"),
+                    importance => ?IMPORTANCE_MEDIUM,
+                    default => <<>>,
+                    converter => fun compile_post_auth_tns_expression/2
+                }
             )}
     ].
 
@@ -64,4 +75,22 @@ to_default_max_sessions(Val) ->
     maybe
         {error, _} ?= typerefl:from_string(default_max_sessions_internal(), Val),
         {error, "Bad value: expecting `infinity` or positive integer"}
+    end.
+
+%% Empty string / undefined means "disabled". Otherwise compile via emqx_variform.
+compile_post_auth_tns_expression(undefined, _Opts) ->
+    undefined;
+compile_post_auth_tns_expression(<<>>, _Opts) ->
+    <<>>;
+compile_post_auth_tns_expression("", _Opts) ->
+    <<>>;
+compile_post_auth_tns_expression(Expression, #{make_serializable := true}) ->
+    case is_binary(Expression) of
+        true -> Expression;
+        false -> emqx_variform:decompile(Expression)
+    end;
+compile_post_auth_tns_expression(Expression, _Opts) ->
+    case emqx_variform:compile(Expression) of
+        {ok, Compiled} -> Compiled;
+        {error, Reason} -> throw(#{expression => Expression, reason => Reason})
     end.

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -1458,7 +1458,7 @@ t_post_auth_tns_expression_disabled(_Config) ->
         username => <<"u1">>,
         client_attrs => #{<<"tns">> => <<"preauth">>}
     },
-    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(ClientInfo)).
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})).
 
 -doc "Expression reads client_attrs.tag and rewrites client_attrs.tns.".
 t_post_auth_tns_expression_reads_client_attrs_tag({init, Config}) ->
@@ -1473,8 +1473,10 @@ t_post_auth_tns_expression_reads_client_attrs_tag(_Config) ->
         client_attrs => #{<<"tag">> => <<"acme">>}
     },
     ?assertMatch(
-        {ok, #{client_attrs := #{<<"tns">> := <<"acme">>, <<"tag">> := <<"acme">>}}},
-        emqx_mt_hookcb:on_post_authn(ClientInfo)
+        {ok, #{
+            client_info := #{client_attrs := #{<<"tns">> := <<"acme">>, <<"tag">> := <<"acme">>}}
+        }},
+        emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})
     ).
 
 -doc "coalesce(client_attrs.tag, username) falls back to username when no tag.".
@@ -1490,8 +1492,8 @@ t_post_auth_tns_expression_coalesce_fallback(_Config) ->
         client_attrs => #{<<"tag">> => <<"acme">>}
     },
     ?assertMatch(
-        {ok, #{client_attrs := #{<<"tns">> := <<"acme">>}}},
-        emqx_mt_hookcb:on_post_authn(CI1)
+        {ok, #{client_info := #{client_attrs := #{<<"tns">> := <<"acme">>}}}},
+        emqx_mt_hookcb:on_post_authn(#{client_info => CI1})
     ),
     CI2 = #{
         clientid => <<"c2">>,
@@ -1499,8 +1501,8 @@ t_post_auth_tns_expression_coalesce_fallback(_Config) ->
         client_attrs => #{}
     },
     ?assertMatch(
-        {ok, #{client_attrs := #{<<"tns">> := <<"alice">>}}},
-        emqx_mt_hookcb:on_post_authn(CI2)
+        {ok, #{client_info := #{client_attrs := #{<<"tns">> := <<"alice">>}}}},
+        emqx_mt_hookcb:on_post_authn(#{client_info => CI2})
     ).
 
 -doc "When expression renders empty, ClientInfo is left unchanged (pre-auth tns kept).".
@@ -1515,7 +1517,7 @@ t_post_auth_tns_expression_empty_render_keeps_preauth(_Config) ->
         username => <<"alice">>,
         client_attrs => #{<<"tns">> => <<"preauth">>}
     },
-    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(ClientInfo)).
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})).
 
 -doc "Expression errors are logged and treated as no-op (client not rejected).".
 t_post_auth_tns_expression_error_is_noop({init, Config}) ->
@@ -1529,7 +1531,7 @@ t_post_auth_tns_expression_error_is_noop(_Config) ->
         username => <<"alice">>,
         client_attrs => #{}
     },
-    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(ClientInfo)).
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})).
 
 -doc "After rewriting tns, decide/3 enforces the namespace quota.".
 t_post_auth_tns_expression_quota_enforced({init, Config}) ->
@@ -1560,7 +1562,7 @@ t_post_auth_tns_expression_quota_enforced(_Config) ->
     },
     ?assertMatch(
         {stop, {error, quota_exceeded}},
-        emqx_mt_hookcb:on_post_authn(ClientInfo)
+        emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})
     ),
     ok = emqtt:stop(Pid1).
 

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -1429,3 +1429,194 @@ t_delete_namespace_with_managed_certs(TCConfig) when is_list(TCConfig) ->
         )
     ),
     ok.
+
+%%------------------------------------------------------------------------------
+%% post_auth_tns_expression
+%%------------------------------------------------------------------------------
+
+set_post_auth_tns_expression(<<>>) ->
+    emqx_config:put([multi_tenancy, post_auth_tns_expression], <<>>),
+    ok;
+set_post_auth_tns_expression(Expr) when is_binary(Expr) ->
+    {ok, Compiled} = emqx_variform:compile(Expr),
+    emqx_config:put([multi_tenancy, post_auth_tns_expression], Compiled),
+    ok.
+
+clear_post_auth_tns_expression() ->
+    set_post_auth_tns_expression(<<>>).
+
+-doc "Sanity: when expression is unset, post-authn hook leaves ClientInfo untouched.".
+t_post_auth_tns_expression_disabled({init, Config}) ->
+    ok = clear_post_auth_tns_expression(),
+    Config;
+t_post_auth_tns_expression_disabled({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression();
+t_post_auth_tns_expression_disabled(_Config) ->
+    ?assertEqual(undefined, emqx_mt_config:get_post_auth_tns_expression()),
+    ClientInfo = #{
+        clientid => <<"c1">>,
+        username => <<"u1">>,
+        client_attrs => #{<<"tns">> => <<"preauth">>}
+    },
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(ClientInfo)).
+
+-doc "Expression reads client_attrs.tag and rewrites client_attrs.tns.".
+t_post_auth_tns_expression_reads_client_attrs_tag({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"client_attrs.tag">>),
+    Config;
+t_post_auth_tns_expression_reads_client_attrs_tag({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression();
+t_post_auth_tns_expression_reads_client_attrs_tag(_Config) ->
+    ClientInfo = #{
+        clientid => <<"c1">>,
+        username => <<"u1">>,
+        client_attrs => #{<<"tag">> => <<"acme">>}
+    },
+    ?assertMatch(
+        {ok, #{client_attrs := #{<<"tns">> := <<"acme">>, <<"tag">> := <<"acme">>}}},
+        emqx_mt_hookcb:on_post_authn(ClientInfo)
+    ).
+
+-doc "coalesce(client_attrs.tag, username) falls back to username when no tag.".
+t_post_auth_tns_expression_coalesce_fallback({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"coalesce(client_attrs.tag, username)">>),
+    Config;
+t_post_auth_tns_expression_coalesce_fallback({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression();
+t_post_auth_tns_expression_coalesce_fallback(_Config) ->
+    CI1 = #{
+        clientid => <<"c1">>,
+        username => <<"alice">>,
+        client_attrs => #{<<"tag">> => <<"acme">>}
+    },
+    ?assertMatch(
+        {ok, #{client_attrs := #{<<"tns">> := <<"acme">>}}},
+        emqx_mt_hookcb:on_post_authn(CI1)
+    ),
+    CI2 = #{
+        clientid => <<"c2">>,
+        username => <<"alice">>,
+        client_attrs => #{}
+    },
+    ?assertMatch(
+        {ok, #{client_attrs := #{<<"tns">> := <<"alice">>}}},
+        emqx_mt_hookcb:on_post_authn(CI2)
+    ).
+
+-doc "When expression renders empty, ClientInfo is left unchanged (pre-auth tns kept).".
+t_post_auth_tns_expression_empty_render_keeps_preauth({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"client_attrs.tag">>),
+    Config;
+t_post_auth_tns_expression_empty_render_keeps_preauth({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression();
+t_post_auth_tns_expression_empty_render_keeps_preauth(_Config) ->
+    ClientInfo = #{
+        clientid => <<"c1">>,
+        username => <<"alice">>,
+        client_attrs => #{<<"tns">> => <<"preauth">>}
+    },
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(ClientInfo)).
+
+-doc "Expression errors are logged and treated as no-op (client not rejected).".
+t_post_auth_tns_expression_error_is_noop({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"nth(100, tokens('a', ','))">>),
+    Config;
+t_post_auth_tns_expression_error_is_noop({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression();
+t_post_auth_tns_expression_error_is_noop(_Config) ->
+    ClientInfo = #{
+        clientid => <<"c1">>,
+        username => <<"alice">>,
+        client_attrs => #{}
+    },
+    ?assertEqual(ok, emqx_mt_hookcb:on_post_authn(ClientInfo)).
+
+-doc "After rewriting tns, decide/3 enforces the namespace quota.".
+t_post_auth_tns_expression_quota_enforced({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"client_attrs.tag">>),
+    emqx_mt_config:tmp_set_default_max_sessions(1),
+    Config;
+t_post_auth_tns_expression_quota_enforced({'end', _Config}) ->
+    emqx_mt_config:tmp_set_default_max_sessions(infinity),
+    ok = clear_post_auth_tns_expression();
+t_post_auth_tns_expression_quota_enforced(_Config) ->
+    Ns = <<"acme_quota">>,
+    C1 = ?NEW_CLIENTID(),
+    C2 = ?NEW_CLIENTID(),
+    %% First client occupies the namespace via the normal pre-auth path
+    %% (mqtt.client_attrs_init sets tns=username) so we register a real session.
+    Pid1 = connect(C1, Ns),
+    ?assertMatch(
+        {ok, #{tns := Ns, clientid := C1}},
+        ?block_until(#{?snk_kind := multi_tenant_client_added}, 3000)
+    ),
+    ?assertEqual({ok, 1}, emqx_mt:count_clients(Ns)),
+    %% Now simulate a post-authn evaluation for a different client that the
+    %% expression routes into the same namespace via client_attrs.tag.
+    ClientInfo = #{
+        clientid => C2,
+        username => <<"someone_else">>,
+        client_attrs => #{<<"tag">> => Ns}
+    },
+    ?assertMatch(
+        {stop, {error, quota_exceeded}},
+        emqx_mt_hookcb:on_post_authn(ClientInfo)
+    ),
+    ok = emqtt:stop(Pid1).
+
+-doc """
+End-to-end: authentication returns `client_attrs.tns` and the post-authn
+expression `client_attrs.tns` forwards it into the namespace check.
+When `allow_only_managed_namespaces = true` and the auth-supplied namespace
+is not an explicitly managed namespace, the client is disconnected; when it
+is managed, the client is allowed.
+""".
+t_post_auth_expression_gates_on_managed_ns({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"client_attrs.tns">>),
+    emqx_config:put([multi_tenancy, allow_only_managed_namespaces], true),
+    %% Bootstrap namespaces: pre-auth tns (derived from username by the suite's
+    %% `mqtt.client_attrs_init`) must already be managed, otherwise the pre-auth
+    %% hook rejects before the authn chain runs.
+    ok = emqx_mt_config:create_managed_ns(<<"user_good">>),
+    ok = emqx_mt_config:create_managed_ns(<<"user_bad">>),
+    ok = emqx_mt_config:create_managed_ns(<<"acme">>),
+    ok = emqx_hooks:add(
+        'client.authenticate', {?MODULE, authn_inject_tns, []}, 975
+    ),
+    on_exit(fun() ->
+        emqx_hooks:del('client.authenticate', {?MODULE, authn_inject_tns})
+    end),
+    Config;
+t_post_auth_expression_gates_on_managed_ns({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression(),
+    emqx_config:put([multi_tenancy, allow_only_managed_namespaces], false),
+    _ = emqx_mt_config:delete_managed_ns(<<"user_good">>),
+    _ = emqx_mt_config:delete_managed_ns(<<"user_bad">>),
+    _ = emqx_mt_config:delete_managed_ns(<<"acme">>),
+    ok;
+t_post_auth_expression_gates_on_managed_ns(_Config) ->
+    %% Auth returns `client_attrs.tns = "acme"` which IS a managed namespace;
+    %% the client must connect and be registered under "acme".
+    GoodCid = ?NEW_CLIENTID(),
+    Pid1 = connect(GoodCid, <<"user_good">>),
+    ?assertMatch(
+        {ok, #{tns := <<"acme">>, clientid := GoodCid}},
+        ?block_until(#{?snk_kind := multi_tenant_client_added}, 3000)
+    ),
+    ?assertEqual({ok, 1}, emqx_mt:count_clients(<<"acme">>)),
+    ok = emqtt:stop(Pid1),
+    %% Auth returns `client_attrs.tns = "ghost"` which is NOT managed;
+    %% the client must be rejected at post-authn with `not_authorized`.
+    BadCid = ?NEW_CLIENTID(),
+    ?assertError(
+        {error, {not_authorized, _}},
+        connect(BadCid, <<"user_bad">>)
+    ),
+    ok.
+
+authn_inject_tns(#{username := <<"user_good">>}, _Acc) ->
+    {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tns">> => <<"acme">>}}}};
+authn_inject_tns(#{username := <<"user_bad">>}, _Acc) ->
+    {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tns">> => <<"ghost">>}}}};
+authn_inject_tns(_ClientInfo, Acc) ->
+    {ok, Acc}.

--- a/changes/ee/feat-17053.en.md
+++ b/changes/ee/feat-17053.en.md
@@ -1,0 +1,7 @@
+Added a new multi-tenancy configuration option `multi_tenancy.post_auth_tns_expression`.
+
+When configured, it is a [Variform](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#variform-expressions) expression evaluated after the authentication chain completes. Its rendered value is written into `client_attrs.tns`, the tenant namespace key used by multi-tenancy quota and routing decisions.
+
+This lets operators derive the tenant namespace from authentication-response attributes (for example, a `tag` field returned by an HTTP auth backend) instead of relying only on pre-authentication `mqtt.client_attrs_init`. Example expressions: `client_attrs.tag`, or with a fallback `coalesce(client_attrs.tag, username)`.
+
+When the expression is empty (default), behavior is unchanged.

--- a/rel/i18n/emqx_metrics.hocon
+++ b/rel/i18n/emqx_metrics.hocon
@@ -230,6 +230,9 @@ emqx_metrics {
     client_authenticate {
         desc: "Number of client Authentication"
     }
+    client_post_authn {
+        desc: "Number of invocations of the 'client.post_authn' hook (runs after the authentication chain succeeds)"
+    }
     client_auth_anonymous {
         desc: "Number of clients who log in anonymously"
     }

--- a/rel/i18n/emqx_mt_schema.hocon
+++ b/rel/i18n/emqx_mt_schema.hocon
@@ -17,4 +17,24 @@ emqx_mt_schema {
             will also be denied connection.~"""
         label: "Allow only managed namespaces"
     }
+    post_auth_tns_expression {
+        desc: """~
+            An expression that is evaluated after the authentication chain completes,
+            and whose rendered value is written back into `client_attrs.tns`, the
+            tenant namespace key used by multi-tenancy quota and routing decisions.
+            Leave empty to disable (default). When empty, multi-tenancy resolves
+            `tns` only from `mqtt.client_attrs_init` (evaluated before authentication).
+            When configured, the expression can reference any binding available to
+            `mqtt.client_attrs_init` (for example, <code>username</code>,
+            <code>clientid</code>, <code>cert_common_name</code>) plus
+            <code>client_attrs.*</code> (merged pre-auth and authentication-response
+            attributes). Example: <code>client_attrs.tag</code> makes the multi-tenancy
+            app treat an auth-server-supplied <code>tag</code> attribute as the
+            tenant namespace. Example with fallback:
+            <code>coalesce(client_attrs.tag, username)</code>.
+            If the expression renders to an empty string, the existing
+            <code>tns</code> value (if any) is kept. If the expression errors, a
+            warning is logged and the client is treated as having no <code>tns</code>.~"""
+        label: "Post-authentication tns expression"
+    }
 }


### PR DESCRIPTION
Fixes <issue-or-jira-number>

Release version: 6.1.2, 6.2.1

## Summary

Adds a new multi-tenancy config `multi_tenancy.post_auth_tns_expression` (a [Variform](https://docs.emqx.com/en/emqx/latest/configuration/configuration.html#variform-expressions) expression; empty by default = disabled) to derive `client_attrs.tns` from authentication-response attributes such as a `tag` returned by an HTTP auth backend.

Because the existing `client.authenticate` hook fold short-circuits on `{stop, _}` when the authn chain completes, emqx_mt (which hooks at `?HP_HIGHEST`) cannot see auth-response attributes there. This PR introduces a new hook `client.post_authn` fired from `emqx_channel:do_authenticate/2` after `merge_auth_result/2`. emqx_mt registers on it: when the expression is configured it is evaluated against the merged `ClientInfo`, the rendered value replaces `client_attrs.tns`, and the namespace quota check runs against the new value. Empty render keeps pre-auth tns; render error is logged and treated as no-op.

Key files:
- `apps/emqx/src/emqx_channel.erl` — new hook fired after authn success.
- `apps/emqx/src/emqx_hookpoints.erl` — register `client.post_authn` hookpoint.
- `apps/emqx/src/emqx_metrics.erl`, `rel/i18n/emqx_metrics.hocon` — metric counter.
- `apps/emqx_mt/src/emqx_mt_schema.erl` — new field with Variform compile converter.
- `apps/emqx_mt/src/emqx_mt_config.erl` — `get_post_auth_tns_expression/0`.
- `apps/emqx_mt/src/emqx_mt_hookcb.erl` — register `on_post_authn/1`, shared `decide/3` helper.
- `rel/i18n/emqx_mt_schema.hocon` — description with examples.
- `apps/emqx_mt/test/emqx_mt_SUITE.erl` — six new CT cases covering disabled/tag/coalesce/empty/error/quota paths.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)