### PR TITLE
fix(emqx_tables): support TLS verify_none without cert files on release-61

### DIFF
--- a/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
+++ b/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
@@ -604,6 +604,64 @@ t_multiple_tables_failure_in_the_end(TCConfig) when is_list(TCConfig) ->
     ok.
 
 -doc """
+Ensure TLS connector can be created with `verify_none` and no cert file paths.
+This mirrors serverless production config: TLS enabled + verify_none only.
+""".
+t_tls_verify_none_without_certfiles() ->
+    [{matrix, true}].
+t_tls_verify_none_without_certfiles(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_verify_none_without_certfiles(TCConfig) when is_list(TCConfig) ->
+    maybe_with_forced_sync_query_mode(TCConfig, fun() ->
+        ?assertMatch(
+            {201, #{
+                <<"status">> := <<"connected">>
+            }},
+            create_connector_api(TCConfig, #{
+                <<"server">> => <<"toxiproxy:4003">>,
+                <<"ssl">> => #{
+                    <<"enable">> => true,
+                    <<"verify">> => <<"verify_none">>,
+                    <<"cacertfile">> => <<>>,
+                    <<"certfile">> => <<>>,
+                    <<"keyfile">> => <<>>
+                }
+            })
+        ),
+        ok
+    end).
+
+-doc """
+Ensure TLS connector still rejects empty cert file paths when verify is `verify_peer`.
+""".
+t_tls_verify_peer_with_empty_certfiles_rejected() ->
+    [{matrix, true}].
+t_tls_verify_peer_with_empty_certfiles_rejected(matrix) ->
+    [[?tls, ?sync, ?without_batch]];
+t_tls_verify_peer_with_empty_certfiles_rejected(TCConfig) when is_list(TCConfig) ->
+    maybe_with_forced_sync_query_mode(TCConfig, fun() ->
+        ?assertMatch(
+            {400, #{
+                <<"code">> := <<"BAD_REQUEST">>,
+                <<"message">> := #{
+                    <<"reason">> := <<"bad_ssl_config">>
+                }
+            }},
+            create_connector_api(TCConfig, #{
+                <<"server">> => <<"toxiproxy:4003">>,
+                <<"ssl">> => #{
+                    <<"enable">> => true,
+                    <<"verify">> => <<"verify_peer">>,
+                    <<"cacertfile">> => <<>>,
+                    <<"certfile">> => <<>>,
+                    <<"keyfile">> => <<>>
+                }
+            })
+        ),
+        ok
+    end).
+
+-doc """
 Checks that we treat port 4001 as the default port when the port is omitted in the server
 field, similar to greptimedb connector.
 """.

--- a/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
+++ b/apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl
@@ -679,8 +679,9 @@ t_default_port(TCConfig) when is_list(TCConfig) ->
     ok.
 
 -doc """
-Checks that we require `cacertfile`, `certfile` and `keyfile` to be set to _some_ value if
-`ssl.enable = true`, so we avoid bizarre errors thrown from the Rust driver.
+Checks that when only `ssl.enable = true` is set, schema default
+`ssl.verify = verify_none` is honored and connector creation is not rejected by
+missing cert file validation.
 """.
 t_inconsistent_ssl_validation() ->
     [{matrix, true}].
@@ -689,12 +690,10 @@ t_inconsistent_ssl_validation(matrix) ->
 t_inconsistent_ssl_validation(TCConfig) when is_list(TCConfig) ->
     ?assertMatch(
         {201, #{
-            <<"status">> := <<"disconnected">>,
-            <<"status_reason">> :=
-                <<
-                    "cacertfile, certfile and keyfile SSL options must"
-                    " be configured when SSL is enabled."
-                >>
+            <<"ssl">> := #{
+                <<"enable">> := true,
+                <<"verify">> := <<"verify_none">>
+            }
         }},
         create_connector_api(TCConfig, #{
             <<"ssl">> => #{

--- a/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl
+++ b/apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl
@@ -447,7 +447,17 @@ maybe_put_auth(_ConnConfig, Opts) ->
     Opts.
 
 maybe_put_tls(#{ssl := #{enable := true} = SSLOpts}, Opts) ->
-    Renamed = maps:fold(
+    TLSOpts = extract_tls_opts(SSLOpts),
+    maps:merge(Opts, TLSOpts#{tls => true});
+maybe_put_tls(_ConnConfig, Opts) ->
+    Opts.
+
+extract_tls_opts(SSLOpts) ->
+    TLSCertOpts = extract_tls_cert_opts(SSLOpts),
+    maybe_put_tls_verify_opt(SSLOpts, TLSCertOpts).
+
+extract_tls_cert_opts(SSLOpts) ->
+    TLSOpts0 = maps:fold(
         fun emqx_utils_maps:rename/3,
         SSLOpts,
         #{
@@ -456,12 +466,46 @@ maybe_put_tls(#{ssl := #{enable := true} = SSLOpts}, Opts) ->
             keyfile => client_key
         }
     ),
-    TLSOpts = maps:map(
-        fun(_, V) -> bin(V) end, maps:with([ca_cert, client_cert, client_key], Renamed)
+    TLSOpts1 = maps:with([ca_cert, client_cert, client_key], TLSOpts0),
+    TLSOpts2 = maps:filter(
+        fun(_, V) -> not is_blank_or_undefined(V) end,
+        TLSOpts1
     ),
-    maps:merge(Opts, TLSOpts#{tls => true});
-maybe_put_tls(_ConnConfig, Opts) ->
-    Opts.
+    maps:map(fun(_, V) -> bin(V) end, TLSOpts2).
+
+maybe_put_tls_verify_opt(SSLOpts, TLSOpts) ->
+    case maps:find(verify, SSLOpts) of
+        {ok, Verify0} ->
+            case normalize_tls_verify(Verify0) of
+                undefined -> TLSOpts;
+                Verify -> TLSOpts#{verify => Verify}
+            end;
+        error ->
+            case maps:find(<<"verify">>, SSLOpts) of
+                {ok, Verify0} ->
+                    case normalize_tls_verify(Verify0) of
+                        undefined -> TLSOpts;
+                        Verify -> TLSOpts#{verify => Verify}
+                    end;
+                error ->
+                    TLSOpts
+            end
+    end.
+
+normalize_tls_verify(verify_none) ->
+    verify_none;
+normalize_tls_verify(<<"verify_none">>) ->
+    verify_none;
+normalize_tls_verify("verify_none") ->
+    verify_none;
+normalize_tls_verify(verify_peer) ->
+    verify_peer;
+normalize_tls_verify(<<"verify_peer">>) ->
+    verify_peer;
+normalize_tls_verify("verify_peer") ->
+    verify_peer;
+normalize_tls_verify(_) ->
+    undefined.
 
 maybe_put_optional_keys(Keys, Source, Target) ->
     lists:foldl(
@@ -476,22 +520,92 @@ maybe_put_optional_keys(Keys, Source, Target) ->
     ).
 
 ensure_consistent_ssl_opts(#{ssl := #{enable := true} = SSLOpts} = _ConnConfig) ->
-    AnyMissing =
-        lists:any(
-            fun(Key) -> is_blank_or_missing(Key, SSLOpts) end,
-            [cacertfile, certfile, keyfile]
-        ),
-    case AnyMissing of
-        true ->
-            throw(<<
-                "cacertfile, certfile and keyfile SSL options must be configured"
-                " when SSL is enabled."
-            >>);
-        false ->
-            ok
+    case normalize_tls_verify(get_ssl_verify_opt(SSLOpts, verify_peer)) of
+        verify_none ->
+            ok;
+        _ ->
+            AnyMissing =
+                lists:any(
+                    fun(Key) -> is_blank_or_missing(Key, SSLOpts) end,
+                    [cacertfile, certfile, keyfile]
+                ),
+            case AnyMissing of
+                true ->
+                    throw(<<
+                        "cacertfile, certfile and keyfile SSL options must be configured"
+                        " when SSL is enabled."
+                    >>);
+                false ->
+                    ok
+            end
     end;
 ensure_consistent_ssl_opts(_ConnConfig) ->
     ok.
 
+get_ssl_verify_opt(SSLOpts, Default) ->
+    case maps:find(verify, SSLOpts) of
+        {ok, Verify} ->
+            Verify;
+        error ->
+            case maps:find(<<"verify">>, SSLOpts) of
+                {ok, Verify} -> Verify;
+                error -> Default
+            end
+    end.
+
 is_blank_or_missing(Key, Cfg) ->
-    <<"">> == maps:get(Key, Cfg, <<"">>).
+    is_blank_or_undefined(maps:get(Key, Cfg, undefined)).
+
+is_blank_or_undefined(undefined) ->
+    true;
+is_blank_or_undefined(null) ->
+    true;
+is_blank_or_undefined(V) when is_binary(V) ->
+    byte_size(V) =:= 0;
+is_blank_or_undefined(V) when is_list(V) ->
+    V =:= [];
+is_blank_or_undefined(_) ->
+    false.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+client_opts_tls_verify_none_without_cert_paths_test() ->
+    ConnConfig = #{
+        server => <<"127.0.0.1:5001">>,
+        dbname => <<"public">>,
+        ssl => #{
+            enable => true,
+            verify => verify_none,
+            cacertfile => <<>>,
+            certfile => <<>>,
+            keyfile => <<>>
+        }
+    },
+    Opts = client_opts(test_res_id, ConnConfig),
+    ?assertEqual(true, maps:get(tls, Opts)),
+    ?assertEqual(verify_none, maps:get(verify, Opts)),
+    ?assertNot(maps:is_key(ca_cert, Opts)),
+    ?assertNot(maps:is_key(client_cert, Opts)),
+    ?assertNot(maps:is_key(client_key, Opts)).
+
+client_opts_tls_verify_peer_keeps_certs_test() ->
+    ConnConfig = #{
+        server => <<"127.0.0.1:5001">>,
+        dbname => <<"public">>,
+        ssl => #{
+            enable => true,
+            verify => verify_peer,
+            cacertfile => <<"/tmp/ca.crt">>,
+            certfile => <<"/tmp/client.crt">>,
+            keyfile => <<"/tmp/client.key">>
+        }
+    },
+    Opts = client_opts(test_res_id, ConnConfig),
+    ?assertEqual(true, maps:get(tls, Opts)),
+    ?assertEqual(verify_peer, maps:get(verify, Opts)),
+    ?assertEqual(<<"/tmp/ca.crt">>, maps:get(ca_cert, Opts)),
+    ?assertEqual(<<"/tmp/client.crt">>, maps:get(client_cert, Opts)),
+    ?assertEqual(<<"/tmp/client.key">>, maps:get(client_key, Opts)).
+
+-endif.

--- a/apps/emqx_connector/mix.exs
+++ b/apps/emqx_connector/mix.exs
@@ -5,7 +5,7 @@ defmodule EMQXConnector.MixProject do
   def project do
     [
       app: :emqx_connector,
-      version: "6.1.0",
+      version: "6.1.1",
       build_path: "../../_build",
       # erlc_options: [
       #   # config_path: "../../config/config.exs",

--- a/apps/emqx_connector/src/emqx_connector_ssl.erl
+++ b/apps/emqx_connector/src/emqx_connector_ssl.erl
@@ -19,7 +19,8 @@ convert_certs(_RltvDir, Config) ->
     {ok, Config}.
 
 new_ssl_config(RltvDir, Config, SSL) ->
-    case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(RltvDir, SSL) of
+    SanitizedSSL = maybe_drop_blank_certs_for_verify_none(SSL),
+    case emqx_tls_lib:ensure_ssl_files_in_mutable_certs_dir(RltvDir, SanitizedSSL) of
         {ok, NewSSL} ->
             {ok, new_ssl_config(Config, NewSSL)};
         {error, Reason} ->
@@ -36,6 +37,71 @@ new_ssl_config(#{<<"ssl">> := _} = Config, NewSSL) ->
     Config#{<<"ssl">> => NewSSL};
 new_ssl_config(Config, _NewSSL) ->
     Config.
+
+maybe_drop_blank_certs_for_verify_none(SSL) ->
+    case normalize_verify(get_ssl_verify(SSL)) of
+        verify_none ->
+            maps:filter(
+                fun(K, V) ->
+                    not (is_cert_key(K) andalso is_blank_or_undefined(V))
+                end,
+                SSL
+            );
+        _ ->
+            SSL
+    end.
+
+get_ssl_verify(SSL) ->
+    case maps:find(verify, SSL) of
+        {ok, Verify} ->
+            Verify;
+        error ->
+            case maps:find(<<"verify">>, SSL) of
+                {ok, Verify} -> Verify;
+                error -> undefined
+            end
+    end.
+
+normalize_verify(verify_none) ->
+    verify_none;
+normalize_verify(<<"verify_none">>) ->
+    verify_none;
+normalize_verify("verify_none") ->
+    verify_none;
+normalize_verify(verify_peer) ->
+    verify_peer;
+normalize_verify(<<"verify_peer">>) ->
+    verify_peer;
+normalize_verify("verify_peer") ->
+    verify_peer;
+normalize_verify(_) ->
+    undefined.
+
+is_cert_key(cacertfile) ->
+    true;
+is_cert_key(certfile) ->
+    true;
+is_cert_key(keyfile) ->
+    true;
+is_cert_key(<<"cacertfile">>) ->
+    true;
+is_cert_key(<<"certfile">>) ->
+    true;
+is_cert_key(<<"keyfile">>) ->
+    true;
+is_cert_key(_) ->
+    false.
+
+is_blank_or_undefined(undefined) ->
+    true;
+is_blank_or_undefined(null) ->
+    true;
+is_blank_or_undefined(V) when is_binary(V) ->
+    byte_size(V) =:= 0;
+is_blank_or_undefined(V) when is_list(V) ->
+    V =:= [];
+is_blank_or_undefined(_) ->
+    false.
 
 map_bad_ssl_error(#{
     pem_check := NotPem,
@@ -65,3 +131,83 @@ map_bad_ssl_error(TLSLibError) ->
         reason => <<"bad_ssl_config">>,
         details => TLSLibError
     }.
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+convert_certs_verify_none_blank_paths_pass_test() ->
+    Config = #{
+        ssl => #{
+            enable => true,
+            verify => verify_none,
+            cacertfile => <<>>,
+            certfile => <<>>,
+            keyfile => <<>>
+        }
+    },
+    ?assertMatch(
+        {ok, #{ssl := #{verify := verify_none}}},
+        convert_certs("dummy-connector", Config)
+    ).
+
+maybe_drop_blank_certs_for_verify_none_with_atom_keys_test() ->
+    SSL = #{
+        enable => true,
+        verify => verify_none,
+        cacertfile => <<>>,
+        certfile => undefined,
+        keyfile => []
+    },
+    ?assertEqual(
+        #{
+            enable => true,
+            verify => verify_none
+        },
+        maybe_drop_blank_certs_for_verify_none(SSL)
+    ).
+
+maybe_drop_blank_certs_for_verify_none_with_binary_keys_test() ->
+    SSL = #{
+        <<"enable">> => true,
+        <<"verify">> => <<"verify_none">>,
+        <<"cacertfile">> => <<>>,
+        <<"certfile">> => <<>>,
+        <<"keyfile">> => <<>>
+    },
+    ?assertEqual(
+        #{
+            <<"enable">> => true,
+            <<"verify">> => <<"verify_none">>
+        },
+        maybe_drop_blank_certs_for_verify_none(SSL)
+    ).
+
+convert_certs_verify_peer_blank_paths_fail_test() ->
+    Config = #{
+        ssl => #{
+            enable => true,
+            verify => verify_peer,
+            cacertfile => <<>>,
+            certfile => <<>>,
+            keyfile => <<>>
+        }
+    },
+    ?assertMatch(
+        {error, #{reason := <<"bad_ssl_config">>}},
+        convert_certs("dummy-connector", Config)
+    ).
+
+convert_certs_verify_none_non_blank_invalid_path_fail_test() ->
+    Config = #{
+        ssl => #{
+            enable => true,
+            verify => verify_none,
+            cacertfile => <<"/definitely/not/exist-ca.pem">>
+        }
+    },
+    ?assertMatch(
+        {error, #{reason := <<"bad_ssl_config">>}},
+        convert_certs("dummy-connector", Config)
+    ).
+
+-endif.

--- a/changes/ee/fix-17068.en.md
+++ b/changes/ee/fix-17068.en.md
@@ -1,0 +1,1 @@
+Fixed EMQX Tables TLS connector startup when `ssl.verify` is `verify_none` and cert file paths are left empty, and aligned Rust NIF TLS verify propagation with connector config.

--- a/mix.exs
+++ b/mix.exs
@@ -319,7 +319,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:greptimedb, github: "emqx/greptimedb-ingester-erl", tag: "v0.2.3-emqx.1"}
 
   def common_dep(:greptimedb_rs),
-    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.8"}
+    do: {:greptimedb_rs, github: "emqx/greptimedb-ingester-erlnif", tag: "0.1.10"}
 
   def common_dep(:sbom), do: {:sbom, "~> 0.8", runtime: false}
 


### PR DESCRIPTION
Fixes N/A

Release version: 6.1.2

## Summary

This backports the serverless EMQX Tables TLS `verify_none` fix to `release-61`.

- add regression coverage for TLS `verify_none` with empty cert-file fields:
  - `apps/emqx_bridge_emqx_tables/test/emqx_bridge_emqx_tables_SUITE.erl`
  - `apps/emqx_connector/src/emqx_connector_ssl.erl` (eunit)
  - `apps/emqx_bridge_greptimedb/src/emqx_bridge_greptimedb_rs_impl.erl` (eunit)
- sanitize SSL config before file-path validation:
  - when `ssl.verify = verify_none`, drop blank `cacertfile` / `certfile` / `keyfile` fields so connector setup does not fail with invalid path errors
- propagate TLS verify mode to Rust NIF connector options:
  - pass normalized `verify` (`verify_none` / `verify_peer`) into `greptimedb_rs` client opts
  - keep cert-path checks for non-`verify_none` mode
- bump `greptimedb_rs` dependency in root `mix.exs` to `0.1.10`
- bump `apps/emqx_connector` app version to `6.1.1` (apps-version-check compatible)
- add release note: `changes/ee/fix-17068.en.md`

## EMQX issue details (API + parameters + reproduction)

### Error 1: `Invalid config file path, No such file or directory (os error 2)`

- EMQX API path:
  - `POST /api/v5/connectors_probe`
- Triggering parameters:
  - `type = emqx_tables`
  - `server = <TLS endpoint>:5001` (CT equivalent: `toxiproxy:4003`)
  - `ssl.enable = true`
  - `ssl.verify = verify_none`
  - cert path fields empty/missing (`cacertfile`, `certfile`, `keyfile`)
- Behavior before fix:
  - connector test fails with file-path error from rust driver (`os error 2`).
- Root cause before fix:
  - blank cert path fields were still propagated to Rust driver options;
  - driver attempted to open them as file paths.

### Error 2: `invalid peer certificate: UnknownIssuer`

- EMQX API path:
  - `POST /api/v5/connectors_probe`
  - (same issue can also surface after `POST /api/v5/connectors` starts the connector)
- Triggering parameters:
  - `type = emqx_tables`
  - `server = <TLS endpoint>:5001` (CT equivalent: `toxiproxy:4003`)
  - `ssl.enable = true`
  - `ssl.verify = verify_none`
- Behavior before fix:
  - TLS handshake still performs peer certificate validation and fails with `UnknownIssuer`.
- Root cause before fix:
  - `verify_none` was not consistently propagated to Rust client TLS options.

## PR Checklist
- ~For internal contributor: there is a jira ticket to track this change~
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- ~Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)~
