### PR TITLE
fix(dsraft): make drop DB propagate through cluster correctly

### DIFF
--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -380,14 +380,10 @@ drop_slab(DB, {Shard, Generation}) ->
 -spec drop_db(emqx_ds:db()) -> ok | {error, _}.
 drop_db(DB) ->
     foreach_shard(DB, fun(Shard) ->
-        {ok, _} = ra:delete_cluster(
-            emqx_ds_builtin_raft_shard:shard_servers(DB, Shard), ra_timeout(DB)
-        )
+        ok = emqx_ds_builtin_raft_shard:drop(DB, Shard, ra_timeout(DB))
     end),
     _ = emqx_ds_builtin_raft_proto_v1:drop_db(list_nodes(), DB),
-    emqx_ds_builtin_raft_meta:drop_db(DB),
-    _ = emqx_ds:close_db(DB),
-    emqx_dsch:drop_db_schema(DB).
+    emqx_ds_builtin_raft_meta:drop_db(DB).
 
 -spec db_group_stats(emqx_ds:db_group(), emqx_ds_storage_layer:db_group()) ->
     {ok, emqx_ds:db_group_stats()} | emqx_ds:error(_).
@@ -890,16 +886,21 @@ wait_replicas(DB, Timeout) ->
 %% RPC targets
 %%================================================================================
 
+-doc """
+Drops all storage data and runtime state belonging to the specifed DS DB on the local node.
+""".
 -spec do_drop_db_v1(emqx_ds:db()) -> ok | {error, _}.
 do_drop_db_v1(DB) ->
-    MyShards = emqx_ds_builtin_raft_meta:my_shards(DB),
-    emqx_ds_builtin_raft_sup:stop_db(DB),
-    lists:foreach(
-        fun(Shard) ->
-            emqx_ds_storage_layer:drop_shard({DB, Shard})
-        end,
-        MyShards
-    ).
+    maybe
+        ok ?= emqx_ds:close_db(DB),
+        lists:foreach(
+            fun(Shard) ->
+                emqx_ds_storage_layer:drop_shard({DB, Shard})
+            end,
+            emqx_ds_builtin_raft_meta:my_shards(DB)
+        ),
+        emqx_dsch:drop_db_schema(DB)
+    end.
 
 -spec do_get_streams_v1(
     emqx_ds:db(),

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -893,6 +893,7 @@ Drops all storage data and runtime state belonging to the specifed DS DB on the 
 do_drop_db_v1(DB) ->
     maybe
         ok ?= emqx_ds:close_db(DB),
+        emqx_ds_builtin_raft_db_sup:drop_db(DB),
         lists:foreach(
             fun(Shard) ->
                 emqx_ds_storage_layer:drop_shard({DB, Shard})

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -719,6 +719,10 @@ update_iterator(ShardId, #'Iterator'{} = Iter, DSKey) ->
     {emqx_ds_builtin_raft_shard_otx, CLUSTER, DB, SHARD}
 ).
 
+-define(ra_server_shutdown_reason(R),
+    (R =:= normal orelse R =:= shutdown orelse element(1, R) =:= shutdown)
+).
+
 otx_get_tx_serial(DB, Shard) ->
     emqx_ds_storage_layer_ttv:get_read_tx_serial({DB, Shard}).
 
@@ -769,7 +773,7 @@ otx_commit_tx_batch({DB, Shard}, SerCtl, Serial, Timestamp, Batches) ->
                     Err;
                 {error, noproc} ->
                     ?err_rec(local_leader_stopped);
-                {error, Reason} when Reason =:= normal orelse Reason =:= shutdown ->
+                {error, Reason} when ?ra_server_shutdown_reason(Reason) ->
                     ?err_rec(local_leader_terminated);
                 Err ->
                     ?err_rec({raft, Err, ?FUNCTION_NAME})
@@ -787,7 +791,7 @@ otx_add_generation(DB, Shard, Since) ->
                     Ret;
                 {error, noproc} ->
                     ?err_rec(local_leader_stopped);
-                {error, Reason} when Reason =:= normal orelse Reason =:= shutdown ->
+                {error, Reason} when ?ra_server_shutdown_reason(Reason) ->
                     ?err_rec(local_leader_terminated);
                 Err ->
                     ?err_rec({raft, Err, ?FUNCTION_NAME})
@@ -988,7 +992,7 @@ announce_otx_leader_pid(Leader, Timeout, Pid) ->
             ?err_rec({leadership_gone, #{Leader => OtherLeader}});
         {error, noproc} ->
             ?err_rec(local_leader_stopped);
-        {error, Reason} when Reason =:= normal orelse Reason =:= shutdown ->
+        {error, Reason} when ?ra_server_shutdown_reason(Reason) ->
             ?err_rec(local_leader_terminated);
         Err ->
             ?err_rec({raft, Err, ?FUNCTION_NAME})
@@ -1186,7 +1190,7 @@ local_raft_leader(DB, Shard) ->
             ?err_rec(local_leader_timeout);
         {error, noproc} ->
             ?err_rec(local_leader_stopped);
-        {error, Reason} when Reason =:= normal orelse Reason =:= shutdown ->
+        {error, Reason} when ?ra_server_shutdown_reason(Reason) ->
             ?err_rec(local_leader_terminated);
         Other ->
             ?err_unrec({invalid_response_from_local_leader, Other})

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft.erl
@@ -897,7 +897,7 @@ Drops all storage data and runtime state belonging to the specifed DS DB on the 
 do_drop_db_v1(DB) ->
     maybe
         ok ?= emqx_ds:close_db(DB),
-        emqx_ds_builtin_raft_db_sup:drop_db(DB),
+        _ = emqx_ds_builtin_raft_db_sup:drop_db(DB),
         lists:foreach(
             fun(Shard) ->
                 emqx_ds_storage_layer:drop_shard({DB, Shard})
@@ -1180,7 +1180,7 @@ communicate with the Raft machine.
     {ok, ra:server_id()} | {error, _, _}.
 local_raft_leader(DB, Shard) ->
     LocalServer = emqx_ds_builtin_raft_shard:local_server(DB, Shard),
-    case ra:ping(LocalServer, 1_000) of
+    case ra_ping(LocalServer) of
         {pong, leader} ->
             %% Local server still considers itself a leader:
             {ok, LocalServer};
@@ -1219,6 +1219,12 @@ ra_command(DB, Shard, Command, Retries) ->
         Error ->
             error(Error, [DB, Shard])
     end.
+
+-spec ra_ping(emqx_ds_builtin_raft_shard:server()) ->
+    {pong, leader | follower | candidate | atom()} | timeout | {error, any()}.
+ra_ping(Server) ->
+    %% NOTE: `ra:ping/2` is underspecified, silencing Dialyzer complaint.
+    apply(ra, ping, [Server, 1_000]).
 
 -spec foreach_shard(emqx_ds:db(), fun((emqx_ds:shard()) -> _)) -> ok.
 foreach_shard(DB, Fun) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
@@ -12,6 +12,7 @@
 -export([
     start_link_db/4,
     whereis_db/1,
+    drop_db/1,
 
     start_shard/1,
     stop_shard/1,
@@ -23,6 +24,7 @@
     start_otx_leader/2,
     stop_otx_leader/2
 ]).
+
 -export([which_dbs/0, which_shards/1]).
 
 %% behaviour callbacks:
@@ -59,6 +61,16 @@ start_link_db(DB, Create, Schema, RTConf) ->
 -spec whereis_db(emqx_ds:db()) -> pid() | undefined.
 whereis_db(DB) ->
     gproc:where(?name(#?db_sup{db = DB})).
+
+-doc "Drops all shared data belonging to the specified DS DB on the local node".
+-spec drop_db(emqx_ds:db()) -> ok | {error, not_found}.
+drop_db(DB) ->
+    case file:del_dir_r(ra_system_data_dir(DB)) of
+        ok ->
+            ok;
+        {error, _Posix} ->
+            {error, not_found}
+    end.
 
 -spec start_shard(emqx_ds_storage_layer:dbshard()) ->
     supervisor:startchild_ret().
@@ -199,7 +211,7 @@ init({#?shard_sup{db = DB, shard = Shard}, _}) ->
     {ok, {SupFlags, Children}}.
 
 start_ra_system(DB, #{replication_options := ReplicationOpts}) ->
-    DataDir = filename:join([emqx_ds_storage_layer:base_dir(), DB, dsrepl]),
+    DataDir = ra_system_data_dir(DB),
     Config = lists:foldr(fun maps:merge/2, #{}, [
         ra_system:default_config(),
         #{
@@ -237,6 +249,9 @@ start_ra_system(DB, #{replication_options := ReplicationOpts}) ->
 
 stop_ra_system(DB) ->
     ra_system:stop(DB).
+
+ra_system_data_dir(DB) ->
+    filename:join([emqx_ds_storage_layer:base_dir(), DB, dsrepl]).
 
 %%================================================================================
 %% Internal exports

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_db_sup.erl
@@ -63,13 +63,13 @@ whereis_db(DB) ->
     gproc:where(?name(#?db_sup{db = DB})).
 
 -doc "Drops all shared data belonging to the specified DS DB on the local node".
--spec drop_db(emqx_ds:db()) -> ok | {error, not_found}.
+-spec drop_db(emqx_ds:db()) -> ok | {error, atom()}.
 drop_db(DB) ->
     case file:del_dir_r(ra_system_data_dir(DB)) of
         ok ->
             ok;
-        {error, _Posix} ->
-            {error, not_found}
+        {error, Reason} ->
+            {error, Reason}
     end.
 
 -spec start_shard(emqx_ds_storage_layer:dbshard()) ->

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -836,8 +836,10 @@ shard_transition_trans(#?SHARD_TAB{shard = DBShard}, LockType) ->
 
 -spec drop_db_trans(emqx_ds:db()) -> ok.
 drop_db_trans(DB) ->
+    Shards = shards(DB),
     mnesia:delete({?META_TAB, DB}),
-    [mnesia:delete({?SHARD_TAB, Shard}) || Shard <- shards(DB)],
+    [mnesia:delete({?SHARD_TAB, {DB, Shard}}) || Shard <- Shards],
+    [mnesia:delete({?TRANSITION_TAB, {DB, Shard}}) || Shard <- Shards],
     ok.
 
 -spec claim_site_trans(site(), node()) -> ok.

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_meta.erl
@@ -589,7 +589,6 @@ unsubscribe(Pid) ->
 init([]) ->
     process_flag(trap_exit, true),
     logger:set_process_metadata(#{domain => [ds, meta]}),
-    ok = ekka:monitor(membership),
     ensure_tables(),
     run_migrations(),
     ensure_site(),
@@ -612,8 +611,6 @@ handle_info({mnesia_table_event, {write, #?SHARD_TAB{shard = {DB, Shard}}, _}}, 
     {noreply, S};
 handle_info({'DOWN', _MRef, process, Pid, _Reason}, S) ->
     {noreply, handle_unsubscribe(Pid, S)};
-handle_info({membership, {node, leaving, _Node}}, S) ->
-    {noreply, S};
 handle_info(_Info, S) ->
     {noreply, S}.
 

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
@@ -63,6 +63,8 @@
     terminate/2
 ]).
 
+-export_type([server/0]).
+
 -type server() :: ra:server_id().
 
 -type server_error() :: server_error(none()).

--- a/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
+++ b/apps/emqx_ds_builtin_raft/src/emqx_ds_builtin_raft_shard.erl
@@ -50,6 +50,9 @@
     is_quorum_reachable/2
 ]).
 
+%% Lifecycle
+-export([drop/3]).
+
 -behaviour(gen_server).
 -export([
     init/1,
@@ -460,6 +463,17 @@ is_quorum_reachable(DB, Shard) ->
 is_quorum_reachable(ShardServers) ->
     KnownShardServers = known_shard_servers(ShardServers),
     length(KnownShardServers) * 2 > length(ShardServers).
+
+%%
+
+-spec drop(emqx_ds:db(), emqx_ds:shard(), timeout()) -> ok | {error, any()}.
+drop(DB, Shard, Timeout) ->
+    case ra:delete_cluster(shard_servers(DB, Shard), Timeout) of
+        {ok, _Leader} ->
+            ok;
+        Error ->
+            Error
+    end.
 
 -spec server_metrics(server()) ->
     #{atom() => integer()} | undefined.

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -51,15 +51,6 @@ appspec(emqx_ds_builtin_raft) ->
         after_start => fun() -> logger:set_module_level(ra_server, info) end
     }}.
 
-t_metadata(init, Config) ->
-    Apps = emqx_cth_suite:start([emqx_ds_builtin_raft], #{
-        work_dir => ?config(work_dir, Config)
-    }),
-    [{apps, Apps} | Config];
-t_metadata('end', Config) ->
-    emqx_cth_suite:stop(?config(apps, Config)),
-    Config.
-
 -doc """
 This testcase verifies that the shard leader supervises optimistic
 transaction server (OTX).
@@ -185,6 +176,15 @@ t_leader_otx_supervion(Config) ->
         []
     ).
 
+t_metadata(init, Config) ->
+    Apps = emqx_cth_suite:start([emqx_ds_builtin_raft], #{
+        work_dir => ?config(work_dir, Config)
+    }),
+    [{apps, Apps} | Config];
+t_metadata('end', Config) ->
+    emqx_cth_suite:stop(?config(apps, Config)),
+    Config.
+
 t_metadata(_Config) ->
     DB = ?FUNCTION_NAME,
     NShards = 1,
@@ -267,13 +267,77 @@ t_shards_allocation(Config) ->
     emqx_ds_raft_test_helpers:assert_db_open([Node], DB, Opts),
     %% Forget the lost node.
     ?ON(Node, emqx_ds_builtin_raft_meta:forget_node(NodeLost)),
-    ?retry(
-        5_000,
-        5,
-        ?assertEqual(
-            [],
-            ?ON(Node, emqx_ds_builtin_raft_meta:sites(lost))
-        )
+    ?assertEqual([], ?ON(Node, emqx_ds_builtin_raft_meta:sites(lost))).
+
+%% This testcase verifies that dropping a DS DB cleans up all relevant state and data
+%% across the whole cluster.
+t_drop_replicated_db(init, Config) ->
+    Apps = [appspec(ra), appspec(emqx_durable_storage), appspec(emqx_ds_builtin_raft)],
+    NodeSpecs = emqx_cth_cluster:mk_nodespecs(
+        [
+            {t_drop_replicated_db1, #{apps => Apps}},
+            {t_drop_replicated_db2, #{apps => Apps}}
+        ],
+        #{work_dir => ?config(work_dir, Config)}
+    ),
+    Nodes = emqx_cth_cluster:start(NodeSpecs),
+    [{nodes, Nodes} | Config];
+t_drop_replicated_db('end', Config) ->
+    ok = emqx_cth_cluster:stop(?config(nodes, Config)).
+
+t_drop_replicated_db(Config) ->
+    Nodes = [N1 | _] = ?config(nodes, Config),
+    ?check_trace(
+        #{timetrap => 20_000},
+        begin
+            %% Initialize DB on all nodes and wait for it to be online.
+            Opts = opts(Config, #{n_shards => 16, n_sites => 2}),
+            emqx_ds_raft_test_helpers:assert_db_open(Nodes, ?DB, Opts),
+            ?assertEqual(
+                [16, 16],
+                [n_shards_online(N, ?DB) || N <- Nodes],
+                "Each site is responsible for each shard"
+            ),
+
+            %% Drop the DB.
+            ?assertEqual(ok, ?ON(N1, emqx_ds:drop_db(?DB)))
+        end,
+        [
+            check_membership_consistent(?DB, Nodes),
+            {"no DB metadata is present", fun(_Trace) ->
+                ?assertEqual(
+                    [false || _ <- Nodes],
+                    ?ON(Nodes, lists:member(?DB, emqx_ds_builtin_raft_meta:dbs()))
+                ),
+                ?assertEqual(
+                    [[] || _ <- Nodes],
+                    ?ON(Nodes, emqx_ds_builtin_raft_meta:shards(?DB))
+                )
+            end},
+            {"no DB processes are still running", fun(_Trace) ->
+                ?assertEqual(
+                    [undefined || _ <- Nodes],
+                    ?ON(Nodes, emqx_dsch:get_db_schema(?DB))
+                ),
+                ?assertEqual(
+                    [undefined || _ <- Nodes],
+                    ?ON(Nodes, emqx_ds_builtin_raft_db_sup:whereis_db(?DB))
+                )
+            end},
+            {"no leftover data files are present", fun(_Trace) ->
+                ?assertEqual(
+                    [[] || _ <- Nodes],
+                    ?ON(
+                        Nodes,
+                        emqx_utils_fs:traverse_dir(
+                            fun(AbsPath, _Info, Acc) -> [AbsPath | Acc] end,
+                            [],
+                            filename:join([emqx_ds_storage_layer:base_dir(), ?DB])
+                        )
+                    )
+                )
+            end}
+        ]
     ).
 
 t_replication_transfers_snapshots(init, Config) ->

--- a/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
+++ b/apps/emqx_ds_builtin_raft/test/emqx_ds_builtin_raft_SUITE.erl
@@ -300,31 +300,38 @@ t_drop_replicated_db(Config) ->
             ),
 
             %% Drop the DB.
-            ?assertEqual(ok, ?ON(N1, emqx_ds:drop_db(?DB)))
-        end,
-        [
-            check_membership_consistent(?DB, Nodes),
-            {"no DB metadata is present", fun(_Trace) ->
+            ?assertEqual(ok, ?ON(N1, emqx_ds:drop_db(?DB))),
+
+            %% Verify DB was dropped cleanly.
+            ?defer_assert(
                 ?assertEqual(
                     [false || _ <- Nodes],
-                    ?ON(Nodes, lists:member(?DB, emqx_ds_builtin_raft_meta:dbs()))
-                ),
+                    ?ON(Nodes, lists:member(?DB, emqx_ds_builtin_raft_meta:dbs())),
+                    "no DB metadata is present"
+                )
+            ),
+            ?defer_assert(
                 ?assertEqual(
                     [[] || _ <- Nodes],
-                    ?ON(Nodes, emqx_ds_builtin_raft_meta:shards(?DB))
+                    ?ON(Nodes, emqx_ds_builtin_raft_meta:shards(?DB)),
+                    "no DB shards metadata is present"
                 )
-            end},
-            {"no DB processes are still running", fun(_Trace) ->
+            ),
+            ?defer_assert(
                 ?assertEqual(
                     [undefined || _ <- Nodes],
-                    ?ON(Nodes, emqx_dsch:get_db_schema(?DB))
-                ),
+                    ?ON(Nodes, emqx_dsch:get_db_schema(?DB)),
+                    "no DB runtime schema is present"
+                )
+            ),
+            ?defer_assert(
                 ?assertEqual(
                     [undefined || _ <- Nodes],
-                    ?ON(Nodes, emqx_ds_builtin_raft_db_sup:whereis_db(?DB))
+                    ?ON(Nodes, emqx_ds_builtin_raft_db_sup:whereis_db(?DB)),
+                    "no DB processes are still running"
                 )
-            end},
-            {"no leftover data files are present", fun(_Trace) ->
+            ),
+            ?defer_assert(
                 ?assertEqual(
                     [[] || _ <- Nodes],
                     ?ON(
@@ -334,10 +341,12 @@ t_drop_replicated_db(Config) ->
                             [],
                             filename:join([emqx_ds_storage_layer:base_dir(), ?DB])
                         )
-                    )
+                    ),
+                    "no leftover data files remain"
                 )
-            end}
-        ]
+            )
+        end,
+        [check_membership_consistent(?DB, Nodes)]
     ).
 
 t_replication_transfers_snapshots(init, Config) ->


### PR DESCRIPTION
Release version: 6.2.1

## Summary

This PR fixes the `emqx_ds:drop_db/1` behavior so that all relevant data is purged across cluster:
* shard and replication storage,
* shared DB metadata,
* runtime DB schemas.

## PR Checklist

- [x] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible
