### PR TITLE
fix(emqx_mt): defer managed-ns gate to post-authn when expression is set

### DIFF
--- a/apps/emqx/include/emqx_release.hrl
+++ b/apps/emqx/include/emqx_release.hrl
@@ -19,4 +19,4 @@
 %% NOTE: Also make sure to follow the instructions in end of
 %% `apps/emqx/src/bpapi/README.md'
 
--define(EMQX_RELEASE_EE, "6.1.2-rc.2").
+-define(EMQX_RELEASE_EE, "6.1.2-rc.3").

--- a/apps/emqx_mt/include/emqx_mt.hrl
+++ b/apps/emqx_mt/include/emqx_mt.hrl
@@ -17,8 +17,9 @@
 -define(CONF_ROOT_KEY, multi_tenancy).
 -define(CONF_ROOT_KEY_BIN, <<"multi_tenancy">>).
 
-%% Matches the "unset" representations of a config value: undefined (key absent)
-%% and the empty binary (explicit empty string from hocon).
--define(IS_NOT_SET(V), (V =:= undefined orelse V =:= <<>>)).
+%% Matches the "unset" representations of a config value: undefined (key absent),
+%% the empty binary or empty string (explicit empty string from hocon; hocon may
+%% materialize either depending on how the config was loaded).
+-define(IS_NOT_SET(V), (V =:= undefined orelse V =:= <<>> orelse V =:= [])).
 
 -endif.

--- a/apps/emqx_mt/src/emqx_mt_hookcb.erl
+++ b/apps/emqx_mt/src/emqx_mt_hookcb.erl
@@ -65,17 +65,31 @@ on_session_created(_ClientInfo, _SessionInfo) ->
     %% not a multi-tenant client
     ok.
 
-on_authenticate(
+on_authenticate(ClientInfo, DefaultResult) ->
+    case emqx_mt_config:get_post_auth_tns_expression() of
+        undefined ->
+            do_on_authenticate(ClientInfo, DefaultResult);
+        _Compiled ->
+            %% Namespace will be (re)derived by the `client.post_authn' hook
+            %% from authn-response client_attrs.  Defer all tns-based gating
+            %% (namespace config errors, quota, managed-ns membership) to
+            %% that hook so that pre-auth tns does not cause spurious
+            %% rejections.
+            ?TRACE("defer_tns_gate_to_post_authn", #{}),
+            DefaultResult
+    end.
+
+do_on_authenticate(
     #{clientid := ClientId, client_attrs := #{?CLIENT_ATTR_NAME_TNS := Tns}}, DefaultResult
 ) ->
     case emqx_config:get_namespace_config_errors(Tns) of
         undefined ->
-            do_on_authenticate(ClientId, Tns, DefaultResult);
+            decide(ClientId, Tns, DefaultResult);
         #{} ->
             ?TRACE("deny_due_to_namespace_config_errors", #{tns => Tns}),
             {stop, {error, server_unavailable}}
     end;
-on_authenticate(_, DefaultResult) ->
+do_on_authenticate(_, DefaultResult) ->
     AllowOnlyManagedNSs = emqx_mt_config:get_allow_only_managed_namespaces(),
     case AllowOnlyManagedNSs of
         true ->
@@ -85,9 +99,6 @@ on_authenticate(_, DefaultResult) ->
             ?TRACE("no_tenant_namespace", #{}),
             DefaultResult
     end.
-
-do_on_authenticate(ClientId, Tns, DefaultResult) ->
-    decide(ClientId, Tns, DefaultResult).
 
 %% Pure namespace/quota decision shared between the pre-auth `client.authenticate'
 %% and post-auth `client.post_authn' callbacks. `OnPass' is whatever the caller

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -1622,3 +1622,58 @@ authn_inject_tns(#{username := <<"user_bad">>}, _Acc) ->
     {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tns">> => <<"ghost">>}}}};
 authn_inject_tns(_ClientInfo, Acc) ->
     {ok, Acc}.
+
+-doc """
+Regression: when `allow_only_managed_namespaces = true` and the pre-auth tns
+is NOT a managed namespace, the client must not be rejected by the pre-auth
+hook. All tns-based gating must be deferred to the post-authn hook so that
+`post_auth_tns_expression' has a chance to derive the final namespace.
+
+Reproduces the tester's report against 6.1.2-rc.2.
+""".
+t_post_auth_expression_bypasses_preauth_managed_gate({init, Config}) ->
+    ok = set_post_auth_tns_expression(<<"coalesce(client_attrs.tag, 'default')">>),
+    emqx_config:put([multi_tenancy, allow_only_managed_namespaces], true),
+    %% Only `acme' is a managed namespace. `user_good'/`user_bad' are used
+    %% as usernames, and the suite's `mqtt.client_attrs_init' sets pre-auth
+    %% tns = username, so pre-auth tns is NOT in managed set.
+    ok = emqx_mt_config:create_managed_ns(<<"acme">>),
+    ok = emqx_hooks:add(
+        'client.authenticate', {?MODULE, authn_inject_tag, []}, 975
+    ),
+    on_exit(fun() ->
+        emqx_hooks:del('client.authenticate', {?MODULE, authn_inject_tag})
+    end),
+    Config;
+t_post_auth_expression_bypasses_preauth_managed_gate({'end', _Config}) ->
+    ok = clear_post_auth_tns_expression(),
+    emqx_config:put([multi_tenancy, allow_only_managed_namespaces], false),
+    _ = emqx_mt_config:delete_managed_ns(<<"acme">>),
+    ok;
+t_post_auth_expression_bypasses_preauth_managed_gate(_Config) ->
+    %% Auth returns `client_attrs.tag = "acme"' (managed).  Even though
+    %% pre-auth tns = "user_good" is unmanaged, the client must connect
+    %% because the pre-auth managed-ns gate is deferred to post-authn.
+    GoodCid = ?NEW_CLIENTID(),
+    Pid1 = connect(GoodCid, <<"user_good">>),
+    ?assertMatch(
+        {ok, #{tns := <<"acme">>, clientid := GoodCid}},
+        ?block_until(#{?snk_kind := multi_tenant_client_added}, 3000)
+    ),
+    ?assertEqual({ok, 1}, emqx_mt:count_clients(<<"acme">>)),
+    ok = emqtt:stop(Pid1),
+    %% Auth returns `client_attrs.tag = "ghost"' (unmanaged); the post-authn
+    %% hook must reject with `not_authorized'.
+    BadCid = ?NEW_CLIENTID(),
+    ?assertError(
+        {error, {not_authorized, _}},
+        connect(BadCid, <<"user_bad">>)
+    ),
+    ok.
+
+authn_inject_tag(#{username := <<"user_good">>}, _Acc) ->
+    {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tag">> => <<"acme">>}}}};
+authn_inject_tag(#{username := <<"user_bad">>}, _Acc) ->
+    {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tag">> => <<"ghost">>}}}};
+authn_inject_tag(_ClientInfo, Acc) ->
+    {ok, Acc}.

--- a/apps/emqx_mt/test/emqx_mt_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_SUITE.erl
@@ -1470,11 +1470,13 @@ t_post_auth_tns_expression_reads_client_attrs_tag(_Config) ->
     ClientInfo = #{
         clientid => <<"c1">>,
         username => <<"u1">>,
-        client_attrs => #{<<"tag">> => <<"acme">>}
+        client_attrs => #{<<"tag">> => <<"bypass_acme">>}
     },
     ?assertMatch(
         {ok, #{
-            client_info := #{client_attrs := #{<<"tns">> := <<"acme">>, <<"tag">> := <<"acme">>}}
+            client_info := #{
+                client_attrs := #{<<"tns">> := <<"bypass_acme">>, <<"tag">> := <<"bypass_acme">>}
+            }
         }},
         emqx_mt_hookcb:on_post_authn(#{client_info => ClientInfo})
     ).
@@ -1489,10 +1491,10 @@ t_post_auth_tns_expression_coalesce_fallback(_Config) ->
     CI1 = #{
         clientid => <<"c1">>,
         username => <<"alice">>,
-        client_attrs => #{<<"tag">> => <<"acme">>}
+        client_attrs => #{<<"tag">> => <<"bypass_acme">>}
     },
     ?assertMatch(
-        {ok, #{client_info := #{client_attrs := #{<<"tns">> := <<"acme">>}}}},
+        {ok, #{client_info := #{client_attrs := #{<<"tns">> := <<"bypass_acme">>}}}},
         emqx_mt_hookcb:on_post_authn(#{client_info => CI1})
     ),
     CI2 = #{
@@ -1637,7 +1639,7 @@ t_post_auth_expression_bypasses_preauth_managed_gate({init, Config}) ->
     %% Only `acme' is a managed namespace. `user_good'/`user_bad' are used
     %% as usernames, and the suite's `mqtt.client_attrs_init' sets pre-auth
     %% tns = username, so pre-auth tns is NOT in managed set.
-    ok = emqx_mt_config:create_managed_ns(<<"acme">>),
+    ok = emqx_mt_config:create_managed_ns(<<"bypass_acme">>),
     ok = emqx_hooks:add(
         'client.authenticate', {?MODULE, authn_inject_tag, []}, 975
     ),
@@ -1648,7 +1650,7 @@ t_post_auth_expression_bypasses_preauth_managed_gate({init, Config}) ->
 t_post_auth_expression_bypasses_preauth_managed_gate({'end', _Config}) ->
     ok = clear_post_auth_tns_expression(),
     emqx_config:put([multi_tenancy, allow_only_managed_namespaces], false),
-    _ = emqx_mt_config:delete_managed_ns(<<"acme">>),
+    _ = emqx_mt_config:delete_managed_ns(<<"bypass_acme">>),
     ok;
 t_post_auth_expression_bypasses_preauth_managed_gate(_Config) ->
     %% Auth returns `client_attrs.tag = "acme"' (managed).  Even though
@@ -1657,10 +1659,10 @@ t_post_auth_expression_bypasses_preauth_managed_gate(_Config) ->
     GoodCid = ?NEW_CLIENTID(),
     Pid1 = connect(GoodCid, <<"user_good">>),
     ?assertMatch(
-        {ok, #{tns := <<"acme">>, clientid := GoodCid}},
+        {ok, #{tns := <<"bypass_acme">>, clientid := GoodCid}},
         ?block_until(#{?snk_kind := multi_tenant_client_added}, 3000)
     ),
-    ?assertEqual({ok, 1}, emqx_mt:count_clients(<<"acme">>)),
+    ?assertEqual({ok, 1}, emqx_mt:count_clients(<<"bypass_acme">>)),
     ok = emqtt:stop(Pid1),
     %% Auth returns `client_attrs.tag = "ghost"' (unmanaged); the post-authn
     %% hook must reject with `not_authorized'.
@@ -1672,7 +1674,7 @@ t_post_auth_expression_bypasses_preauth_managed_gate(_Config) ->
     ok.
 
 authn_inject_tag(#{username := <<"user_good">>}, _Acc) ->
-    {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tag">> => <<"acme">>}}}};
+    {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tag">> => <<"bypass_acme">>}}}};
 authn_inject_tag(#{username := <<"user_bad">>}, _Acc) ->
     {stop, {ok, #{is_superuser => false, client_attrs => #{<<"tag">> => <<"ghost">>}}}};
 authn_inject_tag(_ClientInfo, Acc) ->

--- a/changes/ee/fix-17070.en.md
+++ b/changes/ee/fix-17070.en.md
@@ -1,3 +1,0 @@
-Fixed a bug where clients could not connect when `multi_tenancy.allow_only_managed_namespaces` was set to `true` together with `multi_tenancy.post_auth_tns_expression`.
-
-Previously, the pre-authentication hook rejected clients whose namespace was not yet a managed namespace, before the authentication chain had a chance to return attributes that the post-authentication expression would use to derive the final namespace. The managed-namespace check is now deferred to the post-authentication hook so that the expression can set the tenant namespace first.

--- a/changes/ee/fix-17070.en.md
+++ b/changes/ee/fix-17070.en.md
@@ -1,0 +1,3 @@
+Fixed a bug where clients could not connect when `multi_tenancy.allow_only_managed_namespaces` was set to `true` together with `multi_tenancy.post_auth_tns_expression`.
+
+Previously, the pre-authentication hook rejected clients whose namespace was not yet a managed namespace, before the authentication chain had a chance to return attributes that the post-authentication expression would use to derive the final namespace. The managed-namespace check is now deferred to the post-authentication hook so that the expression can set the tenant namespace first.

--- a/deploy/charts/emqx-enterprise/Chart.yaml
+++ b/deploy/charts/emqx-enterprise/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 6.1.2-rc.2
+version: 6.1.2-rc.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 6.1.2-rc.2
+appVersion: 6.1.2-rc.3


### PR DESCRIPTION
This is a followup fix of PR #17053
Release version: 6.1.2

## Summary

When `multi_tenancy.allow_only_managed_namespaces = true` was combined with `multi_tenancy.post_auth_tns_expression`, the pre-authentication hook rejected any client whose pre-auth `client_attrs.tns` was not already a managed namespace (or was unset), before the authentication chain had a chance to return the attributes used to derive the final namespace.

This made the expression effectively unusable in the scenario it was designed for: deriving the tenant namespace from authentication-response attributes (e.g. `client_attrs.tag`).

Fix: when `post_auth_tns_expression` is configured, skip all tns-based gating in the pre-auth `client.authenticate` hook (managed-ns membership, namespace config errors, quota) and let the `client.post_authn` hook enforce them against the rewritten tns.

- `apps/emqx_mt/src/emqx_mt_hookcb.erl`: short-circuit `on_authenticate/2` when `post_auth_tns_expression` is set.
- `apps/emqx_mt/test/emqx_mt_SUITE.erl`: new regression test `t_post_auth_expression_bypasses_preauth_managed_gate` covering both the managed-ns happy path and the post-authn rejection path.

## PR Checklist
- [x] The changes are covered with new or existing tests
- [~] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)