### PR TITLE
feat(helm): gate ws/wss Service ports behind service.wsEnabled

### DIFF
--- a/changes/ee/feat-17079.en.md
+++ b/changes/ee/feat-17079.en.md
@@ -1,0 +1,1 @@
+Add `service.wsEnabled` option to the Helm chart to suppress the ws/wss Service port entries when MQTT WebSocket listeners are disabled. Defaults to `true` to preserve existing behavior.

--- a/deploy/charts/emqx-enterprise/templates/service.yaml
+++ b/deploy/charts/emqx-enterprise/templates/service.yaml
@@ -53,6 +53,7 @@ spec:
     {{- else if eq .Values.service.type "ClusterIP" }}
     nodePort: null
     {{- end }}
+  {{- if .Values.service.wsEnabled }}
   - name: ws
     port: {{ .Values.service.ws | default 8083 }}
     protocol: TCP
@@ -71,6 +72,7 @@ spec:
     {{- else if eq .Values.service.type "ClusterIP" }}
     nodePort: null
     {{- end }}
+  {{- end }}
   - name: dashboard
     port: {{ .Values.service.dashboard | default 18083 }}
     protocol: TCP
@@ -137,6 +139,7 @@ spec:
     port: {{ .Values.service.mqttssl | default 8883 }}
     protocol: TCP
     targetPort: mqttssl
+  {{- if .Values.service.wsEnabled }}
   - name: ws
     port: {{ .Values.service.ws | default 8083 }}
     protocol: TCP
@@ -145,6 +148,7 @@ spec:
     port: {{ .Values.service.wss | default 8084 }}
     protocol: TCP
     targetPort: wss
+  {{- end }}
   - name: dashboard
     port: {{ .Values.service.dashboard | default 18083 }}
     protocol: TCP

--- a/deploy/charts/emqx-enterprise/values.yaml
+++ b/deploy/charts/emqx-enterprise/values.yaml
@@ -151,10 +151,17 @@ service:
   ## Port for MQTT(SSL)
   ##
   mqttssl: 8883
-  ## Port for WebSocket/HTTP
+  ## Whether to publish the WebSocket (ws/wss) Service ports.
+  ## Set to false to omit the ws and wss port entries from the Service
+  ## (for example, when the corresponding EMQX listeners are disabled).
+  ## Note: if this is false, also disable ingress.ws.enabled and ingress.wss.enabled,
+  ## as those reference service.ws / service.wss.
+  ##
+  wsEnabled: true
+  ## Port for WebSocket/HTTP (used only when wsEnabled is true)
   ##
   ws: 8083
-  ## Port for WSS/HTTPS
+  ## Port for WSS/HTTPS (used only when wsEnabled is true)
   ##
   wss: 8084
   ## Port for dashboard and API


### PR DESCRIPTION
- Fixes: skip / N/A (no upstream issue)
- Release version (per template): 6.0.3, 6.1.2, 6.2.0 under the v6 section
- Summary: reuse the commit body — explains the | default bug, the gate, the default preserving behavior, and the ingress coupling note
- PR Checklist — the "tests" box doesn't really apply to a template-only change; mention that helm template verified both defaults render (ws/wss present) and --set service.wsEnabled=false renders (ws/wss absent) in both main and
  headless Services
- Schema changes box: N/A (Helm values addition only, backward compatible)