### PR TITLE
build: pin erlang-rocksdb 1.8.0-emqx-11

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -248,7 +248,7 @@ defmodule EMQXUmbrella.MixProject do
     do: {:erlang_qq, github: "k32/erlang_qq", tag: "1.0.0", override: true}
 
   def common_dep(:rocksdb),
-    do: {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-10", override: true}
+    do: {:rocksdb, github: "emqx/erlang-rocksdb", tag: "1.8.0-emqx-11", override: true}
 
   def common_dep(:emqx_http_lib),
     do: {:emqx_http_lib, github: "emqx/emqx_http_lib", tag: "0.5.3", override: true}


### PR DESCRIPTION
upgrade from 1.8.0-emqx-10 for pre-build binary download fix

