### PR TITLE
fix(backup): preserve node.cookie when restoring partial node config

### DIFF
--- a/apps/emqx_management/src/emqx_mgmt_data_backup.erl
+++ b/apps/emqx_management/src/emqx_mgmt_data_backup.erl
@@ -967,9 +967,10 @@ do_read_file(FileName) ->
 validate_cluster_hocon(RawConf) ->
     %% write ACL file to comply with the schema...
     RawConf1 = emqx_authz:maybe_write_files(RawConf),
+    MergedRawConf = emqx_utils_maps:deep_merge(emqx:get_raw_config([]), RawConf1),
     emqx_hocon:check(
         emqx_conf:schema_module(),
-        maps:merge(emqx:get_raw_config([]), RawConf1),
+        MergedRawConf,
         #{atom_key => false, required => false}
     ).
 

--- a/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
+++ b/apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl
@@ -261,6 +261,26 @@ t_export_cloud_subset(Config) ->
     ),
     ok.
 
+t_validate_cluster_hocon_preserve_node_cookie_on_partial_node_import(_Config) ->
+    meck:new(emqx, [passthrough]),
+    try
+        ExistingRawConf = #{
+            <<"node">> => #{
+                <<"name">> => <<"emqx@127.0.0.1">>,
+                <<"cookie">> => <<"test-cookie">>
+            }
+        },
+        ok = meck:expect(emqx, get_raw_config, 1, ExistingRawConf),
+        ImportedRawConf = #{
+            <<"node">> => #{
+                <<"name">> => <<"emqx@127.0.0.1">>
+            }
+        },
+        ?assertMatch({ok, _}, emqx_mgmt_data_backup:validate_cluster_hocon(ImportedRawConf))
+    after
+        meck:unload(emqx)
+    end.
+
 t_cluster_hocon_export_import(Config) ->
     RawConfBeforeImport = emqx:get_raw_config([]),
     BootstrapFile = filename:join(?config(data_dir, Config), ?BOOTSTRAP_BACKUP),

--- a/changes/ce/fix-17060.en.md
+++ b/changes/ce/fix-17060.en.md
@@ -1,0 +1,9 @@
+Fixed a backup restore validation regression when importing partial `node` config.
+
+Previously, restore validation used a shallow merge for raw configs. If the imported
+backup contained only part of `node` (for example, `node.name`), it could override the
+existing `node` map and effectively drop `node.cookie`, causing:
+`validation_error` on `node.cookie` with `required_field`.
+
+Now restore validation uses deep merge, so required nested fields such as
+`node.cookie` are preserved from existing config when omitted in imported partial maps.


### PR DESCRIPTION
Fixes N/A (QA report)

Release version: 5.10

## Summary

### Problem / Reproduction

When restoring a backup exported with scoped `root_keys` that include `node`, restore can fail with:

`400 BAD_REQUEST: {"kind":"validation_error","path":"node.cookie","reason":"required_field"}`

Reproduction (Dashboard):
1. Go to **Backup** -> **Export**.
2. Export with `root_keys` including `node`.
3. Go to **Restore** and import that backup.
4. Observe validation failure on `node.cookie`.

Root cause:
- `validate_cluster_hocon/1` merged current config and imported config with shallow `maps:merge/2`.
- If imported payload contains partial `node` config (for example, only `node.name`), it overwrites the whole existing `node` map and drops nested `node.cookie`.

### Fix

- Replace shallow merge with deep merge in `validate_cluster_hocon/1`:
  - `maps:merge(emqx:get_raw_config([]), RawConf1)`
  - -> `emqx_utils_maps:deep_merge(emqx:get_raw_config([]), RawConf1)`
- This preserves required nested fields (such as `node.cookie`) from existing config when imported partial maps do not carry them.

### Tests

Added regression coverage in:
- `apps/emqx_management/test/emqx_mgmt_data_backup_SUITE.erl`
- New case: `t_validate_cluster_hocon_preserve_node_cookie_on_partial_node_import`

The test verifies that a partial imported `node` map (without `cookie`) still passes validation when current raw config already has `node.cookie`.

### Change log

Added user-facing change log entry:
- `changes/ce/fix-17060.en.md`

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
