### PR TITLE
build: bump jq-nif from 0.3.16 to 0.3.17

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1130,7 +1130,7 @@ defmodule EMQXUmbrella.MixProject do
 
   def jq_dep() do
     if enable_jq?(),
-      do: [{:jq, github: "emqx/jq", tag: "v0.3.16", override: true}],
+      do: [{:jq, github: "emqx/jq", tag: "v0.3.17", override: true}],
       else: []
   end
 


### PR DESCRIPTION
0.3.16 is broken due to build pipeline issue, 0.3.17 fixed the github action and published build artifacts
