### PR TITLE
ci: refactor docker workflow

### DIFF
--- a/.github/workflows/build_and_push_docker_images.yaml
+++ b/.github/workflows/build_and_push_docker_images.yaml
@@ -72,7 +72,6 @@ jobs:
     env:
       PROFILE: ${{ matrix.profile }}
       DOCKER_ORG: ${{ github.repository_owner }}
-      DOCKER_LATEST: ${{ inputs.latest }}
       ARCH: ${{ matrix.arch }}
 
     steps:
@@ -157,7 +156,6 @@ jobs:
 
     env:
       PROFILE: ${{ inputs.profile }}
-      DOCKER_LATEST: false
       ARCH: ${{ matrix.arch }}
 
     steps:
@@ -237,13 +235,18 @@ jobs:
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "${{ env.PROFILE }}-sf-docker-${{ matrix.arch }}"
+          name: "${{ env.PROFILE }}-docker-sf-${{ matrix.arch }}"
           path: "${{ env.PROFILE }}-docker-sf-${{ matrix.arch }}.tar.gz"
           retention-days: 7
 
-  publish-docker:
+  publish-base:
     runs-on: ubuntu-22.04
-    if: inputs.publish
+    # Always runs on workflow_dispatch (dry-run when publish=false) so
+    # developers can test the full manifest-assembly flow.
+    # On workflow_call the job only runs when publish=true.
+    if: |
+      !cancelled() && needs.docker.result == 'success'
+      && (inputs.publish || github.event_name == 'workflow_dispatch')
     needs:
       - docker
     defaults:
@@ -258,7 +261,6 @@ jobs:
 
     env:
       PROFILE: ${{ inputs.profile }}
-      DOCKER_LATEST: ${{ inputs.latest }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -271,6 +273,7 @@ jobs:
 
       - name: Login to hub.docker.com
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        if: inputs.publish
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -278,52 +281,36 @@ jobs:
       - name: Download docker images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: "${{ env.PROFILE }}-docker-*"
+          pattern: "${{ inputs.profile }}-docker-*"
           path: images/
           merge-multiple: true
 
-      - name: Load, push and create multiarch manifest
+      - name: Publish multi-arch manifest
+        env:
+          OWNER: ${{ github.repository_owner }}
+          LATEST: ${{ inputs.latest }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
-          # Load AMD64 image and retag to prevent overwriting
-          AMD64_IMAGE=$(docker load < images/$PROFILE-docker-amd64.tar.gz | grep "Loaded image:" | sed 's/Loaded image: //')
-          echo "Loaded AMD64 image: $AMD64_IMAGE"
-          VERSION=$(echo "$AMD64_IMAGE" | sed 's/.*://')
-          LOCAL_BASE="localhost:5000/${{ github.repository_owner }}/${PROFILE}"
-          docker tag "$AMD64_IMAGE" "${LOCAL_BASE}:${VERSION}-amd64"
-          docker push "${LOCAL_BASE}:${VERSION}-amd64"
-
-          # Load ARM64 image and retag
-          ARM64_IMAGE=$(docker load < images/$PROFILE-docker-arm64.tar.gz | grep "Loaded image:" | sed 's/Loaded image: //')
-          echo "Loaded ARM64 image: $ARM64_IMAGE"
-          docker tag "$ARM64_IMAGE" "${LOCAL_BASE}:${VERSION}-arm64"
-          docker push "${LOCAL_BASE}:${VERSION}-arm64"
-
-          # Assemble the list of destination tags for the multiarch manifest
-          TARGET_TAGS=(
-            "docker.io/${{ github.repository_owner }}/${PROFILE}:${VERSION}"
-            "docker.io/emqx/emqx:${VERSION}"
+          set -euo pipefail
+          ARGS=(
+              --amd64 "images/${PROFILE}-docker-amd64.tar.gz"
+              --arm64 "images/${PROFILE}-docker-arm64.tar.gz"
+              --owner "$OWNER"
+              --profile "$PROFILE"
+              --variant base
           )
-          if [ "${DOCKER_LATEST}" = "true" ]; then
-            TARGET_TAGS+=(
-              "docker.io/${{ github.repository_owner }}/${PROFILE}:latest"
-              "docker.io/emqx/emqx:latest"
-            )
-          fi
+          if [ "$LATEST" = "true" ]; then ARGS+=(--latest); fi
+          if [ "$PUBLISH" = "true" ]; then ARGS+=(--publish); fi
+          ./scripts/publish-docker-multi-arch.sh "${ARGS[@]}"
 
-          echo "Creating multiarch manifest for docker.io:"
-          TAG_ARGS=()
-          for t in "${TARGET_TAGS[@]}"; do
-            echo "  - $t"
-            TAG_ARGS+=(--tag "$t")
-          done
-          docker buildx imagetools create \
-            "${TAG_ARGS[@]}" \
-            "${LOCAL_BASE}:${VERSION}-amd64" \
-            "${LOCAL_BASE}:${VERSION}-arm64"
-
-  publish-docker-sfodbc:
+  publish-sf:
     runs-on: ubuntu-22.04
-    if: inputs.publish && inputs.profile == 'emqx-enterprise'
+    # Snowflake variant: runs only when docker-sfodbc actually succeeded.
+    # For non-enterprise builds docker-sfodbc is skipped, so this job is
+    # skipped naturally — no extra gating needed.
+    if: |
+      !cancelled() && needs.docker-sfodbc.result == 'success'
+      && (inputs.publish || github.event_name == 'workflow_dispatch')
     needs:
       - docker-sfodbc
     defaults:
@@ -350,6 +337,7 @@ jobs:
 
       - name: Login to hub.docker.com
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        if: inputs.publish
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
@@ -357,35 +345,25 @@ jobs:
       - name: Download docker images
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          pattern: "${{ env.PROFILE }}-sf-docker-*"
+          pattern: "${{ inputs.profile }}-docker-sf-*"
           path: images/
           merge-multiple: true
 
-      - name: Load, push and create multiarch manifest
+      - name: Publish multi-arch manifest
+        env:
+          OWNER: ${{ github.repository_owner }}
+          PUBLISH: ${{ inputs.publish }}
         run: |
-          # Load AMD64 image and retag to prevent overwriting
-          AMD64_IMAGE=$(docker load < images/$PROFILE-docker-sf-amd64.tar.gz | grep "Loaded image:" | sed 's/Loaded image: //')
-          echo "Loaded AMD64 image: $AMD64_IMAGE"
-          VERSION=$(echo "$AMD64_IMAGE" | sed 's/.*://')
-          LOCAL_BASE="localhost:5000/${{ github.repository_owner }}/${PROFILE}"
-          docker tag "$AMD64_IMAGE" "${LOCAL_BASE}:${VERSION}-amd64"
-          docker push "${LOCAL_BASE}:${VERSION}-amd64"
-
-          # Load ARM64 image and retag
-          ARM64_IMAGE=$(docker load < images/$PROFILE-docker-sf-arm64.tar.gz | grep "Loaded image:" | sed 's/Loaded image: //')
-          echo "Loaded ARM64 image: $ARM64_IMAGE"
-          docker tag "$ARM64_IMAGE" "${LOCAL_BASE}:${VERSION}-arm64"
-          docker push "${LOCAL_BASE}:${VERSION}-arm64"
-
-          # Create multiarch manifest and push to docker.io (only profile-specific tag for snowflake)
-          DOCKER_IO_PROFILE_TAG="docker.io/${{ github.repository_owner }}/${PROFILE}:$VERSION"
-
-          echo "Creating multiarch manifest for docker.io:"
-          echo "  - $DOCKER_IO_PROFILE_TAG"
-          docker buildx imagetools create \
-            --tag "$DOCKER_IO_PROFILE_TAG" \
-            "${LOCAL_BASE}:${VERSION}-amd64" \
-            "${LOCAL_BASE}:${VERSION}-arm64"
+          set -euo pipefail
+          ARGS=(
+              --amd64 "images/${PROFILE}-docker-sf-amd64.tar.gz"
+              --arm64 "images/${PROFILE}-docker-sf-arm64.tar.gz"
+              --owner "$OWNER"
+              --profile "$PROFILE"
+              --variant sf
+          )
+          if [ "$PUBLISH" = "true" ]; then ARGS+=(--publish); fi
+          ./scripts/publish-docker-multi-arch.sh "${ARGS[@]}"
 
   upload:
     runs-on: ubuntu-22.04

--- a/build
+++ b/build
@@ -318,12 +318,6 @@ make_docker() {
     local RUN_FROM="${RUN_FROM:-${EMQX_DOCKER_RUN_FROM}}"
     local EMQX_DOCKERFILE="${EMQX_DOCKERFILE:-deploy/docker/Dockerfile}"
     local EMQX_SOURCE_TYPE="${EMQX_SOURCE_TYPE:-src}"
-    # shellcheck disable=SC2155
-    local VSN_MAJOR="$(scripts/semver.sh "$PKG_VSN" --major)"
-    # shellcheck disable=SC2155
-    local VSN_MINOR="$(scripts/semver.sh "$PKG_VSN" --minor)"
-    # shellcheck disable=SC2155
-    local VSN_PATCH="$(scripts/semver.sh "$PKG_VSN" --patch)"
     local SUFFIX="${DOCKER_IMAGE_SUFFIX:-}"
 
     local DOCKER_REGISTRY="${DOCKER_REGISTRY:-docker.io}"
@@ -331,13 +325,7 @@ make_docker() {
     local default_base_tag="${DOCKER_ORG}/${PROFILE}"
     local EMQX_BASE_IMAGE_TAG="${EMQX_BASE_IMAGE_TAG:-$default_base_tag}"
 
-    DOCKER_IMAGE_TAGS=( )
-    DOCKER_IMAGE_TAGS+=( "$DOCKER_REGISTRY/$EMQX_BASE_IMAGE_TAG:${PKG_VSN}${SUFFIX}" )
-    if [ "${DOCKER_LATEST:-false}" = true ]; then
-      DOCKER_IMAGE_TAGS+=( "$DOCKER_REGISTRY/$EMQX_BASE_IMAGE_TAG:latest${SUFFIX}" )
-      DOCKER_IMAGE_TAGS+=( "$DOCKER_REGISTRY/$EMQX_BASE_IMAGE_TAG:${VSN_MAJOR}.${VSN_MINOR}${SUFFIX}" )
-      DOCKER_IMAGE_TAGS+=( "$DOCKER_REGISTRY/$EMQX_BASE_IMAGE_TAG:${VSN_MAJOR}.${VSN_MINOR}.${VSN_PATCH}${SUFFIX}" )
-    fi
+    DOCKER_IMAGE_TAGS=( "$DOCKER_REGISTRY/$EMQX_BASE_IMAGE_TAG:${PKG_VSN}${SUFFIX}" )
 
     local EDITION=Enterprise
     local LICENSE='BSL-1.1'

--- a/scripts/publish-docker-multi-arch.sh
+++ b/scripts/publish-docker-multi-arch.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+## Build per-arch refs from saved tarballs, push them to a local registry,
+## then assemble a multi-arch manifest at docker.io.
+##
+## Usage:
+##   publish-docker-multi-arch.sh \
+##       --amd64 <tarball> --arm64 <tarball> \
+##       --owner <github-owner> --profile <emqx-profile> \
+##       --variant base|sf \
+##       [--latest] [--publish]
+##
+## Without --publish the buildx command is printed instead of executed
+## (the load/tag/push to the local registry still happen).
+##
+## $LOCAL_BASE may be set in the environment to override the staging-registry
+## prefix (default: localhost:5000/${owner}/${profile}, matching the
+## registry:2 sidecar in the workflow).
+##
+## For unit-testing the tag policy:
+##   publish-docker-multi-arch.sh --print-tags \
+##       --variant base|sf --owner <owner> --profile <profile> \
+##       --version <version> [--latest]
+## In --print-tags mode no docker commands are run; the script only echoes
+## the tag set that would be passed to `docker buildx imagetools create`.
+
+set -euo pipefail
+
+AMD64_TARBALL=
+ARM64_TARBALL=
+OWNER=
+PROFILE=
+VARIANT=
+LATEST=false
+PUBLISH=false
+PRINT_TAGS_ONLY=false
+VERSION_OVERRIDE=
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --amd64)       AMD64_TARBALL=$2; shift 2;;
+        --arm64)       ARM64_TARBALL=$2; shift 2;;
+        --owner)       OWNER=$2; shift 2;;
+        --profile)     PROFILE=$2; shift 2;;
+        --variant)     VARIANT=$2; shift 2;;
+        --latest)      LATEST=true; shift;;
+        --publish)     PUBLISH=true; shift;;
+        --print-tags)  PRINT_TAGS_ONLY=true; shift;;
+        --version)     VERSION_OVERRIDE=$2; shift 2;;
+        *) echo "error: unknown argument: $1" >&2; exit 1;;
+    esac
+done
+
+for required in OWNER PROFILE VARIANT; do
+    if [ -z "${!required}" ]; then
+        echo "error: --${required,,} is required" >&2
+        exit 1
+    fi
+done
+
+case "$VARIANT" in
+    base|sf) ;;
+    *) echo "error: --variant must be 'base' or 'sf', got '$VARIANT'" >&2; exit 1;;
+esac
+
+# Pure function: emits one tag per line.
+# Tag policy:
+#   - Always: ${owner}/${profile}:${version}
+#   - base also: emqx/emqx:${version}
+#   - For stable MAJOR.MINOR.PATCH on base:
+#       additionally :MAJOR.MINOR (always — patch follows its line)
+#       additionally :MAJOR and :latest (only when latest=true)
+#   - For sf: full version only, no mirror, no rolling.
+compute_tags() {
+    local version=$1 variant=$2 owner=$3 profile=$4 latest=$5
+
+    echo "docker.io/${owner}/${profile}:${version}"
+
+    if [ "$variant" = "sf" ]; then
+        return
+    fi
+
+    echo "docker.io/emqx/emqx:${version}"
+
+    # Rolling tags only for stable MAJOR.MINOR.PATCH versions.
+    # Anything else (prereleases, git-hash builds, build metadata) gets
+    # only the full-version tag.
+    if [[ "$version" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+        local major=${BASH_REMATCH[1]}
+        local minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}
+
+        echo "docker.io/${owner}/${profile}:${minor}"
+        echo "docker.io/emqx/emqx:${minor}"
+
+        if [ "$latest" = "true" ]; then
+            echo "docker.io/${owner}/${profile}:${major}"
+            echo "docker.io/emqx/emqx:${major}"
+            echo "docker.io/${owner}/${profile}:latest"
+            echo "docker.io/emqx/emqx:latest"
+        fi
+    fi
+}
+
+if [ "$PRINT_TAGS_ONLY" = "true" ]; then
+    if [ -z "$VERSION_OVERRIDE" ]; then
+        echo "error: --print-tags requires --version" >&2
+        exit 1
+    fi
+    compute_tags "$VERSION_OVERRIDE" "$VARIANT" "$OWNER" "$PROFILE" "$LATEST"
+    exit 0
+fi
+
+if [ -z "$AMD64_TARBALL" ] || [ -z "$ARM64_TARBALL" ]; then
+    echo "error: --amd64 and --arm64 are required" >&2
+    exit 1
+fi
+
+LOCAL_BASE="${LOCAL_BASE:-localhost:5000/${OWNER}/${PROFILE}}"
+
+AMD64_LOADED=$(docker load < "$AMD64_TARBALL" | grep "Loaded image:" | sed 's/Loaded image: //')
+echo "Loaded amd64 image: $AMD64_LOADED"
+VERSION="${AMD64_LOADED##*:}"
+AMD64_REF="${LOCAL_BASE}:${VERSION}-amd64"
+docker tag "$AMD64_LOADED" "$AMD64_REF"
+docker push "$AMD64_REF"
+
+ARM64_LOADED=$(docker load < "$ARM64_TARBALL" | grep "Loaded image:" | sed 's/Loaded image: //')
+echo "Loaded arm64 image: $ARM64_LOADED"
+ARM64_VERSION="${ARM64_LOADED##*:}"
+ARM64_REF="${LOCAL_BASE}:${ARM64_VERSION}-arm64"
+docker tag "$ARM64_LOADED" "$ARM64_REF"
+docker push "$ARM64_REF"
+
+if [ "$VERSION" != "$ARM64_VERSION" ]; then
+    echo "error: amd64 version ($VERSION) does not match arm64 version ($ARM64_VERSION)" >&2
+    exit 1
+fi
+
+mapfile -t TAGS < <(compute_tags "$VERSION" "$VARIANT" "$OWNER" "$PROFILE" "$LATEST")
+
+echo "Tags (publish=${PUBLISH}):"
+printf '  - %s\n' "${TAGS[@]}"
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    {
+        echo "### Multi-arch manifest tags (variant=${VARIANT}, publish=${PUBLISH})"
+        # shellcheck disable=SC2016 # backticks are literal markdown, not command substitution
+        printf -- '- `%s`\n' "${TAGS[@]}"
+    } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+TAG_ARGS=()
+for t in "${TAGS[@]}"; do TAG_ARGS+=(--tag "$t"); done
+
+CMD=(docker buildx imagetools create "${TAG_ARGS[@]}" "$AMD64_REF" "$ARM64_REF")
+if [ "$PUBLISH" = "true" ]; then
+    "${CMD[@]}"
+else
+    echo "dry-run: ${CMD[*]}"
+fi

--- a/scripts/shelltest/publish-docker-multi-arch.test
+++ b/scripts/shelltest/publish-docker-multi-arch.test
@@ -1,0 +1,91 @@
+## Stable release with latest=true: full version, mirror, :MAJOR.MINOR, :MAJOR, :latest.
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.2.1 --latest --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.2.1
+docker.io/emqx/emqx:6.2.1
+docker.io/emqx/emqx-enterprise:6.2
+docker.io/emqx/emqx:6.2
+docker.io/emqx/emqx-enterprise:6
+docker.io/emqx/emqx:6
+docker.io/emqx/emqx-enterprise:latest
+docker.io/emqx/emqx:latest
+>>>= 0
+
+## Stable patch on older line (latest=false): :MAJOR.MINOR follows the line, no :MAJOR, no :latest.
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.1.5 --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.1.5
+docker.io/emqx/emqx:6.1.5
+docker.io/emqx/emqx-enterprise:6.1
+docker.io/emqx/emqx:6.1
+>>>= 0
+
+## Two-digit minor must not be misparsed (6.10 != 6.1).
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.10.5 --latest --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.10.5
+docker.io/emqx/emqx:6.10.5
+docker.io/emqx/emqx-enterprise:6.10
+docker.io/emqx/emqx:6.10
+docker.io/emqx/emqx-enterprise:6
+docker.io/emqx/emqx:6
+docker.io/emqx/emqx-enterprise:latest
+docker.io/emqx/emqx:latest
+>>>= 0
+
+## Prerelease: only the full version, even with --latest.
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.2.1-rc.1 --latest --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.2.1-rc.1
+docker.io/emqx/emqx:6.2.1-rc.1
+>>>= 0
+
+## Git-hash build: only the full version (fails closed; the regex rejects -g suffixes).
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.2.1-g123abc --latest --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.2.1-g123abc
+docker.io/emqx/emqx:6.2.1-g123abc
+>>>= 0
+
+## Build metadata: only the full version.
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.2.1+build.42 --latest --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.2.1+build.42
+docker.io/emqx/emqx:6.2.1+build.42
+>>>= 0
+
+## Snowflake variant: profile-specific full version only, no mirror, no rolling.
+./publish-docker-multi-arch.sh --variant sf --owner emqx --profile emqx-enterprise --version 6.2.1 --latest --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.2.1
+>>>= 0
+
+## Snowflake prerelease: same — just the version.
+./publish-docker-multi-arch.sh --variant sf --owner emqx --profile emqx-enterprise --version 6.2.1-rc.1 --print-tags
+>>>
+docker.io/emqx/emqx-enterprise:6.2.1-rc.1
+>>>= 0
+
+## Invalid variant.
+./publish-docker-multi-arch.sh --variant xx --owner emqx --profile emqx-enterprise --version 6.2.1 --print-tags
+>>>2
+error: --variant must be 'base' or 'sf', got 'xx'
+>>>= 1
+
+## --print-tags without --version.
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --print-tags
+>>>2
+error: --print-tags requires --version
+>>>= 1
+
+## Missing required argument.
+./publish-docker-multi-arch.sh --variant base --owner emqx --version 6.2.1 --print-tags
+>>>2
+error: --profile is required
+>>>= 1
+
+## Unknown argument.
+./publish-docker-multi-arch.sh --variant base --owner emqx --profile emqx-enterprise --version 6.2.1 --bogus --print-tags
+>>>2
+error: unknown argument: --bogus
+>>>= 1


### PR DESCRIPTION
Release version: 6.0.3, 6.1.2, 6.2.1

## Summary

Separate image contents from image distribution.

- `./build docker` produces one tag: `${PROFILE}:${PKG_VSN}`. Moving tags removed from build-time.
- All moving tags (`:latest`, `:MAJOR`, `:MAJOR.MINOR`, `emqx/emqx` mirror) are now applied at publish time by the workflow.
- Publish flow extracted to `scripts/publish-docker-multi-arch.sh` with shelltest coverage of the tag policy.
- Publish job now also runs on `workflow_dispatch` in dry-run mode, so the manifest path is exercised before release day.

https://github.com/emqx/emqx/actions/runs/25051063214

## PR Checklist
<!--
Please convert the PR to a draft if any of the following conditions are not met.
-->
- [ ] The changes are covered with new or existing tests
- [ ] Change log for changes visible by users has been added to `changes/ee/(feat|perf|fix|breaking)-<PR-id>.en.md` files
- [ ] Schema changes are backward compatible or intentionally breaking (describe the changes and the reasoning in the summary)

<!--
Please, take in account the following guidelines while working on PR:
* Try to achieve reasonable coverage of the new code
* Add property-based tests for code that performs complex user input validation or implements a complex algorithm
* Create a PR to [emqx-docs](https://github.com/emqx/emqx-docs) if documentation update is required, or make a follow-up jira ticket
* Do not squash large PRs into a single commit, try to keep comprehensive history of incremental changes
* Do not squash any significant amount of review fixes into the previous commits
-->

<!--
## Checklist for CI (.github/workflows) changes
- [ ] If changed package build workflow, pass [this action](https://github.com/emqx/emqx/actions/workflows/build_packages.yaml) (manual trigger)
- [ ] Change log has been added to `changes/` dir for user-facing artifacts update
-->
