### PR TITLE
feat(mt): inline managed namespace configs in list details

### DIFF
--- a/apps/emqx_mt/src/emqx_mt.erl
+++ b/apps/emqx_mt/src/emqx_mt.erl
@@ -28,7 +28,8 @@
 -type tns() :: binary().
 -type tns_details() :: #{
     name := tns(),
-    created_at := integer() | undefined
+    created_at := integer() | undefined,
+    config => emqx_mt_config:root_config()
 }.
 -type clientid() :: emqx_types:clientid().
 

--- a/apps/emqx_mt/src/emqx_mt_api.erl
+++ b/apps/emqx_mt/src/emqx_mt_api.erl
@@ -192,8 +192,8 @@ schema("/mt/managed_ns_list_details") ->
                 #{
                     200 =>
                         emqx_dashboard_swagger:schema_with_examples(
-                            array(ref(ns_with_details_out)),
-                            example_ns_list_details()
+                            array(ref(managed_ns_with_details_out)),
+                            example_managed_ns_list_details()
                         )
                 }
         }
@@ -478,6 +478,12 @@ fields(ns_with_details_out) ->
     [
         {name, mk(binary(), #{})},
         {created_at, mk(integer(), #{})}
+    ];
+fields(managed_ns_with_details_out) ->
+    [
+        {name, mk(binary(), #{})},
+        {created_at, mk(integer(), #{})},
+        {config, mk(ref(config_out), #{required => false})}
     ];
 fields(metrics_out) ->
     [{metrics, mk(map(), #{})}].
@@ -781,6 +787,26 @@ example_ns_list_details() ->
             }
     }.
 
+example_managed_ns_list_details() ->
+    #{
+        <<"list">> =>
+            #{
+                summary => ?DESC("example_list"),
+                value => [
+                    #{
+                        <<"name">> => <<"ns1">>,
+                        <<"created_at">> => 1747917753,
+                        <<"config">> => maps:get(<<"managed_ns_config">>, example_config_out())
+                    },
+                    #{
+                        <<"name">> => <<"ns2">>,
+                        <<"created_at">> => 1747917754,
+                        <<"config">> => #{}
+                    }
+                ]
+            }
+    }.
+
 example_client_list() ->
     #{
         <<"list">> =>
@@ -927,7 +953,12 @@ limiter_config_out(Unit0, LimiterConfig) ->
     ).
 
 ns_details_out(Details0) ->
-    Details = undefined_to_null(Details0),
+    Details1 =
+        case Details0 of
+            #{config := Configs} -> Details0#{config := configs_out(Configs)};
+            _ -> Details0
+        end,
+    Details = undefined_to_null(Details1),
     emqx_utils_maps:binary_key_map(Details).
 
 undefined_to_null(M) when is_map(M) ->

--- a/apps/emqx_mt/src/emqx_mt_state.erl
+++ b/apps/emqx_mt/src/emqx_mt_state.erl
@@ -247,9 +247,9 @@ get_ns_details(?NS_TAB, #?NS_TAB{ns = Ns, value = []}) ->
 get_ns_details(?NS_TAB, #?NS_TAB{ns = Ns, value = #{} = Extra}) ->
     CreatedAt = maps:get(created_at, Extra, undefined),
     #{name => Ns, created_at => CreatedAt};
-get_ns_details(?CONFIG_TAB, #?CONFIG_TAB{key = Ns, extra = #{} = Extra}) ->
+get_ns_details(?CONFIG_TAB, #?CONFIG_TAB{key = Ns, configs = Configs, extra = #{} = Extra}) ->
     CreatedAt = maps:get(created_at, Extra, undefined),
-    #{name => Ns, created_at => CreatedAt}.
+    #{name => Ns, created_at => CreatedAt, config => Configs}.
 
 -doc """
 List managed namespaces.

--- a/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
+++ b/apps/emqx_mt/test/emqx_mt_api_SUITE.erl
@@ -1348,13 +1348,48 @@ t_creation_date(_Config) ->
         {200, [
             #{
                 <<"name">> := Ns2,
-                <<"created_at">> := I
+                <<"created_at">> := I,
+                <<"config">> := #{}
             }
         ]} when is_integer(I),
         list_managed_nss_details(#{})
     ),
     {204, _} = delete_managed_ns(Ns2),
 
+    ok.
+
+-doc """
+Verifies that `/mt/managed_ns_list_details` inlines each namespace's configuration,
+so the UI doesn't need an N+1 round trip to fetch per-namespace configs.
+""".
+t_managed_ns_list_details_includes_config(_Config) ->
+    Ns1 = <<"mns-cfg-1">>,
+    Ns2 = <<"mns-cfg-2">>,
+    {204, _} = create_managed_ns(Ns1),
+    {204, _} = create_managed_ns(Ns2),
+    {200, _} = update_managed_ns_config(Ns1, tenant_limiter_params()),
+    ?assertMatch(
+        {200, [
+            #{
+                <<"name">> := Ns1,
+                <<"config">> := #{
+                    <<"limiter">> := #{
+                        <<"tenant">> := #{
+                            <<"bytes">> := #{<<"rate">> := <<"10MB/10s">>},
+                            <<"messages">> := #{<<"rate">> := <<"3000/1s">>}
+                        }
+                    }
+                }
+            },
+            #{
+                <<"name">> := Ns2,
+                <<"config">> := #{}
+            }
+        ]},
+        list_managed_nss_details(#{})
+    ),
+    {204, _} = delete_managed_ns(Ns1),
+    {204, _} = delete_managed_ns(Ns2),
     ok.
 
 -doc """

--- a/changes/ee/feat-17078.en.md
+++ b/changes/ee/feat-17078.en.md
@@ -1,0 +1,4 @@
+Inlined each managed namespace's configuration (session and limiter) in the
+response of `GET /api/v5/mt/managed_ns_list_details`, so management UIs can
+render a list of namespaces with their configuration in a single request
+instead of one additional call per namespace.

--- a/rel/i18n/emqx_mt_api.hocon
+++ b/rel/i18n/emqx_mt_api.hocon
@@ -46,7 +46,8 @@ emqx_mt_api {
     }
     managed_ns_list_details {
         desc: """~
-            List all managed namespaces with extra details.
+            List all managed namespaces with extra details, including the namespace
+            configuration (session and limiter).
             The namespaces are sorted in lexicographical order,
             so this API can be used for prefix based fuzzy search.~"""
         label: "List managed namespaces with extra details"


### PR DESCRIPTION
Fixes EMQX-15219

Release version: 6.1.2, 6.2.1

## Summary

This change extends `GET /api/v5/mt/managed_ns_list_details` to inline each managed namespace's configuration in the list response.

The API now returns the namespace config together with `name` and `created_at`, which removes the extra per-namespace config fetch that management UIs previously needed.

The OpenAPI schema was kept backward compatible by using a managed-namespace-specific response shape for this endpoint, so `/mt/ns_list_details` keeps its original contract.

The suite coverage was updated in `emqx_mt_api_SUITE` to verify both the new inlined config payload and the empty-config case.

## PR Checklist
- [ ] For internal contributor: there is a jira ticket to track this change
- [x] The changes are covered with new or existing tests
- [x] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [x] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)
