### PR TITLE
fix(ci): publish :latest docker tag on stable releases

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -258,6 +258,7 @@ jobs:
 
     env:
       PROFILE: ${{ inputs.profile }}
+      DOCKER_LATEST: ${{ inputs.latest }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -297,16 +298,26 @@ jobs:
           docker tag "$ARM64_IMAGE" "${LOCAL_BASE}:${VERSION}-arm64"
           docker push "${LOCAL_BASE}:${VERSION}-arm64"
 
-          # Create multiarch manifests and push to docker.io
-          DOCKER_IO_PROFILE_TAG="docker.io/${{ github.repository_owner }}/${PROFILE}:$VERSION"
-          DOCKER_IO_EMQX_TAG="docker.io/emqx/emqx:$VERSION"
+          # Assemble the list of destination tags for the multiarch manifest
+          TARGET_TAGS=(
+            "docker.io/${{ github.repository_owner }}/${PROFILE}:${VERSION}"
+            "docker.io/emqx/emqx:${VERSION}"
+          )
+          if [ "${DOCKER_LATEST}" = "true" ]; then
+            TARGET_TAGS+=(
+              "docker.io/${{ github.repository_owner }}/${PROFILE}:latest"
+              "docker.io/emqx/emqx:latest"
+            )
+          fi
 
           echo "Creating multiarch manifest for docker.io:"
-          echo "  - $DOCKER_IO_PROFILE_TAG"
-          echo "  - $DOCKER_IO_EMQX_TAG"
+          TAG_ARGS=()
+          for t in "${TARGET_TAGS[@]}"; do
+            echo "  - $t"
+            TAG_ARGS+=(--tag "$t")
+          done
           docker buildx imagetools create \
-            --tag "$DOCKER_IO_PROFILE_TAG" \
-            --tag "$DOCKER_IO_EMQX_TAG" \
+            "${TAG_ARGS[@]}" \
             "${LOCAL_BASE}:${VERSION}-amd64" \
             "${LOCAL_BASE}:${VERSION}-arm64"
 

--- a/scripts/parse-git-ref.sh
+++ b/scripts/parse-git-ref.sh
@@ -44,7 +44,7 @@ elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+-(alpha|beta|rc)\.[0-9]+$ ]]; then
     LATEST=false
 elif [[ $1 =~ ^refs/tags/[6-9]\.[0-9]+\.[0-9]+$ ]]; then
     RELEASE=true
-    LATEST=true
+    LATEST=$(is_latest_stable "$1")
 elif [[ $1 =~ ^refs/tags/.+ ]]; then
     echo "Unrecognized tag: $1" 1>&2
     exit 1


### PR DESCRIPTION
Fixes #17069

Release version:
6.0.3, 6.1.2, 6.2.1

## Summary

After the docker publish workflow was simplified (commit 2f8991fbc8), `publish-docker` only pushed the full `<major>.<minor>.<patch>` multiarch tag, so `emqx/emqx-enterprise:latest` on Docker Hub has not been moved since that refactor — which is what users hit in the linked issue.

This PR:

- Threads `inputs.latest` into `publish-docker` and, when it is `true`, also tags the multiarch manifest with `docker.io/<owner>/<profile>:latest` and `docker.io/emqx/emqx:latest`.
- Fixes `scripts/parse-git-ref.sh` so that only the highest existing stable `X.Y.Z` tag resolves to `latest=true` (via the already-defined `is_latest_stable`). Without this, releasing a patch for an older minor (e.g. `6.0.3` after `6.2.0`) would overwrite `:latest`.

`:<major>.<minor>` tags are intentionally not published — they aren't part of our release convention.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to \`changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md\` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)