### PR TITLE
fix(authn): enforce namespace on authn user collection endpoints

### DIFF
--- a/apps/emqx_auth/mix.exs
+++ b/apps/emqx_auth/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXAuth.MixProject do
   def project do
     [
       app: :emqx_auth,
-      version: "6.1.0",
+      version: "6.1.1",
       build_path: "../../_build",
       compilers: Mix.compilers() ++ [:copy_srcs],
       # used by our `Mix.Tasks.Compile.CopySrcs` compiler

--- a/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
+++ b/apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl
@@ -847,18 +847,23 @@ listener_authenticator_position(
         end
     ).
 
-authenticator_users(post, #{bindings := #{id := AuthenticatorID}, body := UserInfo} = Req) ->
-    ActorNamespace = emqx_dashboard:get_namespace(Req),
-    case UserInfo of
-        #{<<"namespace">> := UserNamespace} when
-            ActorNamespace /= ?global_ns andalso UserNamespace /= ActorNamespace
-        ->
-            ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>);
-        _ ->
-            add_user(?GLOBAL, AuthenticatorID, UserInfo)
+authenticator_users(post, #{
+    bindings := #{id := AuthenticatorID},
+    body := UserInfo,
+    resolved_ns := ResolvedNs
+}) ->
+    case effective_user_namespace(UserInfo, ResolvedNs) of
+        {ok, Namespace} ->
+            add_user(?GLOBAL, AuthenticatorID, UserInfo#{<<"namespace">> => Namespace});
+        {error, forbidden} ->
+            ?FORBIDDEN(<<"User not authorized to operate on requested namespace">>)
     end;
-authenticator_users(get, #{bindings := #{id := AuthenticatorID}, query_string := QueryString}) ->
-    list_users(?GLOBAL, AuthenticatorID, QueryString).
+authenticator_users(get, #{
+    bindings := #{id := AuthenticatorID},
+    query_string := QueryString,
+    resolved_ns := ResolvedNs
+}) ->
+    list_users(?GLOBAL, AuthenticatorID, QueryString#{<<"ns">> => ResolvedNs}).
 
 authenticator_user(
     put,
@@ -1245,22 +1250,27 @@ add_user(
 ) ->
     Namespace = maps:get(<<"namespace">>, UserInfo, ?global_ns),
     IsSuperuser = maps:get(<<"is_superuser">>, UserInfo, false),
-    case
-        emqx_authn_chains:add_user(
-            ChainName,
-            AuthenticatorID,
-            #{
-                namespace => Namespace,
-                user_id => UserID,
-                password => Password,
-                is_superuser => IsSuperuser
-            }
-        )
-    of
-        {ok, User} ->
-            {201, user_out(User)};
+    case check_superuser_allowed(Namespace, IsSuperuser) of
+        ok ->
+            case
+                emqx_authn_chains:add_user(
+                    ChainName,
+                    AuthenticatorID,
+                    #{
+                        namespace => Namespace,
+                        user_id => UserID,
+                        password => Password,
+                        is_superuser => IsSuperuser
+                    }
+                )
+            of
+                {ok, User} ->
+                    {201, user_out(User)};
+                {error, Reason} ->
+                    serialize_error({user_error, Reason})
+            end;
         {error, Reason} ->
-            serialize_error({user_error, Reason})
+            serialize_error(Reason)
     end;
 add_user(_, _, #{<<"user_id">> := _}) ->
     serialize_error({missing_parameter, password});
@@ -1272,18 +1282,41 @@ update_user(ChainName, Namespace, AuthenticatorID, UserID, UserInfo0) ->
         true ->
             serialize_error({missing_parameter, password});
         false ->
-            UserInfo = emqx_utils_maps:safe_atom_key_map(UserInfo0),
-            case
-                emqx_authn_chains:update_user(
-                    ChainName, AuthenticatorID, Namespace, UserID, UserInfo
-                )
-            of
-                {ok, User} ->
-                    {200, user_out(User)};
+            IsSuperuser = maps:get(<<"is_superuser">>, UserInfo0, false),
+            case check_superuser_allowed(Namespace, IsSuperuser) of
+                ok ->
+                    UserInfo = emqx_utils_maps:safe_atom_key_map(UserInfo0),
+                    case
+                        emqx_authn_chains:update_user(
+                            ChainName, AuthenticatorID, Namespace, UserID, UserInfo
+                        )
+                    of
+                        {ok, User} ->
+                            {200, user_out(User)};
+                        {error, Reason} ->
+                            serialize_error({user_error, Reason})
+                    end;
                 {error, Reason} ->
-                    serialize_error({user_error, Reason})
+                    serialize_error(Reason)
             end
     end.
+
+%% A global admin (resolved_ns = ?global_ns) may write to any namespace by
+%% specifying it in the body; a namespaced admin may only write to their own
+%% namespace and any mismatch in the body is rejected.
+effective_user_namespace(UserInfo, ?global_ns) ->
+    {ok, maps:get(<<"namespace">>, UserInfo, ?global_ns)};
+effective_user_namespace(UserInfo, ResolvedNs) ->
+    case maps:get(<<"namespace">>, UserInfo, ResolvedNs) of
+        ResolvedNs -> {ok, ResolvedNs};
+        _Other -> {error, forbidden}
+    end.
+
+%% MQTT users in a non-global namespace must never be superusers: explicit ACL
+%% rules are enforced for tenant clients.
+check_superuser_allowed(?global_ns, _IsSuperuser) -> ok;
+check_superuser_allowed(_Namespace, false) -> ok;
+check_superuser_allowed(_Namespace, _IsSuperuser) -> {error, superuser_not_allowed_in_namespace}.
 
 find_user(ChainName, Namespace, AuthenticatorID, UserID) ->
     case emqx_authn_chains:lookup_user(ChainName, AuthenticatorID, Namespace, UserID) of
@@ -1441,6 +1474,11 @@ serialize_error({bad_ssl_config, Details}) ->
     {400, #{
         code => <<"BAD_REQUEST">>,
         message => binfmt("bad_ssl_config ~0p", [Details])
+    }};
+serialize_error(superuser_not_allowed_in_namespace) ->
+    {400, #{
+        code => <<"BAD_REQUEST">>,
+        message => <<"is_superuser cannot be true for a namespaced user">>
     }};
 serialize_error({missing_parameter, Detail}) ->
     {400, #{

--- a/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
+++ b/apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl
@@ -342,12 +342,30 @@ t_authenticator_users(TCConfig) ->
         InvalidUsers
     ),
 
+    %% Namespaced users cannot be superusers, so the is_superuser=true variant
+    %% is only exercised for the global admin.
+    U2IsSuperuser =
+        case ns_of(TCConfig) of
+            ?global_ns -> true;
+            _ -> false
+        end,
     ValidUsers0 = [
         #{user_id => <<"u1">>, password => <<"p1">>},
-        #{user_id => <<"u2">>, password => <<"p2">>, is_superuser => true},
+        #{user_id => <<"u2">>, password => <<"p2">>, is_superuser => U2IsSuperuser},
         #{user_id => <<"u3">>, password => <<"p3">>}
     ],
     ValidUsers = lists:map(fun(U) -> maybe_add_ns_user_info(U, TCConfig) end, ValidUsers0),
+
+    %% As a namespaced admin, attempting to create a superuser must be rejected.
+    maybe
+        true ?= ns_of(TCConfig) /= ?global_ns,
+        NsSuperUser = maybe_add_ns_user_info(
+            #{user_id => <<"u_super">>, password => <<"p">>, is_superuser => true},
+            TCConfig
+        ),
+        ?assertMatch({400, _}, add_user(NsSuperUser)),
+        ok
+    end,
 
     NsAPIOut =
         case ns_of(TCConfig) of
@@ -438,6 +456,12 @@ t_authenticator_users(TCConfig) ->
         lists:usort([UserId || #{<<"user_id">> := UserId} <- Page1Users ++ Page2Users])
     ),
 
+    {ExpectedSuperUsers, ExpectedNonSuperUsers} =
+        case ns_of(TCConfig) of
+            ?global_ns -> {[<<"u2">>], [<<"u1">>, <<"u3">>]};
+            _ -> {[], [<<"u1">>, <<"u2">>, <<"u3">>]}
+        end,
+
     {200, Super1Data} = list_users(
         maybe_add_ns_qs(
             #{
@@ -448,19 +472,9 @@ t_authenticator_users(TCConfig) ->
             TCConfig
         )
     ),
-
-    #{
-        <<"data">> := Super1Users,
-        <<"meta">> :=
-            #{
-                <<"page">> := 1,
-                <<"limit">> := 3,
-                <<"count">> := 1
-            }
-    } = Super1Data,
-
+    #{<<"data">> := Super1Users} = Super1Data,
     ?assertEqual(
-        [<<"u2">>],
+        ExpectedSuperUsers,
         lists:usort([UserId || #{<<"user_id">> := UserId} <- Super1Users])
     ),
 
@@ -474,19 +488,9 @@ t_authenticator_users(TCConfig) ->
             TCConfig
         )
     ),
-
-    #{
-        <<"data">> := Super2Users,
-        <<"meta">> :=
-            #{
-                <<"page">> := 1,
-                <<"limit">> := 3,
-                <<"count">> := 2
-            }
-    } = Super2Data,
-
+    #{<<"data">> := Super2Users} = Super2Data,
     ?assertEqual(
-        [<<"u1">>, <<"u3">>],
+        ExpectedNonSuperUsers,
         lists:usort([UserId || #{<<"user_id">> := UserId} <- Super2Users])
     ),
 
@@ -534,10 +538,20 @@ t_authenticator_user(TCConfig) ->
     ?assertMatch(#{<<"user_id">> := <<"u1">>}, FetchedUser),
     ?assertNotMatch(#{<<"password">> := _}, FetchedUser),
 
-    ValidUserUpdates = [
-        #{password => <<"p1">>},
-        #{password => <<"p1">>, is_superuser => true}
-    ],
+    %% Namespaced users cannot be marked as superuser; see new invariant.
+    ValidUserUpdates =
+        case ns_of(TCConfig) of
+            ?global_ns ->
+                [
+                    #{password => <<"p1">>},
+                    #{password => <<"p1">>, is_superuser => true}
+                ];
+            _ ->
+                [
+                    #{password => <<"p1">>},
+                    #{password => <<"p1">>, is_superuser => false}
+                ]
+        end,
 
     lists:foreach(
         fun(UserUpdate) ->
@@ -545,6 +559,21 @@ t_authenticator_user(TCConfig) ->
         end,
         ValidUserUpdates
     ),
+
+    %% As a namespaced admin, attempting to promote a user to superuser must be
+    %% rejected.
+    maybe
+        true ?= ns_of(TCConfig) /= ?global_ns,
+        ?assertMatch(
+            {400, _},
+            update_user(
+                <<"u1">>,
+                #{password => <<"p1">>, is_superuser => true},
+                maybe_add_ns_qs(#{}, TCConfig)
+            )
+        ),
+        ok
+    end,
 
     InvalidUserUpdates = [
         #{user_id => <<"u1">>, password => <<"p1">>},
@@ -655,5 +684,78 @@ t_authenticator_import_users_ns(TCConfig) ->
         ]
     }),
     {403, _} = import_users(emqx_utils_json:decode(JSONData), #{<<"type">> => <<"hash">>}),
+
+    ok.
+
+-doc """
+Regression test for CVE-style bypass where a namespaced admin could:
+  (1) list authentication users in the global namespace by omitting the `ns`
+      query parameter; and
+  (2) create users (including superusers) in the global namespace by omitting
+      the `namespace` body field.
+The handlers must now ignore user-controlled input for the namespace and use
+the actor's resolved namespace instead.
+""".
+t_ns_admin_bypass_global() ->
+    [{matrix, true}].
+t_ns_admin_bypass_global(matrix) ->
+    [[?ns]];
+t_ns_admin_bypass_global(TCConfig) ->
+    {200, _} = create_authenticator(emqx_authn_test_lib:built_in_database_example()),
+
+    %% Seed a user in the global namespace directly via the chain API, so we
+    %% do not need a second HTTP admin session.
+    {ok, _} = emqx_authn_chains:add_user(
+        ?GLOBAL,
+        <<"password_based:built_in_database">>,
+        #{
+            namespace => ?global_ns,
+            user_id => <<"global_user">>,
+            password => <<"p">>,
+            is_superuser => false
+        }
+    ),
+
+    put_auth_header(?config(auth_header, TCConfig)),
+
+    %% Bug 1 — GET without `ns` must only return the caller's namespace.
+    {200, ListData} = list_users(#{<<"page">> => <<"1">>, <<"limit">> => <<"50">>}),
+    #{<<"data">> := Rows} = ListData,
+    UserIds = [UserId || #{<<"user_id">> := UserId} <- Rows],
+    ?assertEqual(
+        [],
+        UserIds,
+        #{reason => <<"namespaced admin must not see global users">>}
+    ),
+
+    %% Bug 2 — POST without `namespace` must land in the caller's namespace,
+    %% not global. Creating a superuser via this bypass must also be rejected
+    %% by the new invariant.
+    NsBody = #{
+        <<"user_id">> => <<"ns_created">>,
+        <<"password">> => <<"p">>
+    },
+    {201, Created} = add_user(NsBody),
+    ?assertMatch(#{<<"namespace">> := <<"ns1">>}, Created),
+
+    %% The global table must remain unchanged.
+    {ok, #{user_id := <<"global_user">>}} =
+        emqx_authn_chains:lookup_user(
+            ?GLOBAL, <<"password_based:built_in_database">>, ?global_ns, <<"global_user">>
+        ),
+    ?assertMatch(
+        {error, not_found},
+        emqx_authn_chains:lookup_user(
+            ?GLOBAL, <<"password_based:built_in_database">>, ?global_ns, <<"ns_created">>
+        )
+    ),
+
+    %% Bug 3 — superuser creation as a namespaced admin must be rejected.
+    SuperBody = #{
+        <<"user_id">> => <<"ns_super">>,
+        <<"password">> => <<"p">>,
+        <<"is_superuser">> => true
+    },
+    ?assertMatch({400, _}, add_user(SuperBody)),
 
     ok.

--- a/changes/ee/fix-17064.en.md
+++ b/changes/ee/fix-17064.en.md
@@ -1,0 +1,7 @@
+Closed an authorization gap in the `/authentication/:id/users` REST endpoint
+so that a namespaced administrator can no longer list or create users in the
+global (or another tenant's) namespace by omitting the `ns` query parameter
+or the `namespace` body field.  Authentication users in a non-global
+namespace can no longer be marked as `is_superuser`; requests to create or
+update such a user are rejected so that explicit ACL rules are always
+enforced for tenant MQTT clients.


### PR DESCRIPTION
Fixes a namespaced-admin bypass on `/api/v5/authentication/:id/users`.

Release version:
6.1.2, 6.2.1

## Summary

The `GET` and `POST` handlers for `/authentication/:id/users` in
`apps/emqx_auth/src/emqx_authn/emqx_authn_api.erl` used to look at the raw
request body and query string to decide the target namespace. A tenant
(namespaced) dashboard admin could therefore:

- list every global authentication user by omitting the `ns` query
  parameter; and
- create a user (including a superuser) in the global namespace by
  omitting the `namespace` body field.

Both handlers now rely on `resolved_ns` produced by the route's filter
callback. The `GET` handler injects it into the query string before
calling `list_users/3`; the `POST` handler uses it as the effective
namespace and rejects any mismatching `namespace` explicitly set in the
body (global admins can still target any namespace via the body).

In addition, an MQTT authentication user in a non-global namespace can no
longer be marked as `is_superuser`. Both `add_user/3` and
`update_user/5` reject such requests so that explicit ACL rules are
always enforced for tenant clients.

Covered by updates and a new case in
`apps/emqx_auth_mnesia/test/emqx_authn_api_mnesia_SUITE.erl`
(`t_ns_admin_bypass_global`, plus adjustments to `t_authenticator_users`
and `t_authenticator_user`).

## PR Checklist
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/fix-17064.en.md`
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)