### PR TITLE
fix(dsraft): use `quorum` machine upgrade strategy

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
@@ -146,8 +146,10 @@ init({#?db_sup{db = DB}, [_Create, Schema, RTConf]}) ->
     DefaultOpts = maps:merge(Schema, RTConf),
     emqx_ds_builtin_metrics:init_for_db(DB),
     Opts = emqx_ds_builtin_raft_meta:open_db(DB, DefaultOpts),
-    ok = start_ra_system(DB, Opts),
+    Setup = fun() -> start_ra_system(DB, Opts) end,
+    Teardown = fun() -> stop_ra_system(DB) end,
     Children = [
+        emqx_ds_lib:autoclean(db_autoclean, 5_000, Setup, Teardown),
         liveness_spec(DB),
         sup_spec(#?shards_sup{db = DB}, []),
         shard_allocator_spec(DB)
@@ -204,7 +206,16 @@ start_ra_system(DB, #{replication_options := ReplicationOpts}) ->
             name => DB,
             data_dir => DataDir,
             wal_data_dir => DataDir,
-            names => ra_system:derive_names(DB)
+            names => ra_system:derive_names(DB),
+            %% NOTE
+            %% Require quorum to bump effective machine version.
+            %% 1. EMQX 6.2.0+ relies on machine upgrade to start serving DS APIs.
+            %%    Using `quorum` instead of `all` helps restore the service sooner
+            %%    during rolling updates.
+            %% 2. In specific circumstances, machine upgrade may become stuck after
+            %%    a rolling update, and extra leader re-election is needed to push
+            %%    it through. Doing upgrade earlier prevents it.
+            machine_upgrade_strategy => quorum
         },
         maps:with(
             [
@@ -223,6 +234,9 @@ start_ra_system(DB, #{replication_options := ReplicationOpts}) ->
         {error, {already_started, _System}} ->
             ok
     end.
+
+stop_ra_system(DB) ->
+    ra_system:stop(DB).
 
 %%================================================================================
 %% Internal exports

--- a/changes/ee/fix-17055.en.md
+++ b/changes/ee/fix-17055.en.md
@@ -1,0 +1,1 @@
+Fixed an issue where the internal DS Raft upgrade mechanism could become stuck under specific circumstances during a rolling upgrade to EMQX 6.2.0 release, rendering Durable Storage temporarily unavailable until core nodes were restarted. 


### PR DESCRIPTION
Release version: 6.2.1

## Summary

This PR switches `ra` to use `quorum` strategy to bump effective machine version.
1. EMQX 6.2.0+ relies on machine upgrade to start serving DS APIs. Using `quorum` instead of `all` helps restore the service sooner during rolling updates.
2. In specific circumstances, machine upgrade may become stuck during a rolling update, and extra leader re-election is needed to push it through. Doing upgrade earlier prevents it.

## PR Checklist

- [ ] The changes are covered with new or existing tests
    Tested semi-manually through EMQX Operator version upgrade testsuite.
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
